### PR TITLE
fix: DWRF row size over-estimation of struct type

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -752,8 +752,10 @@ std::optional<size_t> DwrfRowReader::estimatedRowSizeHelper(
     case TypeKind::ARRAY:
     case TypeKind::MAP:
     case TypeKind::ROW: {
-      // start the estimate with the offsets and hasNulls vectors sizes
-      size_t totalEstimate = valueCount * (sizeof(uint8_t) + sizeof(uint64_t));
+      // Start the estimate with the offsets and sizes buffers.
+      size_t totalEstimate = nodeType.kind() == TypeKind::ROW
+          ? 0
+          : 2 * valueCount * sizeof(vector_size_t);
       for (int32_t i = 0; i < nodeType.subtypesSize(); ++i) {
         if (!shouldReadNode(nodeType.subtypes(i))) {
           continue;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -823,7 +823,7 @@ TEST_F(TestReader, testEstimatedSize) {
     rowReaderOpts.select(cs);
 
     auto rowReader = reader->createRowReader(rowReaderOpts);
-    ASSERT_EQ(rowReader->estimatedRowSize(), 79);
+    ASSERT_EQ(rowReader->estimatedRowSize(), 67);
   }
 
   {
@@ -835,7 +835,7 @@ TEST_F(TestReader, testEstimatedSize) {
     RowReaderOptions rowReaderOpts;
     rowReaderOpts.select(cs);
     auto rowReader = reader->createRowReader(rowReaderOpts);
-    ASSERT_EQ(rowReader->estimatedRowSize(), 13);
+    ASSERT_EQ(rowReader->estimatedRowSize(), 4);
   }
 }
 


### PR DESCRIPTION
Summary: We are over-estimating the row size of struct output from DWRF reader.  This slows down the `count(*)` queries mostly.

Differential Revision: D80956796


