### PR TITLE
feat:Support multi-threaded asynchronous data upload to object storage.

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -119,13 +119,13 @@ class S3Config {
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
             {Keys::KS3UploadPartAsync,
-             std::make_pair("uploadPartAsync","false")},
+             std::make_pair("uploadPartAsync", "false")},
             {Keys::kS3PartUploadSize,
              std::make_pair("part-upload-size", std::nullopt)},
             {Keys::KS3WriteFileSemaphoreNum,
-              std::make_pair("writeFileSemaphoreNum", std::nullopt)},
+             std::make_pair("writeFileSemaphoreNum", std::nullopt)},
             {Keys::KS3UploadThreads,
-            std::make_pair("uploadThreads", std::nullopt)},
+             std::make_pair("uploadThreads", std::nullopt)},
         };
     return config;
   }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -76,6 +76,10 @@ class S3Config {
     kRetryMode,
     kUseProxyFromEnv,
     kCredentialsProvider,
+    KS3UploadPartAsync,
+    kS3PartUploadSize,
+    KS3WriteFileSemaphoreNum,
+    KS3UploadThreads,
     kEnd
   };
 
@@ -114,6 +118,14 @@ class S3Config {
              std::make_pair("use-proxy-from-env", "false")},
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
+            {Keys::KS3UploadPartAsync,
+             std::make_pair("uploadPartAsync","false")},
+            {Keys::kS3PartUploadSize,
+             std::make_pair("part-upload-size", std::nullopt)},
+            {Keys::KS3WriteFileSemaphoreNum,
+              std::make_pair("writeFileSemaphoreNum", std::nullopt)},
+            {Keys::KS3UploadThreads,
+            std::make_pair("uploadThreads", std::nullopt)},
         };
     return config;
   }
@@ -241,6 +253,35 @@ class S3Config {
 
   std::optional<std::string> credentialsProvider() const {
     return config_.find(Keys::kCredentialsProvider)->second;
+  }
+
+  bool uploadPartAsync() const {
+    auto value = config_.find(Keys::KS3UploadPartAsync)->second.value();
+    return folly::to<bool>(value);
+  }
+
+  std::optional<int32_t> partUploadSize() const {
+    auto val = config_.find(Keys::kS3PartUploadSize)->second;
+    if (val.has_value()) {
+      return folly::to<uint32_t>(val.value());
+    }
+    return std::optional<uint32_t>();
+  }
+
+  std::optional<int32_t> writeFileSemaphoreNum() const {
+    auto val = config_.find(Keys::KS3WriteFileSemaphoreNum)->second;
+    if (val.has_value()) {
+      return folly::to<uint32_t>(val.value());
+    }
+    return std::optional<uint32_t>();
+  }
+
+  std::optional<int32_t> uploadThreads() const {
+    auto val = config_.find(Keys::KS3UploadThreads)->second;
+    if (val.has_value()) {
+      return folly::to<uint32_t>(val.value());
+    }
+    return std::optional<uint32_t>();
   }
 
  private:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -76,7 +76,7 @@ class S3Config {
     kRetryMode,
     kUseProxyFromEnv,
     kCredentialsProvider,
-    KUploadPartAsync,
+    KPartUploadAsync,
     kPartUploadSize,
     KMaxConcurrentUploadNum,
     KUploadThreads,
@@ -118,8 +118,8 @@ class S3Config {
              std::make_pair("use-proxy-from-env", "false")},
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
-            {Keys::KUploadPartAsync,
-             std::make_pair("upload-part-async", "false")},
+            {Keys::KPartUploadAsync,
+             std::make_pair("part-upload-async", "false")},
             {Keys::kPartUploadSize,
              std::make_pair("part-upload-size", "10485760")},
             {Keys::KMaxConcurrentUploadNum,
@@ -254,8 +254,8 @@ class S3Config {
     return config_.find(Keys::kCredentialsProvider)->second;
   }
 
-  bool uploadPartAsync() const {
-    auto value = config_.find(Keys::KUploadPartAsync)->second.value();
+  bool partUploadAsync() const {
+    auto value = config_.find(Keys::KPartUploadAsync)->second.value();
     return folly::to<bool>(value);
   }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -119,13 +119,13 @@ class S3Config {
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
             {Keys::KS3UploadPartAsync,
-             std::make_pair("uploadPartAsync", "false")},
+             std::make_pair("upload-part-async", "false")},
             {Keys::kS3PartUploadSize,
              std::make_pair("part-upload-size", std::nullopt)},
             {Keys::KS3WriteFileSemaphoreNum,
-             std::make_pair("writeFileSemaphoreNum", std::nullopt)},
+             std::make_pair("write-file-semaphore-num", std::nullopt)},
             {Keys::KS3UploadThreads,
-             std::make_pair("uploadThreads", std::nullopt)},
+             std::make_pair("upload-threads", std::nullopt)},
         };
     return config;
   }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -121,11 +121,10 @@ class S3Config {
             {Keys::KUploadPartAsync,
              std::make_pair("upload-part-async", "false")},
             {Keys::kPartUploadSize,
-             std::make_pair("part-upload-size", std::nullopt)},
+             std::make_pair("part-upload-size", "10485760")},
             {Keys::KMaxConcurrentUploadNum,
-             std::make_pair("max-concurrent-upload-num", std::nullopt)},
-            {Keys::KUploadThreads,
-             std::make_pair("upload-threads", std::nullopt)},
+             std::make_pair("max-concurrent-upload-num", "4")},
+            {Keys::KUploadThreads, std::make_pair("upload-threads", "16")},
         };
     return config;
   }
@@ -260,28 +259,19 @@ class S3Config {
     return folly::to<bool>(value);
   }
 
