### PR TITLE
refactor(expression): Add convenience constructor for CallTypedExpr

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -189,6 +189,16 @@ class CallTypedExpr : public ITypedExpr {
       : ITypedExpr{ExprKind::kCall, std::move(type), std::move(inputs)},
         name_(std::move(name)) {}
 
+  /// @param type Return type.
+  /// @param name Name of the function or special form.
+  /// @param inputs List of input expressions.
+  template <typename... TypedExprs>
+  CallTypedExpr(TypePtr type, std::string name, TypedExprs... inputs)
+      : CallTypedExpr(
+            std::move(type),
+            std::vector<TypedExprPtr>{std::forward<TypedExprs>(inputs)...},
+            std::move(name)) {}
+
   virtual const std::string& name() const {
     return name_;
   }

--- a/velox/core/tests/FilterToExpressionTest.cpp
+++ b/velox/core/tests/FilterToExpressionTest.cpp
@@ -564,9 +564,7 @@ void FilterToExpressionTest::testRoundTrip(
 
       // Create a between expression
       auto betweenExpr = std::make_shared<CallTypedExpr>(
-          callExpr->type(),
-          std::vector<TypedExprPtr>{field, lowerBound, upperBound},
-          "between");
+          callExpr->type(), "between", field, lowerBound, upperBound);
 
       common::Subfield roundTripSubfield;
       auto roundTripFilter =

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -129,10 +129,9 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
   const std::vector<FieldAccessTypedExprPtr> emptyPreGroupingKeys;
   std::vector<std::string> aggregateNames{"sum"};
   std::vector<std::string> emptyAggregateNames{};
-  std::vector<TypedExprPtr> aggregateInputs{
-      std::make_shared<InputTypedExpr>(BIGINT())};
+  auto aggregateInput = std::make_shared<InputTypedExpr>(BIGINT());
   const std::vector<AggregationNode::Aggregate> aggregates{
-      {std::make_shared<core::CallTypedExpr>(BIGINT(), aggregateInputs, "sum"),
+      {std::make_shared<core::CallTypedExpr>(BIGINT(), "sum", aggregateInput),
        {},
        nullptr,
        {},

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -295,8 +295,7 @@ TEST_F(PlanNodeBuilderTest, aggregationNode) {
   const std::vector<std::string> aggregateNames{"a0"};
   const std::vector<AggregationNode::Aggregate> aggregates{
       AggregationNode::Aggregate{
-          .call = std::make_shared<core::CallTypedExpr>(
-              INTEGER(), std::vector<TypedExprPtr>{}, "sum"),
+          .call = std::make_shared<core::CallTypedExpr>(INTEGER(), "sum"),
           .rawInputTypes = {INTEGER()}}};
   const std::vector<vector_size_t> globalGroupingSets{0};
   const std::optional<FieldAccessTypedExprPtr> groupId{
@@ -1060,8 +1059,7 @@ TEST_F(PlanNodeBuilderTest, windowNode) {
   const bool inputsSorted = true;
 
   // Create a dummy window function.
-  const auto functionCall = std::make_shared<CallTypedExpr>(
-      BIGINT(), std::vector<TypedExprPtr>{}, "rank");
+  const auto functionCall = std::make_shared<CallTypedExpr>(BIGINT(), "rank");
   WindowNode::Frame frame{
       WindowNode::WindowType::kRows,
       WindowNode::BoundType::kUnboundedPreceding,

--- a/velox/core/tests/TypedExprSerdeTest.cpp
+++ b/velox/core/tests/TypedExprSerdeTest.cpp
@@ -87,33 +87,25 @@ TEST_F(TypedExprSerDeTest, call) {
   // a + b
   auto expression = std::make_shared<CallTypedExpr>(
       BIGINT(),
-      std::vector<TypedExprPtr>{
-          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
-          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "b"),
-      },
-      "plus");
+      "plus",
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "b"));
 
   testSerde(expression);
 
   // f(g(h(a, b), c))
   expression = std::make_shared<CallTypedExpr>(
       VARCHAR(),
-      std::vector<TypedExprPtr>{
+      "f",
+      std::make_shared<CallTypedExpr>(
+          DOUBLE(),
+          "g",
           std::make_shared<CallTypedExpr>(
-              DOUBLE(),
-              std::vector<TypedExprPtr>{
-                  std::make_shared<CallTypedExpr>(
-                      BIGINT(),
-                      std::vector<TypedExprPtr>{
-                          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
-                          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "b"),
-                      },
-                      "h"),
-                  std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c"),
-              },
-              "g"),
-      },
-      "f");
+              BIGINT(),
+              "h",
+              std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
+              std::make_shared<FieldAccessTypedExpr>(BIGINT(), "b")),
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c")));
   testSerde(expression);
 }
 
@@ -144,13 +136,11 @@ TEST_F(TypedExprSerDeTest, lambda) {
       ROW({"x"}, {BIGINT()}),
       std::make_shared<CallTypedExpr>(
           BOOLEAN(),
-          std::vector<TypedExprPtr>{
-              std::make_shared<FieldAccessTypedExpr>(BIGINT(), "x"),
-              std::make_shared<ConstantTypedExpr>(makeArrayVector<int64_t>({
-                  {1, 2, 3, 4, 5},
-              })),
-          },
-          "in"));
+          "in",
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "x"),
+          std::make_shared<ConstantTypedExpr>(makeArrayVector<int64_t>({
+              {1, 2, 3, 4, 5},
+          }))));
   testSerde(expression);
 }
 

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -103,9 +103,7 @@ int main(int argc, char** argv) {
   // would be automatically and recursively generated based on some input IDL
   // (or by a SQL string parser).
   auto exprTree = std::make_shared<core::CallTypedExpr>(
-      BIGINT(),
-      std::vector<core::TypedExprPtr>{fieldAccessExprNode},
-      "times_two");
+      BIGINT(), "times_two", fieldAccessExprNode);
 
   // Lastly, ExprSet contains the main expression evaluation logic. It takes a
   // vector of expression trees (if there are multiple expressions to be

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -324,9 +324,9 @@ VectorPtr evaluate(
 
   auto exprPlan = std::make_shared<core::CallTypedExpr>(
       OPAQUE<UserDefinedOutput>(),
-      std::vector<core::TypedExprPtr>{
-          fieldAccessExprNode1, fieldAccessExprNode2},
-      functionName);
+      functionName,
+      fieldAccessExprNode1,
+      fieldAccessExprNode2);
 
   exec::ExprSet exprSet({exprPlan}, &execCtx);
   exec::EvalCtx evalCtx(&execCtx, &exprSet, rowVector.get());

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -64,9 +64,8 @@ void toUnaryOperator(
     const std::string& expectedSql) {
   auto expression = std::make_shared<core::CallTypedExpr>(
       INTEGER(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0")},
-      operatorName);
+      operatorName,
+      std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"));
   EXPECT_EQ(toCallSql(expression), expectedSql);
 }
 
@@ -75,10 +74,9 @@ void toBinaryOperator(
     const std::string& expectedSql) {
   auto expression = std::make_shared<core::CallTypedExpr>(
       INTEGER(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
-          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
-      operatorName);
+      operatorName,
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"));
   EXPECT_EQ(toCallSql(expression), expectedSql);
 }
 
@@ -87,9 +85,8 @@ void toIsNullOrIsNotNull(
     const std::string& expectedSql) {
   auto expression = std::make_shared<core::CallTypedExpr>(
       BOOLEAN(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
-      operatorName);
+      operatorName,
+      std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"));
   EXPECT_EQ(toCallSql(expression), expectedSql);
 }
 
@@ -100,10 +97,9 @@ TEST(PrestoSqlTest, toCallSql) {
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1")},
-          "not")),
+          "not",
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1"))),
       "Expected one argument to a unary operator");
 
   // Binary operators
@@ -122,11 +118,10 @@ TEST(PrestoSqlTest, toCallSql) {
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3")},
-          "plus")),
+          "plus",
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3"))),
       "Expected two arguments to a binary operator");
 
   // Functions IS NULL and NOT NULL
