### PR TITLE
fix: Initialize errors only once in JsonCastOperator

### DIFF
--- a/velox/functions/prestosql/types/JsonCastOperator.h
+++ b/velox/functions/prestosql/types/JsonCastOperator.h
@@ -57,8 +57,8 @@ class JsonCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) const;
 
-  mutable folly::once_flag initializeErrors_;
-  mutable std::exception_ptr errors_[simdjson::NUM_ERROR_CODES];
+  inline static folly::once_flag initializeErrors_;
+  inline static std::exception_ptr errors_[simdjson::NUM_ERROR_CODES];
   mutable std::string paddedInput_;
 };
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Ensure that the `errors` array within the `JsonCastOperator` is initialized 
only once, avoiding significant overhead when casting multiple columns.

This PR fixes https://github.com/facebookincubator/velox/issues/14581