### PR TITLE
feat: Add parallel unit loader

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -159,6 +159,15 @@ int32_t HiveConfig::prefetchRowGroups() const {
   return config_->get<int32_t>(kPrefetchRowGroups, 1);
 }
 
+size_t HiveConfig::parallelUnitLoadCount(
+    const config::ConfigBase* session) const {
+  auto count = session->get<size_t>(
+      kParallelUnitLoadCountSession,
+      config_->get<size_t>(kParallelUnitLoadCount, 0));
+  VELOX_CHECK_LE(count, 100, "parallelUnitLoadCount too large: {}", count);
+  return count;
+}
+
 int32_t HiveConfig::loadQuantum(const config::ConfigBase* session) const {
   return session->get<int32_t>(
       kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -146,6 +146,15 @@ class HiveConfig {
   /// meta data together. Optimization to decrease the small IO requests
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
 
+  /// When set to be larger than 0, parallel unit loader feature is enabled and
+  /// it configures how many units (e.g., stripes) we load in parallel.
+  /// When set to 0, parallel unit loader feature is disabled and on demand unit
+  /// loader would be used.
+  static constexpr const char* kParallelUnitLoadCount =
+      "parallel-unit-load-count";
+  static constexpr const char* kParallelUnitLoadCountSession =
+      "parallel_unit_load_count";
+
   /// Config used to create write files. This config is provided to underlying
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
@@ -234,6 +243,8 @@ class HiveConfig {
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
 
   int32_t prefetchRowGroups() const;
+
+  size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
 
   int32_t loadQuantum(const config::ConfigBase* session) const;
 

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -86,6 +86,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
+    folly::Executor* ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions);
 
 bool testFilters(

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -126,7 +126,7 @@ SplitReader::SplitReader(
     const std::shared_ptr<io::IoStatistics>& ioStats,
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
-    folly::Executor* executor,
+    folly::Executor* ioExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec)
     : hiveSplit_(hiveSplit),
       hiveTableHandle_(hiveTableHandle),
@@ -137,7 +137,7 @@ SplitReader::SplitReader(
       ioStats_(ioStats),
       fsStats_(fsStats),
       fileHandleFactory_(fileHandleFactory),
-      executor_(executor),
+      ioExecutor_(ioExecutor),
       pool_(connectorQueryCtx->memoryPool()),
       scanSpec_(scanSpec),
       baseReaderOpts_(connectorQueryCtx->memoryPool()),
@@ -318,7 +318,7 @@ void SplitReader::createReader() {
       connectorQueryCtx_,
       ioStats_,
       fsStats_,
-      executor_);
+      ioExecutor_);
 
   baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.fileFormat())
                     ->createReader(std::move(baseFileInput), baseReaderOpts_);
@@ -378,6 +378,7 @@ void SplitReader::createRowReader(
       hiveSplit_,
       hiveConfig_,
       connectorQueryCtx_->sessionProperties(),
+      ioExecutor_,
       baseRowReaderOpts_);
   baseRowReaderOpts_.setTrackRowSize(
       connectorQueryCtx_->rowSizeTrackingEnabled());

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -185,7 +185,7 @@ class SplitReader {
   const std::shared_ptr<io::IoStatistics> ioStats_;
   const std::shared_ptr<filesystems::File::IoStats> fsStats_;
   FileHandleFactory* const fileHandleFactory_;
-  folly::Executor* const executor_;
+  folly::Executor* const ioExecutor_;
   memory::MemoryPool* const pool_;
 
   std::shared_ptr<common::ScanSpec> scanSpec_;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -84,7 +84,7 @@ void IcebergSplitReader::prepareSplit(
                 hiveSplit_->filePath,
                 fileHandleFactory_,
                 connectorQueryCtx_,
-                executor_,
+                ioExecutor_,
                 hiveConfig_,
                 ioStats_,
                 fsStats_,

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -137,6 +137,7 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
       deleteSplit_,
       nullptr,
       nullptr,
+      nullptr,
       deleteRowReaderOpts);
 
   deleteRowReader_.reset();

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -352,6 +352,7 @@ TEST_F(HiveConnectorUtilTest, configureSstRowReaderOptions) {
       /*hiveSplit=*/hiveSplit,
       /*hiveConfig=*/nullptr,
       /*sessionProperties=*/nullptr,
+      /*ioExecutor=*/nullptr,
       /*rowReaderOptions=*/rowReaderOpts);
 
   EXPECT_EQ(rowReaderOpts.serdeParameters(), hiveSplit->serdeParameters);
@@ -377,6 +378,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_FALSE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -402,6 +404,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -428,6 +431,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -455,6 +459,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -45,6 +45,7 @@ velox_add_library(
   MetadataFilter.cpp
   Options.cpp
   OutputStream.cpp
+  ParallelUnitLoader.cpp
   ParallelFor.cpp
   Range.cpp
   Reader.cpp

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -282,6 +282,22 @@ class RowReaderOptions {
     scanSpec_ = std::move(scanSpec);
   }
 
+  folly::Executor* ioExecutor() const {
+    return ioExecutor_;
+  }
+
+  void setIOExecutor(folly::Executor* const ioExecutor) {
+    ioExecutor_ = ioExecutor;
+  }
+
+  const size_t parallelUnitLoadCount() const {
+    return parallelUnitLoadCount_;
+  }
+
+  void setParallelUnitLoadCount(size_t parallelUnitLoadCount) {
+    parallelUnitLoadCount_ = parallelUnitLoadCount;
+  }
+
   const std::shared_ptr<velox::common::MetadataFilter>& metadataFilter() const {
     return metadataFilter_;
   }
@@ -442,6 +458,7 @@ class RowReaderOptions {
   bool preloadStripe_;
   bool projectSelectedType_;
   bool returnFlatVector_ = false;
+  size_t parallelUnitLoadCount_;
   ErrorTolerance errorTolerance_;
   std::shared_ptr<ColumnSelector> selector_;
   RowTypePtr requestedType_;
@@ -454,7 +471,8 @@ class RowReaderOptions {
   // Whether to generate FlatMapVectors when reading flat maps from the file. By
   // default, converts flat maps in the file to MapVectors.
   bool preserveFlatMapsInMemory_ = false;
-
+  // Optional io executor to enable parallel unit loader.
+  folly::Executor* ioExecutor_;
   // Optional executors to enable internal reader parallelism.
   // 'decodingExecutor' allow parallelising the vector decoding process.
   // 'ioExecutor' enables parallelism when performing file system read

--- a/velox/dwio/common/ParallelUnitLoader.cpp
+++ b/velox/dwio/common/ParallelUnitLoader.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ParallelUnitLoader.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::dwio::common {
+
+class ParallelUnitLoader : public UnitLoader {
+ public:
+  /// Enables concurrent loading of multiple units (stripes, row groups, etc.)
+  /// using asynchronous I/O to improve throughput and reduce read latency.
+  ///
+  /// **Loading Strategy:**
+  /// - Initialization: Preloads up to `maxConcurrentLoads` units concurrently
+  /// - Access pattern: On each getLoadedUnit() call, ensures the requested unit
+  ///   is loaded and triggers loading of subsequent units within the window
+  /// - Memory management: Unloads all previous units to control memory usage
+  ///
+  /// **Performance Characteristics:**
+  /// - Best suited for sequential access patterns
+  /// - Memory usage: O(maxConcurrentLoads * average_unit_size)
+  /// - I/O parallelism: Up to `maxConcurrentLoads` concurrent load operations
+  ///
+  /// **Parameters:**
+  /// @param units All units to be loaded
+  /// @param ioExecutor Thread pool for asynchronous unit loading operations
+  /// @param maxConcurrentLoads Maximum units to load concurrently (sliding
+  /// window size)
+  ///
+  /// **Example with maxConcurrentLoads=3:**
+  /// ```
+  /// Units: [0,1,2,3,4,5,6,7,8,9]
+  /// Init:  Load [0,1,2] concurrently
+  /// Get(0): Wait for unit 0, trigger load of units [0,1,2], unload none
+  /// Get(1): Wait for unit 1, trigger load of units [1,2,3], unload [0]
+  /// Get(2): Wait for unit 2, trigger load of units [2,3,4], unload [0,1]
+  /// ```
+  ParallelUnitLoader(
+      std::vector<std::unique_ptr<LoadUnit>> units,
+      folly::Executor* ioExecutor,
+      uint16_t maxConcurrentLoads)
+      : units_(std::move(units)),
+        ioExecutor_(ioExecutor),
+        maxConcurrentLoads_(maxConcurrentLoads) {
+    VELOX_CHECK_NOT_NULL(ioExecutor, "ParallelUnitLoader ioExecutor is null");
+    VELOX_CHECK_GT(
+        maxConcurrentLoads_,
+        0,
+        "ParallelUnitLoader maxConcurrentLoads should be larger than 0");
+    futures_.resize(units_.size());
+    unitsLoaded_.resize(units_.size());
+
+    for (size_t i = 0; i < units_.size() && i < maxConcurrentLoads; ++i) {
+      load(i);
+    }
+  }
+
+  /// Destructor ensures all pending load operations are properly cancelled
+  /// and waited for to prevent resource leaks and dangling references.
+  ~ParallelUnitLoader() override {
+    for (auto& future : futures_) {
+      future.cancel();
+      future.wait();
+    }
+  }
+
+  LoadUnit& getLoadedUnit(uint32_t unitIndex) override {
+    // Ensure sliding window of units [unitIndex, unitIndex +
+    // maxConcurrentLoads_) is loading
+    for (size_t i = unitIndex;
+         i < units_.size() && i < unitIndex + maxConcurrentLoads_;
+         ++i) {
+      if (!unitsLoaded_[i]) {
+        load(i);
+      }
+    }
+
+    try {
+      futures_[unitIndex].wait();
+    } catch (const std::exception& e) {
+      VELOX_FAIL("Failed to load unit {}: {}", unitIndex, e.what());
+    }
+
+    // Unload the previous units
+    folly::via(ioExecutor_, [this, unitIndex]() { unloadUntil(unitIndex); });
+
+    return *units_[unitIndex];
+  }
+
+  void onRead(uint32_t unit, uint64_t rowOffsetInUnit, uint64_t /* rowCount */)
+      override {
+    VELOX_CHECK_LT(unit, units_.size(), "Unit out of range");
+    VELOX_CHECK_LT(
+        rowOffsetInUnit, units_[unit]->getNumRows(), "Row out of range");
+  }
+
+  void onSeek(uint32_t unit, uint64_t rowOffsetInUnit) override {
+    VELOX_CHECK_LT(unit, units_.size(), "Unit out of range");
+    VELOX_CHECK_LE(
+        rowOffsetInUnit, units_[unit]->getNumRows(), "Row out of range");
+  }
+
+ private:
+  /// Submits the unit's load() to the I/O thread pool
+  void load(uint32_t unitIndex) {
+    VELOX_CHECK_LT(unitIndex, units_.size(), "Unit index out of bounds");
+    VELOX_CHECK_NOT_NULL(ioExecutor_, "ParallelUnitLoader ioExecutor is null");
+
+    futures_[unitIndex] = folly::via(
+        ioExecutor_, [this, unitIndex]() { units_[unitIndex]->load(); });
+    unitsLoaded_[unitIndex] = true;
+  }
+
+  /// Unloads all the units before 'unitIndex'
+  void unloadUntil(uint32_t unitIndex) {
+    for (size_t i = 0; i < unitIndex; ++i) {
+      if (unitsLoaded_[i]) {
+        units_[i]->unload();
+        // Reset the future
+        futures_[i] = folly::Future<folly::Unit>();
+        unitsLoaded_[i] = false;
+      }
+    }
+  }
+
+  std::vector<bool> unitsLoaded_;
+  std::vector<std::unique_ptr<LoadUnit>> units_;
+  std::vector<folly::Future<folly::Unit>> futures_;
+  folly::Executor* ioExecutor_;
+  size_t maxConcurrentLoads_;
+};
+
+std::unique_ptr<UnitLoader> ParallelUnitLoaderFactory::create(
+    std::vector<std::unique_ptr<LoadUnit>> units,
+    uint64_t /* rowsToSkip */) {
+  return std::make_unique<ParallelUnitLoader>(
+      std::move(units), ioExecutor_, maxConcurrentLoads_);
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ParallelUnitLoader.h
+++ b/velox/dwio/common/ParallelUnitLoader.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/futures/Future.h>
+
+#include <vector>
+#include "velox/dwio/common/UnitLoader.h"
+
+namespace facebook::velox::dwio::common {
+class ParallelUnitLoaderFactory : public UnitLoaderFactory {
+ public:
+  ParallelUnitLoaderFactory(
+      folly::Executor* ioExecutor,
+      size_t maxConcurrentLoads)
+      : ioExecutor_(ioExecutor), maxConcurrentLoads_(maxConcurrentLoads) {}
+
+  std::unique_ptr<UnitLoader> create(
+      std::vector<std::unique_ptr<LoadUnit>> units,
+      uint64_t rowsToSkip) override;
+
+ private:
+  folly::Executor* ioExecutor_;
+  size_t maxConcurrentLoads_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   DecoderUtilTest.cpp
   ExecutorBarrierTest.cpp
   OnDemandUnitLoaderTests.cpp
+  ParallelUnitLoaderTest.cpp
   LocalFileSinkTest.cpp
   MemorySinkTest.cpp
   LoggedExceptionTest.cpp

--- a/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
+++ b/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ParallelUnitLoader.h"
+#include "velox/dwio/common/OnDemandUnitLoader.h"
+#include "velox/dwio/common/tests/UnitLoaderBaseTest.h"
+#include "velox/dwio/common/tests/utils/UnitLoaderTestTools.h"
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::dwio::common::test;
+
+class ParallelUnitLoaderTest
+    : public UnitLoaderBaseTest<ParallelUnitLoaderFactory> {
+ protected:
+  ParallelUnitLoaderFactory createFactory() override {
+    return ParallelUnitLoaderFactory(ioExecutor_.get(), 2);
+  }
+
+  std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_ =
+      std::make_unique<folly::CPUThreadPoolExecutor>(4);
+};
+
+TEST_F(ParallelUnitLoaderTest, NoUnitButSkip) {
+  testNoUnitButSkip();
+}
+
+TEST_F(ParallelUnitLoaderTest, InitialSkip) {
+  testInitialSkip();
+}
+
+TEST_F(ParallelUnitLoaderTest, CanRequestUnitMultipleTimes) {
+  testCanRequestUnitMultipleTimes();
+}
+
+TEST_F(ParallelUnitLoaderTest, UnitOutOfRange) {
+  testUnitOutOfRange();
+}
+
+TEST_F(ParallelUnitLoaderTest, SeekOutOfRange) {
+  testSeekOutOfRange();
+}
+
+TEST_F(ParallelUnitLoaderTest, SeekOutOfRangeReaderError) {
+  testSeekOutOfRangeReaderError();
+}
+
+TEST_F(ParallelUnitLoaderTest, LoadsCorrectlyWithReader) {
+  auto factory = createFactory();
+  ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(3)); // Unit: 0, rows: 0-2, load(0)
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(3)); // Unit: 0, rows: 3-5
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(4)); // Unit: 0, rows: 6-9
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(14)); // Unit: 1, rows: 0-13, unload(0), load(1)
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, true, true}));
+
+  // will only read 5 rows, no more rows in unit 1
+  EXPECT_TRUE(readerMock.read(10)); // Unit: 1, rows: 14-19
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, true, true}));
+
+  EXPECT_TRUE(readerMock.read(30)); // Unit: 2, rows: 0-29, unload(1), load(2)
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, true}));
+
+  EXPECT_FALSE(readerMock.read(30)); // No more data
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, true}));
+}
+
+// Performance comparison test
+TEST_F(ParallelUnitLoaderTest, PerformanceComparison) {
+  std::vector<uint64_t> rowsPerUnit = {100, 100, 100, 100, 100, 100, 100, 100};
+  std::vector<uint64_t> ioSizes = {
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
+
+  // Measure ParallelUnitLoader performance
+  auto parallelStart = std::chrono::high_resolution_clock::now();
+  {
+    auto factory = createFactory();
+    ReaderMock reader(rowsPerUnit, ioSizes, factory, 0);
+
+    for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+      uint64_t totalRowsRead = 0;
+      while (totalRowsRead < rowsPerUnit[i]) {
+        reader.read(25);
+        int nextRead = rowsPerUnit[i] - totalRowsRead;
+        totalRowsRead += std::min(25, nextRead);
+      }
+    }
+  }
+  auto parallelEnd = std::chrono::high_resolution_clock::now();
+
+  // Measure OnDemandUnitLoader performance
+  auto onDemandStart = std::chrono::high_resolution_clock::now();
+  {
+    auto factory = std::make_shared<OnDemandUnitLoaderFactory>(nullptr);
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+      uint64_t totalRowsRead = 0;
+      while (totalRowsRead < rowsPerUnit[i]) {
+        reader.read(25);
+        int nextRead = rowsPerUnit[i] - totalRowsRead;
+        totalRowsRead += std::min(25, nextRead);
+      }
+    }
+  }
+  auto onDemandEnd = std::chrono::high_resolution_clock::now();
+
+  auto parallelDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      parallelEnd - parallelStart);
+  auto onDemandDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      onDemandEnd - onDemandStart);
+
+  // ParallelUnitLoader should be faster
+  EXPECT_LT(onDemandDuration.count(), parallelDuration.count());
+}

