### PR TITLE
Add velox-cudf support for TopN

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   CudfLimit.cpp
   CudfLocalPartition.cpp
   CudfOrderBy.cpp
+  CudfTopN.cpp
   DebugUtil.cpp
   ExpressionEvaluator.cpp
   ToCudf.cpp

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -135,18 +135,24 @@ void CudfFilterProject::filter(
   auto filterColumns = filterEvaluator_.compute(
       inputTableColumns, stream, cudf::get_current_device_resource_ref());
   auto filterColumn = filterColumns[0]->view();
-  // is all true in filter_column
-  auto isAllTrue = cudf::reduce(
-      filterColumn,
-      *cudf::make_all_aggregation<cudf::reduce_aggregation>(),
-      cudf::data_type(cudf::type_id::BOOL8),
-      stream,
-      cudf::get_current_device_resource_ref());
-  using ScalarType = cudf::scalar_type_t<bool>;
-  auto result = static_cast<ScalarType*>(isAllTrue.get());
-  // If filter is not all true, apply the filter
-  if (!(result->is_valid(stream) && result->value(stream))) {
-    // Apply the Filter
+
+  bool shouldApplyFilter = [&]() {
+    if (filterColumn.has_nulls()) {
+      return true;
+    }
+    // check if all values in filterColumn are true
+    auto isAllTrue = cudf::reduce(
+        filterColumn,
+        *cudf::make_all_aggregation<cudf::reduce_aggregation>(),
+        cudf::data_type(cudf::type_id::BOOL8),
+        stream,
+        cudf::get_current_device_resource_ref());
+    using ScalarType = cudf::scalar_type_t<bool>;
+    auto result = static_cast<ScalarType*>(isAllTrue.get());
+    // If filter is not all true, apply the filter
+    return !(result->is_valid(stream) && result->value(stream));
+  }();
+  if (shouldApplyFilter) {
     auto filterTable =
         std::make_unique<cudf::table>(std::move(inputTableColumns));
     auto filteredTable =

--- a/velox/experimental/cudf/exec/CudfTopN.cpp
+++ b/velox/experimental/cudf/exec/CudfTopN.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/exec/CudfTopN.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+
+#include <cudf/detail/copy.hpp>
+#include <cudf/detail/gather.hpp>
+#include <cudf/sorting.hpp>
+
+namespace facebook::velox::cudf_velox {
+CudfTopN::CudfTopN(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::TopNNode>& topNNode)
+    : exec::Operator(
+          driverCtx,
+          topNNode->outputType(),
+          operatorId,
+          topNNode->id(),
+          "CudfTopN"),
+      NvtxHelper(
+          nvtx3::rgb{175, 238, 238}, // Pale Turquoise
+          operatorId,
+          fmt::format("[{}]", topNNode->id())),
+      count_(topNNode->count()),
+      topNNode_(topNNode) {
+  const auto numColumns{outputType_->children().size()};
+  const auto numSortingKeys{topNNode->sortingKeys().size()};
+  std::vector<bool> isSortingKey(numColumns);
+  sortKeys_.reserve(numSortingKeys);
+  columnOrder_.reserve(numSortingKeys);
+  nullOrder_.reserve(numSortingKeys);
+
+  for (int i = 0; i < numSortingKeys; ++i) {
+    const auto channel =
+        exec::exprToChannel(topNNode->sortingKeys()[i].get(), outputType_);
+    VELOX_CHECK(
+        channel != kConstantChannel,
+        "OrderBy doesn't allow constant sorting keys");
+    sortKeys_.push_back(channel);
+    isSortingKey[channel] = true;
+    auto const& sortingOrder = topNNode->sortingOrders()[i];
+    columnOrder_.push_back(
+        sortingOrder.isAscending() ? cudf::order::ASCENDING
+                                   : cudf::order::DESCENDING);
+    nullOrder_.push_back(
+        (sortingOrder.isNullsFirst() ^ !sortingOrder.isAscending())
+            ? cudf::null_order::BEFORE
+            : cudf::null_order::AFTER);
+  }
+}
+
+std::unique_ptr<cudf::table> CudfTopN::getTopK(
+    cudf::table_view const& values,
+    int32_t k,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto keys = values.select(sortKeys_);
+  auto const indices =
+      cudf::stable_sorted_order(keys, columnOrder_, nullOrder_, stream, mr);
+  k = std::min(k, values.num_rows());
+  auto const k_indices =
+      cudf::detail::split(indices->view(), {k}, stream).front();
+  return cudf::detail::gather(
+      values,
+      k_indices,
+      cudf::out_of_bounds_policy::DONT_CHECK,
+      cudf::detail::negative_index_policy::NOT_ALLOWED,
+      stream,
+      mr);
+}
+
+// helper to get topk of a table
+CudfVectorPtr CudfTopN::getTopKBatch(CudfVectorPtr cudfInput, int32_t k) {
+  if (k == 0 || cudfInput->size() == 0) {
+    return nullptr;
+  }
+  if (k >= cudfInput->size()) {
+    // no need to sort until getOutput.
+    return cudfInput;
+  }
+  auto stream = cudfInput->stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto values = cudfInput->getTableView();
+  auto result = getTopK(values, k, stream, mr);
+  auto const size = result->num_rows();
+  return std::make_shared<CudfVector>(
+      cudfInput->pool(), cudfInput->type(), size, std::move(result), stream);
+}
+
+void CudfTopN::addInput(RowVectorPtr input) {
+  if (count_ == 0 || input->size() == 0) {
+    return;
+  }
+
+  auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+  VELOX_CHECK_NOT_NULL(cudfInput);
+  // take topk of each input, add to batch. if kBatchSize batches, then concat
+  // and topk once. during getOutput, concat batches and topk once.
+  topNBatches_.push_back(getTopKBatch(cudfInput, count_));
+  // sum of sizes of topNBatches_ >= count_, then concat and topk once.
+  auto totalSize = std::accumulate(
+      topNBatches_.begin(),
+      topNBatches_.end(),
+      0,
+      [](int32_t sum, const auto& batch) { return sum + batch->size(); });
+  if (topNBatches_.size() >= kBatchSize_ and totalSize >= count_) {
+    auto stream = cudfGlobalStreamPool().get_stream();
+    auto mr = cudf::get_current_device_resource_ref();
+    auto result = getTopK(
+        getConcatenatedTable(topNBatches_, stream)->view(), count_, stream, mr);
+    topNBatches_.clear();
+    topNBatches_.push_back(std::make_shared<CudfVector>(
+        pool(), outputType_, result->num_rows(), std::move(result), stream));
+  }
+}
+
+RowVectorPtr CudfTopN::getOutput() {
+  if (finished_ || !noMoreInput_) {
+    return nullptr;
+  }
+  if (topNBatches_.empty()) {
+    finished_ = noMoreInput_;
+    return nullptr;
+  }
+
+  auto stream = topNBatches_[0]->stream();
+  auto mr = cudf::get_current_device_resource_ref();
+  auto result = getTopK(
+      getConcatenatedTable(topNBatches_, stream)->view(), count_, stream, mr);
+  topNBatches_.clear();
+  auto const size = result->num_rows();
+  auto resultTable = std::make_shared<CudfVector>(
+      pool(), outputType_, size, std::move(result), stream);
+
+  finished_ = noMoreInput_ && topNBatches_.empty();
+  return resultTable;
+  // TBD: is batching needed? if so, then we need to batch the resultTable.
+}
+
+void CudfTopN::noMoreInput() {
+  Operator::noMoreInput();
+  if (topNBatches_.empty()) {
+    finished_ = true;
+    return;
+  }
+}
+
+bool CudfTopN::isFinished() {
+  return finished_;
+}
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfTopN.h
+++ b/velox/experimental/cudf/exec/CudfTopN.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/cudf/exec/NvtxHelper.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::cudf_velox {
+
+class CudfTopN : public exec::Operator, public NvtxHelper {
+ public:
+  CudfTopN(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::TopNNode>& topNNode);
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  void noMoreInput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ private:
+  const int32_t count_; // N value of TopN
+
+  std::shared_ptr<const core::TopNNode> topNNode_;
+  std::vector<cudf::size_type> sortKeys_;
+  std::vector<cudf::order> columnOrder_;
+  std::vector<cudf::null_order> nullOrder_;
+
+  CudfVectorPtr getTopKBatch(CudfVectorPtr cudfInput, int32_t k);
+  std::unique_ptr<cudf::table> getTopK(
+      cudf::table_view const& values,
+      int32_t k,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr);
+
+  // As the inputs are added to TopN operator, we use topNBatches_
+  // (a vector of CudfVectorPtrs) to keep track of the topN rows of each input.
+  // We only update the topNBatches_ if number of batches >= 5 and number of
+  // rows in topNBatches_ >= count_. Once all inputs are available, we concat
+  // the topNBatches_ and get the topN rows.
+  std::vector<CudfVectorPtr> topNBatches_;
+  static constexpr size_t kBatchSize_{5};
+  bool finished_ = false;
+};
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(velox_cudf_hash_join_test HashJoinTest.cpp Main.cpp)
 add_executable(velox_cudf_order_by_test Main.cpp OrderByTest.cpp)
+add_executable(velox_cudf_topn_test Main.cpp TopNTest.cpp)
 add_executable(velox_cudf_aggregation_test Main.cpp AggregationTest.cpp)
 add_executable(velox_cudf_table_scan_test Main.cpp TableScanTest.cpp)
 add_executable(velox_cudf_table_write_test Main.cpp TableWriteTest.cpp)
@@ -31,6 +32,12 @@ add_test(
 add_test(
   NAME velox_cudf_order_by_test
   COMMAND velox_cudf_order_by_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_test(
+  NAME velox_cudf_topn_test
+  COMMAND velox_cudf_topn_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -78,6 +85,7 @@ add_test(
 
 set_tests_properties(velox_cudf_hash_join_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_order_by_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_topn_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_aggregation_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_local_partition_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_table_scan_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
@@ -101,6 +109,17 @@ target_link_libraries(
 
 target_link_libraries(
   velox_cudf_order_by_test
+  velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
+  fmt::fmt
+)
+
+target_link_libraries(
+  velox_cudf_topn_test
   velox_cudf_exec
   velox_exec
   velox_exec_test_lib

--- a/velox/experimental/cudf/tests/TopNTest.cpp
+++ b/velox/experimental/cudf/tests/TopNTest.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+class TopNTest : public OperatorTestBase {
+ public:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    cudf_velox::registerCudf();
+  }
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+
+ protected:
+  static std::vector<std::string> getSortOrderSqls() {
+    return {"NULLS LAST", "NULLS FIRST", "DESC NULLS FIRST", "DESC NULLS LAST"};
+  }
+
+  void testSingleKey(
+      const std::vector<RowVectorPtr>& input,
+      const std::string& key,
+      int32_t limit) {
+    auto keyIndex = input[0]->type()->asRow().getChildIdx(key);
+
+    auto sortOrderSqls = getSortOrderSqls();
+
+    for (const auto& sortOrderSql : sortOrderSqls) {
+      auto sql = fmt::format("{} {}", key, sortOrderSql);
+
+      auto plan =
+          PlanBuilder().values(input).topN({sql}, limit, false).planNode();
+
+      assertQueryOrdered(
+          plan,
+          fmt::format("SELECT * FROM tmp ORDER BY {} LIMIT {}", sql, limit),
+          {keyIndex});
+    }
+  }
+
+  void testSingleKey(
+      const std::vector<RowVectorPtr>& input,
+      const std::string& key,
+      const std::string& filter) {
+    auto keyIndex = input[0]->type()->asRow().getChildIdx(key);
+
+    auto sortOrderSqls = getSortOrderSqls();
+
+    for (const auto& sortOrderSql : sortOrderSqls) {
+      auto sql = fmt::format("{} {}", key, sortOrderSql);
+
+      auto plan = PlanBuilder()
+                      .values(input)
+                      .filter(filter)
+                      .topN({sql}, 10, false)
+                      .planNode();
+
+      assertQueryOrdered(
+          plan,
+          fmt::format(
+              "SELECT * FROM tmp WHERE {} ORDER BY {} LIMIT 10", filter, sql),
+          {keyIndex});
+    }
+  }
+
+  void testTwoKeys(
+      const std::vector<RowVectorPtr>& input,
+      const std::string& key1,
+      const std::string& key2,
+      int32_t limit) {
+    auto& rowType = input[0]->type()->asRow();
+    auto keyIndices = {rowType.getChildIdx(key1), rowType.getChildIdx(key2)};
+
+    auto sortOrderSqls = getSortOrderSqls();
+
+    for (const auto& sortOrderSql1 : sortOrderSqls) {
+      for (const auto& sortOrderSql2 : sortOrderSqls) {
+        auto sql1 = fmt::format("{} {}", key1, sortOrderSql1);
+        auto sql2 = fmt::format("{} {}", key2, sortOrderSql2);
+
+        auto plan = PlanBuilder()
+                        .values(input)
+                        .topN({sql1, sql2}, limit, false)
+                        .planNode();
+
+        assertQueryOrdered(
+            plan,
+            fmt::format(
+                "SELECT * FROM tmp ORDER BY {}, {} LIMIT {}",
+                sql1,
+                sql2,
+                limit),
+            keyIndices);
+      }
+    }
+  }
+};
+
+TEST_F(TopNTest, selectiveFilter) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 3; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize,
+        [&](vector_size_t row) { return batchSize * i + row; },
+        nullEvery(5));
+    auto c1 = makeFlatVector<int64_t>(
+        batchSize, [&](vector_size_t row) { return row; }, nullEvery(5));
+    auto c2 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; }, nullEvery(11));
+    vectors.push_back(makeRowVector({c0, c1, c2}));
+  }
+  createDuckDbTable(vectors);
+
+  // c0 values are unique across batches
+  testSingleKey(vectors, "c0", "c0 % 333 = 0");
+
+  // c1 values are unique only within a batch
+  testSingleKey(vectors, "c1", "c1 % 333 = 0");
+}
+
+TEST_F(TopNTest, singleKey) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 2; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](vector_size_t row) { return row; }, nullEvery(5));
+    auto c1 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; }, nullEvery(11));
+    vectors.push_back(makeRowVector({c0, c1}));
+  }
+  createDuckDbTable(vectors);
+
+  // DESC NULLS LAST and ASC NULLS FIRST will return all rows where c0 is null;
+  // There are 400 rows where c0 is null. Use limit greater than 400 to make the
+  // query deterministic.
+  testSingleKey(vectors, "c0", 410);
+
+  // parser doesn't support "is not null" expression, hence, using c0 % 2 >= 0
+  testSingleKey(vectors, "c0", "c0 % 2 >= 0");
+}
+
+TEST_F(TopNTest, multipleKeys) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 2; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [](vector_size_t row) { return row % 4; }, nullEvery(31, 1));
+    auto c1 = makeFlatVector<int32_t>(
+        batchSize, [](vector_size_t row) { return row; }, nullEvery(17));
+    auto c2 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; }, nullEvery(11));
+    vectors.push_back(makeRowVector({c0, c1, c2}));
+  }
+  createDuckDbTable(vectors);
+
+  testTwoKeys(vectors, "c0", "c1", 200);
+}
+
+TEST_F(TopNTest, compaction) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 5; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize,
+        [&](vector_size_t row) { return batchSize * i + row; },
+        nullEvery(31));
+    auto c1 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; }, nullEvery(11));
+    vectors.push_back(makeRowVector({c0, c1, c1, c1, c1, c1}));
+  }
+  createDuckDbTable(vectors);
+
+  // Make sure LIMIT is greater than number of rows with nulls to avoid
+  // non-deterministic results.
+  testSingleKey(vectors, "c0", 500);
+
+  testSingleKey(vectors, "c0", 900);
+}
+
+TEST_F(TopNTest, varchar) {
+  vector_size_t batchSize = 1'000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 5; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize,
+        [&](vector_size_t row) { return batchSize * i + row; },
+        nullEvery(5));
+    auto c1 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; }, nullEvery(11));
+    auto c2 = makeFlatVector<StringView>(
+        batchSize,
+        [](vector_size_t row) {
+          return StringView::makeInline(std::to_string(row));
+        },
+        nullEvery(31));
+    auto c3 = makeFlatVector<std::string>(batchSize, [](vector_size_t row) {
+      return "non inline string " + std::to_string(row);
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+  }
+  createDuckDbTable(vectors);
+
+  // Make sure LIMIT is greater than number of rows with nulls to avoid
+  // non-deterministic results.
+  testSingleKey(vectors, "c2", 200);
+}
+
+TEST_F(TopNTest, multiBatch) {
+  vector_size_t batchSize = 1'000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 5; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](vector_size_t row) { return batchSize * i + row; });
+    auto c1 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; });
+    auto c2 = makeFlatVector<StringView>(batchSize, [](vector_size_t row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2}));
+  }
+  createDuckDbTable(vectors);
+
+  testSingleKey(vectors, "c0", 1'500);
+  testSingleKey(vectors, "c2", 2'500);
+}
+
+TEST_F(TopNTest, empty) {
+  vector_size_t batchSize = 1'000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 5; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize, [&](vector_size_t row) { return batchSize * i + row; });
+    auto c1 = makeFlatVector<double>(
+        batchSize, [](vector_size_t row) { return row * 0.1; });
+    auto c2 = makeFlatVector<StringView>(batchSize, [](vector_size_t row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2}));
+  }
+  createDuckDbTable(vectors);
+
+  testSingleKey(vectors, "c0", "c0 < 0");
+}
+
+TEST_F(TopNTest, lowCardinality) {
+  vector_size_t size = 1'000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 5; ++i) {
+    auto c0 = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 0; });
+    auto c1 = makeFlatVector<int32_t>(size, [](auto /*row*/) { return 10; });
+    auto c2 = makeFlatVector<double>(size, [](auto /*row*/) { return 12.5; });
+    vectors.push_back(makeRowVector({c0, c1, c2}));
+  }
+  createDuckDbTable(vectors);
+
+  testTwoKeys(vectors, "c0", "c1", 200);
+}
+
+// All columns are sorting keys.
+TEST_F(TopNTest, onlyKeys) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 2; ++i) {
+    auto c0 = makeFlatVector<int64_t>(
+        batchSize,
+        [](vector_size_t row) { return row % 20; },
+        nullEvery(31, 1));
+    auto c1 = makeFlatVector<int32_t>(
+        batchSize, [](vector_size_t row) { return row; }, nullEvery(17));
+    vectors.push_back(makeRowVector({c0, c1}));
+  }
+  createDuckDbTable(vectors);
+
+  testTwoKeys(vectors, "c0", "c1", 200);
+}
+
+TEST_F(TopNTest, planNodeValidation) {
+  auto data = makeRowVector(
+      ROW({"a", "b"},
+          {
+              BIGINT(),
+              BIGINT(),
+          }),
+      10);
+  auto plan = [&](const std::vector<std::string>& sortingKeys,
+                  int32_t count = 10) {
+    PlanBuilder().values({data}).topN(sortingKeys, count, false).planNode();
+  };
+
+  VELOX_ASSERT_THROW(plan({}), "TopN must specify sorting keys");
+  VELOX_ASSERT_THROW(
+      plan({"a"}, 0),
+      "TopN must specify greater than zero number of rows to keep");
+  VELOX_ASSERT_THROW(
+      plan({"a", "b", "a"}),
+      "TopN must specify unique sorting keys. Found duplicate key: a");
+}


### PR DESCRIPTION
This PR adds operator CudfTopN to run TopN in GPU.
Unit tests are added to verify the output.

The CudfTopN stores top N values of each input batch, and if number of batches exceed 5, the batches are concatenated together and topN values are stored back to the batch vector. getOutput will concatenated all batches together and return topN values.

The tests are same as TopN, but Setup makes sure they run in GPU.
This PR has additional fix 2288ca913ca4584c273c6690e75acb4f1dd07250 for cudfFilterProject which affects filter results with null values.


