### PR TITLE
refactor: ExceptionContextSetter should be nodiscard

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -442,7 +442,7 @@ ExceptionContext& getExceptionContext();
 /// exception context with the previous context held by the thread_local
 /// variable to allow retrieving the top-level context when there is an
 /// exception context hierarchy.
-class ExceptionContextSetter {
+class [[nodiscard]] ExceptionContextSetter {
  public:
   explicit ExceptionContextSetter(ExceptionContext value)
       : prev_{getExceptionContext()} {


### PR DESCRIPTION
If someone will forget to name it.
It will be warning: ignoring temporary of type 'ExceptionContextSetter' declared with 'nodiscard' attributeclang(-Wunused-value)

Example of issue:
https://github.com/facebookexperimental/verax/pull/259