### PR TITLE
feat: Allow transferring memory to a given memory pool

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -18,6 +18,7 @@
 
 #include <signal.h>
 
+#include "velox/common/Casts.h"
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/base/SuccinctPrinter.h"
@@ -38,14 +39,14 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::memory {
 namespace {
 // Check if memory operation is allowed and increment the named stats.
-#define CHECK_AND_INC_MEM_OP_STATS(stats)                             \
+#define CHECK_AND_INC_MEM_OP_STATS(pool, stats)                       \
   do {                                                                \
-    if (FOLLY_UNLIKELY(kind_ != Kind::kLeaf)) {                       \
+    if (FOLLY_UNLIKELY(pool->kind_ != Kind::kLeaf)) {                 \
       VELOX_FAIL(                                                     \
           "Memory operation is only allowed on leaf memory pool: {}", \
-          toString());                                                \
+          pool->toString());                                          \
     }                                                                 \
-    ++num##stats##_;                                                  \
+    ++pool->num##stats##_;                                            \
   } while (0)
 
 // Check if memory operation is allowed and increment the named stats.
@@ -153,9 +154,9 @@ std::string capacityToString(int64_t capacity) {
   return capacity == kMaxMemory ? "UNLIMITED" : succinctBytes(capacity);
 }
 
-#define DEBUG_RECORD_ALLOC(...)         \
-  if (FOLLY_UNLIKELY(debugEnabled())) { \
-    recordAllocDbg(__VA_ARGS__);        \
+#define DEBUG_RECORD_ALLOC(pool, ...)         \
+  if (FOLLY_UNLIKELY(pool->debugEnabled())) { \
+    pool->recordAllocDbg(__VA_ARGS__);        \
   }
 #define DEBUG_RECORD_FREE(...)          \
   if (FOLLY_UNLIKELY(debugEnabled())) { \
@@ -521,7 +522,7 @@ void* MemoryPoolImpl::allocate(
     }
   }
 
-  CHECK_AND_INC_MEM_OP_STATS(Allocs);
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto alignedSize = sizeAlign(size);
   reserve(alignedSize);
   void* buffer = allocator_->allocateBytes(alignedSize, alignment_);
@@ -534,12 +535,12 @@ void* MemoryPoolImpl::allocate(
         toString(),
         allocator_->getAndClearFailureMessage()));
   }
-  DEBUG_RECORD_ALLOC(buffer, size);
+  DEBUG_RECORD_ALLOC(this, buffer, size);
   return buffer;
 }
 
 void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
-  CHECK_AND_INC_MEM_OP_STATS(Allocs);
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto size = sizeEach * numEntries;
   const auto alignedSize = sizeAlign(size);
   reserve(alignedSize);
@@ -554,12 +555,12 @@ void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
         toString(),
         allocator_->getAndClearFailureMessage()));
   }
-  DEBUG_RECORD_ALLOC(buffer, size);
+  DEBUG_RECORD_ALLOC(this, buffer, size);
   return buffer;
 }
 
 void* MemoryPoolImpl::reallocate(void* p, int64_t size, int64_t newSize) {
-  CHECK_AND_INC_MEM_OP_STATS(Allocs);
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   const auto alignedNewSize = sizeAlign(newSize);
   reserve(alignedNewSize);
 
@@ -574,7 +575,7 @@ void* MemoryPoolImpl::reallocate(void* p, int64_t size, int64_t newSize) {
         toString(),
         allocator_->getAndClearFailureMessage()));
   }
