### PR TITLE
refactor(buffer): Add verbose version of AlignedBuffer::allocate

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -377,6 +377,18 @@ class AlignedBuffer : public Buffer {
     return result;
   }
 
+  /// A verbose version of the allocate() with the exact size.
+  /// May allocate slightly more memory than strictly necessary. Guarantees that
+  /// simd::kPadding bytes past capacity() are addressable and asserts that
+  /// these do not get overrun.
+  template <typename T>
+  static BufferPtr allocateExact(
+      size_t numElements,
+      velox::memory::MemoryPool* pool,
+      const std::optional<T>& initValue = std::nullopt) {
+    return allocate<T>(numElements, pool, initValue, true);
+  }
+
   // Changes the capacity of '*buffer'. The buffer may grow/shrink in
   // place or may change addresses. The content is copied up to the
   // old size() or the new size, whichever is smaller. If the buffer grows, the

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -143,6 +143,20 @@ TEST_F(BufferTest, testAlignedBufferExact) {
   EXPECT_GE(buffer4->capacity(), oneMBMinusPad + 1);
 }
 
+TEST_F(BufferTest, testAllocateExact) {
+  const int32_t oneMBMinusPad = 1024 * 1024 - AlignedBuffer::kPaddedSize;
+
+  BufferPtr buffer1 = AlignedBuffer::allocateExact<char>(
+      oneMBMinusPad + 1, pool_.get(), std::nullopt);
+  EXPECT_EQ(buffer1->size(), oneMBMinusPad + 1);
+  EXPECT_GE(buffer1->capacity(), oneMBMinusPad + 1);
+
+  BufferPtr buffer2 = AlignedBuffer::allocateExact<char>(3, pool_.get(), 'i');
+  for (size_t i = 0; i < buffer2->size(); i++) {
+    EXPECT_EQ(buffer2->as<char>()[i], 'i');
+  }
+}
+
 TEST_F(BufferTest, testAsRange) {
   // Simple 2 element vector.
   std::vector<uint8_t> testData({5, 255});


### PR DESCRIPTION
Summary: 
Current implementation of the AlignedBuffer::allocate does not allocate the exact size by default.
For some cases, when the buffer size is known beforehand, this leads to significant memory
overconsumption because the buffer allocates the best size suggested by the `MemoryPool::getPreferredSize`.

To avoid that overallocation a new allocateExact parameter was recently added to the `AlignedBuffer::allocate`.
However, usage of this parameter is a bit clanky. To make the API call more verbose I introduce a new helper
function `AlignedBuffer::allocateExact`, that is simply a verbose wrapper around `AlignedBuffer::allocate`.

For reference, here are current ranges produced by `MemoryPool::getPreferredSize`:
```
               1 -            8 =            8
               9 -           12 =           12
              13 -           16 =           16
              17 -           24 =           24
              25 -           32 =           32
              33 -           48 =           48
              49 -           64 =           64
              65 -           96 =           96
              97 -          128 =          128
             129 -          192 =          192
             193 -          256 =          256
             257 -          384 =          384
             385 -          512 =          512
             513 -          768 =          768
             769 -        1,024 =        1,024
           1,025 -        1,536 =        1,536
           1,537 -        2,048 =        2,048
           2,049 -        3,072 =        3,072
           3,073 -        4,096 =        4,096
           4,097 -        6,144 =        6,144
           6,145 -        8,192 =        8,192
           8,193 -       12,288 =       12,288
          12,289 -       16,384 =       16,384
          16,385 -       24,576 =       24,576
          24,577 -       32,768 =       32,768
          32,769 -       49,152 =       49,152
          49,153 -       65,536 =       65,536
          65,537 -       98,304 =       98,304
          98,305 -      131,072 =      131,072
         131,073 -      196,608 =      196,608
         196,609 -      262,144 =      262,144
         262,145 -      393,216 =      393,216
         393,217 -      524,288 =      524,288
         524,289 -      786,432 =      786,432
         786,433 -    1,048,576 =    1,048,576
       1,048,577 -    1,572,864 =    1,572,864
       1,572,865 -    2,097,152 =    2,097,152
       2,097,153 -    3,145,728 =    3,145,728
       3,145,729 -    4,194,304 =    4,194,304
       4,194,305 -    6,291,456 =    6,291,456
       6,291,457 -    8,388,608 =    8,388,608
       8,388,609 -   12,582,912 =   12,582,912
      12,582,913 -   16,777,216 =   16,777,216
      16,777,217 -   25,165,824 =   25,165,824
      25,165,825 -   33,554,432 =   33,554,432
      33,554,433 -   50,331,648 =   50,331,648
      50,331,649 -   67,108,864 =   67,108,864
      67,108,865 -  100,663,296 =  100,663,296
     100,663,297 -  134,217,728 =  134,217,728
     134,217,729 -  201,326,592 =  201,326,592
     201,326,593 -  268,435,456 =  268,435,456
     268,435,457 -  402,653,184 =  402,653,184
     402,653,185 -  536,870,912 =  536,870,912
     536,870,913 -  805,306,368 =  805,306,368
     805,306,369 - 1,073,741,824 = 1,073,741,824
   1,073,741,825 - 1,610,612,736 = 1,610,612,736
   1,610,612,737 - 2,147,483,648 = 2,147,483,648
   2,147,483,649 - 3,221,225,472 = 3,221,225,472
   3,221,225,473 - 4,294,967,296 = 4,294,967,296
   ``` 

Differential Revision: D82167134


