### PR TITLE
build: Restrict building benchmark utilities to VELOX_BUILD_TEST_UTILS

### DIFF
--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -33,9 +33,7 @@ if(${VELOX_ENABLE_EXAMPLES} AND ${VELOX_ENABLE_EXPRESSION})
   add_subdirectory(examples)
 endif()
 
-if(${VELOX_ENABLE_BENCHMARKS} OR ${VELOX_ENABLE_BENCHMARKS_BASIC})
-  add_subdirectory(benchmarks)
-endif()
+add_subdirectory(benchmarks)
 
 if(${VELOX_ENABLE_EXPRESSION})
   add_subdirectory(expression)

--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -11,55 +11,60 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(basic)
 
-set(velox_benchmark_deps
-    velox_type
-    velox_vector
-    velox_vector_fuzzer
-    velox_expression
-    velox_parse_parser
-    velox_parse_utils
-    velox_parse_expression
+if(${VELOX_BUILD_TEST_UTILS})
+  set(velox_benchmark_deps
+      velox_type
+      velox_vector
+      velox_vector_fuzzer
+      velox_expression
+      velox_parse_parser
+      velox_parse_utils
+      velox_parse_expression
+      velox_serialization
+      Folly::folly
+      Folly::follybenchmark
+      ${DOUBLE_CONVERSION}
+      gflags::gflags
+      glog::glog)
+
+  add_library(velox_benchmark_builder ExpressionBenchmarkBuilder.cpp)
+  target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps})
+
+  # This is a workaround for the use of VectorTestBase.h which includes gtest.h
+  target_link_libraries(velox_benchmark_builder GTest::gtest)
+
+  add_library(velox_query_benchmark QueryBenchmarkBase.cpp)
+
+  target_link_libraries(
+    velox_query_benchmark
+    velox_aggregates
+    velox_connector
+    velox_exec
+    velox_exec_test_lib
+    velox_dwio_common
+    velox_dwio_common_exception
+    velox_dwio_parquet_reader
+    velox_dwio_common_test_utils
+    velox_exception
+    velox_memory
+    velox_process
     velox_serialization
+    velox_encode
+    velox_type
+    velox_type_fbhive
+    velox_caching
+    velox_vector_test_lib
     Folly::folly
     Folly::follybenchmark
-    ${DOUBLE_CONVERSION}
-    gflags::gflags
-    glog::glog)
+    fmt::fmt)
+endif()
 
-add_library(velox_benchmark_builder ExpressionBenchmarkBuilder.cpp)
-target_link_libraries(
-  velox_benchmark_builder ${velox_benchmark_deps})
-# This is a workaround for the use of VectorTestBase.h which includes gtest.h
-target_link_libraries(
-  velox_benchmark_builder GTest::gtest)
+if(${VELOX_ENABLE_BENCHMARKS_BASIC})
+  add_subdirectory(basic)
+endif()
 
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)
   add_subdirectory(filesystem)
 endif()
-
-add_library(velox_query_benchmark QueryBenchmarkBase.cpp)
-target_link_libraries(
-  velox_query_benchmark
-  velox_aggregates
-  velox_connector
-  velox_exec
-  velox_exec_test_lib
-  velox_dwio_common
-  velox_dwio_common_exception
-  velox_dwio_parquet_reader
-  velox_dwio_common_test_utils
-  velox_exception
-  velox_memory
-  velox_process
-  velox_serialization
-  velox_encode
-  velox_type
-  velox_type_fbhive
-  velox_caching
-  velox_vector_test_lib
-  Folly::folly
-  Folly::follybenchmark
-  fmt::fmt)


### PR DESCRIPTION
Summary:
We'd like to build benchmark utilities without building any benchmarks.

Fixes https://github.com/facebookincubator/velox/issues/14489

Differential Revision: D80693228


