### PR TITLE
build: macos skip brew upgrade when package exists

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -71,10 +71,14 @@ function install_from_brew {
       exit 1
     )
   else
-    (brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula "$pkg") || (
-      echo "Failed to install ${pkg}"
-      exit 1
-    )
+    if command -v "${pkg}" &>/dev/null; then
+      echo "Skipping '${pkg}' already exists"
+    else
+      (brew install --formula "${pkg}" && echo "Installation of ${pkg} is successful" || brew upgrade --formula "$pkg") || (
+        echo "Failed to install ${pkg}"
+        exit 1
+      )
+    fi
   fi
 }
 


### PR DESCRIPTION
Updating macos setup script to skip brew package upgrades when:
1. package is already available and
2. a specific version is not required

This is particularly useful for cmake on macos, where updating to latest (4.x.x) may cause build issues as reported by the community https://github.com/facebookincubator/velox/issues/12927:
```
CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```