### PR TITLE
refactor: Remove redundant calls to registerConnectorFactory

### DIFF
--- a/velox/benchmarks/QueryBenchmarkBase.cpp
+++ b/velox/benchmarks/QueryBenchmarkBase.cpp
@@ -215,12 +215,9 @@ void QueryBenchmarkBase::initialize() {
       std::move(configurationValues));
 
   // Create hive connector with config...
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>());
+  connector::hive::HiveConnectorFactory factory;
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, properties, ioExecutor_.get());
+      factory.newConnector(kHiveConnectorId, properties, ioExecutor_.get());
   connector::registerConnector(hiveConnector);
   parquet::registerParquetReaderFactory();
   dwrf::registerDwrfReaderFactory();

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -95,6 +95,10 @@ std::shared_ptr<Connector> getConnector(const std::string& connectorId) {
   return it->second;
 }
 
+bool hasConnector(const std::string& connectorId) {
+  return connectors().find(connectorId) != connectors().end();
+}
+
 const std::unordered_map<std::string, std::shared_ptr<Connector>>&
 getAllConnectors() {
   return connectors();

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -725,6 +725,10 @@ std::shared_ptr<ConnectorFactory> getConnectorFactory(
 /// true. The return value makes it easy to use with FB_ANONYMOUS_VARIABLE.
 bool registerConnector(std::shared_ptr<Connector> connector);
 
+/// Returns true if a connector with the specified ID has been registered, false
+/// otherwise.
+bool hasConnector(const std::string& connectorId);
+
 /// Removes the connector with specified ID from the registry. Returns true
 /// if connector was removed and false if connector didn't exist.
 bool unregisterConnector(const std::string& connectorId);

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
@@ -26,20 +26,13 @@ class FuzzerConnectorTestBase : public exec::test::OperatorTestBase {
 
   void SetUp() override {
     OperatorTestBase::SetUp();
-    connector::registerConnectorFactory(
-        std::make_shared<connector::fuzzer::FuzzerConnectorFactory>());
-    std::shared_ptr<const config::ConfigBase> config;
-    auto fuzzerConnector =
-        connector::getConnectorFactory(
-            connector::fuzzer::FuzzerConnectorFactory::kFuzzerConnectorName)
-            ->newConnector(kFuzzerConnectorId, config);
+    connector::fuzzer::FuzzerConnectorFactory factory;
+    auto fuzzerConnector = factory.newConnector(kFuzzerConnectorId, nullptr);
     connector::registerConnector(fuzzerConnector);
   }
 
   void TearDown() override {
     connector::unregisterConnector(kFuzzerConnectorId);
-    connector::unregisterConnectorFactory(
-        connector::fuzzer::FuzzerConnectorFactory::kFuzzerConnectorName);
     OperatorTestBase::TearDown();
   }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -40,12 +40,9 @@ class S3ReadTest : public S3Test, public ::test::VectorTestBase {
   void SetUp() override {
     S3Test::SetUp();
     filesystems::registerS3FileSystem();
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
+    connector::hive::HiveConnectorFactory factory;
     auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(kHiveConnectorId, minioServer_->hiveConfig());
+        factory.newConnector(kHiveConnectorId, minioServer_->hiveConfig());
     connector::registerConnector(hiveConnector);
     parquet::registerParquetReaderFactory();
   }
@@ -53,8 +50,6 @@ class S3ReadTest : public S3Test, public ::test::VectorTestBase {
   void TearDown() override {
     parquet::unregisterParquetReaderFactory();
     filesystems::finalizeS3FileSystem();
-    connector::unregisterConnectorFactory(
-        connector::hive::HiveConnectorFactory::kHiveConnectorName);
     connector::unregisterConnector(kHiveConnectorId);
     S3Test::TearDown();
   }

--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -34,13 +34,9 @@ class InsertTest : public velox::test::VectorTestBase {
   void SetUp(
       std::shared_ptr<const config::ConfigBase> hiveConfig,
       folly::Executor* ioExecutor) {
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
-    auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(
-                exec::test::kHiveConnectorId, hiveConfig, ioExecutor);
+    connector::hive::HiveConnectorFactory factory;
+    auto hiveConnector = factory.newConnector(
+        exec::test::kHiveConnectorId, hiveConfig, ioExecutor);
     connector::registerConnector(hiveConnector);
 
     parquet::registerParquetReaderFactory();

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -39,22 +39,16 @@ class TpchConnectorTest : public exec::test::OperatorTestBase {
   void SetUp() override {
     FLAGS_velox_tpch_text_pool_size_mb = 10;
     OperatorTestBase::SetUp();
-    connector::registerConnectorFactory(
-        std::make_shared<connector::tpch::TpchConnectorFactory>());
-    auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
-            ->newConnector(
-                kTpchConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()));
+    connector::tpch::TpchConnectorFactory factory;
+    auto tpchConnector = factory.newConnector(
+        kTpchConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
     connector::registerConnector(tpchConnector);
   }
 
   void TearDown() override {
     connector::unregisterConnector(kTpchConnectorId);
-    connector::unregisterConnectorFactory(
-        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
     OperatorTestBase::TearDown();
   }
 
@@ -446,12 +440,10 @@ TEST_F(TpchConnectorTest, orderDateCount) {
 TEST_F(TpchConnectorTest, config) {
   std::unordered_map<std::string, std::string> properties = {
       {"property", "value"}};
-  auto connector =
-      connector::getConnectorFactory(
-          connector::tpch::TpchConnectorFactory::kTpchConnectorName)
-          ->newConnector(
-              kTpchConnectorId,
-              std::make_shared<config::ConfigBase>(std::move(properties)));
+  connector::tpch::TpchConnectorFactory factory;
+  auto connector = factory.newConnector(
+      kTpchConnectorId,
+      std::make_shared<config::ConfigBase>(std::move(properties)));
 
   const auto& config = connector->connectorConfig();
   auto val = config->get<std::string>("property");

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -55,26 +55,18 @@ class ParquetTpchTest : public testing::Test {
     parquet::registerParquetReaderFactory();
     parquet::registerParquetWriterFactory();
 
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
-    auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(
-                kHiveConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()));
+    connector::hive::HiveConnectorFactory hiveFactory;
+    auto hiveConnector = hiveFactory.newConnector(
+        kHiveConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
 
-    connector::registerConnectorFactory(
-        std::make_shared<connector::tpch::TpchConnectorFactory>());
-    auto tpchConnector =
-        connector::getConnectorFactory(
-            connector::tpch::TpchConnectorFactory::kTpchConnectorName)
-            ->newConnector(
-                kTpchConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()));
+    connector::tpch::TpchConnectorFactory tpchFactory;
+    auto tpchConnector = tpchFactory.newConnector(
+        kTpchConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
     connector::registerConnector(tpchConnector);
 
     saveTpchTablesAsParquet();
@@ -82,10 +74,6 @@ class ParquetTpchTest : public testing::Test {
   }
 
   static void TearDownTestSuite() {
-    connector::unregisterConnectorFactory(
-        connector::hive::HiveConnectorFactory::kHiveConnectorName);
-    connector::unregisterConnectorFactory(
-        connector::tpch::TpchConnectorFactory::kTpchConnectorName);
     connector::unregisterConnector(kHiveConnectorId);
     connector::unregisterConnector(kTpchConnectorId);
     parquet::unregisterParquetReaderFactory();

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -46,15 +46,11 @@ class ParquetWriterTest : public ParquetTestBase {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     testutil::TestValue::enable();
     filesystems::registerLocalFileSystem();
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
-    auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(
-                kHiveConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()));
+    connector::hive::HiveConnectorFactory factory;
+    auto hiveConnector = factory.newConnector(
+        kHiveConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
     parquet::registerParquetWriterFactory();
   }

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -85,18 +85,12 @@ int main(int argc, char** argv) {
   // We need a connector id string to identify the connector.
   const std::string kHiveConnectorId = "test-hive";
 
-  // Register the Hive Connector Factory.
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>());
-  // Create a new connector instance from the connector factory and register
-  // it:
-  auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(
-              kHiveConnectorId,
-              std::make_shared<config::ConfigBase>(
-                  std::unordered_map<std::string, std::string>()));
+  // Create a new connector instance and register it.
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(
+      kHiveConnectorId,
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()));
   connector::registerConnector(hiveConnector);
 
   // To be able to read local files, we need to register the local file

--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -373,17 +373,11 @@ void registerHiveConnector(
   auto configs = hiveConfigs;
   // Make sure not to run out of open file descriptors.
   configs[connector::hive::HiveConfig::kNumCacheFileHandles] = "1000";
-  if (!connector::hasConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)) {
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
-  }
-  auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(
-              kHiveConnectorId,
-              std::make_shared<config::ConfigBase>(std::move(configs)));
+
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(
+      kHiveConnectorId,
+      std::make_shared<config::ConfigBase>(std::move(configs)));
   connector::registerConnector(hiveConnector);
 }
 

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -205,14 +205,11 @@ JoinFuzzer::JoinFuzzer(
   // Make sure not to run out of open file descriptors.
   std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>());
-  auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(
-              test::kHiveConnectorId,
-              std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
+
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(
+      test::kHiveConnectorId,
+      std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
   connector::registerConnector(hiveConnector);
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -278,14 +278,11 @@ MemoryArbitrationFuzzer::MemoryArbitrationFuzzer(size_t initialSeed)
   // Make sure not to run out of open file descriptors.
   std::unordered_map<std::string, std::string> hiveConfig = {
       {connector::hive::HiveConfig::kNumCacheFileHandles, "1000"}};
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>());
-  const auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(
-              test::kHiveConnectorId,
-              std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
+
+  connector::hive::HiveConnectorFactory hiveFactory;
+  const auto hiveConnector = hiveFactory.newConnector(
+      test::kHiveConnectorId,
+      std::make_shared<config::ConfigBase>(std::move(hiveConfig)));
   connector::registerConnector(hiveConnector);
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();

--- a/velox/exec/fuzzer/WriterFuzzerRunner.h
+++ b/velox/exec/fuzzer/WriterFuzzerRunner.h
@@ -77,15 +77,11 @@ class WriterFuzzerRunner {
       std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner) {
     filesystems::registerLocalFileSystem();
     tests::utils::registerFaultyFileSystem();
-    connector::registerConnectorFactory(
-        std::make_shared<connector::hive::HiveConnectorFactory>());
-    auto hiveConnector =
-        connector::getConnectorFactory(
-            connector::hive::HiveConnectorFactory::kHiveConnectorName)
-            ->newConnector(
-                kHiveConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()));
+    connector::hive::HiveConnectorFactory factory;
+    auto hiveConnector = factory.newConnector(
+        kHiveConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
     connector::registerConnector(hiveConnector);
     dwrf::registerDwrfReaderFactory();
     dwrf::registerDwrfWriterFactory();

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -179,15 +179,13 @@ class AsyncConnectorTest : public OperatorTestBase {
  public:
   void SetUp() override {
     OperatorTestBase::SetUp();
-    connector::registerConnectorFactory(
-        std::make_shared<TestConnectorFactory>());
-    auto testConnector =
-        connector::getConnectorFactory(TestConnectorFactory::kTestConnectorName)
-            ->newConnector(
-                kTestConnectorId,
-                std::make_shared<config::ConfigBase>(
-                    std::unordered_map<std::string, std::string>()),
-                nullptr);
+    TestConnectorFactory factory;
+    auto testConnector = factory.newConnector(
+        kTestConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()),
+        nullptr,
+        nullptr);
     connector::registerConnector(testConnector);
   }
 

--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -36,16 +36,12 @@ namespace {
 
 void registerFactories(folly::Executor* ioExecutor) {
   filesystems::registerLocalFileSystem();
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>());
-  auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(
-              TableEvolutionFuzzer::connectorId(),
-              std::make_shared<config::ConfigBase>(
-                  std::unordered_map<std::string, std::string>()),
-              ioExecutor);
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(
+      TableEvolutionFuzzer::connectorId(),
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()),
+      ioExecutor);
   connector::registerConnector(hiveConnector);
   dwio::common::registerFileSinks();
   dwrf::registerDwrfReaderFactory();

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -36,16 +36,12 @@ HiveConnectorTestBase::HiveConnectorTestBase() {
 
 void HiveConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
-  connector::registerConnectorFactory(
-      std::make_shared<connector::hive::HiveConnectorFactory>());
-  auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(
-              kHiveConnectorId,
-              std::make_shared<config::ConfigBase>(
-                  std::unordered_map<std::string, std::string>()),
-              ioExecutor_.get());
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector(
+      kHiveConnectorId,
+      std::make_shared<config::ConfigBase>(
+          std::unordered_map<std::string, std::string>()),
+      ioExecutor_.get());
   connector::registerConnector(hiveConnector);
   dwio::common::registerFileSinks();
   dwrf::registerDwrfReaderFactory();
@@ -60,8 +56,6 @@ void HiveConnectorTestBase::TearDown() {
   dwrf::unregisterDwrfReaderFactory();
   dwrf::unregisterDwrfWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
-  connector::unregisterConnectorFactory(
-      connector::hive::HiveConnectorFactory::kHiveConnectorName);
   text::unregisterTextReaderFactory();
   OperatorTestBase::TearDown();
 }
@@ -69,10 +63,10 @@ void HiveConnectorTestBase::TearDown() {
 void HiveConnectorTestBase::resetHiveConnector(
     const std::shared_ptr<const config::ConfigBase>& config) {
   connector::unregisterConnector(kHiveConnectorId);
+
+  connector::hive::HiveConnectorFactory factory;
   auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector(kHiveConnectorId, config, ioExecutor_.get());
+      factory.newConnector(kHiveConnectorId, config, ioExecutor_.get());
   connector::registerConnector(hiveConnector);
 }
 

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -367,11 +367,9 @@ class TestIndexConnectorFactory : public connector::ConnectorFactory {
   }
 
   static void registerConnector(folly::CPUThreadPoolExecutor* cpuExecutor) {
-    connector::registerConnectorFactory(
-        std::make_shared<TestIndexConnectorFactory>());
+    TestIndexConnectorFactory factory;
     std::shared_ptr<connector::Connector> connector =
-        connector::getConnectorFactory(kTestIndexConnectorName)
-            ->newConnector(kTestIndexConnectorName, {}, nullptr, cpuExecutor);
+        factory.newConnector(kTestIndexConnectorName, {}, nullptr, cpuExecutor);
     connector::registerConnector(connector);
   }
 };

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -160,10 +160,8 @@ void WaveHiveDataSource::registerConnector() {
       std::unordered_map<std::string, std::string>());
 
   // Create hive connector with config...
-  auto hiveConnector =
-      connector::getConnectorFactory(
-          connector::hive::HiveConnectorFactory::kHiveConnectorName)
-          ->newConnector("wavemock", config, nullptr);
+  connector::hive::HiveConnectorFactory factory;
+  auto hiveConnector = factory.newConnector("wavemock", config, nullptr);
   connector::registerConnector(hiveConnector);
   connector::hive::HiveDataSource::registerWaveDelegateHook(
       [](const HiveTableHandlePtr& hiveTableHandle,

--- a/velox/python/runner/PyConnectors.cpp
+++ b/velox/python/runner/PyConnectors.cpp
@@ -30,15 +30,11 @@ template <typename TConnectorFactory>
 void registerConnector(
     const std::string& connectorId,
     std::unordered_map<std::string, std::string> configs) {
-  connector::registerConnectorFactory(
-      std::make_shared<TConnectorFactory>(connectorId.data()));
-
   const auto configBase =
       std::make_shared<velox::config::ConfigBase>(std::move(configs));
-  auto connector =
-      connector::getConnectorFactory(connectorId)
-          ->newConnector(
-              connectorId, configBase, folly::getGlobalCPUExecutor().get());
+  TConnectorFactory factory;
+  auto connector = factory.newConnector(
+      connectorId, configBase, folly::getGlobalCPUExecutor().get());
   connector::registerConnector(connector);
   connectorRegistry().insert(connectorId);
 }
@@ -61,8 +57,7 @@ void registerTpch(
 
 // Is it ok to unregister connectors that were not registered.
 void unregister(const std::string& connectorId) {
-  if (!facebook::velox::connector::unregisterConnector(connectorId) ||
-      !facebook::velox::connector::unregisterConnectorFactory(connectorId)) {
+  if (!facebook::velox::connector::unregisterConnector(connectorId)) {
     throw std::runtime_error(
         fmt::format("Unable to unregister connector '{}'", connectorId));
   }


### PR DESCRIPTION
Summary:
Connector factories are used only by Prestissimo to create multiple instances of the same kind of connector for different catalogs. These factories are not needed for other use cases.

A follow-up would be to move connector factories out of Velox into Prestissimo.

Differential Revision: D81960874


