### PR TITLE
feat: Add hash_code_internal function

### DIFF
--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -65,6 +65,17 @@ struct XxHash64Function {
   }
 };
 
+/// hash_code(varbinary) → bigint
+template <typename T>
+struct HashCodeVarbinaryFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<Varbinary>& input) {
+    result = XXH64(input.data(), input.size(), 0);
+  }
+};
+
 /// md5(varbinary) → varbinary
 template <typename T>
 struct Md5Function {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -22,6 +22,7 @@
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"
+#include "velox/functions/prestosql/HashCodeUtils.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
@@ -1685,6 +1686,18 @@ struct XxHash64TimestampFunction {
     // Use the milliseconds representation of the timestamp
     auto timestamp_millis = input.toMillis();
     result = XXH64(&timestamp_millis, sizeof(timestamp_millis), 0);
+  }
+};
+
+/// hash_code(timestamp) → bigint
+template <typename T>
+struct HashCodeTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<Timestamp>& input) {
+    auto timestamp_millis = input.toMillis();
+    result = HashCodeUtils::hashInteger<int64_t>(timestamp_millis);
   }
 };
 

--- a/velox/functions/prestosql/FloatingPointFunctions.h
+++ b/velox/functions/prestosql/FloatingPointFunctions.h
@@ -19,6 +19,7 @@
 #include <xxhash.h>
 
 #include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/HashCodeUtils.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::functions {
@@ -46,6 +47,28 @@ struct XxHash64DoubleFunction {
   void call(out_type<int64_t>& result, const arg_type<double>& input) {
     // Hash the double value directly
     result = XXH64(&input, sizeof(input), 0);
+  }
+};
+
+/// hash_code(real) → bigint
+template <typename T>
+struct HashCodeRealFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<float>& input) {
+    result = HashCodeUtils::hashReal(input);
+  }
+};
+
+/// hash_code(double) → bigint
+template <typename T>
+struct HashCodeDoubleFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<double>& input) {
+    result = HashCodeUtils::hashDouble(input);
   }
 };
 

--- a/velox/functions/prestosql/HashCodeUtils.h
+++ b/velox/functions/prestosql/HashCodeUtils.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstring>
+
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::velox::functions {
+
+class HashCodeUtils {
+ public:
+  template <typename T>
+  static int64_t hashInteger(T value) {
+    return bits::rotateLeft64(
+               static_cast<uint64_t>(value) * 0xC2B2AE3D27D4EB4FL, 31) *
+        0x9E3779B185EBCA87L;
+  }
+
+  static inline int64_t hashReal(float value) {
+    canonicalizeZero<float>(value);
+    return hashInteger<int32_t>(floatToIntBits(value));
+  }
+
+  static inline int64_t hashDouble(double value) {
+    canonicalizeZero<double>(value);
+    return hashInteger<int64_t>(doubleToLongBits(value));
+  }
+
+ private:
+  // Canonicalize +0 and -0 to a single value.
+  template <typename T>
+  static void canonicalizeZero(T& value) {
+    if (value == 0.0f && std::signbit(value)) {
+      value = 0.0f;
+    }
+  }
+
+  // Canonicalize all NaNs to the same representation.
+  static int32_t floatToIntBits(float x) {
+    if (std::isnan(x)) {
+      return 0x7fc00000;
+    } else {
+      int32_t bits;
+      std::memcpy(&bits, &x, sizeof(bits));
+      return bits;
+    }
+  }
+
+  // Canonicalize all NaNs to the same representation.
+  static int64_t doubleToLongBits(double x) {
+    if (std::isnan(x)) {
+      return 0x7ff8000000000000ULL;
+    } else {
+      int64_t bits;
+      std::memcpy(&bits, &x, sizeof(bits));
+      return bits;
+    }
+  }
+};
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/IntegerFunctions.h
+++ b/velox/functions/prestosql/IntegerFunctions.h
@@ -19,6 +19,7 @@
 #include <xxhash.h>
 
 #include "velox/functions/Udf.h"
+#include "velox/functions/prestosql/HashCodeUtils.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox::functions {
@@ -87,6 +88,50 @@ struct CombineHashFunction {
     result = static_cast<int64_t>(
         31 * static_cast<uint64_t>(previousHashValue) +
         static_cast<uint64_t>(input));
+  }
+};
+
+/// hash_code(bigint) → bigint
+template <typename T>
+struct HashCodeBigintFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const int64_t& input) {
+    result = HashCodeUtils::hashInteger<int64_t>(input);
+  }
+};
+
+/// hash_code(integer) → bigint
+template <typename T>
+struct HashCodeIntegerFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const int32_t& input) {
+    result = HashCodeUtils::hashInteger<int32_t>(input);
+  }
+};
+
+/// hash_code(smallint) → bigint
+template <typename T>
+struct HashCodeSmallintFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const int16_t& input) {
+    result = HashCodeUtils::hashInteger<int16_t>(input);
+  }
+};
+
+/// hash_code(tinyint) → bigint
+template <typename T>
+struct HashCodeTinyintFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const int8_t& input) {
+    result = HashCodeUtils::hashInteger<int8_t>(input);
   }
 };
 

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -672,4 +672,15 @@ struct XxHash64StringFunction {
   }
 };
 
