### PR TITLE
refactor(expression): Formalize ExpressionRewrite framework

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -42,6 +42,7 @@ velox_add_library(
   EvalCtx.cpp
   Expr.cpp
   ExprCompiler.cpp
+  ExprRewriteRegistry.cpp
   ExprToSubfieldFilter.cpp
   ExprUtils.cpp
   FieldReference.cpp

--- a/velox/expression/ExprRewriteRegistry.cpp
+++ b/velox/expression/ExprRewriteRegistry.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/expression/FunctionSignature.h"
+
+namespace facebook::velox::expression {
+
+void ExprRewriteRegistry::registerRewrite(ExpressionRewrite rewrite) {
+  registry_.withWLock([&](auto& list) { list.push_back(std::move(rewrite)); });
+}
+
+void ExprRewriteRegistry::clear() {
+  registry_.withWLock([&](auto& list) { list.clear(); });
+}
+
+core::TypedExprPtr ExprRewriteRegistry::rewrite(
+    const core::TypedExprPtr& expr) {
+  core::TypedExprPtr result = expr;
+  registry_.withRLock([&](const auto& list) {
+    for (const auto& rewrite : list) {
+      VELOX_CHECK_NOT_NULL(rewrite);
+      if (auto rewritten = (rewrite)(expr)) {
+        result = rewritten;
+        break;
+      }
+    }
+  });
+
+  return result;
+}
+} // namespace facebook::velox::expression

--- a/velox/expression/ExprRewriteRegistry.h
+++ b/velox/expression/ExprRewriteRegistry.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Synchronized.h>
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::expression {
+
+/// An expression re-writer that takes an expression and returns an equivalent
+/// expression or nullptr if re-write is not possible.
+using ExpressionRewrite =
+    std::function<core::TypedExprPtr(const core::TypedExprPtr)>;
+
+class ExprRewriteRegistry {
+ public:
+  /// Appends a 'rewrite' to 'expressionRewrites'.
+  ///
+  /// The logic that applies re-writes is very simple and assumes that all
+  /// rewrites are independent. For each expression, rewrites are applied in the
+  /// order they were registered. The first rewrite that returns non-null result
+  /// terminates the re-write for that particular expression.
+  void registerRewrite(ExpressionRewrite rewrite);
+
+  /// Clears the registry to remove all registered rewrites.
+  void clear();
+
+  core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+
+  static ExprRewriteRegistry& instance() {
+    static ExprRewriteRegistry kInstance;
+    return kInstance;
+  }
+
+ private:
+  folly::Synchronized<std::vector<ExpressionRewrite>> registry_;
+};
+} // namespace facebook::velox::expression

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -245,13 +245,4 @@ bool registerVectorFunction(
       name, signatures, factory, metadata, overwrite);
 }
 
-std::vector<ExpressionRewrite>& expressionRewrites() {
-  static std::vector<ExpressionRewrite> rewrites;
-  return rewrites;
-}
-
-void registerExpressionRewrite(ExpressionRewrite rewrite) {
-  expressionRewrites().emplace_back(rewrite);
-}
-
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -279,22 +279,6 @@ bool registerStatefulVectorFunction(
     VectorFunctionMetadata metadata = {},
     bool overwrite = true);
 
-/// An expression re-writer that takes an expression and returns an equivalent
-/// expression or nullptr if re-write is not possible.
-using ExpressionRewrite = std::function<core::TypedExprPtr(core::TypedExprPtr)>;
-
-/// Returns a list of registered re-writes.
-std::vector<ExpressionRewrite>& expressionRewrites();
-
-/// Appends a 'rewrite' to 'expressionRewrites'.
-///
-/// The logic that applies re-writes is very simple and assumes that all
-/// rewrites are independent. Re-writes are applied to all expressions starting
-/// at the root and going down the hierarchy. For each expression, rewrites are
-/// applied in the order they were registered. The first rewrite that returns
-/// non-null result terminates the re-write for this particular expression.
-void registerExpressionRewrite(ExpressionRewrite rewrite);
-
 } // namespace facebook::velox::exec
 
 // Private. Return the external function name given a UDF tag.

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   CustomTypeTest.cpp
   ExprCompilerTest.cpp
   ExprEncodingsTest.cpp
+  ExprRewriteRegistryTest.cpp
   ExprStatsTest.cpp
   ExprTest.cpp
   ExprToSubfieldFilterTest.cpp

