### PR TITLE
feat: Add parallel unit loader

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -159,6 +159,15 @@ int32_t HiveConfig::prefetchRowGroups() const {
   return config_->get<int32_t>(kPrefetchRowGroups, 1);
 }
 
+size_t HiveConfig::parallelUnitLoadCount(
+    const config::ConfigBase* session) const {
+  auto count = session->get<size_t>(
+      kParallelUnitLoadCountSession,
+      config_->get<size_t>(kParallelUnitLoadCount, 0));
+  VELOX_CHECK_LE(count, 100, "parallelUnitLoadCount too large: {}", count);
+  return count;
+}
+
 int32_t HiveConfig::loadQuantum(const config::ConfigBase* session) const {
   return session->get<int32_t>(
       kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -146,6 +146,15 @@ class HiveConfig {
   /// meta data together. Optimization to decrease the small IO requests
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
 
+  /// When set to be larger than 0, parallel unit loader feature is enabled and
+  /// it configures how many units (e.g., stripes) we load in parallel.
+  /// When set to 0, parallel unit loader feature is disabled and on demand unit
+  /// loader would be used.
+  static constexpr const char* kParallelUnitLoadCount =
+      "parallel-unit-load-count";
+  static constexpr const char* kParallelUnitLoadCountSession =
+      "parallel_unit_load_count";
+
   /// Config used to create write files. This config is provided to underlying
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
@@ -234,6 +243,8 @@ class HiveConfig {
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
 
   int32_t prefetchRowGroups() const;
+
+  size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
 
   int32_t loadQuantum(const config::ConfigBase* session) const;
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -613,6 +613,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
+    folly::Executor* const ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions) {
   auto skipRowsIt =
       tableParameters.find(dwio::common::TableParameter::kSkipHeaderLineCount);
@@ -620,6 +621,7 @@ void configureRowReaderOptions(
     rowReaderOptions.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
   }
   rowReaderOptions.setScanSpec(scanSpec);
+  rowReaderOptions.setIOExecutor(ioExecutor);
   rowReaderOptions.setMetadataFilter(std::move(metadataFilter));
   rowReaderOptions.setRequestedType(rowType);
   rowReaderOptions.range(hiveSplit->start, hiveSplit->length);
@@ -628,6 +630,13 @@ void configureRowReaderOptions(
         hiveConfig->readTimestampUnit(sessionProperties)));
     rowReaderOptions.setPreserveFlatMapsInMemory(
         hiveConfig->preserveFlatMapsInMemory(sessionProperties));
+    rowReaderOptions.setParallelUnitLoadCount(
+        hiveConfig->parallelUnitLoadCount(sessionProperties));
+    // When parallel unit loader is enabled, all units would be loaded by
+    // ParallelUnitLoader, thus disable eagerFirstStripeLoad.
+    if (hiveConfig->parallelUnitLoadCount(sessionProperties) > 0) {
+      rowReaderOptions.setEagerFirstStripeLoad(false);
+    }
   }
   rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -86,6 +86,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
+    folly::Executor* ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions);
 
 bool testFilters(

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -379,6 +379,7 @@ void SplitReader::createRowReader(
       hiveSplit_,
       hiveConfig_,
       connectorQueryCtx_->sessionProperties(),
+      ioExecutor_,
       baseRowReaderOpts_);
   baseRowReaderOpts_.setTrackRowSize(
       rowSizeTrackingEnabled.has_value()

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -137,6 +137,7 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
       deleteSplit_,
       nullptr,
       nullptr,
+      nullptr,
       deleteRowReaderOpts);
 
   deleteRowReader_.reset();

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -352,6 +352,7 @@ TEST_F(HiveConnectorUtilTest, configureSstRowReaderOptions) {
       /*hiveSplit=*/hiveSplit,
       /*hiveConfig=*/nullptr,
       /*sessionProperties=*/nullptr,
+      /*ioExecutor=*/nullptr,
       /*rowReaderOptions=*/rowReaderOpts);
 
   EXPECT_EQ(rowReaderOpts.serdeParameters(), hiveSplit->serdeParameters);
@@ -377,6 +378,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_FALSE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -402,6 +404,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -428,6 +431,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -455,6 +459,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveSplit=*/hiveSplit,
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
+        /*ioExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -46,6 +46,7 @@ velox_add_library(
   MetadataFilter.cpp
   Options.cpp
   OutputStream.cpp
+  ParallelUnitLoader.cpp
   ParallelFor.cpp
   Range.cpp
   Reader.cpp

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -282,6 +282,22 @@ class RowReaderOptions {
     scanSpec_ = std::move(scanSpec);
   }
 
+  folly::Executor* ioExecutor() const {
+    return ioExecutor_;
+  }
+
+  void setIOExecutor(folly::Executor* const ioExecutor) {
+    ioExecutor_ = ioExecutor;
+  }
+
+  const size_t parallelUnitLoadCount() const {
+    return parallelUnitLoadCount_;
+  }
+
+  void setParallelUnitLoadCount(size_t parallelUnitLoadCount) {
+    parallelUnitLoadCount_ = parallelUnitLoadCount;
+  }
+
   const std::shared_ptr<velox::common::MetadataFilter>& metadataFilter() const {
     return metadataFilter_;
   }
@@ -442,6 +458,7 @@ class RowReaderOptions {
   bool preloadStripe_;
   bool projectSelectedType_;
   bool returnFlatVector_ = false;
+  size_t parallelUnitLoadCount_ = 0;
   ErrorTolerance errorTolerance_;
   std::shared_ptr<ColumnSelector> selector_;
   RowTypePtr requestedType_;
@@ -454,7 +471,8 @@ class RowReaderOptions {
   // Whether to generate FlatMapVectors when reading flat maps from the file. By
   // default, converts flat maps in the file to MapVectors.
   bool preserveFlatMapsInMemory_ = false;
-
+  // Optional io executor to enable parallel unit loader.
+  folly::Executor* ioExecutor_;
   // Optional executors to enable internal reader parallelism.
   // 'decodingExecutor' allow parallelising the vector decoding process.
   // 'ioExecutor' enables parallelism when performing file system read

--- a/velox/dwio/common/ParallelUnitLoader.cpp
+++ b/velox/dwio/common/ParallelUnitLoader.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ParallelUnitLoader.h"
+#include <numeric>
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/time/Timer.h"
+
+namespace facebook::velox::dwio::common {
+
+class ParallelUnitLoader : public UnitLoader {
+ public:
+  /// Enables concurrent loading of multiple units (stripes, row groups, etc.)
+  /// using asynchronous I/O to improve throughput and reduce read latency.
+  ///
+  /// **Loading Strategy:**
+  /// - Initialization: Preloads up to `maxConcurrentLoads` units concurrently
+  /// - Access pattern: On each getLoadedUnit() call, ensures the requested unit
+  ///   is loaded and triggers loading of subsequent units within the window
+  /// - Memory management: Unloads all previous units to control memory usage
+  ///
+  /// **Performance Characteristics:**
+  /// - Best suited for sequential access patterns
+  /// - Memory usage: O(maxConcurrentLoads * average_unit_size)
+  /// - I/O parallelism: Up to `maxConcurrentLoads` concurrent load operations
+  ///
+  /// **Parameters:**
+  /// @param units All units to be loaded
+  /// @param ioExecutor Thread pool for asynchronous unit loading operations
+  /// @param maxConcurrentLoads Maximum units to load concurrently (sliding
+  /// window size)
+  ///
+  /// **Example with maxConcurrentLoads=3:**
+  /// ```
+  /// Units: [0,1,2,3,4,5,6,7,8,9]
+  /// Init:  Load [0,1,2] concurrently
+  /// Get(0): Wait for unit 0, trigger load of units [0,1,2], unload none
+  /// Get(1): Wait for unit 1, trigger load of units [1,2,3], unload [0]
+  /// Get(2): Wait for unit 2, trigger load of units [2,3,4], unload [0,1]
+  /// ```
+  ParallelUnitLoader(
+      std::vector<std::unique_ptr<LoadUnit>> units,
+      folly::Executor* ioExecutor,
+      uint16_t maxConcurrentLoads)
+      : loadUnits_(std::move(units)),
+        ioExecutor_(ioExecutor),
+        maxConcurrentLoads_(maxConcurrentLoads) {
+    VELOX_CHECK_NOT_NULL(ioExecutor, "ParallelUnitLoader ioExecutor is null");
+    VELOX_CHECK_GT(
+        maxConcurrentLoads_,
+        0,
+        "ParallelUnitLoader maxConcurrentLoads should be larger than 0");
+    futures_.resize(loadUnits_.size());
+    unloadFutures_.resize(loadUnits_.size());
+    unitsLoaded_.resize(loadUnits_.size());
+  }
+
+  /// Destructor ensures all pending load operations are properly cancelled
+  /// and waited for to prevent resource leaks and dangling references.
+  ~ParallelUnitLoader() override {
+    for (auto& future : futures_) {
+      future.cancel();
+      future.wait();
+    }
+  }
+
+  LoadUnit& getLoadedUnit(uint32_t unit) override {
+    VELOX_CHECK_LT(unit, loadUnits_.size(), "Unit out of range");
+
+    processedUnits_.insert(unit);
+    // Ensure sliding window of units [unit, unit + maxConcurrentLoads_) is
+    // loading
+    for (size_t i = unit;
+         i < loadUnits_.size() && i < unit + maxConcurrentLoads_;
+         ++i) {
+      if (!unitsLoaded_[i]) {
+        load(i);
+      }
+    }
+
+    uint64_t unitLoadNanos{0};
+    try {
+      NanosecondTimer timer{&unitLoadNanos};
+      futures_[unit].wait();
+    } catch (const std::exception& e) {
+      VELOX_FAIL("Failed to load unit {}: {}", unit, e.what());
+    }
+    waitForUnitReadyNanos_ += unitLoadNanos;
+
+    // Unload the previous units
+    unloadUntil(unit);
+
+    return *loadUnits_[unit];
+  }
+
+  void onRead(uint32_t unit, uint64_t rowOffsetInUnit, uint64_t /* rowCount */)
+      override {
+    VELOX_CHECK_LT(unit, loadUnits_.size(), "Unit out of range");
+    VELOX_CHECK_LT(
+        rowOffsetInUnit, loadUnits_[unit]->getNumRows(), "Row out of range");
+  }
+
+  void onSeek(uint32_t unit, uint64_t rowOffsetInUnit) override {
+    VELOX_CHECK_LT(unit, loadUnits_.size(), "Unit out of range");
+    VELOX_CHECK_LE(
+        rowOffsetInUnit, loadUnits_[unit]->getNumRows(), "Row out of range");
+  }
+
+  UnitLoaderStats stats() override {
+    UnitLoaderStats stats;
+    stats.addCounter("processedUnits", RuntimeCounter(processedUnits_.size()));
+    stats.addCounter(
+        "waitForUnitReadyNanos",
+        RuntimeCounter(
+            waitForUnitReadyNanos_ > std::numeric_limits<int64_t>::max()
+                ? std::numeric_limits<int64_t>::max()
+                : waitForUnitReadyNanos_,
+            RuntimeCounter::Unit::kNanos));
+    return stats;
+  }
+
+ private:
+  /// Submits the unit's load() to the I/O thread pool
+  void load(uint32_t unitIndex) {
+    VELOX_CHECK_LT(unitIndex, loadUnits_.size(), "Unit index out of bounds");
+    VELOX_CHECK_NOT_NULL(ioExecutor_, "ParallelUnitLoader ioExecutor is null");
+
+    futures_[unitIndex] = folly::via(
+        ioExecutor_, [this, unitIndex]() { loadUnits_[unitIndex]->load(); });
+    unitsLoaded_[unitIndex] = true;
+  }
+
+  /// Unloads all the units before 'unitIndex'
+  void unloadUntil(uint32_t unitIndex) {
+    for (size_t i = 0; i < unitIndex; ++i) {
+      if (unitsLoaded_[i]) {
+        loadUnits_[i]->unload();
+        unitsLoaded_[i] = false;
+      }
+    }
+  }
+
+  std::vector<bool> unitsLoaded_;
+  std::vector<std::unique_ptr<LoadUnit>> loadUnits_;
+  std::vector<folly::Future<folly::Unit>> futures_;
+  std::vector<folly::Future<folly::Unit>> unloadFutures_;
+  folly::Executor* ioExecutor_;
+  size_t maxConcurrentLoads_;
+
+  // Stats
+  std::unordered_set<uint32_t> processedUnits_;
+  uint64_t waitForUnitReadyNanos_{0};
+};
+
+std::unique_ptr<UnitLoader> ParallelUnitLoaderFactory::create(
+    std::vector<std::unique_ptr<LoadUnit>> loadUnits,
+    uint64_t rowsToSkip) {
+  const auto totalRows = std::accumulate(
+      loadUnits.cbegin(), loadUnits.cend(), 0UL, [](uint64_t sum, auto& unit) {
+        return sum + unit->getNumRows();
+      });
+  VELOX_CHECK_LE(
+      rowsToSkip,
+      totalRows,
+      "Can only skip up to the past-the-end row of the file.");
+  return std::make_unique<ParallelUnitLoader>(
+      std::move(loadUnits), ioExecutor_, maxConcurrentLoads_);
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ParallelUnitLoader.h
+++ b/velox/dwio/common/ParallelUnitLoader.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <folly/futures/Future.h>
+
+#include <vector>
+#include "velox/dwio/common/UnitLoader.h"
+
+namespace facebook::velox::dwio::common {
+class ParallelUnitLoaderFactory : public UnitLoaderFactory {
+ public:
+  ParallelUnitLoaderFactory(
+      folly::Executor* ioExecutor,
+      size_t maxConcurrentLoads)
+      : ioExecutor_(ioExecutor), maxConcurrentLoads_(maxConcurrentLoads) {}
+
+  std::unique_ptr<UnitLoader> create(
+      std::vector<std::unique_ptr<LoadUnit>> loadUnits,
+      uint64_t rowsToSkip) override;
+
+ private:
+  folly::Executor* ioExecutor_;
+  size_t maxConcurrentLoads_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -149,7 +149,9 @@ class ScanSpec {
   }
 
   void setSubscript(int64_t subscript) {
-    subscript_ = subscript;
+    if (subscript_ != subscript) {
+      subscript_ = subscript;
+    }
   }
 
   // True if the value is returned from scan.  A runtime pushdown of a filter

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -18,6 +18,7 @@
 
 #include <folly/Hash.h>
 #include <folly/container/F14Map.h>
+#include "velox/dwio/common/UnitLoader.h"
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
@@ -558,10 +559,14 @@ struct RuntimeStatistics {
 
   int64_t numStripes{0};
 
+  UnitLoaderStats unitLoaderStats;
   ColumnReaderStatistics columnReaderStatistics;
 
   std::unordered_map<std::string, RuntimeCounter> toMap() {
     std::unordered_map<std::string, RuntimeCounter> result;
+    for (const auto& [name, metric] : unitLoaderStats.stats()) {
+      result.emplace(name, RuntimeCounter(metric.sum, metric.unit));
+    }
     if (skippedSplits > 0) {
       result.emplace("skippedSplits", RuntimeCounter(skippedSplits));
     }

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
   DecoderUtilTest.cpp
   ExecutorBarrierTest.cpp
   OnDemandUnitLoaderTests.cpp
+  ParallelUnitLoaderTest.cpp
   LocalFileSinkTest.cpp
   MemorySinkTest.cpp
   LoggedExceptionTest.cpp

--- a/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
+++ b/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ParallelUnitLoader.h"
+#include "velox/dwio/common/OnDemandUnitLoader.h"
+#include "velox/dwio/common/tests/UnitLoaderBaseTest.h"
+#include "velox/dwio/common/tests/utils/UnitLoaderTestTools.h"
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/Future.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::dwio::common::test;
+
+class ParallelUnitLoaderTest
+    : public UnitLoaderBaseTest<ParallelUnitLoaderFactory> {
+ protected:
+  ParallelUnitLoaderFactory createFactory() override {
+    return ParallelUnitLoaderFactory(ioExecutor_.get(), 2);
+  }
+
+  std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_ =
+      std::make_unique<folly::CPUThreadPoolExecutor>(10);
+};
+
+TEST_F(ParallelUnitLoaderTest, NoUnitButSkip) {
+  testNoUnitButSkip();
+}
+
+TEST_F(ParallelUnitLoaderTest, InitialSkip) {
+  testInitialSkip();
+}
+
+TEST_F(ParallelUnitLoaderTest, CanRequestUnitMultipleTimes) {
+  testCanRequestUnitMultipleTimes();
+}
+
+TEST_F(ParallelUnitLoaderTest, UnitOutOfRange) {
+  testUnitOutOfRange();
+}
+
+TEST_F(ParallelUnitLoaderTest, SeekOutOfRange) {
+  testSeekOutOfRange();
+}
+
+TEST_F(ParallelUnitLoaderTest, SeekOutOfRangeReaderError) {
+  testSeekOutOfRangeReaderError();
+}
+
+TEST_F(ParallelUnitLoaderTest, LoadsCorrectlyWithReader) {
+  auto factory = createFactory();
+  ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
+
+  EXPECT_TRUE(readerMock.read(3)); // Unit: 0, rows: 0-2, load(0)
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(3)); // Unit: 0, rows: 3-5
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(4)); // Unit: 0, rows: 6-9
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({true, true, false}));
+
+  EXPECT_TRUE(readerMock.read(14)); // Unit: 1, rows: 0-13, unload(0), load(1)
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, true, true}));
+
+  // will only read 5 rows, no more rows in unit 1
+  EXPECT_TRUE(readerMock.read(10)); // Unit: 1, rows: 14-19
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, true, true}));
+
+  EXPECT_TRUE(readerMock.read(30)); // Unit: 2, rows: 0-29, unload(1), load(2)
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, true}));
+
+  EXPECT_FALSE(readerMock.read(30)); // No more data
+  EXPECT_EQ(readerMock.unitsLoaded(), std::vector<bool>({false, false, true}));
+}
+
+// Performance comparison test
+TEST_F(ParallelUnitLoaderTest, PerformanceComparison) {
+  std::vector<uint64_t> rowsPerUnit = {100, 100, 100, 100, 100, 100, 100, 100};
+  std::vector<uint64_t> ioSizes = {
+      1024, 1024, 1024, 1024, 1024, 1024, 1024, 1024};
+
+  // Measure ParallelUnitLoader performance
+  auto parallelStart = std::chrono::high_resolution_clock::now();
+  {
+    auto factory = createFactory();
+    ReaderMock reader(rowsPerUnit, ioSizes, factory, 0);
+
+    for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+      uint64_t totalRowsRead = 0;
+      while (totalRowsRead < rowsPerUnit[i]) {
+        reader.read(25);
+        int nextRead = rowsPerUnit[i] - totalRowsRead;
+        totalRowsRead += std::min(25, nextRead);
+      }
+    }
+  }
+  auto parallelEnd = std::chrono::high_resolution_clock::now();
+
+  // Measure OnDemandUnitLoader performance
+  auto onDemandStart = std::chrono::high_resolution_clock::now();
+  {
+    auto factory = std::make_shared<OnDemandUnitLoaderFactory>(nullptr);
+    ReaderMock reader(rowsPerUnit, ioSizes, *factory, 0);
+
+    for (size_t i = 0; i < rowsPerUnit.size(); ++i) {
+      uint64_t totalRowsRead = 0;
+      while (totalRowsRead < rowsPerUnit[i]) {
+        reader.read(25);
+        int nextRead = rowsPerUnit[i] - totalRowsRead;
+        totalRowsRead += std::min(25, nextRead);
+      }
+    }
+  }
+  auto onDemandEnd = std::chrono::high_resolution_clock::now();
+
+  auto parallelDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      parallelEnd - parallelStart);
+  auto onDemandDuration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      onDemandEnd - onDemandStart);
+
+  // ParallelUnitLoader should be faster
+  EXPECT_GT(onDemandDuration.count(), parallelDuration.count());
+}

