### PR TITLE
build: Make monolithic library the default

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -181,7 +181,10 @@ jobs:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
           ICU_SOURCE: SYSTEM
           MAKEFLAGS: NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3
-          EXTRA_CMAKE_FLAGS: -DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_EXAMPLES=ON
+          EXTRA_CMAKE_FLAGS: >-
+            -DCMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY
+            -DVELOX_ENABLE_PARQUET=ON
+            -DVELOX_ENABLE_EXAMPLES=ON
         run: |
           # Faiss (link issue when using Clang) is excluded for Clang compilation and needs to be added back when using GCC.
           if [[ "${USE_CLANG}" = "true" ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ option(
    This will override other build options."
   OFF
 )
-option(VELOX_MONO_LIBRARY "Build single unified library." OFF)
+option(VELOX_MONO_LIBRARY "Build single unified library." ON)
 option(ENABLE_ALL_WARNINGS "Enable -Wall and -Wextra compiler warnings." ON)
 option(VELOX_BUILD_SHARED "Build Velox as shared libraries." OFF)
 option(VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST "Disable Wave branch kernel test." OFF)


### PR DESCRIPTION
We have been testing it in CI for a long time now and it has big benefits in binary sizes etc. so we should make it the default!