### PR TITLE
fix: Aggregate destroyAccumulator memset call with dynamic class input

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -434,7 +434,7 @@ class Aggregate {
     if (isInitialized(group)) {
       auto accumulator = value<T>(group);
       std::destroy_at(accumulator);
-      ::memset(accumulator, 0, sizeof(T));
+      ::memset(static_cast<void*>(accumulator), 0, sizeof(T));
     }
   }
 


### PR DESCRIPTION
If we use a dynamic class in the Accumulator, then the `memset` call in `destroyAccumulator` fails during build with 
```
velox/velox/exec/Aggregate.h:437:16: error: destination for this 'memset' call is a pointer to class containing a dynamic class 'update_theta_sketch_alloc<std::allocator<unsigned long long>>'; vtable pointer will be overwritten [-Werror,-Wdynamic-class-memaccess]
  437 |       ::memset(accumulator, 0, sizeof(T));
```

Encountered this when working on https://github.com/prestodb/presto/pull/25685