### PR TITLE
fix: Handle parse_presto_data_size behavior on ASCII inputs correctly

### DIFF
--- a/velox/functions/prestosql/DataSizeFunctions.h
+++ b/velox/functions/prestosql/DataSizeFunctions.h
@@ -100,11 +100,15 @@ struct ParsePrestoDataSizeFunction {
       const arg_type<Varchar>& input) {
     result = getDecimal(input);
   }
-  // Fail Non-ASCII characters in input.
   FOLLY_ALWAYS_INLINE void call(
       out_type<LongDecimal<P1, S1>>& result,
       const arg_type<Varchar>& input) {
-    VELOX_USER_FAIL("Invalid data size: '{}'", input);
+    // If ASCII input process else fail.
+    if (stringCore::isAscii(input.data(), input.size())) {
+      result = getDecimal(input);
+    } else {
+      VELOX_USER_FAIL("Invalid data size: '{}'", input);
+    }
   }
 };
 


### PR DESCRIPTION
Summary:
Fix parse_presto_data_size ASCII issue: https://github.com/facebookincubator/velox/issues/14556.

Handle ASCII vs non-ASCII case gracefully in call(). 

If a value reaches call() and it is ASCII then call getDecimal() , else fail as non-ASCII. 
Old behavior - anything that reaches call() was failed as if was non-ASCII

Differential Revision: D80762604


