### PR TITLE
feat: Restrict the length of 'Field not found' error message

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -394,14 +394,23 @@ template <typename T>
 std::string makeFieldNotFoundErrorMessage(
     const T& name,
     const std::vector<std::string>& availableNames) {
+  static constexpr auto kMaxFields = 50;
+
+  const auto numAvailable = availableNames.size();
+
   std::stringstream errorMessage;
   errorMessage << "Field not found: " << name << ". Available fields are: ";
-  for (auto i = 0; i < availableNames.size(); ++i) {
+  for (auto i = 0; i < numAvailable && i < kMaxFields; ++i) {
     if (i > 0) {
       errorMessage << ", ";
     }
     errorMessage << availableNames[i];
   }
+
+  if (numAvailable > kMaxFields) {
+    errorMessage << ", ..." << (numAvailable - kMaxFields) << " more";
+  }
+
   errorMessage << ".";
   return errorMessage.str();
 }
@@ -875,7 +884,7 @@ RowTypePtr ROW(std::vector<std::string> names, std::vector<TypePtr> types) {
   return TypeFactory<TypeKind::ROW>::create(std::move(names), std::move(types));
 }
 
-RowTypePtr ROW(std::vector<std::string> names, TypePtr childType) {
+RowTypePtr ROW(std::vector<std::string> names, const TypePtr& childType) {
   const auto cnt = names.size();
   return ROW(std::move(names), std::vector(cnt, childType));
 }

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -488,6 +488,21 @@ TEST(TypeTest, row) {
   testTypeSerde(rowInner);
 }
 
+TEST(TypeTest, wideRow) {
+  std::vector<std::string> names;
+  names.reserve(1'000);
+  for (auto i = 0; i < 1'000; ++i) {
+    names.push_back(fmt::format("c{}", i));
+  }
+
+  auto rowType = ROW(std::move(names), BIGINT());
+
+  ASSERT_EQ(rowType->findChild("c17")->toString(), "BIGINT");
+  VELOX_ASSERT_THROW(
+      rowType->findChild("blah"),
+      "Field not found: blah. Available fields are: c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33, c34, c35, c36, c37, c38, c39, c40, c41, c42, c43, c44, c45, c46, c47, c48, c49, ...950 more");
+}
+
 TEST(TypeTest, serdeCache) {
   std::vector<std::string> names;
   names.reserve(100);


### PR DESCRIPTION
Summary: Include up to 50 available fields.

Differential Revision: D81520527


