### PR TITLE
refactor: Make local merge source queue size configurable

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -139,6 +139,11 @@ class QueryConfig {
   static constexpr const char* kLocalExchangePartitionBufferPreserveEncoding =
       "local_exchange_partition_buffer_preserve_encoding";
 
+  /// Maximum number of vectors buffered in each local merge source before
+  /// blocking to wait for consumers.
+  static constexpr const char* kLocalMergeSourceQueueSize =
+      "local_merge_source_queue_size";
+
   /// Maximum size in bytes to accumulate in ExchangeQueue. Enforced
   /// approximately, not strictly.
   static constexpr const char* kMaxExchangeBufferSize =
@@ -525,7 +530,7 @@ class QueryConfig {
 
   /// Some lambda functions over arrays and maps are evaluated in batches of the
   /// underlying elements that comprise the arrays/maps. This is done to make
-  /// the batch size managable as array vectors can have thousands of elements
+  /// the batch size manageable as array vectors can have thousands of elements
   /// each and hit scaling limits as implementations typically expect
   /// BaseVectors to a couple of thousand entries. This lets up tune those batch
   /// sizes.
@@ -794,6 +799,10 @@ class QueryConfig {
   bool localExchangePartitionBufferPreserveEncoding() const {
     /// Trying to preserve encoding can be expensive. Disabled by default.
     return get<bool>(kLocalExchangePartitionBufferPreserveEncoding, false);
+  }
+
+  uint32_t localMergeSourceQueueSize() const {
+    return get<uint32_t>(kLocalMergeSourceQueueSize, 2);
   }
 
   uint64_t maxExchangeBufferSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -106,6 +106,10 @@ Generic Configuration
        client. Enforced approximately, not strictly. A larger size can increase network throughput
        for larger clusters and thus decrease query processing time at the expense of reducing the
        amount of memory available for other usage.
+   * - local_merge_source_queue_size
+     - integer
+     - 2
+     - Maximum number of vectors buffered in each local merge source before blocking to wait for consumers.
    * - max_page_partitioning_buffer_size
      - integer
      - 32MB

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -122,7 +122,10 @@ OperatorSupplier makeOperatorSupplier(
           std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {
     return [localMerge](int32_t operatorId, DriverCtx* ctx) {
       auto mergeSource = ctx->task->addLocalMergeSource(
-          ctx->splitGroupId, localMerge->id(), localMerge->outputType());
+          ctx->splitGroupId,
+          localMerge->id(),
+          localMerge->outputType(),
+          ctx->queryConfig().localMergeSourceQueueSize());
       auto consumerCb =
           [mergeSource](
               RowVectorPtr input, bool drained, ContinueFuture* future) {

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -290,6 +290,7 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
           spillReadFilesGroup,
       vector_size_t maxOutputBatchRows,
       uint64_t maxOutputBatchBytes,
+      int mergeSourceQueueSize,
       const common::SpillConfig* spillConfig,
       const std::shared_ptr<folly::Synchronized<common::SpillStats>>&
           spillStats,
@@ -305,7 +306,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
  private:
   static std::vector<std::shared_ptr<MergeSource>> createMergeSources(
-      size_t numSpillSources);
+      size_t numSpillSources,
+      int queueSize);
 
   static std::vector<std::unique_ptr<BatchStream>> createBatchStreams(
       std::vector<std::vector<std::unique_ptr<SpillReadFile>>>

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -291,11 +291,9 @@ class MergeExchangeSource : public MergeSource {
 };
 } // namespace
 
-std::shared_ptr<MergeSource> MergeSource::createLocalMergeSource() {
-  // Buffer up to 2 vectors from each source before blocking to wait
-  // for consumers.
-  static const int kDefaultQueueSize = 2;
-  return std::make_shared<LocalMergeSource>(kDefaultQueueSize);
+std::shared_ptr<MergeSource> MergeSource::createLocalMergeSource(
+    int queueSize) {
+  return std::make_shared<LocalMergeSource>(queueSize);
 }
 
 std::shared_ptr<MergeSource> MergeSource::createMergeExchangeSource(

--- a/velox/exec/MergeSource.h
+++ b/velox/exec/MergeSource.h
@@ -46,7 +46,7 @@ class MergeSource {
   virtual void close() = 0;
 
   // Factory methods to create MergeSources.
-  static std::shared_ptr<MergeSource> createLocalMergeSource();
+  static std::shared_ptr<MergeSource> createLocalMergeSource(int queueSize);
 
   static std::shared_ptr<MergeSource> createMergeExchangeSource(
       MergeExchange* mergeExchange,

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2929,8 +2929,9 @@ folly::dynamic Task::toJson() const {
 std::shared_ptr<MergeSource> Task::addLocalMergeSource(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId,
-    const RowTypePtr& rowType) {
-  auto source = MergeSource::createLocalMergeSource();
+    const RowTypePtr& rowType,
+    int queueSize) {
+  auto source = MergeSource::createLocalMergeSource(queueSize);
   splitGroupStates_[splitGroupId].localMergeSources[planNodeId].push_back(
       source);
   return source;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -464,7 +464,8 @@ class Task : public std::enable_shared_from_this<Task> {
   std::shared_ptr<MergeSource> addLocalMergeSource(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId,
-      const RowTypePtr& rowType);
+      const RowTypePtr& rowType,
+      int queueSize);
 
   /// Returns all MergeSource's for the specified splitGroupId and planNodeId.
   const std::vector<std::shared_ptr<MergeSource>>& getLocalMergeSources(


### PR DESCRIPTION
Summary:
Add the new query config `local_merge_source_queue_size` to control how
many vectors we buffer in a local merge source.  This can be used to control the
memory usage of the pipeline.

This change does not alter any behavior of existing applications, which continue to use the default value (2) same as before.

Differential Revision: D80626475