@@ -135,201 +130,176 @@ TEST(PrestoSqlTest, toCallSql) {
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
-          "is_null")),
+          "is_null",
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"))),
       "Expected one argument to function 'is_null' or 'not_null'");
 
   // Function IN
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b")},
-          "in")),
+          "in",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"))),
       "'a' in ('b')");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d")},
-          "in")),
+          "in",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d"))),
       "'a' in ('b', 'c', 'd')");
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a")},
-          "in")),
+          "in",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"))),
       "Expected at least two arguments to function 'in'");
 
   // Function LIKE
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a")},
-          "like")),
+          "like",
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"))),
       "(c0 like 'a')");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b")},
-          "like")),
+          "like",
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"))),
       "(c0 like 'a' escape 'b')");
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a")},
-          "like")),
+          "like",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"))),
       "Expected at least two arguments to function 'like'");
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d")},
-          "like")),
+          "like",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d"))),
       "Expected at most three arguments to function 'like'");
 
   // Functions OR and AND
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
-          "or")),
+          "or",
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false))),
       "(BOOLEAN 'true' or BOOLEAN 'false')");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
-          "and")),
+          "and",
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false))),
       "(BOOLEAN 'true' and BOOLEAN 'false')");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
-          "or")),
+          "or",
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false))),
       "(BOOLEAN 'true' or BOOLEAN 'false' or BOOLEAN 'true' or BOOLEAN 'false')");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-              std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false)},
