### PR TITLE
misc: Consistently use the name 'ioExecutor' in connector API

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -668,6 +668,14 @@ class Connector {
       const std::string& scanId,
       int32_t loadQuantum);
 
+  /// Returns the IOExecutor used by the connector. It is used to run async IO
+  /// operations by the connector.
+  virtual folly::Executor* ioExecutor() const {
+    return nullptr;
+  }
+
+  // This is for backward compatibility, todo: remove after verax repo is
+  // updated
   virtual folly::Executor* executor() const {
     return nullptr;
   }

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -39,7 +39,7 @@ hiveConnectorMetadataFactories() {
 HiveConnector::HiveConnector(
     const std::string& id,
     std::shared_ptr<const config::ConfigBase> config,
-    folly::Executor* executor)
+    folly::Executor* ioExecutor)
     : Connector(id, std::move(config)),
       hiveConfig_(std::make_shared<HiveConfig>(connectorConfig())),
       fileHandleFactory_(
@@ -48,7 +48,7 @@ HiveConnector::HiveConnector(
                     hiveConfig_->numCacheFileHandles())
               : nullptr,
           std::make_unique<FileHandleGenerator>(hiveConfig_->config())),
-      executor_(executor) {
+      ioExecutor_(ioExecutor) {
   if (hiveConfig_->isFileHandleCacheEnabled()) {
     LOG(INFO) << "Hive connector " << connectorId()
               << " created with maximum of "
@@ -77,7 +77,7 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
       tableHandle,
       columnHandles,
       &fileHandleFactory_,
-      executor_,
+      ioExecutor_,
       connectorQueryCtx,
       hiveConfig_);
 }

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -65,8 +65,8 @@ class HiveConnector : public Connector {
       ConnectorQueryCtx* connectorQueryCtx,
       CommitStrategy commitStrategy) override;
 
-  folly::Executor* executor() const override {
-    return executor_;
+  folly::Executor* ioExecutor() const override {
+    return ioExecutor_;
   }
 
   FileHandleCacheStats fileHandleCacheStats() {
@@ -82,7 +82,7 @@ class HiveConnector : public Connector {
  protected:
   const std::shared_ptr<HiveConfig> hiveConfig_;
   FileHandleFactory fileHandleFactory_;
-  folly::Executor* executor_;
+  folly::Executor* ioExecutor_;
   std::shared_ptr<ConnectorMetadata> metadata_;
 };
 

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -61,11 +61,11 @@ HiveDataSource::HiveDataSource(
     const connector::ConnectorTableHandlePtr& tableHandle,
     const connector::ColumnHandleMap& columnHandles,
     FileHandleFactory* fileHandleFactory,
-    folly::Executor* executor,
+    folly::Executor* ioExecutor,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<HiveConfig>& hiveConfig)
     : fileHandleFactory_(fileHandleFactory),
-      executor_(executor),
+      ioExecutor_(ioExecutor),
       connectorQueryCtx_(connectorQueryCtx),
       hiveConfig_(hiveConfig),
       pool_(connectorQueryCtx->memoryPool()),
@@ -217,7 +217,7 @@ std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
       ioStats_,
       fsStats_,
       fileHandleFactory_,
-      executor_,
+      ioExecutor_,
       scanSpec_);
 }
 
@@ -550,7 +550,7 @@ std::shared_ptr<wave::WaveDataSource> HiveDataSource::toWaveDataSource() {
         readerOutputType_,
         &partitionKeys_,
         fileHandleFactory_,
-        executor_,
+        ioExecutor_,
         connectorQueryCtx_,
         hiveConfig_,
         ioStats_,

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -102,7 +102,7 @@ class HiveDataSource : public DataSource {
   virtual std::unique_ptr<SplitReader> createSplitReader();
 
   FileHandleFactory* const fileHandleFactory_;
-  folly::Executor* const executor_;
+  folly::Executor* const ioExecutor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<HiveConfig> hiveConfig_;
   memory::MemoryPool* const pool_;

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<SplitReader> SplitReader::create(
     const std::shared_ptr<io::IoStatistics>& ioStats,
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
-    folly::Executor* executor,
+    folly::Executor* ioExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec) {
   //  Create the SplitReader based on hiveSplit->customSplitInfo["table_format"]
   if (hiveSplit->customSplitInfo.count("table_format") > 0 &&
@@ -98,7 +98,7 @@ std::unique_ptr<SplitReader> SplitReader::create(
         ioStats,
         fsStats,
         fileHandleFactory,
-        executor,
+        ioExecutor,
         scanSpec);
   } else {
     return std::unique_ptr<SplitReader>(new SplitReader(
@@ -111,7 +111,7 @@ std::unique_ptr<SplitReader> SplitReader::create(
         ioStats,
         fsStats,
         fileHandleFactory,
-        executor,
+        ioExecutor,
         scanSpec));
   }
 }
@@ -126,7 +126,7 @@ SplitReader::SplitReader(
     const std::shared_ptr<io::IoStatistics>& ioStats,
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
-    folly::Executor* executor,
+    folly::Executor* ioExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec)
     : hiveSplit_(hiveSplit),
       hiveTableHandle_(hiveTableHandle),
@@ -137,7 +137,7 @@ SplitReader::SplitReader(
       ioStats_(ioStats),
       fsStats_(fsStats),
       fileHandleFactory_(fileHandleFactory),
-      executor_(executor),
+      ioExecutor_(ioExecutor),
       pool_(connectorQueryCtx->memoryPool()),
       scanSpec_(scanSpec),
       baseReaderOpts_(connectorQueryCtx->memoryPool()),
@@ -318,7 +318,7 @@ void SplitReader::createReader() {
       connectorQueryCtx_,
       ioStats_,
       fsStats_,
-      executor_);
+      ioExecutor_);
 
   baseReader_ = dwio::common::getReaderFactory(baseReaderOpts_.fileFormat())
                     ->createReader(std::move(baseFileInput), baseReaderOpts_);

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -66,7 +66,7 @@ class SplitReader {
       const std::shared_ptr<io::IoStatistics>& ioStats,
       const std::shared_ptr<filesystems::File::IoStats>& fsStats,
       FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
+      folly::Executor* ioExecutor,
       const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   virtual ~SplitReader() = default;
@@ -185,7 +185,7 @@ class SplitReader {
   const std::shared_ptr<io::IoStatistics> ioStats_;
   const std::shared_ptr<filesystems::File::IoStats> fsStats_;
   FileHandleFactory* const fileHandleFactory_;
-  folly::Executor* const executor_;
+  folly::Executor* const ioExecutor_;
   memory::MemoryPool* const pool_;
 
   std::shared_ptr<common::ScanSpec> scanSpec_;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -84,7 +84,7 @@ void IcebergSplitReader::prepareSplit(
                 hiveSplit_->filePath,
                 fileHandleFactory_,
                 connectorQueryCtx_,
-                executor_,
+                ioExecutor_,
                 hiveConfig_,
                 ioStats_,
                 fsStats_,

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -466,8 +466,8 @@ void TableScan::preload(
 }
 
 void TableScan::checkPreload() {
-  auto* executor = connector_->executor();
-  if (maxSplitPreloadPerDriver_ == 0 || !executor ||
+  auto* ioExecutor = connector_->ioExecutor();
+  if (maxSplitPreloadPerDriver_ == 0 || !ioExecutor ||
       !connector_->supportsSplitPreload()) {
     return;
   }
@@ -476,11 +476,11 @@ void TableScan::checkPreload() {
         maxSplitPreloadPerDriver_;
     if (!splitPreloader_) {
       splitPreloader_ =
-          [executor,
+          [ioExecutor,
            this](const std::shared_ptr<connector::ConnectorSplit>& split) {
             preload(split);
 
-            executor->add([connectorSplit = split]() mutable {
+            ioExecutor->add([connectorSplit = split]() mutable {
               connectorSplit->dataSource->prepare();
               connectorSplit.reset();
             });

--- a/velox/experimental/wave/exec/TableScan.cpp
+++ b/velox/experimental/wave/exec/TableScan.cpp
@@ -195,8 +195,8 @@ void TableScan::preload(std::shared_ptr<connector::ConnectorSplit> split) {
 }
 
 void TableScan::checkPreload() {
-  auto executor = connector_->executor();
-  if (maxPreloadedSplits_ == 0 || !executor ||
+  auto ioExecutor = connector_->ioExecutor();
+  if (maxPreloadedSplits_ == 0 || !ioExecutor ||
       !connector_->supportsSplitPreload()) {
     return;
   }
@@ -205,10 +205,10 @@ void TableScan::checkPreload() {
         maxSplitPreloadPerDriver_;
     if (!splitPreloader_) {
       splitPreloader_ =
-          [executor, this](std::shared_ptr<connector::ConnectorSplit> split) {
+          [ioExecutor, this](std::shared_ptr<connector::ConnectorSplit> split) {
             preload(split);
 
-            executor->add(
+            ioExecutor->add(
                 [taskHolder = driver_->operatorCtx()->task(), split]() mutable {
                   split->dataSource->prepare();
                   split.reset();


### PR DESCRIPTION
In newConnector API, an 'ioExecutor' is passed down to connector's constructor, 
but down the callstack, it's changed to 'executor'