### PR TITLE
fix: Data race inside tpch gen

### DIFF
--- a/velox/tpch/gen/dbgen/bm_utils.cpp
+++ b/velox/tpch/gen/dbgen/bm_utils.cpp
@@ -107,7 +107,7 @@ char* getenv PROTO((const char* name));
 namespace facebook::velox::tpch::dbgen {
 
 void usage();
-void permute_dist(distribution* d, seed_t* seed);
+void permute_dist(distribution* d, seed_t* seed, DBGenContext* ctx);
 
 /*
  * tpch_env_config: look for a environmental variable setting and return its
@@ -297,7 +297,6 @@ void read_dist(const char* path, const char* name, distribution* target) {
     fprintf(stderr, "Read error on dist '%s'\n", name);
     exit(1);
   }
-  target->permute = reinterpret_cast<long*>(NULL);
   return;
 }
 
@@ -305,16 +304,21 @@ void read_dist(const char* path, const char* name, distribution* target) {
  * agg_str(set, count) build an aggregated string from count unique
  * selections taken from set
  */
-void agg_str(distribution* set, long count, seed_t* seed, char* dest) {
+void agg_str(
+    distribution* set,
+    long count,
+    seed_t* seed,
+    char* dest,
+    DBGenContext* ctx) {
   distribution* d;
   int i;
 
   d = set;
   *dest = '\0';
 
-  permute_dist(d, seed);
+  permute_dist(d, seed, ctx);
   for (i = 0; i < count; i++) {
-    strcat(dest, DIST_MEMBER(set, DIST_PERMUTE(d, i)));
+    strcat(dest, DIST_MEMBER(set, ctx->permute[i]));
     strcat(dest, " ");
   }
   *(dest + static_cast<int>(strlen(dest)) - 1) = '\0';

--- a/velox/tpch/gen/dbgen/build.cpp
+++ b/velox/tpch/gen/dbgen/build.cpp
@@ -268,7 +268,11 @@ long mk_part(DSS_HUGE index, part_t* p, DBGenContext* ctx) {
 
   p->partkey = index;
   agg_str(
-      &colors, static_cast<long>(P_NAME_SCL), &ctx->Seed[P_NAME_SD], p->name);
+      &colors,
+      static_cast<long>(P_NAME_SCL),
+      &ctx->Seed[P_NAME_SD],
+      p->name,
+      ctx);
   RANDOM(temp, P_MFG_MIN, P_MFG_MAX, &ctx->Seed[P_MFG_SD]);
   sprintf(p->mfgr, partSzFormat, P_MFG_TAG, temp);
   RANDOM(brnd, P_BRND_MIN, P_BRND_MAX, &ctx->Seed[P_BRND_SD]);

--- a/velox/tpch/gen/dbgen/dbgen_gunk.cpp
+++ b/velox/tpch/gen/dbgen/dbgen_gunk.cpp
@@ -72,10 +72,6 @@ static void cleanup_dist(distribution* target) {
     }
     free(target->list);
   }
-  /* Allocated from permute_dist */
-  if (target->permute) {
-    free(target->permute);
-  }
 }
 
 void cleanup_dists(void) {

--- a/velox/tpch/gen/dbgen/permute.cpp
+++ b/velox/tpch/gen/dbgen/permute.cpp
@@ -34,7 +34,7 @@ namespace facebook::velox::tpch::dbgen {
 
 DSS_HUGE NextRand(DSS_HUGE seed);
 void permute(long* set, int cnt, seed_t* seed);
-void permute_dist(distribution* d, seed_t* seed);
+void permute_dist(distribution* d, seed_t* seed, DBGenContext* ctx);
 long seed;
 char* eol[2] = {" ", "},"};
 
@@ -44,8 +44,8 @@ char* eol[2] = {" ", "},"};
 
 void permute(long* a, int c, seed_t* seed) {
   int i;
-  static DSS_HUGE source;
-  static long temp;
+  DSS_HUGE source;
+  long temp;
 
   if (a != reinterpret_cast<long*>(NULL)) {
     for (i = 0; i < c; i++) {
@@ -59,17 +59,18 @@ void permute(long* a, int c, seed_t* seed) {
   return;
 }
 
-void permute_dist(distribution* d, seed_t* seed) {
+void permute_dist(distribution* d, seed_t* seed, DBGenContext* ctx) {
   int i;
 
   if (d != NULL) {
-    if (d->permute == reinterpret_cast<long*>(NULL)) {
-      d->permute = reinterpret_cast<long*>(malloc(sizeof(long) * DIST_SIZE(d)));
-      MALLOC_CHECK(d->permute);
+    if (ctx->permute == reinterpret_cast<long*>(NULL)) {
+      ctx->permute =
+          reinterpret_cast<long*>(malloc(sizeof(long) * DIST_SIZE(d)));
+      MALLOC_CHECK(ctx->permute);
     }
     for (i = 0; i < DIST_SIZE(d); i++)
-      *(d->permute + i) = i;
-    permute(d->permute, DIST_SIZE(d), seed);
+      *(ctx->permute + i) = i;
+    permute(ctx->permute, DIST_SIZE(d), seed);
   } else
     INTERNAL_ERROR("Bad call to permute_dist");
 


### PR DESCRIPTION
Axiom q9 is flaky because of that.

Fix adopted from duckdb (https://github.com/duckdb/duckdb/pull/12337)

<details>
  <summary>TSAN report</summary>

```
WARNING: ThreadSanitizer: data race (pid=1943105)
  Write of size 8 at 0x725800010540 by thread T74 (mutexes: read M0):
    #0 facebook::velox::tpch::dbgen::permute_dist(facebook::velox::tpch::dbgen::distribution*, facebook::velox::tpch::dbgen::SEED_T*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/permute.cpp:71:25 (axiom_optimizer_tpch_plan_test+0x7cf0f1e) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #1 facebook::velox::tpch::dbgen::agg_str(facebook::velox::tpch::dbgen::distribution*, long, facebook::velox::tpch::dbgen::SEED_T*, char*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/bm_utils.cpp:315:3 (axiom_optimizer_tpch_plan_test+0x7ceda8c) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #2 facebook::velox::tpch::dbgen::mk_part(long long, facebook::velox::tpch::dbgen::part_t*, facebook::velox::tpch::dbgen::DBGenContext*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/build.cpp:270:3 (axiom_optimizer_tpch_plan_test+0x7cefaeb) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #3 facebook::velox::tpch::DBGenIterator::genPart(unsigned long, facebook::velox::tpch::dbgen::part_t&) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/DBGenIterator.cpp:119:3 (axiom_optimizer_tpch_plan_test+0x7ce2aa6) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #4 facebook::velox::tpch::genTpchPartSupp(facebook::velox::memory::MemoryPool*, unsigned long, unsigned long, double) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/TpchGen.cpp:611:13 (axiom_optimizer_tpch_plan_test+0x7cdd03a) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #5 facebook::velox::connector::tpch::(anonymous namespace)::getTpchData(facebook::velox::tpch::Table, unsigned long, unsigned long, double, facebook::velox::memory::MemoryPool*) /home/mironov/projects/serenedb/verax/velox/velox/connectors/tpch/TpchConnector.cpp:46:14 (axiom_optimizer_tpch_plan_test+0x492ba54) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #6 facebook::velox::connector::tpch::TpchDataSource::next(unsigned long, folly::SemiFuture<folly::Unit>&) /home/mironov/projects/serenedb/verax/velox/velox/connectors/tpch/TpchConnector.cpp:227:7 (axiom_optimizer_tpch_plan_test+0x492b71b) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #7 facebook::velox::exec::TableScan::getOutput() /home/mironov/projects/serenedb/verax/velox/velox/exec/TableScan.cpp:204:35 (axiom_optimizer_tpch_plan_test+0x174f348b) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #8 facebook::velox::exec::(anonymous namespace)::getOutput(facebook::velox::exec::Operator*, std::shared_ptr<facebook::velox::RowVector>&) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:446:16 (axiom_optimizer_tpch_plan_test+0x171224d6) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #9 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_4::operator()() const /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:574:15 (axiom_optimizer_tpch_plan_test+0x17121dd1) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #10 void facebook::velox::exec::Driver::withDeltaCpuWallTimer<facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_4>(facebook::velox::exec::Operator*, facebook::velox::CpuWallTiming facebook::velox::exec::OperatorStats::*, facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_4&&) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:1176:3 (axiom_optimizer_tpch_plan_test+0x171162f3) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #11 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:571:13 (axiom_optimizer_tpch_plan_test+0x17113b85) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #12 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:736:23 (axiom_optimizer_tpch_plan_test+0x17116d8f) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #13 facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0::operator()() const /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:243:20 (axiom_optimizer_tpch_plan_test+0x1711c4d6) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #14 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(folly::detail::function::Data&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:341:5 (axiom_optimizer_tpch_plan_test+0x1711c3fd) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #15 folly::detail::function::FunctionTraits<void ()>::operator()() /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:370:12 (axiom_optimizer_tpch_plan_test+0x6808053) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #16 void folly::catch_exception<folly::Function<void ()>&, void (&)(char const*) noexcept, char const*&, void>(folly::Function<void ()>&, void (&)(char const*) noexcept, char const*&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/lang/Exception.h:359:12 (axiom_optimizer_tpch_plan_test+0x18d8a126) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #17 void folly::Executor::invokeCatchingExns<folly::Function<void ()>>(char const*, folly::Function<void ()>) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Executor.h:234:5 (axiom_optimizer_tpch_plan_test+0x18d8a126)
    #18 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/executors/ThreadPoolExecutor.cpp:142:7 (axiom_optimizer_tpch_plan_test+0x18d8a126)
    #19 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/executors/CPUThreadPoolExecutor.cpp:364:5 (axiom_optimizer_tpch_plan_test+0x18d00932) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #20 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:74:14 (axiom_optimizer_tpch_plan_test+0x18d95576) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #21 std::__invoke_result<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>::type std::__invoke<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14 (axiom_optimizer_tpch_plan_test+0x18d953a5) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #22 void std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::__call<void, 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:506:11 (axiom_optimizer_tpch_plan_test+0x18d9533a) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #23 void std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::operator()<void>() /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:591:17 (axiom_optimizer_tpch_plan_test+0x18d95296) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #24 void folly::detail::function::call_<std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>, true, false, void>(folly::detail::function::Data&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:341:5 (axiom_optimizer_tpch_plan_test+0x18d9506d) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #25 folly::detail::function::FunctionTraits<void ()>::operator()() /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:370:12 (axiom_optimizer_tpch_plan_test+0x6808053) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #26 folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()::operator()() /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/executors/thread_factory/NamedThreadFactory.h:40:11 (axiom_optimizer_tpch_plan_test+0x6807fe9) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #27 void std::__invoke_impl<void, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>(std::__invoke_other, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14 (axiom_optimizer_tpch_plan_test+0x6807f75) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #28 std::__invoke_result<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>::type std::__invoke<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>(folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14 (axiom_optimizer_tpch_plan_test+0x6807ee5) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #29 void std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:292:13 (axiom_optimizer_tpch_plan_test+0x6807e9d) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #30 std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:299:11 (axiom_optimizer_tpch_plan_test+0x6807e45) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #31 std::thread::_State_impl<std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:244:13 (axiom_optimizer_tpch_plan_test+0x6807ba9) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #32 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)

  Previous write of size 8 at 0x725800010540 by thread T75 (mutexes: read M1):
    #0 facebook::velox::tpch::dbgen::permute(long*, int, facebook::velox::tpch::dbgen::SEED_T*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/permute.cpp:55:16 (axiom_optimizer_tpch_plan_test+0x7cf0dc3) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #1 facebook::velox::tpch::dbgen::permute_dist(facebook::velox::tpch::dbgen::distribution*, facebook::velox::tpch::dbgen::SEED_T*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/permute.cpp:72:5 (axiom_optimizer_tpch_plan_test+0x7cf0f88) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #2 facebook::velox::tpch::dbgen::agg_str(facebook::velox::tpch::dbgen::distribution*, long, facebook::velox::tpch::dbgen::SEED_T*, char*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/bm_utils.cpp:315:3 (axiom_optimizer_tpch_plan_test+0x7ceda8c) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #3 facebook::velox::tpch::dbgen::mk_part(long long, facebook::velox::tpch::dbgen::part_t*, facebook::velox::tpch::dbgen::DBGenContext*) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/dbgen/build.cpp:270:3 (axiom_optimizer_tpch_plan_test+0x7cefaeb) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #4 facebook::velox::tpch::DBGenIterator::genPart(unsigned long, facebook::velox::tpch::dbgen::part_t&) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/DBGenIterator.cpp:119:3 (axiom_optimizer_tpch_plan_test+0x7ce2aa6) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #5 facebook::velox::tpch::genTpchPart(facebook::velox::memory::MemoryPool*, unsigned long, unsigned long, double) /home/mironov/projects/serenedb/verax/velox/velox/tpch/gen/TpchGen.cpp:520:13 (axiom_optimizer_tpch_plan_test+0x7cdc3b2) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #6 facebook::velox::connector::tpch::(anonymous namespace)::getTpchData(facebook::velox::tpch::Table, unsigned long, unsigned long, double, facebook::velox::memory::MemoryPool*) /home/mironov/projects/serenedb/verax/velox/velox/connectors/tpch/TpchConnector.cpp:42:14 (axiom_optimizer_tpch_plan_test+0x492ba12) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #7 facebook::velox::connector::tpch::TpchDataSource::next(unsigned long, folly::SemiFuture<folly::Unit>&) /home/mironov/projects/serenedb/verax/velox/velox/connectors/tpch/TpchConnector.cpp:227:7 (axiom_optimizer_tpch_plan_test+0x492b71b) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #8 facebook::velox::exec::TableScan::getOutput() /home/mironov/projects/serenedb/verax/velox/velox/exec/TableScan.cpp:204:35 (axiom_optimizer_tpch_plan_test+0x174f348b) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #9 facebook::velox::exec::(anonymous namespace)::getOutput(facebook::velox::exec::Operator*, std::shared_ptr<facebook::velox::RowVector>&) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:446:16 (axiom_optimizer_tpch_plan_test+0x171224d6) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #10 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_4::operator()() const /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:574:15 (axiom_optimizer_tpch_plan_test+0x17121dd1) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #11 void facebook::velox::exec::Driver::withDeltaCpuWallTimer<facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_4>(facebook::velox::exec::Operator*, facebook::velox::CpuWallTiming facebook::velox::exec::OperatorStats::*, facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_4&&) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:1176:3 (axiom_optimizer_tpch_plan_test+0x171162f3) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #12 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:571:13 (axiom_optimizer_tpch_plan_test+0x17113b85) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #13 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>) /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:736:23 (axiom_optimizer_tpch_plan_test+0x17116d8f) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #14 facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0::operator()() const /home/mironov/projects/serenedb/verax/velox/velox/exec/Driver.cpp:243:20 (axiom_optimizer_tpch_plan_test+0x1711c4d6) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #15 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(folly::detail::function::Data&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:341:5 (axiom_optimizer_tpch_plan_test+0x1711c3fd) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #16 folly::detail::function::FunctionTraits<void ()>::operator()() /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:370:12 (axiom_optimizer_tpch_plan_test+0x6808053) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #17 void folly::catch_exception<folly::Function<void ()>&, void (&)(char const*) noexcept, char const*&, void>(folly::Function<void ()>&, void (&)(char const*) noexcept, char const*&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/lang/Exception.h:359:12 (axiom_optimizer_tpch_plan_test+0x18d8a126) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #18 void folly::Executor::invokeCatchingExns<folly::Function<void ()>>(char const*, folly::Function<void ()>) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Executor.h:234:5 (axiom_optimizer_tpch_plan_test+0x18d8a126)
    #19 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/executors/ThreadPoolExecutor.cpp:142:7 (axiom_optimizer_tpch_plan_test+0x18d8a126)
    #20 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/executors/CPUThreadPoolExecutor.cpp:364:5 (axiom_optimizer_tpch_plan_test+0x18d00932) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #21 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:74:14 (axiom_optimizer_tpch_plan_test+0x18d95576) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #22 std::__invoke_result<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>::type std::__invoke<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14 (axiom_optimizer_tpch_plan_test+0x18d953a5) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #23 void std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::__call<void, 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:506:11 (axiom_optimizer_tpch_plan_test+0x18d9533a) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #24 void std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::operator()<void>() /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/functional:591:17 (axiom_optimizer_tpch_plan_test+0x18d95296) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #25 void folly::detail::function::call_<std::_Bind<void (folly::ThreadPoolExecutor::* (folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>, true, false, void>(folly::detail::function::Data&) /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:341:5 (axiom_optimizer_tpch_plan_test+0x18d9506d) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #26 folly::detail::function::FunctionTraits<void ()>::operator()() /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/Function.h:370:12 (axiom_optimizer_tpch_plan_test+0x6808053) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #27 folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()::operator()() /home/mironov/projects/serenedb/verax/_build/debug/_deps/folly-src/folly/executors/thread_factory/NamedThreadFactory.h:40:11 (axiom_optimizer_tpch_plan_test+0x6807fe9) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #28 void std::__invoke_impl<void, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>(std::__invoke_other, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14 (axiom_optimizer_tpch_plan_test+0x6807f75) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #29 std::__invoke_result<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>::type std::__invoke<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>(folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:96:14 (axiom_optimizer_tpch_plan_test+0x6807ee5) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #30 void std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>>::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:292:13 (axiom_optimizer_tpch_plan_test+0x6807e9d) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #31 std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>>::operator()() /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:299:11 (axiom_optimizer_tpch_plan_test+0x6807e45) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #32 std::thread::_State_impl<std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::'lambda'()>>>::_M_run() /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_thread.h:244:13 (axiom_optimizer_tpch_plan_test+0x6807ba9) (BuildId: b96642ebfc3f8acf82de2bad53ac07cafcb3b2d6)
    #33 <null> <null> (libstdc++.so.6+0xecdb3) (BuildId: ca77dae775ec87540acd7218fa990c40d1c94ab1)
```

</details>