### PR TITLE
fix: Fix race in MemoryPool in debug mode

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -1263,7 +1263,7 @@ void MemoryPoolImpl::recordAllocDbg(const void* addr, uint64_t size) {
         succinctBytes(size),
         succinctBytes(usedBytes),
         it->second.callStack.toString(),
-        dumpRecordsDbg());
+        dumpRecordsDbgLocked());
   }
 }
 
@@ -1352,7 +1352,7 @@ void MemoryPoolImpl::leakCheckDbg() {
       dumpRecordsDbg()));
 }
 
-std::string MemoryPoolImpl::dumpRecordsDbg() const {
+std::string MemoryPoolImpl::dumpRecordsDbgLocked() const {
   VELOX_CHECK(debugEnabled());
   std::stringstream oss;
   oss << fmt::format("Found {} allocations:\n", debugAllocRecords_.size());

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -1010,7 +1010,12 @@ class MemoryPoolImpl : public MemoryPool {
 
   // Dump the recorded call sites of the memory allocations in
   // 'debugAllocRecords_' to the string.
-  std::string dumpRecordsDbg() const;
+  std::string dumpRecordsDbgLocked() const;
+
+  std::string dumpRecordsDbg() const {
+    std::lock_guard<std::mutex> l(debugAllocMutex_);
+    return dumpRecordsDbgLocked();
+  }
 
   void handleAllocationFailure(const std::string& failureMessage);
 
@@ -1075,7 +1080,7 @@ class MemoryPoolImpl : public MemoryPool {
   std::atomic_uint64_t numCapacityGrowths_{0};
 
   // Mutex for 'debugAllocRecords_'.
-  std::mutex debugAllocMutex_;
+  mutable std::mutex debugAllocMutex_;
 
   // Map from address to 'AllocationRecord'.
   std::unordered_map<uint64_t, AllocationRecord> debugAllocRecords_;


### PR DESCRIPTION
Summary:
`MemoryPool::toString()` calls `dumpRecordsDbg()` without locking `debugAllocMutex_` mutex.
```
std::string MemoryPoolImpl::toString(bool detail) const {
  std::string result;
  {
    std::lock_guard<std::mutex> l(mutex_);
    result = toStringLocked();
  }
  if (detail) {
    result += "\n" + treeMemoryUsage();
  }
  if (FOLLY_UNLIKELY(debugEnabled())) {
    result += "\n" + dumpRecordsDbg();
  }
  return result;
}
```
Let's have 2 versions for `dumpRecordsDbg()` method to avoid confusion.

Differential Revision: D83418591


