### PR TITLE
fix: Schema evolution on flatmap key type

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -360,7 +360,8 @@ createSelectiveFlatMapColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     DwrfParams& params,
     common::ScanSpec& scanSpec) {
-  auto kind = fileType->childAt(0)->type()->kind();
+  VELOX_DCHECK(requestedType->isMap());
+  auto kind = requestedType->childAt(0)->kind();
   switch (kind) {
     case TypeKind::TINYINT:
       return createReader<int8_t>(


### PR DESCRIPTION
Summary: When the key type is promoted, we were still using the old type to do dynamic casts and result in nullptr crashes.

Differential Revision: D81138210