-  DEBUG_RECORD_ALLOC(newP, newSize);
+  DEBUG_RECORD_ALLOC(this, newP, newSize);
   if (p != nullptr) {
     ::memcpy(newP, p, std::min(size, newSize));
     free(p, size);
@@ -583,18 +584,41 @@ void* MemoryPoolImpl::reallocate(void* p, int64_t size, int64_t newSize) {
 }
 
 void MemoryPoolImpl::free(void* p, int64_t size) {
-  CHECK_AND_INC_MEM_OP_STATS(Frees);
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
   const auto alignedSize = sizeAlign(size);
   DEBUG_RECORD_FREE(p, size);
   allocator_->freeBytes(p, alignedSize);
   release(alignedSize);
 }
 
+bool MemoryPoolImpl::transferTo(MemoryPool* dest, void* buffer, int64_t size) {
+  if (!isLeaf() || !dest->isLeaf()) {
+    return false;
+  }
+  VELOX_CHECK_NOT_NULL(dest);
+  auto* destImpl = checked_pointer_cast<MemoryPoolImpl, MemoryPool>(dest);
+  VELOX_CHECK_NOT_NULL(destImpl);
+  if (allocator_ != destImpl->allocator_) {
+    return false;
+  }
+
+  CHECK_AND_INC_MEM_OP_STATS(destImpl, Allocs);
+  const auto alignedSize = sizeAlign(size);
+  destImpl->reserve(alignedSize);
+  DEBUG_RECORD_ALLOC(destImpl, buffer, size);
+
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
+  DEBUG_RECORD_FREE(buffer, size);
+  release(alignedSize);
+
+  return true;
+}
+
 void MemoryPoolImpl::allocateNonContiguous(
     MachinePageCount numPages,
     Allocation& out,
     MachinePageCount minSizeClass) {
-  CHECK_AND_INC_MEM_OP_STATS(Allocs);
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   if (!out.empty()) {
     INC_MEM_OP_STATS(Frees);
   }
@@ -622,14 +646,14 @@ void MemoryPoolImpl::allocateNonContiguous(
         toString(),
         allocator_->getAndClearFailureMessage()));
   }
-  DEBUG_RECORD_ALLOC(out);
+  DEBUG_RECORD_ALLOC(this, out);
   VELOX_CHECK(!out.empty());
   VELOX_CHECK_NULL(out.pool());
   out.setPool(this);
 }
 
 void MemoryPoolImpl::freeNonContiguous(Allocation& allocation) {
-  CHECK_AND_INC_MEM_OP_STATS(Frees);
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
   DEBUG_RECORD_FREE(allocation);
   const int64_t freedBytes = allocator_->freeNonContiguous(allocation);
   VELOX_CHECK(allocation.empty());
@@ -648,7 +672,7 @@ void MemoryPoolImpl::allocateContiguous(
     MachinePageCount numPages,
     ContiguousAllocation& out,
     MachinePageCount maxPages) {
-  CHECK_AND_INC_MEM_OP_STATS(Allocs);
+  CHECK_AND_INC_MEM_OP_STATS(this, Allocs);
   if (!out.empty()) {
     INC_MEM_OP_STATS(Frees);
   }
@@ -674,14 +698,14 @@ void MemoryPoolImpl::allocateContiguous(
         toString(),
         allocator_->getAndClearFailureMessage()));
   }