+/// hash_code(varchar) → bigint
+template <typename T>
+struct HashCodeStringFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<Varchar>& input) {
+    result = XXH64(input.data(), input.size(), 0);
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -44,6 +44,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "spooky_hash_v2_32"});
   registerFunction<SpookyHashV264Function, Varbinary, Varbinary>(
       {prefix + "spooky_hash_v2_64"});
+  registerFunction<HashCodeVarbinaryFunction, int64_t, Varbinary>(
+      {prefix + "hash_code_internal"});
 
   registerFunction<ToHexFunction, Varchar, Varbinary>({prefix + "to_hex"});
   registerFunction<FromHexFunction, Varbinary, Varchar>({prefix + "from_hex"});

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -288,6 +288,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "xxhash64_internal"});
   registerFunction<XxHash64TimestampFunction, int64_t, Timestamp>(
       {prefix + "xxhash64_internal"});
+  registerFunction<HashCodeTimestampFunction, int64_t, Timestamp>(
+      {prefix + "hash_code_internal"});
 
   registerFunction<ParseDurationFunction, IntervalDayTime, Varchar>(
       {prefix + "parse_duration"});

--- a/velox/functions/prestosql/registration/FloatingPointFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/FloatingPointFunctionsRegistration.cpp
@@ -25,6 +25,10 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "xxhash64_internal"});
   registerFunction<XxHash64DoubleFunction, int64_t, double>(
       {prefix + "xxhash64_internal"});
+  registerFunction<HashCodeRealFunction, int64_t, float>(
+      {prefix + "hash_code_internal"});
+  registerFunction<HashCodeDoubleFunction, int64_t, double>(
+      {prefix + "hash_code_internal"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/registration/IntegerFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/IntegerFunctionsRegistration.cpp
@@ -32,6 +32,15 @@ void registerSimpleFunctions(const std::string& prefix) {
 
   registerFunction<CombineHashFunction, int64_t, int64_t, int64_t>(
       {prefix + "combine_hash_internal"});
+
+  registerFunction<HashCodeBigintFunction, int64_t, int64_t>(
+      {prefix + "hash_code_internal"});
+  registerFunction<HashCodeIntegerFunction, int64_t, int32_t>(
+      {prefix + "hash_code_internal"});
+  registerFunction<HashCodeSmallintFunction, int64_t, int16_t>(
+      {prefix + "hash_code_internal"});
+  registerFunction<HashCodeTinyintFunction, int64_t, int8_t>(
+      {prefix + "hash_code_internal"});
 }
 } // namespace
 

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -46,6 +46,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<LengthFunction, int64_t, Varchar>({prefix + "length"});
   registerFunction<XxHash64StringFunction, int64_t, Varchar>(
       {prefix + "xxhash64_internal"});
+  registerFunction<HashCodeStringFunction, int64_t, Varchar>(
+      {prefix + "hash_code_internal"});
 
   // Length for varbinary have different semantics.
   registerFunction<LengthVarbinaryFunction, int64_t, Varbinary>(

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -866,4 +866,26 @@ TEST_F(BinaryFunctionsTest, murmur3_x64_128) {
   EXPECT_EQ(murmur3_x64_128(std::nullopt), std::nullopt);
 }
 
+TEST_F(BinaryFunctionsTest, hashCodeFunctionVarbinary) {
+  const auto hashCode = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t>(
+        "hash_code_internal(c0)", VARBINARY(), std::move(value));
+  };
+
+  EXPECT_EQ(std::nullopt, hashCode(std::nullopt));
+
+  EXPECT_EQ(-1205034819632174695, hashCode(""));
+  EXPECT_EQ(4952883123889572249, hashCode("abc"));
+  EXPECT_EQ(-1843406881296486760, hashCode("ABC"));
+  EXPECT_EQ(-2731884271685740652, hashCode("string to hash_code as param"));
+  EXPECT_EQ(6332497344822543626, hashCode("special characters %_@"));
+  EXPECT_EQ(-3364246049109667261, hashCode("    leading space"));
+  // Unicode characters
+  EXPECT_EQ(-7331673579364787606, hashCode("café"));
+  // String with null bytes
+  EXPECT_EQ(160339756714205673, hashCode("abc\\x00def"));
+  // Non-ASCII strings
+  EXPECT_EQ(8176744303664166369, hashCode("日本語"));
+}
+
 } // namespace

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -5494,3 +5494,27 @@ TEST_F(DateTimeFunctionsTest, xxHash64FunctionTimestamp) {
   EXPECT_EQ(
       7585368295023641328, xxhash64(parseTimestamp("1900-01-01 00:00:00.000")));
 }
