### PR TITLE
test: Set timestamp precision to microseconds back in Spark aggregation fuzzer

### DIFF
--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -132,10 +132,8 @@ int main(int argc, char** argv) {
   options.skipFunctions = skipFunctions;
   options.customVerificationFunctions = customVerificationFunctions;
   options.orderableGroupKeys = true;
-  // Set timestamp precision as milliseconds, as timestamp may be used as
-  // paritition key, and presto doesn't supports nanosecond precision
   options.timestampPrecision =
-      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
+      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
   options.hiveConfigs = {
       {facebook::velox::connector::hive::HiveConfig::kReadTimestampUnit, "6"}};
   return Runner::run(initialSeed, std::move(sparkQueryRunner), options);


### PR DESCRIPTION
The timestamp precision in SparkAggregationFuzzerTest.cpp was set to millis temporarily in https://github.com/facebookincubator/velox/pull/13494.

Since a related issue https://github.com/facebookincubator/velox/issues/14413 is now fixed we should be able to set the precision back to micros.