### PR TITLE
fix: Return non-empty distribution function on empty QDigest

### DIFF
--- a/velox/functions/lib/QuantileDigest.h
+++ b/velox/functions/lib/QuantileDigest.h
@@ -1348,10 +1348,6 @@ QuantileDigest<T, Allocator>::getDistributionFunction(T rangeStart, T rangeEnd)
   std::vector<CdfEntry, RebindAlloc<CdfEntry>> cdf(
       RebindAlloc<CdfEntry>(counts_.get_allocator()));
 
-  if (weightedCount_ == 0 || root_ == -1) {
-    return cdf;
-  }
-
   VELOX_USER_CHECK_LE(
       rangeStart,
       rangeEnd,

--- a/velox/functions/lib/tests/QuantileDigestTest.cpp
+++ b/velox/functions/lib/tests/QuantileDigestTest.cpp
@@ -990,6 +990,31 @@ TEST_F(QuantileDigestTest, getDistributionFunction) {
   testGetDistributionFunction<float>();
 }
 
+template <typename T>
+void testEmptyDistributionFunction() {
+  std::allocator<T> allocator;
+  // Create empty QuantileDigest and get CDF
+  QuantileDigest<T, std::allocator<T>> digest(allocator, 0.01);
+  auto cdf = digest.getDistributionFunction(0, 100);
+  ASSERT_EQ(cdf.size(), 2);
+
+  // By convention, the CDF should always start at (rangeStart, 0) and end at
+  // (rangeEnd, 1) Since the digest is empty, these will be the only points
+  std::vector<T> expectedCdfUpperBound = {0, 100};
+  std::vector<double> expectedCdfCumulativeProbability = {0, 1};
+  for (auto i = 0; i < cdf.size(); i++) {
+    ASSERT_EQ(
+        cdf[i].cumulativeProbability, expectedCdfCumulativeProbability[i]);
+    ASSERT_EQ(cdf[i].upperBound, expectedCdfUpperBound[i]);
+  }
+}
+
+TEST_F(QuantileDigestTest, emptyDistributionFunction) {
+  testEmptyDistributionFunction<int64_t>();
+  testEmptyDistributionFunction<double>();
+  testEmptyDistributionFunction<float>();
+}
+
 TEST_F(QuantileDigestTest, getValuesInQuantileRangeBigInt) {
   QuantileDigest<int64_t> digest{StlAllocator<int64_t>(allocator()), 0.01};
 


### PR DESCRIPTION
Summary:
On an empty Q-Digest, the distribution function currently returns an empty vector. While the concept of the distribution function is not particularly well defined for an empty set, it is more convenient to maintain the invariant that the distribution function over the range [rangeStart, rangeEnd] will always include the points (rangeStart, 0) and (rangeEnd, 1).

This change enforces that invariant in `QuantileDigest::getDistributionFunction`, so that an empty digest will return a vector with (rangeStart, 0) and (rangeEnd, 1). Non-empty digests add points in between these.

Differential Revision: D81058154


