### PR TITLE
Enable TDigest and QDigest fuzzers

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -114,10 +114,15 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
         {"quantile_at_value",
          std::make_shared<UnifiedDigestArgValuesGenerator>(
              "quantile_at_value")},
+        {"quantiles_at_values",
+         std::make_shared<TDigestArgValuesGenerator>("quantiles_at_values")},
         {"destructure_tdigest",
          std::make_shared<TDigestArgValuesGenerator>("destructure_tdigest")},
         {"trimmed_mean",
-         std::make_shared<TDigestArgValuesGenerator>("trimmed_mean")}};
+         std::make_shared<TDigestArgValuesGenerator>("trimmed_mean")},
+        {"merge_tdigest",
+         std::make_shared<TDigestArgValuesGenerator>("merge_tdigest")},
+};
 
 // TODO: List of the functions that at some point crash or fail and need to
 // be fixed before we can enable.
@@ -129,17 +134,9 @@ std::unordered_set<std::string> skipFunctions = {
     "merge_sfm", // Fuzzer can generate sketches of different sizes.
     "element_at",
     "width_bucket",
-    // Fuzzer and the underlying engine are confused about TDigest functions
-    // (since TDigest is a user defined type), and tries to pass a
-    // VARBINARY (since TDigest's implementation uses an
-    // alias to VARBINARY).
-    "value_at_quantile",
-    "values_at_quantiles",
-    "merge_tdigest",
-    "scale_tdigest",
-    "quantiles_at_values",
+    // Handle valid inputs to create tdigest
     "construct_tdigest",
-    "destructure_tdigest",
+    // Handle quantile constraints
     "trimmed_mean",
     // Fuzzer cannot generate valid 'comparator' lambda.
     "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
@@ -403,6 +400,9 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "$internal$contains",
     "localtime", // localtime cannot be called with paranthesis:
                  // https://github.com/facebookincubator/velox/issues/14937
+    // Velox is more accurate than Presto, results are different
+    "merge_tdigest",
+    "scale_tdigest",
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
Enable fuzzer (SOT and DuckDb)
- value_at_quantile
- values_at_quantiles
- quantile_at_value
- scale_qdigest
- quantiles_at_values (TODO)

Enable function fuzzing (DuckDB only)
- merge_tdigest
- scale_tdigest


TODO
Trimmed Mean - check error
construct_tdigest is still skipped. So `construct_tdigest` is **not** in the [`**TDigestArgValuesGenerator**`](command:code-compose.open?%5B%22%2Fdata%2Fusers%2Fnasehgal%2Ffbsource%2Ffbcode%2Fvelox%2Fexpression%2Ffuzzer%2FExpressionFuzzerTest.cpp%22%2C65%5D "TDigestArgValuesGenerator") because it has **different input requirements** - it needs arrays of means and counts rather than just a TDigest input like the other functions. It would need its own specialized argument values generator to create proper test inputs.

Differential Revision: D83363239


