### PR TITLE
feat: Add basic support for writing to an Iceberg table

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 
 #include <boost/lexical_cast.hpp>
 #include <memory>
@@ -73,6 +74,16 @@ std::unique_ptr<DataSink> HiveConnector::createDataSink(
     ConnectorInsertTableHandlePtr connectorInsertTableHandle,
     ConnectorQueryCtx* connectorQueryCtx,
     CommitStrategy commitStrategy) {
+  if (auto icebergInsertHandle =
+          std::dynamic_pointer_cast<const iceberg::IcebergInsertTableHandle>(
+              connectorInsertTableHandle)) {
+    return std::make_unique<iceberg::IcebergDataSink>(
+        inputType,
+        icebergInsertHandle,
+        connectorQueryCtx,
+        commitStrategy,
+        hiveConfig_);
+  }
   auto hiveInsertHandle =
       std::dynamic_pointer_cast<const HiveInsertTableHandle>(
           connectorInsertTableHandle);

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -682,7 +682,10 @@ bool HiveDataSink::finish() {
 std::vector<std::string> HiveDataSink::close() {
   setState(State::kClosed);
   closeInternal();
+  return commitMessage();
+}
 
+std::vector<std::string> HiveDataSink::commitMessage() const {
   std::vector<std::string> partitionUpdates;
   partitionUpdates.reserve(writerInfo_.size());
   for (int i = 0; i < writerInfo_.size(); ++i) {

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -337,9 +337,11 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
 
   std::string toString() const override;
 
- private:
+ protected:
   const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
   const std::shared_ptr<const LocationHandle> locationHandle_;
+
+ private:
   const dwio::common::FileFormat storageFormat_;
   const std::shared_ptr<const HiveBucketProperty> bucketProperty_;
   const std::optional<common::CompressionKind> compressionKind_;
@@ -544,10 +546,18 @@ class HiveDataSink : public DataSink {
 
   bool canReclaim() const;
 
- private:
+ protected:
   // Validates the state transition from 'oldState' to 'newState'.
   void checkStateTransition(State oldState, State newState);
   void setState(State newState);
+
+  // Generates commit messages for all writers containing metadata about written
+  // files. Creates a JSON object for each writer with partition name,
+  // file paths, file names, data sizes, and row counts. This metadata is used
+  // by the coordinator to commit the transaction and update the metastore.
+  //
+  // @return Vector of JSON strings, one per writer.
+  virtual std::vector<std::string> commitMessage() const;
 
   class WriterReclaimer : public exec::MemoryReclaimer {
    public:

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 velox_add_library(
   velox_hive_iceberg_splitreader
+  IcebergDataSink.cpp
   IcebergSplitReader.cpp
   IcebergSplit.cpp
   PositionalDeleteFileReader.cpp

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/common/base/Fs.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+IcebergInsertTableHandle::IcebergInsertTableHandle(
+    std::vector<HiveColumnHandlePtr> inputColumns,
+    LocationHandlePtr locationHandle,
+    dwio::common::FileFormat tableStorageFormat,
+    std::optional<common::CompressionKind> compressionKind,
+    const std::unordered_map<std::string, std::string>& serdeParameters)
+    : HiveInsertTableHandle(
+          std::move(inputColumns),
+          std::move(locationHandle),
+          tableStorageFormat,
+          nullptr,
+          compressionKind,
+          serdeParameters,
+          nullptr,
+          false,
+          std::make_shared<const HiveInsertFileNameGenerator>()) {
+  VELOX_USER_CHECK(
+      !inputColumns_.empty(),
+      "Input columns cannot be empty for Iceberg tables.");
+  VELOX_USER_CHECK_NOT_NULL(
+      locationHandle_, "Location handle is required for Iceberg tables.");
+}
+
+IcebergDataSink::IcebergDataSink(
+    RowTypePtr inputType,
+    IcebergInsertTableHandlePtr insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy,
+    const std::shared_ptr<const HiveConfig>& hiveConfig)
+    : HiveDataSink(
+          std::move(inputType),
+          insertTableHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig,
+          0,
+          nullptr) {}
+
+std::vector<std::string> IcebergDataSink::commitMessage() const {
+  std::vector<std::string> commitTasks;
+  commitTasks.reserve(writerInfo_.size());
+
+  for (auto i = 0; i < writerInfo_.size(); ++i) {
+    const auto& info = writerInfo_.at(i);
+    VELOX_CHECK_NOT_NULL(info);
+    // Following metadata (json format) is consumed by Presto CommitTaskData.
+    // It contains the minimal subset of metadata.
+    // TODO: Complete metrics is missing now and this could lead to suboptimal
+    // query plan, will collect full iceberg metrics in following PR.
+    // clang-format off
+    folly::dynamic commitData = folly::dynamic::object(
+    "path", (fs::path(info->writerParameters.writeDirectory()) /
+                    info->writerParameters.writeFileName()).string())
+      ("fileSizeInBytes", ioStats_.at(i)->rawBytesWritten())
+      ("metrics",
+        folly::dynamic::object("recordCount", info->numWrittenRows))
+      ("partitionSpecJson", 0)
+      ("fileFormat", "PARQUET")
+      ("content", "DATA");
+    // clang-format on
+    auto commitDataJson = folly::toJson(commitData);
+    commitTasks.push_back(commitDataJson);
+  }
+  return commitTasks;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/HiveDataSink.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Represents a request for Iceberg write.
+class IcebergInsertTableHandle final : public HiveInsertTableHandle {
+ public:
+  /// @param inputColumns Columns from the table schema to write.
+  /// The input RowVector must have the same number of columns and matching
+  /// types in the same order.
+  /// Column names in the RowVector may differ from those in inputColumns,
+  /// only position and type must align. All columns present in the input
+  /// data must be included, mismatches can lead to write failure.
+  /// @param locationHandle Contains the target location information including:
+  /// - Base directory path where data files will be written.
+  /// - File naming scheme and temporary directory paths.
+  /// @param compressionKind Optional compression to apply to data files.
+  /// @param serdeParameters Additional serialization/deserialization parameters
+  /// for the file format.
+  IcebergInsertTableHandle(
+      std::vector<HiveColumnHandlePtr> inputColumns,
+      LocationHandlePtr locationHandle,
+      dwio::common::FileFormat tableStorageFormat,
+      std::optional<common::CompressionKind> compressionKind = {},
+      const std::unordered_map<std::string, std::string>& serdeParameters = {});
+};
+
+using IcebergInsertTableHandlePtr =
+    std::shared_ptr<const IcebergInsertTableHandle>;
+
+class IcebergDataSink : public HiveDataSink {
+ public:
+  IcebergDataSink(
+      RowTypePtr inputType,
+      IcebergInsertTableHandlePtr insertTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      CommitStrategy commitStrategy,
+      const std::shared_ptr<const HiveConfig>& hiveConfig);
+
+  /// Generates Iceberg-specific commit messages for all writers containing
+  /// metadata about written files. Creates a JSON object for each writer
+  /// in the format expected by Presto and Spark for Iceberg tables.
+  ///
+  /// Each commit message contains:
+  /// - path: full file path where data was written.
+  /// - fileSizeInBytes: raw bytes written to disk.
+  /// - metrics: object with recordCount (number of rows written).
+  /// - partitionSpecJson: partition specification.
+  /// - fileFormat: storage format (e.g., "PARQUET").
+  /// - content: file content type ("DATA" for data files).
+  ///
+  /// See
+  /// https://github.com/prestodb/presto/blob/master/presto-iceberg/src/main/java/com/facebook/presto/iceberg/CommitTaskData.java
+  ///
+  /// Note: Complete Iceberg metrics are not yet implemented, which results in
+  /// incomplete manifest files that may lead to suboptimal query planning.
+  ///
+  /// @return Vector of JSON strings, one per writer, formatted according to
+  /// Presto and Spark Iceberg commit protocol.
+  std::vector<std::string> commitMessage() const override;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -56,9 +56,29 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest
     GTest::gtest_main
   )
+
+  add_executable(velox_hive_iceberg_insert_test IcebergInsertTest.cpp IcebergTestBase.cpp Main.cpp)
+
+  add_test(velox_hive_iceberg_insert_test velox_hive_iceberg_insert_test)
+
+  target_link_libraries(
+    velox_hive_iceberg_insert_test
+    velox_exec_test_lib
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_vector_fuzzer
+    GTest::gtest
+  )
+
   if(VELOX_ENABLE_PARQUET)
     target_link_libraries(velox_hive_iceberg_test velox_dwio_parquet_reader)
 
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
+    target_link_libraries(
+      velox_hive_iceberg_insert_test
+      velox_dwio_parquet_reader
+      velox_dwio_parquet_writer
+    )
   endif()
 endif()

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+namespace {
+
+class IcebergInsertTest : public test::IcebergTestBase {
+ protected:
+  void test(const RowTypePtr& rowType, double nullRatio = 0.0) {
+    const auto outputDirectory = exec::test::TempDirectoryPath::create();
+    const auto dataPath = fmt::format("{}", outputDirectory->getPath());
+    constexpr int32_t numBatches = 10;
+    constexpr int32_t vectorSize = 5'000;
+    const auto vectors =
+        createTestData(rowType, numBatches, vectorSize, nullRatio);
+    auto dataSink =
+        createIcebergDataSink(rowType, outputDirectory->getPath(), {});
+
+    for (const auto& vector : vectors) {
+      dataSink->appendData(vector);
+    }
+
+    ASSERT_TRUE(dataSink->finish());
+    const auto commitTasks = dataSink->close();
+    createDuckDbTable(vectors);
+    auto splits = createSplitsForDirectory(dataPath);
+    ASSERT_EQ(splits.size(), commitTasks.size());
+    auto plan = exec::test::PlanBuilder().tableScan(rowType).planNode();
+    assertQuery(plan, splits, "SELECT * FROM tmp");
+  }
+};
+
+TEST_F(IcebergInsertTest, basic) {
+  auto rowType =
+      ROW({"c1", "c2", "c3", "c4", "c5", "c6", "c7", "c8", "c9", "c10", "c11"},
+          {BIGINT(),
+           INTEGER(),
+           SMALLINT(),
+           BOOLEAN(),
+           REAL(),
+           DECIMAL(18, 5),
+           VARCHAR(),
+           VARBINARY(),
+           DATE(),
+           TIMESTAMP(),
+           ROW({"id", "name"}, {INTEGER(), VARCHAR()})});
+  test(rowType, 0.2);
+}
+
+TEST_F(IcebergInsertTest, mapAndArray) {
+  auto rowType =
+      ROW({"c1", "c2"}, {MAP(INTEGER(), VARCHAR()), ARRAY(VARCHAR())});
+  test(rowType);
+}
+
+#ifdef VELOX_ENABLE_PARQUET
+TEST_F(IcebergInsertTest, bigDecimal) {
+  auto rowType = ROW({"c1"}, {DECIMAL(38, 5)});
+  fileFormat_ = dwio::common::FileFormat::PARQUET;
+  test(rowType);
+}
+#endif
+
+} // namespace
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+
+namespace facebook::velox::connector::hive::iceberg::test {
+
+void IcebergTestBase::SetUp() {
+  HiveConnectorTestBase::SetUp();
+#ifdef VELOX_ENABLE_PARQUET
+  parquet::registerParquetReaderFactory();
+  parquet::registerParquetWriterFactory();
+#endif
+  Type::registerSerDe();
+
+  connectorSessionProperties_ = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>(), true);
+
+  connectorConfig_ =
+      std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
+
+  setupMemoryPools();
+
+  fuzzerOptions_.vectorSize = 100;
+  fuzzerOptions_.nullRatio = 0.1;
+  fuzzer_ = std::make_unique<VectorFuzzer>(fuzzerOptions_, opPool_.get());
+}
+
+void IcebergTestBase::TearDown() {
+  fuzzer_.reset();
+  connectorQueryCtx_.reset();
+  connectorPool_.reset();
+  opPool_.reset();
+  root_.reset();
+  HiveConnectorTestBase::TearDown();
+}
+
+void IcebergTestBase::setupMemoryPools() {
+  root_.reset();
+  opPool_.reset();
+  connectorPool_.reset();
+  connectorQueryCtx_.reset();
+
+  root_ = memory::memoryManager()->addRootPool(
+      "IcebergTest", 1L << 30, exec::MemoryReclaimer::create());
+  opPool_ = root_->addLeafChild("operator");
+  connectorPool_ =
+      root_->addAggregateChild("connector", exec::MemoryReclaimer::create());
+
+  connectorQueryCtx_ = std::make_unique<connector::ConnectorQueryCtx>(
+      opPool_.get(),
+      connectorPool_.get(),
+      connectorSessionProperties_.get(),
+      nullptr,
+      common::PrefixSortConfig(),
+      nullptr,
+      nullptr,
+      "query.IcebergTest",
+      "task.IcebergTest",
+      "planNodeId.IcebergTest",
+      0,
+      "");
+}
+
+std::vector<RowVectorPtr> IcebergTestBase::createTestData(
+    RowTypePtr rowType,
+    int32_t numBatches,
+    vector_size_t rowsPerBatch,
+    double nullRatio) {
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(numBatches);
+
+  fuzzerOptions_.nullRatio = nullRatio;
+  fuzzerOptions_.allowDictionaryVector = false;
+  fuzzerOptions_.timestampPrecision =
+      fuzzer::FuzzerTimestampPrecision::kMilliSeconds;
+  fuzzer_->setOptions(fuzzerOptions_);
+
+  for (auto i = 0; i < numBatches; ++i) {
+    vectors.push_back(fuzzer_->fuzzRow(rowType, rowsPerBatch, false));
+  }
+
+  return vectors;
+}
+
+IcebergInsertTableHandlePtr IcebergTestBase::createIcebergInsertTableHandle(
+    const RowTypePtr& rowType,
+    const std::string& outputDirectoryPath) {
+  std::vector<HiveColumnHandlePtr> columnHandles;
+  for (auto i = 0; i < rowType->size(); ++i) {
+    auto columnName = rowType->nameOf(i);
+    auto columnType = HiveColumnHandle::ColumnType::kRegular;
+    columnHandles.push_back(std::make_shared<HiveColumnHandle>(
+        columnName, columnType, rowType->childAt(i), rowType->childAt(i)));
+  }
+
+  auto locationHandle = std::make_shared<LocationHandle>(
+      outputDirectoryPath,
+      outputDirectoryPath,
+      LocationHandle::TableType::kNew);
+
+  return std::make_shared<const IcebergInsertTableHandle>(
+      columnHandles,
+      locationHandle,
+      fileFormat_,
+      common::CompressionKind::CompressionKind_ZSTD);
+}
+
+std::shared_ptr<IcebergDataSink> IcebergTestBase::createIcebergDataSink(
+    const RowTypePtr& rowType,
+    const std::string& outputDirectoryPath,
+    const std::vector<std::string>& partitionTransforms) {
+  auto tableHandle =
+      createIcebergInsertTableHandle(rowType, outputDirectoryPath);
+  return std::make_shared<IcebergDataSink>(
+      rowType,
+      tableHandle,
+      connectorQueryCtx_.get(),
+      connector::CommitStrategy::kNoCommit,
+      connectorConfig_);
+}
+
+std::vector<std::string> IcebergTestBase::listFiles(
+    const std::string& dirPath) {
+  std::vector<std::string> files;
+  if (!std::filesystem::exists(dirPath)) {
+    return files;
+  }
+
+  for (auto& dirEntry :
+       std::filesystem::recursive_directory_iterator(dirPath)) {
+    if (dirEntry.is_regular_file()) {
+      files.push_back(dirEntry.path().string());
+    }
+  }
+  return files;
+}
+
+std::vector<std::shared_ptr<ConnectorSplit>>
+IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  std::unordered_map<std::string, std::string> customSplitInfo;
+  customSplitInfo["table_format"] = "hive-iceberg";
+
+  auto files = listFiles(directory);
+  for (const auto& filePath : files) {
+    const auto file = filesystems::getFileSystem(filePath, nullptr)
+                          ->openFileForRead(filePath);
+    splits.push_back(std::make_shared<HiveIcebergSplit>(
+        exec::test::kHiveConnectorId,
+        filePath,
+        fileFormat_,
+        0,
+        file->size(),
+        std::unordered_map<std::string, std::optional<std::string>>{},
+        std::nullopt,
+        customSplitInfo,
+        nullptr,
+        /*cacheable=*/true,
+        std::vector<IcebergDeleteFile>()));
+  }
+
+  return splits;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+#include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#include "velox/dwio/parquet/reader/ParquetReader.h"
+#endif
+
+namespace facebook::velox::connector::hive::iceberg::test {
+
+class IcebergTestBase : public exec::test::HiveConnectorTestBase {
+ protected:
+  void SetUp() override;
+
+  void TearDown() override;
+
+  std::vector<RowVectorPtr> createTestData(
+      RowTypePtr rowType,
+      int32_t numBatches,
+      vector_size_t rowsPerBatch,
+      double nullRatio = 0.0);
+
+  std::shared_ptr<IcebergDataSink> createIcebergDataSink(
+      const RowTypePtr& rowType,
+      const std::string& outputDirectoryPath,
+      const std::vector<std::string>& partitionTransforms = {});
+
+  std::vector<std::shared_ptr<ConnectorSplit>> createSplitsForDirectory(
+      const std::string& directory);
+
+  std::vector<std::string> listFiles(const std::string& dirPath);
+
+  dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
+
+ private:
+  IcebergInsertTableHandlePtr createIcebergInsertTableHandle(
+      const RowTypePtr& rowType,
+      const std::string& outputDirectoryPath);
+
+  std::vector<std::string> listPartitionDirectories(
+      const std::string& dataPath);
+
+  void setupMemoryPools();
+
+  std::shared_ptr<memory::MemoryPool> root_;
+  std::shared_ptr<memory::MemoryPool> opPool_;
+  std::shared_ptr<memory::MemoryPool> connectorPool_;
+  std::shared_ptr<config::ConfigBase> connectorSessionProperties_;
+  std::shared_ptr<HiveConfig> connectorConfig_;
+  std::unique_ptr<ConnectorQueryCtx> connectorQueryCtx_;
+  VectorFuzzer::Options fuzzerOptions_;
+  std::unique_ptr<VectorFuzzer> fuzzer_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/Main.cpp
+++ b/velox/connectors/hive/iceberg/tests/Main.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/ThreadDebugInfo.h"
+
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+// This main is needed for some tests on linux.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  // Signal handler required for ThreadDebugInfoTest
+  facebook::velox::process::addDefaultFatalSignalHandler();
+  folly::Init init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
As per review request from https://github.com/facebookincubator/velox/pull/10996, we should split #10996 to multiple smaller PRs.

This is the first PR of them. It adds support for basic insertion without partition transforms or data file statistics. The implementation supports both primitive data types and nested types, including struct, map, and array.

A series of follow-up PRs will extend this work to make Iceberg write fully compatible with the Iceberg specification.

1. Iceberg partition spec (new files).
2. Add new option for Timestamp::tmToStringView to meet Iceberg spec (completely standalone code).
3. Customise iceberg writer options.
4. Iceberg file name generator.
5. Iceberg partition ID generator (new files).
6. Identity partition transform.
