### PR TITLE
build: Add 'abseil' as a build dependency for re2

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -125,6 +125,8 @@ function install_boost {
 }
 
 function install_protobuf {
+  install_abseil
+
   wget_and_untar https://github.com/protocolbuffers/protobuf/releases/download/v"${PROTOBUF_VERSION}"/protobuf-all-"${PROTOBUF_VERSION}".tar.gz protobuf
   cmake_install_dir protobuf -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package
 }
@@ -139,9 +141,20 @@ function install_ranges_v3 {
   cmake_install_dir ranges_v3 -DRANGES_ENABLE_WERROR=OFF -DRANGE_V3_TESTS=OFF -DRANGE_V3_EXAMPLES=OFF
 }
 
+function install_abseil {
+  github_checkout abseil/abseil-cpp "${ABSEIL_VERSION}" --depth 1
+  cmake_install \
+    -DABSL_BUILD_TESTING=OFF \
+    -DCMAKE_CXX_STANDARD=17 \
+    -DABSL_PROPAGATE_CXX_STD=ON \
+    -DABSL_ENABLE_INSTALL=ON
+}
+
 function install_re2 {
+  install_abseil
+
   wget_and_untar https://github.com/google/re2/archive/refs/tags/"${RE2_VERSION}".tar.gz re2
-  cmake_install_dir re2 -DRE2_BUILD_TESTING=OFF
+  cmake_install_dir re2 -DRE2_BUILD_TESTING=OFF -Dabsl_DIR="${INSTALL_PREFIX}/lib/cmake/absl"
 }
 
 function install_glog {
@@ -303,12 +316,7 @@ function install_gcs-sdk-cpp {
   # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md#required-libraries
 
   # abseil-cpp
-  github_checkout abseil/abseil-cpp "${ABSEIL_VERSION}" --depth 1
-  cmake_install \
-    -DABSL_BUILD_TESTING=OFF \
-    -DCMAKE_CXX_STANDARD=17 \
-    -DABSL_PROPAGATE_CXX_STD=ON \
-    -DABSL_ENABLE_INSTALL=ON
+  install_abseil
 
   # protobuf
   github_checkout protocolbuffers/protobuf v"${PROTOBUF_VERSION}" --depth 1


### PR DESCRIPTION
This script failed for me.  It seems that re2 has trouble building on Mac with Homebrew.  This fixes the problem.  Is there a better solution for this issue?

See below for the error message I encountered:

```
+ install_re2
+ wget_and_untar https://github.com/google/re2/archive/refs/tags/2024-07-02.tar.gz re2
+ local URL=https://github.com/google/re2/archive/refs/tags/2024-07-02.tar.gz
+ local DIR=re2
+ mkdir -p /Users/tdcmeehan/git/clones/dyncon/presto-native-execution/velox/deps-download
+ pushd /Users/tdcmeehan/git/clones/dyncon/presto-native-execution/velox/deps-download
~/git/clones/dyncon/presto-native-execution/velox/deps-download ~/git/clones/dyncon/presto-native-execution/velox
+ SUDO=
+ '[' -d re2 ']'
+ mkdir -p re2
+ pushd re2
~/git/clones/dyncon/presto-native-execution/velox/deps-download/re2 ~/git/clones/dyncon/presto-native-execution/velox/deps-download ~/git/clones/dyncon/presto-native-execution/velox
+ curl -L https://github.com/google/re2/archive/refs/tags/2024-07-02.tar.gz -o re2.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  381k    0  381k    0     0   869k      0 --:--:-- --:--:-- --:--:--  869k
+ tar -xz --strip-components=1 --no-same-owner -f re2.tar.gz
+ popd
~/git/clones/dyncon/presto-native-execution/velox/deps-download ~/git/clones/dyncon/presto-native-execution/velox
+ popd
~/git/clones/dyncon/presto-native-execution/velox
+ cmake_install_dir re2 -DRE2_BUILD_TESTING=OFF
+ pushd /Users/tdcmeehan/git/clones/dyncon/presto-native-execution/velox/deps-download/re2
~/git/clones/dyncon/presto-native-execution/velox/deps-download/re2 ~/git/clones/dyncon/presto-native-execution/velox
+ shift
+ cmake_install -DRE2_BUILD_TESTING=OFF
+ local NAME
+++ pwd
++ basename /Users/tdcmeehan/git/clones/dyncon/presto-native-execution/velox/deps-download/re2
+ NAME=re2
+ local BINARY_DIR=_build
+ SUDO=
+ '[' -d _build ']'
+ mkdir -p _build
++ get_cxx_flags
++ local CPU_ARCH=
++ local OS
+++ uname
++ OS=Darwin
++ local MACHINE
+++ uname -m
++ MACHINE=arm64
++ [[ -z '' ]]
++ '[' Darwin = Darwin ']'
++ '[' arm64 = arm64 ']'
++ CPU_ARCH=arm64
++ case $CPU_ARCH in
++ echo -n -mcpu=apple-m1+crc
+ COMPILER_FLAGS=-mcpu=apple-m1+crc
+ COMPILER_FLAGS+=' -isystem /opt/homebrew/include '
+ COMPILER_FLAGS+=
+ cmake -Wno-dev '' -B_build -GNinja -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_PREFIX_PATH=/Users/tdcmeehan/velox/velox_dependency_install -DCMAKE_INSTALL_PREFIX=/Users/tdcmeehan/velox/velox_dependency_install '-DCMAKE_CXX_FLAGS=-mcpu=apple-m1+crc -isystem /opt/homebrew/include ' -DBUILD_TESTING=OFF -DRE2_BUILD_TESTING=OFF
CMake Warning:
  Ignoring empty string ("") provided on the command line.


-- The CXX compiler identification is AppleClang 15.0.0.15000309
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Library/Developer/CommandLineTools/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
CMake Error at CMakeLists.txt:84 (find_package):
  By not providing "Findabsl.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "absl", but
  CMake did not find one.

  Could not find a package configuration file provided by "absl" with any of
  the following names:

    abslConfig.cmake
    absl-config.cmake

  Add the installation prefix of "absl" to CMAKE_PREFIX_PATH or set
  "absl_DIR" to a directory containing one of the above files.  If "absl"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
```