### PR TITLE
feat: support dynamic quantile stat

### DIFF
--- a/velox/common/base/StatsReporter.h
+++ b/velox/common/base/StatsReporter.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <folly/Singleton.h>
-#include <memory>
 
 /// StatsReporter designed to assist in reporting various metrics of the
 /// application that uses velox library. The library itself does not implement
@@ -136,6 +135,24 @@ class BaseStatsReporter {
       const std::vector<double>& pcts,
       const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
 
+  /// Register a dynamic quantile metric with a template key pattern that
+  /// supports runtime substitution.
+  /// @param keyPattern The key pattern with {} placeholders for substitution.
+  /// @param statTypes The list of stat types to export.
+  /// @param pcts The quantile percentiles to track.
+  /// @param slidingWindowsSeconds The sliding window periods in seconds.
+  virtual void registerDynamicQuantileMetricExportType(
+      const char* keyPattern,
+      const std::vector<StatType>& statTypes,
+      const std::vector<double>& pcts,
+      const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
+
+  virtual void registerDynamicQuantileMetricExportType(
+      folly::StringPiece keyPattern,
+      const std::vector<StatType>& statTypes,
+      const std::vector<double>& pcts,
+      const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
+
   /// Add the given value to the stat.
   virtual void addMetricValue(const std::string& key, size_t value = 1)
       const = 0;
@@ -163,6 +180,22 @@ class BaseStatsReporter {
 
   virtual void addQuantileMetricValue(folly::StringPiece key, size_t value = 1)
       const = 0;
+
+  /// Add the given value to a quantile metric.
+  virtual void addDynamicQuantileMetricValue(
+      const std::string& key,
+      folly::Range<const folly::StringPiece*> subkeys,
+      size_t value = 1) const = 0;
+
+  virtual void addDynamicQuantileMetricValue(
+      const char* key,
+      folly::Range<const folly::StringPiece*> subkeys,
+      size_t value = 1) const = 0;
+
+  virtual void addDynamicQuantileMetricValue(
+      folly::StringPiece key,
+      folly::Range<const folly::StringPiece*> subkeys,
+      size_t value = 1) const = 0;
 
   /// Return the aggregated metrics in a serialized string format.
   virtual std::string fetchMetrics() = 0;
@@ -206,6 +239,18 @@ class DummyStatsReporter : public BaseStatsReporter {
       const std::vector<double>& /* pcts */,
       const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
 
+  void registerDynamicQuantileMetricExportType(
+      const char* /* keyPattern */,
+      const std::vector<StatType>& /* statTypes */,
+      const std::vector<double>& /* pcts */,
+      const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
+
+  void registerDynamicQuantileMetricExportType(
+      folly::StringPiece /* keyPattern */,
+      const std::vector<StatType>& /* statTypes */,
+      const std::vector<double>& /* pcts */,
+      const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
+
   void addMetricValue(const std::string& /* key */, size_t /* value */)
       const override {}
 
@@ -232,6 +277,21 @@ class DummyStatsReporter : public BaseStatsReporter {
 
   void addQuantileMetricValue(folly::StringPiece /* key */, size_t /* value */)
       const override {}
+
+  void addDynamicQuantileMetricValue(
+      const std::string& /* key */,
+      folly::Range<const folly::StringPiece*> /* subkeys */,
+      size_t /* value */) const override {}
+
+  void addDynamicQuantileMetricValue(
+      const char* /* key */,
+      folly::Range<const folly::StringPiece*> /* subkeys */,
+      size_t /* value */) const override {}
+
+  void addDynamicQuantileMetricValue(
+      folly::StringPiece /* key */,
+      folly::Range<const folly::StringPiece*> /* subkeys */,
+      size_t /* value */) const override {}
 
   std::string fetchMetrics() override {
     return "";
@@ -261,6 +321,29 @@ template <typename... Args>
 std::vector<size_t> slidingWindowsSeconds(Args... args) {
   return std::vector<size_t>{static_cast<size_t>(args)...};
 }
+
+/// Helper class that stores subkeys in a member array and converts to
+/// folly::Range. This is a temporary object that lives just for the duration of
+/// the macro call.
+template <size_t N>
+class subkeys {
+  std::array<folly::StringPiece, N> pieces_;
+
+ public:
+  template <typename... Args>
+  subkeys(Args&&... args)
+      : pieces_{folly::StringPiece(std::forward<Args>(args))...} {}
+
+  /// Conversion operator to folly::Range<const folly::StringPiece*>
+  operator folly::Range<const folly::StringPiece*>() const {
+    return folly::Range<const folly::StringPiece*>(
+        pieces_.data(), pieces_.size());
+  }
+};
+
+/// Template deduction guide for subkeys class
+template <typename... Args>
+subkeys(Args&&...) -> subkeys<sizeof...(Args)>;
 
 #define DEFINE_METRIC(key, type)                               \
   {                                                            \
@@ -332,5 +415,30 @@ std::vector<size_t> slidingWindowsSeconds(Args... args) {
         reporter->addQuantileMetricValue((key), ##__VA_ARGS__); \
       }                                                         \
     }                                                           \
+  }
+
+#define DEFINE_DYNAMIC_QUANTILE_STAT(                                    \
+    keyPattern, statTypes, percentiles, slidingWindows)                  \
+  {                                                                      \
+    if (::facebook::velox::BaseStatsReporter::registered) {              \
+      auto reporter = folly::Singleton<                                  \
+          facebook::velox::BaseStatsReporter>::try_get_fast();           \
+      if (FOLLY_LIKELY(reporter != nullptr)) {                           \
+        reporter->registerDynamicQuantileMetricExportType(               \
+            (keyPattern), (statTypes), (percentiles), (slidingWindows)); \
+      }                                                                  \
+    }                                                                    \
+  }
+
+#define RECORD_DYNAMIC_QUANTILE_STAT_VALUE(keyPattern, subkeys, ...) \
+  {                                                                  \
+    if (::facebook::velox::BaseStatsReporter::registered) {          \
+      auto reporter = folly::Singleton<                              \
+          facebook::velox::BaseStatsReporter>::try_get_fast();       \
+      if (FOLLY_LIKELY(reporter != nullptr)) {                       \
+        reporter->addDynamicQuantileMetricValue(                     \
+            (keyPattern), (subkeys), ##__VA_ARGS__);                 \
+      }                                                              \
+    }                                                                \
   }
 } // namespace facebook::velox

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/common/base/StatsReporter.h"
-#include <folly/Singleton.h>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
 #include <cstdint>
@@ -23,6 +22,7 @@
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/PeriodicStatsReporter.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/base/tests/StatsReporterUtils.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/CacheTTLController.h"
 #include "velox/common/caching/SsdCache.h"
@@ -30,144 +30,15 @@
 
 namespace facebook::velox {
 
-class TestReporter : public BaseStatsReporter {
- public:
-  mutable std::mutex m;
-  mutable std::map<std::string, size_t> counterMap;
-  mutable std::unordered_map<std::string, StatType> statTypeMap;
-  mutable std::unordered_map<std::string, std::vector<int32_t>>
-      histogramPercentilesMap;
-
-  mutable std::unordered_map<std::string, std::vector<StatType>>
-      quantileStatTypesMap;
-  mutable std::unordered_map<std::string, std::vector<double>>
-      quantilePercentilesMap;
-  mutable std::unordered_map<std::string, std::vector<size_t>>
-      quantileSlidingWindowsMap;
-
-  void clear() {
-    std::lock_guard<std::mutex> l(m);
-    counterMap.clear();
-    statTypeMap.clear();
-    histogramPercentilesMap.clear();
-    quantileStatTypesMap.clear();
-    quantilePercentilesMap.clear();
-    quantileSlidingWindowsMap.clear();
-  }
-
-  void registerMetricExportType(const char* key, StatType statType)
-      const override {
-    statTypeMap[key] = statType;
-  }
-
-  void registerMetricExportType(folly::StringPiece key, StatType statType)
-      const override {
-    statTypeMap[std::string(key)] = statType;
-  }
-
-  void registerHistogramMetricExportType(
-      const char* key,
-      int64_t /* bucketWidth */,
-      int64_t /* min */,
-      int64_t /* max */,
-      const std::vector<int32_t>& pcts) const override {
-    histogramPercentilesMap[key] = pcts;
-  }
-
-  void registerHistogramMetricExportType(
-      folly::StringPiece key,
-      int64_t /* bucketWidth */,
-      int64_t /* min */,
-      int64_t /* max */,
-      const std::vector<int32_t>& pcts) const override {
-    histogramPercentilesMap[std::string(key)] = pcts;
-  }
-
-  void registerQuantileMetricExportType(
-      const char* key,
-      const std::vector<StatType>& statTypes,
-      const std::vector<double>& pcts,
-      const std::vector<size_t>& slidingWindowsSeconds) const override {
-    std::lock_guard<std::mutex> l(m);
-    quantileStatTypesMap[key] = statTypes;
-    quantilePercentilesMap[key] = pcts;
-    quantileSlidingWindowsMap[key] = slidingWindowsSeconds;
-  }
-
-  void registerQuantileMetricExportType(
-      folly::StringPiece key,
-      const std::vector<StatType>& statTypes,
-      const std::vector<double>& pcts,
-      const std::vector<size_t>& slidingWindowsSeconds) const override {
-    std::lock_guard<std::mutex> l(m);
-    quantileStatTypesMap[std::string(key)] = statTypes;
-    quantilePercentilesMap[std::string(key)] = pcts;
-    quantileSlidingWindowsMap[std::string(key)] = slidingWindowsSeconds;
-  }
-
-  void addMetricValue(const std::string& key, const size_t value)
-      const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[key] += value;
-  }
-
-  void addMetricValue(const char* key, const size_t value) const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[key] += value;
-  }
-
-  void addMetricValue(folly::StringPiece key, size_t value) const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[std::string(key)] += value;
-  }
-
-  void addHistogramMetricValue(const std::string& key, size_t value)
-      const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[key] = std::max(counterMap[key], value);
-  }
-
-  void addHistogramMetricValue(const char* key, size_t value) const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[key] = std::max(counterMap[key], value);
-  }
-
-  void addHistogramMetricValue(folly::StringPiece key, size_t value)
-      const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[std::string(key)] =
-        std::max(counterMap[std::string(key)], value);
-  }
-
-  void addQuantileMetricValue(const std::string& key, size_t value)
-      const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[key] += value;
-  }
-
-  void addQuantileMetricValue(const char* key, size_t value) const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[key] += value;
-  }
-
-  void addQuantileMetricValue(folly::StringPiece key, size_t value)
-      const override {
-    std::lock_guard<std::mutex> l(m);
-    counterMap[std::string(key)] += value;
-  }
-
-  std::string fetchMetrics() override {
-    std::stringstream ss;
-    ss << "[";
-    auto sep = "";
-    for (const auto& [key, value] : counterMap) {
-      ss << sep << key << ":" << value;
-      sep = ",";
-    }
-    ss << "]";
-    return ss.str();
-  }
+struct QuantileConfig {
+  std::vector<StatType> statTypes;
+  std::vector<double> percentiles;
+  std::vector<size_t> slidingWindows;
 };
+
+inline QuantileConfig createStandardConfig() {
+  return {{StatType::AVG, StatType::COUNT}, {0.5, 0.95}, {60, 600}};
+}
 
 class StatsReporterTest : public testing::Test {
  protected:
@@ -184,7 +55,48 @@ class StatsReporterTest : public testing::Test {
     BaseStatsReporter::registered = false;
   }
 
+ public:
   std::shared_ptr<TestReporter> reporter_;
+
+  void verifyQuantileRegistration(
+      const std::string& key,
+      const QuantileConfig& config) {
+    EXPECT_TRUE(reporter_->quantileStatTypesMap.count(key));
+    EXPECT_EQ(config.statTypes, reporter_->quantileStatTypesMap[key]);
+    EXPECT_EQ(config.percentiles, reporter_->quantilePercentilesMap[key]);
+    EXPECT_EQ(config.slidingWindows, reporter_->quantileSlidingWindowsMap[key]);
+  }
+
+  void verifyDynamicQuantileRegistration(
+      const std::string& pattern,
+      const QuantileConfig& config) {
+    EXPECT_TRUE(reporter_->dynamicQuantileStatTypesMap.count(pattern));
+    EXPECT_EQ(
+        config.statTypes, reporter_->dynamicQuantileStatTypesMap[pattern]);
+    EXPECT_EQ(
+        config.percentiles, reporter_->dynamicQuantilePercentilesMap[pattern]);
+    EXPECT_EQ(
+        config.slidingWindows,
+        reporter_->dynamicQuantileSlidingWindowsMap[pattern]);
+  }
+
+  template <typename KeyType>
+  void registerAndVerifyQuantile(
+      KeyType key,
+      const QuantileConfig& config = createStandardConfig()) {
+    reporter_->registerQuantileMetricExportType(
+        key, config.statTypes, config.percentiles, config.slidingWindows);
+    verifyQuantileRegistration(std::string(key), config);
+  }
+
+  template <typename KeyType>
+  void registerAndVerifyDynamicQuantile(
+      KeyType pattern,
+      const QuantileConfig& config = createStandardConfig()) {
+    reporter_->registerDynamicQuantileMetricExportType(
+        pattern, config.statTypes, config.percentiles, config.slidingWindows);
+    verifyDynamicQuantileRegistration(std::string(pattern), config);
+  }
 };
 
 TEST_F(StatsReporterTest, trivialReporter) {
@@ -667,99 +579,50 @@ TEST_F(PeriodicStatsReporterTest, allNullOption) {
 }
 
 TEST_F(StatsReporterTest, registerQuantileMetricExportType) {
-  reporter_->registerQuantileMetricExportType(
-      "test_quantile_stat",
-      statTypes(StatType::AVG, StatType::SUM, StatType::COUNT),
-      percentiles(0.5, 0.95, 0.99),
-      slidingWindowsSeconds(60, 600));
-
-  EXPECT_TRUE(reporter_->quantileStatTypesMap.count("test_quantile_stat"));
-  std::vector<StatType> expectedStatTypes = {
-      StatType::AVG, StatType::SUM, StatType::COUNT};
-  std::vector<double> expectedPercentiles = {0.5, 0.95, 0.99};
-  std::vector<size_t> expectedSlidingWindows = {60, 600};
-  EXPECT_EQ(
-      expectedStatTypes, reporter_->quantileStatTypesMap["test_quantile_stat"]);
-  EXPECT_EQ(
-      expectedPercentiles,
-      reporter_->quantilePercentilesMap["test_quantile_stat"]);
-  EXPECT_EQ(
-      expectedSlidingWindows,
-      reporter_->quantileSlidingWindowsMap["test_quantile_stat"]);
+  QuantileConfig config = {
+      {StatType::AVG, StatType::SUM, StatType::COUNT},
+      {0.5, 0.95, 0.99},
+      {60, 600}};
+  registerAndVerifyQuantile("test_quantile_stat", config);
 }
 
-TEST_F(StatsReporterTest, registerQuantileMetricExportTypeWithStringPiece) {
-  // Test registration with StringPiece key
-  folly::StringPiece key("stringpiece_quantile_stat");
-  reporter_->registerQuantileMetricExportType(
-      key,
-      statTypes(StatType::RATE),
-      percentiles(0.75, 0.90),
-      slidingWindowsSeconds(3600));
+TEST_F(StatsReporterTest, quantileRegistrationWithValues) {
+  // Test registration and value addition (covers all key types via templates)
+  const char* charKey = "test_quantile_char";
+  std::string stringKey = "test_quantile_string";
+  folly::StringPiece spKey("test_quantile_sp");
 
-  EXPECT_TRUE(reporter_->quantileStatTypesMap.count(std::string(key)));
-  std::vector<StatType> expectedStatTypes = {StatType::RATE};
-  std::vector<double> expectedPercentiles = {0.75, 0.90};
-  std::vector<size_t> expectedSlidingWindows = {3600};
-  EXPECT_EQ(
-      expectedStatTypes, reporter_->quantileStatTypesMap[std::string(key)]);
-  EXPECT_EQ(
-      expectedPercentiles, reporter_->quantilePercentilesMap[std::string(key)]);
-  EXPECT_EQ(
-      expectedSlidingWindows,
-      reporter_->quantileSlidingWindowsMap[std::string(key)]);
-}
+  QuantileConfig config1 = {
+      {StatType::AVG, StatType::COUNT}, {0.5, 0.95}, {60, 600}};
+  QuantileConfig config2 = {
+      {StatType::SUM, StatType::COUNT}, {0.75, 0.99}, {300}};
+  QuantileConfig config3 = {{StatType::RATE}, {0.75, 0.90}, {3600}};
 
-TEST_F(StatsReporterTest, addQuantileMetricValue) {
-  // Test adding values to quantile metrics with const char*
-  reporter_->addQuantileMetricValue("test_metric", 100);
-  reporter_->addQuantileMetricValue("test_metric", 50);
+  registerAndVerifyQuantile(charKey, config1);
+  registerAndVerifyQuantile(stringKey, config2);
+  registerAndVerifyQuantile(spKey, config3);
 
-  EXPECT_EQ(150, reporter_->counterMap["test_metric"]);
+  // Test value addition
+  reporter_->addQuantileMetricValue(charKey, 100);
+  reporter_->addQuantileMetricValue(charKey, 50);
+  EXPECT_EQ(150, reporter_->counterMap[std::string(charKey)]);
 
-  // Test with StringPiece
-  folly::StringPiece key("stringpiece_metric");
-  reporter_->addQuantileMetricValue(key, 25);
-  reporter_->addQuantileMetricValue(key, 75);
-
-  EXPECT_EQ(100, reporter_->counterMap[std::string(key)]);
-
-  // Test with const std::string&
-  std::string stringKey("string_metric");
   reporter_->addQuantileMetricValue(stringKey, 200);
   reporter_->addQuantileMetricValue(stringKey, 300);
-
   EXPECT_EQ(500, reporter_->counterMap[stringKey]);
+
+  reporter_->addQuantileMetricValue(spKey, 25);
+  reporter_->addQuantileMetricValue(spKey, 75);
+  EXPECT_EQ(100, reporter_->counterMap[std::string(spKey)]);
 }
 
 TEST_F(StatsReporterTest, multipleQuantileStats) {
-  reporter_->registerQuantileMetricExportType(
-      "metric1",
-      statTypes(StatType::AVG),
-      percentiles(0.5),
-      slidingWindowsSeconds(60));
-  reporter_->registerQuantileMetricExportType(
-      "metric2",
-      statTypes(StatType::COUNT, StatType::SUM),
-      percentiles(0.95, 0.99, 0.999),
-      slidingWindowsSeconds(300, 900));
+  QuantileConfig config1 = {{StatType::AVG}, {0.5}, {60}};
+  QuantileConfig config2 = {
+      {StatType::COUNT, StatType::SUM}, {0.95, 0.99, 0.999}, {300, 900}};
 
-  std::vector<StatType> expectedStatTypes1 = {StatType::AVG};
-  std::vector<double> expectedPercentiles1 = {0.5};
-  std::vector<size_t> expectedSlidingWindows1 = {60};
-  std::vector<StatType> expectedStatTypes2 = {StatType::COUNT, StatType::SUM};
-  std::vector<double> expectedPercentiles2 = {0.95, 0.99, 0.999};
-  std::vector<size_t> expectedSlidingWindows2 = {300, 900};
-
-  EXPECT_EQ(expectedStatTypes1, reporter_->quantileStatTypesMap["metric1"]);
-  EXPECT_EQ(expectedPercentiles1, reporter_->quantilePercentilesMap["metric1"]);
-  EXPECT_EQ(
-      expectedSlidingWindows1, reporter_->quantileSlidingWindowsMap["metric1"]);
-
-  EXPECT_EQ(expectedStatTypes2, reporter_->quantileStatTypesMap["metric2"]);
-  EXPECT_EQ(expectedPercentiles2, reporter_->quantilePercentilesMap["metric2"]);
-  EXPECT_EQ(
-      expectedSlidingWindows2, reporter_->quantileSlidingWindowsMap["metric2"]);
+  registerAndVerifyQuantile("metric1", config1);
+  registerAndVerifyQuantile("metric2", config2);
 }
 
 TEST_F(StatsReporterTest, emptyVectors) {
@@ -778,31 +641,261 @@ TEST_F(StatsReporterTest, emptyVectors) {
 }
 
 TEST_F(StatsReporterTest, quantileStatMacros) {
-  // Test the new DEFINE_QUANTILE_STAT and RECORD_QUANTILE_STAT_VALUE macros
   DEFINE_QUANTILE_STAT(
       "macro_test_stat",
       statTypes(StatType::AVG, StatType::COUNT),
       percentiles(0.5, 0.95, 0.99),
       slidingWindowsSeconds(60, 600));
 
-  EXPECT_TRUE(reporter_->quantileStatTypesMap.count("macro_test_stat"));
-  std::vector<StatType> expectedStatTypes = {StatType::AVG, StatType::COUNT};
-  std::vector<double> expectedPercentiles = {0.5, 0.95, 0.99};
-  std::vector<size_t> expectedSlidingWindows = {60, 600};
-  EXPECT_EQ(
-      expectedStatTypes, reporter_->quantileStatTypesMap["macro_test_stat"]);
-  EXPECT_EQ(
-      expectedPercentiles,
-      reporter_->quantilePercentilesMap["macro_test_stat"]);
-  EXPECT_EQ(
-      expectedSlidingWindows,
-      reporter_->quantileSlidingWindowsMap["macro_test_stat"]);
+  QuantileConfig expectedConfig = {
+      {StatType::AVG, StatType::COUNT}, {0.5, 0.95, 0.99}, {60, 600}};
+  verifyQuantileRegistration("macro_test_stat", expectedConfig);
 
   RECORD_QUANTILE_STAT_VALUE("macro_test_stat", 100);
   RECORD_QUANTILE_STAT_VALUE("macro_test_stat", 50);
   RECORD_QUANTILE_STAT_VALUE("macro_test_stat"); // Default value of 1
 
   EXPECT_EQ(151, reporter_->counterMap["macro_test_stat"]);
+}
+
+TEST_F(StatsReporterTest, dynamicQuantileRegistrationWithValues) {
+  // Test registration and value addition for different key types
+  const char* charPattern = "test_metric_char.{}.{}";
+  std::string stringPattern = "test_metric_string.{}.{}";
+  folly::StringPiece spPattern("test_metric_sp.{}.{}");
+
+  QuantileConfig config1 = {{StatType::AVG}, {0.95}, {300}};
+  QuantileConfig config2 = {{StatType::COUNT}, {0.5}, {60}};
+  QuantileConfig config3 = {{StatType::SUM}, {0.5, 0.99}, {60, 600}};
+
+  registerAndVerifyDynamicQuantile(charPattern, config1);
+  registerAndVerifyDynamicQuantile(stringPattern, config2);
+  registerAndVerifyDynamicQuantile(spPattern, config3);
+
+  auto subkeys1 = subkeys("db1", "table1");
+  auto subkeys2 = subkeys("server1", "endpoint1");
+  auto subkeys3 = subkeys("region1", "service1");
+
+  reporter_->addDynamicQuantileMetricValue(charPattern, subkeys1, 50);
+  reporter_->addDynamicQuantileMetricValue(charPattern, subkeys1, 150);
+  EXPECT_EQ(200, reporter_->counterMap["test_metric_char.db1.table1"]);
+
+  reporter_->addDynamicQuantileMetricValue(stringPattern, subkeys2, 100);
+  reporter_->addDynamicQuantileMetricValue(stringPattern, subkeys2, 200);
+  EXPECT_EQ(300, reporter_->counterMap["test_metric_string.server1.endpoint1"]);
+
+  reporter_->addDynamicQuantileMetricValue(spPattern, subkeys3, 75);
+  reporter_->addDynamicQuantileMetricValue(spPattern, subkeys3, 125);
+  EXPECT_EQ(200, reporter_->counterMap["test_metric_sp.region1.service1"]);
+}
+
+TEST_F(StatsReporterTest, dynamicQuantileRegistrationOnly) {
+  // Test registration without values (registration-only test)
+  QuantileConfig config = {
+      {StatType::AVG, StatType::COUNT}, {0.5, 0.95}, {60, 600}};
+  const char* pattern = "registration_test.{}.{}";
+
+  registerAndVerifyDynamicQuantile(pattern, config);
+
+  // Verify registration worked but no values recorded yet
+  EXPECT_EQ(0, reporter_->counterMap.count("registration_test.key1.key2"));
+}
+
+TEST_F(StatsReporterTest, dynamicQuantileMetricUnregisteredPattern) {
+  // Try to add a value for a dynamic quantile metric that was never registered
+  // This should silently ignore the value (not crash)
+  auto subkeyValues = subkeys("unregistered", "pattern");
+  EXPECT_NO_THROW(reporter_->addDynamicQuantileMetricValue(
+      "unregistered_pattern.{}.{}", subkeyValues, 42));
+
+  // Verify no value was recorded
+  EXPECT_EQ(
+      0,
+      reporter_->counterMap.count("unregistered_pattern.unregistered.pattern"));
+}
+
+struct DynamicQuantilePatternTestCase {
+  std::string testName;
+  std::function<void(StatsReporterTest*)> testFunc;
+};
+
+class DynamicQuantilePatternTest
+    : public StatsReporterTest,
+      public testing::WithParamInterface<DynamicQuantilePatternTestCase> {};
+
+TEST_P(DynamicQuantilePatternTest, PatternScenarios) {
+  const auto& testCase = GetParam();
+  testCase.testFunc(this);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    PatternScenarios,
+    DynamicQuantilePatternTest,
+    testing::Values(
+        DynamicQuantilePatternTestCase{
+            "DefaultValue",
+            [](StatsReporterTest* test) {
+              test->reporter_->registerDynamicQuantileMetricExportType(
+                  "default_value_metric.{}",
+                  statTypes(StatType::COUNT),
+                  percentiles(0.5),
+                  slidingWindowsSeconds(60));
+
+              auto subkeyValues = subkeys("test");
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "default_value_metric.{}", subkeyValues, 1);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "default_value_metric.{}", subkeyValues, 1);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "default_value_metric.{}", subkeyValues, 1);
+
+              EXPECT_EQ(
+                  3, test->reporter_->counterMap["default_value_metric.test"]);
+            }},
+        DynamicQuantilePatternTestCase{
+            "MultiplePatterns",
+            [](StatsReporterTest* test) {
+              test->reporter_->registerDynamicQuantileMetricExportType(
+                  "pattern1.{}.{}",
+                  statTypes(StatType::AVG),
+                  percentiles(0.5),
+                  slidingWindowsSeconds(60));
+
+              test->reporter_->registerDynamicQuantileMetricExportType(
+                  "pattern2.{}.{}.{}",
+                  statTypes(StatType::COUNT, StatType::SUM),
+                  percentiles(0.95, 0.99, 0.999),
+                  slidingWindowsSeconds(300, 900));
+
+              auto subkeys2 = subkeys("key1", "key2");
+              auto subkeys3 = subkeys("key1", "key2", "key3");
+
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "pattern1.{}.{}", subkeys2, 100);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "pattern2.{}.{}.{}", subkeys3, 200);
+
+              EXPECT_EQ(100, test->reporter_->counterMap["pattern1.key1.key2"]);
+              EXPECT_EQ(
+                  200, test->reporter_->counterMap["pattern2.key1.key2.key3"]);
+            }},
+        DynamicQuantilePatternTestCase{
+            "ComplexPattern",
+            [](StatsReporterTest* test) {
+              test->reporter_->registerDynamicQuantileMetricExportType(
+                  "complex.{}.latency.{}.p95",
+                  statTypes(StatType::AVG, StatType::COUNT),
+                  percentiles(0.95, 0.99),
+                  slidingWindowsSeconds(60, 300, 3600));
+
+              auto subkeyValues = subkeys("http_server", "endpoint_api");
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "complex.{}.latency.{}.p95", subkeyValues, 150);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "complex.{}.latency.{}.p95", subkeyValues, 200);
+
+              EXPECT_EQ(
+                  350,
+                  test->reporter_->counterMap
+                      ["complex.http_server.latency.endpoint_api.p95"]);
+            }},
+        DynamicQuantilePatternTestCase{
+            "SingleSubkey",
+            [](StatsReporterTest* test) {
+              test->reporter_->registerDynamicQuantileMetricExportType(
+                  "single_sub.{}",
+                  statTypes(StatType::RATE),
+                  percentiles(0.75),
+                  slidingWindowsSeconds(600));
+
+              auto subkeyValues = subkeys("single_value");
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "single_sub.{}", subkeyValues, 300);
+
+              EXPECT_EQ(
+                  300, test->reporter_->counterMap["single_sub.single_value"]);
+            }},
+        DynamicQuantilePatternTestCase{
+            "MultipleInstances",
+            [](StatsReporterTest* test) {
+              test->reporter_->registerDynamicQuantileMetricExportType(
+                  "instance_test.{}.{}",
+                  statTypes(StatType::SUM),
+                  percentiles(0.5),
+                  slidingWindowsSeconds(60));
+
+              auto subkeys1 = subkeys("instance1", "metric1");
+              auto subkeys2 = subkeys("instance2", "metric2");
+              auto subkeys3 = subkeys("instance1", "metric2");
+
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "instance_test.{}.{}", subkeys1, 100);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "instance_test.{}.{}", subkeys2, 200);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "instance_test.{}.{}", subkeys3, 300);
+              test->reporter_->addDynamicQuantileMetricValue(
+                  "instance_test.{}.{}", subkeys1, 50);
+
+              EXPECT_EQ(
+                  150,
+                  test->reporter_
+                      ->counterMap["instance_test.instance1.metric1"]);
+              EXPECT_EQ(
+                  200,
+                  test->reporter_
+                      ->counterMap["instance_test.instance2.metric2"]);
+              EXPECT_EQ(
+                  300,
+                  test->reporter_
+                      ->counterMap["instance_test.instance1.metric2"]);
+            }}));
+
+TEST_F(StatsReporterTest, dynamicQuantileMetricEmptyVectors) {
+  // Test registration with empty vectors (should be allowed)
+  std::vector<StatType> emptyStatTypes;
+  std::vector<double> emptyPercentiles;
+  std::vector<size_t> emptySlidingWindows;
+
+  EXPECT_NO_THROW(reporter_->registerDynamicQuantileMetricExportType(
+      "empty_metric.{}",
+      emptyStatTypes,
+      emptyPercentiles,
+      emptySlidingWindows));
+
+  EXPECT_TRUE(reporter_->dynamicQuantileStatTypesMap.count("empty_metric.{}"));
+  EXPECT_TRUE(
+      reporter_->dynamicQuantileStatTypesMap["empty_metric.{}"].empty());
+  EXPECT_TRUE(
+      reporter_->dynamicQuantilePercentilesMap["empty_metric.{}"].empty());
+  EXPECT_TRUE(
+      reporter_->dynamicQuantileSlidingWindowsMap["empty_metric.{}"].empty());
+
+  // Try to use the empty pattern
+  auto subkeyValues = subkeys("test");
+  EXPECT_NO_THROW(reporter_->addDynamicQuantileMetricValue(
+      "empty_metric.{}", subkeyValues, 100));
+}
+
+TEST_F(StatsReporterTest, dynamicQuantileStatMacros) {
+  DEFINE_DYNAMIC_QUANTILE_STAT(
+      "macro_test.{}.{}",
+      statTypes(StatType::AVG, StatType::COUNT),
+      percentiles(0.5, 0.95, 0.99),
+      slidingWindowsSeconds(60, 600));
+
+  QuantileConfig expectedConfig = {
+      {StatType::AVG, StatType::COUNT}, {0.5, 0.95, 0.99}, {60, 600}};
+  verifyDynamicQuantileRegistration("macro_test.{}.{}", expectedConfig);
+
+  RECORD_DYNAMIC_QUANTILE_STAT_VALUE(
+      "macro_test.{}.{}", subkeys("service", "method"), 100);
+  RECORD_DYNAMIC_QUANTILE_STAT_VALUE(
+      "macro_test.{}.{}", subkeys("service", "method"), 50);
+  RECORD_DYNAMIC_QUANTILE_STAT_VALUE(
+      "macro_test.{}.{}", subkeys("service", "method")); // Default value of 1
+
+  EXPECT_EQ(151, reporter_->counterMap["macro_test.service.method"]);
 }
 
 // Registering to folly Singleton with intended reporter type

