### PR TITLE
fix: Rename emptyUnnestValueName to markerName and fix semantics

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1343,14 +1343,14 @@ UnnestNode::UnnestNode(
     std::vector<FieldAccessTypedExprPtr> unnestVariables,
     std::vector<std::string> unnestNames,
     std::optional<std::string> ordinalityName,
-    std::optional<std::string> emptyUnnestValueName,
+    std::optional<std::string> markerName,
     const PlanNodePtr& source)
     : PlanNode(id),
       replicateVariables_{std::move(replicateVariables)},
       unnestVariables_{std::move(unnestVariables)},
       unnestNames_{std::move(unnestNames)},
       ordinalityName_{std::move(ordinalityName)},
-      emptyUnnestValueName_(std::move(emptyUnnestValueName)),
+      markerName_(std::move(markerName)),
       sources_{source} {
   // Calculate output type. First come "replicate" columns, followed by
   // "unnest" columns, followed by an optional ordinality column.
@@ -1387,8 +1387,8 @@ UnnestNode::UnnestNode(
     types.emplace_back(BIGINT());
   }
 
-  if (emptyUnnestValueName_.has_value()) {
-    names.emplace_back(emptyUnnestValueName_.value());
+  if (markerName_.has_value()) {
+    names.emplace_back(markerName_.value());
     types.emplace_back(BOOLEAN());
   }
 
@@ -1408,8 +1408,8 @@ folly::dynamic UnnestNode::serialize() const {
   if (ordinalityName_.has_value()) {
     obj["ordinalityName"] = ordinalityName_.value();
   }
-  if (emptyUnnestValueName_.has_value()) {
-    obj["emptyUnnestValueName"] = emptyUnnestValueName_.value();
+  if (markerName_.has_value()) {
+    obj["markerName"] = markerName_.value();
   }
   return obj;
 }
@@ -1431,9 +1431,9 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("ordinalityName")) {
     ordinalityName = obj["ordinalityName"].asString();
   }
-  std::optional<std::string> emptyUnnestValueName = std::nullopt;
-  if (obj.count("emptyUnnestValueName")) {
-    emptyUnnestValueName = obj["emptyUnnestValueName"].asString();
+  std::optional<std::string> markerName = std::nullopt;
+  if (obj.count("markerName")) {
+    markerName = obj["markerName"].asString();
   }
   return std::make_shared<UnnestNode>(
       deserializePlanNodeId(obj),
@@ -1441,7 +1441,7 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
       std::move(unnestVariables),
       std::move(unnestNames),
       std::move(ordinalityName),
-      std::move(emptyUnnestValueName),
+      std::move(markerName),
       std::move(source));
 }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4245,17 +4245,17 @@ class UnnestNode : public PlanNode {
   /// names must appear in the same order as unnestVariables.
   /// @param ordinalityName Optional name for the ordinality columns. If not
   /// present, ordinality column is not produced.
-  /// @param emptyUnnestValueName Optional name for column which indicates an
-  /// output row has empty unnest value or not. If not present, emptyUnnestValue
-  /// column is not provided and the unnest operator also skips producing output
-  /// rows with empty unnest value.
+  /// @param markerName Optional name for column which indicates whether an
+  /// output row has non-empty unnested value. If not present, marker column is
+  /// not provided and the unnest operator also skips producing output rows
+  /// with empty unnest value.
   UnnestNode(
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
       std::vector<FieldAccessTypedExprPtr> unnestVariables,
       std::vector<std::string> unnestNames,
       std::optional<std::string> ordinalityName,
-      std::optional<std::string> emptyUnnestValueName,
+      std::optional<std::string> markerName,
       const PlanNodePtr& source);
 
   class Builder {
@@ -4304,9 +4304,8 @@ class UnnestNode : public PlanNode {
       return *this;
     }
 
-    Builder& emptyUnnestValueName(
-        std::optional<std::string> emptyUnnestValueName) {
-      emptyUnnestValueName_ = std::move(emptyUnnestValueName);
+    Builder& markerName(std::optional<std::string> markerName) {
+      markerName_ = std::move(markerName);
       return *this;
     }
 
@@ -4328,7 +4327,7 @@ class UnnestNode : public PlanNode {
           unnestVariables_.value(),
           unnestNames_.value(),
           ordinalityName_,
-          emptyUnnestValueName_,
+          markerName_,
           source_.value());
     }
 
@@ -4338,7 +4337,7 @@ class UnnestNode : public PlanNode {
     std::optional<std::vector<FieldAccessTypedExprPtr>> unnestVariables_;
     std::optional<std::vector<std::string>> unnestNames_;
     std::optional<std::string> ordinalityName_;
-    std::optional<std::string> emptyUnnestValueName_;
+    std::optional<std::string> markerName_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -4380,12 +4379,12 @@ class UnnestNode : public PlanNode {
     return ordinalityName_.has_value();
   }
 
-  const std::optional<std::string>& emptyUnnestValueName() const {
-    return emptyUnnestValueName_;
+  const std::optional<std::string>& markerName() const {
+    return markerName_;
   }
 
-  bool hasEmptyUnnestValue() const {
-    return emptyUnnestValueName_.has_value();
+  bool hasMarker() const {
+    return markerName_.has_value();
   }
 
   std::string_view name() const override {
@@ -4403,7 +4402,7 @@ class UnnestNode : public PlanNode {
   const std::vector<FieldAccessTypedExprPtr> unnestVariables_;
   const std::vector<std::string> unnestNames_;
   const std::optional<std::string> ordinalityName_;
-  const std::optional<std::string> emptyUnnestValueName_;
+  const std::optional<std::string> markerName_;
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;
 };

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -446,7 +446,7 @@ core::PlanNodePtr getTraceNode(
         unnestNode->unnestVariables(),
         unnestNode->unnestNames(),
         unnestNode->ordinalityName(),
-        unnestNode->emptyUnnestValueName(),
+        unnestNode->markerName(),
         std::make_shared<DummySourceNode>(
             unnestNode->sources().front()->outputType()));
   }

--- a/velox/exec/Unnest.h
+++ b/velox/exec/Unnest.h
@@ -134,15 +134,15 @@ class Unnest : public Operator {
   // Invoked by generateOutput for the ordinality column.
   VectorPtr generateOrdinalityVector(const RowRange& rowRange);
 
-  // Invoked by generateOutput for the empty unnest value column.
-  VectorPtr generateEmptyUnnestValueVector(const RowRange& rowRange);
+  // Invoked by generateOutput for the marker column.
+  VectorPtr generateMarkerVector(const RowRange& rowRange);
 
   // Invoked when finish one input batch processing to reset the internal
   // execution state for the next batch.
   void finishInput();
 
   const bool withOrdinality_;
-  const bool withEmptyUnnestValue_;
+  const bool withMarker_;
   // The maximum number of output batch rows.
   const vector_size_t maxOutputSize_;
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2006,7 +2006,7 @@ PlanBuilder& PlanBuilder::unnest(
     const std::vector<std::string>& replicateColumns,
     const std::vector<std::string>& unnestColumns,
     const std::optional<std::string>& ordinalColumn,
-    const std::optional<std::string>& emptyUnnestValueName) {
+    const std::optional<std::string>& markerName) {
   VELOX_CHECK_NOT_NULL(planNode_, "Unnest cannot be the source node");
   std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
       replicateFields;
@@ -2042,7 +2042,7 @@ PlanBuilder& PlanBuilder::unnest(
       unnestFields,
       unnestNames,
       ordinalColumn,
-      emptyUnnestValueName,
+      markerName,
       planNode_);
   VELOX_CHECK(planNode_->supportsBarrier());
   return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1360,16 +1360,16 @@ class PlanBuilder {
   /// @param ordinalColumn An optional name for the 'ordinal' column to produce.
   /// This column contains the index of the element of the unnested array or
   /// map. If not specified, the output will not contain this column.
-  /// @param emptyUnnestValueName An optional name for the
-  /// 'emptyUnnestValue' column to produce. This column contains a boolean
-  /// indicating if the output row has empty unnest value or not. If not
-  /// specified, the output will not contain this column and the unnest operator
-  /// also skips producing output rows with empty unnest value.
+  /// @param markerName An optional name for the marker column to produce.
+  /// This column contains a boolean indicating whether the output row has
+  /// non-empty unnested value. If not specified, the output will not contain
+  /// this column and the unnest operator also skips producing output rows
+  /// with empty unnest value.
   PlanBuilder& unnest(
       const std::vector<std::string>& replicateColumns,
       const std::vector<std::string>& unnestColumns,
       const std::optional<std::string>& ordinalColumn = std::nullopt,
-      const std::optional<std::string>& emptyUnnestValueName = std::nullopt);
+      const std::optional<std::string>& markerName = std::nullopt);
 
   /// Add a WindowNode to compute one or more windowFunctions.
   /// @param windowFunctions A list of one or more window function SQL like

--- a/velox/tool/trace/UnnestReplayer.cpp
+++ b/velox/tool/trace/UnnestReplayer.cpp
@@ -36,7 +36,7 @@ core::PlanNodePtr UnnestReplayer::createPlanNode(
       unnestNode->unnestVariables(),
       unnestNode->unnestNames(),
       unnestNode->ordinalityName(),
-      unnestNode->emptyUnnestValueName(),
+      unnestNode->markerName(),
       source);
 }
 } // namespace facebook::velox::tool::trace


### PR DESCRIPTION
Summary:
*   Renamed the `emptyUnnestValueName` parameter to `markerName` across all Velox unnest-related APIs
*   Fixed the semantics so the marker column now indicates the **presence** of unnested data rather than the absence
*   Updated all related components including `core::UnnestNode`, `PlanBuilder`, `Unnest` operator implementation, and test utilities
*   The change makes the API more intuitive - the marker column now indicates when there is actual data to process

Differential Revision: D81402456


