### PR TITLE
feat: Centralize error propagation in SpillMerger

### DIFF
--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -624,6 +624,9 @@ std::unique_ptr<SourceMerger> SpillMerger::createSourceMerger(
 void SpillMerger::readFromSpillFileStream(
     const std::weak_ptr<SpillMerger>& mergeHolder,
     size_t streamIdx) {
+  TestValue::adjust(
+      "facebook::velox::exec::SpillMerger::readFromSpillFileStream",
+      static_cast<void*>(0));
   try {
     const auto merger = mergeHolder.lock();
     if (merger == nullptr) {

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -634,7 +634,6 @@ void SpillMerger::readFromSpillFileStream(
 
     if (hasError()) {
       ContinueFuture future{ContinueFuture::makeEmpty()};
-      LOG(ERROR) << "Stop the " << streamIdx << " th source on error.";
       sources_[streamIdx]->enqueue(nullptr, &future);
       VELOX_CHECK(!future.valid());
       return;

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -571,11 +571,11 @@ RowVectorPtr SpillMerger::getOutput(
   }
   auto output = sourceMerger_->getOutput(sourceBlockingFutures, atEnd);
   if (atEnd) {
-    if (*error_.rlock() != nullptr) {
+    if (hasError()) {
       sourceMerger_.reset();
       batchStreams_.clear();
       sources_.clear();
-      std::rethrow_exception(*error_.rlock());
+      std::rethrow_exception(exception_);
     }
   }
   return output;
@@ -636,7 +636,7 @@ void SpillMerger::readFromSpillFileStream(
       return;
     }
 
-    if (*error_.rlock() != nullptr) {
+    if (hasError()) {
       ContinueFuture future{ContinueFuture::makeEmpty()};
       LOG(ERROR) << "Stop the " << streamIdx << " th source on error.";
       sources_[streamIdx]->enqueue(nullptr, &future);
@@ -667,7 +667,7 @@ void SpillMerger::readFromSpillFileStream(
             }
             if (t.hasException()) {
               LOG(ERROR) << "Stop the " << streamIdx << " th source on error.";
-              *error_.wlock() = std::make_exception_ptr(t.exception());
+              setError(std::make_exception_ptr(t.exception()));
               ContinueFuture future{ContinueFuture::makeEmpty()};
               sources_[streamIdx]->enqueue(nullptr, &future);
             } else {
@@ -676,7 +676,8 @@ void SpillMerger::readFromSpillFileStream(
           });
     }
   } catch (const std::exception& e) {
-    *error_.wlock() = std::current_exception();
+    LOG(ERROR) << "The " << streamIdx << " th catch exception. " << e.what();
+    setError(std::current_exception());
     readFromSpillFileStream(mergeHolder, streamIdx);
   }
 }
@@ -688,6 +689,19 @@ void SpillMerger::scheduleAsyncSpillFileStreamReads() {
       readFromSpillFileStream(std::weak_ptr(shared_from_this()), streamIdx);
     });
   }
+}
+
+void SpillMerger::setError(const std::exception_ptr& exception) {
+  std::lock_guard l(mutex_);
+  if (exception_ != nullptr) {
+    return;
+  }
+  exception_ = exception;
+}
+
+bool SpillMerger::hasError() const {
+  std::lock_guard l(mutex_);
+  return exception_ != nullptr;
 }
 
 LocalMerge::LocalMerge(

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -331,6 +331,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
   bool hasError() const;
 
+  void checkError();
+
   folly::Executor* const executor_;
   const std::shared_ptr<folly::Synchronized<common::SpillStats>> spillStats_;
   const std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -302,7 +302,7 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
   RowVectorPtr getOutput(
       std::vector<ContinueFuture>& sourceBlockingFutures,
-      bool& atEnd) const;
+      bool& atEnd);
 
  private:
   static std::vector<std::shared_ptr<MergeSource>> createMergeSources(

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -321,10 +321,6 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
       uint64_t maxOutputBatchBytes,
       velox::memory::MemoryPool* pool);
 
-  void asyncReadFromSpillFileStream(
-      const std::weak_ptr<SpillMerger>& mergeHolder,
-      size_t streamIdx);
-
   void readFromSpillFileStream(
       const std::weak_ptr<SpillMerger>& mergeHolder,
       size_t streamIdx);

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -321,11 +321,13 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
       uint64_t maxOutputBatchBytes,
       velox::memory::MemoryPool* pool);
 
-  static void asyncReadFromSpillFileStream(
+  void asyncReadFromSpillFileStream(
       const std::weak_ptr<SpillMerger>& mergeHolder,
       size_t streamIdx);
 
-  void readFromSpillFileStream(size_t streamIdx);
+  void readFromSpillFileStream(
+      const std::weak_ptr<SpillMerger>& mergeHolder,
+      size_t streamIdx);
 
   void scheduleAsyncSpillFileStreamReads();
 
@@ -336,6 +338,7 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
   std::vector<std::shared_ptr<MergeSource>> sources_;
   std::vector<std::unique_ptr<BatchStream>> batchStreams_;
   std::unique_ptr<SourceMerger> sourceMerger_;
+  folly::Synchronized<std::exception_ptr> error_;
 };
 
 // LocalMerge merges its source's output into a single stream of

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -327,6 +327,10 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
   void scheduleAsyncSpillFileStreamReads();
 
+  void setError(const std::exception_ptr& exception);
+
+  bool hasError() const;
+
   folly::Executor* const executor_;
   const std::shared_ptr<folly::Synchronized<common::SpillStats>> spillStats_;
   const std::shared_ptr<memory::MemoryPool> pool_;
@@ -334,7 +338,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
   std::vector<std::shared_ptr<MergeSource>> sources_;
   std::vector<std::unique_ptr<BatchStream>> batchStreams_;
   std::unique_ptr<SourceMerger> sourceMerger_;
-  folly::Synchronized<std::exception_ptr> error_;
+  std::exception_ptr exception_ = nullptr;
+  mutable std::timed_mutex mutex_;
 };
 
 // LocalMerge merges its source's output into a single stream of

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -321,6 +321,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
       uint64_t maxOutputBatchBytes,
       velox::memory::MemoryPool* pool);
 
