### PR TITLE
feat(cudf): Remove gflags in favor of CudfConfig

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -25,16 +25,18 @@ struct CudfConfig {
   /// Clients must set the configs below before invoking registerCudf().
   static CudfConfig& getInstance();
 
+  /// Enable cudf by default.
+  /// Clients can disable here and enable it via the QueryConfig as well.
+  bool enabled{true};
   /// Enable debug printing.
   bool debugEnabled{false};
   /// Memory resource for cuDF.
   /// Possible values are (cuda, pool, async, arena, managed, managed_pool).
   std::string memoryResource{"async"};
+  /// The initial percent of GPU memory to allocate for memory resource.
+  int memoryPercent{50};
   /// Register all the functions with the functionNamePrefix.
   std::string functionNamePrefix;
-  /// The initial percent of GPU memory to allocate for memory resource for one
-  /// thread.
-  int memoryPercent{50};
   /// Force replacement of operators. Throws an error if a replacement fails.
   bool forceReplace{false};
 };

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -17,26 +17,44 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 
 namespace facebook::velox::cudf_velox {
 
 struct CudfConfig {
+  /// Keys used by the initialize() method.
+  static constexpr const char* kCudfEnabled{"cudf.enabled"};
+  static constexpr const char* kCudfDebugEnabled{"cudf.debug_enabled"};
+  static constexpr const char* kCudfMemoryResource{"cudf.memory_resource"};
+  static constexpr const char* kCudfMemoryPercent{"cudf.memory_percent"};
+  static constexpr const char* kCudfFunctionNamePrefix{
+      "cudf.function_name_prefix"};
+  static constexpr const char* kCudfForceReplace{"cudf.force_replace"};
+
   /// Singleton CudfConfig instance.
   /// Clients must set the configs below before invoking registerCudf().
   static CudfConfig& getInstance();
 
+  /// Initialize from a map with the above keys.
+  void initialize(std::unordered_map<std::string, std::string>&&);
+
   /// Enable cudf by default.
   /// Clients can disable here and enable it via the QueryConfig as well.
   bool enabled{true};
+
   /// Enable debug printing.
   bool debugEnabled{false};
+
   /// Memory resource for cuDF.
   /// Possible values are (cuda, pool, async, arena, managed, managed_pool).
   std::string memoryResource{"async"};
+
   /// The initial percent of GPU memory to allocate for memory resource.
-  int memoryPercent{50};
+  int32_t memoryPercent{50};
+
   /// Register all the functions with the functionNamePrefix.
   std::string functionNamePrefix;
+
   /// Force replacement of operators. Throws an error if a replacement fails.
   bool forceReplace{false};
 };

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::cudf_velox {
+
+struct CudfConfig {
+  /// Singleton CudfConfig instance.
+  /// Clients must set the configs below before invoking registerCudf().
+  static CudfConfig& getInstance();
+
+  /// Enable debug printing.
+  bool debugEnabled{false};
+  /// Memory resource for cuDF.
+  /// Possible values are (cuda, pool, async, arena, managed, managed_pool).
+  std::string memoryResource{"async"};
+  /// Register all the functions with the functionNamePrefix.
+  std::string functionNamePrefix;
+  /// The initial percent of GPU memory to allocate for memory resource for one
+  /// thread.
+  int memoryPercent{50};
+  /// Force replacement of operators. Throws an error if a replacement fails.
+  bool forceReplace{false};
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -49,7 +49,8 @@ struct CudfConfig {
   /// Possible values are (cuda, pool, async, arena, managed, managed_pool).
   std::string memoryResource{"async"};
 
-  /// The initial percent of GPU memory to allocate for memory resource.
+  /// The initial percent of GPU memory to allocate for pool or arena memory
+  /// resources.
   int32_t memoryPercent{50};
 
   /// Register all the functions with the functionNamePrefix.

--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
@@ -68,7 +69,7 @@ CudfFilterProject::CudfFilterProject(
                                   : filter_->sources()[0]->outputType();
 
   // convert to AST
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     int i = 0;
     for (auto expr : info.exprs->exprs()) {
       std::cout << "expr[" << i++ << "] " << expr->toString() << std::endl;
@@ -114,7 +115,7 @@ RowVectorPtr CudfFilterProject::getOutput() {
   stream.synchronize();
   auto const numColumns = outputTable->num_columns();
   auto const size = outputTable->num_rows();
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "cudfProject Output: " << size << " rows, " << numColumns
               << " columns " << std::endl;
   }

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
-#include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
@@ -426,7 +426,7 @@ std::unique_ptr<cudf_velox::CudfHashAggregation::Aggregator> createAggregator(
     VectorPtr constant,
     bool isGlobal,
     const TypePtr& resultType) {
-  auto prefix = cudf_velox::CudfOptions::getInstance().prefix();
+  auto prefix = cudf_velox::CudfConfig::getInstance().functionNamePrefix;
   if (kind.rfind(prefix + "sum", 0) == 0) {
     return std::make_unique<SumAggregator>(
         step, inputIndex, constant, isGlobal, resultType);

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/ExpressionEvaluator.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
@@ -34,7 +35,7 @@ namespace facebook::velox::cudf_velox {
 
 void CudfHashJoinBridge::setHashTable(
     std::optional<CudfHashJoinBridge::hash_type> hashObject) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridge::setHashTable" << std::endl;
   }
   std::vector<ContinuePromise> promises;
@@ -51,24 +52,24 @@ void CudfHashJoinBridge::setHashTable(
 
 std::optional<CudfHashJoinBridge::hash_type> CudfHashJoinBridge::hashOrFuture(
     ContinueFuture* future) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridge::hashOrFuture" << std::endl;
   }
   std::lock_guard<std::mutex> l(mutex_);
   if (hashObject_.has_value()) {
     return hashObject_;
   }
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridge::hashOrFuture constructing promise"
               << std::endl;
   }
   promises_.emplace_back("CudfHashJoinBridge::hashOrFuture");
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridge::hashOrFuture getSemiFuture"
               << std::endl;
   }
   *future = promises_.back().getSemiFuture();
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridge::hashOrFuture returning nullopt"
               << std::endl;
   }
@@ -91,13 +92,13 @@ CudfHashJoinBuild::CudfHashJoinBuild(
           operatorId,
           fmt::format("[{}]", joinNode->id())),
       joinNode_(joinNode) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "CudfHashJoinBuild constructor" << std::endl;
   }
 }
 
 void CudfHashJoinBuild::addInput(RowVectorPtr input) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBuild::addInput" << std::endl;
   }
   // Queue inputs, process all at once.
@@ -119,7 +120,7 @@ void CudfHashJoinBuild::addInput(RowVectorPtr input) {
 }
 
 bool CudfHashJoinBuild::needsInput() const {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBuild::needsInput" << std::endl;
   }
   return !noMoreInput_;
@@ -130,7 +131,7 @@ RowVectorPtr CudfHashJoinBuild::getOutput() {
 }
 
 void CudfHashJoinBuild::noMoreInput() {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBuild::noMoreInput" << std::endl;
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
@@ -168,7 +169,7 @@ void CudfHashJoinBuild::noMoreInput() {
   inputs_.clear();
 
   VELOX_CHECK_NOT_NULL(tbl);
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Build table number of columns: " << tbl->num_columns()
               << std::endl;
     std::cout << "Build table number of rows: " << tbl->num_rows() << std::endl;
@@ -197,7 +198,7 @@ void CudfHashJoinBuild::noMoreInput() {
     VELOX_CHECK_NOT_NULL(hashObject);
   }
 
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     if (hashObject != nullptr) {
       printf("hashObject is not nullptr %p\n", hashObject.get());
     } else {
@@ -241,7 +242,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
           operatorId,
           fmt::format("[{}]", joinNode->id())),
       joinNode_(joinNode) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "CudfHashJoinProbe constructor" << std::endl;
   }
   auto probeType = joinNode_->sources()[0]->outputType();
@@ -249,7 +250,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
   auto const& leftKeys = joinNode_->leftKeys(); // probe keys
   auto const& rightKeys = joinNode_->rightKeys(); // build keys
 
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     for (int i = 0; i < probeType->names().size(); i++) {
       std::cout << "Left column " << i << ": " << probeType->names()[i]
                 << std::endl;
@@ -293,7 +294,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
   rightColumnOutputIndices_ = std::vector<size_t>();
   for (int i = 0; i < outputType->names().size(); i++) {
     auto const outputName = outputType->names()[i];
-    if (cudfDebugEnabled()) {
+    if (CudfConfig::getInstance().debugEnabled) {
       std::cout << "Output column " << i << ": " << outputName << std::endl;
     }
     auto channel = probeType->getChildIdxIfExists(outputName);
@@ -314,7 +315,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
         "Join field {} not in probe or build input", outputType->children()[i]);
   }
 
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     for (int i = 0; i < leftColumnIndicesToGather_.size(); i++) {
       std::cout << "Left index to gather " << i << ": "
                 << leftColumnIndicesToGather_[i] << std::endl;
@@ -368,7 +369,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
 }
 
 bool CudfHashJoinProbe::needsInput() const {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinProbe::needsInput" << std::endl;
   }
   if (joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) {
@@ -406,7 +407,7 @@ void CudfHashJoinProbe::addInput(RowVectorPtr input) {
 }
 
 void CudfHashJoinProbe::noMoreInput() {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinProbe::noMoreInput" << std::endl;
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
@@ -447,7 +448,7 @@ void CudfHashJoinProbe::noMoreInput() {
 
   VELOX_CHECK_NOT_NULL(tbl);
 
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Probe table number of columns: " << tbl->num_columns()
               << std::endl;
     std::cout << "Probe table number of rows: " << tbl->num_rows() << std::endl;
@@ -465,7 +466,7 @@ void CudfHashJoinProbe::noMoreInput() {
 }
 
 RowVectorPtr CudfHashJoinProbe::getOutput() {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinProbe::getOutput" << std::endl;
   }
   VELOX_NVTX_OPERATOR_FUNC_RANGE();
@@ -481,7 +482,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   VELOX_CHECK_NOT_NULL(cudfInput);
   auto stream = cudfInput->stream();
   auto leftTable = cudfInput->release(); // probe table
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Probe table number of columns: " << leftTable->num_columns()
               << std::endl;
     std::cout << "Probe table number of rows: " << leftTable->num_rows()
@@ -494,7 +495,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   auto& rightTable = hashObject_.value().first;
   auto& hb = hashObject_.value().second;
   VELOX_CHECK_NOT_NULL(rightTable);
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     if (rightTable != nullptr)
       printf(
           "right_table is not nullptr %p hasValue(%d)\n",
@@ -669,7 +670,7 @@ RowVectorPtr CudfHashJoinProbe::getOutput() {
   auto rightResult =
       cudf::gather(rightInput, rightIndicesCol, oobPolicy, stream);
 
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Left result number of columns: " << leftResult->num_columns()
               << std::endl;
     std::cout << "Right result number of columns: "
@@ -730,7 +731,7 @@ exec::BlockingReason CudfHashJoinProbe::isBlocked(ContinueFuture* future) {
   auto hashObject = cudfJoinBridge->hashOrFuture(future);
 
   if (!hashObject.has_value()) {
-    if (cudfDebugEnabled()) {
+    if (CudfConfig::getInstance().debugEnabled) {
       std::cout << "CudfHashJoinProbe is blocked, waiting for join build"
                 << std::endl;
     }
@@ -774,7 +775,7 @@ std::unique_ptr<exec::Operator> CudfHashJoinBridgeTranslator::toOperator(
     exec::DriverCtx* ctx,
     int32_t id,
     const core::PlanNodePtr& node) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridgeTranslator::toOperator"
               << std::endl;
   }
@@ -787,7 +788,7 @@ std::unique_ptr<exec::Operator> CudfHashJoinBridgeTranslator::toOperator(
 
 std::unique_ptr<exec::JoinBridge> CudfHashJoinBridgeTranslator::toJoinBridge(
     const core::PlanNodePtr& node) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridgeTranslator::toJoinBridge"
               << std::endl;
   }
@@ -801,7 +802,7 @@ std::unique_ptr<exec::JoinBridge> CudfHashJoinBridgeTranslator::toJoinBridge(
 
 exec::OperatorSupplier CudfHashJoinBridgeTranslator::toOperatorSupplier(
     const core::PlanNodePtr& node) {
-  if (cudfDebugEnabled()) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Calling CudfHashJoinBridgeTranslator::toOperatorSupplier"
               << std::endl;
   }

--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ExpressionEvaluator.h"
-#include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "velox/expression/ConstantExpr.h"
 #include "velox/expression/FieldReference.h"
@@ -283,7 +283,7 @@ namespace detail {
 
 bool canBeEvaluated(const std::shared_ptr<velox::exec::Expr>& expr) {
   const auto name =
-      stripPrefix(expr->name(), CudfOptions::getInstance().prefix());
+      stripPrefix(expr->name(), CudfConfig::getInstance().functionNamePrefix);
   if (supportedOps.count(name) || binaryOps.count(name) ||
       unaryOps.count(name)) {
     return std::all_of(
@@ -413,7 +413,7 @@ cudf::ast::expression const& AstContext::multipleInputsToPairWise(
   using Operation = cudf::ast::operation;
 
   const auto name =
-      stripPrefix(expr->name(), CudfOptions::getInstance().prefix());
+      stripPrefix(expr->name(), CudfConfig::getInstance().functionNamePrefix);
   auto len = expr->inputs().size();
   // Create a simple chain of operations
   auto result = &pushExprToTree(expr->inputs()[0]);
@@ -439,7 +439,7 @@ cudf::ast::expression const& AstContext::pushExprToTree(
   using velox::exec::FieldReference;
 
   const auto name =
-      stripPrefix(expr->name(), CudfOptions::getInstance().prefix());
+      stripPrefix(expr->name(), CudfConfig::getInstance().functionNamePrefix);
   auto len = expr->inputs().size();
   auto& type = expr->type();
 

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -351,7 +351,8 @@ struct CudfDriverAdapter {
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {
-    if (!driver.driverCtx()->queryConfig().get<bool>(kCudfEnabled, true)) {
+    if (!driver.driverCtx()->queryConfig().get<bool>(
+            kCudfEnabled, CudfConfig::getInstance().enabled)) {
       return false;
     }
     auto state = CompileState(factory, driver);

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveConnector.h"
 #include "velox/experimental/cudf/connectors/hive/CudfHiveDataSource.h"
 #include "velox/experimental/cudf/exec/CudfConversion.h"
@@ -45,9 +46,8 @@
 
 #include <iostream>
 
-DEFINE_bool(velox_cudf_enabled, true, "Enable cuDF-Velox acceleration");
-DEFINE_string(velox_cudf_memory_resource, "async", "Memory resource for cuDF");
-DEFINE_bool(velox_cudf_debug, false, "Enable debug printing");
+static const std::string kCudfAdapterName = "cuDF";
+static const std::string kCudfEnabled = "cudf.enabled";
 
 namespace facebook::velox::cudf_velox {
 
@@ -63,7 +63,7 @@ bool isAnyOf(const Base* p) {
 bool CompileState::compile(bool force_replace) {
   auto operators = driver_.operators();
 
-  if (FLAGS_velox_cudf_debug) {
+  if (CudfConfig::getInstance().debugEnabled) {
     std::cout << "Operators before adapting for cuDF: count ["
               << operators.size() << "]" << std::endl;
     for (auto& op : operators) {
@@ -290,7 +290,7 @@ bool CompileState::compile(bool force_replace) {
     }
 
     if (force_replace) {
-      if (FLAGS_velox_cudf_debug) {
+      if (CudfConfig::getInstance().debugEnabled) {
         std::printf(
             "Operator: ID %d: %s, keepOperator = %d, replaceOp.size() = %ld\n",
             oper->operatorId(),
@@ -329,7 +329,7 @@ bool CompileState::compile(bool force_replace) {
     }
   }
 
-  if (FLAGS_velox_cudf_debug) {
+  if (CudfConfig::getInstance().debugEnabled) {
     operators = driver_.operators();
     std::cout << "Operators after adapting for cuDF: count ["
               << operators.size() << "]" << std::endl;
@@ -362,27 +362,29 @@ struct CudfDriverAdapter {
 
 static bool isCudfRegistered = false;
 
-void registerCudf(const CudfOptions& options) {
+bool cudfIsRegistered() {
+  return isCudfRegistered;
+}
+
+void registerCudf() {
   if (cudfIsRegistered()) {
     return;
   }
-  if (!options.cudfEnabled) {
-    return;
-  }
 
-  registerBuiltinFunctions(options.prefix());
+  registerBuiltinFunctions(CudfConfig::getInstance().functionNamePrefix);
 
   CUDF_FUNC_RANGE();
   cudaFree(nullptr); // Initialize CUDA context at startup
 
-  const std::string mrMode = options.cudfMemoryResource;
-  auto mr = cudf_velox::createMemoryResource(mrMode, options.memoryPercent);
+  const std::string mrMode = CudfConfig::getInstance().memoryResource;
+  auto mr = cudf_velox::createMemoryResource(
+      mrMode, CudfConfig::getInstance().memoryPercent);
   cudf::set_current_device_resource(mr.get());
   mr_ = mr;
 
   exec::Operator::registerOperator(
       std::make_unique<CudfHashJoinBridgeTranslator>());
-  CudfDriverAdapter cda{options.force_replace};
+  CudfDriverAdapter cda{CudfConfig::getInstance().forceReplace};
   exec::DriverAdapter cudfAdapter{kCudfAdapterName, {}, cda};
   exec::DriverFactory::registerAdapter(cudfAdapter);
   isCudfRegistered = true;
@@ -402,12 +404,8 @@ void unregisterCudf() {
   isCudfRegistered = false;
 }
 
-bool cudfIsRegistered() {
-  return isCudfRegistered;
+CudfConfig& CudfConfig::getInstance() {
+  static CudfConfig instance;
+  return instance;
 }
-
-bool cudfDebugEnabled() {
-  return FLAGS_velox_cudf_debug;
-}
-
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -21,18 +21,7 @@
 
 #include <rmm/mr/device/device_memory_resource.hpp>
 
-#include <gflags/gflags.h>
-
-DECLARE_bool(velox_cudf_enabled);
-DECLARE_string(velox_cudf_memory_resource);
-DECLARE_bool(velox_cudf_debug);
-
 namespace facebook::velox::cudf_velox {
-
-static const std::string kCudfAdapterName = "cuDF";
-
-// QueryConfig key. Enable or disable cudf in task level.
-static const std::string kCudfEnabled = "cudf.enabled";
 
 class CompileState {
  public:
@@ -51,59 +40,13 @@ class CompileState {
   exec::Driver& driver_;
 };
 
-class CudfOptions {
- public:
-  static CudfOptions& getInstance() {
-    static CudfOptions instance;
-    return instance;
-  }
-
-  void setPrefix(const std::string& prefix) {
-    prefix_ = prefix;
-  }
-
-  const std::string& prefix() const {
-    return prefix_;
-  }
-
-  const bool cudfEnabled;
-  const std::string cudfMemoryResource;
-  // The initial percent of GPU memory to allocate for memory resource for one
-  // thread.
-  int memoryPercent;
-  const bool force_replace;
-
-  CudfOptions(bool force_repl)
-      : cudfEnabled(FLAGS_velox_cudf_enabled),
-        cudfMemoryResource(FLAGS_velox_cudf_memory_resource),
-        memoryPercent(50),
-        force_replace{force_repl},
-        prefix_("") {}
-
- private:
-  CudfOptions()
-      : cudfEnabled(FLAGS_velox_cudf_enabled),
-        cudfMemoryResource(FLAGS_velox_cudf_memory_resource),
-        memoryPercent(50),
-        force_replace{false},
-        prefix_("") {}
-  CudfOptions(const CudfOptions&) = delete;
-  CudfOptions& operator=(const CudfOptions&) = delete;
-  std::string prefix_;
-};
-
 extern std::shared_ptr<rmm::mr::device_memory_resource> mr_;
 
 /// Registers adapter to add cuDF operators to Drivers.
-void registerCudf(const CudfOptions& options = CudfOptions::getInstance());
+void registerCudf();
 void unregisterCudf();
 
 /// Returns true if cuDF is registered.
 bool cudfIsRegistered();
-
-/**
- * @brief Returns true if the velox_cudf_debug flag is set to true.
- */
-bool cudfDebugEnabled();
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(velox_cudf_local_partition_test Main.cpp LocalPartitionTest.cpp)
 add_executable(velox_cudf_filter_project_test Main.cpp FilterProjectTest.cpp)
 add_executable(velox_cudf_subfield_filter_ast_test Main.cpp SubfieldFilterAstTest.cpp)
 add_executable(velox_cudf_limit_test Main.cpp LimitTest.cpp)
+add_executable(velox_cudf_config_test Main.cpp ConfigTest.cpp)
 
 add_test(
   NAME velox_cudf_hash_join_test
@@ -77,6 +78,12 @@ add_test(
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+add_test(
+  NAME velox_cudf_config_test
+  COMMAND velox_cudf_config_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 set_tests_properties(velox_cudf_hash_join_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_order_by_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_aggregation_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
@@ -86,6 +93,7 @@ set_tests_properties(velox_cudf_table_scan_test PROPERTIES LABELS cuda_driver TI
 set_tests_properties(velox_cudf_filter_project_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_subfield_filter_ast_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_limit_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_config_test PROPERTIES LABELS cuda_driver TIMEOUT 300)
 
 target_link_libraries(
   velox_cudf_hash_join_test
@@ -187,6 +195,8 @@ target_link_libraries(
   gtest
   gtest_main
 )
+
+target_link_libraries(velox_cudf_config_test velox_cudf_exec gtest gtest_main)
 
 add_subdirectory(utils)
 

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/CudfConfig.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::cudf_velox::test {
+
+TEST(ConfigTest, CudfConfig) {
+  std::unordered_map<std::string, std::string> options = {
+      {CudfConfig::kCudfEnabled, "false"},
+      {CudfConfig::kCudfDebugEnabled, "true"},
+      {CudfConfig::kCudfMemoryResource, "arena"},
+      {CudfConfig::kCudfMemoryPercent, "25"},
+      {CudfConfig::kCudfFunctionNamePrefix, "presto"},
+      {CudfConfig::kCudfForceReplace, "true"}};
+
+  CudfConfig config;
+  config.initialize(std::move(options));
+  ASSERT_EQ(config.enabled, false);
+  ASSERT_EQ(config.debugEnabled, true);
+  ASSERT_EQ(config.memoryResource, "arena");
+  ASSERT_EQ(config.memoryPercent, 25);
+  ASSERT_EQ(config.functionNamePrefix, "presto");
+  ASSERT_EQ(config.forceReplace, true);
+}
+} // namespace facebook::velox::cudf_velox::test

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 
 #include "folly/experimental/EventCount.h"
@@ -54,8 +55,8 @@ class HashJoinTest : public HashJoinTestBase {
 
   void SetUp() override {
     HashJoinTestBase::SetUp();
-    auto options = cudf_velox::CudfOptions(true);
-    cudf_velox::registerCudf(std::move(options));
+    cudf_velox::CudfConfig::getInstance().forceReplace = true;
+    cudf_velox::registerCudf();
   }
 
   void TearDown() override {

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -35,6 +35,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
+#include <gflags/gflags.h>
 #include <re2/re2.h>
 
 #include <string>
@@ -54,6 +55,8 @@ using namespace facebook::velox::cudf_velox::exec;
 using namespace facebook::velox::cudf_velox::exec::test;
 
 constexpr uint64_t kQueryMemoryCapacity = 512 * MB;
+
+DEFINE_bool(velox_cudf_debug, false, "Enable debug printing");
 
 namespace {
 
@@ -154,7 +157,7 @@ class TableWriteTest : public CudfHiveConnectorTestBase {
         commitStrategy_(testParam_.commitStrategy()),
         compressionKind_(testParam_.compressionKind()) {
     LOG(INFO) << testParam_.toString();
-    if (cudfDebugEnabled()) {
+    if (FLAGS_velox_cudf_debug) {
       std::cout << testParam_.toString() << std::endl;
     }
 


### PR DESCRIPTION
gflags are not recommended to be part of any core library. The preferred way is to use configs, as they are
easier to change in a deployment.
This PR introduces a CudfConfig class and adds a singleton to be used in place of gflags.
Existing cuDF clients that depended on these gflags must either move to using this singleton
or can add these gflags in the client and translate to the singleton.
A helper method `initialize()` has been added to help with the translation.
See changes inside HashJoinTest.cpp and TableWriteTest.cpp
