### PR TITLE
feat: Add merge_hll Presto scalar function

### DIFF
--- a/velox/docs/functions/presto/hyperloglog.rst
+++ b/velox/docs/functions/presto/hyperloglog.rst
@@ -70,3 +70,10 @@ Functions
 
     Returns the ``HyperLogLog`` of the aggregate union of the individual ``hll``
     HyperLogLog structures.
+
+.. function:: merge_hll(array(HyperLogLog)) -> HyperLogLog
+
+    Returns the ``HyperLogLog`` of the union of an array of ``HyperLogLog`` structures.
+
+    * Returns ``NULL`` if the input array is ``NULL``, empty, or contains only ``NULL`` elements
+    * Ignores ``NULL`` elements and merges only valid ``HyperLogLog`` structures when the array contains a mix of ``NULL`` and non-null elements

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -129,6 +129,8 @@ std::unordered_set<std::string> skipFunctions = {
     "merge_sfm", // Fuzzer can generate sketches of different sizes.
     "element_at",
     "width_bucket",
+    // Varbinary output can't be compared exactly with Java.
+    "merge_hll",
     // Fuzzer and the underlying engine are confused about TDigest functions
     // (since TDigest is a user defined type), and tries to pass a
     // VARBINARY (since TDigest's implementation uses an

--- a/velox/functions/prestosql/HyperLogLogFunctions.h
+++ b/velox/functions/prestosql/HyperLogLogFunctions.h
@@ -78,4 +78,131 @@ struct EmptyApproxSetWithMaxErrorFunction {
     return true;
   }
 };
