### PR TITLE
fix: Centralize the places that we do lazy materialization

### DIFF
--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -331,6 +331,10 @@ class MergeJoin : public Operator {
   // rows from the left side that have a match on the right.
   RowVectorPtr filterOutputForAntiJoin(const RowVectorPtr& output);
 
+  void clearLeftInput();
+
+  void clearRightInput();
+
   // As we populate the results of the join, we track whether a given
   // output row is a result of a match between left and right sides or a miss.
   // We use JoinTracker::addMatch and addMiss methods for that.


### PR DESCRIPTION
Summary: We currently handle the left hand side lazy load in different places in the code but load all the rows without selectivity. This is error prone and cause subtle difference between left/right side processing. This change lazy load them once at add input.

Differential Revision: D81526796


