### PR TITLE
fix: Remove redundant partition value handling in Iceberg column adaptation

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -28,30 +28,28 @@ namespace facebook::velox::connector::hive {
 namespace {
 
 template <TypeKind kind>
-VectorPtr newConstantFromString(
+VectorPtr newConstantFromStringImpl(
     const TypePtr& type,
     const std::optional<std::string>& value,
-    vector_size_t size,
     velox::memory::MemoryPool* pool,
-    const std::string& sessionTimezone,
-    bool asLocalTime,
-    bool isPartitionDateDaysSinceEpoch = false) {
+    bool isLocalTimestamp,
+    bool isDaysSinceEpoch) {
   using T = typename TypeTraits<kind>::NativeType;
   if (!value.has_value()) {
-    return std::make_shared<ConstantVector<T>>(pool, size, true, type, T());
+    return std::make_shared<ConstantVector<T>>(pool, 1, true, type, T());
   }
 
   if (type->isDate()) {
     int32_t days = 0;
     // For Iceberg, the date partition values are already in daysSinceEpoch
     // form.
-    if (isPartitionDateDaysSinceEpoch) {
+    if (isDaysSinceEpoch) {
       days = folly::to<int32_t>(value.value());
     } else {
       days = DATE()->toDays(value.value());
     }
     return std::make_shared<ConstantVector<int32_t>>(
-        pool, size, false, type, std::move(days));
+        pool, 1, false, type, std::move(days));
   }
 
   if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
@@ -62,28 +60,44 @@ VectorPtr newConstantFromString(
           StringView(value.value()), precision, scale, result);
       VELOX_USER_CHECK(status.ok(), status.message());
       return std::make_shared<ConstantVector<T>>(
-          pool, size, false, type, std::move(result));
+          pool, 1, false, type, std::move(result));
     }
   }
 
   if constexpr (std::is_same_v<T, StringView>) {
     return std::make_shared<ConstantVector<StringView>>(
-        pool, size, false, type, StringView(value.value()));
+        pool, 1, false, type, StringView(value.value()));
   } else {
     auto copy = velox::util::Converter<kind>::tryCast(value.value())
                     .thenOrThrow(folly::identity, [&](const Status& status) {
                       VELOX_USER_FAIL("{}", status.message());
                     });
     if constexpr (kind == TypeKind::TIMESTAMP) {
-      if (asLocalTime) {
+      if (isLocalTimestamp) {
         copy.toGMT(Timestamp::defaultTimezone());
       }
     }
     return std::make_shared<ConstantVector<T>>(
-        pool, size, false, type, std::move(copy));
+        pool, 1, false, type, std::move(copy));
   }
 }
 } // namespace
