### PR TITLE
fix: Read lazy ROW value in flat map vector returning incorrect result

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -255,6 +255,11 @@ class SelectiveFlatMapAsMapReader : public SelectiveStructColumnReaderBase {
                 scanSpec,
                 dwio::common::flatmap::FlatMapOutput::kMap)) {}
 
+  void setIsTopLevel() override {
+    // Children are not considered top level since this is materialized as MAP.
+    SelectiveColumnReader::setIsTopLevel();
+  }
+
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
       override {
     flatMap_.read(offset, rows, incomingNulls);

--- a/velox/exec/tests/TableEvolutionFuzzer.h
+++ b/velox/exec/tests/TableEvolutionFuzzer.h
@@ -105,7 +105,7 @@ class TableEvolutionFuzzer {
       const std::string& outputDir,
       const std::vector<column_index_t>& bucketColumnIndices,
       FuzzerGenerator& rng,
-      bool enableFlatMap = false);
+      bool enableFlatMap);
 
   template <typename To, typename From>
   VectorPtr liftToPrimitiveType(


### PR DESCRIPTION
Summary:
When the following conditions are satisfied:
1. The flat map column has ROW as the map value (there is no prod data with this type; we discovered it using table evolution fuzzer)
2. The flat map column is read as ordinary map
3. The flat map column has a push down filter in the query
4. A second filter is evaluated and reducing the number of rows after flat map column

The children in the ROW map values would be read lazily; however the output row
set of the ROW column is not set correctly, because we consider its parent a MAP
column and its value should not be read lazily.  Fix this by not allowing the
MAP children to be read lazily in the flat map as map column readers.

Differential Revision: D81390639


