### PR TITLE
Add ROUND ROBIN to cudfLocalPartition

### DIFF
--- a/velox/experimental/cudf/exec/CudfLocalPartition.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.cpp
@@ -86,8 +86,14 @@ CudfLocalPartition::CudfLocalPartition(
         partitionKeyIndices_.push_back(fieldIndex);
       }
     }
+    partitionFunctionType_ = PartitionFunctionType::kHash;
+  } else if (
+      numPartitions_ > 1 && spec.find("ROUND ROBIN") != std::string::npos) {
+    partitionFunctionType_ = PartitionFunctionType::kRoundRobin;
   }
-  VELOX_CHECK(numPartitions_ == 1 || partitionKeyIndices_.size() > 0);
+  VELOX_CHECK(
+      numPartitions_ == 1 || partitionKeyIndices_.size() > 0 ||
+      partitionFunctionType_ == PartitionFunctionType::kRoundRobin);
 
   // Since we're replacing the LocalPartition with CudfLocalPartition, the
   // number of producers is already set. Adding producer only adds to a counter
@@ -105,20 +111,29 @@ void CudfLocalPartition::addInput(RowVectorPtr input) {
   auto stream = cudfVector->stream();
 
   if (numPartitions_ > 1) {
-    // Use cudf hash partitioning
-    auto tableView = cudfVector->getTableView();
-    std::vector<cudf::size_type> partitionKeyIndices;
-    for (const auto& idx : partitionKeyIndices_) {
-      partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
-    }
+    auto [partitionedTable, partitionOffsets] = [&]() {
+      auto tableView = cudfVector->getTableView();
+      // Use cudf hash partitioning
+      if (partitionFunctionType_ == PartitionFunctionType::kHash) {
+        std::vector<cudf::size_type> partitionKeyIndices;
+        for (const auto& idx : partitionKeyIndices_) {
+          partitionKeyIndices.push_back(static_cast<cudf::size_type>(idx));
+        }
 
-    auto [partitionedTable, partitionOffsets] = cudf::hash_partition(
-        tableView,
-        partitionKeyIndices,
-        numPartitions_,
-        cudf::hash_id::HASH_MURMUR3,
-        cudf::DEFAULT_HASH_SEED,
-        stream);
+        return cudf::hash_partition(
+            tableView,
+            partitionKeyIndices,
+            numPartitions_,
+            cudf::hash_id::HASH_MURMUR3,
+            cudf::DEFAULT_HASH_SEED,
+            stream);
+      } else if (partitionFunctionType_ == PartitionFunctionType::kRoundRobin) {
+        return cudf::round_robin_partition(
+            tableView, numPartitions_, counter_, stream);
+        counter_ = (counter_ + cudfVector->size()) % numPartitions_;
+      }
+      VELOX_FAIL("Unsupported partition function");
+    }();
 
     VELOX_CHECK(partitionOffsets.size() == numPartitions_);
     VELOX_CHECK(partitionOffsets[0] == 0);

--- a/velox/experimental/cudf/exec/CudfLocalPartition.h
+++ b/velox/experimental/cudf/exec/CudfLocalPartition.h
@@ -22,6 +22,11 @@
 
 namespace facebook::velox::cudf_velox {
 
+enum class PartitionFunctionType {
+  kHash,
+  kRoundRobin,
+};
+
 class CudfLocalPartition : public exec::Operator, public NvtxHelper {
  public:
   CudfLocalPartition(
@@ -54,6 +59,8 @@ class CudfLocalPartition : public exec::Operator, public NvtxHelper {
  protected:
   const std::vector<std::shared_ptr<exec::LocalExchangeQueue>> queues_;
   const size_t numPartitions_;
+  PartitionFunctionType partitionFunctionType_;
+  size_t counter_{0};
 
   std::vector<exec::BlockingReason> blockingReasons_;
   std::vector<ContinueFuture> futures_;


### PR DESCRIPTION
This PR add ROUND ROBIN partitioning to cudfLocalPartition operator

Round robin partition is supported by cudf, and also in Velox [velox/exec/RoundRobinPartitionFunction.h ](https://github.com/facebookincubator/velox/blob/3fa7acf3cd31b9f140cd7912244ab2d675e50f9e/velox/exec/RoundRobinPartitionFunction.h) . This PR adds round robin  to velox-cudf

- TBD unit test for round robin
