### PR TITLE
refactor: Move driver creation into task init from the first next call (#13075)

### DIFF
--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -52,6 +52,13 @@ using GetSpillDirectoryPathCB = std::function<std::string_view()>;
 /// bytes exceed the set limit.
 using UpdateAndCheckSpillLimitCB = std::function<void(uint64_t)>;
 
+/// Specifies the options for spill to disk.
+struct SpillDiskOptions {
+  std::string spillDirPath;
+  bool spillDirCreated{true};
+  std::function<std::string()> spillDirCreateCb{nullptr};
+};
+
 /// Specifies the config for spilling.
 struct SpillConfig {
   SpillConfig() = default;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -1424,12 +1424,20 @@ TEST_P(SharedArbitrationTestWithThreadingModes, reserveReleaseCounters) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SharedArbitrationTest,
     SharedArbitrationTestWithParallelExecutionModeOnly,
-    testing::ValuesIn(std::vector<TestParam>{{false}}));
+    testing::ValuesIn(std::vector<TestParam>{{false}}),
+    [](const testing::TestParamInfo<TestParam>& info) {
+      return fmt::format(
+          "{}", info.param.isSerialExecutionMode ? "serial" : "parallel");
+    });
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
     SharedArbitrationTest,
     SharedArbitrationTestWithThreadingModes,
-    testing::ValuesIn(std::vector<TestParam>{{false}, {true}}));
+    testing::ValuesIn(std::vector<TestParam>{{false}, {true}}),
+    [](const testing::TestParamInfo<TestParam>& info) {
+      return fmt::format(
+          "{}", info.param.isSerialExecutionMode ? "serial" : "parallel");
+    });
 } // namespace facebook::velox::memory
 
 int main(int argc, char** argv) {

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -135,7 +135,8 @@ int main(int argc, char** argv) {
       writerPlanFragment,
       /*destination=*/0,
       core::QueryCtx::create(executor.get()),
-      exec::Task::ExecutionMode::kSerial);
+      exec::Task::ExecutionMode::kSerial,
+      exec::Consumer{});
 
   // next() starts execution using the client thread. The loop pumps output
   // vectors out of the task (there are none in this query fragment).