+
+class MergeHllFunction : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("hyperloglog")
+                .argumentType("array(hyperloglog)")
+                .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->as<FlatVector<StringView>>();
+
+    exec::LocalDecodedVector arrayDecoder(context, *args[0], rows);
+    auto decodedArray = arrayDecoder.get();
+    auto baseArray = decodedArray->base()->as<ArrayVector>();
+    auto rawSizes = baseArray->rawSizes();
+    auto rawOffsets = baseArray->rawOffsets();
+    auto indices = decodedArray->indices();
+    auto arrayElements = baseArray->elements();
+    auto flatArrayElements = arrayElements->as<FlatVector<StringView>>();
+
+    memory::MemoryPool* memoryPool = context.pool();
+    using SparseHll = common::hll::SparseHll<memory::MemoryPool>;
+    using DenseHll = common::hll::DenseHll<memory::MemoryPool>;
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedArray->isNullAt(row)) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      auto arraySize = rawSizes[indices[row]];
+      auto arrayOffset = rawOffsets[indices[row]];
+
+      std::optional<int8_t> indexBitLength;
+      std::optional<SparseHll> sparseHll;
+      std::optional<DenseHll> denseHll;
+
+      for (vector_size_t i = 0; i < arraySize; ++i) {
+        auto elementIndex = arrayOffset + i;
+        if (arrayElements->isNullAt(elementIndex)) {
+          continue;
+        }
+
+        auto hllData = flatArrayElements->valueAt(elementIndex);
+        if (hllData.empty()) {
+          continue;
+        }
+
+        const bool isSparseHllData =
+            common::hll::SparseHlls::canDeserialize(hllData.data());
+        const bool isDenseHllData = !isSparseHllData &&
+            common::hll::DenseHlls::canDeserialize(hllData.data());
+
+        VELOX_USER_CHECK(
+            isSparseHllData || isDenseHllData, "Invalid HLL data format");
+
+        const auto hllIndexBitLength = isSparseHllData
+            ? common::hll::SparseHlls::deserializeIndexBitLength(hllData.data())
+            : common::hll::DenseHlls::deserializeIndexBitLength(hllData.data());
+
+        if (indexBitLength.has_value()) {
+          VELOX_USER_CHECK_EQ(
+              indexBitLength.value(),
+              hllIndexBitLength,
+              "Cannot merge HLLs with different indexBitLength");
+        } else {
+          indexBitLength = hllIndexBitLength;
+        }
+
+        if (isSparseHllData) {
+          if (denseHll.has_value()) {
+            SparseHll temp{hllData.data(), memoryPool};
+            temp.toDense(*denseHll);
+          } else {
+            if (!sparseHll.has_value()) {
+              sparseHll.emplace(memoryPool);
+              sparseHll->setSoftMemoryLimit(
+                  common::hll::DenseHlls::estimateInMemorySize(
+                      indexBitLength.value()));
+            }
+
+            sparseHll->mergeWith(hllData.data());
+            if (sparseHll->overLimit()) {
+              denseHll.emplace(indexBitLength.value(), memoryPool);
+              sparseHll->toDense(*denseHll);
+              sparseHll.reset();
+            }
+          }
+        } else {
+          if (sparseHll.has_value()) {
+            denseHll.emplace(indexBitLength.value(), memoryPool);
+            sparseHll->toDense(*denseHll);
+            sparseHll.reset();
+          } else if (!denseHll.has_value()) {
+            denseHll.emplace(indexBitLength.value(), memoryPool);
+          }
+          denseHll->mergeWith(hllData.data());
+        }
+      }
+
+      if (!sparseHll.has_value() && !denseHll.has_value()) {
+        flatResult->setNull(row, true);
+      } else if (sparseHll.has_value()) {
+        auto size = sparseHll->serializedSize();
+        char* buffer = flatResult->getRawStringBufferWithSpace(size);
+        sparseHll->serialize(indexBitLength.value(), buffer);
+        flatResult->setNoCopy(row, StringView(buffer, size));
+      } else {
+        auto size = denseHll->serializedSize();
+        char* buffer = flatResult->getRawStringBufferWithSpace(size);
+        denseHll->serialize(buffer);
+        flatResult->setNoCopy(row, StringView(buffer, size));
+      }
+    });
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/HyperLogFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/HyperLogFunctionsRegistration.cpp
@@ -31,5 +31,10 @@ void registerHyperLogFunctions(const std::string& prefix) {
       Constant<double>>({prefix + "empty_approx_set"});
   registerFunction<EmptyApproxSetFunction, HyperLogLog>(
       {prefix + "empty_approx_set"});
+
+  exec::registerVectorFunction(
+      prefix + "merge_hll",
+      MergeHllFunction::signatures(),
+      std::make_unique<MergeHllFunction>());
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/hyperloglog/SparseHll.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #define XXH_INLINE_ALL
 #include <xxhash.h>
 
-using facebook::velox::common::hll::DenseHll;
-using facebook::velox::common::hll::SparseHll;
+using namespace facebook::velox::common::hll;
 
 namespace facebook::velox {
 namespace {
@@ -50,6 +50,28 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return serialized;
   }
 
+  // Creates sparse HLL with values from start (inclusive) to end (exclusive).
+  // modValue applies modulo operation if non-zero.
+  std::string
+  createSparse(int8_t indexBitLength, int start, int end, int modValue = 0) {
+    SparseHll<> hll{&allocator_};
+    for (int i = start; i < end; i++) {
+      hll.insertHash(hashOne(modValue ? (i % modValue) : i));
+    }
+    return serialize(indexBitLength, hll);
+  }
+
+  // Creates dense HLL with values from start (inclusive) to end (exclusive).
+  // modValue applies modulo operation if non-zero.
+  std::string
+  createDense(int8_t indexBitLength, int start, int end, int modValue = 0) {
+    DenseHll<> hll{indexBitLength, &allocator_};
+    for (int i = start; i < end; i++) {
+      hll.insertHash(hashOne(modValue ? (i % modValue) : i));
+    }
+    return serialize(hll);
+  }
+
   std::shared_ptr<memory::MemoryPool> pool_{
       memory::memoryManager()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
@@ -77,12 +99,7 @@ TEST_F(HyperLogLogFunctionsTest, cardinalitySparse) {
     return evaluateOnce<int64_t>("cardinality(c0)", HYPERLOGLOG(), input);
   };
 
-  SparseHll<> sparseHll{&allocator_};
-  for (int i = 0; i < 1'000; i++) {
-    sparseHll.insertHash(hashOne(i % 17));
-  }
-
-  auto serialized = serialize(11, sparseHll);
+  auto serialized = createSparse(11, 0, 1000, 17);
   EXPECT_EQ(17, cardinality(serialized));
 }
 
@@ -91,13 +108,14 @@ TEST_F(HyperLogLogFunctionsTest, cardinalityDense) {
     return evaluateOnce<int64_t>("cardinality(c0)", HYPERLOGLOG(), input);
   };
 
-  DenseHll<> denseHll{12, &allocator_};
+  DenseHll<> expectedHll{12, &allocator_};
   for (int i = 0; i < 10'000'000; i++) {
-    denseHll.insertHash(hashOne(i));
+    expectedHll.insertHash(hashOne(i));
   }
+  auto expectedCardinality = expectedHll.cardinality();
 
-  auto serialized = serialize(denseHll);
-  EXPECT_EQ(denseHll.cardinality(), cardinality(serialized));
+  auto serialized = createDense(12, 0, 10'000'000);
+  EXPECT_EQ(expectedCardinality, cardinality(serialized));
 }
 
 TEST_F(HyperLogLogFunctionsTest, emptyApproxSet) {
@@ -110,6 +128,133 @@ TEST_F(HyperLogLogFunctionsTest, emptyApproxSet) {
       0,
       evaluateOnce<int64_t>(
           "cardinality(empty_approx_set(0.1))", makeRowVector(ROW({}), 1)));
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHll) {
+  // Test merging two HLL instances with different value ranges.
+  const int8_t indexBitLength = 12;
+
+  std::vector<std::string> serializedHlls = {
+      createSparse(indexBitLength, 0, 10),
+      createSparse(indexBitLength, 10, 20)};
+
+  auto elements = makeFlatVector(serializedHlls, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 2}, elements);
+
+  auto cardinality = evaluateOnce<int64_t>(
+      "cardinality(merge_hll(c0))", makeRowVector({arrayVector}));
+
+  EXPECT_EQ(20, cardinality);
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllMixedSparseAndDense) {
+  // Test merging sparse and dense HLL instances.
+  const int8_t indexBitLength = 12;
+
+  std::vector<std::string> serializedHlls = {
+      createSparse(indexBitLength, 0, 50),
+      createDense(indexBitLength, 50, 2000)};
+
+  auto elements = makeFlatVector(serializedHlls, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 2}, elements);
+
+  auto cardinality = evaluateOnce<int64_t>(
+      "cardinality(merge_hll(c0))", makeRowVector({arrayVector}));
+
+  EXPECT_EQ(1978, cardinality);
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllWithNull) {
+  auto serialized = createSparse(12, 0, 10);
+  auto elements = makeNullableFlatVector<std::string>(
+      {serialized, std::nullopt, serialized}, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 3}, elements);
+
+  auto cardinality = evaluateOnce<int64_t>(
+      "cardinality(merge_hll(c0))", makeRowVector({arrayVector}));
+  EXPECT_EQ(10, cardinality);
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllEmpty) {
+  auto input = makeRowVector(
+      {makeArrayVectorFromJson<std::string>({"null"}, ARRAY(HYPERLOGLOG()))});
+  auto result = evaluate("merge_hll(c0)", input);
+  ASSERT_TRUE(result->isNullAt(0));
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllNullArray) {
+  auto input = makeRowVector({makeNullableArrayVector<std::string>(
+      {std::nullopt}, ARRAY(HYPERLOGLOG()))});
+  auto result = evaluate("merge_hll(c0)", input);
+  ASSERT_TRUE(result->isNullAt(0));
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllAllNulls) {
+  auto input = makeRowVector({makeArrayVectorFromJson<std::string>(
+      {"[null, null, null]"}, ARRAY(HYPERLOGLOG()))});
+  auto result = evaluate("merge_hll(c0)", input);
+  ASSERT_TRUE(result->isNullAt(0));
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllInvalidData) {
+  // Test with invalid HLL data format.
+  std::string invalidData = "invalid_hll_data";
+  auto elements = makeFlatVector<std::string>({invalidData}, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 1}, elements);
+
+  VELOX_ASSERT_THROW(
+      evaluate("merge_hll(c0)", makeRowVector({arrayVector})),
+      "Invalid HLL data format");
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllMismatchedIndexBitLength) {
+  const int8_t indexBitLength1 = 11;
+  const int8_t indexBitLength2 = 12;
+
+  std::vector<std::string> serializedHlls = {
+      createSparse(indexBitLength1, 0, 5),
+      createSparse(indexBitLength2, 5, 10)};
+
+  auto elements = makeFlatVector(serializedHlls, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 2}, elements);
+
+  VELOX_ASSERT_THROW(
+      evaluate("merge_hll(c0)", makeRowVector({arrayVector})),
+      "Cannot merge HLLs with different indexBitLength");
+}
+
+TEST_F(
+    HyperLogLogFunctionsTest,
+    mergeHllMismatchedIndexBitLengthDenseVsSparse) {
+  const int8_t indexBitLength1 = 11;
+  const int8_t indexBitLength2 = 12;
+
+  std::vector<std::string> serializedHlls = {
+      createSparse(indexBitLength1, 0, 50),
+      createDense(indexBitLength2, 50, 2000)};
+
+  auto elements = makeFlatVector(serializedHlls, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 2}, elements);
+
+  VELOX_ASSERT_THROW(
+      evaluate("merge_hll(c0)", makeRowVector({arrayVector})),
+      "Cannot merge HLLs with different indexBitLength");
+}
+
+TEST_F(HyperLogLogFunctionsTest, mergeHllDenseFirstThenSparse) {
+  const int8_t indexBitLength = 12;
+
+  std::vector<std::string> serializedHlls = {
+      createDense(indexBitLength, 0, 2000),
+      createSparse(indexBitLength, 2000, 2050)};
+
+  auto elements = makeFlatVector(serializedHlls, HYPERLOGLOG());
+  auto arrayVector = makeArrayVector({0, 2}, elements);
+
+  auto cardinality = evaluateOnce<int64_t>(
+      "cardinality(merge_hll(c0))", makeRowVector({arrayVector}));
+
+  EXPECT_EQ(2035, cardinality);
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Add merge_hll native function

Use Vector Function as Simple Function currently does not have functionality to provide memory allocator
Here we use query context memory pool, available from the vector function instead of creating a HashStringAllocator


Differential Revision: D82038217


