### PR TITLE
feat(type): Add support for signatures with homogeneous structs

### DIFF
--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -124,7 +124,7 @@ TEST_F(FunctionSignatureBuilderTest, typeParamTests) {
           .returnType("integer")
           .argumentType("row(..., varchar)")
           .build(),
-      "Failed to parse type signature [row(..., varchar)]: syntax error, unexpected COMMA");
+      "Failed to parse type signature [row(..., varchar)]: syntax error, unexpected ELLIPSIS");
 
   // Type params cant have type params.
   VELOX_ASSERT_THROW(

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -169,11 +169,11 @@ void validate(
 
   // Disallow homogeneous row as a return type.
   VELOX_USER_CHECK(
-    !returnType.isHomogeneousRow(),
-    "Homogeneous row cannot be used as a return type");
+      !returnType.isHomogeneousRow(),
+      "Homogeneous row cannot be used as a return type");
 
   validateBaseTypeAndCollectTypeParams(
-    variables, returnType, usedVariables, true);
+      variables, returnType, usedVariables, true);
 
   VELOX_USER_CHECK_EQ(
       usedVariables.size(),

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -147,6 +147,12 @@ void validate(
     const std::vector<TypeSignature>& argumentTypes,
     const std::vector<bool>& constantArguments,
     const std::vector<TypeSignature>& additionalTypes = {}) {
+  // Disallow homogeneous row as a return type early so this error surfaces
+  // before other validation errors (e.g., unused type variables).
+  VELOX_USER_CHECK(
+      !returnType.isHomogeneousRow(),
+      "Homogeneous row cannot be used as a return type");
+
   std::unordered_set<std::string> usedVariables;
   // Validate the additional types, and collect the used variables.
   for (const auto& type : additionalTypes) {
@@ -166,11 +172,6 @@ void validate(
           "Some type variables are not used in the inputs");
     }
   }
-
-  // Disallow homogeneous row as a return type.
-  VELOX_USER_CHECK(
-      !returnType.isHomogeneousRow(),
-      "Homogeneous row cannot be used as a return type");
 
   validateBaseTypeAndCollectTypeParams(
       variables, returnType, usedVariables, true);

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -167,8 +167,13 @@ void validate(
     }
   }
 
