### PR TITLE
Replace FOLLY_LIKELY/UNLIKELY with C++ standard attributes (Ref #14398)

### DIFF
--- a/velox/common/base/SimdUtil.cpp
+++ b/velox/common/base/SimdUtil.cpp
@@ -27,7 +27,7 @@ void gatherBits(
   const auto size = indexRange.size();
   auto indices = indexRange.data();
   uint8_t* resultPtr = reinterpret_cast<uint8_t*>(result);
-  if (FOLLY_LIKELY(size < 5)) {
+  if (size < 5)[[likely]] {
     uint8_t smallResult = 0;
     for (auto i = 0; i < size; ++i) {
       smallResult |= static_cast<uint8_t>(bits::isBitSet(bits, indices[i]))


### PR DESCRIPTION
This draft PR starts replacing `FOLLY_LIKELY` / `FOLLY_UNLIKELY` with
the standard C++ attributes `[[likely]]` / `[[unlikely]]`.

Example: Applied in `SimdUtil.cpp` to illustrate the approach.

Since `FOLLY_LIKELY` / `FOLLY_UNLIKELY` are defined in Folly and Velox
just uses them, I wanted to clarify the preferred approach:

- Should I replace all usages in Velox directly with the C++ standard attributes?  
- Or would you prefer introducing Velox-local wrappers (e.g., `VELOX_LIKELY` / `VELOX_UNLIKELY`) to decouple from Folly while keeping flexibility?  

Please advise before I proceed further.  

Ref: #14398
