### PR TITLE
fix(fuzzer): Disable streaming aggregation for Spark fuzzer test

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -603,7 +603,7 @@ jobs:
         run: |
           bash /opt/start-spark.sh
           # Sleep for 60 seconds to allow Spark server to start.
-          sleep 60
+          sleep 120
           mkdir -p /tmp/spark_aggregate_fuzzer_repro/logs/
           chmod -R 777 /tmp/spark_aggregate_fuzzer_repro
           chmod +x spark_aggregation_fuzzer_test
@@ -613,6 +613,7 @@ jobs:
                 --seed ${random_seed} \
                 --duration_sec $DURATION \
                 --enable_sorted_aggregations=false \
+                --enable_streaming_aggregations=false \
                 --minloglevel=0 \
                 --stderrthreshold=2 \
                 --log_dir=/tmp/spark_aggregate_fuzzer_repro/logs \

--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -34,6 +34,11 @@ DEFINE_bool(
     true,
     "When true, generates plans with aggregations over sorted inputs");
 
+DEFINE_bool(
+    enable_streaming_aggregations,
+    true,
+    "When true, generates plans with streaming aggregations");
+
 using facebook::velox::fuzzer::CallableSignature;
 using facebook::velox::fuzzer::SignatureTemplate;
 
@@ -749,7 +754,7 @@ bool AggregationFuzzer::verifyAggregation(
         projections,
         tableScanPlans);
 
-    if (!groupingKeys.empty()) {
+    if (FLAGS_enable_streaming_aggregations && !groupingKeys.empty()) {
       // Use OrderBy + StreamingAggregation on original input.
       makeStreamingPlansWithTableScan(
           groupingKeys,
@@ -780,7 +785,7 @@ bool AggregationFuzzer::verifyAggregation(
     makeAlternativePlansWithValues(
         groupingKeys, aggregates, masks, flatInput, projections, valuesPlans);
 
-    if (!groupingKeys.empty()) {
+    if (FLAGS_enable_streaming_aggregations && !groupingKeys.empty()) {
       // Use OrderBy + StreamingAggregation on original input.
       makeStreamingPlansWithValues(
           groupingKeys, aggregates, masks, input, projections, valuesPlans);
@@ -847,7 +852,7 @@ bool AggregationFuzzer::verifySortedAggregation(
   std::vector<PlanWithSplits> plans;
   plans.push_back({firstPlan, {}});
 
-  if (!groupingKeys.empty()) {
+  if (FLAGS_enable_streaming_aggregations && !groupingKeys.empty()) {
     plans.push_back(
         {PlanBuilder()
              .values(input)
@@ -877,7 +882,7 @@ bool AggregationFuzzer::verifySortedAggregation(
              .planNode(),
          splits});
 
-    if (!groupingKeys.empty()) {
+    if (FLAGS_enable_streaming_aggregations && !groupingKeys.empty()) {
       plans.push_back(
           {PlanBuilder()
                .tableScan(inputRowType)
@@ -1143,7 +1148,7 @@ bool AggregationFuzzer::verifyDistinctAggregation(
   std::vector<PlanWithSplits> plans;
   plans.push_back({firstPlan, {}});
 
-  if (!groupingKeys.empty()) {
+  if (FLAGS_enable_streaming_aggregations && !groupingKeys.empty()) {
     plans.push_back(
         {PlanBuilder()
              .values(input)
@@ -1175,7 +1180,7 @@ bool AggregationFuzzer::verifyDistinctAggregation(
              .planNode(),
          splits});
 
-    if (!groupingKeys.empty()) {
+    if (FLAGS_enable_streaming_aggregations && !groupingKeys.empty()) {
       plans.push_back(
           {PlanBuilder()
                .tableScan(inputRowType)


### PR DESCRIPTION
Since the last workflow failures occurred in the streaming aggregation test, 
this PR temporarily disables it and increases the wait time for Spark connect
service to start.

https://github.com/facebookincubator/velox/issues/13942, https://github.com/facebookincubator/velox/issues/15993