### PR TITLE
fix: Fix incorrect initialization of empty 'folly::Promise' object

### DIFF
--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -271,7 +271,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
   }
 
   bool checkSetRequestPromise() {
-    VeloxPromise<Response> promise;
+    VeloxPromise<Response> promise{VeloxPromise<Response>::makeEmpty()};
     {
       std::lock_guard<std::mutex> l(queue_->mutex());
       promise = std::move(promise_);


### PR DESCRIPTION
X-link: https://github.com/prestodb/presto/pull/26171

For an empty `folly::Promise` object that is expected to be overwritten,
we should use `folly::makeEmpty()` to initialize it (it is 'invalid')
instead of the default constructor (it will be 'valid' but
'not fulfilled', assigning to it will cause an exception. Creating an
exception triggers a stack unwind, which can saturate the CPU in
high-concurrency scenarios, **causing significant performance issues**.