### PR TITLE
build(ci): Fix build report

### DIFF
--- a/.github/workflows/build-metrics.yml
+++ b/.github/workflows/build-metrics.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   metrics:
     name: Linux ${{ matrix.link-type }} - ${{ matrix.type }} with adapters
-    if: ${{ github.repository == 'facebookincubator/velox' }}
+    if: false # ${{ github.repository == 'facebookincubator/velox' }}
     runs-on: ${{ matrix.runner }}
     container: ghcr.io/facebookincubator/velox-dev:adapters
     strategy:
@@ -142,7 +142,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     name: Generate and Upload Build Metric Report
-    needs: metrics
+    # needs: metrics
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/scripts/ci/bm-report/report.qmd
+++ b/scripts/ci/bm-report/report.qmd
@@ -50,7 +50,7 @@ run_shas <- runs |>
   jsonlite::fromJSON()
 
 run_ids <- mruns(run_shas) |>
-  filter(commit.branch == "facebookincubator:main", substr(id, 1, 2) == "BM") |>
+  filter(substr(id, 1, 2) == "BM") |>
   pull(id)
 
 # Speed up local dev by saving 'results' as conbench requests can't be memoised


### PR DESCRIPTION
I thought there was an issue with the report code breaking the build but it was actually our conbench instance. It seems to have issues with fetching Github metadata (I have already started investigating).

This is a workaround but should not cause any issues as we don't collect metrics in PRs. 