-          "and")),
+          "and",
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
+          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), false))),
       "(BOOLEAN 'true' and BOOLEAN 'false' and BOOLEAN 'true' and BOOLEAN 'false')");
   VELOX_ASSERT_THROW(
-      toCallSql(std::make_shared<core::CallTypedExpr>(
-          BOOLEAN(), std::vector<core::TypedExprPtr>{}, "or")),
+      toCallSql(std::make_shared<core::CallTypedExpr>(BOOLEAN(), "or")),
       "Expected at least two arguments to function 'or' or 'and'");
 
   // Functions ARRAY_CONSTRUCTOR and ROW_CONSTRUCTOR
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           ARRAY(INTEGER()),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c")},
-          "array_constructor")),
+          "array_constructor",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"))),
       "ARRAY['a', 'b', 'c']");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
-          ARRAY(INTEGER()),
-          std::vector<core::TypedExprPtr>{},
-          "array_constructor")),
+          ARRAY(INTEGER()), "array_constructor")),
       "ARRAY[]");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
-              std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d")},
-          "row_constructor")),
+          "row_constructor",
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "a"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "b"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "c"),
+          std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "d"))),
       "row('a', 'b', 'c', 'd')");
   VELOX_ASSERT_THROW(
-      toCallSql(std::make_shared<core::CallTypedExpr>(
-          BOOLEAN(), std::vector<core::TypedExprPtr>{}, "row_constructor")),
+      toCallSql(
+          std::make_shared<core::CallTypedExpr>(BOOLEAN(), "row_constructor")),
       "Expected at least one argument to function 'row_constructor'");
 
   // Function BETWEEN
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c2")},
-          "between")),
+          "between",
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c2"))),
       "(c0 between c1 and c2)");
   // Edge case check for ambiguous parantheses processing, query will fail
   // without the parantheses wrapping the left-hand side.
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::CallTypedExpr>(
-                  BOOLEAN(),
-                  std::vector<core::TypedExprPtr>{
-                      std::make_shared<core::FieldAccessTypedExpr>(
-                          INTEGER(), "c0"),
-                      std::make_shared<core::FieldAccessTypedExpr>(
-                          INTEGER(), "c0"),
-                      std::make_shared<core::ConstantTypedExpr>(
-                          INTEGER(), variant::null(TypeKind::INTEGER))},
-                  "between"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
-          "lt")),
+          "lt",
+          std::make_shared<core::CallTypedExpr>(
+              BOOLEAN(),
+              "between",
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+              std::make_shared<core::ConstantTypedExpr>(
+                  INTEGER(), variant::null(TypeKind::INTEGER))),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"))),
       "((c0 between c0 and cast(null as INTEGER)) < c0)");
   VELOX_ASSERT_THROW(
-      toCallSql(std::make_shared<core::CallTypedExpr>(
-          BOOLEAN(), std::vector<core::TypedExprPtr>{}, "between")),
+      toCallSql(std::make_shared<core::CallTypedExpr>(BOOLEAN(), "between")),
       "Expected three arguments to function 'between'");
 
   // Function SUBSCRIPT, builds '[]' SQL
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(
-                  ARRAY(INTEGER()), "array"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
-          "subscript")),
+          "subscript",
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(INTEGER()), "array"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"))),
       "array[c0]");
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(
-                  ARRAY(INTEGER()), "array"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
-          "subscript")),
+          "subscript",
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ARRAY(INTEGER()), "array"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"))),
       "Expected two arguments to function 'subscript'");
 
   // Function SWITCH, builds 'CASE WHEN ... THEN ... ELSE ... END' SQL
@@ -337,54 +307,47 @@ TEST(PrestoSqlTest, toCallSql) {
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1")},
-          "switch")),
+          "switch",
+          std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1"))),
       "case when c0 then c1 end");
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
-              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c2"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3")},
-          "switch")),
+          "switch",
+          std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+          std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c2"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3"))),
       "case when c0 then c1 when c2 then c3 end");
   // SWITCH case with ELSE.
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
-              std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c2"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c4")},
-          "switch")),
+          "switch",
+          std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"),
+          std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c2"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c3"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c4"))),
       "case when c0 then c1 when c2 then c3 else c4 end");
   VELOX_ASSERT_THROW(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0")},
-          "switch")),
+          "switch",
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0"))),
       "Expected at least two arguments to function 'switch'");
 
   // Generic functions
   EXPECT_EQ(
       toCallSql(std::make_shared<core::CallTypedExpr>(
           INTEGER(),
-          std::vector<core::TypedExprPtr>{
-              std::make_shared<core::FieldAccessTypedExpr>(
-                  ARRAY(INTEGER()), "c0"),
-              std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1")},
-          "array_top_n")),
+          "array_top_n",
+          std::make_shared<core::FieldAccessTypedExpr>(ARRAY(INTEGER()), "c0"),
+          std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c1"))),
       "array_top_n(c0, c1)");
   EXPECT_EQ(
-      toCallSql(std::make_shared<core::CallTypedExpr>(
-          REAL(), std::vector<core::TypedExprPtr>{}, "infinity")),
+      toCallSql(std::make_shared<core::CallTypedExpr>(REAL(), "infinity")),
       "infinity()");
 }
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -456,8 +456,8 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
       BIGINT(), inputs, "missing-function");
   auto wrongInputTypes =
       std::make_shared<core::CallTypedExpr>(BIGINT(), inputs, "test_aggregate");
