### PR TITLE
fix(cudf): Store memory resource mr_ to retain mr

### DIFF
--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -347,10 +347,7 @@ std::shared_ptr<rmm::mr::device_memory_resource> mr_;
 struct CudfDriverAdapter {
   bool force_replace_;
 
-  CudfDriverAdapter(
-      std::shared_ptr<rmm::mr::device_memory_resource> mr,
-      bool force_replace)
-      : force_replace_{force_replace} {}
+  CudfDriverAdapter(bool force_replace) : force_replace_{force_replace} {}
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -342,14 +342,15 @@ bool CompileState::compile(bool force_replace) {
   return replacementsMade;
 }
 
+std::shared_ptr<rmm::mr::device_memory_resource> mr_;
+
 struct CudfDriverAdapter {
-  std::shared_ptr<rmm::mr::device_memory_resource> mr_;
   bool force_replace_;
 
   CudfDriverAdapter(
       std::shared_ptr<rmm::mr::device_memory_resource> mr,
       bool force_replace)
-      : mr_(mr), force_replace_{force_replace} {}
+      : force_replace_{force_replace} {}
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {
@@ -380,16 +381,18 @@ void registerCudf(const CudfOptions& options) {
   const std::string mrMode = options.cudfMemoryResource;
   auto mr = cudf_velox::createMemoryResource(mrMode, options.memoryPercent);
   cudf::set_current_device_resource(mr.get());
+  mr_ = mr;
 
   exec::Operator::registerOperator(
       std::make_unique<CudfHashJoinBridgeTranslator>());
-  CudfDriverAdapter cda{mr, options.force_replace};
+  CudfDriverAdapter cda{options.force_replace};
   exec::DriverAdapter cudfAdapter{kCudfAdapterName, {}, cda};
   exec::DriverFactory::registerAdapter(cudfAdapter);
   isCudfRegistered = true;
 }
 
 void unregisterCudf() {
+  mr_ = nullptr;
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -19,6 +19,8 @@
 #include "velox/exec/Driver.h"
 #include "velox/exec/Operator.h"
 
+#include <rmm/mr/device/device_memory_resource.hpp>
+
 #include <gflags/gflags.h>
 
 DECLARE_bool(velox_cudf_enabled);
@@ -89,6 +91,8 @@ class CudfOptions {
   CudfOptions& operator=(const CudfOptions&) = delete;
   std::string prefix_;
 };
+
+extern std::shared_ptr<rmm::mr::device_memory_resource> mr_;
 
 /// Registers adapter to add cuDF operators to Drivers.
 void registerCudf(const CudfOptions& options = CudfOptions::getInstance());


### PR DESCRIPTION
This moved memory resource out of CudfDriverAdapter functor and moves to global variable.

Fixes a bug: functor stored as function pointer, does not retain functor object. so, mr is lost. This fixes that bug.