-  DEBUG_RECORD_ALLOC(out);
+  DEBUG_RECORD_ALLOC(this, out);
   VELOX_CHECK(!out.empty());
   VELOX_CHECK_NULL(out.pool());
   out.setPool(this);
 }
 
 void MemoryPoolImpl::freeContiguous(ContiguousAllocation& allocation) {
-  CHECK_AND_INC_MEM_OP_STATS(Frees);
+  CHECK_AND_INC_MEM_OP_STATS(this, Frees);
   const int64_t bytesToFree = allocation.size();
   DEBUG_RECORD_FREE(allocation);
   allocator_->freeContiguous(allocation);
@@ -775,7 +799,7 @@ std::shared_ptr<MemoryPool> MemoryPoolImpl::genChild(
 }
 
 bool MemoryPoolImpl::maybeReserve(uint64_t increment) {
-  CHECK_AND_INC_MEM_OP_STATS(Reserves);
+  CHECK_AND_INC_MEM_OP_STATS(this, Reserves);
   TestValue::adjust(
       "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve", this);
   // TODO: make this a configurable memory pool option.
@@ -923,7 +947,7 @@ void MemoryPoolImpl::incrementReservationLocked(uint64_t bytes) {
 }
 
 void MemoryPoolImpl::release() {
-  CHECK_AND_INC_MEM_OP_STATS(Releases);
+  CHECK_AND_INC_MEM_OP_STATS(this, Releases);
   release(0, true);
 }
 

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -252,6 +252,13 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Frees an allocated buffer.
   virtual void free(void* p, int64_t size) = 0;
 
+  /// Transfer the ownership of memory at 'buffer' for 'size' bytes to the
+  /// memory pool 'dest'. Returns true if the transfer succeeds.
+  virtual bool
+  transferTo(MemoryPool* /*dest*/, void* /*buffer*/, int64_t /*size*/) {
+    return false;
+  }
+
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
   /// <= the size of the largest size class. The new memory is returned in 'out'
@@ -615,6 +622,8 @@ class MemoryPoolImpl : public MemoryPool {
   void* reallocate(void* p, int64_t size, int64_t newSize) override;
 
   void free(void* p, int64_t size) override;
+
+  bool transferTo(MemoryPool* dest, void* buffer, int64_t size) override;
 
   void allocateNonContiguous(
       MachinePageCount numPages,

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -4037,6 +4037,221 @@ TEST_P(MemoryPoolTest, allocationWithCoveredCollateral) {
   pool->freeContiguous(contiguousAllocation);
 }
 
+TEST_P(MemoryPoolTest, transferTo) {
+  MemoryManager::Options options;
+  options.alignment = MemoryAllocator::kMinAlignment;
+  options.allocatorCapacity = kDefaultCapacity;
+  setupMemory(options);
+  auto manager = getMemoryManager();
+
+  auto largestSizeClass = manager->allocator()->largestSizeClass();
+  std::vector<MachinePageCount> pageCounts{
+      largestSizeClass,
+      largestSizeClass + 1,
+      largestSizeClass / 10,
+      1,
+      largestSizeClass * 2,
+      largestSizeClass * 3 + 1};
+
+  auto assertEqualBytes = [](const memory::MemoryPool* pool,
+                             int64_t usedBytes,
+                             int64_t peakBytes,
+                             int64_t reservedBytes) {
+    EXPECT_EQ(pool->usedBytes(), usedBytes);
+    EXPECT_EQ(pool->peakBytes(), peakBytes);
+    EXPECT_EQ(pool->reservedBytes(), reservedBytes);
+  };
+
+  auto assertZeroByte = [&assertEqualBytes](const memory::MemoryPool* pool) {
+    EXPECT_EQ(pool->usedBytes(), 0);
+    EXPECT_EQ(pool->reservedBytes(), 0);
+  };
+
+  auto getMemoryBytes = [](const memory::MemoryPool* pool) {
+    return std::make_tuple(
+        pool->usedBytes(), pool->peakBytes(), pool->reservedBytes());
+  };
+
+  auto createPools = [&manager](bool betweenDifferentRoots) {
+    auto root1 = manager->addRootPool("root1");
+    auto root2 = manager->addRootPool("root2");
+    std::shared_ptr<MemoryPool> from;
+    std::shared_ptr<MemoryPool> to;
+    if (betweenDifferentRoots) {
+      from = root1->addLeafChild("from");
+      to = root2->addLeafChild("to");
+    } else {
+      from = root1->addLeafChild("from");
+      to = root1->addLeafChild("to");
+    }
+    return std::make_tuple(root1, root2, from, to);
+  };
+
+  auto testTransferAllocate = [&assertZeroByte,
+                               &assertEqualBytes,
+                               &getMemoryBytes,
+                               &createPools,
+                               &manager](bool betweenDifferentRoots) {
+    auto [root1, root2, from, to] = createPools(betweenDifferentRoots);
+    assertZeroByte(from.get());
+    assertZeroByte(to.get());
+    assertZeroByte(from->root());
+    assertZeroByte(to->root());
+
+    const auto kSize = 1024;
+    int64_t usedBytes, rootUsedBytes;
+    int64_t peakBytes, rootPeakBytes;
+    int64_t reservedBytes, rootReservedBytes;
+    auto buffer = from->allocate(kSize);
+    // Transferring between non-leaf pools is not allowed.
+    EXPECT_FALSE(from->root()->transferTo(to.get(), buffer, kSize));
+    EXPECT_FALSE(from->transferTo(to->root(), buffer, kSize));
+
+    std::tie(usedBytes, peakBytes, reservedBytes) = getMemoryBytes(from.get());
+    std::tie(rootUsedBytes, rootPeakBytes, rootReservedBytes) =
+        getMemoryBytes(from->root());
+    from->transferTo(to.get(), buffer, kSize);
+    assertEqualBytes(to.get(), usedBytes, peakBytes, reservedBytes);
+    if (from->root() == to->root()) {
+      rootPeakBytes *= 2;
+    }
+    assertEqualBytes(
+        to->root(), rootUsedBytes, rootPeakBytes, rootReservedBytes);
+    to->free(buffer, kSize);
+    assertZeroByte(from.get());
+    assertZeroByte(to.get());
+    assertZeroByte(from->root());
+    assertZeroByte(to->root());
+  };
+
+  auto testTransferAllocateZeroFilled = [&assertZeroByte,
+                                         &assertEqualBytes,
+                                         &getMemoryBytes,
+                                         &createPools,
+                                         &manager](bool betweenDifferentRoots) {
+    auto [root1, root2, from, to] = createPools(betweenDifferentRoots);
+    assertZeroByte(from.get());
+    assertZeroByte(to.get());
+    assertZeroByte(from->root());
+    assertZeroByte(to->root());
+
+    const auto kSize = 1024;
+    int64_t usedBytes, rootUsedBytes;
+    int64_t peakBytes, rootPeakBytes;
+    int64_t reservedBytes, rootReservedBytes;
+    auto buffer = from->allocateZeroFilled(8, kSize / 8);
+    std::tie(usedBytes, peakBytes, reservedBytes) = getMemoryBytes(from.get());
+    std::tie(rootUsedBytes, rootPeakBytes, rootReservedBytes) =
+        getMemoryBytes(from->root());
+    from->transferTo(to.get(), buffer, kSize);
+    assertEqualBytes(to.get(), usedBytes, peakBytes, reservedBytes);
+    if (from->root() == to->root()) {
+      rootPeakBytes *= 2;
+    }
+    assertEqualBytes(
+        to->root(), rootUsedBytes, rootPeakBytes, rootReservedBytes);
+    to->free(buffer, kSize);
+    assertZeroByte(from.get());
+    assertZeroByte(to.get());
+    assertZeroByte(from->root());
+    assertZeroByte(to->root());
+  };
+
+  auto testTransferAllocateContiguous =
+      [&assertZeroByte,
+       &assertEqualBytes,
+       &getMemoryBytes,
+       &createPools,
+       &manager](int64_t pageCount, bool betweenDifferentRoots) {
+        auto [root1, root2, from, to] = createPools(betweenDifferentRoots);
+        assertZeroByte(from.get());
+        assertZeroByte(to.get());
+        assertZeroByte(from->root());
+        assertZeroByte(to->root());
+
+        int64_t usedBytes, rootUsedBytes;
+        int64_t peakBytes, rootPeakBytes;
+        int64_t reservedBytes, rootReservedBytes;
+        ContiguousAllocation out;
+        from->allocateContiguous(pageCount, out);
+        std::tie(usedBytes, peakBytes, reservedBytes) =
+            getMemoryBytes(from.get());
+        std::tie(rootUsedBytes, rootPeakBytes, rootReservedBytes) =
+            getMemoryBytes(from->root());
+        from->transferTo(to.get(), out.data(), out.size());
+        assertEqualBytes(to.get(), usedBytes, peakBytes, reservedBytes);
+        if (from->root() == to->root()) {
+          rootPeakBytes *= 2;
+        }
+        assertEqualBytes(
+            to->root(), rootUsedBytes, rootPeakBytes, rootReservedBytes);
+        to->freeContiguous(out);
+        assertZeroByte(from.get());
+        assertZeroByte(to.get());
+        assertZeroByte(from->root());
+        assertZeroByte(to->root());
+      };
+
+  auto testTransferAllocateNonContiguous =
+      [&assertZeroByte,
+       &assertEqualBytes,
+       &getMemoryBytes,
+       &createPools,
+       &manager](int64_t pageCount, bool betweenDifferentRoots) {
+        auto [root1, root2, from, to] = createPools(betweenDifferentRoots);
+        assertZeroByte(from.get());
+        assertZeroByte(to.get());
+        assertZeroByte(from->root());
+        assertZeroByte(to->root());
+
+        int64_t usedBytes, rootUsedBytes;
+        int64_t peakBytes, rootPeakBytes;
+        int64_t reservedBytes, rootReservedBytes;
+        Allocation out;
+        from->allocateNonContiguous(pageCount, out);
+        std::tie(usedBytes, peakBytes, reservedBytes) =
+            getMemoryBytes(from.get());
+        std::tie(rootUsedBytes, rootPeakBytes, rootReservedBytes) =
+            getMemoryBytes(from->root());
+        for (auto i = 0; i < out.numRuns(); ++i) {
+          const auto& run = out.runAt(i);
+          from->transferTo(to.get(), run.data(), run.numBytes());
+        }
+        assertEqualBytes(to.get(), usedBytes, peakBytes, reservedBytes);
+        if (from->root() == to->root()) {
+          EXPECT_EQ(to->root()->usedBytes(), rootUsedBytes);
+          // We reserve and release memory run-by-run, so the peak bytes would
+          // be no greater than twice of the original peak bytes.
+          EXPECT_LE(to->root()->peakBytes(), rootPeakBytes * 2);
+          EXPECT_EQ(to->root()->reservedBytes(), rootReservedBytes);
+        } else {
+          assertEqualBytes(
+              to->root(), rootUsedBytes, rootPeakBytes, rootReservedBytes);
+        }
+        to->freeNonContiguous(out);
+        assertZeroByte(from.get());
+        assertZeroByte(to.get());
+        assertZeroByte(from->root());
+        assertZeroByte(to->root());
+      };
+
+  // Test transfer between siblings of the same root pool.
+  testTransferAllocate(false);
+  testTransferAllocateZeroFilled(false);
+  for (auto pageCount : pageCounts) {
+    testTransferAllocateContiguous(pageCount, false);
+    testTransferAllocateNonContiguous(pageCount, false);
+  }
+
+  // Test transfer between different root pools.
+  testTransferAllocate(true);
+  testTransferAllocateZeroFilled(true);
+  for (auto pageCount : pageCounts) {
+    testTransferAllocateContiguous(pageCount, true);
+    testTransferAllocateNonContiguous(pageCount, true);
+  }
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     MemoryPoolTestSuite,
     MemoryPoolTest,


### PR DESCRIPTION
Summary:
This diff adds a new API
`bool MemoryPool::transferTo(MemoryPool* dest, void* buffer, int64_t size)`
that allows transferring the ownership of the memory starting from `buffer` of size 
`size` to the `dest` pool. This API requires the calling pool and the destination pool 
are both leaf pools and use the same allocator. If the requirements are satisfied, this 
API transfers the ownership and return true. If not, this API does nothing and return 
false.

Differential Revision: D82877273


