### PR TITLE
feaf(cudf): Add `start`, `length` and `infoColumns` fields to `CudfHiveConnectorSplit`

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.cpp
@@ -25,17 +25,6 @@
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
-int64_t CudfHiveConfig::skipRows() const {
-  return config_->get<int64_t>(kSkipRows, 0);
-}
-
-std::optional<cudf::size_type> CudfHiveConfig::numRows() const {
-  auto numRows = config_->get<cudf::size_type>(kNumRows);
-  return numRows.has_value()
-      ? std::make_optional<cudf::size_type>(numRows.value())
-      : std::nullopt;
-}
-
 std::size_t CudfHiveConfig::maxChunkReadLimit() const {
   // chunk read limit = 0 means no limit
   return config_->get<std::size_t>(kMaxChunkReadLimit, 0);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
@@ -32,13 +32,6 @@ class CudfHiveConfig {
  public:
   // Reader config options
 
-  // Number of rows to skip from the start; CudfHive stores the number of rows
-  // as int64_t
-  static constexpr const char* kSkipRows = "parquet.reader.skip-rows";
-
-  // Number of rows to read; `nullopt` is all
-  static constexpr const char* kNumRows = "parquet.reader.num-rows";
-
   // This isn't a typo; parquet connector and session config names are different
   // ('-' vs '_').
   static constexpr const char* kMaxChunkReadLimit =
@@ -127,9 +120,6 @@ class CudfHiveConfig {
 
   std::size_t maxPassReadLimit() const;
   std::size_t maxPassReadLimitSession(const config::ConfigBase* session) const;
-
-  int64_t skipRows() const;
-  std::optional<cudf::size_type> numRows() const;
 
   bool isConvertStringsToCategories() const;
   bool isConvertStringsToCategoriesSession(

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
@@ -27,20 +27,30 @@ struct source_info;
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 namespace facebook::velox::cudf_velox::connector::hive {
 
 struct CudfHiveConnectorSplit
     : public facebook::velox::connector::ConnectorSplit {
   const std::string filePath;
+  const uint64_t start;
+  const uint64_t length;
   const facebook::velox::dwio::common::FileFormat fileFormat{
       facebook::velox::dwio::common::FileFormat::PARQUET};
   const std::unique_ptr<cudf::io::source_info> cudfSourceInfo;
 
+  /// These represent columns like $file_size, $file_modified_time that are
+  /// associated with the CudfHiveConnectorSplit.
+  std::unordered_map<std::string, std::string> infoColumns = {};
+
   CudfHiveConnectorSplit(
       const std::string& connectorId,
       const std::string& _filePath,
-      int64_t _splitWeight = 0);
+      uint64_t _start = 0,
+      uint64_t _length = std::numeric_limits<uint64_t>::max(),
+      int64_t _splitWeight = 0,
+      const std::unordered_map<std::string, std::string>& _infoColumns = {});
 
   std::string toString() const override;
   std::string getFileName() const;
@@ -48,6 +58,10 @@ struct CudfHiveConnectorSplit
   const cudf::io::source_info& getCudfSourceInfo() const {
     return *cudfSourceInfo;
   }
+
+  uint64_t size() const override;
+
+  folly::dynamic serialize() const override;
 
   static std::shared_ptr<CudfHiveConnectorSplit> create(
       const folly::dynamic& obj);
@@ -57,6 +71,23 @@ class CudfHiveConnectorSplitBuilder {
  public:
   explicit CudfHiveConnectorSplitBuilder(std::string filePath)
       : filePath_{std::move(filePath)} {}
+
+  CudfHiveConnectorSplitBuilder& start(uint64_t start) {
+    start_ = start;
+    return *this;
+  }
+
+  CudfHiveConnectorSplitBuilder& length(uint64_t length) {
+    length_ = length;
+    return *this;
+  }
+
+  CudfHiveConnectorSplitBuilder& infoColumn(
+      const std::string& name,
+      const std::string& value) {
+    infoColumns_.emplace(std::move(name), std::move(value));
+    return *this;
+  }
 
   CudfHiveConnectorSplitBuilder& splitWeight(int64_t splitWeight) {
     splitWeight_ = splitWeight;
@@ -75,8 +106,11 @@ class CudfHiveConnectorSplitBuilder {
 
  private:
   const std::string filePath_;
+  uint64_t start_{0};
+  uint64_t length_{std::numeric_limits<uint64_t>::max()};
   std::string connectorId_;
   int64_t splitWeight_{0};
+  std::unordered_map<std::string, std::string> infoColumns_ = {};
 };
 
 } // namespace facebook::velox::cudf_velox::connector::hive

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h"
 #include "velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h"
 
+#include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/tests/FaultyFile.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
@@ -418,24 +419,21 @@ TEST_F(TableScanTest, filterPushdown) {
 #endif
 }
 
-TEST_F(TableScanTest, splitOffset) {
-  auto vectors = makeVectors(1, 10);
+TEST_F(TableScanTest, splitOffsetAndLength) {
+  auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->getPath(), vectors);
+  createDuckDbTable(vectors);
 
-  auto plan = tableScanNode();
+  assertQuery(
+      tableScanNode(),
+      makeCudfHiveConnectorSplit(
+          filePath->getPath(), 0, fs::file_size(filePath->getPath()) / 2),
+      "SELECT * FROM tmp");
 
-  auto split = facebook::velox::connector::hive::HiveConnectorSplitBuilder(
-                   filePath->getPath())
-                   .connectorId(kCudfHiveConnectorId)
-                   .start(1)
-                   .fileFormat(dwio::common::FileFormat::PARQUET)
-                   .build();
-
-  VELOX_ASSERT_THROW(
-      AssertQueryBuilder(duckDbQueryRunner_)
-          .plan(plan)
-          .splits({split})
-          .assertEmptyResults(),
-      "CudfHiveDataSource cannot process splits with non-zero offset");
+  assertQuery(
+      tableScanNode(),
+      makeCudfHiveConnectorSplit(
+          filePath->getPath(), fs::file_size(filePath->getPath()) / 2),
+      "SELECT * FROM tmp LIMIT 0");
 }

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
@@ -224,7 +224,12 @@ CudfHiveConnectorTestBase::makeCudfHiveConnectorSplits(
   std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
       splits;
   for (const auto& filePath : filePaths) {
-    splits.push_back(makeCudfHiveConnectorSplit(filePath->getPath()));
+    splits.push_back(makeCudfHiveConnectorSplit(
+        filePath->getPath(),
+        filePath->fileSize(),
+        filePath->fileModifiedTime(),
+        0,
+        std::numeric_limits<uint64_t>::max()));
   }
   return splits;
 }
@@ -233,7 +238,9 @@ std::vector<
     std::shared_ptr<facebook::velox::connector::hive::HiveConnectorSplit>>
 CudfHiveConnectorTestBase::makeCudfHiveConnectorSplits(
     const std::string& filePath,
-    uint32_t splitCount) {
+    uint32_t splitCount,
+    const std::optional<std::unordered_map<std::string, std::string>>&
+        infoColumns) {
   auto file =
       filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
   const int64_t fileSize = file->size();
@@ -244,12 +251,18 @@ CudfHiveConnectorTestBase::makeCudfHiveConnectorSplits(
       splits;
   // Add all the splits.
   for (int i = 0; i < splitCount; i++) {
-    auto split =
+    auto splitBuilder =
         facebook::velox::connector::hive::HiveConnectorSplitBuilder(filePath)
             .connectorId(kCudfHiveConnectorId)
             .fileFormat(facebook::velox::dwio::common::FileFormat::PARQUET)
-            .build();
-    splits.push_back(std::move(split));
+            .start(i * splitSize)
+            .length(splitSize);
+    if (infoColumns.has_value()) {
+      for (auto infoColumn : infoColumns.value()) {
+        splitBuilder.infoColumn(infoColumn.first, infoColumn.second);
+      }
+    }
+    splits.push_back(splitBuilder.build());
   }
   return splits;
 }
@@ -257,14 +270,32 @@ CudfHiveConnectorTestBase::makeCudfHiveConnectorSplits(
 std::shared_ptr<facebook::velox::connector::hive::HiveConnectorSplit>
 CudfHiveConnectorTestBase::makeCudfHiveConnectorSplit(
     const std::string& filePath,
+    uint64_t start,
+    uint64_t length,
     int64_t splitWeight) {
   return facebook::velox::connector::hive::HiveConnectorSplitBuilder(filePath)
       .connectorId(kCudfHiveConnectorId)
       .fileFormat(facebook::velox::dwio::common::FileFormat::PARQUET)
+      .start(start)
+      .length(length)
       .splitWeight(splitWeight)
       .build();
 }
 
+std::shared_ptr<facebook::velox::connector::hive::HiveConnectorSplit>
+CudfHiveConnectorTestBase::makeCudfHiveConnectorSplit(
+    const std::string& filePath,
+    int64_t fileSize,
+    int64_t fileModifiedTime,
+    uint64_t start,
+    uint64_t length) {
+  return facebook::velox::connector::hive::HiveConnectorSplitBuilder(filePath)
+      .infoColumn("$file_size", fmt::format("{}", fileSize))
+      .infoColumn("$file_modified_time", fmt::format("{}", fileModifiedTime))
+      .start(start)
+      .length(length)
+      .build();
+}
 // static
 std::shared_ptr<connector::hive::CudfHiveInsertTableHandle>
 CudfHiveConnectorTestBase::makeCudfHiveInsertTableHandle(

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
@@ -85,7 +85,18 @@ class CudfHiveConnectorTestBase
   static std::shared_ptr<facebook::velox::connector::hive::HiveConnectorSplit>
   makeCudfHiveConnectorSplit(
       const std::string& filePath,
+      uint64_t start = 0,
+      uint64_t length =
+          static_cast<uint64_t>(std::numeric_limits<cudf::size_type>::max()),
       int64_t splitWeight = 0);
+
+  static std::shared_ptr<facebook::velox::connector::hive::HiveConnectorSplit>
+  makeCudfHiveConnectorSplit(
+      const std::string& filePath,
+      int64_t fileSize,
+      int64_t fileModifiedTime,
+      uint64_t start,
+      uint64_t length);
 
   static std::vector<
       std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
@@ -96,7 +107,11 @@ class CudfHiveConnectorTestBase
 
   static std::vector<
       std::shared_ptr<facebook::velox::connector::hive::HiveConnectorSplit>>
-  makeCudfHiveConnectorSplits(const std::string& filePath, uint32_t splitCount);
+  makeCudfHiveConnectorSplits(
+      const std::string& filePath,
+      uint32_t splitCount,
+      const std::optional<std::unordered_map<std::string, std::string>>&
+          infoColumns = {});
 
   static std::shared_ptr<facebook::velox::connector::hive::HiveTableHandle>
   makeTableHandle(


### PR DESCRIPTION
## Description

Closes https://github.com/rapidsai/velox/issues/16 (duplicate of https://github.com/facebookincubator/velox/pull/14129)

This PR adds `start`, `length` and `infoColumns` fields to the `CudfHiveConnectorSplit` to allow splitting parquet file read across multiple splits. These fields also allow direct conversion from `HiveConnectorSplit` to `CudfHiveConnectorSplit`.

## Checklist
- [ ] Update RAPIDS/cuDF pinning to the latest commit or `25.10` release to pull in backend changes from https://github.com/rapidsai/cudf/pull/19991