### PR TITLE
refactor: Use 'cbegin()' to assign to 'const_iterator'

### DIFF
--- a/velox/dwio/common/PositionProvider.h
+++ b/velox/dwio/common/PositionProvider.h
@@ -23,7 +23,7 @@ namespace facebook::velox::dwio::common {
 class PositionProvider {
  public:
   explicit PositionProvider(const std::vector<uint64_t>& positions)
-      : position_{positions.begin()}, end_{positions.end()} {}
+      : position_{positions.cbegin()}, end_{positions.cend()} {}
 
   uint64_t next();
 


### PR DESCRIPTION
Using `cbegin()` makes the intent more explicit, although it's not 
actually necessary because `positions` is already a const vector.