--- a/velox/dwio/common/tests/UnitLoaderBaseTest.h
+++ b/velox/dwio/common/tests/UnitLoaderBaseTest.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/UnitLoaderTools.h"
+#include "velox/dwio/common/tests/utils/UnitLoaderTestTools.h"
+
+using facebook::velox::dwio::common::LoadUnit;
+using facebook::velox::dwio::common::test::getUnitsLoadedWithFalse;
+using facebook::velox::dwio::common::test::LoadUnitMock;
+using facebook::velox::dwio::common::test::ReaderMock;
+
+/// Base test class template that provides common test functionality for
+/// different UnitLoader implementations. This template class can be inherited
+/// by specific test classes to get access to common test methods. Each derived
+/// class should provide a createFactory() method that returns the appropriate
+/// factory instance.
+template <typename UnitLoaderFactoryType>
+class UnitLoaderBaseTest : public ::testing::Test {
+ protected:
+  /// Factory method to create the appropriate UnitLoaderFactory instance.
+  /// This method should be implemented by derived classes.
+  virtual UnitLoaderFactoryType createFactory() = 0;
+
+  /// Test that UnitLoader factory handles the case where no units exist but
+  /// skip is requested
+  void testNoUnitButSkip() {
+    UnitLoaderFactoryType factory = createFactory();
+    std::vector<std::unique_ptr<LoadUnit>> units;
+
+    EXPECT_NO_THROW(factory.create(std::move(units), 0));
+
+    std::vector<std::unique_ptr<LoadUnit>> units2;
+    VELOX_ASSERT_THROW(
+        factory.create(std::move(units2), 1),
+        "Can only skip up to the past-the-end row of the file.");
+  }
+
+  /// Test that UnitLoader factory handles initial skip correctly for various
+  /// skip values
+  void testInitialSkip() {
+    auto getFactoryWithSkip = [this](uint64_t skipToRow) {
+      auto factory = createFactory();
+      std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(3));
+      std::vector<std::unique_ptr<LoadUnit>> units;
+      units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+      units.push_back(std::make_unique<LoadUnitMock>(20, 0, unitsLoaded, 1));
+      units.push_back(std::make_unique<LoadUnitMock>(30, 0, unitsLoaded, 2));
+      factory.create(std::move(units), skipToRow);
+    };
+
+    EXPECT_NO_THROW(getFactoryWithSkip(0));
+    EXPECT_NO_THROW(getFactoryWithSkip(1));
+    EXPECT_NO_THROW(getFactoryWithSkip(9));
+    EXPECT_NO_THROW(getFactoryWithSkip(10));
+    EXPECT_NO_THROW(getFactoryWithSkip(11));
+    EXPECT_NO_THROW(getFactoryWithSkip(29));
+    EXPECT_NO_THROW(getFactoryWithSkip(30));
+    EXPECT_NO_THROW(getFactoryWithSkip(31));
+    EXPECT_NO_THROW(getFactoryWithSkip(59));
+    EXPECT_NO_THROW(getFactoryWithSkip(60));
+    VELOX_ASSERT_THROW(
+        getFactoryWithSkip(61),
+        "Can only skip up to the past-the-end row of the file.");
+    VELOX_ASSERT_THROW(
+        getFactoryWithSkip(100),
+        "Can only skip up to the past-the-end row of the file.");
+  }
+
+  /// Test that the same unit can be requested multiple times without issues
+  void testCanRequestUnitMultipleTimes() {
+    auto factory = createFactory();
+    std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(1));
+    std::vector<std::unique_ptr<LoadUnit>> units;
+    units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+
+    auto unitLoader = factory.create(std::move(units), 0);
+    unitLoader->getLoadedUnit(0);
+    unitLoader->getLoadedUnit(0);
+    unitLoader->getLoadedUnit(0);
+  }
+
+  /// Test that requesting a unit index out of range throws an exception
+  void testUnitOutOfRange() {
+    auto factory = createFactory();
+    std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(1));
+    std::vector<std::unique_ptr<LoadUnit>> units;
+    units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+
+    auto unitLoader = factory.create(std::move(units), 0);
+    unitLoader->getLoadedUnit(0);
+
+    VELOX_ASSERT_THROW(unitLoader->getLoadedUnit(1), "Unit out of range");
+  }
+
+  /// Test that seeking out of range throws an exception
+  void testSeekOutOfRange() {
+    auto factory = createFactory();
+    std::vector<std::atomic_bool> unitsLoaded(getUnitsLoadedWithFalse(1));
+    std::vector<std::unique_ptr<LoadUnit>> units;
+    units.push_back(std::make_unique<LoadUnitMock>(10, 0, unitsLoaded, 0));
+
+    auto unitLoader = factory.create(std::move(units), 0);
+
+    unitLoader->onSeek(0, 10);
+
+    VELOX_ASSERT_THROW(unitLoader->onSeek(0, 11), "Row out of range");
+  }
+
+  /// Test that seeking out of range in ReaderMock throws appropriate exception
+  void testSeekOutOfRangeReaderError() {
+    auto factory = createFactory();
+    ReaderMock readerMock{{10, 20, 30}, {0, 0, 0}, factory, 0};
+
+    readerMock.seek(59);
+    readerMock.seek(60);
+
+    VELOX_ASSERT_THROW(
+        readerMock.seek(61),
+        "Can't seek to possition 61 in file. Must be up to 60.");
+  }
+};