-  auto missingInputs = std::make_shared<core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{}, "test_aggregate");
+  auto missingInputs =
+      std::make_shared<core::CallTypedExpr>(BIGINT(), "test_aggregate");
 
   auto makePlan = [&](const core::CallTypedExprPtr& aggExpr) {
     return PlanBuilder()
@@ -518,9 +518,7 @@ TEST_F(AggregationTest, missingLambdaFunction) {
       std::make_shared<core::LambdaTypedExpr>(
           ROW({"a", "b"}, {BIGINT(), BIGINT()}),
           std::make_shared<core::CallTypedExpr>(
-              BIGINT(),
-              std::vector<core::TypedExprPtr>{field("a"), field("b")},
-              "multiply")),
+              BIGINT(), "multiply", field("a"), field("b"))),
   };
 
   auto plan = PlanBuilder()

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -726,9 +726,7 @@ TEST_P(StreamingAggregationTest, closeUninitialized) {
                             std::make_shared<core::FieldAccessTypedExpr>(
                                 BIGINT(), "c0"),
                             std::make_shared<core::CallTypedExpr>(
-                                BIGINT(),
-                                std::vector<core::TypedExprPtr>{},
-                                "do-not-exist")},
+                                BIGINT(), "do-not-exist")},
                         source);
                   })
                   .partialStreamingAggregation({"c0"}, {"sum(x)"})

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -1911,51 +1911,41 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
   core::TypedExprPtr intInputField =
       std::make_shared<const core::FieldAccessTypedExpr>(SMALLINT(), "c2");
   auto minCallExpr = std::make_shared<const core::CallTypedExpr>(
-      SMALLINT(), std::vector<core::TypedExprPtr>{intInputField}, "min");
+      SMALLINT(), "min", intInputField);
   auto maxCallExpr = std::make_shared<const core::CallTypedExpr>(
-      SMALLINT(), std::vector<core::TypedExprPtr>{intInputField}, "max");
+      SMALLINT(), "max", intInputField);
   auto distinctCountCallExpr = std::make_shared<const core::CallTypedExpr>(
-      VARBINARY(),
-      std::vector<core::TypedExprPtr>{intInputField},
-      "approx_distinct");
+      VARBINARY(), "approx_distinct", intInputField);
 
   core::TypedExprPtr strInputField =
       std::make_shared<const core::FieldAccessTypedExpr>(VARCHAR(), "c5");
   auto maxDataSizeCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(),
-      std::vector<core::TypedExprPtr>{strInputField},
-      "max_data_size_for_stats");
+      BIGINT(), "max_data_size_for_stats", strInputField);
   auto sumDataSizeCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(),
-      std::vector<core::TypedExprPtr>{strInputField},
-      "sum_data_size_for_stats");
+      BIGINT(), "sum_data_size_for_stats", strInputField);
 
   core::TypedExprPtr boolInputField =
       std::make_shared<const core::FieldAccessTypedExpr>(BOOLEAN(), "c6");
   auto countCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{boolInputField}, "count");
+      BIGINT(), "count", boolInputField);
   auto countIfCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{boolInputField}, "count_if");
+      BIGINT(), "count_if", boolInputField);
 
   core::TypedExprPtr mapInputField =
       std::make_shared<const core::FieldAccessTypedExpr>(
           MAP(DATE(), BIGINT()), "c7");
   auto countMapCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{mapInputField}, "count");
+      BIGINT(), "count", mapInputField);
   auto sumDataSizeMapCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(),
-      std::vector<core::TypedExprPtr>{mapInputField},
-      "sum_data_size_for_stats");
+      BIGINT(), "sum_data_size_for_stats", mapInputField);
 
   core::TypedExprPtr arrayInputField =
       std::make_shared<const core::FieldAccessTypedExpr>(
           MAP(DATE(), BIGINT()), "c7");
   auto countArrayCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{mapInputField}, "count");
+      BIGINT(), "count", mapInputField);
   auto sumDataSizeArrayCallExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(),
