### PR TITLE
fix: Folly::init -> folly::Init in velox

### DIFF
--- a/velox/exec/benchmarks/SetAccumulatorBenchmark.cpp
+++ b/velox/exec/benchmarks/SetAccumulatorBenchmark.cpp
@@ -111,7 +111,7 @@ BENCHMARK(twoBigints) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  const folly::Init init(&argc, &argv);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
 
   bm = std::make_unique<SetAccumulatorBenchmark>();


### PR DESCRIPTION
Summary: `folly::init` has been deprecated in favor of `folly::Init` for over two years. Let's make this switch.

Reviewed By: dtolnay

Differential Revision: D82664256


