### PR TITLE
feat: Add insertTableHandle as input parameter to tableWrite

### DIFF
--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
 #include "velox/exec/WindowFunction.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/TestIndexStorageConnector.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -395,6 +396,56 @@ TEST_F(PlanBuilderTest, indexLookupJoinBuilder) {
   ASSERT_EQ(indexJoinNode->outputType()->names()[0], "t0");
   ASSERT_EQ(indexJoinNode->outputType()->names()[1], "u1");
   ASSERT_EQ(indexJoinNode->filter()->toString(), "gt(ROW[\"t0\"],0)");
+}
+
+TEST_F(PlanBuilderTest, insertTableHandleParameter) {
+  auto data = makeRowVector({makeFlatVector<int64_t>(10, folly::identity)});
+  auto directory = "/some/test/directory";
+
+  // Lambda to create a plan with given insertableHandle and verify it
+  auto testInsertTableHandle =
+      [&](std::shared_ptr<core::InsertTableHandle> insertTableHandle) {
+        // Create a plan with insertTableHandle
+        auto planBuilder = PlanBuilder().values({data}).tableWrite(
+            directory,
+            {},
+            0,
+            {},
+            {},
+            dwio::common::FileFormat::DWRF,
+            {},
+            PlanBuilder::kHiveDefaultConnectorId,
+            {},
+            nullptr,
+            "",
+            common::CompressionKind_NONE,
+            nullptr,
+            false,
+            connector::CommitStrategy::kNoCommit,
+            insertTableHandle);
+
+        // Verify the plan node has the correct insert Table Handle.
+        auto tableWriteNode =
+            std::dynamic_pointer_cast<const core::TableWriteNode>(
+                planBuilder.planNode());
+        ASSERT_NE(tableWriteNode, nullptr);
+        ASSERT_EQ(tableWriteNode->insertTableHandle(), insertTableHandle);
+      };
+
+  auto rowType = ROW({"c0", "c1", "c2"}, {BIGINT(), INTEGER(), SMALLINT()});
+  auto hiveHandle = HiveConnectorTestBase::makeHiveInsertTableHandle(
+      rowType->names(),
+      rowType->children(),
+      {rowType->names()[0]}, // partitionedBy
+      nullptr, // bucketProperty
+      HiveConnectorTestBase::makeLocationHandle(
+          "/path/to/test",
+          std::nullopt,
+          connector::hive::LocationHandle::TableType::kNew));
+
+  auto insertHandle = std::make_shared<core::InsertTableHandle>(
+      std::string(PlanBuilder::kHiveDefaultConnectorId), hiveHandle);
+  testInsertTableHandle(insertHandle);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -718,7 +718,8 @@ PlanBuilder& PlanBuilder::tableWrite(
     const common::CompressionKind compressionKind,
     const RowTypePtr& schema,
     const bool ensureFiles,
-    const connector::CommitStrategy commitStrategy) {
+    const connector::CommitStrategy commitStrategy,
+    std::shared_ptr<core::InsertTableHandle> insertTableHandle) {
   return TableWriterBuilder(*this)
       .outputDirectoryPath(outputDirectoryPath)
       .outputFileName(outputFileName)
@@ -735,6 +736,7 @@ PlanBuilder& PlanBuilder::tableWrite(
       .compressionKind(compressionKind)
       .ensureFiles(ensureFiles)
       .commitStrategy(commitStrategy)
+      .insertHandle(insertTableHandle)
       .endTableWriter();
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -825,6 +825,12 @@ class PlanBuilder {
   /// output of the previous operator.
   /// @param ensureFiles When this option is set the HiveDataSink will always
   /// create a file even if there is no data.
+  /// @param commitStrategy The commit strategy to use for the table write
+  /// operation, default is kNoCommit.
+  /// @param insertTableHandle Encapsulates information needed to write data
+  /// to a table through a connector. If not specified, tableWrite will build
+  /// a HiveInsertTableHandle with columnHandles, bucketProperty and
+  /// locationHandle.
   PlanBuilder& tableWrite(
       const std::string& outputDirectoryPath,
       const std::vector<std::string>& partitionBy,
@@ -843,7 +849,8 @@ class PlanBuilder {
       const RowTypePtr& schema = nullptr,
       const bool ensureFiles = false,
       const connector::CommitStrategy commitStrategy =
-          connector::CommitStrategy::kNoCommit);
+          connector::CommitStrategy::kNoCommit,
+      std::shared_ptr<core::InsertTableHandle> insertTableHandle = nullptr);
 
   /// Add a TableWriteMergeNode.
   PlanBuilder& tableWriteMerge();


### PR DESCRIPTION
Summary:
Add `insertTableHandle` as an optional input parameter to `PlanBuilder::tableWrite` 
With this change, we are able to construct tableWriteNode with the provided custom insertTableHandle instead of creating a new `HiveInsertTableHandle`

Differential Revision: D82049550