-      std::vector<core::TypedExprPtr>{mapInputField},
-      "sum_data_size_for_stats");
+      BIGINT(), "sum_data_size_for_stats", mapInputField);
 
   const std::vector<std::string> aggregateNames = {
       "min",

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -438,9 +438,8 @@ TEST_F(WindowTest, missingFunctionSignature) {
 
   auto callExpr = std::make_shared<core::CallTypedExpr>(
       BIGINT(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1")},
-      "sum");
+      "sum",
+      std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c1"));
 
   VELOX_ASSERT_THROW(
       runWindow(callExpr),
@@ -448,9 +447,8 @@ TEST_F(WindowTest, missingFunctionSignature) {
 
   callExpr = std::make_shared<core::CallTypedExpr>(
       VARCHAR(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c2")},
-      "sum");
+      "sum",
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c2"));
 
   VELOX_ASSERT_THROW(
       runWindow(callExpr),

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -252,9 +252,7 @@ void addConjunct(
     conjunction = conjunct;
   } else {
     conjunction = std::make_shared<core::CallTypedExpr>(
-        BOOLEAN(),
-        std::vector<core::TypedExprPtr>{conjunction, conjunct},
-        "and");
+        BOOLEAN(), "and", conjunction, conjunct);
   }
 }
 } // namespace
@@ -783,9 +781,8 @@ PlanBuilder& PlanBuilder::tableWriteMerge() {
       core::AggregationNode::Aggregate aggregate = writerSpec.aggregates[i];
       aggregate.call = std::make_shared<core::CallTypedExpr>(
           aggregate.call->type(),
-          std::vector<core::TypedExprPtr>{
-              field(inputType, writerSpec.aggregateNames[i])},
-          aggregate.call->name());
+          aggregate.call->name(),
+          field(inputType, writerSpec.aggregateNames[i]));
       aggregates.push_back(std::move(aggregate));
       aggregateNames.push_back(fmt::format("a{}", i));
     }

--- a/velox/exec/tests/utils/TableWriterTestBase.cpp
+++ b/velox/exec/tests/utils/TableWriterTestBase.cpp
@@ -103,8 +103,8 @@ core::ColumnStatsSpec TableWriterTestBase::generateColumnStatsSpec(
     AggregationNode::Step step) {
   core::TypedExprPtr inputField =
       std::make_shared<const core::FieldAccessTypedExpr>(BIGINT(), name);
-  auto callExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{inputField}, "min");
+  auto callExpr =
+      std::make_shared<const core::CallTypedExpr>(BIGINT(), "min", inputField);
   std::vector<std::string> aggregateNames = {"min"};
   std::vector<core::AggregationNode::Aggregate> aggregates = {
       core::AggregationNode::Aggregate{

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -122,9 +122,9 @@ core::TypedExprPtr toJoinConditionExpr(
                 condition)) {
       conditionExprs.push_back(std::make_shared<const core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              inCondition->list, std::move(indexColumnExpr)},
-          "contains"));
+          "contains",
+          inCondition->list,
+          std::move(indexColumnExpr)));
       continue;
     }
     if (auto betweenCondition =
@@ -132,21 +132,17 @@ core::TypedExprPtr toJoinConditionExpr(
                 condition)) {
       conditionExprs.push_back(std::make_shared<const core::CallTypedExpr>(
           BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::move(indexColumnExpr),
-              betweenCondition->lower,
-              betweenCondition->upper},
-          "between"));
+          "between",
+          std::move(indexColumnExpr),
+          betweenCondition->lower,
+          betweenCondition->upper));
       continue;
     }
     if (auto equalCondition =
             std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
                 condition)) {
       conditionExprs.push_back(std::make_shared<const core::CallTypedExpr>(
-          BOOLEAN(),
-          std::vector<core::TypedExprPtr>{
-              std::move(indexColumnExpr), equalCondition->value},
-          "eq"));
+          BOOLEAN(), "eq", std::move(indexColumnExpr), equalCondition->value));
       continue;
     }
     VELOX_FAIL("Invalid index join condition: {}", condition->toString());

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -291,27 +291,18 @@ TEST_F(TableScanTest, filterPushdown) {
   // c1 >= 0 or null and c3 is true
   auto c1Expr = std::make_shared<core::CallTypedExpr>(
       BOOLEAN(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c1"),
-          std::make_shared<core::ConstantTypedExpr>(BIGINT(), int64_t(0)),
-      },
-      "gte");
+      "gte",
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c1"),
+      std::make_shared<core::ConstantTypedExpr>(BIGINT(), int64_t(0)));
 
   auto c3Expr = std::make_shared<core::CallTypedExpr>(
       BOOLEAN(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c3"),
-          std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true),
-      },
-      "eq");
+      "eq",
+      std::make_shared<core::FieldAccessTypedExpr>(BOOLEAN(), "c3"),
+      std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true));
 
