### PR TITLE
feat: Add a delegate function to HiveConnector to control what datasource gets created

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -28,6 +28,12 @@ using namespace facebook::velox::exec;
 
 namespace facebook::velox::connector::hive {
 
+HiveConnector::DataSourceDelegate HiveConnector::dataSourceDelegate_ = nullptr;
+
+void HiveConnector::registerDataSourceDelegate(DataSourceDelegate delegate) {
+  dataSourceDelegate_ = std::move(delegate);
+}
+
 namespace {
 std::vector<std::unique_ptr<HiveConnectorMetadataFactory>>&
 hiveConnectorMetadataFactories() {
@@ -72,6 +78,21 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
     const ConnectorTableHandlePtr& tableHandle,
     const std::unordered_map<std::string, ColumnHandlePtr>& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
+  // If a delegate is registered, give it the first chance to create a data
+  // source.  It may return nullptr to fallback to the default HiveDataSource.
+  if (dataSourceDelegate_) {
+    if (auto dataSource = dataSourceDelegate_(
+            outputType,
+            tableHandle,
+            columnHandles,
+            &fileHandleFactory_,
+            executor_,
+            connectorQueryCtx,
+            hiveConfig_)) {
+      return dataSource;
+    }
+  }
+
   return std::make_unique<HiveDataSource>(
       outputType,
       tableHandle,


### PR DESCRIPTION
This PR adds a `DataSourceDelegate` along with registering functions HiveConnector to give control over what datasource gets created from it.

Context:
While integrating Velox with cudf, we'd like to use cuDF's parquet reader with the existing velox `TableScan` operator and `HiveConnector`. In order to do that, we would like to use the aforementioned delegate mechanism to create a CudfDataSource which will use cudf's file readers and cudf's expression evaluation for processing the remaining filter.

Contributes to https://github.com/facebookincubator/velox/issues/14183