### PR TITLE
fix(build): Fix TextReader build errors with Clang 15

### DIFF
--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -1096,17 +1096,17 @@ void TextRowReader::readElement(
     case TypeKind::BIGINT:
       if (reqT->isShortDecimal()) {
         const std::string& str = getString(*this, isNull, delim);
-        auto [precision, scale] = getDecimalPrecisionScale(*reqT);
+        auto precisionScale = getDecimalPrecisionScale(*reqT);
         setValueFromString<int64_t>(
             str,
             data,
             insertionRow,
-            [precision, scale](const std::string& s) -> std::optional<int64_t> {
+            [precisionScale](const std::string& s) -> std::optional<int64_t> {
               int64_t v = 0;
               const auto status = DecimalUtil::castFromString(
                   StringView(s.data(), static_cast<int32_t>(s.size())),
-                  precision,
-                  scale,
+                  precisionScale.first,
+                  precisionScale.second,
                   v);
               return status.ok() ? std::optional<int64_t>(v) : std::nullopt;
             });
@@ -1119,18 +1119,17 @@ void TextRowReader::readElement(
     case TypeKind::HUGEINT: {
       const std::string& str = getString(*this, isNull, delim);
       if (reqT->isLongDecimal()) {
-        auto [precision, scale] = getDecimalPrecisionScale(*reqT);
+        auto precisionScale = getDecimalPrecisionScale(*reqT);
         setValueFromString<int128_t>(
             str,
             data,
             insertionRow,
-            [precision,
-             scale](const std::string& s) -> std::optional<int128_t> {
+            [precisionScale](const std::string& s) -> std::optional<int128_t> {
               int128_t v = 0;
               const auto status = DecimalUtil::castFromString(
                   StringView(s.data(), static_cast<int32_t>(s.size())),
-                  precision,
-                  scale,
+                  precisionScale.first,
+                  precisionScale.second,
                   v);
               return status.ok() ? std::optional<int128_t>(v) : std::nullopt;
             });


### PR DESCRIPTION
Fixes TextReader build failures with Clang 15.

Capturing structured bindings in lambdas is a C++20 feature, and Clang added support for it starting in Clang 16.
https://releases.llvm.org/16.0.0/tools/clang/docs/ReleaseNotes.html.
> Implemented [P1091R3](https://wg21.link/p1091r3) and [P1381R1](https://wg21.link/P1381R1) to support capturing structured bindings in lambdas ([#52720](https://github.com/llvm/llvm-project/issues/52720), [#54300](https://github.com/llvm/llvm-project/issues/54300), [#54301](https://github.com/llvm/llvm-project/issues/54301), [#49430](https://github.com/llvm/llvm-project/issues/49430)).