### PR TITLE
feat(cudf): Support round function

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -722,11 +722,12 @@ class RoundFunction : public CudfFunction {
  public:
   explicit RoundFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
     const auto argSize = expr->inputs().size();
-    VELOX_CHECK(argSize >= 1 && argSize <=2, "round expects 1 or 2 inputs");
+    VELOX_CHECK(argSize >= 1 && argSize <= 2, "round expects 1 or 2 inputs");
     auto stream = cudf::get_default_stream();
     auto mr = cudf::get_current_device_resource_ref();
     if (argSize == 2) {
-      auto scaleExpr = std::dynamic_pointer_cast<exec::ConstantExpr>(expr->inputs()[1]);
+      auto scaleExpr =
+          std::dynamic_pointer_cast<exec::ConstantExpr>(expr->inputs()[1]);
       VELOX_CHECK_NOT_NULL(scaleExpr, "round scale must be a constant");
       scale_ = scaleExpr->value()->as<SimpleVector<int32_t>>()->valueAt(0);
     }
@@ -736,19 +737,20 @@ class RoundFunction : public CudfFunction {
       std::vector<ColumnOrView>& inputColumns,
       rmm::cuda_stream_view stream,
       rmm::device_async_resource_ref mr) const override {
-    VELOX_CHECK(!inputColumns.empty(), "round expects first column is not literal");
+    VELOX_CHECK(
+        !inputColumns.empty(), "round expects first column is not literal");
     return cudf::round_decimal(
         asView(inputColumns[0]),
         scale_,
         cudf::rounding_method::HALF_UP,
         stream,
-        mr);;
+        mr);
+    ;
   }
 
-  private:
-    int32_t scale_ = 0;
+ private:
+  int32_t scale_ = 0;
 };
-
 
 class SubstrFunction : public CudfFunction {
  public:

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -724,7 +724,7 @@ class RoundFunction : public CudfFunction {
     const auto argSize = expr->inputs().size();
     VELOX_CHECK(argSize >= 1 && argSize <= 2, "round expects 1 or 2 inputs");
     VELOX_CHECK_NULL(
-        std::dynamic_pointer_cast<ConstantExpr>(expr->inputs()[0]),
+        std::dynamic_pointer_cast<exec::ConstantExpr>(expr->inputs()[0]),
         "round expects first column is not literal");
     if (argSize == 2) {
       auto scaleExpr =

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -647,17 +647,17 @@ TEST_F(CudfFilterProjectTest, round) {
                   .planNode();
   AssertQueryBuilder(plan).assertResults(data);
   plan = PlanBuilder()
-                  .setParseOptions(options)
-                  .values({data})
-                  .project({"round(c0) as c1"})
-                  .planNode();
+             .setParseOptions(options)
+             .values({data})
+             .project({"round(c0) as c1"})
+             .planNode();
   AssertQueryBuilder(plan).assertResults(data);
 
   plan = PlanBuilder()
-                  .setParseOptions(options)
-                  .values({data})
-                  .project({"round(c0, -3) as c1"})
-                  .planNode();
+             .setParseOptions(options)
+             .values({data})
+             .project({"round(c0, -3) as c1"})
+             .planNode();
   auto expected = makeRowVector({makeFlatVector<int64_t>({4000, 456789000})});
   AssertQueryBuilder(plan).assertResults(expected);
 }

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -636,6 +636,19 @@ TEST_F(CudfFilterProjectTest, mixedInOperation) {
   testMixedInOperation(vectors);
 }
 
+TEST_F(CudfFilterProjectTest, round) {
+  vector_size_t batchSize = 1000;
+  auto vectors = makeVectors(DOUBLE(), 2, batchSize);
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .project({"round(c0) as c1"})
+                  .planNode();
+
+  assertQuery(plan, "SELECT round(c0) FROM tmp");
+}
+
 TEST_F(CudfFilterProjectTest, simpleFilter) {
   vector_size_t batchSize = 1000;
   auto vectors = makeVectors(rowType_, 2, batchSize);


### PR DESCRIPTION
To resolve this [issue](https://github.com/rapidsai/cudf/issues/15862), round for floating point is not supported in cudf, so only support round integral data type, spark and presto supports floating data type.
Cudf could support as Velox RoundFunction https://github.com/facebookincubator/velox/blob/main/velox/functions/prestosql/ArithmeticImpl.h#L37