### PR TITLE
fix: Expose symbol tpcds::fromTableName

### DIFF
--- a/velox/tpcds/gen/TpcdsGen.cpp
+++ b/velox/tpcds/gen/TpcdsGen.cpp
@@ -27,8 +27,8 @@ namespace {
 // parent tables (TBL_CATALOG_SALES, TBL_STORE_SALES, or TBL_WEB_SALES) is 16.
 static constexpr vector_size_t kMaxParentTableRows = 16;
 
-std::unordered_map<std::string, Table> tpcdsTableMap() {
-  static const std::unordered_map<std::string, Table> map{
+std::unordered_map<std::string_view, Table> tpcdsTableMap() {
+  static const std::unordered_map<std::string_view, Table> map{
       {"call_center", Table::TBL_CALL_CENTER},
       {"catalog_page", Table::TBL_CATALOG_PAGE},
       {"catalog_returns", Table::TBL_CATALOG_RETURNS},
@@ -57,8 +57,8 @@ std::unordered_map<std::string, Table> tpcdsTableMap() {
   return map;
 }
 
-std::unordered_map<Table, std::string> invertTpcdsTableMap() {
-  std::unordered_map<Table, std::string> inverted;
+std::unordered_map<Table, std::string_view> invertTpcdsTableMap() {
+  std::unordered_map<Table, std::string_view> inverted;
   for (const auto& [key, value] : tpcdsTableMap()) {
     inverted.emplace(value, key);
   }
@@ -821,7 +821,7 @@ const RowTypePtr getTableSchema(Table table) {
   }
 }
 
-std::string toTableName(Table table) {
+std::string_view toTableName(Table table) {
   auto inverted = invertTpcdsTableMap();
   auto it = inverted.find(table);
   if (it != inverted.end()) {
@@ -830,7 +830,7 @@ std::string toTableName(Table table) {
   VELOX_UNREACHABLE("Invalid TPC-DS table: {}", static_cast<uint8_t>(table));
 }
 
-Table fromTableName(const std::string& tableName) {
+Table fromTableName(std::string_view tableName) {
   auto map = tpcdsTableMap();
   auto it = map.find(tableName);
   if (it != map.end()) {

--- a/velox/tpcds/gen/TpcdsGen.h
+++ b/velox/tpcds/gen/TpcdsGen.h
@@ -85,12 +85,13 @@ static const auto tables = {
     tpcds::Table::TBL_WEB_SITE};
 
 /// Returns table name as a string.
-std::string toTableName(Table table);
+std::string_view toTableName(Table table);
 
 /// Returns the schema (RowType) for a particular TPC-DS table.
 const velox::RowTypePtr getTableSchema(Table table);
 
-Table fromTableName(const std::string_view& tableName);
+/// Returns TPC-DS table enum corresponding to name.
+Table fromTableName(std::string_view tableName);
 
 /// Returns a row vector containing at most `maxRows` rows of the `table`,
 /// starting at `offset`, with the given `scaleFactor`. DSDGen allows data


### PR DESCRIPTION
The helper function `fromTableName`, used to retrieve Tpcds table from it's name, is not exposed via `velox_tpcds_gen` because the datatype for argument differs in function's definition and declaration (`std::string` vs `std::string_view`). 
The function `fromTableName`, when referenced in Presto C++ from `TpcdsPrestoToVeloxConnector::toVeloxTableHandle` (in https://github.com/prestodb/presto/pull/24751), results in a build failure:
```
Undefined symbols for architecture arm64:
  "facebook::velox::tpcds::fromTableName(std::__1::basic_string_view<char, std::__1::char_traits<char>> const&)", referenced from:
      facebook::presto::TpcdsPrestoToVeloxConnector::toVeloxTableHandle(facebook::presto::protocol::TableHandle const&, facebook::presto::VeloxExprConverter const&, facebook::presto::TypeParser const&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::shared_ptr<facebook::velox::connector::ColumnHandle const>, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::shared_ptr<facebook::velox::connector::ColumnHandle const>>>>&) const in libpresto_connectors.a[4](PrestoToVeloxConnector.cpp.o)
ld: symbol(s) not found for architecture arm64
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```

Fixes this error by making the function declaration consistent with the definition.