### PR TITLE
feat: Change storage stats to per call instead per driver

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -266,7 +266,15 @@ class DataSource {
   /// Returns the number of input rows processed so far.
   virtual uint64_t getCompletedRows() = 0;
 
-  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() {
+    return {};
+  }
+#endif
+
+  virtual std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() {
+    return {};
+  }
 
   /// Returns true if 'this' has initiated all the prefetch this will initiate.
   /// This means that the caller should schedule next splits to prefetch in the

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -77,7 +77,7 @@ class FuzzerDataSource : public DataSource {
     return completedBytes_;
   }
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override {
     // TODO: Which stats do we want to expose here?
     return {};
   }

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -60,7 +60,7 @@ class HiveDataSource : public DataSource {
     return completedRows_;
   }
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override;
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override;
 
   bool allPrefetchIssued() const override {
     return splitReader_ && splitReader_->allPrefetchIssued();

--- a/velox/connectors/tpcds/TpcdsConnector.h
+++ b/velox/connectors/tpcds/TpcdsConnector.h
@@ -102,7 +102,7 @@ class TpcdsDataSource : public velox::connector::DataSource {
     return completedBytes_;
   }
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override {
     return {};
   }
 

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -117,7 +117,7 @@ class TpchDataSource : public DataSource {
     return completedBytes_;
   }
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override {
     // TODO: Which stats do we want to expose here?
     return {};
   }

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -562,40 +562,40 @@ struct RuntimeStatistics {
   UnitLoaderStats unitLoaderStats;
   ColumnReaderStatistics columnReaderStatistics;
 
-  std::unordered_map<std::string, RuntimeCounter> toMap() {
-    std::unordered_map<std::string, RuntimeCounter> result;
+  std::unordered_map<std::string, RuntimeMetric> toRuntimeMetricMap() {
+    std::unordered_map<std::string, RuntimeMetric> result;
     for (const auto& [name, metric] : unitLoaderStats.stats()) {
-      result.emplace(name, RuntimeCounter(metric.sum, metric.unit));
+      result.emplace(name, RuntimeMetric(metric.sum, metric.unit));
     }
     if (skippedSplits > 0) {
-      result.emplace("skippedSplits", RuntimeCounter(skippedSplits));
+      result.emplace("skippedSplits", RuntimeMetric(skippedSplits));
     }
     if (processedSplits > 0) {
-      result.emplace("processedSplits", RuntimeCounter(processedSplits));
+      result.emplace("processedSplits", RuntimeMetric(processedSplits));
     }
     if (skippedSplitBytes > 0) {
       result.emplace(
           "skippedSplitBytes",
-          RuntimeCounter(skippedSplitBytes, RuntimeCounter::Unit::kBytes));
+          RuntimeMetric(skippedSplitBytes, RuntimeCounter::Unit::kBytes));
     }
     if (skippedStrides > 0) {
-      result.emplace("skippedStrides", RuntimeCounter(skippedStrides));
+      result.emplace("skippedStrides", RuntimeMetric(skippedStrides));
     }
     if (processedStrides > 0) {
-      result.emplace("processedStrides", RuntimeCounter(processedStrides));
+      result.emplace("processedStrides", RuntimeMetric(processedStrides));
     }
     if (footerBufferOverread > 0) {
       result.emplace(
           "footerBufferOverread",
-          RuntimeCounter(footerBufferOverread, RuntimeCounter::Unit::kBytes));
+          RuntimeMetric(footerBufferOverread, RuntimeCounter::Unit::kBytes));
     }
     if (numStripes > 0) {
-      result.emplace("numStripes", RuntimeCounter(numStripes));
+      result.emplace("numStripes", RuntimeMetric(numStripes));
     }
     if (columnReaderStatistics.flattenStringDictionaryValues > 0) {
       result.emplace(
           "flattenStringDictionaryValues",
-          RuntimeCounter(columnReaderStatistics.flattenStringDictionaryValues));
+          RuntimeMetric(columnReaderStatistics.flattenStringDictionaryValues));
     }
     return result;
   }

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -304,15 +304,15 @@ bool TableScan::getSplit() {
   if (!split.hasConnectorSplit()) {
     noMoreSplits_ = true;
     if (dataSource_) {
-      const auto connectorStats = dataSource_->runtimeStats();
+      const auto connectorStats = dataSource_->getRuntimeStats();
       auto lockedStats = stats_.wlock();
-      for (const auto& [name, counter] : connectorStats) {
+      for (const auto& [name, metric] : connectorStats) {
         if (FOLLY_UNLIKELY(lockedStats->runtimeStats.count(name) == 0)) {
-          lockedStats->runtimeStats.emplace(name, RuntimeMetric(counter.unit));
+          lockedStats->runtimeStats.emplace(name, RuntimeMetric(metric.unit));
         } else {
-          VELOX_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, counter.unit);
+          VELOX_CHECK_EQ(lockedStats->runtimeStats.at(name).unit, metric.unit);
         }
-        lockedStats->runtimeStats.at(name).addValue(counter.value);
+        lockedStats->runtimeStats.at(name).merge(metric);
       }
     }
     return false;

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -126,7 +126,7 @@ class TestDataSource : public connector::DataSource {
     return 0;
   }
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override {
     return {};
   }
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -374,14 +374,14 @@ void CudfHiveDataSource::resetSplit() {
   columnNames_.clear();
 }
 
-std::unordered_map<std::string, RuntimeCounter>
-CudfHiveDataSource::runtimeStats() {
-  auto res = runtimeStats_.toMap();
+std::unordered_map<std::string, RuntimeMetric>
+CudfHiveDataSource::getRuntimeStats() {
+  auto res = runtimeStats_.toRuntimeMetricMap();
   res.insert({
       {"totalScanTime",
-       RuntimeCounter(ioStats_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
+       RuntimeMetric(ioStats_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
       {"totalRemainingFilterTime",
-       RuntimeCounter(
+       RuntimeMetric(
            totalRemainingFilterTime_.load(std::memory_order_relaxed),
            RuntimeCounter::Unit::kNanos)},
   });

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h
@@ -71,7 +71,7 @@ class CudfHiveDataSource : public DataSource, public NvtxHelper {
     return completedBytes_;
   }
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override;
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override;
 
  private:
   // Create a cudf::io::chunked_parquet_reader with the given split.

--- a/velox/experimental/wave/exec/TableScan.h
+++ b/velox/experimental/wave/exec/TableScan.h
@@ -96,6 +96,9 @@ class TableScan : public WaveSourceOperator {
   void updateStats(
       std::unordered_map<std::string, RuntimeCounter> stats,
       WaveSplitReader* splitReader = nullptr);
+  void updateStats(
+      std::unordered_map<std::string, RuntimeMetric> stats,
+      WaveSplitReader* splitReader = nullptr);
 
   // Process-wide IO wait time.
   static std::atomic<uint64_t> ioWaitNanos_;

--- a/velox/experimental/wave/exec/WaveDataSource.h
+++ b/velox/experimental/wave/exec/WaveDataSource.h
@@ -56,7 +56,7 @@ class WaveDataSource : public std::enable_shared_from_this<WaveDataSource> {
 
   virtual uint64_t getCompletedRows() = 0;
 
-  virtual std::unordered_map<std::string, RuntimeCounter> runtimeStats() = 0;
+  virtual std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() = 0;
 
   virtual void setFromDataSource(std::shared_ptr<WaveDataSource> source) {
     VELOX_UNSUPPORTED();

--- a/velox/experimental/wave/exec/WaveHiveDataSource.cpp
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.cpp
@@ -140,11 +140,12 @@ uint64_t WaveHiveDataSource::getCompletedRows() {
   return completedRows_;
 }
 
-std::unordered_map<std::string, RuntimeCounter>
-WaveHiveDataSource::runtimeStats() {
-  auto map = runtimeStats_.toMap();
+std::unordered_map<std::string, RuntimeMetric>
+WaveHiveDataSource::getRuntimeStats() {
+  auto map = runtimeStats_.toRuntimeMetricMap();
   for (const auto& [name, counter] : splitReaderStats_) {
-    map.insert(std::make_pair(name, counter));
+    map.insert(
+        std::make_pair(name, RuntimeMetric(counter.value, counter.unit)));
   }
   return map;
 }

--- a/velox/experimental/wave/exec/WaveHiveDataSource.h
+++ b/velox/experimental/wave/exec/WaveHiveDataSource.h
@@ -59,7 +59,7 @@ class WaveHiveDataSource : public WaveDataSource {
 
   uint64_t getCompletedRows() override;
 
-  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override;
+  std::unordered_map<std::string, RuntimeMetric> getRuntimeStats() override;
 
   static void registerConnector();
 


### PR DESCRIPTION
Summary:
Storage stats are currently [aggregated at per driver level,](https://www.internalfb.com/code/fbsource/[d5afc76c0d1efcf59e0d9eb8083dbc0d488b391c]/fbcode/velox/connectors/hive/HiveDataSource.cpp?lines=474) which makes min, max, and count values inaccurate. This diff changes
1. Return type of `runtimeStats()` of `DataSource` from `std::unordered_map<std::string, velox::RuntimeCounter>`  to `std::unordered_map<std::string, velox::RuntimeMetric>` to preserve the min, max, and count values.
2. Processing of runtime stats in `TableScan` from `addValue` to `merge`
3. The return type of any inheritors of DataSource

Differential Revision: D83120348


