### PR TITLE
fix: Fix the partition scale and stats report condition and the scale writer test flakiness

### DIFF
--- a/velox/common/base/SkewedPartitionBalancer.cpp
+++ b/velox/common/base/SkewedPartitionBalancer.cpp
@@ -174,9 +174,10 @@ void SkewedPartitionRebalancer::rebalanceBasedOnTaskSkewness(
 
       const uint32_t totalAssignedTasks =
           partitionAssignments_[maxPartition].size();
-      if (partitionBytes_[maxPartition] <
-          (minProcessedBytesRebalanceThresholdPerPartition_ *
-           totalAssignedTasks)) {
+      if (partitionBytes_[maxPartition] == 0 ||
+          (partitionBytes_[maxPartition] <
+           (minProcessedBytesRebalanceThresholdPerPartition_ *
+            totalAssignedTasks))) {
         break;
       }
 

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -223,10 +223,9 @@ uint32_t ScaleWriterPartitioningLocalPartition::getNextWriterId(
 void ScaleWriterPartitioningLocalPartition::close() {
   LocalPartition::close();
 
-  // The last driver operator reports the shared table partition rebalancer
-  // stats. We expect one reference hold by this operator and one referenced by
-  // the task.
-  if (tablePartitionRebalancer_.use_count() != 2) {
+  // The first driver operator instance reports the shared table partition
+  // rebalancer stats.
+  if (operatorCtx_->driverCtx()->driverId != 0) {
     return;
   }
 

--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -812,11 +812,10 @@ TEST_F(ScaleWriterLocalPartitionTest, partitionBasic) {
       {4, 4, 4, 1ULL << 30, 1.0, 0, {1, 2}, 0.8, 0.6, false},
       {1, 4, 4, 0, 1.0, 0, {1, 2}, 0.3, 0.2, false},
       {4, 4, 4, 0, 1.0, 0, {1, 2}, 0.3, 0.2, false},
-      {1, 4, 4, 0, 0.1, queryCapacity / 2, {1, 2}, 0.8, 0.6, false},
-      {4, 4, 4, 0, 0.1, queryCapacity / 2, {1, 2}, 0.8, 0.6, false},
+      {1, 4, 4, 0, 0.0001, queryCapacity / 2, {1, 2}, 0.8, 0.6, false},
+      {4, 4, 4, 0, 0.0001, queryCapacity / 2, {1, 2}, 0.8, 0.6, false},
       {1, 32, 128, 0, 1.0, 0, {1, 2, 3, 4, 5, 6, 7, 8}, 0.8, 0.6, true},
-      {4, 32, 128, 0, 1.0, 0, {1, 2, 3, 4, 5, 6, 7, 8}, 0.8, 0.6, true},
-  };
+      {4, 32, 128, 0, 1.0, 0, {1, 2, 3, 4, 5, 6, 7, 8}, 0.8, 0.6, true}};
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
@@ -888,17 +887,25 @@ TEST_F(ScaleWriterLocalPartitionTest, partitionBasic) {
             .copyResults(pool_.get(), task);
     auto planStats = toPlanStats(task->taskStats());
     if (testData.expectedRebalance) {
-      ASSERT_EQ(
+      // NOTE: thre is time race across multiple drivers on the shared balancer
+      // stats reporting which can't totally avoid in tests under some extreme
+      // conditions like the rebalance happens on the last close driver.
+      ASSERT_LE(
           planStats.at(exchnangeNodeId)
               .customStats.count(
                   ScaleWriterPartitioningLocalPartition::kScaledPartitions),
           1);
-      ASSERT_GT(
-          planStats.at(exchnangeNodeId)
-              .customStats
-              .at(ScaleWriterPartitioningLocalPartition::kScaledPartitions)
-              .sum,
-          0);
+      if (planStats.at(exchnangeNodeId)
+              .customStats.count(
+                  ScaleWriterPartitioningLocalPartition::kScaledPartitions) ==
+          1) {
+        ASSERT_GT(
+            planStats.at(exchnangeNodeId)
+                .customStats
+                .at(ScaleWriterPartitioningLocalPartition::kScaledPartitions)
+                .sum,
+            0);
+      }
       ASSERT_EQ(
           planStats.at(exchnangeNodeId)
               .customStats.count(


### PR DESCRIPTION
Summary:
Fix the scale partition condition to skip balancing partition which has zero bytes in case that the scale threshold bytes is also zero. Also fix two extreme cases that
(1) all written data go to very few partition so that once rebalance gets triggered, then it will trigger rebalance. The failed test case is to verify the rebalance never triggers if the memory threshold is set to low enough, fix the flakiness by reducing the ratio from 0.1 to 0.001 and verified with 2000 runs;
(2) there is time race in rebalance stats reporting across multiple drivers. The current code reports the stats when there is no other shared reference (the last closed driver operator). But this is not reliable as it is possible (from the test logs), all the drivers close at the same time and no one report the stats. Fix the production code to report the stats from the first driver operator instance (driver id = 0), this ensures we have sth to report and it is sufficient good in production. This still can cause the test flakiness if the rebalance happens while some driver starts closing. We can totally prevent such as so relax the check a bit in test for the test case that we expect rebalance to trigger. Verified with 2000 runs.

Differential Revision: D81610234


