### PR TITLE
feat(connector): Retain configuration object in TPCH connector

### DIFF
--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -35,7 +35,7 @@ TpchConnector::TpchConnector(
     const std::string& id,
     std::shared_ptr<const config::ConfigBase> config,
     folly::Executor* /*executor*/)
-    : Connector(id) {
+    : Connector(id), config_(std::move(config)) {
   for (auto& factory : tpchConnectorMetadataFactories()) {
     metadata_ = factory->create(this);
     if (metadata_ != nullptr) {

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -163,6 +163,11 @@ class TpchConnector final : public Connector {
       std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* /*executor*/);
 
+  const std::shared_ptr<const config::ConfigBase>& connectorConfig()
+      const override {
+    return config_;
+  }
+
   std::unique_ptr<DataSource> createDataSource(
       const RowTypePtr& outputType,
       const ConnectorTableHandlePtr& tableHandle,
@@ -186,6 +191,7 @@ class TpchConnector final : public Connector {
   }
 
  private:
+  std::shared_ptr<const config::ConfigBase> config_;
   std::shared_ptr<ConnectorMetadata> metadata_;
 };
 

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -443,6 +443,22 @@ TEST_F(TpchConnectorTest, orderDateCount) {
   EXPECT_EQ(9, orderDate->size());
 }
 
+TEST_F(TpchConnectorTest, config) {
+  std::unordered_map<std::string, std::string> properties = {
+      {"property", "value"}};
+  auto connector =
+      connector::getConnectorFactory(
+          connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+          ->newConnector(
+              kTpchConnectorId,
+              std::make_shared<config::ConfigBase>(std::move(properties)));
+
+  const auto& config = connector->connectorConfig();
+  auto val = config->get<std::string>("property");
+  EXPECT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "value");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
In this change I am retaining the connector configuration provided by the factory method in the TPCH connector. These config are also made available via the connectorConfig() API, which was previously unimplemented.

Adding a test to check that the config provided to the factory method is properly retained and exposed by the TPCH Connector.

Differential Revision: D81365452


