### PR TITLE
feat: Add match marker for left index join

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -779,7 +779,7 @@ void IndexLookupJoin::fillOutputMatchRows(
     return;
   }
   VELOX_CHECK_NOT_NULL(rawMatchValues_);
-  bits::fillBits(rawMatchValues_, offset, size, match);
+  bits::fillBits(rawMatchValues_, offset, offset + size, match);
 }
 
 RowVectorPtr IndexLookupJoin::produceOutputForLeftJoin(

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -30,6 +30,11 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
  protected:
   IndexLookupJoinTestBase() = default;
 
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    rng_.seed(123);
+  }
+
   struct SequenceTableData {
     RowVectorPtr keyData;
     RowVectorPtr valueData;
@@ -185,5 +190,6 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
   PlanNodeId joinNodeId_;
   PlanNodeId indexScanNodeId_;
   PlanNodeId probeScanNodeId_;
+  folly::Random::DefaultGenerator rng_;
 };
 } // namespace fecebook::velox::exec::test


### PR DESCRIPTION
Index lookup join doesn't fill the match column properly. It set the fill end bit to the number of bits to fill which is wrong. This is discovered by the extension to TestIndexJoin.cpp. The followup is to add velox side unit test to cover this.


