### PR TITLE
fix(hdfs): Add close() method to disconnect the hdfs connection

### DIFF
--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -179,6 +179,8 @@ class FileSystem {
       std::string_view path,
       const FileOptions& options = {}) = 0;
 
+  virtual void close() {}
+
   /// Deletes the file at 'path'. Throws on error.
   virtual void remove(std::string_view path) = 0;
 

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -55,12 +55,25 @@ class HdfsFileSystem::Impl {
         driver_->GetLastExceptionRootCause());
   }
 
-  ~Impl() {
-    LOG(INFO) << "Disconnecting HDFS file system";
-    int disconnectResult = driver_->Disconnect(hdfsClient_);
-    if (disconnectResult != 0) {
-      LOG(WARNING) << "hdfs disconnect failure in HdfsReadFile close: "
-                   << errno;
+  ~Impl() {}
+
+  // The HdfsFileSystem::Disconnect operation requires the JVM method
+  // definitions to be loaded within an active JVM process.
+  //  Therefore, it must be invoked before the JVM shuts down.
+
+  // To address this, we’ve introduced a new close() API that performs the
+  // disconnect operation. Third-party applications can call this close() method
+  // prior to JVM termination to ensure proper cleanup.
+  void close() {
+    if (!closed_) {
+      LOG(WARNING) << "Disconnecting HDFS file system";
+      int disconnectResult = driver_->Disconnect(hdfsClient_);
+      if (disconnectResult != 0) {
+        LOG(WARNING) << "hdfs disconnect failure in HdfsReadFile close: "
+                     << errno;
+      }
+
+      closed_ = true;
     }
   }
 
@@ -75,6 +88,7 @@ class HdfsFileSystem::Impl {
  private:
   hdfsFS hdfsClient_;
   filesystems::arrow::io::internal::LibHdfsShim* driver_;
+  bool closed_ = false;
 };
 
 HdfsFileSystem::HdfsFileSystem(
@@ -107,6 +121,10 @@ std::unique_ptr<WriteFile> HdfsFileSystem::openFileForWrite(
     const FileOptions& /*unused*/) {
   return std::make_unique<HdfsWriteFile>(
       impl_->hdfsShim(), impl_->hdfsClient(), path);
+}
+
+void HdfsFileSystem::close() {
+  impl_->close();
 }
 
 bool HdfsFileSystem::isHdfsFile(const std::string_view filePath) {

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -61,6 +61,8 @@ class HdfsFileSystem : public FileSystem {
       std::string_view path,
       const FileOptions& options = {}) override;
 
+  void close() override;
+
   // Deletes the hdfs files.
   void remove(std::string_view path) override;
 


### PR DESCRIPTION
The HdfsFileSystem::Disconnect operation requires the JVM method definitions to be loaded within an active JVM process. Therefore, it must be invoked before the JVM shuts down.

To address this, we’ve introduced a new close() API that performs the
disconnect operation. Third-party applications, such as Gluten, can call this close() method prior to JVM termination to ensure proper cleanup.