### PR TITLE
feat(cudf): Add the LOG_VALIDATION_MSG Micro to get the fallback reason

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/experimental/cudf/exec/ExpressionEvaluator.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
+#include "velox/experimental/cudf/exec/Validation.h"
 
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/FieldReference.h"
@@ -286,8 +287,12 @@ bool canBeEvaluated(const std::shared_ptr<velox::exec::Expr>& expr) {
     return std::all_of(
         expr->inputs().begin(), expr->inputs().end(), canBeEvaluated);
   }
-  return std::dynamic_pointer_cast<velox::exec::FieldReference>(expr) !=
-      nullptr;
+  if (std::dynamic_pointer_cast<velox::exec::FieldReference>(expr) == nullptr) {
+    LOG_VALIDATION_MSG("The expression {} is not supported", name);
+    return false;
+  }
+
+  return true;
 }
 
 } // namespace detail

--- a/velox/experimental/cudf/exec/Validation.h
+++ b/velox/experimental/cudf/exec/Validation.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/ExceptionHelper.h"
+
+namespace facebook::velox::cudf_velox {
+
+DEFINE_bool(
+    velox_cudf_log_validation_failure,
+    true,
+    "Whether log the validation failure information");
+
+namespace detail {
+const char* extractFileName(const char* file) {
+  return strrchr(file, '/') ? strrchr(file, '/') + 1 : file;
+}
+} // namespace detail
+
+#define LOG_VALIDATION_MSG(...)                                             \
+  do {                                                                      \
+    if (FLAGS_velox_cudf_log_validation_failure) {                          \
+      auto message = ::facebook::velox::errorMessage(__VA_ARGS__);          \
+      LOG(WARNING) << fmt::format(                                          \
+          "Validation failed at file:{}, line:{}, function:{}, reason:{}",  \
+          ::facebook::velox::cudf_velox::detail::extractFileName(__FILE__), \
+          __LINE__,                                                         \
+          __FUNCTION__,                                                     \
+          message);                                                         \
+    }                                                                       \
+  } while (0)
+} // namespace facebook::velox::cudf_velox


### PR DESCRIPTION
This micro can help user to find why the query fallbacks, this is an essential information, fallback will cause extra cost, the format conversion.