### PR TITLE
fix: Fix build error on ubuntu 22.04 with Clang 15

### DIFF
--- a/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp
@@ -33,7 +33,7 @@ class FunctionBenchmark : public functions::test::FunctionBenchmarkBase {
     for (auto i = 0; i < 1000; i++) {
       auto functions = getFunctionSignatures();
       auto size = functions.size();
-      total += size;
+      total = total + size;
     }
     std::cout << total << std::endl;
   }


### PR DESCRIPTION
When set VELOX_ENABLE_BENCHMARKS and build on ubuntu 22.04,
received following error

```
/root/git/velox/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp: In member function ‘void FunctionBenchmark::run()’:
/root/git/velox/velox/functions/sparksql/benchmarks/FunctionBenchmark.cpp:36:13: error: compound assignment with ‘volatile’-qualified left operand is deprecated [-Werror=volatile]
   36 |       total += size;
      |       ~~~~~~^~~~~~~
cc1plus: all warnings being treated as errors
```



Velox System Info v0.0.2
Commit: ca20a49babc578f5823d7bbfca1f2fa94de9cda5
CMake Version: 3.28.3
System: Linux-5.15.0-152-generic
Arch: x86_64
C++ Compiler: /usr/bin/clang++-15
C++ Compiler Version: 15.0.7
C Compiler: /usr/bin/clang-15
C Compiler Version: 15.0.7
CMake Prefix Path: /usr/local;/usr;/;/root/.local/share/uv/tools/cmake/lib/python3.10/site-packages/cmake/data;/usr/local;/usr/X11R6;/usr/pkg;/opt