+
+TEST_F(DateTimeFunctionsTest, hashCodeFunctionTimestamp) {
+  const auto hashCode = [&](std::optional<Timestamp> value) {
+    return evaluateOnce<int64_t>("hash_code_internal(c0)", value);
+  };
+
+  EXPECT_EQ(std::nullopt, hashCode(std::nullopt));
+
+  EXPECT_EQ(0, hashCode(parseTimestamp("1970-01-01 00:00:00.000")));
+  EXPECT_EQ(
+      9155312661752487122, hashCode(parseTimestamp("1970-01-01 00:00:00.001")));
+  EXPECT_EQ(
+      7397604632328768595, hashCode(parseTimestamp("2023-05-15 12:30:45.123")));
+  EXPECT_EQ(
+      -6288327804501791043,
+      hashCode(parseTimestamp("2023-05-15 12:30:45.456")));
+  EXPECT_NE(std::nullopt, hashCode(Timestamp::now()));
+  EXPECT_EQ(
+      -7046770406857882998,
+      hashCode(parseTimestamp("2050-12-31 23:59:59.999")));
+  EXPECT_EQ(
+      -5802362750313934913,
+      hashCode(parseTimestamp("1900-01-01 00:00:00.000")));
+}

--- a/velox/functions/prestosql/tests/FloatingPointFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/FloatingPointFunctionsTest.cpp
@@ -61,3 +61,75 @@ TEST_F(FloatingPointFunctionsTest, xxHash64FunctionDouble) {
   EXPECT_EQ(
       3642075027047404498, xxhash64(-std::numeric_limits<double>::infinity()));
 }
