### PR TITLE
fix: Add includes for -inl.h files

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -299,6 +299,8 @@ macro names are always upper-snake-case. Also:
     the interface. Only if someone needs to understand your implementation
     should opening the `-inl.h` be necessary (or the .cpp file, for that
     matter).
+  * Add `#pragma once` and `#include header.h` in `header-inl.h`, otherwise
+    clangd based autocomplete won't work.
 
 ## Function Arguments
 

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include <numeric>
+#include "velox/common/base/SimdUtil.h"
 
 #if XSIMD_WITH_NEON
 namespace xsimd::types {

--- a/velox/exec/VectorHasher-inl.h
+++ b/velox/exec/VectorHasher-inl.h
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
+
+#include "velox/exec/VectorHasher.h"
+
 namespace facebook::velox::exec {
 
 template <typename T>

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -18,6 +18,7 @@
 #include "velox/common/base/CountBits.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
+#include "velox/expression/CastExpr.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/type/Type.h"
 #include "velox/vector/SelectivityVector.h"

--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -20,6 +20,7 @@
 #include <queue>
 #include <type_traits>
 #include "velox/common/base/Exceptions.h"
+#include "velox/functions/lib/KllSketch.h"
 
 namespace facebook::velox::functions::kll {
 

--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include <type_traits>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/vector/BiasVector.h"
 #include "velox/vector/BuilderTypeUtils.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/TypeAliases.h"

--- a/velox/vector/ConstantVector-inl.h
+++ b/velox/vector/ConstantVector-inl.h
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
+
+#include "velox/vector/ConstantVector.h"
 
 namespace facebook::velox {
 

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/vector/BuilderTypeUtils.h"
+#include "velox/vector/DictionaryVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/TypeAliases.h"
 

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
+
 #include <folly/hash/Hash.h>
 
 #include "velox/common/base/BitUtil.h"
@@ -21,6 +23,7 @@
 #include "velox/vector/BuilderTypeUtils.h"
 #include "velox/vector/ConstantVector.h"
 #include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox {

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include <folly/Conv.h>
 
 #include "velox/vector/BuilderTypeUtils.h"
+#include "velox/vector/SequenceVector.h"
 
 namespace facebook::velox {
 

--- a/velox/vector/tests/utils/VectorMaker-inl.h
+++ b/velox/vector/tests/utils/VectorMaker-inl.h
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#pragma once
 
 #include <algorithm>
 
 #include "velox/vector/SimpleVector.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::test {
 


### PR DESCRIPTION
We need to include `#pragma once` and `#include header.h` in header-int.h to enable autocomplete in clangd-based IDEs (e.g. VSCode).