### PR TITLE
feat: Add connector::ColumnHandle::toString API

### DIFF
--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -174,17 +174,4 @@ folly::dynamic ConnectorTableHandle::serialize() const {
   return serializeBase("ConnectorTableHandle");
 }
 
-// static
-ConnectorTableHandlePtr ConnectorTableHandle::create(
-    const folly::dynamic& obj,
-    void* /*unused*/) {
-  const auto connectorId = obj["connectorId"].asString();
-  return std::make_shared<const ConnectorTableHandle>(connectorId);
-}
-
-// static
-void ConnectorTableHandle::registerSerDe() {
-  auto& registry = DeserializationWithContextRegistryForSharedPtr();
-  registry.Register("ConnectorTableHandle", create);
-}
 } // namespace facebook::velox::connector

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -94,8 +94,10 @@ class ColumnHandle : public ISerializable {
  public:
   virtual ~ColumnHandle() = default;
 
-  virtual const std::string& name() const {
-    VELOX_UNSUPPORTED();
+  virtual const std::string& name() const = 0;
+
+  virtual std::string toString() const {
+    return name();
   }
 
   folly::dynamic serialize() const override;
@@ -119,33 +121,29 @@ class ConnectorTableHandle : public ISerializable {
 
   virtual ~ConnectorTableHandle() = default;
 
-  virtual std::string toString() const {
-    VELOX_NYI();
-  }
-
   const std::string& connectorId() const {
     return connectorId_;
   }
 
-  /// Returns the connector-dependent table name. Used with
-  /// ConnectorMetadata. Implementations need to supply a definition
-  /// to work with metadata.
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   virtual const std::string& name() const {
-    VELOX_UNSUPPORTED();
+    VELOX_NYI();
   }
+#else
+  /// Returns the table name.
+  virtual const std::string& name() const = 0;
+#endif
 
   /// Returns true if the connector table handle supports index lookup.
   virtual bool supportsIndexLookup() const {
     return false;
   }
 
+  virtual std::string toString() const {
+    return name();
+  }
+
   virtual folly::dynamic serialize() const override;
-
-  static ConnectorTableHandlePtr create(
-      const folly::dynamic& obj,
-      void* context);
-
-  static void registerSerDe();
 
  protected:
   folly::dynamic serializeBase(std::string_view name) const;

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -34,7 +34,7 @@ namespace facebook::velox::connector::fuzzer {
 
 class FuzzerTableHandle : public ConnectorTableHandle {
  public:
-  explicit FuzzerTableHandle(
+  FuzzerTableHandle(
       std::string connectorId,
       VectorFuzzer::Options options,
       size_t fuzzerSeed = 0)
@@ -42,14 +42,13 @@ class FuzzerTableHandle : public ConnectorTableHandle {
         fuzzerOptions(options),
         fuzzerSeed(fuzzerSeed) {}
 
-  ~FuzzerTableHandle() override {}
-
-  std::string toString() const override {
-    return "fuzzer-mock-table";
+  const std::string& name() const override {
+    static const std::string kName = "fuzzer-mock-table";
+    return kName;
   }
 
   const VectorFuzzer::Options fuzzerOptions;
-  size_t fuzzerSeed;
+  const size_t fuzzerSeed;
 };
 
 class FuzzerDataSource : public DataSource {

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -110,7 +110,7 @@ class HiveColumnHandle : public ColumnHandle {
         ColumnParseParameters::kDaysSinceEpoch;
   }
 
-  std::string toString() const;
+  std::string toString() const override;
 
   folly::dynamic serialize() const override;
 

--- a/velox/connectors/tpcds/TpcdsConnector.h
+++ b/velox/connectors/tpcds/TpcdsConnector.h
@@ -47,11 +47,14 @@ class TpcdsTableHandle : public ConnectorTableHandle {
       double scaleFactor = 0.01)
       : ConnectorTableHandle(std::move(connectorId)),
         table_(table),
+        name_(toTableName(table)),
         scaleFactor_(scaleFactor) {
     VELOX_CHECK_GT(scaleFactor, 0.0, "Tpcds scale factor must be non-negative");
   }
 
-  ~TpcdsTableHandle() override {}
+  const std::string& name() const override {
+    return name_;
+  }
 
   std::string toString() const override;
 
@@ -65,7 +68,8 @@ class TpcdsTableHandle : public ConnectorTableHandle {
 
  private:
   const velox::tpcds::Table table_;
-  double scaleFactor_;
+  const std::string name_;
+  const double scaleFactor_;
 };
 
 class TpcdsDataSource : public velox::connector::DataSource {

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -123,6 +123,10 @@ class TestConnectorTableHandleForLookupJoin
   explicit TestConnectorTableHandleForLookupJoin(std::string connectorId)
       : connector::ConnectorTableHandle(std::move(connectorId)) {}
 
+  const std::string& name() const override {
+    VELOX_NYI();
+  }
+
   bool supportsIndexLookup() const override {
     return true;
   }
@@ -255,14 +259,30 @@ TEST_F(PlanNodeBuilderTest, projectNode) {
   verify(node2);
 }
 
+class DummyTableHandle : public connector::ConnectorTableHandle {
+ public:
+  DummyTableHandle(const std::string& connectorId)
+      : connector::ConnectorTableHandle(connectorId) {}
+
+  const std::string& name() const override {
+    VELOX_NYI();
+  }
+};
+
+class DummyColumnHandle : public connector::ColumnHandle {
+ public:
+  const std::string& name() const override {
+    VELOX_NYI();
+  }
+};
+
 TEST_F(PlanNodeBuilderTest, tableScanNode) {
   const PlanNodeId id = "table_scan_node_id";
   const RowTypePtr outputType = ROW({"c0", "c1"}, {INTEGER(), VARCHAR()});
-  const auto tableHandle =
-      std::make_shared<connector::ConnectorTableHandle>("connector_id");
+  const auto tableHandle = std::make_shared<DummyTableHandle>("connector_id");
   const connector::ColumnHandleMap assignments{
-      {"c0", std::make_shared<connector::ColumnHandle>()},
-      {"c1", std::make_shared<connector::ColumnHandle>()}};
+      {"c0", std::make_shared<DummyColumnHandle>()},
+      {"c1", std::make_shared<DummyColumnHandle>()}};
 
   const auto verify = [&](const std::shared_ptr<const TableScanNode>& node) {
     EXPECT_EQ(node->id(), id);
@@ -751,7 +771,7 @@ TEST_F(PlanNodeBuilderTest, indexLookupJoinNode) {
           .outputType(ROW({"c1"}, {VARCHAR()}))
           .tableHandle(std::make_shared<TestConnectorTableHandleForLookupJoin>(
               "connector_id"))
-          .assignments({{"c1", std::make_shared<connector::ColumnHandle>()}})
+          .assignments({{"c1", std::make_shared<DummyColumnHandle>()}})
           .build();
   const auto outputType = ROW({"c0"}, {BIGINT()});
 

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -32,11 +32,16 @@ const std::string kTestConnectorId = "test";
 
 class TestTableHandle : public connector::ConnectorTableHandle {
  public:
-  TestTableHandle() : connector::ConnectorTableHandle(kTestConnectorId) {}
+  TestTableHandle(std::string name)
+      : connector::ConnectorTableHandle(kTestConnectorId),
+        name_{std::move(name)} {}
 
-  std::string toString() const override {
-    VELOX_NYI();
+  const std::string& name() const override {
+    return name_;
   }
+
+ private:
+  const std::string name_;
 };
 
 class TestSplit : public connector::ConnectorSplit {
@@ -193,7 +198,7 @@ class AsyncConnectorTest : public OperatorTestBase {
 };
 
 TEST_F(AsyncConnectorTest, basic) {
-  auto tableHandle = std::make_shared<TestTableHandle>();
+  auto tableHandle = std::make_shared<TestTableHandle>("test");
   core::PlanNodeId scanId;
   auto plan = PlanBuilder()
                   .startTableScan()

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -289,7 +289,6 @@ void TraceReplayRunner::init() {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
 
-  connector::ConnectorTableHandle::registerSerDe();
   connector::hive::HiveTableHandle::registerSerDe();
   connector::hive::LocationHandle::registerSerDe();
   connector::hive::HiveColumnHandle::registerSerDe();

--- a/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
+++ b/velox/tool/trace/tests/FilterProjectReplayerTest.cpp
@@ -23,24 +23,14 @@
 #include <folly/experimental/EventCount.h>
 
 #include "velox/common/file/FileSystems.h"
-#include "velox/common/hyperloglog/SparseHll.h"
-#include "velox/common/testutil/TestValue.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/exec/PartitionFunction.h"
-#include "velox/exec/TableWriter.h"
 #include "velox/exec/TraceUtil.h"
-#include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/tool/trace/FilterProjectReplayer.h"
-
-#include "velox/common/file/Utils.h"
-#include "velox/exec/PlanNodeStats.h"
-
-#include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::core;
@@ -54,6 +44,7 @@ using namespace facebook::velox::common::testutil;
 using namespace facebook::velox::common::hll;
 
 namespace facebook::velox::tool::trace::test {
+namespace {
 class FilterProjectReplayerTest : public HiveConnectorTestBase {
  protected:
   static void SetUpTestCase() {
@@ -65,7 +56,6 @@ class FilterProjectReplayerTest : public HiveConnectorTestBase {
     }
     Type::registerSerDe();
     common::Filter::registerSerDe();
-    connector::ConnectorTableHandle::registerSerDe();
     connector::hive::HiveTableHandle::registerSerDe();
     connector::hive::LocationHandle::registerSerDe();
     connector::hive::HiveColumnHandle::registerSerDe();
@@ -352,4 +342,5 @@ TEST_F(FilterProjectReplayerTest, dryRun) {
                              .run();
   assertEqualResults({result}, {replayingResult});
 }
+} // namespace
 } // namespace facebook::velox::tool::trace::test


### PR DESCRIPTION
Summary:
Also,
- make ConnectorTableHandle::name() and ColumnHandle::name() APIs pure virtual;
- remove incorrect ConnectorTableHandle::create and related APIs.

Differential Revision: D81485362


