### PR TITLE
fix: Make setType() support RowVector with missing subfields

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -249,7 +249,10 @@ void RowVector::copy(
 void RowVector::setType(const TypePtr& type) {
   BaseVector::setType(type);
   for (auto i = 0; i < childrenSize_; i++) {
-    children_[i]->setType(type_->asRow().childAt(i));
+    auto& child = children_[i];
+    if (child) {
+      child->setType(type_->asRow().childAt(i));
+    }
   }
 }
 


### PR DESCRIPTION
Summary: There are cases where RowVector may be missing subfields (particularly in the dwio field reader usage when a field is not projected). Previous setType() implementation doesn't handle missing subfield case.

Differential Revision: D81987618


