### PR TITLE
Enhancement: Add getters for nested arrays and maps in Variant

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -560,6 +560,19 @@ class Variant {
     return values;
   }
 
+  /// Returns a std::map of primitive keys to std::vector of primitive values. Assumes all keys and values are not null.
+  template <typename K, typename V>
+  std::map<K, std::vector<V>> mapOfArrays() const {
+    const auto& variants = value<TypeKind::MAP>();
+
+    std::map<K, std::vector<V>> values;
+    for (const auto& [k, v] : variants) {
+      values.emplace(k.template value<K>(), v.template array<V>());
+    }
+    
+    return values;
+  }
+
   /// Returns a std::vector of Variants.
   const std::vector<Variant>& array() const {
     return value<TypeKind::ARRAY>();
@@ -596,6 +609,21 @@ class Variant {
       } else {
         values.emplace_back(v.template value<T>());
       }
+    }
+
+    return values;
+  }
+
+  /// Returns a std::vector of std::vector of primitive values. Assumes that all values are not null.
+  template <typename T>
+  std::vector<std::vector<T>> arrayOfArrays() const {
+    const auto& variants = value<TypeKind::ARRAY>();
+
+    std::vector<std::vector<T>> values;
+    values.reserve(variants.size());
+
+    for (const auto& v : variants) {
+      values.emplace_back(v.template array<T>());
     }
 
     return values;

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -811,5 +811,58 @@ TEST(VariantTest, mapGetter) {
       {{1, 1.2}, {2, 2.3}, {3, std::nullopt}});
 }
 
+template <typename T>
+void testArrayOfArraysGetter(const std::vector<std::vector<T>>& inputs) {
+  std::vector<Variant> variants;
+  variants.reserve(inputs.size());
+  for (const auto& arr : inputs) {
+    std::vector<Variant> innerVariants;
+    innerVariants.reserve(arr.size());
+    for (const auto& v : arr) {
+      innerVariants.emplace_back(v);
+    }
+    variants.emplace_back(Variant::array(innerVariants));
+  }
+
+  auto value = Variant::array(variants);
+  EXPECT_FALSE(value.isNull());
+
+  {
+    auto primitiveItems = value.template arrayOfArrays<T>();
+    EXPECT_EQ(primitiveItems, inputs);
+  }
+}
+
+TEST(VariantTest, arrayOfArraysGetter) {
+  testArrayOfArraysGetter<int32_t>({{1, 2}, {3, 4, 5}, {}});
+  testArrayOfArraysGetter<double>({{1.1, 2.2}, {}, {3.3}});
+}
+
+template <typename K, typename V>
+void testMapOfArraysGetter(const std::map<K, std::vector<V>>& inputs) {
+  std::map<Variant, Variant> variants;
+  for (const auto& [k, arr] : inputs) {
+    std::vector<Variant> innerVariants;
+    innerVariants.reserve(arr.size());
+    for (const auto& v : arr) {
+      innerVariants.emplace_back(v);
+    }
+    variants.emplace(k, Variant::array(innerVariants));
+  }
+
+  auto value = Variant::map(variants);
+  EXPECT_FALSE(value.isNull());
+
+  {
+    auto primitiveItems = value.template mapOfArrays<K, V>();
+    EXPECT_EQ(primitiveItems, inputs);
+  }
+}
+
+TEST(VariantTest, mapOfArraysGetter) {
+  testMapOfArraysGetter<int32_t, float>({{1, {1.1f, 2.2f}}, {2, {3.3f}}, {3, {}}});
+  testMapOfArraysGetter<std::string, int64_t>({{"a", {1, 2}}, {"b", {}}, {"c", {3}}});
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Issue : #14577 
Summary:
This adds support for extracting nested arrays and maps of arrays from Variant.

- arrayOfArrays<T>() returning std::vector<std::vector<T>>
-  mapOfArrays<K,V>() returning std::map<K, std::vector<V>>