-  std::optional<int32_t> partUploadSize() const {
-    auto val = config_.find(Keys::kPartUploadSize)->second;
-    if (val.has_value()) {
-      return folly::to<uint32_t>(val.value());
-    }
-    return std::optional<uint32_t>();
+  int32_t partUploadSize() const {
+    auto value = config_.find(Keys::kPartUploadSize)->second.value();
+    return folly::to<uint32_t>(value);
   }
 
-  std::optional<int32_t> maxConcurrentUploadNum() const {
-    auto val = config_.find(Keys::KMaxConcurrentUploadNum)->second;
-    if (val.has_value()) {
-      return folly::to<uint32_t>(val.value());
-    }
-    return std::optional<uint32_t>();
+  int32_t maxConcurrentUploadNum() const {
+    auto value = config_.find(Keys::KMaxConcurrentUploadNum)->second.value();
+    return folly::to<uint32_t>(value);
   }
 
-  std::optional<int32_t> uploadThreads() const {
-    auto val = config_.find(Keys::KUploadThreads)->second;
-    if (val.has_value()) {
-      return folly::to<uint32_t>(val.value());
-    }
-    return std::optional<uint32_t>();
+  int32_t uploadThreads() const {
+    auto value = config_.find(Keys::KUploadThreads)->second.value();
+    return folly::to<uint32_t>(value);
   }
 
  private:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -76,10 +76,10 @@ class S3Config {
     kRetryMode,
     kUseProxyFromEnv,
     kCredentialsProvider,
-    KS3UploadPartAsync,
-    kS3PartUploadSize,
-    KS3WriteFileSemaphoreNum,
-    KS3UploadThreads,
+    KUploadPartAsync,
+    kPartUploadSize,
+    KMaxConcurrentUploadNum,
+    KUploadThreads,
     kEnd
   };
 
@@ -118,13 +118,13 @@ class S3Config {
              std::make_pair("use-proxy-from-env", "false")},
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
-            {Keys::KS3UploadPartAsync,
+            {Keys::KUploadPartAsync,
              std::make_pair("upload-part-async", "false")},
-            {Keys::kS3PartUploadSize,
+            {Keys::kPartUploadSize,
              std::make_pair("part-upload-size", std::nullopt)},
-            {Keys::KS3WriteFileSemaphoreNum,
-             std::make_pair("write-file-semaphore-num", std::nullopt)},
-            {Keys::KS3UploadThreads,
+            {Keys::KMaxConcurrentUploadNum,
+             std::make_pair("max-concurrent-upload-num", std::nullopt)},
+            {Keys::KUploadThreads,
              std::make_pair("upload-threads", std::nullopt)},
         };
     return config;
@@ -256,20 +256,20 @@ class S3Config {
   }
 
   bool uploadPartAsync() const {
-    auto value = config_.find(Keys::KS3UploadPartAsync)->second.value();
+    auto value = config_.find(Keys::KUploadPartAsync)->second.value();
     return folly::to<bool>(value);
   }
 
   std::optional<int32_t> partUploadSize() const {
-    auto val = config_.find(Keys::kS3PartUploadSize)->second;
+    auto val = config_.find(Keys::kPartUploadSize)->second;
     if (val.has_value()) {
       return folly::to<uint32_t>(val.value());
     }
     return std::optional<uint32_t>();
   }
 
-  std::optional<int32_t> writeFileSemaphoreNum() const {
-    auto val = config_.find(Keys::KS3WriteFileSemaphoreNum)->second;
+  std::optional<int32_t> maxConcurrentUploadNum() const {
+    auto val = config_.find(Keys::KMaxConcurrentUploadNum)->second;
     if (val.has_value()) {
       return folly::to<uint32_t>(val.value());
     }
@@ -277,7 +277,7 @@ class S3Config {
   }
 
   std::optional<int32_t> uploadThreads() const {
-    auto val = config_.find(Keys::KS3UploadThreads)->second;
+    auto val = config_.find(Keys::KUploadThreads)->second;
     if (val.has_value()) {
       return folly::to<uint32_t>(val.value());
     }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -254,21 +254,28 @@ class S3Config {
     return config_.find(Keys::kCredentialsProvider)->second;
   }
 
+  /// If true, enables asynchronous upload of parts for S3 multipart uploads,
+  /// false otherwise.
   bool partUploadAsync() const {
     auto value = config_.find(Keys::KPartUploadAsync)->second.value();
     return folly::to<bool>(value);
   }
 
+  /// Return the size (in bytes) of each part for S3 multipart uploads.
   int32_t partUploadSize() const {
     auto value = config_.find(Keys::kPartUploadSize)->second.value();
     return folly::to<uint32_t>(value);
   }
 
+  /// Return the maximum number of concurrent uploads for S3 multipart uploads,
+  /// applicable only when asynchronous uploads are enabled.
   int32_t maxConcurrentUploadNum() const {
     auto value = config_.find(Keys::KMaxConcurrentUploadNum)->second.value();
     return folly::to<uint32_t>(value);
   }
 
+  /// Return the number of threads to use for S3 multipart uploads,
+  /// applicable only when asynchronous uploads are enabled.
   int32_t uploadThreads() const {
     auto value = config_.find(Keys::KUploadThreads)->second.value();
     return folly::to<uint32_t>(value);

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -15,8 +15,6 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
-#include <folly/executors/CPUThreadPoolExecutor.h>
-#include <folly/synchronization/ThrottledLifoSem.h>
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
@@ -229,72 +227,6 @@ void registerCredentialsProvider(
   });
 }
 
-std::shared_ptr<S3UploadManager> S3UploadManager::instance_ = nullptr;
-S3UploadManager::S3UploadManager(const S3Config& s3Config) {
-  uploadPartAsyncEnabled = s3Config.uploadPartAsync();
-  setPartUploadSize(s3Config.partUploadSize().value_or(kDefaultPartUploadSize));
-  setWriteFileSemaphoreNum(
-      s3Config.writeFileSemaphoreNum().value_or(kDefaultWriteFileSemaphore));
-  setUploadThreadPool(s3Config.uploadThreads().value_or(kDefaultUploadThreads));
-}
-
-std::shared_ptr<S3UploadManager> S3UploadManager::getInstance(
-    const S3Config& s3Config) {
-#ifndef NDEBUG
-  // In debug mode, always create a new S3UploadManager instance for each
-  // s3Config.
-  instance_ = std::make_shared<S3UploadManager>(s3Config);
-#else
-  // In no debug mode, create a new instance only if it doesn't already exist.
-  if (!instance_) {
-    instance_ = std::make_shared<UploadPartAsync>(s3Config);
-  }
-#endif
-  return instance_;
-}
-
-bool S3UploadManager::isUploadPartAsyncEnabled() const {
-  return uploadPartAsyncEnabled;
-}
-
-size_t S3UploadManager::getPartUploadSize() const {
-  return kPartUploadSize;
-}
-
-size_t S3UploadManager::getWriteFileSemaphoreNum() const {
-  return writeFileSemaphore;
-}
-
-std::shared_ptr<folly::CPUThreadPoolExecutor>
-S3UploadManager::getUploadThreadPool() const {
-  return uploadThreadPool_;
-}
-
-void S3UploadManager::setPartUploadSize(size_t partUploadSize) {
-  kPartUploadSize =
-      validatePositiveValue(partUploadSize, "hive.s3.part-upload-size");
-}
-
-void S3UploadManager::setWriteFileSemaphoreNum(size_t value) {
-  writeFileSemaphore =
-      validatePositiveValue(value, "hive.s3.write-file-semaphore-num");
-}
-
-void S3UploadManager::setUploadThreadPool(size_t value) {
-  auto threadPool = std::make_shared<folly::CPUThreadPoolExecutor>(
-      validatePositiveValue(value, "hive.s3.upload-threads"));
-  uploadThreadPool_ = threadPool;
-}
-
-size_t S3UploadManager::validatePositiveValue(
-    size_t value,
-    const std::string& name) {
-  VELOX_USER_CHECK(
-      value > 0,
-      fmt::format("Invalid configuration: '{}' must be greater than 0.", name));
-  return value;
-}
-
 class S3FileSystem::Impl {
  public:
   Impl(const S3Config& s3Config) {
@@ -362,7 +294,26 @@ class S3FileSystem::Impl {
 
     auto credentialsProvider = getCredentialsProvider(s3Config);
 
-    uploadManager_ = S3UploadManager::getInstance(s3Config);
+    if (s3Config.uploadPartAsync() && !asyncUploadInfo_) {
+      asyncUploadInfo_ = std::make_shared<AsyncUploadInfo>();
+
+      auto partUploadSize = s3Config.partUploadSize();
+      if (partUploadSize.has_value()) {
+        asyncUploadInfo_->partUploadSize = partUploadSize.value();
+      }
+
+      auto maxConcurrentUploadNum = s3Config.maxConcurrentUploadNum();
+      if (maxConcurrentUploadNum.has_value()) {
+        asyncUploadInfo_->maxConcurrentUploadNum =
+            maxConcurrentUploadNum.value();
+      }
+
+      auto uploadThreads = s3Config.uploadThreads();
+      if (uploadThreads.has_value()) {
+        asyncUploadInfo_->uploadThreads = uploadThreads.value();
+      }
+    }
+
     client_ = std::make_shared<Aws::S3::S3Client>(
         credentialsProvider, nullptr /* endpointProvider */, clientConfig);
     ++fileSystemCount;
@@ -502,8 +453,8 @@ class S3FileSystem::Impl {
     return client_.get();
   }
 
-  std::shared_ptr<S3UploadManager> s3UploadManager() const {
-    return uploadManager_;
+  std::shared_ptr<AsyncUploadInfo> getAsyncUploadInfo() const {
+    return asyncUploadInfo_;
   }
 
   std::string getLogLevelName() const {
@@ -516,7 +467,7 @@ class S3FileSystem::Impl {
 
  private:
   std::shared_ptr<Aws::S3::S3Client> client_;
-  std::shared_ptr<S3UploadManager> uploadManager_;
+  std::shared_ptr<AsyncUploadInfo> asyncUploadInfo_;
 };
 
 S3FileSystem::S3FileSystem(
@@ -549,7 +500,7 @@ std::unique_ptr<WriteFile> S3FileSystem::openFileForWrite(
     const FileOptions& options) {
   const auto path = getPath(s3Path);
   auto s3file = std::make_unique<S3WriteFile>(
-      path, impl_->s3Client(), options.pool, impl_->s3UploadManager());
+      path, impl_->s3Client(), options.pool, impl_->getAsyncUploadInfo());
   return s3file;
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 #include "velox/common/base/StatsReporter.h"
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/synchronization/ThrottledLifoSem.h>
 #include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
@@ -227,6 +229,12 @@ void registerCredentialsProvider(
   });
 }
 
+bool S3FileSystem::uploadPartAsyncEnabled = false;
+size_t S3FileSystem::kPartUploadSize = 10485760;
+size_t S3FileSystem::writeFileSemaphore = 4;
+std::shared_ptr<folly::CPUThreadPoolExecutor> S3FileSystem::uploadThreadPool_ =
+    nullptr;
+
 class S3FileSystem::Impl {
  public:
   Impl(const S3Config& s3Config) {
@@ -293,6 +301,18 @@ class S3FileSystem::Impl {
         inferPayloadSign(s3Config.payloadSigningPolicy());
 
     auto credentialsProvider = getCredentialsProvider(s3Config);
+
+    S3FileSystem::setUploadPartAsyncEnabled(s3Config.uploadPartAsync());
+    S3FileSystem::setPartUploadSize(
+    s3Config.partUploadSize().value_or(10485760));
+
+    S3FileSystem::setWriteFileSemaphoreNum(
+        s3Config.writeFileSemaphoreNum().value_or(4));
+
+    auto threadPoolSize =  s3Config.uploadThreads().value_or(16);
+    S3FileSystem::setUploadThreadPool(
+        std::make_shared<folly::CPUThreadPoolExecutor>(threadPoolSize));
+    LOG(INFO) << "partUploadSize : " << S3FileSystem::getPartUploadSize();
 
     client_ = std::make_shared<Aws::S3::S3Client>(
         credentialsProvider, nullptr /* endpointProvider */, clientConfig);

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
-#include "velox/common/base/StatsReporter.h"
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/synchronization/ThrottledLifoSem.h>
+#include "velox/common/base/StatsReporter.h"
 #include "velox/common/config/Config.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
@@ -304,15 +304,14 @@ class S3FileSystem::Impl {
 
     S3FileSystem::setUploadPartAsyncEnabled(s3Config.uploadPartAsync());
     S3FileSystem::setPartUploadSize(
-    s3Config.partUploadSize().value_or(10485760));
+        s3Config.partUploadSize().value_or(10485760));
 
     S3FileSystem::setWriteFileSemaphoreNum(
         s3Config.writeFileSemaphoreNum().value_or(4));
 
-    auto threadPoolSize =  s3Config.uploadThreads().value_or(16);
+    auto threadPoolSize = s3Config.uploadThreads().value_or(16);
     S3FileSystem::setUploadThreadPool(
         std::make_shared<folly::CPUThreadPoolExecutor>(threadPoolSize));
-    LOG(INFO) << "partUploadSize : " << S3FileSystem::getPartUploadSize();
 
     client_ = std::make_shared<Aws::S3::S3Client>(
         credentialsProvider, nullptr /* endpointProvider */, clientConfig);

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -123,9 +123,9 @@ class S3FileSystem : public FileSystem {
   static void setUploadThreadPool(
       std::shared_ptr<folly::CPUThreadPoolExecutor> threadPool) {
     VELOX_USER_CHECK(
-     threadPool != nullptr && threadPool.get() != nullptr &&
-        threadPool->numThreads() > 0,
-     "Invalid configuration: 'hive.s3.uploadThreads' must be greater than 0.");
+        threadPool != nullptr && threadPool.get() != nullptr &&
+            threadPool->numThreads() > 0,
+        "Invalid configuration: 'hive.s3.uploadThreads' must be greater than 0.");
     uploadThreadPool_ = threadPool;
   }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <folly/executors/CPUThreadPoolExecutor.h>
 #include "velox/common/file/FileSystems.h"
 
 namespace Aws::Auth {
@@ -34,31 +33,10 @@ void finalizeS3();
 
 class S3Config;
 
-struct S3UploadManager {
-  explicit S3UploadManager(const S3Config& s3Config);
-  static std::shared_ptr<S3UploadManager> getInstance(const S3Config& s3Config);
-
-  bool isUploadPartAsyncEnabled() const;
-  size_t getPartUploadSize() const;
-  size_t getWriteFileSemaphoreNum() const;
-  std::shared_ptr<folly::CPUThreadPoolExecutor> getUploadThreadPool() const;
-
- private:
-  static constexpr bool kDefaultUploadPartAsyncEnabled = false;
-  static constexpr size_t kDefaultPartUploadSize = 10485760;
-  static constexpr size_t kDefaultWriteFileSemaphore = 4;
-  static constexpr size_t kDefaultUploadThreads = 16;
-
-  bool uploadPartAsyncEnabled;
-  size_t kPartUploadSize;
-  size_t writeFileSemaphore;
-  std::shared_ptr<folly::CPUThreadPoolExecutor> uploadThreadPool_;
-  static std::shared_ptr<S3UploadManager> instance_;
-
-  void setPartUploadSize(size_t partUploadSize);
-  void setWriteFileSemaphoreNum(size_t value);
-  void setUploadThreadPool(size_t value);
-  static size_t validatePositiveValue(size_t value, const std::string& name);
+struct AsyncUploadInfo {
+  std::optional<int32_t> partUploadSize{10485760};
+  std::optional<int32_t> maxConcurrentUploadNum{4};
+  std::optional<int32_t> uploadThreads{16};
 };
 
 using AWSCredentialsProviderFactory =

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -33,12 +33,6 @@ void finalizeS3();
 
 class S3Config;
 
-struct AsyncUploadInfo {
-  std::optional<int32_t> partUploadSize{10485760};
-  std::optional<int32_t> maxConcurrentUploadNum{4};
-  std::optional<int32_t> uploadThreads{16};
-};
-
 using AWSCredentialsProviderFactory =
     std::function<std::shared_ptr<Aws::Auth::AWSCredentialsProvider>(
         const S3Config& config)>;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
@@ -46,7 +46,7 @@ class S3WriteFile::Impl {
     VELOX_CHECK_NOT_NULL(client);
     VELOX_CHECK_NOT_NULL(pool);
     partUploadSize_ = s3Config->partUploadSize();
-    if (s3Config->uploadPartAsync()) {
+    if (s3Config->partUploadAsync()) {
       maxConcurrentUploadNum_ = std::make_unique<folly::ThrottledLifoSem>(
           s3Config->maxConcurrentUploadNum());
       if (!uploadThreadPool_) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
@@ -236,16 +236,14 @@ class S3WriteFile::Impl {
           uploadPartSeq(uploadState_.id, ++uploadState_.partNumber, partData);
       uploadState_.completedParts.push_back(std::move(completedPart));
     };
-    if (uploadThreadPool_) {
-      // If this is the last part and no parts have been uploaded yet,
-      // use the synchronous upload method.
-      if (isLast && uploadState_.partNumber == 0) {
-        uploadPartSync(part);
-      } else {
-        uploadPartAsync(part);
-      }
-    } else {
+    // If this is the last part and no parts have been uploaded yet,
+    // use the synchronous upload method.
+    bool useSyncUpload =
+        !uploadThreadPool_ || (isLast && uploadState_.partNumber == 0);
+    if (useSyncUpload) {
       uploadPartSync(part);
+    } else {
+      uploadPartAsync(part);
     }
   }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -72,8 +72,6 @@ class S3WriteFile : public WriteFile {
 
  protected:
   class Impl;
-
- protected:
   std::shared_ptr<Impl> impl_;
 };
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -18,6 +18,7 @@
 
 #include "velox/common/file/File.h"
 #include "velox/common/memory/MemoryPool.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 
 namespace Aws::S3 {
 class S3Client;
@@ -50,7 +51,8 @@ class S3WriteFile : public WriteFile {
   S3WriteFile(
       std::string_view path,
       Aws::S3::S3Client* client,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      std::shared_ptr<S3UploadManager> uploadManager);
 
   /// Appends data to the end of the file.
   /// Uploads a part on reaching part size limit.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -52,7 +52,7 @@ class S3WriteFile : public WriteFile {
       std::string_view path,
       Aws::S3::S3Client* client,
       memory::MemoryPool* pool,
-      std::shared_ptr<S3UploadManager> uploadManager);
+      std::shared_ptr<AsyncUploadInfo> asyncUploadInfo);
 
   /// Appends data to the end of the file.
   /// Uploads a part on reaching part size limit.
@@ -69,9 +69,9 @@ class S3WriteFile : public WriteFile {
 
   /// Return the number of parts uploaded so far.
   int numPartsUploaded() const;
+  class Impl;
 
  protected:
-  class Impl;
   std::shared_ptr<Impl> impl_;
 };
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -18,7 +18,7 @@
 
 #include "velox/common/file/File.h"
 #include "velox/common/memory/MemoryPool.h"
-#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
 
 namespace Aws::S3 {
 class S3Client;
@@ -52,7 +52,7 @@ class S3WriteFile : public WriteFile {
       std::string_view path,
       Aws::S3::S3Client* client,
       memory::MemoryPool* pool,
-      std::shared_ptr<AsyncUploadInfo> asyncUploadInfo);
+      S3Config* s3Config);
 
   /// Appends data to the end of the file.
   /// Uploads a part on reaching part size limit.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -69,6 +69,8 @@ class S3WriteFile : public WriteFile {
 
   /// Return the number of parts uploaded so far.
   int numPartsUploaded() const;
+
+ protected:
   class Impl;
 
  protected:

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_s3AsyncUpload_benchmark S3AsyncUploadBenchmark.cpp)
+add_executable(velox_s3asyncupload_benchmark S3AsyncUploadBenchmark.cpp)
 
-add_test(velox_s3AsyncUpload_benchmark velox_s3AsyncUpload_benchmark)
+add_test(velox_s3asyncupload_benchmark velox_s3asyncupload_benchmark)
 target_link_libraries(
-  velox_s3AsyncUpload_benchmark
+  velox_s3asyncupload_benchmark
   velox_file
   velox_s3fs
   velox_core

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -11,19 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_s3FileSystem_benchmark
-        S3FileSystemBenchmark.cpp)
+add_executable(velox_s3FileSystem_benchmark S3FileSystemBenchmark.cpp)
 
 add_test(velox_s3FileSystem_benchmark velox_s3FileSystem_benchmark)
 target_link_libraries(
-        velox_s3FileSystem_benchmark
-        velox_file
-        velox_s3fs
-        velox_core
-        velox_exec_test_lib
-        velox_dwio_common_exception
-        velox_exec
-        GTest::gtest
-        Folly::folly
-        Folly::follybenchmark
-        GTest::gtest_main)
+  velox_s3FileSystem_benchmark
+  velox_file
+  velox_s3fs
+  velox_core
+  velox_exec_test_lib
+  velox_dwio_common_exception
+  velox_exec
+  GTest::gtest
+  Folly::folly
+  Folly::follybenchmark
+  GTest::gtest_main)

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_s3FileSystem_benchmark S3FileSystemBenchmark.cpp)
+add_executable(velox_s3AsyncUpload_benchmark S3AsyncUploadBenchmark.cpp)
 
-add_test(velox_s3FileSystem_benchmark velox_s3FileSystem_benchmark)
+add_test(velox_s3AsyncUpload_benchmark velox_s3AsyncUpload_benchmark)
 target_link_libraries(
-  velox_s3FileSystem_benchmark
+  velox_s3AsyncUpload_benchmark
   velox_file
   velox_s3fs
   velox_core

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -11,23 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_executable(velox_s3FileSystem_benchmark
+        S3FileSystemBenchmark.cpp)
 
-# for generated headers
-
-velox_add_library(velox_s3fs RegisterS3FileSystem.cpp)
-if(VELOX_ENABLE_S3)
-  velox_sources(
-    velox_s3fs
-    PRIVATE S3FileSystem.cpp S3Util.cpp S3Config.cpp S3WriteFile.cpp S3ReadFile.cpp
-  )
-
-  velox_include_directories(velox_s3fs PRIVATE ${AWSSDK_INCLUDE_DIRS})
-  velox_link_libraries(velox_s3fs PRIVATE velox_dwio_common Folly::folly ${AWSSDK_LIBRARIES})
-
-  if(${VELOX_BUILD_TESTING})
-    add_subdirectory(tests)
-  endif()
-  if(${VELOX_ENABLE_BENCHMARKS})
-    add_subdirectory(benchmark)
-  endif()
-endif()
+add_test(velox_s3FileSystem_benchmark velox_s3FileSystem_benchmark)
+target_link_libraries(
+        velox_s3FileSystem_benchmark
+        velox_file
+        velox_s3fs
+        velox_core
+        velox_exec_test_lib
+        velox_dwio_common_exception
+        velox_exec
+        GTest::gtest
+        Folly::folly
+        Folly::follybenchmark
+        GTest::gtest_main)

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/CMakeLists.txt
@@ -25,4 +25,5 @@ target_link_libraries(
   GTest::gtest
   Folly::folly
   Folly::follybenchmark
-  GTest::gtest_main)
+  GTest::gtest_main
+)

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3FileSystemBenchmark.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3FileSystemBenchmark.cpp
@@ -57,7 +57,7 @@ class S3FileSystemBenchmark {
     addBucket(bucketName);
     const auto s3File = s3URI(bucketName, file.c_str());
     auto hiveConfig = minioServer_->hiveConfig(
-        {{"hive.s3.uploadPartAsync",
+        {{"hive.s3.upload-part-async",
           enableUploadPartAsync ? "true" : "false"}});
     filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
     suspender.dismiss();

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3FileSystemBenchmark.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3FileSystemBenchmark.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+using namespace facebook::velox::filesystems;
+class S3FileSystemBenchmark {
+ public:
+  S3FileSystemBenchmark() {
+    minioServer_ = std::make_unique<MinioServer>();
+    minioServer_->start();
+    ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
+    filesystems::initializeS3("Info", kLogLocation_);
+  }
+  ~S3FileSystemBenchmark() {
+    minioServer_->stop();
+    filesystems::finalizeS3();
+  }
+  std::unique_ptr<MinioServer> minioServer_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+  std::string_view kLogLocation_ = "/tmp/foobar/";
+
+  std::string localPath(const char* directory) {
+    return minioServer_->path() + "/" + directory;
+  }
+  void addBucket(const char* bucket) {
+    minioServer_->addBucket(bucket);
+  }
+  void
+  run(const std::string& name, bool enableUploadPartAsync, int32_t size_MiB) {
+    folly::BenchmarkSuspender suspender;
+    const auto bucketName = "writedata";
+    const auto file = fmt::format("test_{}_{}.txt", name, size_MiB);
+    const auto filename = localPath(bucketName) + "/" + file.c_str();
+    addBucket(bucketName);
+    const auto s3File = s3URI(bucketName, file.c_str());
+    auto hiveConfig = minioServer_->hiveConfig(
+        {{"hive.s3.uploadPartAsync",
+          enableUploadPartAsync ? "true" : "false"}});
+    filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+    suspender.dismiss();
+    auto pool = memory::memoryManager()->addLeafPool("S3FileSystemBenchmark");
+    auto writeFile =
+        s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+    auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
+    // 1024
+    std::string dataContent(1024, 'a');
+
+    EXPECT_EQ(writeFile->size(), 0);
+    std::int64_t contentSize = dataContent.length();
+    // dataContent length is 1024.
+    EXPECT_EQ(contentSize, 1024);
+
+    // Append and flush a small batch of data.
+    writeFile->append(dataContent.substr(0, 10));
+    EXPECT_EQ(writeFile->size(), 10);
+    writeFile->append(dataContent.substr(10, contentSize - 10));
+    EXPECT_EQ(writeFile->size(), contentSize);
+    writeFile->flush();
+    // No parts must have been uploaded.
+    EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
+
+    // Append data
+    for (int i = 0; i < 1024 * size_MiB - 1; ++i) {
+      writeFile->append(dataContent);
+    }
+    writeFile->close();
+    EXPECT_EQ(
+        writeFile->size(), static_cast<std::int64_t>(1024) * 1024 * size_MiB);
+  }
+};
+
+auto benchmark = S3FileSystemBenchmark();
+
+#define DEFINE_BENCHMARKS(size)                     \
+  BENCHMARK(non_async_upload_##size##M) {           \
+    benchmark.run("non_async_upload", false, size); \
+  }                                                 \
+  BENCHMARK_RELATIVE(async_upload_##size##M) {      \
+    benchmark.run("async_upload", true, size);      \
+  }
+
+DEFINE_BENCHMARKS(4)
+DEFINE_BENCHMARKS(8)
+DEFINE_BENCHMARKS(16)
+DEFINE_BENCHMARKS(32)
+DEFINE_BENCHMARKS(64)
+DEFINE_BENCHMARKS(128)
+DEFINE_BENCHMARKS(256)
+DEFINE_BENCHMARKS(512)
+DEFINE_BENCHMARKS(1024)
+DEFINE_BENCHMARKS(2048)
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize(
+      facebook::velox::memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -247,7 +247,7 @@ TEST_F(S3FileSystemTest, writeFileAsync) {
   const auto s3File = s3URI(bucketName, file);
 
   auto hiveConfig =
-      minioServer_->hiveConfig({{"hive.s3.uploadPartAsync", "true"}});
+      minioServer_->hiveConfig({{"hive.s3.upload-part-async", "true"}});
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
 
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
@@ -329,8 +329,7 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
   const auto filename = localPath(bucketName) + "/" + file;
   const auto s3File = s3URI(bucketName, file);
 
-  auto hiveConfig =
-      minioServer_->hiveConfig({{"hive.s3.uploadPartAsync", "false"}});
+  auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
   auto writeFile =

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -247,7 +247,7 @@ TEST_F(S3FileSystemTest, writeFileAsync) {
   const auto s3File = s3URI(bucketName, file);
 
   auto hiveConfig =
-      minioServer_->hiveConfig({{"hive.s3.upload-part-async", "true"}});
+      minioServer_->hiveConfig({{"hive.s3.part-upload-async", "true"}});
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
 
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -240,168 +240,93 @@ TEST_F(S3FileSystemTest, mkdirAndRename) {
   ASSERT_FALSE(s3fs.exists(s3File));
 }
 
-TEST_F(S3FileSystemTest, writeFileAsync) {
-  const auto bucketName = "writedata";
-  const auto file = "test.txt";
-  const auto filename = localPath(bucketName) + "/" + file;
-  const auto s3File = s3URI(bucketName, file);
-
-  auto hiveConfig =
-      minioServer_->hiveConfig({{"hive.s3.part-upload-async", "true"}});
-  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
-
-  auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
-  auto writeFile =
-      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
-  auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
-  std::string dataContent =
-      "Dance me to your beauty with a burning violin"
-      "Dance me through the panic till I'm gathered safely in"
-      "Lift me like an olive branch and be my homeward dove"
-      "Dance me to the end of love";
-
-  EXPECT_EQ(writeFile->size(), 0);
-  std::int64_t contentSize = dataContent.length();
-  // dataContent length is 178.
-  EXPECT_EQ(contentSize, 178);
-
-  // Append and flush a small batch of data.
-  writeFile->append(dataContent.substr(0, 10));
-  EXPECT_EQ(writeFile->size(), 10);
-  writeFile->append(dataContent.substr(10, contentSize - 10));
-  EXPECT_EQ(writeFile->size(), contentSize);
-  writeFile->flush();
-  // No parts must have been uploaded.
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
-
-  // Append data 178 * 100'000 ~ 16MiB.
-  // Should have 1 part in total with kUploadPartSize = 10MiB.
-  for (int i = 0; i < 100'000; ++i) {
-    writeFile->append(dataContent);
-  }
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 1);
-  EXPECT_EQ(writeFile->size(), 100'001 * contentSize);
-
-  // Append a large data buffer 178 * 150'000 ~ 25MiB (2 parts).
-  std::vector<char> largeBuffer(contentSize * 150'000);
-  for (int i = 0; i < 150'000; ++i) {
-    memcpy(
-        largeBuffer.data() + (i * contentSize),
-        dataContent.data(),
-        contentSize);
-  }
-
-  writeFile->append({largeBuffer.data(), largeBuffer.size()});
-  EXPECT_EQ(writeFile->size(), 250'001 * contentSize);
-  // Total data = ~41 MB = 5 parts.
-  // But parts uploaded will be 4.
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 4);
-
-  // Upload the last part.
-  writeFile->close();
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 5);
-
-  VELOX_ASSERT_THROW(
-      writeFile->append(dataContent.substr(0, 10)), "File is closed");
-
-  auto readFile = s3fs.openFileForRead(s3File);
-  ASSERT_EQ(readFile->size(), contentSize * 250'001);
-  // Sample and verify every 1'000 dataContent chunks.
-  for (int i = 0; i < 250; ++i) {
-    ASSERT_EQ(
-        readFile->pread(i * (1'000 * contentSize), contentSize), dataContent);
-  }
-  // Verify the last chunk.
-  ASSERT_EQ(readFile->pread(contentSize * 250'000, contentSize), dataContent);
-
-  // Verify the S3 list function.
-  auto result = s3fs.list(s3File);
-
-  ASSERT_EQ(result.size(), 1);
-  ASSERT_TRUE(result[0] == file);
-
-  ASSERT_TRUE(s3fs.exists(s3File));
-}
-
 TEST_F(S3FileSystemTest, writeFileAndRead) {
   const auto bucketName = "writedata";
   const auto file = "test.txt";
   const auto filename = localPath(bucketName) + "/" + file;
   const auto s3File = s3URI(bucketName, file);
-
-  auto hiveConfig = minioServer_->hiveConfig();
-  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
-  auto writeFile =
-      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
-  auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
-  std::string dataContent =
-      "Dance me to your beauty with a burning violin"
-      "Dance me through the panic till I'm gathered safely in"
-      "Lift me like an olive branch and be my homeward dove"
-      "Dance me to the end of love";
+  auto uploadPart = [&](bool uploadPartAsync) {
+    auto hiveConfig = minioServer_->hiveConfig();
+    auto hiveConfig = minioServer_->hiveConfig(
+        {{"hive.s3.part-upload-async", uploadPartAsync ? "true" : "false"}});
+    filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+    filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+    auto writeFile =
+        s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+    auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
+    std::string dataContent =
+        "Dance me to your beauty with a burning violin"
+        "Dance me through the panic till I'm gathered safely in"
+        "Lift me like an olive branch and be my homeward dove"
+        "Dance me to the end of love";
 
-  EXPECT_EQ(writeFile->size(), 0);
-  std::int64_t contentSize = dataContent.length();
-  // dataContent length is 178.
-  EXPECT_EQ(contentSize, 178);
+    EXPECT_EQ(writeFile->size(), 0);
+    std::int64_t contentSize = dataContent.length();
+    // dataContent length is 178.
+    EXPECT_EQ(contentSize, 178);
 
-  // Append and flush a small batch of data.
-  writeFile->append(dataContent.substr(0, 10));
-  EXPECT_EQ(writeFile->size(), 10);
-  writeFile->append(dataContent.substr(10, contentSize - 10));
-  EXPECT_EQ(writeFile->size(), contentSize);
-  writeFile->flush();
-  // No parts must have been uploaded.
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
+    // Append and flush a small batch of data.
+    writeFile->append(dataContent.substr(0, 10));
+    EXPECT_EQ(writeFile->size(), 10);
+    writeFile->append(dataContent.substr(10, contentSize - 10));
+    EXPECT_EQ(writeFile->size(), contentSize);
+    writeFile->flush();
+    // No parts must have been uploaded.
+    EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
 
-  // Append data 178 * 100'000 ~ 16MiB.
-  // Should have 1 part in total with kUploadPartSize = 10MiB.
-  for (int i = 0; i < 100'000; ++i) {
-    writeFile->append(dataContent);
-  }
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 1);
-  EXPECT_EQ(writeFile->size(), 100'001 * contentSize);
+    // Append data 178 * 100'000 ~ 16MiB.
+    // Should have 1 part in total with kUploadPartSize = 10MiB.
+    for (int i = 0; i < 100'000; ++i) {
+      writeFile->append(dataContent);
+    }
+    EXPECT_EQ(s3WriteFile->numPartsUploaded(), 1);
+    EXPECT_EQ(writeFile->size(), 100'001 * contentSize);
 
-  // Append a large data buffer 178 * 150'000 ~ 25MiB (2 parts).
-  std::vector<char> largeBuffer(contentSize * 150'000);
-  for (int i = 0; i < 150'000; ++i) {
-    memcpy(
-        largeBuffer.data() + (i * contentSize),
-        dataContent.data(),
-        contentSize);
-  }
+    // Append a large data buffer 178 * 150'000 ~ 25MiB (2 parts).
+    std::vector<char> largeBuffer(contentSize * 150'000);
+    for (int i = 0; i < 150'000; ++i) {
+      memcpy(
+          largeBuffer.data() + (i * contentSize),
+          dataContent.data(),
+          contentSize);
+    }
 
-  writeFile->append({largeBuffer.data(), largeBuffer.size()});
-  EXPECT_EQ(writeFile->size(), 250'001 * contentSize);
-  // Total data = ~41 MB = 5 parts.
-  // But parts uploaded will be 4.
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 4);
+    writeFile->append({largeBuffer.data(), largeBuffer.size()});
+    EXPECT_EQ(writeFile->size(), 250'001 * contentSize);
+    // Total data = ~41 MB = 5 parts.
+    // But parts uploaded will be 4.
+    EXPECT_EQ(s3WriteFile->numPartsUploaded(), 4);
 
-  // Upload the last part.
-  writeFile->close();
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 5);
+    // Upload the last part.
+    writeFile->close();
+    EXPECT_EQ(s3WriteFile->numPartsUploaded(), 5);
 
-  VELOX_ASSERT_THROW(
-      writeFile->append(dataContent.substr(0, 10)), "File is closed");
+    VELOX_ASSERT_THROW(
+        writeFile->append(dataContent.substr(0, 10)), "File is closed");
 
-  auto readFile = s3fs.openFileForRead(s3File);
-  ASSERT_EQ(readFile->size(), contentSize * 250'001);
-  // Sample and verify every 1'000 dataContent chunks.
-  for (int i = 0; i < 250; ++i) {
-    ASSERT_EQ(
-        readFile->pread(i * (1'000 * contentSize), contentSize), dataContent);
-  }
-  // Verify the last chunk.
-  ASSERT_EQ(readFile->pread(contentSize * 250'000, contentSize), dataContent);
+    auto readFile = s3fs.openFileForRead(s3File);
+    ASSERT_EQ(readFile->size(), contentSize * 250'001);
+    // Sample and verify every 1'000 dataContent chunks.
+    for (int i = 0; i < 250; ++i) {
+      ASSERT_EQ(
+          readFile->pread(i * (1'000 * contentSize), contentSize), dataContent);
+    }
+    // Verify the last chunk.
+    ASSERT_EQ(readFile->pread(contentSize * 250'000, contentSize), dataContent);
 
-  // Verify the S3 list function.
-  auto result = s3fs.list(s3File);
+    // Verify the S3 list function.
+    auto result = s3fs.list(s3File);
 
-  ASSERT_EQ(result.size(), 1);
-  ASSERT_TRUE(result[0] == file);
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_TRUE(result[0] == file);
 
-  ASSERT_TRUE(s3fs.exists(s3File));
+    ASSERT_TRUE(s3fs.exists(s3File));
+  };
+  // Upload parts synchronously.
+  uploadPart(false);
+  // Upload parts asynchronously.
+  uploadPart(true);
 }
 
 TEST_F(S3FileSystemTest, invalidConnectionSettings) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -240,13 +240,97 @@ TEST_F(S3FileSystemTest, mkdirAndRename) {
   ASSERT_FALSE(s3fs.exists(s3File));
 }
 
+TEST_F(S3FileSystemTest, writeFileAsync) {
+  const auto bucketName = "writedata";
+  const auto file = "test.txt";
+  const auto filename = localPath(bucketName) + "/" + file;
+  const auto s3File = s3URI(bucketName, file);
+
+  auto hiveConfig =
+      minioServer_->hiveConfig({{"hive.s3.uploadPartAsync", "true"}});
+  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+
+  auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
+  auto writeFile =
+      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+  auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
+  std::string dataContent =
+      "Dance me to your beauty with a burning violin"
+      "Dance me through the panic till I'm gathered safely in"
+      "Lift me like an olive branch and be my homeward dove"
+      "Dance me to the end of love";
+
+  EXPECT_EQ(writeFile->size(), 0);
+  std::int64_t contentSize = dataContent.length();
+  // dataContent length is 178.
+  EXPECT_EQ(contentSize, 178);
+
+  // Append and flush a small batch of data.
+  writeFile->append(dataContent.substr(0, 10));
+  EXPECT_EQ(writeFile->size(), 10);
+  writeFile->append(dataContent.substr(10, contentSize - 10));
+  EXPECT_EQ(writeFile->size(), contentSize);
+  writeFile->flush();
+  // No parts must have been uploaded.
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
+
+  // Append data 178 * 100'000 ~ 16MiB.
+  // Should have 1 part in total with kUploadPartSize = 10MiB.
+  for (int i = 0; i < 100'000; ++i) {
+    writeFile->append(dataContent);
+  }
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 1);
+  EXPECT_EQ(writeFile->size(), 100'001 * contentSize);
+
+  // Append a large data buffer 178 * 150'000 ~ 25MiB (2 parts).
+  std::vector<char> largeBuffer(contentSize * 150'000);
+  for (int i = 0; i < 150'000; ++i) {
+    memcpy(
+        largeBuffer.data() + (i * contentSize),
+        dataContent.data(),
+        contentSize);
+  }
+
+  writeFile->append({largeBuffer.data(), largeBuffer.size()});
+  EXPECT_EQ(writeFile->size(), 250'001 * contentSize);
+  // Total data = ~41 MB = 5 parts.
+  // But parts uploaded will be 4.
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 4);
+
+  // Upload the last part.
+  writeFile->close();
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 5);
+
+  VELOX_ASSERT_THROW(
+      writeFile->append(dataContent.substr(0, 10)), "File is closed");
+
+  auto readFile = s3fs.openFileForRead(s3File);
+  ASSERT_EQ(readFile->size(), contentSize * 250'001);
+  // Sample and verify every 1'000 dataContent chunks.
+  for (int i = 0; i < 250; ++i) {
+    ASSERT_EQ(
+        readFile->pread(i * (1'000 * contentSize), contentSize), dataContent);
+  }
+  // Verify the last chunk.
+  ASSERT_EQ(readFile->pread(contentSize * 250'000, contentSize), dataContent);
+
+  // Verify the S3 list function.
+  auto result = s3fs.list(s3File);
+
+  ASSERT_EQ(result.size(), 1);
+  ASSERT_TRUE(result[0] == file);
+
+  ASSERT_TRUE(s3fs.exists(s3File));
+}
+
 TEST_F(S3FileSystemTest, writeFileAndRead) {
   const auto bucketName = "writedata";
   const auto file = "test.txt";
   const auto filename = localPath(bucketName) + "/" + file;
   const auto s3File = s3URI(bucketName, file);
 
-  auto hiveConfig = minioServer_->hiveConfig();
+  auto hiveConfig =
+      minioServer_->hiveConfig({{"hive.s3.uploadPartAsync", "false"}});
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
   auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
   auto writeFile =

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -879,6 +879,22 @@ Each query can override the config by setting corresponding query session proper
      -
      - A custom credential provider, if specified, will be used to create the client in favor of other authentication mechanisms.
        The provider must be registered using "registerAWSCredentialsProvider" before it can be used.
+   * - hive.s3.upload-part-async
+     - bool
+     - false
+     - If true, enables asynchronous upload of parts for S3 multipart uploads.
+   * - hive.s3.part-upload-size
+     - integer
+     -
+     - Specifies the size (in bytes) of each part for S3 multipart uploads.
+   * - hive.s3.max-concurrent-upload-num
+     - integer
+     -
+     - Specifies the maximum number of concurrent uploads for S3 multipart uploads.
+   * - hive.s3.upload-threads
+     - integer
+     -
+     - Specifies the number of threads to use for S3 multipart uploads.
 
 Bucket Level Configuration
 """"""""""""""""""""""""""

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -885,15 +885,15 @@ Each query can override the config by setting corresponding query session proper
      - If true, enables asynchronous upload of parts for S3 multipart uploads.
    * - hive.s3.part-upload-size
      - integer
-     -
+     - 10485760
      - Specifies the size (in bytes) of each part for S3 multipart uploads.
    * - hive.s3.max-concurrent-upload-num
      - integer
-     -
+     - 4
      - Specifies the maximum number of concurrent uploads for S3 multipart uploads.
    * - hive.s3.upload-threads
      - integer
-     -
+     - 16
      - Specifies the number of threads to use for S3 multipart uploads.
 
 Bucket Level Configuration

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -879,7 +879,7 @@ Each query can override the config by setting corresponding query session proper
      -
      - A custom credential provider, if specified, will be used to create the client in favor of other authentication mechanisms.
        The provider must be registered using "registerAWSCredentialsProvider" before it can be used.
-   * - hive.s3.upload-part-async
+   * - hive.s3.part-upload-async
      - bool
      - false
      - If true, enables asynchronous upload of parts for S3 multipart uploads.


### PR DESCRIPTION
https://github.com/facebookincubator/velox/issues/14471
Support multi-threaded asynchronous data upload to object storage.
<img width="3879" height="1869" alt="image" src="https://github.com/user-attachments/assets/75d6c2be-0c51-4a4b-92fe-f82f390d3299" />

 This PR also adds a benchmark named `S3AsyncUploadBenchmark`, the output of benchmark show below :
```
============================================================================
[...]/benchmark/S3AsyncUploadBenchmark.cpp     relative  time/iter   iters/s
============================================================================
sync_upload_4M                                             48.82ms     20.48
async_upload_4M                                 108.32%    45.07ms     22.19
sync_upload_8M                                             79.81ms     12.53
async_upload_8M                                 104.41%    76.44ms     13.08
sync_upload_16M                                           138.74ms      7.21
async_upload_16M                                117.11%   118.47ms      8.44
sync_upload_32M                                           260.98ms      3.83
async_upload_32M                                170.03%   153.49ms      6.52
sync_upload_64M                                           509.86ms      1.96
async_upload_64M                                247.14%   206.30ms      4.85
sync_upload_128M                                          998.46ms      1.00
async_upload_128M                               284.82%   350.56ms      2.85
sync_upload_256M                                             2.00s   499.29m
async_upload_256M                               316.53%   632.76ms      1.58
sync_upload_512M                                             4.01s   249.50m
async_upload_512M                               339.35%      1.18s   846.68m
sync_upload_1024M                                            7.84s   127.62m
async_upload_1024M                              342.67%      2.29s   437.32m
sync_upload_2048M                                           16.40s    60.99m
async_upload_2048M                              332.71%      4.93s   202.93m
```

We used this PR on spark +gluten+ velox [incubator-gluten](https://github.com/apache/incubator-gluten) and set the `hive.s3.uploadPartAsync ` to be true in our environment, and the average write performance improved by 85%.

Before this PR:   **Total Time Across All Tasks: 64.3 h**
<img width="1790" height="1240" alt="image" src="https://github.com/user-attachments/assets/9fa9ab2d-0465-4cf6-9cdf-208fa06d58a8" />

After this PR:   **Total Time Across All Tasks:  32.4 h**
<img width="1582" height="1192" alt="image" src="https://github.com/user-attachments/assets/c67fa31e-f4ef-4aad-91d1-93151c6a4a4f" />

