### PR TITLE
fix: macro VELOX_ASSERT_ERROR_STATUS has variable conflict

### DIFF
--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -61,13 +61,15 @@
       facebook::velox::VeloxRuntimeError, _expression, _errorMessage)
 
 #define VELOX_ASSERT_ERROR_STATUS(_expression, _statusCode, _errorMessage) \
-  const auto status = (_expression);                                       \
-  ASSERT_TRUE(status.code() == _statusCode)                                \
-      << "Expected error code to be '" << toString(_statusCode)            \
-      << "', but received '" << toString(status.code()) << "'.";           \
-  ASSERT_TRUE(status.message().find(_errorMessage) != std::string::npos)   \
-      << "Expected error message to contain '" << (_errorMessage)          \
-      << "', but received '" << status.message() << "'."
+  {                                                                        \
+    const auto status = (_expression);                                     \
+    ASSERT_TRUE(status.code() == _statusCode)                              \
+        << "Expected error code to be '" << toString(_statusCode)          \
+        << "', but received '" << toString(status.code()) << "'.";         \
+    ASSERT_TRUE(status.message().find(_errorMessage) != std::string::npos) \
+        << "Expected error message to contain '" << (_errorMessage)        \
+        << "', but received '" << status.message() << "'.";                \
+  }
 
 #define VELOX_ASSERT_ERROR_CODE_IMPL(                                         \
     _type, _expression, _errorCode, _errorMessage)                            \


### PR DESCRIPTION
Fix error "Local variable const Status status has already been defined or declared"
when using `VELOX_ASSERT_ERROR_STATUS` multiple times in the same scope.