### PR TITLE
feat: Add page load time metric

### DIFF
--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -233,7 +233,7 @@ int IcebergSplitReaderBenchmark::read(
     const RowTypePtr& rowType,
     uint32_t nextSize,
     std::unique_ptr<IcebergSplitReader> icebergSplitReader) {
-  runtimeStats_ = RuntimeStatistics();
+  runtimeStats_.clear();
   icebergSplitReader->resetFilterCaches();
   int resultSize = 0;
   auto result = BaseVector::create(rowType, 0, leafPool_.get());

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -533,12 +533,34 @@ class Statistics {
 };
 
 struct ColumnReaderStatistics {
+  void clear() {
+    pageScanTime.store(0, std::memory_order_relaxed);
+    flattenStringDictionaryValues = 0;
+  }
+
+  void incPageScanTime(uint64_t v) {
+    pageScanTime.fetch_add(v, std::memory_order_relaxed);
+  }
+
   // Number of rows returned by string dictionary reader that is flattened
   // instead of keeping dictionary encoding.
   int64_t flattenStringDictionaryValues{0};
+
+  std::atomic<uint64_t> pageScanTime{0};
 };
 
 struct RuntimeStatistics {
+  void clear() {
+    skippedSplits = 0;
+    processedSplits = 0;
+    skippedSplitBytes = 0;
+    skippedStrides = 0;
+    processedStrides = 0;
+    footerBufferOverread = 0;
+    numStripes = 0;
+    columnReaderStatistics.clear();
+  }
+
   // Number of splits skipped based on statistics.
   int64_t skippedSplits{0};
 
@@ -591,6 +613,10 @@ struct RuntimeStatistics {
       result.emplace(
           "flattenStringDictionaryValues",
           RuntimeCounter(columnReaderStatistics.flattenStringDictionaryValues));
+    }
+    if (columnReaderStatistics.pageScanTime > 0) {
+      result.emplace(
+          "pageScanTime", RuntimeCounter(columnReaderStatistics.pageScanTime));
     }
     return result;
   }

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -534,19 +534,20 @@ class Statistics {
 
 struct ColumnReaderStatistics {
   void clear() {
-    pageScanTime.store(0, std::memory_order_relaxed);
+    pageLoadTime.store(0, std::memory_order_relaxed);
     flattenStringDictionaryValues = 0;
   }
 
-  void incPageScanTime(uint64_t v) {
-    pageScanTime.fetch_add(v, std::memory_order_relaxed);
+  void incPageLoadTime(uint64_t v) {
+    pageLoadTime.fetch_add(v, std::memory_order_relaxed);
   }
 
   // Number of rows returned by string dictionary reader that is flattened
   // instead of keeping dictionary encoding.
   int64_t flattenStringDictionaryValues{0};
 
-  std::atomic<uint64_t> pageScanTime{0};
+  // Total time spent in loading pages, in nanoseconds.
+  std::atomic<uint64_t> pageLoadTime{0};
 };
 
 struct RuntimeStatistics {
@@ -614,9 +615,9 @@ struct RuntimeStatistics {
           "flattenStringDictionaryValues",
           RuntimeCounter(columnReaderStatistics.flattenStringDictionaryValues));
     }
-    if (columnReaderStatistics.pageScanTime > 0) {
+    if (columnReaderStatistics.pageLoadTime > 0) {
       result.emplace(
-          "pageScanTime", RuntimeCounter(columnReaderStatistics.pageScanTime));
+          "pageLoadTime", RuntimeCounter(columnReaderStatistics.pageLoadTime));
     }
     return result;
   }

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -162,7 +162,7 @@ void E2EFilterTestBase::readWithFilter(
   }
   OwnershipChecker ownershipChecker;
   auto rowReader = reader->createRowReader(rowReaderOpts);
-  runtimeStats_ = dwio::common::RuntimeStatistics();
+  runtimeStats_.clear();
   auto rowIndex = 0;
   auto resultBatch = BaseVector::create(rowType_, 1, leafPool_.get());
   resetReadBatchSizes();

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -2574,7 +2574,7 @@ TEST_F(TestReader, readStringDictionaryAsFlat) {
   ASSERT_EQ(rowReader->next(20, actual), 20);
   ASSERT_EQ(actual->size(), 1);
   ASSERT_TRUE(actual->as<RowVector>()->childAt(0)->isFlatEncoding());
-  stats = {};
+  stats.clear();
   rowReader->updateRuntimeStats(stats);
   ASSERT_EQ(stats.columnReaderStatistics.flattenStringDictionaryValues, 1);
 }

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -87,7 +87,12 @@ PageHeader PageReader::readPageHeader() {
   if (bufferEnd_ == bufferStart_) {
     const void* buffer;
     int32_t size;
-    inputStream_->Next(&buffer, &size);
+    uint64_t readUs{0};
+    {
+      MicrosecondTimer timer(&readUs);
+      inputStream_->Next(&buffer, &size);
+    }
+    stats_.incPageLoadTime(readUs * 1'000);
     bufferStart_ = reinterpret_cast<const char*>(buffer);
     bufferEnd_ = bufferStart_ + size;
   }
@@ -130,7 +135,7 @@ const char* PageReader::readBytes(int32_t size, BufferPtr& copy) {
         bufferStart_,
         bufferEnd_);
   }
-  stats_.incPageScanTime(readUs * 1'000);
+  stats_.incPageLoadTime(readUs * 1'000);
   return copy->as<char>();
 }
 
@@ -373,12 +378,17 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       if (pageData_) {
         memcpy(dictionary_.values->asMutable<char>(), pageData_, numBytes);
       } else {
-        dwio::common::readBytes(
-            numBytes,
-            inputStream_.get(),
-            dictionary_.values->asMutable<char>(),
-            bufferStart_,
-            bufferEnd_);
+        uint64_t readUs{0};
+        {
+          MicrosecondTimer timer(&readUs);
+          dwio::common::readBytes(
+              numBytes,
+              inputStream_.get(),
+              dictionary_.values->asMutable<char>(),
+              bufferStart_,
+              bufferEnd_);
+        }
+        stats_.incPageLoadTime(readUs * 1'000);
       }
       if (type_->type()->isShortDecimal() &&
           parquetType == thrift::Type::INT32) {
@@ -408,12 +418,17 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       if (pageData_) {
         memcpy(dictionary_.values->asMutable<char>(), pageData_, numBytes);
       } else {
-        dwio::common::readBytes(
-            numBytes,
-            inputStream_.get(),
-            dictionary_.values->asMutable<char>(),
-            bufferStart_,
-            bufferEnd_);
+        uint64_t readUs{0};
+        {
+          MicrosecondTimer timer(&readUs);
+          dwio::common::readBytes(
+              numBytes,
+              inputStream_.get(),
+              dictionary_.values->asMutable<char>(),
+              bufferStart_,
+              bufferEnd_);
+        }
+        stats_.incPageLoadTime(readUs * 1'000);
       }
       // Expand the Parquet type length values to Velox type length.
       // We start from the end to allow in-place expansion.
@@ -440,8 +455,13 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       if (pageData_) {
         memcpy(strings, pageData_, numBytes);
       } else {
-        dwio::common::readBytes(
-            numBytes, inputStream_.get(), strings, bufferStart_, bufferEnd_);
+        uint64_t readUs{0};
+        {
+          MicrosecondTimer timer(&readUs);
+          dwio::common::readBytes(
+              numBytes, inputStream_.get(), strings, bufferStart_, bufferEnd_);
+        }
+        stats_.incPageLoadTime(readUs * 1'000);
       }
       auto header = strings;
       for (auto i = 0; i < dictionary_.numValues; ++i) {
@@ -463,12 +483,17 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
       if (pageData_) {
         memcpy(data, pageData_, numParquetBytes);
       } else {
-        dwio::common::readBytes(
-            numParquetBytes,
-            inputStream_.get(),
-            data,
-            bufferStart_,
-            bufferEnd_);
+        uint64_t readUs{0};
+        {
+          MicrosecondTimer timer(&readUs);
+          dwio::common::readBytes(
+              numParquetBytes,
+              inputStream_.get(),
+              data,
+              bufferStart_,
+              bufferEnd_);
+        }
+        stats_.incPageLoadTime(readUs * 1'000);
       }
       if (type_->type()->isShortDecimal()) {
         // Parquet decimal values have a fixed typeLength_ and are in big-endian

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -42,6 +42,7 @@ class PageReader {
       ParquetTypeWithIdPtr fileType,
       common::CompressionKind codec,
       int64_t chunkSize,
+      dwio::common::ColumnReaderStatistics& stats,
       const tz::TimeZone* sessionTimezone)
       : pool_(pool),
         inputStream_(std::move(stream)),
@@ -52,6 +53,7 @@ class PageReader {
         codec_(codec),
         chunkSize_(chunkSize),
         nullConcatenation_(pool_),
+        stats_(stats),
         sessionTimezone_(sessionTimezone) {
     type_->makeLevelInfo(leafInfo_);
   }
@@ -62,6 +64,7 @@ class PageReader {
       memory::MemoryPool& pool,
       common::CompressionKind codec,
       int64_t chunkSize,
+      dwio::common::ColumnReaderStatistics& stats,
       const tz::TimeZone* sessionTimezone = nullptr)
       : pool_(pool),
         inputStream_(std::move(stream)),
@@ -71,6 +74,7 @@ class PageReader {
         codec_(codec),
         chunkSize_(chunkSize),
         nullConcatenation_(pool_),
+        stats_(stats),
         sessionTimezone_(sessionTimezone) {}
 
   /// Advances 'numRows' top level rows.
@@ -501,6 +505,8 @@ class PageReader {
 
   // Base values of dictionary when reading a string dictionary.
   VectorPtr dictionaryValues_;
+
+  dwio::common::ColumnReaderStatistics& stats_;
 
   const tz::TimeZone* sessionTimezone_{nullptr};
 

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<dwio::common::FormatData> ParquetParams::toFormatData(
     const std::shared_ptr<const dwio::common::TypeWithId>& type,
     const common::ScanSpec& /*scanSpec*/) {
   return std::make_unique<ParquetData>(
-      type, metaData_, pool(), sessionTimezone_);
+      type, metaData_, pool(), runtimeStatistics(), sessionTimezone_);
 }
 
 void ParquetData::filterRowGroups(
@@ -128,6 +128,7 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
       type_,
       metadata.compression(),
       metadata.totalCompressedSize(),
+      stats_,
       sessionTimezone_);
   return dwio::common::PositionProvider(empty);
 }

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -42,7 +42,6 @@ class ParquetParams : public dwio::common::FormatParams {
         metaData_(metaData),
         sessionTimezone_(sessionTimezone),
         timestampPrecision_(timestampPrecision) {}
-
   std::unique_ptr<dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const common::ScanSpec& scanSpec) override;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1186,6 +1186,9 @@ class ParquetRowReader::Impl {
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
     stats.skippedStrides += skippedStrides_;
     stats.processedStrides += rowGroupIds_.size();
+    stats.columnReaderStatistics.pageScanTime.fetch_add(
+        columnReaderStats_.pageScanTime.load(std::memory_order_relaxed),
+        std::memory_order_relaxed);
   }
 
   void resetFilterCaches() {

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1186,8 +1186,8 @@ class ParquetRowReader::Impl {
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
     stats.skippedStrides += skippedStrides_;
     stats.processedStrides += rowGroupIds_.size();
-    stats.columnReaderStatistics.pageScanTime.fetch_add(
-        columnReaderStats_.pageScanTime.load(std::memory_order_relaxed),
+    stats.columnReaderStatistics.pageLoadTime.fetch_add(
+        columnReaderStats_.pageLoadTime.load(std::memory_order_relaxed),
         std::memory_order_relaxed);
   }
 

--- a/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -31,11 +31,13 @@ TEST_F(ParquetPageReaderTest, smallPage) {
   auto headerSize = file->getLength();
   auto inputStream = std::make_unique<SeekableFileInputStream>(
       std::move(file), 0, headerSize, *leafPool_, LogType::TEST);
+  dwio::common::ColumnReaderStatistics stats;
   auto pageReader = std::make_unique<PageReader>(
       std::move(inputStream),
       *leafPool_,
       common::CompressionKind::CompressionKind_GZIP,
-      headerSize);
+      headerSize,
+      stats);
   auto header = pageReader->readPageHeader();
   EXPECT_EQ(header.type, thrift::PageType::type::DATA_PAGE);
   EXPECT_EQ(header.uncompressed_page_size, 16950);
@@ -59,11 +61,13 @@ TEST_F(ParquetPageReaderTest, largePage) {
   auto headerSize = file->getLength();
   auto inputStream = std::make_unique<SeekableFileInputStream>(
       std::move(file), 0, headerSize, *leafPool_, LogType::TEST);
+  dwio::common::ColumnReaderStatistics stats;
   auto pageReader = std::make_unique<PageReader>(
       std::move(inputStream),
       *leafPool_,
       common::CompressionKind::CompressionKind_GZIP,
-      headerSize);
+      headerSize,
+      stats);
   auto header = pageReader->readPageHeader();
 
   EXPECT_EQ(header.type, thrift::PageType::type::DATA_PAGE);
@@ -92,11 +96,13 @@ TEST_F(ParquetPageReaderTest, corruptedPageHeader) {
   // In the corrupted_page_header, the min_value length is set incorrectly on
   // purpose. This is to simulate the situation where the Parquet Page Header is
   // corrupted. And an error is expected to be thrown.
+  dwio::common::ColumnReaderStatistics stats;
   auto pageReader = std::make_unique<PageReader>(
       std::move(inputStream),
       *leafPool_,
       common::CompressionKind::CompressionKind_GZIP,
-      headerSize);
+      headerSize,
+      stats);
 
   EXPECT_THROW(pageReader->readPageHeader(), VeloxException);
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -124,7 +124,7 @@ int ParquetReaderBenchmark::read(
     std::shared_ptr<ScanSpec> scanSpec,
     uint32_t nextSize) {
   auto rowReader = createReader(scanSpec, rowType);
-  runtimeStats_ = dwio::common::RuntimeStatistics();
+  runtimeStats_.clear();
 
   rowReader->resetFilterCaches();
   auto result = BaseVector::create(rowType, 1, leafPool_.get());

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -81,6 +81,7 @@ class ParquetWriterTest : public ParquetTestBase {
   };
 
   inline static const std::string kHiveConnectorId = "test-hive";
+  dwio::common::ColumnReaderStatistics stats;
 };
 
 class ArrowMemoryPool final : public ::arrow::MemoryPool {
@@ -203,7 +204,8 @@ TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
               std::move(inputStream),
               *leafPool_,
               colChunkPtr.compression(),
-              colChunkPtr.totalCompressedSize());
+              colChunkPtr.totalCompressedSize(),
+              stats);
           return pageReader->readPageHeader();
         }
         constexpr int64_t kFirstDataPageCompressedSize = 1291;
@@ -219,7 +221,8 @@ TEST_F(ParquetWriterTest, dictionaryEncodingWithDictionaryPageSize) {
             std::move(inputStream),
             *leafPool_,
             colChunkPtr.compression(),
-            colChunkPtr.totalCompressedSize());
+            colChunkPtr.totalCompressedSize(),
+            stats);
         return pageReader->readPageHeader();
       };
 
@@ -371,7 +374,8 @@ TEST_F(ParquetWriterTest, dictionaryEncodingOff) {
             std::move(inputStream),
             *leafPool_,
             colChunkPtr.compression(),
-            colChunkPtr.totalCompressedSize());
+            colChunkPtr.totalCompressedSize(),
+            stats);
         return pageReader->readPageHeader();
       };
 
@@ -538,7 +542,8 @@ TEST_F(ParquetWriterTest, testPageSizeAndBatchSizeConfiguration) {
             std::move(inputStream),
             *leafPool_,
             colChunkPtr.compression(),
-            colChunkPtr.totalCompressedSize());
+            colChunkPtr.totalCompressedSize(),
+            stats);
         return pageReader->readPageHeader();
       };
 
@@ -685,7 +690,8 @@ TEST_F(ParquetWriterTest, toggleDataPageVersion) {
             std::move(inputStream),
             *leafPool_,
             colChunkPtr.compression(),
-            colChunkPtr.totalCompressedSize());
+            colChunkPtr.totalCompressedSize(),
+            stats);
 
         return pageReader->readPageHeader().type;
       };


### PR DESCRIPTION
The time spent in page load is useful for the table scan profiling, and this PR 
adds the page load time metric in runtime stats.