### PR TITLE
Fix bash array syntax for adding CMake flags

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -109,10 +109,10 @@ jobs:
           else
             # cuDF (unsupported for Clang) and Faiss (link issue when using Clang)
             # are excluded for Clang compilation and need to be added back when using GCC.
-            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_CUDF=ON"
-            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_FAISS=ON"
+            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_CUDF=ON")
+            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_FAISS=ON")
             # Investigate issues with remote function service: Issue #13897
-            EXTRA_CMAKE_FLAGS+="-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON"
+            EXTRA_CMAKE_FLAGS+=("-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON")
           fi
           make release EXTRA_CMAKE_FLAGS="${EXTRA_CMAKE_FLAGS[*]}"
 


### PR DESCRIPTION
This PR fixes some bash array syntax to ensure that the proper CMake flags are set in CI builds.

The options for building benchmarks, building cuDF, building FAISS, and enabling remote functions appear to be affected.

In brief, the bug is that we want to append to a bash array but we're tacking on a string rather than an array element.

```bash
$ TESTVAR=("A" "B" "C")
$ echo ${TESTVAR[*]}
A B C
$ TESTVAR+="D"  # This is not what we want
$ echo ${TESTVAR[*]}
AD B C
$ TESTVAR+=("E")  # This is what we want
$ echo ${TESTVAR[*]}
AD B C E
```

This means we are getting a single CMake flag like `-DVELOX_ENABLE_BENCHMARKS=ON-DVELOX_ENABLE_CUDF=ON-DVELOX_ENABLE_FAISS=ON-DVELOX_ENABLE_REMOTE_FUNCTIONS=ON` with no spaces.
