### PR TITLE
fix: Ambiguity in VectorTestBase::makeFlatVector with brace initialization

### DIFF
--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -33,7 +33,7 @@ using namespace facebook::velox::exec;
 namespace facebook::velox {
 namespace {
 
-static constexpr int64_t overflowSize = 3UL << 30;
+static constexpr vector_size_t invalidSize = -1;
 
 class GenericWriterTest : public functions::test::FunctionBaseTest {};
 
@@ -42,7 +42,7 @@ TEST_F(GenericWriterTest, boolean) {
   BaseVector::ensureWritable(SelectivityVector(5), BOOLEAN(), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 5; ++i) {
@@ -69,7 +69,7 @@ TEST_F(GenericWriterTest, integer) {
   BaseVector::ensureWritable(SelectivityVector(100), BIGINT(), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 100; ++i) {
@@ -92,7 +92,7 @@ TEST_F(GenericWriterTest, ArrayOfGeneric) {
       SelectivityVector(2), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Array<Any>> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result->as<ArrayVector>());
 
   for (int i = 0; i < 2; ++i) {
@@ -146,7 +146,7 @@ TEST_F(GenericWriterTest, ensureSizeDoesNotResize) {
   BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), result);
   EXPECT_EQ(result->size(), 6);
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
   writer.ensureSize(1);
   EXPECT_EQ(result->size(), 6);
@@ -157,7 +157,7 @@ TEST_F(GenericWriterTest, varchar) {
   BaseVector::ensureWritable(SelectivityVector(6), VARCHAR(), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 5; ++i) {
@@ -185,7 +185,7 @@ TEST_F(GenericWriterTest, arrayAnyCast) {
       SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
   for (int i = 0; i < 5; ++i) {
     writer.setOffset(i);
@@ -218,7 +218,7 @@ TEST_F(GenericWriterTest, castToDifferentTypesNotSupported) {
   BaseVector::ensureWritable(
       SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   writer.setOffset(0);
@@ -242,7 +242,7 @@ TEST_F(GenericWriterTest, arrayIntCast) {
       SelectivityVector(5), ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
   for (int i = 0; i < 5; ++i) {
     writer.setOffset(i);
@@ -277,7 +277,7 @@ TEST_F(GenericWriterTest, arrayWriteThenCommitNull) {
   BaseVector::ensureWritable(rows, ARRAY(BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
   {
     writer.setOffset(0);
@@ -312,7 +312,7 @@ TEST_F(GenericWriterTest, genericWriteThenCommitNull) {
   BaseVector::ensureWritable(rows, CppToType<test_t>::create(), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
   {
     writer.setOffset(0);
@@ -348,7 +348,7 @@ TEST_F(GenericWriterTest, mapAnyAnyCast) {
       SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 4; ++i) {
@@ -384,7 +384,7 @@ TEST_F(GenericWriterTest, mapVarcharIntCast) {
       SelectivityVector(4), MAP(VARCHAR(), BIGINT()), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 4; ++i) {
@@ -423,7 +423,7 @@ TEST_F(GenericWriterTest, row) {
       result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 3; ++i) {
@@ -486,7 +486,7 @@ TEST_F(GenericWriterTest, dynamicRow) {
       SelectivityVector(6), ROW({BIGINT(), DOUBLE()}), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   writer.setOffset(0);
@@ -568,7 +568,7 @@ TEST_F(GenericWriterTest, nested) {
       result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 3; ++i) {
@@ -645,7 +645,7 @@ TEST_F(GenericWriterTest, commitNull) {
   BaseVector::ensureWritable(SelectivityVector(3), BIGINT(), pool(), result);
 
   VectorWriter<Any> writer;
-  VELOX_ASSERT_THROW(writer.ensureSize(overflowSize), "");
+  VELOX_ASSERT_THROW(writer.ensureSize(invalidSize), "");
   writer.init(*result);
 
   for (int i = 0; i < 3; ++i) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1609,6 +1609,15 @@ TEST_F(VectorTest, rowPrepareForReuse) {
   }
 }
 
+TEST_F(VectorTest, makeFlatVectorWithInitializerList) {
+  auto vector = makeFlatVector<int64_t>({803});
+
+  ASSERT_NE(vector, nullptr);
+  EXPECT_EQ(vector->size(), 1);
+
+  EXPECT_EQ(vector->asFlatVector<int64_t>()->valueAt(0), 803);
+}
+
 TEST_F(VectorTest, wrapConstantInDictionary) {
   // Wrap Constant in Dictionary with no extra nulls. Expect Constant.
   auto indices = makeIndices(10, [](auto row) { return row % 2; });

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -196,6 +196,13 @@ class VectorTestBase {
   }
 
   template <typename T>
+  FlatVectorPtr<EvalType<T>> makeFlatVector(
+      const std::initializer_list<T>& data,
+      const TypePtr& type = CppToType<T>::create()) {
+    return vectorMaker_.flatVector<T>(data, type);
+  }
+
+  template <typename T>
   FlatVectorPtr<EvalType<T>> makeNullableFlatVector(
       const std::vector<std::optional<T>>& data,
       const TypePtr& type = CppToType<T>::create()) {


### PR DESCRIPTION
## Problem
When using `makeFlatVector` with brace initialization syntax like `makeFlatVector<int64_t>({803})`, there was a compilation ambiguity between the existing overloads:
- `makeFlatVector(vector_size_t size, ...)` - where `size_t` could be implicitly constructed from single-element initializer lists
- `makeFlatVector(const std::vector<T>& data, ...)` - which accepts vector-like containers

This ambiguity made it difficult for users to create simple flat vectors using the convenient brace initialization syntax, which is a common pattern in test code.

## Solution
Added a new template overload that explicitly accepts `std::initializer_list<T>`:
```cpp
template <typename T>
FlatVectorPtr<EvalType<T>> makeFlatVector(
    const std::initializer_list<T>& data,
    const TypePtr& type = CppToType<T>::create())
```

## Benefits
- Resolves compilation ambiguity when using brace initialization
- Allows users to write more concise test code: `makeFlatVector<int64_t>({1})`
- Maintains backward compatibility with existing code
- Follows the same pattern as the existing vector-based overload


The test code is output like this when it is not modified:
<img width="433" height="154" alt="Screenshot 2025-08-19 at 20 01 20" src="https://github.com/user-attachments/assets/d202844b-d8d7-488b-9143-267f59532ea0" />
