### PR TITLE
feat: Support using custom fs username based on source and client tags

### DIFF
--- a/velox/common/file/PlainUserNameTokenProvider.h
+++ b/velox/common/file/PlainUserNameTokenProvider.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include "velox/common/file/TokenProvider.h"
+
+namespace facebook::velox::filesystems {
+
+class PlainUserNameAccessToken : public filesystems::AccessToken {
+ public:
+  explicit PlainUserNameAccessToken(const std::string& user) : user_(user) {}
+  ~PlainUserNameAccessToken() override = default;
+  std::string getUser() const {
+    return user_;
+  }
+
+ private:
+  std::string user_;
+};
+
+class PlainUserNameTokenProvider : public filesystems::TokenProvider {
+ public:
+  explicit PlainUserNameTokenProvider(const std::string& user) : user_(user) {}
+  bool equals(const TokenProvider& other) const override {
+    auto* o = dynamic_cast<const PlainUserNameTokenProvider*>(&other);
+    return o && o->user_ == user_;
+  }
+  size_t hash() const override {
+    return std::hash<std::string>()(user_);
+  }
+  std::shared_ptr<filesystems::AccessToken> getToken(
+      const filesystems::AccessTokenKey& /*key*/) const override {
+    return std::make_shared<PlainUserNameAccessToken>(user_);
+  }
+
+ private:
+  std::string user_;
+};
+
+} // namespace facebook::velox::filesystems

