### PR TITLE
build: Fix unsupported bison syntax with bison 3.0.4

### DIFF
--- a/velox/expression/signature_parser/SignatureParser.yy
+++ b/velox/expression/signature_parser/SignatureParser.yy
@@ -7,7 +7,7 @@
 %require "3.0.4"
 %language "C++"
 
-%define api.parser.class {Parser}
+%define parser_class_name {Parser}
 %define api.namespace {facebook::velox::exec}
 %define api.value.type variant
 %parse-param {Scanner* scanner}


### PR DESCRIPTION
Velox requires bison 3.0.4 but PR https://github.com/facebookincubator/velox/pull/14675 introduced a syntax that is only supported by bison >= ~~3.8~~ 3.3.

This is a tentative hot fix.

Fixes https://github.com/facebookincubator/velox/issues/14959.