### PR TITLE
feat(cudf): Add velox-cudf support for AssignUniqueId

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(
   velox_cudf_exec
+  CudfAssignUniqueId.cpp
   CudfConversion.cpp
   CudfFilterProject.cpp
   CudfHashAggregation.cpp

--- a/velox/experimental/cudf/exec/CudfAssignUniqueId.cpp
+++ b/velox/experimental/cudf/exec/CudfAssignUniqueId.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/exec/CudfAssignUniqueId.h"
+
+#include <cudf/lists/filling.hpp>
+
+#include <utility>
+
+namespace facebook::velox::cudf_velox {
+
+CudfAssignUniqueId::CudfAssignUniqueId(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::AssignUniqueIdNode>& planNode,
+    int32_t uniqueTaskId,
+    std::shared_ptr<std::atomic_int64_t> rowIdPool)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "CudfAssignUniqueId"),
+      NvtxHelper(
+          nvtx3::rgb{160, 82, 45}, // Sienna
+          operatorId,
+          fmt::format("[{}]", planNode->id())),
+      rowIdPool_(std::move(rowIdPool)) {
+  VELOX_USER_CHECK_LT(
+      uniqueTaskId,
+      kTaskUniqueIdLimit,
+      "Unique 24-bit ID specified for CudfAssignUniqueId exceeds the limit");
+  uniqueValueMask_ = static_cast<int64_t>(uniqueTaskId) << 40;
+
+  rowIdCounter_ = 0;
+  maxRowIdCounterValue_ = 0;
+}
+
+void CudfAssignUniqueId::addInput(RowVectorPtr input) {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  auto numInput = input->size();
+  VELOX_CHECK_NE(
+      numInput, 0, "CudfAssignUniqueId::addInput received empty set of rows");
+  input_ = std::move(input);
+}
+
+RowVectorPtr CudfAssignUniqueId::getOutput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+
+  if (input_ == nullptr) {
+    return nullptr;
+  }
+
+  auto cudfVector = std::dynamic_pointer_cast<CudfVector>(input_);
+  VELOX_CHECK(cudfVector, "Input must be a CudfVector");
+  auto stream = cudfVector->stream();
+  auto uniqueIdColumn = generateIdColumn(
+      input_->size(), stream, cudf::get_current_device_resource_ref());
+  // output = [input, uniqueIdColumn]
+  auto size = cudfVector->size();
+  auto columns = cudfVector->release()->release();
+  columns.push_back(std::move(uniqueIdColumn));
+  auto output = std::make_shared<CudfVector>(
+      input_->pool(),
+      outputType_,
+      size,
+      std::make_unique<cudf::table>(std::move(columns)),
+      stream);
+  input_ = nullptr;
+  return output;
+}
+
+bool CudfAssignUniqueId::isFinished() {
+  return noMoreInput_ && input_ == nullptr;
+}
+
+std::unique_ptr<cudf::column> CudfAssignUniqueId::generateIdColumn(
+    vector_size_t size,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::vector<int64_t> starts, sizes;
+  starts.reserve(size / kRowIdsPerRequest + 1);
+  sizes.reserve(size / kRowIdsPerRequest + 1);
+
+  vector_size_t start = 0;
+  while (start < size) {
+    if (rowIdCounter_ >= maxRowIdCounterValue_) {
+      requestRowIds();
+    }
+
+    const auto numAvailableIds =
+        std::min(maxRowIdCounterValue_ - rowIdCounter_, kRowIdsPerRequest);
+    const vector_size_t end =
+        std::min(static_cast<int64_t>(size), start + numAvailableIds);
+    VELOX_CHECK_EQ(
+        (rowIdCounter_ + (end - start)) & uniqueValueMask_,
+        0,
+        "Ran out of unique IDs at {}. Need {} more.",
+        rowIdCounter_,
+        (end - start));
+    // std::iota(rawResults + start, rawResults + end,
+    // uniqueValueMask_ | rowIdCounter_);
+    starts.push_back(uniqueValueMask_ | rowIdCounter_);
+    sizes.push_back(end - start);
+
+    rowIdCounter_ += (end - start);
+    start = end;
+  }
+
+  // copy starts and sizes to device
+  rmm::device_buffer d_starts_buffer(
+      starts.data(), starts.size() * sizeof(int64_t), stream, mr);
+  rmm::device_buffer d_sizes_buffer(
+      sizes.data(), sizes.size() * sizeof(int64_t), stream, mr);
+  auto d_starts_column_view = cudf::column_view(
+      cudf::data_type(cudf::type_id::INT64),
+      starts.size(),
+      d_starts_buffer.data(),
+      nullptr,
+      0,
+      0);
+  auto d_sizes_column_view = cudf::column_view(
+      cudf::data_type(cudf::type_id::INT64),
+      sizes.size(),
+      d_sizes_buffer.data(),
+      nullptr,
+      0,
+      0);
+
+  auto list_sequence = cudf::lists::sequences(
+      d_starts_column_view, d_sizes_column_view, stream, mr);
+  // discard offsets
+  return std::move(list_sequence->release().children[1]);
+}
+
+void CudfAssignUniqueId::requestRowIds() {
+  rowIdCounter_ = rowIdPool_->fetch_add(kRowIdsPerRequest);
+  maxRowIdCounterValue_ =
+      std::min(rowIdCounter_ + kRowIdsPerRequest, kMaxRowId);
+}
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfAssignUniqueId.h
+++ b/velox/experimental/cudf/exec/CudfAssignUniqueId.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/cudf/exec/NvtxHelper.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/exec/Operator.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::cudf_velox {
+
+class CudfAssignUniqueId : public exec::Operator, public NvtxHelper {
+ public:
+  CudfAssignUniqueId(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::AssignUniqueIdNode>& planNode,
+      int32_t uniqueTaskId,
+      std::shared_ptr<std::atomic_int64_t> rowIdPool);
+
+  bool isFilter() const override {
+    return true;
+  }
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return input_ == nullptr;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool startDrain() override {
+    // No need to drain for assignUniqueId operator.
+    return false;
+  }
+
+  bool isFinished() override;
+
+ private:
+  std::unique_ptr<cudf::column> generateIdColumn(
+      vector_size_t size,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  void requestRowIds();
+
+  const int64_t kRowIdsPerRequest = 1L << 20;
+  const int64_t kMaxRowId = 1L << 40;
+  const int64_t kTaskUniqueIdLimit = 1L << 24;
+
+  int64_t uniqueValueMask_;
+  int64_t rowIdCounter_;
+  int64_t maxRowIdCounterValue_;
+
+  std::shared_ptr<std::atomic_int64_t> rowIdPool_;
+};
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/exec/CudfAssignUniqueId.h"
 #include "velox/experimental/cudf/exec/CudfConversion.h"
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
@@ -25,6 +26,7 @@
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 
+#include "velox/exec/AssignUniqueId.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/FilterProject.h"
 #include "velox/exec/HashAggregation.h"
@@ -134,7 +136,8 @@ bool CompileState::compile() {
                    exec::HashAggregation,
                    exec::Limit,
                    exec::LocalPartition,
-                   exec::LocalExchange>(op) ||
+                   exec::LocalExchange,
+                   exec::AssignUniqueId>(op) ||
             isFilterProjectSupported(op) || isJoinSupported(op) ||
             isTableScanSupported(op);
       };
@@ -151,7 +154,8 @@ bool CompileState::compile() {
                exec::OrderBy,
                exec::HashAggregation,
                exec::Limit,
-               exec::LocalPartition>(op) ||
+               exec::LocalPartition,
+               exec::AssignUniqueId>(op) ||
         isFilterProjectSupported(op) || isJoinSupported(op);
   };
   auto producesGpuOutput = [isFilterProjectSupported,
@@ -161,7 +165,8 @@ bool CompileState::compile() {
                exec::OrderBy,
                exec::HashAggregation,
                exec::Limit,
-               exec::LocalExchange>(op) ||
+               exec::LocalExchange,
+               exec::AssignUniqueId>(op) ||
         isFilterProjectSupported(op) ||
         (isAnyOf<exec::HashProbe>(op) && isJoinSupported(op)) ||
         (isTableScanSupported(op));
@@ -264,6 +269,18 @@ bool CompileState::compile() {
     } else if (
         auto localExchangeOp = dynamic_cast<exec::LocalExchange*>(oper)) {
       keepOperator = 1;
+    } else if (
+        auto assignUniqueIdOp = dynamic_cast<exec::AssignUniqueId*>(oper)) {
+      auto planNode = std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(
+          getPlanNode(assignUniqueIdOp->planNodeId()));
+      VELOX_CHECK(planNode != nullptr);
+      replaceOp.push_back(std::make_unique<CudfAssignUniqueId>(
+          id,
+          ctx,
+          planNode,
+          planNode->taskUniqueId(),
+          planNode->uniqueIdCounter()));
+      replaceOp.back()->initialize();
     }
 
     if (producesGpuOutput(oper) and

--- a/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
+++ b/velox/experimental/cudf/tests/AssignUniqueIdTest.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+
+namespace facebook::velox::exec {
+
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class AssignUniqueIdTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void verifyUniqueId(
+      const std::shared_ptr<const core::PlanNode>& plan,
+      const std::vector<RowVectorPtr>& input) {
+    CursorParameters params;
+    params.planNode = plan;
+    params.queryConfigs.insert(
+        {cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "1"});
+    auto result = readCursor(params);
+    ASSERT_EQ(result.second[0]->childrenSize(), input[0]->childrenSize() + 1);
+    verifyUniqueId(input, result.second);
+
+    auto task = result.first->task();
+    // Verify number of memory allocations. As no memory is allocated for the
+    // unique ID vector generation in GPU, the number of memory allocations
+    // should be 0. cudf can generate new columns, and cannot reuse the memory.
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(0, stats.at(uniqueNodeId_).numMemoryAllocations);
+    // check if CudfAssignUniqueId operator is executed with stats
+    ASSERT_EQ(
+        1, stats.at(uniqueNodeId_).operatorStats.count("CudfAssignUniqueId"));
+  }
+
+  void verifyUniqueId(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<facebook::velox::RowVectorPtr>& vectors) {
+    auto numColumns = vectors[0]->childrenSize();
+    ASSERT_EQ(numColumns, input[0]->childrenSize() + 1);
+
+    std::set<int64_t> ids;
+    for (int i = 0; i < numColumns; i++) {
+      for (auto batch = 0; batch < vectors.size(); ++batch) {
+        auto column = vectors[batch]->childAt(i);
+        if (i < numColumns - 1) {
+          assertEqualVectors(input[batch]->childAt(i), column);
+        } else {
+          auto idValues = column->asFlatVector<int64_t>()->rawValues();
+          std::copy(
+              idValues,
+              idValues + column->size(),
+              std::inserter(ids, ids.end()));
+        }
+      }
+    }
+
+    vector_size_t totalInputSize = 0;
+    for (const auto& vector : input) {
+      totalInputSize += vector->size();
+    }
+
+    ASSERT_EQ(totalInputSize, ids.size());
+  }
+
+  core::PlanNodeId uniqueNodeId_;
+};
+
+TEST_F(AssignUniqueIdTest, multiBatch) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> input;
+  input.reserve(3);
+  for (int i = 0; i < 3; ++i) {
+    input.push_back(
+        makeRowVector({makeFlatVector<int32_t>(batchSize, folly::identity)}));
+  }
+
+  auto plan = PlanBuilder()
+                  .values(input)
+                  .assignUniqueId()
+                  .capturePlanNodeId(uniqueNodeId_)
+                  .planNode();
+
+  verifyUniqueId(plan, input);
+}
+
+TEST_F(AssignUniqueIdTest, exceedRequestLimit) {
+  vector_size_t requestLimit = 1 << 20L;
+  auto input = {
+      makeRowVector(
+          {makeFlatVector<int32_t>(requestLimit - 10, folly::identity)}),
+      makeRowVector({makeFlatVector<int32_t>(100, folly::identity)}),
+      makeRowVector({makeFlatVector<int32_t>(100, folly::identity)}),
+  };
+
+  auto plan = PlanBuilder()
+                  .values(input)
+                  .assignUniqueId()
+                  .capturePlanNodeId(uniqueNodeId_)
+                  .planNode();
+
+  verifyUniqueId(plan, input);
+}
+
+TEST_F(AssignUniqueIdTest, multiThread) {
+  for (int i = 0; i < 3; i++) {
+    vector_size_t batchSize = 1000;
+    auto input = {
+        makeRowVector({makeFlatVector<int32_t>(batchSize, folly::identity)})};
+    auto plan = PlanBuilder()
+                    .values(input, true)
+                    .assignUniqueId()
+                    .capturePlanNodeId(uniqueNodeId_)
+                    .planNode();
+
+    std::shared_ptr<exec::Task> task;
+    auto result = AssertQueryBuilder(plan)
+                      .config(cudf_velox::CudfFromVelox::kGpuBatchSizeRows, "1")
+                      .maxDrivers(8)
+                      .copyResults(pool(), task);
+    ASSERT_EQ(batchSize * 8, result->size());
+
+    std::set<int64_t> ids;
+    auto idValues =
+        result->children().back()->asFlatVector<int64_t>()->rawValues();
+    std::copy(
+        idValues, idValues + result->size(), std::inserter(ids, ids.end()));
+
+    ASSERT_EQ(batchSize * 8, ids.size());
+
+    // Verify number of memory allocations. As no memory is allocated for the
+    // unique ID vector generation in GPU, the number of memory allocations
+    // should be 0. cudf can generate new columns, and cannot reuse the memory.
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(0, stats.at(uniqueNodeId_).numMemoryAllocations);
+  }
+}
+
+TEST_F(AssignUniqueIdTest, maxRowIdLimit) {
+  auto input = {makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})};
+
+  auto plan = PlanBuilder().values(input).assignUniqueId().planNode();
+
+  // Increase the counter to kMaxRowId.
+  std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(plan)
+      ->uniqueIdCounter()
+      ->fetch_add(1L << 40);
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Ran out of unique IDs at 1099511627776");
+}
+
+TEST_F(AssignUniqueIdTest, taskUniqueIdLimit) {
+  auto input = {makeRowVector({makeFlatVector<int32_t>({1, 2, 3})})};
+
+  auto plan =
+      PlanBuilder().values(input).assignUniqueId("unique", 1L << 24).planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "(16777216 vs. 16777216) Unique 24-bit ID specified for AssignUniqueId exceeds the limit");
+}
+
+// TODO: Add test for barrier execution, other operators does support draining
+// yet.
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(velox_cudf_local_partition_test Main.cpp LocalPartitionTest.cpp)
 add_executable(velox_cudf_filter_project_test Main.cpp FilterProjectTest.cpp)
 add_executable(velox_cudf_subfield_filter_ast_test Main.cpp SubfieldFilterAstTest.cpp)
 add_executable(velox_cudf_limit_test Main.cpp LimitTest.cpp)
+add_executable(velox_cudf_assign_unique_id_test Main.cpp AssignUniqueIdTest.cpp)
 
 add_test(
   NAME velox_cudf_hash_join_test
@@ -70,9 +71,11 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_test(NAME velox_cudf_limit_test COMMAND velox_cudf_limit_test)
+
 add_test(
-  NAME velox_cudf_limit_test
-  COMMAND velox_cudf_limit_test
+  NAME velox_cudf_assign_unique_id_test
+  COMMAND velox_cudf_assign_unique_id_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -85,6 +88,7 @@ set_tests_properties(velox_cudf_table_write_test PROPERTIES LABELS cuda_driver T
 set_tests_properties(velox_cudf_filter_project_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_subfield_filter_ast_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_limit_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_assign_unique_id_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 
 target_link_libraries(
   velox_cudf_hash_join_test
@@ -179,6 +183,16 @@ target_link_libraries(
 
 target_link_libraries(
   velox_cudf_limit_test
+  velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
+)
+
+target_link_libraries(
+  velox_cudf_assign_unique_id_test
   velox_cudf_exec
   velox_exec
   velox_exec_test_lib


### PR DESCRIPTION
This PR adds operator CudfAssignUniqueId to run AssignUniqueId in GPU.
Unit tests are added to verify the output, execution in GPU using stats.

The CudfAssignUniqueId offloads work to GPU with single call to list sequences function in libcudf. Other core logic of AssignUniqueId is same and the output of GPU operator should match exactly with CPU operator output.

Note on testing: Since the conversion operators might affect the batchsize to GPU operators, it needs to be set to minimal value for testing. Otherwise multiple batches are concatenated as single batch for GPU.