-  auto subfieldFilterExpr = std::make_shared<core::CallTypedExpr>(
-      BOOLEAN(),
-      std::vector<core::TypedExprPtr>{
-          c1Expr,
-          c3Expr,
-      },
-      "and");
+  auto subfieldFilterExpr =
+      std::make_shared<core::CallTypedExpr>(BOOLEAN(), "and", c1Expr, c3Expr);
   auto tableHandle = makeTableHandle(
       "parquet_table", rowType, true, std::move(subfieldFilterExpr), nullptr);
 

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -64,8 +64,8 @@ static std::shared_ptr<core::AggregationNode> generateColumnStatsSpec(
     const PlanNodePtr& source) {
   core::TypedExprPtr inputField =
       std::make_shared<const core::FieldAccessTypedExpr>(BIGINT(), name);
-  auto callExpr = std::make_shared<const core::CallTypedExpr>(
-      BIGINT(), std::vector<core::TypedExprPtr>{inputField}, "min");
+  auto callExpr =
+      std::make_shared<const core::CallTypedExpr>(BIGINT(), "min", inputField);
   std::vector<std::string> aggregateNames = {"min"};
   std::vector<core::AggregationNode::Aggregate> aggregates = {
       core::AggregationNode::Aggregate{

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -290,8 +290,8 @@ void ExpressionFuzzerVerifier::retryWithTry(
   // Wrap each expression tree with 'try'.
   std::vector<core::TypedExprPtr> tryPlans;
   for (auto& plan : plans) {
-    tryPlans.push_back(std::make_shared<core::CallTypedExpr>(
-        plan->type(), std::vector<core::TypedExprPtr>{plan}, "try"));
+    tryPlans.push_back(
+        std::make_shared<core::CallTypedExpr>(plan->type(), "try", plan));
   }
 
   std::vector<ResultOrError> tryResults;

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -2525,8 +2525,8 @@ TEST_F(CastExprTest, castAsCall) {
   auto input = makeRowVector({makeNullableFlatVector(inputValues)});
   core::TypedExprPtr inputField =
       std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c0");
-  core::TypedExprPtr callExpr = std::make_shared<const core::CallTypedExpr>(
-      DOUBLE(), std::vector<core::TypedExprPtr>{inputField}, "cast");
+  core::TypedExprPtr callExpr =
+      std::make_shared<const core::CallTypedExpr>(DOUBLE(), "cast", inputField);
 
   auto result = evaluate(callExpr, input);
   auto expected = makeNullableFlatVector(outputValues);

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -49,15 +49,13 @@ class ExprCompilerTest : public testing::Test,
   core::TypedExprPtr andCall(
       const core::TypedExprPtr& a,
       const core::TypedExprPtr& b) {
-    return std::make_shared<core::CallTypedExpr>(
-        BOOLEAN(), std::vector<core::TypedExprPtr>{a, b}, "and");
+    return std::make_shared<core::CallTypedExpr>(BOOLEAN(), "and", a, b);
   }
 
   core::TypedExprPtr orCall(
       const core::TypedExprPtr& a,
       const core::TypedExprPtr& b) {
-    return std::make_shared<core::CallTypedExpr>(
-        BOOLEAN(), std::vector<core::TypedExprPtr>{a, b}, "or");
+    return std::make_shared<core::CallTypedExpr>(BOOLEAN(), "or", a, b);
   }
 
   core::TypedExprPtr concatCall(
@@ -252,9 +250,7 @@ TEST_F(ExprCompilerTest, concatArrayFlattening) {
 
 TEST_F(ExprCompilerTest, functionNameNotRegistered) {
   auto expression = std::make_shared<core::CallTypedExpr>(
-      VARCHAR(),
-      std::vector<core::TypedExprPtr>{varchar("---"), varchar("...")},
-      "not_registered_function");
+      VARCHAR(), "not_registered_function", varchar("---"), varchar("..."));
 
   VELOX_ASSERT_THROW(
       compile(expression),

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -264,17 +264,16 @@ TEST_F(ExprToSubfieldFilterTest, userError) {
 TEST_F(ExprToSubfieldFilterTest, dereferenceWithEmptyField) {
   auto call = std::make_shared<core::CallTypedExpr>(
       BOOLEAN(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::DereferenceTypedExpr>(
-              REAL(),
-              std::make_shared<core::FieldAccessTypedExpr>(
-                  ROW({{"", DOUBLE()}, {"", REAL()}, {"", BIGINT()}}),
-                  std::make_shared<core::InputTypedExpr>(ROW(
-                      {{"c0",
-                        ROW({{"", DOUBLE()}, {"", REAL()}, {"", BIGINT()}})}})),
-                  "c0"),
-              1)},
-      "is_null");
+      "is_null",
+      std::make_shared<core::DereferenceTypedExpr>(
+          REAL(),
+          std::make_shared<core::FieldAccessTypedExpr>(
+              ROW({{"", DOUBLE()}, {"", REAL()}, {"", BIGINT()}}),
+              std::make_shared<core::InputTypedExpr>(ROW(
+                  {{"c0",
+                    ROW({{"", DOUBLE()}, {"", REAL()}, {"", BIGINT()}})}})),
+              "c0"),
+          1));
   Subfield subfield;
   auto filter =
       ExprToSubfieldFilterParser::getInstance()->leafCallToSubfieldFilter(

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -528,14 +528,12 @@ core::TypedExprPtr rewriteArraySortCall(
 
     auto rewritten = std::make_shared<core::CallTypedExpr>(
         call->type(),
-        std::vector<core::TypedExprPtr>{
-            call->inputs()[0],
-            std::make_shared<core::LambdaTypedExpr>(
-                ROW({lambda->signature()->nameOf(0)},
-                    {lambda->signature()->childAt(0)}),
-                comparison->expr),
-        },
-        name);
+        name,
+        call->inputs()[0],
+        std::make_shared<core::LambdaTypedExpr>(
+            ROW({lambda->signature()->nameOf(0)},
+                {lambda->signature()->childAt(0)}),
+            comparison->expr));
 
     return rewritten;
   }

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -325,19 +325,13 @@ core::TypedExprPtr toArraySum(
   auto lambda = std::make_shared<core::LambdaTypedExpr>(
       ROW({inputArgs->nameOf(1)}, {inputArgs->childAt(1)}), expr);
   auto transform = std::make_shared<core::CallTypedExpr>(
-      ARRAY(expr->type()),
-      std::vector<core::TypedExprPtr>({reduce.inputs()[0], lambda}),
-      prefix + "transform");
+      ARRAY(expr->type()), prefix + "transform", reduce.inputs()[0], lambda);
   auto arraySum = std::make_shared<core::CallTypedExpr>(
-      sumType,
-      std::vector<core::TypedExprPtr>({transform}),
-      prefix + "array_sum_propagate_element_null");
+      sumType, prefix + "array_sum_propagate_element_null", transform);
   auto cast =
       std::make_shared<core::CastTypedExpr>(initial->type(), arraySum, false);
   auto plus = std::make_shared<core::CallTypedExpr>(
-      initial->type(),
-      std::vector<core::TypedExprPtr>({initial, cast}),
-      prefix + "plus");
+      initial->type(), prefix + "plus", initial, cast);
   VLOG(1) << "Rewrite expression: " << reduce.toString() << " => "
           << plus->toString();
   addThreadLocalRuntimeStat("numReduceRewrite", RuntimeCounter(1));
@@ -393,9 +387,7 @@ core::TypedExprPtr rewriteReduce(
       return nullptr;
     }
     auto minus = std::make_shared<core::CallTypedExpr>(
-        fx->type(),
-        std::vector<core::TypedExprPtr>({fx, inputBody->inputs()[1]}),
-        prefix + "minus");
+        fx->type(), prefix + "minus", fx, inputBody->inputs()[1]);
     return toArraySum(prefix, *reduce, inputArgs, minus);
   } else if (inputBody->name() == "if" && inputBody->inputs().size() == 3) {
     // if(h(x), s + f(x), s + g(x)) =>
@@ -409,9 +401,7 @@ core::TypedExprPtr rewriteReduce(
       return nullptr;
     }
     auto ifExpr = std::make_shared<core::CallTypedExpr>(
-        fx->type(),
-        std::vector<core::TypedExprPtr>({inputBody->inputs()[0], fx, gx}),
-        "if");
+        fx->type(), "if", inputBody->inputs()[0], fx, gx);
     return toArraySum(prefix, *reduce, inputArgs, ifExpr);
   }
   return nullptr;

--- a/velox/functions/prestosql/SplitToMap.cpp
+++ b/velox/functions/prestosql/SplitToMap.cpp
@@ -70,13 +70,11 @@ core::TypedExprPtr rewriteSplitToMapCall(
 
   return std::make_shared<core::CallTypedExpr>(
       call->type(),
-      std::vector<core::TypedExprPtr>{
-          call->inputs()[0],
-          call->inputs()[1],
-          call->inputs()[2],
-          std::make_shared<core::ConstantTypedExpr>(
-              BOOLEAN(), keepFirst.value())},
-      "$internal$split_to_map");
+      "$internal$split_to_map",
+      call->inputs()[0],
+      call->inputs()[1],
+      call->inputs()[2],
+      std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), keepFirst.value()));
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/tests/MergeAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MergeAggregateTest.cpp
@@ -159,9 +159,7 @@ class MergeAggregateTest : public AggregationTestBase {
     auto fieldAccess =
         std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0");
     auto fromBase64 = std::make_shared<core::CallTypedExpr>(
-        VARBINARY(),
-        std::vector<core::TypedExprPtr>{fieldAccess},
-        "from_base64");
+        VARBINARY(), "from_base64", fieldAccess);
     auto castToDigest =
         std::make_shared<core::CastTypedExpr>(digestType, fromBase64, true);
     auto aggResultAccess =
@@ -169,9 +167,7 @@ class MergeAggregateTest : public AggregationTestBase {
     auto castToVarbinary = std::make_shared<core::CastTypedExpr>(
         VARBINARY(), aggResultAccess, true);
     auto toBase64 = std::make_shared<core::CallTypedExpr>(
-        VARCHAR(),
-        std::vector<core::TypedExprPtr>{castToVarbinary},
-        "to_base64");
+        VARCHAR(), "to_base64", castToVarbinary);
 
     return PlanBuilder()
         .values({input})

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -150,11 +150,11 @@ class JsonFunctionsTest : public functions::test::FunctionBaseTest {
       const TypePtr& returnType,
       const RowVectorPtr& data,
       const VectorPtr& expected) {
-    auto inputFeild =
+    auto inputField =
         std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0");
 
     auto expression = std::make_shared<core::CallTypedExpr>(
-        returnType, std::vector<core::TypedExprPtr>{inputFeild}, functionName);
+        returnType, functionName, inputField);
 
     SelectivityVector rows(data->size());
     std::vector<VectorPtr> result(1);

--- a/velox/functions/sparksql/benchmarks/FromJsonBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/FromJsonBenchmark.cpp
@@ -42,11 +42,10 @@ class FromJsonBenchmark : public functions::test::FunctionBenchmarkBase {
     folly::BenchmarkSuspender suspender;
     auto rowVector = makeData(input);
 
-    std::vector<core::TypedExprPtr> inputs = {
-        std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0")};
+    auto input = std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c0");
 
     auto typedExpr = std::make_shared<const core::CallTypedExpr>(
-        outputType, std::move(inputs), "from_json");
+        outputType, "from_json", input);
     exec::ExprSet exprSet({typedExpr}, &execCtx_);
     suspender.dismiss();
 

--- a/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
+++ b/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
@@ -30,13 +30,11 @@ class GetArrayStructFieldsTest : public SparkFunctionBaseTest {
       const VectorPtr& input,
       int ordinal,
       const VectorPtr& expected) {
-    std::vector<core::TypedExprPtr> inputs = {
-        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
-        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal))};
     auto expr = std::make_shared<const core::CallTypedExpr>(
         expected->type(),
-        std::move(inputs),
-        GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields);
+        GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields,
+        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
+        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
 
     // Input is flat.
     auto result = evaluate(expr, makeRowVector({input}));

--- a/velox/functions/sparksql/tests/GetStructFieldTest.cpp
+++ b/velox/functions/sparksql/tests/GetStructFieldTest.cpp
@@ -32,11 +32,11 @@ class GetStructFieldTest : public SparkFunctionBaseTest {
       const VectorPtr& input,
       int ordinal,
       const VectorPtr& expected) {
-    std::vector<core::TypedExprPtr> inputs = {
-        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
-        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal))};
     auto expr = std::make_shared<const core::CallTypedExpr>(
-        expected->type(), std::move(inputs), "get_struct_field");
+        expected->type(),
+        "get_struct_field",
+        std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
+        std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
 
     // Input is flat.
     auto result = evaluate(expr, makeRowVector({input}));

--- a/velox/functions/sparksql/tests/MakeDecimalTest.cpp
+++ b/velox/functions/sparksql/tests/MakeDecimalTest.cpp
@@ -36,7 +36,7 @@ class MakeDecimalTest : public SparkFunctionBaseTest {
         outputType, std::move(inputs), "make_decimal");
     if (tryMakeDecimal) {
       return std::make_shared<core::CallTypedExpr>(
-          outputType, std::vector<core::TypedExprPtr>{makeDecimal}, "try");
+          outputType, "try", makeDecimal);
     } else {
       return makeDecimal;
     }

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -314,8 +314,7 @@ TypedExprPtr toVeloxExpression(
           std::move(children),
           name);
       if (negate) {
-        return std::make_shared<CallTypedExpr>(
-            BOOLEAN(), std::vector<TypedExprPtr>{call}, "not");
+        return std::make_shared<CallTypedExpr>(BOOLEAN(), "not", call);
       }
       return call;
     }
