### PR TITLE
build: Fix CuDF + Parquet test build failure

### DIFF
--- a/velox/experimental/cudf/tests/utils/ParquetConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/ParquetConnectorTestBase.cpp
@@ -67,7 +67,8 @@ ParquetConnectorTestBase::ParquetConnectorTestBase() {
 
 void ParquetConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
-  facebook::velox::connector::parquet::ParquetConnectorFactory factory;
+  facebook::velox::cudf_velox::connector::parquet::ParquetConnectorFactory
+      factory;
   auto parquetConnector = factory.newConnector(
       kParquetConnectorId,
       std::make_shared<facebook::velox::config::ConfigBase>(
@@ -89,7 +90,8 @@ void ParquetConnectorTestBase::resetParquetConnector(
     const std::shared_ptr<const facebook::velox::config::ConfigBase>& config) {
   facebook::velox::connector::unregisterConnector(kParquetConnectorId);
 
-  facebook::velox::connector::parquet::ParquetConnectorFactory factory;
+  facebook::velox::cudf_velox::connector::parquet::ParquetConnectorFactory
+      factory;
   auto parquetConnector =
       factory.newConnector(kParquetConnectorId, config, ioExecutor_.get());
   facebook::velox::connector::registerConnector(parquetConnector);


### PR DESCRIPTION
Fixes #14869

`connector::parquet::ParquetConnectorFactory` exists in `facebook::velox::cudf_velox` not `facebook::velox`.