### PR TITLE
feat: Show constant projections separately in Plan Summary

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -107,15 +107,19 @@ extern const SortOrder kDescNullsLast;
 struct PlanSummaryOptions {
   /// Options that apply specifically to PROJECT nodes.
   struct ProjectOptions {
-    /// For a given PROJECT node, maximum number of non-identity projection
-    /// expressions to include in the summary. By default, no expression is
-    /// included.
+    /// For a given PROJECT node, maximum number of non-identity and
+    /// non-constant projection expressions to include in the summary. By
+    /// default, no expression is included.
     size_t maxProjections = 0;
 
     /// For a given PROJECT node, maximum number of dereference (access of a
     /// struct field) expressions to include in the summary. By default, no
     /// expression is included.
     size_t maxDereferences = 0;
+
+    /// For a given PROJECT node, maximum number of constant expressions to
+    /// include in the summary. By default, no expression is included.
+    size_t maxConstants = 0;
   };
 
   ProjectOptions project = {};


### PR DESCRIPTION
Summary:
Some plans have a lot of constant projections. It helps to separate these from non-identity and non-constant expressions.

```
        projections: 2979 out of 5647
           __temp17874: plus(bucketize("__temp7337",{0.0004116561613045633...
           __temp15078: plus(bucketize("__temp7005",{0, 1, 2, 3, 4, ...39 ...
           __temp14499: plus(bucketize("__temp5787",{4, 8, 13, 18, 23, ......
           ... 2976 more
        constant projections: 2155 out of 5647
```

Differential Revision: D81220088


