### PR TITLE
fix(build): Replace actor with owner for determining merge base

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -124,9 +124,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           INPUT_REF: ${{ inputs.ref || 'main' }}
-          HEAD_REF: ${{ github.head_ref }}
           BASE_REF: ${{ github.base_ref }}
-          ACTOR: ${{ github.actor }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
         id: get-merge-base
         run: |
           if [ '${{ github.event_name == 'push' }}' == "true" ]; then
@@ -135,12 +135,11 @@ jobs:
           elif [ '${{ github.event_name == 'pull_request' }}' == "true" ]; then
             # Get the merge base from the api
             head_main=$(gh api -q '.merge_base_commit.sha' \
-              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$ACTOR:$HEAD_REF \
+              /repos/facebookincubator/velox/compare/facebookincubator:$BASE_REF...$PR_AUTHOR:$HEAD_REF \
             )
           else
             head_main=$INPUT_REF
           fi
-
           echo "Determined SHA: $head_main"
           echo "head_main=$head_main" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Previously the actor (the workflow initiator) was used to try and determine the merge base commit sha. However, a user pushing to a different repo becomes the owner and $OWNER:$HEAD_REF does not exist in that scenario. Instead, try to use the PR creator name. We’ve seen HTTP 404 from GH CLI when the actor does not match the repo name.