### PR TITLE
feat: Velox scalar function unknown support

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1258,10 +1258,13 @@ std::shared_ptr<exec::VectorFunction> makeRe2MatchImpl(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config) {
-  if (inputArgs.size() != 2 || !inputArgs[0].type->isVarchar() ||
-      !inputArgs[1].type->isVarchar()) {
+  if (inputArgs.size() != 2 ||
+      (!inputArgs[0].type->isVarchar() &&
+       inputArgs[0].type->kind() != TypeKind::UNKNOWN) ||
+      (!inputArgs[1].type->isVarchar() &&
+       inputArgs[1].type->kind() != TypeKind::UNKNOWN)) {
     VELOX_UNSUPPORTED(
-        "{} expected (VARCHAR, VARCHAR) but got ({})",
+        "{} expected (VARCHAR, VARCHAR) or (VARCHAR, UNKNOWN) but got ({})",
         name,
         printTypesCsv(inputArgs));
   }
@@ -1670,11 +1673,27 @@ std::shared_ptr<exec::VectorFunction> makeRe2Search(
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2SearchSignatures() {
   // varchar, varchar -> boolean
-  return {exec::FunctionSignatureBuilder()
-              .returnType("boolean")
-              .argumentType("varchar")
-              .argumentType("varchar")
-              .build()};
+  return {
+      exec::FunctionSignatureBuilder()
+          .returnType("boolean")
+          .argumentType("varchar")
+          .argumentType("varchar")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("boolean")
+          .argumentType("varchar")
+          .argumentType("unknown")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("boolean")
+          .argumentType("unknown")
+          .argumentType("varchar")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("boolean")
+          .argumentType("unknown")
+          .argumentType("unknown")
+          .build()};
 }
 
 std::shared_ptr<exec::VectorFunction> makeRe2Extract(

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -326,6 +326,32 @@ void testRe2Search(F&& regexSearch) {
   EXPECT_EQ(std::nullopt, regexSearch("", std::nullopt));
 }
 
+TEST_F(Re2FunctionsTest, regexSearchUnknown) {
+  // varchar, unknown
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<bool>(
+          "re2_search(c0, c1)",
+          std::optional<std::string>("hello123"),
+          std::vector<std::optional<UnknownValue>>{std::nullopt}[0]));
+
+  // unknown, varchar
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<bool>(
+          "re2_search(c0, c1)",
+          std::optional<std::string>(std::nullopt),
+          std::optional<std::string>("hello123")));
+
+  // unknown, unknown
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<bool>(
+          "re2_search(c0, c1)",
+          std::vector<std::optional<UnknownValue>>{std::nullopt}[0],
+          std::vector<std::optional<UnknownValue>>{std::nullopt}[0]));
+}
+
 TEST_F(Re2FunctionsTest, regexSearchConstantPattern) {
   testRe2Search([&](std::optional<std::string> str,
                     std::optional<std::string> pattern) {
@@ -1558,5 +1584,6 @@ TEST_F(Re2FunctionsTest, parseSubstrings) {
   test("%aa%bb%%", {"aa", "bb"});
   test("%aa%bb%%%cc%", {"aa", "bb", "cc"});
 }
+
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Add support for implicit casting on UNKNOWN type to support Prestissimo functionalities

now re2SearchSignatures and makeRe2MatchImpl both supports:
(varchar, unknown) -> boolean
(unknown, varchar) -> boolean
(unknown, unknown) -> boolean

Differential Revision: D80494068


