### PR TITLE
fix: Add check to isInMap before casting as mutable buffer

### DIFF
--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -190,9 +190,11 @@ class MapFilterFunction : public FilterFunctionBase {
     // Flatten inMap buffer.
     auto* mutableFlattedInMap = flattenedInMap->asMutable<uint64_t>();
     bits::fillBits(mutableFlattedInMap, 0, inMapSize, false);
-    auto* mutableInMap = inMap->asMutable<uint64_t>();
+    auto* mutableInMap = inMap ? inMap->asMutable<uint64_t>() : nullptr;
     rows.applyToSelected([&](vector_size_t row) {
-      if (bits::isBitSet(mutableInMap, decodedIndices[row])) {
+      // If inMap is null, short circuit and set bit because key is present in
+      // all rows.
+      if (!inMap || bits::isBitSet(mutableInMap, decodedIndices[row])) {
         bits::setBit(mutableFlattedInMap, decodedIndices[row]);
       }
     });

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -214,8 +214,12 @@ class FlatMapVector : public BaseVector {
     if (inMaps_.size() <= keyChannel) {
       return true;
     }
-    auto* inMap = inMapsAt(keyChannel)->asMutable<uint64_t>();
-    return inMap ? bits::isBitSet(inMap, index) : true;
+    if (auto& inMap = inMapsAt(keyChannel)) {
+      return bits::isBitSet(inMap->as<uint64_t>(), index);
+    } else {
+      // If inMap is null, key is present in all rows.
+      return true;
+    }
   }
 
   /// Get the map values vector at a given a map key channel.

--- a/velox/vector/tests/FlatMapVectorTest.cpp
+++ b/velox/vector/tests/FlatMapVectorTest.cpp
@@ -253,6 +253,28 @@ TEST_F(FlatMapVectorTest, withNulls) {
   EXPECT_TRUE(flatMapVector->isInMap(*channel, 2));
 }
 
+TEST_F(FlatMapVectorTest, nullInMaps) {
+  // Construct a flat map with two null BufferPtrs in the inMaps vector.
+  auto vectorSize = 1;
+  auto distinctKeys = maker_.flatVector<int32_t>({1, 2, 3});
+  std::vector<VectorPtr> mapValues(distinctKeys->size());
+  std::vector<BufferPtr> inMaps(distinctKeys->size());
+  inMaps[1] = AlignedBuffer::allocate<bool>(vectorSize, pool_.get(), 0);
+  auto flatMap = std::make_shared<FlatMapVector>(
+      pool_.get(),
+      MAP(INTEGER(), INTEGER()),
+      nullptr,
+      vectorSize,
+      distinctKeys,
+      mapValues,
+      inMaps);
+
+  // Channels with null inMaps (0 and 2) will always return true.
+  EXPECT_TRUE(flatMap->isInMap(0, 0));
+  EXPECT_FALSE(flatMap->isInMap(1, 0));
+  EXPECT_TRUE(flatMap->isInMap(2, 0));
+}
+
 TEST_F(FlatMapVectorTest, primitiveKeys) {
   // bigint key.
   auto flatMapVector = maker_.flatMapVector<int64_t, double>({


### PR DESCRIPTION
Summary:
Add check to flatMapVector function isInMap to confirm inMaps[channel] is not null before casting as mutable buffer.

inMap is allowed to be null and is encouraged for short circuiting for keys that are present in every row; however, we must confirm that it is not null before casting as mutable buffer and attempting to reference individual bits.

Differential Revision: D81077301


