### PR TITLE
fix: Print real schema in s3fs

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -461,8 +461,7 @@ std::string S3FileSystem::getLogPrefix() const {
 std::unique_ptr<ReadFile> S3FileSystem::openFileForRead(
     std::string_view s3Path,
     const FileOptions& options) {
-  const auto path = getPath(s3Path);
-  auto s3file = std::make_unique<S3ReadFile>(path, impl_->s3Client());
+  auto s3file = std::make_unique<S3ReadFile>(s3Path, impl_->s3Client());
   s3file->initialize(options);
   return s3file;
 }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -40,9 +40,11 @@ Aws::IOStreamFactory AwsWriteableStreamFactory(void* data, int64_t nbytes) {
 
 class S3ReadFile ::Impl {
  public:
-  explicit Impl(std::string_view path, Aws::S3::S3Client* client)
+  explicit Impl(std::string_view fullPath, Aws::S3::S3Client* client)
       : client_(client) {
-    getBucketAndKeyFromPath(path, bucket_, key_);
+    const auto pathInfo = parseS3Path(fullPath);
+    scheme_ = pathInfo.scheme;
+    getBucketAndKeyFromPath(pathInfo.path, bucket_, key_);
   }
 
   // Gets the length of the file.
@@ -134,7 +136,7 @@ class S3ReadFile ::Impl {
   }
 
   std::string getName() const {
-    return fmt::format("s3://{}/{}", bucket_, key_);
+    return fmt::format("{}{}/{}", scheme_, bucket_, key_);
   }
 
  private:
@@ -164,6 +166,7 @@ class S3ReadFile ::Impl {
   }
 
   Aws::S3::S3Client* client_;
+  std::string_view scheme_;
   std::string bucket_;
   std::string key_;
   int64_t length_ = -1;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h
@@ -27,7 +27,7 @@ namespace facebook::velox::filesystems {
 /// Implementation of s3 read file.
 class S3ReadFile : public ReadFile {
  public:
-  S3ReadFile(std::string_view path, Aws::S3::S3Client* client);
+  S3ReadFile(std::string_view fullPath, Aws::S3::S3Client* client);
 
   ~S3ReadFile() override;
 


### PR DESCRIPTION
When using an object storage service other than S3, S3ReadFile.getName returns the wrong object storage prefix because the schema information is discarded when creating S3ReadFile. This modification adds schema information to S3ReadFile to ensure that the actual object storage prefix is used when printing.