--- a/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
+++ b/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
@@ -32,16 +32,20 @@ class LoadUnitMock : public LoadUnit {
       uint64_t rowCount,
       uint64_t ioSize,
       std::vector<std::atomic_bool>& unitsLoaded,
-      size_t unitId)
+      size_t unitId,
+      std::chrono::milliseconds loadDelay = std::chrono::milliseconds(100))
       : rowCount_{rowCount},
         ioSize_{ioSize},
         unitsLoaded_{unitsLoaded},
-        unitId_{unitId} {}
+        unitId_{unitId},
+        loadDelay_(loadDelay) {}
 
   ~LoadUnitMock() override = default;
 
   void load() override {
     VELOX_CHECK(!isLoaded());
+    // Simulate loading time
+    std::this_thread::sleep_for(loadDelay_);
     unitsLoaded_[unitId_] = true;
   }
 
@@ -67,6 +71,7 @@ class LoadUnitMock : public LoadUnit {
   uint64_t ioSize_;
   std::vector<std::atomic_bool>& unitsLoaded_;
   size_t unitId_;
+  std::chrono::milliseconds loadDelay_;
 };
 
 class ReaderMock {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -113,6 +113,7 @@ class DwrfRowReader : public StrideIndexProvider,
     stats.numStripes += stripeCeiling_ - firstStripe_;
     stats.columnReaderStatistics.flattenStringDictionaryValues +=
         columnReaderStatistics_.flattenStringDictionaryValues;
+    stats.unitLoaderStats.merge(unitLoadStats_);
   }
 
   void resetFilterCaches() override;
