### PR TITLE
Enable filter length for plan summary printing

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -150,6 +150,13 @@ struct PlanSummaryOptions {
   };
 
   AggregateOptions aggregate = {};
+
+  // Options that apply specifically to FILTER nodes.
+  struct FilterOptions {
+    size_t maxConditions = 50;
+  };
+
+  FilterOptions filter = {};
 };
 
 class PlanNode : public ISerializable {


### PR DESCRIPTION
Summary: Enable filter condition length setup from planSummary options. Allows printing longer filter node condition outputs without getting truncated.

Differential Revision: D81531071


