### PR TITLE
feat: Add support for TIME in Simple Function Interface

### DIFF
--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -150,6 +150,13 @@ struct resolver<IntervalYearMonth> {
   using out_type = int32_t;
 };
 
+template <>
+struct resolver<Time> {
+  using in_type = int64_t;
+  using null_free_in_type = in_type;
+  using out_type = int64_t;
+};
+
 template <typename T>
 struct resolver<std::shared_ptr<T>> {
   using in_type = std::shared_ptr<T>;

--- a/velox/type/CppToType.h
+++ b/velox/type/CppToType.h
@@ -91,6 +91,9 @@ struct CppToType<double> : public CppToTypeBase<TypeKind::DOUBLE> {};
 template <>
 struct CppToType<Timestamp> : public CppToTypeBase<TypeKind::TIMESTAMP> {};
 
+template <>
+struct CppToType<Time> : public CppToTypeBase<TypeKind::BIGINT> {};
+
 // TODO: maybe do something smarter than just matching any shared_ptr, e.g. we
 // can declare "registered" types explicitly
 template <typename T>

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -354,18 +354,24 @@ template <>
 struct SimpleTypeTrait<Varbinary> : public TypeTraits<TypeKind::VARBINARY> {};
 
 template <>
-struct SimpleTypeTrait<Date> : public SimpleTypeTrait<int32_t> {
+struct SimpleTypeTrait<Date> : public TypeTraits<TypeKind::INTEGER> {
   static constexpr const char* name = "DATE";
 };
 
 template <>
-struct SimpleTypeTrait<IntervalDayTime> : public SimpleTypeTrait<int64_t> {
+struct SimpleTypeTrait<IntervalDayTime> : public TypeTraits<TypeKind::BIGINT> {
   static constexpr const char* name = "INTERVAL DAY TO SECOND";
 };
 
 template <>
-struct SimpleTypeTrait<IntervalYearMonth> : public SimpleTypeTrait<int32_t> {
+struct SimpleTypeTrait<IntervalYearMonth>
+    : public TypeTraits<TypeKind::INTEGER> {
   static constexpr const char* name = "INTERVAL YEAR TO MONTH";
+};
+
+template <>
+struct SimpleTypeTrait<Time> : public TypeTraits<TypeKind::BIGINT> {
+  static constexpr const char* name = "TIME";
 };
 
 template <typename T, bool comparable, bool orderable>

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1606,10 +1606,9 @@ FOLLY_ALWAYS_INLINE bool Type::isTime() const {
   return (this == TIME().get());
 }
 
-// Type used for function registration.
-struct TimeT {
-  using type = int64_t; // Underlying storage as milliseconds since midnight
-  static constexpr const char* typeName = "time";
+struct Time {
+ private:
+  Time() {}
 };
 
 /// Used as T for SimpleVector subclasses that wrap another vector when


### PR DESCRIPTION
Summary:
This change adds support for TIME with Velox's simple function interface. Subsequent PR's will add support for casting and most common udf's used with this type.

Differential Revision: D82054731