+
+TEST_F(FloatingPointFunctionsTest, hashCodeFunctionReal) {
+  const auto hashCode = [&](std::optional<float> value) {
+    return evaluateOnce<int64_t>("hash_code_internal(c0)", REAL(), value);
+  };
+
+  EXPECT_EQ(std::nullopt, hashCode(std::nullopt));
+  EXPECT_EQ(-6641611864725600567, hashCode(1.0f));
+  EXPECT_EQ(0, hashCode(0.0f));
+  EXPECT_EQ(2784844071412975419, hashCode(-100.0f));
+  EXPECT_EQ(-4588979133863754154, hashCode(std::numeric_limits<float>::max()));
+  EXPECT_EQ(
+      -3262782034081892214, hashCode(std::numeric_limits<float>::lowest()));
+  EXPECT_EQ(
+      8964690910873101096, hashCode(std::numeric_limits<float>::infinity()));
+  EXPECT_EQ(
+      -1153498660964261917, hashCode(-std::numeric_limits<float>::infinity()));
+
+  // NaN canonicalization, different NaN types should hash to the same value
+  float standardNaN =
+      std::numeric_limits<float>::quiet_NaN(); // Standard library NaN
+  float mathNaN = std::sqrt(-1.0f); // Math operation NaN
+  float divisionNaN = 0.0f / 0.0f; // Division by zero NaN
+
+  auto hash1 = hashCode(standardNaN);
+  auto hash2 = hashCode(mathNaN);
+  auto hash3 = hashCode(divisionNaN);
+
+  EXPECT_EQ(hash1, hash2);
+  EXPECT_EQ(hash2, hash3);
+
+  // Zero canonicalization, -0.0f and 0.0f should hash to the same values
+  float positiveZero = +0.0f;
+  float negativeZero = -0.0f;
+  EXPECT_EQ(hashCode(positiveZero), hashCode(negativeZero));
+}
+
+TEST_F(FloatingPointFunctionsTest, hashCodeFunctionDouble) {
+  const auto hashCode = [&](std::optional<double> value) {
+    return evaluateOnce<int64_t>("hash_code_internal(c0)", DOUBLE(), value);
+  };
+
+  EXPECT_EQ(std::nullopt, hashCode(std::nullopt));
+  EXPECT_EQ(2156309669339463680, hashCode(1.0));
+  EXPECT_EQ(0, hashCode(0.0));
+  EXPECT_EQ(-6670936232284880896, hashCode(-100.0));
+  EXPECT_EQ(-7863427759443830617, hashCode(std::numeric_limits<double>::max()));
+  EXPECT_EQ(
+      -839234414081238873, hashCode(std::numeric_limits<double>::lowest()));
+  EXPECT_EQ(
+      -5754144386326200320, hashCode(std::numeric_limits<double>::infinity()));
+  EXPECT_EQ(
+      5668406342020759552, hashCode(-std::numeric_limits<double>::infinity()));
+
+  // NaN canonicalization, different NaN types should hash to the same value
+  double standardNaN =
+      std::numeric_limits<double>::quiet_NaN(); // Standard library NaN
+  double mathNaN = std::sqrt(-1.0); // Math operation NaN
+  double divisionNaN = 0.0 / 0.0; // Division by zero NaN
+
+  auto hash1 = hashCode(standardNaN);
+  auto hash2 = hashCode(mathNaN);
+  auto hash3 = hashCode(divisionNaN);
+
+  EXPECT_EQ(hash1, hash2);
+  EXPECT_EQ(hash2, hash3);
+
+  // Zero canonicalization, -0.0f and 0.0f should hash to the same values
+  double positiveZero = +0.0;
+  double negativeZero = -0.0;
+  EXPECT_EQ(hashCode(positiveZero), hashCode(negativeZero));
+}

--- a/velox/functions/prestosql/tests/IntegerFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IntegerFunctionsTest.cpp
@@ -20,7 +20,14 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::test;
 
