### PR TITLE
feat: Add TIME type support to Arrow bridge

### DIFF
--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -547,6 +547,48 @@ TEST_F(ArrowBridgeArrayExportTest, flatTimestamp) {
       VeloxUserError);
 }
 
+TEST_F(ArrowBridgeArrayExportTest, flatTime) {
+  std::vector<std::optional<int64_t>> inputData = {
+      0L,
+      std::nullopt,
+      1'000L,
+      60'000L,
+      3'600'000L,
+      std::nullopt,
+      50'402'000L,
+      86'399'999L,
+      std::nullopt};
+
+  auto flatVector = vectorMaker_.flatVectorNullable(inputData, TIME());
+  ArrowArray arrowArray;
+  ArrowSchema arrowSchema;
+  velox::exportToArrow(flatVector, arrowArray, pool_.get(), options_);
+  velox::exportToArrow(flatVector, arrowSchema, options_);
+
+  EXPECT_STREQ(arrowSchema.format, "ttm"); // time32 milliseconds.
+  EXPECT_EQ(arrowArray.length, inputData.size());
+  EXPECT_EQ(arrowArray.n_buffers, 2);
+
+  const uint64_t* nulls = static_cast<const uint64_t*>(arrowArray.buffers[0]);
+  const int32_t* values = static_cast<const int32_t*>(arrowArray.buffers[1]);
+
+  ASSERT_NE(nulls, nullptr);
+
+  for (auto i = 0; i < inputData.size(); ++i) {
+    if (inputData[i] == std::nullopt) {
+      EXPECT_TRUE(bits::isBitNull(nulls, i));
+    } else {
+      EXPECT_FALSE(bits::isBitNull(nulls, i));
+      // Velox milliseconds exported as Arrow time32 milliseconds (int32).
+      EXPECT_EQ(static_cast<int32_t>(inputData[i].value()), values[i])
+          << "mismatch at index " << i;
+    }
+  }
+
+  arrowArray.release(&arrowArray);
+  arrowSchema.release(&arrowSchema);
+}
+
 TEST_F(ArrowBridgeArrayExportTest, flatString) {
   testFlatVector<std::string>({
       "my string",
@@ -1203,6 +1245,18 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
         std::is_same_v<TInput, int128_t> && std::is_same_v<TOutput, int64_t>) {
       assertShortDecimalVectorContent(
           inputValues, output, arrowArray.null_count);
+    } else if constexpr (
+        std::is_same_v<TOutput, int64_t> &&
+        (std::is_same_v<TInput, int32_t> || std::is_same_v<TInput, int64_t>)) {
+      // TIME: Arrow time32 (int32) or time64 (int64) to Velox TIME (int64
+      // millis) Check if format starts with "tt" to distinguish from regular
+      // int32/int64.
+      if (format[0] == 't' && format[1] == 't') {
+        assertTimeVectorContent(
+            inputValues, output, arrowArray.null_count, format);
+      } else {
+        assertVectorContent(inputValues, output, arrowArray.null_count);
+      }
     } else {
       assertVectorContent(inputValues, output, arrowArray.null_count);
     }
@@ -1287,6 +1341,29 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
           tsString, {0, std::nullopt, Timestamp::kMaxSeconds});
     }
 