--- a/velox/common/file/TokenProvider.h
+++ b/velox/common/file/TokenProvider.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace facebook::velox::filesystems {
@@ -25,11 +26,13 @@ namespace facebook::velox::filesystems {
 /// be passed down and stored in the ReadFile/WriteFile object of the specific
 /// file system.
 class AccessTokenKey {
+ public:
   virtual ~AccessTokenKey() = default;
 };
 
 /// Abstract token each file system can implement and cast.
 class AccessToken {
+ public:
   virtual ~AccessToken() = default;
 };
 

--- a/velox/common/file/tests/PlainUserNameTokenProviderTest.cpp
+++ b/velox/common/file/tests/PlainUserNameTokenProviderTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/file/PlainUserNameTokenProvider.h"
+#include <gtest/gtest.h>
+#include "velox/common/file/TokenProvider.h"
+
+using namespace ::testing;
+namespace facebook::velox::filesystems {
+TEST(PlainUserNameTokenProviderTest, testTokenProviderUserName) {
+  filesystems::AccessTokenKey key;
+  auto tokenProvider =
+      std::make_shared<PlainUserNameTokenProvider>("test_user");
+  auto baseToken = tokenProvider->getToken(key);
+  auto userToken =
+      std::dynamic_pointer_cast<PlainUserNameAccessToken>(baseToken);
+  ASSERT_EQ(userToken->getUser(), "test_user");
+}
+
+TEST(PlainUserNameTokenProviderTest, testTokenProviderEquals) {
+  auto tokenProvider1 =
+      std::make_shared<PlainUserNameTokenProvider>("test_user_1");
+  auto tokenProvider2 = tokenProvider1;
+  auto tokenProvider3 =
+      std::make_shared<PlainUserNameTokenProvider>("test_user_1");
+  auto tokenProvider4 =
+      std::make_shared<PlainUserNameTokenProvider>("test_user_2");
+  ASSERT_TRUE(tokenProvider1->equals(*tokenProvider2));
+  ASSERT_TRUE(tokenProvider1->equals(*tokenProvider3));
+  ASSERT_FALSE(tokenProvider1->equals(*tokenProvider4));
+}
+
+TEST(PlainUserNameTokenProviderTest, testTokenProviderHash) {
+  auto tokenProvider1 =
+      std::make_shared<PlainUserNameTokenProvider>("test_user_1");
+  auto tokenProvider2 =
+      std::make_shared<PlainUserNameTokenProvider>("test_user_1");
+  auto tokenProvider3 =
+      std::make_shared<PlainUserNameTokenProvider>("test_user_2");
+  ASSERT_EQ(tokenProvider1->hash(), tokenProvider2->hash());
+  ASSERT_NE(tokenProvider1->hash(), tokenProvider3->hash());
+}
+} // namespace facebook::velox::filesystems

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -664,6 +664,13 @@ class QueryConfig {
   static constexpr const char* kMaxNumSplitsListenedTo =
       "max_num_splits_listened_to";
 
+  /// Source of the query. Used by Presto to identify the file system username.
+  static constexpr const char* kSource = "source";
+
+  /// Client tags of the query. Used by Presto to identify the file system
+  /// username.
+  static constexpr const char* kClientTags = "client_tags";
+
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
@@ -1201,6 +1208,14 @@ class QueryConfig {
 
   int32_t maxNumSplitsListenedTo() const {
     return get<int32_t>(kMaxNumSplitsListenedTo, 0);
+  }
+
+  std::string source() const {
+    return get<std::string>(kSource, "");
+  }
+
+  std::string clientTags() const {
+    return get<std::string>(kClientTags, "");
   }
 
   template <typename T>

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -30,7 +30,8 @@ std::shared_ptr<QueryCtx> QueryCtx::create(
     cache::AsyncDataCache* cache,
     std::shared_ptr<memory::MemoryPool> pool,
     folly::Executor* spillExecutor,
-    const std::string& queryId) {
+    const std::string& queryId,
+    std::shared_ptr<filesystems::TokenProvider> tokenProvider) {
   std::shared_ptr<QueryCtx> queryCtx(new QueryCtx(
       executor,
       std::move(queryConfig),
@@ -38,7 +39,8 @@ std::shared_ptr<QueryCtx> QueryCtx::create(
       cache,
       std::move(pool),
       spillExecutor,
-      queryId));
+      queryId,
+      std::move(tokenProvider)));
   queryCtx->maybeSetReclaimer();
   return queryCtx;
 }
@@ -51,14 +53,16 @@ QueryCtx::QueryCtx(
     cache::AsyncDataCache* cache,
     std::shared_ptr<memory::MemoryPool> pool,
     folly::Executor* spillExecutor,
-    const std::string& queryId)
+    const std::string& queryId,
+    std::shared_ptr<filesystems::TokenProvider> tokenProvider)
     : queryId_(queryId),
       executor_(executor),
       spillExecutor_(spillExecutor),
       cache_(cache),
       connectorSessionProperties_(connectorSessionProperties),
       pool_(std::move(pool)),
-      queryConfig_{std::move(queryConfig)} {
+      queryConfig_{std::move(queryConfig)},
+      fsTokenProvider_(std::move(tokenProvider)) {
   initPool(queryId);
 }
 

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -51,7 +51,8 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
       cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       folly::Executor* spillExecutor = nullptr,
-      const std::string& queryId = "");
+      const std::string& queryId = "",
+      std::shared_ptr<filesystems::TokenProvider> tokenProvider = {});
 
   static std::string generatePoolName(const std::string& queryId);
 
@@ -87,6 +88,10 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   const std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>&
   connectorSessionProperties() const {
     return connectorSessionProperties_;
+  }
+
+  std::shared_ptr<filesystems::TokenProvider> fsTokenProvider() const {
+    return fsTokenProvider_;
   }
 
   /// Overrides the previous configuration. Note that this function is NOT
@@ -153,7 +158,8 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
       cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       folly::Executor* spillExecutor = nullptr,
-      const std::string& queryId = "");
+      const std::string& queryId = "",
+      std::shared_ptr<filesystems::TokenProvider> tokenProvider = {});
 
   class MemoryReclaimer : public memory::MemoryReclaimer {
    public:
@@ -227,6 +233,7 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   // Indicates if this query is under memory arbitration or not.
   std::atomic_bool underArbitration_{false};
   std::vector<ContinuePromise> arbitrationPromises_;
+  std::shared_ptr<filesystems::TokenProvider> fsTokenProvider_;
 };
 
 // Represents the state of one thread of query execution.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -68,7 +68,8 @@ OperatorCtx::createConnectorQueryCtx(
       driverCtx_->driverId,
       driverCtx_->queryConfig().sessionTimezone(),
       driverCtx_->queryConfig().adjustTimestampToTimezone(),
-      task->getCancellationToken());
+      task->getCancellationToken(),
+      task->queryCtx()->fsTokenProvider());
   connectorQueryCtx->setSelectiveNimbleReaderEnabled(
       driverCtx_->queryConfig().selectiveNimbleReaderEnabled());
   return connectorQueryCtx;


### PR DESCRIPTION
Summary:
This PR is to support using custom filesystem username based on source and client tags.
1. Adds client tags and source to `QueryConfig` and token provider to `QueryCtx`
2. Pass token provider from `QueryCtx` to `ConnectorQueryCtx`
3. Implements `PlainUserNameTokenProvider` which returns token with username

Reviewed By: Yuhta

Differential Revision: D79621706