--- a/velox/dwio/common/tests/UnitLoaderBaseTest.h
+++ b/velox/dwio/common/tests/UnitLoaderBaseTest.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/UnitLoaderTools.h"
+#include "velox/dwio/common/tests/utils/UnitLoaderTestTools.h"
+
+using facebook::velox::dwio::common::LoadUnit;
+using facebook::velox::dwio::common::test::getUnitsLoadedWithFalse;
+using facebook::velox::dwio::common::test::LoadUnitMock;
+using facebook::velox::dwio::common::test::ReaderMock;
+
+/// Base test class template that provides common test functionality for
+/// different UnitLoader implementations. This template class can be inherited
+/// by specific test classes to get access to common test methods. Each derived
+/// class should provide a createFactory() method that returns the appropriate
+/// factory instance.
+template <typename UnitLoaderFactoryType>
+class UnitLoaderBaseTest : public ::testing::Test {
+ protected:
+  /// Factory method to create the appropriate UnitLoaderFactory instance.
+  /// This method should be implemented by derived classes.
+  virtual UnitLoaderFactoryType createFactory() = 0;
+
+  /// Test that UnitLoader handles the case where no units exist but skip is
+  /// requested
+  void testNoUnitButSkip() {
+    UnitLoaderFactoryType factory = createFactory();
+    std::vector<std::unique_ptr<LoadUnit>> units;
+
+    EXPECT_NO_THROW(factory.create(std::move(units), 0));
+
+    std::vector<std::unique_ptr<LoadUnit>> units2;
+    VELOX_ASSERT_THROW(
+        factory.create(std::move(units2), 1),
+        "Can only skip up to the past-the-end row of the file.");
+  }
+
+  /// Test that UnitLoader handles initial skip correctly for various skip
+  /// values
+  void testInitialSkip() {
+    auto getFactoryWithSkip = [this](uint64_t skipToRow) {
+      auto factory = createFactory();
+      std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(3));
+      std::vector<std::unique_ptr<LoadUnit>> units;
+      units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+      units.push_back(std::make_unique<LoadUnitMock>(20, 0, unitsLoaded, 1));
+      units.push_back(std::make_unique<LoadUnitMock>(30, 0, unitsLoaded, 2));
+      factory.create(std::move(units), skipToRow);
+    };
+
+    EXPECT_NO_THROW(getFactoryWithSkip(0));
+    EXPECT_NO_THROW(getFactoryWithSkip(1));
+    EXPECT_NO_THROW(getFactoryWithSkip(9));
+    EXPECT_NO_THROW(getFactoryWithSkip(10));
+    EXPECT_NO_THROW(getFactoryWithSkip(11));
+    EXPECT_NO_THROW(getFactoryWithSkip(29));
+    EXPECT_NO_THROW(getFactoryWithSkip(30));
+    EXPECT_NO_THROW(getFactoryWithSkip(31));
+    EXPECT_NO_THROW(getFactoryWithSkip(59));
+    EXPECT_NO_THROW(getFactoryWithSkip(60));
+    VELOX_ASSERT_THROW(
+        getFactoryWithSkip(61),
+        "Can only skip up to the past-the-end row of the file.");
+    VELOX_ASSERT_THROW(
+        getFactoryWithSkip(100),
+        "Can only skip up to the past-the-end row of the file.");
+  }
+
+  /// Test that the same unit can be requested multiple times without issues
+  void testCanRequestUnitMultipleTimes() {
+    auto factory = createFactory();
+    std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(1));
+    std::vector<std::unique_ptr<LoadUnit>> units;
+    units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+
+    auto unitLoader = factory.create(std::move(units), 0);
+    unitLoader->getLoadedUnit(0);
+    unitLoader->getLoadedUnit(0);
+    unitLoader->getLoadedUnit(0);
+  }
+
+  /// Test that requesting a unit index out of range throws an exception
+  void testUnitOutOfRange() {
+    auto factory = createFactory();
+    std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(1));
+    std::vector<std::unique_ptr<LoadUnit>> units;
+    units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+
+    auto unitLoader = factory.create(std::move(units), 0);
+    unitLoader->getLoadedUnit(0);
+
+    VELOX_ASSERT_THROW(unitLoader->getLoadedUnit(1), "Unit out of range");
+  }
+
+  /// Test that seeking out of range throws an exception
+  void testSeekOutOfRange() {
+    auto factory = createFactory();
+    std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(1));
+    std::vector<std::unique_ptr<LoadUnit>> units;
+    units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+
+    auto unitLoader = factory.create(std::move(units), 0);
+
+    unitLoader->onSeek(0, 10);
+
+    VELOX_ASSERT_THROW(unitLoader->onSeek(0, 11), "Row out of range");
+  }
+
+  /// Test that seeking out of range in ReaderMock throws appropriate exception
+  void testSeekOutOfRangeReaderError() {
+    auto factory = createFactory();
+    ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
+
+    readerMock.seek(59);
+    readerMock.seek(60);
+
+    VELOX_ASSERT_THROW(
+        readerMock.seek(61),
+        "Can't seek to possition 61 in file. Must be up to 60.");
+  }
+};

