### PR TITLE
fix: Fix the needs input condition in smj plus other small fixes

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -199,10 +199,7 @@ void IndexLookupJoin::ensureInputLoaded(const InputBatchState& batch) {
   VELOX_CHECK_GT(numInputBatches(), 0);
   // Ensure each input vector are lazy loaded before process next batch. This is
   // to ensure the ordered lazy materialization in the source readers.
-  auto& input = batch.input;
-  for (auto i = 0; i < input->childrenSize(); ++i) {
-    input->childAt(i)->loadedVector();
-  }
+  loadColumns(batch.input, *operatorCtx_->execCtx());
 }
 
 void IndexLookupJoin::initInputBatches() {


### PR DESCRIPTION
Summary:
Fix the `needsInput()` condition in sorted merge join (SMJ), fix the start index in handleRightSideNullRows pluse code refactoring to enhance readability.

Key Changes
-----------

### 🐛 **Bug Fixes**

*   **Fixed `needsInput()` logic**: Removed incorrect special case for right joins that was checking for both `input_` and `rightInput_`. Now correctly returns `input_ == nullptr` for all join types, ensuring proper input flow control, such as clear input_ for right join when there is no right input.
*   **Added input validation**: Added `VELOX_CHECK_NULL(input_)` in `addInput()` to ensure input is null when adding new input, preventing potential issues with multiple inputs.

* **Fixed `handleRightSideNullRows()`: to search null from the next row and fix the output processing.

### 🔧 **Code Refactoring & Cleanup**

*   **Extracted helper methods** for better code organization:
    *   `needsInputFromRightSide()`: Checks if we need to fetch more input from the right side
    *   `getNextFromRightSide()`: Handles getting the next batch from the right side with proper error handling
    *   `processDrain()`: Manages draining logic when one or both sides are exhausted
*   **Improved method naming consistency**:
    *   `finishedLeftBatch()` → `leftBatchFinished()`
    *   `finishedRightBatch()` → `rightBatchFinished()`
    *   `futureRightSideInput_` → `rightSideInputFuture_`

Differential Revision: D81422339


