### PR TITLE
fix: Use correct C++ without UB (data race), that produce same or faster code

### DIFF
--- a/velox/exec/benchmarks/AtomicsBench.cpp
+++ b/velox/exec/benchmarks/AtomicsBench.cpp
@@ -16,16 +16,40 @@
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
-#include <gtest/gtest.h>
+#include <folly/synchronization/SanitizeThread.h>
 #include <atomic>
 #include <thread>
 #include <vector>
+#include "velox/common/base/Portability.h"
 #include "velox/exec/OneWayStatusFlag.h"
 
-using namespace ::testing;
-using namespace facebook::velox;
-static const size_t kNumThreads = 88;
-static const size_t kNumIterations = 10000;
+namespace {
+
+using facebook::velox::exec::OneWayStatusFlag;
+constexpr size_t kNumThreads = 88;
+constexpr size_t kNumIterations = 10000;
+
+#if defined(__x86_64__) && !defined(TSAN_BUILD)
+
+class OneWayStatusFlagUnsafe {
+ public:
+  bool check() const {
+    return fastStatus_ || atomicStatus_.load();
+  }
+
+  void set() {
+    if (!fastStatus_) {
+      atomicStatus_.store(true);
+      fastStatus_ = true;
+    }
+  }
+
+ private:
+  bool fastStatus_{false};
+  std::atomic_bool atomicStatus_{false};
+};
+
+#endif
 
 void runParallelUpdates(
     std::function<void(size_t iter)> callback,
@@ -46,12 +70,28 @@ void runParallelUpdates(
   }
 }
 
-BENCHMARK(std_atomic_bool_write) {
-  std::atomic<bool> flag{false};
+BENCHMARK(std_atomic_bool_write_seq_cst) {
+  std::atomic_bool flag{false};
   runParallelUpdates(
       [&](size_t iters) {
         for (size_t i = 0; i < iters; ++i) {
           flag.store(true);
+          bool dummy{};
+          folly::doNotOptimizeAway(dummy);
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_write_release) {
+  std::atomic_bool flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          flag.store(true, std::memory_order_release);
+          bool dummy{};
+          folly::doNotOptimizeAway(dummy);
         }
       },
       kNumThreads, // Threads
@@ -59,25 +99,13 @@ BENCHMARK(std_atomic_bool_write) {
 }
 
 BENCHMARK(std_atomic_bool_write_relaxed) {
-  std::atomic<bool> flag{false};
+  std::atomic_bool flag{false};
   runParallelUpdates(
       [&](size_t iters) {
         for (size_t i = 0; i < iters; ++i) {
           flag.store(true, std::memory_order_relaxed);
-        }
-      },
-      kNumThreads, // Threads
-      kNumIterations); // Iterations per thread
-}
-
-BENCHMARK(std_atomic_bool_read_write_relaxed) {
-  std::atomic<bool> flag{false};
-  runParallelUpdates(
-      [&](size_t iters) {
-        for (size_t i = 0; i < iters; ++i) {
-          if (!flag.load(std::memory_order_relaxed)) {
-            flag.store(true, std::memory_order_acq_rel);
-          }
+          bool dummy{};
+          folly::doNotOptimizeAway(dummy);
         }
       },
       kNumThreads, // Threads
@@ -85,32 +113,64 @@ BENCHMARK(std_atomic_bool_read_write_relaxed) {
 }
 
 BENCHMARK(one_way_flag_write) {
-  exec::OneWayStatusFlag flag;
+  OneWayStatusFlag flag;
   runParallelUpdates(
       [&](size_t iters) {
         for (size_t i = 0; i < iters; ++i) {
           flag.set();
+          bool dummy{};
+          folly::doNotOptimizeAway(dummy);
         }
       },
       kNumThreads, // Threads
       kNumIterations); // Iterations per thread
 }
 
-// Read Benchmarks
-BENCHMARK(std_atomic_bool_read) {
-  std::atomic<bool> flag{false};
+#if defined(__x86_64__) && !defined(TSAN_BUILD)
+
+BENCHMARK(one_way_flag_unsafe_write) {
+  OneWayStatusFlagUnsafe flag;
   runParallelUpdates(
       [&](size_t iters) {
         for (size_t i = 0; i < iters; ++i) {
-          folly::doNotOptimizeAway(flag.load());
+          flag.set();
+          bool dummy{};
+          folly::doNotOptimizeAway(dummy);
         }
       },
       kNumThreads, // Threads
       kNumIterations); // Iterations per thread
 }
 
-BENCHMARK(std_atomic_bool_relaxed_read) {
-  std::atomic<bool> flag{false};
+#endif
+
+// Read Benchmarks
+BENCHMARK(std_atomic_bool_read_seq_cst) {
+  std::atomic_bool flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.load(std::memory_order_seq_cst));
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_read_acquire) {
+  std::atomic_bool flag{false};
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.load(std::memory_order_acquire));
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+BENCHMARK(std_atomic_bool_read_relaxed) {
+  std::atomic_bool flag{false};
   runParallelUpdates(
       [&](size_t iters) {
         for (size_t i = 0; i < iters; ++i) {
@@ -121,22 +181,8 @@ BENCHMARK(std_atomic_bool_relaxed_read) {
       kNumIterations); // Iterations per thread
 }
 
-BENCHMARK(std_atomic_bool_read_relaxed_acquire) {
-  std::atomic<bool> flag{false};
-  runParallelUpdates(
-      [&](size_t iters) {
-        for (size_t i = 0; i < iters; ++i) {
-          folly::doNotOptimizeAway(
-              flag.load(std::memory_order_relaxed) ||
-              flag.load(std::memory_order_acquire));
-        }
-      },
-      kNumThreads, // Threads
-      kNumIterations); // Iterations per thread
-}
-
 BENCHMARK(one_way_flag_read) {
-  exec::OneWayStatusFlag flag;
+  OneWayStatusFlag flag;
   runParallelUpdates(
       [&](size_t iters) {
         for (size_t i = 0; i < iters; ++i) {
@@ -146,6 +192,24 @@ BENCHMARK(one_way_flag_read) {
       kNumThreads, // Threads
       kNumIterations); // Iterations per thread
 }
+
+#if defined(__x86_64__) && !defined(TSAN_BUILD)
+
+BENCHMARK(one_way_flag_unsafe_read) {
+  OneWayStatusFlagUnsafe flag;
+  runParallelUpdates(
+      [&](size_t iters) {
+        for (size_t i = 0; i < iters; ++i) {
+          folly::doNotOptimizeAway(flag.check());
+        }
+      },
+      kNumThreads, // Threads
+      kNumIterations); // Iterations per thread
+}
+
+#endif
+
+} // namespace
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);

--- a/velox/exec/benchmarks/AtomicsBench.cpp
+++ b/velox/exec/benchmarks/AtomicsBench.cpp
@@ -16,7 +16,6 @@
 
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
-#include <folly/synchronization/SanitizeThread.h>
 #include <atomic>
 #include <thread>
 #include <vector>

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -158,3 +158,10 @@ target_link_libraries(
   velox_vector_fuzzer
   Folly::follybenchmark
 )
+
+add_executable(velox_atomics_benchmark AtomicsBench.cpp)
+
+target_link_libraries(
+  velox_atomics_benchmark
+  Folly::follybenchmark
+)

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -161,7 +161,4 @@ target_link_libraries(
 
 add_executable(velox_atomics_benchmark AtomicsBench.cpp)
 
-target_link_libraries(
-  velox_atomics_benchmark
-  Folly::follybenchmark
-)
+target_link_libraries(velox_atomics_benchmark Folly::follybenchmark)


### PR DESCRIPTION
Another argument is `annotate_ignore_thread_sanitizer_guard` should be used only to mark false positive issues, not the real one.

Benchmark results:
AMD Ryzen 9 9950X, bare metal
```
============================================================================
[...]elox/exec/benchmarks/AtomicsBench.cpp     relative  time/iter   iters/s
============================================================================
std_atomic_bool_write_seq_cst                              1.16min    14.36m
std_atomic_bool_write_release                                4.50s   222.17m
std_atomic_bool_write_relaxed                                4.48s   223.00m
one_way_flag_write                                         55.20ms     18.12
one_way_flag_unsafe_write                                  55.57ms     17.99
std_atomic_bool_read_seq_cst                               29.66ms     33.72
std_atomic_bool_read_acquire                               30.10ms     33.22
std_atomic_bool_read_relaxed                               30.00ms     33.33
one_way_flag_read                                          29.84ms     33.51
one_way_flag_unsafe_read                                   59.68ms     16.76
```