### PR TITLE
Fix(tpcds): return const& from toTableName and avoid redundant map construction (#14678)

### DIFF
--- a/test_tpcds_optimization.cpp
+++ b/test_tpcds_optimization.cpp
@@ -1,0 +1,81 @@
+#include "velox/tpcds/gen/TpcdsGen.h"
+#include <iostream>
+#include <chrono>
+
+using namespace facebook::velox::tpcds;
+
+int main() {
+    // Test basic functionality
+    std::cout << "Testing TPC-DS table name optimization...\n";
+    
+    // Test all table names
+    const auto tables = {
+        Table::TBL_CALL_CENTER,
+        Table::TBL_CATALOG_PAGE,
+        Table::TBL_CATALOG_RETURNS,
+        Table::TBL_CATALOG_SALES,
+        Table::TBL_CUSTOMER,
+        Table::TBL_CUSTOMER_ADDRESS,
+        Table::TBL_CUSTOMER_DEMOGRAPHICS,
+        Table::TBL_DATE_DIM,
+        Table::TBL_HOUSEHOLD_DEMOGRAPHICS,
+        Table::TBL_INCOME_BAND,
+        Table::TBL_INVENTORY,
+        Table::TBL_ITEM,
+        Table::TBL_PROMOTION,
+        Table::TBL_REASON,
+        Table::TBL_SHIP_MODE,
+        Table::TBL_STORE,
+        Table::TBL_STORE_RETURNS,
+        Table::TBL_STORE_SALES,
+        Table::TBL_TIME_DIM,
+        Table::TBL_WAREHOUSE,
+        Table::TBL_WEB_PAGE,
+        Table::TBL_WEB_RETURNS,
+        Table::TBL_WEB_SALES,
+        Table::TBL_WEB_SITE
+    };
+    
+    // Test correctness
+    std::cout << "Testing correctness:\n";
+    for (auto table : tables) {
+        const std::string& name = toTableName(table);
+        std::cout << "Table " << static_cast<int>(table) << " -> " << name << std::endl;
+        
+        // Test round-trip conversion
+        Table backToTable = fromTableName(name);
+        if (backToTable != table) {
+            std::cerr << "ERROR: Round-trip conversion failed for " << name << std::endl;
+            return 1;
+        }
+    }
+    
+    // Test performance - measure time for many calls
+    std::cout << "\nTesting performance:\n";
+    const int iterations = 100000;
+    
+    auto start = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < iterations; ++i) {
+        for (auto table : tables) {
+            const std::string& name = toTableName(table);
+            (void)name; // Suppress unused variable warning
+        }
+    }
+    auto end = std::chrono::high_resolution_clock::now();
+    
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+    std::cout << "Time for " << iterations << " iterations: " << duration.count() << " microseconds\n";
+    std::cout << "Average time per call: " << (double)duration.count() / (iterations * tables.size()) << " microseconds\n";
+    
+    // Test using TableName directly (the new enum-based approach)
+    std::cout << "\nTesting TableName enum interface:\n";
+    std::cout << "call_center: " << TableName::toName(Table::TBL_CALL_CENTER) << std::endl;
+    
+    auto maybeTable = TableName::tryToTable("customer");
+    if (maybeTable) {
+        std::cout << "customer -> Table enum value: " << static_cast<int>(*maybeTable) << std::endl;
+    }
+    
+    std::cout << "\nAll tests passed! ✓\n";
+    return 0;
+}

--- a/velox/tpcds/gen/TpcdsGen.h
+++ b/velox/tpcds/gen/TpcdsGen.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/common/memory/Memory.h"
+#include "velox/common/Enums.h"
 
 namespace facebook::velox {
 class RowVector;
@@ -84,8 +85,10 @@ static const auto tables = {
     tpcds::Table::TBL_WEB_SALES,
     tpcds::Table::TBL_WEB_SITE};
 
-/// Returns table name as a string.
-std::string toTableName(Table table);
+VELOX_DECLARE_ENUM_NAME(Table);
+
+/// Returns table name as a const reference to avoid copying.
+const std::string& toTableName(Table table);
 
 /// Returns the schema (RowType) for a particular TPC-DS table.
 const velox::RowTypePtr getTableSchema(Table table);


### PR DESCRIPTION
### Summary
- Changed `toTableName()` to return `const std::string&` instead of `std::string` to avoid unnecessary string copies.
- Removed redundant map reconstruction (`invertTpcdsTableMap`) by introducing a static map that is built once and reused.
- Added `VELOX_DEFINE_ENUM_NAME(Table)` for consistent enum-to-string mapping.
- Updated `fromTableName()` to use `TableName::tryToTable` for efficient reverse lookups.
- Added a test (`test_tpcds_optimization.cpp`) to validate behavior.

### Benefits
- Eliminates repeated map rebuilding, improving performance.
- Avoids extra string allocations and copies.
- Aligns with Velox coding style and enum handling.
- Ensures correctness with new test coverage.

Closes #14678