### PR TITLE
refactor: Use IConfig for connectors and filesystems

### DIFF
--- a/velox/benchmarks/filesystem/ReadBenchmark.cpp
+++ b/velox/benchmarks/filesystem/ReadBenchmark.cpp
@@ -60,7 +60,7 @@ DEFINE_validator(path, &notEmpty);
 
 namespace facebook::velox {
 
-std::shared_ptr<config::ConfigBase> readConfig(const std::string& filePath) {
+config::ConfigPtr readConfig(const std::string& filePath) {
   std::ifstream configFile(filePath);
   if (!configFile.is_open()) {
     throw std::runtime_error(
@@ -108,7 +108,7 @@ void ReadBenchmark::initialize() {
     filesystems::registerGcsFileSystem();
     filesystems::registerHdfsFileSystem();
     filesystems::registerAbfsFileSystem();
-    std::shared_ptr<config::ConfigBase> config;
+    config::ConfigPtr config;
     if (!FLAGS_config.empty()) {
       config = readConfig(FLAGS_config);
     }

--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -130,4 +130,12 @@ class ConfigBase : public IConfig {
   const bool mutable_;
 };
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+using OldConfig = ConfigBase;
+using ConfigPtr = std::shared_ptr<const ConfigBase>;
+#else
+// Remove this using declaration once backward compatibility is removed.
+using OldConfig = IConfig;
+#endif
+
 } // namespace facebook::velox::config

--- a/velox/common/config/IConfig.h
+++ b/velox/common/config/IConfig.h
@@ -23,11 +23,9 @@
 
 namespace facebook::velox::config {
 
-/// IConfig - Read-only config interface
-/// for accessing key-value parameters.
-/// Supports value retrieval by key and
-/// duplication of the raw configuration data.
-/// Can be used by velox::QueryConfig to access
+/// IConfig - Read-only config interface for accessing key-value parameters.
+/// Supports value retrieval by key and duplication of the raw config data.
+/// Can be used by velox::QueryConfig or connector/file-system config to access
 /// externally managed system configuration.
 class IConfig {
  public:
@@ -66,5 +64,9 @@ class IConfig {
  private:
   virtual std::optional<std::string> access(const std::string& key) const = 0;
 };
+
+#ifndef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+using ConfigPtr = std::shared_ptr<const IConfig>;
+#endif
 
 } // namespace facebook::velox::config

--- a/velox/common/file/tests/FaultyFileSystem.cpp
+++ b/velox/common/file/tests/FaultyFileSystem.cpp
@@ -37,11 +37,9 @@ std::function<bool(std::string_view)> schemeMatcher() {
 
 folly::once_flag faultFilesystemInitOnceFlag;
 
-std::function<std::shared_ptr<
-    FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
+std::function<std::shared_ptr<FileSystem>(config::ConfigPtr, std::string_view)>
 fileSystemGenerator() {
-  return [](std::shared_ptr<const config::ConfigBase> properties,
-            std::string_view /*unused*/) {
+  return [](config::ConfigPtr properties, std::string_view /*unused*/) {
     // One instance of faulty FileSystem is sufficient. Initializes on first
     // access and reuse after that.
     static std::shared_ptr<FileSystem> lfs;

--- a/velox/common/file/tests/FaultyFileSystem.h
+++ b/velox/common/file/tests/FaultyFileSystem.h
@@ -31,7 +31,7 @@ using namespace filesystems;
 /// file operation to the real file system underneath.
 class FaultyFileSystem : public FileSystem {
  public:
-  explicit FaultyFileSystem(std::shared_ptr<const config::ConfigBase> config)
+  explicit FaultyFileSystem(config::ConfigPtr config)
       : FileSystem(std::move(config)) {}
 
   ~FaultyFileSystem() override {}

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -39,9 +39,6 @@ class Config;
 namespace facebook::velox::wave {
 class WaveDataSource;
 }
-namespace facebook::velox::config {
-class ConfigBase;
-}
 
 namespace facebook::velox::core {
 class ITypedExpr;
@@ -425,7 +422,7 @@ class ConnectorQueryCtx {
   ConnectorQueryCtx(
       memory::MemoryPool* operatorPool,
       memory::MemoryPool* connectorPool,
-      const config::ConfigBase* sessionProperties,
+      const config::OldConfig* sessionProperties,
       const common::SpillConfig* spillConfig,
       common::PrefixSortConfig prefixSortConfig,
       std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator,
@@ -470,7 +467,7 @@ class ConnectorQueryCtx {
     return connectorPool_;
   }
 
-  const config::ConfigBase* sessionProperties() const {
+  const config::OldConfig* sessionProperties() const {
     return sessionProperties_;
   }
 
@@ -556,7 +553,7 @@ class ConnectorQueryCtx {
  private:
   memory::MemoryPool* const operatorPool_;
   memory::MemoryPool* const connectorPool_;
-  const config::ConfigBase* const sessionProperties_;
+  const config::OldConfig* const sessionProperties_;
   const common::SpillConfig* const spillConfig_;
   const common::PrefixSortConfig prefixSortConfig_;
   const std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;
@@ -589,7 +586,7 @@ class ConnectorFactory {
 
   virtual std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) = 0;
 
@@ -599,9 +596,7 @@ class ConnectorFactory {
 
 class Connector {
  public:
-  explicit Connector(
-      const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config = nullptr)
+  explicit Connector(const std::string& id, config::ConfigPtr config = nullptr)
       : id_(id), config_(std::move(config)) {}
 
   virtual ~Connector() = default;
@@ -610,7 +605,7 @@ class Connector {
     return id_;
   }
 
-  const std::shared_ptr<const config::ConfigBase>& connectorConfig() const {
+  const config::ConfigPtr& connectorConfig() const {
     return config_;
   }
 
@@ -745,7 +740,7 @@ class Connector {
   static void unregisterTracker(cache::ScanTracker* tracker);
 
   const std::string id_;
-  const std::shared_ptr<const config::ConfigBase> config_;
+  const config::ConfigPtr config_;
 
   static folly::Synchronized<
       std::unordered_map<std::string_view, std::weak_ptr<cache::ScanTracker>>>

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -103,7 +103,7 @@ class FuzzerConnector final : public Connector {
  public:
   FuzzerConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* /*executor*/)
       : Connector(id) {}
 
@@ -136,7 +136,7 @@ class FuzzerConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<FuzzerConnector>(id, config, ioExecutor);

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -104,7 +104,7 @@ using FileHandleCache =
 class FileHandleGenerator {
  public:
   FileHandleGenerator() {}
-  FileHandleGenerator(std::shared_ptr<const config::ConfigBase> properties)
+  FileHandleGenerator(config::ConfigPtr properties)
       : properties_(std::move(properties)) {}
   std::unique_ptr<FileHandle> operator()(
       const FileHandleKey& filename,
@@ -112,7 +112,7 @@ class FileHandleGenerator {
       filesystems::File::IoStats* stats);
 
  private:
-  const std::shared_ptr<const config::ConfigBase> properties_;
+  const config::ConfigPtr properties_;
 };
 
 using FileHandleFactory = CachedFactory<

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -54,20 +54,20 @@ std::string HiveConfig::insertExistingPartitionsBehaviorString(
 
 HiveConfig::InsertExistingPartitionsBehavior
 HiveConfig::insertExistingPartitionsBehavior(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return stringToInsertExistingPartitionsBehavior(session->get<std::string>(
       kInsertExistingPartitionsBehaviorSession,
       config_->get<std::string>(kInsertExistingPartitionsBehavior, "ERROR")));
 }
 
 uint32_t HiveConfig::maxPartitionsPerWriters(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<uint32_t>(
       kMaxPartitionsPerWritersSession,
       config_->get<uint32_t>(kMaxPartitionsPerWriters, 128));
 }
 
-uint32_t HiveConfig::maxBucketCount(const config::ConfigBase* session) const {
+uint32_t HiveConfig::maxBucketCount(const config::IConfig* session) const {
   return session->get<uint32_t>(
       kMaxBucketCountSession, config_->get<uint32_t>(kMaxBucketCount, 100'000));
 }
@@ -98,49 +98,47 @@ std::optional<std::string> HiveConfig::gcsAuthAccessTokenProvider() const {
       config_->get<std::string>(kGcsAuthAccessTokenProvider));
 }
 
-bool HiveConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
+bool HiveConfig::isOrcUseColumnNames(const config::IConfig* session) const {
   return session->get<bool>(
       kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));
 }
 
-bool HiveConfig::isParquetUseColumnNames(
-    const config::ConfigBase* session) const {
+bool HiveConfig::isParquetUseColumnNames(const config::IConfig* session) const {
   return session->get<bool>(
       kParquetUseColumnNamesSession,
       config_->get<bool>(kParquetUseColumnNames, false));
 }
 
 bool HiveConfig::isFileColumnNamesReadAsLowerCase(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kFileColumnNamesReadAsLowerCaseSession,
       config_->get<bool>(kFileColumnNamesReadAsLowerCase, false));
 }
 
 bool HiveConfig::isPartitionPathAsLowerCase(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(kPartitionPathAsLowerCaseSession, true);
 }
 
-bool HiveConfig::allowNullPartitionKeys(
-    const config::ConfigBase* session) const {
+bool HiveConfig::allowNullPartitionKeys(const config::IConfig* session) const {
   return session->get<bool>(
       kAllowNullPartitionKeysSession,
       config_->get<bool>(kAllowNullPartitionKeys, true));
 }
 
-bool HiveConfig::ignoreMissingFiles(const config::ConfigBase* session) const {
+bool HiveConfig::ignoreMissingFiles(const config::IConfig* session) const {
   return session->get<bool>(kIgnoreMissingFilesSession, false);
 }
 
-int64_t HiveConfig::maxCoalescedBytes(const config::ConfigBase* session) const {
+int64_t HiveConfig::maxCoalescedBytes(const config::IConfig* session) const {
   return session->get<int64_t>(
       kMaxCoalescedBytesSession,
       config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20)); // 128MB
 }
 
 int32_t HiveConfig::maxCoalescedDistanceBytes(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   const auto distance = config::toCapacity(
       session->get<std::string>(
           kMaxCoalescedDistanceSession,
@@ -159,8 +157,7 @@ int32_t HiveConfig::prefetchRowGroups() const {
   return config_->get<int32_t>(kPrefetchRowGroups, 1);
 }
 
-size_t HiveConfig::parallelUnitLoadCount(
-    const config::ConfigBase* session) const {
+size_t HiveConfig::parallelUnitLoadCount(const config::IConfig* session) const {
   auto count = session->get<size_t>(
       kParallelUnitLoadCountSession,
       config_->get<size_t>(kParallelUnitLoadCount, 0));
@@ -168,7 +165,7 @@ size_t HiveConfig::parallelUnitLoadCount(
   return count;
 }
 
-int32_t HiveConfig::loadQuantum(const config::ConfigBase* session) const {
+int32_t HiveConfig::loadQuantum(const config::IConfig* session) const {
   return session->get<int32_t>(
       kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));
 }
@@ -190,14 +187,14 @@ std::string HiveConfig::writeFileCreateConfig() const {
 }
 
 uint32_t HiveConfig::sortWriterMaxOutputRows(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<uint32_t>(
       kSortWriterMaxOutputRowsSession,
       config_->get<uint32_t>(kSortWriterMaxOutputRows, 1024));
 }
 
 uint64_t HiveConfig::sortWriterMaxOutputBytes(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return config::toCapacity(
       session->get<std::string>(
           kSortWriterMaxOutputBytesSession,
@@ -206,13 +203,13 @@ uint64_t HiveConfig::sortWriterMaxOutputBytes(
 }
 
 uint64_t HiveConfig::sortWriterFinishTimeSliceLimitMs(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<uint64_t>(
       kSortWriterFinishTimeSliceLimitMsSession,
       config_->get<uint64_t>(kSortWriterFinishTimeSliceLimitMs, 5'000));
 }
 uint64_t HiveConfig::maxTargetFileSizeBytes(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return config::toCapacity(
       session->get<std::string>(
           kMaxTargetFileSizeSession,
@@ -228,7 +225,7 @@ uint64_t HiveConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
 }
 
-uint8_t HiveConfig::readTimestampUnit(const config::ConfigBase* session) const {
+uint8_t HiveConfig::readTimestampUnit(const config::IConfig* session) const {
   const auto unit = session->get<uint8_t>(
       kReadTimestampUnitSession,
       config_->get<uint8_t>(kReadTimestampUnit, 3 /*milli*/));
@@ -239,36 +236,36 @@ uint8_t HiveConfig::readTimestampUnit(const config::ConfigBase* session) const {
 }
 
 bool HiveConfig::readTimestampPartitionValueAsLocalTime(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kReadTimestampPartitionValueAsLocalTimeSession,
       config_->get<bool>(kReadTimestampPartitionValueAsLocalTime, true));
 }
 
 bool HiveConfig::readStatsBasedFilterReorderDisabled(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kReadStatsBasedFilterReorderDisabledSession,
       config_->get<bool>(kReadStatsBasedFilterReorderDisabled, false));
 }
 
 bool HiveConfig::preserveFlatMapsInMemory(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kPreserveFlatMapsInMemorySession,
       config_->get<bool>(kPreserveFlatMapsInMemory, false));
 }
 
-std::string HiveConfig::user(const config::ConfigBase* session) const {
+std::string HiveConfig::user(const config::IConfig* session) const {
   return session->get<std::string>(kUser, config_->get<std::string>(kUser, ""));
 }
 
-std::string HiveConfig::source(const config::ConfigBase* session) const {
+std::string HiveConfig::source(const config::IConfig* session) const {
   return session->get<std::string>(
       kSource, config_->get<std::string>(kSource, ""));
 }
 
-std::string HiveConfig::schema(const config::ConfigBase* session) const {
+std::string HiveConfig::schema(const config::IConfig* session) const {
   return session->get<std::string>(
       kSchema, config_->get<std::string>(kSchema, ""));
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -20,8 +20,14 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::config {
+class IConfig;
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
 class ConfigBase;
-}
+using ConfigPtr = std::shared_ptr<const ConfigBase>;
+#else
+using ConfigPtr = std::shared_ptr<const IConfig>;
+#endif
+} // namespace facebook::velox::config
 
 namespace facebook::velox::connector::hive {
 
@@ -213,11 +219,11 @@ class HiveConfig {
   static constexpr const char* kSchema = "schema";
 
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
-  uint32_t maxPartitionsPerWriters(const config::ConfigBase* session) const;
+  uint32_t maxPartitionsPerWriters(const config::IConfig* session) const;
 
-  uint32_t maxBucketCount(const config::ConfigBase* session) const;
+  uint32_t maxBucketCount(const config::IConfig* session) const;
 
   bool immutablePartitions() const;
 
@@ -231,28 +237,27 @@ class HiveConfig {
 
   std::optional<std::string> gcsAuthAccessTokenProvider() const;
 
-  bool isOrcUseColumnNames(const config::ConfigBase* session) const;
+  bool isOrcUseColumnNames(const config::IConfig* session) const;
 
-  bool isParquetUseColumnNames(const config::ConfigBase* session) const;
+  bool isParquetUseColumnNames(const config::IConfig* session) const;
 
-  bool isFileColumnNamesReadAsLowerCase(
-      const config::ConfigBase* session) const;
+  bool isFileColumnNamesReadAsLowerCase(const config::IConfig* session) const;
 
-  bool isPartitionPathAsLowerCase(const config::ConfigBase* session) const;
+  bool isPartitionPathAsLowerCase(const config::IConfig* session) const;
 
-  bool allowNullPartitionKeys(const config::ConfigBase* session) const;
+  bool allowNullPartitionKeys(const config::IConfig* session) const;
 
-  bool ignoreMissingFiles(const config::ConfigBase* session) const;
+  bool ignoreMissingFiles(const config::IConfig* session) const;
 
-  int64_t maxCoalescedBytes(const config::ConfigBase* session) const;
+  int64_t maxCoalescedBytes(const config::IConfig* session) const;
 
-  int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
+  int32_t maxCoalescedDistanceBytes(const config::IConfig* session) const;
 
   int32_t prefetchRowGroups() const;
 
-  size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
+  size_t parallelUnitLoadCount(const config::IConfig* session) const;
 
-  int32_t loadQuantum(const config::ConfigBase* session) const;
+  int32_t loadQuantum(const config::IConfig* session) const;
 
   int32_t numCacheFileHandles() const;
 
@@ -264,57 +269,57 @@ class HiveConfig {
 
   std::string writeFileCreateConfig() const;
 
-  uint32_t sortWriterMaxOutputRows(const config::ConfigBase* session) const;
+  uint32_t sortWriterMaxOutputRows(const config::IConfig* session) const;
 
-  uint64_t sortWriterMaxOutputBytes(const config::ConfigBase* session) const;
+  uint64_t sortWriterMaxOutputBytes(const config::IConfig* session) const;
 
   uint64_t sortWriterFinishTimeSliceLimitMs(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
-  uint64_t maxTargetFileSizeBytes(const config::ConfigBase* session) const;
+  uint64_t maxTargetFileSizeBytes(const config::IConfig* session) const;
 
   uint64_t footerEstimatedSize() const;
 
   uint64_t filePreloadThreshold() const;
 
   // Returns the timestamp unit used when reading timestamps from files.
-  uint8_t readTimestampUnit(const config::ConfigBase* session) const;
+  uint8_t readTimestampUnit(const config::IConfig* session) const;
 
   // Whether to read timestamp partition value as local time. If false, read as
   // UTC.
   bool readTimestampPartitionValueAsLocalTime(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
   /// Returns true if the stats based filter reorder for read is disabled.
   bool readStatsBasedFilterReorderDisabled(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.
-  bool preserveFlatMapsInMemory(const config::ConfigBase* session) const;
+  bool preserveFlatMapsInMemory(const config::IConfig* session) const;
 
   /// User of the query. Used for storage logging.
-  std::string user(const config::ConfigBase* session) const;
+  std::string user(const config::IConfig* session) const;
 
   /// Source of the query. Used for storage access and logging.
-  std::string source(const config::ConfigBase* session) const;
+  std::string source(const config::IConfig* session) const;
 
   /// Schema of the query. Used for storage logging.
-  std::string schema(const config::ConfigBase* session) const;
+  std::string schema(const config::IConfig* session) const;
 
-  HiveConfig(std::shared_ptr<const config::ConfigBase> config) {
+  HiveConfig(config::ConfigPtr config) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for HiveConfig initialization");
     config_ = std::move(config);
     // TODO: add sanity check
   }
 
-  const std::shared_ptr<const config::ConfigBase>& config() const {
+  const config::ConfigPtr& config() const {
     return config_;
   }
 
  private:
-  std::shared_ptr<const config::ConfigBase> config_;
+  config::ConfigPtr config_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -30,7 +30,7 @@ namespace facebook::velox::connector::hive {
 
 HiveConnector::HiveConnector(
     const std::string& id,
-    std::shared_ptr<const config::ConfigBase> config,
+    config::ConfigPtr config,
     folly::Executor* ioExecutor)
     : Connector(id, std::move(config)),
       hiveConfig_(std::make_shared<HiveConfig>(connectorConfig())),

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -31,7 +31,7 @@ class HiveConnector : public Connector {
  public:
   HiveConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* executor);
 
   bool canAddDynamicFilter() const override {
@@ -87,7 +87,7 @@ class HiveConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       [[maybe_unused]] folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<HiveConnector>(id, config, ioExecutor);

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -643,7 +643,7 @@ void configureRowReaderOptions(
     const RowTypePtr& rowType,
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
-    const config::ConfigBase* sessionProperties,
+    const config::IConfig* sessionProperties,
     folly::Executor* const ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions) {
   auto skipRowsIt =

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -126,7 +126,7 @@ void configureRowReaderOptions(
     const RowTypePtr& rowType,
     const std::shared_ptr<const HiveConnectorSplit>& hiveSplit,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
-    const config::ConfigBase* sessionProperties,
+    const config::IConfig* sessionProperties,
     folly::Executor* ioExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions);
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -215,7 +215,7 @@ std::shared_ptr<memory::MemoryPool> createSortPool(
 
 uint64_t getFinishTimeSliceLimitMsFromHiveConfig(
     const std::shared_ptr<const HiveConfig>& config,
-    const config::ConfigBase* sessions) {
+    const config::IConfig* sessions) {
   const uint64_t flushTimeSliceLimitMsFromConfig =
       config->sortWriterFinishTimeSliceLimitMs(sessions);
   // NOTE: if the flush time slice limit is set to 0, then we treat it as no

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -42,7 +42,7 @@ void registerIcebergInternalFunctions(const std::string& prefix) {
 
 IcebergConnector::IcebergConnector(
     const std::string& id,
-    std::shared_ptr<const config::ConfigBase> config,
+    config::ConfigPtr config,
     folly::Executor* ioExecutor)
     : HiveConnector(id, config, ioExecutor),
       functionPrefix_(config->get<std::string>(

--- a/velox/connectors/hive/iceberg/IcebergConnector.h
+++ b/velox/connectors/hive/iceberg/IcebergConnector.h
@@ -33,7 +33,7 @@ class IcebergConnector final : public HiveConnector {
  public:
   IcebergConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor);
 
   /// Creates IcebergDataSink for writing to Iceberg tables.
@@ -78,7 +78,7 @@ class IcebergConnectorFactory final : public ConnectorFactory {
   /// @return Shared pointer to the newly created IcebergConnector instance
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       [[maybe_unused]] folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<IcebergConnector>(id, config, ioExecutor);

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.cpp
@@ -28,8 +28,7 @@
 
 namespace facebook::velox::filesystems {
 
-AbfsFileSystem::AbfsFileSystem(std::shared_ptr<const config::ConfigBase> config)
-    : FileSystem(config) {
+AbfsFileSystem::AbfsFileSystem(config::ConfigPtr config) : FileSystem(config) {
   VELOX_CHECK_NOT_NULL(config.get());
 }
 

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsFileSystem.h
@@ -34,7 +34,7 @@ namespace facebook::velox::filesystems {
 /// https://learn.microsoft.com/en-us/azure/databricks/storage/azure-storage.
 class AbfsFileSystem : public FileSystem {
  public:
-  explicit AbfsFileSystem(std::shared_ptr<const config::ConfigBase> config);
+  explicit AbfsFileSystem(config::ConfigPtr config);
 
   std::string name() const override;
 

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.cpp
@@ -26,7 +26,7 @@ class AbfsReadFile::Impl {
   constexpr static uint64_t kReadConcurrency = 8;
 
  public:
-  explicit Impl(std::string_view path, const config::ConfigBase& config) {
+  explicit Impl(std::string_view path, const config::IConfig& config) {
     auto abfsPath = std::make_shared<AbfsPath>(path);
     filePath_ = abfsPath->filePath();
     fileClient_ =
@@ -150,7 +150,7 @@ class AbfsReadFile::Impl {
 
 AbfsReadFile::AbfsReadFile(
     std::string_view path,
-    const config::ConfigBase& config) {
+    const config::IConfig& config) {
   impl_ = std::make_shared<Impl>(path, config);
 }
 

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.h
@@ -18,16 +18,10 @@
 
 #include "velox/common/file/File.h"
 
-namespace facebook::velox::config {
-class ConfigBase;
-}
-
 namespace facebook::velox::filesystems {
 class AbfsReadFile final : public ReadFile {
  public:
-  explicit AbfsReadFile(
-      std::string_view path,
-      const config::ConfigBase& config);
+  explicit AbfsReadFile(std::string_view path, const config::IConfig& config);
 
   void initialize(const FileOptions& options);
 

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.cpp
@@ -20,11 +20,10 @@
 
 namespace facebook::velox::filesystems {
 
-std::vector<CacheKey> extractCacheKeyFromConfig(
-    const config::ConfigBase& config) {
+std::vector<CacheKey> extractCacheKeyFromConfig(const config::IConfig& config) {
   std::vector<CacheKey> cacheKeys;
   constexpr std::string_view authTypePrefix{kAzureAccountAuthType};
-  for (const auto& [key, value] : config.rawConfigs()) {
+  for (const auto& [key, value] : config.rawConfigsCopy()) {
     if (key.find(authTypePrefix) == 0) {
       // Extract the accountName after "fs.azure.account.auth.type.".
       auto remaining = std::string_view(key).substr(authTypePrefix.size() + 1);

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsUtil.h
@@ -26,8 +26,6 @@ constexpr std::string_view kAbfsScheme{"abfs://"};
 constexpr std::string_view kAbfssScheme{"abfss://"};
 } // namespace
 
-class ConfigBase;
-
 struct CacheKey {
   const std::string accountName;
   const std::string authType;
@@ -55,7 +53,6 @@ inline std::string throwStorageExceptionWithOperationDetails(
   VELOX_FAIL(errMsg);
 }
 
-std::vector<CacheKey> extractCacheKeyFromConfig(
-    const config::ConfigBase& config);
+std::vector<CacheKey> extractCacheKeyFromConfig(const config::IConfig& config);
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.cpp
@@ -89,7 +89,7 @@ class AbfsWriteFile::Impl {
 
 AbfsWriteFile::AbfsWriteFile(
     std::string_view path,
-    const config::ConfigBase& config) {
+    const config::IConfig& config) {
   const auto abfsPath = std::make_shared<AbfsPath>(path);
   auto client =
       AzureClientProviderFactories::getWriteFileClient(abfsPath, config);

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsWriteFile.h
@@ -18,10 +18,6 @@
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/storage_adapters/abfs/AzureDataLakeFileClient.h"
 
-namespace facebook::velox::config {
-class ConfigBase;
-}
-
 namespace facebook::velox::filesystems {
 
 /// We are using the DFS (Data Lake Storage) endpoint for Azure Blob File write
@@ -39,7 +35,7 @@ class AbfsWriteFile : public WriteFile {
 
   /// @param path The file path to write.
   /// @param connectStr The connection string used to auth the storage account.
-  AbfsWriteFile(std::string_view path, const config::ConfigBase& config);
+  AbfsWriteFile(std::string_view path, const config::IConfig& config);
 
   /// @param path The file path to write.
   /// @param client The AdlsFileClient.

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProvider.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProvider.h
@@ -31,12 +31,12 @@ class AzureClientProvider {
   // Creates AzureBlobClient for file read operations.
   virtual std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& path,
-      const config::ConfigBase& config) = 0;
+      const config::IConfig& config) = 0;
 
   // Creates AzureDataLakeFileClient for file write operations.
   virtual std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& path,
-      const config::ConfigBase& config) = 0;
+      const config::IConfig& config) = 0;
 };
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.cpp
@@ -63,7 +63,7 @@ AzureClientProviderFactory AzureClientProviderFactories::getClientFactory(
 std::unique_ptr<AzureBlobClient>
 AzureClientProviderFactories::getReadFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
-    const config::ConfigBase& config) {
+    const config::IConfig& config) {
   auto factory = getClientFactory(abfsPath->accountName());
   return factory(abfsPath->accountName())->getReadFileClient(abfsPath, config);
 }
@@ -71,7 +71,7 @@ AzureClientProviderFactories::getReadFileClient(
 std::unique_ptr<AzureDataLakeFileClient>
 AzureClientProviderFactories::getWriteFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
-    const config::ConfigBase& config) {
+    const config::IConfig& config) {
   auto factory = getClientFactory(abfsPath->accountName());
   return factory(abfsPath->accountName())->getWriteFileClient(abfsPath, config);
 }

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h
@@ -49,14 +49,14 @@ class AzureClientProviderFactories {
   /// is registered for the account specified in `abfsPath`.
   static std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
   /// Uses the registered AzureClientProviderFactory to create an
   /// AzureDataLakeFileClient for file write operations. Throws exception if no
   /// factory is registered for the account specified in `abfsPath`.
   static std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 };
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderImpl.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderImpl.h
@@ -29,21 +29,21 @@ class SharedKeyAzureClientProvider final : public AzureClientProvider {
  public:
   std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   // Test only.
   std::string connectionString(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
  private:
   void init(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
   std::string connectionString_;
 };
@@ -53,21 +53,21 @@ class OAuthAzureClientProvider final : public AzureClientProvider {
  public:
   std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   // Test only.
   std::pair<std::string, std::string> tenantIdAndAuthorityHost(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
  private:
   void init(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
   std::string tenentId_;
   std::string authorityHost_;
@@ -79,21 +79,21 @@ class FixedSasAzureClientProvider final : public AzureClientProvider {
  public:
   std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   // Test only.
   std::string sas(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
  private:
   void init(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config);
+      const config::IConfig& config);
 
   std::string sas_;
 };

--- a/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.cpp
@@ -200,7 +200,7 @@ DynamicSasTokenClientProvider::DynamicSasTokenClientProvider(
     const std::shared_ptr<SasTokenProvider>& sasTokenProvider)
     : AzureClientProvider(), sasTokenProvider_(sasTokenProvider) {}
 
-void DynamicSasTokenClientProvider::init(const config::ConfigBase& config) {
+void DynamicSasTokenClientProvider::init(const config::IConfig& config) {
   sasTokenRenewPeriod_ = config.get<int64_t>(
       kAzureSasTokenRenewPeriod, kDefaultSasTokenRenewPeriod);
 }
@@ -208,7 +208,7 @@ void DynamicSasTokenClientProvider::init(const config::ConfigBase& config) {
 std::unique_ptr<AzureBlobClient>
 DynamicSasTokenClientProvider::getReadFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
-    const config::ConfigBase& config) {
+    const config::IConfig& config) {
   init(config);
   return std::make_unique<DynamicSasTokenBlobClient>(
       abfsPath, sasTokenProvider_, sasTokenRenewPeriod_);
@@ -217,7 +217,7 @@ DynamicSasTokenClientProvider::getReadFileClient(
 std::unique_ptr<AzureDataLakeFileClient>
 DynamicSasTokenClientProvider::getWriteFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
-    const config::ConfigBase& config) {
+    const config::IConfig& config) {
   init(config);
   return std::make_unique<DynamicSasTokenDataLakeFileClient>(
       abfsPath, sasTokenProvider_, sasTokenRenewPeriod_);

--- a/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.h
+++ b/velox/connectors/hive/storage_adapters/abfs/DynamicSasTokenClientProvider.h
@@ -57,14 +57,14 @@ class DynamicSasTokenClientProvider : public AzureClientProvider {
 
   std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
   std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
-      const config::ConfigBase& config) override;
+      const config::IConfig& config) override;
 
  private:
-  void init(const config::ConfigBase& config);
+  void init(const config::IConfig& config);
 
   std::shared_ptr<SasTokenProvider> sasTokenProvider_;
   int64_t sasTokenRenewPeriod_;

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -33,7 +33,7 @@ namespace facebook::velox::filesystems {
 folly::once_flag abfsInitiationFlag;
 
 std::shared_ptr<FileSystem> abfsFileSystemGenerator(
-    std::shared_ptr<const config::ConfigBase> properties,
+    config::ConfigPtr properties,
     std::string_view filePath) {
   static std::shared_ptr<FileSystem> filesystem;
   folly::call_once(abfsInitiationFlag, [&properties]() {
@@ -66,7 +66,7 @@ void registerAbfsFileSystem() {
 #endif
 }
 
-void registerAzureClientProvider(const config::ConfigBase& config) {
+void registerAzureClientProvider(const config::IConfig& config) {
 #ifdef VELOX_ENABLE_ABFS
 
   for (const auto& [accountName, authType] :

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h
@@ -22,7 +22,13 @@
 
 namespace facebook::velox::config {
 
+class IConfig;
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
 class ConfigBase;
+using ConfigPtr = std::shared_ptr<const ConfigBase>;
+#else
+using ConfigPtr = std::shared_ptr<const IConfig>;
+#endif
 
 } // namespace facebook::velox::config
 
@@ -40,7 +46,7 @@ void registerAbfsFileSystem();
 
 /// Register the AzureClientProvider implementation in `AzureClientProviders`
 /// based on the configuration.
-void registerAzureClientProvider(const config::ConfigBase& config);
+void registerAzureClientProvider(const config::IConfig& config);
 
 /// Registers a factory for creating AzureClientProvider instances.
 /// Any existing factory registered for the specified account will be

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -55,13 +55,13 @@ class TestAzureClientProvider final : public AzureClientProvider {
 
   std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& path,
-      const config::ConfigBase& config) override {
+      const config::IConfig& config) override {
     return delegated_->getReadFileClient(path, config);
   }
 
   std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& path,
-      const config::ConfigBase& config) override {
+      const config::IConfig& config) override {
     return std::make_unique<MockDataLakeFileClient>();
   }
 

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
@@ -30,13 +30,13 @@ class DummyAzureClientProvider final : public AzureClientProvider {
  public:
   std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& path,
-      const config::ConfigBase& config) override {
+      const config::IConfig& config) override {
     VELOX_FAIL("DummyAzureClientProvider: Not implemented.");
   }
 
   std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& path,
-      const config::ConfigBase& config) override {
+      const config::IConfig& config) override {
     VELOX_FAIL("DummyAzureClientProvider: Not implemented.");
   }
 };

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.cpp
@@ -32,7 +32,7 @@ std::string AzuriteServer::fileURI() const {
 
 // Return the hiveConfig for the Azurite instance.
 // Specify configOverride map to update the default config map.
-std::shared_ptr<const config::ConfigBase> AzuriteServer::hiveConfig(
+config::ConfigPtr AzuriteServer::hiveConfig(
     const std::unordered_map<std::string, std::string> configOverride) const {
   auto endpoint = fmt::format("http://127.0.0.1:{}/{}", port_, account_);
   std::unordered_map<std::string, std::string> config(

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.h
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzuriteServer.h
@@ -51,7 +51,7 @@ class AzuriteServer {
     return file_;
   }
 
-  std::shared_ptr<const config::ConfigBase> hiveConfig(
+  config::ConfigPtr hiveConfig(
       const std::unordered_map<std::string, std::string> configOverride = {})
       const;
 

--- a/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<GcsOAuthCredentialsProvider> getCredentialsProviderByName(
 
 class GcsFileSystem::Impl {
  public:
-  Impl(const std::string& bucket, const config::ConfigBase* config)
+  Impl(const std::string& bucket, const config::IConfig* config)
       : bucket_(bucket),
         hiveConfig_(
             std::make_shared<HiveConfig>(std::make_shared<config::ConfigBase>(
@@ -153,7 +153,7 @@ class GcsFileSystem::Impl {
 
 GcsFileSystem::GcsFileSystem(
     const std::string& bucket,
-    std::shared_ptr<const config::ConfigBase> config)
+    config::ConfigPtr config)
     : FileSystem(config) {
   impl_ = std::make_shared<Impl>(bucket, config.get());
 }

--- a/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsFileSystem.h
@@ -28,9 +28,7 @@ namespace facebook::velox::filesystems {
 /// (register|generate)ReadFile and (register|generate)WriteFile functions.
 class GcsFileSystem : public FileSystem {
  public:
-  explicit GcsFileSystem(
-      const std::string& bucket,
-      std::shared_ptr<const config::ConfigBase> config);
+  explicit GcsFileSystem(const std::string& bucket, config::ConfigPtr config);
 
   /// Initialize the google::cloud::storage::Client from the input Config
   /// parameters.

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsEmulator.h
@@ -89,7 +89,7 @@ class GcsEmulator : public testing::Environment {
     }
   }
 
-  std::shared_ptr<const config::ConfigBase> hiveConfig(
+  config::ConfigPtr hiveConfig(
       const std::unordered_map<std::string, std::string> configOverride = {})
       const {
     std::unordered_map<std::string, std::string> config(

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -28,7 +28,7 @@ class HdfsFileSystem::Impl {
  public:
   // Keep config here for possible use in the future.
   explicit Impl(
-      const config::ConfigBase* config,
+      const config::IConfig* config,
       const HdfsServiceEndpoint& endpoint) {
     auto status = filesystems::arrow::io::internal::ConnectLibHdfs(&driver_);
     if (!status.ok()) {
@@ -97,7 +97,7 @@ class HdfsFileSystem::Impl {
 };
 
 HdfsFileSystem::HdfsFileSystem(
-    const std::shared_ptr<const config::ConfigBase>& config,
+    const config::ConfigPtr& config,
     const HdfsServiceEndpoint& endpoint)
     : FileSystem(config) {
   impl_ = std::make_shared<Impl>(config.get(), endpoint);
@@ -140,7 +140,7 @@ bool HdfsFileSystem::isHdfsFile(const std::string_view filePath) {
 /// fixed one from configuration.
 HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(
     const std::string_view filePath,
-    const config::ConfigBase* config) {
+    const config::IConfig* config) {
   if (filePath.find(kViewfsScheme) == 0) {
     return HdfsServiceEndpoint{"viewfs", "", true};
   }

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -48,7 +48,7 @@ struct HdfsServiceEndpoint {
 class HdfsFileSystem : public FileSystem {
  public:
   explicit HdfsFileSystem(
-      const std::shared_ptr<const config::ConfigBase>& config,
+      const config::ConfigPtr& config,
       const HdfsServiceEndpoint& endpoint);
 
   std::string name() const override;
@@ -88,7 +88,7 @@ class HdfsFileSystem : public FileSystem {
   /// will be used.
   static HdfsServiceEndpoint getServiceEndpoint(
       const std::string_view filePath,
-      const config::ConfigBase* config);
+      const config::IConfig* config);
 
   static std::string_view kScheme;
 

--- a/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
@@ -31,45 +31,41 @@ std::mutex mtx;
 folly::ConcurrentHashMap<std::string, std::shared_ptr<HdfsFileSystem>>
     registeredFilesystems;
 
-std::function<std::shared_ptr<
-    FileSystem>(std::shared_ptr<const config::ConfigBase>, std::string_view)>
+std::function<std::shared_ptr<FileSystem>(config::ConfigPtr, std::string_view)>
 hdfsFileSystemGenerator() {
-  static auto filesystemGenerator =
-      [](std::shared_ptr<const config::ConfigBase> properties,
-         std::string_view filePath) {
-        static folly::
-            ConcurrentHashMap<std::string, std::shared_ptr<folly::once_flag>>
-                hdfsInitiationFlags;
-        HdfsServiceEndpoint endpoint =
-            HdfsFileSystem::getServiceEndpoint(filePath, properties.get());
-        std::string hdfsIdentity = endpoint.identity();
-        if (registeredFilesystems.find(hdfsIdentity) !=
-            registeredFilesystems.end()) {
-          return registeredFilesystems[hdfsIdentity];
-        }
-        std::unique_lock<std::mutex> lk(mtx, std::defer_lock);
-        /// If the init flag for a given hdfs identity is not found,
-        /// create one for init use. It's a singleton.
-        if (hdfsInitiationFlags.find(hdfsIdentity) ==
-            hdfsInitiationFlags.end()) {
-          lk.lock();
-          if (hdfsInitiationFlags.find(hdfsIdentity) ==
-              hdfsInitiationFlags.end()) {
-            std::shared_ptr<folly::once_flag> initiationFlagPtr =
-                std::make_shared<folly::once_flag>();
-            hdfsInitiationFlags.insert(hdfsIdentity, initiationFlagPtr);
-          }
-          lk.unlock();
-        }
-        folly::call_once(
-            *hdfsInitiationFlags[hdfsIdentity].get(),
-            [&properties, endpoint, hdfsIdentity]() {
-              auto filesystem =
-                  std::make_shared<HdfsFileSystem>(properties, endpoint);
-              registeredFilesystems.insert(hdfsIdentity, filesystem);
-            });
-        return registeredFilesystems[hdfsIdentity];
-      };
+  static auto filesystemGenerator = [](config::ConfigPtr properties,
+                                       std::string_view filePath) {
+    static folly::
+        ConcurrentHashMap<std::string, std::shared_ptr<folly::once_flag>>
+            hdfsInitiationFlags;
+    HdfsServiceEndpoint endpoint =
+        HdfsFileSystem::getServiceEndpoint(filePath, properties.get());
+    std::string hdfsIdentity = endpoint.identity();
+    if (registeredFilesystems.find(hdfsIdentity) !=
+        registeredFilesystems.end()) {
+      return registeredFilesystems[hdfsIdentity];
+    }
+    std::unique_lock<std::mutex> lk(mtx, std::defer_lock);
+    /// If the init flag for a given hdfs identity is not found,
+    /// create one for init use. It's a singleton.
+    if (hdfsInitiationFlags.find(hdfsIdentity) == hdfsInitiationFlags.end()) {
+      lk.lock();
+      if (hdfsInitiationFlags.find(hdfsIdentity) == hdfsInitiationFlags.end()) {
+        std::shared_ptr<folly::once_flag> initiationFlagPtr =
+            std::make_shared<folly::once_flag>();
+        hdfsInitiationFlags.insert(hdfsIdentity, initiationFlagPtr);
+      }
+      lk.unlock();
+    }
+    folly::call_once(
+        *hdfsInitiationFlags[hdfsIdentity].get(),
+        [&properties, endpoint, hdfsIdentity]() {
+          auto filesystem =
+              std::make_shared<HdfsFileSystem>(properties, endpoint);
+          registeredFilesystems.insert(hdfsIdentity, filesystem);
+        });
+    return registeredFilesystems[hdfsIdentity];
+  };
   return filesystemGenerator;
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -49,7 +49,7 @@ FileSystemMap& fileSystems() {
 CacheKeyFn cacheKeyFunc;
 
 std::shared_ptr<FileSystem> fileSystemGenerator(
-    std::shared_ptr<const config::ConfigBase> properties,
+    config::ConfigPtr properties,
     std::string_view s3Path) {
   std::string cacheKey, bucketName, key;
   getBucketAndKeyFromPath(getPath(s3Path), bucketName, key);

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -26,13 +26,19 @@ class AWSCredentialsProvider;
 } // namespace Aws::Auth
 
 namespace facebook::velox::config {
+class IConfig;
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
 class ConfigBase;
-}
+using ConfigPtr = std::shared_ptr<const ConfigBase>;
+#else
+using ConfigPtr = std::shared_ptr<const IConfig>;
+#endif
+} // namespace facebook::velox::config
 
 namespace facebook::velox::filesystems {
 
-using CacheKeyFn = std::function<
-    std::string(std::shared_ptr<const config::ConfigBase>, std::string_view)>;
+using CacheKeyFn =
+    std::function<std::string(config::ConfigPtr, std::string_view)>;
 
 // Register the S3 filesystem.
 void registerS3FileSystem(CacheKeyFn cacheKeyFunc = nullptr);

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -20,8 +20,14 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::config {
+class IConfig;
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
 class ConfigBase;
-}
+using ConfigPtr = std::shared_ptr<const ConfigBase>;
+#else
+using ConfigPtr = std::shared_ptr<const IConfig>;
+#endif
+} // namespace facebook::velox::config
 
 namespace facebook::velox::filesystems {
 
@@ -118,16 +124,14 @@ class S3Config {
     return config;
   }
 
-  S3Config(
-      std::string_view bucket,
-      std::shared_ptr<const config::ConfigBase> config);
+  S3Config(std::string_view bucket, const config::ConfigPtr& config);
 
   /// cacheKey is used as a key for the S3FileSystem instance map.
   /// This will be the bucket endpoint or the base endpoint if they exist plus
   /// bucket name.
   static std::string cacheKey(
       std::string_view bucket,
-      std::shared_ptr<const config::ConfigBase> config);
+      const config::ConfigPtr& config);
 
   /// Return the base config for the input Key.
   static std::string baseConfigKey(Keys key) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -453,7 +453,7 @@ class S3FileSystem::Impl {
 
 S3FileSystem::S3FileSystem(
     std::string_view bucketName,
-    const std::shared_ptr<const config::ConfigBase> config)
+    const config::ConfigPtr config)
     : FileSystem(config) {
   S3Config s3Config(bucketName, config);
   impl_ = std::make_shared<Impl>(s3Config);

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -46,9 +46,7 @@ void registerCredentialsProvider(
 /// type of file can be constructed based on a filename.
 class S3FileSystem : public FileSystem {
  public:
-  S3FileSystem(
-      std::string_view bucketName,
-      const std::shared_ptr<const config::ConfigBase> config);
+  S3FileSystem(std::string_view bucketName, const config::ConfigPtr config);
 
   std::string name() const override;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/MinioServer.h
@@ -54,7 +54,7 @@ class MinioServer {
     return tempPath_->getPath();
   }
 
-  std::shared_ptr<const config::ConfigBase> hiveConfig(
+  config::ConfigPtr hiveConfig(
       const std::unordered_map<std::string, std::string> configOverride = {})
       const {
     std::unordered_map<std::string, std::string> config({

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemRegistrationTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemRegistrationTest.cpp
@@ -20,9 +20,7 @@
 namespace facebook::velox::filesystems {
 namespace {
 
-std::string cacheKeyFunc(
-    std::shared_ptr<const config::ConfigBase> config,
-    std::string_view path) {
+std::string cacheKeyFunc(config::ConfigPtr config, std::string_view path) {
   return config->get<std::string>("hive.s3.endpoint").value();
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -199,7 +199,7 @@ TEST_F(S3MultipleEndpoints, bucketEndpoints) {
   const int64_t kExpectedRows = 1'000;
   const auto outputDirectory{filesystems::s3URI(kBucketName, "")};
 
-  auto configOverride = [](std::shared_ptr<const config::ConfigBase> config) {
+  auto configOverride = [](config::ConfigPtr config) {
     return std::unordered_map<std::string, std::string>{
         {"hive.s3.bucket.writedata.endpoint",
          config->get<std::string>("hive.s3.endpoint").value()},

--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -31,9 +31,7 @@ namespace facebook::velox::test {
 
 class InsertTest : public velox::test::VectorTestBase {
  protected:
-  void SetUp(
-      std::shared_ptr<const config::ConfigBase> hiveConfig,
-      folly::Executor* ioExecutor) {
+  void SetUp(config::ConfigPtr hiveConfig, folly::Executor* ioExecutor) {
     connector::hive::HiveConnectorFactory factory;
     auto hiveConnector = factory.newConnector(
         exec::test::kHiveConnectorId, hiveConfig, ioExecutor);

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -49,7 +49,7 @@ class TestConnectorFactory : public connector::ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> /*config*/,
+      config::ConfigPtr /*config*/,
       folly::Executor* /*ioExecutor*/ = nullptr,
       folly::Executor* /*cpuExecutor*/ = nullptr) override {
     return std::make_shared<TestConnector>(id);

--- a/velox/connectors/tpcds/TpcdsConnector.h
+++ b/velox/connectors/tpcds/TpcdsConnector.h
@@ -135,7 +135,7 @@ class TpcdsConnector final : public velox::connector::Connector {
  public:
   TpcdsConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* FOLLY_NULLABLE /*executor*/)
       : Connector(id) {}
 
@@ -174,7 +174,7 @@ class TpcdsConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<TpcdsConnector>(id, config, ioExecutor);

--- a/velox/connectors/tpch/TpchConnector.cpp
+++ b/velox/connectors/tpch/TpchConnector.cpp
@@ -25,7 +25,7 @@ using facebook::velox::tpch::Table;
 
 TpchConnector::TpchConnector(
     const std::string& id,
-    std::shared_ptr<const config::ConfigBase> config,
+    config::ConfigPtr config,
     folly::Executor* /*executor*/)
     : Connector(id, std::move(config)) {}
 

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -212,7 +212,7 @@ class TpchConnector final : public Connector {
  public:
   TpchConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* /*executor*/);
 
   std::unique_ptr<DataSource> createDataSource(
@@ -250,7 +250,7 @@ class TpchConnectorFactory : public ConnectorFactory {
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) override {
     return std::make_shared<TpchConnector>(id, config, ioExecutor);

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -27,9 +27,7 @@ QueryConfig::QueryConfig(std::unordered_map<std::string, std::string> values)
           ConfigTag{},
           std::make_shared<config::ConfigBase>(std::move(values))} {}
 
-QueryConfig::QueryConfig(
-    ConfigTag /*tag*/,
-    std::shared_ptr<const config::IConfig> config)
+QueryConfig::QueryConfig(ConfigTag /*tag*/, config::ConfigPtr config)
     : config_{std::move(config)} {
   validateConfig();
 }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -33,9 +33,7 @@ class QueryConfig {
   // QueryConfig{{}} or QueryConfig({}).
   struct ConfigTag {};
 
-  explicit QueryConfig(
-      ConfigTag /*tag*/,
-      std::shared_ptr<const config::IConfig> config);
+  explicit QueryConfig(ConfigTag /*tag*/, config::ConfigPtr config);
 
   /// Maximum memory that a query can use on a single host.
   static constexpr const char* kQueryMaxMemoryPerNode =
@@ -1470,7 +1468,7 @@ class QueryConfig {
     return config_->get<T>(key);
   }
 
-  const std::shared_ptr<const config::IConfig>& config() const {
+  const config::ConfigPtr& config() const {
     return config_;
   }
 
@@ -1484,6 +1482,6 @@ class QueryConfig {
  private:
   void validateConfig();
 
-  std::shared_ptr<const config::IConfig> config_;
+  config::ConfigPtr config_;
 };
 } // namespace facebook::velox::core

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -25,8 +25,7 @@ namespace facebook::velox::core {
 std::shared_ptr<QueryCtx> QueryCtx::create(
     folly::Executor* executor,
     QueryConfig&& queryConfig,
-    std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-        connectorConfigs,
+    ConnectorConfigs connectorConfigs,
     cache::AsyncDataCache* cache,
     std::shared_ptr<memory::MemoryPool> pool,
     folly::Executor* spillExecutor,
@@ -65,23 +64,22 @@ std::shared_ptr<QueryCtx> QueryCtx::Builder::build() {
 QueryCtx::QueryCtx(
     folly::Executor* executor,
     QueryConfig&& queryConfig,
-    std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-        connectorSessionProperties,
+    ConnectorConfigs&& connectorConfigs,
     cache::AsyncDataCache* cache,
     std::shared_ptr<memory::MemoryPool> pool,
     folly::Executor* spillExecutor,
-    const std::string& queryId,
+    std::string&& queryId,
     std::shared_ptr<filesystems::TokenProvider> tokenProvider,
     TraceCtxProvider traceCtxProvider)
-    : queryId_(queryId),
-      executor_(executor),
-      spillExecutor_(spillExecutor),
-      cache_(cache),
-      connectorSessionProperties_(connectorSessionProperties),
-      pool_(std::move(pool)),
+    : queryId_{std::move(queryId)},
+      executor_{executor},
+      spillExecutor_{spillExecutor},
+      cache_{cache},
+      connectorSessionProperties_{std::move(connectorConfigs)},
+      pool_{std::move(pool)},
       queryConfig_{std::move(queryConfig)},
-      fsTokenProvider_(std::move(tokenProvider)),
-      traceCtxProvider_(std::move(traceCtxProvider)) {
+      fsTokenProvider_{std::move(tokenProvider)},
+      traceCtxProvider_{std::move(traceCtxProvider)} {
   initPool(queryId);
 }
 

--- a/velox/core/tests/QueryCtxTest.cpp
+++ b/velox/core/tests/QueryCtxTest.cpp
@@ -31,7 +31,7 @@ TEST_F(QueryCtxTest, withSysRootPool) {
   auto queryCtx = QueryCtx::create(
       nullptr,
       QueryConfig{{}},
-      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+      ConnectorConfigs{},
       nullptr,
       memory::deprecatedRootPool().shared_from_this());
   auto* queryPool = queryCtx->pool();
@@ -60,7 +60,7 @@ TEST_F(QueryCtxTest, releaseCallbacks) {
     auto queryCtx = QueryCtx::create(
         nullptr,
         QueryConfig{{}},
-        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+        ConnectorConfigs{},
         nullptr,
         nullptr,
         nullptr,
@@ -91,7 +91,7 @@ TEST_F(QueryCtxTest, releaseCallbackException) {
     auto queryCtx = QueryCtx::create(
         nullptr,
         QueryConfig{{}},
-        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+        ConnectorConfigs{},
         nullptr,
         nullptr,
         nullptr,

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -37,8 +37,7 @@ class FileSink : public Closeable {
     bool bufferWrite{true};
     /// Connector properties are required to create a FileSink on FileSystems
     /// such as S3.
-    const std::shared_ptr<const config::ConfigBase>& connectorProperties{
-        nullptr};
+    const config::ConfigPtr& connectorProperties{nullptr};
     /// Config used to create sink files. This config is provided to underlying
     /// file system and the config is free form. The form should be defined by
     /// the underlying file system.
@@ -115,7 +114,7 @@ class FileSink : public Closeable {
       const std::function<uint64_t(const DataBuffer<char>&)>& callback);
 
   const std::string name_;
-  const std::shared_ptr<const config::ConfigBase> connectorProperties_;
+  const config::ConfigPtr connectorProperties_;
   memory::MemoryPool* const pool_;
   const MetricsLogPtr metricLogger_;
   IoStatistics* const stats_;

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -776,8 +776,8 @@ struct WriterOptions {
   // WriterOption implementations can implement this function to specify how to
   // process format-specific session and connector configs.
   virtual void processConfigs(
-      const config::ConfigBase& connectorConfig,
-      const config::ConfigBase& session) {}
+      const config::OldConfig& connectorConfig,
+      const config::OldConfig& session) {}
 
   virtual ~WriterOptions() = default;
 };

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -55,8 +55,8 @@ dwio::common::StripeProgress getStripeProgress(const WriterContext& context) {
 }
 
 uint64_t orcWriterMaxStripeSize(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   return config::toCapacity(
       session.get<std::string>(
           dwrf::Config::kOrcWriterMaxStripeSizeSession,
@@ -66,8 +66,8 @@ uint64_t orcWriterMaxStripeSize(
 }
 
 uint64_t orcWriterMaxDictionaryMemory(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   return config::toCapacity(
       session.get<std::string>(
           dwrf::Config::kOrcWriterMaxDictionaryMemorySession,
@@ -77,8 +77,8 @@ uint64_t orcWriterMaxDictionaryMemory(
 }
 
 bool isOrcWriterIntegerDictionaryEncodingEnabled(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   return session.get<bool>(
       dwrf::Config::kOrcWriterIntegerDictionaryEncodingEnabledSession,
       config.get<bool>(
@@ -86,8 +86,8 @@ bool isOrcWriterIntegerDictionaryEncodingEnabled(
 }
 
 bool isOrcWriterStringDictionaryEncodingEnabled(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   return session.get<bool>(
       dwrf::Config::kOrcWriterStringDictionaryEncodingEnabledSession,
       config.get<bool>(
@@ -95,8 +95,8 @@ bool isOrcWriterStringDictionaryEncodingEnabled(
 }
 
 bool orcWriterLinearStripeSizeHeuristics(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   return session.get<bool>(
       dwrf::Config::kOrcWriterLinearStripeSizeHeuristicsSession,
       config.get<bool>(
@@ -104,16 +104,16 @@ bool orcWriterLinearStripeSizeHeuristics(
 }
 
 uint64_t orcWriterMinCompressionSize(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   return session.get<uint64_t>(
       dwrf::Config::kOrcWriterMinCompressionSizeSession,
       config.get<uint64_t>(dwrf::Config::kOrcWriterMinCompressionSize, 1024));
 }
 
 std::optional<uint8_t> orcWriterCompressionLevel(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   auto sessionProp =
       session.get<uint8_t>(dwrf::Config::kOrcWriterCompressionLevelSession);
 
@@ -134,16 +134,16 @@ std::optional<uint8_t> orcWriterCompressionLevel(
 }
 
 uint8_t orcWriterZLIBCompressionLevel(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   constexpr uint8_t kDefaultZlibCompressionLevel = 4;
   return orcWriterCompressionLevel(config, session)
       .value_or(kDefaultZlibCompressionLevel);
 }
 
 uint8_t orcWriterZSTDCompressionLevel(
-    const config::ConfigBase& config,
-    const config::ConfigBase& session) {
+    const config::IConfig& config,
+    const config::IConfig& session) {
   constexpr uint8_t kDefaultZstdCompressionLevel = 3;
   return orcWriterCompressionLevel(config, session)
       .value_or(kDefaultZstdCompressionLevel);
@@ -918,8 +918,8 @@ DwrfWriterFactory::createWriterOptions() {
 }
 
 void WriterOptions::processConfigs(
-    const config::ConfigBase& connectorConfig,
-    const config::ConfigBase& session) {
+    const config::OldConfig& connectorConfig,
+    const config::OldConfig& session) {
   auto dwrfWriterOptions = dynamic_cast<dwrf::WriterOptions*>(this);
   VELOX_CHECK_NOT_NULL(
       dwrfWriterOptions, "Expected a DWRF WriterOptions object.");

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -47,8 +47,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
   DwrfFormat format{DwrfFormat::kDwrf};
 
   void processConfigs(
-      const config::ConfigBase& connectorConfig,
-      const config::ConfigBase& session) override;
+      const config::OldConfig& connectorConfig,
+      const config::OldConfig& session) override;
 };
 
 class Writer : public dwio::common::Writer {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -285,7 +285,7 @@ std::shared_ptr<::arrow::Field> updateFieldNameAndIdRecursive(
 }
 
 std::optional<TimestampPrecision> getTimestampUnit(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   if (const auto unit = config.get<uint8_t>(configKey)) {
     VELOX_CHECK(
@@ -309,7 +309,7 @@ TimestampPrecision stringToTimestampPrecision(const std::string& value) {
 }
 
 std::optional<std::string> getTimestampTimeZone(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   if (const auto timezone = config.get<std::string>(configKey)) {
     return timezone.value();
@@ -318,7 +318,7 @@ std::optional<std::string> getTimestampTimeZone(
 }
 
 std::optional<bool> isParquetEnableDictionary(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   try {
     if (const auto enableDictionary = config.get<bool>(configKey)) {
@@ -332,7 +332,7 @@ std::optional<bool> isParquetEnableDictionary(
 }
 
 std::optional<bool> getParquetDataPageVersion(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   if (const auto version = config.get<std::string>(configKey)) {
     if (version == "V1") {
@@ -347,7 +347,7 @@ std::optional<bool> getParquetDataPageVersion(
 }
 
 std::optional<int64_t> getParquetPageSize(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   if (const auto pageSize = config.get<std::string>(configKey)) {
     return config::toCapacity(pageSize.value(), config::CapacityUnit::BYTE);
@@ -356,7 +356,7 @@ std::optional<int64_t> getParquetPageSize(
 }
 
 std::optional<int64_t> getParquetBatchSize(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   try {
     if (const auto batchSize = config.get<int64_t>(configKey)) {
@@ -369,7 +369,7 @@ std::optional<int64_t> getParquetBatchSize(
 }
 
 std::optional<std::string> getParquetCreatedBy(
-    const config::ConfigBase& config,
+    const config::IConfig& config,
     const char* configKey) {
   if (config.get<std::string>(configKey).has_value()) {
     return config.get<std::string>(configKey).value();
@@ -622,8 +622,8 @@ ParquetWriterFactory::createWriterOptions() {
 }
 
 void WriterOptions::processConfigs(
-    const config::ConfigBase& connectorConfig,
-    const config::ConfigBase& session) {
+    const config::OldConfig& connectorConfig,
+    const config::OldConfig& session) {
   auto parquetWriterOptions = dynamic_cast<WriterOptions*>(this);
   VELOX_CHECK_NOT_NULL(
       parquetWriterOptions, "Expected a Parquet WriterOptions object.");

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -165,8 +165,8 @@ struct WriterOptions : public dwio::common::WriterOptions {
 
   // Process hive connector and session configs.
   void processConfigs(
-      const config::ConfigBase& connectorConfig,
-      const config::ConfigBase& session) override;
+      const config::OldConfig& connectorConfig,
+      const config::OldConfig& session) override;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.

--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -194,8 +194,7 @@ class TaskCursorBase : public TaskCursor {
       queryCtx_ = core::QueryCtx::create(
           executor_.get(),
           core::QueryConfig({}),
-          std::
-              unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+          core::ConnectorConfigs{},
           cache::AsyncDataCache::getInstance(),
           nullptr,
           nullptr,

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -168,7 +168,7 @@ class TestConnectorFactory : public connector::ConnectorFactory {
 
   std::shared_ptr<connector::Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* /* ioExecutor */,
       folly::Executor* /* cpuExecutor */) override {
     return std::make_shared<TestConnector>(id);

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -302,12 +302,10 @@ TEST_F(OperatorTraceTest, traceMetadata) {
           {core::QueryConfig::kSpillNumPartitionBits, "17"},
           {"key1", "value1"},
       };
-  const auto expectedConnectorProperties =
-      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{
-          {"test_trace",
-           std::make_shared<config::ConfigBase>(
-               std::unordered_map<std::string, std::string>{
-                   {"cKey1", "cVal1"}})}};
+  const auto expectedConnectorProperties = core::ConnectorConfigs{
+      {"test_trace",
+       std::make_shared<config::ConfigBase>(
+           std::unordered_map<std::string, std::string>{{"cKey1", "cVal1"}})}};
   const auto queryCtx = core::QueryCtx::create(
       executor_.get(),
       core::QueryConfig(expectedQueryConfigs),
@@ -398,12 +396,11 @@ TEST_F(OperatorTraceTest, task) {
             {"key1", "value1"},
         };
 
-    const auto expectedConnectorProperties =
-        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{
-            {"test_trace",
-             std::make_shared<config::ConfigBase>(
-                 std::unordered_map<std::string, std::string>{
-                     {"cKey1", "cVal1"}})}};
+    const auto expectedConnectorProperties = core::ConnectorConfigs{
+        {"test_trace",
+         std::make_shared<config::ConfigBase>(
+             std::unordered_map<std::string, std::string>{
+                 {"cKey1", "cVal1"}})}};
     const auto queryCtx = core::QueryCtx::create(
         executor_.get(),
         core::QueryConfig(expectedQueryConfigs),

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -120,8 +120,7 @@ TEST_F(TableScanTest, directBufferInputRawInputBytes) {
                   .planNode();
 
   std::unordered_map<std::string, std::string> config;
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-      connectorConfigs = {};
+  core::ConnectorConfigs connectorConfigs = {};
   auto queryCtx = core::QueryCtx::create(
       executor_.get(),
       core::QueryConfig(std::move(config)),
@@ -175,8 +174,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, pendingCoalescedIoWhenTaskFailed) {
                   .planNode();
 
   std::unordered_map<std::string, std::string> config;
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-      connectorConfigs = {};
+  core::ConnectorConfigs connectorConfigs = {};
   // Create query ctx without cache to read through direct buffer input.
   auto queryCtx = core::QueryCtx::create(
       executor_.get(),

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -1589,7 +1589,7 @@ TEST_P(UnpartitionedTableWriterTest, immutableSettings) {
     std::unordered_map<std::string, std::string> propFromFile{
         {"hive.immutable-partitions",
          testData.immutablePartitionsEnabled ? "true" : "false"}};
-    std::shared_ptr<const config::ConfigBase> config{
+    config::ConfigPtr config{
         std::make_shared<config::ConfigBase>(std::move(propFromFile))};
     resetHiveConnector(config);
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -2393,7 +2393,7 @@ DEBUG_ONLY_TEST_F(TaskTest, taskReclaimStats) {
   auto queryCtx = core::QueryCtx::create(
       driverExecutor_.get(),
       core::QueryConfig{{}},
-      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+      core::ConnectorConfigs{},
       nullptr,
       std::move(queryPool),
       nullptr);
@@ -2468,7 +2468,7 @@ DEBUG_ONLY_TEST_F(TaskTest, taskPauseTime) {
   auto queryCtx = core::QueryCtx::create(
       driverExecutor_.get(),
       core::QueryConfig{{}},
-      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+      core::ConnectorConfigs{},
       nullptr,
       std::move(queryPool),
       nullptr);

--- a/velox/exec/tests/ThreadDebugInfoTest.cpp
+++ b/velox/exec/tests/ThreadDebugInfoTest.cpp
@@ -104,7 +104,7 @@ DEBUG_ONLY_TEST_F(ThreadDebugInfoDeathTest, withinTheCallingThread) {
   auto queryCtx = core::QueryCtx::create(
       executor_.get(),
       core::QueryConfig({}),
-      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+      core::ConnectorConfigs{},
       cache::AsyncDataCache::getInstance(),
       nullptr,
       nullptr,

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -61,7 +61,7 @@ void HiveConnectorTestBase::TearDown() {
 }
 
 void HiveConnectorTestBase::resetHiveConnector(
-    const std::shared_ptr<const config::ConfigBase>& config) {
+    const config::ConfigPtr& config) {
   connector::unregisterConnector(kHiveConnectorId);
 
   connector::hive::HiveConnectorFactory factory;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -34,8 +34,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
   void SetUp() override;
   void TearDown() override;
 
-  void resetHiveConnector(
-      const std::shared_ptr<const config::ConfigBase>& config);
+  void resetHiveConnector(const config::ConfigPtr& config);
 
   void writeToFiles(
       const std::vector<std::string>& filePaths,

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -594,7 +594,7 @@ RowVectorPtr TestIndexSource::ResultIterator::createConditionInput() {
 
 TestIndexConnector::TestIndexConnector(
     const std::string& id,
-    std::shared_ptr<const config::ConfigBase> /*unused*/,
+    config::ConfigPtr /*unused*/,
     folly::Executor* executor)
     : Connector(id), executor_(executor) {}
 

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -357,7 +357,7 @@ class TestIndexConnector : public connector::Connector {
  public:
   TestIndexConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* executor);
 
   bool supportsIndexLookup() const override {
@@ -399,7 +399,7 @@ class TestIndexConnectorFactory : public connector::ConnectorFactory {
 
   std::shared_ptr<connector::Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const config::ConfigBase> properties,
+      config::ConfigPtr properties,
       folly::Executor* /*unused*/,
       folly::Executor* cpuExecutor) override {
     return std::make_shared<TestIndexConnector>(id, properties, cpuExecutor);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.cpp
@@ -42,7 +42,7 @@ std::size_t CudfHiveConfig::maxChunkReadLimit() const {
 }
 
 std::size_t CudfHiveConfig::maxChunkReadLimitSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   // pass read limit = 0 means no limit
   return session->get<std::size_t>(
       kMaxChunkReadLimitSession,
@@ -55,7 +55,7 @@ std::size_t CudfHiveConfig::maxPassReadLimit() const {
 }
 
 std::size_t CudfHiveConfig::maxPassReadLimitSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   // pass read limit = 0 means no limit
   return session->get<std::size_t>(
       kMaxPassReadLimitSession,
@@ -67,7 +67,7 @@ bool CudfHiveConfig::isConvertStringsToCategories() const {
 }
 
 bool CudfHiveConfig::isConvertStringsToCategoriesSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kConvertStringsToCategoriesSession,
       config_->get<bool>(kConvertStringsToCategories, false));
@@ -78,7 +78,7 @@ bool CudfHiveConfig::isUsePandasMetadata() const {
 }
 
 bool CudfHiveConfig::isUsePandasMetadataSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kUsePandasMetadataSession, config_->get<bool>(kUsePandasMetadata, true));
 }
@@ -88,7 +88,7 @@ bool CudfHiveConfig::isUseArrowSchema() const {
 }
 
 bool CudfHiveConfig::isUseArrowSchemaSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kUseArrowSchemaSession, config_->get<bool>(kUseArrowSchema, true));
 }
@@ -98,7 +98,7 @@ bool CudfHiveConfig::isAllowMismatchedCudfHiveSchemas() const {
 }
 
 bool CudfHiveConfig::isAllowMismatchedCudfHiveSchemasSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kAllowMismatchedCudfHiveSchemasSession,
       config_->get<bool>(kAllowMismatchedCudfHiveSchemas, false));
@@ -118,7 +118,7 @@ cudf::data_type CudfHiveConfig::timestampType() const {
 }
 
 cudf::data_type CudfHiveConfig::timestampTypeSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   const auto unit = session->get<cudf::type_id>(
       kTimestampTypeSession,
       config_->get<cudf::type_id>(
@@ -138,7 +138,7 @@ bool CudfHiveConfig::useBufferedInput() const {
 }
 
 bool CudfHiveConfig::useBufferedInputSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kUseBufferedInputSession, config_->get<bool>(kUseBufferedInput, true));
 }
@@ -148,7 +148,7 @@ bool CudfHiveConfig::useExperimentalCudfReader() const {
 }
 
 bool CudfHiveConfig::useExperimentalCudfReaderSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kUseExperimentalCudfReaderSession,
       config_->get<bool>(kUseExperimentalCudfReader, false));
@@ -159,7 +159,7 @@ bool CudfHiveConfig::immutableFiles() const {
 }
 
 uint64_t CudfHiveConfig::sortWriterFinishTimeSliceLimitMs(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<uint64_t>(
       kSortWriterFinishTimeSliceLimitMsSession,
       config_->get<uint64_t>(kSortWriterFinishTimeSliceLimitMs, 5'000));
@@ -170,7 +170,7 @@ bool CudfHiveConfig::writeTimestampsAsUTC() const {
 }
 
 bool CudfHiveConfig::writeTimestampsAsUTCSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kWriteTimestampsAsUTCSession,
       config_->get<bool>(kWriteTimestampsAsUTC, true));
@@ -181,7 +181,7 @@ bool CudfHiveConfig::writeArrowSchema() const {
 }
 
 bool CudfHiveConfig::writeArrowSchemaSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kWriteArrowSchemaSession, config_->get<bool>(kWriteArrowSchema, false));
 }
@@ -191,7 +191,7 @@ bool CudfHiveConfig::writev2PageHeaders() const {
 }
 
 bool CudfHiveConfig::writev2PageHeadersSession(
-    const config::ConfigBase* session) const {
+    const config::IConfig* session) const {
   return session->get<bool>(
       kWritev2PageHeadersSession,
       config_->get<bool>(kWritev2PageHeaders, false));

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
@@ -22,10 +22,6 @@
 
 #include <optional>
 
-namespace facebook::velox::config {
-class ConfigBase;
-}
-
 namespace facebook::velox::cudf_velox::connector::hive {
 
 class CudfHiveConfig {
@@ -123,64 +119,63 @@ class CudfHiveConfig {
   static constexpr const char* kWritev2PageHeadersSession =
       "parquet.writer.write_v2_page_headers";
 
-  CudfHiveConfig(std::shared_ptr<const config::ConfigBase> config) {
+  CudfHiveConfig(config::ConfigPtr config) {
     VELOX_CHECK_NOT_NULL(
         config, "Config is null for CudfHiveConfig initialization");
     config_ = std::move(config);
   }
 
-  const std::shared_ptr<const config::ConfigBase>& config() const {
+  const config::ConfigPtr& config() const {
     return config_;
   }
 
   uint64_t sortWriterFinishTimeSliceLimitMs(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
   std::size_t maxChunkReadLimit() const;
-  std::size_t maxChunkReadLimitSession(const config::ConfigBase* session) const;
+  std::size_t maxChunkReadLimitSession(const config::IConfig* session) const;
 
   std::size_t maxPassReadLimit() const;
-  std::size_t maxPassReadLimitSession(const config::ConfigBase* session) const;
+  std::size_t maxPassReadLimitSession(const config::IConfig* session) const;
 
   int64_t skipRows() const;
   std::optional<cudf::size_type> numRows() const;
 
   bool isConvertStringsToCategories() const;
   bool isConvertStringsToCategoriesSession(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
   bool isUsePandasMetadata() const;
-  bool isUsePandasMetadataSession(const config::ConfigBase* session) const;
+  bool isUsePandasMetadataSession(const config::IConfig* session) const;
 
   bool isUseArrowSchema() const;
-  bool isUseArrowSchemaSession(const config::ConfigBase* session) const;
+  bool isUseArrowSchemaSession(const config::IConfig* session) const;
 
   bool isAllowMismatchedCudfHiveSchemas() const;
   bool isAllowMismatchedCudfHiveSchemasSession(
-      const config::ConfigBase* session) const;
+      const config::IConfig* session) const;
 
   cudf::data_type timestampType() const;
-  cudf::data_type timestampTypeSession(const config::ConfigBase* session) const;
+  cudf::data_type timestampTypeSession(const config::IConfig* session) const;
 
   bool useBufferedInput() const;
-  bool useBufferedInputSession(const config::ConfigBase* session) const;
+  bool useBufferedInputSession(const config::IConfig* session) const;
 
   bool useExperimentalCudfReader() const;
-  bool useExperimentalCudfReaderSession(
-      const config::ConfigBase* session) const;
+  bool useExperimentalCudfReaderSession(const config::IConfig* session) const;
 
   bool immutableFiles() const;
 
   bool writeTimestampsAsUTC() const;
-  bool writeTimestampsAsUTCSession(const config::ConfigBase* session) const;
+  bool writeTimestampsAsUTCSession(const config::IConfig* session) const;
 
   bool writeArrowSchema() const;
-  bool writeArrowSchemaSession(const config::ConfigBase* session) const;
+  bool writeArrowSchemaSession(const config::IConfig* session) const;
 
   bool writev2PageHeaders() const;
-  bool writev2PageHeadersSession(const config::ConfigBase* session) const;
+  bool writev2PageHeadersSession(const config::IConfig* session) const;
 
  private:
-  std::shared_ptr<const config::ConfigBase> config_;
+  config::ConfigPtr config_;
 };
 } // namespace facebook::velox::cudf_velox::connector::hive

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.cpp
@@ -26,7 +26,7 @@ using namespace facebook::velox::connector;
 
 CudfHiveConnector::CudfHiveConnector(
     const std::string& id,
-    std::shared_ptr<const facebook::velox::config::ConfigBase> config,
+    config::ConfigPtr config,
     folly::Executor* executor)
     : ::facebook::velox::connector::hive::HiveConnector(id, config, executor),
       cudfHiveConfig_(std::make_shared<CudfHiveConfig>(config)) {
@@ -68,7 +68,7 @@ std::unique_ptr<DataSource> CudfHiveConnector::createDataSource(
 
 std::shared_ptr<Connector> CudfHiveConnectorFactory::newConnector(
     const std::string& id,
-    std::shared_ptr<const facebook::velox::config::ConfigBase> config,
+    config::ConfigPtr config,
     folly::Executor* ioExecutor,
     folly::Executor* cpuExecutor) {
   return std::make_shared<CudfHiveConnector>(id, config, ioExecutor);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
@@ -34,7 +34,7 @@ class CudfHiveConnector final
  public:
   CudfHiveConnector(
       const std::string& id,
-      std::shared_ptr<const ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* executor);
 
   std::unique_ptr<DataSource> createDataSource(
@@ -70,7 +70,7 @@ class CudfHiveConnectorFactory
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,
-      std::shared_ptr<const ConfigBase> config,
+      config::ConfigPtr config,
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) override;
 };

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
@@ -60,7 +60,7 @@ std::unordered_map<V, K> invertMap(const std::unordered_map<K, V>& mapping) {
 
 uint64_t getFinishTimeSliceLimitMsFromCudfHiveConfig(
     const std::shared_ptr<const CudfHiveConfig>& config,
-    const config::ConfigBase* sessions) {
+    const config::IConfig* sessions) {
   const uint64_t flushTimeSliceLimitMsFromConfig =
       config->sortWriterFinishTimeSliceLimitMs(sessions);
   // NOTE: if the flush time slice limit is set to 0, then we treat it as no

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -368,8 +368,7 @@ TEST_F(TableScanTest, directBufferInputRawInputBytes) {
                   .planNode();
 
   std::unordered_map<std::string, std::string> config;
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-      connectorConfigs = {};
+  core::ConnectorConfigs connectorConfigs = {};
   auto queryCtx = core::QueryCtx::create(
       executor_.get(),
       core::QueryConfig(std::move(config)),

--- a/velox/experimental/cudf/tests/TableWriteTest.cpp
+++ b/velox/experimental/cudf/tests/TableWriteTest.cpp
@@ -795,7 +795,7 @@ TEST_P(UnpartitionedTableWriterTest, immutableSettings) {
     std::unordered_map<std::string, std::string> propFromFile{
         {"parquet.immutable-files",
          testData.immutableFilesEnabled ? "true" : "false"}};
-    std::shared_ptr<const config::ConfigBase> config{
+    config::ConfigPtr config{
         std::make_shared<config::ConfigBase>(std::move(propFromFile))};
     resetCudfHiveConnector(config);
 

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
@@ -102,7 +102,7 @@ void CudfHiveConnectorTestBase::TearDown() {
 }
 
 void CudfHiveConnectorTestBase::resetCudfHiveConnector(
-    const std::shared_ptr<const facebook::velox::config::ConfigBase>& config) {
+    const facebook::velox::config::ConfigPtr& config) {
   facebook::velox::connector::unregisterConnector(kCudfHiveConnectorId);
 
   facebook::velox::cudf_velox::connector::hive::CudfHiveConnectorFactory

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
@@ -44,8 +44,7 @@ class CudfHiveConnectorTestBase
   void SetUp() override;
   void TearDown() override;
 
-  void resetCudfHiveConnector(
-      const std::shared_ptr<const facebook::velox::config::ConfigBase>& config);
+  void resetCudfHiveConnector(const facebook::velox::config::ConfigPtr& config);
 
   void writeToFile(
       const std::string& filePath,

--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -128,8 +128,7 @@ std::shared_ptr<core::QueryCtx> OperatorReplayerBase::createQueryCtx() {
   auto queryPool = memory::memoryManager()->addRootPool(
       fmt::format("{}_replayer_{}", nodeName_, replayQueryId++),
       queryCapacity_);
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>
-      connectorConfigs;
+  core::ConnectorConfigs connectorConfigs;
   for (auto& [connectorId, configs] : connectorConfigs_) {
     connectorConfigs.emplace(
         connectorId, std::make_shared<config::ConfigBase>(std::move(configs)));


### PR DESCRIPTION
We can use IConfig interface instead of ConfigBase for connectors and filesystems.
This will resolve following issues:
1. Ensure Config not mutated by velox connector/filesystems code
2. Allow to have specific config implementation on user side (for an example behind one interface can be multiple map)
3. This also can be used to avoid construction of ConfigBase for every query, instead can be used some connection specific config