### PR TITLE
feat: Add allocation records to local memory exceeds exception in debug mode

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -910,9 +910,16 @@ void MemoryPoolImpl::growCapacity(MemoryPool* requestor, uint64_t size) {
   VELOX_CHECK(requestor->isLeaf());
   ++numCapacityGrowths_;
 
-  {
+  try {
     MemoryPoolArbitrationSection arbitrationSection(requestor);
     arbitrator_->growCapacity(this, size);
+  } catch (const VeloxRuntimeError& veloxError) {
+    if (FOLLY_UNLIKELY(
+            debugEnabled() &&
+            veloxError.errorCode() == error_code::kMemCapExceeded)) {
+      std::rethrow_exception(wrapExceptionDbg(veloxError));
+    }
+    throw;
   }
   // The memory pool might have been aborted during the time it leaves the
   // arbitration no matter the arbitration succeed or not.
@@ -1252,10 +1259,7 @@ void MemoryPoolImpl::recordAllocDbg(const void* addr, uint64_t size) {
       debugWarnThresholdExceeded_) {
     return;
   }
-  const auto usedBytes = [this]() -> int64_t {
-    std::lock_guard<std::mutex> l(mutex_);
-    return reservedBytes();
-  }();
+  const auto usedBytes = reservedBytes();
   if (usedBytes >= debugOptions_->debugPoolWarnThresholdBytes) {
     debugWarnThresholdExceeded_ = true;
     VELOX_MEM_LOG(WARNING) << fmt::format(
@@ -1360,10 +1364,72 @@ void MemoryPoolImpl::leakCheckDbg() {
           dumpRecordsDbg()));
 }
 
+void MemoryPoolImpl::treeAllocationRecordsDbg(
+    std::vector<MemoryPoolDump>& poolDumps) const {
+  VELOX_CHECK(debugEnabled());
+  {
+    std::lock_guard<std::mutex> debugAllocLock(debugAllocMutex_);
+    if (!debugAllocRecords_.empty()) {
+      MemoryPoolDump dump{
+          .dumpedRecords = fmt::format(
+              "Memory pool '{}' - {}", name(), dumpRecordsDbgLocked()),
+          .bytes = reservedBytes(),
+      };
+      poolDumps.emplace_back(std::move(dump));
+    }
+  }
+  if (isLeaf()) {
+    return;
+  }
+  visitChildren([&poolDumps](MemoryPool* pool) {
+    toImpl(pool)->treeAllocationRecordsDbg(poolDumps);
+    return true;
+  });
+}
+
+std::exception_ptr MemoryPoolImpl::wrapExceptionDbg(
+    const VeloxRuntimeError& veloxError) const {
+  VELOX_CHECK(debugEnabled());
+  VELOX_CHECK(isRoot());
+  std::vector<MemoryPoolDump> poolAllocationsSorted;
+  treeAllocationRecordsDbg(poolAllocationsSorted);
+  std::stringstream oss;
+  if (poolAllocationsSorted.empty()) {
+    oss << "No allocation records found.";
+  } else {
+    std::sort(
+        poolAllocationsSorted.begin(),
+        poolAllocationsSorted.end(),
+        [](const auto& a, const auto& b) { return a.bytes > b.bytes; });
+    for (const auto& record : poolAllocationsSorted) {
+      oss << record.dumpedRecords << "\n\n";
+    }
+  }
+  const auto wrappedMessage = fmt::format(
+      "{}\n\n"
+      "======= Current Allocations ======\n"
+      "{}",
+      veloxError.message(),
+      oss.str());
+  return std::make_exception_ptr(VeloxRuntimeError(
+      veloxError.file(),
+      veloxError.line(),
+      veloxError.function(),
+      veloxError.failingExpression(),
+      wrappedMessage,
+      veloxError.errorSource(),
+      veloxError.errorCode(),
+      veloxError.isRetriable(),
+      veloxError.exceptionName()));
+}
+
 std::string MemoryPoolImpl::dumpRecordsDbgLocked() const {
   VELOX_CHECK(debugEnabled());
   std::stringstream oss;
-  oss << fmt::format("Found {} allocations:\n", debugAllocRecords_.size());
+  oss << fmt::format(
+      "Found {} allocations with {} total size:\n",
+      debugAllocRecords_.size(),
+      succinctBytes(reservedBytes()));
   struct AllocationStats {
     uint64_t size{0};
     uint64_t numAllocations{0};

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -1008,6 +1008,24 @@ class MemoryPoolImpl : public MemoryPool {
   // pool is enabled.
   void leakCheckDbg();
 
+  // Holds formatted string of dumped allocation records for a leaf memory pool,
+  // along with the total pool size in bytes.
+  struct MemoryPoolDump {
+    std::string dumpedRecords;
+    int64_t bytes;
+  };
+
+  // Recursively collects 'MemoryPoolDump' records for this memory pool and
+  // all its descendants in the tree. Called during memory capacity-exceeded
+  // exceptions to extend the error message with additional debug information.
+  void treeAllocationRecordsDbg(std::vector<MemoryPoolDump>& poolDumps) const;
+
+  // Wraps the message of a memory capacity exceeded exception with debug
+  // allocation records from all memory pools in the subtree. This function is
+  // called from the root memory pool.
+  std::exception_ptr wrapExceptionDbg(
+      const VeloxRuntimeError& veloxError) const;
+
   // Dump the recorded call sites of the memory allocations in
   // 'debugAllocRecords_' to the string.
   std::string dumpRecordsDbgLocked() const;


### PR DESCRIPTION
### Summary:

If leaf memory pool is in debug mode, we track the callsites of all memory allocations in it.
Let's add that information to EXCEEDED_LOCAL_MEMORY_LIMIT exception message. It should simplify debugging.

### Differential Revision: D82004831

### Test plan:

1. Found query failed with EXCEEDED_LOCAL_MEMORY_LIMIT error
2. Resubmitted with enabled debug mode: `SET SESSION native_debug_memory_pool_name_regex='.*';`
3. Got the error with callstacks in the message: 

<details><summary>Error message</summary>

```
Exceeded memory pool capacity. Can't grow 20250911_074748_00043_pxy5b_0 capacity with 8.00MB. This will exceed its max capacity 14.00GB, current capacity 14.00GB.
ARBITRATOR[SHARED CAPACITY[38.00GB] STATS[numRequests 18 numRunning 1 numSucceded 0 numAborted 0 numFailures 0 numNonReclaimableAttempts 0 reclaimedFreeCapacity 11.00MB reclaimedUsedCapacity 0B maxCapacity 38.00GB freeCapacity 24.00GB freeReservedCapacity 4.00GB] CONFIG[kind=SHARED;capacity=38.00GB;arbitrationStateCheckCb=(set);global-arbitration-abort-time-ratio=0.5;global-arbitration-memory-reclaim-pct=10;memory-reclaim-threads-hw-multiplier=0.5;memory-pool-min-reclaim-bytes=128MB;check-usage-leak=0;fast-exponential-growth-capacity-limit=512MB;slow-capacity-grow-pct=0.25;global-arbitration-enabled=true;memory-pool-min-free-capacity-pct=0.25;max-memory-arbitration-time=5m;memory-pool-reserved-capacity=64MB;global-arbitration-without-spill=false;memory-pool-min-free-capacity=128MB;memory-pool-initial-capacity=512MB;memory-pool-abort-capacity-limit=8GB;reserved-capacity=4GB;]]

Memory Pool[20250911_074748_00043_pxy5b_0 AGGREGATE root[20250911_074748_00043_pxy5b_0] parent[null] MMAP track-usage thread-safe]<max capacity 14.00GB capacity 14.00GB used 13.97GB available 0B reservation [used 0B, reserved 14.00GB, min 0B] counters [allocs 0, frees 0, reserves 0, releases 0, collisions 0])>

Top 10 leaf memory pool usages:
    op.24.2.0.Window usage 13.72GB reserved 13.72GB peak 13.72GB
    exchangeClient.1797.3 usage 39.33MB reserved 40.00MB peak 54.34MB
    op.1797.3.5.Exchange usage 23.34MB reserved 24.00MB peak 34.34MB
    op.1797.3.7.Exchange usage 20.25MB reserved 24.00MB peak 29.00MB
    op.1797.3.14.Exchange usage 19.00MB reserved 20.00MB peak 29.00MB
    op.1797.3.1.Exchange usage 18.70MB reserved 20.00MB peak 34.20MB
    op.1797.3.4.Exchange usage 16.03MB reserved 20.00MB peak 31.53MB
    op.1797.3.13.Exchange usage 15.89MB reserved 16.00MB peak 38.14MB
    op.1797.3.8.Exchange usage 14.34MB reserved 15.00MB peak 29.84MB
    op.1797.3.6.Exchange usage 14.34MB reserved 15.00MB peak 29.84MB

20250911_074748_00043_pxy5b_0 usage 13.97GB reserved 14.00GB peak 14.00GB
    task.20250911_074748_00043_pxy5b.2.0.0.0 usage 13.97GB reserved 14.00GB peak 14.00GB
        node.1797 usage 257.61MB reserved 272.00MB peak 325.00MB
            op.1797.3.14.Exchange usage 19.00MB reserved 20.00MB peak 29.00MB
            op.1797.3.13.Exchange usage 15.89MB reserved 16.00MB peak 38.14MB
            op.1797.3.12.Exchange usage 11.53MB reserved 12.00MB peak 31.53MB
            exchangeClient.1797.3 usage 39.33MB reserved 40.00MB peak 54.34MB
            op.1797.3.0.Exchange usage 10.84MB reserved 11.00MB peak 29.84MB
            op.1797.3.6.Exchange usage 14.34MB reserved 15.00MB peak 29.84MB
            op.1797.3.1.Exchange usage 18.70MB reserved 20.00MB peak 34.20MB
            op.1797.3.8.Exchange usage 14.34MB reserved 15.00MB peak 29.84MB
            op.1797.3.2.Exchange usage 9.70MB reserved 10.00MB peak 31.95MB
            op.1797.3.3.Exchange usage 9.00MB reserved 9.00MB peak 29.00MB
            op.1797.3.11.Exchange usage 7.88MB reserved 8.00MB peak 30.12MB
            op.1797.3.4.Exchange usage 16.03MB reserved 20.00MB peak 31.53MB
            op.1797.3.5.Exchange usage 23.34MB reserved 24.00MB peak 34.34MB
            op.1797.3.7.Exchange usage 20.25MB reserved 24.00MB peak 29.00MB
            op.1797.3.9.Exchange usage 13.50MB reserved 14.00MB peak 29.00MB
            op.1797.3.10.Exchange usage 13.92MB reserved 14.00MB peak 29.42MB
        node.24 usage 13.72GB reserved 13.72GB peak 13.72GB
            op.24.2.0.Window usage 13.72GB reserved 13.72GB peak 13.72GB
        node.30 usage 11.25KB reserved 15.00MB peak 15.00MB
            op.30.1.14.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.0.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.12.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.1.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.2.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.13.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.6.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.3.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.4.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.10.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.7.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.8.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.5.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.9.FilterProject usage 768B reserved 1.00MB peak 768B
            op.30.1.11.FilterProject usage 768B reserved 1.00MB peak 768B



Memory pool 'op.24.2.0.Window' - Found 52 allocations:
======== 31 allocations of 13.72GB total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocateContiguous(unsigned long, facebook::velox::memory::ContiguousAllocation&, unsigned long)
# 2  facebook::velox::memory::AllocationPool::newRunImpl(unsigned long)
# 3  facebook::velox::memory::AllocationPool::allocateFixed(unsigned long, int)
# 4  facebook::velox::exec::RowContainer::newRow()
# 5  facebook::velox::exec::SortWindowBuild::addInput(std::shared_ptr<facebook::velox::RowVector>)
# 6  facebook::velox::exec::Window::addInput(std::shared_ptr<facebook::velox::RowVector>)
# 7  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_5::operator()() const
# 8  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 9  facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 10 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 11 void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 12 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 13 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 14 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 15 execute_native_thread_routine
# 16 start_thread
# 17 __clone3

======== 4 allocations of 256.00KB total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocateNonContiguous(unsigned long, facebook::velox::memory::Allocation&, unsigned long)
# 2  facebook::velox::memory::AllocationPool::newRunImpl(unsigned long)
# 3  facebook::velox::memory::AllocationPool::allocateFixed(unsigned long, int)
# 4  facebook::velox::exec::RowContainer::newRow()
# 5  facebook::velox::exec::SortWindowBuild::addInput(std::shared_ptr<facebook::velox::RowVector>)
# 6  facebook::velox::exec::Window::addInput(std::shared_ptr<facebook::velox::RowVector>)
# 7  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_5::operator()() const
# 8  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 9  facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 10 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 11 void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 12 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 13 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 14 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 15 execute_native_thread_routine
# 16 start_thread
# 17 __clone3

======== 1 allocations of 64.00KB total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocateNonContiguous(unsigned long, facebook::velox::memory::Allocation&, unsigned long)
# 2  facebook::velox::memory::AllocationPool::newRunImpl(unsigned long)
# 3  facebook::velox::memory::AllocationPool::allocateFixed(unsigned long, int)
# 4  facebook::velox::HashStringAllocator::newSlab()
# 5  facebook::velox::HashStringAllocator::allocate(long, bool)
# 6  std::allocator_traits<facebook::velox::StlAllocator<unsigned int> >::allocate(facebook::velox::StlAllocator<unsigned int>&, unsigned long)
# 7  std::vector<unsigned int, facebook::velox::StlAllocator<unsigned int> >::vector(unsigned long, facebook::velox::StlAllocator<unsigned int> const&)
# 8  facebook::velox::functions::kll::KllSketch<double, facebook::velox::StlAllocator<double>, facebook::velox::util::floating_point::NaNAwareLessThan<double, true> >::KllSketch(unsigned int, facebook::velox::StlAllocator<double> const&, unsigned int)
# 9  facebook::velox::aggregate::prestosql::(anonymous namespace)::KllSketchAccumulator<double>::KllSketchAccumulator(facebook::velox::HashStringAllocator*, std::optional<unsigned int>)
# 10 facebook::velox::aggregate::prestosql::(anonymous namespace)::ApproxPercentileAggregate<double>::initializeNewGroupsInternal(char**, folly::Range<int const*>)
# 11 facebook::velox::exec::Aggregate::initializeNewGroups(char**, folly::Range<int const*>)
# 12 std::enable_if<is_invocable_r_v<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>, std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > >::type std::__invoke_r<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>(facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 13 std::_Function_handler<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&), facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0>::_M_invoke(std::_Any_data const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 14 std::function<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)>::operator()(std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&) const
# 15 facebook::velox::exec::WindowFunction::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)
# 16 facebook::velox::exec::Window::createWindowFunctions()
# 17 facebook::velox::exec::Window::initialize()
# 18 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 19 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 20 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 21 void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 22 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 23 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 24 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 25 execute_native_thread_routine
# 26 start_thread
# 27 __clone3

======== 6 allocations of 36.00KB total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocate(long, std::optional<unsigned int>)
# 2  boost::intrusive_ptr<facebook::velox::Buffer> facebook::velox::AlignedBuffer::allocate<int>(unsigned long, facebook::velox::memory::MemoryPool*, std::optional<int> const&, bool)
# 3  facebook::velox::exec::Window::createPeerAndFrameBuffers()
# 4  facebook::velox::exec::Window::initialize()
# 5  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 6  facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 7  void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 8  void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 9  folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 10 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 11 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 12 execute_native_thread_routine
# 13 start_thread
# 14 __clone3

======== 6 allocations of 640B total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocate(long, std::optional<unsigned int>)
# 2  boost::intrusive_ptr<facebook::velox::Buffer> facebook::velox::AlignedBuffer::allocate<double>(unsigned long, facebook::velox::memory::MemoryPool*, std::optional<double> const&, bool)
# 3  facebook::velox::BaseVector::createInternal(std::shared_ptr<facebook::velox::Type const> const&, int, facebook::velox::memory::MemoryPool*)
# 4  std::enable_if<is_invocable_r_v<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>, std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > >::type std::__invoke_r<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>(facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 5  std::_Function_handler<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&), facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0>::_M_invoke(std::_Any_data const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 6  std::function<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)>::operator()(std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&) const
# 7  facebook::velox::exec::WindowFunction::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)
# 8  facebook::velox::exec::Window::createWindowFunctions()
# 9  facebook::velox::exec::Window::initialize()
# 10 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 11 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 12 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 13 void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 14 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 15 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 16 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 17 execute_native_thread_routine
# 18 start_thread
# 19 __clone3

======== 2 allocations of 512B total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocate(long, std::optional<unsigned int>)
# 2  boost::intrusive_ptr<facebook::velox::Buffer> facebook::velox::AlignedBuffer::allocate<char>(unsigned long, facebook::velox::memory::MemoryPool*, std::optional<char> const&, bool)
# 3  std::enable_if<is_invocable_r_v<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>, std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > >::type std::__invoke_r<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>(facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 4  std::_Function_handler<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&), facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0>::_M_invoke(std::_Any_data const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 5  std::function<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)>::operator()(std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&) const
# 6  facebook::velox::exec::WindowFunction::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)
# 7  facebook::velox::exec::Window::createWindowFunctions()
# 8  facebook::velox::exec::Window::initialize()
# 9  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 10 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 11 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 12 void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 13 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 14 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 15 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 16 execute_native_thread_routine
# 17 start_thread
# 18 __clone3

======== 2 allocations of 256B total size ========
# 0  facebook::velox::memory::MemoryPoolImpl::recordAllocDbg(void const*, unsigned long)
# 1  facebook::velox::memory::MemoryPoolImpl::allocate(long, std::optional<unsigned int>)
# 2  boost::intrusive_ptr<facebook::velox::Buffer> facebook::velox::AlignedBuffer::allocate<unsigned long>(unsigned long, facebook::velox::memory::MemoryPool*, std::optional<unsigned long> const&, bool)
# 3  facebook::velox::ConstantVector<double>::makeNullsBuffer()
# 4  facebook::velox::ConstantVector<double>::ConstantVector(facebook::velox::memory::MemoryPool*, int, bool, std::shared_ptr<facebook::velox::Type const>, double&&, facebook::velox::SimpleVectorStats<double> const&, std::optional<int>, std::optional<int>)
# 5  std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<facebook::velox::ConstantVector<double>, std::allocator<facebook::velox::ConstantVector<double> >, facebook::velox::memory::MemoryPool*&, int&, bool, std::shared_ptr<facebook::velox::Type const> const&, double>(facebook::velox::ConstantVector<double>*&, std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::ConstantVector<double> > >, facebook::velox::memory::MemoryPool*&, int&, bool&&, std::shared_ptr<facebook::velox::Type const> const&, double&&)
# 6  std::shared_ptr<facebook::velox::BaseVector> facebook::velox::(anonymous namespace)::newNullConstant<(facebook::velox::TypeKind)6>(std::shared_ptr<facebook::velox::Type const> const&, int, facebook::velox::memory::MemoryPool*)
# 7  facebook::velox::BaseVector::createNullConstant(std::shared_ptr<facebook::velox::Type const> const&, int, facebook::velox::memory::MemoryPool*)
# 8  facebook::velox::aggregate::prestosql::(anonymous namespace)::ApproxPercentileAggregate<double>::extractValues(char**, int, std::shared_ptr<facebook::velox::BaseVector>*)
# 9  std::enable_if<is_invocable_r_v<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>, std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > >::type std::__invoke_r<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> >, facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&>(facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 10 std::_Function_handler<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&), facebook::velox::exec::registerAggregateWindowFunction(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::$_0>::_M_invoke(std::_Any_data const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool&&, facebook::velox::memory::MemoryPool*&&, facebook::velox::HashStringAllocator*&&, facebook::velox::core::QueryConfig const&)
# 11 std::function<std::unique_ptr<facebook::velox::exec::WindowFunction, std::default_delete<facebook::velox::exec::WindowFunction> > (std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)>::operator()(std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&) const
# 12 facebook::velox::exec::WindowFunction::create(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<facebook::velox::exec::WindowFunctionArg, std::allocator<facebook::velox::exec::WindowFunctionArg> > const&, std::shared_ptr<facebook::velox::Type const> const&, bool, facebook::velox::memory::MemoryPool*, facebook::velox::HashStringAllocator*, facebook::velox::core::QueryConfig const&)
# 13 facebook::velox::exec::Window::createWindowFunctions()
# 14 facebook::velox::exec::Window::initialize()
# 15 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 16 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 17 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 18 void folly::detail::function::call_<facebook::unicorn::utils::MonitoredExecutor::wrapFunc(folly::Function<void ()>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 19 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 20 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 21 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 22 execute_native_thread_routine
# 23 start_thread
# 24 __clone3
```
</details>
