### PR TITLE
fix: Allow release of window build resource on window output completion

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -686,6 +686,9 @@ RowVectorPtr Window::getOutput() {
 
   const auto numRowsLeft = numRows_ - numProcessedRows_;
   if (numRowsLeft == 0) {
+    if (windowBuild_ != nullptr) {
+      windowBuild_->release();
+    }
     return nullptr;
   }
 

--- a/velox/exec/WindowBuild.h
+++ b/velox/exec/WindowBuild.h
@@ -74,6 +74,12 @@ class WindowBuild {
     return data_->estimateRowSize();
   }
 
+  /// Releases the memory held by the window build. This is called by the
+  /// window operator when all rows have been processed.
+  void release() {
+    data_->clear();
+  }
+
   void setNumRowsPerOutput(vector_size_t numRowsPerOutput) {
     numRowsPerOutput_ = numRowsPerOutput;
   }


### PR DESCRIPTION
Summary: Window operator currently holds resources allocated by row container till destructor is called. The resource held by row container could have been released as soon as all output has been produced. This change applies the above in time release logic.

Differential Revision: D80433738


