### PR TITLE
fix: Disable intermediate/final type validation as they are not prod ready yet

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -19,7 +19,6 @@
 #include <unordered_map>
 #include "velox/exec/AggregateCompanionAdapter.h"
 #include "velox/exec/AggregateCompanionSignatures.h"
-#include "velox/exec/AggregateFunctionRegistry.h"
 #include "velox/exec/AggregateWindow.h"
 
 namespace facebook::velox::exec {
@@ -295,24 +294,6 @@ std::unique_ptr<Aggregate> Aggregate::create(
     const std::vector<TypePtr>& argTypes,
     const TypePtr& resultType,
     const core::QueryConfig& config) {
-  // Validate output types.
-  const auto [finalType, intermediateType] =
-      resolveAggregateFunction(name, argTypes);
-  if (isPartialOutput(step)) {
-    VELOX_CHECK(
-        resultType->equivalent(*intermediateType),
-        "Intermediate type mismatch. Aggregate function: '{}', expected: {}, actual: {}",
-        name,
-        intermediateType->toString(),
-        resultType->toString());
-  } else {
-    VELOX_CHECK(
-        resultType->equivalent(*finalType),
-        "Final type mismatch. Aggregate function: '{}', expected: {}, actual: {}",
-        name,
-        finalType->toString(),
-        resultType->toString());
-  }
   // Lookup the function in the new registry first.
   if (auto func = getAggregateFunctionEntry(name)) {
     return func->factory(step, argTypes, resultType, config);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -550,47 +550,6 @@ TEST_F(AggregationTest, missingLambdaFunction) {
       readCursor(params), "Aggregate function not registered: missing-lambda");
 }
 
-TEST_F(AggregationTest, outputTypeMismatch) {
-  using Step = core::AggregationNode::Step;
-
-  registerAggregateFunction(
-      "test_aggregate",
-      {AggregateFunctionSignatureBuilder()
-           .returnType("bigint")
-           .intermediateType("bigint")
-           .argumentType("bigint")
-           .build()},
-      [&](Step /*step*/,
-          const std::vector<TypePtr>& /*argTypes*/,
-          const TypePtr& /*resultType*/,
-          const core::QueryConfig& /*config*/)
-          -> std::unique_ptr<exec::Aggregate> { VELOX_UNREACHABLE(); },
-      false /*registerCompanionFunctions*/,
-      true /*overwrite*/);
-
-  for (auto step : {Step::kIntermediate, Step::kPartial}) {
-    VELOX_ASSERT_THROW(
-        Aggregate::create(
-            "test_aggregate",
-            step,
-            std::vector<TypePtr>{BIGINT()},
-            INTEGER(),
-            core::QueryConfig{{}}),
-        "Intermediate type mismatch");
-  }
-
-  for (auto step : {Step::kFinal, Step::kSingle}) {
-    VELOX_ASSERT_THROW(
-        Aggregate::create(
-            "test_aggregate",
-            step,
-            std::vector<TypePtr>{BIGINT()},
-            INTEGER(),
-            core::QueryConfig{{}}),
-        "Final type mismatch");
-  }
-}
-
 TEST_F(AggregationTest, global) {
   auto vectors = makeVectors(rowType_, 10, 100);
   createDuckDbTable(vectors);


### PR DESCRIPTION
Summary:
It's too dangerous change it was not really well tested. 
It was merged here: https://github.com/facebookincubator/velox/pull/14934

Some queries started to fail: https://fburl.com/scuba/presto_queries/slqfb9ay

Let's revert this, do better testing and return it back.

Differential Revision: D83712888


