### PR TITLE
feat: Add convenience API to create homogeneous ROW type

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -866,31 +866,48 @@ ArrayTypePtr ARRAY(TypePtr elementType) {
   return TypeFactory<TypeKind::ARRAY>::create(std::move(elementType));
 }
 
+MapTypePtr MAP(TypePtr keyType, TypePtr valueType) {
+  return TypeFactory<TypeKind::MAP>::create(
+      std::move(keyType), std::move(valueType));
+}
+
 RowTypePtr ROW(std::vector<std::string> names, std::vector<TypePtr> types) {
   return TypeFactory<TypeKind::ROW>::create(std::move(names), std::move(types));
 }
 
+RowTypePtr ROW(std::vector<std::string> names, TypePtr childType) {
+  const auto cnt = names.size();
+  return ROW(std::move(names), std::vector(cnt, childType));
+}
+
+RowTypePtr ROW(
+    std::initializer_list<std::string> names,
+    const TypePtr& childType) {
+  const auto cnt = names.size();
+  return TypeFactory<TypeKind::ROW>::create(
+      std::vector(names), std::vector(cnt, childType));
+}
+
+RowTypePtr ROW(std::string name, TypePtr type) {
+  return ROW({{std::move(name), std::move(type)}});
+}
+
 RowTypePtr ROW(
     std::initializer_list<std::pair<const std::string, TypePtr>>&& pairs) {
-  std::vector<TypePtr> types;
   std::vector<std::string> names;
-  types.reserve(pairs.size());
+  std::vector<TypePtr> types;
   names.reserve(pairs.size());
-  for (auto& p : pairs) {
-    types.push_back(p.second);
-    names.push_back(p.first);
+  types.reserve(pairs.size());
+  for (const auto& [name, type] : pairs) {
+    names.push_back(name);
+    types.push_back(type);
   }
   return TypeFactory<TypeKind::ROW>::create(std::move(names), std::move(types));
 }
 
 RowTypePtr ROW(std::vector<TypePtr>&& types) {
   std::vector<std::string> names(types.size(), "");
-  return TypeFactory<TypeKind::ROW>::create(std::move(names), std::move(types));
-}
-
-MapTypePtr MAP(TypePtr keyType, TypePtr valType) {
-  return TypeFactory<TypeKind::MAP>::create(
-      std::move(keyType), std::move(valType));
+  return ROW(std::move(names), std::move(types));
 }
 
 std::shared_ptr<const FunctionType> FUNCTION(

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1555,16 +1555,51 @@ struct TypeFactory<TypeKind::ROW> {
   }
 };
 
+/// Returns an array of 'elementType'.
+///
+/// Example: ARRAY(INTEGER()).
 ArrayTypePtr ARRAY(TypePtr elementType);
 
+/// Returns a map of 'keyType' and 'valueType'.
+///
+/// Example: MAP(INTEGER(), REAL()).
+MapTypePtr MAP(TypePtr keyType, TypePtr valueType);
+
+/// Returns a struct with specified field names and types. Number of 'names'
+/// must match number of 'types'. Empty 'names' and 'types' are allowed.
+///
+/// Example: ROW({"a", "b", "c"}, {INTEGER(), BIGINT(), VARCHAR()}).
 RowTypePtr ROW(std::vector<std::string> names, std::vector<TypePtr> types);
 
+/// Returns a homogenous struct where all fields have the same type.
+///
+/// Example:
+///
+///   ROW({"a", "b", "c"}, REAL()) is a shortcut for
+///     ROW({"a", "b", "c"}, {REAL(), REAL(), REAL()}).
+RowTypePtr ROW(std::vector<std::string> names, const TypePtr& childType);
+
+RowTypePtr ROW(
+    std::initializer_list<std::string> names,
+    const TypePtr& childType);
+
+/// Creates a RowType from list of (name, type) pairs.
+///
+/// Example: ROW({{"a", INTEGER()}, {"b", BIGINT()}, {"c", VARCHAR()}}).
 RowTypePtr ROW(
     std::initializer_list<std::pair<const std::string, TypePtr>>&& pairs);
 
-RowTypePtr ROW(std::vector<TypePtr>&& types);
+/// Returns a struct with a single field.
+///
+/// Example: ROW("a", BIGINT()) is a shortcut for ROW({{"a", BIGINT()}}).
+RowTypePtr ROW(std::string name, TypePtr type);
 
-MapTypePtr MAP(TypePtr keyType, TypePtr valType);
+/// Returns anonymoous struct where field names are empty.
+///
+/// Examples:
+///    ROW({INTEGER(), BIGINT(), VARCHAR()})
+///    ROW({}) // Struct with no fields.
+RowTypePtr ROW(std::vector<TypePtr>&& types);
 
 std::shared_ptr<const FunctionType> FUNCTION(
     std::vector<TypePtr>&& argumentTypes,

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -532,6 +532,26 @@ TEST(TypeTest, emptyRow) {
   testTypeSerde(row);
 }
 
+TEST(TypeTest, singleFieldRow) {
+  auto rowType = ROW("a", REAL());
+  testTypeSerde(rowType);
+
+  auto equivalentRowType = ROW({{"a", REAL()}});
+  ASSERT_EQ(*rowType, *equivalentRowType);
+  testTypeSerde(equivalentRowType);
+
+  equivalentRowType = ROW({"a"}, {REAL()});
+  ASSERT_EQ(*rowType, *equivalentRowType);
+  testTypeSerde(equivalentRowType);
+}
+
+TEST(TypeTest, homogenousRow) {
+  auto rowType = ROW({"a", "b", "c"}, REAL());
+  auto equivalentRowType = ROW({"a", "b", "c"}, {REAL(), REAL(), REAL()});
+  ASSERT_EQ(*rowType, *equivalentRowType);
+  testTypeSerde(rowType);
+}
+
 TEST(TypeTest, rowParametersMultiThreaded) {
   std::vector<std::string> names;
   std::vector<TypePtr> types;


### PR DESCRIPTION
Summary:
Add convenience API to create a struct where all fields have the same type. Also, add an API to easily make a struct with a single field.

```
/// Returns a homogenous struct where all fields have the same type.
///
/// Example:
///
///   ROW({"a", "b", "c"}, REAL()) is a shortcut for
///     ROW({"a", "b", "c"}, {REAL(), REAL(), REAL()}).
RowTypePtr ROW(std::vector<std::string> names, const TypePtr& childType);

/// Returns a struct with a single field.
///
/// Example: ROW("a", BIGINT()) is a shortcut for ROW({{"a", BIGINT()}}).
RowTypePtr ROW(std::string name, TypePtr type);
```

Differential Revision: D81127629


