### PR TITLE
feat(readers): Customize column loader to track average row size

### DIFF
--- a/velox/dwio/common/ColumnLoader.h
+++ b/velox/dwio/common/ColumnLoader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
+#include "velox/vector/LazyVector.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -30,11 +31,13 @@ class ColumnLoader : public VectorLoader {
         fieldReader_(fieldReader),
         version_(version) {}
 
+  virtual ~ColumnLoader() = default;
+
   bool supportsHook() const override {
     return true;
   }
 
- private:
+ protected:
   void loadInternal(
       RowSet rows,
       ValueHook* hook,

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -531,6 +531,12 @@ bool SelectiveStructColumnReaderBase::isChildMissing(
        childSpec.channel() >= fileType_->size());
 }
 
+std::unique_ptr<velox::dwio::common::ColumnLoader>
+SelectiveStructColumnReaderBase::makeColumnLoader(vector_size_t index) {
+  return std::make_unique<velox::dwio::common::ColumnLoader>(
+      this, children_[index], numReads_);
+}
+
 void SelectiveStructColumnReaderBase::getValues(
     const RowSet& rows,
     VectorPtr* result) {
@@ -616,7 +622,7 @@ void SelectiveStructColumnReaderBase::getValues(
     // LazyVector result.
     setOutputRowsForLazy(rows);
     setLazyField(
-        std::make_unique<ColumnLoader>(this, children_[index], numReads_),
+        makeColumnLoader(index),
         resultRow->type()->childAt(channel),
         rows.size(),
         memoryPool_,

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -20,6 +20,8 @@
 
 namespace facebook::velox::dwio::common {
 
+class ColumnLoader;
+
 template <typename T, typename KeyNode, typename FormatData>
 class SelectiveFlatMapColumnReaderHelper;
 
@@ -161,6 +163,12 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       const int64_t offset,
       const int32_t rowsPerRowGroup);
 
+  virtual std::unique_ptr<velox::dwio::common::ColumnLoader> makeColumnLoader(
+      vector_size_t index);
+
+  // Sequence number of output batch. Checked against ColumnLoaders
+  // created by 'this' to verify they are still valid at load.
+  uint64_t numReads_ = 0;
   std::vector<SelectiveColumnReader*> children_;
 
  private:
@@ -188,10 +196,6 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
 
   // Dense set of rows to read in next().
   raw_vector<vector_size_t> rows_;
-
-  // Sequence number of output batch. Checked against ColumnLoaders
-  // created by 'this' to verify they are still valid at load.
-  uint64_t numReads_ = 0;
 
   int64_t lazyVectorReadOffset_;
 

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -221,6 +221,9 @@ class DwrfRowReader : public StrideIndexProvider,
 
   std::unique_ptr<dwio::common::UnitLoader> unitLoader_;
   DwrfUnit* currentUnit_;
+
+  mutable std::optional<size_t> estimatedRowSize_;
+  mutable bool hasRowEstimate_{false};
 };
 
 class DwrfReader : public dwio::common::Reader {

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1178,9 +1178,14 @@ class ParquetRowReader::Impl {
   std::optional<size_t> estimatedRowSize() const {
     auto index =
         nextRowGroupIdsIdx_ < 1 ? 0 : rowGroupIds_[nextRowGroupIdsIdx_ - 1];
-    return readerBase_->rowGroupUncompressedSize(
-               index, *readerBase_->schemaWithId()) /
+    if (index == lastRowGroupWithRowEstimate_) {
+      return estimatedRowSize_;
+    }
+    estimatedRowSize_ = readerBase_->rowGroupUncompressedSize(
+                            index, *readerBase_->schemaWithId()) /
         rowGroups_[index].num_rows;
+    lastRowGroupWithRowEstimate_ = index;
+    return estimatedRowSize_;
   }
 
   void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const {
@@ -1237,6 +1242,9 @@ class ParquetRowReader::Impl {
   ParquetStatsContext parquetStatsContext_;
 
   dwio::common::ColumnReaderStatistics columnReaderStats_;
+
+  mutable std::optional<size_t> estimatedRowSize_;
+  mutable int32_t lastRowGroupWithRowEstimate_{-1};
 };
 
 ParquetRowReader::ParquetRowReader(

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -180,15 +180,16 @@ RowVectorPtr TableScan::getOutput() {
         }
         continue;
       }
-      const auto estimatedRowSize = dataSource_->estimatedRowSize();
-      readBatchSize_ =
-          estimatedRowSize == connector::DataSource::kUnknownRowSize
-          ? outputBatchRows()
-          : outputBatchRows(estimatedRowSize);
     }
     VELOX_CHECK(!needNewSplit_);
     VELOX_CHECK(!hasDrained());
 
+    const auto estimatedRowSize = dataSource_->estimatedRowSize();
+    // TODO: Expose this to operator stats.
+    LOG(INFO) << "estimatedRowSize = " << estimatedRowSize;
+    readBatchSize_ = estimatedRowSize == connector::DataSource::kUnknownRowSize
+        ? outputBatchRows()
+        : outputBatchRows(estimatedRowSize);
     int32_t readBatchSize = readBatchSize_;
     if (maxFilteringRatio_ > 0) {
       readBatchSize = std::min(


### PR DESCRIPTION
Summary:
Add a framework to complement the row size estimate heuristics, based on the retained vector sizes.

Currently this framework is used as a stop gap solution to still have functional row estimates when column stats are missing, and decoders couldn't provide a relatively cheap estimate. The current functionality gap in decoder row estimates caused various queries to run with super small batches (frequently just 10 rows), and vastly slowing down the downstream eval.

Reviewed By: Yuhta

Differential Revision: D80310282


