### PR TITLE
fix: Added yield check for NestLoopJoinProbe

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -892,7 +892,7 @@ void HashBuild::processSpillInput() {
     if (!isRunning()) {
       return;
     }
-    if (operatorCtx_->driver()->shouldYield()) {
+    if (shouldYield()) {
       state_ = State::kYield;
       future_ = ContinueFuture{folly::Unit{}};
       return;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -658,6 +658,15 @@ class Operator : public BaseRuntimeStatWriter {
   /// could copy directly from input to output if no cardinality change.
   bool isIdentityProjection_ = false;
 
+  /// Returns true if the driver should yield execution to prevent getting
+  /// stuck in long processing loops that exceed their allocated CPU time
+  /// slice limits. Operators should call this method as yield points during
+  /// time-consuming operations to allow other tasks to be scheduled and
+  /// maintain system responsiveness.
+  bool shouldYield() const {
+    return operatorCtx_->driverCtx()->driver->shouldYield();
+  }
+
  private:
   // Setup 'inputTracer_' to record the processed input vectors.
   void setupInputTracer(const std::string& traceDir);

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -509,7 +509,7 @@ void RowNumber::recursiveSpillInput() {
   while (spillInputReader_->nextBatch(unspilledInput)) {
     spillInput(unspilledInput, pool());
 
-    if (operatorCtx_->driver()->shouldYield()) {
+    if (shouldYield()) {
       yield_ = true;
       return;
     }


### PR DESCRIPTION
Summary:
NestedLoopJoinProbe::getOutput can be time-consuming when processing large cross products or when data skew occurs, potentially causing driver threads to exceed their time slice limits.
check the query 20250805_213420_29014_yrwfs ,

Differential Revision: D80727020


