### PR TITLE
fix: Ignore sfmsketch type in ExpressionFuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -451,6 +451,7 @@ bool ExpressionFuzzer::isSupportedSignature(
   if (usesTypeName(signature, "opaque") ||
       usesTypeName(signature, "interval day to second") ||
       usesTypeName(signature, "ipprefix") ||
+      usesTypeName(signature, "sfmsketch") ||
       (!options_.enableDecimalType && usesTypeName(signature, "decimal")) ||
       (!options_.enableComplexTypes && useComplexType) ||
       (options_.enableComplexTypes && usesTypeName(signature, "unknown"))) {


### PR DESCRIPTION
Summary:
SFMSketch doesnt across two runs even with same seed doesnt produce the same sketch the size produced by sketch differs ; See : https://www.internalfb.com/code/fbsource/[82343deea988]/fbcode/velox/functions/prestosql/types/fuzzer_utils/SfmSketchInputGenerator.h?lines=40 . 

Certain tests in ExpressionFuzzer fail due to this , see diff : D78992756

Differential Revision: D80848847


