### PR TITLE
fix: Change array_sort lambda signature

### DIFF
--- a/velox/functions/lib/ArraySort.cpp
+++ b/velox/functions/lib/ArraySort.cpp
@@ -450,7 +450,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
             .typeVariable("T")
             .returnType("array(T)")
             .argumentType("array(T)")
-            .constantArgumentType("function(T,T,bigint)")
+            .constantArgumentType("function(T,T,integer)")
             .build());
   }
   return signatures;

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -334,6 +334,7 @@ ArrayVectorPtr ArraySortTest::arrayVector<TestRowType>(
 }
 
 void ArraySortTest::SetUp() {
+  options_.parseIntegerAsBigint = false;
   for (const TypeKind type : kSupportedTypes) {
     switch (type) {
       case TypeKind::BOOLEAN:


### PR DESCRIPTION
Summary:
array_sort lambda signature is defined as function(T, T, bigint) , however Presto has this defined as function(T, T, int) . This causes the side car to fail array_sort queries that use this lambda. See details in [this issue](https://github.com/prestodb/presto/issues/26146). 

This change changes the signature to match Presto which fixes the side car.

Differential Revision: D83353566


