### PR TITLE
fix: Do not allow registering companion functions for TDigest aggregate functions

### DIFF
--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -189,10 +189,7 @@ extern void registerVarianceAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerTDigestAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite);
+extern void registerTDigestAggregate(const std::string& prefix, bool overwrite);
 
 void registerAllAggregateFunctions(
     const std::string& prefix,
@@ -246,7 +243,7 @@ void registerAllAggregateFunctions(
   registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);
   registerSumAggregate(prefix, withCompanionFunctions, overwrite);
   registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
-  registerTDigestAggregate(prefix, withCompanionFunctions, overwrite);
+  registerTDigestAggregate(prefix, overwrite);
   registerNoisyApproxSfmAggregate(prefix, withCompanionFunctions, overwrite);
   registerNumericHistogramAggregate(prefix, withCompanionFunctions, overwrite);
 }

--- a/velox/functions/prestosql/aggregates/TDigestAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/TDigestAggregate.cpp
@@ -289,10 +289,7 @@ class TDigestAggregate : public exec::Aggregate {
 };
 } // namespace
 
-void registerTDigestAggregate(
-    const std::string& prefix,
-    bool withCompanionFunctions,
-    bool overwrite) {
+void registerTDigestAggregate(const std::string& prefix, bool overwrite) {
   std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures;
   for (const auto& signature :
        {AggregateFunctionSignatureBuilder()
@@ -356,7 +353,7 @@ void registerTDigestAggregate(
             hasWeight, hasCompression, resultTypes);
       },
       {},
-      withCompanionFunctions,
+      false /*registerCompanionFunctions*/,
       overwrite);
 }
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION

> I think the companion functions of tdigest_agg would be unnecessary for normal use cases, so we can remove the unused bool parameter and just pass false here. This is what we did with registerQDigestAggAggregate too.

https://github.com/facebookincubator/velox/pull/14995#discussion_r2395964880

