### PR TITLE
fix: Support write to oracle cloud

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -232,6 +232,10 @@ class S3FileSystem::Impl {
   Impl(const S3Config& s3Config) {
     VELOX_CHECK(getAwsInstance()->isInitialized(), "S3 is not initialized");
     Aws::S3::S3ClientConfiguration clientConfig;
+    clientConfig.checksumConfig.requestChecksumCalculation =
+        Aws::Client::RequestChecksumCalculation::WHEN_REQUIRED;
+    clientConfig.checksumConfig.responseChecksumValidation =
+        Aws::Client::ResponseChecksumValidation::WHEN_REQUIRED;
     if (s3Config.endpoint().has_value()) {
       clientConfig.endpointOverride = s3Config.endpoint().value();
     }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
@@ -89,10 +89,6 @@ class S3WriteFile::Impl {
       /// (https://github.com/apache/arrow/issues/11934). So we instead default
       /// to application/octet-stream which is less misleading.
       request.SetContentType(kApplicationOctetStream);
-      // The default algorithm used is MD5. However, MD5 is not supported with
-      // fips and can cause a SIGSEGV. Set CRC32 instead which is a standard for
-      // checksum computation and is not restricted by fips.
-      request.SetChecksumAlgorithm(Aws::S3::Model::ChecksumAlgorithm::CRC32);
 
       auto outcome = client_->CreateMultipartUpload(request);
       VELOX_CHECK_AWS_OUTCOME(
@@ -213,10 +209,6 @@ class S3WriteFile::Impl {
       request.SetContentLength(part.size());
       request.SetBody(
           std::make_shared<StringViewStream>(part.data(), part.size()));
-      // The default algorithm used is MD5. However, MD5 is not supported with
-      // fips and can cause a SIGSEGV. Set CRC32 instead which is a standard for
-      // checksum computation and is not restricted by fips.
-      request.SetChecksumAlgorithm(Aws::S3::Model::ChecksumAlgorithm::CRC32);
       auto outcome = client_->UploadPart(request);
       VELOX_CHECK_AWS_OUTCOME(outcome, "Failed to upload", bucket_, key_);
       // Append ETag and part number for this uploaded part.


### PR DESCRIPTION
Insert would fail with content-length header required, when trying to write to Oracle Cloud.