### PR TITLE
fix: Fix unable to locate package error on ubuntu 22.04

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -58,7 +58,7 @@ function install_clang15 {
   if [[ ${VERSION} =~ "22.04" ]]; then
     CLANG_PACKAGE_LIST="${CLANG_PACKAGE_LIST} gcc-12 g++-12 libc++-12-dev"
   fi
-  ${SUDO} apt install "${CLANG_PACKAGE_LIST}" -y
+  ${SUDO} apt install ${CLANG_PACKAGE_LIST} -y
 }
 
 # For Ubuntu 20.04 we need add the toolchain PPA to get access to gcc11.


### PR DESCRIPTION
When running setup-ubuntu.sh on Ubuntu 22.04, and  `export USE_CLANG=true`
following error messages is showed up and setup scripts failed to run.

```
0 upgraded, 0 newly installed, 0 to remove and 81 not upgraded.
+ install_uv
+ command -v uv
+ echo 'uv is already installed.'
uv is already installed.
+ uv_install cmake==3.28.3
+ uv tool install cmake==3.28.3
`cmake==3.28.3` is already installed
+ install_gcc11_if_needed
+ [[ VERSION_ID="22.04" =~ 20\.04 ]]
+ [[ true != \f\a\l\s\e ]]
+ install_clang15
+ [[ ! VERSION_ID="22.04" =~ 22\.04 ]]
+ CLANG_PACKAGE_LIST=clang-15
+ [[ VERSION_ID="22.04" =~ 22\.04 ]]
+ CLANG_PACKAGE_LIST='clang-15 gcc-12 g++-12 libc++-12-dev'
+ sudo --preserve-env apt install 'clang-15 gcc-12 g++-12 libc++-12-dev' -y
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package clang-15 gcc-12 g++-12 libc++-12-dev
```

