### PR TITLE
fix: Add missing includes

### DIFF
--- a/velox/common/base/CountBits.h
+++ b/velox/common/base/CountBits.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/CPortability.h>
+
 namespace facebook::velox {
 
 // Copied from format.h of fmt.

--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <mutex>
 #include <vector>
 
 inline size_t count_trailing_zeros(uint64_t x) {


### PR DESCRIPTION
Add missing includes
1. mutex needed because of std::lock_guard in velox/common/base/Portability.h
2. folly_always_inline in velox/common/base/CountBits.h