### PR TITLE
fix: Addup expression stats in PlanNodeStats::operator+=()

### DIFF
--- a/velox/common/time/CpuWallTimer.h
+++ b/velox/common/time/CpuWallTimer.h
@@ -29,6 +29,8 @@ struct CpuWallTiming {
   uint64_t wallNanos = 0;
   uint64_t cpuNanos = 0;
 
+  auto operator<=>(const CpuWallTiming&) const = default;
+
   void add(const CpuWallTiming& other) {
     count += other.count;
     cpuNanos += other.cpuNanos;

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -59,6 +59,14 @@ PlanNodeStats& PlanNodeStats::operator+=(const PlanNodeStats& another) {
     }
   }
 
+  for (const auto& [name, exprStats] : another.expressionStats) {
+    auto const [it, inserted] =
+        this->expressionStats.try_emplace(name, exprStats);
+    if (!inserted) {
+      it->second.add(exprStats);
+    }
+  }
+
   // Populating number of drivers for plan nodes with multiple operators is not
   // useful. Each operator could have been executed in different pipelines with
   // different number of drivers.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(
   ParallelProjectTest.cpp
   PartitionedOutputTest.cpp
   PlanNodeSerdeTest.cpp
+  PlanNodeStatsTest.cpp
   PlanNodeToStringTest.cpp
   PlanNodeToSummaryStringTest.cpp
   PrefixSortTest.cpp

--- a/velox/exec/tests/PlanNodeStatsTest.cpp
+++ b/velox/exec/tests/PlanNodeStatsTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/PlanNodeStats.h"
+#include <gtest/gtest.h>
+
+namespace facebook::velox::exec::test {
+
+TEST(PlanNodeStatsTest, exprStatsTotal) {
+  PlanNodeStats stats;
+  stats.expressionStats["foo"] = ExprStats{
+      .timing = {.wallNanos = 1, .cpuNanos = 2},
+      .numProcessedRows = 3,
+      .numProcessedVectors = 4};
+
+  PlanNodeStats total;
+  total += stats;
+  EXPECT_EQ(total.expressionStats["foo"], stats.expressionStats["foo"]);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/expression/ExprStats.h
+++ b/velox/expression/ExprStats.h
@@ -35,6 +35,8 @@ struct ExprStats {
   /// evaluation of rows.
   bool defaultNullRowsSkipped{false};
 
+  auto operator<=>(const ExprStats&) const = default;
+
   void add(const ExprStats& other) {
     timing.add(other.timing);
     numProcessedRows += other.numProcessedRows;


### PR DESCRIPTION
Summary: The logic of adding up expressionStats is missing from [PlanNodeStats::operator+=()](https://github.com/facebookincubator/velox/blob/main/velox/exec/PlanNodeStats.cpp#L22). It is present in [PlanNodeStats::addTotals()](https://github.com/facebookincubator/velox/blob/main/velox/exec/PlanNodeStats.cpp#L94). Hence, the result is correct when adding up OperatorStats, but incorrect when adding up PlanNodeStats.

Differential Revision: D83536288


