### PR TITLE
Add session properties for small batch size mitigation

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -698,7 +698,8 @@ class QueryConfig {
   /// username.
   static constexpr const char* kClientTags = "client_tags";
 
-  /// Enable row size tracker as a fallback to file level row size estimates.
+  /// Enable (reader) row size tracker as a fallback to file level row size
+  /// estimates.
   static constexpr const char* kRowSizeTrackingEnabled =
       "row_size_tracking_enabled";
 


### PR DESCRIPTION
Summary:
Add the relevant session properties that can help control and mitigate specific regressions. 

Notably `preferred_output_batch_bytes`, `preferred_output_batch_rows` and `max_output_batch_rows` are existing velox query configs that were just not exposed.

`row_size_tracking_enabled` is to expose the newly added fallback to missing/failed average row size estimates.

Differential Revision: D81291261