--- a/velox/expression/tests/ExprRewriteRegistryTest.cpp
+++ b/velox/expression/tests/ExprRewriteRegistryTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "gtest/gtest.h"
+
+namespace facebook::velox::expression {
+
+namespace {
+
+class ExprRewriteRegistryTest : public testing::Test {};
+
+TEST_F(ExprRewriteRegistryTest, basic) {
+  expression::ExprRewriteRegistry registry;
+  expression::ExpressionRewrite testRewrite =
+      [&](const core::TypedExprPtr& input) {
+        return std::make_shared<core::CallTypedExpr>(
+            input->type(), "test_expr", input, input);
+      };
+  registry.registerRewrite(testRewrite);
+
+  auto input =
+      std::make_shared<core::ConstantTypedExpr>(BIGINT(), variant(123));
+  const auto rewritten = registry.rewrite(input);
+  ASSERT_TRUE(rewritten->isCallKind());
+  ASSERT_TRUE(rewritten->type()->isBigint());
+  const auto rewrittenCall = rewritten->asUnchecked<core::CallTypedExpr>();
+  ASSERT_EQ(rewrittenCall->inputs().size(), 2);
+  ASSERT_EQ(rewrittenCall->name(), "test_expr");
+
+  registry.clear();
+  const auto rewriteAfterClear = registry.rewrite(input);
+  ASSERT_TRUE(*rewriteAfterClear == *input);
+}
+
+} // namespace
+} // namespace facebook::velox::expression

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -16,6 +16,7 @@
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/core/Expressions.h"
 #include "velox/expression/ExprConstants.h"
+#include "velox/expression/ExprRewriteRegistry.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 
@@ -423,7 +424,7 @@ VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     std::make_unique<ReduceFunction>());
 
 void registerReduceRewrites(const std::string& prefix) {
-  exec::registerExpressionRewrite(
+  expression::ExprRewriteRegistry::instance().registerRewrite(
       [prefix](const auto& expr) { return rewriteReduce(prefix, expr); });
 }
 

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -16,6 +16,7 @@
 
 #include <string>
 
+#include "velox/expression/ExprRewriteRegistry.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/ArrayRemoveNullFunction.h"
 #include "velox/functions/lib/ArrayShuffle.h"
@@ -170,9 +171,10 @@ void registerArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_flatten, prefix + "flatten");
 
   auto checker = std::make_shared<SimpleComparisonChecker>();
-  exec::registerExpressionRewrite([prefix, checker](const auto& expr) {
-    return rewriteArraySortCall(prefix, expr, checker);
-  });
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      [prefix, checker](const auto& expr) {
+        return rewriteArraySortCall(prefix, expr, checker);
+      });
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");
   exec::registerStatefulVectorFunction(

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/expression/ExprRewriteRegistry.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/prestosql/RegexpReplace.h"
@@ -189,9 +190,10 @@ void registerSplitToMap(const std::string& prefix) {
       Varchar,
       Varchar,
       bool>({"$internal$split_to_map"});
-  exec::registerExpressionRewrite([prefix](const auto& expr) {
-    return rewriteSplitToMapCall(prefix, expr);
-  });
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      [prefix](const auto& expr) {
+        return rewriteSplitToMapCall(prefix, expr);
+      });
 }
 } // namespace
 

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/expression/ExprRewriteRegistry.h"
 #include "velox/functions/lib/ArrayRemoveNullFunction.h"
 #include "velox/functions/lib/ArrayShuffle.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
@@ -224,9 +225,10 @@ void registerArrayFunctions(const std::string& prefix) {
       prefix + "sort_array", sortArraySignatures(), makeSortArray);
 
   auto checker = std::make_shared<SparkSimpleComparisonChecker>();
-  exec::registerExpressionRewrite([prefix, checker](const auto& expr) {
-    return rewriteArraySortCall(prefix, expr, checker);
-  });
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      [prefix, checker](const auto& expr) {
+        return rewriteArraySortCall(prefix, expr, checker);
+      });
   exec::registerStatefulVectorFunction(
       prefix + "array_repeat",
       repeatSignatures(),


### PR DESCRIPTION
Expression rewrites are currently defined in `VectorFunction.cpp`, rewrites are registered only for scalar functions, and rewrites are applied during expression compilation. In the upcoming `ExpressionOptimizer` work (#14523), we intend to build on the existing `ExpressionRewrite` support and introduce more expression rewrites for special form expressions. 

This refactor formalizes the existing `ExpressionRewrite` framework so it can be expanded upon in the `ExpressionOptimizer`.