+
+VectorPtr newConstantFromString(
+    const TypePtr& type,
+    const std::optional<std::string>& value,
+    velox::memory::MemoryPool* pool,
+    bool isLocalTimestamp,
+    bool isDaysSinceEpoch) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+      newConstantFromStringImpl,
+      type->kind(),
+      type,
+      value,
+      pool,
+      isLocalTimestamp,
+      isDaysSinceEpoch);
+}
 
 std::unique_ptr<SplitReader> SplitReader::create(
     const std::shared_ptr<hive::HiveConnectorSplit>& hiveSplit,
@@ -424,16 +438,13 @@ std::vector<TypePtr> SplitReader::adaptColumns(
                iter != hiveSplit_->infoColumns.end()) {
       auto infoColumnType =
           readerOutputType_->childAt(readerOutputType_->getChildIdx(fieldName));
-      auto constant = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
-          newConstantFromString,
-          infoColumnType->kind(),
+      auto constant = newConstantFromString(
           infoColumnType,
           iter->second,
-          1,
           connectorQueryCtx_->memoryPool(),
-          connectorQueryCtx_->sessionTimezone(),
           hiveConfig_->readTimestampPartitionValueAsLocalTime(
-              connectorQueryCtx_->sessionProperties()));
+              connectorQueryCtx_->sessionProperties()),
+          false);
       childSpec->setConstantValue(constant);
     } else if (
         childSpec->columnType() == common::ScanSpec::ColumnType::kRegular) {
@@ -480,14 +491,10 @@ void SplitReader::setPartitionValue(
       "ColumnHandle is missing for partition key {}",
       partitionKey);
   auto type = it->second->dataType();
-  auto constant = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
-      newConstantFromString,
-      type->kind(),
+  auto constant = newConstantFromString(
       type,
       value,
-      1,
       connectorQueryCtx_->memoryPool(),
-      connectorQueryCtx_->sessionTimezone(),
       hiveConfig_->readTimestampPartitionValueAsLocalTime(
           connectorQueryCtx_->sessionProperties()),
       it->second->isPartitionDateValueDaysSinceEpoch());

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -47,6 +47,36 @@ class MemoryPool;
 
 namespace facebook::velox::connector::hive {
 
+/// Creates a constant vector of size 1 from a string representation of a value.
+///
+/// Used to materialize partition column values and info columns (e.g., $path,
+/// $file_size) when reading Hive and Iceberg tables. Partition values are
+/// stored as strings in HiveConnectorSplit::partitionKeys and need to be
+/// converted to their appropriate types.
+///
+/// @param type The target Velox type for the constant vector. Supports all
+/// scalar types including primitives, dates, timestamps, and decimals.
+/// @param value The string representation of the value to convert, formatted
+/// the same way as CAST(x as VARCHAR). Date values must be formatted using ISO
+/// 8601 as YYYY-MM-DD. If nullopt, creates a null constant vector.
+/// @param pool Memory pool for allocating the constant vector.
+/// @param isLocalTimestamp If true and type is TIMESTAMP, interprets the string
+/// value as local time and converts it to GMT. If false, treats the value
+/// as already in GMT.
+/// @param isDaysSinceEpoch If true and type is DATE, treats the string value as
+/// an integer representing days since epoch (used by Iceberg). If false, parses
+/// the string as a date string in ISO 8601 format (used by Hive).
+///
+/// @return A constant vector of size 1 containing the converted value, or a
+/// null constant if value is nullopt.
+/// @throws VeloxUserError if the string cannot be converted to the target type.
+VectorPtr newConstantFromString(
+    const TypePtr& type,
+    const std::optional<std::string>& value,
+    velox::memory::MemoryPool* pool,
+    bool isLocalTimestamp,
+    bool isDaysSinceEpoch);
+
 struct HiveConnectorSplit;
 class HiveTableHandle;
 class HiveColumnHandle;
@@ -163,17 +193,24 @@ class SplitReader {
       VectorPtr& output,
       const std::vector<BaseVector::CopyRange>& ranges);
 
- private:
-  /// Different table formats may have different meatadata columns.
-  /// This function will be used to update the scanSpec for these columns.
-  std::vector<TypePtr> adaptColumns(
-      const RowTypePtr& fileType,
-      const std::shared_ptr<const velox::RowType>& tableSchema) const;
-
+  /// Sets a constant partition value on the scanSpec for a partition column.
+  /// Converts the partition key string value to the appropriate type and sets
+  /// it as a constant value in the scanSpec, so the column will be filled
+  /// with this constant value.
+  ///
+  /// @param spec The scan spec to set the constant value on.
+  /// @param partitionKey The name of the partition column.
   void setPartitionValue(
       common::ScanSpec* spec,
       const std::string& partitionKey,
       const std::optional<std::string>& value) const;
+
+ private:
+  /// Different table formats may have different meatadata columns.
+  /// This function will be used to update the scanSpec for these columns.
+  virtual std::vector<TypePtr> adaptColumns(
+      const RowTypePtr& fileType,
+      const RowTypePtr& tableSchema) const;
 
  protected:
   std::shared_ptr<const HiveConnectorSplit> hiveSplit_;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -141,4 +141,56 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
   return rowsScanned;
 }
 
+std::vector<TypePtr> IcebergSplitReader::adaptColumns(
+    const RowTypePtr& fileType,
+    const RowTypePtr& tableSchema) const {
+  std::vector<TypePtr> columnTypes = fileType->children();
+  auto& childrenSpecs = scanSpec_->children();
+  // Iceberg table stores all column's data in data file.
+  for (const auto& childSpec : childrenSpecs) {
+    const std::string& fieldName = childSpec->fieldName();
+    if (auto iter = hiveSplit_->infoColumns.find(fieldName);
+        iter != hiveSplit_->infoColumns.end()) {
+      auto infoColumnType = readerOutputType_->findChild(fieldName);
+      auto constant = newConstantFromString(
+          infoColumnType,
+          iter->second,
+          connectorQueryCtx_->memoryPool(),
+          hiveConfig_->readTimestampPartitionValueAsLocalTime(
+              connectorQueryCtx_->sessionProperties()),
+          false);
+      childSpec->setConstantValue(constant);
+    } else {
+      auto fileTypeIdx = fileType->getChildIdxIfExists(fieldName);
+      auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);
+      if (outputTypeIdx.has_value() && fileTypeIdx.has_value()) {
+        childSpec->setConstantValue(nullptr);
+        auto& outputType = readerOutputType_->childAt(*outputTypeIdx);
+        columnTypes[*fileTypeIdx] = outputType;
+      } else if (!fileTypeIdx.has_value()) {
+        // Handle columns missing from the data file in two scenarios:
+        // 1. Schema evolution: Column was added after the data file was
+        // written and doesn't exist in older data files.
+        // 2. Partition columns: Hive migrated table. In Hive-written data
+        // files, partition column values are stored in partition metadata
+        // rather than in the data file itself, following Hive's partitioning
+        // convention.
+        if (auto it = hiveSplit_->partitionKeys.find(fieldName);
+            it != hiveSplit_->partitionKeys.end()) {
+          setPartitionValue(childSpec.get(), fieldName, it->second);
+        } else {
+          childSpec->setConstantValue(BaseVector::createNullConstant(
+              tableSchema->findChild(fieldName),
+              1,
+              connectorQueryCtx_->memoryPool()));
+        }
+      }
+    }
+  }
+
+  scanSpec_->resetCachedValues(false);
+
+  return columnTypes;
+}
+
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -50,6 +50,49 @@ class IcebergSplitReader : public SplitReader {
   uint64_t next(uint64_t size, VectorPtr& output) override;
 
  private:
+  /// Adapts the data file schema to match the table schema expected by the
+  /// query.
+  ///
+  /// This method reconciles differences between the physical data file schema
+  /// and the logical table schema, handling various scenarios where columns may
+  /// be missing, added, or need special treatment.
+  ///
+  /// @param fileType The schema read from the data file's metadata. This
+  /// represents the actual columns physically present in the Parquet/ORC file.
+  /// @param tableSchema The logical schema defined in the catalog (e.g., from
+  /// DDL). This represents the current table schema that queries expect.
+  ///
+  /// @return A vector of column types adapted to match the query's
+  /// expectations, with appropriate type conversions and constant values set
+  /// for missing or special columns.
+  ///
+  /// The method handles the following scenarios for each column in the scan
+  /// spec:
+  ///
+  /// 1. Info columns (e.g., $path, $data_sequence_number, $deleted)
+  ///    These are virtual columns that provide metadata about the file itself.
+  ///    Values are read from hiveSplit_->infoColumns map and set as constant
+  ///    values in the scanSpec so they're materialized for all rows.
+  ///
+  /// 2. Regular columns present in File:
+  ///    Column exists in both fileType and readerOutputType. Type is adapted
+  ///    from fileType to match the expected output type, handling schema
+  ///    evolution where column types may have changed.
+  ///
+  /// 3. Columns missing from File:
+  ///    a) Partition columns (hive-migrated tables):
+  ///       Column is marked as partition key in hiveSplit_->partitionKeys.
+  ///       In Hive-written Iceberg tables, partition column values are stored
+  ///       in partition metadata, not in the data file itself. Value is read
+  ///       from partition metadata and set as a constant.
+  ///    b) Schema evolution (newly added columns):
+  ///       Column was added to the table schema after this data file was
+  ///       written. Set as NULL constant since the old file doesn't contain
+  ///       this column.
+  std::vector<TypePtr> adaptColumns(
+      const RowTypePtr& fileType,
+      const RowTypePtr& tableSchema) const override;
+
   // The read offset to the beginning of the split in number of rows for the
   // current batch for the base data file
   uint64_t baseReadOffset_;


### PR DESCRIPTION
 Implement IcebergSplitReader::adaptColumns. Without overriding this method, current iceberg reader uses `SplitReader::adaptColumns` which is specific to Hive implementation. One difference between Hive and Iceberg is Iceberg spec requires all columns should be wrote to data files while in Hive, it only write non-partition columns to data file. So, there are special logic to handle this during read in `SplitReader::adaptColumns`. But in Iceberg this is not needed.
And for Hive, it populates the column data with partition value directly, this is correct for Hive only, but for Iceberg, there are different kinds transforms other than Identity transform. And we can not deduce the original column from the partition value.

