### PR TITLE
fix: Register companion functions in registerTDigestAggregate

### DIFF
--- a/velox/functions/prestosql/aggregates/TDigestAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/TDigestAggregate.cpp
@@ -356,7 +356,7 @@ void registerTDigestAggregate(
             hasWeight, hasCompression, resultTypes);
       },
       {true /*orderSensitive*/, false /*companionFunction*/},
-      false /*companionFunction*/,
+      withCompanionFunctions,
       overwrite);
 }
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
Otherwise companion functions don't registered for TDigest aggregation functions