### PR TITLE
refactor: Make PlanBuilder connector agnostic part 1

### DIFF
--- a/velox/connectors/CMakeLists.txt
+++ b/velox/connectors/CMakeLists.txt
@@ -32,3 +32,9 @@ endif()
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()
+
+add_library(velox_registered_connector_factories STATIC RegisterConnectorFactories.cpp)
+target_link_libraries(
+  velox_registered_connector_factories
+  PUBLIC $<$<BOOL:${VELOX_ENABLE_PARQUET}>:velox_dwio_parquet_reader> velox_dwio_common
+)

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -58,8 +58,8 @@ bool hasConnectorFactory(const std::string& connectorName) {
 }
 
 bool unregisterConnectorFactory(const std::string& connectorName) {
-  auto count = connectorFactories().erase(connectorName);
-  return count == 1;
+  auto factoryCount = connectorFactories().erase(connectorName);
+  return factoryCount == 1;
 }
 
 std::shared_ptr<ConnectorFactory> getConnectorFactory(
@@ -168,5 +168,7 @@ folly::dynamic ConnectorTableHandle::serializeBase(
 folly::dynamic ConnectorTableHandle::serialize() const {
   return serializeBase("ConnectorTableHandle");
 }
+
+ConnectorLocationHandle::~ConnectorLocationHandle() = default;
 
 } // namespace facebook::velox::connector

--- a/velox/connectors/ConnectorNames.h
+++ b/velox/connectors/ConnectorNames.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::connector {
+
+// TODO: Add a demo connector
+
+constexpr const char* kFuzzerConnectorName = "fuzzer";
+constexpr const char* kHiveConnectorName = "hive";
+constexpr const char* kIcebergConnectorName = "iceberg";
+constexpr const char* kTpchConnectorName = "tpch";
+constexpr const char* kTpcdsConnectorName = "tpcds";
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/RegisterConnectorFactories.cpp
+++ b/velox/connectors/RegisterConnectorFactories.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/RegisterConnectorFactories.h"
+
+#ifdef VELOX_ENABLE_HIVE_CONNECTOR
+#include "velox/connectors/hive/HiveConnector.h"
+#endif
+#ifdef VELOX_ENABLE_TPCDS_CONNECTOR
+#include "velox/connectors/tpcds/TpcdsConnector.h"
+#endif
+#ifdef VELOX_ENABLE_TPCH_CONNECTOR
+#include "velox/connectors/tpch/TpchConnector.h"
+#endif
+#ifdef VELOX_ENABLE_FUZZER_CONNECTOR
+#include "velox/connectors/fuzzer/FuzzerConnector.h"
+#endif
+
+namespace facebook::velox::connector {
+
+void registerConnectorFactories() {
+#ifdef VELOX_ENABLE_HIVE_CONNECTOR
+  hive::registerHiveConnectorFactory();
+#endif
+#ifdef VELOX_ENABLE_TPCDS_CONNECTOR
+  tpcds::registerTpcdsConnectorFactory();
+#endif
+#ifdef VELOX_ENABLE_TPCH_CONNECTOR
+  tpch::registerTpchConnectorFactory();
+#endif
+#ifdef VELOX_ENABLE_FUZZER_CONNECTOR
+  fuzzer::registerFuzzerConnectorFactory();
+#endif
+}
+
+void unregisterConnectorFactories() {
+#ifdef VELOX_ENABLE_HIVE_CONNECTOR
+  hive::registerHiveConnectorFactory();
+#endif
+#ifdef VELOX_ENABLE_TPCDS_CONNECTOR
+  tpcds::registerTpcdsConnectorFactory();
+#endif
+#ifdef VELOX_ENABLE_TPCH_CONNECTOR
+  tpch::registerTpchConnectorFactory();
+#endif
+#ifdef VELOX_ENABLE_FUZZER_CONNECTOR
+  fuzzer::registerFuzzerConnectorFactory();
+#endif
+}
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/RegisterConnectorFactories.h
+++ b/velox/connectors/RegisterConnectorFactories.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::connector {
+
+void registerConnectorFactories();
+
+void unregisterConnectorFactories();
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/fuzzer/FuzzerConnector.cpp
+++ b/velox/connectors/fuzzer/FuzzerConnector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/connectors/fuzzer/FuzzerConnector.h"
+#include "velox/connectors/ConnectorNames.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::connector::fuzzer {
@@ -67,6 +68,15 @@ std::optional<RowVectorPtr> FuzzerDataSource::next(
   completedRows_ += outputVector->size();
   completedBytes_ += outputVector->retainedSize();
   return outputVector;
+}
+
+bool registerFuzzerConnectorFactory(
+    std::unique_ptr<FuzzerConnectorFactory> factory) {
+  connector::registerConnectorFactory(std::move(factory));
+}
+
+bool unregisterFuzzerConnectorFactory() {
+  connector::unregisterConnectorFactory(connector::kFuzzerConnectorName);
 }
 
 } // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -145,4 +145,9 @@ class FuzzerConnectorFactory : public ConnectorFactory {
   // TODO: Add object makers like makeTableHandle, makeColumnHandle, etc.
 };
 
+bool registerFuzzerConnectorFactory(
+    std::unique_ptr<FuzzerConnectorFactory> factory);
+
+bool unregisterFuzzerConnectorFactory();
+
 } // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -141,6 +141,8 @@ class FuzzerConnectorFactory : public ConnectorFactory {
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<FuzzerConnector>(id, config, ioExecutor);
   }
+
+  // TODO: Add object makers like makeTableHandle, makeColumnHandle, etc.
 };
 
 } // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/hive/HiveConnector.h"
 
