### PR TITLE
docs: Clarify documentation for from_unixtime(timestamp) Presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -144,7 +144,10 @@ Date and Time Functions
 
 .. function:: from_unixtime(unixtime) -> timestamp
 
-    Returns the UNIX timestamp ``unixtime`` as a timestamp.
+    Returns the UNIX timestamp ``unixtime`` as a timestamp.  If the
+    :doc:`adjust_timestamp_to_session_timezone <../../configs>` property is set
+    to true, then the timestamp is adjusted to the time zone specified in
+    :doc:`session_timezone <../../configs>`.
 
 .. function:: from_unixtime(unixtime, string) -> timestamp with time zone
     :noindex:


### PR DESCRIPTION
Summary: The from_unixtime(timestamp) function converts the input into a timestamp in the time zone associated with the query.  Calls to this function with identical arguments will return different results if they are issued from query sessions with different time zones.

Differential Revision: D82222298


