### PR TITLE
misc: Remove the registerAbfsFileSystem() API definition from AbfsFileSystem.

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
@@ -76,5 +76,4 @@ class AbfsFileSystem : public FileSystem {
   }
 };
 
-void registerAbfsFileSystem();
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.h"
+#include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.h"
 #include "velox/connectors/hive/storage_adapters/abfs/tests/MockDataLakeFileClient.h"
 #include "velox/dwio/common/FileSink.h"


### PR DESCRIPTION
Remove the registerAbfsFileSystem() API definition from AbfsFileSystem.h, and retain it only in RegisterAbfsFileSystem.h.