### PR TITLE
fix(join): Enable parallel execution for non-null-aware RightSemiProjectJoin

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -908,9 +908,9 @@ RowVectorPtr HashProbe::getBuildSideOutput() {
 
   if (isRightSemiProjectJoin(joinType_)) {
     // Populate 'match' column.
-    if (noInput_) {
+    if (noInput_ && nullAware_) {
       // Probe side is empty. All rows should return 'match = false', even ones
-      // with a null join key.
+      // with a null join key. (This applies to null-aware joins only.)
       matchColumn() = createConstantFalse(numOut, pool());
     } else {
       table_->rows()->extractProbedFlags(

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -312,8 +312,9 @@ uint32_t maxDrivers(
       return 1;
     } else if (
         auto join = std::dynamic_pointer_cast<const core::HashJoinNode>(node)) {
-      // Right semi project doesn't support multi-threaded execution.
-      if (join->isRightSemiProjectJoin()) {
+      // Null-aware right semi project doesn't support multi-threaded
+      // execution.
+      if (join->isRightSemiProjectJoin() && join->isNullAware()) {
         return 1;
       }
     } else if (


### PR DESCRIPTION
### Background

 #3275 addressed a correctness issue related to RightSemiProjectJoin semantics. It ensured that for a RightSemiProjectJoin with an empty probe side, a NULL join key on the build side should return 'match = false'.
#8701 was introduced as a conservative workaround for a race condition in the parallel implementation of this logic. To avoid complex cross-thread coordination, it forced all RightSemiProjectJoin operations to run single-threaded.

### Problem
The workaround in #8701, while safe, caused a significant performance regression for the very common non-null-aware (`nullAware_ = false`) joins used in `EXISTS`  clause. This broad restriction is unnecessary because the correctness issue is specific to the null-aware case.

### Proposed Solution
This PR refines the single-threaded restriction, applying it only to the null-aware RightSemiProjectJoin where it is strictly necessary, while **enabling parallel execution for non-null-aware RightSemiProjectJoin**.

### Rationale for Safety
The argument for safely re-enabling parallelism for non-null-aware RightSemiProjectJoin is as follows:

SQL Semantics: A non-null-aware RightSemiProjectJoin corresponds to `EXISTS` clause, which functions as a filter predicate within a WHERE clause.

WHERE Clause Behavior: The original race condition could cause a NULL build-side key to produce a NULL match result when the probe side is empty. However, in a WHERE clause, a predicate that evaluates to NULL is treated as false.

Identical Final Outcome: Therefore, whether the intermediate match result is NULL (from the race condition) or false (the correct result), the row is ultimately filtered out. The final query result remains identical.

Given this, the single-threaded restriction for non-null-aware RightSemiProjectJoin is unnecessary, as the potential race condition in this scenario does not produce incorrect final results.

### Testing and Validation
The fix was validated using velox_join_fuzzer with 6 concurrent processes (100 iterations each):

Before this fix (reverting #8701), the concurrent fuzzer test consistently failed with "Unexpected results," confirming the presence of the original race condition.

After Fix (this PR): The exact same concurrent test suite passed successfully across all processes.
This demonstrates the fix is both effective and safe.