### PR TITLE
feat: Add VarcharEnum type support to TypeParser

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -301,6 +301,19 @@ struct TypeAnalysis<facebook::velox::BigintEnumT<E>> {
   }
 };
 
+template <typename E>
+struct TypeAnalysis<facebook::velox::VarcharEnumT<E>> {
+  void run(TypeAnalysisResults& results) {
+    results.stats.concreteCount++;
+
+    const auto e = E::name();
+    results.out << fmt::format("varchar_enum({})", e);
+    results.addVariable(exec::SignatureVariable(
+        e, std::nullopt, exec::ParameterType::kEnumParameter));
+    results.physicalType = VARCHAR();
+  }
+};
+
 template <typename K, typename V>
 struct TypeAnalysis<Map<K, V>> {
   void run(TypeAnalysisResults& results) {
@@ -396,6 +409,15 @@ struct TypeAnalysis<BigintEnum<E>> {
     // Need to call the TypeAnalysis on T, not T::type for BigintEnum type (on
     // BigintEnumT, not Bigint).
     TypeAnalysis<facebook::velox::BigintEnumT<E>>().run(results);
+  }
+};
+
+template <typename E>
+struct TypeAnalysis<VarcharEnum<E>> {
+  void run(TypeAnalysisResults& results) {
+    // Need to call the TypeAnalysis on T, not T::type for VarcharEnum type (on
+    // VarcharEnumT, not Varchar).
+    TypeAnalysis<facebook::velox::VarcharEnumT<E>>().run(results);
   }
 };
 

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -177,6 +177,7 @@ GEOMETRY                  VARBINARY
 TDIGEST                   VARBINARY
 QDIGEST                   VARBINARY
 BIGINT_ENUM               BIGINT
+VARCHAR_ENUM              VARCHAR
 ========================  =====================
 
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
@@ -232,6 +233,14 @@ different enum type as a singleton. The LongEnumParameter is used as the key to 
 and a new instance is only created if it has not been created with the given LongEnumParameter.
 Casting is permitted from any integer type to an enum type. Casting is only permitted from an enum type
 to a BIGINT type. Casting between different enum types is not permitted.
+Comparison operations are only allowed between values of the same enum type.
+
+VARCHAR_ENUM(VarcharEnumParameter) type represents an enumerated value where the physical type is VARCHAR.
+It takes one VarcharEnumParameter as parameter, which consists of a string name and a mapping of
+string keys to VARCHAR values.
+Similar to BIGINT_ENUM, there is a static cache which stores instances of different VARCHAR_ENUM types, with the
+VarcharEnumParameter as the key.
+Casting is only permitted to and from VARCHAR type, and is case-sensitive. Casting between different enum types is not permitted.
 Comparison operations are only allowed between values of the same enum type.
 
 Spark Types

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -333,13 +333,16 @@ TypePtr sanitizeTryResolveType(
     const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
     std::unordered_map<std::string, int>& integerVariablesBindings,
     const std::unordered_map<std::string, LongEnumParameter>&
-        longEnumParameterVariablesBindings) {
+        longEnumParameterVariablesBindings,
+    const std::unordered_map<std::string, VarcharEnumParameter>&
+        varcharEnumParameterVariablesBindings) {
   return sanitize(SignatureBinder::tryResolveType(
       typeSignature,
       variables,
       typeVariablesBindings,
       integerVariablesBindings,
-      longEnumParameterVariablesBindings));
+      longEnumParameterVariablesBindings,
+      varcharEnumParameterVariablesBindings));
 }
 
 void setupMemory(

--- a/velox/exec/fuzzer/FuzzerUtil.h
+++ b/velox/exec/fuzzer/FuzzerUtil.h
@@ -119,7 +119,9 @@ TypePtr sanitizeTryResolveType(
     const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
     std::unordered_map<std::string, int>& integerVariablesBindings,
     const std::unordered_map<std::string, LongEnumParameter>&
-        longEnumParameterVariablesBindings);
+        longEnumParameterVariablesBindings,
+    const std::unordered_map<std::string, VarcharEnumParameter>&
+        varcharEnumParameterVariablesBindings);
 
 // Invoked to set up memory system with arbitration.
 void setupMemory(

--- a/velox/expression/ReverseSignatureBinder.h
+++ b/velox/expression/ReverseSignatureBinder.h
@@ -63,6 +63,16 @@ class ReverseSignatureBinder : private SignatureBinderBase {
     return longEnumVariablesBindings_;
   }
 
+  /// Return the VarcharEnumParameter bindings produced by 'tryBind'. This
+  /// function should be called after 'tryBind' and only if 'tryBind' returns
+  /// true.
+  const std::unordered_map<std::string, VarcharEnumParameter>&
+  varcharEnumParameterBindings() const {
+    VELOX_CHECK(
+        tryBindSucceeded_, "tryBind() must be called first and succeed");
+    return varcharEnumVariablesBindings_;
+  }
+
  private:
   const TypePtr returnType_;
 

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -61,6 +61,10 @@ class SignatureBinderBase {
   /// Record concrete values that are bound to LongEnumParameter variables.
   std::unordered_map<std::string, LongEnumParameter> longEnumVariablesBindings_;
 
+  /// Record concrete values that are bound to VarcharEnumParameter variables.
+  std::unordered_map<std::string, VarcharEnumParameter>
+      varcharEnumVariablesBindings_;
+
  private:
   /// If the integer parameter is set, then it must match with value.
   /// Returns false if values do not match or the parameter does not exist.
@@ -70,6 +74,11 @@ class SignatureBinderBase {
   bool checkOrSetLongEnumParameter(
       const std::string& parameterName,
       const LongEnumParameter& params);
+
+  /// Try to bind the VarcharEnumParameter from the actualType.
+  bool checkOrSetVarcharEnumParameter(
+      const std::string& parameterName,
+      const VarcharEnumParameter& params);
 
   /// Try to bind the integer parameter from the actualType.
   bool tryBindIntegerParameters(
@@ -122,7 +131,8 @@ class SignatureBinder : private SignatureBinderBase {
         variables(),
         typeVariablesBindings_,
         integerVariablesBindings_,
-        longEnumVariablesBindings_);
+        longEnumVariablesBindings_,
+        varcharEnumVariablesBindings_);
   }
 
   // Try resolve types for all specified signatures. Return empty list if some
@@ -150,12 +160,14 @@ class SignatureBinder : private SignatureBinderBase {
       const std::unordered_map<std::string, TypePtr>& resolvedTypeVariables) {
     std::unordered_map<std::string, int> dummyEmpty;
     std::unordered_map<std::string, LongEnumParameter> dummyEmpty2;
+    std::unordered_map<std::string, VarcharEnumParameter> dummyEmpty3;
     return tryResolveType(
         typeSignature,
         variables,
         resolvedTypeVariables,
         dummyEmpty,
-        dummyEmpty2);
+        dummyEmpty2,
+        dummyEmpty3);
   }
 
   // Given a pre-computed binding for type variables and integer variables,
@@ -167,7 +179,9 @@ class SignatureBinder : private SignatureBinderBase {
       const std::unordered_map<std::string, TypePtr>& typeVariablesBindings,
       std::unordered_map<std::string, int>& integerVariablesBindings,
       const std::unordered_map<std::string, LongEnumParameter>&
-          bigintEnumVariablesBindings);
+          bigintEnumVariablesBindings,
+      const std::unordered_map<std::string, VarcharEnumParameter>&
+          varcharEnumVariablesBindings);
 
  private:
   bool tryBind(bool allowCoercions, std::vector<Coercion>& coercions);

