### PR TITLE
fix(CacheInputStream): Prevent int32_t overflow in CacheInputStream::nextQuantizedLoadRegion

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -394,7 +394,7 @@ velox::common::Region CacheInputStream::nextQuantizedLoadRegion(
   nextRegion.offset += (prevLoadedPosition / loadQuantum_) * loadQuantum_;
   // Set length to be the lesser of 'loadQuantum_' and distance to end of
   // 'region_'
-  nextRegion.length = std::min<int32_t>(
+  nextRegion.length = std::min<uint64_t>(
       loadQuantum_, region_.length - (nextRegion.offset - region_.offset));
   return nextRegion;
 }


### PR DESCRIPTION
This MR fixes an integer overflow bug in `CacheInputStream::nextQuantizedLoadRegion` that can cause data loading to hang when processing regions larger than 2GB.

The bug is caused by using `std::min<int32_t>` to compare `uint64_t` values. If the remaining region length exceeds `INT32_MAX` (~2GB), `nextRegion.length` overflows to a negative number, which is then converted to a massive `uint64_t` length. This incorrect length causes subsequent read operations to hang.

The fix is to use `std::min<uint64_t>` to ensure the comparison is done with the correct type, preventing the overflow.

Before:
```cpp
nextRegion.length = std::min<int32_t>(
    loadQuantum_, region_.length - (nextRegion.offset - region_.offset));
```    
 After:
```cpp
nextRegion.length = std::min<uint64_t>(
    loadQuantum_, region_.length - (nextRegion.offset - region_.offset));
```    