### PR TITLE
feat: Add current_timezone function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -180,6 +180,14 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+.. function:: current_timezone() -> varchar
+
+    Returns the current session time zone as a varchar.
+
+    Example::
+
+        SELECT current_timezone;   -- Asia/Kolkata
+
 Truncation Function
 -------------------
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1782,6 +1782,21 @@ struct CurrentDateFunction {
 };
 
 template <typename T>
+struct CurrentTimezoneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  std::string tzName_;
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>&,
+      const core::QueryConfig& config) {
+    tzName_ = config.sessionTimezone();
+  }
+  FOLLY_ALWAYS_INLINE void call(out_type<Varchar>& result) {
+    result = std::string_view(tzName_);
+  }
+};
+
+template <typename T>
 struct TimeZoneHourFunction : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -90,6 +90,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "to_unixtime"});
 
   registerFromUnixtime(prefix + "from_unixtime");
+  registerFunction<CurrentTimezoneFunction, Varchar>(
+      {prefix + "current_timezone"});
 
   registerFunction<DateFunction, Date, Varchar>({prefix + "date"});
   registerFunction<DateFunction, Date, Timestamp>({prefix + "date"});

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -6801,3 +6801,21 @@ TEST_F(DateTimeFunctionsTest, dateAddDateVariableUnit) {
 
   assertEqualVectors(expected, result);
 }
+
+TEST_F(DateTimeFunctionsTest, currentTimezone) {
+  {
+    setQueryTimeZone("Asia/Kolkata");
+    auto tz = evaluateOnce<std::string>(
+        "current_timezone()", makeRowVector(ROW({}), 1));
+    ASSERT_TRUE(tz.has_value());
+    EXPECT_EQ(tz.value(), "Asia/Kolkata");
+  }
+
+  {
+    setQueryTimeZone("America/New_York");
+    auto tz = evaluateOnce<std::string>(
+        "current_timezone()", makeRowVector(ROW({}), 1));
+    ASSERT_TRUE(tz.has_value());
+    EXPECT_EQ(tz.value(), "America/New_York");
+  }
+}


### PR DESCRIPTION
In the past, we were not implementing functions like current_timezone that returned constants in Velox. This was because Presto Java would infer the constant value at the co-ordinator and fold it, so the worker was never passed this function in execution.

However, with recent changes for side-car and worker based constant folding implementation, we need native implementations for functions like current_timezone, so adding to Velox as well.