### PR TITLE
fix: Fix undefined reference to facebook::velox::dwio::common::compression::createDecompressor

### DIFF
--- a/velox/dwio/text/reader/CMakeLists.txt
+++ b/velox/dwio/text/reader/CMakeLists.txt
@@ -18,6 +18,7 @@ velox_link_libraries(
   velox_dwio_text_reader
   velox_type_fbhive
   velox_dwio_common
+  velox_dwio_common_compression
   velox_encode
   fmt::fmt
 )


### PR DESCRIPTION
Fix https://github.com/facebookincubator/velox/issues/14736