--- a/velox/common/base/tests/StatsReporterUtils.h
+++ b/velox/common/base/tests/StatsReporterUtils.h
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <fmt/args.h>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "velox/common/base/StatsReporter.h"
+
+namespace facebook::velox {
+
+/**
+ * A test implementation of BaseStatsReporter for use in unit tests.
+ * This class provides a mock implementation that captures all metric
+ * registrations and values for verification in tests.
+ */
+class TestReporter : public BaseStatsReporter {
+ public:
+  mutable std::mutex m;
+  mutable std::map<std::string, size_t> counterMap;
+  mutable std::unordered_map<std::string, StatType> statTypeMap;
+  mutable std::unordered_map<std::string, std::vector<int32_t>>
+      histogramPercentilesMap;
+
+  mutable std::unordered_map<std::string, std::vector<StatType>>
+      quantileStatTypesMap;
+  mutable std::unordered_map<std::string, std::vector<double>>
+      quantilePercentilesMap;
+  mutable std::unordered_map<std::string, std::vector<size_t>>
+      quantileSlidingWindowsMap;
+
+  mutable std::unordered_map<std::string, std::vector<StatType>>
+      dynamicQuantileStatTypesMap;
+  mutable std::unordered_map<std::string, std::vector<double>>
+      dynamicQuantilePercentilesMap;
+  mutable std::unordered_map<std::string, std::vector<size_t>>
+      dynamicQuantileSlidingWindowsMap;
+
+  void clear() {
+    std::lock_guard<std::mutex> l(m);
+    counterMap.clear();
+    statTypeMap.clear();
+    histogramPercentilesMap.clear();
+    quantileStatTypesMap.clear();
+    quantilePercentilesMap.clear();
+    quantileSlidingWindowsMap.clear();
+    dynamicQuantileStatTypesMap.clear();
+    dynamicQuantilePercentilesMap.clear();
+    dynamicQuantileSlidingWindowsMap.clear();
+  }
+
+  void registerMetricExportType(const char* key, StatType statType)
+      const override {
+    statTypeMap[key] = statType;
+  }
+
+  void registerMetricExportType(folly::StringPiece key, StatType statType)
+      const override {
+    statTypeMap[std::string(key)] = statType;
+  }
+
+  void registerHistogramMetricExportType(
+      const char* key,
+      int64_t /* bucketWidth */,
+      int64_t /* min */,
+      int64_t /* max */,
+      const std::vector<int32_t>& pcts) const override {
+    histogramPercentilesMap[key] = pcts;
+  }
+
+  void registerHistogramMetricExportType(
+      folly::StringPiece key,
+      int64_t /* bucketWidth */,
+      int64_t /* min */,
+      int64_t /* max */,
+      const std::vector<int32_t>& pcts) const override {
+    histogramPercentilesMap[std::string(key)] = pcts;
+  }
+
+  void registerQuantileMetricExportType(
+      const char* key,
+      const std::vector<StatType>& statTypes,
+      const std::vector<double>& pcts,
+      const std::vector<size_t>& slidingWindowsSeconds) const override {
+    std::lock_guard<std::mutex> l(m);
+    quantileStatTypesMap[key] = statTypes;
+    quantilePercentilesMap[key] = pcts;
+    quantileSlidingWindowsMap[key] = slidingWindowsSeconds;
+  }
+
+  void registerQuantileMetricExportType(
+      folly::StringPiece key,
+      const std::vector<StatType>& statTypes,
+      const std::vector<double>& pcts,
+      const std::vector<size_t>& slidingWindowsSeconds) const override {
+    std::lock_guard<std::mutex> l(m);
+    quantileStatTypesMap[std::string(key)] = statTypes;
+    quantilePercentilesMap[std::string(key)] = pcts;
+    quantileSlidingWindowsMap[std::string(key)] = slidingWindowsSeconds;
+  }
+
+  void addMetricValue(const std::string& key, const size_t value)
+      const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[key] += value;
+  }
+
+  void addMetricValue(const char* key, const size_t value) const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[key] += value;
+  }
+
+  void addMetricValue(folly::StringPiece key, size_t value) const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[std::string(key)] += value;
+  }
+
+  void addHistogramMetricValue(const std::string& key, size_t value)
+      const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[key] = std::max(counterMap[key], value);
+  }
+
+  void addHistogramMetricValue(const char* key, size_t value) const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[key] = std::max(counterMap[key], value);
+  }
+
+  void addHistogramMetricValue(folly::StringPiece key, size_t value)
+      const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[std::string(key)] =
+        std::max(counterMap[std::string(key)], value);
+  }
+
+  void addQuantileMetricValue(const std::string& key, size_t value)
+      const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[key] += value;
+  }
+
+  void addQuantileMetricValue(const char* key, size_t value) const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[key] += value;
+  }
+
+  void addQuantileMetricValue(folly::StringPiece key, size_t value)
+      const override {
+    std::lock_guard<std::mutex> l(m);
+    counterMap[std::string(key)] += value;
+  }
+
+  void registerDynamicQuantileMetricExportType(
+      const char* keyPattern,
+      const std::vector<StatType>& statTypes,
+      const std::vector<double>& pcts,
+      const std::vector<size_t>& slidingWindowsSeconds) const override {
+    std::lock_guard<std::mutex> l(m);
+    dynamicQuantileStatTypesMap[keyPattern] = statTypes;
+    dynamicQuantilePercentilesMap[keyPattern] = pcts;
+    dynamicQuantileSlidingWindowsMap[keyPattern] = slidingWindowsSeconds;
+  }
+
+  void registerDynamicQuantileMetricExportType(
+      folly::StringPiece keyPattern,
+      const std::vector<StatType>& statTypes,
+      const std::vector<double>& pcts,
+      const std::vector<size_t>& slidingWindowsSeconds) const override {
+    std::lock_guard<std::mutex> l(m);
+    dynamicQuantileStatTypesMap[std::string(keyPattern)] = statTypes;
+    dynamicQuantilePercentilesMap[std::string(keyPattern)] = pcts;
+    dynamicQuantileSlidingWindowsMap[std::string(keyPattern)] =
+        slidingWindowsSeconds;
+  }
+
+  void addDynamicQuantileMetricValue(
+      const std::string& key,
+      folly::Range<const folly::StringPiece*> subkeys,
+      size_t value) const override {
+    std::lock_guard<std::mutex> l(m);
+    // Check if the pattern was registered, if not silently ignore
+    if (dynamicQuantileStatTypesMap.find(key) ==
+        dynamicQuantileStatTypesMap.end()) {
+      return;
+    }
+
+    // Substitute placeholders in the key pattern with subkeys using fmt::format
+    std::string formattedKey;
+    fmt::dynamic_format_arg_store<fmt::format_context> store;
+    for (const auto& subkey : subkeys) {
+      store.push_back(subkey);
+    }
+    formattedKey = fmt::vformat(key, store);
+    counterMap[formattedKey] += value;
+  }
+
+  void addDynamicQuantileMetricValue(
+      const char* key,
+      folly::Range<const folly::StringPiece*> subkeys,
+      size_t value) const override {
+    addDynamicQuantileMetricValue(std::string(key), subkeys, value);
+  }
+
+  void addDynamicQuantileMetricValue(
+      folly::StringPiece key,
+      folly::Range<const folly::StringPiece*> subkeys,
+      size_t value) const override {
+    addDynamicQuantileMetricValue(std::string(key), subkeys, value);
+  }
+
+  std::string fetchMetrics() override {
+    std::stringstream ss;
+    ss << "[";
+    auto sep = "";
+    for (const auto& [key, value] : counterMap) {
+      ss << sep << key << ":" << value;
+      sep = ",";
+    }
+    ss << "]";
+    return ss.str();
+  }
+
+  /**
+   * Get the current counter value for a specific key.
+   * Returns 0 if the key doesn't exist.
+   */
+  size_t getCounterValue(const std::string& key) const {
+    std::lock_guard<std::mutex> l(m);
+    auto it = counterMap.find(key);
+    return it != counterMap.end() ? it->second : 0;
+  }
+};
+
+} // namespace facebook::velox


### PR DESCRIPTION
Summary: This will break existing external (to meta) code that derives from BaseStatsReporter since the classes will become abstract. If we want to keep compatibility I need to make a default implementation for the methods that throws.

Differential Revision: D81272645


