### PR TITLE
build(ci): Always run pre-commit on all files

### DIFF
--- a/.github/workflows/preliminary_checks.yml
+++ b/.github/workflows/preliminary_checks.yml
@@ -32,29 +32,12 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - run: python -m pip install pre-commit
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
-          fetch-depth: 2
           persist-credentials: false
+      - uses: actions/setup-python@3542bca2639a428e1796aaa6a2ffef0c0f575566 # v3.1.4
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
-      - uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            pre-commit-
-
-      - name: Run pre-commit
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          files=$(git diff --name-only HEAD^1 HEAD)
-          echo "::group::Changed files"
-          echo $files | tr ' ' '\n'
-          echo "::endgroup::"
-          pre-commit run --show-diff-on-failure --color=always --files $files
   title-check:
     name: PR Title Format
     runs-on: ubuntu-latest

--- a/python/test/test_runner.py
+++ b/python/test/test_runner.py
@@ -191,10 +191,7 @@ class TestPyVeloxRunner(unittest.TestCase):
         base = list(range(batch_size))
 
         input_vector = to_velox(
-            pyarrow.record_batch(
-                [pyarrow.array([base])],
-                names=["c0"]
-            )
+            pyarrow.record_batch([pyarrow.array([base])], names=["c0"])
         )
         # Single row containing an array column with `batch_size` elements.
         self.assertEqual(input_vector.size(), 1)
@@ -213,9 +210,7 @@ class TestPyVeloxRunner(unittest.TestCase):
         # Unnest then stream aggregate it back to ensure we get the input
         # vector back.
         plan_builder = PlanBuilder()
-        plan_builder.values(
-            [input_vector]
-        ).unnest(
+        plan_builder.values([input_vector]).unnest(
             unnest_columns=["c0"],
         ).streaming_aggregate(
             grouping_keys=[],

--- a/velox/python/plan_builder/plan_builder.pyi
+++ b/velox/python/plan_builder/plan_builder.pyi
@@ -59,7 +59,7 @@ class PlanBuilder:
         build_plan_node: PlanNode,
         output: list[str] = [],
         filter: str = "",
-        join_type: JoinType = JoinType.INNER
+        join_type: JoinType = JoinType.INNER,
     ) -> PlanBuilder: ...
     def aggregate(
         self,


### PR DESCRIPTION
Without our special check on changed files only we can simplify the workflow a lot and use the official action that handles caching.
Fixes #14474 