### PR TITLE
fix: Add generalized array_frequency array support to any element type

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -126,6 +126,7 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
 // testing. Use function signature to exclude only a specific signature.
 std::unordered_set<std::string> skipFunctions = {
     "noisy_empty_approx_set_sfm", // Non-deterministic because of privacy.
+    "array_frequency", // velox rewrite due to inline function in presto.
     "merge_sfm", // Fuzzer can generate sketches of different sizes.
     "element_at",
     "width_bucket",

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -340,6 +340,11 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayFrequencyFunctions<Timestamp>(prefix);
   registerArrayFrequencyFunctions<Date>(prefix);
   registerArrayFrequencyFunctions<Varchar>(prefix);
+  // Register generic nested array support for array_frequency
+  registerFunction<
+      ParameterBinder<ArrayFrequencyFunction, Array<Generic<T1>>>,
+      Map<Array<Generic<T1>>, int>,
+      Array<Array<Generic<T1>>>>({prefix + "array_frequency"});
 
   registerArrayNormalizeFunctions<int8_t>(prefix);
   registerArrayNormalizeFunctions<int16_t>(prefix);

--- a/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
@@ -103,4 +103,119 @@ TEST_F(ArrayFrequencyTest, varcharArrayWithoutNull) {
   testArrayFrequency(expected, array);
 }
 
+TEST_F(ArrayFrequencyTest, nestedArrayOfVarchar) {
+  // Create nested array: [["a","b"], ["a","b"], ["c"]], [], [["x"], ["x"],
+  // ["y","z"]]
+
+  // inner arrays
+  auto innerArrays = makeArrayVector<StringView>({
+      {"a"_sv, "b"_sv},
+      {"a"_sv, "b"_sv},
+      {"c"_sv},
+      {"x"_sv},
+      {"x"_sv},
+      {"y"_sv, "z"_sv},
+  });
+
+  // outer array using offsets
+  auto nestedArray = makeArrayVector({0, 3, 3, 6}, innerArrays);
+
+  auto result =
+      evaluate<BaseVector>("array_frequency(C0)", makeRowVector({nestedArray}));
+
+  // verify it doesn't crash and returns the expected type
+  EXPECT_EQ(result->type()->toString(), "MAP<ARRAY<VARCHAR>,INTEGER>");
+  EXPECT_EQ(result->size(), nestedArray->size());
+
+  // verify that it's not null
+  EXPECT_FALSE(result->isNullAt(0));
+
+  // empty array, array_frequency returns an empty map, not null
+  auto mapResult = result->as<MapVector>();
+  EXPECT_EQ(mapResult->sizeAt(1), 0); // empty array should result in empty map
+  EXPECT_FALSE(result->isNullAt(2));
+  EXPECT_FALSE(result->isNullAt(3));
+}
+
+TEST_F(ArrayFrequencyTest, nestedArrayOfVarcharWithNulls) {
+  // Test case matching Presto's actual behavior: arrays with null elements
+  auto innerArrays = makeNullableArrayVector<StringView>({
+      {"a"_sv, "b"_sv},
+      {std::nullopt, "b"_sv}, // Contains null - should be included
+      {"a"_sv, "b"_sv}, // Duplicate of first
+      {}, // Empty array
+      {"x"_sv},
+      {"x"_sv}, // Duplicate
+      {std::nullopt}, // Contains only null - should be included
+      {"y"_sv, "z"_sv},
+  });
+
+  // [["a", "b"], [null, "b"], ["a", "b"]] -> ["a", "b"] appears twice, [null,
+  // "b"] once
+  // [] -> empty outer array
+  // [[], ["x"], ["x"], [null]] -> [] once, ["x"] twice, [null] once
+  // [["y", "z"]] -> ["y", "z"] once
+  auto nestedArray = makeArrayVector({0, 3, 3, 7, 8}, innerArrays);
+
+  auto result =
+      evaluate<BaseVector>("array_frequency(C0)", makeRowVector({nestedArray}));
+
+  EXPECT_EQ(result->type()->toString(), "MAP<ARRAY<VARCHAR>,INTEGER>");
+  EXPECT_EQ(result->size(), nestedArray->size());
+  EXPECT_FALSE(result->isNullAt(0));
+  EXPECT_FALSE(result->isNullAt(1));
+  EXPECT_FALSE(result->isNullAt(2));
+  EXPECT_FALSE(result->isNullAt(3));
+
+  auto mapResult = result->as<MapVector>();
+
+  // Row 0: Should have 2 entries: ["a", "b"] -> 2, [null, "b"] -> 1
+  EXPECT_EQ(mapResult->sizeAt(0), 2);
+
+  // Row 1: Empty outer array should result in empty map
+  EXPECT_EQ(mapResult->sizeAt(1), 0);
+
+  // Row 2: Should have 3 entries: [] -> 1, ["x"] -> 2, [null] -> 1
+  EXPECT_EQ(mapResult->sizeAt(2), 3);
+
+  // Row 3: Should have 1 entry: ["y", "z"] -> 1
+  EXPECT_EQ(mapResult->sizeAt(3), 1);
+}
+
+TEST_F(ArrayFrequencyTest, nestedArrayOfIntegers) {
+  // Test generic implementation with nested arrays of integers
+  auto innerArrays = makeArrayVector<int64_t>({
+      {1, 2},
+      {1, 2}, // Duplicate
+      {3},
+      {}, // Empty array
+      {10, 20, 30},
+      {10, 20, 30}, // Duplicate
+  });
+
+  // [[1, 2], [1, 2], [3]] -> [1, 2] appears twice, [3] once
+  // [] -> empty outer array
+  // [[], [10, 20, 30], [10, 20, 30]] -> [] once, [10, 20, 30] twice
+  auto nestedArray = makeArrayVector({0, 3, 3, 6}, innerArrays);
+
+  auto result =
+      evaluate<BaseVector>("array_frequency(C0)", makeRowVector({nestedArray}));
+
+  EXPECT_EQ(result->type()->toString(), "MAP<ARRAY<BIGINT>,INTEGER>");
+  EXPECT_EQ(result->size(), nestedArray->size());
+  EXPECT_FALSE(result->isNullAt(0));
+  EXPECT_FALSE(result->isNullAt(1));
+  EXPECT_FALSE(result->isNullAt(2));
+
+  auto mapResult = result->as<MapVector>();
+
+  // Row 0: Should have 2 entries: [1, 2] -> 2, [3] -> 1
+  EXPECT_EQ(mapResult->sizeAt(0), 2);
+
+  // Row 1: Empty outer array should result in empty map
+  EXPECT_EQ(mapResult->sizeAt(1), 0);
+
+  // Row 2: Should have 2 entries: [] -> 1, [10, 20, 30] -> 2
+  EXPECT_EQ(mapResult->sizeAt(2), 2);
+}
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
Summary:
Add the array_frequency function's nested array implementation to support arrays of any element type, not just varchar arrays. This change replaces the Array<Varchar> specialization with a more generic Array<Generic<T1>> template that can handle nested arrays containing integers, dates, timestamps, maps, and other types.

Replace Array<Varchar> specialization with Array<Generic<T1>> to support any element type like array(array(bigint)), array(map(bigint, bigint)), etc.
Use element.hash() instead of string-specific hashing for better performance and generality
Implement proper null-safe comparison using CompareFlags::equality with kNullAsIndeterminate for robust element equality checks
Add comprehensive error handling for unsupported null-containing elements with clear user error messages
Update function registration to use the generic template approach instead of explicit Array<Varchar> registration
Add test coverage for nested integer arrays to validate the generic implementation

Differential Revision: D83199256


