### PR TITLE
fix(build): Benchmark compilation

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -109,10 +109,10 @@ jobs:
           else
             # cuDF (unsupported for Clang) and Faiss (link issue when using Clang)
             # are excluded for Clang compilation and need to be added back when using GCC.
-            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_CUDF=ON"
-            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_FAISS=ON"
+            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_CUDF=ON")
+            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_FAISS=ON")
             # Investigate issues with remote function service: Issue #13897
-            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
+            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON")
           fi
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
 

--- a/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
@@ -29,7 +29,7 @@ class FunctionBenchmark : public functions::test::FunctionBenchmarkBase {
   }
 
   void run() {
-    volatile int total = 0;
+    int total = 0;
     for (auto i = 0; i < 1000; i++) {
       auto functions = getFunctionSignatures();
       auto size = functions.size();


### PR DESCRIPTION
With the C++20 change using volatile is an error.
There was one benchmark that did use this. but it didn’t come up in the CI which didn’t seem to build the benchmarks at all. As a result the CI needed a fix to ensure proper compilation.