+  void finishSource(size_t streamIdx) const;
+
   void readFromSpillFileStream(
       const std::weak_ptr<SpillMerger>& mergeHolder,
       size_t streamIdx);

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -327,10 +327,13 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
   void scheduleAsyncSpillFileStreamReads();
 
+  // Sets `exception_` when an async reader throws.
   void setError(const std::exception_ptr& exception);
 
+  // Returns true if any async reader has thrown an exception.
   bool hasError() const;
 
+  // If any async reader has thrown an exception, rethrows it.
   void checkError();
 
   folly::Executor* const executor_;
@@ -340,8 +343,8 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
   std::vector<std::shared_ptr<MergeSource>> sources_;
   std::vector<std::unique_ptr<BatchStream>> batchStreams_;
   std::unique_ptr<SourceMerger> sourceMerger_;
-  std::exception_ptr exception_ = nullptr;
   mutable std::timed_mutex mutex_;
+  std::exception_ptr exception_ = nullptr;
 };
 
 // LocalMerge merges its source's output into a single stream of

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -327,7 +327,7 @@ class SpillMerger : public std::enable_shared_from_this<SpillMerger> {
 
   void scheduleAsyncSpillFileStreamReads();
 
-  // Sets `exception_` when an async reader throws.
+  // Sets 'exception_' when an async reader throws.
   void setError(const std::exception_ptr& exception);
 
   // Returns true if any async reader has thrown an exception.

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -124,10 +124,13 @@ class LocalMergeSource : public MergeSource {
 
       if (data_.empty()) {
         if (atEnd_) {
+          LOG(ERROR) << "Macduan atEnd";
           return BlockingReason::kNotBlocked;
         }
+
         consumerPromises_.emplace_back("LocalMergeSourceQueue::next");
         *future = consumerPromises_.back().getSemiFuture();
+        LOG(ERROR) << "Macduan kWaitForProducer";
         return BlockingReason::kWaitForProducer;
       }
 
@@ -136,6 +139,7 @@ class LocalMergeSource : public MergeSource {
       // advance to next batch.
       data_.pop_front();
 
+      LOG(ERROR) << "Macduan notifyProducers";
       notifyProducers(notification);
       return BlockingReason::kNotBlocked;
     }
@@ -146,6 +150,7 @@ class LocalMergeSource : public MergeSource {
         ScopedPromiseNotification& notification) {
       if (!input) {
         atEnd_ = true;
+        LOG(ERROR) << "Macduan enqueue atEnd notify consumers";
         notifyConsumers(notification);
         return BlockingReason::kNotBlocked;
       }
@@ -157,13 +162,16 @@ class LocalMergeSource : public MergeSource {
       }
 
       data_.push_back(input);
+      LOG(ERROR) << "Macduan notify consumers";
       notifyConsumers(notification);
 
       if (data_.full()) {
         producerPromises_.emplace_back("LocalMergeSourceQueue::enqueue");
         *future = producerPromises_.back().getSemiFuture();
+        LOG(ERROR) << "Macduan enqueue wait consumers";
         return BlockingReason::kWaitForConsumer;
       }
+      LOG(ERROR) << "Macduan enqueue kNotBlocked";
       return BlockingReason::kNotBlocked;
     }
 

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -130,7 +130,6 @@ class LocalMergeSource : public MergeSource {
 
         consumerPromises_.emplace_back("LocalMergeSourceQueue::next");
         *future = consumerPromises_.back().getSemiFuture();
-        LOG(ERROR) << "Macduan kWaitForProducer";
         return BlockingReason::kWaitForProducer;
       }
 
@@ -139,7 +138,6 @@ class LocalMergeSource : public MergeSource {
       // advance to next batch.
       data_.pop_front();
 
-      LOG(ERROR) << "Macduan notifyProducers";
       notifyProducers(notification);
       return BlockingReason::kNotBlocked;
     }
@@ -150,7 +148,6 @@ class LocalMergeSource : public MergeSource {
         ScopedPromiseNotification& notification) {
       if (!input) {
         atEnd_ = true;
-        LOG(ERROR) << "Macduan enqueue atEnd notify consumers";
         notifyConsumers(notification);
         return BlockingReason::kNotBlocked;
       }
@@ -162,16 +159,13 @@ class LocalMergeSource : public MergeSource {
       }
 
       data_.push_back(input);
-      LOG(ERROR) << "Macduan notify consumers";
       notifyConsumers(notification);
 
       if (data_.full()) {
         producerPromises_.emplace_back("LocalMergeSourceQueue::enqueue");
         *future = producerPromises_.back().getSemiFuture();
-        LOG(ERROR) << "Macduan enqueue wait consumers";
         return BlockingReason::kWaitForConsumer;
       }
-      LOG(ERROR) << "Macduan enqueue kNotBlocked";
       return BlockingReason::kNotBlocked;
     }
 

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -126,7 +126,6 @@ class LocalMergeSource : public MergeSource {
         if (atEnd_) {
           return BlockingReason::kNotBlocked;
         }
-
         consumerPromises_.emplace_back("LocalMergeSourceQueue::next");
         *future = consumerPromises_.back().getSemiFuture();
         return BlockingReason::kWaitForProducer;

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -124,7 +124,6 @@ class LocalMergeSource : public MergeSource {
 
       if (data_.empty()) {
         if (atEnd_) {
-          LOG(ERROR) << "Macduan atEnd";
           return BlockingReason::kNotBlocked;
         }
 

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -436,6 +436,9 @@ std::unique_ptr<BatchStream> ConcatFilesSpillBatchStream::create(
 }
 
 bool ConcatFilesSpillBatchStream::nextBatch(RowVectorPtr& batch) {
+  TestValue::adjust(
+      "facebook::velox::exec::ConcatFilesSpillBatchStream::nextBatch",
+      static_cast<void*>(0));
   VELOX_CHECK_NULL(batch);
   VELOX_CHECK(!atEnd_);
   for (; fileIndex_ < spillFiles_.size(); ++fileIndex_) {

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -437,8 +437,7 @@ std::unique_ptr<BatchStream> ConcatFilesSpillBatchStream::create(
 
 bool ConcatFilesSpillBatchStream::nextBatch(RowVectorPtr& batch) {
   TestValue::adjust(
-      "facebook::velox::exec::ConcatFilesSpillBatchStream::nextBatch",
-      static_cast<void*>(0));
+      "facebook::velox::exec::ConcatFilesSpillBatchStream::nextBatch", nullptr);
   VELOX_CHECK_NULL(batch);
   VELOX_CHECK(!atEnd_);
   for (; fileIndex_ < spillFiles_.size(); ++fileIndex_) {

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -735,7 +735,7 @@ DEBUG_ONLY_TEST_F(MergeTest, localMergeAbort) {
           }));
 
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::SpillMerger::asyncReadFromSpillFileStream",
+      "facebook::velox::exec::SpillMerger::readFromSpillFileStream",
       std::function<void(void*)>([&](void* /*unused*/) {
         if (cnt++ == 2) {
           blocked = true;

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -450,13 +450,12 @@ TEST_F(MergerTest, spillMergerException) {
   testSettings.push_back({1024, 8, 2});
 
   std::atomic_int cnt{0};
-  const auto errorMessage = "SpillMerger::readFromSpillFileStream fail";
+  const auto errorMessage = "ConcatFilesSpillBatchStream::nextBatch fail";
   SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::SpillMerger::readFromSpillFileStream",
+      "facebook::velox::exec::ConcatFilesSpillBatchStream::nextBatch",
       std::function<void(void*)>([&](void* /*unused*/) {
         if (cnt++ == 3) {
-          // LOG(ERROR) << "Throw SpillMerger::readFromSpillFileStream fail";
-          VELOX_FAIL("SpillMerger::readFromSpillFileStream fail");
+          VELOX_FAIL("ConcatFilesSpillBatchStream::nextBatch fail");
         }
       }));
   const auto sources = createMergeSources(5, 2);

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -422,7 +422,7 @@ TEST_F(MergerTest, spillMerger) {
   }
 }
 
-TEST_F(MergerTest, spillMergerException) {
+DEBUG_ONLY_TEST_F(MergerTest, spillMergerException) {
   struct TestSetting {
     size_t maxOutputRows;
     size_t numSources;
@@ -442,7 +442,7 @@ TEST_F(MergerTest, spillMergerException) {
   SCOPED_TESTVALUE_SET(
       "facebook::velox::exec::ConcatFilesSpillBatchStream::nextBatch",
       std::function<void(void*)>([&](void* /*unused*/) {
-        if (cnt++ == 3) {
+        if (cnt++ == 11) {
           VELOX_FAIL("ConcatFilesSpillBatchStream::nextBatch fail");
         }
       }));

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -455,6 +455,7 @@ TEST_F(MergerTest, spillMergerException) {
       "facebook::velox::exec::SpillMerger::readFromSpillFileStream",
       std::function<void(void*)>([&](void* /*unused*/) {
         if (cnt++ == 3) {
+          // LOG(ERROR) << "Throw SpillMerger::readFromSpillFileStream fail";
           VELOX_FAIL("SpillMerger::readFromSpillFileStream fail");
         }
       }));


### PR DESCRIPTION
`SpillMerger::start` dispatches reader threads to fetch data from their respective
spill file streams, while `SpillMerger::getOutput` pulls and merges the data. If any
reader throws, it sets `SpillMerger::error_` and exits; other readers detect the flag,
enqueue `nullptr`, and terminate early. `SpillMerger::getOutput` waits for all readers
to finish, reaches EOF, and rethrows the captured error. Centralizing error propagation
by rethrowing only on the main thread (`SpillMerger::getOutput`) prevents resource leaks.

Part of #13260 