### PR TITLE
fix: Replace {} initialization in tests for GCC support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,8 @@ if(ENABLE_ALL_WARNINGS)
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "14.0.0")
       string(APPEND KNOWN_COMPILER_SPECIFIC_WARNINGS
              " -Wno-error=template-id-cdtor")
+      string(APPEND KNOWN_COMPILER_SPECIFIC_WARNINGS
+             " -Wno-error=overloaded-virtual")
     endif()
   endif()
 

--- a/velox/functions/sparksql/tests/ToJsonTest.cpp
+++ b/velox/functions/sparksql/tests/ToJsonTest.cpp
@@ -53,7 +53,10 @@ TEST_F(ToJsonTest, basicStruct) {
 
 TEST_F(ToJsonTest, basicArray) {
   auto input = makeNullableArrayVector<int64_t>(
-      {{{1}}, {{2, std::nullopt, 3}}, {{}}, std::nullopt});
+      {{{1}},
+       {{2, std::nullopt, 3}},
+       {std::vector<std::optional<int64_t>>{}},
+       std::nullopt});
   auto expected = makeNullableFlatVector<std::string>(
       {R"([1])", R"([2,null,3])", R"([])", std::nullopt});
   testToJson(input, expected);
@@ -64,7 +67,7 @@ TEST_F(ToJsonTest, basicMap) {
   auto input = makeNullableMapVector<std::string, int64_t>(
       {{{{"a", 1}, {"b", 2}, {"c", 3}}},
        std::nullopt,
-       {{}},
+       {std::vector<std::pair<std::string, std::optional<int64_t>>>{}},
        {{{"a", 1}, {"b", std::nullopt}}}});
   auto expected = makeNullableFlatVector<std::string>(
       {R"({"a":1,"b":2,"c":3})", std::nullopt, R"({})", R"({"a":1,"b":null})"});
@@ -74,7 +77,7 @@ TEST_F(ToJsonTest, basicMap) {
   input = makeNullableMapVector<int64_t, std::string>(
       {{{{1, "a"}, {2, "b"}, {3, "c"}}},
        std::nullopt,
-       {{}},
+       {std::vector<std::pair<int64_t, std::optional<std::string>>>{}},
        {{{1, "a"}, {2, std::nullopt}}}});
   expected = makeNullableFlatVector<std::string>(
       {R"({"1":"a","2":"b","3":"c"})",
@@ -282,7 +285,7 @@ TEST_F(ToJsonTest, nestedMap) {
       {0, 18321, -25567, 2932896, std::nullopt}, DateType::get());
   auto data2 = makeNullableArrayVector<std::string>(
       {{{"a", "b", std::nullopt}},
-       {{}},
+       {std::vector<std::optional<std::string>>{}},
        {{"d", "e"}},
        {{"f", std::nullopt, "h"}},
        std::nullopt});


### PR DESCRIPTION
Summary:
TL;DR
Replace `{}` with explicit empty container and add no-error flag for virtual function overload to support gcc14 build

 ---
The following error occurs when building ToJsonTest in velox with gcc14
```
error: converting to 'std::in_place_t' from list would use explicit contructor
```

Which means that `{}` leads to copy initialization which is not allowed since `in_place_t` is marked explicit

Differential Revision: D80583340
