### PR TITLE
build: Fix TpcdsConnector error "'this' pointer is null"

### DIFF
--- a/velox/connectors/tpcds/TpcdsConnector.cpp
+++ b/velox/connectors/tpcds/TpcdsConnector.cpp
@@ -65,7 +65,7 @@ TpcdsDataSource::TpcdsDataSource(
         handle,
         "ColumnHandle must be an instance of TpcdsColumnHandle "
         "for '{}' on table '{}'",
-        handle->name(),
+        it->second->name(),
         toTableName(table_));
 
     auto idx = tpcdsTableSchema->getChildIdxIfExists(handle->name());


### PR DESCRIPTION
The error message when building Velox:

```
FAILED: velox/buffer/CMakeFiles/velox.dir/__/connectors/tpcds/TpcdsConnector.cpp.o
/usr/bin/ccache /usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DGEOS_INLINE -DGFLAGS_IS_A_DLL=0 -DNDEBUG -DSIMDJSON_EXPERIMENTAL_ALLOW_INCOMPLETE_JSON -DSIMDJSON_THREADS_ENABLED=1 -DUSE_UNSTABLE_GEOS_CPP_API -DVELOX_DISABLE_GOOGLETEST -DVELOX_ENABLE_COMPRESSION_LZ4 -DVELOX_ENABLE_GEO -DVELOX_ENABLE_PARQUET -I/opt/gluten/ep/build-velox/build/velox_ep/. -I/opt/gluten/ep/build-velox/build/velox_ep/velox/external/xxhash -I/opt/gluten/ep/build-velox/build/velox_ep/_build/release -I/opt/gluten/ep/build-velox/build/velox_ep/velox/tpch/gen/dbgen/include -I/opt/gluten/ep/build-velox/build/velox_ep/velox/tpcds/gen/dsdgen/include -isystem /opt/gluten/ep/build-velox/build/velox_ep/velox -isystem /opt/gluten/ep/build-velox/build/velox_ep/velox/external -isystem /usr/include/libdwarf -isystem /usr/include/double-conversion -isystem /opt/gluten/ep/_ep/arrow_ep/cpp/_build/thrift_ep-install/include -isystem /usr/local/include/geos -Wno-error=stringop-overflow -Wno-error=cpp -Wno-missing-field-initializers -Wno-unknown-warning-option -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -DFOLLY_CFG_NO_COROUTINES -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-implicit-fallthrough          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -Werror -O3 -DNDEBUG -std=gnu++20 -fPIC -fdiagnostics-color=always -pthread -ffp-contract=off -MD -MT velox/buffer/CMakeFiles/velox.dir/__/connectors/tpcds/TpcdsConnector.cpp.o -MF velox/buffer/CMakeFiles/velox.dir/__/connectors/tpcds/TpcdsConnector.cpp.o.d -o velox/buffer/CMakeFiles/velox.dir/__/connectors/tpcds/TpcdsConnector.cpp.o -c /opt/gluten/ep/build-velox/build/velox_ep/velox/connectors/tpcds/TpcdsConnector.cpp
In file included from /opt/gluten/ep/build-velox/build/velox_ep/./velox/common/Enums.h:19,
                 from /opt/gluten/ep/build-velox/build/velox_ep/./velox/connectors/Connector.h:19,
                 from /opt/gluten/ep/build-velox/build/velox_ep/./velox/connectors/tpcds/TpcdsConnector.h:19,
                 from /opt/gluten/ep/build-velox/build/velox_ep/velox/connectors/tpcds/TpcdsConnector.cpp:19:
/opt/gluten/ep/build-velox/build/velox_ep/velox/connectors/tpcds/TpcdsConnector.cpp: In constructor ‘facebook::velox::connector::tpcds::TpcdsDataSource::TpcdsDataSource(const std::shared_ptr<const facebook::velox::RowType>&, const std::shared_ptr<const facebook::velox::connector::ConnectorTableHandle>&, const std::unordered_map<std::__cxx11::basic_string<char>, std::shared_ptr<const facebook::velox::connector::ColumnHandle> >&, facebook::velox::memory::MemoryPool*)’:
/opt/gluten/ep/build-velox/build/velox_ep/velox/connectors/tpcds/TpcdsConnector.cpp:68:21: error: ‘this’ pointer is null [-Werror=nonnull]
   68 |         handle->name(),
      |         ~~~~~~~~~~~~^~
```

The environment:

```
Velox System Info v0.0.2
Commit: c0227b40b88af7dbb44eb7a7755825cdb418b0fc
CMake Version: 3.28.3
System: Linux-6.1.141-155.222.amzn2023.x86_64
Arch: x86_64
C++ Compiler: /usr/bin/c++
C++ Compiler Version: 13.3.0
C Compiler: /usr/bin/cc
C Compiler Version: 13.3.0
CMake Prefix Path: /usr/local;/usr;/;/root/.local/share/uv/tools/cmake/lib/python3.12/site-packages/cmake/data;/usr/local;/usr/X11R6;/usr/pkg;/opt
```

I haven't figured out why the error only happens in one specific build environment of mine, but apparently the build error is reasonable and we should fix it.