### PR TITLE
feat: Extend PlanConsistencyChecker to check AggregationNode

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1103,14 +1103,14 @@ class AggregationNode : public PlanNode {
 
     /// Optional name of input column to use as a mask. Column type must be
     /// BOOLEAN.
-    FieldAccessTypedExprPtr mask;
+    FieldAccessTypedExprPtr mask{};
 
     /// Optional list of input columns to sort by before applying aggregate
     /// function.
-    std::vector<FieldAccessTypedExprPtr> sortingKeys;
+    std::vector<FieldAccessTypedExprPtr> sortingKeys{};
 
     /// A list of sorting orders that goes together with 'sortingKeys'.
-    std::vector<SortOrder> sortingOrders;
+    std::vector<SortOrder> sortingOrders{};
 
     /// Boolean indicating whether inputs must be de-duplicated before
     /// aggregating.


### PR DESCRIPTION
Summary:
- Verify aggregate names are unique and not empty;
- Verify all expressions used in grouping keys, aggregates, mask, sorting keys are referencing existing input columns.

Differential Revision: D82561483