+#include "velox/connectors/ConnectorNames.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/HiveDataSource.h"
@@ -586,6 +587,12 @@ void HivePartitionFunctionSpec::registerSerDe() {
   auto& registry = DeserializationWithContextRegistryForSharedPtr();
   registry.Register(
       "HivePartitionFunctionSpec", HivePartitionFunctionSpec::deserialize);
+}
+
+bool registerHiveConnectorMetadataFactory(
+    std::unique_ptr<HiveConnectorMetadataFactory> factory) {
+  hiveConnectorMetadataFactories().push_back(std::move(factory));
+  return true;
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 
 using namespace facebook::velox::exec;
+using namespace facebook::velox::common;
 
 namespace facebook::velox::connector::hive {
 
@@ -97,6 +98,401 @@ void HiveConnector::registerSerDe() {
   HiveBucketProperty::registerSerDe();
   HiveSortingColumn::registerSerDe();
   HivePartitionFunctionSpec::registerSerDe();
+}
+
+std::shared_ptr<ConnectorSplit> HiveConnectorFactory::makeConnectorSplit(
+    const std::string& connectorId,
+    const std::string& filePath,
+    uint64_t start,
+    uint64_t length,
+    const folly::dynamic& options) const {
+  auto builder = HiveConnectorSplitBuilder(filePath)
+                     .start(start)
+                     .length(length)
+                     .connectorId(connectorId);
+
+  dwio::common::FileFormat fileFormat =
+      (!options.isNull() && options.count("fileFormat"))
+      ? static_cast<dwio::common::FileFormat>(options["fileFormat"].asInt())
+      : defaultFileFormat_;
+  builder.fileFormat(fileFormat);
+
+  int64_t splitWeight = (!options.isNull() && options.count("splitWeight"))
+      ? options["splitWeight"].asInt()
+      : 0;
+  builder.splitWeight(splitWeight);
+
+  bool cacheable = (!options.isNull() && options.count("cacheable"))
+      ? options["cacheable"].asBool()
+      : true;
+  builder.cacheable(cacheable);
+
+  if (!options.isNull() && options.count("infoColumns")) {
+    for (auto& kv : options["infoColumns"].items()) {
+      builder.infoColumn(kv.first.asString(), kv.second.asString());
+    }
+  }
+
+  if (!options.isNull() && options.count("partitionKeys")) {
+    for (auto& kv : options["partitionKeys"].items()) {
+      builder.partitionKey(
+          kv.first.asString(),
+          kv.second.isNull()
+              ? std::nullopt
+              : std::optional<std::string>(kv.second.asString()));
+    }
+  }
+
+  if (!options.isNull() && options.count("tableBucketNumber")) {
+    builder.tableBucketNumber(options["tableBucketNumber"].asInt());
+  }
+
+  if (!options.isNull() && options.count("bucketConversion")) {
+    HiveBucketConversion bucketConversion;
+    const auto& bucketConversionOption = options["bucketConversion"];
+    bucketConversion.tableBucketCount =
+        bucketConversionOption["tableBucketCount"].asInt();
+    bucketConversion.partitionBucketCount =
+        bucketConversionOption["partitionBucketCount"].asInt();
+    for (auto& bucketColumnHandlesOption :
+         bucketConversionOption["bucketColumnHandles"]) {
+      bucketConversion.bucketColumnHandles.push_back(
+          std::const_pointer_cast<HiveColumnHandle>(
+              ISerializable::deserialize<HiveColumnHandle>(
+                  bucketColumnHandlesOption)));
+    }
+    builder.bucketConversion(bucketConversion);
+  }
+
+  if (!options.isNull() && options.count("customSplitInfo")) {
+    std::unordered_map<std::string, std::string> info;
+    for (auto& kv : options["customSplitInfo"].items()) {
+      info[kv.first.asString()] = kv.second.asString();
+    }
+    builder.customSplitInfo(info);
+  }
+
+  if (!options.isNull() && options.count("extraFileInfo")) {
+    auto extra = options["extraFileInfo"].isNull()
+        ? std::shared_ptr<std::string>()
+        : std::make_shared<std::string>(options["extraFileInfo"].asString());
+    builder.extraFileInfo(extra);
+  }
+
+  if (!options.isNull() && options.count("serdeParameters")) {
+    std::unordered_map<std::string, std::string> serde;
+    for (auto& kv : options["serdeParameters"].items()) {
+      serde[kv.first.asString()] = kv.second.asString();
+    }
+    builder.serdeParameters(serde);
+  }
+
+  if (!options.isNull() && options.count("fileProperties")) {
+    FileProperties props;
+    const auto& propertiesOption = options["fileProperties"];
+    if (propertiesOption.count("fileSize") &&
+        !propertiesOption["fileSize"].isNull()) {
+      props.fileSize = propertiesOption["fileSize"].asInt();
+    }
+    if (propertiesOption.count("modificationTime") &&
+        !propertiesOption["modificationTime"].isNull()) {
+      props.modificationTime = propertiesOption["modificationTime"].asInt();
+    }
+    builder.fileProperties(props);
+  }
+
+  if (!options.isNull() && options.count("rowIdProperties")) {
+    RowIdProperties rowIdProperties;
+    const auto& rowIdPropertiesOption = options["rowIdProperties"];
+    rowIdProperties.metadataVersion =
+        rowIdPropertiesOption["metadataVersion"].asInt();
+    rowIdProperties.partitionId = rowIdPropertiesOption["partitionId"].asInt();
+    rowIdProperties.tableGuid = rowIdPropertiesOption["tableGuid"].asString();
+    builder.rowIdProperties(rowIdProperties);
+  }
+
+  return builder.build();
+}
+
+std::shared_ptr<connector::ColumnHandle> HiveConnectorFactory::makeColumnHandle(
+    const std::string& connectorId,
+    const std::string& name,
+    const TypePtr& dataType,
+    const folly::dynamic& options) const {
+  using HiveColumnType = hive::HiveColumnHandle::ColumnType;
+  HiveColumnType hiveColumnType = HiveColumnType::kRegular;
+
+  if (options.isNull()) {
+    return std::make_shared<HiveColumnHandle>(
+        name, hiveColumnType, dataType, dataType);
+  }
+
+  if (options.count("columnType") && options["columnType"].isString()) {
+    std::string columnType = options["columnType"].asString();
+    // Accept a few friendly spellings, case-insensitive.
+    folly::toLowerAscii(columnType);
+
+    if (columnType == "kpartitionkey" || columnType == "partition_key" ||
+        columnType == "partitionkey") {
+      hiveColumnType = HiveColumnType::kPartitionKey;
+    } else if (columnType == "kregular" || columnType == "regular") {
+      hiveColumnType = HiveColumnType::kRegular;
+    } else if (
+        columnType == "ksynthesized" || columnType == "synthesized" ||
+        columnType == "synthetic") {
+      hiveColumnType = HiveColumnType::kSynthesized;
+    } else if (
+        columnType == "krowindex" || columnType == "row_index" ||
+        columnType == "rowindex") {
+      hiveColumnType = HiveColumnType::kRowIndex;
+    } else if (
+        columnType == "krowid" || columnType == "row_id" ||
+        columnType == "rowid") {
+      hiveColumnType = HiveColumnType::kRowId;
+    }
+  }
+
+  TypePtr hiveType =
+      options.count("hiveType") ? Type::create(options["hiveType"]) : dataType;
+
+  //  subfields would be serialized as a vector of strings;
+  std::vector<common::Subfield> subfields;
+  if (auto rs = options.get_ptr("requiredSubfields")) {
+    subfields.reserve(rs->size());
+    for (auto& v : *rs) {
+      subfields.emplace_back(v.asString());
+    }
+  }
+
+  HiveColumnHandle::ColumnParseParameters parseParams{
+      HiveColumnHandle::ColumnParseParameters::kISO8601};
+  if (auto cp = options.get_ptr("columnParseParameters")) {
+    auto formatName =
+        cp->getDefault("partitionDateValueFormat", "ISO8601").asString();
+    if (formatName == "DaysSinceEpoch" || formatName == "kDaysSinceEpoch") {
+      parseParams.partitionDateValueFormat =
+          HiveColumnHandle::ColumnParseParameters::kDaysSinceEpoch;
+    } else {
+      parseParams.partitionDateValueFormat =
+          HiveColumnHandle::ColumnParseParameters::kISO8601;
+    }
+  }
+
+  return std::make_shared<HiveColumnHandle>(
+      name,
+      hiveColumnType,
+      dataType,
+      hiveType,
+      std::move(subfields),
+      parseParams);
+}
+
+std::shared_ptr<ConnectorTableHandle> HiveConnectorFactory::makeTableHandle(
+    const std::string& connectorId,
+    const std::string& tableName,
+    std::vector<std::shared_ptr<const connector::ColumnHandle>> columnHandles,
+    const folly::dynamic& options) const {
+  bool filterPushdownEnabled =
+      options.getDefault("filterPushdownEnabled", true).asBool();
+
+  common::SubfieldFilters subfieldFilters;
+  if (auto sf = options.get_ptr("subfieldFilters")) {
+    subfieldFilters.reserve(sf->size());
+
+    for (auto& kv : sf->items()) {
+      // 1) Parse the key string into a Subfield
+      //    (uses Subfield(const std::string&) and default separators)
+      Subfield subfield(kv.first.asString());
+
+      // 2) Deserialize the Filter from its dynamic form.
+      //    Assumes every Filter subclass registered a SerDe entry in
+      //    Filter::registerSerDe().
+      auto filter = ISerializable::deserialize<Filter>(
+          kv.second, /* context = */ nullptr);
+
+      subfieldFilters.emplace(
+          std::move(subfield), std::const_pointer_cast<Filter>(filter));
+    }
+  }
+
+  core::TypedExprPtr remainingFilter = nullptr;
+  if (auto rf = options.get_ptr("remainingFilter")) {
+    // assuming rf["expr"] holds the serialized expression
+    remainingFilter = ISerializable::deserialize<core::ITypedExpr>(*rf);
+  }
+
+  std::unordered_map<std::string, std::string> tableParameters;
+  if (auto tp = options.get_ptr("tableParameters")) {
+    for (auto& kv : tp->items()) {
+      tableParameters.emplace(kv.first.asString(), kv.second.asString());
+    }
+  }
+
+  // build RowTypePtr from columnHandles
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  names.reserve(columnHandles.size());
+  types.reserve(columnHandles.size());
+  for (auto& col : columnHandles) {
+    auto hiveCol = std::static_pointer_cast<const HiveColumnHandle>(col);
+    names.push_back(hiveCol->name());
+    types.push_back(hiveCol->dataType());
+  }
+  auto dataColumns = ROW(std::move(names), std::move(types));
+
+  return std::make_shared<HiveTableHandle>(
+      connectorId,
+      tableName,
+      filterPushdownEnabled,
+      std::move(subfieldFilters),
+      std::move(remainingFilter),
+      dataColumns,
+      std::move(tableParameters));
+}
+
+std::shared_ptr<ConnectorInsertTableHandle>
+HiveConnectorFactory::makeInsertTableHandle(
+    const std::string& connectorId,
+    std::vector<std::shared_ptr<const connector::ColumnHandle>> inputColumns,
+    std::shared_ptr<const ConnectorLocationHandle> locationHandle,
+    const folly::dynamic& options) const {
+  // Convert inputColumns
+  std::vector<std::shared_ptr<const HiveColumnHandle>> inputHiveColumns;
+  inputHiveColumns.reserve(inputColumns.size());
+  for (const auto& handle : inputColumns) {
+    inputHiveColumns.push_back(
+        std::static_pointer_cast<const HiveColumnHandle>(handle));
+  }
+
+  auto hiveLoc =
+      std::dynamic_pointer_cast<const hive::LocationHandle>(locationHandle);
+  VELOX_CHECK(
+      hiveLoc,
+      "HiveConnectorFactory::makeInsertTableHandle: "
+      "expected HiveLocationHandle");
+
+  auto fmt =
+      options
+          .getDefault(
+              "storageFormat", static_cast<int>(dwio::common::FileFormat::DWRF))
+          .asInt();
+  auto storageFormat = static_cast<dwio::common::FileFormat>(fmt);
+
+  std::shared_ptr<const HiveBucketProperty> bucketProperty = nullptr;
+  if (auto bp = options.get_ptr("bucketProperty")) {
+    bucketProperty = HiveBucketProperty::deserialize(*bp, nullptr);
+  }
+
+  std::optional<common::CompressionKind> compressionKind;
+  if (auto ck = options.get_ptr("compressionKind")) {
+    compressionKind = static_cast<common::CompressionKind>(ck->asInt());
+  }
+
+  std::unordered_map<std::string, std::string> serdeParameters;
+  if (auto sp = options.get_ptr("serdeParameters")) {
+    for (auto& kv : sp->items()) {
+      serdeParameters.emplace(kv.first.asString(), kv.second.asString());
+    }
+  }
+
+  std::shared_ptr<dwio::common::WriterOptions> writerOptions = nullptr;
+  if (auto wo = options.get_ptr("writerOptions")) {
+    writerOptions = dwio::common::WriterOptions::deserialize(*wo);
+  }
+
+  bool ensureFiles = options.getDefault("ensureFiles", false).asBool();
+
+  auto fileNameGen = HiveInsertFileNameGenerator::deserialize(
+      *options.get_ptr("fileNameGenerator"), nullptr);
+
+  return std::make_shared<HiveInsertTableHandle>(
+      std::move(inputHiveColumns),
+      hiveLoc,
+      storageFormat,
+      std::move(bucketProperty),
+      compressionKind,
+      std::move(serdeParameters),
+      std::move(writerOptions),
+      ensureFiles,
+      std::move(fileNameGen));
+}
+
+std::shared_ptr<ConnectorLocationHandle>
+HiveConnectorFactory::makeLocationHandle(
+    const std::string& connectorId,
+    LocationHandle::TableType tableType,
+    const folly::dynamic& options) const {
+  VELOX_CHECK(options.isObject(), "Expected options to be a dynamic object");
+
+  // Required fields
+  auto targetPath = options.at("targetPath").asString();
+  auto writePath = options.at("writePath").asString();
+
+  // Optional field: targetFileName
+  std::string targetFileName;
+  if (options.count("targetFileName") &&
+      !options.at("targetFileName").isNull()) {
+    targetFileName = options.at("targetFileName").asString();
+  }
+
+  return std::make_shared<LocationHandle>(
+      std::move(targetPath),
+      std::move(writePath),
+      tableType,
+      std::move(targetFileName),
+      connectorId);
+}
+
+core::PartitionFunctionSpecPtr HiveConnectorFactory::makePartitionFunctionSpec(
+    const std::string& /*connectorId*/,
+    const folly::dynamic& options) const {
+  VELOX_CHECK(options.isObject(), "Expected options to be a dynamic object");
+
+  // Required: number of buckets
+  const int numBuckets = options.at("numBuckets").asInt();
+
+  // Optional: explicit bucket-to-partition mapping
+  std::vector<int> bucketToPartition;
+  if (options.count("bucketToPartition") &&
+      !options["bucketToPartition"].isNull()) {
+    bucketToPartition = ISerializable::deserialize<std::vector<int>>(
+        options["bucketToPartition"]);
+  }
+
+  // Required: key channels (by column index) for the bucket function
+  // NOTE: Keep the key name consistent with HashPartitionFunctionSpec
+  // ("keyChannels")
+  std::vector<column_index_t> channels =
+      ISerializable::deserialize<std::vector<column_index_t>>(
+          options.at("keyChannels"));
+
+  // Optional: constants used as key(s) (serialized ConstantTypedExpr[])
+  std::vector<VectorPtr> constValues;
+  if (options.count("constants") && !options["constants"].isNull()) {
+    const auto typedConsts =
+        ISerializable::deserialize<std::vector<velox::core::ConstantTypedExpr>>(
+            options["constants"]);
+    constValues.reserve(typedConsts.size());
+
+    for (const auto& c : typedConsts) {
+      VELOX_CHECK_NOT_NULL(c);
+      constValues.emplace_back(c->toConstantVector(pool_.get()));
+    }
+  }
+
+  if (bucketToPartition.empty()) {
+    // Spec form where mapping is derived at create() time (round-robin and
+    // optional local shuffle).
+    return std::make_shared<velox::connector::hive::HivePartitionFunctionSpec>(
+        numBuckets, std::move(channels), std::move(constValues));
+  }
+
+  // Spec with explicit mapping.
+  return std::make_shared<velox::connector::hive::HivePartitionFunctionSpec>(
+      numBuckets,
+      std::move(bucketToPartition),
+      std::move(channels),
+      std::move(constValues));
 }
 
 std::unique_ptr<core::PartitionFunction> HivePartitionFunctionSpec::create(

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -193,4 +193,8 @@ class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {
   const std::vector<VectorPtr> constValues_;
 };
 
+bool registerHiveConnectorFactory(std::unique_ptr<HiveConnectorFactory>);
+
+bool unregisterHiveConnectorFactory();
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -19,6 +19,7 @@
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/core/PlanNode.h"
+#include "velox/dwio/common/Options.h"
 
 namespace facebook::velox::dwio::common {
 class DataSink;
@@ -98,6 +99,47 @@ class HiveConnectorFactory : public ConnectorFactory {
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<HiveConnector>(id, config, ioExecutor);
   }
+
+  std::shared_ptr<connector::ConnectorSplit> makeConnectorSplit(
+      const std::string& connectorId,
+      const std::string& filePath,
+      uint64_t start,
+      uint64_t length,
+      const folly::dynamic& options = {}) const override;
+
+  std::shared_ptr<connector::ColumnHandle> makeColumnHandle(
+      const std::string& connectorId,
+      const std::string& name,
+      const TypePtr& type,
+      const folly::dynamic& options = {}) const override;
+
+  std::shared_ptr<ConnectorTableHandle> makeTableHandle(
+      const std::string& connectorId,
+      const std::string& tableName,
+      std::vector<std::shared_ptr<const connector::ColumnHandle>> columnHandles,
+      const folly::dynamic& options) const override;
+
+  std::shared_ptr<ConnectorInsertTableHandle> makeInsertTableHandle(
+      const std::string& connectorId,
+      std::vector<std::shared_ptr<const connector::ColumnHandle>> inputColumns,
+      std::shared_ptr<const ConnectorLocationHandle> locationHandle,
+      const folly::dynamic& options = {}) const override;
+
+  std::shared_ptr<connector::ConnectorLocationHandle> makeLocationHandle(
+      const std::string& connectorId,
+      connector::ConnectorLocationHandle::TableType tableType =
+          connector::ConnectorLocationHandle::TableType::kNew,
+      const folly::dynamic& options = {}) const override;
+
+  core::PartitionFunctionSpecPtr makePartitionFunctionSpec(
+      const std::string& connectorId,
+      const folly::dynamic& options = {}) const override;
+
+ private:
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  dwio::common::FileFormat defaultFileFormat_{
+      dwio::common::FileFormat::PARQUET};
 };
 
 class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {

--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -17,6 +17,7 @@
 
 #include <optional>
 #include <unordered_map>
+
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileProperties.h"
 #include "velox/connectors/hive/TableHandle.h"

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -17,6 +17,7 @@
 
 #include "velox/common/compression/Compression.h"
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/ConnectorNames.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
 #include "velox/connectors/hive/TableHandle.h"
@@ -31,24 +32,18 @@ class LocationHandle;
 using LocationHandlePtr = std::shared_ptr<const LocationHandle>;
 
 /// Location related properties of the Hive table to be written.
-class LocationHandle : public ISerializable {
+class LocationHandle : public ConnectorLocationHandle {
  public:
-  enum class TableType {
-    /// Write to a new table to be created.
-    kNew,
-    /// Write to an existing table.
-    kExisting,
-  };
-
   LocationHandle(
       std::string targetPath,
       std::string writePath,
       TableType tableType,
-      std::string targetFileName = "")
-      : targetPath_(std::move(targetPath)),
+      std::string targetFileName = "",
+      const std::string& connectorId = kHiveConnectorName)
+      : ConnectorLocationHandle(connectorId, tableType),
+        targetPath_(std::move(targetPath)),
         targetFileName_(std::move(targetFileName)),
-        writePath_(std::move(writePath)),
-        tableType_(tableType) {}
+        writePath_(std::move(writePath)) {}
 
   const std::string& targetPath() const {
     return targetPath_;
@@ -62,15 +57,11 @@ class LocationHandle : public ISerializable {
     return writePath_;
   }
 
-  TableType tableType() const {
-    return tableType_;
-  }
-
-  std::string toString() const;
-
-  static void registerSerDe();
+  std::string toString() const override;
 
   folly::dynamic serialize() const override;
+
+  static void registerSerDe();
 
   static LocationHandlePtr create(const folly::dynamic& obj);
 
@@ -85,8 +76,6 @@ class LocationHandle : public ISerializable {
   const std::string targetFileName_;
   // Staging directory path.
   const std::string writePath_;
-  // Whether the table to be written is new, already existing or temporary.
-  const TableType tableType_;
 };
 
 class HiveSortingColumn : public ISerializable {
@@ -128,6 +117,14 @@ class HiveBucketProperty : public ISerializable {
       const std::vector<std::string>& bucketedBy,
       const std::vector<TypePtr>& bucketedTypes,
       const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy);
+
+  HiveBucketProperty(
+      Kind kind,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const std::vector<TypePtr>& bucketedTypes,
+      const std::vector<std::string>& sortColumns,
+      const std::vector<core::SortOrder>& sortOrders);
 
   Kind kind() const {
     return kind_;
@@ -177,7 +174,7 @@ class HiveBucketProperty : public ISerializable {
   const int32_t bucketCount_;
   const std::vector<std::string> bucketedBy_;
   const std::vector<TypePtr> bucketTypes_;
-  const std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy_;
+  std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy_;
 };
 
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsMultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsMultipleEndpointsTest.cpp
@@ -91,6 +91,7 @@ class GcsMultipleEndpointsTest : public testing::Test,
                         0,
                         {},
                         {},
+                        {},
                         dwio::common::FileFormat::PARQUET,
                         {},
                         connectorId)

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -93,6 +93,7 @@ class S3MultipleEndpoints : public S3Test, public ::test::VectorTestBase {
                         0,
                         {},
                         {},
+                        {},
                         dwio::common::FileFormat::PARQUET,
                         {},
                         connectorId)

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   HiveConnectorTest.cpp
   HiveConnectorUtilTest.cpp
   HiveConnectorSerDeTest.cpp
+  HiveObjectFactoryTest.cpp
   HivePartitionFunctionTest.cpp
   HivePartitionUtilTest.cpp
   HiveSplitTest.cpp

--- a/velox/connectors/hive/tests/HiveObjectFactoryTest.cpp
+++ b/velox/connectors/hive/tests/HiveObjectFactoryTest.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/dynamic.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/MemoryAllocator.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::connector::hive::test {
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive;
+using facebook::velox::connector::ConnectorLocationHandle;
+
+static constexpr char kConnectorId[] = "hive-test";
+
+class HiveObjectFactoryTest : public exec::test::OperatorTestBase {
+ public:
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+
+    Type::registerSerDe();
+    common::Filter::registerSerDe();
+    connector::hive::HiveTableHandle::registerSerDe();
+    connector::hive::LocationHandle::registerSerDe();
+    connector::hive::HiveColumnHandle::registerSerDe();
+    connector::hive::HiveInsertTableHandle::registerSerDe();
+    connector::hive::HiveConnectorSplit::registerSerDe();
+    connector::hive::HiveInsertFileNameGenerator::registerSerDe();
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+    Type::registerSerDe();
+  }
+
+  void TearDown() override {
+    factory_.reset();
+  }
+
+  std::shared_ptr<connector::ColumnHandle> makeHiveColumnHandle(
+      const std::string& name,
+      HiveColumnHandle::ColumnType columnType,
+      const TypePtr& dataType,
+      const TypePtr& hiveType,
+      std::vector<std::string> requiredSubfields) {
+    folly::dynamic opts = folly::dynamic::object;
+
+    // columnType would be serialized as int32_t
+    opts["columnType"] = (int32_t)columnType;
+    opts["hiveType"] = hiveType->serialize();
+
+    opts["requiredSubfields"] = folly::dynamic::array();
+    for (const auto& subfield : requiredSubfields) {
+      opts["requiredSubfields"].push_back(subfield);
+    }
+
+    auto colHandle =
+        factory_->makeColumnHandle(kConnectorId, "colX", dataType, opts);
+
+    return colHandle;
+  }
+
+ protected:
+  std::unique_ptr<HiveConnectorFactory> factory_;
+};
+
+TEST_F(HiveObjectFactoryTest, MakeConnectorSplitDefaults) {
+  // No options: only filePath/start/length/connectorId are set
+  auto splitPtr = factory_->makeConnectorSplit(
+      kConnectorId, "s3://bucket/path/file.orc", 123, 456);
+  auto* split = dynamic_cast<HiveConnectorSplit*>(splitPtr.get());
+  ASSERT_NE(split, nullptr);
+  EXPECT_EQ(split->filePath, "s3://bucket/path/file.orc");
+  EXPECT_EQ(split->start, 123);
+  EXPECT_EQ(split->length, 456);
+  EXPECT_EQ(split->connectorId, kConnectorId);
+
+  // Defaults: PARQUET format, weight=0, cacheable=true
+  // TODO: use constant literal
+  EXPECT_EQ(split->fileFormat, dwio::common::FileFormat::PARQUET);
+  EXPECT_EQ(split->splitWeight, 0);
+  EXPECT_TRUE(split->cacheable);
+}
+
+TEST_F(HiveObjectFactoryTest, MakeConnectorSplitWithOptions) {
+  folly::dynamic opts = folly::dynamic::object;
+
+  // Basic configuration
+  opts["fileFormat"] = static_cast<int>(dwio::common::FileFormat::PARQUET);
+  opts["splitWeight"] = 42;
+  opts["cacheable"] = true;
+
+  // Info columns map: column name -> info string
+  opts["infoColumns"] = folly::dynamic::object;
+  opts["infoColumns"]["colA"] = "infoA";
+  opts["infoColumns"]["colB"] = "infoB";
+
+  // Partition keys map: key -> value
+  opts["partitionKeys"] = folly::dynamic::object;
+  opts["partitionKeys"]["p1"] = "v1";
+
+  auto splitPtr =
+      factory_->makeConnectorSplit(kConnectorId, "/tmp/f.p", 0, 10, opts);
+  auto* split = dynamic_cast<HiveConnectorSplit*>(splitPtr.get());
+  ASSERT_NE(split, nullptr);
+
+  EXPECT_EQ(split->fileFormat, dwio::common::FileFormat::PARQUET);
+  EXPECT_EQ(split->splitWeight, 42);
+  EXPECT_TRUE(split->cacheable);
+
+  // infoColumns
+  auto info = split->infoColumns;
+  EXPECT_EQ(info.at("colA"), "infoA");
+  EXPECT_EQ(info.at("colB"), "infoB");
+
+  // partitionKeys
+  auto parts = split->partitionKeys;
+  ASSERT_EQ(parts.size(), 1);
+  EXPECT_EQ(parts.count("p1"), 1);
+  EXPECT_EQ(parts["p1"], "v1");
+}
+
+TEST_F(HiveObjectFactoryTest, MakeTableHandleWithOptions) {
+  // Build a RowType for data columns: two ints
+  auto rowType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
+
+  // ColumnHandles
+  auto c0 = makeHiveColumnHandle(
+      "c0",
+      HiveColumnHandle::ColumnType::kRegular,
+      INTEGER(),
+      INTEGER(),
+      {"c0"});
+  auto c1 = makeHiveColumnHandle(
+      "c1", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT(), {"c1"});
+
+  // Options: disable filter pushdown, add subfield filter & remaining filter &
+  // tableParameters
+  folly::dynamic opts = folly::dynamic::object;
+
+  // Basic configuration
+  opts["filterPushdownEnabled"] = false;
+
+  // common::SubfieldFilters : std::unordered_map<Subfield, FilterPtr>;
+  auto filter = std::make_unique<common::BigintRange>(-100, 100, false);
+  opts["subfieldFilters"] = folly::dynamic::object;
+  opts["subfieldFilters"]["c0"] = filter->serialize();
+
+  // core::TypedExprPtr remainingFilter : std::shared_ptr<const ITypedExpr>;
+  auto remainingFilter = parseExpr("c1 + 1 > 1", rowType);
+  opts["remainingFilter"] = remainingFilter->serialize();
+
+  // Arbitrary table parameters
+  opts["tableParameters"] = folly::dynamic::object;
+  opts["tableParameters"]["pA"] = "vA";
+
+  auto handlePtr =
+      factory_->makeTableHandle(kConnectorId, "tbl", {c0, c1}, opts);
+  auto* hiveHandle = dynamic_cast<HiveTableHandle*>(handlePtr.get());
+  ASSERT_NE(hiveHandle, nullptr);
+
+  EXPECT_FALSE(hiveHandle->isFilterPushdownEnabled());
+
+  const auto& subfieldFilters = hiveHandle->subfieldFilters();
+  ASSERT_EQ(subfieldFilters.count(common::Subfield("c0")), 1);
+  subfieldFilters.at(common::Subfield("c0"))->testingEquals(*filter);
+
+  auto remainingFilterCreated = hiveHandle->remainingFilter();
+  ASSERT_NE(remainingFilterCreated, nullptr);
+  ASSERT_EQ(*remainingFilterCreated, *remainingFilter);
+
+  auto params = hiveHandle->tableParameters();
+  ASSERT_EQ(params.size(), 1);
+  EXPECT_EQ(params.at("pA"), "vA");
+}
+
+TEST_F(HiveObjectFactoryTest, MakeColumnHandle) {
+  auto colHandle = makeHiveColumnHandle(
+      "colX",
+      HiveColumnHandle::ColumnType::kRegular,
+      BIGINT(),
+      BIGINT(),
+      std::vector<std::string>({"f1", "f2"}));
+
+  auto* hiveColumnHandle = dynamic_cast<HiveColumnHandle*>(colHandle.get());
+  ASSERT_NE(hiveColumnHandle, nullptr);
+
+  EXPECT_EQ(hiveColumnHandle->name(), "colX");
+  EXPECT_EQ(
+      hiveColumnHandle->columnType(), HiveColumnHandle::ColumnType::kRegular);
+  EXPECT_EQ(hiveColumnHandle->dataType(), BIGINT());
+  EXPECT_EQ(hiveColumnHandle->hiveType(), BIGINT());
+
+  std::vector<common::Subfield> requiredSubfields;
+  requiredSubfields.emplace_back("f1");
+  requiredSubfields.emplace_back("f2");
+  EXPECT_EQ(hiveColumnHandle->requiredSubfields(), requiredSubfields);
+}
+
+TEST_F(HiveObjectFactoryTest, MakeLocationHandle) {
+  folly::dynamic opts = folly::dynamic::object;
+
+  // Basic configuration
+  opts["targetPath"] = "/tmp/out1";
+  opts["writePath"] = "/tmp/out2";
+  opts["targetFileName"] = "test.parquet";
+
+  // Default: writeDirectory == targetDirectory
+  auto locationHandle1 = factory_->makeLocationHandle(
+      kConnectorId, ConnectorLocationHandle::TableType::kNew, opts);
+
+  auto* hiveLocationHandle =
+      dynamic_cast<hive::LocationHandle*>(locationHandle1.get());
+  ASSERT_NE(hiveLocationHandle, nullptr);
+
+  EXPECT_EQ(hiveLocationHandle->targetPath(), "/tmp/out1");
+  EXPECT_EQ(hiveLocationHandle->writePath(), "/tmp/out2");
+  EXPECT_EQ(hiveLocationHandle->targetFileName(), "test.parquet");
+  EXPECT_EQ(
+      locationHandle1->tableType(), ConnectorLocationHandle::TableType::kNew);
+}
+
+} // namespace facebook::velox::connector::hive::test

--- a/velox/connectors/tpcds/TpcdsConnector.cpp
+++ b/velox/connectors/tpcds/TpcdsConnector.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include "velox/connectors/ConnectorNames.h"
 #include "velox/connectors/tpcds/TpcdsConnector.h"
 #include "velox/tpcds/gen/DSDGenIterator.h"
 
@@ -138,4 +139,14 @@ std::optional<RowVectorPtr> TpcdsDataSource::next(
 
   return projectOutputColumns(outputVector);
 }
+
+bool registerTpcdsConnectorFactory(
+    std::unique_ptr<TpcdsConnectorFactory> factory) {
+  connector::registerConnectorFactory(std::move(factory));
+}
+
+bool unregisterTpcdsConnectorFactory() {
+  connector::unregisterConnectorFactory(connector::kTpcdsConnectorName);
+}
+
 } // namespace facebook::velox::connector::tpcds

--- a/velox/connectors/tpcds/TpcdsConnector.h
+++ b/velox/connectors/tpcds/TpcdsConnector.h
@@ -179,6 +179,8 @@ class TpcdsConnectorFactory : public ConnectorFactory {
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<TpcdsConnector>(id, config, ioExecutor);
   }
+
+  // TODO: Add object makers like makeTableHandle, makeColumnHandle, etc.
 };
 
 } // namespace facebook::velox::connector::tpcds

--- a/velox/connectors/tpcds/TpcdsConnector.h
+++ b/velox/connectors/tpcds/TpcdsConnector.h
@@ -183,4 +183,9 @@ class TpcdsConnectorFactory : public ConnectorFactory {
   // TODO: Add object makers like makeTableHandle, makeColumnHandle, etc.
 };
 
+bool registerTpchConnectorFactory(
+    std::unique_ptr<TpcdsConnectorFactory> factory);
+
+bool unregisterTpcdsConnectorFactory();
+
 } // namespace facebook::velox::connector::tpcds

--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/connectors/tpch/TpchConnector.h"
+
+#include "velox/connectors/ConnectorNames.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/expression/Expr.h"
 #include "velox/tpch/gen/TpchGen.h"
@@ -28,6 +30,15 @@ TpchConnector::TpchConnector(
     std::shared_ptr<const config::ConfigBase> config,
     folly::Executor* /*executor*/)
     : Connector(id, std::move(config)) {}
+
+bool registerTpchConnectorFactory(
+    std::unique_ptr<TpchConnectorFactory> factory) {
+  connector::registerConnectorFactory(std::move(factory));
+}
+
+bool unregisterTpcdsConnectorFactory() {
+  connector::unregisterConnectorFactory(connector::kTpchConnectorName);
+}
 
 namespace {
 

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -201,4 +201,9 @@ class TpchConnectorFactory : public ConnectorFactory {
   }
 };
 
+bool registerTpchConnectorFactory(
+    std::unique_ptr<TpchConnectorFactory> factory);
+
+bool unregisterTpcdsConnectorFactory();
+
 } // namespace facebook::velox::connector::tpch

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -34,7 +34,7 @@ class TpchColumnHandle : public ColumnHandle {
  public:
   explicit TpchColumnHandle(const std::string& name) : name_(name) {}
 
-  const std::string& name() const {
+  const std::string& name() const override {
     return name_;
   }
 
@@ -196,6 +196,8 @@ class TpchConnectorFactory : public ConnectorFactory {
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<TpchConnector>(id, config, ioExecutor);
+
+    // TODO: Add object makers like makeTableHandle, makeColumnHandle, etc.
   }
 };
 

--- a/velox/core/PartitionFunction.h
+++ b/velox/core/PartitionFunction.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::core {
+
+/// Calculates partition number for each row of the specified vector.
+class PartitionFunction {
+ public:
+  virtual ~PartitionFunction() = default;
+
+  /// @param input RowVector to split into partitions.
+  /// @param [out] partitions Computed partition numbers for each row in
+  /// 'input'.
+  /// @return Returns partition number in case all rows of 'input' are
+  /// assigned to the same partition. In this case 'partitions' vector is left
+  /// unchanged. Used to optimize round-robin partitioning in local exchange.
+  virtual std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) = 0;
+};
+
+/// Factory class for creating PartitionFunction instances.
+class PartitionFunctionSpec : public ISerializable {
+ public:
+  /// If 'localExchange' is true, the partition function is used for local
+  /// exchange within a velox task.
+  virtual std::unique_ptr<PartitionFunction> create(
+      int numPartitions,
+      bool localExchange = false) const = 0;
+
+  virtual ~PartitionFunctionSpec() = default;
+
+  virtual std::string toString() const = 0;
+};
+
+using PartitionFunctionSpecPtr = std::shared_ptr<const PartitionFunctionSpec>;
+
+class GatherPartitionFunctionSpec : public PartitionFunctionSpec {
+ public:
+  std::unique_ptr<PartitionFunction> create(
+      int /*numPartitions*/,
+      bool /*localExchange*/) const override {
+    VELOX_UNREACHABLE();
+  }
+
+  std::string toString() const override {
+    return "gather";
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "GatherPartitionFunctionSpec";
+    return obj;
+  }
+
+  static PartitionFunctionSpecPtr deserialize(
+      const folly::dynamic& /* obj */,
+      void* /* context */) {
+    return std::make_shared<GatherPartitionFunctionSpec>();
+  }
+};
+
+} // namespace facebook::velox::core

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -22,6 +22,7 @@
 #include "velox/common/Enums.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
+#include "velox/core/PartitionFunction.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/vector/VectorStream.h"
 
@@ -2340,63 +2341,6 @@ class LocalMergeNode : public PlanNode {
 };
 
 using LocalMergeNodePtr = std::shared_ptr<const LocalMergeNode>;
-
-/// Calculates partition number for each row of the specified vector.
-class PartitionFunction {
- public:
-  virtual ~PartitionFunction() = default;
-
-  /// @param input RowVector to split into partitions.
-  /// @param [out] partitions Computed partition numbers for each row in
-  /// 'input'.
-  /// @return Returns partition number in case all rows of 'input' are
-  /// assigned to the same partition. In this case 'partitions' vector is left
-  /// unchanged. Used to optimize round-robin partitioning in local exchange.
-  virtual std::optional<uint32_t> partition(
-      const RowVector& input,
-      std::vector<uint32_t>& partitions) = 0;
-};
-
-/// Factory class for creating PartitionFunction instances.
-class PartitionFunctionSpec : public ISerializable {
- public:
-  /// If 'localExchange' is true, the partition function is used for local
-  /// exchange within a velox task.
-  virtual std::unique_ptr<PartitionFunction> create(
-      int numPartitions,
-      bool localExchange = false) const = 0;
-
-  virtual ~PartitionFunctionSpec() = default;
-
-  virtual std::string toString() const = 0;
-};
-
-using PartitionFunctionSpecPtr = std::shared_ptr<const PartitionFunctionSpec>;
-
-class GatherPartitionFunctionSpec : public PartitionFunctionSpec {
- public:
-  std::unique_ptr<PartitionFunction> create(
-      int /*numPartitions*/,
-      bool /*localExchange*/) const override {
-    VELOX_UNREACHABLE();
-  }
-
-  std::string toString() const override {
-    return "gather";
-  }
-
-  folly::dynamic serialize() const override {
-    folly::dynamic obj = folly::dynamic::object;
-    obj["name"] = "GatherPartitionFunctionSpec";
-    return obj;
-  }
-
-  static PartitionFunctionSpecPtr deserialize(
-      const folly::dynamic& /* obj */,
-      void* /* context */) {
-    return std::make_shared<GatherPartitionFunctionSpec>();
-  }
-};
 
 /// Partitions data using specified partition function. The number of
 /// partitions is determined by the parallelism of the upstream pipeline. Can

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -36,6 +36,7 @@ using PlanNodeId = std::string;
 
 /// Generic representation of InsertTable
 struct InsertTableHandle {
+  // TODO: Merge into connectors/Connector.h
  public:
   InsertTableHandle(
       const std::string& connectorId,

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -684,7 +684,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool allowEmptyFile_{false};
 };
 
-struct WriterOptions {
+struct WriterOptions : public ISerializable {
   TypePtr schema{nullptr};
   velox::memory::MemoryPool* memoryPool{nullptr};
   const velox::common::SpillConfig* spillConfig{nullptr};
@@ -713,6 +713,10 @@ struct WriterOptions {
       const config::ConfigBase& session) {}
 
   virtual ~WriterOptions() = default;
+
+  folly::dynamic serialize() const override;
+  static std::shared_ptr<WriterOptions> deserialize(const folly::dynamic& obj);
+  static void registerSerDe();
 };
 
 // Options for creating a column reader.

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -315,6 +315,7 @@ TEST_F(PlanBuilderTest, commitStrategyParameter) {
         0,
         {},
         {},
+        {},
         dwio::common::FileFormat::DWRF,
         {},
         PlanBuilder::kHiveDefaultConnectorId,

--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -846,7 +846,8 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
           /*partitionBy=*/{},
           /*bucketCount=*/0,
           /*bucketedBy=*/{},
-          /*sortBy=*/{},
+          /*sortColumns=*/{},
+          /*sortBys=*/{},
           setup.fileFormat,
           /*aggregates=*/{},
           /*connectorId=*/PlanBuilder::kHiveDefaultConnectorId,
@@ -866,7 +867,8 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
           /*partitionBy=*/{},
           setup.bucketCount(),
           bucketColumnNames,
-          /*sortBy=*/{},
+          /*sortColumns=*/{},
+          /*sortBys=*/{},
           setup.fileFormat,
           /*aggregates=*/{},
           /*connectorId=*/PlanBuilder::kHiveDefaultConnectorId,
@@ -877,7 +879,8 @@ std::unique_ptr<TaskCursor> TableEvolutionFuzzer::makeWriteTask(
           /*partitionBy=*/{},
           setup.bucketCount(),
           bucketColumnNames,
-          /*sortBy=*/{},
+          /*sortColumns=*/{},
+          /*sortBys=*/{},
           setup.fileFormat);
     }
   }

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -130,6 +130,7 @@ TEST_F(BasicTableWriterTestBase, structAsMap) {
                       0,
                       {},
                       {},
+                      {},
                       dwio::common::FileFormat::DWRF,
                       {},
                       PlanBuilder::kHiveDefaultConnectorId,
@@ -2932,10 +2933,8 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromSortTableWriter) {
                   {"c0"},
                   4,
                   {"c1"},
-                  {
-                      std::make_shared<HiveSortingColumn>(
-                          "c2", core::SortOrder{false, false}),
-                  })
+                  {"c2"},
+                  {core::SortOrder{false, false}})
               .project({TableWriteTraits::rowCountColumnName()})
               .singleAggregation(
                   {},
@@ -3330,10 +3329,8 @@ DEBUG_ONLY_TEST_F(
               {"c0"},
               4,
               {"c1"},
-              {
-                  std::make_shared<HiveSortingColumn>(
-                      "c2", core::SortOrder{false, false}),
-              })
+              {"c2"},
+              {core::SortOrder{false, false}})
           .project({TableWriteTraits::rowCountColumnName()})
           .singleAggregation(
               {},

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 #include <folly/init/Init.h>
+
 #include "velox/common/memory/Memory.h"
+#include "velox/connectors/ConnectorNames.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
 #include "velox/core/Expressions.h"
@@ -53,8 +55,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
     // Create and register a TPC-H connector.
     auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
+        connector::getConnectorFactory(connector::kTpchConnectorName)
             ->newConnector(
                 kTpchConnectorId,
                 std::make_shared<config::ConfigBase>(
@@ -64,8 +65,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
   ~VeloxIn10MinDemo() {
     connector::unregisterConnector(kTpchConnectorId);
-    connector::unregisterConnectorFactory(
-        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
+    connector::unregisterConnectorFactory(connector::kTpchConnectorName);
   }
 
   /// Parse SQL expression into a typed expression tree using DuckDB SQL parser.

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -43,6 +43,8 @@ target_link_libraries(
   velox_vector_test_lib
   velox_vector_fuzzer
   velox_temp_path
+  velox_connector
+  velox_registered_connector_factories
   velox_cursor
   velox_core
   velox_exception

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -19,6 +19,7 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/tpcds/TpcdsConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/core/PartitionFunction.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashPartitionFunction.h"

--- a/velox/tool/trace/TableWriterReplayer.cpp
+++ b/velox/tool/trace/TableWriterReplayer.cpp
@@ -16,6 +16,7 @@
 
 #include <folly/executors/IOThreadPoolExecutor.h>
 
+#include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/TraceUtil.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"


### PR DESCRIPTION
# What PR #14687 Does

The PR is part of the ongoing decoupling of Hive from Velox exec tests:

## Before: 
Many velox/exec unit tests (for TableScan, TableWriter, Exchange, etc.) directly created HiveTableHandle, HiveColumnHandle, or HivePartitionFunctionSpec. This meant the tests wouldn’t compile or run without the Hive connector being statically linked.

## Now: 
The PR replaces those direct Hive references with calls into the ConnectorObjectFactory and connector-agnostic interfaces.

For example, in tests that used to say:
```c++
auto handle = std::make_shared<HiveTableHandle>(...);
```

they now construct folly::dynamic options and call:
```c++
auto handle = factory.makeTableHandle("hive", tableName, cols, options);
```

Similarly, partitioning specs that used to directly instantiate `HivePartitionFunctionSpec` are now requested through:
```c++
factory.makePartitionFunctionSpec("hive", opts);
```

This ensures the exec layer and its tests depend only on the abstract connector API, not on Hive headers.

# Why Exec Tests Need to Be Connector Agnostic

- Build isolation: If every exec test pulls in Hive, any change in Hive (even trivial) will force a recompile of all exec tests.
- Future connectors: Iceberg, Hudi, DeltaLake all need to reuse exec operators. Tests should validate operator logic, not Hive specifics.
- Portability: Connector-agnostic tests can run even if a connector plugin isn’t present, as long as a minimal factory (real or mock) is registered.

This is part of a larger effort to make the connector plugin architecture. Whether or not to support dynamic loading of connectors is still under discussion, but making exec tests connector agnostic is a must-do item to make Velox compile with VELOX_ENABLE_HIVE_CONNECTOR=OFF. Exec tests that link against Hive types would make the build fail if VELOX_ENABLE_HIVE_CONNECTOR=OFF. This is what we have agreed on in https://github.com/facebookincubator/velox/issues/13698.

# Steps to Make Exec Tests Connector Agnostic

1. Introduce ConnectorObjectFactory: Define abstract factory methods: makeTableHandle, makeColumnHandle, makeInsertTableHandle, makePartitionFunctionSpec, etc.  https://github.com/facebookincubator/velox/pull/13798

2. Implement connector-specific factories: Hive (and later Iceberg) provide a HiveObjectFactory implementing these methods. https://github.com/facebookincubator/velox/pull/13798

3. Refactor PlanBuilder, including TableScanBuilder, TableWriterBuilder and PartitionFunctionSpec related code in exec test utils.  Replace direct Hive handle creation with factory calls. Update affected tests too.  (this PR)

4. Finish PlanBuilder refactor to remove Tpch and Tpcds specific code. Can be done as a new beginner task.
5. Refactor HiveConnectorTestBase, make it connector agnostic. We can potentially rename it as ConnectorTestBase and move it back to connectors/common/tests. Hive tests, Iceberg tests or other connector-specific tests can also inherit it.


Depends on https://github.com/facebookincubator/velox/pull/13798