### PR TITLE
feat(connectors): Pass connector configuration during Connector construction

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -564,7 +564,10 @@ class ConnectorMetadata;
 
 class Connector {
  public:
-  explicit Connector(const std::string& id) : id_(id) {}
+  explicit Connector(
+      const std::string& id,
+      std::shared_ptr<const config::ConfigBase> config = nullptr)
+      : id_(id), config_(std::move(config)) {}
 
   virtual ~Connector() = default;
 
@@ -572,9 +575,8 @@ class Connector {
     return id_;
   }
 
-  virtual const std::shared_ptr<const config::ConfigBase>& connectorConfig()
-      const {
-    VELOX_NYI("connectorConfig is not supported yet");
+  const std::shared_ptr<const config::ConfigBase>& connectorConfig() const {
+    return config_;
   }
 
   /// Returns true if this connector would accept a filter dynamically
@@ -684,6 +686,7 @@ class Connector {
   static void unregisterTracker(cache::ScanTracker* tracker);
 
   const std::string id_;
+  const std::shared_ptr<const config::ConfigBase> config_;
 
   static folly::Synchronized<
       std::unordered_map<std::string_view, std::weak_ptr<cache::ScanTracker>>>

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -40,8 +40,8 @@ HiveConnector::HiveConnector(
     const std::string& id,
     std::shared_ptr<const config::ConfigBase> config,
     folly::Executor* executor)
-    : Connector(id),
-      hiveConfig_(std::make_shared<HiveConfig>(config)),
+    : Connector(id, std::move(config)),
+      hiveConfig_(std::make_shared<HiveConfig>(connectorConfig())),
       fileHandleFactory_(
           hiveConfig_->isFileHandleCacheEnabled()
               ? std::make_unique<SimpleLRUCache<FileHandleKey, FileHandle>>(

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -34,11 +34,6 @@ class HiveConnector : public Connector {
       std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* executor);
 
-  const std::shared_ptr<const config::ConfigBase>& connectorConfig()
-      const override {
-    return hiveConfig_->config();
-  }
-
   bool canAddDynamicFilter() const override {
     return true;
   }

--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -35,7 +35,7 @@ TpchConnector::TpchConnector(
     const std::string& id,
     std::shared_ptr<const config::ConfigBase> config,
     folly::Executor* /*executor*/)
-    : Connector(id) {
+    : Connector(id, std::move(config)) {
   for (auto& factory : tpchConnectorMetadataFactories()) {
     metadata_ = factory->create(this);
     if (metadata_ != nullptr) {

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -443,6 +443,22 @@ TEST_F(TpchConnectorTest, orderDateCount) {
   EXPECT_EQ(9, orderDate->size());
 }
 
+TEST_F(TpchConnectorTest, config) {
+  std::unordered_map<std::string, std::string> properties = {
+      {"property", "value"}};
+  auto connector =
+      connector::getConnectorFactory(
+          connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+          ->newConnector(
+              kTpchConnectorId,
+              std::make_shared<config::ConfigBase>(std::move(properties)));
+
+  const auto& config = connector->connectorConfig();
+  auto val = config->get<std::string>("property");
+  EXPECT_TRUE(val.has_value());
+  EXPECT_EQ(val.value(), "value");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {

--- a/velox/experimental/cudf/connectors/parquet/ParquetConnector.cpp
+++ b/velox/experimental/cudf/connectors/parquet/ParquetConnector.cpp
@@ -25,8 +25,8 @@ ParquetConnector::ParquetConnector(
     const std::string& id,
     std::shared_ptr<const facebook::velox::config::ConfigBase> config,
     folly::Executor* executor)
-    : Connector(id),
-      parquetConfig_(std::make_shared<ParquetConfig>(config)),
+    : Connector(id, std::move(config)),
+      parquetConfig_(std::make_shared<ParquetConfig>(connectorConfig())),
       executor_(executor) {
   LOG(INFO) << "cudf::Parquet connector " << connectorId() << " created.";
 }

--- a/velox/experimental/cudf/connectors/parquet/ParquetConnector.h
+++ b/velox/experimental/cudf/connectors/parquet/ParquetConnector.h
@@ -45,10 +45,6 @@ class ParquetConnector final : public Connector {
       const ColumnHandleMap& columnHandles,
       ConnectorQueryCtx* connectorQueryCtx) override final;
 
-  const std::shared_ptr<const ConfigBase>& connectorConfig() const override {
-    return parquetConfig_->config();
-  }
-
   std::unique_ptr<DataSink> createDataSink(
       RowTypePtr inputType,
       ConnectorInsertTableHandlePtr connectorInsertTableHandle,


### PR DESCRIPTION
Summary:
Previously for some connectors we were overriding the connectorConfig() method and returning a child class configuration field. Instead, we can create a constructor parameter for the connector config object and implement connectorConfig() directly in the interface class

Ran all the velox/connector/ tests to verify this change

Differential Revision: D81501098


