### PR TITLE
feat: Add parallel unit loader

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -159,6 +159,14 @@ int32_t HiveConfig::prefetchRowGroups() const {
   return config_->get<int32_t>(kPrefetchRowGroups, 1);
 }
 
+size_t HiveConfig::parallelUnitLoadCount(const config::ConfigBase* session) const {
+  auto count = session->get<size_t>(
+      kParallelUnitLoadCountSession,
+      config_->get<size_t>(kParallelUnitLoadCount, 0));
+  VELOX_CHECK_LE(count, 1000, "parallelUnitLoadCount too large: {}", count);
+  return count;
+}
+
 int32_t HiveConfig::loadQuantum(const config::ConfigBase* session) const {
   return session->get<int32_t>(
       kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -146,6 +146,11 @@ class HiveConfig {
   /// meta data together. Optimization to decrease the small IO requests
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
 
+  /// Configures how many stripes we read in parallel.
+  /// When set to 0, parallel unit loader is disabled.
+  static constexpr const char* kParallelUnitLoadCount = "parallel-unit-load-count";
+  static constexpr const char* kParallelUnitLoadCountSession = "parallel_unit_load_count";
+
   /// Config used to create write files. This config is provided to underlying
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
@@ -234,6 +239,8 @@ class HiveConfig {
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
 
   int32_t prefetchRowGroups() const;
+
+  size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
 
   int32_t loadQuantum(const config::ConfigBase* session) const;
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -615,6 +615,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
+    folly::Executor* const ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions) {
   auto skipRowsIt =
       tableParameters.find(dwio::common::TableParameter::kSkipHeaderLineCount);
@@ -622,6 +623,7 @@ void configureRowReaderOptions(
     rowReaderOptions.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
   }
   rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setIOExecutor(ioExecutor);
   rowReaderOptions.setMetadataFilter(std::move(metadataFilter));
   rowReaderOptions.setRequestedType(rowType);
   rowReaderOptions.range(hiveSplit->start, hiveSplit->length);
@@ -630,6 +632,10 @@ void configureRowReaderOptions(
         hiveConfig->readTimestampUnit(sessionProperties)));
     rowReaderOptions.setPreserveFlatMapsInMemory(
         hiveConfig->preserveFlatMapsInMemory(sessionProperties));
+    rowReaderOptions.setParallelUnitLoadCount(hiveConfig->parallelUnitLoadCount(sessionProperties));
+    if (hiveConfig->parallelUnitLoadCount(sessionProperties) > 0) {
+      rowReaderOptions.setEagerFirstStripeLoad(false);
+    }
   }
   rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -86,6 +86,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
+    folly::Executor* ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions);
 
 bool testFilters(

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -126,7 +126,7 @@ SplitReader::SplitReader(
     const std::shared_ptr<io::IoStatistics>& ioStats,
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
-    folly::Executor* executor,
+    folly::Executor* ioExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec)
     : hiveSplit_(hiveSplit),
       hiveTableHandle_(hiveTableHandle),
@@ -137,7 +137,7 @@ SplitReader::SplitReader(
       ioStats_(ioStats),
       fsStats_(fsStats),
       fileHandleFactory_(fileHandleFactory),
-      executor_(executor),
+      ioExecutor_(ioExecutor),
       pool_(connectorQueryCtx->memoryPool()),
       scanSpec_(scanSpec),
       baseReaderOpts_(connectorQueryCtx->memoryPool()),
@@ -318,7 +318,7 @@ void SplitReader::createReader() {
       connectorQueryCtx_,
       ioStats_,
       fsStats_,
-      executor_);
+      ioExecutor_);
 
   baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.fileFormat())
                     ->createReader(std::move(baseFileInput), baseReaderOpts_);
@@ -378,6 +378,7 @@ void SplitReader::createRowReader(
       hiveSplit_,
       hiveConfig_,
       connectorQueryCtx_->sessionProperties(),
+      ioExecutor_,
       baseRowReaderOpts_);
   baseRowReaderOpts_.setTrackRowSize(
       connectorQueryCtx_->rowSizeTrackingEnabled());

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -185,7 +185,7 @@ class SplitReader {
   const std::shared_ptr<io::IoStatistics> ioStats_;
   const std::shared_ptr<filesystems::File::IoStats> fsStats_;
   FileHandleFactory* const fileHandleFactory_;
-  folly::Executor* const executor_;
+  folly::Executor* const ioExecutor_;
   memory::MemoryPool* const pool_;
 
   std::shared_ptr<common::ScanSpec> scanSpec_;

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   MetadataFilter.cpp
   Options.cpp
   OutputStream.cpp
+  ParallelUnitLoader.cpp
   ParallelFor.cpp
   Range.cpp
   Reader.cpp

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -282,6 +282,22 @@ class RowReaderOptions {
     scanSpec_ = std::move(scanSpec);
   }
 
+  folly::Executor* ioExecutor() const {
+    return ioExecutor_;
+  }
+
+  void setIOExecutor(folly::Executor* const executor) {
+    ioExecutor_ = executor;
+  }
+
+  const size_t parallelUnitLoadCount() const {
+    return parallelUnitLoadCount_;
+  }
+
+  void setParallelUnitLoadCount(size_t parallelUnitLoadCount) {
+    parallelUnitLoadCount_ = parallelUnitLoadCount;
+  }
+
   const std::shared_ptr<velox::common::MetadataFilter>& metadataFilter() const {
     return metadataFilter_;
   }
@@ -442,6 +458,7 @@ class RowReaderOptions {
   bool preloadStripe_;
   bool projectSelectedType_;
   bool returnFlatVector_ = false;
+  size_t parallelUnitLoadCount_;
   ErrorTolerance errorTolerance_;
   std::shared_ptr<ColumnSelector> selector_;
   RowTypePtr requestedType_;
@@ -455,6 +472,8 @@ class RowReaderOptions {
   // default, converts flat maps in the file to MapVectors.
   bool preserveFlatMapsInMemory_ = false;
 
+  // Executors to enable parallel read of stripes
+  folly::Executor* ioExecutor_;
   // Optional executors to enable internal reader parallelism.
   // 'decodingExecutor' allow parallelising the vector decoding process.
   // 'ioExecutor' enables parallelism when performing file system read

--- a/velox/dwio/common/ParallelUnitLoader.cpp
+++ b/velox/dwio/common/ParallelUnitLoader.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ParallelUnitLoader.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::dwio::common {
+
+class ParallelUnitLoader : public UnitLoader {
+ public:
+  /// ParallelUnitLoader enables concurrent loading of multiple units (e.g.,
+  /// stripes, row groups) to improve I/O throughput and reduce read latency.
+  ///
+  /// **Loading Strategy:**
+  /// - On initialization: Starts loading up to 'maxConcurrentLoads' units
+  /// concurrently
+  /// - On consumption: As each unit is accessed, triggers loading of the next
+  /// unit
+  /// - Memory management: Unloads units outside the sliding window to control
+  /// memory usage
+  /// - Limitation: it only supports continuous loading of units in sliding
+  /// window and doesn't support random loading
+  ///
+  /// **Parameters:**
+  /// @param units Vector of all units that need to be loaded
+  /// @param ioExecutor Executor for running unit loading operations
+  /// asynchronously
+  /// @param maxConcurrentLoads Number of units to keep in the loading/loaded
+  /// state simultaneously
+  ///
+  /// **Example:**
+  /// With maxConcurrentLoads=3 and 10 total units:
+  /// - Initially loads units [0,1,2]
+  /// - When unit 0 is consumed, starts loading unit 3 and unloads unit 0
+  /// - When unit 1 is consumed, starts loading unit 4 and unloads unit 1
+  /// - And so on...
+  ParallelUnitLoader(
+      std::vector<std::unique_ptr<LoadUnit>> units,
+      folly::Executor* ioExecutor,
+      uint16_t maxConcurrentLoads)
+      : units_(std::move(units)),
+        ioExecutor_(ioExecutor),
+        maxConcurrentLoads_(maxConcurrentLoads) {
+    VELOX_CHECK_NOT_NULL(ioExecutor, "ParallelUnitLoader ioExecutor is null");
+    VELOX_CHECK_LE(
+        maxConcurrentLoads_,
+        1,
+        "ParallelUnitLoader maxConcurrentLoads should be larger than 0");
+    futures_.resize(units_.size());
+
+    for (size_t i = 0; i < units_.size() && i < maxConcurrentLoads; ++i) {
+      prefetch(i);
+    }
+  }
+
+  ~ParallelUnitLoader() override {
+    for (auto& future : futures_) {
+      future.cancel();
+      future.wait();
+    }
+  }
+
+  LoadUnit& getLoadedUnit(uint32_t unitIndex) override {
+    // TODO: Add support to load random unit.
+    VELOX_CHECK(
+        futures_[unitIndex].valid(),
+        "unit is not loaded in ParallelUnitLoader");
+
+    try {
+      futures_[unitIndex].wait();
+    } catch (const std::exception& e) {
+      VELOX_FAIL("Failed to load unit {}: {}", unitIndex, e.what());
+    }
+
+    if (unitIndex + maxConcurrentLoads_ < units_.size()) {
+      prefetch(unitIndex + maxConcurrentLoads_);
+    }
+
+    // Unload the oldest stripe that is outside our look-behind window to save
+    // memory
+    if (unitIndex >= maxConcurrentLoads_) {
+      uint32_t unloadIndex = unitIndex - maxConcurrentLoads_;
+      VELOX_CHECK(
+          futures_[unloadIndex].isReady(), "getLoadedUnit unload error");
+      units_[unloadIndex]->unload();
+      // Reset the future
+      futures_[unloadIndex] = folly::Future<folly::Unit>();
+    }
+
+    return *units_[unitIndex];
+  }
+
+  void onRead(uint32_t unit, uint64_t rowOffsetInUnit, uint64_t /* rowCount */)
+      override {
+    VELOX_CHECK_LT(unit, units_.size(), "Unit out of range");
+    VELOX_CHECK_LT(
+        rowOffsetInUnit, units_[unit]->getNumRows(), "Row out of range");
+  }
+
+  void onSeek(uint32_t unit, uint64_t rowOffsetInUnit) override {
+    VELOX_CHECK_LT(unit, units_.size(), "Unit out of range");
+    VELOX_CHECK_LE(
+        rowOffsetInUnit, units_[unit]->getNumRows(), "Row out of range");
+  }
+
+ private:
+  void prefetch(uint32_t unitIndex) {
+    VELOX_CHECK_LT(
+        unitIndex, units_.size(), "ParallelUnitLoader prefetch invalid index");
+    VELOX_CHECK_NOT_NULL(ioExecutor_, "ParallelUnitLoader ioExecutor is null");
+
+    // Submit the unit's load() function to the I/O thread pool
+    futures_[unitIndex] = folly::via(
+        ioExecutor_, [this, unitIndex]() { units_[unitIndex]->load(); });
+  }
+
+  std::vector<std::unique_ptr<LoadUnit>> units_;
+  std::vector<folly::Future<folly::Unit>> futures_;
+  folly::Executor* ioExecutor_;
+  size_t maxConcurrentLoads_;
+};
+
+std::unique_ptr<UnitLoader> ParallelUnitLoaderFactory::create(
+    std::vector<std::unique_ptr<LoadUnit>> units,
+    uint64_t /* rowsToSkip */) {
+  return std::make_unique<ParallelUnitLoader>(
+      std::move(units), ioExecutor_, maxConcurrentLoads_);
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ParallelUnitLoader.h
+++ b/velox/dwio/common/ParallelUnitLoader.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/futures/Future.h>
+
+#include <vector>
+#include "velox/dwio/common/UnitLoader.h"
+
+namespace facebook::velox::dwio::common {
+class ParallelUnitLoaderFactory : public UnitLoaderFactory {
+ public:
+  ParallelUnitLoaderFactory(folly::Executor* ioExecutor, size_t maxConcurrentLoads)
+      : ioExecutor_(ioExecutor), maxConcurrentLoads_(maxConcurrentLoads) {}
+
+  std::unique_ptr<UnitLoader> create(
+      std::vector<std::unique_ptr<LoadUnit>> units,
+      uint64_t rowsToSkip) override;
+
+ private:
+  folly::Executor* ioExecutor_;
+  size_t maxConcurrentLoads_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(
   UnitLoaderToolsTests.cpp
   WriterTest.cpp
   OptionsTests.cpp
+  ParallelUnitLoaderTest.cpp
 )
 add_test(velox_dwio_common_test velox_dwio_common_test)
 target_link_libraries(

--- a/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
+++ b/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ParallelUnitLoader.h"
+#include "velox/dwio/common/OnDemandUnitLoader.h"
+#include "velox/dwio/common/tests/utils/UnitLoaderTestTools.h"
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::dwio::common::test;
+
+namespace facebook::velox::dwio::common {
+
+class ParallelUnitLoaderTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(4);
+  }
+
+  void TearDown() override {
+    executor_.reset();
+  }
+
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+};
+
+// Enhanced LoadUnitMock for testing parallel loading with timing
+class TimedLoadUnitMock : public LoadUnit {
+ public:
+  TimedLoadUnitMock(
+      uint64_t rowCount,
+      uint64_t ioSize,
+      std::vector<std::atomic_bool>& unitsLoaded,
+      size_t unitId,
+      std::chrono::milliseconds loadDelay = std::chrono::milliseconds(10),
+      bool shouldFail = false)
+      : rowCount_(rowCount),
+        ioSize_(ioSize),
+        unitsLoaded_(unitsLoaded),
+        unitId_(unitId),
+        loadDelay_(loadDelay),
+        shouldFail_(shouldFail) {}
+
+  void load() override {
+    if (shouldFail_) {
+      throw std::runtime_error("Mock load failure for unit " + std::to_string(unitId_));
+    }
+
+    VELOX_CHECK(!isLoaded());
+
+    // Simulate loading time
+    std::this_thread::sleep_for(loadDelay_);
+
+    unitsLoaded_[unitId_] = true;
+  }
+
+  void unload() override {
+    VELOX_CHECK(isLoaded());
+    unitsLoaded_[unitId_] = false;
+  }
+
+  uint64_t getNumRows() override {
+    return rowCount_;
+  }
+
+  uint64_t getIoSize() override {
+    return ioSize_;
+  }
+
+  bool isLoaded() const {
+    return unitsLoaded_[unitId_];
+  }
+
+  size_t getUnitId() const {
+    return unitId_;
+  }
+
+ private:
+  uint64_t rowCount_;
+  uint64_t ioSize_;
+  std::vector<std::atomic_bool>& unitsLoaded_;
+  size_t unitId_;
+  std::chrono::milliseconds loadDelay_;
+  bool shouldFail_;
+};
+
+TEST_F(ParallelUnitLoaderTest, BasicFunctionality) {
+  std::vector<uint64_t> rowsPerUnit = {100, 200, 150, 300, 250};
+  std::vector<uint64_t> ioSizes = {1024, 2048, 1536, 3072, 2560};
+
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 2);
+  ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+  // Read through all units
+  for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+    uint64_t totalRowsRead = 0;
+    while (totalRowsRead < rowsPerUnit[i]) {
+      EXPECT_TRUE(reader.read(50));
+      totalRowsRead += std::min(50UL, rowsPerUnit[i] - totalRowsRead);
+    }
+  }
+}
+
+TEST_F(ParallelUnitLoaderTest, PrefetchWindowBehavior) {
+  std::vector<uint64_t> rowsPerUnit = {100, 100, 100, 100, 100};
+  std::vector<uint64_t> ioSizes = {1024, 1024, 1024, 1024, 1024};
+
+  // Create factory with prefetch window of 3
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 3);
+
+  // Create units manually to test loading behavior
+  auto unitsLoaded = getUnitsLoadedWithFalse(5);
+  std::vector<std::unique_ptr<LoadUnit>> units;
+  for (size_t i = 0; i < 5; ++i) {
+    units.emplace_back(std::make_unique<TimedLoadUnitMock>(
+        rowsPerUnit[i], ioSizes[i], unitsLoaded, i, std::chrono::milliseconds(20)));
+  }
+
+  auto loader = factory->create(std::move(units), 0);
+
+  // Give some time for initial prefetch
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  // First 3 units should be loaded or in the process of loading
+  // Access first unit
+  auto& unit0 = loader->getLoadedUnit(0);
+  EXPECT_EQ(unit0.getNumRows(), 100);
+
+  // Access more units to test sliding window
+  auto& unit1 = loader->getLoadedUnit(1);
+  auto& unit2 = loader->getLoadedUnit(2);
+  auto& unit3 = loader->getLoadedUnit(3);
+
+  EXPECT_EQ(unit1.getNumRows(), 100);
+  EXPECT_EQ(unit2.getNumRows(), 100);
+  EXPECT_EQ(unit3.getNumRows(), 100);
+}
+
+TEST_F(ParallelUnitLoaderTest, LoadFailureHandling) {
+  auto unitsLoaded = getUnitsLoadedWithFalse(5);
+  std::vector<std::unique_ptr<LoadUnit>> units;
+
+  // Create units where unit 2 will fail to load
+  for (size_t i = 0; i < 5; ++i) {
+    bool shouldFail = (i == 2);
+    units.emplace_back(std::make_unique<TimedLoadUnitMock>(
+        100, 1024, unitsLoaded, i, std::chrono::milliseconds(10), shouldFail));
+  }
+
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 2);
+  auto loader = factory->create(std::move(units), 0);
+
+  // Access units 0 and 1 should work
+  EXPECT_NO_THROW(loader->getLoadedUnit(0));
+  EXPECT_NO_THROW(loader->getLoadedUnit(1));
+
+  // Unit 2 should throw an exception
+  EXPECT_THROW(loader->getLoadedUnit(2), velox::VeloxException);
+}
+
+TEST_F(ParallelUnitLoaderTest, OnReadAndOnSeekValidation) {
+  auto unitsLoaded = getUnitsLoadedWithFalse(3);
+  std::vector<std::unique_ptr<LoadUnit>> units;
+  for (size_t i = 0; i < 3; ++i) {
+    units.emplace_back(std::make_unique<TimedLoadUnitMock>(
+        100, 1024, unitsLoaded, i));
+  }
+
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 2);
+  auto loader = factory->create(std::move(units), 0);
+
+  // Test valid onRead calls
+  EXPECT_NO_THROW(loader->onRead(0, 50, 10));
+  EXPECT_NO_THROW(loader->onRead(1, 0, 100));
+  EXPECT_NO_THROW(loader->onRead(2, 99, 1));
+
+  // Test invalid onRead calls
+  EXPECT_THROW(loader->onRead(3, 0, 10), velox::VeloxException); // Unit out of range
+  EXPECT_THROW(loader->onRead(0, 100, 1), velox::VeloxException); // Row out of range
+
+  // Test valid onSeek calls
+  EXPECT_NO_THROW(loader->onSeek(0, 50));
+  EXPECT_NO_THROW(loader->onSeek(1, 0));
+  EXPECT_NO_THROW(loader->onSeek(2, 100)); // At end is valid
+
+  // Test invalid onSeek calls
+  EXPECT_THROW(loader->onSeek(3, 0), velox::VeloxException); // Unit out of range
+  EXPECT_THROW(loader->onSeek(0, 101), velox::VeloxException); // Row out of range
+}
+
+TEST_F(ParallelUnitLoaderTest, CompareWithOnDemandLoader) {
+  std::vector<uint64_t> rowsPerUnit = {100, 200, 150, 300};
+  std::vector<uint64_t> ioSizes = {1024, 2048, 1536, 3072};
+
+  // Test with ParallelUnitLoader
+  auto parallelFactory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 2);
+  ReaderMock parallelReader(rowsPerUnit, ioSizes, *parallelFactory, 0);
+
+  // Test with OnDemandUnitLoader
+  auto onDemandFactory = std::make_shared<OnDemandUnitLoaderFactory>();
+  ReaderMock onDemandReader(rowsPerUnit, ioSizes, *onDemandFactory, 0);
+
+  // Both should produce the same results
+  for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+    uint64_t totalRowsRead = 0;
+    while (totalRowsRead < rowsPerUnit[i]) {
+      bool parallelResult = parallelReader.read(50);
+      bool onDemandResult = onDemandReader.read(50);
+
+      EXPECT_EQ(parallelResult, onDemandResult);
+      totalRowsRead += std::min(50UL, rowsPerUnit[i] - totalRowsRead);
+    }
+  }
+}
+
+TEST_F(ParallelUnitLoaderTest, SeekFunctionality) {
+  std::vector<uint64_t> rowsPerUnit = {100, 200, 150};
+  std::vector<uint64_t> ioSizes = {1024, 2048, 1536};
+
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 2);
+  ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+  // Test seeking to different positions
+  reader.seek(0);    // Beginning of first unit
+  reader.seek(50);   // Middle of first unit
+  reader.seek(100);  // Beginning of second unit
+  reader.seek(250);  // Middle of second unit
+  reader.seek(300);  // Beginning of third unit
+  reader.seek(449);  // End of file
+
+  // Test reading after seek
+  reader.seek(150);
+  EXPECT_TRUE(reader.read(50));
+}
+
+TEST_F(ParallelUnitLoaderTest, SkipRowsFunctionality) {
+  std::vector<uint64_t> rowsPerUnit = {100, 200, 150};
+  std::vector<uint64_t> ioSizes = {1024, 2048, 1536};
+
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 2);
+
+  // Skip first 150 rows (entire first unit + 50 rows of second unit)
+  ReaderMock reader(rowsPerUnit, ioSizes, *factory, 150);
+
+  // Should start reading from row 150 (middle of second unit)
+  EXPECT_TRUE(reader.read(50));
+}
+
+TEST_F(ParallelUnitLoaderTest, EdgeCases) {
+  // Test with zero prefetch window
+  {
+    std::vector<uint64_t> rowsPerUnit = {100, 100};
+    std::vector<uint64_t> ioSizes = {1024, 1024};
+
+    auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 0);
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    EXPECT_TRUE(reader.read(50));
+  }
+
+  // Test with prefetch window larger than number of units
+  {
+    std::vector<uint64_t> rowsPerUnit = {100, 100};
+    std::vector<uint64_t> ioSizes = {1024, 1024};
+
+    auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 10);
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    EXPECT_TRUE(reader.read(50));
+  }
+
+  // Test with single unit
+  {
+    std::vector<uint64_t> rowsPerUnit = {100};
+    std::vector<uint64_t> ioSizes = {1024};
+
+    auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 3);
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    EXPECT_TRUE(reader.read(50));
+    EXPECT_TRUE(reader.read(50));
+    EXPECT_FALSE(reader.read(50)); // Should be at end
+  }
+}
+
+TEST_F(ParallelUnitLoaderTest, ConcurrentAccess) {
+  std::vector<uint64_t> rowsPerUnit = {100, 100, 100, 100, 100};
+  std::vector<uint64_t> ioSizes = {1024, 1024, 1024, 1024, 1024};
+
+  auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 3);
+
+  // Create multiple readers to test concurrent access
+  std::vector<std::unique_ptr<ReaderMock>> readers;
+  for (int i = 0; i < 3; ++i) {
+    readers.push_back(std::make_unique<ReaderMock>(rowsPerUnit, ioSizes, *factory, 0));
+  }
+
+  // Test concurrent reading
+  std::vector<std::thread> threads;
+  std::atomic<int> successCount{0};
+
+  for (int t = 0; t < 3; ++t) {
+    threads.emplace_back([&readers, &successCount, t]() {
+      try {
+        auto& reader = *readers[t];
+        for (size_t i = 0; i < 5; ++i) {
+          if (reader.read(20)) {
+            successCount++;
+          }
+        }
+      } catch (const std::exception& e) {
+        // Some concurrent access might have issues, which is acceptable
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  // At least some reads should succeed
+  EXPECT_GT(successCount.load(), 0);
+}
+
+// Performance comparison test
+TEST_F(ParallelUnitLoaderTest, PerformanceComparison) {
+  std::vector<uint64_t> rowsPerUnit = {100, 100, 100, 100, 100, 100, 100, 100};
+  std::vector<uint64_t> ioSizes = {1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
+
+  // Measure ParallelUnitLoader performance
+  auto parallelStart = std::chrono::high_resolution_clock::now();
+  {
+    auto factory = std::make_shared<ParallelUnitLoaderFactory>(executor_.get(), 3);
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+      uint64_t totalRowsRead = 0;
+      while (totalRowsRead < rowsPerUnit[i]) {
+        reader.read(25);
+        totalRowsRead += std::min(25UL, rowsPerUnit[i] - totalRowsRead);
+      }
+    }
+  }
+  auto parallelEnd = std::chrono::high_resolution_clock::now();
+
+  // Measure OnDemandUnitLoader performance
+  auto onDemandStart = std::chrono::high_resolution_clock::now();
+  {
+    auto factory = std::make_shared<OnDemandUnitLoaderFactory>();
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+      uint64_t totalRowsRead = 0;
+      while (totalRowsRead < rowsPerUnit[i]) {
+        reader.read(25);
+        totalRowsRead += std::min(25UL, rowsPerUnit[i] - totalRowsRead);
+      }
+    }
+  }
+  auto onDemandEnd = std::chrono::high_resolution_clock::now();
+
+  auto parallelDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      parallelEnd - parallelStart);
+  auto onDemandDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      onDemandEnd - onDemandStart);
+
+  // ParallelUnitLoader should be faster or at least not significantly slower
+  // Note: This is a rough performance test and results may vary
+  std::cout << "ParallelUnitLoader time: " << parallelDuration.count() << "ms" << std::endl;
+  std::cout << "OnDemandUnitLoader time: " << onDemandDuration.count() << "ms" << std::endl;
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -18,6 +18,7 @@
 
 #include <chrono>
 
+#include "dwio/common/ParallelUnitLoader.h"
 #include "velox/dwio/common/OnDemandUnitLoader.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exception.h"
@@ -341,9 +342,15 @@ std::unique_ptr<dwio::common::UnitLoader> DwrfRowReader::getUnitLoader() {
   std::shared_ptr<UnitLoaderFactory> unitLoaderFactory =
       options_.unitLoaderFactory();
   if (!unitLoaderFactory) {
-    unitLoaderFactory =
+    if (options_.parallelUnitLoadCount() > 0) {
+      unitLoaderFactory =
+        std::make_shared<dwio::common::ParallelUnitLoaderFactory>(
+            options_.ioExecutor(), options_.parallelUnitLoadCount());
+    } else {
+      unitLoaderFactory =
         std::make_shared<dwio::common::OnDemandUnitLoaderFactory>(
             options_.blockedOnIoCallback());
+    }
   }
   return unitLoaderFactory->create(std::move(loadUnits), 0);
 }


### PR DESCRIPTION
Introduce ParallelUnitLoader that enables concurrent loading of multiple units 
(e.g., stripes) in sliding window fashion to improve I/O throughput and reduce r
ead latency