### PR TITLE
fix: Fix flaky ScaleWriterLocalPartitionTest.unpartitionBasic

### DIFF
--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -81,6 +81,10 @@ class TestExchangeController {
     if (holdBufferBytes_ == 0) {
       return;
     }
+    if (holdBuffer_ != nullptr) {
+      return;
+    }
+
     holdPool_ = pool;
     holdBuffer_ = holdPool_->allocate(holdBufferBytes_);
   }
@@ -227,11 +231,6 @@ class FakeSourceOperator : public SourceOperator {
  private:
   void initialize() override {
     Operator::initialize();
-
-    if (operatorCtx_->driverCtx()->driverId != 0) {
-      return;
-    }
-
     testController_->maybeHoldBuffer(pool());
   }
 


### PR DESCRIPTION
The test ScaleWriterLocalPartitionTest.unpartitionBasic is flaky on the case of
`numProducers 4, numConsumers 4, rebalanceProcessBytesThreshold 0B,`
`scaleWriterRebalanceMaxMemoryUsageRatio 0.1, holdBufferBytes 128.00MB,`
`producerBufferedMemoryRatio 0.8, consumerBufferedMemoryRatio 0.6,`
`expectedRebalance false`.
It fails at the check
`ASSERT_EQ(planStats.at(exchnangeNodeId).customStats`
`    .count(ScaleWriterLocalPartition::kScaledWriters), 0);`
No writer scaling is expected to have happened.

It's meant to test the necessary condition for writer scaling
`if (queryPool_->reservedBytes()`
`    < queryPool_->maxCapacity() * maxQueryMemoryUsageRatio_)`,
With `queryPool_->reservedBytes()` is set to 128MB by
`TestExchangeController::maybeHoldBuffer()`,
and `queryPool_->maxCapacity() * maxQueryMemoryUsageRatio_` very small,
the condition is expected to not pass.

However, with multiple producers and consumers, there is race condition
that the necessary condition check is hit in one driver before another driver calls
`maybeHoldBuffer()` in `FakeSourceOperator::initialize()` to reserve memory,
in which case `queryPool_->reservedBytes()` is 0. In `FakeSourceOperator::initialize()`,
`maybeHoldBuffer()` is called under condition
`if (operatorCtx_->driverCtx()->driverId == 0)`, which does not guarantee
`maybeHoldBuffer()` is invoked before all drivers proceed.

This fix makes sure `maybeHoldBuffer()` is invoked to reserve memory before
the necessary condition check for writer scaling is hit.

#Resolve #14822