-class IntegerFunctionsTest : public FunctionBaseTest {};
+class IntegerFunctionsTest : public FunctionBaseTest {
+ protected:
+  template <typename T>
+  std::optional<int64_t> hashCode(std::optional<T> value) {
+    return evaluateOnce<int64_t>("hash_code_internal(c0)", value);
+  }
+};
+
 TEST_F(IntegerFunctionsTest, xxHash64FunctionBigInt) {
   const auto xxhash64 = [&](std::optional<int64_t> value) {
     return evaluateOnce<int64_t>("xxhash64_internal(c0)", BIGINT(), value);
@@ -79,4 +86,59 @@ TEST_F(IntegerFunctionsTest, xxHash64FunctionTinyInt) {
   // int8_t max and min
   EXPECT_EQ(3642125596470818657, xxhash64(127));
   EXPECT_EQ(-2392536786243718838, xxhash64(-128));
+}
+
+TEST_F(IntegerFunctionsTest, hashCodeFunctionBigint) {
+  EXPECT_EQ(std::nullopt, hashCode<int64_t>(std::nullopt));
+  EXPECT_EQ(0, hashCode<int64_t>(0));
+  EXPECT_EQ(9155312661752487122, hashCode<int64_t>(1));
+  EXPECT_EQ(-6507640756101998425, hashCode<int64_t>(-1));
+  EXPECT_EQ(6845023471056522234, hashCode<int64_t>(-128));
+  EXPECT_EQ(1951949442083825868, hashCode<int64_t>(-127));
+  EXPECT_EQ(695722463566662829, hashCode<int64_t>(127));
+  EXPECT_EQ(7899085683235324083, hashCode<int64_t>(255));
+  EXPECT_EQ(-4530432376425028794, hashCode<int64_t>(-32768));
+  EXPECT_EQ(7178104282075517491, hashCode<int64_t>(32768));
+  EXPECT_EQ(7848567808049036557, hashCode<int64_t>(65535));
+  EXPECT_EQ(516552589260593319, hashCode<int64_t>(INT64_MAX));
+  EXPECT_EQ(7024193345362591744, hashCode<int64_t>(INT64_MIN));
+}
+
+TEST_F(IntegerFunctionsTest, hashCodeFunctionInteger) {
+  EXPECT_EQ(std::nullopt, hashCode<int32_t>(std::nullopt));
+  EXPECT_EQ(0, hashCode<int32_t>(0));
+  EXPECT_EQ(9155312661752487122, hashCode<int32_t>(1));
+  EXPECT_EQ(-6507640756101998425, hashCode<int32_t>(-1));
+  EXPECT_EQ(6845023471056522234, hashCode<int32_t>(-128));
+  EXPECT_EQ(1951949442083825868, hashCode<int32_t>(-127));
+  EXPECT_EQ(695722463566662829, hashCode<int32_t>(127));
+  EXPECT_EQ(7899085683235324083, hashCode<int32_t>(255));
+  EXPECT_EQ(-4530432376425028794, hashCode<int32_t>(-32768));
+  EXPECT_EQ(7178104282075517491, hashCode<int32_t>(32768));
+  EXPECT_EQ(7848567808049036557, hashCode<int32_t>(65535));
+  EXPECT_EQ(-3072160283202506188, hashCode<int32_t>(INT32_MAX));
+  EXPECT_EQ(-3072160283202506188, hashCode<int32_t>(INT32_MIN));
+}
+
+TEST_F(IntegerFunctionsTest, hashCodeFunctionSmallint) {
+  EXPECT_EQ(std::nullopt, hashCode<int16_t>(std::nullopt));
+  EXPECT_EQ(0, hashCode<int16_t>(0));
+  EXPECT_EQ(9155312661752487122, hashCode<int16_t>(1));
+  EXPECT_EQ(-6507640756101998425, hashCode<int16_t>(-1));
+  EXPECT_EQ(6845023471056522234, hashCode<int16_t>(-128));
+  EXPECT_EQ(1951949442083825868, hashCode<int16_t>(-127));
+  EXPECT_EQ(695722463566662829, hashCode<int16_t>(127));
+  EXPECT_EQ(7899085683235324083, hashCode<int16_t>(255));
+  EXPECT_EQ(670463525973519066, hashCode<int16_t>(INT16_MAX));
+  EXPECT_EQ(-4530432376425028794, hashCode<int16_t>(INT16_MIN));
+}
+
+TEST_F(IntegerFunctionsTest, hashCodeFunctionTinyint) {
+  EXPECT_EQ(std::nullopt, hashCode<int8_t>(std::nullopt));
+  EXPECT_EQ(0, hashCode<int8_t>(0));
+  EXPECT_EQ(9155312661752487122, hashCode<int8_t>(1));
+  EXPECT_EQ(-6507640756101998425, hashCode<int8_t>(-1));
+  EXPECT_EQ(1951949442083825868, hashCode<int8_t>(-127));
+  EXPECT_EQ(6845023471056522234, hashCode<int8_t>(INT8_MIN));
+  EXPECT_EQ(6845023471056522234, hashCode<int8_t>(INT8_MAX));
 }

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -2322,3 +2322,25 @@ TEST_F(StringFunctionsTest, xxHash64FunctionVarchar) {
   // Non-ASCII strings
   EXPECT_EQ(8176744303664166369, xxhash64("日本語"));
 }
+
+TEST_F(StringFunctionsTest, hashCodeFunctionVarchar) {
+  const auto hashCode = [&](std::optional<std::string> value) {
+    return evaluateOnce<int64_t>(
+        "hash_code_internal(c0)", VARCHAR(), std::move(value));
+  };
+
+  EXPECT_EQ(std::nullopt, hashCode(std::nullopt));
+
+  EXPECT_EQ(-1205034819632174695, hashCode(""));
+  EXPECT_EQ(4952883123889572249, hashCode("abc"));
+  EXPECT_EQ(-1843406881296486760, hashCode("ABC"));
+  EXPECT_EQ(9087872763436141786, hashCode("string to xxhash64 as param"));
+  EXPECT_EQ(6332497344822543626, hashCode("special characters %_@"));
+  EXPECT_EQ(-3364246049109667261, hashCode("    leading space"));
+  // Unicode characters
+  EXPECT_EQ(-7331673579364787606, hashCode("café"));
+  // String with null bytes
+  EXPECT_EQ(160339756714205673, hashCode("abc\\x00def"));
+  // Non-ASCII strings
+  EXPECT_EQ(8176744303664166369, hashCode("日本語"));
+}


### PR DESCRIPTION
Summary:
Added hash_code_internal function implementation for:
- integer types
- real, double
- timestamp
- varchar
- varbinary
according to the Java implementations of the HASH_CODE operator.

Differential Revision: D81938190


