### PR TITLE
feat(geo): Add optional geometry and radius fields to SpatialJoinNode

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -391,6 +391,10 @@ std::vector<FieldAccessTypedExprPtr> deserializeFields(
       array, context);
 }
 
+FieldAccessTypedExprPtr deserializeField(const folly::dynamic& obj) {
+  return ISerializable::deserialize<FieldAccessTypedExpr>(obj);
+}
+
 std::vector<std::string> deserializeStrings(const folly::dynamic& array) {
   return ISerializable::deserialize<std::vector<std::string>>(array);
 }
@@ -3075,12 +3079,55 @@ SpatialJoinNode::SpatialJoinNode(
     const PlanNodeId& id,
     JoinType joinType,
     TypedExprPtr joinCondition,
+    FieldAccessTypedExprPtr probeGeometry,
+    FieldAccessTypedExprPtr buildGeometry,
+    std::optional<FieldAccessTypedExprPtr> radius,
     PlanNodePtr left,
     PlanNodePtr right,
     RowTypePtr outputType)
     : PlanNode(id),
       joinType_(joinType),
       joinCondition_(std::move(joinCondition)),
+      probeGeometry_(std::move(probeGeometry)),
+      buildGeometry_(std::move(buildGeometry)),
+      radius_(std::move(radius)),
+      sources_({std::move(left), std::move(right)}),
+      outputType_(std::move(outputType)) {
+  VELOX_USER_CHECK(
+      isSupported(joinType_),
+      "The join type is not supported by spatial join: {}",
+      JoinTypeName::toName(joinType_));
+  VELOX_USER_CHECK(
+      joinCondition_ != nullptr,
+      "The join condition must not be null for spatial join");
+  VELOX_USER_CHECK_EQ(
+      sources_.size(), 2, "Must have 2 sources for spatial joins");
+  VELOX_USER_CHECK(
+      sources_[0] != nullptr, "Left source must not be null for spatial joins");
+  VELOX_USER_CHECK(
+      sources_[1] != nullptr,
+      "Right source must not be null for spatial joins");
+
+  checkJoinColumnNames(
+      sources_[0]->outputType(),
+      sources_[1]->outputType(),
+      outputType_,
+      outputType_->size());
+}
+
+SpatialJoinNode::SpatialJoinNode(
+    const PlanNodeId& id,
+    JoinType joinType,
+    TypedExprPtr joinCondition,
+    PlanNodePtr left,
+    PlanNodePtr right,
+    RowTypePtr outputType)
+    : PlanNode(id),
+      joinType_(joinType),
+      joinCondition_(std::move(joinCondition)),
+      probeGeometry_{},
+      buildGeometry_{},
+      radius_{},
       sources_({std::move(left), std::move(right)}),
       outputType_(std::move(outputType)) {
   VELOX_USER_CHECK(
@@ -3121,6 +3168,15 @@ void SpatialJoinNode::addDetails(std::stringstream& stream) const {
   if (joinCondition_) {
     stream << ", joinCondition: " << joinCondition_->toString();
   }
+  if (probeGeometry_) {
+    stream << ", probeGeometry: " << probeGeometry_.value()->name();
+  }
+  if (buildGeometry_) {
+    stream << ", buildGeometry: " << buildGeometry_.value()->name();
+  }
+  if (radius_) {
+    stream << ", radius: " << radius_.value()->name();
+  }
 }
 
 folly::dynamic SpatialJoinNode::serialize() const {
@@ -3130,6 +3186,15 @@ folly::dynamic SpatialJoinNode::serialize() const {
     obj["joinCondition"] = joinCondition_->serialize();
   }
   obj["outputType"] = outputType_->serialize();
+  if (probeGeometry_) {
+    obj["probeGeometry"] = probeGeometry_.value()->serialize();
+  }
+  if (buildGeometry_) {
+    obj["buildGeometry"] = buildGeometry_.value()->serialize();
+  }
+  if (radius_) {
+    obj["radius"] = radius_.value()->serialize();
+  }
   return obj;
 }
 
@@ -3150,6 +3215,36 @@ PlanNodePtr SpatialJoinNode::create(const folly::dynamic& obj, void* context) {
   }
 
   auto outputType = deserializeRowType(obj["outputType"]);
+  std::optional<FieldAccessTypedExprPtr> probeGeometry;
+  if (obj.count("probeGeometry")) {
+    probeGeometry = deserializeField(obj["probeGeometry"]);
+  }
+  std::optional<FieldAccessTypedExprPtr> buildGeometry;
+  if (obj.count("buildGeometry")) {
+    buildGeometry = deserializeField(obj["buildGeometry"]);
+  }
+  std::optional<FieldAccessTypedExprPtr> radius;
+  if (obj.count("radius")) {
+    radius = deserializeField(obj["radius"]);
+  }
+
+  VELOX_USER_CHECK(
+      (probeGeometry.has_value() && buildGeometry.has_value()) ||
+          (!probeGeometry.has_value() && !buildGeometry.has_value()),
+      "Either probe and build geometry must both be set, or neither");
+
+  if (probeGeometry.has_value() && buildGeometry.has_value()) {
+    return std::make_shared<SpatialJoinNode>(
+        deserializePlanNodeId(obj),
+        JoinTypeName::toJoinType(obj["joinType"].asString()),
+        joinCondition,
+        probeGeometry.value(),
+        buildGeometry.value(),
+        radius,
+        sources[0],
+        sources[1],
+        outputType);
+  }
 
   return std::make_shared<SpatialJoinNode>(
       deserializePlanNodeId(obj),

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3883,6 +3883,17 @@ class SpatialJoinNode : public PlanNode {
       const PlanNodeId& id,
       JoinType joinType,
       TypedExprPtr joinCondition,
+      FieldAccessTypedExprPtr probeGeometry,
+      FieldAccessTypedExprPtr buildGeometry,
+      std::optional<FieldAccessTypedExprPtr> radius,
+      PlanNodePtr left,
+      PlanNodePtr right,
+      RowTypePtr outputType);
+
+  SpatialJoinNode(
+      const PlanNodeId& id,
+      JoinType joinType,
+      TypedExprPtr joinCondition,
       PlanNodePtr left,
       PlanNodePtr right,
       RowTypePtr outputType);
@@ -3895,6 +3906,9 @@ class SpatialJoinNode : public PlanNode {
       id_ = other.id();
       joinType_ = other.joinType();
       joinCondition_ = other.joinCondition();
+      probeGeometry_ = other.probeGeometry();
+      buildGeometry_ = other.buildGeometry();
+      radius_ = other.radius();
       VELOX_CHECK_EQ(other.sources().size(), 2);
       left_ = other.sources()[0];
       right_ = other.sources()[1];
@@ -3913,6 +3927,21 @@ class SpatialJoinNode : public PlanNode {
 
     Builder& joinCondition(TypedExprPtr joinCondition) {
       joinCondition_ = std::move(joinCondition);
+      return *this;
+    }
+
+    Builder& probeGeometry(FieldAccessTypedExprPtr probeGeometry) {
+      probeGeometry_ = std::move(probeGeometry);
+      return *this;
+    }
+
+    Builder& buildGeometry(FieldAccessTypedExprPtr buildGeometry) {
+      buildGeometry_ = std::move(buildGeometry);
+      return *this;
+    }
+
+    Builder& radius(FieldAccessTypedExprPtr radius) {
+      radius_ = std::move(radius);
       return *this;
     }
 
@@ -3940,6 +3969,24 @@ class SpatialJoinNode : public PlanNode {
       VELOX_USER_CHECK(
           outputType_.has_value(), "SpatialJoinNode outputType is not set");
 
+      VELOX_USER_CHECK(
+          (probeGeometry_.has_value() && buildGeometry_.has_value()) ||
+              (!probeGeometry_.has_value() && !buildGeometry_.has_value()),
+          "Either probe and build geometry must both be set, or neither");
+
+      if (probeGeometry_.has_value() && buildGeometry_.has_value()) {
+        return std::make_shared<SpatialJoinNode>(
+            id_.value(),
+            joinType_,
+            joinCondition_,
+            probeGeometry_.value(),
+            buildGeometry_.value(),
+            radius_,
+            left_.value(),
+            right_.value(),
+            outputType_.value());
+      }
+
       return std::make_shared<SpatialJoinNode>(
           id_.value(),
           joinType_,
@@ -3953,6 +4000,9 @@ class SpatialJoinNode : public PlanNode {
     std::optional<PlanNodeId> id_;
     JoinType joinType_ = kDefaultJoinType;
     TypedExprPtr joinCondition_;
+    std::optional<FieldAccessTypedExprPtr> probeGeometry_;
+    std::optional<FieldAccessTypedExprPtr> buildGeometry_;
+    std::optional<FieldAccessTypedExprPtr> radius_;
     std::optional<PlanNodePtr> left_;
     std::optional<PlanNodePtr> right_;
     std::optional<RowTypePtr> outputType_;
@@ -3977,6 +4027,18 @@ class SpatialJoinNode : public PlanNode {
     return joinCondition_;
   }
 
+  const std::optional<FieldAccessTypedExprPtr>& probeGeometry() const {
+    return probeGeometry_;
+  }
+
+  const std::optional<FieldAccessTypedExprPtr>& buildGeometry() const {
+    return buildGeometry_;
+  }
+
+  const std::optional<FieldAccessTypedExprPtr>& radius() const {
+    return radius_;
+  }
+
   JoinType joinType() const {
     return joinType_;
   }
@@ -3995,6 +4057,9 @@ class SpatialJoinNode : public PlanNode {
 
   const JoinType joinType_;
   const TypedExprPtr joinCondition_;
+  const std::optional<FieldAccessTypedExprPtr> probeGeometry_;
+  const std::optional<FieldAccessTypedExprPtr> buildGeometry_;
+  const std::optional<FieldAccessTypedExprPtr> radius_;
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
 };


### PR DESCRIPTION
Summary:
In preparation for spatial join using envelope intersection as the indexing
method, let's expose optional fields for probeGeometry, buildGeometry, and
radius to construct the envelopes.  Also add a constructor that allows these
fields.  This way, Presto Java can add these fields and not break
compatibility.  Once PResto Java adds these fields, we can remove the
optionality and requires them in Velox.

Differential Revision: D83143313