--- a/velox/expression/fuzzer/ArgumentTypeFuzzer.h
+++ b/velox/expression/fuzzer/ArgumentTypeFuzzer.h
@@ -120,6 +120,10 @@ class ArgumentTypeFuzzer {
   /// Bindings between LongEnumParameter variables and their actual types.
   std::unordered_map<std::string, LongEnumParameter> longEnumParameterBindings_;
 
+  /// Bindings between VarcharEnumParameter variables and their actual types.
+  std::unordered_map<std::string, VarcharEnumParameter>
+      varcharEnumParameterBindings_;
+
   /// RNG to generate random types for unbounded type variables when necessary.
   FuzzerGenerator& rng_;
 

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -237,6 +237,7 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
       "QDIGEST",
       "SFMSKETCH",
       "BIGINT_ENUM",
+      "VARCHAR_ENUM",
   };
 #ifdef VELOX_ENABLE_GEO
   expectedTypes.insert("GEOMETRY");
@@ -284,6 +285,13 @@ TEST_F(CustomTypeTest, nullConstant) {
       auto type = getCustomType(name, {TypeParameter(moodInfo)});
       checkNullConstant(
           type, "test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0})");
+    } else if (name == "VARCHAR_ENUM") {
+      VarcharEnumParameter colorInfo(
+          "test.enum.color", {{"RED", "red"}, {"BLUE", "blue"}});
+      auto type = getCustomType(name, {TypeParameter(colorInfo)});
+      checkNullConstant(
+          type,
+          "test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"})");
     } else {
       auto type = getCustomType(name, {});
       checkNullConstant(type, type->toString());

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -247,7 +247,7 @@ TEST(SignatureBinderTest, decimals) {
       std::unordered_map<std::string, int> integerVariables;
       ASSERT_EQ(
           exec::SignatureBinder::tryResolveType(
-              typeSignature, {}, {}, integerVariables, {}),
+              typeSignature, {}, {}, integerVariables, {}, {}),
           nullptr);
     }
     // Type parameter + constraint = error.

