### PR TITLE
fix: Add TIME type support for DuckDbQueryRunner

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -79,6 +79,9 @@ LogicalType fromVeloxType(const TypePtr& type) {
       if (type->isIntervalDayTime()) {
         return LogicalType::INTERVAL;
       }
+      if (type->isTime()) {
+        return LogicalType::TIME;
+      }
       return LogicalType::BIGINT;
     case TypeKind::REAL:
       return LogicalType::FLOAT;

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -132,6 +132,13 @@ template <>
     return ::duckdb::Value::INTERVAL(0, days, microseconds);
   }
 
+  if (type->isTime()) {
+    // TIME is stored as milliseconds since midnight in Velox.
+    // DuckDB TIME is stored as microseconds since midnight.
+    const auto timeMillis = vector->as<SimpleVector<int64_t>>()->valueAt(index);
+    return ::duckdb::Value::TIME(::duckdb::dtime_t(timeMillis * 1000L));
+  }
+
   return ::duckdb::Value(vector->as<SimpleVector<T>>()->valueAt(index));
 }
 
@@ -448,6 +455,12 @@ std::vector<MaterializedRow> materialize(
         auto value = variant(
             ::duckdb::Date::EpochDays(
                 dataChunk->GetValue(j, i).GetValue<::duckdb::date_t>()));
+        row.push_back(value);
+      } else if (type->isTime()) {
+        // DuckDB TIME is in microseconds, Velox TIME is in milliseconds.
+        auto value = variant(
+            dataChunk->GetValue(j, i).GetValue<::duckdb::dtime_t>().micros /
+            1000L);
         row.push_back(value);
       } else {
         auto value = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(


### PR DESCRIPTION
Add conversion support for Velox TIME type in DuckDB query runner to
enable TIME type testing in Velox tests that use DuckDB for verification.