### PR TITLE
feat: Add getters for nullable nested arrays maps

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -574,6 +574,24 @@ class Variant {
     return values;
   }
 
+  /// Returns a std::map of primitive keys to optional std::vector of optional primitive values.
+  /// Null values are returned as unset optional.
+  template <typename K, typename V>
+  std::map<K, std::optional<std::vector<std::optional<V>>>> nullableMapOfArrays() const {
+    const auto& variants = value<TypeKind::MAP>();
+
+    std::map<K, std::optional<std::vector<std::optional<V>>>> values;
+    for (const auto& [k, v] : variants) {
+      if (v.isNull()) {
+        values.emplace(k.template value<K>(), std::nullopt);
+      } else {
+        values.emplace(k.template value<K>(), v.template nullableArray<V>());
+      }
+    }
+    
+    return values;
+  }
+
   /// Returns a std::vector of Variants.
   const std::vector<Variant>& array() const {
     return value<TypeKind::ARRAY>();
@@ -626,6 +644,26 @@ class Variant {
 
     for (const auto& v : variants) {
       values.emplace_back(v.template array<T>());
+    }
+
+    return values;
+  }
+
+  /// Returns a std::vector of std::vector of primitive values.Null values are
+  /// returned as unset optional.
+  template <typename T>
+  std::vector<std::optional<std::vector<std::optional<T>>>> nullableArrayOfArrays() const {
+    const auto& variants = value<TypeKind::ARRAY>();
+
+    std::vector<std::optional<std::vector<std::optional<T>>>> values;
+    values.reserve(variants.size());
+
+    for (const auto& v : variants) {
+      if(v.isNull()) {
+        values.emplace_back(std::nullopt);
+      } else {
+        values.emplace_back(v.template nullableArray<T>());
+      }
     }
 
     return values;

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -560,6 +560,19 @@ class Variant {
     return values;
   }
 
+  /// Returns a std::map of primitive keys to std::vector of primitive values. Assumes all keys and values are not null.
+  template <typename K, typename V>
+  std::map<K, std::vector<V>> mapOfArrays() const {
+    const auto& variants = value<TypeKind::MAP>();
+
+    std::map<K, std::vector<V>> values;
+    for (const auto& [k, v] : variants) {
+      values.emplace(k.template value<K>(), v.template array<V>());
+    }
+    
+    return values;
+  }
+
   /// Returns a std::vector of Variants.
   const std::vector<Variant>& array() const {
     return value<TypeKind::ARRAY>();
@@ -596,6 +609,21 @@ class Variant {
       } else {
         values.emplace_back(v.template value<T>());
       }
+    }
+
+    return values;
+  }
+
+  /// Returns a std::vector of std::vector of primitive values. Assumes that all values are not null.
+  template <typename T>
+  std::vector<std::vector<T>> arrayOfArrays() const {
+    const auto& variants = value<TypeKind::ARRAY>();
+
+    std::vector<std::vector<T>> values;
+    values.reserve(variants.size());
+
+    for (const auto& v : variants) {
+      values.emplace_back(v.template array<T>());
     }
 
     return values;

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -560,7 +560,8 @@ class Variant {
     return values;
   }
 
-  /// Returns a std::map of primitive keys to std::vector of primitive values. Assumes all keys and values are not null.
+  /// Returns a std::map of primitive keys to std::vector of primitive values.
+  /// Assumes all keys and values are not null.
   template <typename K, typename V>
   std::map<K, std::vector<V>> mapOfArrays() const {
     const auto& variants = value<TypeKind::MAP>();
@@ -614,7 +615,8 @@ class Variant {
     return values;
   }
 
-  /// Returns a std::vector of std::vector of primitive values. Assumes that all values are not null.
+  /// Returns a std::vector of std::vector of primitive values. Assumes that all
+  /// values are not null.
   template <typename T>
   std::vector<std::vector<T>> arrayOfArrays() const {
     const auto& variants = value<TypeKind::ARRAY>();

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -569,7 +569,7 @@ class Variant {
     for (const auto& [k, v] : variants) {
       values.emplace(k.template value<K>(), v.template array<V>());
     }
-    
+
     return values;
   }
 

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -815,6 +815,7 @@ template <typename T>
 void testArrayOfArraysGetter(const std::vector<std::vector<T>>& inputs) {
   std::vector<Variant> variants;
   variants.reserve(inputs.size());
+
   for (const auto& arr : inputs) {
     std::vector<Variant> innerVariants;
     innerVariants.reserve(arr.size());
@@ -841,6 +842,7 @@ TEST(VariantTest, arrayOfArraysGetter) {
 template <typename K, typename V>
 void testMapOfArraysGetter(const std::map<K, std::vector<V>>& inputs) {
   std::map<Variant, Variant> variants;
+
   for (const auto& [k, arr] : inputs) {
     std::vector<Variant> innerVariants;
     innerVariants.reserve(arr.size());

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -868,5 +868,83 @@ TEST(VariantTest, mapOfArraysGetter) {
       {{"a", {1, 2}}, {"b", {}}, {"c", {3}}});
 }
 
+template <typename T>
+void testNullableArrayOfArraysGetter(const std::vector<std::optional<std::vector<std::optional<T>>>>& inputs) {
+  std::vector<Variant> variants;
+  variants.reserve(inputs.size());
+  for (const auto& arrOpt : inputs) {
+    if (!arrOpt.has_value()) {
+      variants.emplace_back(Variant::null(TypeKind::ARRAY));
+    } else {
+      std::vector<Variant> innerVariants;
+      innerVariants.reserve(arrOpt->size());
+      for (const auto& vOpt : *arrOpt) {
+        if (vOpt.has_value()) {
+          innerVariants.emplace_back(*vOpt);
+        } else {
+          innerVariants.emplace_back(Variant::null(CppToType<T>::typeKind));
+        }
+      }
+      variants.emplace_back(Variant::array(innerVariants));
+    }
+  }
+  auto value = Variant::array(variants);
+  EXPECT_FALSE(value.isNull());
+  auto primitiveItems = value.template nullableArrayOfArrays<T>();
+  EXPECT_EQ(primitiveItems, inputs);
+}
+
+TEST(VariantTest, nullableArrayOfArraysGetter) {
+  testNullableArrayOfArraysGetter<int32_t>({
+    std::nullopt,
+    std::vector<std::optional<int32_t>>{1, std::nullopt, 3},
+    std::vector<std::optional<int32_t>>{},
+    std::vector<std::optional<int32_t>>{std::nullopt, 2}
+  });
+  testNullableArrayOfArraysGetter<double>({
+    std::vector<std::optional<double>>{1.1, std::nullopt},
+    std::nullopt,
+    std::vector<std::optional<double>>{3.3}
+  });
+}
+
+template <typename K, typename V>
+void testNullableMapOfArraysGetter(const std::map<K, std::optional<std::vector<std::optional<V>>>>& inputs) {
+  std::map<Variant, Variant> variants;
+  for (const auto& [k, arrOpt] : inputs) {
+    if (!arrOpt.has_value()) {
+      variants.emplace(k, Variant::null(TypeKind::ARRAY));
+    } else {
+      std::vector<Variant> innerVariants;
+      innerVariants.reserve(arrOpt->size());
+      for (const auto& vOpt : *arrOpt) {
+        if (vOpt.has_value()) {
+          innerVariants.emplace_back(*vOpt);
+        } else {
+          innerVariants.emplace_back(Variant::null(CppToType<V>::typeKind));
+        }
+      }
+      variants.emplace(k, Variant::array(innerVariants));
+    }
+  }
+  auto value = Variant::map(variants);
+  EXPECT_FALSE(value.isNull());
+  auto primitiveItems = value.template nullableMapOfArrays<K, V>();
+  EXPECT_EQ(primitiveItems, inputs);
+}
+
+TEST(VariantTest, nullableMapOfArraysGetter) {
+  testNullableMapOfArraysGetter<int32_t, float>({
+    {1, std::nullopt},
+    {2, std::vector<std::optional<float>>{1.1f, std::nullopt}},
+    {3, std::vector<std::optional<float>>{}}
+  });
+  testNullableMapOfArraysGetter<std::string, int64_t>({
+    {"a", std::vector<std::optional<int64_t>>{1, std::nullopt}},
+    {"b", std::nullopt},
+    {"c", std::vector<std::optional<int64_t>>{3}}
+  });
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -862,8 +862,10 @@ void testMapOfArraysGetter(const std::map<K, std::vector<V>>& inputs) {
 }
 
 TEST(VariantTest, mapOfArraysGetter) {
-  testMapOfArraysGetter<int32_t, float>({{1, {1.1f, 2.2f}}, {2, {3.3f}}, {3, {}}});
-  testMapOfArraysGetter<std::string, int64_t>({{"a", {1, 2}}, {"b", {}}, {"c", {3}}});
+  testMapOfArraysGetter<int32_t, float>(
+      {{1, {1.1f, 2.2f}}, {2, {3.3f}}, {3, {}}});
+  testMapOfArraysGetter<std::string, int64_t>(
+      {{"a", {1, 2}}, {"b", {}}, {"c", {3}}});
 }
 
 } // namespace

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -811,5 +811,58 @@ TEST(VariantTest, mapGetter) {
       {{1, 1.2}, {2, 2.3}, {3, std::nullopt}});
 }
 
+template <typename T>
+void testArrayOfArraysGetter(const std::vector<std::vector<T>>& inputs) {
+  std::vector<Variant> variants;
+  variants.reserve(inputs.size());
+  for (const auto& arr : inputs) {
+    std::vector<Variant> innerVariants;
+    innerVariants.reserve(arr.size());
+    for (const auto& v : arr) {
+      innerVariants.emplace_back(v);
+    }
+    variants.emplace_back(Variant::array(innerVariants));
+  }
+
+  auto value = Variant::array(variants);
+  EXPECT_FALSE(value.isNull());
+
+  {
+    auto primitiveItems = value.template arrayOfArrays<T>();
+    EXPECT_EQ(primitiveItems, inputs);
+  }
+}
+
+TEST(VariantTest, arrayOfArraysGetter) {
+  testArrayOfArraysGetter<int32_t>({{1, 2}, {3, 4, 5}, {}});
+  testArrayOfArraysGetter<double>({{1.1, 2.2}, {}, {3.3}});
+}
+
+template <typename K, typename V>
+void testMapOfArraysGetter(const std::map<K, std::vector<V>>& inputs) {
+  std::map<Variant, Variant> variants;
+  for (const auto& [k, arr] : inputs) {
+    std::vector<Variant> innerVariants;
+    innerVariants.reserve(arr.size());
+    for (const auto& v : arr) {
+      innerVariants.emplace_back(v);
+    }
+    variants.emplace(k, Variant::array(innerVariants));
+  }
+
+  auto value = Variant::map(variants);
+  EXPECT_FALSE(value.isNull());
+
+  {
+    auto primitiveItems = value.template mapOfArrays<K, V>();
+    EXPECT_EQ(primitiveItems, inputs);
+  }
+}
+
+TEST(VariantTest, mapOfArraysGetter) {
+  testMapOfArraysGetter<int32_t, float>({{1, {1.1f, 2.2f}}, {2, {3.3f}}, {3, {}}});
+  testMapOfArraysGetter<std::string, int64_t>({{"a", {1, 2}}, {"b", {}}, {"c", {3}}});
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Added nullable nested arrays and maps for Variant class:
`nullableArrayOfArrays<T>()`: Returns a std::vector<std::optional<std::vector<std::optional<T>>>> for arrays of arrays with possible nulls at both levels.
`nullableMapOfArrays<K, V>():` Returns a std::map<K, std::optional<std::vector<std::optional<V>>>> for maps with array values, supporting nulls for both the map value and array elements.
Enhancement was referenced in :
https://github.com/facebookincubator/velox/issues/14577#issuecomment-3218887536
