### PR TITLE
feat(Nimble): New Flush Policy Implementation With Chunking

### DIFF
--- a/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTestUtil.cpp
+++ b/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTestUtil.cpp
@@ -348,7 +348,8 @@ std::vector<std::unique_ptr<StreamLoader>> writeToNimbleAndGetStreamLoaders(
   writerOptions.minStreamChunkRawSize = 0;
   writerOptions.flushPolicyFactory = [] {
     return std::make_unique<LambdaFlushPolicy>(
-        [](const StripeProgress&) { return FlushDecision::Chunk; });
+        /*flushLambda=*/[](const StripeProgress&) { return false; },
+        /*chunkLambda=*/[](const StripeProgress&) { return true; });
   };
 
   std::vector<std::unique_ptr<StreamLoader>> allStreamLoaders;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/240

This is an implementation of the new chunking policy described in this [doc](https://fburl.com/gdoc/gkdwwju1). It has two phases:

**Phase 1 - Memory Pressure Management (shouldChunk)**
The policy monitors total in-memory data size:
*  When memory usage exceeds the maximum threshold, initiates chunking to reduce memory footprint while continuing data ingestion
*  When previous chunking attempts succeeded and memory remains above the minimum threshold, continues chunking to further reduce memory usage
*   When chunking fails to reduce memory usage effectively and memory stays above the minimum threshold, forces a full stripe flush to guarantee memory relief

**Phase 2 - Storage Size Optimization (shouldFlush)**
 Implements compression-aware stripe size prediction:
*   Calculates the anticipated final compressed stripe size by applying the estimated compression ratio to unencoded data
*   Triggers stripe flush when the predicted compressed size reaches the target stripe size threshold

Differential Revision: D81516697