--- a/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
+++ b/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
@@ -32,16 +32,20 @@ class LoadUnitMock : public LoadUnit {
       uint64_t rowCount,
       uint64_t ioSize,
       std::vector<std::atomic_bool>& unitsLoaded,
-      size_t unitId)
+      size_t unitId,
+      std::chrono::milliseconds loadDelay = std::chrono::milliseconds(100))
       : rowCount_{rowCount},
         ioSize_{ioSize},
         unitsLoaded_{unitsLoaded},
-        unitId_{unitId} {}
+        unitId_{unitId},
+        loadDelay_(loadDelay) {}
 
   ~LoadUnitMock() override = default;
 
   void load() override {
     VELOX_CHECK(!isLoaded());
+    // Simulate loading time
+    std::this_thread::sleep_for(loadDelay_);
     unitsLoaded_[unitId_] = true;
   }
 
@@ -67,6 +71,7 @@ class LoadUnitMock : public LoadUnit {
   uint64_t ioSize_;
   std::vector<std::atomic_bool>& unitsLoaded_;
   size_t unitId_;
+  std::chrono::milliseconds loadDelay_;
 };
 
 class ReaderMock {

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -19,6 +19,7 @@
 #include <chrono>
 
 #include "velox/dwio/common/OnDemandUnitLoader.h"
+#include "velox/dwio/common/ParallelUnitLoader.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
@@ -341,9 +342,16 @@ std::unique_ptr<dwio::common::UnitLoader> DwrfRowReader::getUnitLoader() {
   std::shared_ptr<UnitLoaderFactory> unitLoaderFactory =
       options_.unitLoaderFactory();
   if (!unitLoaderFactory) {
-    unitLoaderFactory =
-        std::make_shared<dwio::common::OnDemandUnitLoaderFactory>(
-            options_.blockedOnIoCallback());
+    if (options_.parallelUnitLoadCount() > 0 &&
+        options_.ioExecutor() != nullptr) {
+      unitLoaderFactory =
+          std::make_shared<dwio::common::ParallelUnitLoaderFactory>(
+              options_.ioExecutor(), options_.parallelUnitLoadCount());
+    } else {
+      unitLoaderFactory =
+          std::make_shared<dwio::common::OnDemandUnitLoaderFactory>(
+              options_.blockedOnIoCallback());
+    }
   }
   return unitLoaderFactory->create(std::move(loadUnits), 0);
 }


### PR DESCRIPTION
Introduce ParallelUnitLoader that enables concurrent loading of 
multiple units (e.g., stripes) in sliding window fashion to improve 
I/O throughput and reduce read latency