### PR TITLE
fix: Rename iceberg cmake target name

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -34,7 +34,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_hive_connector
-  PUBLIC velox_hive_iceberg_splitreader
+  PUBLIC velox_hive_iceberg_connector
   PRIVATE velox_common_io velox_connector velox_dwio_catalog_fbhive
           velox_hive_partition_function)
 

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-velox_add_library(velox_hive_iceberg_splitreader IcebergSplitReader.cpp
+velox_add_library(velox_hive_iceberg_connector IcebergSplitReader.cpp
                   IcebergSplit.cpp PositionalDeleteFileReader.cpp)
 
-velox_link_libraries(velox_hive_iceberg_splitreader velox_connector
-                     Folly::folly)
+velox_link_libraries(velox_hive_iceberg_connector velox_connector Folly::folly)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -46,7 +46,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_hive_iceberg_test
     velox_dwio_iceberg_reader_benchmark_lib
     velox_hive_connector
-    velox_hive_iceberg_splitreader
+    velox_hive_iceberg_connector
     velox_hive_partition_function
     velox_dwio_common_exception
     velox_dwio_common_test_utils


### PR DESCRIPTION
Currently the iceberg source code been compiled to a cmake target with name of `velox_hive_iceberg_splitreader`.  This limit it purpose to serve only read, but it should serve other purposes too such as write. 
We should rename it to `velox_hive_iceberg_connector`.
