### PR TITLE
feat: Add filter support for index join which can't be converted into join conditions

### DIFF
--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -163,7 +163,7 @@ class TestIndexTableHandle : public connector::ConnectorTableHandle {
   }
 };
 
-TEST_F(PlanNodeTest, isIndexLookupJoin) {
+TEST_F(PlanNodeTest, indexLookupJoin) {
   const auto rowType = ROW({"name"}, {BIGINT()});
   const auto valueNode = std::make_shared<ValuesNode>("orderBy", rowData_);
   ASSERT_FALSE(isIndexLookupJoin(valueNode.get()));
@@ -193,12 +193,17 @@ TEST_F(PlanNodeTest, isIndexLookupJoin) {
             leftKeys,
             rightKeys,
             std::vector<IndexLookupConditionPtr>{},
-            /*includeMatchColumn=*/false,
+            /*filter=*/nullptr,
+            /*hasMarker=*/false,
             probeNode,
             buildNode,
             outputType);
     ASSERT_TRUE(isIndexLookupJoin(indexJoinNodeWithInnerJoin.get()));
-    ASSERT_FALSE(indexJoinNodeWithInnerJoin->includeMatchColumn());
+    ASSERT_FALSE(indexJoinNodeWithInnerJoin->hasMarker());
+    ASSERT_EQ(indexJoinNodeWithInnerJoin->filter(), nullptr);
+    ASSERT_EQ(
+        indexJoinNodeWithInnerJoin->toString(/*detailed=*/true),
+        "-- IndexLookupJoin[indexJoinNode][INNER c0=c1] -> c0:BIGINT, c1:BIGINT\n");
   }
   {
     const RowTypePtr outputTypeWithMatchColumn =
@@ -210,12 +215,39 @@ TEST_F(PlanNodeTest, isIndexLookupJoin) {
             leftKeys,
             rightKeys,
             std::vector<IndexLookupConditionPtr>{},
-            /*includeMatchColumn=*/true,
+            /*filter=*/nullptr,
+            /*hasMarker=*/true,
             probeNode,
             buildNode,
             outputTypeWithMatchColumn);
     ASSERT_TRUE(isIndexLookupJoin(indexJoinNodeWithLeftJoin.get()));
-    ASSERT_TRUE(indexJoinNodeWithLeftJoin->includeMatchColumn());
+    ASSERT_TRUE(indexJoinNodeWithLeftJoin->hasMarker());
+    ASSERT_EQ(indexJoinNodeWithLeftJoin->filter(), nullptr);
+    ASSERT_EQ(
+        indexJoinNodeWithLeftJoin->toString(/*detailed=*/true),
+        "-- IndexLookupJoin[indexJoinNode][LEFT c0=c1] -> c0:BIGINT, c1:BIGINT, c2:BOOLEAN\n");
+  }
+  {
+    // Test IndexLookupJoinNode with filter
+    const auto filterExpr = std::make_shared<core::FieldAccessTypedExpr>(
+        BOOLEAN(), "filter_column");
+    const auto indexJoinNodeWithFilter = std::make_shared<IndexLookupJoinNode>(
+        "indexJoinNodeWithFilter",
+        core::JoinType::kInner,
+        leftKeys,
+        rightKeys,
+        std::vector<IndexLookupConditionPtr>{},
+        /*filter=*/filterExpr,
+        /*hasMarker=*/false,
+        probeNode,
+        buildNode,
+        outputType);
+    ASSERT_TRUE(isIndexLookupJoin(indexJoinNodeWithFilter.get()));
+    ASSERT_FALSE(indexJoinNodeWithFilter->hasMarker());
+    ASSERT_EQ(indexJoinNodeWithFilter->filter(), filterExpr);
+    ASSERT_EQ(
+        indexJoinNodeWithFilter->toString(/*detailed=*/true),
+        "-- IndexLookupJoin[indexJoinNodeWithFilter][INNER c0=c1, filter: \"filter_column\"] -> c0:BIGINT, c1:BIGINT\n");
   }
   // Error case.
   {
@@ -226,7 +258,8 @@ TEST_F(PlanNodeTest, isIndexLookupJoin) {
             leftKeys,
             rightKeys,
             std::vector<IndexLookupConditionPtr>{},
-            /*includeMatchColumn=*/true,
+            /*filter=*/nullptr,
+            /*hasMarker=*/true,
             probeNode,
             buildNode,
             outputType),
@@ -240,7 +273,8 @@ TEST_F(PlanNodeTest, isIndexLookupJoin) {
             leftKeys,
             rightKeys,
             std::vector<IndexLookupConditionPtr>{},
-            /*includeMatchColumn=*/true,
+            /*filter=*/nullptr,
+            /*hasMarker=*/true,
             probeNode,
             buildNode,
             outputType),
@@ -256,7 +290,8 @@ TEST_F(PlanNodeTest, isIndexLookupJoin) {
             leftKeys,
             rightKeys,
             std::vector<IndexLookupConditionPtr>{},
-            /*includeMatchColumn=*/true,
+            /*filter=*/nullptr,
+            /*hasMarker=*/true,
             probeNode,
             buildNode,
             outputTypeWithDuplicateMatchColumn),

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -407,7 +407,8 @@ core::PlanNodePtr getTraceNode(
         indexLookupJoinNode->leftKeys(),
         indexLookupJoinNode->rightKeys(),
         indexLookupJoinNode->joinConditions(),
-        indexLookupJoinNode->includeMatchColumn(),
+        indexLookupJoinNode->filter(),
+        indexLookupJoinNode->hasMarker(),
         std::make_shared<DummySourceNode>(
             indexLookupJoinNode->sources().front()->outputType()), // Probe side
         indexLookupJoinNode->lookupSource(), // Index side

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -374,9 +374,10 @@ TEST_F(PlanBuilderTest, indexLookupJoinBuilder) {
                   .rightKeys({"u0"})
                   .indexSource(rightScan)
                   .joinConditions({"contains(t1, u1)"})
-                  .includeMatchColumn(false)
+                  .hasMarker(false)
                   .outputLayout({"t0", "u1"})
                   .joinType(core::JoinType::kInner)
+                  .filter("t0 > 0")
                   .endIndexLookupJoin()
                   .planNode();
 
@@ -389,7 +390,11 @@ TEST_F(PlanBuilderTest, indexLookupJoinBuilder) {
   ASSERT_EQ(indexJoinNode->leftKeys()[0]->name(), "t0");
   ASSERT_EQ(indexJoinNode->rightKeys()[0]->name(), "u0");
   ASSERT_EQ(indexJoinNode->joinConditions().size(), 1);
-  ASSERT_FALSE(indexJoinNode->includeMatchColumn());
+  ASSERT_FALSE(indexJoinNode->hasMarker());
+  ASSERT_EQ(indexJoinNode->outputType()->names().size(), 2);
+  ASSERT_EQ(indexJoinNode->outputType()->names()[0], "t0");
+  ASSERT_EQ(indexJoinNode->outputType()->names()[1], "u1");
+  ASSERT_EQ(indexJoinNode->filter()->toString(), "gt(ROW[\"t0\"],0)");
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
@@ -22,8 +22,7 @@ namespace fecebook::velox::exec::test {
 using namespace facebook::velox::test;
 
 namespace {
-std::vector<std::string> appendMatchColumn(
-    const std::vector<std::string> columns) {
+std::vector<std::string> appendMarker(const std::vector<std::string> columns) {
   std::vector<std::string> resultColumns;
   resultColumns.reserve(columns.size() + 1);
   for (const auto& column : columns) {
@@ -259,7 +258,7 @@ PlanNodePtr IndexLookupJoinTestBase::makeLookupPlan(
     const std::vector<std::string>& leftKeys,
     const std::vector<std::string>& rightKeys,
     const std::vector<std::string>& joinConditions,
-    bool includeMatchColumn,
+    bool hasMarker,
     JoinType joinType,
     const std::vector<std::string>& outputColumns,
     PlanNodeId& joinNodeId) {
@@ -272,9 +271,8 @@ PlanNodePtr IndexLookupJoinTestBase::makeLookupPlan(
       .rightKeys(rightKeys)
       .indexSource(indexScanNode)
       .joinConditions(joinConditions)
-      .includeMatchColumn(includeMatchColumn)
-      .outputLayout(
-          includeMatchColumn ? appendMatchColumn(outputColumns) : outputColumns)
+      .hasMarker(hasMarker)
+      .outputLayout(hasMarker ? appendMarker(outputColumns) : outputColumns)
       .joinType(joinType)
       .endIndexLookupJoin()
       .capturePlanNodeId(joinNodeId)
@@ -287,7 +285,8 @@ PlanNodePtr IndexLookupJoinTestBase::makeLookupPlan(
     const std::vector<std::string>& leftKeys,
     const std::vector<std::string>& rightKeys,
     const std::vector<std::string>& joinConditions,
-    bool includeMatchColumn,
+    const std::string& filter,
+    bool hasMarker,
     JoinType joinType,
     const std::vector<std::string>& outputColumns) {
   VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
@@ -302,9 +301,9 @@ PlanNodePtr IndexLookupJoinTestBase::makeLookupPlan(
       .rightKeys(rightKeys)
       .indexSource(indexScanNode)
       .joinConditions(joinConditions)
-      .includeMatchColumn(includeMatchColumn)
-      .outputLayout(
-          includeMatchColumn ? appendMatchColumn(outputColumns) : outputColumns)
+      .filter(filter)
+      .hasMarker(hasMarker)
+      .outputLayout(hasMarker ? appendMarker(outputColumns) : outputColumns)
       .joinType(joinType)
       .endIndexLookupJoin()
       .capturePlanNodeId(joinNodeId_)

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -86,7 +86,7 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
   /// @param probeVectors: the probe input vectors.
   /// @param leftKeys: the left join keys of index lookup join.
   /// @param rightKeys: the right join keys of index lookup join.
-  /// @param includeMatchColumn: whether the index join output includes a match
+  /// @param hasMarker: whether the index join output includes a match
   /// column at the end.
   /// @param joinType: the join type of index lookup join.
   /// @param outputColumns: the output column names of index lookup join.
@@ -99,30 +99,32 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
       const std::vector<std::string>& leftKeys,
       const std::vector<std::string>& rightKeys,
       const std::vector<std::string>& joinConditions,
-      bool includeMatchColumn,
+      bool hasMarker,
       core::JoinType joinType,
       const std::vector<std::string>& outputColumns,
       core::PlanNodeId& joinNodeId);
 
   /// Makes lookup join plan with the following parameters:
+  /// @param planNodeIdGenerator: generator for creating unique plan node IDs.
   /// @param indexScanNode: the index table scan node.
-  /// @param probeVectors: the probe input vectors.
   /// @param leftKeys: the left join keys of index lookup join.
   /// @param rightKeys: the right join keys of index lookup join.
-  /// @param includeMatchColumn: whether the index join output includes a match
+  /// @param joinConditions: the join conditions for index lookup join that
+  /// can't be converted into simple equality join conditions.
+  /// @param filter: additional filter condition SQL string to apply on join
+  /// results. Can be empty string if no additional filter is needed.
+  /// @param hasMarker: whether the index join output includes a match
   /// column at the end.
   /// @param joinType: the join type of index lookup join.
   /// @param outputColumns: the output column names of index lookup join.
-  /// @param joinNodeId: returns the plan node id of the index lookup join
-  /// node.
-  /// @param probeScanNodeId: returns the plan node id of the probe table scan
   PlanNodePtr makeLookupPlan(
       const std::shared_ptr<PlanNodeIdGenerator>& planNodeIdGenerator,
       TableScanNodePtr indexScanNode,
       const std::vector<std::string>& leftKeys,
       const std::vector<std::string>& rightKeys,
       const std::vector<std::string>& joinConditions,
-      bool includeMatchColumn,
+      const std::string& filter,
+      bool hasMarker,
       JoinType joinType,
       const std::vector<std::string>& outputColumns);
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -395,14 +395,21 @@ class PlanBuilder {
       return *this;
     }
 
-    IndexLookupJoinBuilder& includeMatchColumn(bool includeMatchColumn) {
-      includeMatchColumn_ = includeMatchColumn;
+    IndexLookupJoinBuilder& hasMarker(bool hasMarker) {
+      hasMarker_ = hasMarker;
       return *this;
     }
 
     IndexLookupJoinBuilder& outputLayout(
         std::vector<std::string> outputLayout) {
       outputLayout_ = std::move(outputLayout);
+      return *this;
+    }
+
+    /// @param filter SQL expression for the additional join filter. Can
+    /// use columns from both probe and build sides of the join.
+    IndexLookupJoinBuilder& filter(std::string filter) {
+      filter_ = std::move(filter);
       return *this;
     }
 
@@ -427,7 +434,8 @@ class PlanBuilder {
     std::vector<std::string> rightKeys_;
     core::TableScanNodePtr indexSource_;
     std::vector<std::string> joinConditions_;
-    bool includeMatchColumn_{false};
+    std::string filter_;
+    bool hasMarker_{false};
     std::vector<std::string> outputLayout_;
     core::JoinType joinType_{core::JoinType::kInner};
   };
@@ -1315,6 +1323,11 @@ class PlanBuilder {
   /// node. Second input is specified in 'right' parameter and must be a
   /// table source with the connector table handle with index lookup support.
   ///
+  /// @param leftKeys Join keys from the probe side, the preceding plan node.
+  /// Cannot be empty.
+  /// @param rightKeys Join keys from the index lookup side, the plan node
+  /// specified in 'right' parameter. The number and types of left and right
+  /// keys must be the same.
   /// @param right The right input source with index lookup support.
   /// @param joinConditions SQL expressions as the join conditions. Each join
   /// condition must use columns from both sides. For the right side, it can
@@ -1327,18 +1340,23 @@ class PlanBuilder {
   /// where "a" is the index column from right side and "b", "c" are either
   /// condition column from left side or a constant but at least one of them
   /// must not be constant. They all have the same type.
-  /// @param joinType Type of the join supported: inner, left.
-  /// @param includeMatchColumn if true, 'outputLayout' should include a boolean
+  /// @param filter SQL expression for the additional join filter to apply on
+  /// join results. This supports filters that can't be converted into join
+  /// conditions or lookup conditions. Can be an empty string if no additional
+  /// filter is needed.
+  /// @param hasMarker if true, 'outputLayout' should include a boolean
   /// column at the end to indicate if a join output row has a match or not.
   /// This only applies for left join.
-  ///
-  /// See hashJoin method for the description of the other parameters.
+  /// @param outputLayout Output layout consisting of columns from probe and
+  /// build sides.
+  /// @param joinType Type of the join supported: inner, left.
   PlanBuilder& indexLookupJoin(
       const std::vector<std::string>& leftKeys,
       const std::vector<std::string>& rightKeys,
       const core::TableScanNodePtr& right,
       const std::vector<std::string>& joinConditions,
-      bool includeMatchColumn,
+      const std::string& filter,
+      bool hasMarker,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 

--- a/velox/python/plan_builder/PyPlanBuilder.cpp
+++ b/velox/python/plan_builder/PyPlanBuilder.cpp
@@ -306,7 +306,8 @@ PyPlanBuilder& PyPlanBuilder::indexLookupJoin(
         rightKeys,
         tableScanNode,
         {},
-        /*includeMatchColumn=*/false,
+        /*filter=*/"",
+        /*hasMarker=*/false,
         output,
         joinType);
   } else {

--- a/velox/tool/trace/IndexLookupJoinReplayer.cpp
+++ b/velox/tool/trace/IndexLookupJoinReplayer.cpp
@@ -36,7 +36,8 @@ core::PlanNodePtr IndexLookupJoinReplayer::createPlanNode(
       indexLookupJoinNode->leftKeys(),
       indexLookupJoinNode->rightKeys(),
       indexLookupJoinNode->joinConditions(),
-      indexLookupJoinNode->includeMatchColumn(),
+      indexLookupJoinNode->filter(),
+      indexLookupJoinNode->hasMarker(),
       source, // Probe side
       indexLookupJoinNode->lookupSource(), // Index side
       indexLookupJoinNode->outputType());

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -262,7 +262,8 @@ TEST_F(IndexLookupJoinReplayerTest, test) {
               rightKeys,
               std::dynamic_pointer_cast<const core::TableScanNode>(indexScan),
               /*joinConditions=*/{},
-              /*includeMatchColumn=*/false,
+              /*filter=*/"",
+              /*hasMarker=*/false,
               concat(probeType_, indexType_)->names(),
               core::JoinType::kInner)
           .capturePlanNodeId(traceNodeId_)


### PR DESCRIPTION
Summary:
Add filter support in index join for filter which can't be converted into join conditions that can be pushdown to index source. The filter is executed on the lookup result before left join processing. This is to enable Meta AI data exploration query shapes

The followup is to consider use join match tracker inside index lookup to handle this logic to be consistent with other join type implementations.

Differential Revision: D82149399


