### PR TITLE
docs: Add Ke Jia to Storage Adapters maintainer list

### DIFF
--- a/website/docs/community/03-components-and-maintainers.md
+++ b/website/docs/community/03-components-and-maintainers.md
@@ -84,6 +84,7 @@ maintainers of that component.
 ### Storage Adapters (S3/HDFS/GCS/ABFS)
 
 * Deepak Majeti - [majetideepak](https://github.com/majetideepak) / deepak.majeti@ibm.com
+* Ke Jia - [JkSelf](https://github.com/jkself) / ke.a.jia@intel.com
 
 ### Builds and CI
 


### PR DESCRIPTION
Summary:
Adding Ke Jia to Storage Adapters maintainer list, following internal
maintainer's voting.

Differential Revision: D83110692


