### PR TITLE
refactor(abfs): Extract the logic to get the accountName and authType from the config into common method

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h"
+#include "velox/common/config/Config.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AbfsPath.h"
+
+namespace facebook::velox::filesystems {
+
+std::vector<CacheKey> extractCacheKeyFromConfig(
+    const config::ConfigBase& config) {
+  std::vector<CacheKey> cacheKeys;
+  for (const auto& [key, value] : config.rawConfigs()) {
+    constexpr std::string_view authTypePrefix{kAzureAccountAuthType};
+    if (key.find(authTypePrefix) == 0) {
+      std::string_view skey = key;
+      // Extract the accountName after "fs.azure.account.auth.type.".
+      auto remaining = skey.substr(authTypePrefix.size() + 1);
+      auto dot = remaining.find(".");
+      VELOX_USER_CHECK_NE(
+          dot,
+          std::string_view::npos,
+          "Invalid Azure account auth type key: {}",
+          key);
+      auto accountName = std::string(remaining.substr(0, dot));
+      cacheKeys.emplace_back(CacheKey{accountName, value});
+    }
+  }
+  return cacheKeys;
+}
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
@@ -26,17 +26,15 @@ std::vector<CacheKey> extractCacheKeyFromConfig(
   constexpr std::string_view authTypePrefix{kAzureAccountAuthType};
   for (const auto& [key, value] : config.rawConfigs()) {
     if (key.find(authTypePrefix) == 0) {
-      std::string_view skey = key;
       // Extract the accountName after "fs.azure.account.auth.type.".
-      auto remaining = skey.substr(authTypePrefix.size() + 1);
+      auto remaining = std::string_view(key).substr(authTypePrefix.size() + 1);
       auto dot = remaining.find(".");
       VELOX_USER_CHECK_NE(
           dot,
           std::string_view::npos,
           "Invalid Azure account auth type key: {}",
           key);
-      std::string_view accountName = std::string(remaining.substr(0, dot));
-      cacheKeys.emplace_back(CacheKey{accountName, value});
+      cacheKeys.emplace_back(CacheKey{remaining.substr(0, dot), value});
     }
   }
   return cacheKeys;

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
@@ -23,8 +23,8 @@ namespace facebook::velox::filesystems {
 std::vector<CacheKey> extractCacheKeyFromConfig(
     const config::ConfigBase& config) {
   std::vector<CacheKey> cacheKeys;
+  constexpr std::string_view authTypePrefix{kAzureAccountAuthType};
   for (const auto& [key, value] : config.rawConfigs()) {
-    constexpr std::string_view authTypePrefix{kAzureAccountAuthType};
     if (key.find(authTypePrefix) == 0) {
       std::string_view skey = key;
       // Extract the accountName after "fs.azure.account.auth.type.".
@@ -35,7 +35,7 @@ std::vector<CacheKey> extractCacheKeyFromConfig(
           std::string_view::npos,
           "Invalid Azure account auth type key: {}",
           key);
-      auto accountName = std::string(remaining.substr(0, dot));
+      std::string_view accountName = std::string(remaining.substr(0, dot));
       cacheKeys.emplace_back(CacheKey{accountName, value});
     }
   }

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h
@@ -31,6 +31,9 @@ class ConfigBase;
 struct CacheKey {
   std::string accountName;
   std::string authType;
+
+  CacheKey(std::string_view accountName, std::string_view authType)
+      : accountName(accountName), authType(authType) {}
 };
 
 inline bool isAbfsFile(const std::string_view filename) {

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h
@@ -29,8 +29,8 @@ constexpr std::string_view kAbfssScheme{"abfss://"};
 class ConfigBase;
 
 struct CacheKey {
-  std::string accountName;
-  std::string authType;
+  const std::string accountName;
+  const std::string authType;
 
   CacheKey(std::string_view accountName, std::string_view authType)
       : accountName(accountName), authType(authType) {}

--- a/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/abfs/CMakeLists.txt
@@ -23,6 +23,7 @@ if(VELOX_ENABLE_ABFS)
       AbfsFileSystem.cpp
       AbfsPath.cpp
       AbfsReadFile.cpp
+      AbfsUtil.cpp
       AbfsWriteFile.cpp
       AzureClientProviderFactories.cpp
       AzureClientProviderImpl.cpp

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -68,29 +68,29 @@ void registerAbfsFileSystem() {
 
 void registerAzureClientProvider(const config::ConfigBase& config) {
 #ifdef VELOX_ENABLE_ABFS
-  std::string accountName;
-  std::string authType;
-  extractCacheKeyFromConfig(config, accountName, authType);
 
-  if (authType == kAzureSharedKeyAuthType) {
-    AzureClientProviderFactories::registerFactory(
-        accountName, [](const std::string&) {
-          return std::make_unique<SharedKeyAzureClientProvider>();
-        });
-  } else if (authType == kAzureOAuthAuthType) {
-    AzureClientProviderFactories::registerFactory(
-        accountName, [](const std::string&) {
-          return std::make_unique<OAuthAzureClientProvider>();
-        });
-  } else if (authType == kAzureSASAuthType) {
-    AzureClientProviderFactories::registerFactory(
-        accountName, [](const std::string&) {
-          return std::make_unique<FixedSasAzureClientProvider>();
-        });
-  } else {
-    VELOX_USER_FAIL(
-        "Unsupported auth type {}, supported auth types are SharedKey, OAuth and SAS.",
-        authType);
+  for (const auto& [accountName, authType] :
+       extractCacheKeyFromConfig(config)) {
+    if (authType == kAzureSharedKeyAuthType) {
+      AzureClientProviderFactories::registerFactory(
+          accountName, [](const std::string&) {
+            return std::make_unique<SharedKeyAzureClientProvider>();
+          });
+    } else if (authType == kAzureOAuthAuthType) {
+      AzureClientProviderFactories::registerFactory(
+          accountName, [](const std::string&) {
+            return std::make_unique<OAuthAzureClientProvider>();
+          });
+    } else if (authType == kAzureSASAuthType) {
+      AzureClientProviderFactories::registerFactory(
+          accountName, [](const std::string&) {
+            return std::make_unique<FixedSasAzureClientProvider>();
+          });
+    } else {
+      VELOX_USER_FAIL(
+          "Unsupported auth type {}, supported auth types are SharedKey, OAuth and SAS.",
+          authType);
+    }
   }
 #endif
 }


### PR DESCRIPTION
We also need to include both `accountName `and `authType ` in the cache key to support multiple ABFS FileSystem instances. Therefore, this PR extracts the related code into a common method.