### PR TITLE
fix(cuDF): Fix an exception when we get empty input for avg aggregation

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -582,9 +582,22 @@ auto toIntermediateAggregators(
 std::unique_ptr<cudf::table> makeEmptyTable(TypePtr const& inputType) {
   std::vector<std::unique_ptr<cudf::column>> emptyColumns;
   for (size_t i = 0; i < inputType->size(); ++i) {
-    auto emptyColumn = cudf::make_empty_column(
-        cudf_velox::veloxToCudfTypeId(inputType->childAt(i)));
-    emptyColumns.push_back(std::move(emptyColumn));
+    if (auto const& childType = inputType->childAt(i);
+        childType->kind() == TypeKind::ROW) {
+      auto tbl = makeEmptyTable(childType);
+      auto structColumn = std::make_unique<cudf::column>(
+          cudf::data_type(cudf::type_id::STRUCT),
+          0,
+          rmm::device_buffer(),
+          rmm::device_buffer(),
+          0,
+          tbl->release());
+      emptyColumns.push_back(std::move(structColumn));
+    } else {
+      auto emptyColumn = cudf::make_empty_column(
+          cudf_velox::veloxToCudfTypeId(inputType->childAt(i)));
+      emptyColumns.push_back(std::move(emptyColumn));
+    }
   }
   return std::make_unique<cudf::table>(std::move(emptyColumns));
 }

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -667,15 +667,15 @@ TEST_F(EmptyInputAggregationTest, groupedPartialFinalAggregation) {
   plan_ = PlanBuilder()
               .values({data_})
               .filter(filter_)
-              .partialAggregation({"c2"}, {"sum(c0)", "count(c1)", "max(c1)"})
+              .partialAggregation(
+                  {"c2"}, {"sum(c0)", "count(c1)", "max(c1)", "avg(c1)"})
               .finalAggregation()
               .planNode();
-  // TODO (dm): "avg(c1)"
 
   // should return empty result for partial-final aggregation
   assertQuery(
       plan_,
-      "SELECT c2, sum(c0), count(c1), max(c1) FROM tmp WHERE c0 > 10 GROUP BY c2");
+      "SELECT c2, sum(c0), count(c1), max(c1), avg(c1) FROM tmp WHERE c0 > 10 GROUP BY c2");
 }
 
 TEST_F(EmptyInputAggregationTest, globalPartialFinalAggregation) {
@@ -684,14 +684,15 @@ TEST_F(EmptyInputAggregationTest, globalPartialFinalAggregation) {
   plan_ = PlanBuilder()
               .values({data_})
               .filter(filter_)
-              .partialAggregation({}, {"sum(c0)", "count(c1)", "max(c1)"})
+              .partialAggregation(
+                  {}, {"sum(c0)", "count(c1)", "max(c1)", "avg(c1)"})
               .finalAggregation()
               .planNode();
-  // TODO (dm): "avg(c1)"
 
   // global partial-final aggregation should return 1 row with null/zero values
   assertQuery(
-      plan_, "SELECT sum(c0), count(c1), max(c1) FROM tmp WHERE c0 > 10");
+      plan_,
+      "SELECT sum(c0), count(c1), max(c1), avg(c1) FROM tmp WHERE c0 > 10");
 }
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
In https://github.com/facebookincubator/velox/pull/13953 we fixed the case where Single/Final aggregation received no input. That PR added the fix for sum/min/max/count but deferred the fix for avg. This PR adds that.