### PR TITLE
Remove unused-but-set variables in velox/experimental/wave/exec/WavePlan.cpp +1

### DIFF
--- a/velox/experimental/wave/exec/WavePlan.cpp
+++ b/velox/experimental/wave/exec/WavePlan.cpp
@@ -849,8 +849,7 @@ void CompileState::planSegment(
       } else if (dynamic_cast<const core::ValuesNode*>(node)) {
         candidate.currentBox->steps.push_back(segment.steps[0]);
         needNewKernel = true;
-      } else if (
-          auto* read = dynamic_cast<const core::AggregationNode*>(node)) {
+      } else if (dynamic_cast<const core::AggregationNode*>(node)) {
         auto* step = segment.steps[0];
         candidate.currentBox->steps.push_back(step);
       }


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: dtolnay

Differential Revision: D80552360


