### PR TITLE
misc: Optimize error handling in _VELOX_RETURN_IMPL 

### DIFF
--- a/velox/common/base/Status.h
+++ b/velox/common/base/Status.h
@@ -530,6 +530,9 @@ void Status::moveFrom(Status& s) {
 #define _VELOX_RETURN_IMPL(expr, exprStr, error, ...)                    \
   do {                                                                   \
     if (FOLLY_UNLIKELY(expr)) {                                          \
+      if (::facebook::velox::threadSkipErrorDetails()) {                 \
+        return error();                                                  \
+      }                                                                  \
       auto message = ::facebook::velox::errorMessage(__VA_ARGS__);       \
       return error(                                                      \
           ::facebook::velox::internal::generateError(message, exprStr)); \

--- a/velox/common/base/tests/StatusTest.cpp
+++ b/velox/common/base/tests/StatusTest.cpp
@@ -211,6 +211,22 @@ TEST(StatusTest, statusMacros) {
           "Reason: User error occurred.\nExpression: status != nullptr\n"));
 }
 
+TEST(StatusTest, statusMacrosSkipDetails) {
+  ScopedThreadSkipErrorDetails skipErrorDetails(true);
+  ASSERT_EQ(returnMacroCheck(), Status::UserError());
+  ASSERT_EQ(returnMacroEmptyMessage(), Status::UserError());
+  ASSERT_EQ(returnMacroFormat(), Status::UserError());
+  ASSERT_EQ(returnMacroGT(), Status::UserError());
+  ASSERT_EQ(returnMacroGE(), Status::UserError());
+  ASSERT_EQ(returnMacroLT(), Status::UserError());
+  ASSERT_EQ(returnMacroLE(), Status::UserError());
+  ASSERT_EQ(returnMacroEQ(), Status::UserError());
+  ASSERT_EQ(returnMacroNE(), Status::UserError());
+  ASSERT_EQ(returnMacroNULL(), Status::UserError());
+  Status status = Status::OK();
+  ASSERT_EQ(returnNotNull(&status), Status::UserError());
+}
+
 Expected<int> modulo(int a, int b) {
   if (b == 0) {
     return folly::makeUnexpected(Status::UserError("division by zero"));


### PR DESCRIPTION
Update _VELOX_RETURN_IMPL to respect the threadSkipErrorDetails 
flag, allowing error returns without generating detailed error messages when the 
flag is set.