### PR TITLE
fix: Remove spammy log message from TableScan

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -186,7 +186,6 @@ RowVectorPtr TableScan::getOutput() {
 
     const auto estimatedRowSize = dataSource_->estimatedRowSize();
     // TODO: Expose this to operator stats.
-    LOG(INFO) << "estimatedRowSize = " << estimatedRowSize;
     readBatchSize_ = estimatedRowSize == connector::DataSource::kUnknownRowSize
         ? outputBatchRows()
         : outputBatchRows(estimatedRowSize);


### PR DESCRIPTION
Summary: Looks like this was introduced by accident in https://github.com/facebookincubator/velox/pull/14647

Differential Revision: D81392041


