### PR TITLE
refactor: All function literals that registered without prefix should be listed in single place (with Spark)

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -21,6 +21,7 @@
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 
 namespace facebook::velox::connector::hive {
@@ -899,8 +900,8 @@ core::TypedExprPtr extractFiltersFromRemainingFilter(
     return inner ? replaceInputs(call, {inner}) : nullptr;
   }
 
-  if ((call->name() == "and" && !negated) ||
-      (call->name() == "or" && negated)) {
+  if ((call->name() == expression::kAnd && !negated) ||
+      (call->name() == expression::kOr && negated)) {
     auto lhs = extractFiltersFromRemainingFilter(
         call->inputs()[0], evaluator, negated, filters, sampleRate);
     auto rhs = extractFiltersFromRemainingFilter(

--- a/velox/dwio/common/MetadataFilter.cpp
+++ b/velox/dwio/common/MetadataFilter.cpp
@@ -18,6 +18,7 @@
 
 #include <folly/container/F14Map.h>
 #include "velox/dwio/common/ScanSpec.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 
 namespace facebook::velox::common {
@@ -163,19 +164,19 @@ std::unique_ptr<MetadataFilter::Node> MetadataFilter::Node::fromExpression(
   if (!call) {
     return nullptr;
   }
-  if (call->name() == "and") {
+  if (call->name() == expression::kAnd) {
     auto lhs = fromExpression(*call->inputs()[0], evaluator, negated);
     auto rhs = fromExpression(*call->inputs()[1], evaluator, negated);
     return negated ? OrNode::create(std::move(lhs), std::move(rhs))
                    : AndNode::create(std::move(lhs), std::move(rhs));
   }
-  if (call->name() == "or") {
+  if (call->name() == expression::kOr) {
     auto lhs = fromExpression(*call->inputs()[0], evaluator, negated);
     auto rhs = fromExpression(*call->inputs()[1], evaluator, negated);
     return negated ? AndNode::create(std::move(lhs), std::move(rhs))
                    : OrNode::create(std::move(lhs), std::move(rhs));
   }
-  if (call->name() == "not") {
+  if (call->name() == expression::bug::kNot) {
     return fromExpression(*call->inputs()[0], evaluator, !negated);
   }
   try {

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -27,7 +27,7 @@ CoalesceExpr::CoalesceExpr(
           SpecialFormKind::kCoalesce,
           std::move(type),
           std::move(inputs),
-          expression::kCoalesce,
+          expression::old::kCoalesce,
           inputsSupportFlatNoNullsFastPath,
           false /* trackCpuUsage */) {
   std::vector<TypePtr> inputTypes;

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -446,7 +446,7 @@ ExprPtr compileRewrittenExpression(
     case core::ExprKind::kConcat: {
       result = getSpecialForm(
           config,
-          RowConstructorCallToSpecialForm::kRowConstructor,
+          expression::kRowConstructor,
           resultType,
           std::move(compiledInputs),
           trackCpuUsage);

--- a/velox/expression/ExprConstants.h
+++ b/velox/expression/ExprConstants.h
@@ -15,16 +15,67 @@
  */
 #pragma once
 
+/// This file contains string literals for function names.
+/// These literals listed in single place to explicitly list functions that
+/// names used once even in case when user specify some prefix on registration.
+
 namespace facebook::velox::expression {
 
-constexpr const char* kAnd = "and";
-constexpr const char* kOr = "or";
-constexpr const char* kSwitch = "switch";
-constexpr const char* kIf = "if";
-constexpr const char* kFail = "fail";
-constexpr const char* kCoalesce = "coalesce";
-constexpr const char* kCast = "cast";
-constexpr const char* kTryCast = "try_cast";
-constexpr const char* kTry = "try";
+/// These functions registered without prefix and velox code rely on this.
+inline constexpr const char* kAnd = "and";
+inline constexpr const char* kOr = "or";
+inline constexpr const char* kIn = "in";
+inline constexpr const char* kCast = "cast";
+inline constexpr const char* kTryCast = "try_cast";
+inline constexpr const char* kIsNull = "is_null";
+inline constexpr const char* kRowConstructor = "row_constructor";
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+inline constexpr const char* kSwitch = "switch";
+inline constexpr const char* kIf = "if";
+inline constexpr const char* kFail = "fail";
+inline constexpr const char* kCoalesce = "coalesce";
+inline constexpr const char* kTry = "try";
+#endif
+
+/// These functions are also registered without prefix, but right now velox code
+/// doesn't rely on this. So please try to avoid such dependency in future,
+/// because it can be changed. To discourage usage of these literals in new code
+/// we put them to `old` namespace.
+namespace old {
+
+/// common, presto and spark special form functions without prefix
+inline constexpr const char* kCoalesce = "coalesce";
+inline constexpr const char* kIf = "if";
+inline constexpr const char* kSwitch = "switch";
+inline constexpr const char* kTry = "try";
+
+/// spark special form functions without prefix
+inline constexpr const char* kMakeDecimal = "make_decimal";
+inline constexpr const char* kRoundDecimal = "decimal_round";
+inline constexpr const char* kAtLeastNNonNulls = "at_least_n_non_nulls";
+inline constexpr const char* kFromJson = "from_json";
+inline constexpr const char* kGetStructField = "get_struct_field";
+inline constexpr const char* kGetArrayStructFields = "get_array_struct_fields";
+inline constexpr const char* kConcatWs = "concat_ws";
+
+} // namespace old
+
+/// TODO: If you're using these literals you don't account that these functions
+/// created with prefix. In general we should fix these usages or create these
+/// functions without prefix. Or move these files to test/benchmark utils.
+/// To encourage to fix these usages we put these literals to `bug` namespace.
+namespace bug {
+
+inline constexpr const char* kNot = "not";
+inline constexpr const char* kEq = "eq";
+inline constexpr const char* kNeq = "neq";
+inline constexpr const char* kLt = "lt";
+inline constexpr const char* kLte = "lte";
+inline constexpr const char* kGt = "gt";
+inline constexpr const char* kGte = "gte";
+inline constexpr const char* kArrayConstructor = "array_constructor";
+inline constexpr const char* kBetween = "between";
+
+} // namespace bug
 } // namespace facebook::velox::expression

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -17,6 +17,7 @@
 #include "velox/expression/ExprToSubfieldFilter.h"
 
 #include "velox/expression/Expr.h"
+#include "velox/expression/ExprConstants.h"
 
 using namespace facebook::velox;
 
@@ -477,47 +478,47 @@ PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
 
   const auto* leftSide = call.inputs()[0].get();
 
-  if (call.name() == "eq") {
+  if (call.name() == expression::bug::kEq) {
     if (toSubfield(leftSide, subfield)) {
       return negated ? makeNotEqualFilter(call.inputs()[1], evaluator)
                      : makeEqualFilter(call.inputs()[1], evaluator);
     }
-  } else if (call.name() == "neq") {
+  } else if (call.name() == expression::bug::kNeq) {
     if (toSubfield(leftSide, subfield)) {
       return negated ? makeEqualFilter(call.inputs()[1], evaluator)
                      : makeNotEqualFilter(call.inputs()[1], evaluator);
     }
-  } else if (call.name() == "lte") {
+  } else if (call.name() == expression::bug::kLte) {
     if (toSubfield(leftSide, subfield)) {
       return negated ? makeGreaterThanFilter(call.inputs()[1], evaluator)
                      : makeLessThanOrEqualFilter(call.inputs()[1], evaluator);
     }
-  } else if (call.name() == "lt") {
+  } else if (call.name() == expression::bug::kLt) {
     if (toSubfield(leftSide, subfield)) {
       return negated ? makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator)
                      : makeLessThanFilter(call.inputs()[1], evaluator);
     }
-  } else if (call.name() == "gte") {
+  } else if (call.name() == expression::bug::kGte) {
     if (toSubfield(leftSide, subfield)) {
       return negated
           ? makeLessThanFilter(call.inputs()[1], evaluator)
           : makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator);
     }
-  } else if (call.name() == "gt") {
+  } else if (call.name() == expression::bug::kGt) {
     if (toSubfield(leftSide, subfield)) {
       return negated ? makeLessThanOrEqualFilter(call.inputs()[1], evaluator)
                      : makeGreaterThanFilter(call.inputs()[1], evaluator);
     }
-  } else if (call.name() == "between") {
+  } else if (call.name() == expression::bug::kBetween) {
     if (toSubfield(leftSide, subfield)) {
       return makeBetweenFilter(
           call.inputs()[1], call.inputs()[2], evaluator, negated);
     }
-  } else if (call.name() == "in") {
+  } else if (call.name() == expression::kIn) {
     if (toSubfield(leftSide, subfield)) {
       return makeInFilter(call.inputs()[1], evaluator, negated);
     }
-  } else if (call.name() == "is_null") {
+  } else if (call.name() == expression::kIsNull) {
     if (toSubfield(leftSide, subfield)) {
       if (negated) {
         return isNotNull();
@@ -532,7 +533,7 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator) {
   if (auto call = asCall(expr.get())) {
-    if (call->name() == "or") {
+    if (call->name() == expression::kOr) {
       auto left = toSubfieldFilter(call->inputs()[0], evaluator);
       auto right = toSubfieldFilter(call->inputs()[1], evaluator);
       VELOX_CHECK(left.first == right.first);
@@ -542,7 +543,7 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
     }
     common::Subfield subfield;
     std::unique_ptr<common::Filter> filter;
-    if (call->name() == "not") {
+    if (call->name() == expression::bug::kNot) {
       if (auto* inner = asCall(call->inputs()[0].get())) {
         filter =
             ExprToSubfieldFilterParser::getInstance()->leafCallToSubfieldFilter(

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -28,6 +28,7 @@
 #include "velox/expression/TryExpr.h"
 
 namespace facebook::velox::exec {
+
 void registerFunctionCallToSpecialForms() {
   registerFunctionCallToSpecialForm(
       expression::kAnd,
@@ -37,18 +38,20 @@ void registerFunctionCallToSpecialForms() {
   registerFunctionCallToSpecialForm(
       expression::kTryCast, std::make_unique<TryCastCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      expression::kCoalesce, std::make_unique<CoalesceCallToSpecialForm>());
+      expression::old::kCoalesce,
+      std::make_unique<CoalesceCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      expression::kIf, std::make_unique<IfCallToSpecialForm>());
+      expression::old::kIf, std::make_unique<IfCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
       expression::kOr,
       std::make_unique<ConjunctCallToSpecialForm>(false /* isAnd */));
   registerFunctionCallToSpecialForm(
-      expression::kSwitch, std::make_unique<SwitchCallToSpecialForm>());
+      expression::old::kSwitch, std::make_unique<SwitchCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      expression::kTry, std::make_unique<TryCallToSpecialForm>());
+      expression::old::kTry, std::make_unique<TryCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      RowConstructorCallToSpecialForm::kRowConstructor,
+      expression::kRowConstructor,
       std::make_unique<RowConstructorCallToSpecialForm>());
 }
+
 } // namespace facebook::velox::exec

--- a/velox/expression/RegisterSpecialForm.h
+++ b/velox/expression/RegisterSpecialForm.h
@@ -17,5 +17,7 @@
 #pragma once
 
 namespace facebook::velox::exec {
+
 void registerFunctionCallToSpecialForms();
-}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/RowConstructor.cpp
+++ b/velox/expression/RowConstructor.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/expression/RowConstructor.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/VectorFunction.h"
 
 namespace facebook::velox::exec {
@@ -40,13 +41,15 @@ ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(
       [&config](auto& functionMap) -> std::pair<
                                        std::shared_ptr<VectorFunction>,
                                        VectorFunctionMetadata> {
-        auto functionIterator = functionMap.find(kRowConstructor);
+        auto functionIterator = functionMap.find(expression::kRowConstructor);
         if (functionIterator != functionMap.end()) {
           return {
-              functionIterator->second.factory(kRowConstructor, {}, config),
+              functionIterator->second.factory(
+                  expression::kRowConstructor, {}, config),
               functionIterator->second.metadata};
         } else {
-          VELOX_FAIL("Function {} is not registered.", kRowConstructor);
+          VELOX_FAIL(
+              "Function {} is not registered.", expression::kRowConstructor);
         }
       });
 
@@ -55,7 +58,7 @@ ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren),
       function,
       metadata,
-      kRowConstructor,
+      expression::kRowConstructor,
       trackCpuUsage);
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/RowConstructor.h
+++ b/velox/expression/RowConstructor.h
@@ -28,7 +28,5 @@ class RowConstructorCallToSpecialForm : public FunctionCallToSpecialForm {
       std::vector<ExprPtr>&& compiledChildren,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kRowConstructor = "row_constructor";
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/SwitchExpr.h"
 #include "velox/expression/BooleanMix.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/ScopedVarSetter.h"
 
@@ -35,7 +36,7 @@ SwitchExpr::SwitchExpr(
           SpecialFormKind::kSwitch,
           std::move(type),
           inputs,
-          "switch",
+          expression::old::kSwitch,
           hasElseClause(inputs) && inputsSupportFlatNoNullsFastPath,
           false /* trackCpuUsage */),
       numCases_{inputs_.size() / 2},

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -29,7 +29,7 @@ class TryExpr : public SpecialForm {
             SpecialFormKind::kTry,
             std::move(type),
             {std::move(input)},
-            expression::kTry,
+            expression::old::kTry,
             false /* supportsFlatNoNullsFastPath */,
             false /* trackCpuUsage */) {}
 

--- a/velox/functions/CoverageUtil.cpp
+++ b/velox/functions/CoverageUtil.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/WindowFunction.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/functions/FunctionRegistry.h"
 
 namespace facebook::velox::functions {
@@ -297,7 +298,9 @@ bool isCompanionFunctionName(
 /// excluding companion functions.
 std::vector<std::string> getSortedScalarNames() {
   // Do not print "internal" functions.
-  static const std::unordered_set<std::string> kBlockList = {"row_constructor"};
+  static const folly::F14FastSet<std::string_view> kBlockList{
+      expression::kRowConstructor,
+  };
 
   auto functions = getFunctionSignatures();
 

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/core/Expressions.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 
@@ -389,7 +390,9 @@ core::TypedExprPtr rewriteReduce(
     auto minus = std::make_shared<core::CallTypedExpr>(
         fx->type(), prefix + "minus", fx, inputBody->inputs()[1]);
     return toArraySum(prefix, *reduce, inputArgs, minus);
-  } else if (inputBody->name() == "if" && inputBody->inputs().size() == 3) {
+  } else if (
+      inputBody->name() == expression::old::kIf &&
+      inputBody->inputs().size() == 3) {
     // if(h(x), s + f(x), s + g(x)) =>
     // array_sum(transform(array, x -> if(h(x), f(x), g(x))))
     auto fx = extractFromAddition(prefix, inputBody->inputs()[1], s);
@@ -401,7 +404,7 @@ core::TypedExprPtr rewriteReduce(
       return nullptr;
     }
     auto ifExpr = std::make_shared<core::CallTypedExpr>(
-        fx->type(), "if", inputBody->inputs()[0], fx, gx);
+        fx->type(), expression::old::kIf, inputBody->inputs()[0], fx, gx);
     return toArraySum(prefix, *reduce, inputArgs, ifExpr);
   }
   return nullptr;

--- a/velox/functions/prestosql/SimpleComparisonMatcher.cpp
+++ b/velox/functions/prestosql/SimpleComparisonMatcher.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/prestosql/SimpleComparisonMatcher.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/vector/ConstantVector.h"
 
 namespace facebook::velox::functions::prestosql {
@@ -50,7 +51,8 @@ class IfMatcher : public Matcher {
 
   bool match(const core::TypedExprPtr& expr) override {
     if (auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
-      if (call->name() == "if" && allMatch(call->inputs(), inputMatchers_)) {
+      if (call->name() == expression::old::kIf &&
+          allMatch(call->inputs(), inputMatchers_)) {
         return true;
       }
     }

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/RegisterSpecialForm.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/IsNull.h"
@@ -69,17 +70,16 @@ extern void registerElementAtFunction(
     const std::string& name,
     bool enableCaching);
 
-// Special form functions don't have any prefix.
-void registerAllSpecialFormGeneralFunctions() {
+void registerAllSpecialFormGeneralFunctions(const std::string& prefix) {
   exec::registerFunctionCallToSpecialForms();
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_in, "in");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_in, expression::kIn);
   registerFunction<
       GenericInPredicateFunction,
       bool,
       Generic<T1>,
-      Variadic<Generic<T1>>>({"in"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "row_constructor");
-  registerIsNullFunction("is_null");
+      Variadic<Generic<T1>>>({expression::kIn});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, expression::kRowConstructor);
+  registerIsNullFunction(expression::kIsNull);
 }
 
 void registerGeneralFunctions(const std::string& prefix) {
@@ -101,7 +101,7 @@ void registerGeneralFunctions(const std::string& prefix) {
 
   registerFailFunction({prefix + "fail"});
 
-  registerAllSpecialFormGeneralFunctions();
+  registerAllSpecialFormGeneralFunctions(prefix);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/ConcatWs.cpp
+++ b/velox/functions/sparksql/ConcatWs.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/sparksql/ConcatWs.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/VectorFunction.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -383,7 +384,7 @@ exec::ExprPtr ConcatWsCallToSpecialForm::constructSpecialForm(
       std::move(args),
       std::move(concatWsFunction),
       exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
-      kConcatWs,
+      expression::old::kConcatWs,
       trackCpuUsage);
 }
 

--- a/velox/functions/sparksql/ConcatWs.h
+++ b/velox/functions/sparksql/ConcatWs.h
@@ -29,7 +29,5 @@ class ConcatWsCallToSpecialForm : public exec::FunctionCallToSpecialForm {
       std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kConcatWs = "concat_ws";
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
+++ b/velox/functions/sparksql/registration/RegisterSpecialForm.cpp
@@ -26,36 +26,39 @@
 #include "velox/functions/sparksql/specialforms/SparkCastExpr.h"
 
 namespace facebook::velox::functions {
-void registerSparkSpecialFormFunctions() {
-  VELOX_REGISTER_VECTOR_FUNCTION(
-      udf_concat_row, exec::RowConstructorCallToSpecialForm::kRowConstructor);
+
+static void registerSparkSpecialFormFunctions() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, expression::kRowConstructor);
 }
 
 namespace sparksql {
+
 void registerSpecialFormGeneralFunctions(const std::string& prefix) {
   exec::registerFunctionCallToSpecialForms();
-  exec::registerFunctionCallToSpecialForm(
-      MakeDecimalCallToSpecialForm::kMakeDecimal,
+  registerFunctionCallToSpecialForm(
+      expression::old::kMakeDecimal,
       std::make_unique<MakeDecimalCallToSpecialForm>());
-  exec::registerFunctionCallToSpecialForm(
-      DecimalRoundCallToSpecialForm::kRoundDecimal,
+  registerFunctionCallToSpecialForm(
+      expression::old::kRoundDecimal,
       std::make_unique<DecimalRoundCallToSpecialForm>());
-  exec::registerFunctionCallToSpecialForm(
-      AtLeastNNonNullsCallToSpecialForm::kAtLeastNNonNulls,
+  registerFunctionCallToSpecialForm(
+      expression::old::kAtLeastNNonNulls,
       std::make_unique<AtLeastNNonNullsCallToSpecialForm>());
   registerSparkSpecialFormFunctions();
   registerFunctionCallToSpecialForm(
       expression::kCast, std::make_unique<SparkCastCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
       expression::kTryCast, std::make_unique<SparkTryCastCallToSpecialForm>());
-  exec::registerFunctionCallToSpecialForm(
-      FromJsonCallToSpecialForm::kFromJson,
+  registerFunctionCallToSpecialForm(
+      expression::old::kFromJson,
       std::make_unique<FromJsonCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      "get_struct_field", std::make_unique<GetStructFieldCallToSpecialForm>());
+      expression::old::kGetStructField,
+      std::make_unique<GetStructFieldCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields,
+      expression::old::kGetArrayStructFields,
       std::make_unique<GetArrayStructFieldsCallToSpecialForm>());
 }
+
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/registration/RegisterString.cpp
+++ b/velox/functions/sparksql/registration/RegisterString.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/UpperLower.h"
@@ -147,7 +148,7 @@ void registerStringFunctions(const std::string& prefix) {
       Varchar,
       Varchar>({prefix + "mask"});
   registerFunctionCallToSpecialForm(
-      ConcatWsCallToSpecialForm::kConcatWs,
+      expression::old::kConcatWs,
       std::make_unique<ConcatWsCallToSpecialForm>());
   registerFunction<LuhnCheckFunction, bool, Varchar>({prefix + "luhn_check"});
 

--- a/velox/functions/sparksql/specialforms/AtLeastNNonNulls.cpp
+++ b/velox/functions/sparksql/specialforms/AtLeastNNonNulls.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/AtLeastNNonNulls.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/SpecialForm.h"
 
 using namespace facebook::velox::exec;
@@ -33,7 +34,7 @@ class AtLeastNNonNullsExpr : public SpecialForm {
             SpecialFormKind::kCustom,
             std::move(type),
             std::move(inputs),
-            AtLeastNNonNullsCallToSpecialForm::kAtLeastNNonNulls,
+            expression::old::kAtLeastNNonNulls,
             true,
             trackCpuUsage),
         n_(n) {}

--- a/velox/functions/sparksql/specialforms/AtLeastNNonNulls.h
+++ b/velox/functions/sparksql/specialforms/AtLeastNNonNulls.h
@@ -29,7 +29,5 @@ class AtLeastNNonNullsCallToSpecialForm
       std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kAtLeastNNonNulls = "at_least_n_non_nulls";
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/DecimalRound.cpp
+++ b/velox/functions/sparksql/specialforms/DecimalRound.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {
@@ -252,7 +253,7 @@ exec::ExprPtr DecimalRoundCallToSpecialForm::constructSpecialForm(
       std::move(args),
       std::move(decimalRound),
       exec::VectorFunctionMetadata{},
-      kRoundDecimal,
+      expression::old::kRoundDecimal,
       trackCpuUsage);
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/DecimalRound.h
+++ b/velox/functions/sparksql/specialforms/DecimalRound.h
@@ -43,7 +43,5 @@ class DecimalRoundCallToSpecialForm : public exec::FunctionCallToSpecialForm {
   /// with Spark version after 3.3.
   static std::pair<uint8_t, uint8_t>
   getResultPrecisionScale(uint8_t precision, uint8_t scale, int32_t roundScale);
-
-  static constexpr const char* kRoundDecimal = "decimal_round";
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/FromJson.cpp
+++ b/velox/functions/sparksql/specialforms/FromJson.cpp
@@ -22,6 +22,7 @@
 #include <utility>
 
 #include "velox/expression/EvalCtx.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/expression/SpecialForm.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/lib/string/StringCore.h"
@@ -850,7 +851,7 @@ exec::ExprPtr FromJsonCallToSpecialForm::constructSpecialForm(
       std::move(args),
       func,
       exec::VectorFunctionMetadata{},
-      kFromJson,
+      expression::old::kFromJson,
       trackCpuUsage);
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/FromJson.h
+++ b/velox/functions/sparksql/specialforms/FromJson.h
@@ -31,8 +31,6 @@ class FromJsonCallToSpecialForm : public exec::FunctionCallToSpecialForm {
       std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kFromJson = "from_json";
 };
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
+++ b/velox/functions/sparksql/specialforms/GetArrayStructFields.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -138,7 +139,7 @@ exec::ExprPtr GetArrayStructFieldsCallToSpecialForm::constructSpecialForm(
       std::move(args),
       std::move(getArrayStructFieldsFunction),
       exec::VectorFunctionMetadata{},
-      kGetArrayStructFields,
+      expression::old::kGetArrayStructFields,
       trackCpuUsage);
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetArrayStructFields.h
+++ b/velox/functions/sparksql/specialforms/GetArrayStructFields.h
@@ -32,9 +32,6 @@ class GetArrayStructFieldsCallToSpecialForm
       std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kGetArrayStructFields =
-      "get_array_struct_fields";
 };
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetStructField.cpp
+++ b/velox/functions/sparksql/specialforms/GetStructField.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/GetStructField.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -104,7 +105,7 @@ exec::ExprPtr GetStructFieldCallToSpecialForm::constructSpecialForm(
       std::move(args),
       std::move(getStructFieldFunction),
       exec::VectorFunctionMetadata{},
-      kGetStructField,
+      expression::old::kGetStructField,
       trackCpuUsage);
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/GetStructField.h
+++ b/velox/functions/sparksql/specialforms/GetStructField.h
@@ -36,8 +36,6 @@ class GetStructFieldCallToSpecialForm : public exec::FunctionCallToSpecialForm {
       std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kGetStructField = "get_struct_field";
 };
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/MakeDecimal.cpp
+++ b/velox/functions/sparksql/specialforms/MakeDecimal.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/MakeDecimal.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/expression/ExprConstants.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {
@@ -183,7 +184,7 @@ exec::ExprPtr MakeDecimalCallToSpecialForm::constructSpecialForm(
       std::move(args),
       createMakeDecimal(type, nullOnOverflow),
       exec::VectorFunctionMetadata{},
-      kMakeDecimal,
+      expression::old::kMakeDecimal,
       trackCpuUsage);
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/MakeDecimal.h
+++ b/velox/functions/sparksql/specialforms/MakeDecimal.h
@@ -35,7 +35,5 @@ class MakeDecimalCallToSpecialForm : public exec::FunctionCallToSpecialForm {
       std::vector<exec::ExprPtr>&& args,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-
-  static constexpr const char* kMakeDecimal = "make_decimal";
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/DecimalRoundTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalRoundTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/core/Expressions.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 
 namespace facebook::velox::functions::sparksql::test {
@@ -54,7 +55,7 @@ class DecimalRoundTest : public SparkFunctionBaseTest {
     return std::make_shared<const core::CallTypedExpr>(
         DECIMAL(resultPrecision, resultScale),
         std::move(inputs),
-        DecimalRoundCallToSpecialForm::kRoundDecimal);
+        expression::old::kRoundDecimal);
   }
 
   void testDecimalRound(

--- a/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
+++ b/velox/functions/sparksql/tests/GetArrayStructFieldsTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/sparksql/specialforms/GetArrayStructFields.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
+#include "velox/expression/ExprConstants.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -32,7 +33,7 @@ class GetArrayStructFieldsTest : public SparkFunctionBaseTest {
       const VectorPtr& expected) {
     auto expr = std::make_shared<const core::CallTypedExpr>(
         expected->type(),
-        GetArrayStructFieldsCallToSpecialForm::kGetArrayStructFields,
+        facebook::velox::expression::old::kGetArrayStructFields,
         std::make_shared<const core::FieldAccessTypedExpr>(input->type(), "c0"),
         std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(ordinal)));
 


### PR DESCRIPTION
Also some of these literals actively used in code, so velox code sometimes rely on fact that these functions are literals.

Now it should be clear from code.

I didn't touch `experimental/` folder, benchmarks, tests and something like duckdb parser utils