### PR TITLE
build: Add missing find_package(Thrift) in FindArrow.cmake

### DIFF
--- a/CMake/FindArrow.cmake
+++ b/CMake/FindArrow.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(FindPackageHandleStandardArgs)
+find_package(Thrift)
 
 set(find_package_args)
 if(Arrow_FIND_VERSION)

--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -15,8 +15,10 @@ project(Arrow)
 
 if(VELOX_ENABLE_ARROW)
   if(Thrift_FOUND)
+    set(ARROW_WITH_THRIFT OFF)
     set(THRIFT_SOURCE "SYSTEM")
   else()
+    set(ARROW_WITH_THRIFT ON)
     set(THRIFT_SOURCE "BUNDLED")
   endif()
   # Apache Arrow 21.0.0 uses archive.apache.org as the default mirror, which
@@ -31,7 +33,7 @@ if(VELOX_ENABLE_ARROW)
   set(ARROW_CMAKE_ARGS
       -DARROW_PARQUET=OFF
       -DARROW_DEPENDENCY_SOURCE=AUTO
-      -DARROW_WITH_THRIFT=ON
+      -DARROW_WITH_THRIFT=${ARROW_WITH_THRIFT}
       -DARROW_WITH_LZ4=ON
       -DARROW_WITH_SNAPPY=ON
       -DARROW_WITH_ZLIB=ON
@@ -51,8 +53,10 @@ if(VELOX_ENABLE_ARROW)
       -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH})
   set(ARROW_LIBDIR ${ARROW_PREFIX}/install/${CMAKE_INSTALL_LIBDIR})
 
-  add_library(thrift STATIC IMPORTED GLOBAL)
-  if(NOT Thrift_FOUND)
+  if(Thrift_FOUND)
+    set(ARROW_THRIFT_LIB)
+  else()
+    add_library(thrift::thrift STATIC IMPORTED GLOBAL)
     set(THRIFT_SOURCE_ROOT ${ARROW_PREFIX}/src/arrow_ep-build/_deps/thrift-src)
     set(THRIFT_BUILD_ROOT ${ARROW_PREFIX}/src/arrow_ep-build/_deps/thrift-build)
     set(THRIFT_INCLUDE_DIR ${THRIFT_BUILD_ROOT}
@@ -60,10 +64,11 @@ if(VELOX_ENABLE_ARROW)
     foreach(dir ${THRIFT_INCLUDE_DIR})
       file(MAKE_DIRECTORY ${dir})
     endforeach()
-    set(THRIFT_LIB ${ARROW_PREFIX}/src/arrow_ep-build/lib/libthrift.a)
+    set(ARROW_THRIFT_LIB ${ARROW_PREFIX}/src/arrow_ep-build/lib/libthrift.a)
+    target_include_directories(thrift::thrift INTERFACE ${THRIFT_INCLUDE_DIR})
+    set_property(TARGET thrift::thrift PROPERTY IMPORTED_LOCATION
+                                                ${ARROW_THRIFT_LIB})
   endif()
-  target_include_directories(thrift INTERFACE ${THRIFT_INCLUDE_DIR})
-  set_property(TARGET thrift PROPERTY IMPORTED_LOCATION ${THRIFT_LIB})
 
   set(VELOX_ARROW_BUILD_VERSION 21.0.0)
   set(VELOX_ARROW_BUILD_SHA256_CHECKSUM
@@ -92,19 +97,22 @@ if(VELOX_ENABLE_ARROW)
     ${CMAKE_COMMAND}
     CMAKE_ARGS ${ARROW_CMAKE_ARGS}
     BUILD_BYPRODUCTS ${ARROW_LIBDIR}/libarrow.a
-                     ${ARROW_LIBDIR}/libarrow_testing.a ${THRIFT_LIB})
+                     ${ARROW_LIBDIR}/libarrow_testing.a ${ARROW_THRIFT_LIB})
 
   add_library(arrow STATIC IMPORTED GLOBAL)
   add_library(arrow_testing STATIC IMPORTED GLOBAL)
   add_dependencies(arrow arrow_ep)
   add_dependencies(arrow_testing arrow)
