### PR TITLE
fix: Support clustered raw input n EbfAggregator to optimize the memory allocations

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -99,7 +99,11 @@ class NoopArbitrator : public MemoryArbitrator {
   }
 
   void removePool(MemoryPool* pool) override {
-    VELOX_CHECK_EQ(pool->reservedBytes(), 0);
+    VELOX_CHECK_EQ(
+        pool->reservedBytes(),
+        0,
+        "Memory pool has unexpected reserved bytes on removal: {}",
+        pool->name());
   }
 
   // Noop arbitrator has no memory capacity limit so no operation needed for

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -846,8 +846,9 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   writer = maybeCreateBucketSortWriter(std::move(writer));
   writers_.emplace_back(std::move(writer));
   addThreadLocalRuntimeStat(
-      std::string(dwio::common::toString(insertTableHandle_->storageFormat())) +
-          "WriterCount",
+      fmt::format(
+          "{}WriterCount",
+          dwio::common::toString(insertTableHandle_->storageFormat())),
       RuntimeCounter(1));
   // Extends the buffer used for partition rows calculations.
   partitionSizes_.emplace_back(0);


### PR DESCRIPTION
Summary: Add clustered raw input support and this can avoid a copy of encoded event. This change also optimize the memory allocations of result vector by allocating string buffer once and the memory allocation counters drop from 13317 to 2191. But we don't see much improvement in cpu time.

Differential Revision: D83032862