@@ -165,7 +166,8 @@ int main(int argc, char** argv) {
       readPlanFragment,
       /*destination=*/0,
       core::QueryCtx::create(executor.get()),
-      exec::Task::ExecutionMode::kSerial);
+      exec::Task::ExecutionMode::kSerial,
+      exec::Consumer{});
 
   // Now that we have the query fragment and Task structure set up, we will
   // add data to it via `splits`.

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -19,14 +19,14 @@ velox_add_library(
   AggregateCompanionSignatures.cpp
   AggregateFunctionRegistry.cpp
   AggregateInfo.cpp
-  AggregationMasks.cpp
   AggregateWindow.cpp
+  AggregationMasks.cpp
   ArrowStream.cpp
   AssignUniqueId.cpp
   BlockingReason.cpp
   CallbackSink.cpp
-  ContainerRowSerde.cpp
   ColumnStatsCollector.cpp
+  ContainerRowSerde.cpp
   DistinctAggregations.cpp
   Driver.cpp
   EnforceSingleRow.cpp
@@ -56,36 +56,31 @@ velox_add_library(
   MergeSource.cpp
   NestedLoopJoinBuild.cpp
   NestedLoopJoinProbe.cpp
-  SpatialJoinBuild.cpp
-  SpatialJoinProbe.cpp
   Operator.cpp
+  OperatorTraceReader.cpp
+  OperatorTraceScan.cpp
+  OperatorTraceWriter.cpp
   OperatorUtils.cpp
   OrderBy.cpp
   OutputBuffer.cpp
   OutputBufferManager.cpp
-  OperatorTraceReader.cpp
-  OperatorTraceScan.cpp
-  OperatorTraceWriter.cpp
   ParallelProject.cpp
-  TaskStructs.cpp
-  TaskTraceReader.cpp
-  TaskTraceWriter.cpp
-  Trace.cpp
-  TraceUtil.cpp
-  PartitionedOutput.cpp
   PartitionFunction.cpp
   PartitionStreamingWindowBuild.cpp
+  PartitionedOutput.cpp
   PlanNodeStats.cpp
   PrefixSort.cpp
   ProbeOperatorState.cpp
-  RowsStreamingWindowBuild.cpp
   RowContainer.cpp
   RowNumber.cpp
-  ScaledScanController.cpp
+  RowsStreamingWindowBuild.cpp
   ScaleWriterLocalPartition.cpp
+  ScaledScanController.cpp
   SortBuffer.cpp
-  SortedAggregations.cpp
   SortWindowBuild.cpp
+  SortedAggregations.cpp
+  SpatialJoinBuild.cpp
+  SpatialJoinProbe.cpp
   Spill.cpp
   SpillFile.cpp
   Spiller.cpp
@@ -95,8 +90,13 @@ velox_add_library(
   TableWriteMerge.cpp
   TableWriter.cpp
   Task.cpp
+  TaskStructs.cpp
+  TaskTraceReader.cpp
+  TaskTraceWriter.cpp
   TopN.cpp
   TopNRowNumber.cpp
+  Trace.cpp
+  TraceUtil.cpp
   Unnest.cpp
   Values.cpp
   VectorHasher.cpp

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -71,6 +71,12 @@ struct CursorParameters {
   /// would be built from it.
   std::string spillDirectory;
 
+  /// Callback function to dynamically create or determine the spill directory
+  /// path at runtime. If provided, this callback is invoked when spilling is
+  /// needed and must return a valid directory path. This allows for dynamic
+  /// spill directory creation or path resolution based on runtime conditions.
+  std::function<std::string()> spillDirectoryCallback;
+
   bool copyResult = true;
 
   /// If true, use serial execution mode. Use parallel execution mode

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -1102,9 +1102,13 @@ std::string Driver::toString() const {
   }
 
   out << "{Operators: ";
-  for (auto& op : operators_) {
-    out << op->toString() << ", ";
-  }
+  std::vector<std::string> opStrs;
+  opStrs.reserve(operators_.size());
+  std::ranges::transform(
+      operators_, std::back_inserter(opStrs), [](const auto& op) {
+        return op->toString();
+      });
+  out << folly::join(", ", opStrs);
   out << "}";
   const auto ocs = opCallStatus();
   if (!ocs.empty()) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -320,8 +320,8 @@ std::shared_ptr<Task> Task::create(
     ExecutionMode mode,
     Consumer consumer,
     int32_t memoryArbitrationPriority,
+    std::optional<common::SpillDiskOptions> spillDiskOpts,
     std::function<void(std::exception_ptr)> onError) {
-  VELOX_CHECK_NOT_NULL(planFragment.planNode);
   return Task::create(
       taskId,
       std::move(planFragment),
@@ -331,6 +331,7 @@ std::shared_ptr<Task> Task::create(
       (consumer ? [c = std::move(consumer)]() { return c; }
                 : ConsumerSupplier{}),
       memoryArbitrationPriority,
+      std::move(spillDiskOpts),
       std::move(onError));
 }
 
@@ -344,6 +345,29 @@ std::shared_ptr<Task> Task::create(
     ConsumerSupplier consumerSupplier,
     int32_t memoryArbitrationPriority,
     std::function<void(std::exception_ptr)> onError) {
+  return Task::create(
+      taskId,
+      std::move(planFragment),
+      destination,
+      std::move(queryCtx),
+      mode,
+      std::move(consumerSupplier),
+      memoryArbitrationPriority,
+      /*spillDiskOpts=*/std::nullopt,
+      std::move(onError));
+}
+
+// static
+std::shared_ptr<Task> Task::create(
+    const std::string& taskId,
+    core::PlanFragment planFragment,
+    int destination,
+    std::shared_ptr<core::QueryCtx> queryCtx,
+    ExecutionMode mode,
+    ConsumerSupplier consumerSupplier,
+    int32_t memoryArbitrationPriority,
+    std::optional<common::SpillDiskOptions> spillDiskOpts,
+    std::function<void(std::exception_ptr)> onError) {
   VELOX_CHECK_NOT_NULL(planFragment.planNode);
   auto task = std::shared_ptr<Task>(new Task(
       taskId,
@@ -354,7 +378,7 @@ std::shared_ptr<Task> Task::create(
       std::move(consumerSupplier),
       memoryArbitrationPriority,
       std::move(onError)));
-  task->initTaskPool();
+  task->init(std::move(spillDiskOpts));
   task->addToTaskList();
   return task;
 }
@@ -469,6 +493,72 @@ void Task::ensureBarrierSupport() const {
       firstNodeNotSupportingBarrier_->name());
 }
 
+void Task::init(std::optional<common::SpillDiskOptions>&& spillDiskOpts) {
+  VELOX_CHECK(driverFactories_.empty());
+  initTaskPool();
+
+  setSpillDiskConfig(std::move(spillDiskOpts));
+
+  if (mode_ != Task::ExecutionMode::kSerial) {
+    return;
+  }
+
+  // Create drivers.
+  VELOX_CHECK_NULL(
+      consumerSupplier_,
+      "Serial execution mode doesn't support delivering results to a "
+      "callback");
+
+  taskStats_.executionStartTimeMs = getCurrentTimeMs();
+  LocalPlanner::plan(
+      planFragment_, nullptr, &driverFactories_, queryCtx_->queryConfig(), 1);
+  exchangeClients_.resize(driverFactories_.size());
+
+  // In Task::next() we always assume ungrouped execution.
+  for (const auto& factory : driverFactories_) {
+    VELOX_CHECK(factory->supportsSerialExecution());
+    numDriversUngrouped_ += factory->numDrivers;
+    numTotalDrivers_ += factory->numTotalDrivers;
+    taskStats_.pipelineStats.emplace_back(
+        factory->inputDriver, factory->outputDriver);
+  }
+
+  // Create drivers.
+  createSplitGroupStateLocked(kUngroupedGroupId);
+  std::vector<std::shared_ptr<Driver>> drivers =
+      createDriversLocked(kUngroupedGroupId);
+  if (pool_->reservedBytes() != 0) {
+    VELOX_FAIL(
+        "Unexpected memory pool allocations during task[{}] driver initialization: {}",
+        taskId_,
+        pool_->treeMemoryUsage());
+  }
+
+  drivers_ = std::move(drivers);
+  driverBlockingStates_.reserve(drivers_.size());
+  for (auto i = 0; i < drivers_.size(); ++i) {
+    driverBlockingStates_.emplace_back(
+        std::make_unique<DriverBlockingState>(drivers_[i].get()));
+  }
+}
+
+void Task::setSpillDiskConfig(
+    std::optional<common::SpillDiskOptions>&& spillDiskOpts) {
+  if (!spillDiskOpts.has_value()) {
+    return;
+  }
+  VELOX_CHECK(
+      !spillDiskOpts->spillDirPath.empty(), "Spill directory can't be empty");
+  VELOX_CHECK(
+      spillDiskOpts->spillDirCreated || spillDiskOpts->spillDirCreateCb);
+  VELOX_CHECK_NULL(spillDirectoryCallback_);
+  VELOX_CHECK(!spillDirectoryCreated_);
+  VELOX_CHECK(spillDirectory_.empty());
+  spillDirectory_ = std::move(spillDiskOpts->spillDirPath);
+  spillDirectoryCreated_ = spillDiskOpts->spillDirCreated;
+  spillDirectoryCallback_ = std::move(spillDiskOpts->spillDirCreateCb);
+}
+
 Task::TaskList& Task::taskList() {
   static TaskList taskList;
   return taskList;
@@ -547,7 +637,7 @@ bool Task::allNodesReceivedNoMoreSplitsMessageLocked() const {
 const std::string& Task::getOrCreateSpillDirectory() {
   VELOX_CHECK(
       !spillDirectory_.empty() || spillDirectoryCallback_,
-      "Spill directory or spill directory callback must be set ");
+      "Spill directory or spill directory callback must be set");
   if (spillDirectoryCreated_) {
     return spillDirectory_;
   }
@@ -769,48 +859,8 @@ RowVectorPtr Task::next(ContinueFuture* future) {
     }
   }
 
-  // On first call, create the drivers.
-  if (driverFactories_.empty()) {
-    VELOX_CHECK_NULL(
-        consumerSupplier_,
-        "Serial execution mode doesn't support delivering results to a "
-        "callback");
-
-    taskStats_.executionStartTimeMs = getCurrentTimeMs();
-    LocalPlanner::plan(
-        planFragment_, nullptr, &driverFactories_, queryCtx_->queryConfig(), 1);
-    exchangeClients_.resize(driverFactories_.size());
-
-    // In Task::next() we always assume ungrouped execution.
-    for (const auto& factory : driverFactories_) {
-      VELOX_CHECK(factory->supportsSerialExecution());
-      numDriversUngrouped_ += factory->numDrivers;
-      numTotalDrivers_ += factory->numTotalDrivers;
-      taskStats_.pipelineStats.emplace_back(
-          factory->inputDriver, factory->outputDriver);
-    }
-
-    // Create drivers.
-    createSplitGroupStateLocked(kUngroupedGroupId);
-    std::vector<std::shared_ptr<Driver>> drivers =
-        createDriversLocked(kUngroupedGroupId);
-    if (pool_->reservedBytes() != 0) {
-      VELOX_FAIL(
-          "Unexpected memory pool allocations during task[{}] driver initialization: {}",
-          taskId_,
-          pool_->treeMemoryUsage());
-    }
-
-    drivers_ = std::move(drivers);
-    driverBlockingStates_.reserve(drivers_.size());
-    for (auto i = 0; i < drivers_.size(); ++i) {
-      driverBlockingStates_.emplace_back(
-          std::make_unique<DriverBlockingState>(drivers_[i].get()));
-    }
-    if (underBarrier()) {
-      startDriverBarriersLocked();
-    }
-  }
+  VELOX_CHECK_EQ(
+      state_, TaskState::kRunning, "Task has already finished processing.");
 
   // Run drivers one at a time. If a driver blocks, continue running the other
   // drivers. Running other drivers is expected to unblock some or all blocked

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -68,11 +68,16 @@ class Task : public std::enable_shared_from_this<Task> {
   /// @param consumer Optional factory function to get callbacks to pass the
   /// results of the execution. In a parallel execution mode, results from each
   /// thread are passed on to a separate consumer.
+  /// @param memoryArbitrationPriority Priority used by the memory arbitrator
+  /// to determine which task should have its memory reclaimed first when the
+  /// system is under memory pressure. Higher values indicate higher priority
+  /// (lower likelihood of being reclaimed). Default is 0.
+  /// @param spillDiskOpts Optional configuration for spill disk storage. When
+  /// provided, allows operators to spill intermediate data to disk during
+  /// execution when memory pressure is high. Includes spill directory path
+  /// and callback options. Default is std::nullopt (no spilling).
   /// @param onError Optional callback to receive an exception if task
   /// execution fails.
-  /// @param memoryArbitrationPriority Optional priority on task that, in a
-  /// multi task system, is used for memory arbitration to decide the order of
-  /// reclaiming.
   static std::shared_ptr<Task> create(
       const std::string& taskId,
       core::PlanFragment planFragment,
@@ -81,6 +86,7 @@ class Task : public std::enable_shared_from_this<Task> {
       ExecutionMode mode,
       Consumer consumer = nullptr,
       int32_t memoryArbitrationPriority = 0,
+      std::optional<common::SpillDiskOptions> spillDiskOpts = std::nullopt,
       std::function<void(std::exception_ptr)> onError = nullptr);
 
   static std::shared_ptr<Task> create(
@@ -93,12 +99,24 @@ class Task : public std::enable_shared_from_this<Task> {
       int32_t memoryArbitrationPriority = 0,
       std::function<void(std::exception_ptr)> onError = nullptr);
 
+  static std::shared_ptr<Task> create(
+      const std::string& taskId,
+      core::PlanFragment planFragment,
+      int destination,
+      std::shared_ptr<core::QueryCtx> queryCtx,
+      ExecutionMode mode,
+      ConsumerSupplier consumerSupplier,
+      int32_t memoryArbitrationPriority = 0,
+      std::optional<common::SpillDiskOptions> spillDiskOpts = std::nullopt,
+      std::function<void(std::exception_ptr)> onError = nullptr);
+
   /// Convenience function for shortening a Presto taskId. To be used
   /// in debugging messages and listings.
   static std::string shortId(const std::string& id);
 
   ~Task();
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   /// Specify directory to which data will be spilled if spilling is enabled and
   /// required. Set 'alreadyCreated' to true if the directory has already been
   /// created by the caller.
@@ -114,6 +132,7 @@ class Task : public std::enable_shared_from_this<Task> {
     VELOX_CHECK_NULL(spillDirectoryCallback_);
     spillDirectoryCallback_ = std::move(spillDirectoryCallback);
   }
+#endif
 
   /// Returns human-friendly representation of the plan augmented with runtime
   /// statistics. The implementation invokes exec::printPlanWithStats().
@@ -823,6 +842,13 @@ class Task : public std::enable_shared_from_this<Task> {
       int32_t memoryArbitrationPriority = 0,
       std::function<void(std::exception_ptr)> onError = nullptr);
 
+  // Invoked to do post-create initialization.
+  void init(std::optional<common::SpillDiskOptions>&& spillDiskOpts);
+
+  // Invoked to initialize the spill storage config for this task.
+  void setSpillDiskConfig(
+      std::optional<common::SpillDiskOptions>&& spillDiskOpts);
+
   // Invoked to add this to the system-wide running task list on task creation.
   void addToTaskList();
 
@@ -1379,7 +1405,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // The promises for the futures returned to callers of requestBarrier().
   std::vector<ContinuePromise> barrierFinishPromises_;
 
-  std::atomic<int32_t> toYield_ = 0;
+  std::atomic_int32_t toYield_ = 0;
   int32_t numThreads_ = 0;
   // Microsecond real time when 'this' last went from no threads to
   // one thread running. Used to decide if continuous run should be

--- a/velox/exec/benchmarks/WindowPrefixSortBenchmark.cpp
+++ b/velox/exec/benchmarks/WindowPrefixSortBenchmark.cpp
@@ -192,7 +192,8 @@ class WindowPrefixSortBenchmark : public HiveConnectorTestBase {
           std::move(plan),
           0,
           core::QueryCtx::create(executor_.get()),
-          Task::ExecutionMode::kSerial);
+          Task::ExecutionMode::kSerial,
+          exec::Consumer{});
     } else {
       const std::unordered_map<std::string, std::string> queryConfigMap(
           {{core::QueryConfig::kPrefixSortNormalizedKeyMaxBytes, "0"}});
@@ -202,7 +203,8 @@ class WindowPrefixSortBenchmark : public HiveConnectorTestBase {
           0,
           core::QueryCtx::create(
               executor_.get(), core::QueryConfig(queryConfigMap)),
-          Task::ExecutionMode::kSerial);
+          Task::ExecutionMode::kSerial,
+          exec::Consumer{});
     }
   }
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -1614,7 +1614,8 @@ DEBUG_ONLY_TEST_F(DriverTest, driverCpuTimeSlicingCheck) {
           0,
           core::QueryCtx::create(
               driverExecutor_.get(), core::QueryConfig{std::move(queryConfig)}),
-          testParam.executionMode);
+          testParam.executionMode,
+          exec::Consumer{});
       while (task->next() != nullptr) {
       }
     }

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -91,7 +91,8 @@ class ExchangeClientTest
         core::PlanFragment{plan},
         0,
         std::move(queryCtx),
-        Task::ExecutionMode::kParallel);
+        Task::ExecutionMode::kParallel,
+        exec::Consumer{});
   }
 
   int32_t enqueue(

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -127,7 +127,9 @@ class MultiFragmentTest : public HiveConnectorTestBase,
       std::unordered_map<std::string, std::string>& extraQueryConfigs,
       int destination = 0,
       Consumer consumer = nullptr,
-      int64_t maxMemory = memory::kMaxMemory) const {
+      int64_t maxMemory = memory::kMaxMemory,
+      const std::optional<common::SpillDiskOptions>& diskSpillOpts =
+          std::nullopt) const {
     auto configCopy = configSettings_;
     for (const auto& [k, v] : extraQueryConfigs) {
       configCopy[k] = v;
@@ -148,7 +150,9 @@ class MultiFragmentTest : public HiveConnectorTestBase,
         destination,
         std::move(queryCtx),
         Task::ExecutionMode::kParallel,
-        std::move(consumer));
+        std::move(consumer),
+        /*memoryArbitrationPriority=*/0,
+        diskSpillOpts);
   }
 
   std::vector<RowVectorPtr> makeVectors(int count, int rowsPerVector) {
@@ -917,11 +921,17 @@ TEST_P(MultiFragmentTest, mergeExchangeWithSpill) {
             .capturePlanNodeId(partitionNodeId)
             .planNode();
     localMergeNodeIds.push_back(localMergeNodeId);
-    auto sortTask =
-        makeTask(sortTaskId, partialSortPlan, spillMergeConfigs, tasks.size());
     spillDirectories.push_back(TempDirectoryPath::create());
-    sortTask->setSpillDirectory(
-        spillDirectories[numPartialSortTasks]->getPath());
+    common::SpillDiskOptions spillOpts;
+    spillOpts.spillDirPath = spillDirectories[numPartialSortTasks]->getPath();
+    auto sortTask = makeTask(
+        sortTaskId,
+        partialSortPlan,
+        spillMergeConfigs,
+        tasks.size(),
+        /*consumer=*/nullptr,
+        memory::kMaxMemory,
+        spillOpts);
     tasks.push_back(sortTask);
     sortTask->start(4);
 

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -48,7 +48,8 @@ class OperatorUtilsTest : public OperatorTestBase {
         std::move(planFragment),
         0,
         core::QueryCtx::create(executor_.get()),
-        Task::ExecutionMode::kParallel);
+        Task::ExecutionMode::kParallel,
+        exec::Consumer{});
     driver_ = Driver::testingCreate();
     driverCtx_ = std::make_unique<DriverCtx>(task_, 0, 0, 0, 0);
     driverCtx_->driver = driver_.get();

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -109,7 +109,8 @@ class OutputBufferManagerTest : public testing::Test {
         std::move(planFragment),
         0,
         std::move(queryCtx),
-        Task::ExecutionMode::kParallel);
+        Task::ExecutionMode::kParallel,
+        exec::Consumer{});
 
     bufferManager_->initializeTask(task, kind, numDestinations, numDrivers);
     return task;

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -524,7 +524,8 @@ class TaskTest : public HiveConnectorTestBase {
         plan,
         0,
         core::QueryCtx::create(),
-        Task::ExecutionMode::kSerial);
+        Task::ExecutionMode::kSerial,
+        exec::Consumer{});
 
     for (const auto& [nodeId, paths] : filePaths) {
       for (const auto& path : paths) {
@@ -573,7 +574,8 @@ TEST_F(TaskTest, toJson) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
 
   ASSERT_EQ(
       task->toString(),
@@ -638,7 +640,8 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
 
   // Add split for the source node.
   task->addSplit("0", exec::Split(folly::copy(connectorSplit)));
@@ -694,7 +697,8 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   errorMessage =
       "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
   VELOX_ASSERT_THROW(
@@ -721,7 +725,8 @@ TEST_F(TaskTest, duplicatePlanNodeIds) {
           std::move(plan),
           0,
           core::QueryCtx::create(driverExecutor_.get()),
-          Task::ExecutionMode::kParallel),
+          Task::ExecutionMode::kParallel,
+          exec::Consumer{}),
       "Plan node IDs must be unique. Found duplicate ID: 0.")
 }
 
@@ -1228,7 +1233,8 @@ TEST_F(TaskTest, serialExecutionExternalBlockable) {
       plan,
       0,
       core::QueryCtx::create(),
-      Task::ExecutionMode::kSerial);
+      Task::ExecutionMode::kSerial,
+      exec::Consumer{});
   std::vector<RowVectorPtr> results;
   for (;;) {
     auto result = nonBlockingTask->next(&continueFuture);
@@ -1254,7 +1260,8 @@ TEST_F(TaskTest, serialExecutionExternalBlockable) {
       plan,
       0,
       core::QueryCtx::create(),
-      Task::ExecutionMode::kSerial);
+      Task::ExecutionMode::kSerial,
+      exec::Consumer{});
   // Before we block, we expect `next` to get data normally.
   results.push_back(blockingTask->next(&continueFuture));
   EXPECT_TRUE(results.back() != nullptr);
