### PR TITLE
misc: Remove doy alias for Spark dayofyear function

### DIFF
--- a/velox/functions/sparksql/registration/RegisterDatetime.cpp
+++ b/velox/functions/sparksql/registration/RegisterDatetime.cpp
@@ -65,8 +65,7 @@ void registerDatetimeFunctions(const std::string& prefix) {
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
   registerFunction<DayFunction, int32_t, Date>(
       {prefix + "day", prefix + "dayofmonth"});
-  registerFunction<DayOfYearFunction, int32_t, Date>(
-      {prefix + "doy", prefix + "dayofyear"});
+  registerFunction<DayOfYearFunction, int32_t, Date>({prefix + "dayofyear"});
   registerFunction<DayOfWeekFunction, int32_t, Date>({prefix + "dayofweek"});
   registerFunction<WeekdayFunction, int32_t, Date>({prefix + "weekday"});
   registerFunction<QuarterFunction, int32_t, Date>({prefix + "quarter"});


### PR DESCRIPTION
In Spark, `dayofyear` function does not have a `doy` alias, so remove it.