### PR TITLE
fix: Avoid vector reallocation in Presto serializer (#14882)

### DIFF
--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -139,6 +139,7 @@ void serializeWrappedRanges(
     VectorStream* stream,
     Scratch& scratch) {
   std::vector<IndexRange> newRanges;
+  newRanges.reserve(rangesTotalSize(ranges));
   const bool mayHaveNulls = vector->mayHaveNulls();
   const VectorPtr& wrapped = BaseVector::wrappedVectorShared(vector);
   for (int32_t i = 0; i < ranges.size(); ++i) {


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookincubator/velox/pull/14882

Reviewed By: marksantaniello

Differential Revision: D82315332
