### PR TITLE
feat(streaming): add streaming related support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,7 @@ option(
 )
 option(VELOX_SIMDJSON_SKIPUTF8VALIDATION "Skip simdjson utf8 validation in JSON parsing" OFF)
 option(VELOX_ENABLE_FAISS "Build faiss vector search support" OFF)
+option(VELOX_ENABLE_STREAMING "Build streaming related support" OFF)
 
 # Explicitly force compilers to generate colored output. Compilers usually do
 # this by default if they detect the output is a terminal, but this assumption

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -78,6 +78,10 @@ if(VELOX_ENABLE_WAVE OR VELOX_ENABLE_CUDF)
   endif()
 endif()
 
+if(VELOX_ENABLE_STREAMING)
+  add_subdirectory(experimental/streaming)
+endif()
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tool)
 endif()

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -796,21 +796,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Returns true if all the splits have finished.
   bool testingAllSplitsFinished();
 
- private:
-  // Hook of system-wide running task list.
-  struct TaskListEntry {
-    std::weak_ptr<Task> taskPtr;
-    folly::IntrusiveListHook listHook;
-  };
-  using TaskList =
-      folly::IntrusiveList<TaskListEntry, &TaskListEntry::listHook>;
-
-  // Returns the system-wide running task list.
-  FOLLY_EXPORT static TaskList& taskList();
-
-  // Returns the lock that protects the system-wide running task list.
-  FOLLY_EXPORT static folly::SharedMutex& taskListLock();
-
+ protected:
   Task(
       const std::string& taskId,
       core::PlanFragment planFragment,
@@ -823,6 +809,25 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Invoked to add this to the system-wide running task list on task creation.
   void addToTaskList();
+
+  // Invoked to initialize the memory pool for this task on creation.
+  void initTaskPool();
+
+ private:
+  // Hook of system-wide running task list.
+  struct TaskListEntry {
+    std::weak_ptr<Task> taskPtr;
+    folly::IntrusiveListHook listHook;
+  };
+
+  using TaskList =
+      folly::IntrusiveList<TaskListEntry, &TaskListEntry::listHook>;
+
+  // Returns the system-wide running task list.
+  FOLLY_EXPORT static TaskList& taskList();
+
+  // Returns the lock that protects the system-wide running task list.
+  FOLLY_EXPORT static folly::SharedMutex& taskListLock();
 
   // Invoked to remove this from the system-wide running task list on task
   // destruction.
@@ -865,9 +870,6 @@ class Task : public std::enable_shared_from_this<Task> {
   // Remove the spill directory, if the Task was creating it for potential
   // spilling.
   void removeSpillDirectoryIfExists();
-
-  // Invoked to initialize the memory pool for this task on creation.
-  void initTaskPool();
 
   // Creates a scaled scan controller for a given table scan node.
   void addScaledScanControllerLocked(

--- a/velox/experimental/streaming/CMakeLists.txt
+++ b/velox/experimental/streaming/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_add_library(
+  velox_streaming_exec
+  OBJECT
+  StreamingTask.cpp
+  StreamingPlanner.cpp
+  StreamingPlanNode.cpp
+  StreamingOperator.cpp
+  CombinedWatermarkStatus.cpp)
+
+velox_link_libraries(
+  velox_streaming_exec
+  PRIVATE
+  velox_common_base
+  velox_exec)

--- a/velox/experimental/streaming/CombinedWatermarkStatus.cpp
+++ b/velox/experimental/streaming/CombinedWatermarkStatus.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/streaming/CombinedWatermarkStatus.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::streaming {
+
+bool CombinedWatermarkStatus::updateWatermark(int index, long timestamp) {
+  VELOX_CHECK(index < partialWatermarks_.size(), "Index out of range");
+  auto& watermark = partialWatermarks_[index];
+
+  if (!watermark.setWatermark(timestamp)) {
+    return false;
+  }
+
+  // If the watermark is already set, we do not update it.
+  return updateCombinedWatermark();
+}
+
+long CombinedWatermarkStatus::getCombinedWatermark() {
+  return combinedWatermark_;
+}
+
+bool CombinedWatermarkStatus::updateCombinedWatermark() {
+  long minimumOverAll = LONG_MIN;
+  bool allIdle = true;
+  for (const auto& watermark : partialWatermarks_) {
+    if (!watermark.idle()) {
+      minimumOverAll = std::max(minimumOverAll, watermark.watermark());
+      allIdle = false;
+    }
+  }
+
+  idle_ = allIdle;
+  if (!allIdle && minimumOverAll > combinedWatermark_) {
+    combinedWatermark_ = minimumOverAll;
+    return true;
+  }
+
+  // If the new combined watermark is not greater, we do not update it.
+  return false;
+}
+
+bool PartialWatermark::setWatermark(long watermark) {
+  if (watermark < watermark_) {
+    // If the new watermark is less than or equal to the current one, we do not update it.
+    return false;
+  }
+
+  watermark_ = watermark;
+  idle_ = false;
+  return true;
+}
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/CombinedWatermarkStatus.h
+++ b/velox/experimental/streaming/CombinedWatermarkStatus.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <climits>
+#include <vector>
+
+namespace facebook::velox::streaming {
+
+class PartialWatermark;
+
+/**
+ * This class is used to calculate the watermark of an streaming operator.
+ * An operator may have several inputs, the watermark is the minimal one
+ * pushed down from all inputs.
+ */
+class CombinedWatermarkStatus {
+ public:
+  CombinedWatermarkStatus(int numWatermarks) {
+    partialWatermarks_.resize(numWatermarks);
+  }
+
+  bool updateWatermark(int index, long timestamp);
+
+  long getCombinedWatermark();
+
+ private:
+  bool updateCombinedWatermark();
+
+  std::vector<PartialWatermark> partialWatermarks_;
+  bool idle_ = false;
+  long combinedWatermark_ = LONG_MIN;
+};
+
+class PartialWatermark {
+ public:
+  bool setWatermark(long watermark);
+
+  bool idle() const {
+    return idle_;
+  }
+
+  long watermark() const {
+    return watermark_;
+  }
+
+  void setIdle(bool idle) {
+    idle_ = idle;
+  }
+
+ private:
+  long watermark_ = LONG_MIN;
+  bool idle_ = false;
+};
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamElement.h
+++ b/velox/experimental/streaming/StreamElement.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::streaming {
+
+/**
+ * Streaming operators may be RowVector or Watermark, and it may need
+ * some additional info to tell the caller who generate the result.
+ */
+class StreamElement {
+ public:
+  StreamElement(std::string nodeId) : nodeId_(std::move(nodeId)) {}
+
+  virtual bool isWatermark() = 0;
+
+  virtual bool isRecord() = 0;
+
+  const std::string nodeId() const {
+    return nodeId_;
+  }
+
+ private:
+  // Node ID of the operator that generates this element.
+  const std::string nodeId_;
+};
+
+using StreamElementPtr = std::shared_ptr<StreamElement>;
+
+class Watermark :  public StreamElement {
+ public:
+  Watermark(std::string nodeId, long timestamp)
+      : StreamElement(nodeId), timestamp_(timestamp) {}
+
+  long timestamp() const {
+    return timestamp_;
+  }
+
+  bool isWatermark() override {
+    return true;
+  }
+
+  bool isRecord() override {
+    return false;
+  }
+
+ private:
+  const long timestamp_;
+};
+
+class StreamRecord :  public StreamElement {
+ public:
+  StreamRecord(std::string nodeId, RowVectorPtr record)
+      : StreamElement(nodeId),
+        record_(std::move(record)),
+        timestamp_(-1),
+        hasTimestamp_(false),
+        key_(-1) {}
+
+  StreamRecord(std::string nodeId, RowVectorPtr record, long timestamp)
+      : StreamElement(nodeId),
+        record_(std::move(record)),
+        timestamp_(timestamp),
+        hasTimestamp_(true),
+        key_(-1) {}
+
+  StreamRecord(std::string nodeId, int key, RowVectorPtr record)
+      : StreamElement(nodeId),
+        record_(std::move(record)),
+        timestamp_(-1),
+        hasTimestamp_(false),
+        key_(key) {}
+
+  const RowVectorPtr& record() const {
+    return record_;
+  }
+
+  long timestamp() const {
+    return timestamp_;
+  }
+
+  int key() const {
+    return key_;
+  }
+
+  bool isWatermark() override {
+    return false;
+  }
+
+  bool isRecord() override {
+    return true;
+  }
+
+  bool hasTimestamp() const {
+    return hasTimestamp_;
+  }
+
+ private:
+  const RowVectorPtr record_;
+  const long timestamp_;
+  bool hasTimestamp_ = false;
+  const int key_;
+};
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingOperator.cpp
+++ b/velox/experimental/streaming/StreamingOperator.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/streaming/StreamingOperator.h"
+#include "velox/experimental/streaming/StreamingTask.h"
+#include "velox/experimental/streaming/StreamElement.h"
+
+#include <iostream>
+
+namespace facebook::velox::streaming {
+
+void StreamingOperator::initialize() {
+  operator_->initialize();
+  for (auto& target : targets_) {
+    target->initialize();
+  }
+  combinedWatermarkStatus_ = std::make_shared<CombinedWatermarkStatus>(numInputs());
+}
+  
+bool StreamingOperator::isFinished() {
+  return operator_->isFinished();
+}
+
+void StreamingOperator::addInput(RowVectorPtr input) {
+  operator_->traceInput(input);
+  operator_->addInput(std::move(input));
+}
+
+bool StreamingOperator::sourceEmpty() {
+  return sourceEmpty_;
+}
+
+void StreamingOperator::close() {
+  operator_->close();
+  for (auto& target : targets_) {
+    target->close();
+  }
+  operator_.reset();
+  targets_.clear();
+}
+
+void StreamingOperator::getOutput() {
+  sourceEmpty_ = true;
+  auto intermediateResult = operator_->getOutput();
+  if (!intermediateResult) {
+    return;
+  }
+  sourceEmpty_ = false;
+  pushOutput(std::move(intermediateResult));
+}
+
+void StreamingOperator::pushOutput(RowVectorPtr output) {
+  if (targets_.empty()) {
+    auto outNodeId = operator_->planNodeId();
+    auto task = std::static_pointer_cast<StreamingTask>(operator_->operatorCtx()->driverCtx()->task);
+    task->addOutput(std::make_shared<StreamRecord>(outNodeId, std::move(output)));
+    return;
+  }
+  for (int i = 0; i < targets_.size(); i++) {
+    targets_[i]->addInput(output);
+    targets_[i]->getOutput();
+  }
+}
+
+void StreamingOperator::pushWatermark(long timestamp, int index) {
+  // watermark need not to be written to sink.
+  if (isSink())
+    return;
+  if (targets_.empty()) {
+    auto outNodeId = operator_->planNodeId();
+    auto task = std::static_pointer_cast<StreamingTask>(operator_->operatorCtx()->driverCtx()->task);
+    task->addOutput(std::make_shared<Watermark>(outNodeId, timestamp));
+    return;
+  }
+  for (int i = 0; i < targets_.size(); i++) {
+    targets_[i]->processWatermark(timestamp, index);
+  }
+}
+
+void StreamingOperator::processWatermark(long timestamp, int index) {
+  if (combinedWatermarkStatus_->updateWatermark(index - 1, timestamp)) {
+    long combinedWatermark = combinedWatermarkStatus_->getCombinedWatermark();
+    // If the watermark is updated, we need to notify the operator,
+    // it may need to do something, e.g. advance the timer service or tirgger the window.
+    processWatermarkInternal(combinedWatermark);
+    pushWatermark(combinedWatermark, 1);
+  }
+}
+
+void StreamingOperator::snapshotState(long checkpointId) {
+  // TODO: not impltemented yet
+}
+
+void StreamingOperator::notifyCheckpointComplete(long checkpointId) {
+  // TODO: not impltemented yet
+}
+
+void StreamingOperator::notifyCheckpointAborted(long checkpointId) {
+  // TODO: not impltemented yet
+}
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingOperator.h
+++ b/velox/experimental/streaming/StreamingOperator.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/experimental/streaming/CombinedWatermarkStatus.h"
+
+namespace facebook::velox::streaming {
+
+/**
+ * This class is to support streaming engines. Unlike batch jobs,
+ * operators in streaming jobs may have several outputs,
+ * so the pull mode of velox that downstream call its upstream to get output
+ * will not fit for it. We need to use push mode that sources
+ * an output, and then push to its downstreams and so on.
+ *
+ * StreamingOperator is designed to hold the state and an velox operator,
+ * it gives the state and input to velox operator to calculate the result.
+ * For example, Streaming Top1 node gets the previous result from state,
+ * and then call TopN operator to get new result, and at last update the state.
+ */
+class StreamingOperator {
+ public:
+  StreamingOperator(
+      std::unique_ptr<exec::Operator> op,
+      std::vector<std::unique_ptr<StreamingOperator>> targets)
+      : operator_(std::move(op)),
+        targets_(std::move(targets)) {
+    isSink_ = operator_->operatorType() == "TableWrite";
+  }
+
+  virtual void initialize();
+
+  virtual bool isFinished();
+
+  virtual void addInput(RowVectorPtr input);
+
+  virtual void getOutput();
+
+  bool sourceEmpty();
+
+  virtual void close();
+
+  void processWatermark(long timestamp, int index);
+
+  void snapshotState(long checkpointId);
+
+  void notifyCheckpointComplete(long checkpointId);
+
+  void notifyCheckpointAborted(long checkpointId);
+
+  virtual std::string name() const {
+    return operator_->operatorType();
+  }
+
+ protected:
+  void pushOutput(RowVectorPtr output);
+  void pushWatermark(long timestamp, int index);
+  virtual void processWatermarkInternal(long timestamp) {}
+
+  virtual int numInputs() const {
+    return 1;
+  }
+
+  std::unique_ptr<exec::Operator>& op() {
+    return operator_;
+  }
+
+ private:
+  bool isSink() {
+    return isSink_;
+  }
+
+  std::unique_ptr<exec::Operator> operator_;
+  std::vector<std::unique_ptr<StreamingOperator>> targets_;
+  bool isSink_;
+  bool sourceEmpty_ = true;
+  std::shared_ptr<CombinedWatermarkStatus> combinedWatermarkStatus_;
+};
+
+using StreamingOperatorPtr = std::unique_ptr<StreamingOperator>;
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingPlanNode.cpp
+++ b/velox/experimental/streaming/StreamingPlanNode.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/streaming/StreamingPlanNode.h"
+
+namespace facebook::velox::streaming {
+
+const std::vector<core::PlanNodePtr>& StreamingPlanNode::sources() const {
+  return node_->sources();
+}
+
+void StreamingPlanNode::addDetails(std::stringstream& stream) const {
+  stream << "Node: " << node_->toString(true, true);
+  stream << "Targets: [" << std::endl;
+  for (auto target : targets_) {
+    stream << target->toString(true, true) << "," << std::endl;
+  }
+  stream << "]" << std::endl;
+}
+
+folly::dynamic StreamingPlanNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["node"] = node_->serialize();
+  obj["targets"] = folly::dynamic::array;
+  for (const auto& target : targets_) {
+    obj["targets"].push_back(target->serialize());
+  }
+  return obj;
+}
+
+// static
+core::PlanNodePtr StreamingPlanNode::create(const folly::dynamic& obj, void* context) {
+  auto node = ISerializable::deserialize<core::PlanNode>(
+      obj["node"], context);
+  auto targets = std::vector<core::PlanNodePtr>();
+  if (obj.count("targets")) {
+    targets = ISerializable::deserialize<std::vector<core::PlanNode>>(
+        obj["targets"], context);
+  }
+
+  return std::make_shared<const StreamingPlanNode>(std::move(node), std::move(targets));
+}
+
+void StreamingPlanNode::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+
+  registry.Register("StreamingPlanNode", StreamingPlanNode::create);
+}
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingPlanNode.h
+++ b/velox/experimental/streaming/StreamingPlanNode.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+namespace facebook::velox::streaming {
+
+class StreamingPlanNode : public core::PlanNode {
+ public:
+  StreamingPlanNode(
+    const core::PlanNodePtr& node,
+    const std::vector<core::PlanNodePtr>& targets)
+    : PlanNode(node->id()), node_(std::move(node)), targets_(targets) {}
+
+  const RowTypePtr& outputType() const override {
+      return node_->outputType();
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override;
+
+  std::string_view name() const override {
+    return node_->name();
+  }
+
+  bool requiresSplits() const override {
+    return node_->requiresSplits();
+  }
+
+  static void registerSerDe();
+
+  folly::dynamic serialize() const override;
+
+  static core::PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+  const core::PlanNodePtr node() const {
+    return node_;
+  }
+
+  const std::vector<core::PlanNodePtr> targets() const {
+    return targets_;
+  }
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  const core::PlanNodePtr node_;
+  const std::vector<core::PlanNodePtr> targets_;
+};
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingPlanner.cpp
+++ b/velox/experimental/streaming/StreamingPlanner.cpp
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/PlanFragment.h"
+#include "velox/exec/AssignUniqueId.h"
+#include "velox/exec/CallbackSink.h"
+#include "velox/exec/EnforceSingleRow.h"
+#include "velox/exec/Exchange.h"
+#include "velox/exec/Expand.h"
+#include "velox/exec/FilterProject.h"
+#include "velox/exec/GroupId.h"
+#include "velox/exec/HashAggregation.h"
+#include "velox/exec/HashBuild.h"
+#include "velox/exec/HashProbe.h"
+#include "velox/exec/IndexLookupJoin.h"
+#include "velox/exec/Limit.h"
+#include "velox/exec/MarkDistinct.h"
+#include "velox/exec/Merge.h"
+#include "velox/exec/MergeJoin.h"
+#include "velox/exec/NestedLoopJoinBuild.h"
+#include "velox/exec/NestedLoopJoinProbe.h"
+#include "velox/exec/OrderBy.h"
+#include "velox/exec/RoundRobinPartitionFunction.h"
+#include "velox/exec/RowNumber.h"
+#include "velox/exec/StreamingAggregation.h"
+#include "velox/exec/TableScan.h"
+#include "velox/exec/TableWriteMerge.h"
+#include "velox/exec/TableWriter.h"
+#include "velox/exec/Task.h"
+#include "velox/exec/TopN.h"
+#include "velox/exec/TopNRowNumber.h"
+#include "velox/exec/Unnest.h"
+#include "velox/exec/Values.h"
+#include "velox/exec/Window.h"
+#include "velox/experimental/streaming/StreamingPlanner.h"
+#include "velox/experimental/streaming/StreamingPlanNode.h"
+
+namespace facebook::velox::streaming {
+
+static std::atomic<int> opId = 0;
+
+// static
+StreamingOperatorPtr StreamingPlanner::plan(
+    const core::PlanFragment& planFragment,
+    exec::DriverCtx* ctx) {
+  return nodeToStreamingOperator(planFragment.planNode, ctx);
+}
+
+//static
+StreamingOperatorPtr StreamingPlanner::nodeToStreamingOperator(
+    const core::PlanNodePtr& planNode,
+    exec::DriverCtx* ctx) {
+  auto streamingNode =
+      std::dynamic_pointer_cast<const StreamingPlanNode>(planNode);
+  VELOX_CHECK(streamingNode, "Not streaming node: {}", planNode->toString());
+  std::vector<StreamingOperatorPtr> targets;
+  std::unique_ptr<exec::Operator> op = std::move(nodeToOperator(streamingNode->node(), ctx));
+  for (auto target : streamingNode->targets()) {
+    targets.push_back(std::move(nodeToStreamingOperator(target, ctx)));
+  }
+  return std::make_unique<StreamingOperator>(std::move(op), std::move(targets));
+}
+
+//static
+std::unique_ptr<exec::Operator> StreamingPlanner::nodeToOperator(
+    const core::PlanNodePtr& planNode,
+    exec::DriverCtx* ctx) {
+  if (auto filterNode =
+      std::dynamic_pointer_cast<const core::FilterNode>(planNode)) {
+    if (planNode->sources().size() == 1) {
+      auto next = planNode->sources()[0];
+      if (auto projectNode =
+          std::dynamic_pointer_cast<const core::ProjectNode>(next)) {
+        return std::make_unique<exec::FilterProject>(
+            opId.fetch_add(1),
+            ctx,
+            filterNode,
+            projectNode);
+      }
+    }
+    return std::make_unique<exec::FilterProject>(opId.fetch_add(1), ctx, filterNode, nullptr);
+  } else if (
+      auto projectNode =
+          std::dynamic_pointer_cast<const core::ProjectNode>(planNode)) {
+    return std::make_unique<exec::FilterProject>(opId.fetch_add(1), ctx, nullptr, projectNode);
+  } else if (
+      auto valuesNode =
+          std::dynamic_pointer_cast<const core::ValuesNode>(planNode)) {
+    return std::make_unique<exec::Values>(opId.fetch_add(1), ctx, valuesNode);
+  } else if (
+      auto tableScanNode =
+          std::dynamic_pointer_cast<const core::TableScanNode>(planNode)) {
+    return std::make_unique<exec::TableScan>(opId.fetch_add(1), ctx, tableScanNode);
+  } else if (
+      auto tableWriteNode =
+          std::dynamic_pointer_cast<const core::TableWriteNode>(planNode)) {
+      return std::make_unique<exec::TableWriter>(opId.fetch_add(1), ctx, tableWriteNode);
+  } else if (
+      auto tableWriteMergeNode =
+          std::dynamic_pointer_cast<const core::TableWriteMergeNode>(planNode)) {
+    return std::make_unique<exec::TableWriteMerge>(opId.fetch_add(1), ctx, tableWriteMergeNode);
+  } else if (
+      auto joinNode =
+          std::dynamic_pointer_cast<const core::HashJoinNode>(planNode)) {
+    return std::make_unique<exec::HashProbe>(opId.fetch_add(1), ctx, joinNode);
+  } else if (
+      auto joinNode =
+          std::dynamic_pointer_cast<const core::NestedLoopJoinNode>(planNode)) {
+    return std::make_unique<exec::NestedLoopJoinProbe>(opId.fetch_add(1), ctx, joinNode);
+  } else if (
+      auto joinNode =
+          std::dynamic_pointer_cast<const core::IndexLookupJoinNode>(planNode)) {
+    return std::make_unique<exec::IndexLookupJoin>(opId.fetch_add(1), ctx, joinNode);
+  } else if (
+      auto aggregationNode =
+          std::dynamic_pointer_cast<const core::AggregationNode>(planNode)) {
+    if (aggregationNode->isPreGrouped()) {
+      return std::make_unique<exec::StreamingAggregation>(opId.fetch_add(1), ctx, aggregationNode);
+    } else {
+      return std::make_unique<exec::HashAggregation>(opId.fetch_add(1), ctx, aggregationNode);
+    }
+  } else if (
+      auto expandNode =
+          std::dynamic_pointer_cast<const core::ExpandNode>(planNode)) {
+    return std::make_unique<exec::Expand>(opId.fetch_add(1), ctx, expandNode);
+  } else if (
+      auto groupIdNode =
+          std::dynamic_pointer_cast<const core::GroupIdNode>(planNode)) {
+    return std::make_unique<exec::GroupId>(opId.fetch_add(1), ctx, groupIdNode);
+  } else if (
+      auto topNNode =
+          std::dynamic_pointer_cast<const core::TopNNode>(planNode)) {
+      return std::make_unique<exec::TopN>(opId.fetch_add(1), ctx, topNNode);
+  } else if (
+      auto limitNode =
+          std::dynamic_pointer_cast<const core::LimitNode>(planNode)) {
+    return std::make_unique<exec::Limit>(opId.fetch_add(1), ctx, limitNode);
+  } else if (
+      auto orderByNode =
+          std::dynamic_pointer_cast<const core::OrderByNode>(planNode)) {
+    return std::make_unique<exec::OrderBy>(opId.fetch_add(1), ctx, orderByNode);
+  } else if (
+      auto windowNode =
+          std::dynamic_pointer_cast<const core::WindowNode>(planNode)) {
+    return std::make_unique<exec::Window>(opId.fetch_add(1), ctx, windowNode);
+  } else if (
+      auto rowNumberNode =
+          std::dynamic_pointer_cast<const core::RowNumberNode>(planNode)) {
+    return std::make_unique<exec::RowNumber>(opId.fetch_add(1), ctx, rowNumberNode);
+  } else if (
+      auto topNRowNumberNode =
+          std::dynamic_pointer_cast<const core::TopNRowNumberNode>(planNode)) {
+    return std::make_unique<exec::TopNRowNumber>(opId.fetch_add(1), ctx, topNRowNumberNode);
+  } else if (
+      auto markDistinctNode =
+          std::dynamic_pointer_cast<const core::MarkDistinctNode>(planNode)) {
+    return std::make_unique<exec::MarkDistinct>(opId.fetch_add(1), ctx, markDistinctNode);
+  } else if (
+      auto mergeJoin =
+          std::dynamic_pointer_cast<const core::MergeJoinNode>(planNode)) {
+    auto mergeJoinOp = std::make_unique<exec::MergeJoin>(opId.fetch_add(1), ctx, mergeJoin);
+    ctx->task->createMergeJoinSource(ctx->splitGroupId, mergeJoin->id());
+    return std::move(mergeJoinOp);
+  } else if (
+      auto unnest =
+          std::dynamic_pointer_cast<const core::UnnestNode>(planNode)) {
+    return std::make_unique<exec::Unnest>(opId.fetch_add(1), ctx, unnest);
+  } else if (
+      auto enforceSingleRow =
+          std::dynamic_pointer_cast<const core::EnforceSingleRowNode>(planNode)) {
+    return std::make_unique<exec::EnforceSingleRow>(opId.fetch_add(1), ctx, enforceSingleRow);
+  } else if (
+      auto assignUniqueIdNode =
+          std::dynamic_pointer_cast<const core::AssignUniqueIdNode>(planNode)) {
+    return std::make_unique<exec::AssignUniqueId>(
+        opId.fetch_add(1),
+        ctx,
+        assignUniqueIdNode,
+        assignUniqueIdNode->taskUniqueId(),
+        assignUniqueIdNode->uniqueIdCounter());
+  } else {
+    std::unique_ptr<exec::Operator> extended;
+    extended = exec::Operator::fromPlanNode(ctx, opId.fetch_add(1), planNode);
+    VELOX_CHECK(extended, "Unsupported plan node: {}", planNode->toString());
+    return extended;
+  }
+}
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingPlanner.h
+++ b/velox/experimental/streaming/StreamingPlanner.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/experimental/streaming/StreamingOperator.h"
+
+namespace facebook::velox::core {
+struct PlanFragment;
+} // namespace facebook::velox::core
+
+namespace facebook::velox::streaming {
+
+class StreamingPlanner {
+
+ public:
+  // Create streaming operator chain according to plan.
+  static StreamingOperatorPtr plan(
+      const core::PlanFragment& planFragment,
+      exec::DriverCtx* ctx);
+
+ private:
+  static std::unique_ptr<StreamingOperator> nodeToStreamingOperator(
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx);
+
+  static std::unique_ptr<exec::Operator> nodeToOperator(
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx);
+};
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingTask.cpp
+++ b/velox/experimental/streaming/StreamingTask.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/streaming/StreamingPlanner.h"
+#include "velox/experimental/streaming/StreamingTask.h"
+
+#include <iostream>
+
+namespace facebook::velox::streaming {
+
+// static
+std::shared_ptr<StreamingTask> StreamingTask::create(
+    const std::string& taskId,
+    core::PlanFragment planFragment,
+    std::shared_ptr<core::QueryCtx> queryCtx) {
+  VELOX_CHECK_NOT_NULL(planFragment.planNode);
+  auto task = std::shared_ptr<StreamingTask>(new StreamingTask(
+      taskId,
+      std::move(planFragment),
+      std::move(queryCtx)));
+  task->initTaskPool();
+  task->addToTaskList();
+  return task;
+}
+
+StreamingTask::StreamingTask(
+    const std::string& taskId,
+    core::PlanFragment planFragment,
+    std::shared_ptr<core::QueryCtx> queryCtx)
+    : exec::Task(
+          taskId,
+          std::move(planFragment),
+          0,
+          std::move(queryCtx),
+          exec::Task::ExecutionMode::kSerial,
+          nullptr,
+          0,
+          nullptr) {
+}
+
+StreamingTask::~StreamingTask() {
+}
+
+void StreamingTask::init() {
+  initOperators();
+  operatorChain_->initialize();
+}
+
+void StreamingTask::initOperators() {
+  auto self = shared_from_this();
+  // Create the operators.
+  VELOX_CHECK_NULL(operatorChain_);
+  auto driverCtx = std::make_unique<exec::DriverCtx>(self, 0, 0, -1, 0);
+  driver = exec::Driver::testingCreate(std::move(driverCtx));
+  operatorChain_ =
+      std::move(StreamingPlanner::plan(planFragment(), driver->driverCtx()));
+}
+
+StreamElementPtr StreamingTask::next(int32_t& retCode) {
+  retCode = 0;
+
+  if (!pendings_.empty()) {
+    return std::move(popOutput());
+  } else if (state() == exec::TaskState::kFinished) {
+    // If the task is already finished, return null and 1 for retCode.
+    retCode = 1;
+    return nullptr;
+  }
+
+  // Run operators one by one. If an operator has output, run its downstream operators.
+  // If the last operator has output, return the output.
+  // If source operator has no output, check whether it is finished.
+  // If source is finished, return null and 1 for rerCode, else return null and 0 for retCode.
+  for (;;) {
+    VELOX_CHECK_EQ(
+        state(), exec::TaskState::kRunning, "Task has already finished processing.");
+
+    operatorChain_->getOutput();
+    if (pendings_.empty()) {
+      if (operatorChain_->isFinished()) {
+        finish();
+        // finish may trigger window flush and generate output.
+        if (pendings_.empty()) {
+          retCode = 1;
+          return nullptr;
+        }
+      } else if (operatorChain_->sourceEmpty()) {
+        return nullptr;
+      } else {
+        continue;
+      }
+    }
+    return std::move(popOutput());
+  }
+}
+
+void StreamingTask::addOutput(StreamElementPtr output) {
+  pendings_.push_back(std::move(output));
+}
+
+void StreamingTask::notifyWatermark(long watermark, int index) {
+  operatorChain_->processWatermark(watermark, index);
+}
+
+void StreamingTask::snapshotState(long checkpointId) {
+  operatorChain_->snapshotState(checkpointId);
+}
+
+void StreamingTask::notifyCheckpointComplete(long checkpointId) {
+  operatorChain_->notifyCheckpointComplete(checkpointId);
+}
+
+void StreamingTask::notifyCheckpointAborted(long checkpointId) {
+  operatorChain_->notifyCheckpointAborted(checkpointId);
+}
+
+StreamElementPtr StreamingTask::popOutput() {
+  auto out = std::move(pendings_.front());
+  pendings_.pop_front();
+  return out;
+}
+
+void StreamingTask::finish() {
+  VELOX_CHECK(
+      pendings_.empty(),
+      "Outputs have {} not been consumed before finishing the task.",
+      pendings_.size());
+  operatorChain_->close();
+  // TODO: update operator stats
+
+  // remove operators to release memory.
+  operatorChain_.reset();
+  driver.reset();
+  testingFinish();
+}
+
+} // namespace facebook::velox::streaming

--- a/velox/experimental/streaming/StreamingTask.h
+++ b/velox/experimental/streaming/StreamingTask.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/exec/Task.h"
+#include "velox/experimental/streaming/StreamingOperator.h"
+#include "velox/experimental/streaming/StreamElement.h"
+
+namespace facebook::velox::streaming {
+
+/**
+ * StreamingTask is used to support streaming engines such as Flink.
+ * It only runs in a streaming mode, which call next and get a result once,
+ * also, it needs to handle state operations  
+ * Make it based on Task to reuse context releated classes.
+ */
+class StreamingTask : public exec::Task {
+ public:
+
+  /// Creates a streaming task to execute a plan fragment, but doesn't start execution
+  /// until StreamingTask::next() method is called.
+  /// @param taskId Unique task identifier.
+  /// @param planFragment Plan fragment.
+  /// @param queryCtx Query context containing MemoryPool and MemoryAllocator
+  /// instances to use for memory allocations during execution, executor to
+  /// schedule operators on, and session properties.
+  /// execution fails.
+  static std::shared_ptr<StreamingTask> create(
+      const std::string& taskId,
+      core::PlanFragment planFragment,
+      std::shared_ptr<core::QueryCtx> queryCtx);
+
+  ~StreamingTask();
+
+  /// Single-threaded execution API. Runs the query and returns results one
+  /// batch at a time. Returns nullptr and retCode 1 if query evaluation is finished and no
+  /// more data will be produced, return nullptt and retCode 0 is no data produced for this batch.
+  ///  Throws an exception if query execution failed.
+  ///
+  /// This API is available for streaming plans such as Flink.
+  ///
+  /// The caller is required to add all the necessary splits, and signal
+  /// no-more-splits before calling 'next' for the first time.
+  StreamElementPtr next(int32_t& retCode);
+
+  void notifyWatermark(long watermark, int index);
+
+  void snapshotState(long checkpointId);
+
+  void notifyCheckpointComplete(long checkpointId);
+
+  void notifyCheckpointAborted(long checkpointId);
+
+  void init();
+
+  // The task is finished, close all operators and reset driver
+  void finish();
+
+  void addOutput(StreamElementPtr element);
+
+ private:
+ 
+  StreamingTask(
+      const std::string& taskId,
+      core::PlanFragment planFragment,
+      std::shared_ptr<core::QueryCtx> queryCtx);
+
+  void initOperators();
+
+  void initStateBackend();
+
+  StreamElementPtr popOutput();
+
+  std::unique_ptr<StreamingOperator> operatorChain_;
+
+  // A task may have multi outputs once run,
+  // store them and return one by one.
+  std::list<StreamElementPtr> pendings_;
+
+  // hold the driver only to avoid it be released.
+  std::shared_ptr<exec::Driver> driver;
+};
+
+} // namespace facebook::velox::streaming


### PR DESCRIPTION
As proposed in https://github.com/facebookincubator/velox/discussions/14793, we try to make velox can support streaming engine like Flink.
Streaming processing has some difference with batch. 
1. A streaming task may contains some streaming operators, and a record is passed down from one operator to its downstreams at once without persistant. So the pull based mode of velox that sink call its source to get the output and so on doesn't fit for streaming. Instead, we should use the pushed based mode, that source generate outputs continously, and then push the records to its targets.
2. Streaming processing need state and watermark, some operators may store the temporary result in state and then calculate a result with the state and new coming input. Watermark may be used to trigger a window or finish a partition.
In this pr, we create the base framework to support streaming.
The class StreamingTask is used to manage the pushed based processing, it return a result every time called next(). It also has some state related method like snapshot().
StreamingOperator is used to manager the processing logic. Velox now have many operators, but they are all stateless, we hope we can hold the state in StreamingOperator, and reuse the existing operator to computing with input and state. This may need to modify some operators a little, as some operators like Aggs may only output when input finish, but streaming never finish.
StreamingPlanNode is used to help build the streaming graph accoring pushed model.
The result return to streaming framework may be a RowVector or a Watermark, so we use StreamRecord as the result.