@@ -209,6 +210,8 @@ class DwrfRowReader : public StrideIndexProvider,
 
   // Number of processed strides.
   int64_t processedStrides_{0};
+
+  dwio::common::UnitLoaderStats unitLoadStats_;
 
   // Set to true after clearing filter caches, i.e. adding a dynamic filter.
   // Causes filters to be re-evaluated against stride stats on next stride

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -48,6 +48,12 @@ void compareOutputs(
   for (; std::getline(iss, line);) {
     lineCount++;
     std::vector<std::string> potentialLines;
+    if (expectedLineIndex >= expectedRegex.size()) {
+      ASSERT_FALSE(true) << "Output has more lines than expected."
+                         << "\n  Source: " << testName
+                         << "\n  Line number: " << lineCount
+                         << "\n  Unexpected Line: " << line;
+    }
     auto expectedLine = expectedRegex.at(expectedLineIndex++);
     while (!RE2::FullMatch(line, expectedLine.line)) {
       potentialLines.push_back(expectedLine.line);
@@ -59,11 +65,18 @@ void compareOutputs(
                            << "\n  Expected Line one of: "
                            << folly::join(",", potentialLines);
       }
+      if (expectedLineIndex >= expectedRegex.size()) {
+        ASSERT_FALSE(true)
+            << "Output did not match and no more patterns to check."
+            << "\n  Source: " << testName << "\n  Line number: " << lineCount
+            << "\n  Line: " << line
+            << "\n  Expected Line one of: " << folly::join(",", potentialLines);
+      }
       expectedLine = expectedRegex.at(expectedLineIndex++);
     }
   }
   for (int i = expectedLineIndex; i < expectedRegex.size(); i++) {
-    ASSERT_TRUE(expectedRegex[expectedLineIndex].optional);
+    ASSERT_TRUE(expectedRegex[i].optional);
   }
 }
 