@@ -360,7 +359,7 @@ PlanNodePtr toVeloxPlan(
       veloxFilter = conjunct;
     } else {
       veloxFilter = std::make_shared<CallTypedExpr>(
-          BOOLEAN(), std::vector<TypedExprPtr>{veloxFilter, conjunct}, "and");
+          BOOLEAN(), "and", veloxFilter, conjunct);
     }
   }
   return std::make_shared<FilterNode>(
@@ -857,7 +856,7 @@ PlanNodePtr processDelimGetJoin(
       veloxFilter = conjunct;
     } else {
       veloxFilter = std::make_shared<CallTypedExpr>(
-          BOOLEAN(), std::vector<TypedExprPtr>{veloxFilter, conjunct}, "and");
+          BOOLEAN(), "and", veloxFilter, conjunct);
     }
   }
   return std::make_shared<FilterNode>(

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -239,7 +239,7 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
     core::TypedExprPtr inputField =
         std::make_shared<const core::FieldAccessTypedExpr>(BIGINT(), name);
     auto callExpr = std::make_shared<const core::CallTypedExpr>(
-        BIGINT(), std::vector<core::TypedExprPtr>{inputField}, "min");
+        BIGINT(), "min", inputField);
     std::vector<std::string> aggregateNames = {"min"};
     std::vector<core::AggregationNode::Aggregate> aggregates = {
         core::AggregationNode::Aggregate{


### PR DESCRIPTION
This simplifies the usage of CallTypedExpr in many cases and code has been adapted to use the new constructor.