### PR TITLE
feat: Avoid use embedded aggregation op to collect column stats in table writers

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -26,6 +26,7 @@ velox_add_library(
   BlockingReason.cpp
   CallbackSink.cpp
   ContainerRowSerde.cpp
+  ColumnStatsCollector.cpp
   DistinctAggregations.cpp
   Driver.cpp
   EnforceSingleRow.cpp

--- a/velox/exec/ColumnStatsCollector.cpp
+++ b/velox/exec/ColumnStatsCollector.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/ColumnStatsCollector.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/exec/AggregateInfo.h"
+#include "velox/exec/VectorHasher.h"
+
+namespace facebook::velox::exec {
+
+ColumnStatsCollector::ColumnStatsCollector(
+    const core::ColumnStatsSpec& statsSpec,
+    const RowTypePtr& inputType,
+    const core::QueryConfig* queryConfig,
+    memory::MemoryPool* pool,
+    tsan_atomic<bool>* nonReclaimableSection)
+    : statsSpec_(statsSpec),
+      inputType_(inputType),
+      queryConfig_(queryConfig),
+      pool_(pool),
+      nonReclaimableSection_(nonReclaimableSection),
+      maxOutputBatchRows_(
+          statsSpec_.groupingKeys.empty() ? 1 : kMaxOutputBatchRows) {
+  VELOX_CHECK_NOT_NULL(inputType_);
+  VELOX_CHECK_NOT_NULL(queryConfig_);
+  VELOX_CHECK_NOT_NULL(pool_);
+  VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
+}
+
+void ColumnStatsCollector::initialize() {
+  if (initialized_) {
+    return;
+  }
+  SCOPE_EXIT {
+    initialized_ = true;
+  };
+  setOutputType();
+  VELOX_CHECK_NOT_NULL(outputType_);
+  createGroupingSet();
+  VELOX_CHECK_NOT_NULL(groupingSet_);
+}
+
+// static
+RowTypePtr ColumnStatsCollector::outputType(
+    const core::ColumnStatsSpec& statsSpec) {
+  // Create output type based on the column stats collection specs.
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  const auto numAggregates = statsSpec.aggregates.size();
+  const auto outputTypeSize = statsSpec.groupingKeys.size() + numAggregates;
+  names.reserve(outputTypeSize);
+  types.reserve(outputTypeSize);
+  for (const auto& key : statsSpec.groupingKeys) {
+    names.push_back(key->name());
+    types.push_back(key->type());
+  }
+  for (auto i = 0; i < numAggregates; ++i) {
+    names.push_back(statsSpec.aggregateNames[i]);
+    types.push_back(statsSpec.aggregates[i].call->type());
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+void ColumnStatsCollector::setOutputType() {
+  VELOX_CHECK_NULL(outputType_);
+  outputType_ = outputType(statsSpec_);
+}
+
+std::pair<std::vector<column_index_t>, std::vector<column_index_t>>
+ColumnStatsCollector::setupGroupingKeyChannelProjections() const {
+  const auto& groupingKeys = statsSpec_.groupingKeys;
+  std::vector<column_index_t> groupingKeyInputChannels;
+  groupingKeyInputChannels.reserve(groupingKeys.size());
+  for (auto i = 0; i < groupingKeys.size(); ++i) {
+    groupingKeyInputChannels.push_back(
+        exprToChannel(groupingKeys[i].get(), inputType_));
+  }
+
+  std::vector<column_index_t> groupingKeyOutputChannels(groupingKeys.size());
+  std::iota(
+      groupingKeyOutputChannels.begin(), groupingKeyOutputChannels.end(), 0);
+  return std::make_pair(groupingKeyInputChannels, groupingKeyOutputChannels);
+}
+
+std::vector<AggregateInfo> ColumnStatsCollector::createAggregates(
+    size_t numGroupingKeys) {
+  VELOX_CHECK_NOT_NULL(outputType_);
+  const auto step = statsSpec_.aggregationStep;
+  const auto numAggregates = statsSpec_.aggregates.size();
+  std::vector<AggregateInfo> aggregateInfos;
+  aggregateInfos.reserve(numAggregates);
+  for (auto i = 0; i < numAggregates; ++i) {
+    const auto& aggregate = statsSpec_.aggregates[i];
+    AggregateInfo info;
+    auto& channels = info.inputs;
+    auto& constants = info.constantInputs;
+    for (const auto& arg : aggregate.call->inputs()) {
+      if (auto field =
+              dynamic_cast<const core::FieldAccessTypedExpr*>(arg.get())) {
+        channels.push_back(inputType_->getChildIdx(field->name()));
+        constants.push_back(nullptr);
+      } else {
+        VELOX_FAIL(
+            "Aggregation expression must be field access for column stats collection: {}",
+            arg->toString());
+      }
+    }
+    VELOX_CHECK(!aggregate.distinct);
+    info.intermediateType = resolveAggregateFunction(
+                                aggregate.call->name(), aggregate.rawInputTypes)
+                                .second;
+    // Column stats collection doesn't support aggregation mask.
+    VELOX_CHECK_NULL(aggregate.mask);
+    info.mask = std::nullopt;
+    const auto outputChannel = numGroupingKeys + i;
+    const auto& aggResultType = outputType_->childAt(outputChannel);
+    info.function = Aggregate::create(
+        aggregate.call->name(),
+        isPartialOutput(step) ? core::AggregationNode::Step::kPartial
+                              : core::AggregationNode::Step::kSingle,
+        aggregate.rawInputTypes,
+        aggResultType,
+        *queryConfig_);
+    VELOX_CHECK(aggregate.sortingKeys.empty());
+    VELOX_CHECK(aggregate.sortingOrders.empty());
+    info.output = outputChannel;
+    aggregateInfos.emplace_back(std::move(info));
+  }
+  return aggregateInfos;
+}
+
+void ColumnStatsCollector::createGroupingSet() {
+  VELOX_CHECK_NULL(groupingSet_);
+
+  auto [groupingKeyInputChannels, groupingKeyOutputChannels] =
+      setupGroupingKeyChannelProjections();
+
+  auto hashers = createVectorHashers(inputType_, groupingKeyInputChannels);
+  const auto numHashers = hashers.size();
+
+  // Setup aggregates based on the column stats specifications
+  auto aggregateInfos = createAggregates(numHashers);
+  // Create the grouping set for aggregation execution.
+  groupingSet_ = std::make_unique<GroupingSet>(
+      inputType_,
+      std::move(hashers),
+      /*preGroupedKeys=*/std::vector<column_index_t>{},
+      std::move(groupingKeyOutputChannels),
+      std::move(aggregateInfos),
+      /*ignoreNullKey=*/false,
+      /*isPartial=*/isPartialOutput(statsSpec_.aggregationStep),
+      /*isRawInput=*/isRawInput(statsSpec_.aggregationStep),
+      /*globalGroupingSets=*/std::vector<vector_size_t>{},
+      /*groupIdChannel=*/std::nullopt,
+      /*spillConfig=*/nullptr,
+      nonReclaimableSection_,
+      queryConfig_,
+      pool_,
+      /*spillStats=*/nullptr);
+}
+
+void ColumnStatsCollector::addInput(RowVectorPtr input) {
+  VELOX_CHECK_NOT_NULL(input);
+  VELOX_CHECK(initialized_);
+
+  if (input->size() == 0) {
+    return;
+  }
+
+  // Add input to the grouping set
+  groupingSet_->addInput(input, /*mayPushdown=*/false);
+}
+
+void ColumnStatsCollector::noMoreInput() {
+  if (!noMoreInput_) {
+    noMoreInput_ = true;
+    if (groupingSet_) {
+      groupingSet_->noMoreInput();
+    }
+  }
+}
+
+void ColumnStatsCollector::prepareOutput() {
+  if (output_) {
+    VectorPtr output = std::move(output_);
+    BaseVector::prepareForReuse(output, maxOutputBatchRows_);
+    output_ = std::static_pointer_cast<RowVector>(output);
+  } else {
+    output_ = std::static_pointer_cast<RowVector>(
+        BaseVector::create(outputType_, maxOutputBatchRows_, pool_));
+  }
+}
+
+RowVectorPtr ColumnStatsCollector::getOutput() {
+  VELOX_CHECK(initialized_);
+
+  if (!groupingSet_ || !noMoreInput_ || finished_) {
+    return nullptr;
+  }
+
+  prepareOutput();
+  const bool hasMoreOutput = groupingSet_->getOutput(
+      maxOutputBatchRows_, kMaxOutputBatchBytes, outputIterator_, output_);
+  if (!hasMoreOutput) {
+    finished_ = true;
+    return nullptr;
+  }
+  return output_;
+}
+
+bool ColumnStatsCollector::finished() const {
+  return finished_;
+}
+
+void ColumnStatsCollector::close() {
+  if (groupingSet_) {
+    groupingSet_.reset();
+  }
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/ColumnStatsCollector.h
+++ b/velox/exec/ColumnStatsCollector.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/GroupingSet.h"
+
+namespace facebook::velox::exec {
+
+/// ColumnStatsCollector collects column statistics during table write
+/// operations by leveraging the GroupingSet aggregation framework. It supports
+/// both partitioned and unpartitioned tables, computing aggregated statistics
+/// such as min, max, count, etc. for specified columns.
+///
+/// Usage pattern:
+/// 1. Create instance with ColumnStatsSpec defining desired statistics
+/// 2. Call initialize() once before processing any input
+/// 3. Call addInput() repeatedly with data batches
+/// 4. Call noMoreInput() when all input has been provided
+/// 5. Call getOutput() until finished() returns true to retrieve all results
+/// 6. Call close() to cleanup resources
+class ColumnStatsCollector {
+ public:
+  /// Constructs a ColumnStatsCollector for collecting statistics during table
+  /// writes.
+  /// @param statsSpec Specification defining grouping keys, aggregation step,
+  /// and aggregation functions to compute
+  /// @param inputType Schema of the input data that will be processed
+  /// @param queryConfig Query configuration settings
+  /// @param pool Memory pool for allocations
+  /// @param nonReclaimableSection Atomic flag indicating non-reclaimable memory
+  /// section
+  ColumnStatsCollector(
+      const core::ColumnStatsSpec& statsSpec,
+      const RowTypePtr& inputType,
+      const core::QueryConfig* queryConfig,
+      memory::MemoryPool* pool,
+      tsan_atomic<bool>* nonReclaimableSection);
+
+  /// Returns the output row type that will be produced by this collector.
+  /// The output type is determined by the grouping keys and aggregate functions
+  /// specified in the ColumnStatsSpec.
+  static RowTypePtr outputType(const core::ColumnStatsSpec& statsSpec);
+
+  /// Initializes the stats collector. Must be called exactly once before
+  /// adding any input data. Sets up internal aggregation structures based
+  /// on the provided ColumnStatsSpec.
+  void initialize();
+
+  /// Adds a batch of input data for statistics collection. Can be called
+  /// multiple times with different batches until all input data has been
+  /// processed.
+  /// @param input Batch of input data to process for statistics collection
+  void addInput(RowVectorPtr input);
+
+  /// Signals that no more input data will be provided. Must be called after
+  /// all addInput() calls to finalize the aggregation computation.
+  void noMoreInput();
+
+  /// Retrieves the computed column statistics. For partitioned tables, results
+  /// are returned one partition at a time, so this method may need to be called
+  /// multiple times until finished() returns true.
+  RowVectorPtr getOutput();
+
+  /// Checks whether all computed statistics have been returned. For partitioned
+  /// tables, there is one output row per partition, so multiple getOutput()
+  /// calls may be required. Returns true when all statistics have been
+  /// retrieved.
+  bool finished() const;
+
+  /// Cleans up and releases all resources used by the stats collector.
+  /// Should be called after all statistics have been retrieved and the
+  /// collector is no longer needed.
+  void close();
+
+ private:
+  void setOutputType();
+
+  // Creates the grouping key channel projections for the column stats
+  // collection for partitioned table write with one group per each table
+  // partition.
+  std::pair<std::vector<column_index_t>, std::vector<column_index_t>>
+  setupGroupingKeyChannelProjections() const;
+
+  void createGroupingSet();
+
+  std::vector<AggregateInfo> createAggregates(size_t numGroupingKeys);
+
+  void prepareOutput();
+
+  static const int kMaxOutputBatchRows = 512;
+  static const int kMaxOutputBatchBytes = 128 << 20;
+
+  const core::ColumnStatsSpec statsSpec_;
+  const RowTypePtr inputType_;
+  const core::QueryConfig* const queryConfig_;
+  memory::MemoryPool* const pool_;
+  tsan_atomic<bool>* const nonReclaimableSection_;
+  const vector_size_t maxOutputBatchRows_;
+
+  bool initialized_{false};
+  bool noMoreInput_{false};
+  bool finished_{false};
+
+  std::unique_ptr<GroupingSet> groupingSet_;
+  RowTypePtr outputType_;
+  RowVectorPtr output_;
+  RowContainerIterator outputIterator_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/TableWriteMerge.h
+++ b/velox/exec/TableWriteMerge.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanNode.h"
+#include "velox/exec/ColumnStatsCollector.h"
 #include "velox/exec/Operator.h"
 
 namespace facebook::velox::exec {
@@ -51,6 +52,8 @@ class TableWriteMerge : public Operator {
     return finished_;
   }
 
+  void close() override;
+
  private:
   // Creates non-last output with fragments and last commit context only.
   RowVectorPtr createFragmentsOutput();
@@ -65,7 +68,7 @@ class TableWriteMerge : public Operator {
   // Check if the input is statistics input.
   bool isStatistics(RowVectorPtr input);
 
-  std::unique_ptr<Operator> aggregation_;
+  std::unique_ptr<ColumnStatsCollector> statsCollector_;
   bool finished_{false};
   // The sum of written rows.
   int64_t numRows_{0};

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanNode.h"
+#include "velox/exec/ColumnStatsCollector.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Operator.h"
 
@@ -75,8 +76,8 @@ class TableWriteTraits {
       "pageSinkCommitStrategy";
   static constexpr std::string_view klastPageContextKey = "lastPage";
 
-  static const RowTypePtr outputType(
-      const core::AggregationNodePtr& aggregationNode = nullptr);
+  static RowTypePtr outputType(
+      const std::optional<core::ColumnStatsSpec>& columnStatsSpec);
 
   /// Returns the parsed commit context from table writer 'output'.
   static folly::dynamic getTableCommitContext(const RowVectorPtr& output);
@@ -236,7 +237,7 @@ class TableWriter : public Operator {
   // slow scaled writer scheduling in Prestissimo.
   const uint64_t createTimeUs_{0};
 
-  std::unique_ptr<Operator> aggregation_;
+  std::unique_ptr<ColumnStatsCollector> statsCollector_;
   std::shared_ptr<connector::Connector> connector_;
   std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;
   std::unique_ptr<connector::DataSink> dataSink_;

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -420,10 +420,10 @@ core::PlanNodePtr getTraceNode(
         nodeId,
         tableWriteNode->columns(),
         tableWriteNode->columnNames(),
-        tableWriteNode->aggregationNode(),
+        tableWriteNode->columnStatsSpec(),
         tableWriteNode->insertTableHandle(),
         tableWriteNode->hasPartitioningScheme(),
-        TableWriteTraits::outputType(tableWriteNode->aggregationNode()),
+        TableWriteTraits::outputType(tableWriteNode->columnStatsSpec()),
         tableWriteNode->commitStrategy(),
         std::make_shared<DummySourceNode>(
             tableWriteNode->sources().front()->outputType()));

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(
   AsyncConnectorTest.cpp
   ConcatFilesSpillMergeStreamTest.cpp
   ContainerRowSerdeTest.cpp
+  ColumnStatsCollectorTest.cpp
   CustomJoinTest.cpp
   EnforceSingleRowTest.cpp
   ExchangeClientTest.cpp

--- a/velox/exec/tests/ColumnStatsCollectorTest.cpp
+++ b/velox/exec/tests/ColumnStatsCollectorTest.cpp
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/PlanNode.h"
+#include "velox/duckdb/conversion/DuckParser.h"
+#include "velox/exec/ColumnStatsCollector.h"
+#include "velox/exec/tests/utils/AggregationResolver.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/TypeResolver.h"
+
+namespace facebook::velox::exec::test {
+
+class ColumnStatsCollectorTest : public OperatorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+  }
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+  }
+
+  core::ColumnStatsSpec createStatsSpec(
+      const RowTypePtr& type,
+      const std::vector<std::string>& groupingKeys,
+      core::AggregationNode::Step step,
+      const std::vector<std::string>& aggregates) {
+    VELOX_CHECK(
+        step == core::AggregationNode::Step::kPartial ||
+            step == core::AggregationNode::Step::kSingle,
+        "Unsupported aggregation step: {}",
+        core::AggregationNode::toName(step));
+
+    std::vector<core::AggregationNode::Aggregate> aggs;
+    aggs.reserve(aggregates.size());
+    std::vector<std::string> names;
+    names.reserve(aggregates.size());
+
+    duckdb::ParseOptions options;
+    options.parseIntegerAsBigint = true;
+    AggregateTypeResolver resolver(step);
+
+    for (auto i = 0; i < aggregates.size(); ++i) {
+      const auto& aggregate = aggregates[i];
+      const auto untypedExpr = duckdb::parseAggregateExpr(aggregate, options);
+
+      core::AggregationNode::Aggregate agg;
+      agg.call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
+          core::Expressions::inferTypes(untypedExpr.expr, type, pool()));
+
+      for (const auto& input : agg.call->inputs()) {
+        agg.rawInputTypes.push_back(input->type());
+      }
+
+      VELOX_CHECK_NULL(untypedExpr.maskExpr);
+      VELOX_CHECK(!untypedExpr.distinct);
+      VELOX_CHECK(untypedExpr.orderBy.empty());
+
+      aggs.emplace_back(agg);
+
+      if (untypedExpr.expr->alias().has_value()) {
+        names.push_back(untypedExpr.expr->alias().value());
+      } else {
+        names.push_back(fmt::format("a{}", i));
+      }
+    }
+    VELOX_CHECK_EQ(aggs.size(), names.size());
+
+    std::vector<core::FieldAccessTypedExprPtr> groupingKeyExprs;
+    groupingKeyExprs.reserve(groupingKeys.size());
+    for (const auto& groupingKey : groupingKeys) {
+      auto untypedGroupingKeyExpr = duckdb::parseExpr(groupingKey, options);
+      auto groupingKeyExpr =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+              core::Expressions::inferTypes(
+                  untypedGroupingKeyExpr, type, pool()));
+      VELOX_CHECK_NOT_NULL(
+          groupingKeyExpr,
+          "Grouping key must use a column name, not an expression: {}",
+          groupingKey);
+      groupingKeyExprs.emplace_back(std::move(groupingKeyExpr));
+    }
+
+    return core::ColumnStatsSpec(
+        std::move(groupingKeyExprs), step, std::move(names), std::move(aggs));
+  }
+
+  // Helper to create test data
+  std::vector<RowVectorPtr> createTestData(
+      const RowTypePtr& rowType,
+      size_t numBatches,
+      size_t batchSize,
+      bool withNulls = false) {
+    VectorFuzzer fuzzer(
+        {.vectorSize = batchSize, .nullRatio = withNulls ? 0.2 : 0.0}, pool());
+    std::vector<RowVectorPtr> batches;
+    batches.reserve(numBatches);
+    for (int i = 0; i < numBatches; ++i) {
+      batches.push_back(fuzzer.fuzzInputRow(rowType));
+    }
+    return batches;
+  }
+
+  std::unique_ptr<ColumnStatsCollector> createStatsCollector(
+      const core::ColumnStatsSpec& statsSpec,
+      const RowTypePtr& inputType) {
+    return std::make_unique<ColumnStatsCollector>(
+        statsSpec, inputType, &queryConfig_, pool(), &nonReclaimableSection_);
+  }
+
+  void verifyResult(
+      const std::vector<RowVectorPtr>& inputBatches,
+      const std::vector<std::string>& groupingKeys,
+      core::AggregationNode::Step step,
+      const std::vector<std::string>& aggregates,
+      const std::vector<RowVectorPtr>& resultBatches) {
+    core::PlanNodePtr plan;
+    if (step == core::AggregationNode::Step::kSingle) {
+      plan = PlanBuilder()
+                 .values(inputBatches)
+                 .singleAggregation(groupingKeys, aggregates)
+                 .planNode();
+    } else {
+      plan = PlanBuilder()
+                 .values(inputBatches)
+                 .partialAggregation(groupingKeys, aggregates)
+                 .planNode();
+    }
+
+    const auto expectedResult = AssertQueryBuilder(plan).copyResults(pool());
+    assertEqualResults(resultBatches, {expectedResult});
+  }
+
+  core::QueryConfig queryConfig_{{}};
+  tsan_atomic<bool> nonReclaimableSection_{false};
+};
+
+TEST_F(ColumnStatsCollectorTest, basic) {
+  const auto inputType =
+      ROW({"c0", "c1", "c2"}, {INTEGER(), DOUBLE(), INTEGER()});
+
+  struct {
+    std::vector<std::string> groupingKeys;
+    std::vector<std::string> aggregates;
+    core::AggregationNode::Step step;
+    bool hasNulls;
+
+    std::string debugString() const {
+      return fmt::format(
+          "groupingKeys: {}, aggregates: {}, {}, hasNulls: {}",
+          folly::join(",", groupingKeys),
+          folly::join(",", aggregates),
+          core::AggregationNode::toName(step),
+          hasNulls);
+    }
+  } testCases[] = {
+      {std::vector<std::string>{},
+       std::vector<std::string>{"sum(c0)", "count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kSingle,
+       false},
+      {std::vector<std::string>{"c0"},
+       std::vector<std::string>{"count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kSingle,
+       false},
+      {std::vector<std::string>{},
+       std::vector<std::string>{"sum(c0)", "count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kPartial,
+       false},
+      {std::vector<std::string>{"c0"},
+       std::vector<std::string>{"count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kPartial,
+       false},
+      {std::vector<std::string>{},
+       std::vector<std::string>{"sum(c0)", "count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kSingle,
+       true},
+      {std::vector<std::string>{"c0"},
+       std::vector<std::string>{"count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kSingle,
+       true},
+      {std::vector<std::string>{},
+       std::vector<std::string>{"sum(c0)", "count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kPartial,
+       true},
+      {std::vector<std::string>{"c0"},
+       std::vector<std::string>{"count(c1)", "sum(c2)"},
+       core::AggregationNode::Step::kPartial,
+       true},
+      // Multiple grouping keys.
+      {std::vector<std::string>{"c0", "c1"},
+       std::vector<std::string>{"sum(c2)"},
+       core::AggregationNode::Step::kSingle,
+       false},
+      {std::vector<std::string>{"c0", "c1"},
+       std::vector<std::string>{"sum(c2)"},
+       core::AggregationNode::Step::kPartial,
+       false},
+      {std::vector<std::string>{"c0", "c1"},
+       std::vector<std::string>{"sum(c2)"},
+       core::AggregationNode::Step::kSingle,
+       true},
+      {std::vector<std::string>{"c0", "c1"},
+       std::vector<std::string>{"sum(c2)"},
+       core::AggregationNode::Step::kPartial,
+       true}};
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    // Create stats spec for count and sum
+    auto statsSpec = createStatsSpec(
+        inputType, testCase.groupingKeys, testCase.step, testCase.aggregates);
+
+    // Create collector.
+    auto collector = createStatsCollector(statsSpec, inputType);
+
+    // Create test data.
+    auto inputBatches = createTestData(inputType, 10, 100, testCase.hasNulls);
+    VELOX_ASSERT_THROW(collector->addInput(inputBatches[0]), "");
+
+    // Initialize.
+    collector->initialize();
+
+    // Add input.
+    for (const auto& input : inputBatches) {
+      collector->addInput(input);
+      ASSERT_EQ(collector->getOutput(), nullptr);
+    }
+    ASSERT_FALSE(collector->finished());
+    collector->noMoreInput();
+    ASSERT_FALSE(collector->finished());
+
+    // Get output
+    std::vector<RowVectorPtr> outputBatches;
+    for (;;) {
+      auto output = collector->getOutput();
+      if (output != nullptr) {
+        // Single output row without grouping keys.
+        if (testCase.groupingKeys.empty()) {
+          ASSERT_EQ(output->size(), 1);
+        }
+        ASSERT_EQ(
+            output->childrenSize(),
+            testCase.aggregates.size() + testCase.groupingKeys.size());
+        // Verify column names (using asRowType to access field names)
+        auto rowType = std::dynamic_pointer_cast<const RowType>(output->type());
+        ASSERT_NE(rowType, nullptr);
+        auto outputChannel = testCase.groupingKeys.size();
+        const int numAggregates = testCase.aggregates.size();
+        for (int i = 0; i < numAggregates; ++i) {
+          EXPECT_EQ(
+              rowType->nameOf(outputChannel++), statsSpec.aggregateNames[i]);
+        }
+        outputBatches.push_back(output);
+        EXPECT_FALSE(collector->finished());
+      } else {
+        break;
+      }
+    }
+    // Verify finished.
+    EXPECT_TRUE(collector->finished());
+
+    verifyResult(
+        inputBatches,
+        testCase.groupingKeys,
+        testCase.step,
+        testCase.aggregates,
+        outputBatches);
+  }
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/exec/PartitionFunction.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -708,25 +709,19 @@ TEST_F(PlanNodeSerdeTest, tableWriteMerge) {
 
   plan = PlanBuilder(pool_.get())
              .values(data_)
-             .tableWrite("targetDirectory")
+             .tableWrite(
+                 "targetDirectory", dwio::common::FileFormat::DWRF, {"min(c0)"})
              .localPartition(std::vector<std::string>{})
              .tableWriteMerge()
              .planNode();
   testSerde(plan);
 
-  const auto aggregationNode =
-      std::dynamic_pointer_cast<const core::AggregationNode>(
-          PlanBuilder(pool_.get())
-              .values({data_})
-              .partialAggregation({"c0"}, {"count(ARRAY[1,2])"})
-              .finalAggregation()
-              .planNode());
-
   plan = PlanBuilder(pool_.get())
              .values(data_)
-             .tableWrite("targetDirectory")
+             .tableWrite(
+                 "targetDirectory", dwio::common::FileFormat::DWRF, {"min(c0)"})
              .localPartition(std::vector<std::string>{})
-             .tableWriteMerge(aggregationNode)
+             .tableWriteMerge()
              .planNode();
   testSerde(plan);
 }
@@ -745,8 +740,233 @@ TEST_F(PlanNodeSerdeTest, tableWriteWithStats) {
                        "approx_distinct(c2)",
                        "sum_data_size_for_stats(c2)",
                        "max_data_size_for_stats(c2)"})
+                  .localPartition(std::vector<std::string>{})
+                  .tableWriteMerge()
                   .planNode();
   testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, columnStatsSpec) {
+  // Helper function to create typed expressions
+  const auto createFieldAccess = [&](const std::string& name,
+                                     const TypePtr& type) {
+    return std::make_shared<core::FieldAccessTypedExpr>(type, name);
+  };
+
+  const auto createCallExpr = [&](const std::string& name,
+                                  const TypePtr& returnType,
+                                  const std::vector<core::TypedExprPtr>& args) {
+    return std::make_shared<core::CallTypedExpr>(returnType, args, name);
+  };
+
+  // Test 1: Empty ColumnStatsSpec
+  {
+    VELOX_ASSERT_THROW(
+        std::make_unique<core::ColumnStatsSpec>(
+            std::vector<core::FieldAccessTypedExprPtr>{},
+            core::AggregationNode::Step::kSingle,
+            std::vector<std::string>{},
+            std::vector<core::AggregationNode::Aggregate>{}),
+        "");
+  }
+
+  // Test 2: ColumnStatsSpec with only aggregates (no grouping keys)
+  {
+    std::vector<core::FieldAccessTypedExprPtr> groupingKeys;
+    std::vector<std::string> aggregateNames = {"min", "max", "count"};
+    std::vector<core::AggregationNode::Aggregate> aggregates;
+
+    // Create min(c0) aggregate
+    auto minInput = createFieldAccess("c0", BIGINT());
+    auto minCall = createCallExpr("min", BIGINT(), {minInput});
+    aggregates.push_back({minCall, {BIGINT()}, nullptr, {}, {}, false});
+
+    // Create max(c0) aggregate
+    auto maxInput = createFieldAccess("c0", BIGINT());
+    auto maxCall = createCallExpr("max", BIGINT(), {maxInput});
+    aggregates.push_back({maxCall, {BIGINT()}, nullptr, {}, {}, false});
+
+    // Create count(c1) aggregate
+    auto countInput = createFieldAccess("c1", INTEGER());
+    auto countCall = createCallExpr("count", BIGINT(), {countInput});
+    aggregates.push_back({countCall, {INTEGER()}, nullptr, {}, {}, false});
+
+    core::ColumnStatsSpec spec(
+        std::move(groupingKeys),
+        core::AggregationNode::Step::kPartial,
+        std::move(aggregateNames),
+        std::move(aggregates));
+
+    auto serialized = spec.serialize();
+    auto deserialized = core::ColumnStatsSpec::create(serialized, pool());
+
+    EXPECT_TRUE(deserialized.groupingKeys.empty());
+    EXPECT_EQ(deserialized.aggregateNames.size(), 3);
+    EXPECT_EQ(deserialized.aggregates.size(), 3);
+    EXPECT_EQ(
+        deserialized.aggregationStep, core::AggregationNode::Step::kPartial);
+    EXPECT_EQ(deserialized.aggregateNames.size(), 3);
+
+    EXPECT_EQ(deserialized.aggregateNames[0], "min");
+    EXPECT_EQ(deserialized.aggregateNames[1], "max");
+    EXPECT_EQ(deserialized.aggregateNames[2], "count");
+    EXPECT_EQ(deserialized.aggregates[0].call->name(), "min");
+    EXPECT_EQ(deserialized.aggregates[1].call->name(), "max");
+    EXPECT_EQ(deserialized.aggregates[2].call->name(), "count");
+  }
+
+  // Test 3: ColumnStatsSpec with grouping keys and aggregates
+  {
+    std::vector<core::FieldAccessTypedExprPtr> groupingKeys;
+    groupingKeys.push_back(createFieldAccess("partition_key", VARCHAR()));
+    groupingKeys.push_back(createFieldAccess("bucket_id", INTEGER()));
+
+    std::vector<std::string> aggregateNames = {"min", "sum"};
+    std::vector<core::AggregationNode::Aggregate> aggregates;
+
+    // Create min(c0) aggregate
+    auto minInput = createFieldAccess("c0", BIGINT());
+    auto minCall = createCallExpr("min", BIGINT(), {minInput});
+    aggregates.push_back({minCall, {BIGINT()}, nullptr, {}, {}, false});
+
+    // Create sum(c1) aggregate
+    auto sumInput = createFieldAccess("c1", DOUBLE());
+    auto sumCall = createCallExpr("sum", DOUBLE(), {sumInput});
+    aggregates.push_back({sumCall, {DOUBLE()}, nullptr, {}, {}, false});
+
+    core::ColumnStatsSpec spec(
+        std::move(groupingKeys),
+        core::AggregationNode::Step::kIntermediate,
+        std::move(aggregateNames),
+        std::move(aggregates));
+
+    auto serialized = spec.serialize();
+    auto deserialized = core::ColumnStatsSpec::create(serialized, pool());
+
+    EXPECT_EQ(deserialized.groupingKeys.size(), 2);
+    EXPECT_EQ(deserialized.aggregateNames.size(), 2);
+    EXPECT_EQ(deserialized.aggregates.size(), 2);
+    EXPECT_EQ(
+        deserialized.aggregationStep,
+        core::AggregationNode::Step::kIntermediate);
+    EXPECT_EQ(deserialized.aggregateNames.size(), 2);
+
+    EXPECT_EQ(deserialized.groupingKeys[0]->name(), "partition_key");
+    EXPECT_EQ(deserialized.groupingKeys[0]->type(), VARCHAR());
+    EXPECT_EQ(deserialized.groupingKeys[1]->name(), "bucket_id");
+    EXPECT_EQ(deserialized.groupingKeys[1]->type(), INTEGER());
+
+    EXPECT_EQ(deserialized.aggregateNames[0], "min");
+    EXPECT_EQ(deserialized.aggregateNames[1], "sum");
+    EXPECT_EQ(deserialized.aggregates[0].call->name(), "min");
+    EXPECT_EQ(deserialized.aggregates[1].call->name(), "sum");
+  }
+
+  // Test 4: ColumnStatsSpec with different aggregation steps
+  for (auto step :
+       {core::AggregationNode::Step::kSingle,
+        core::AggregationNode::Step::kPartial,
+        core::AggregationNode::Step::kIntermediate,
+        core::AggregationNode::Step::kFinal}) {
+    std::vector<core::FieldAccessTypedExprPtr> groupingKeys;
+    std::vector<std::string> aggregateNames = {"count"};
+    std::vector<core::AggregationNode::Aggregate> aggregates;
+
+    auto countInput = createFieldAccess("test_col", BIGINT());
+    auto countCall = createCallExpr("count", BIGINT(), {countInput});
+    aggregates.push_back({countCall, {BIGINT()}, nullptr, {}, {}, false});
+
+    core::ColumnStatsSpec spec(
+        std::move(groupingKeys),
+        step,
+        std::move(aggregateNames),
+        std::move(aggregates));
+
+    auto serialized = spec.serialize();
+    auto deserialized = core::ColumnStatsSpec::create(serialized, pool());
+
+    EXPECT_EQ(deserialized.aggregationStep, step);
+    EXPECT_EQ(deserialized.aggregateNames.size(), 1);
+    EXPECT_EQ(deserialized.aggregateNames[0], "count");
+  }
+
+  // Test 5: ColumnStatsSpec with complex aggregates (distinct, with mask, with
+  // sorting)
+  {
+    std::vector<core::FieldAccessTypedExprPtr> groupingKeys;
+    std::vector<std::string> aggregateNames = {
+        "count_distinct", "array_agg_sorted"};
+    std::vector<core::AggregationNode::Aggregate> aggregates;
+
+    // Create count(distinct c0) aggregate
+    auto distinctInput = createFieldAccess("c0", VARCHAR());
+    auto countDistinctCall = createCallExpr("count", BIGINT(), {distinctInput});
+    auto maskField = createFieldAccess("mask_col", BOOLEAN());
+    aggregates.push_back(
+        {countDistinctCall, {VARCHAR()}, maskField, {}, {}, true});
+
+    // Create array_agg(c1 ORDER BY c2) aggregate
+    auto arrayInput = createFieldAccess("c1", INTEGER());
+    auto arrayAggCall =
+        createCallExpr("array_agg", ARRAY(INTEGER()), {arrayInput});
+    auto sortingKey = createFieldAccess("c2", BIGINT());
+    std::vector<core::FieldAccessTypedExprPtr> sortingKeys = {sortingKey};
+    std::vector<core::SortOrder> sortingOrders = {core::SortOrder(true, true)};
+    aggregates.push_back(
+        {arrayAggCall,
+         {INTEGER()},
+         nullptr,
+         sortingKeys,
+         sortingOrders,
+         false});
+
+    core::ColumnStatsSpec spec(
+        std::move(groupingKeys),
+        core::AggregationNode::Step::kSingle,
+        std::move(aggregateNames),
+        std::move(aggregates));
+
+    auto serialized = spec.serialize();
+    auto deserialized = core::ColumnStatsSpec::create(serialized, pool());
+
+    EXPECT_EQ(deserialized.aggregates.size(), 2);
+
+    // Check distinct aggregate
+    EXPECT_TRUE(deserialized.aggregates[0].distinct);
+    EXPECT_NE(deserialized.aggregates[0].mask, nullptr);
+    EXPECT_EQ(deserialized.aggregates[0].mask->name(), "mask_col");
+
+    // Check sorted aggregate
+    EXPECT_FALSE(deserialized.aggregates[1].distinct);
+    EXPECT_EQ(deserialized.aggregates[1].mask, nullptr);
+    EXPECT_EQ(deserialized.aggregates[1].sortingKeys.size(), 1);
+    EXPECT_EQ(deserialized.aggregates[1].sortingKeys[0]->name(), "c2");
+    EXPECT_EQ(deserialized.aggregates[1].sortingOrders.size(), 1);
+    EXPECT_TRUE(deserialized.aggregates[1].sortingOrders[0].isAscending());
+    EXPECT_TRUE(deserialized.aggregates[1].sortingOrders[0].isNullsFirst());
+  }
+
+  // Error cases.
+  {
+    std::vector<core::FieldAccessTypedExprPtr> groupingKeys;
+    groupingKeys.push_back(createFieldAccess("partition_key", VARCHAR()));
+    groupingKeys.push_back(createFieldAccess("bucket_id", INTEGER()));
+
+    std::vector<std::string> aggregateNames = {"min", "sum"};
+    std::vector<core::AggregationNode::Aggregate> aggregates;
+
+    // Create min(c0) aggregate
+    auto minInput = createFieldAccess("c0", BIGINT());
+    auto minCall = createCallExpr("min", BIGINT(), {minInput});
+    aggregates.push_back({minCall, {BIGINT()}, nullptr, {}, {}, false});
+    VELOX_ASSERT_THROW(
+        core::ColumnStatsSpec(
+            std::move(groupingKeys),
+            core::AggregationNode::Step::kSingle,
+            std::move(aggregateNames),
+            std::move(aggregates)),
+        "");
+  }
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/AggregationResolver.cpp
+++ b/velox/exec/tests/utils/AggregationResolver.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/AggregationResolver.h"
+
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionCallToSpecialForm.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+std::string throwAggregateFunctionDoesntExist(const std::string& name) {
+  std::stringstream error;
+  error << "Aggregate function doesn't exist: " << name << ".";
+  exec::aggregateFunctions().withRLock([&](const auto& functionsMap) {
+    if (functionsMap.empty()) {
+      error << " Registry of aggregate functions is empty. "
+               "Make sure to register some aggregate functions.";
+    }
+  });
+  VELOX_USER_FAIL(error.str());
+}
+
+std::string throwAggregateFunctionSignatureNotSupported(
+    const std::string& name,
+    const std::vector<TypePtr>& types,
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>&
+        signatures) {
+  std::stringstream error;
+  error << "Aggregate function signature is not supported: "
+        << toString(name, types)
+        << ". Supported signatures: " << toString(signatures) << ".";
+  VELOX_USER_FAIL(error.str());
+}
+} // namespace
+
+TypePtr resolveAggregateType(
+    const std::string& aggregateName,
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& rawInputTypes,
+    bool nullOnFailure) {
+  if (auto signatures = exec::getAggregateFunctionSignatures(aggregateName)) {
+    for (const auto& signature : signatures.value()) {
+      exec::SignatureBinder binder(*signature, rawInputTypes);
+      if (binder.tryBind()) {
+        return binder.tryResolveType(
+            exec::isPartialOutput(step) ? signature->intermediateType()
+                                        : signature->returnType());
+      }
+    }
+
+    if (nullOnFailure) {
+      return nullptr;
+    }
+
+    throwAggregateFunctionSignatureNotSupported(
+        aggregateName, rawInputTypes, signatures.value());
+  }
+
+  // We may be parsing lambda expression used in a lambda aggregate function. In
+  // this case, 'aggregateName' would refer to a scalar function.
+  //
+  // TODO Enhance the parser to allow for specifying separate resolver for
+  // lambda expressions.
+  if (auto type =
+          exec::resolveTypeForSpecialForm(aggregateName, rawInputTypes)) {
+    return type;
+  }
+
+  if (auto type = parse::resolveScalarFunctionType(
+          aggregateName, rawInputTypes, true)) {
+    return type;
+  }
+
+  if (nullOnFailure) {
+    return nullptr;
+  }
+
+  throwAggregateFunctionDoesntExist(aggregateName);
+  return nullptr;
+}
+
+AggregateTypeResolver::AggregateTypeResolver(core::AggregationNode::Step step)
+    : step_(step), previousHook_(core::Expressions::getResolverHook()) {
+  core::Expressions::setTypeResolverHook(
+      [&](const auto& inputs, const auto& expr, bool nullOnFailure) {
+        return resolveType(inputs, expr, nullOnFailure);
+      });
+}
+
+AggregateTypeResolver::~AggregateTypeResolver() {
+  core::Expressions::setTypeResolverHook(previousHook_);
+}
+
+TypePtr AggregateTypeResolver::resolveType(
+    const std::vector<core::TypedExprPtr>& inputs,
+    const std::shared_ptr<const core::CallExpr>& expr,
+    bool nullOnFailure) const {
+  auto functionName = expr->name();
+
+  // Use raw input types (if available) to resolve intermediate and final
+  // result types.
+  if (exec::isRawInput(step_)) {
+    std::vector<TypePtr> types;
+    for (auto& input : inputs) {
+      types.push_back(input->type());
+    }
+
+    return resolveAggregateType(functionName, step_, types, nullOnFailure);
+  }
+
+  if (!rawInputTypes_.empty()) {
+    return resolveAggregateType(
+        functionName, step_, rawInputTypes_, nullOnFailure);
+  }
+
+  if (!nullOnFailure) {
+    VELOX_USER_FAIL(
+        "Cannot resolve aggregation function return type without raw input types: {}",
+        functionName);
+  }
+  return nullptr;
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/AggregationResolver.h
+++ b/velox/exec/tests/utils/AggregationResolver.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/ITypedExpr.h"
+#include "velox/core/PlanNode.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/TypeResolver.h"
+
+namespace facebook::velox::exec::test {
+class AggregateTypeResolver {
+ public:
+  explicit AggregateTypeResolver(core::AggregationNode::Step step);
+
+  ~AggregateTypeResolver();
+
+  void setRawInputTypes(const std::vector<TypePtr>& types) {
+    rawInputTypes_ = types;
+  }
+
+ private:
+  TypePtr resolveType(
+      const std::vector<core::TypedExprPtr>& inputs,
+      const std::shared_ptr<const core::CallExpr>& expr,
+      bool nullOnFailure) const;
+
+  const core::AggregationNode::Step step_;
+  const core::Expressions::TypeResolverHook previousHook_;
+  std::vector<TypePtr> rawInputTypes_;
+};
+
+/// Resolves the output type for an aggregate function given its name,
+/// aggregation step, and input types.
+///
+/// The resolution process follows these steps:
+/// 1. Looks up registered aggregate function signatures by name
+/// 2. Attempts to bind the provided raw input types to available signatures
+/// 3. Returns the appropriate output type based on the aggregation step:
+///    - For partial steps (kPartial, kIntermediate): returns intermediate type
+///    - For final steps (kSingle, kFinal): returns the final result type
+/// 4. Falls back to scalar function or special form resolution if aggregate
+///    function lookup fails (useful for lambda expressions in aggregates)
+///
+/// @param aggregateName The name of the aggregate function (e.g., "sum",
+/// "count", "avg")
+/// @param step The aggregation step indicating the stage in multi-phase
+/// aggregation
+/// @param rawInputTypes The types of the raw input arguments to the aggregate
+/// function
+/// @param nullOnFailure If true, returns nullptr when type resolution fails;
+///                      if false, throws an exception on failure
+/// @return The resolved output type for the aggregate function, or nullptr if
+///         nullOnFailure is true and resolution fails
+/// @throws VeloxUserError if type resolution fails and nullOnFailure is false
+TypePtr resolveAggregateType(
+    const std::string& aggregateName,
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& rawInputTypes,
+    bool nullOnFailure);
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(velox_temp_path velox_exception)
 
 add_library(
   velox_exec_test_lib
+  AggregationResolver.cpp
   AssertQueryBuilder.cpp
   ArbitratorTestUtil.cpp
   HiveConnectorTestBase.cpp

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -761,8 +761,7 @@ class PlanBuilder {
           connector::CommitStrategy::kNoCommit);
 
   /// Add a TableWriteMergeNode.
-  PlanBuilder& tableWriteMerge(
-      const core::AggregationNodePtr& aggregationNode = nullptr);
+  PlanBuilder& tableWriteMerge();
 
   /// Add an AggregationNode representing partial aggregation with the
   /// specified grouping keys, aggregates and optional masks.

--- a/velox/exec/tests/utils/TableWriterTestBase.h
+++ b/velox/exec/tests/utils/TableWriterTestBase.h
@@ -105,7 +105,7 @@ class TableWriterTestBase : public HiveConnectorTestBase {
   static std::function<PlanNodePtr(std::string, PlanNodePtr)> addTableWriter(
       const RowTypePtr& inputColumns,
       const std::vector<std::string>& tableColumnNames,
-      const std::shared_ptr<core::AggregationNode>& aggregationNode,
+      const std::optional<core::ColumnStatsSpec>& columnStatsSpec,
       const std::shared_ptr<core::InsertTableHandle>& insertHandle,
       bool hasPartitioningScheme,
       connector::CommitStrategy commitStrategy =
@@ -115,11 +115,10 @@ class TableWriterTestBase : public HiveConnectorTestBase {
       const std::vector<std::string>& partitionedKeys,
       const RowTypePtr& rowType);
 
-  static std::shared_ptr<core::AggregationNode> generateAggregationNode(
+  static core::ColumnStatsSpec generateColumnStatsSpec(
       const std::string& name,
       const std::vector<core::FieldAccessTypedExprPtr>& groupingKeys,
-      AggregationNode::Step step,
-      const PlanNodePtr& source);
+      AggregationNode::Step step);
 
   std::shared_ptr<Task> assertQueryWithWriterConfigs(
       const core::PlanNodePtr& plan,
@@ -207,7 +206,7 @@ class TableWriterTestBase : public HiveConnectorTestBase {
           connector::hive::LocationHandle::TableType::kNew,
       const CommitStrategy& outputCommitStrategy = CommitStrategy::kNoCommit,
       bool aggregateResult = true,
-      std::shared_ptr<core::AggregationNode> aggregationNode = nullptr);
+      const std::optional<ColumnStatsSpec>& columnStatsSpec = std::nullopt);
 
   PlanNodePtr createInsertPlan(
       PlanBuilder& inputPlan,
@@ -222,7 +221,7 @@ class TableWriterTestBase : public HiveConnectorTestBase {
           connector::hive::LocationHandle::TableType::kNew,
       const CommitStrategy& outputCommitStrategy = CommitStrategy::kNoCommit,
       bool aggregateResult = true,
-      std::shared_ptr<core::AggregationNode> aggregationNode = nullptr);
+      const std::optional<ColumnStatsSpec>& columnStatsSpec = std::nullopt);
 
   PlanNodePtr createInsertPlanWithSingleWriter(
       PlanBuilder& inputPlan,
@@ -235,7 +234,7 @@ class TableWriterTestBase : public HiveConnectorTestBase {
       const connector::hive::LocationHandle::TableType& outputTableType,
       const CommitStrategy& outputCommitStrategy,
       bool aggregateResult,
-      std::shared_ptr<core::AggregationNode> aggregationNode);
+      std::optional<ColumnStatsSpec> columnStatsSpec);
 
   PlanNodePtr createInsertPlanForBucketTable(
       PlanBuilder& inputPlan,
@@ -248,7 +247,7 @@ class TableWriterTestBase : public HiveConnectorTestBase {
       const connector::hive::LocationHandle::TableType& outputTableType,
       const CommitStrategy& outputCommitStrategy,
       bool aggregateResult,
-      std::shared_ptr<core::AggregationNode> aggregationNode);
+      std::optional<ColumnStatsSpec> columnStatsSpec);
 
   // Return the corresponding column names in 'inputRowType' of
   // 'tableColumnNames' from 'tableRowType'.
@@ -267,7 +266,7 @@ class TableWriterTestBase : public HiveConnectorTestBase {
       const connector::hive::LocationHandle::TableType& outputTableType,
       const CommitStrategy& outputCommitStrategy,
       bool aggregateResult,
-      std::shared_ptr<core::AggregationNode> aggregationNode);
+      std::optional<ColumnStatsSpec> columnStatsSpec);
 
   // Parameter partitionName is string formatted in the Hive style
   // key1=value1/key2=value2/... Parameter partitionTypes are types of partition

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -57,7 +57,7 @@ constexpr uint64_t kQueryMemoryCapacity = 512 * MB;
 
 namespace {
 
-static std::shared_ptr<core::AggregationNode> generateAggregationNode(
+static std::shared_ptr<core::AggregationNode> generateColumnStatsSpec(
     const std::string& name,
     const std::vector<core::FieldAccessTypedExprPtr>& groupingKeys,
     AggregationNode::Step step,

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -78,10 +78,10 @@ core::PlanNodePtr TableWriterReplayer::createPlanNode(
       nodeId,
       tableWriterNode->columns(),
       tableWriterNode->columnNames(),
-      tableWriterNode->aggregationNode(),
+      tableWriterNode->columnStatsSpec(),
       insertTableHandle,
       tableWriterNode->hasPartitioningScheme(),
-      TableWriteTraits::outputType(tableWriterNode->aggregationNode()),
+      TableWriteTraits::outputType(tableWriterNode->columnStatsSpec()),
       tableWriterNode->commitStrategy(),
       source);
 }


### PR DESCRIPTION
Summary: This diff refactors the column statistics collection mechanism in table writers to avoid using embedded aggregation operations. Instead of relying on embedded aggregation operators to collect column statistics during table writing, this change introduces a dedicated `ColumnStatsCollector` component that handles statistics collection more efficiently and  `ColumnStatsSpec` to specify the aggregates functions used for statistic collection in table write plan node.

Differential Revision: D80904627


