### PR TITLE
feat: Add operator<< to VELOX_DECLARE_ENUM_NAME macro

### DIFF
--- a/velox/common/Enums.h
+++ b/velox/common/Enums.h
@@ -77,7 +77,8 @@ struct Enums {
     static std::string_view toName(EnumType value);                        \
     static EnumType to##EnumType(std::string_view name);                   \
     static std::optional<EnumType> tryTo##EnumType(std::string_view name); \
-  };
+  };                                                                       \
+  std::ostream& operator<<(std::ostream& os, const EnumType& value);
 
 #define VELOX_DEFINE_ENUM_NAME(EnumType, Names)                             \
   std::string_view EnumType##Name::toName(EnumType value) {                 \
@@ -107,6 +108,10 @@ struct Enums {
       return std::nullopt;                                                  \
     }                                                                       \
     return it->second;                                                      \
+  }                                                                         \
+  std::ostream& operator<<(std::ostream& os, const EnumType& value) {       \
+    os << EnumType##Name::toName(value);                                    \
+    return os;                                                              \
   }
 
 #define VELOX_DECLARE_EMBEDDED_ENUM_NAME(EnumType)     \

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -100,11 +100,6 @@ struct OpaqueSerdeRegistry {
 };
 } // namespace
 
-std::ostream& operator<<(std::ostream& os, const TypeKind& kind) {
-  os << TypeKindName::toName(kind);
-  return os;
-}
-
 namespace {
 std::vector<TypePtr> deserializeChildTypes(const folly::dynamic& obj) {
   return velox::ISerializable::deserialize<std::vector<Type>>(obj["cTypes"]);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -106,8 +106,6 @@ inline std::string mapTypeKindToName(const TypeKind& typeKind) {
   return std::string(TypeKindName::toName(typeKind));
 }
 
-std::ostream& operator<<(std::ostream& os, const TypeKind& kind);
-
 template <TypeKind KIND>
 class ScalarType;
 class ShortDecimalType;


### PR DESCRIPTION
Summary: Allow enums to be used in VELOX_CHECK_EQ(a, b).

Differential Revision: D80426060


