### PR TITLE
fix: Reenable intermediate/final type validation for aggregate functions

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -19,8 +19,8 @@
 #include <unordered_map>
 #include "velox/exec/AggregateCompanionAdapter.h"
 #include "velox/exec/AggregateCompanionSignatures.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
 #include "velox/exec/AggregateWindow.h"
-#include "velox/expression/SignatureBinder.h"
 
 namespace facebook::velox::exec {
 
@@ -295,24 +295,24 @@ std::unique_ptr<Aggregate> Aggregate::create(
     const std::vector<TypePtr>& argTypes,
     const TypePtr& resultType,
     const core::QueryConfig& config) {
-  // TODO(timaou, kletkavrubashku): Reneable the validation once "regr_slope"
-  // signature is fixed
-  //
-  // Validate the result type. if (isPartialOutput(step)) {
-  //   auto intermediateType = Aggregate::intermediateType(name, argTypes);
-  //   VELOX_CHECK(
-  //       resultType->equivalent(*intermediateType),
-  //       "Intermediate type mismatch. Expected: {}, actual: {}",
-  //       intermediateType->toString(),
-  //       resultType->toString());
-  // } else {
-  //   auto finalType = Aggregate::finalType(name, argTypes);
-  //   VELOX_CHECK(
-  //       resultType->equivalent(*finalType),
-  //       "Final type mismatch. Expected: {}, actual: {}",
-  //       finalType->toString(),
-  //       resultType->toString());
-  // }
+  // Validate output types.
+  const auto [finalType, intermediateType] =
+      resolveAggregateFunction(name, argTypes);
+  if (isPartialOutput(step)) {
+    VELOX_CHECK(
+        resultType->equivalent(*intermediateType),
+        "Intermediate type mismatch. Aggregate function: '{}', expected: {}, actual: {}",
+        name,
+        intermediateType->toString(),
+        resultType->toString());
+  } else {
+    VELOX_CHECK(
+        resultType->equivalent(*finalType),
+        "Final type mismatch. Aggregate function: '{}', expected: {}, actual: {}",
+        name,
+        finalType->toString(),
+        resultType->toString());
+  }
   // Lookup the function in the new registry first.
   if (auto func = getAggregateFunctionEntry(name)) {
     return func->factory(step, argTypes, resultType, config);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -550,7 +550,7 @@ TEST_F(AggregationTest, missingLambdaFunction) {
       readCursor(params), "Aggregate function not registered: missing-lambda");
 }
 
-TEST_F(AggregationTest, DISABLED_resultTypeMismatch) {
+TEST_F(AggregationTest, outputTypeMismatch) {
   using Step = core::AggregationNode::Step;
 
   registerAggregateFunction(


### PR DESCRIPTION
Summary:
In https://github.com/facebookincubator/velox/pull/13505 the validation was disabled, because regr_* functions in Presto and Velox had different signatures.

The signature in Velox is more efficient, so I landed the fix on Presto side:
https://github.com/prestodb/presto/pull/25748
They're included into v0.295-edge13 presto release.

Differential Revision: D82904840


