### PR TITLE
fix(build): Fix wrong link target for velox_dwio_text_reader

### DIFF
--- a/velox/dwio/text/reader/CMakeLists.txt
+++ b/velox/dwio/text/reader/CMakeLists.txt
@@ -17,7 +17,7 @@ velox_add_library(velox_dwio_text_reader TextReader.cpp)
 velox_link_libraries(
   velox_dwio_text_reader
   velox_type_fbhive
-  velox_dwio_common
+  velox_dwio_common_compression
   velox_encode
   fmt::fmt
 )


### PR DESCRIPTION
Fixes #14673

This may be related to #14003. `velox/dwio/text/reader/TextReader.cpp` uses
`facebook::velox::dwio::common::compression::createDecompressor()` since #14003.
`facebook::velox::dwio::common::compression::createDecompressor()` is included in `velox_dwio_common_compression` not `velox_dwio_common`. So `velox_dwio_text_reader` needs to be linked to `velox_dwio_common_compression` not `velox_dwio_common`.