### PR TITLE
fix: Disable cpr CURL_ZLIB build in CACHE

### DIFF
--- a/CMake/resolve_dependency_modules/cpr.cmake
+++ b/CMake/resolve_dependency_modules/cpr.cmake
@@ -43,7 +43,7 @@ set(BUILD_SHARED_LIBS ${VELOX_BUILD_SHARED})
 set(CPR_USE_SYSTEM_CURL OFF)
 # ZLIB has already been found by find_package(ZLIB, REQUIRED), set CURL_ZLIB=OFF
 # to save compile time.
-set(CURL_ZLIB OFF)
+set(CURL_ZLIB "OFF" CACHE STRING "Enable or disable ZLIB support")
 FetchContent_MakeAvailable(cpr)
 # libcpr in its CMakeLists.txt file disables the BUILD_TESTING globally when
 # CPR_USE_SYSTEM_CURL=OFF. unset BUILD_TESTING here.


### PR DESCRIPTION
CURL_ZLIB needs to be configured in the CACHE in order to properly disable its compilation. Otherwise, it will not be effectively turned off, because `NOT DEFINED CACHE{CURL_ZLIB}` will be true.

https://github.com/libcpr/cpr/blob/7fa467321f41c883ab83cc12d7f51c58653a0522/CMakeLists.txt#L213