### PR TITLE
feat: Support write field_id to parquet metadata SchemaElement

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -22,6 +22,7 @@
 #include "velox/common/config/Config.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/core/QueryConfig.h"
+#include "velox/dwio/parquet/writer/arrow/ArrowSchema.h"
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
 #include "velox/dwio/parquet/writer/arrow/Writer.h"
 #include "velox/exec/MemoryReclaimer.h"
@@ -193,47 +194,70 @@ void validateSchemaRecursive(const RowTypePtr& schema) {
   }
 }
 
-std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
+std::shared_ptr<::arrow::Field> updateFieldRecursive(
     const std::shared_ptr<::arrow::Field>& field,
     const Type& type,
-    const std::string& name = "") {
+    const std::string& name = "",
+    const ParquetFieldId* fieldId = nullptr) {
+  std::shared_ptr<::arrow::Field> newField{nullptr};
   if (type.isRow()) {
     auto& rowType = type.asRow();
-    auto newField = field->WithName(name);
+    newField = field->WithName(name);
     auto structType =
         std::dynamic_pointer_cast<::arrow::StructType>(newField->type());
     auto childrenSize = rowType.size();
     std::vector<std::shared_ptr<::arrow::Field>> newFields;
     newFields.reserve(childrenSize);
-    for (auto i = 0; i < childrenSize; i++) {
-      newFields.push_back(updateFieldNameRecursive(
-          structType->fields()[i], *rowType.childAt(i), rowType.nameOf(i)));
+    for (auto i = 0; i < childrenSize; ++i) {
+      const auto* childSetting = fieldId ? &fieldId->children.at(i) : nullptr;
+      newFields.push_back(updateFieldRecursive(
+          structType->fields()[i],
+          *rowType.childAt(i),
+          rowType.nameOf(i),
+          childSetting));
     }
-    return newField->WithType(::arrow::struct_(newFields));
+    newField = newField->WithType(::arrow::struct_(newFields));
   } else if (type.isArray()) {
-    auto newField = field->WithName(name);
+    newField = field->WithName(name);
     auto listType =
         std::dynamic_pointer_cast<::arrow::BaseListType>(newField->type());
     auto elementType = type.asArray().elementType();
     auto elementField = listType->value_field();
-    return newField->WithType(
-        ::arrow::list(updateFieldNameRecursive(elementField, *elementType)));
+    const auto* childSetting = fieldId ? &fieldId->children.at(0) : nullptr;
+    auto updatedElementField =
+        updateFieldRecursive(elementField, *elementType, name, childSetting);
+    newField = newField->WithType(::arrow::list(updatedElementField));
   } else if (type.isMap()) {
     auto mapType = type.asMap();
-    auto newField = field->WithName(name);
+    newField = field->WithName(name);
     auto arrowMapType =
         std::dynamic_pointer_cast<::arrow::MapType>(newField->type());
-    auto newKeyField =
-        updateFieldNameRecursive(arrowMapType->key_field(), *mapType.keyType());
-    auto newValueField = updateFieldNameRecursive(
-        arrowMapType->item_field(), *mapType.valueType());
-    return newField->WithType(
-        ::arrow::map(newKeyField->type(), newValueField->type()));
+    const auto* keySetting = fieldId ? &fieldId->children.at(0) : nullptr;
+    const auto* valueSetting = fieldId ? &fieldId->children.at(1) : nullptr;
+    auto newKeyField = updateFieldRecursive(
+        arrowMapType->key_field(),
+        *mapType.keyType(),
+        mapType.nameOf(0),
+        keySetting);
+    auto newValueField = updateFieldRecursive(
+        arrowMapType->item_field(),
+        *mapType.valueType(),
+        mapType.nameOf(1),
+        valueSetting);
+    newField = newField->WithType(
+        std::make_shared<::arrow::MapType>(newKeyField, newValueField));
   } else if (name != "") {
-    return field->WithName(name);
+    newField = field->WithName(name);
   } else {
-    return field;
+    newField = field;
   }
+
+  if (fieldId) {
+    newField =
+        newField->WithMetadata(arrow::arrow::FieldIdMetadata(fieldId->fieldId));
+  }
+
+  return newField;
 }
 
 std::optional<TimestampPrecision> getTimestampUnit(
@@ -351,6 +375,7 @@ Writer::Writer(
   setMemoryReclaimers();
   writeInt96AsTimestamp_ = options.writeInt96AsTimestamp;
   arrowMemoryPool_ = options.arrowMemoryPool;
+  parquetFieldIds_ = options.parquetFieldIds;
 }
 
 Writer::Writer(
@@ -446,8 +471,11 @@ void Writer::write(const VectorPtr& data) {
   std::vector<std::shared_ptr<::arrow::Field>> newFields;
   auto childSize = schema_->size();
   for (auto i = 0; i < childSize; i++) {
-    newFields.push_back(updateFieldNameRecursive(
-        arrowSchema->fields()[i], *schema_->childAt(i), schema_->nameOf(i)));
+    newFields.push_back(updateFieldRecursive(
+        arrowSchema->fields()[i],
+        *schema_->childAt(i),
+        schema_->nameOf(i),
+        parquetFieldIds_ ? &parquetFieldIds_->at(i) : nullptr));
   }
 
   PARQUET_ASSIGN_OR_THROW(

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -88,6 +88,13 @@ class LambdaFlushPolicy : public DefaultFlushPolicy {
   std::function<bool()> lambda_;
 };
 
+// Settings for specifying Parquet field IDs during write operations.
+// Used to explicitly control field ID assignment in the Parquet schema.
+struct ParquetFieldId {
+  int32_t fieldId;
+  std::vector<ParquetFieldId> children;
+};
+
 struct WriterOptions : public dwio::common::WriterOptions {
   // Growth ratio passed to ArrowDataBufferSink. The default value is a
   // heuristic borrowed from
@@ -115,6 +122,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<std::string> createdBy;
 
   std::shared_ptr<arrow::MemoryPool> arrowMemoryPool;
+
+  std::shared_ptr<std::vector<ParquetFieldId>> parquetFieldIds;
 
   // Parsing session and hive configs.
 
@@ -213,6 +222,8 @@ class Writer : public dwio::common::Writer {
   std::shared_ptr<ArrowDataBufferSink> stream_;
 
   std::shared_ptr<ArrowContext> arrowContext_;
+
+  std::shared_ptr<std::vector<ParquetFieldId>> parquetFieldIds_;
 
   std::unique_ptr<DefaultFlushPolicy> flushPolicy_;
 

--- a/velox/dwio/parquet/writer/arrow/ArrowSchema.cpp
+++ b/velox/dwio/parquet/writer/arrow/ArrowSchema.cpp
@@ -64,6 +64,8 @@ using ParquetType = Type;
 
 namespace {
 
+static constexpr char FIELD_ID_KEY[] = "PARQUET:field_id";
+
 /// Increments levels according to the cardinality of node.
 void IncrementLevels(LevelInfo& current_levels, const schema::Node& node) {
   if (node.is_repeated()) {
@@ -342,16 +344,6 @@ static Status GetTimestampMetadata(
   }
 
   return Status::OK();
-}
-
-static constexpr char FIELD_ID_KEY[] = "PARQUET:field_id";
-
-std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int field_id) {
-  if (field_id >= 0) {
-    return ::arrow::key_value_metadata({FIELD_ID_KEY}, {ToChars(field_id)});
-  } else {
-    return nullptr;
-  }
 }
 
 int FieldIdFromMetadata(
@@ -1221,6 +1213,14 @@ Result<bool> ApplyOriginalMetadata(
 }
 
 } // namespace
+
+std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int field_id) {
+  if (field_id >= 0) {
+    return ::arrow::key_value_metadata({FIELD_ID_KEY}, {ToChars(field_id)});
+  } else {
+    return nullptr;
+  }
+}
 
 Status FieldToNode(
     const std::shared_ptr<Field>& field,

--- a/velox/dwio/parquet/writer/arrow/ArrowSchema.h
+++ b/velox/dwio/parquet/writer/arrow/ArrowSchema.h
@@ -195,5 +195,7 @@ struct PARQUET_EXPORT SchemaManifest {
   }
 };
 
+std::shared_ptr<::arrow::KeyValueMetadata> FieldIdMetadata(int32_t field_id);
+
 } // namespace arrow
 } // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/Metadata.cpp
+++ b/velox/dwio/parquet/writer/arrow/Metadata.cpp
@@ -389,6 +389,10 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     return std::nullopt;
   }
 
+  inline int32_t field_id() const {
+    return descr_->schema_node()->field_id();
+  }
+
  private:
   mutable std::shared_ptr<Statistics> possible_stats_;
   std::vector<Encoding::type> encodings_;
@@ -533,6 +537,10 @@ int64_t ColumnChunkMetaData::total_uncompressed_size() const {
 
 int64_t ColumnChunkMetaData::total_compressed_size() const {
   return impl_->total_compressed_size();
+}
+
+int32_t ColumnChunkMetaData::field_id() const {
+  return impl_->field_id();
 }
 
 std::unique_ptr<ColumnCryptoMetaData> ColumnChunkMetaData::crypto_metadata()

--- a/velox/dwio/parquet/writer/arrow/Metadata.h
+++ b/velox/dwio/parquet/writer/arrow/Metadata.h
@@ -187,6 +187,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   int64_t index_page_offset() const;
   int64_t total_compressed_size() const;
   int64_t total_uncompressed_size() const;
+  int32_t field_id() const;
   std::unique_ptr<ColumnCryptoMetaData> crypto_metadata() const;
   std::optional<IndexLocation> GetColumnIndexLocation() const;
   std::optional<IndexLocation> GetOffsetIndexLocation() const;


### PR DESCRIPTION
Parquet writer does NOT write `field_id`  to file metadata.

As per apache-iceberg [parquet specification](https://iceberg.apache.org/spec/#parquet), it requires that iceberg column IDs should be stored as field-ids in parquet schema.

Solution:
Creates metadata value with the key `PARQUET:field_id` to determine the field_id when converting an arrow schema into a parquet schema. If there is no such metadata entry then the field_id will not be present. And we can use existing function `FieldIdMetadata` to create such metadata.
To add field_id to nested data types, we can leverage `updateFieldNameRecursive` method.