+  // Disallow homogeneous row as a return type.
+  VELOX_USER_CHECK(
+    !returnType.isHomogeneousRow(),
+    "Homogeneous row cannot be used as a return type");
+
   validateBaseTypeAndCollectTypeParams(
-      variables, returnType, usedVariables, true);
+    variables, returnType, usedVariables, true);
 
   VELOX_USER_CHECK_EQ(
       usedVariables.size(),

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -499,10 +499,6 @@ struct hash<facebook::velox::exec::TypeSignature> {
     for (const auto& parameter : key.parameters()) {
       val = val * 31 + this->operator()(parameter);
     }
-    if (key.rowFieldName().has_value()) {
-      val = val * 31 + std::hash<std::string>{}(*key.rowFieldName());
-    }
-    val = val * 31 + std::hash<bool>{}(key.hasVariadicArity());
     return val;
   }
 };

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -502,7 +502,7 @@ struct hash<facebook::velox::exec::TypeSignature> {
     if (key.rowFieldName().has_value()) {
       val = val * 31 + std::hash<std::string>{}(*key.rowFieldName());
     }
-    val = val * 31 + std::hash<bool>{}(key.hasVariadicLastParam());
+    val = val * 31 + std::hash<bool>{}(key.hasVariadicArity());
     return val;
   }
 };

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -499,6 +499,10 @@ struct hash<facebook::velox::exec::TypeSignature> {
     for (const auto& parameter : key.parameters()) {
       val = val * 31 + this->operator()(parameter);
     }
+    if (key.rowFieldName().has_value()) {
+      val = val * 31 + std::hash<std::string>{}(*key.rowFieldName());
+    }
+    val = val * 31 + std::hash<bool>{}(key.hasVariadicLastParam());
     return val;
   }
 };

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -111,7 +111,6 @@ bool SignatureBinder::tryBind(
   const auto& formalArgs = signature_.argumentTypes();
   const auto formalArgsCnt = formalArgs.size();
 
-
   if (signature_.variableArity()) {
     if (actualTypes_.size() < formalArgsCnt - 1) {
       return false;
@@ -281,7 +280,6 @@ bool SignatureBinderBase::tryBind(
     if (actualChildTypes.empty()) {
       return true; // Empty row is valid
     }
-
 
     if (variables().count(paramBaseName)) {
       // Ensure all children are equivalent; use helper.

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -110,9 +110,6 @@ bool SignatureBinder::tryBind(
   const auto& formalArgs = signature_.argumentTypes();
   const auto formalArgsCnt = formalArgs.size();
 
-  if (signature_.returnType().isHomogeneousRow()) {
-    return false;
-  }
 
   if (signature_.variableArity()) {
     if (actualTypes_.size() < formalArgsCnt - 1) {
@@ -287,12 +284,6 @@ bool SignatureBinderBase::tryBind(
       return true; // Empty row is valid
     }
 
-    // Defensive: check that none of the child types are null
-    for (const auto& t : actualChildTypes) {
-      if (!t) {
-        return false;
-      }
-    }
 
     if (variables().count(paramBaseName)) {
       auto commonType = actualChildTypes[0];

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -110,6 +110,10 @@ bool SignatureBinder::tryBind(
   const auto& formalArgs = signature_.argumentTypes();
   const auto formalArgsCnt = formalArgs.size();
 
+  if (signature_.returnType().isHomogeneousRow()) {
+    return false;
+  }
+
   if (signature_.variableArity()) {
     if (actualTypes_.size() < formalArgsCnt - 1) {
       return false;

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -253,14 +253,15 @@ bool SignatureBinderBase::tryBind(
   }
 
   const auto& params = typeSignature.parameters();
-  
+
   // Handle homogeneous row case: row(T, ...)
   if (typeSignature.isHomogeneousRow() && typeName == "ROW") {
-    VELOX_CHECK_EQ(params.size(), 1, "Homogeneous row must have exactly one parameter");
-    
+    VELOX_CHECK_EQ(
+        params.size(), 1, "Homogeneous row must have exactly one parameter");
+
     // Actual type must be a ROW with k >= 0 children
     const auto& actualParams = actualType->parameters();
-    
+
     if (actualParams.empty()) {
       // Empty row case - bind the type variable to any type (we'll use UNKNOWN)
       const auto& typeParam = params[0];
@@ -270,11 +271,11 @@ bool SignatureBinderBase::tryBind(
         return true;
       }
     }
-    
+
     // All children must unify to the same type variable T
     const auto& typeParam = params[0];
     const auto& paramBaseName = typeParam.baseName();
-    
+
     // First, try to bind all actual parameters to the type variable
     std::vector<TypePtr> actualChildTypes;
     for (const auto& actualParam : actualParams) {
@@ -283,11 +284,11 @@ bool SignatureBinderBase::tryBind(
       }
       actualChildTypes.push_back(actualParam.type);
     }
-    
+
     if (actualChildTypes.empty()) {
       return true; // Empty row is valid
     }
-    
+
     // Check if this is a type variable that needs binding
     if (variables().count(paramBaseName)) {
       // Find the greatest common supertype of all actual child types
@@ -296,10 +297,11 @@ bool SignatureBinderBase::tryBind(
         // Try to find common supertype - use the logic similar to arrays
         // For now, require all types to be exactly the same
         if (!commonType->equivalent(*actualChildTypes[i])) {
-          return false; // All children must be the same type for homogeneous rows
+          return false; // All children must be the same type for homogeneous
+                        // rows
         }
       }
-      
+
       // Bind the type variable to the common type
       if (typeVariablesBindings_.count(paramBaseName)) {
         // Variable already bound, check consistency

--- a/velox/expression/TypeSignature.cpp
+++ b/velox/expression/TypeSignature.cpp
@@ -30,7 +30,7 @@ std::string TypeSignature::toString() const {
   }
   out << baseName_;
   if (!parameters_.empty()) {
-    if (baseName_ == "row" && parameters_.size() == 1 && variadicLastParam_) {
+    if (baseName_ == "row" && parameters_.size() == 1 && variadicArity_) {
       out << "(" << parameters_[0].toString() << ", …)";
     } else {
       out << "(" << folly::join(",", parameters_) << ")";

--- a/velox/expression/TypeSignature.cpp
+++ b/velox/expression/TypeSignature.cpp
@@ -31,7 +31,7 @@ std::string TypeSignature::toString() const {
   out << baseName_;
   if (!parameters_.empty()) {
     if (baseName_ == "row" && parameters_.size() == 1 && variadicArity_) {
-      out << "(" << parameters_[0].toString() << ", …)";
+      out << "(" << parameters_[0].toString() << ", ... )";
     } else {
       out << "(" << folly::join(",", parameters_) << ")";
     }

--- a/velox/expression/TypeSignature.cpp
+++ b/velox/expression/TypeSignature.cpp
@@ -31,7 +31,7 @@ std::string TypeSignature::toString() const {
   out << baseName_;
   if (!parameters_.empty()) {
     if (baseName_ == "row" && parameters_.size() == 1 && variadicArity_) {
-      out << "(" << parameters_[0].toString() << ", ... )";
+      out << "(" << parameters_[0].toString() << ", ..." << ")";
     } else {
       out << "(" << folly::join(",", parameters_) << ")";
     }

--- a/velox/expression/TypeSignature.cpp
+++ b/velox/expression/TypeSignature.cpp
@@ -30,7 +30,11 @@ std::string TypeSignature::toString() const {
   }
   out << baseName_;
   if (!parameters_.empty()) {
-    out << "(" << folly::join(",", parameters_) << ")";
+    if (baseName_ == "row" && parameters_.size() == 1 && variadicLastParam_) {
+      out << "(" << parameters_[0].toString() << ", …)";
+    } else {
+      out << "(" << folly::join(",", parameters_) << ")";
+    }
   }
   return out.str();
 }

--- a/velox/expression/TypeSignature.h
+++ b/velox/expression/TypeSignature.h
@@ -33,13 +33,16 @@ class TypeSignature {
   /// @param rowFieldName if this type signature is a field of another parent
   /// row type, it can optionally have a name. E.g. `row(id bigint)` would have
   /// "id" set as rowFieldName in the "bigint" parameter.
+  /// @param variadicLastParam indicates if the last parameter is variadic.
   TypeSignature(
       std::string baseName,
       std::vector<TypeSignature> parameters,
-      std::optional<std::string> rowFieldName = std::nullopt)
+      std::optional<std::string> rowFieldName = std::nullopt,
+      bool variadicLastParam = false)
       : baseName_{std::move(baseName)},
         parameters_{std::move(parameters)},
-        rowFieldName_(std::move(rowFieldName)) {}
+        rowFieldName_(std::move(rowFieldName)),
+        variadicLastParam_{variadicLastParam} {}
 
   const std::string& baseName() const {
     return baseName_;
@@ -53,11 +56,20 @@ class TypeSignature {
     return rowFieldName_;
   }
 
+  bool hasVariadicLastParam() const {
+    return variadicLastParam_;
+  }
+
+  bool isHomogeneousRow() const {
+    return baseName_ == "row" && parameters_.size() == 1 && variadicLastParam_;
+  }
+
   std::string toString() const;
 
   bool operator==(const TypeSignature& rhs) const {
     return baseName_ == rhs.baseName_ && parameters_ == rhs.parameters_ &&
-        rowFieldName_ == rhs.rowFieldName_;
+        rowFieldName_ == rhs.rowFieldName_ &&
+        variadicLastParam_ == rhs.variadicLastParam_;
   }
 
  private:
@@ -67,6 +79,9 @@ class TypeSignature {
   // If this object is a field of another parent row type, it can optionally
   // have a name, e.g, `row(id bigint)`
   const std::optional<std::string> rowFieldName_;
+
+  // Indicates if the last parameter is variadic
+  bool variadicLastParam_{false};
 };
 
 using TypeSignaturePtr = std::shared_ptr<TypeSignature>;

--- a/velox/expression/TypeSignature.h
+++ b/velox/expression/TypeSignature.h
@@ -33,16 +33,16 @@ class TypeSignature {
   /// @param rowFieldName if this type signature is a field of another parent
   /// row type, it can optionally have a name. E.g. `row(id bigint)` would have
   /// "id" set as rowFieldName in the "bigint" parameter.
-  /// @param variadicLastParam indicates if the last parameter is variadic.
+  /// @param variadicArity indicates if the parameter is variadic.
   TypeSignature(
       std::string baseName,
       std::vector<TypeSignature> parameters,
       std::optional<std::string> rowFieldName = std::nullopt,
-      bool variadicLastParam = false)
+      bool variadicArity = false)
       : baseName_{std::move(baseName)},
         parameters_{std::move(parameters)},
         rowFieldName_(std::move(rowFieldName)),
-        variadicLastParam_{variadicLastParam} {}
+        variadicArity_{variadicArity} {}
 
   const std::string& baseName() const {
     return baseName_;
@@ -56,12 +56,12 @@ class TypeSignature {
     return rowFieldName_;
   }
 
-  bool hasVariadicLastParam() const {
-    return variadicLastParam_;
+  bool hasVariadicArity() const {
+    return variadicArity_;
   }
 
   bool isHomogeneousRow() const {
-    return baseName_ == "row" && parameters_.size() == 1 && variadicLastParam_;
+    return baseName_ == "row" && parameters_.size() == 1 && variadicArity_;
   }
 
   std::string toString() const;
@@ -69,7 +69,7 @@ class TypeSignature {
   bool operator==(const TypeSignature& rhs) const {
     return baseName_ == rhs.baseName_ && parameters_ == rhs.parameters_ &&
         rowFieldName_ == rhs.rowFieldName_ &&
-        variadicLastParam_ == rhs.variadicLastParam_;
+        variadicArity_ == rhs.variadicArity_;
   }
 
  private:
@@ -80,8 +80,8 @@ class TypeSignature {
   // have a name, e.g, `row(id bigint)`
   const std::optional<std::string> rowFieldName_;
 
-  // Indicates if the last parameter is variadic
-  bool variadicLastParam_{false};
+  // Indicates if the parameter is variadic
+  bool variadicArity_{false};
 };
 
 using TypeSignaturePtr = std::shared_ptr<TypeSignature>;

--- a/velox/expression/TypeSignature.h
+++ b/velox/expression/TypeSignature.h
@@ -33,7 +33,7 @@ class TypeSignature {
   /// @param rowFieldName if this type signature is a field of another parent
   /// row type, it can optionally have a name. E.g. `row(id bigint)` would have
   /// "id" set as rowFieldName in the "bigint" parameter.
-  /// @param variadicArity indicates if the parameter is variadic.
+  /// @param variadicArity indicates if the last parameter is variadic.
   TypeSignature(
       std::string baseName,
       std::vector<TypeSignature> parameters,

--- a/velox/expression/signature_parser/SignatureParser.ll
+++ b/velox/expression/signature_parser/SignatureParser.ll
@@ -67,7 +67,6 @@ ROW               (ROW|STRUCT)
 "("                return Parser::token::LPAREN;
 ")"                return Parser::token::RPAREN;
 ","                return Parser::token::COMMA;
-"…"                return Parser::token::ELLIPSIS;
 "..."              return Parser::token::ELLIPSIS;
 (ARRAY)            return Parser::token::ARRAY;
 (MAP)              return Parser::token::MAP;

--- a/velox/expression/signature_parser/SignatureParser.ll
+++ b/velox/expression/signature_parser/SignatureParser.ll
@@ -66,6 +66,8 @@ ROW               (ROW|STRUCT)
 "("                return Parser::token::LPAREN;
 ")"                return Parser::token::RPAREN;
 ","                return Parser::token::COMMA;
+"…"                return Parser::token::ELLIPSIS;
+"..."              return Parser::token::ELLIPSIS;
 (ARRAY)            return Parser::token::ARRAY;
 (MAP)              return Parser::token::MAP;
 (FUNCTION)         return Parser::token::FUNCTION;

--- a/velox/expression/signature_parser/SignatureParser.ll
+++ b/velox/expression/signature_parser/SignatureParser.ll
@@ -1,3 +1,4 @@
+%option 8bit
 %{
 #include <vector>
 #include <memory>
@@ -31,7 +32,7 @@ std::string unescape_doublequote(const char* yytext) {
 }
 %}
 
-%option c++ noyywrap noyylineno nodefault caseless
+%option c++ noyywrap noyylineno nodefault caseless 8bit
 
 A   [A|a]
 B   [B|b]

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -79,14 +79,14 @@ type_list_opt_names : named_type                           { $$.push_back(*($1))
 
 row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
          | ROW LPAREN type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
-         | ROW LPAREN QUOTED_ID type COMMA ELLIPSIS RPAREN { 
-             std::string fieldName = $3; 
-             fieldName.erase(0, 1); 
-             fieldName.pop_back(); 
-             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{exec::TypeSignature($4->baseName(), $4->parameters(), fieldName)}, std::nullopt, true); 
+         | ROW LPAREN QUOTED_ID type COMMA ELLIPSIS RPAREN {
+             std::string fieldName = $3;
+             fieldName.erase(0, 1);
+             fieldName.pop_back();
+             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{exec::TypeSignature($4->baseName(), $4->parameters(), fieldName)}, std::nullopt, true);
            }
-         | ROW LPAREN WORD type COMMA ELLIPSIS RPAREN { 
-             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{exec::TypeSignature($4->baseName(), $4->parameters(), $3)}, std::nullopt, true); 
+         | ROW LPAREN WORD type COMMA ELLIPSIS RPAREN {
+             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{exec::TypeSignature($4->baseName(), $4->parameters(), $3)}, std::nullopt, true);
            }
          ;
 

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -34,7 +34,7 @@
 %expect 1
 
 %nterm <std::shared_ptr<exec::TypeSignature>> special_type function_type decimal_type row_type array_type map_type
-%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named
+%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named type_list_with_ellipsis
 %nterm <std::vector<exec::TypeSignature>> type_list type_list_opt_names
 %nterm <std::vector<std::string>> type_with_spaces
 
@@ -81,8 +81,11 @@ type_list_opt_names : type_or_named                               { $$.push_back
                     | type_list_opt_names COMMA type_or_named { $1.push_back(*($3)); $$ = std::move($1); }
                     ;
 
-row_type : ROW LPAREN type_list_opt_names RPAREN      { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
-         | ROW LPAREN type_or_named COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
+type_list_with_ellipsis : type_list_opt_names                    { $$ = std::make_shared<exec::TypeSignature>("row", $1); }
+                        | type_or_named COMMA ELLIPSIS           { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($1)}, std::nullopt, true); }
+                        ;
+
+row_type : ROW LPAREN type_list_with_ellipsis RPAREN { $$ = $3; }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -27,7 +27,7 @@
     #define yylex(x) scanner->lex(x)
 }
 
-%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION
+%token               LPAREN RPAREN COMMA ARRAY MAP ROW FUNCTION ELLIPSIS
 %token <std::string> WORD VARIABLE QUOTED_ID DECIMAL
 %token YYEOF         0
 
@@ -78,6 +78,8 @@ type_list_opt_names : named_type                           { $$.push_back(*($1))
                     ;
 
 row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
+         | ROW LPAREN type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
+         | ROW LPAREN named_type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -31,6 +31,8 @@
 %token <std::string> WORD VARIABLE QUOTED_ID DECIMAL
 %token YYEOF         0
 
+%expect 2
+
 %nterm <std::shared_ptr<exec::TypeSignature>> special_type function_type decimal_type row_type array_type map_type
 %nterm <std::shared_ptr<exec::TypeSignature>> type named_type
 %nterm <std::vector<exec::TypeSignature>> type_list type_list_opt_names

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -34,9 +34,8 @@
 %expect 0
 
 %nterm <std::shared_ptr<exec::TypeSignature>> special_type function_type decimal_type row_type array_type map_type
-%nterm <std::shared_ptr<exec::TypeSignature>> type named_type
-%nterm <std::vector<exec::TypeSignature>> type_list type_list_opt_names
-%nterm <bool> row_ellipsis_opt
+%nterm <std::shared_ptr<exec::TypeSignature>> type named_type row_field
+%nterm <std::vector<exec::TypeSignature>> type_list row_field_list
 %nterm <std::vector<std::string>> type_with_spaces
 
 %%
@@ -74,32 +73,24 @@ type_list : type                   { $$.push_back(*($1)); }
           | type_list COMMA type   { $1.push_back(*($3)); $$ = std::move($1); }
           ;
 
-type_list_opt_names : named_type                           { $$.push_back(*($1)); }
-                    | type_list_opt_names COMMA named_type { $1.push_back(*($3)); $$ = std::move($1); }
-                    | type                                 { $$.push_back(*($1)); }
-                    | type_list_opt_names COMMA type       { $1.push_back(*($3)); $$ = std::move($1); }
-                    ;
+row_field : named_type { $$ = $1; }
+          | type       { $$ = $1; }
+          ;
 
-// Factor row fields and an optional trailing ", ..." to avoid ambiguity between
-// heterogeneous rows and homogeneous rows with ...
-row_type : ROW LPAREN type_list_opt_names row_ellipsis_opt RPAREN
-                     {
-                         if ($4) {
-                             // Homogeneous row: require a single element to define the repeated field type.
-                             VELOX_CHECK(!($3).empty(), "row(T, ...) requires exactly one element");
-                             VELOX_CHECK((($3).size() == 1), "row(T, ...) must have exactly one element, got {}", ($3).size());
-                             VELOX_CHECK(!($3)[0].rowFieldName().has_value(), "row(T, ...) does not support named fields; use row(T, ...) only");
-                             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{($3)[0]}, std::nullopt, true);
-                         } else {
-                             // Heterogeneous row with explicit field list.
-                             $$ = std::make_shared<exec::TypeSignature>("row", $3);
-                         }
-                     }
-                 ;
+row_field_list : row_field { $$.push_back(*($1)); }
+               | row_field_list COMMA row_field { $1.push_back(*($3)); $$ = std::move($1); }
+               ;
 
-row_ellipsis_opt : /* empty */     { $$ = false; }
-                                 | COMMA ELLIPSIS  { $$ = true; }
-                                 ;
+row_type
+    : ROW LPAREN row_field RPAREN
+        { std::vector<exec::TypeSignature> params; params.push_back(*($3)); $$ = std::make_shared<exec::TypeSignature>("row", params); }
+    | ROW LPAREN row_field COMMA ELLIPSIS RPAREN
+        { if ($3->rowFieldName().has_value()) { VELOX_FAIL("Homogeneous row cannot have a field name"); } std::vector<exec::TypeSignature> params; params.push_back(*($3)); $$ = std::make_shared<exec::TypeSignature>("row", params, std::nullopt, true); }
+    | ROW LPAREN row_field COMMA row_field_list RPAREN
+        { std::vector<exec::TypeSignature> params; params.push_back(*($3)); for (auto& f : $5) { params.push_back(f); } $$ = std::make_shared<exec::TypeSignature>("row", params); }
+    ;
+
+// Homogeneous rows use only the explicit pattern: row(T, ...)
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }
            | ARRAY LPAREN type_with_spaces RPAREN { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *inferTypeWithSpaces($3) })); }

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -79,7 +79,15 @@ type_list_opt_names : named_type                           { $$.push_back(*($1))
 
 row_type : ROW LPAREN type_list_opt_names RPAREN  { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
          | ROW LPAREN type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
-         | ROW LPAREN named_type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
+         | ROW LPAREN QUOTED_ID type COMMA ELLIPSIS RPAREN { 
+             std::string fieldName = $3; 
+             fieldName.erase(0, 1); 
+             fieldName.pop_back(); 
+             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{exec::TypeSignature($4->baseName(), $4->parameters(), fieldName)}, std::nullopt, true); 
+           }
+         | ROW LPAREN WORD type COMMA ELLIPSIS RPAREN { 
+             $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{exec::TypeSignature($4->baseName(), $4->parameters(), $3)}, std::nullopt, true); 
+           }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -31,12 +31,8 @@
 %token <std::string> WORD VARIABLE QUOTED_ID DECIMAL
 %token YYEOF         0
 
-%left COMMA
-%right ELLIPSIS
-%expect 1
-
 %nterm <std::shared_ptr<exec::TypeSignature>> special_type function_type decimal_type row_type array_type map_type
-%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named
+%nterm <std::shared_ptr<exec::TypeSignature>> type named_type
 %nterm <std::vector<exec::TypeSignature>> type_list type_list_opt_names
 %nterm <std::vector<std::string>> type_with_spaces
 
@@ -64,10 +60,6 @@ named_type : QUOTED_ID type          { $1.erase(0, 1); $1.pop_back(); $$ = std::
            | type_with_spaces        { $$ = inferTypeWithSpaces($1, true); }
            ;
 
-type_or_named : type       { $$ = $1; }
-              | named_type { $$ = $1; }
-              ;
-
 type_with_spaces : type_with_spaces WORD { $1.push_back($2); $$ = std::move($1); }
                  | WORD WORD             { $$.push_back($1); $$.push_back($2); }
                  ;
@@ -79,12 +71,15 @@ type_list : type                   { $$.push_back(*($1)); }
           | type_list COMMA type   { $1.push_back(*($3)); $$ = std::move($1); }
           ;
 
-type_list_opt_names : type_or_named                               { $$.push_back(*($1)); }
-                    | type_list_opt_names COMMA type_or_named { $1.push_back(*($3)); $$ = std::move($1); }
+type_list_opt_names : named_type                           { $$.push_back(*($1)); }
+                    | type_list_opt_names COMMA named_type { $1.push_back(*($3)); $$ = std::move($1); }
+                    | type                                 { $$.push_back(*($1)); }
+                    | type_list_opt_names COMMA type       { $1.push_back(*($3)); $$ = std::move($1); }
                     ;
 
 row_type : ROW LPAREN type_list_opt_names RPAREN      { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
-         | ROW LPAREN type_or_named COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
+         | ROW LPAREN type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
+         | ROW LPAREN named_type COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -81,12 +81,12 @@ type_list_opt_names : named_type                           { $$.push_back(*($1))
                     ;
 
 // Factor row fields and an optional trailing ", ..." to avoid ambiguity between
-// heterogeneous rows and homogeneous rows with ellipsis.
+// heterogeneous rows and homogeneous rows with ...
 row_type : ROW LPAREN type_list_opt_names row_ellipsis_opt RPAREN
                      {
                          if ($4) {
                              // Homogeneous row: require a single element to define the repeated field type.
-                             VELOX_CHECK(!($3).empty(), "row(T, ...) requires at exactly one element");
+                             VELOX_CHECK(!($3).empty(), "row(T, ...) requires exactly one element");
                              VELOX_CHECK((($3).size() == 1), "row(T, ...) must have exactly one element, got {}", ($3).size());
                              VELOX_CHECK(!($3)[0].rowFieldName().has_value(), "row(T, ...) does not support named fields; use row(T, ...) only");
                              $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{($3)[0]}, std::nullopt, true);

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -88,6 +88,7 @@ row_type : ROW LPAREN type_list_opt_names row_ellipsis_opt RPAREN
                              // Homogeneous row: require a single element to define the repeated field type.
                              VELOX_CHECK(!($3).empty(), "row(T, ...) requires at least one element");
                              VELOX_CHECK((($3).size() == 1), "row(T, ...) must have exactly one element, got {}", ($3).size());
+                             VELOX_CHECK(!($3)[0].rowFieldName().has_value(), "row(T, ...) does not support named fields; use row(T, ...) only");
                              $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{($3)[0]}, std::nullopt, true);
                          } else {
                              // Heterogeneous row with explicit field list.

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -86,7 +86,7 @@ row_type : ROW LPAREN type_list_opt_names row_ellipsis_opt RPAREN
                      {
                          if ($4) {
                              // Homogeneous row: require a single element to define the repeated field type.
-                             VELOX_CHECK(!($3).empty(), "row(T, ...) requires at least one element");
+                             VELOX_CHECK(!($3).empty(), "row(T, ...) requires at exactly one element");
                              VELOX_CHECK((($3).size() == 1), "row(T, ...) must have exactly one element, got {}", ($3).size());
                              VELOX_CHECK(!($3)[0].rowFieldName().has_value(), "row(T, ...) does not support named fields; use row(T, ...) only");
                              $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{($3)[0]}, std::nullopt, true);

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -31,10 +31,12 @@
 %token <std::string> WORD VARIABLE QUOTED_ID DECIMAL
 %token YYEOF         0
 
+%left COMMA
+%right ELLIPSIS
 %expect 1
 
 %nterm <std::shared_ptr<exec::TypeSignature>> special_type function_type decimal_type row_type array_type map_type
-%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named type_list_with_ellipsis
+%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named
 %nterm <std::vector<exec::TypeSignature>> type_list type_list_opt_names
 %nterm <std::vector<std::string>> type_with_spaces
 
@@ -81,11 +83,8 @@ type_list_opt_names : type_or_named                               { $$.push_back
                     | type_list_opt_names COMMA type_or_named { $1.push_back(*($3)); $$ = std::move($1); }
                     ;
 
-type_list_with_ellipsis : type_list_opt_names                    { $$ = std::make_shared<exec::TypeSignature>("row", $1); }
-                        | type_or_named COMMA ELLIPSIS           { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($1)}, std::nullopt, true); }
-                        ;
-
-row_type : ROW LPAREN type_list_with_ellipsis RPAREN { $$ = $3; }
+row_type : ROW LPAREN type_list_opt_names RPAREN      { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
+         | ROW LPAREN type_or_named COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }

--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -34,7 +34,7 @@
 %expect 1
 
 %nterm <std::shared_ptr<exec::TypeSignature>> special_type function_type decimal_type row_type array_type map_type
-%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named type_list_with_ellipsis
+%nterm <std::shared_ptr<exec::TypeSignature>> type named_type type_or_named
 %nterm <std::vector<exec::TypeSignature>> type_list type_list_opt_names
 %nterm <std::vector<std::string>> type_with_spaces
 
@@ -81,11 +81,8 @@ type_list_opt_names : type_or_named                               { $$.push_back
                     | type_list_opt_names COMMA type_or_named { $1.push_back(*($3)); $$ = std::move($1); }
                     ;
 
-type_list_with_ellipsis : type_list_opt_names                    { $$ = std::make_shared<exec::TypeSignature>("row", $1); }
-                        | type_or_named COMMA ELLIPSIS           { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($1)}, std::nullopt, true); }
-                        ;
-
-row_type : ROW LPAREN type_list_with_ellipsis RPAREN { $$ = $3; }
+row_type : ROW LPAREN type_list_opt_names RPAREN      { $$ = std::make_shared<exec::TypeSignature>("row", $3); }
+         | ROW LPAREN type_or_named COMMA ELLIPSIS RPAREN { $$ = std::make_shared<exec::TypeSignature>("row", std::vector<exec::TypeSignature>{*($3)}, std::nullopt, true); }
          ;
 
 array_type : ARRAY LPAREN type RPAREN             { $$ = std::make_shared<exec::TypeSignature>(exec::TypeSignature("array", { *($3) })); }

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -265,13 +265,13 @@ TEST_F(ParseTypeSignatureTest, row) {
     auto signature = parseTypeSignature("row(varchar, …)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
-    ASSERT_TRUE(signature.hasVariadicLastParam());
+    ASSERT_TRUE(signature.hasVariadicArity());
     ASSERT_TRUE(signature.isHomogeneousRow());
     ASSERT_EQ(signature.toString(), "row(varchar, …)");
 
     auto field0 = signature.parameters()[0];
     ASSERT_EQ(field0.baseName(), "varchar");
-    ASSERT_FALSE(field0.hasVariadicLastParam());
+    ASSERT_FALSE(field0.hasVariadicArity());
   }
 
   // Test homogeneous row with three-dot syntax
@@ -279,7 +279,7 @@ TEST_F(ParseTypeSignatureTest, row) {
     auto signature = parseTypeSignature("row(integer, ...)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
-    ASSERT_TRUE(signature.hasVariadicLastParam());
+    ASSERT_TRUE(signature.hasVariadicArity());
     ASSERT_TRUE(signature.isHomogeneousRow());
     ASSERT_EQ(signature.toString(), "row(integer, …)");
   }

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -260,14 +260,14 @@ TEST_F(ParseTypeSignatureTest, row) {
   // Single double quote is an error.
   EXPECT_THROW(parseTypeSignature("row(\"a\"b\" INTEGER)"), VeloxRuntimeError);
 
-  // Test homogeneous row syntax with ellipsis
+  // Test homogeneous row syntax with three dots
   {
-    auto signature = parseTypeSignature("row(varchar, …)");
+    auto signature = parseTypeSignature("row(varchar, ...)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
     ASSERT_TRUE(signature.hasVariadicArity());
     ASSERT_TRUE(signature.isHomogeneousRow());
-    ASSERT_EQ(signature.toString(), "row(varchar, …)");
+    ASSERT_EQ(signature.toString(), "row(varchar, ...)");
 
     auto field0 = signature.parameters()[0];
     ASSERT_EQ(field0.baseName(), "varchar");
@@ -281,11 +281,11 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(signature.parameters().size(), 1);
     ASSERT_TRUE(signature.hasVariadicArity());
     ASSERT_TRUE(signature.isHomogeneousRow());
-    ASSERT_EQ(signature.toString(), "row(integer, …)");
+    ASSERT_EQ(signature.toString(), "row(integer, ...)");
   }
 
   // Test that homogeneous row with named field is rejected
-  EXPECT_THROW(parseTypeSignature("row(name varchar, …)"), VeloxRuntimeError);
+  EXPECT_THROW(parseTypeSignature("row(name varchar, ...)"), VeloxRuntimeError);
 }
 
 TEST_F(ParseTypeSignatureTest, tdigest) {
@@ -314,11 +314,9 @@ TEST_F(ParseTypeSignatureTest, roundTrip) {
       "row(map(K,V),map(bigint,array(double)))");
 
   // Test homogeneous row round-trip parsing
-  ASSERT_EQ(roundTrip("row(T, …)"), "row(T, …)");
-  ASSERT_EQ(
-      roundTrip("row(varchar, ...)"),
-      "row(varchar, …)"); // ASCII dots convert to Unicode
-  ASSERT_EQ(roundTrip("row(bigint, …)"), "row(bigint, …)");
+  ASSERT_EQ(roundTrip("row(T, ...)") , "row(T, ...)");
+  ASSERT_EQ(roundTrip("row(varchar, ...)") , "row(varchar, ...)");
+  ASSERT_EQ(roundTrip("row(bigint, ...)") , "row(bigint, ...)");
 }
 
 TEST_F(ParseTypeSignatureTest, invalidSignatures) {

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -259,13 +259,14 @@ TEST_F(ParseTypeSignatureTest, row) {
 
   // Single double quote is an error.
   EXPECT_THROW(parseTypeSignature("row(\"a\"b\" INTEGER)"), VeloxRuntimeError);
+}
 
-  // Test homogeneous row syntax with three dots
+TEST_F(ParseTypeSignatureTest, homogeneousRow) {
   {
+    // Test homogeneous row syntax with three dots
     auto signature = parseTypeSignature("row(varchar, ...)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
-    ASSERT_TRUE(signature.hasVariadicArity());
     ASSERT_TRUE(signature.isHomogeneousRow());
     ASSERT_EQ(signature.toString(), "row(varchar, ...)");
 
@@ -274,12 +275,11 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_FALSE(field0.hasVariadicArity());
   }
 
-  // Test homogeneous row with three-dot syntax
   {
+    // Test homogeneous row syntax with three dots and a different type
     auto signature = parseTypeSignature("row(integer, ...)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
-    ASSERT_TRUE(signature.hasVariadicArity());
     ASSERT_TRUE(signature.isHomogeneousRow());
     ASSERT_EQ(signature.toString(), "row(integer, ...)");
   }
@@ -314,9 +314,9 @@ TEST_F(ParseTypeSignatureTest, roundTrip) {
       "row(map(K,V),map(bigint,array(double)))");
 
   // Test homogeneous row round-trip parsing
-  ASSERT_EQ(roundTrip("row(T, ...)") , "row(T, ...)");
-  ASSERT_EQ(roundTrip("row(varchar, ...)") , "row(varchar, ...)");
-  ASSERT_EQ(roundTrip("row(bigint, ...)") , "row(bigint, ...)");
+  ASSERT_EQ(roundTrip("row(T, ...)"), "row(T, ...)");
+  ASSERT_EQ(roundTrip("row(varchar, ...)"), "row(varchar, ...)");
+  ASSERT_EQ(roundTrip("row(bigint, ...)"), "row(bigint, ...)");
 }
 
 TEST_F(ParseTypeSignatureTest, invalidSignatures) {

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include <gtest/gtest.h>
-
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/signature_parser/SignatureParser.h"
 
 using namespace facebook::velox::exec;
@@ -214,7 +214,7 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(signature.parameters().size(), 2);
     ASSERT_FALSE(signature.rowFieldName().has_value());
     auto field0 = signature.parameters()[0];
-    ASSERT_EQ(field0.baseName(), "array");S
+    ASSERT_EQ(field0.baseName(), "array");
     ASSERT_EQ(field0.rowFieldName(), "field 0");
     ASSERT_EQ(field0.parameters().size(), 1);
     auto arrayElement = field0.parameters()[0];
@@ -285,7 +285,9 @@ TEST_F(ParseTypeSignatureTest, homogeneousRow) {
   }
 
   // Test that homogeneous row with named field is rejected.
-  VELOX_ASSERT_THROW(parseTypeSignature("row(name varchar, ...)"), VeloxRuntimeError);
+  VELOX_ASSERT_RUNTIME_THROW(
+      parseTypeSignature("row(name varchar, ...)"),
+      "Homogeneous row cannot have a field name");
 }
 
 TEST_F(ParseTypeSignatureTest, tdigest) {

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -268,7 +268,7 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_TRUE(signature.hasVariadicLastParam());
     ASSERT_TRUE(signature.isHomogeneousRow());
     ASSERT_EQ(signature.toString(), "row(varchar, …)");
-    
+
     auto field0 = signature.parameters()[0];
     ASSERT_EQ(field0.baseName(), "varchar");
     ASSERT_FALSE(field0.hasVariadicLastParam());
@@ -291,7 +291,7 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(signature.parameters().size(), 1);
     ASSERT_TRUE(signature.hasVariadicLastParam());
     ASSERT_TRUE(signature.isHomogeneousRow());
-    
+
     auto field0 = signature.parameters()[0];
     ASSERT_EQ(field0.baseName(), "varchar");
     ASSERT_EQ(field0.rowFieldName(), "name");
@@ -322,10 +322,12 @@ TEST_F(ParseTypeSignatureTest, roundTrip) {
   ASSERT_EQ(
       roundTrip("row(map(K,V),map(bigint,array(double)))"),
       "row(map(K,V),map(bigint,array(double)))");
-      
+
   // Test homogeneous row round-trip parsing
   ASSERT_EQ(roundTrip("row(T, …)"), "row(T, …)");
-  ASSERT_EQ(roundTrip("row(varchar, ...)"), "row(varchar, …)"); // ASCII dots convert to Unicode
+  ASSERT_EQ(
+      roundTrip("row(varchar, ...)"),
+      "row(varchar, …)"); // ASCII dots convert to Unicode
   ASSERT_EQ(roundTrip("row(bigint, …)"), "row(bigint, …)");
 }
 

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -284,18 +284,8 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(signature.toString(), "row(integer, …)");
   }
 
-  // Test homogeneous row with named field
-  {
-    auto signature = parseTypeSignature("row(name varchar, …)");
-    ASSERT_EQ(signature.baseName(), "row");
-    ASSERT_EQ(signature.parameters().size(), 1);
-    ASSERT_TRUE(signature.hasVariadicLastParam());
-    ASSERT_TRUE(signature.isHomogeneousRow());
-
-    auto field0 = signature.parameters()[0];
-    ASSERT_EQ(field0.baseName(), "varchar");
-    ASSERT_EQ(field0.rowFieldName(), "name");
-  }
+  // Test that homogeneous row with named field is rejected
+  EXPECT_THROW(parseTypeSignature("row(name varchar, …)"), VeloxRuntimeError);
 }
 
 TEST_F(ParseTypeSignatureTest, tdigest) {

--- a/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
+++ b/velox/expression/signature_parser/tests/ParseTypeSignatureTest.cpp
@@ -191,7 +191,7 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(signature.parameters().size(), 1);
   }
 
-  // test quoted row fields.
+  // TSest quoted row fields.
   {
     auto signature = parseTypeSignature("row(\"12col0\" v, l)");
     ASSERT_EQ(signature.baseName(), "row");
@@ -214,7 +214,7 @@ TEST_F(ParseTypeSignatureTest, row) {
     ASSERT_EQ(signature.parameters().size(), 2);
     ASSERT_FALSE(signature.rowFieldName().has_value());
     auto field0 = signature.parameters()[0];
-    ASSERT_EQ(field0.baseName(), "array");
+    ASSERT_EQ(field0.baseName(), "array");S
     ASSERT_EQ(field0.rowFieldName(), "field 0");
     ASSERT_EQ(field0.parameters().size(), 1);
     auto arrayElement = field0.parameters()[0];
@@ -263,20 +263,20 @@ TEST_F(ParseTypeSignatureTest, row) {
 
 TEST_F(ParseTypeSignatureTest, homogeneousRow) {
   {
-    // Test homogeneous row syntax with three dots
+    // Test homogeneous row syntax with three dots.
     auto signature = parseTypeSignature("row(varchar, ...)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
     ASSERT_TRUE(signature.isHomogeneousRow());
     ASSERT_EQ(signature.toString(), "row(varchar, ...)");
 
-    auto field0 = signature.parameters()[0];
-    ASSERT_EQ(field0.baseName(), "varchar");
-    ASSERT_FALSE(field0.hasVariadicArity());
+    auto field = signature.parameters()[0];
+    ASSERT_EQ(field.baseName(), "varchar");
+    ASSERT_FALSE(field.hasVariadicArity());
   }
 
   {
-    // Test homogeneous row syntax with three dots and a different type
+    // Test homogeneous row syntax with three dots and a different type.
     auto signature = parseTypeSignature("row(integer, ...)");
     ASSERT_EQ(signature.baseName(), "row");
     ASSERT_EQ(signature.parameters().size(), 1);
@@ -284,8 +284,8 @@ TEST_F(ParseTypeSignatureTest, homogeneousRow) {
     ASSERT_EQ(signature.toString(), "row(integer, ...)");
   }
 
-  // Test that homogeneous row with named field is rejected
-  EXPECT_THROW(parseTypeSignature("row(name varchar, ...)"), VeloxRuntimeError);
+  // Test that homogeneous row with named field is rejected.
+  VELOX_ASSERT_THROW(parseTypeSignature("row(name varchar, ...)"), VeloxRuntimeError);
 }
 
 TEST_F(ParseTypeSignatureTest, tdigest) {
@@ -308,12 +308,12 @@ TEST_F(ParseTypeSignatureTest, roundTrip) {
 
   ASSERT_EQ(roundTrip("function(S,R)"), "function(S,R)");
 
-  // Test a complex type as the second field in a row
+  // Test a complex type as the second field in a row.
   ASSERT_EQ(
       roundTrip("row(map(K,V),map(bigint,array(double)))"),
       "row(map(K,V),map(bigint,array(double)))");
 
-  // Test homogeneous row round-trip parsing
+  // Test homogeneous row round-trip parsing.
   ASSERT_EQ(roundTrip("row(T, ...)"), "row(T, ...)");
   ASSERT_EQ(roundTrip("row(varchar, ...)"), "row(varchar, ...)");
   ASSERT_EQ(roundTrip("row(bigint, ...)"), "row(bigint, ...)");

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1123,7 +1123,7 @@ TEST(SignatureBinderTest, coercions) {
       /*allowCoercion*/ true);
 }
 
-TEST_F(SignatureBinderTest, homogeneous_rows) {
+TEST(SignatureBinderTest, homogeneous_rows) {
   // row(T, …) -> boolean - tests homogeneous row binding
   {
     auto signature = exec::FunctionSignatureBuilder()

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1124,12 +1124,12 @@ TEST(SignatureBinderTest, coercions) {
 }
 
 TEST(SignatureBinderTest, homogeneous_rows) {
-  // row(T, …) -> boolean - tests homogeneous row binding
+  // row(T, ...) -> boolean - tests homogeneous row binding
   {
     auto signature = exec::FunctionSignatureBuilder()
                          .typeVariable("T")
                          .returnType("boolean")
-                         .argumentType("row(T, …)")
+                         .argumentType("row(T, ...)")
                          .build();
 
     testSignatureBinder(signature, {ROW({BIGINT()})}, BOOLEAN());
@@ -1152,8 +1152,8 @@ TEST(SignatureBinderTest, homogeneous_rows) {
     auto signature = exec::FunctionSignatureBuilder()
                          .typeVariable("T")
                          .returnType("T")
-                         .argumentType("row(T, …)")
-                         .argumentType("row(T, …)")
+                         .argumentType("row(T, ...)")
+                         .argumentType("row(T, ...)")
                          .build();
 
     testSignatureBinder(

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1199,12 +1199,12 @@ TEST(SignatureBinderTest, homogeneousRowReturnType) {
   // Negative test: constructing or binding a function with homogeneous row
   // return is invalid.
   VELOX_ASSERT_USER_THROW(
-   (exec::FunctionSignatureBuilder()
-     .typeVariable("T")
-     .returnType("row(T, ...)")
-     .argumentType("bigint")
-     .build()),
-   "Homogeneous row cannot be used as a return type");
+      (exec::FunctionSignatureBuilder()
+           .typeVariable("T")
+           .returnType("row(T, ...)")
+           .argumentType("bigint")
+           .build()),
+      "Homogeneous row cannot be used as a return type");
 }
 
 } // namespace

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1123,8 +1123,8 @@ TEST(SignatureBinderTest, coercions) {
       /*allowCoercion*/ true);
 }
 
-TEST(SignatureBinderTest, homogeneous_rows) {
-  // row(T, ...) -> boolean - tests homogeneous row binding
+TEST(SignatureBinderTest, homogeneousRow) {
+  // row(T, ...) -> boolean
   {
     auto signature = exec::FunctionSignatureBuilder()
                          .typeVariable("T")
@@ -1166,7 +1166,7 @@ TEST(SignatureBinderTest, homogeneous_rows) {
   }
 }
 
-TEST(SignatureBinderTest, homogeneous_row_map) {
+TEST(SignatureBinderTest, homogeneousRowsToMap) {
   // Positive test: (row(T,...), row(U,...)) -> map(T,U)
   auto signature = exec::FunctionSignatureBuilder()
                        .typeVariable("T")
@@ -1186,7 +1186,7 @@ TEST(SignatureBinderTest, homogeneous_row_map) {
       signature, {ROW({BIGINT(), BIGINT()}), ROW({BIGINT(), VARCHAR()})});
 }
 
-TEST(SignatureBinderTest, homogeneous_row_return_type_not_allowed) {
+TEST(SignatureBinderTest, homogeneousRowReturnType) {
   // Negative test: constructing or binding a function with homogeneous row
   // return is invalid.
   EXPECT_THROW(
@@ -1198,7 +1198,7 @@ TEST(SignatureBinderTest, homogeneous_row_return_type_not_allowed) {
                              .build();
         // If build unexpectedly succeeds without throwing, still assert bind
         // fails.
-        assertCannotResolve(signature, {BIGINT()});
+        VELOX_ASSERT_THROW(signature, {BIGINT()});
       },
       VeloxUserError);
 }

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1187,14 +1187,20 @@ TEST(SignatureBinderTest, homogeneous_row_map) {
 }
 
 TEST(SignatureBinderTest, homogeneous_row_return_type_not_allowed) {
-  // Negative test: row(T, ...) as return type should throw
-  auto signature = exec::FunctionSignatureBuilder()
-                       .typeVariable("T")
-                       .returnType("row(T, ...)")
-                       .argumentType("bigint")
-                       .build();
-
-  assertCannotResolve(signature, {BIGINT()});
+  // Negative test: constructing or binding a function with homogeneous row
+  // return is invalid.
+  EXPECT_THROW(
+      {
+        auto signature = exec::FunctionSignatureBuilder()
+                             .typeVariable("T")
+                             .returnType("row(T, ...)")
+                             .argumentType("bigint")
+                             .build();
+        // If build unexpectedly succeeds without throwing, still assert bind
+        // fails.
+        assertCannotResolve(signature, {BIGINT()});
+      },
+      VeloxUserError);
 }
 
 } // namespace

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1132,23 +1132,17 @@ TEST(SignatureBinderTest, homogeneous_rows) {
                          .argumentType("row(T, …)")
                          .build();
 
-    // Should succeed for row(bigint)
     testSignatureBinder(signature, {ROW({BIGINT()})}, BOOLEAN());
 
-    // Should succeed for row(bigint,bigint,bigint)
     testSignatureBinder(
         signature, {ROW({BIGINT(), BIGINT(), BIGINT()})}, BOOLEAN());
 
-    // Should succeed for row(varchar,varchar)
     testSignatureBinder(signature, {ROW({VARCHAR(), VARCHAR()})}, BOOLEAN());
 
-    // Should succeed for row() (empty)
     testSignatureBinder(signature, {ROW({})}, BOOLEAN());
 
-    // Should fail for row(bigint,varchar) - mixed types
     assertCannotResolve(signature, {ROW({BIGINT(), VARCHAR()})});
 
-    // Should fail for non-row types
     assertCannotResolve(signature, {BIGINT()});
     assertCannotResolve(signature, {ARRAY(BIGINT())});
   }
@@ -1162,13 +1156,11 @@ TEST(SignatureBinderTest, homogeneous_rows) {
                          .argumentType("row(T, …)")
                          .build();
 
-    // Should succeed when both arguments have same element type
     testSignatureBinder(
         signature,
         {ROW({BIGINT(), BIGINT()}), ROW({BIGINT(), BIGINT(), BIGINT()})},
         BIGINT()); // Return type is just the common element type T
 
-    // Should fail when arguments have different element types
     assertCannotResolve(
         signature, {ROW({BIGINT(), BIGINT()}), ROW({VARCHAR(), VARCHAR()})});
   }

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1134,24 +1134,25 @@ TEST_F(SignatureBinderTest, homogeneous_rows) {
 
     // Should succeed for row(bigint)
     testSignatureBinder(signature, {ROW({BIGINT()})}, BOOLEAN());
-    
+
     // Should succeed for row(bigint,bigint,bigint)
-    testSignatureBinder(signature, {ROW({BIGINT(), BIGINT(), BIGINT()})}, BOOLEAN());
-    
+    testSignatureBinder(
+        signature, {ROW({BIGINT(), BIGINT(), BIGINT()})}, BOOLEAN());
+
     // Should succeed for row(varchar,varchar)
     testSignatureBinder(signature, {ROW({VARCHAR(), VARCHAR()})}, BOOLEAN());
-    
+
     // Should succeed for row() (empty)
     testSignatureBinder(signature, {ROW({})}, BOOLEAN());
-    
+
     // Should fail for row(bigint,varchar) - mixed types
     assertCannotResolve(signature, {ROW({BIGINT(), VARCHAR()})});
-    
+
     // Should fail for non-row types
     assertCannotResolve(signature, {BIGINT()});
     assertCannotResolve(signature, {ARRAY(BIGINT())});
   }
-  
+
   // Test with multiple homogeneous row arguments
   {
     auto signature = exec::FunctionSignatureBuilder()
@@ -1162,12 +1163,14 @@ TEST_F(SignatureBinderTest, homogeneous_rows) {
                          .build();
 
     // Should succeed when both arguments have same element type
-    testSignatureBinder(signature, 
-        {ROW({BIGINT(), BIGINT()}), ROW({BIGINT(), BIGINT(), BIGINT()})}, 
+    testSignatureBinder(
+        signature,
+        {ROW({BIGINT(), BIGINT()}), ROW({BIGINT(), BIGINT(), BIGINT()})},
         BIGINT()); // Return type is just the common element type T
-    
+
     // Should fail when arguments have different element types
-    assertCannotResolve(signature, {ROW({BIGINT(), BIGINT()}), ROW({VARCHAR(), VARCHAR()})});
+    assertCannotResolve(
+        signature, {ROW({BIGINT(), BIGINT()}), ROW({VARCHAR(), VARCHAR()})});
   }
 }
 

--- a/velox/type/TypeUtil.cpp
+++ b/velox/type/TypeUtil.cpp
@@ -33,4 +33,22 @@ velox::RowTypePtr concatRowTypes(
   return velox::ROW(std::move(columnNames), std::move(columnTypes));
 }
 
+const velox::TypePtr isHomogeneousRow(const velox::TypePtr& type) {
+  if (!type || type->kind() != velox::TypeKind::ROW) {
+    return nullptr;
+  }
+  auto row = velox::asRowType(type);
+  const auto& children = row->children();
+  if (children.empty()) {
+    return nullptr; // No child type to infer
+  }
+  const auto& first = children.front();
+  for (size_t i = 1; i < children.size(); ++i) {
+    if (!first->equivalent(*children[i])) {
+      return nullptr;
+    }
+  }
+  return first;
+}
+
 } // namespace facebook::velox::type

--- a/velox/type/TypeUtil.cpp
+++ b/velox/type/TypeUtil.cpp
@@ -45,8 +45,8 @@ velox::TypePtr tryGetHomogeneousRowChild(const velox::TypePtr& type) {
   auto first = type->childAt(0);
   for (size_t i = 1; i < childCount; ++i) {
     auto child = type->childAt(i);
-    // All child types must be exactly equal (not just equivalent).
-    if (!first->equals(*child)) {
+    // All child types must be exactly equal (use public operator==).
+    if (!(*first == *child)) {
       return nullptr;
     }
   }

--- a/velox/type/TypeUtil.h
+++ b/velox/type/TypeUtil.h
@@ -26,8 +26,8 @@ velox::RowTypePtr concatRowTypes(
     const std::vector<velox::RowTypePtr>& rowTypes);
 
 // Returns the common child type if 'type' is a Row where all children are
-// equivalent to each other. Returns nullptr otherwise. Empty rows return
-// nullptr as there is no child type to return.
-const velox::TypePtr isHomogeneousRow(const velox::TypePtr& type);
+// the same. Returns nullptr otherwise. Empty rows return nullptr.
+// Precondition: 'type' must not be null.
+velox::TypePtr tryGetHomogeneousRowChild(const velox::TypePtr& type);
 
 } // namespace facebook::velox::type

--- a/velox/type/TypeUtil.h
+++ b/velox/type/TypeUtil.h
@@ -25,4 +25,9 @@ namespace facebook::velox::type {
 velox::RowTypePtr concatRowTypes(
     const std::vector<velox::RowTypePtr>& rowTypes);
 
+// Returns the common child type if 'type' is a Row where all children are
+// equivalent to each other. Returns nullptr otherwise. Empty rows return
+// nullptr as there is no child type to return.
+const velox::TypePtr isHomogeneousRow(const velox::TypePtr& type);
+
 } // namespace facebook::velox::type

--- a/velox/type/tests/TypeUtilTest.cpp
+++ b/velox/type/tests/TypeUtilTest.cpp
@@ -35,5 +35,31 @@ TEST(TypeUtilTest, ConcatRowTypes) {
   EXPECT_EQ(type->toString(), expected->toString());
 }
 
+TEST(TypeUtilTest, tryGetHomogeneousRowChild_NonRow) {
+  auto t = velox::INTEGER();
+  auto child = tryGetHomogeneousRowChild(t);
+  ASSERT_EQ(child, nullptr);
+}
+
+TEST(TypeUtilTest, tryGetHomogeneousRowChild_EmptyRow) {
+  auto row = velox::ROW({}, {});
+  auto child = tryGetHomogeneousRowChild(row);
+  ASSERT_EQ(child, nullptr);
+}
+
+TEST(TypeUtilTest, tryGetHomogeneousRowChild_Homogeneous) {
+  auto row = velox::ROW(
+      {"c1", "c2", "c3"}, {velox::BIGINT(), velox::BIGINT(), velox::BIGINT()});
+  auto child = tryGetHomogeneousRowChild(row);
+  ASSERT_NE(child, nullptr);
+  ASSERT_TRUE(child->equals(*velox::BIGINT()));
+}
+
+TEST(TypeUtilTest, tryGetHomogeneousRowChild_Heterogeneous) {
+  auto row = velox::ROW({"c1", "c2"}, {velox::BIGINT(), velox::VARCHAR()});
+  auto child = tryGetHomogeneousRowChild(row);
+  ASSERT_EQ(child, nullptr);
+}
+
 } // namespace
 } // namespace facebook::velox::type


### PR DESCRIPTION
Part of #14630

Adds support for homogeneous row/struct type signatures where all fields have the same type. This lets us write function signatures like row(T, ...) to match rows (structs) with any number of fields of type T.

What's changed:

TypeSignature updates:
- Added variadicArity_ flag to track ellipsis syntax
- New isHomogeneousRow() helper method
- Updated toString() to print row(T, ...) correctly

Parser changes:
- Added ELLIPSIS token that recognizes only "..." (ASCII); Unicode “…” is not supported
- Extended row grammar to parse row(T, ...)
- Enforces homogeneous constraints: row(name T, ...) and row(T, U, ...) are rejected
- Existing row(a, b, c) syntax still works fine

Binding logic:
- New branch in SignatureBinder for homogeneous rows
- Uses TypeUtil::isHomogeneousRow(TypePtr) to verify that all row fields have the same type and to extract the common child type
- Binds the common child type to the type variable T; empty rows are accepted in the variable case

Validation:
- Homogeneous row cannot be used as a return type; enforced during FunctionSignature validation with a user error

Tests:
- Parser tests for the new syntax and constraints (including rejection of named homogeneous rows and Unicode ellipsis)
- Added comprehensive binder tests covering successful type resolution, error handling for non-homogeneous arguments, and the new return type restriction.


This should set up the foundation for future work like:

-- Transform all fields in a row
transform_row(row(T, ...), lambda) → row(U, ...)