### PR TITLE
fix(build): Add a missing space after "." in shared library warning message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ endif()
 if(VELOX_BUILD_SHARED)
   message(
     WARNING
-    "When building Velox as a shared library it's recommended to build against a shared build of folly to avoid issues with linking of gflags."
+    "When building Velox as a shared library it's recommended to build against a shared build of folly to avoid issues with linking of gflags. "
     "This is currently NOT being enforced so user discretion is advised."
   )
 endif()


### PR DESCRIPTION
Here is the current output:

    CMake Warning at CMakeLists.txt:111 (message):
      When building Velox as a shared library it's recommended to build against a
      shared build of folly to avoid issues with linking of gflags.This is
      currently NOT being enforced so user discretion is advised.
      
A space is missing after "gflags." before "This".