### PR TITLE
feat(parquet): Add NaN statistics to Parquet writer

### DIFF
--- a/velox/dwio/parquet/writer/arrow/Statistics.cpp
+++ b/velox/dwio/parquet/writer/arrow/Statistics.cpp
@@ -18,8 +18,6 @@
 
 #include "velox/dwio/parquet/writer/arrow/Statistics.h"
 
-#include "velox/functions/lib/string/StringImpl.h"
-
 #include <algorithm>
 #include <cmath>
 #include <cstring>
@@ -42,6 +40,7 @@
 #include "velox/dwio/parquet/writer/arrow/Platform.h"
 #include "velox/dwio/parquet/writer/arrow/Schema.h"
 #include "velox/functions/lib/Utf8Utils.h"
+#include "velox/functions/lib/string/StringImpl.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/HugeInt.h"
 
@@ -613,9 +612,11 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
       int64_t num_values,
       int64_t null_count,
       int64_t distinct_count,
+      int64_t nan_count,
       bool has_min_max,
       bool has_null_count,
       bool has_distinct_count,
+      bool has_nan_count,
       MemoryPool* pool)
       : TypedStatisticsImpl(descr, pool) {
     TypedStatisticsImpl::IncrementNumValues(num_values);
@@ -628,6 +629,12 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
       SetDistinctCount(distinct_count);
     } else {
       has_distinct_count_ = false;
+    }
+
+    if (has_nan_count) {
+      IncrementNaNValues(nan_count);
+    } else {
+      has_nan_count_ = false;
     }
 
     if (!encoded_min.empty()) {
@@ -649,6 +656,10 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     return has_null_count_;
   };
 
+  bool HasNaNCount() const override {
+    return has_nan_count_;
+  };
+
   void IncrementNullCount(int64_t n) override {
     statistics_.null_count += n;
     has_null_count_ = true;
@@ -656,6 +667,13 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
 
   void IncrementNumValues(int64_t n) override {
     num_values_ += n;
+  }
+
+  void IncrementNaNValues(int64_t n) override {
+    if (n > 0) {
+      nan_count_ += n;
+      has_nan_count_ = true;
+    }
   }
 
   bool Equals(const Statistics& raw_other) const override {
@@ -695,6 +713,10 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
       this->statistics_.null_count += other.null_count();
     } else {
       this->has_null_count_ = false;
+    }
+    if (other.HasNaNCount()) {
+      this->nan_count_ += other.nan_count();
+      this->has_nan_count_ = true;
     }
     if (has_distinct_count_ && other.HasDistinctCount() &&
         (distinct_count() == 0 || other.distinct_count() == 0)) {
@@ -829,6 +851,9 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     if (HasDistinctCount()) {
       s.set_distinct_count(this->distinct_count());
     }
+    if (has_nan_count_) {
+      s.set_nan_count(nan_count_);
+    }
     return s;
   }
 
@@ -840,6 +865,10 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   }
   int64_t num_values() const override {
     return num_values_;
+  }
+
+  int64_t nan_count() const override {
+    return nan_count_;
   }
 
   bool MaxGreaterThan(const Statistics& other) const override {
@@ -859,6 +888,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   bool has_min_max_ = false;
   bool has_null_count_ = false;
   bool has_distinct_count_ = false;
+  bool has_nan_count_ = false;
   T min_;
   T max_;
   ::arrow::MemoryPool* pool_;
@@ -868,6 +898,8 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   // a statistics thrift message which doesn't have the optional null_count,
   // `num_values_` may include null values.
   int64_t num_values_ = 0;
+  // NaN count is tracked separately since it's not written to the parquet file.
+  int64_t nan_count_ = 0;
   EncodedStatistics statistics_;
   std::shared_ptr<TypedComparator<DType>> comparator_;
   std::shared_ptr<ResizableBuffer> min_buffer_, max_buffer_;
@@ -888,6 +920,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
   void ResetCounts() {
     this->statistics_.null_count = 0;
     this->statistics_.distinct_count = 0;
+    this->nan_count_ = 0;
     this->num_values_ = 0;
   }
 
@@ -900,6 +933,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
     this->has_distinct_count_ = false;
     // Null count calculation is cheap and enabled by default.
     this->has_null_count_ = true;
+    this->has_nan_count_ = false;
   }
 
   void SetMinMaxPair(std::pair<T, T> min_max) {
@@ -924,6 +958,46 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
           comparator_->Compare(max_, max) ? max : max_,
           &max_,
           max_buffer_.get());
+    }
+  }
+
+  int64_t CountNaN(const T* values, int64_t length) {
+    if constexpr (!std::is_floating_point_v<T>) {
+      return 0;
+    } else {
+      int64_t count = 0;
+      for (auto i = 0; i < length; i++) {
+        const auto val = SafeLoad(values + i);
+        if (std::isnan(val)) {
+          count++;
+        }
+      }
+      return count;
+    }
+  }
+
+  int64_t CountNaNSpaced(
+      const T* values,
+      int64_t length,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) {
+    if constexpr (!std::is_floating_point_v<T>) {
+      return 0;
+    } else {
+      int64_t count = 0;
+      ::arrow::internal::VisitSetBitRunsVoid(
+          valid_bits,
+          valid_bits_offset,
+          length,
+          [&](int64_t position, int64_t run_length) {
+            for (auto i = 0; i < run_length; i++) {
+              const auto val = SafeLoad(values + i + position);
+              if (std::isnan(val)) {
+                count++;
+              }
+            }
+          });
+      return count;
     }
   }
 };
