### PR TITLE
fix: Fix velox exec build

### DIFF
--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -61,21 +61,3 @@ target_link_libraries(
   velox_functions_prestosql
   velox_aggregates
 )
-
-if(${VELOX_BUILD_RUNNER})
-  add_library(velox_exec_runner_test_util DistributedPlanBuilder.cpp
-                                          LocalRunnerTestBase.cpp)
-
-  target_link_libraries(
-    velox_exec_runner_test_util
-    velox_temp_path
-    velox_exec_test_lib
-    velox_exec
-    velox_file_test_utils
-    velox_hive_connector
-    velox_tpch_connector
-    velox_tpcds_connector
-    velox_local_runner
-  )
-
-endif()


### PR DESCRIPTION
```
-- Configuring done (71.3s)
CMake Error at velox/exec/tests/utils/CMakeLists.txt:66 (add_library):
  Cannot find source file:

    DistributedPlanBuilder.cpp


CMake Generate step failed.  Build files cannot be regenerated correctly.
-- Generating done (4.1s)
make[1]: *** [Makefile:98: cmake] Error 1
make[1]: Leaving directory '/home/runner/work/velox/velox/velox'
```