### PR TITLE
refactor: Eliminate the warning of `total += size`

### DIFF
--- a/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
@@ -33,7 +33,7 @@ class FunctionBenchmark : public functions::test::FunctionBenchmarkBase {
     for (auto i = 0; i < 1000; i++) {
       auto functions = getFunctionSignatures();
       auto size = functions.size();
-      total += size;
+      total = total + size;
     }
     std::cout << total << std::endl;
   }


### PR DESCRIPTION
According to the comments at https://github.com/facebookincubator/velox/pull/14378#issuecomment-3193080496, this PR try to eliminate the warning of `total += size`.
This PR follows up https://github.com/facebookincubator/velox/pull/14378.