@@ -981,6 +1055,7 @@ void TypedStatisticsImpl<DType>::Update(
   if (num_values == 0)
     return;
   SetMinMaxPair(comparator_->GetMinMax(values, num_values));
+  IncrementNaNValues(CountNaN(values, num_values));
 }
 
 template <typename DType>
@@ -1001,6 +1076,8 @@ void TypedStatisticsImpl<DType>::UpdateSpaced(
     return;
   SetMinMaxPair(comparator_->GetMinMaxSpaced(
       values, num_spaced_values, valid_bits, valid_bits_offset));
+  IncrementNaNValues(
+      CountNaNSpaced(values, num_spaced_values, valid_bits, valid_bits_offset));
 }
 
 template <typename DType>
@@ -1165,9 +1242,11 @@ std::shared_ptr<Statistics> Statistics::Make(
       num_values,
       encoded_stats->null_count,
       encoded_stats->distinct_count,
+      encoded_stats->nan_count,
       encoded_stats->has_min && encoded_stats->has_max,
       encoded_stats->has_null_count,
       encoded_stats->has_distinct_count,
+      encoded_stats->has_nan_count,
       pool);
 }
 
@@ -1178,9 +1257,11 @@ std::shared_ptr<Statistics> Statistics::Make(
     int64_t num_values,
     int64_t null_count,
     int64_t distinct_count,
+    int64_t nan_count,
     bool has_min_max,
     bool has_null_count,
     bool has_distinct_count,
+    bool has_nan_count,
     ::arrow::MemoryPool* pool) {
 #define MAKE_STATS(CAP_TYPE, KLASS)                      \
   case Type::CAP_TYPE:                                   \
@@ -1191,9 +1272,11 @@ std::shared_ptr<Statistics> Statistics::Make(
         num_values,                                      \
         null_count,                                      \
         distinct_count,                                  \
+        nan_count,                                       \
         has_min_max,                                     \
         has_null_count,                                  \
         has_distinct_count,                              \
+        has_nan_count,                                   \
         pool)
 
   switch (descr->physical_type()) {

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -344,9 +344,11 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
         this->values_.size(),
         0,
         0,
+        0,
         true,
         true,
-        true);
+        true,
+        false);
 
     auto statistics3 = MakeStatistics<TestType>(this->schema_.Column(0));
     std::vector<uint8_t> valid_bits(
@@ -610,9 +612,11 @@ void TestStatistics<ByteArrayType>::TestMinMaxEncode() {
       this->values_.size(),
       0,
       0,
+      0,
       true,
       true,
-      true);
+      true,
+      false);
 
   ASSERT_EQ(encoded_min, statistics2->EncodeMin());
   ASSERT_EQ(encoded_max, statistics2->EncodeMax());
@@ -1533,6 +1537,7 @@ void CheckNaNs() {
   auto some_nan_stats = MakeStatistics<ParquetType>(&descr);
   // Ingesting only nans should not yield valid min max
   AssertUnsetMinMax(some_nan_stats, all_nans);
+  EXPECT_EQ(some_nan_stats->nan_count(), all_nans.size());
   // Ingesting a mix of NaNs and non-NaNs should not yield valid min max.
   AssertMinMaxAre(some_nan_stats, some_nans, min, max);
   // Ingesting only nans after a valid min/max, should have not effect
@@ -1550,6 +1555,7 @@ void CheckNaNs() {
       1.5f, max, -3.0f, -1.0f, nan, 2.0f, min, nan};
   auto other_stats = MakeStatistics<ParquetType>(&descr);
   AssertMinMaxAre(other_stats, other_nans, min, max);
+  EXPECT_EQ(other_stats->nan_count(), 2);
 }
 
 TEST(TestStatistic, NaNFloatValues) {
@@ -1574,6 +1580,7 @@ TEST(TestStatisticsSortOrderFloatNaN, NaNAndNullsInfiniteLoop) {
   uint8_t all_but_last_valid = 0x7F; // 0b01111111
   auto stats = MakeStatistics<FloatType>(&descr);
   AssertUnsetMinMax(stats, nans_but_last, &all_but_last_valid);
+  EXPECT_EQ(stats->nan_count(), kNumValues - 1);
 }
 
 template <


### PR DESCRIPTION
Add NaN statistic to Parquet writer

This change introduces a NaN statistic in the Parquet writer. Unlike other statistics (e.g., null_count, distinct_count), the NaN statistic is not written to the Parquet file footer. It is only reported to the Parquet writer caller when needed, such as when writing Iceberg Parquet data files.