+  if(NOT Thrift_FOUND)
+    add_dependencies(thrift::thrift arrow_ep)
+  endif()
   file(MAKE_DIRECTORY ${ARROW_PREFIX}/install/include)
   set_target_properties(
     arrow arrow_testing PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
                                    ${ARROW_PREFIX}/install/include)
   set_target_properties(arrow PROPERTIES IMPORTED_LOCATION
                                          ${ARROW_LIBDIR}/libarrow.a)
-  set_property(TARGET arrow PROPERTY INTERFACE_LINK_LIBRARIES ${RE2} thrift)
+  target_link_libraries(arrow INTERFACE ${RE2})
   set_target_properties(
     arrow_testing PROPERTIES IMPORTED_LOCATION
                              ${ARROW_LIBDIR}/libarrow_testing.a)

--- a/velox/dwio/parquet/common/CMakeLists.txt
+++ b/velox/dwio/parquet/common/CMakeLists.txt
@@ -29,5 +29,5 @@ velox_link_libraries(
   fmt::fmt
   Folly::folly
   Snappy::snappy
-  thrift
+  thrift::thrift
   zstd::zstd)

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -37,5 +37,5 @@ velox_link_libraries(
   fmt::fmt
   arrow
   Snappy::snappy
-  thrift
+  thrift::thrift
   zstd::zstd)

--- a/velox/dwio/parquet/tests/common/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/common/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(
   velox_dwio_parquet_common_test
   velox_dwio_parquet_common
   arrow
-  thrift
+  thrift::thrift
   velox_link_libs
   velox_exec
   GTest::gtest

--- a/velox/dwio/parquet/tests/thrift/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/thrift/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(velox_dwio_parquet_thrift_test velox_dwio_parquet_thrift_test)
 target_link_libraries(
   velox_dwio_parquet_thrift_test
   arrow
-  thrift
+  thrift::thrift
   velox_link_libs
   GTest::gtest
   GTest::gtest_main)

--- a/velox/dwio/parquet/thrift/CMakeLists.txt
+++ b/velox/dwio/parquet/thrift/CMakeLists.txt
@@ -16,6 +16,6 @@ velox_add_library(velox_dwio_parquet_thrift ParquetThriftTypes.cpp)
 velox_link_libraries(
   velox_dwio_parquet_thrift
   arrow
-  thrift
+  thrift::thrift
   Boost::headers
   fmt::fmt)

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -86,7 +86,7 @@ if(${VELOX_ENABLE_PARQUET})
     velox_vector_test_lib
     Folly::follybenchmark
     arrow
-    thrift)
+    thrift::thrift)
 endif()
 
 add_library(velox_orderby_benchmark_util OrderByBenchmarkUtil.cpp)


### PR DESCRIPTION
https://github.com/facebookincubator/velox/pull/14102 removed `find_package(Thrift)` from `FindArrow.cmake` but it was wrong. If we remove `find_package(Thrift)` from `FindArrow.cmake`, Apache Thrift isn't found with system Apache Arrow.

We need Apache Thrift for our bundled Apache Parquet implementation. System Apache Arrow doesn't depend on Apache Thrift. So we need to find Apache Thrift explicitly with system Apache Arrow.

This also changes CMake target name for Apache Thrift to `thrift::thrift` from `thrift`. If we use no namespace CMake target name (`thrift`) and the CMake target doesn't exit, CMake treats it as `-lthrift`. If we use namespace CMake target (`thrift::thrift`) and the CMake target doesn't exist, CMake reports an error that `thrift::thrift` doesn't exist. It will help us to find this problem.

This also improves bundled Apache Arrow. We don't build bundled Apache Thrift in Apache Arrow when system Apache Thrift is found. It will reduce needless build time.

Fixes #14547