### PR TITLE
fix: Fix velox writer use int32_t instead of size_t with overflow check

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -48,7 +48,7 @@ class VectorWriterBase {
     offset_ = offset;
   }
   virtual void commit(bool isSet) = 0;
-  virtual void ensureSize(size_t size) = 0;
+  virtual void ensureSize(vector_size_t size) = 0;
   virtual void finish() {}
   // Implementations that write variable length data or complex types should
   // override this to reset their state and that of their children.

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -47,7 +47,8 @@ struct VectorWriter : public VectorWriterBase {
     }
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > vector_->size()) {
       vector_->resize(size, /*setNotNull*/ false);
       data_ = vector_->mutableRawValues();
@@ -118,7 +119,8 @@ struct VectorWriter<Array<V>> : public VectorWriterBase {
     return *arrayVector_;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > arrayVector_->size()) {
       arrayVector_->resize(size);
     }
@@ -198,7 +200,8 @@ struct VectorWriter<Map<K, V>> : public VectorWriterBase {
     return *mapVector_;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > mapVector_->size()) {
       mapVector_->resize(size);
     }
@@ -275,7 +278,8 @@ struct VectorWriter<Row<T...>> : public VectorWriterBase {
     return *rowVector_;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > rowVector_->size()) {
       // Note order is important here, we resize children first to ensure
       // data_ is cached and are not reset when rowVector resizes them.
@@ -359,9 +363,10 @@ struct VectorWriter<
     proxy_.vector_ = &vector;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > proxy_.vector_->size()) {
-      proxy_.vector_->resize(size, /*setNotNull*/ false);
+      proxy_.vector_->resize(size, /*setNotNull=*/false);
     }
   }
 
@@ -410,7 +415,8 @@ struct VectorWriter<T, std::enable_if_t<std::is_same_v<T, bool>>>
     vector_ = &vector;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > vector_->size()) {
       vector_->resize(size, /*setNotNull*/ false);
     }
@@ -457,7 +463,8 @@ struct VectorWriter<std::shared_ptr<T>> : public VectorWriterBase {
     vector_ = &vector;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > vector_->size()) {
       vector_->resize(size, /*setNotNull*/ false);
     }
@@ -546,7 +553,8 @@ struct VectorWriter<Generic<T, comparable, orderable>>
     }
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (castType_) {
       castWriter_->ensureSize(size);
     } else {
@@ -723,7 +731,8 @@ struct VectorWriter<DynamicRow, void> : public VectorWriterBase {
     return *rowVector_;
   }
 
-  void ensureSize(size_t size) override {
+  void ensureSize(vector_size_t size) override {
+    VELOX_CHECK_GE(size, 0);
     if (size > rowVector_->size()) {
       for (int i = 0; i < writer_.childrenCount_; ++i) {
         writer_.childrenWriters_[i]->ensureSize(size);

--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <optional>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/Udf.h"
@@ -32,6 +33,8 @@ using namespace facebook::velox::exec;
 namespace facebook::velox {
 namespace {
 
+static constexpr int64_t overflowSize = 3UL << 30;
+
 class GenericWriterTest : public functions::test::FunctionBaseTest {};
 
 TEST_F(GenericWriterTest, boolean) {
@@ -39,6 +42,7 @@ TEST_F(GenericWriterTest, boolean) {
   BaseVector::ensureWritable(SelectivityVector(5), BOOLEAN(), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 5; ++i) {
@@ -65,6 +69,7 @@ TEST_F(GenericWriterTest, integer) {
   BaseVector::ensureWritable(SelectivityVector(100), BIGINT(), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 100; ++i) {
@@ -87,6 +92,7 @@ TEST_F(GenericWriterTest, ArrayOfGeneric) {
       SelectivityVector(2), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Array<Any>> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result->as<ArrayVector>());
 
   for (int i = 0; i < 2; ++i) {
@@ -140,6 +146,7 @@ TEST_F(GenericWriterTest, ensureSizeDoesNotResize) {
   BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), result);
   EXPECT_EQ(result->size(), 6);
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
   writer.ensureSize(1);
   EXPECT_EQ(result->size(), 6);
@@ -150,6 +157,7 @@ TEST_F(GenericWriterTest, varchar) {
   BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 5; ++i) {
@@ -177,6 +185,7 @@ TEST_F(GenericWriterTest, arrayAnyCast) {
       SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
   for (int i = 0; i < 5; ++i) {
     writer.setOffset(i);
@@ -209,6 +218,7 @@ TEST_F(GenericWriterTest, castToDifferentTypesNotSupported) {
   BaseVector::ensureWritable(
       SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   writer.setOffset(0);
@@ -232,6 +242,7 @@ TEST_F(GenericWriterTest, arrayIntCast) {
       SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
   for (int i = 0; i < 5; ++i) {
     writer.setOffset(i);
@@ -266,6 +277,7 @@ TEST_F(GenericWriterTest, arrayWriteThenCommitNull) {
   BaseVector::ensureWritable(rows, ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
   {
     writer.setOffset(0);
@@ -300,6 +312,7 @@ TEST_F(GenericWriterTest, genericWriteThenCommitNull) {
   BaseVector::ensureWritable(rows, CppToType<test_t>::create(), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
   {
     writer.setOffset(0);
@@ -335,6 +348,7 @@ TEST_F(GenericWriterTest, mapAnyAnyCast) {
       SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 4; ++i) {
@@ -370,6 +384,7 @@ TEST_F(GenericWriterTest, mapVarcharIntCast) {
       SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 4; ++i) {
@@ -408,6 +423,7 @@ TEST_F(GenericWriterTest, row) {
       result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 3; ++i) {
@@ -470,6 +486,7 @@ TEST_F(GenericWriterTest, dynamicRow) {
       SelectivityVector(6), ROW({BIGINT(), DOUBLE()}), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   writer.setOffset(0);
@@ -551,6 +568,7 @@ TEST_F(GenericWriterTest, nested) {
       result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 3; ++i) {
@@ -627,6 +645,7 @@ TEST_F(GenericWriterTest, commitNull) {
   BaseVector::ensureWritable(SelectivityVector(3), BIGINT(), pool(), result);
 
   VectorWriter<Any> writer;
+  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 3; ++i) {


### PR DESCRIPTION
Summary: Fix velox writer to take velox_vector_size which is int32_t to catch the overflow early

Differential Revision: D80490183