--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 
 namespace facebook::velox::functions {
 namespace {
@@ -86,6 +87,9 @@ std::string typeName(const TypePtr& type) {
     case TypeKind::VARCHAR:
       if (isJsonType(type)) {
         return "json";
+      }
+      if (isVarcharEnumType(*type)) {
+        return asVarcharEnum(type)->enumName();
       }
       return "varchar";
     case TypeKind::VARBINARY:

--- a/velox/functions/prestosql/registration/EnumFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/EnumFunctionsRegistration.cpp
@@ -26,7 +26,13 @@ void registerEnumFunctions(const std::string& prefix) {
   registerBigintEnumType();
   registerVarcharEnumType();
 
-  registerFunction<EnumKeyFunction, Varchar, BigintEnum<E1>>(
-      {prefix + "enum_key"});
+  registerFunction<
+      ParameterBinder<EnumKeyFunction, BigintEnumTypePtr>,
+      Varchar,
+      BigintEnum<E1>>({prefix + "enum_key"});
+  registerFunction<
+      ParameterBinder<EnumKeyFunction, VarcharEnumTypePtr>,
+      Varchar,
+      VarcharEnum<E1>>({prefix + "enum_key"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -16,7 +16,6 @@
 #include <string>
 #include "velox/functions/prestosql/IPAddressFunctions.h"
 #include "velox/functions/prestosql/UuidFunctions.h"
-#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
 
 namespace facebook::velox::functions {
 

--- a/velox/functions/prestosql/tests/EnumFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/EnumFunctionsTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox::functions::test;
@@ -30,23 +31,33 @@ class EnumFunctionsTest : public FunctionBaseTest {
   void SetUp() override {
     FunctionBaseTest::SetUp();
   }
+  std::optional<std::string> enumKey(
+      std::optional<int64_t> val,
+      TypePtr inputType) {
+    return evaluateOnce<std::string>("enum_key(c0)", inputType, val);
+  }
+
+  std::optional<std::string> enumKey(
+      std::optional<std::string> val,
+      TypePtr inputType) {
+    return evaluateOnce<std::string>("enum_key(c0)", inputType, std::move(val));
+  }
 };
 
-TEST_F(EnumFunctionsTest, enumKey) {
+TEST_F(EnumFunctionsTest, enumKeyBigintEnum) {
   LongEnumParameter moodInfo("test.enum.mood", {{"CURIOUS", -2}, {"HAPPY", 0}});
   auto bigintEnum = BIGINT_ENUM(moodInfo);
-  const auto enumKey = [&](std::optional<int64_t> val, TypePtr inputType) {
-    return evaluateOnce<std::string>("enum_key(c0)", inputType, val);
-  };
+
   EXPECT_EQ("CURIOUS", enumKey(-2, bigintEnum));
-  EXPECT_EQ(std::nullopt, enumKey(std::nullopt, bigintEnum));
+  EXPECT_EQ(std::nullopt, enumKey(std::optional<int64_t>{}, bigintEnum));
 
   VELOX_ASSERT_THROW(
-      enumKey(1, bigintEnum), "Value '1' not in enum 'BigintEnum'");
+      enumKey(1, bigintEnum),
+      "Value '1' not in BigintEnum: test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0})");
 
   VELOX_ASSERT_THROW(
       enumKey(1, BIGINT()),
-      "Scalar function signature is not supported: enum_key(BIGINT). Supported signatures: (bigint_enum(E1)) -> varchar.");
+      "Scalar function signature is not supported: enum_key(BIGINT). Supported signatures: (varchar_enum(E1)) -> varchar, (bigint_enum(E1)) -> varchar.");
 
   VELOX_ASSERT_THROW(
       evaluateOnce<std::string>(
@@ -54,7 +65,33 @@ TEST_F(EnumFunctionsTest, enumKey) {
           {bigintEnum, BIGINT()},
           std::optional<int64_t>(0),
           std::optional<int64_t>(5)),
-      "Scalar function signature is not supported: enum_key(test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}), BIGINT). Supported signatures: (bigint_enum(E1)) -> varchar.");
+      "Scalar function signature is not supported: enum_key(test.enum.mood:BigintEnum({\"CURIOUS\": -2, \"HAPPY\": 0}), BIGINT). Supported signatures: (varchar_enum(E1)) -> varchar, (bigint_enum(E1)) -> varchar.");
+}
+
+TEST_F(EnumFunctionsTest, enumKeyVarcharEnum) {
+  VarcharEnumParameter colorInfo(
+      "test.enum.color",
+      {{"RED", "red_value"}, {"BLUE", "blue_value"}, {"GREEN", "green_value"}});
+  auto varcharEnum = VARCHAR_ENUM(colorInfo);
+
+  EXPECT_EQ("RED", enumKey("red_value", varcharEnum));
+  EXPECT_EQ(std::nullopt, enumKey(std::optional<std::string>{}, varcharEnum));
+
+  VELOX_ASSERT_THROW(
+      enumKey("non-existent value", varcharEnum),
+      "Value 'non-existent value' not in VarcharEnum: test.enum.color:VarcharEnum({\"BLUE\": \"blue_value\", \"GREEN\": \"green_value\", \"RED\": \"red_value\"})");
+
+  VELOX_ASSERT_THROW(
+      enumKey("red_value", VARCHAR()),
+      "Scalar function signature is not supported: enum_key(VARCHAR). Supported signatures: (varchar_enum(E1)) -> varchar, (bigint_enum(E1)) -> varchar.");
+
+  VELOX_ASSERT_THROW(
+      evaluateOnce<std::string>(
+          "enum_key(c0, c1)",
+          {varcharEnum, BIGINT()},
+          std::optional<std::string>("red_value"),
+          std::optional<int64_t>(5)),
+      "Scalar function signature is not supported: enum_key(test.enum.color:VarcharEnum({\"BLUE\": \"blue_value\", \"GREEN\": \"green_value\", \"RED\": \"red_value\"}), BIGINT). Supported signatures: (varchar_enum(E1)) -> varchar, (bigint_enum(E1)) -> varchar.");
 }
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 
 namespace facebook::velox::functions {
 namespace {
@@ -92,6 +93,13 @@ TEST_F(TypeOfTest, customTypes) {
   LongEnumParameter otherInfo("someEnumType", enumMap);
   EXPECT_EQ("test.enum.mood", typeOf(BIGINT_ENUM(moodInfo)));
   EXPECT_EQ("someEnumType", typeOf(BIGINT_ENUM(otherInfo)));
+
+  std::unordered_map<std::string, std::string> varcharEnumMap = {
+      {"RED", "red"}, {"BLUE", "blue"}};
+  VarcharEnumParameter colorInfo("test.enum.color", varcharEnumMap);
+  VarcharEnumParameter otherColorInfo("someColorType", varcharEnumMap);
+  EXPECT_EQ("test.enum.color", typeOf(VARCHAR_ENUM(colorInfo)));
+  EXPECT_EQ("someColorType", typeOf(VARCHAR_ENUM(otherColorInfo)));
 }
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/VarcharEnumCastTest.cpp
+++ b/velox/functions/prestosql/tests/VarcharEnumCastTest.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
+
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox {
+namespace {
+
+class VarcharEnumCastTest : public functions::test::CastBaseTest {
+ protected:
+  VarcharEnumCastTest() {
+    registerVarcharEnumType();
+    VarcharEnumParameter colorInfo(
+        "test.enum.color", {{"RED", "red"}, {"BLUE", "blue"}});
+    colorEnum_ = VARCHAR_ENUM(colorInfo);
+  }
+
+  VarcharEnumTypePtr colorEnum_;
+};
+
+TEST_F(VarcharEnumCastTest, castTo) {
+  // Cast VARCHAR type to enum type.
+  testCast<StringView, StringView>(
+      VARCHAR(),
+      colorEnum_,
+      {"red"_sv, "blue"_sv, std::nullopt},
+      {"red"_sv, "blue"_sv, std::nullopt});
+
+  // Cast enum type to same enum type.
+  testCast<StringView, StringView>(
+      colorEnum_,
+      colorEnum_,
+      {"red"_sv, "blue"_sv, std::nullopt},
+      {"red"_sv, "blue"_sv, std::nullopt});
+}
+
+TEST_F(VarcharEnumCastTest, invalidCastTo) {
+  // Cast is only permitted from VARCHAR types to enum type.
+  testThrow<int64_t>(
+      BIGINT(),
+      colorEnum_,
+      {1},
+      "Cannot cast BIGINT to test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"}).");
+
+  testThrow<StringView>(
+      VARBINARY(),
+      colorEnum_,
+      {"red"_sv, ""_sv},
+      "Cannot cast VARBINARY to test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"}).");
+
+  testThrow<bool>(
+      BOOLEAN(),
+      colorEnum_,
+      {1},
+      "Cannot cast BOOLEAN to test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"}).");
+
+  // Cast base type to enum type where the value does not exist in the enum.
+  // Casting is case-sensitive.
+  testThrow<StringView>(
+      VARCHAR(),
+      colorEnum_,
+      {"green"_sv},
+      "No value 'green' in test.enum.color");
+
+  testThrow<StringView>(
+      VARCHAR(), colorEnum_, {"RED"_sv}, "No value 'RED' in test.enum.color");
+
+  // Cast enum type to different enum type.
+  std::unordered_map<std::string, std::string> differentMap = {
+      {"RED", "red"}, {"BLUE", "navy"}};
+  VarcharEnumParameter differentEnumInfo("someEnumType", differentMap);
+  testThrow<StringView>(
+      VARCHAR_ENUM(differentEnumInfo),
+      colorEnum_,
+      {"red"_sv},
+      "Cannot cast someEnumType:VarcharEnum({\"BLUE\": \"navy\", \"RED\": \"red\"}) to test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"}).");
+
+  // Cast enum type to different enum type with same name.
+  VarcharEnumParameter sameNameDifferentMap("test.enum.color", differentMap);
+  testThrow<StringView>(
+      VARCHAR_ENUM(sameNameDifferentMap),
+      colorEnum_,
+      {"red"_sv},
+      "Cannot cast test.enum.color:VarcharEnum({\"BLUE\": \"navy\", \"RED\": \"red\"}) to test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"})");
+}
+
+TEST_F(VarcharEnumCastTest, fromVarcharEnum) {
+  // Cast enum type to base type.
+  testCast<StringView, StringView>(
+      colorEnum_,
+      VARCHAR(),
+      {"red"_sv, "blue"_sv, std::nullopt},
+      {"red"_sv, "blue"_sv, std::nullopt});
+
+  // Casting enum type to all other types including other string types is not
+  // permitted.
+  testThrow<StringView>(
+      colorEnum_,
+      VARBINARY(),
+      {"red"_sv},
+      "Cannot cast test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"}) to VARBINARY.");
+
+  testThrow<StringView>(
+      colorEnum_,
+      BIGINT(),
+      {"red"_sv},
+      "Cannot cast test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"}) to BIGINT.");
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/BigintEnumType.h
+++ b/velox/functions/prestosql/types/BigintEnumType.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/functions/prestosql/types/EnumTypeBase.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -25,44 +26,22 @@ using BigintEnumTypePtr = std::shared_ptr<const BigintEnumType>;
 /// Represents an enumerated value where the physical type is a bigint. Each
 /// enum type has a name and a set of string keys which map to bigint values,
 /// passed in as a LongEnumParameter TypeParameterKind.
-class BigintEnumType : public BigintType {
+class BigintEnumType
+    : public EnumTypeBase<int64_t, LongEnumParameter, BigintType> {
  public:
   static BigintEnumTypePtr get(const LongEnumParameter& parameter);
 
-  bool equivalent(const Type& other) const override {
-    return this == &other;
-  }
-
   const char* name() const override {
     return "BIGINT_ENUM";
-  }
-
-  const std::vector<TypeParameter>& parameters() const override {
-    return parameters_;
   }
 
   std::string toString() const override;
 
   folly::dynamic serialize() const override;
 
-  bool containsValue(int64_t value) const {
-    return flippedMap_.contains(value);
-  }
-
-  /// Returns the string key given an integer value. If the value does not exist
-  /// in the flippedMap_, return std::nullopt.
-  const std::optional<std::string> keyAt(int64_t value) const;
-
-  const std::string& enumName() const {
-    return name_;
-  }
-
  private:
   explicit BigintEnumType(const LongEnumParameter& parameters);
-
-  const std::vector<TypeParameter> parameters_;
-  const std::string name_;
-  const std::unordered_map<int64_t, std::string> flippedMap_;
+  friend class EnumTypeBase<int64_t, LongEnumParameter, BigintType>;
 };
 
 inline BigintEnumTypePtr BIGINT_ENUM(const LongEnumParameter& parameter) {

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -19,16 +19,19 @@ velox_add_library(
   BigintEnumType.cpp
   BingTileRegistration.cpp
   BingTileType.cpp
+  EnumTypeBase.cpp
   HyperLogLogRegistration.cpp
   IPAddressRegistration.cpp
   IPPrefixRegistration.cpp
   JsonCastOperator.cpp
   JsonRegistration.cpp
+  QDigestRegistration.cpp
   SfmSketchRegistration.cpp
   TDigestRegistration.cpp
-  QDigestRegistration.cpp
   TimestampWithTimeZoneRegistration.cpp
   UuidRegistration.cpp
+  VarcharEnumRegistration.cpp
+  VarcharEnumType.cpp
 )
 if(VELOX_ENABLE_GEO)
   velox_sources(velox_presto_types PRIVATE GeometryRegistration.cpp)

--- a/velox/functions/prestosql/types/EnumTypeBase.cpp
+++ b/velox/functions/prestosql/types/EnumTypeBase.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/EnumTypeBase.h"
+#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
+
+namespace facebook::velox {
+namespace {
+// Flips the keys and values of the original map and validates that all values
+// are unique.
+template <typename TValue>
+static std::unordered_map<TValue, std::string> toFlippedMap(
+    const std::unordered_map<std::string, TValue>& map,
+    const std::string& name) {
+  std::unordered_map<TValue, std::string> flippedMap;
+  for (const auto& [key, value] : map) {
+    bool ok = flippedMap.emplace(value, key).second;
+    VELOX_USER_CHECK(
+        ok, "Invalid enum type {}, contains duplicate value {}", name, value);
+  }
+  return flippedMap;
+}
+} // namespace
+
+template <typename TValue, typename TParameter, typename TPhysical>
+EnumTypeBase<TValue, TParameter, TPhysical>::EnumTypeBase(
+    const TParameter& parameters)
+    : parameters_{TypeParameter(parameters)},
+      name_{parameters.name},
+      flippedMap_{toFlippedMap<TValue>(parameters.valuesMap, name_)} {}
+
+template <typename TValue, typename TParameter, typename TPhysical>
+std::string EnumTypeBase<TValue, TParameter, TPhysical>::flippedMapToString()
+    const {
+  std::ostringstream oss;
+  oss << "{";
+  std::map<std::string, TValue> sortedMap;
+  for (const auto& [key, value] : flippedMap_) {
+    sortedMap[value] = key;
+  }
+  for (auto it = sortedMap.begin(); it != sortedMap.end(); ++it) {
+    if (it != sortedMap.begin()) {
+      oss << ", ";
+    }
+    oss << "\"" << it->first << "\"" << ": ";
+    if constexpr (std::is_same_v<TValue, std::string>) {
+      oss << "\"" << it->second << "\"";
+    } else {
+      oss << it->second;
+    }
+  }
+  oss << "}";
+  return oss.str();
+}
+
+template <typename TValue, typename TParameter, typename TPhysical>
+template <typename EnumType>
+std::shared_ptr<const EnumType>
+EnumTypeBase<TValue, TParameter, TPhysical>::getCached(
+    const TParameter& parameter) {
+  static const int maxCacheSize = 1000;
+  static folly::Synchronized<Cache> kCache{Cache(maxCacheSize)};
+  return kCache.withWLock([&](auto& cache) -> std::shared_ptr<const EnumType> {
+    auto it = cache.find(parameter);
+    if (it != cache.end()) {
+      return std::static_pointer_cast<const EnumType>(it->second);
+    }
+    // Can't use std::make_shared because calling private ctor.
+    auto instance = std::shared_ptr<const EnumType>(new EnumType(parameter));
+    cache.insert(parameter, instance);
+    return instance;
+  });
+}
+
+template class EnumTypeBase<int64_t, LongEnumParameter, BigintType>;
+template class EnumTypeBase<std::string, VarcharEnumParameter, VarcharType>;
+
+template BigintEnumTypePtr
+EnumTypeBase<int64_t, LongEnumParameter, BigintType>::getCached<BigintEnumType>(
+    const LongEnumParameter&);
+template VarcharEnumTypePtr
+EnumTypeBase<std::string, VarcharEnumParameter, VarcharType>::getCached<
+    VarcharEnumType>(const VarcharEnumParameter&);
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/EnumTypeBase.h
+++ b/velox/functions/prestosql/types/EnumTypeBase.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Synchronized.h>
+#include <folly/container/EvictingCacheMap.h>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+/// Template base class for enum types that provides common functionality
+/// for BigintEnumType and VarcharEnumType.
+/// @tparam TValue Type of enum value, either int64_t or std::string
+/// @tparam TParameter TypeParameter used to instantiate enum type, either
+/// LongEnumParameter or VarcharEnumParameter
+/// @tparam TPhysical Type extended by the enum type.
+template <typename TValue, typename TParameter, typename TPhysical>
+class EnumTypeBase : public TPhysical {
+ public:
+  using TReverseMap = std::unordered_map<TValue, std::string>;
+
+  /// Stores instances of enum types using the type parameters as keys.
+  using Cache = folly::EvictingCacheMap<
+      TParameter,
+      std::shared_ptr<const EnumTypeBase>,
+      typename TParameter::Hash>;
+
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    return parameters_;
+  }
+
+  bool containsValue(const TValue& value) const {
+    return flippedMap_.contains(value);
+  }
+
+  /// Returns the string key given a value. If the value does not exist
+  /// in the flippedMap_, return std::nullopt.
+  const std::optional<std::string> keyAt(const TValue& value) const {
+    auto it = flippedMap_.find(value);
+    if (it != flippedMap_.end()) {
+      return it->second;
+    }
+    return std::nullopt;
+  }
+
+  const std::string& enumName() const {
+    return name_;
+  }
+
+ protected:
+  explicit EnumTypeBase(const TParameter& parameters);
+
+  /// Converts the flipped map to a string representation for toString() method.
+  std::string flippedMapToString() const;
+
+  /// Returns cached instance of enum type or creates and returns a new enum
+  /// type if the type has not already been instantiated with the given
+  /// parameters.
+  template <typename EnumType>
+  static std::shared_ptr<const EnumType> getCached(const TParameter& parameter);
+
+  const std::vector<TypeParameter> parameters_;
+  const std::string name_;
+  const TReverseMap flippedMap_;
+};
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/VarcharEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/VarcharEnumRegistration.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
+#include "velox/expression/CastExpr.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
+
+namespace facebook::velox {
+namespace {
+class VarcharEnumCastOperator : public exec::CastOperator {
+ public:
+  static const std::shared_ptr<const CastOperator>& get() {
+    static const std::shared_ptr<const CastOperator> kInstance =
+        std::make_shared<const VarcharEnumCastOperator>();
+
+    return kInstance;
+  }
+
+  // Casting is only supported from VARCHAR type.
+  bool isSupportedFromType(const TypePtr& other) const override {
+    return VARCHAR()->equivalent(*other);
+  }
+
+  // Casting is only supported to VARCHAR type.
+  bool isSupportedToType(const TypePtr& other) const override {
+    return VARCHAR()->equivalent(*other);
+  }
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+    auto* flatResult = result->asChecked<FlatVector<StringView>>();
+    flatResult->clearNulls(rows);
+
+    auto enumType = asVarcharEnum(resultType);
+    const auto* varcharVector = input.as<SimpleVector<StringView>>();
+    rows.applyToSelected([&](vector_size_t row) {
+      const std::string varcharToCast = varcharVector->valueAt(row).str();
+      if (!enumType->containsValue(varcharToCast)) {
+        context.setStatus(
+            row,
+            Status::UserError(
+                "No value '{}' in {}", varcharToCast, enumType->enumName()));
+        return;
+      }
+      flatResult->set(row, StringView(varcharToCast));
+    });
+  }
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override {
+    context.ensureWritable(rows, resultType, result);
+    auto* flatResult = result->asChecked<FlatVector<StringView>>();
+    flatResult->copy(&input, rows, nullptr);
+  }
+};
+
+class VarcharEnumTypeFactory : public CustomTypeFactory {
+ public:
+  TypePtr getType(const std::vector<TypeParameter>& parameters) const override {
+    VELOX_CHECK_EQ(
+        parameters.size(),
+        1,
+        "Expected exactly one type parameters for VarcharEnumType");
+    VELOX_CHECK(
+        parameters[0].varcharEnumLiteral.has_value(),
+        "VarcharEnumType parameter must be varcharEnumLiteral");
+    return VARCHAR_ENUM(parameters[0].varcharEnumLiteral.value());
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return VarcharEnumCastOperator::get();
+  }
+
+  AbstractInputGeneratorPtr getInputGenerator(
+      const InputGeneratorConfig& /*config*/) const override {
+    return nullptr;
+  }
+};
+} // namespace
+
+void registerVarcharEnumType() {
+  registerCustomType(
+      "varchar_enum", std::make_unique<const VarcharEnumTypeFactory>());
+}
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/VarcharEnumRegistration.h
+++ b/velox/functions/prestosql/types/VarcharEnumRegistration.h
@@ -14,19 +14,10 @@
  * limitations under the License.
  */
 
-#include "velox/functions/Registerer.h"
-#include "velox/functions/prestosql/EnumFunctions.h"
-#include "velox/functions/prestosql/types/BigintEnumRegistration.h"
-#include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
-#include "velox/type/SimpleFunctionApi.h"
+#pragma once
 
-namespace facebook::velox::functions {
+namespace facebook::velox {
 
-void registerEnumFunctions(const std::string& prefix) {
-  registerBigintEnumType();
-  registerVarcharEnumType();
+void registerVarcharEnumType();
 
-  registerFunction<EnumKeyFunction, Varchar, BigintEnum<E1>>(
-      {prefix + "enum_key"});
-}
-} // namespace facebook::velox::functions
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/VarcharEnumType.cpp
+++ b/velox/functions/prestosql/types/VarcharEnumType.cpp
@@ -14,29 +14,31 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
 
 namespace facebook::velox {
 
 // Should only be called from get() to create a new instance.
-BigintEnumType::BigintEnumType(const LongEnumParameter& parameters)
-    : EnumTypeBase<int64_t, LongEnumParameter, BigintType>(parameters) {}
-
-std::string BigintEnumType::toString() const {
-  return fmt::format("{}:BigintEnum({})", name_, flippedMapToString());
+VarcharEnumType::VarcharEnumType(const VarcharEnumParameter& parameters)
+    : EnumTypeBase<std::string, VarcharEnumParameter, VarcharType>(parameters) {
 }
 
-BigintEnumTypePtr BigintEnumType::get(const LongEnumParameter& parameter) {
-  return getCached<BigintEnumType>(parameter);
+std::string VarcharEnumType::toString() const {
+  return fmt::format("{}:VarcharEnum({})", name_, flippedMapToString());
 }
 
-folly::dynamic BigintEnumType::serialize() const {
+VarcharEnumTypePtr VarcharEnumType::get(const VarcharEnumParameter& parameter) {
+  return getCached<VarcharEnumType>(parameter);
+}
+
+folly::dynamic VarcharEnumType::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["name"] = "Type";
   obj["type"] = name();
-  // parameters_[0].longEnumLiteral is assumed to have a value since it is
-  // constructed from a LongEnumParameter.
-  obj["kLongEnumParam"] = parameters_[0].longEnumLiteral.value().serialize();
+  // parameters_[0].varcharEnumLiteral is assumed to have a value since it is
+  // constructed from a VarcharEnumParameter.
+  obj["kVarcharEnumParam"] =
+      parameters_[0].varcharEnumLiteral.value().serialize();
   return obj;
 }
 

--- a/velox/functions/prestosql/types/VarcharEnumType.h
+++ b/velox/functions/prestosql/types/VarcharEnumType.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/prestosql/types/EnumTypeBase.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+class VarcharEnumType;
+using VarcharEnumTypePtr = std::shared_ptr<const VarcharEnumType>;
+
+/// Represents an enumerated value where the physical type is a varchar. Each
+/// enum type has a name and a set of string keys which map to string values,
+/// passed in as a VarcharEnumParameter TypeParameterKind.
+class VarcharEnumType
+    : public EnumTypeBase<std::string, VarcharEnumParameter, VarcharType> {
+ public:
+  static VarcharEnumTypePtr get(const VarcharEnumParameter& parameter);
+
+  const char* name() const override {
+    return "VARCHAR_ENUM";
+  }
+
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+ private:
+  explicit VarcharEnumType(const VarcharEnumParameter& parameters);
+  friend class EnumTypeBase<std::string, VarcharEnumParameter, VarcharType>;
+};
+
+inline VarcharEnumTypePtr VARCHAR_ENUM(const VarcharEnumParameter& parameter) {
+  return VarcharEnumType::get(parameter);
+}
+
+FOLLY_ALWAYS_INLINE bool isVarcharEnumType(const Type& type) {
+  return type.kind() == TypeKind::VARCHAR &&
+      dynamic_cast<const VarcharEnumType*>(&type) != nullptr;
+}
+
+FOLLY_ALWAYS_INLINE VarcharEnumTypePtr asVarcharEnum(const TypePtr& type) {
+  return std::dynamic_pointer_cast<const VarcharEnumType>(type);
+}
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/parser/ParserUtil.cpp
+++ b/velox/functions/prestosql/types/parser/ParserUtil.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <boost/algorithm/string.hpp>
 #include <string>
 #include "velox/type/Type.h"
 
@@ -65,35 +66,103 @@ std::pair<std::string, std::shared_ptr<const Type>> inferTypeWithSpaces(
       fieldName, typeFromString(allWords.substr(fieldName.size() + 1)));
 }
 
+namespace {
+std::array<int, 256> base32CharMap() {
+  std::array<int, 256> map{};
+  map.fill(-1);
+  const std::string base32Chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+  for (size_t i = 0; i < base32Chars.size(); ++i) {
+    char upper = base32Chars[i];
+    char lower = std::tolower(upper);
+    map[static_cast<unsigned char>(upper)] = static_cast<int>(i);
+    map[static_cast<unsigned char>(lower)] = static_cast<int>(i);
+  }
+  return map;
+}
+
+static const std::array<int, 256> base32Map = base32CharMap();
+
+std::string base32Decode(const std::string& encoded) {
+  std::vector<uint8_t> decodedBytes;
+  int buffer = 0;
+  int bitsLeft = 0;
+
+  for (char c : encoded) {
+    // Skip padding and whitespace.
+    if (c == '=' || std::isspace(static_cast<unsigned char>(c))) {
+      continue;
+    }
+
+    int val = base32Map[static_cast<unsigned char>(c)];
+    VELOX_CHECK_NE(
+        val,
+        -1,
+        "Failed to parse value {}, invalid Base32 character: {}",
+        encoded,
+        c);
+
+    buffer = (buffer << 5) | val;
+    bitsLeft += 5;
+    if (bitsLeft >= 8) {
+      bitsLeft -= 8;
+      decodedBytes.push_back((buffer >> bitsLeft) & 0xFF);
+    }
+  }
+  std::string decoded(decodedBytes.begin(), decodedBytes.end());
+
+  return decoded;
+}
+
 // The values map of the enum type is passed into this function in the format:
-// "[["CURIOUS",-2], ["HAPPY",0]]" as an array of key-value pairs (as opposed to
-// a JSON map like "{"CURIOUS":-2, "HAPPY":0}") so that the function can fail
-// on duplicate keys and values. folly::parseJson on a JSON map will silently
-// drop duplicate elements.
-std::unordered_map<std::string, int64_t> parseMapFromString(
+// "[["CURIOUS",-2], ["HAPPY",0]]" as an array of key-value pairs (as opposed
+// to a JSON map like "{"CURIOUS":-2, "HAPPY":0}") so that the function can
+// fail on duplicate keys and values. folly::parseJson on a JSON map will
+// silently drop duplicate elements.
+template <typename T>
+std::unordered_map<std::string, T> parseMapFromString(
     const std::string& input) {
   folly::dynamic obj = folly::parseJson(input);
   VELOX_CHECK(
       obj.isArray(),
       "Expected an array of key-value pairs for input: {}",
       input);
-  std::unordered_map<std::string, int64_t> result;
-  std::unordered_set<int> seenValues;
+  std::unordered_map<std::string, T> result;
+  std::unordered_set<T> seenValues;
 
   for (const auto& pair : obj) {
     VELOX_CHECK(
-        pair.isArray() && pair.size() == 2 && pair[0].isString() &&
-            pair[1].isInt(),
-        "Failed to parse map: {}, each element must be a [string key, int value] pair");
-
-    std::string key = pair[0].asString();
-    int64_t value = pair[1].asInt();
-
+        pair.isArray() && pair.size() == 2 && pair[0].isString(),
+        "Failed to parse map: {}, each element must be have a string key.",
+        input);
+    std::string key = boost::algorithm::to_upper_copy(pair[0].asString());
     VELOX_CHECK(
         !result.contains(key),
         "Failed to parse map: {}, duplicate key found: {}",
         input,
         key);
+    T value;
+    if constexpr (std::is_same_v<T, int64_t>) {
+      VELOX_CHECK(
+          pair[1].isInt(),
+          "Failed to parse map: {}, each element must have an integer value.",
+          input);
+      value = pair[1].asInt();
+    } else if constexpr (std::is_same_v<T, std::string>) {
+      VELOX_CHECK(
+          pair[1].isString(),
+          "Failed to parse map: {}, each element must have a string value.",
+          input);
+      // For a VarcharEnum map where the values are strings, the values from the
+      // Presto coordinator are received as base32-encoded strings to match the
+      // standard Presto TypeSignature format.
+      // Hence decode the value before creating a VarcharEnumParameter.
+      // https://github.com/prestodb/presto/blob/master/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java#L128
+      value = base32Decode(pair[1].asString());
+    } else {
+      VELOX_UNSUPPORTED(
+          "parseMapFromString is only supported for int64_t and std::string values.");
+    }
     VELOX_CHECK(
         seenValues.insert(value).second,
         "Failed to parse map: {}, duplicate value found: {}",
@@ -104,18 +173,26 @@ std::unordered_map<std::string, int64_t> parseMapFromString(
   }
   return result;
 }
+} // namespace
 
 TypePtr getEnumType(
     const std::string& enumType,
     const std::string& enumName,
     const std::string& valuesMap) {
   std::vector<TypeParameter> params;
-  LongEnumParameter longEnumParameter(enumName, parseMapFromString(valuesMap));
-  params.emplace_back(TypeParameter(longEnumParameter));
   if (enumType == "BigintEnum") {
+    LongEnumParameter longEnumParameter(
+        enumName, parseMapFromString<int64_t>(valuesMap));
+    params.emplace_back(TypeParameter(longEnumParameter));
     return getType("BIGINT_ENUM", params);
+  } else if (enumType == "VarcharEnum") {
+    VarcharEnumParameter varcharEnumParameter(
+        enumName, parseMapFromString<std::string>(valuesMap));
+    params.emplace_back(TypeParameter(varcharEnumParameter));
+    return getType("VARCHAR_ENUM", params);
   }
 
-  VELOX_UNREACHABLE("Invalid type {}, expected BigintEnum", enumType);
+  VELOX_UNREACHABLE(
+      "Invalid type {}, expected BigintEnum or VarcharEnum", enumType);
 }
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/types/parser/TypeParser.yy
+++ b/velox/functions/prestosql/types/parser/TypeParser.yy
@@ -170,6 +170,7 @@ enum_map_entries_json : LBRACE enum_map_entries RBRACE {$$ = "[" + $2 + "]"; }
 
 enum_map_entry : QUOTED_ID COLON SIGNED_INT {  $$ = "[" + $1 + "," + std::to_string($3) + "]"; }
                | QUOTED_ID COLON NUMBER     {  $$ = "[" + $1 + "," + std::to_string($3) + "]"; }
+               | QUOTED_ID COLON QUOTED_ID  {  $$ = "[" + $1 + "," + $3 + "]"; }
                ;
 
 enum_kind : WORD { if ($1 != "BigintEnum" && $1 != "VarcharEnum" )

--- a/velox/functions/prestosql/types/tests/VarcharEnumTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/VarcharEnumTypeTest.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/types/VarcharEnumType.h"
+#include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
+#include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+
+namespace facebook::velox {
+namespace {
+class VarcharEnumTypeTest : public testing::Test, public test::TypeTestBase {
+ protected:
+  VarcharEnumTypeTest() {
+    registerVarcharEnumType();
+    VarcharEnumParameter colorInfo(
+        "test.enum.color", {{"RED", "red"}, {"BLUE", "blue"}});
+    colorEnum_ = VARCHAR_ENUM(colorInfo);
+  }
+
+  VarcharEnumTypePtr colorEnum_;
+};
+
+TEST_F(VarcharEnumTypeTest, basic) {
+  ASSERT_TRUE(hasType("VARCHAR_ENUM"));
+  VarcharEnumParameter colorInfo(
+      "test.enum.color", {{"RED", "red"}, {"BLUE", "blue"}});
+  std::vector<TypeParameter> colorParams = {TypeParameter(colorInfo)};
+  ASSERT_EQ(getType("VARCHAR_ENUM", colorParams), colorEnum_);
+
+  ASSERT_STREQ(colorEnum_->name(), "VARCHAR_ENUM");
+  ASSERT_STREQ(colorEnum_->kindName(), "VARCHAR");
+  ASSERT_EQ(colorEnum_->enumName(), "test.enum.color");
+  ASSERT_EQ(colorEnum_->parameters().size(), 1);
+  ASSERT_EQ(
+      colorEnum_->toString(),
+      "test.enum.color:VarcharEnum({\"BLUE\": \"blue\", \"RED\": \"red\"})");
+
+  // Different TypeParameters with different enumName, same enumMap
+  VarcharEnumParameter differentNameSameMap(
+      "test.enum.color2", {{"RED", "red"}, {"BLUE", "blue"}});
+  ASSERT_NE(colorEnum_, VARCHAR_ENUM(differentNameSameMap));
+  EXPECT_FALSE(colorEnum_->equivalent(*VARCHAR_ENUM(differentNameSameMap)));
+
+  // Different TypeParameters with same enumName, different enumMap
+  VarcharEnumParameter sameNameDifferentMap(
+      "test.enum.color",
+      {{"RED", "red"}, {"BLUE", "blue"}, {"GREEN", "green"}});
+  ASSERT_NE(colorEnum_, VARCHAR_ENUM(sameNameDifferentMap));
+  EXPECT_FALSE(colorEnum_->equivalent(*VARCHAR_ENUM(sameNameDifferentMap)));
+
+  // Type Parameter with duplicate value in the enum map.
+  VarcharEnumParameter duplicateValuesInfo(
+      "duplicate.values.enum",
+      {{"RED", "red"}, {"CRIMSON", "red"}, {"BLUE", "blue"}});
+  VELOX_ASSERT_THROW(
+      VARCHAR_ENUM(duplicateValuesInfo),
+      "Invalid enum type duplicate.values.enum, contains duplicate value red");
+
+  // Different TypeParameters with same enumName and enumMap but in different
+  // order
+  VarcharEnumParameter differentOrderMapColorInfo(
+      "test.enum.color", {{"BLUE", "blue"}, {"RED", "red"}});
+  ASSERT_EQ(colorEnum_, VARCHAR_ENUM(differentOrderMapColorInfo));
+  EXPECT_TRUE(
+      colorEnum_->equivalent(*VARCHAR_ENUM(differentOrderMapColorInfo)));
+}
+
+TEST_F(VarcharEnumTypeTest, serde) {
+  testTypeSerde(colorEnum_);
+}
+} // namespace
+} // namespace facebook::velox

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -246,6 +246,18 @@ struct BigintEnumT {
 template <typename E>
 using BigintEnum = CustomType<BigintEnumT<E>>;
 
+// Type to use for inputs and outputs of simple functions with VarcharEnum
+// types. E.g. arg_type<VarcharEnum<E1>> and out_type<VarcharEnum<E1>>.
+template <typename E>
+struct VarcharEnumT {
+  using type = Varchar;
+
+  static inline const std::string typeName = "varchar_enum(" + E::name() + ")";
+};
+
+template <typename E>
+using VarcharEnum = CustomType<VarcharEnumT<E>>;
+
 template <typename T>
 struct Constant {};
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -404,7 +404,7 @@ struct LongEnumParameter {
     return name == other.name && valuesMap == other.valuesMap;
   }
 
-  folly::dynamic serializeEnumParameter() const;
+  folly::dynamic serialize() const;
 
   struct Hash {
     size_t operator()(const LongEnumParameter& param) const;
@@ -417,6 +417,23 @@ struct LongEnumParameter {
 /// Represents the parameters for a VarcharEnumType.
 /// Consists of the name of the enum and a map of string keys to string values.
 struct VarcharEnumParameter {
+  VarcharEnumParameter() = default;
+
+  VarcharEnumParameter(
+      std::string enumName,
+      std::unordered_map<std::string, std::string> enumValuesMap)
+      : name(std::move(enumName)), valuesMap(std::move(enumValuesMap)) {}
+
+  bool operator==(const VarcharEnumParameter& other) const {
+    return name == other.name && valuesMap == other.valuesMap;
+  }
+
+  folly::dynamic serialize() const;
+
+  struct Hash {
+    size_t operator()(const VarcharEnumParameter& param) const;
+  };
+
   std::string name;
   std::unordered_map<std::string, std::string> valuesMap;
 };


### PR DESCRIPTION
Summary:
Modified TypeParser to be able to accept VarcharEnum types in the format:
test.enum.mood:BigintEnum(test.enum.mood{\"CURIOUS\":-2, \"HAPPY\":-2})

and return a VARCHAR_ENUM with VarcharEnumParameter constructed from the parsed type info.

Differential Revision: D81118053
