### PR TITLE
feat: Add convenient getters for Variant arrays and maps

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -523,12 +523,44 @@ class Variant {
     return value<TypeKind::ROW>();
   }
 
+  /// Returns a map of Variants.
   const std::map<Variant, Variant>& map() const {
     return value<TypeKind::MAP>();
   }
 
+  /// Returns a map of primitive values. Assumes all keys and values are not
+  /// null.
+  template <typename K, typename V>
+  std::map<K, V> map() const {
+    const auto& variants = value<TypeKind::MAP>();
+
+    std::map<K, V> values;
+    for (const auto& [k, v] : variants) {
+      values.emplace(k.template value<K>(), v.template value<V>());
+    }
+
+    return values;
+  }
+
+  /// Returns a std::vector of Variants.
   const std::vector<Variant>& array() const {
     return value<TypeKind::ARRAY>();
+  }
+
+  /// Returns a std::vector of primitive values. Assumes that all values are not
+  /// null.
+  template <typename T>
+  std::vector<T> array() const {
+    const auto& variants = value<TypeKind::ARRAY>();
+
+    std::vector<T> values;
+    values.reserve(variants.size());
+
+    for (const auto& v : variants) {
+      values.emplace_back(v.template value<T>());
+    }
+
+    return values;
   }
 
   template <class T>

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 
-using namespace facebook::velox;
+namespace facebook::velox {
 
 namespace {
 void testSerDe(const Variant& value) {
@@ -29,7 +29,6 @@ void testSerDe(const Variant& value) {
 
   ASSERT_EQ(value, copy);
 }
-} // namespace
 
 TEST(VariantTest, arrayInferType) {
   EXPECT_EQ(*ARRAY(UNKNOWN()), *Variant(TypeKind::ARRAY).inferType());
@@ -433,7 +432,7 @@ TEST_F(VariantSerializationTest, opaqueToJson) {
   const auto type = value_.inferType();
 
   const auto expected =
-      R"(Opaque<type:OPAQUE<SerializableClass>,value:"{"name":"test_class","value":false}">)";
+      R"(Opaque<type:OPAQUE<facebook::velox::(anonymous namespace)::SerializableClass>,value:"{"name":"test_class","value":false}">)";
   EXPECT_EQ(value_.toJson(type), expected);
   EXPECT_EQ(value_.toString(type), expected);
 }
@@ -651,3 +650,89 @@ TEST(VariantTest, toString) {
       Variant::row({1, 2, 3}).toString(ROW({INTEGER(), INTEGER(), INTEGER()})),
       "[1,2,3]");
 }
+
+template <typename T>
+void testPrimitiveGetter(T v) {
+  auto value = Variant(v);
+  EXPECT_FALSE(value.isNull());
+  EXPECT_EQ(value.value<T>(), value);
+}
+
+TEST(VariantTest, primitiveGetters) {
+  testPrimitiveGetter<bool>(true);
+  testPrimitiveGetter<int32_t>(10);
+  testPrimitiveGetter<int64_t>(10);
+  testPrimitiveGetter<float>(1.2);
+  testPrimitiveGetter<double>(1.2);
+}
+
+template <typename T>
+void testArrayGetter(const std::vector<T>& inputs) {
+  std::vector<Variant> variants;
+  variants.reserve(inputs.size());
+  for (const auto& v : inputs) {
+    variants.emplace_back(v);
+  }
+
+  auto value = Variant::array(variants);
+
+  EXPECT_FALSE(value.isNull());
+
+  auto variantItems = value.array();
+  EXPECT_EQ(variantItems.size(), inputs.size());
+  for (auto i = 0; i < inputs.size(); ++i) {
+    EXPECT_FALSE(variantItems.at(i).isNull());
+    EXPECT_EQ(variantItems.at(i).template value<T>(), inputs.at(i));
+  }
+
+  auto primitiveItems = value.template array<T>();
+  EXPECT_EQ(primitiveItems.size(), inputs.size());
+  for (auto i = 0; i < inputs.size(); ++i) {
+    EXPECT_EQ(primitiveItems.at(i), inputs.at(i));
+  }
+}
+
+TEST(VariantTest, arrayGetter) {
+  testArrayGetter<bool>({true, false, true});
+  testArrayGetter<int32_t>({1, 2, 3});
+  testArrayGetter<int64_t>({1, 2, 3});
+  testArrayGetter<float>({1.2, 2.3, 3.4});
+  testArrayGetter<double>({1.2, 2.3, 3.4});
+}
+
+template <typename K, typename V>
+void testMapGetter(const std::map<K, V>& inputs) {
+  std::map<Variant, Variant> variants;
+  for (const auto& [k, v] : inputs) {
+    variants.emplace(k, v);
+  }
+
+  auto value = Variant::map(variants);
+
+  EXPECT_FALSE(value.isNull());
+
+  auto variantItems = value.map();
+  EXPECT_EQ(variantItems.size(), inputs.size());
+
+  auto expectedIt = inputs.begin();
+  for (auto it = variantItems.begin(); it != variantItems.end(); it++) {
+    auto [k, v] = *it;
+
+    EXPECT_FALSE(k.isNull());
+    EXPECT_FALSE(v.isNull());
+    EXPECT_EQ(k.template value<K>(), (*expectedIt).first);
+    EXPECT_EQ(v.template value<V>(), (*expectedIt).second);
+    expectedIt++;
+  }
+
+  auto primitiveItems = value.template map<K, V>();
+  EXPECT_EQ(primitiveItems, inputs);
+}
+
+TEST(VariantTest, mapGetter) {
+  testMapGetter<int32_t, float>({{1, 1.2}, {2, 2.3}, {3, 3.4}});
+  testMapGetter<int8_t, double>({{1, 1.2}, {2, 2.3}, {3, 3.4}});
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
Allow for extracting a std::vector of primitive values from a Variant.

The new `variant.array<int32_t>()` returns `std::vector<int32_t>`, while existing `variant.array()` returns `std::vector<Variant>`.

Differential Revision: D80559182