@@ -209,6 +222,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
         true},
        {"          processedSplits[ ]+sum: 20, count: 1, min: 20, max: 20, avg: 20"},
        {"          processedStrides[ ]+sum: 20, count: 1, min: 20, max: 20, avg: 20"},
+       {"          processedUnits      [ ]* sum: .+, count: .+, min: .+, max: .+"},
        {"          ramReadBytes        [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"          readyPreloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
         true},
@@ -218,6 +232,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"          storageReadBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"          totalRemainingFilterWallNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
        {"          totalScanTime       [ ]* sum: .+, count: .+, min: .+, max: .+"},
+       {"          unitLoadNanos[ ]* sum: .+, count: .+, min: .+, max: .+, avg: .+"},
        {"          waitForPreloadSplitNanos[ ]* sum: .+, count: .+, min: .+, max: .+, avg: .+"},
        {"    -- Project\\[1\\]\\[expressions: \\(u_c0:INTEGER, ROW\\[\"c0\"\\]\\), \\(u_c1:BIGINT, ROW\\[\"c1\"\\]\\)\\] -> u_c0:INTEGER, u_c1:BIGINT"},
        {"       Output: 100 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: 0B, Memory allocations: .+, Threads: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
@@ -303,6 +318,7 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
          {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
          {"        processedSplits  [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
          {"        processedStrides [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
+         {"        processedUnits   [ ]* sum: .+, count: .+, min: .+, max: .+"},
          {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
           true},
          {"        ramReadBytes     [ ]* sum: .+, count: 1, min: .+, max: .+"},
@@ -313,7 +329,8 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
          {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
          {"        storageReadBytes [ ]* sum: .+, count: 1, min: .+, max: .+"},
          {"        totalRemainingFilterWallNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
-         {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
+         {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"},
+         {"        unitLoadNanos[ ]* sum: .+, count: .+, min: .+, max: .+, avg: .+"}});
   }
 }
 
@@ -378,6 +395,7 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
        {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"        processedSplits  [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
        {"        processedStrides [ ]* sum: 1, count: 1, min: 1, max: 1, avg: 1"},
+       {"        processedUnits   [ ]* sum: .+, count: .+, min: .+, max: .+"},
        {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
         true},
        {"        ramReadBytes     [ ]* sum: .+, count: 1, min: .+, max: .+"},
@@ -388,7 +406,8 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
        {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        storageReadBytes [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"        totalRemainingFilterWallNanos\\s+sum: .+, count: .+, min: .+, max: .+"},
-       {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
+       {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"},
+       {"        unitLoadNanos[ ]* sum: .+, count: .+, min: .+, max: .+, avg: .+"}});
 }
 
 TEST_F(PrintPlanWithStatsTest, taskAPI) {


### PR DESCRIPTION
Introduce ParallelUnitLoader that enables concurrent loading of
multiple units (e.g., stripes) in sliding window fashion to improve
I/O throughput and reduce read latency