### PR TITLE
refactor(expression): Move constants into separate header

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -17,13 +17,11 @@
 #pragma once
 
 #include "velox/expression/CastHooks.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
-
-constexpr folly::StringPiece kCast = "cast";
-constexpr folly::StringPiece kTryCast = "try_cast";
 
 /// Custom operator for casts from and to custom types.
 class CastOperator {
@@ -93,7 +91,7 @@ class CastExpr : public SpecialForm {
             SpecialFormKind::kCast,
             type,
             std::vector<ExprPtr>({expr}),
-            isTryCast ? kTryCast.data() : kCast.data(),
+            isTryCast ? expression::kTryCast : expression::kCast,
             false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
         isTryCast_(isTryCast),

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/expression/CoalesceExpr.h"
 
+#include "velox/expression/ExprConstants.h"
+
 namespace facebook::velox::exec {
 
 CoalesceExpr::CoalesceExpr(
@@ -25,7 +27,7 @@ CoalesceExpr::CoalesceExpr(
           SpecialFormKind::kCoalesce,
           std::move(type),
           std::move(inputs),
-          kCoalesce,
+          expression::kCoalesce,
           inputsSupportFlatNoNullsFastPath,
           false /* trackCpuUsage */) {
   std::vector<TypePtr> inputTypes;

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -20,8 +20,6 @@
 
 namespace facebook::velox::exec {
 
-const char* const kCoalesce = "coalesce";
-
 class CoalesceExpr : public SpecialForm {
  public:
   CoalesceExpr(

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -16,13 +16,11 @@
 #pragma once
 
 #include "velox/common/base/SelectivityInfo.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
-
-constexpr const char* kAnd = "and";
-constexpr const char* kOr = "or";
 
 class ConjunctExpr : public SpecialForm {
  public:
@@ -35,7 +33,7 @@ class ConjunctExpr : public SpecialForm {
             isAnd ? SpecialFormKind::kAnd : SpecialFormKind::kOr,
             std::move(type),
             std::move(inputs),
-            isAnd ? kAnd : kOr,
+            isAnd ? expression::kAnd : expression::kOr,
             inputsSupportFlatNoNullsFastPath,
             false /* trackCpuUsage */),
         isAnd_(isAnd) {

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -17,6 +17,7 @@
 #include "velox/expression/ExprCompiler.h"
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/LambdaExpr.h"
 #include "velox/expression/RowConstructor.h"
@@ -30,9 +31,6 @@ namespace {
 
 using core::ITypedExpr;
 using core::TypedExprPtr;
-
-const char* const kAnd = "and";
-const char* const kOr = "or";
 
 struct ITypedExprHasher {
   size_t operator()(const ITypedExpr* expr) const {
@@ -108,7 +106,7 @@ std::optional<std::string> shouldFlatten(
     const auto* call = expr->asUnchecked<core::CallTypedExpr>();
     // Currently only supports the most common case for flattening where all
     // inputs are of the same type.
-    if (call->name() == kAnd || call->name() == kOr ||
+    if (call->name() == expression::kAnd || call->name() == expression::kOr ||
         (flatteningCandidates.count(call->name()) &&
          allInputTypesEquivalent(expr))) {
       return call->name();
@@ -457,7 +455,7 @@ ExprPtr compileCast(
   const auto* cast = expr->asUnchecked<core::CastTypedExpr>();
   return getSpecialForm(
       config,
-      cast->isTryCast() ? "try_cast" : "cast",
+      cast->isTryCast() ? expression::kTryCast : expression::kCast,
       resultType,
       std::move(inputs),
       trackCpuUsage);

--- a/velox/expression/ExprConstants.h
+++ b/velox/expression/ExprConstants.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::velox::expression {
+
+constexpr const char* kConjunt = "conjunct";
+constexpr const char* kAnd = "and";
+constexpr const char* kOr = "or";
+constexpr const char* kSwitch = "switch";
+constexpr const char* kIn = "in";
+constexpr const char* kIf = "if";
+constexpr const char* kFail = "fail";
+constexpr const char* kCoalesce = "coalesce";
+constexpr const char* kCast = "cast";
+constexpr const char* kTryCast = "try_cast";
+constexpr const char* kTry = "try";
+
+} // namespace facebook::velox::expression

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -20,6 +20,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/ConjunctExpr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
@@ -29,21 +30,23 @@
 namespace facebook::velox::exec {
 void registerFunctionCallToSpecialForms() {
   registerFunctionCallToSpecialForm(
-      kAnd, std::make_unique<ConjunctCallToSpecialForm>(true /* isAnd */));
+      expression::kAnd,
+      std::make_unique<ConjunctCallToSpecialForm>(true /* isAnd */));
   registerFunctionCallToSpecialForm(
-      kCast.str(), std::make_unique<CastCallToSpecialForm>());
+      expression::kCast, std::make_unique<CastCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      kTryCast.str(), std::make_unique<TryCastCallToSpecialForm>());
+      expression::kTryCast, std::make_unique<TryCastCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      kCoalesce, std::make_unique<CoalesceCallToSpecialForm>());
+      expression::kCoalesce, std::make_unique<CoalesceCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      kIf, std::make_unique<IfCallToSpecialForm>());
+      expression::kIf, std::make_unique<IfCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      kOr, std::make_unique<ConjunctCallToSpecialForm>(false /* isAnd */));
+      expression::kOr,
+      std::make_unique<ConjunctCallToSpecialForm>(false /* isAnd */));
   registerFunctionCallToSpecialForm(
-      kSwitch, std::make_unique<SwitchCallToSpecialForm>());
+      expression::kSwitch, std::make_unique<SwitchCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      kTry, std::make_unique<TryCallToSpecialForm>());
+      expression::kTry, std::make_unique<TryCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
       RowConstructorCallToSpecialForm::kRowConstructor,
       std::make_unique<RowConstructorCallToSpecialForm>());

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -20,9 +20,6 @@
 
 namespace facebook::velox::exec {
 
-constexpr const char* kIf = "if";
-constexpr const char* kSwitch = "switch";
-
 /// CASE expression:
 ///
 /// case

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -15,12 +15,11 @@
  */
 #pragma once
 
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
-
-constexpr const char* kTry = "try";
 
 class TryExpr : public SpecialForm {
  public:
@@ -30,7 +29,7 @@ class TryExpr : public SpecialForm {
             SpecialFormKind::kTry,
             std::move(type),
             {std::move(input)},
-            kTry,
+            expression::kTry,
             false /* supportsFlatNoNullsFastPath */,
             false /* trackCpuUsage */) {}
 

--- a/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
+++ b/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/expression/RegisterSpecialForm.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/functions/sparksql/specialforms/AtLeastNNonNulls.h"
@@ -44,9 +45,9 @@ void registerSpecialFormGeneralFunctions(const std::string& prefix) {
       std::make_unique<AtLeastNNonNullsCallToSpecialForm>());
   registerSparkSpecialFormFunctions();
   registerFunctionCallToSpecialForm(
-      "cast", std::make_unique<SparkCastCallToSpecialForm>());
+      expression::kCast, std::make_unique<SparkCastCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      "try_cast", std::make_unique<SparkTryCastCallToSpecialForm>());
+      expression::kTryCast, std::make_unique<SparkTryCastCallToSpecialForm>());
   exec::registerFunctionCallToSpecialForm(
       FromJsonCallToSpecialForm::kFromJson,
       std::make_unique<FromJsonCallToSpecialForm>());


### PR DESCRIPTION
Collect the constants used to identify special forms into a new common header. This is used later to refer to the same constants where applicable instead of literals.