### PR TITLE
refactor: Move FilterToExpression to test util

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -19,7 +19,6 @@ velox_add_library(
   velox_core
   Expressions.cpp
   ITypedExpr.cpp
-  FilterToExpression.cpp
   PlanConsistencyChecker.cpp
   PlanFragment.cpp
   PlanNode.cpp

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -15,7 +15,6 @@
 add_executable(
   velox_core_test
   ConstantTypedExprTest.cpp
-  FilterToExpressionTest.cpp
   PlanFragmentTest.cpp
   PlanNodeTest.cpp
   QueryConfigTest.cpp

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(
   ExchangeClientTest.cpp
   ExpandTest.cpp
   FilterProjectTest.cpp
+  FilterToExpressionTest.cpp
   FunctionResolutionTest.cpp
   HashBitRangeTest.cpp
   HashJoinBridgeTest.cpp

--- a/velox/exec/tests/FilterToExpressionTest.cpp
+++ b/velox/exec/tests/FilterToExpressionTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/core/FilterToExpression.h"
+#include "velox/exec/tests/utils/FilterToExpression.h"
 #include <gtest/gtest.h>
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryCtx.h"

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   AggregationResolver.cpp
   AssertQueryBuilder.cpp
   ArbitratorTestUtil.cpp
+  FilterToExpression.cpp
   HiveConnectorTestBase.cpp
   IndexLookupJoinTestBase.cpp
   LocalExchangeSource.cpp

--- a/velox/exec/tests/utils/FilterToExpression.cpp
+++ b/velox/exec/tests/utils/FilterToExpression.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "velox/core/FilterToExpression.h"
+#include "velox/exec/tests/utils/FilterToExpression.h"
 #include "velox/core/Expressions.h"
 
-namespace facebook::velox::core {
+namespace facebook::velox::core::test {
 
 core::TypedExprPtr createBooleanExpr(
     const std::vector<TypedExprPtr>& conditions) {
@@ -613,4 +613,4 @@ core::TypedExprPtr filterToExpr(
       return subfieldExpr;
   }
 }
-} // namespace facebook::velox::core
+} // namespace facebook::velox::core::test

--- a/velox/exec/tests/utils/FilterToExpression.h
+++ b/velox/exec/tests/utils/FilterToExpression.h
@@ -20,7 +20,7 @@
 #include "velox/type/Filter.h"
 #include "velox/type/Subfield.h"
 
-namespace facebook::velox::core {
+namespace facebook::velox::core::test {
 /// Converts a Filter object to a TypedExpr object that can be used in Velox's
 /// expression evaluation system.
 ///
@@ -42,4 +42,4 @@ core::TypedExprPtr filterToExpr(
     const common::Filter* filter,
     const RowTypePtr& rowType,
     memory::MemoryPool* pool);
-} // namespace facebook::velox::core
+} // namespace facebook::velox::core::test

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -19,7 +19,6 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/tpcds/TpcdsConnector.h"
 #include "velox/connectors/tpch/TpchConnector.h"
-#include "velox/core/FilterToExpression.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/HashPartitionFunction.h"
@@ -27,6 +26,7 @@
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/WindowFunction.h"
 #include "velox/exec/tests/utils/AggregationResolver.h"
+#include "velox/exec/tests/utils/FilterToExpression.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/SignatureBinder.h"
@@ -291,7 +291,7 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
 
   if (filtersAsNode_) {
     for (const auto& [subfield, filter] : subfieldFiltersMap_) {
-      auto filterExpr = core::filterToExpr(
+      auto filterExpr = core::test::filterToExpr(
           subfield, filter.get(), parseType, planBuilder_.pool_);
 
       addConjunct(filterExpr, filterNodeExpr);


### PR DESCRIPTION
Summary: FilterToExpression is now in prod but currently only used by TableEvolutionFuzzer via PlanBuilder, it has risk of being put in prod since it uses hardcode function names.

Differential Revision: D81796186
