### PR TITLE
fix: Use microsecond timestamp precision in Spark aggregation fuzzer test

### DIFF
--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -132,10 +132,8 @@ int main(int argc, char** argv) {
   options.skipFunctions = skipFunctions;
   options.customVerificationFunctions = customVerificationFunctions;
   options.orderableGroupKeys = true;
-  // Set timestamp precision as milliseconds, as timestamp may be used as
-  // paritition key, and presto doesn't supports nanosecond precision
   options.timestampPrecision =
-      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
+      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
   options.hiveConfigs = {
       {facebook::velox::connector::hive::HiveConfig::kReadTimestampUnit, "6"}};
   return Runner::run(initialSeed, std::move(sparkQueryRunner), options);


### PR DESCRIPTION
Spark aggregation fuzzer test starts to use millisecond timestamp precision 
after 1d20f63 to avoid a deep recursion caused by microsecond timestamp. 
Following the 2e4a083 fix to VectorHasher, microsecond precision can be 
utilized to be consistent with Spark.