### PR TITLE
build: Remove needless `gflags::gflags` workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,9 +544,7 @@ if(NOT TARGET gflags::gflags)
   # target even when velox is built as a subproject which uses
   # `find_package(gflags)` which does not create a globally imported target that
   # we can ALIAS.
-  add_library(gflags_gflags INTERFACE)
-  target_link_libraries(gflags_gflags INTERFACE gflags)
-  add_library(gflags::gflags ALIAS gflags_gflags)
+  add_library(gflags::gflags ALIAS gflags)
 endif()
 
 if(${gflags_SOURCE} STREQUAL "BUNDLED")


### PR DESCRIPTION
Fixes #14760

It's needed for old CMake such as CMake 3.16. CMake 3.18 or later can create an alias CMake target for non-`GLOBAL` CMake target:

https://cmake.org/cmake/help/latest/command/add_library.html#alias-libraries

> Added in version 3.18: An ALIAS can target a non-GLOBAL Imported
> Target. Such alias is scoped to the directory in which it is created
> and below. The ALIAS_GLOBAL target property can be used to check if
> the alias is global or not.

Now, we require CMake 3.28 or later. So we can remove the `gflags_gflags` workaround.

I confirmed that this change works with Presto C++.