### PR TITLE
refactor: Reuse SplitReader::createRowReader in Meta internal SplitReader implementation

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -170,7 +170,7 @@ void SplitReader::prepareSplit(
     return;
   }
 
-  createRowReader(std::move(metadataFilter), std::move(rowType));
+  createRowReader(std::move(metadataFilter), std::move(rowType), std::nullopt);
 }
 
 void SplitReader::setBucketConversion(
@@ -368,7 +368,8 @@ bool SplitReader::checkIfSplitIsEmpty(
 
 void SplitReader::createRowReader(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
-    RowTypePtr rowType) {
+    RowTypePtr rowType,
+    std::optional<bool> rowSizeTrackingEnabled) {
   VELOX_CHECK_NULL(baseRowReader_);
   configureRowReaderOptions(
       hiveTableHandle_->tableParameters(),
@@ -380,7 +381,9 @@ void SplitReader::createRowReader(
       connectorQueryCtx_->sessionProperties(),
       baseRowReaderOpts_);
   baseRowReaderOpts_.setTrackRowSize(
-      connectorQueryCtx_->rowSizeTrackingEnabled());
+      rowSizeTrackingEnabled.has_value()
+          ? *rowSizeTrackingEnabled
+          : connectorQueryCtx_->rowSizeTrackingEnabled());
   baseRowReader_ = baseReader_->createRowReader(baseRowReaderOpts_);
 }
 

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -147,7 +147,8 @@ class SplitReader {
   /// ColumnReaders that will be used to read the data
   void createRowReader(
       std::shared_ptr<common::MetadataFilter> metadataFilter,
-      RowTypePtr rowType);
+      RowTypePtr rowType,
+      std::optional<bool> rowSizeTrackingEnabled);
 
   const folly::F14FastSet<column_index_t>& bucketChannels() const {
     return bucketChannels_;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -66,7 +66,7 @@ void IcebergSplitReader::prepareSplit(
     return;
   }
 
-  createRowReader(std::move(metadataFilter), std::move(rowType));
+  createRowReader(std::move(metadataFilter), std::move(rowType), std::nullopt);
 
   std::shared_ptr<const HiveIcebergSplit> icebergSplit =
       std::dynamic_pointer_cast<const HiveIcebergSplit>(hiveSplit_);


### PR DESCRIPTION
Summary: So that any future change on `createRowReader` will not be forgotten.

Differential Revision: D82544173


