### PR TITLE
fix: Do not overwrite valid promise

### DIFF
--- a/velox/common/base/AdmissionController.cpp
+++ b/velox/common/base/AdmissionController.cpp
@@ -32,12 +32,10 @@ void AdmissionController::accept(uint64_t resourceUnits) {
   {
     std::lock_guard<std::mutex> l(mu_);
     if (unitsUsed_ + resourceUnits > config_.maxLimit) {
-      auto [unblockPromise, unblockFuture] = makeVeloxContinuePromiseContract();
       Request req;
       req.unitsRequested = resourceUnits;
-      req.promise = std::move(unblockPromise);
+      future = req.promise.getSemiFuture();
       queue_.push_back(std::move(req));
-      future = std::move(unblockFuture);
     } else {
       updatedValue = unitsUsed_ += resourceUnits;
     }

--- a/velox/common/future/VeloxPromise.h
+++ b/velox/common/future/VeloxPromise.h
@@ -65,6 +65,12 @@ using ContinuePromise = VeloxPromise<folly::Unit>;
 using ContinueFuture = folly::SemiFuture<folly::Unit>;
 
 /// Equivalent of folly's makePromiseContract for VeloxPromise.
+///
+/// NOTE: When you already have a valid promise, just call
+/// Promise::getSemiFuture() on it to get the future, instead of using this
+/// function to overwrite the promise.  Overwriting valid promise would cause
+/// exception throwing and stack unwinding thus performance issue.  See
+/// https://github.com/prestodb/presto/issues/26094 for details.
 static inline std::pair<ContinuePromise, ContinueFuture>
 makeVeloxContinuePromiseContract(const std::string& promiseContext = "") {
   auto p = ContinuePromise(promiseContext);


### PR DESCRIPTION
Summary:
When you already have a valid promise, just call
`Promise::getSemiFuture()` on it to get the future, instead of using this
function to overwrite the promise.  Overwriting valid promise would cause
exception throwing and stack unwinding thus performance issue.  See
https://github.com/prestodb/presto/issues/26094 for details.

Differential Revision: D82966344


