### PR TITLE
misc: Remove unneeded use-count checking logic

### DIFF
--- a/velox/common/caching/tests/StringIdMapTest.cpp
+++ b/velox/common/caching/tests/StringIdMapTest.cpp
@@ -22,7 +22,7 @@
 using namespace facebook::velox;
 
 TEST(StringIdMapTest, basic) {
-  constexpr const char* kFile1 = "file_1";
+  constexpr std::string_view kFile1 = "file_1";
   StringIdMap map;
   uint64_t id = 0;
   {
@@ -33,7 +33,7 @@ TEST(StringIdMapTest, basic) {
     id = lease2.id();
     lease1 = lease2;
     EXPECT_EQ(id, lease1.id());
-    EXPECT_EQ(strlen(kFile1), map.pinnedSize());
+    EXPECT_EQ(kFile1.size(), map.pinnedSize());
   }
   StringIdLease lease3(map, kFile1);
   EXPECT_NE(lease3.id(), id);
@@ -56,50 +56,48 @@ TEST(StringIdMapTest, rehash) {
 }
 
 TEST(StringIdMapTest, recover) {
-  constexpr const char* kRecoverFile1 = "file_1";
-  constexpr const char* kRecoverFile2 = "file_2";
-  constexpr const char* kRecoverFile3 = "file_3";
+  constexpr std::string_view kRecoverFile1("file_1");
+  constexpr std::string_view kRecoverFile2("file_2");
+  constexpr std::string_view kRecoverFile3("file_3");
   StringIdMap map;
   const uint64_t recoverId1{10};
   const uint64_t recoverId2{20};
   {
     StringIdLease lease(map, recoverId1, kRecoverFile1);
     ASSERT_TRUE(lease.hasValue());
-    ASSERT_EQ(map.pinnedSize(), ::strlen(kRecoverFile1));
+    ASSERT_EQ(map.pinnedSize(), kRecoverFile1.size());
     ASSERT_EQ(map.testingLastId(), recoverId1);
     VELOX_ASSERT_THROW(
-        std::make_unique<StringIdLease>(map, recoverId1, kRecoverFile2),
+        StringIdLease(map, recoverId1, kRecoverFile2),
         "(1 vs. 0) Reused recover id 10 assigned to file_2");
     VELOX_ASSERT_THROW(
-        std::make_unique<StringIdLease>(map, recoverId2, kRecoverFile1),
+        StringIdLease(map, recoverId2, kRecoverFile1),
         "(20 vs. 10) Multiple recover ids assigned to file_1");
   }
   ASSERT_EQ(map.pinnedSize(), 0);
 
   StringIdLease lease1(map, kRecoverFile1);
-  ASSERT_EQ(map.pinnedSize(), ::strlen(kRecoverFile1));
+  ASSERT_EQ(map.pinnedSize(), kRecoverFile1.size());
   ASSERT_EQ(map.testingLastId(), recoverId1 + 1);
 
   {
     StringIdLease lease(map, recoverId2, kRecoverFile2);
     ASSERT_TRUE(lease.hasValue());
     ASSERT_EQ(lease.id(), recoverId2);
-    ASSERT_EQ(
-        map.pinnedSize(), ::strlen(kRecoverFile1) + ::strlen(kRecoverFile2));
+    ASSERT_EQ(map.pinnedSize(), kRecoverFile1.size() + kRecoverFile2.size());
     ASSERT_EQ(map.testingLastId(), recoverId2);
     VELOX_ASSERT_THROW(
-        std::make_unique<StringIdLease>(map, recoverId2, kRecoverFile3),
+        StringIdLease(map, recoverId2, kRecoverFile3),
         "(1 vs. 0) Reused recover id 20 assigned to file_3");
     VELOX_ASSERT_THROW(
-        std::make_unique<StringIdLease>(map, recoverId2, kRecoverFile1),
+        StringIdLease(map, recoverId2, kRecoverFile1),
         "(20 vs. 11) Multiple recover ids assigned to file_1");
     StringIdLease dupLease(map, recoverId2, kRecoverFile2);
     ASSERT_TRUE(lease.hasValue());
     ASSERT_EQ(lease.id(), recoverId2);
-    ASSERT_EQ(
-        map.pinnedSize(), ::strlen(kRecoverFile1) + ::strlen(kRecoverFile2));
+    ASSERT_EQ(map.pinnedSize(), kRecoverFile1.size() + kRecoverFile2.size());
   }
 
   ASSERT_EQ(map.testingLastId(), recoverId2);
-  ASSERT_EQ(map.pinnedSize(), ::strlen(kRecoverFile1));
+  ASSERT_EQ(map.pinnedSize(), kRecoverFile1.size());
 }


### PR DESCRIPTION
`StirngIdMap::release()` ensures that the use-count(`numInUse`) 
of all entries in `idToEntry_` and `stringToId_` will never be equal 
to 0.  This is because once an entry's use-count reaches zero, it is 
removed from both maps.

This PR also includes two refactorings of 'StringIdMapTest.cpp':
- Remove unnecessary `make_unique`;
- Replace `const char*` with `std::string_view`, eliminating the need 
  for `strlen`.