### PR TITLE
feat(type): Support homogeneous row (struct) signatures: row(T, …)

### DIFF
--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -499,6 +499,10 @@ struct hash<facebook::velox::exec::TypeSignature> {
     for (const auto& parameter : key.parameters()) {
       val = val * 31 + this->operator()(parameter);
     }
+    if (key.rowFieldName().has_value()) {
+      val = val * 31 + std::hash<std::string>{}(*key.rowFieldName());
+    }
+    val = val * 31 + std::hash<bool>{}(key.hasVariadicLastParam());
     return val;
   }
 };

--- a/velox/expression/TypeSignature.cpp
+++ b/velox/expression/TypeSignature.cpp
@@ -30,7 +30,11 @@ std::string TypeSignature::toString() const {
   }
   out << baseName_;
   if (!parameters_.empty()) {
-    out << "(" << folly::join(",", parameters_) << ")";
+    if (baseName_ == "row" && parameters_.size() == 1 && variadicLastParam_) {
+      out << "(" << parameters_[0].toString() << ", …)";
+    } else {
+      out << "(" << folly::join(",", parameters_) << ")";
+    }
   }
   return out.str();
 }

--- a/velox/expression/TypeSignature.h
+++ b/velox/expression/TypeSignature.h
@@ -33,13 +33,16 @@ class TypeSignature {
   /// @param rowFieldName if this type signature is a field of another parent
   /// row type, it can optionally have a name. E.g. `row(id bigint)` would have
   /// "id" set as rowFieldName in the "bigint" parameter.
+  /// @param variadicLastParam indicates if the last parameter is variadic.
   TypeSignature(
       std::string baseName,
       std::vector<TypeSignature> parameters,
-      std::optional<std::string> rowFieldName = std::nullopt)
+      std::optional<std::string> rowFieldName = std::nullopt,
+      bool variadicLastParam = false)
       : baseName_{std::move(baseName)},
         parameters_{std::move(parameters)},
-        rowFieldName_(std::move(rowFieldName)) {}
+        rowFieldName_(std::move(rowFieldName)),
+        variadicLastParam_{variadicLastParam} {}
 
   const std::string& baseName() const {
     return baseName_;
@@ -53,11 +56,20 @@ class TypeSignature {
     return rowFieldName_;
   }
 
+  bool hasVariadicLastParam() const {
+    return variadicLastParam_;
+  }
+
+  bool isHomogeneousRow() const {
+    return baseName_ == "row" && parameters_.size() == 1 && variadicLastParam_;
+  }
+
   std::string toString() const;
 
   bool operator==(const TypeSignature& rhs) const {
     return baseName_ == rhs.baseName_ && parameters_ == rhs.parameters_ &&
-        rowFieldName_ == rhs.rowFieldName_;
+        rowFieldName_ == rhs.rowFieldName_ &&
+        variadicLastParam_ == rhs.variadicLastParam_;
   }
 
  private:
@@ -67,6 +79,9 @@ class TypeSignature {
   // If this object is a field of another parent row type, it can optionally
   // have a name, e.g, `row(id bigint)`
   const std::optional<std::string> rowFieldName_;
+
+  // Indicates if the last parameter is variadic
+  bool variadicLastParam_{false};
 };
 
 using TypeSignaturePtr = std::shared_ptr<TypeSignature>;

--- a/velox/expression/signature_parser/SignatureParser.ll
+++ b/velox/expression/signature_parser/SignatureParser.ll
@@ -66,6 +66,8 @@ ROW               (ROW|STRUCT)
 "("                return Parser::token::LPAREN;
 ")"                return Parser::token::RPAREN;
 ","                return Parser::token::COMMA;
+"…"                return Parser::token::ELLIPSIS;
+"..."              return Parser::token::ELLIPSIS;
 (ARRAY)            return Parser::token::ARRAY;
 (MAP)              return Parser::token::MAP;
 (FUNCTION)         return Parser::token::FUNCTION;

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -27,7 +27,7 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION
+%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION ELLIPSIS
 %token <std::string> WORD VARIABLE QUOTED_ID DECIMAL
 %token YYEOF         0
 
@@ -78,6 +78,8 @@ type_list_opt_names : named_type                           { $$.push_back(*($1))
                     ;
 
 row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
+         | ROW LPAREN type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
+         | ROW LPAREN named_type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }


### PR DESCRIPTION


#Support homogeneous row (struct) signatures: row(T, …)

Fixes #14630

Adds support for homogeneous row/struct type signatures where all fields have the same type. This lets us write function signatures like row(T, …) to match rows (structs) with any number of fields of type T.

What's changed:

**TypeSignature updates:**
- Added `variadicLastParam_` flag to track ellipsis syntax
- New `isHomogeneousRow()` helper method
- Updated `toString()` to print `row(T, …)` correctly

**Parser changes:**
- Added ELLIPSIS token that handles both `…` and `...`
- Extended row grammar to parse `row(T, …)` and `row(name T, …)`
- Existing `row(a, b, c)` syntax still works fine

**Binding logic:**
- New branch in SignatureBinder for homogeneous rows
- Checks that all row fields unify to the same type variable
- Handles empty rows and functions with multiple homogeneous row args
- Good error messages when types don't match

**Tests:**
- Parser tests for the new ellipsis syntax
- Binder tests covering happy path and error cases


This should set up the foundation for future work like:

-- Transform all fields in a row
transform_row(row(T, …), lambda) → row(U, …)

 --Functions that take variable width homogeneous rows  
my_func(row(bigint, …))  -- matches row(bigint), row(bigint, bigint), etc.