@@ -1291,16 +1298,17 @@ TEST_F(TaskTest, supportSerialExecutionMode) {
                   .project({"c0 % 10"})
                   .partitionedOutput({}, 1, std::vector<std::string>{"p0"})
                   .planFragment();
-  auto task = Task::create(
-      "single.execution.task.0",
-      plan,
-      0,
-      core::QueryCtx::create(),
-      Task::ExecutionMode::kSerial);
-
   // PartitionedOutput does not support serial execution mode, therefore the
   // task doesn't support it either.
-  ASSERT_FALSE(task->supportSerialExecutionMode());
+  VELOX_ASSERT_THROW(
+      Task::create(
+          "single.execution.task.0",
+          plan,
+          0,
+          core::QueryCtx::create(),
+          Task::ExecutionMode::kSerial,
+          exec::Consumer{}),
+      "");
 }
 
 TEST_F(TaskTest, updateBroadCastOutputBuffers) {
@@ -1316,7 +1324,8 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
         plan,
         0,
         core::QueryCtx::create(driverExecutor_.get()),
-        Task::ExecutionMode::kParallel);
+        Task::ExecutionMode::kParallel,
+        exec::Consumer{});
 
     task->start(1, 1);
 
@@ -1334,7 +1343,8 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
         plan,
         0,
         core::QueryCtx::create(driverExecutor_.get()),
