### PR TITLE
fix(fuzzer) Restrict range of Json float values to avoid scientific notation

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.cpp
+++ b/velox/common/fuzzer/ConstrainedGenerators.cpp
@@ -110,9 +110,9 @@ folly::dynamic JsonInputGenerator::convertVariantToDynamic(
     case TypeKind::BIGINT:
       return convertVariantToDynamicPrimitive<TypeKind::BIGINT>(object);
     case TypeKind::REAL:
-      return convertVariantToDynamicPrimitive<TypeKind::REAL>(object);
+      return convertVariantToDynamicFloatingPoint<TypeKind::REAL>(object);
     case TypeKind::DOUBLE:
-      return convertVariantToDynamicPrimitive<TypeKind::DOUBLE>(object);
+      return convertVariantToDynamicFloatingPoint<TypeKind::DOUBLE>(object);
     case TypeKind::VARCHAR:
       return convertVariantToDynamicPrimitive<TypeKind::VARCHAR>(object);
     case TypeKind::VARBINARY:


### PR DESCRIPTION
Summary: Restrict Json Input fuzzer float values to ```[10^-3, 10^7]``` to avoid conversion to scientific notation in presto SOT tests. ```json_parse``` in presto uses java's toString which converts any floats that do not belong to  the above mentioned range into the scientific notation and leads to mismatches in fuzzer tests.

Differential Revision: D80122608


