### PR TITLE
feat: Improve contract for addContext in PlanNode::toStream

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -48,7 +48,7 @@ void RuntimeMetric::merge(const RuntimeMetric& other)
   max = std::max(max, other.max);
 }
 
-void RuntimeMetric::printMetric(std::stringstream& stream) const {
+void RuntimeMetric::printMetric(std::ostream& stream) const {
   switch (unit) {
     case RuntimeCounter::Unit::kNanos:
       stream << " sum: " << succinctNanos(sum) << ", count: " << count

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -19,9 +19,6 @@
 #include <fmt/format.h>
 #include <folly/CppAttributes.h>
 #include <limits>
-#include <sstream>
-
-#include "velox/common/base/SuccinctPrinter.h"
 
 namespace facebook::velox {
 
@@ -57,7 +54,7 @@ struct RuntimeMetric {
   /// positive.
   void aggregate();
 
-  void printMetric(std::stringstream& stream) const;
+  void printMetric(std::ostream& stream) const;
 
   void merge(const RuntimeMetric& other);
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3308,7 +3308,7 @@ void PlanNode::toString(
     const std::function<void(
         const PlanNodeId& planNodeId,
         const std::string& indentation,
-        std::stringstream& stream)>& addContext) const {
+        std::ostream& stream)>& addContext) const {
   const std::string indentation(indentationSize, ' ');
 
   stream << indentation << "-- " << name() << "[" << id() << "]";
@@ -3323,10 +3323,8 @@ void PlanNode::toString(
   stream << std::endl;
 
   if (addContext) {
-    auto contextIndentation = indentation + "   ";
-    stream << contextIndentation;
+    const auto contextIndentation = indentation + "   ";
     addContext(id(), contextIndentation, stream);
-    stream << std::endl;
   }
 
   if (recursive) {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -225,16 +225,15 @@ class PlanNode : public ISerializable {
   ///
   /// @param addContext Optional lambda to add context for a given plan node.
   /// Receives plan node ID, indentation and std::stringstream where to append
-  /// the context. Use indentation for second and subsequent lines of a
-  /// multi-line context. Do not use indentation for single-line context. Do not
-  /// add trailing new-line character for the last or only line of context.
+  /// the context. Start each line of context with 'indentation' and end with a
+  /// new-line character.
   std::string toString(
       bool detailed = false,
       bool recursive = false,
       const std::function<void(
           const PlanNodeId& planNodeId,
           const std::string& indentation,
-          std::stringstream& stream)>& addContext = nullptr) const {
+          std::ostream& stream)>& addContext = nullptr) const {
     std::stringstream stream;
     toString(stream, detailed, recursive, 0, addContext);
     return stream.str();
@@ -292,7 +291,7 @@ class PlanNode : public ISerializable {
       const std::function<void(
           const PlanNodeId& planNodeId,
           const std::string& indentation,
-          std::stringstream& stream)>& addContext) const;
+          std::ostream& stream)>& addContext) const;
 
   // The default implementation calls 'addDetails' and truncates the result.
   virtual void addSummaryDetails(

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -298,7 +298,7 @@ namespace {
 void printCustomStats(
     const std::unordered_map<std::string, RuntimeMetric>& stats,
     const std::string& indentation,
-    std::stringstream& stream) {
+    std::ostream& stream) {
   int width = 0;
   for (const auto& entry : stats) {
     if (width < entry.first.size()) {
@@ -314,9 +314,9 @@ void printCustomStats(
   }
 
   for (const auto& [name, metric] : orderedStats) {
-    stream << std::endl;
     stream << indentation << std::left << std::setw(width) << name;
     metric.printMetric(stream);
+    stream << std::endl;
   }
 }
 } // namespace
@@ -338,16 +338,15 @@ std::string printPlanWithStats(
         // Print input rows and sizes only for leaf plan nodes. Including this
         // information for other plan nodes is redundant as it is the same as
         // output of the source nodes.
-        const bool includeInputStats = leafPlanNodes.count(planNodeId) > 0;
-        stream << stats.toString(includeInputStats);
+        const bool includeInputStats = leafPlanNodes.contains(planNodeId);
+        stream << indentation << stats.toString(includeInputStats) << std::endl;
 
         // Include break down by operator type for plan nodes with multiple
         // operators. Print input rows and sizes for all such nodes.
         if (stats.isMultiOperatorTypeNode()) {
           for (const auto& entry : stats.operatorStats) {
-            stream << std::endl;
             stream << indentation << entry.first << ": "
-                   << entry.second->toString(true);
+                   << entry.second->toString(true) << std::endl;
 
             if (includeCustomStats) {
               printCustomStats(

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -91,9 +91,9 @@ TEST_F(PlanNodeToStringTest, recursiveAndDetailed) {
 
 TEST_F(PlanNodeToStringTest, withContext) {
   auto addContext = [](const core::PlanNodeId& planNodeId,
-                       const std::string& /* indentation */,
-                       std::stringstream& stream) {
-    stream << "Context for " << planNodeId;
+                       const std::string& indentation,
+                       std::ostream& stream) {
+    stream << indentation << "Context for " << planNodeId << std::endl;
   };
 
   ASSERT_EQ(
@@ -136,9 +136,11 @@ TEST_F(PlanNodeToStringTest, withContext) {
 TEST_F(PlanNodeToStringTest, withMultiLineContext) {
   auto addContext = [](const core::PlanNodeId& planNodeId,
                        const std::string& indentation,
-                       std::stringstream& stream) {
-    stream << "Context for " << planNodeId << ": line 1" << std::endl;
-    stream << indentation << "Context for " << planNodeId << ": line 2";
+                       std::ostream& stream) {
+    stream << indentation << "Context for " << planNodeId << ": line 1"
+           << std::endl;
+    stream << indentation << "Context for " << planNodeId << ": line 2"
+           << std::endl;
   };
 
   ASSERT_EQ(


### PR DESCRIPTION
Summary: The original contract didn't work well for cases where context is added for some plan nodes, but not all.

Differential Revision: D81442066