-        Task::ExecutionMode::kParallel);
+        Task::ExecutionMode::kParallel,
+        exec::Consumer{});
 
     task->start(1, 1);
 
@@ -1622,8 +1632,13 @@ DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
     auto plan =
         PlanBuilder().values({data, data, data}).project({"c0"}).planFragment();
     auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
-    auto task =
-        Task::create("task.0", plan, 0, queryCtx, Task::ExecutionMode::kSerial);
+    auto task = Task::create(
+        "task.0",
+        plan,
+        0,
+        queryCtx,
+        Task::ExecutionMode::kSerial,
+        exec::Consumer{});
 
     task->next();
     VELOX_ASSERT_THROW(task->start(4, 1), "Inconsistent task execution mode.");
@@ -1957,17 +1972,24 @@ TEST_F(TaskTest, driverCreationMemoryAllocationCheck) {
           .planFragment();
   for (bool singleThreadExecution : {false, true}) {
     SCOPED_TRACE(fmt::format("singleThreadExecution: ", singleThreadExecution));
-    auto badTask = Task::create(
-        "driverCreationMemoryAllocationCheck",
-        plan,
-        0,
-        core::QueryCtx::create(
-            singleThreadExecution ? nullptr : driverExecutor_.get()),
-        singleThreadExecution ? Task::ExecutionMode::kSerial
-                              : Task::ExecutionMode::kParallel);
     if (singleThreadExecution) {
-      VELOX_ASSERT_THROW(badTask->next(), "Unexpected memory pool allocations");
+      VELOX_ASSERT_THROW(
+          Task::create(
+              "driverCreationMemoryAllocationCheck",
+              plan,
+              0,
+              core::QueryCtx::create(nullptr),
+              Task::ExecutionMode::kSerial,
+              exec::Consumer{}),
+          "Unexpected memory pool allocations");
     } else {
+      auto badTask = Task::create(
+          "driverCreationMemoryAllocationCheck",
+          plan,
+          0,
+          core::QueryCtx::create(driverExecutor_.get()),
+          Task::ExecutionMode::kParallel,
+          exec::Consumer{});
       VELOX_ASSERT_THROW(
           badTask->start(1), "Unexpected memory pool allocations");
     }
@@ -1994,36 +2016,34 @@ TEST_F(TaskTest, spillDirectoryCallback) {
       {{core::QueryConfig::kSpillEnabled, "true"},
        {core::QueryConfig::kAggregationSpillEnabled, "true"}});
   params.maxDrivers = 1;
-
-  auto cursor = TaskCursor::create(params);
-
-  std::shared_ptr<Task> task = cursor->task();
-  auto tmpRootDir = exec::test::TempDirectoryPath::create();
-  auto tmpParentSpillDir = fmt::format(
+  auto spillRootDir = exec::test::TempDirectoryPath::create();
+  auto spillParentDir = fmt::format(
       "{}{}/parent_spill/",
       tests::utils::FaultyFileSystem::scheme(),
-      tmpRootDir->getPath());
-  auto tmpSpillDir = fmt::format(
+      spillRootDir->getPath());
+  auto spillDir = fmt::format(
       "{}{}/parent_spill/spill/",
       tests::utils::FaultyFileSystem::scheme(),
-      tmpRootDir->getPath());
+      spillRootDir->getPath());
 
-  EXPECT_FALSE(task->hasCreateSpillDirectoryCb());
-
-  task->setCreateSpillDirectoryCb([tmpParentSpillDir, tmpSpillDir]() {
-    auto filesystem = filesystems::getFileSystem(tmpParentSpillDir, nullptr);
+  params.spillDirectory = spillDir;
+  params.spillDirectoryCallback = [spillParentDir, spillDir]() {
+    auto filesystem = filesystems::getFileSystem(spillParentDir, nullptr);
     filesystems::DirectoryOptions options;
     options.values.emplace(
         filesystems::DirectoryOptions::kMakeDirectoryConfig.toString(),
         "dummy.config=123");
-    filesystem->mkdir(tmpParentSpillDir, options);
-    filesystem->mkdir(tmpSpillDir);
-    return tmpSpillDir;
-  });
+    filesystem->mkdir(spillParentDir, options);
+    filesystem->mkdir(spillDir);
+    return spillDir;
+  };
 
+  auto cursor = TaskCursor::create(params);
+  std::shared_ptr<Task> task = cursor->task();
   EXPECT_TRUE(task->hasCreateSpillDirectoryCb());
+
   auto fs = std::dynamic_pointer_cast<tests::utils::FaultyFileSystem>(
-      filesystems::getFileSystem(tmpParentSpillDir, nullptr));
+      filesystems::getFileSystem(spillParentDir, nullptr));
 
   fs->setFileSystemInjectionError(
       std::make_exception_ptr(std::runtime_error("test exception")),
@@ -2039,7 +2059,7 @@ TEST_F(TaskTest, spillDirectoryCallback) {
     auto mkdirOp =
         static_cast<tests::utils::FaultFileSystemMkdirOperation*>(op);
     if (mkdirOp->path ==
-        fmt::format("{}/parent_spill/", tmpRootDir->getPath())) {
+        fmt::format("{}/parent_spill/", spillRootDir->getPath())) {
       parentDirectoryCreated = true;
       auto it = mkdirOp->options.values.find(
           filesystems::DirectoryOptions::kMakeDirectoryConfig.toString());
@@ -2047,7 +2067,7 @@ TEST_F(TaskTest, spillDirectoryCallback) {
       EXPECT_EQ(it->second, "dummy.config=123");
     }
     if (mkdirOp->path ==
-        fmt::format("{}/parent_spill/spill/", tmpRootDir->getPath())) {
+        fmt::format("{}/parent_spill/spill/", spillRootDir->getPath())) {
       spillDirectoryCreated = true;
     }
     return;
@@ -2092,13 +2112,13 @@ TEST_F(TaskTest, spillDirectoryLifecycleManagement) {
       {{core::QueryConfig::kSpillEnabled, "true"},
        {core::QueryConfig::kAggregationSpillEnabled, "true"}});
   params.maxDrivers = 1;
+  const auto rootTempDir = exec::test::TempDirectoryPath::create();
+  const auto tmpDirectoryPath =
+      rootTempDir->getPath() + "/spillDirectoryLifecycleManagement";
+  params.spillDirectory = tmpDirectoryPath;
 
   auto cursor = TaskCursor::create(params);
   std::shared_ptr<Task> task = cursor->task();
-  auto rootTempDir = exec::test::TempDirectoryPath::create();
-  auto tmpDirectoryPath =
-      rootTempDir->getPath() + "/spillDirectoryLifecycleManagement";
-  task->setSpillDirectory(tmpDirectoryPath, false);
 
   TestScopedSpillInjection scopedSpillInjection(100);
   while (cursor->moveNext()) {
@@ -2154,7 +2174,6 @@ TEST_F(TaskTest, spillDirNotCreated) {
   auto* task = cursor->task().get();
   auto rootTempDir = exec::test::TempDirectoryPath::create();
   auto tmpDirectoryPath = rootTempDir->getPath() + "/spillDirNotCreated";
-  task->setSpillDirectory(tmpDirectoryPath, false);
 
   while (cursor->moveNext()) {
   }
@@ -2200,7 +2219,8 @@ DEBUG_ONLY_TEST_F(TaskTest, resumeAfterTaskFinish) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(4, 1);
 
   // Request pause and then unblock operators to proceed.
@@ -2231,7 +2251,12 @@ DEBUG_ONLY_TEST_F(TaskTest, serialLongRunningOperatorInTaskReclaimerAbort) {
   auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
 
   auto blockingTask = Task::create(
-      "blocking.task.0", plan, 0, queryCtx, Task::ExecutionMode::kSerial);
+      "blocking.task.0",
+      plan,
+      0,
+      queryCtx,
+      Task::ExecutionMode::kSerial,
+      exec::Consumer{});
 
   // Before we block, we expect `next` to get data normally.
   EXPECT_NE(nullptr, blockingTask->next());
@@ -2306,7 +2331,12 @@ DEBUG_ONLY_TEST_F(TaskTest, longRunningOperatorInTaskReclaimerAbort) {
   auto queryCtx = core::QueryCtx::create(driverExecutor_.get());
 
   auto blockingTask = Task::create(
-      "blocking.task.0", plan, 0, queryCtx, Task::ExecutionMode::kParallel);
+      "blocking.task.0",
+      plan,
+      0,
+      queryCtx,
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
 
   blockingTask->start(4, 1);
   const std::string abortErrorMessage("Synthetic Exception");
@@ -2372,7 +2402,8 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimStats) {
       std::move(plan),
       0,
       std::move(queryCtx),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(4, 1);
 
   const int numReclaims{10};
@@ -2446,7 +2477,8 @@ DEBUG_ONLY_TEST_F(TaskTest, taskPauseTime) {
       std::move(plan),
       0,
       std::move(queryCtx),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(4, 1);
 
   // Wait for the task driver starts to run.
@@ -2495,7 +2527,8 @@ TEST_F(TaskTest, updateStatsWhileCloseOffThreadDriver) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(4, 1);
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
   task->testingVisitDrivers(
@@ -2540,7 +2573,8 @@ DEBUG_ONLY_TEST_F(TaskTest, driverEnqueAfterFailedAndPausedTask) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(4, 1);
 
   // Request pause.
@@ -2660,7 +2694,8 @@ DEBUG_ONLY_TEST_F(TaskTest, taskCancellation) {
       std::move(plan),
       0,
       core::QueryCtx::create(driverExecutor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(4, 1);
   auto cancellationToken = task->getCancellationToken();
   ASSERT_FALSE(cancellationToken.isCancellationRequested());
@@ -2735,6 +2770,9 @@ TEST_F(TaskTest, invalidPlanNodeForBarrier) {
   VELOX_ASSERT_THROW(
       task->requestBarrier(),
       "Name of the first node that doesn't support barriered execution:");
+  while (auto next = task->next()) {
+  }
+  ASSERT_TRUE(task->isFinished());
 }
 
 TEST_F(TaskTest, barrierAfterNoMoreSplits) {
@@ -2769,6 +2807,9 @@ TEST_F(TaskTest, barrierAfterNoMoreSplits) {
   VELOX_ASSERT_THROW(
       task->requestBarrier(),
       "Can't start barrier on task which has already received no more splits");
+  while (auto next = task->next()) {
+  }
+  ASSERT_TRUE(task->isFinished());
 }
 
 TEST_F(TaskTest, invalidTaskModeForBarrier) {

--- a/velox/exec/tests/ThreadDebugInfoTest.cpp
+++ b/velox/exec/tests/ThreadDebugInfoTest.cpp
@@ -63,6 +63,7 @@ template <typename T>
 struct InduceSegFaultFunction {
   template <typename TResult, typename TInput>
   void call(TResult& out, const TInput& in) {
+    LOG(ERROR) << "error";
     int* nullpointer = nullptr;
     *nullpointer = 6;
   }
@@ -117,9 +118,10 @@ DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, withinTheCallingThread) {
 
 #ifndef IS_BUILDING_WITH_SAN
   ASSERT_DEATH(
-      (task->next()),
+      task->next(),
       ".*Fatal signal handler. Query Id= TaskCursorQuery_0 Task Id= single.execution.task.0.*");
 #endif
+  task->requestCancel();
 }
 
 DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, noThreadContextSet) {

--- a/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/ReduceAgg.cpp
@@ -190,7 +190,8 @@ class ReduceAggBenchmark : public HiveConnectorTestBase {
         std::move(plan),
         0,
         core::QueryCtx::create(executor_.get()),
-        exec::Task::ExecutionMode::kSerial);
+        exec::Task::ExecutionMode::kSerial,
+        exec::Consumer{});
 
     task->addSplit(
         "0", exec::Split(makeHiveConnectorSplit(filePath_->getPath())));

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -165,7 +165,8 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
         std::move(plan),
         0,
         core::QueryCtx::create(executor_.get()),
-        exec::Task::ExecutionMode::kSerial);
+        exec::Task::ExecutionMode::kSerial,
+        exec::Consumer{});
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/TwoStringKeys.cpp
@@ -113,7 +113,8 @@ class TwoStringKeysBenchmark : public HiveConnectorTestBase {
         std::move(plan),
         0,
         core::QueryCtx::create(executor_.get()),
-        exec::Task::ExecutionMode::kSerial);
+        exec::Task::ExecutionMode::kSerial,
+        exec::Consumer{});
 
     task->addSplit(
         "0", exec::Split(makeHiveConnectorSplit((filePath_->getPath()))));

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -140,7 +140,8 @@ RowVectorPtr PartitionedOutputReplayer::run(bool /*unused*/) {
       core::PlanFragment{createPlan()},
       0,
       createQueryContext(queryConfigs_, executor_.get()),
-      Task::ExecutionMode::kParallel);
+      Task::ExecutionMode::kParallel,
+      exec::Consumer{});
   task->start(driverIds_.size());
 
   consumeAllData(

--- a/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
+++ b/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
@@ -114,7 +114,8 @@ class PartitionedOutputReplayerTest
               std::to_string(8UL << 20)},
              {core::QueryConfig::kMaxOutputBufferSize,
               std::to_string(8UL << 20)}}),
-        Task::ExecutionMode::kParallel);
+        Task::ExecutionMode::kParallel,
+        exec::Consumer{});
     return task;
   }
 


### PR DESCRIPTION
Summary:

This is required for task barrier processing.

Differential Revision: D73299498


