### PR TITLE
fix: Remove geometry from supported types for Presto Expr fuzzers

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -318,17 +318,30 @@ bool PrestoQueryRunner::isConstantExprSupported(
 }
 
 bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
-  // TODO: support queries with these types. Among the types below, hugeint is
-  // not a native type in Presto, so fuzzer should not use it as the type of
-  // cast-to or constant literals. Hyperloglog and TDigest can only be casted
-  // from varbinary and cannot be used as the type of constant literals.
-  // Interval year to month can only be casted from NULL and cannot be used as
-  // the type of constant literals. Json, Ipaddress, Ipprefix, and UUID require
-  // special handling, because Presto requires literals of these types to be
-  // valid, and doesn't allow creating HIVE columns of these types.
+  // TODO: support queries with these types.
+  // Types not supported by PrestoQueryRunner and their reasons:
+  //
+  // hugeint:
+  //   - Not a native type in Presto
+  //   - Fuzzer should not use it for cast-to or constant literals
+  //
+  // interval year to month:
+  //   - Can only be casted from NULL
+  //   - Cannot be used as constant literal types
+  //
+  // ipaddress, ipprefix, uuid:
+  //   - Require special handling in Presto
+  //   - Presto requires literals of these types to be valid
+  //   - Cannot create HIVE columns of these types
+  //
+  // geometry:
+  //   - Under development in Presto
+  //   - Cannot be used as constant literals
+  //   - Expected differences between Presto Java and Velox C++ implementations
   return !(
       usesTypeName(signature, "interval year to month") ||
       usesTypeName(signature, "hugeint") ||
+      usesTypeName(signature, "geometry") ||
       usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
       usesInputTypeName(signature, "uuid"));


### PR DESCRIPTION
Summary:
1. Revert D82870319 which adds cast to skip list which is not the right way
2. Remove geometry type from the supported types
3. Cleaned up the documentation on unsupported types to make it readable

Differential Revision: D83174277


