### PR TITLE
fix(build): Fix install_stemmer on Macs

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -232,7 +232,7 @@ function install_stemmer {
   wget_and_untar https://snowballstem.org/dist/libstemmer_c-"${STEMMER_VERSION}".tar.gz stemmer
   (
     cd "${DEPENDENCY_DIR}"/stemmer || exit
-    sed -i '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
+    sed -i='' '/CPPFLAGS=-Iinclude/ s/$/ -fPIC/' Makefile
     make clean && make "-j${NPROC}"
     ${SUDO} cp libstemmer.a "${INSTALL_PREFIX}"/lib/
     ${SUDO} cp include/libstemmer.h "${INSTALL_PREFIX}"/include/


### PR DESCRIPTION
Summary:
Macs typically have BSD sed which requires a suffix with the -i option, Linux typically uses
GNU sed where it is optional.

Update the sed command in install_stemmer to work with either sed distribution.

Differential Revision: D80298887