+    testArrowImport<int64_t, int32_t>(
+        "tts", {0, std::nullopt, 1, 60, 3600, 50402, 86399});
+    testArrowImport<int64_t, int32_t>(
+        "ttm", {0, std::nullopt, 1000, 60000, 3600000, 50402000, 86399999});
+    testArrowImport<int64_t, int64_t>(
+        "ttu",
+        {0,
+         std::nullopt,
+         1'000'000,
+         60'000'000,
+         3'600'000'000,
+         50'402'000'000,
+         86'399'999'000});
+    testArrowImport<int64_t, int64_t>(
+        "ttn",
+        {0,
+         std::nullopt,
+         1'000'000'000,
+         60'000'000'000,
+         3'600'000'000'000,
+         50'402'000'000'000,
+         86'399'999'000'000});
+
     testArrowImport<int64_t, int128_t>(
         "d:5,2", {1, -1, 0, 12345, -12345, std::nullopt});
     testArrowImport<int128_t, int128_t>(
@@ -1323,6 +1400,17 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
         std::is_same_v<TInput, int64_t> && std::is_same_v<TOutput, Timestamp>) {
       assertTimestampVectorContent(
           inputValues, output, arrowArray1.null_count, format);
+    } else if constexpr (
+        std::is_same_v<TOutput, int64_t> &&
+        (std::is_same_v<TInput, int32_t> || std::is_same_v<TInput, int64_t>)) {
+      // TIME: Arrow time32 (int32) or time64 (int64) to Velox TIME (int64
+      // millis).
+      if (format[0] == 't' && format[1] == 't') {
+        assertTimeVectorContent(
+            inputValues, output, arrowArray1.null_count, format);
+      } else {
+        assertVectorContent(inputValues, output, arrowArray1.null_count);
+      }
     } else {
       assertVectorContent(inputValues, output, arrowArray1.null_count);
     }
@@ -1424,6 +1512,47 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
       }
     }
     assertVectorContent(decValues, actual, nullCount);
+  }
+
+  // Creates TIME from int32/int64 and asserts the content of actual vector with
+  // the expected TIME values (in milliseconds).
+  template <typename TInput>
+  void assertTimeVectorContent(
+      const std::vector<std::optional<TInput>>& expectedValues,
+      const VectorPtr& actual,
+      size_t nullCount,
+      const char* format) {
+    VELOX_USER_CHECK_GE(
+        strlen(format), 3, "At least three characters are expected.");
+    std::vector<std::optional<int64_t>> timeValues;
+    timeValues.reserve(expectedValues.size());
+    for (const auto& value : expectedValues) {
+      if (!value.has_value()) {
+        timeValues.emplace_back(std::nullopt);
+      } else {
+        int64_t millis;
+        // Convert from Arrow time unit to Velox TIME (milliseconds).
+        switch (format[2]) {
+          case 's':
+            millis = static_cast<int64_t>(value.value()) * 1'000;
+            break;
+          case 'm':
+            millis = static_cast<int64_t>(value.value());
+            break;
+          case 'u':
+            millis = static_cast<int64_t>(value.value()) / 1'000;
+            break;
+          case 'n':
+            millis = static_cast<int64_t>(value.value()) / 1'000'000;
+            break;
+          default:
+            VELOX_UNREACHABLE();
+        }
+        timeValues.emplace_back(millis);
+      }
+    }
+    auto expected = vectorMaker_.flatVectorNullable(timeValues, TIME());
+    assertVectorContent(timeValues, actual, nullCount);
   }
 
   // Creates timestamp from bigint and asserts the content of actual vector with

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -487,8 +487,6 @@ TEST_F(ArrowBridgeSchemaImportTest, unsupported) {
   EXPECT_THROW(testSchemaImport("w:42"), VeloxUserError);
 
   EXPECT_THROW(testSchemaImport("tdm"), VeloxUserError);
-  EXPECT_THROW(testSchemaImport("tts"), VeloxUserError);
-  EXPECT_THROW(testSchemaImport("ttm"), VeloxUserError);
   EXPECT_THROW(testSchemaImport("tDs"), VeloxUserError);
 
   EXPECT_THROW(testSchemaImport("+"), VeloxUserError);


### PR DESCRIPTION
Export Velox TIME (int64 millis) as Arrow time32 (int32 millis, format "ttm").
Import Arrow time32/time64 to Velox TIME, supporting all time units.

This enables writing TIME to Parquet with TIME_MILLIS logical type and INT32
physical type.

Parquet metadata for TIME columns:
- Physical type: INT32
- Logical type: TIME

Example:
■■■■■■■■SchemaElement
■■■■■■■■■■■■type = 1
■■■■■■■■■■■■repetition_type = 1
■■■■■■■■■■■■name = c_time
■■■■■■■■■■■■converted_type = 7
■■■■■■■■■■■■logicalType = LogicalType
■■■■■■■■■■■■■■■■TIME = TimeType
■■■■■■■■■■■■■■■■■■■■isAdjustedToUTC = True
■■■■■■■■■■■■■■■■■■■■unit = TimeUnit
■■■■■■■■■■■■■■■■■■■■■■■■MILLIS = MilliSeconds
