### PR TITLE
feat(cudf): Support hash_with_seed in cudf

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -26,6 +26,7 @@
 
 #include <cudf/column/column_factories.hpp>
 #include <cudf/datetime.hpp>
+#include <cudf/hashing.hpp>
 #include <cudf/lists/count_elements.hpp>
 #include <cudf/strings/attributes.hpp>
 #include <cudf/strings/case.hpp>
@@ -40,6 +41,7 @@
 
 namespace facebook::velox::cudf_velox {
 namespace {
+
 template <TypeKind kind>
 cudf::ast::literal makeScalarAndLiteral(
     const TypePtr& type,
@@ -274,7 +276,8 @@ const std::unordered_set<std::string> supportedOps = {
     "like",
     "cardinality",
     "split",
-    "lower"};
+    "lower",
+    "hash_with_seed"};
 
 namespace detail {
 
@@ -626,6 +629,11 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     VELOX_CHECK_EQ(len, 3);
     auto node = CudfExpressionNode::create(expr);
     return addPrecomputeInstructionOnSide(0, 0, "split", "", node);
+  } else if (name == "hash_with_seed") {
+    // Only supports hash one value now.
+    VELOX_CHECK_EQ(len, 2);
+    auto node = CudfExpressionNode::create(expr);
+    return addPrecomputeInstructionOnSide(0, 0, "hash_with_seed", "", node);
   } else if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr)) {
     // Refer to the appropriate side
     const auto fieldName =
@@ -774,6 +782,33 @@ class SubstrFunction : public CudfFunction {
   std::unique_ptr<cudf::numeric_scalar<cudf::size_type>> stepScalar_;
 };
 
+class HashFunction : public CudfFunction {
+ public:
+  HashFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
+    using velox::exec::ConstantExpr;
+    VELOX_CHECK_GE(expr->inputs().size(), 2, "hash expects at least 2 inputs");
+    auto seedExpr = std::dynamic_pointer_cast<ConstantExpr>(expr->inputs()[0]);
+    VELOX_CHECK_NOT_NULL(seedExpr, "hash seed must be a constant");
+    int32_t seedValue =
+        seedExpr->value()->as<SimpleVector<int32_t>>()->valueAt(0);
+    VELOX_CHECK_GE(seedValue, 0);
+    seedValue_ = seedValue;
+  }
+
+  ColumnOrView eval(
+      std::vector<ColumnOrView>& inputColumns,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    VELOX_CHECK(!inputColumns.empty());
+    auto inputTableView = cudf::table_view({asView(inputColumns[0])});
+    return cudf::hashing::murmurhash3_x86_32(
+        inputTableView, seedValue_, stream, mr);
+  }
+
+ private:
+  uint32_t seedValue_;
+};
+
 std::unordered_map<std::string, CudfFunctionFactory>&
 getCudfFunctionRegistry() {
   static std::unordered_map<std::string, CudfFunctionFactory> registry;
@@ -838,6 +873,18 @@ bool registerBuiltinFunctions(const std::string& prefix) {
       prefix + "substr",
       [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
         return std::make_shared<SubstrFunction>(expr);
+      });
+
+  registerCudfFunction(
+      prefix + "hash_with_seed",
+      [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
+        return std::make_shared<HashFunction>(expr);
+      });
+
+  registerCudfFunction(
+      "hash_with_seed",
+      [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
+        return std::make_shared<HashFunction>(expr);
       });
 
   return true;

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -804,7 +804,8 @@ class HashFunction : public CudfFunction {
   }
 
  private:
-  static cudf::table_view convertToTableView(std::vector<ColumnOrView>& inputColumns) {
+  static cudf::table_view convertToTableView(
+      std::vector<ColumnOrView>& inputColumns) {
     std::vector<cudf::column_view> columns;
     columns.reserve(inputColumns.size());
 

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -804,7 +804,7 @@ class HashFunction : public CudfFunction {
   }
 
  private:
-  cudf::table_view convertToTableView(std::vector<ColumnOrView>& inputColumns) {
+  static cudf::table_view convertToTableView(std::vector<ColumnOrView>& inputColumns) {
     std::vector<cudf::column_view> columns;
     columns.reserve(inputColumns.size());
 

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -804,17 +804,16 @@ class HashFunction : public CudfFunction {
   }
 
  private:
-
-cudf::table_view convertToTableView(std::vector<ColumnOrView>& inputColumns) {
+  cudf::table_view convertToTableView(std::vector<ColumnOrView>& inputColumns) {
     std::vector<cudf::column_view> columns;
     columns.reserve(inputColumns.size());
 
     for (auto& col : inputColumns) {
-        columns.push_back(asView(col));
+      columns.push_back(asView(col));
     }
 
     return cudf::table_view(columns);
-}
+  }
 
   uint32_t seedValue_;
 };

--- a/velox/experimental/cudf/tests/sparksql/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/sparksql/CMakeLists.txt
@@ -36,3 +36,28 @@ target_link_libraries(
   GTest::gtest
   GTest::gtest_main
 )
+
+add_executable(velox_cudf_spark_filter_project_test FilterProjectTest.cpp Main.cpp)
+
+add_test(
+  NAME velox_cudf_spark_filter_project_test
+  COMMAND velox_cudf_spark_filter_project_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set_tests_properties(
+  velox_cudf_spark_filter_project_test
+  PROPERTIES LABELS cuda_driver TIMEOUT 3000
+)
+
+target_link_libraries(
+  velox_cudf_spark_filter_project_test
+  velox_cudf_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  velox_functions_spark
+  velox_vector_fuzzer
+  gflags::gflags
+  GTest::gtest
+  GTest::gtest_main
+)

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfFilterProject.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox;
+
+namespace {
+
+class CudfFilterProjectTest
+    : public facebook::velox::functions::sparksql::test::SparkFunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    facebook::velox::functions::sparksql::test::SparkFunctionBaseTest::
+        SetUpTestCase();
+    cudf_velox::registerCudf();
+  }
+
+  static void TearDownTestCase() {
+    facebook::velox::functions::sparksql::test::SparkFunctionBaseTest::
+        TearDownTestCase();
+    cudf_velox::unregisterCudf();
+  }
+
+  CudfFilterProjectTest() {
+    options_.parseIntegerAsBigint = false;
+  }
+};
+
+TEST_F(CudfFilterProjectTest, hashWithSeed) {
+  auto input = makeFlatVector<int64_t>({INT64_MAX, INT64_MIN});
+  auto data = makeRowVector({input});
+  auto hashPlan = PlanBuilder()
+                      .setParseOptions(options_)
+                      .values({data})
+                      .project({"hash_with_seed(42, c0) AS c1"})
+                      .planNode();
+  auto hashResults = AssertQueryBuilder(hashPlan).copyResults(pool());
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({
+          1049813396,
+          1800792340,
+      }),
+  });
+  facebook::velox::test::assertEqualVectors(expected, hashResults);
+}
+} // namespace

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -80,8 +80,8 @@ TEST_F(CudfFilterProjectTest, hashWithSeedMultiColumns) {
 
   auto expected = makeRowVector({
       makeFlatVector<int32_t>({
-          1049813396,
-          1800792340,
+          -864217843,
+          821064941,
       }),
   });
   facebook::velox::test::assertEqualVectors(expected, hashResults);

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -67,4 +67,23 @@ TEST_F(CudfFilterProjectTest, hashWithSeed) {
   });
   facebook::velox::test::assertEqualVectors(expected, hashResults);
 }
+
+TEST_F(CudfFilterProjectTest, hashWithSeedMultiColumns) {
+  auto input = makeFlatVector<int64_t>({INT64_MAX, INT64_MIN});
+  auto data = makeRowVector({input, input});
+  auto hashPlan = PlanBuilder()
+                      .setParseOptions(options_)
+                      .values({data})
+                      .project({"hash_with_seed(42, c0, c1) AS c2"})
+                      .planNode();
+  auto hashResults = AssertQueryBuilder(hashPlan).copyResults(pool());
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({
+          1049813396,
+          1800792340,
+      }),
+  });
+  facebook::velox::test::assertEqualVectors(expected, hashResults);
+}
 } // namespace


### PR DESCRIPTION
hash_with_seed signature is (constant integer, any...) -> integer.
Add a new test executable velox_cudf_spark_filter_project_test which needs to register spark functions.