### PR TITLE
feat(SelectivityIterator): Enable copy constructor for SelectivityIterator

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -412,6 +412,12 @@ class SelectivityIterator {
     index_ = begin / 64;
   }
 
+  SelectivityIterator(const SelectivityIterator& other)
+      : bits_(other.bits_),
+        current_(other.current_),
+        index_(other.index_),
+        end_(other.end_) {}
+
   inline bool next(vector_size_t& row) {
     while (current_ == 0) {
       if ((index_ + 1) * 64 >= end_) {


### PR DESCRIPTION
Summary:
I am trying to write a UDF function that will operate on std::range of input values to avoid copying them to a new container.

It works if I make`SelectivityIterator` copyable as ranges require that. I still need to build a wrapper around it to add iterator tags and iterator concepts, but it is not too bad as long as iterator logic is encapsulated in `SelectivityIterator`.

Differential Revision: D81847304


