### PR TITLE
feat: Support iceberg partition transform

### DIFF
--- a/velox/connectors/hive/PartitionIdGenerator.h
+++ b/velox/connectors/hive/PartitionIdGenerator.h
@@ -38,10 +38,12 @@ class PartitionIdGenerator {
       memory::MemoryPool* pool,
       bool partitionPathAsLowerCase);
 
+  virtual ~PartitionIdGenerator() = default;
+
   /// Generate sequential partition IDs for input vector.
   /// @param input Input RowVector.
   /// @param result Generated integer IDs indexed by input row number.
-  void run(const RowVectorPtr& input, raw_vector<uint64_t>& result);
+  virtual void run(const RowVectorPtr& input, raw_vector<uint64_t>& result);
 
   /// Return the total number of distinct partitions processed so far.
   uint64_t numPartitions() const {
@@ -52,15 +54,51 @@ class PartitionIdGenerator {
   /// style. It is derived from the partitionValues_ at index partitionId.
   /// Partition keys appear in the order of partition columns in the table
   /// schema.
-  std::string partitionName(uint64_t partitionId) const;
+  virtual std::string partitionName(uint32_t partitionId) const;
 
- private:
-  static constexpr const int32_t kHasherReservePct = 20;
+ protected:
+  PartitionIdGenerator(
+      std::vector<column_index_t> partitionChannels,
+      uint32_t maxPartitions,
+      memory::MemoryPool* pool,
+      bool partitionPathAsLowerCase);
 
   // Computes value IDs using VectorHashers for all rows in 'input'.
   void computeValueIds(
       const RowVectorPtr& input,
       raw_vector<uint64_t>& valueIds);
+
+  // Computes value IDs, maps them to sequential partition IDs, and saves
+  // partition values for each partition.
+  // Each unique value ID gets a sequential partition ID (0, 1, 2, ...).
+  // Reuses existing partition IDs for duplicate value IDs.
+  // Saves partition values for new partitions for later partition name
+  // generation.
+  //
+  // @param input RowVector containing the partition column values (either
+  // original or transformed).
+  // @param result Output vector to store partition IDs, indexed by row number.
+  void computeAndSavePartitionIds(
+      const RowVectorPtr& input,
+      raw_vector<uint64_t>& result);
+
+  const std::vector<column_index_t> partitionChannels_;
+
+  const uint32_t maxPartitions_;
+
+  std::vector<std::unique_ptr<exec::VectorHasher>> hashers_;
+
+  // A vector holding unique partition key values. One row per partition. Row
+  // numbers match partition IDs.
+  RowVectorPtr partitionValues_;
+
+  // A mapping from value ID produced by VectorHashers to a partition ID.
+  std::unordered_map<uint64_t, uint64_t> partitionIds_;
+
+  const bool partitionPathAsLowerCase_;
+
+ private:
+  static constexpr const int32_t kHasherReservePct = 20;
 
   // In case of rehash (when value IDs produced by VectorHashers change), we
   // update value id for pre-existing partitions while keeping partition ids.
@@ -70,28 +108,14 @@ class PartitionIdGenerator {
 
   // Copies partition values of 'row' from 'input' into 'partitionId' row in
   // 'partitionValues_'.
-  void savePartitionValues(
-      uint64_t partitionId,
+  virtual void savePartitionValues(
+      uint32_t partitionId,
       const RowVectorPtr& input,
       vector_size_t row);
 
   memory::MemoryPool* const pool_;
 
-  const std::vector<column_index_t> partitionChannels_;
-
-  const uint32_t maxPartitions_;
-
-  const bool partitionPathAsLowerCase_;
-
-  std::vector<std::unique_ptr<exec::VectorHasher>> hashers_;
   bool hasMultiplierSet_ = false;
-
-  // A mapping from value ID produced by VectorHashers to a partition ID.
-  std::unordered_map<uint64_t, uint64_t> partitionIds_;
-
-  // A vector holding unique partition key values. One row per partition. Row
-  // numbers match partition IDs.
-  RowVectorPtr partitionValues_;
 
   // All rows are set valid to compute partition IDs for all input rows.
   SelectivityVector allRows_;

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -15,12 +15,26 @@
 velox_add_library(
   velox_hive_iceberg_splitreader
   IcebergDataSink.cpp
-  IcebergSplitReader.cpp
+  IcebergPartitionIdGenerator.cpp
+  IcebergPartitionPath.cpp
   IcebergSplit.cpp
+  IcebergSplitReader.cpp
+  PartitionSpec.cpp
   PositionalDeleteFileReader.cpp
+  TransformEvaluator.cpp
+  TransformExprBuilder.cpp
 )
 
-velox_link_libraries(velox_hive_iceberg_splitreader velox_connector Folly::folly)
+velox_link_libraries(
+  velox_hive_iceberg_splitreader
+  velox_connector
+  velox_functions_iceberg
+  Folly::folly
+)
+
+if(VELOX_ENABLE_PARQUET)
+  velox_link_libraries(velox_hive_iceberg_splitreader velox_dwio_arrow_parquet_writer)
+endif()
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -15,14 +15,109 @@
  */
 
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
 #include "velox/common/base/Fs.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.h"
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/writer/Writer.h"
+#endif
+#include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+std::string toJson(const std::vector<folly::dynamic>& partitionValues) {
+  folly::dynamic jsonObject = folly::dynamic::object();
+  folly::dynamic valuesArray = folly::dynamic::array();
+  for (const auto& value : partitionValues) {
+    valuesArray.push_back(value);
+  }
+  jsonObject["partitionValues"] = valuesArray;
+  return folly::toJson(jsonObject);
+}
+
+template <TypeKind Kind>
+folly::dynamic extractPartitionValue(
+    const DecodedVector* block,
+    vector_size_t row) {
+  using T = typename TypeTraits<Kind>::NativeType;
+  return block->valueAt<T>(row);
+}
+
+template <>
+folly::dynamic extractPartitionValue<TypeKind::VARCHAR>(
+    const DecodedVector* block,
+    vector_size_t row) {
+  return block->valueAt<StringView>(row).str();
+}
+
+template <>
+folly::dynamic extractPartitionValue<TypeKind::VARBINARY>(
+    const DecodedVector* block,
+    vector_size_t row) {
+  return block->valueAt<StringView>(row).str();
+}
+
+template <>
+folly::dynamic extractPartitionValue<TypeKind::TIMESTAMP>(
+    const DecodedVector* block,
+    vector_size_t row) {
+  return block->valueAt<Timestamp>(row).toMicros();
+}
+
+class IcebergFileNameGenerator : public FileNameGenerator {
+ public:
+  std::pair<std::string, std::string> gen(
+      std::optional<uint32_t> bucketId,
+      const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+      const ConnectorQueryCtx& connectorQueryCtx,
+      bool commitRequired) const override;
+
+  folly::dynamic serialize() const override;
+
+  std::string toString() const override;
+};
+
+std::string makeUuid() {
+  return boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+}
+
+std::pair<std::string, std::string> IcebergFileNameGenerator::gen(
+    std::optional<uint32_t> bucketId,
+    const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
+    const ConnectorQueryCtx& connectorQueryCtx,
+    bool commitRequired) const {
+  auto targetFileName = insertTableHandle->locationHandle()->targetFileName();
+  if (targetFileName.empty()) {
+    targetFileName = fmt::format("{}", makeUuid());
+  }
+  auto fileFormat = dwio::common::toString(insertTableHandle->storageFormat());
+  return {
+      fmt::format("{}.{}", targetFileName, fileFormat),
+      fmt::format("{}.{}", targetFileName, fileFormat)};
+}
+
+folly::dynamic IcebergFileNameGenerator::serialize() const {
+  VELOX_UNREACHABLE();
+}
+
+std::string IcebergFileNameGenerator::toString() const {
+  return "IcebergFileNameGenerator";
+}
+
+} // namespace
 
 IcebergInsertTableHandle::IcebergInsertTableHandle(
     std::vector<HiveColumnHandlePtr> inputColumns,
     LocationHandlePtr locationHandle,
     dwio::common::FileFormat tableStorageFormat,
+    IcebergPartitionSpecPtr partitionSpec,
     std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters)
     : HiveInsertTableHandle(
@@ -34,12 +129,18 @@ IcebergInsertTableHandle::IcebergInsertTableHandle(
           serdeParameters,
           nullptr,
           false,
-          std::make_shared<const HiveInsertFileNameGenerator>()) {
+          std::make_shared<const IcebergFileNameGenerator>()),
+      partitionSpec_(std::move(partitionSpec)) {
   VELOX_USER_CHECK(
       !inputColumns_.empty(),
       "Input columns cannot be empty for Iceberg tables.");
   VELOX_USER_CHECK_NOT_NULL(
       locationHandle_, "Location handle is required for Iceberg tables.");
+  VELOX_USER_CHECK_EQ(
+      tableStorageFormat,
+      dwio::common::FileFormat::PARQUET,
+      "Only Parquet file format is supported when writing Iceberg tables. Format: {}",
+      dwio::common::toString(tableStorageFormat));
 }
 
 IcebergDataSink::IcebergDataSink(
@@ -48,18 +149,75 @@ IcebergDataSink::IcebergDataSink(
     const ConnectorQueryCtx* connectorQueryCtx,
     CommitStrategy commitStrategy,
     const std::shared_ptr<const HiveConfig>& hiveConfig)
-    : HiveDataSink(
+    : IcebergDataSink(
           std::move(inputType),
           insertTableHandle,
           connectorQueryCtx,
           commitStrategy,
           hiveConfig,
+          [&insertTableHandle]() {
+            const auto& inputColumns = insertTableHandle->inputColumns();
+            const auto& partitionSpec = insertTableHandle->partitionSpec();
+            std::unordered_map<std::string, column_index_t> partitionKeyMap;
+            for (auto i = 0; i < inputColumns.size(); ++i) {
+              if (inputColumns[i]->isPartitionKey()) {
+                partitionKeyMap[inputColumns[i]->name()] = i;
+              }
+            }
+            std::vector<column_index_t> channels;
+            channels.reserve(partitionSpec->fields.size());
+            for (const auto& field : partitionSpec->fields) {
+              if (auto it = partitionKeyMap.find(field.name);
+                  it != partitionKeyMap.end()) {
+                channels.push_back(it->second);
+              }
+            }
+            return channels;
+          }(),
+          [&insertTableHandle]() {
+            std::vector<column_index_t> channels(
+                insertTableHandle->inputColumns().size());
+            std::iota(channels.begin(), channels.end(), 0);
+            return channels;
+          }()) {}
+
+IcebergDataSink::IcebergDataSink(
+    RowTypePtr inputType,
+    IcebergInsertTableHandlePtr insertTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    CommitStrategy commitStrategy,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    const std::vector<column_index_t>& partitionChannels,
+    const std::vector<column_index_t>& dataChannels)
+    : HiveDataSink(
+          inputType,
+          insertTableHandle,
+          connectorQueryCtx,
+          commitStrategy,
+          hiveConfig,
           0,
-          nullptr) {}
+          nullptr,
+          partitionChannels,
+          dataChannels,
+          !partitionChannels.empty()
+              ? std::make_unique<IcebergPartitionIdGenerator>(
+                    inputType,
+                    partitionChannels,
+                    insertTableHandle->partitionSpec(),
+                    hiveConfig->maxPartitionsPerWriters(
+                        connectorQueryCtx->sessionProperties()),
+                    connectorQueryCtx)
+              : nullptr) {
+  partitionData_.resize(maxOpenWriters_);
+}
 
 std::vector<std::string> IcebergDataSink::commitMessage() const {
   std::vector<std::string> commitTasks;
   commitTasks.reserve(writerInfo_.size());
+
+  auto icebergInsertTableHandle =
+      std::dynamic_pointer_cast<const IcebergInsertTableHandle>(
+          insertTableHandle_);
 
   for (auto i = 0; i < writerInfo_.size(); ++i) {
     const auto& info = writerInfo_.at(i);
@@ -75,14 +233,113 @@ std::vector<std::string> IcebergDataSink::commitMessage() const {
       ("fileSizeInBytes", ioStats_.at(i)->rawBytesWritten())
       ("metrics",
         folly::dynamic::object("recordCount", info->numWrittenRows))
-      ("partitionSpecJson", 0)
+      ("partitionSpecJson", icebergInsertTableHandle->partitionSpec()->specId)
       ("fileFormat", "PARQUET")
       ("content", "DATA");
     // clang-format on
+    if (!(partitionData_.empty() || partitionData_[i].empty())) {
+      commitData["partitionDataJson"] = toJson(partitionData_[i]);
+    }
     auto commitDataJson = folly::toJson(commitData);
     commitTasks.push_back(commitDataJson);
   }
   return commitTasks;
+}
+
+std::vector<folly::dynamic> IcebergDataSink::extractPartitionValues(
+    uint32_t writerIndex) {
+  std::vector<folly::dynamic> partitionValues(partitionChannels_.size());
+  auto icebergPartitionIdGenerator =
+      dynamic_cast<const IcebergPartitionIdGenerator*>(
+          partitionIdGenerator_.get());
+  VELOX_CHECK_NOT_NULL(icebergPartitionIdGenerator);
+  const auto& transformedValues = icebergPartitionIdGenerator->partitionKeys();
+  for (auto i = 0; i < partitionChannels_.size(); ++i) {
+    const auto& block = transformedValues->childAt(i);
+    if (block->isNullAt(writerIndex)) {
+      partitionValues[i] = nullptr;
+    } else {
+      DecodedVector decoded(*block);
+      partitionValues[i] = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          extractPartitionValue, block->typeKind(), &decoded, writerIndex);
+    }
+  }
+  return partitionValues;
+}
+
+void IcebergDataSink::splitInputRowsAndEnsureWriters(
+    const RowVectorPtr& input) {
+  VELOX_CHECK(isPartitioned());
+
+  std::fill(partitionSizes_.begin(), partitionSizes_.end(), 0);
+
+  const auto numRows = partitionIds_.size();
+  for (auto row = 0; row < numRows; ++row) {
+    auto id = getIcebergWriterId(row);
+    uint32_t index = ensureWriter(id);
+
+    updatePartitionRows(index, numRows, row);
+
+    if (partitionData_[index].empty()) {
+      partitionData_[index] = extractPartitionValues(index);
+    }
+  }
+
+  for (auto i = 0; i < partitionSizes_.size(); ++i) {
+    if (partitionSizes_[i] != 0) {
+      VELOX_CHECK_NOT_NULL(partitionRows_[i]);
+      partitionRows_[i]->setSize(partitionSizes_[i] * sizeof(vector_size_t));
+    }
+  }
+}
+
+void IcebergDataSink::appendData(RowVectorPtr input) {
+  checkRunning();
+  if (!isPartitioned()) {
+    const auto index = ensureWriter(HiveWriterId::unpartitionedId());
+    write(index, input);
+    return;
+  }
+
+  // Compute partition and bucket numbers.
+  computePartitionAndBucketIds(input);
+
+  splitInputRowsAndEnsureWriters(input);
+
+  for (auto index = 0; index < writers_.size(); ++index) {
+    const auto partitionSize = partitionSizes_[index];
+    if (partitionSize == 0) {
+      continue;
+    }
+
+    const RowVectorPtr writerInput = partitionSize == input->size()
+        ? input
+        : exec::wrap(partitionSize, partitionRows_[index], input);
+    write(index, writerInput);
+  }
+}
+
+HiveWriterId IcebergDataSink::getIcebergWriterId(size_t row) const {
+  std::optional<uint32_t> partitionId;
+  if (isPartitioned()) {
+    VELOX_CHECK_LT(partitionIds_[row], std::numeric_limits<uint32_t>::max());
+    partitionId = static_cast<uint32_t>(partitionIds_[row]);
+  }
+
+  return HiveWriterId{partitionId, std::nullopt};
+}
+
+std::shared_ptr<dwio::common::WriterOptions>
+IcebergDataSink::createWriterOptions() const {
+  auto options = HiveDataSink::createWriterOptions();
+#ifdef VELOX_ENABLE_PARQUET
+  auto parquetOptions =
+      std::dynamic_pointer_cast<parquet::WriterOptions>(options);
+  VELOX_CHECK_NOT_NULL(parquetOptions);
+  parquetOptions->parquetWriteTimestampTimeZone = std::nullopt;
+  parquetOptions->parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
+#endif
+  return options;
 }
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.cpp
+++ b/velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.h"
+
+#include "velox/connectors/hive/HivePartitionUtil.h"
+#include "velox/connectors/hive/iceberg/IcebergPartitionPath.h"
+#include "velox/connectors/hive/iceberg/TransformEvaluator.h"
+#include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
+#include "velox/functions/prestosql/URLFunctions.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+template <TypeKind Kind>
+std::pair<std::string, std::string> makePartitionKeyValueString(
+    const IcebergPartitionPathPtr& formatter,
+    const BaseVector& partitionVector,
+    vector_size_t row,
+    const std::string& name,
+    const TypePtr& type) {
+  using T = typename TypeTraits<Kind>::NativeType;
+  if (partitionVector.isNullAt(row)) {
+    return std::make_pair(name, "null");
+  }
+
+  return std::make_pair(
+      name,
+      formatter->toPartitionString(
+          partitionVector.as<SimpleVector<T>>()->valueAt(row), type));
+}
+
+} // namespace
+
+IcebergPartitionIdGenerator::IcebergPartitionIdGenerator(
+    const RowTypePtr& inputType,
+    std::vector<column_index_t> partitionChannels,
+    IcebergPartitionSpecPtr partitionSpec,
+    uint32_t maxPartitions,
+    const ConnectorQueryCtx* connectorQueryCtx)
+    : PartitionIdGenerator(
+          partitionChannels,
+          maxPartitions,
+          connectorQueryCtx->memoryPool(),
+          /*partitionPathAsLowerCase=*/false),
+      partitionSpec_(partitionSpec),
+      connectorQueryCtx_(connectorQueryCtx),
+      transformEvaluator_(
+          std::make_unique<TransformEvaluator>(
+              TransformExprBuilder::toExpressions(
+                  partitionSpec_,
+                  partitionChannels_,
+                  inputType),
+              connectorQueryCtx_)) {
+  // Build partition key types and names from transforms.
+  // For each transform, create a hasher for its result type and build the
+  // partition key name (either source column name for identity transforms,
+  // or "columnName_transformName" for other transforms).
+  std::vector<TypePtr> partitionKeyTypes;
+  std::vector<std::string> partitionKeyNames;
+  column_index_t idx{0};
+  for (const auto& field : partitionSpec_->fields) {
+    hashers_.emplace_back(
+        exec::VectorHasher::create(field.resultType(), idx++));
+
+    VELOX_USER_CHECK(
+        hashers_.back()->typeSupportsValueIds(),
+        "Type is not supported as a partition column: {}",
+        field.resultType()->toString());
+
+    partitionKeyTypes.emplace_back(field.resultType());
+    std::string key = field.transformType == TransformType::kIdentity
+        ? field.name
+        : fmt::format(
+              "{}_{}",
+              field.name,
+              TransformTypeName::toName(field.transformType));
+    partitionKeyNames.emplace_back(std::move(key));
+  }
+
+  rowType_ = ROW(std::move(partitionKeyNames), std::move(partitionKeyTypes));
+
+  // At least one partition.
+  partitionValues_ = BaseVector::create<RowVector>(
+      rowType_, 1, connectorQueryCtx_->memoryPool());
+}
+
+void IcebergPartitionIdGenerator::savePartitionValues(
+    uint32_t partitionId,
+    const RowVectorPtr& input,
+    vector_size_t row) {
+  if (partitionId >= partitionValues_->size()) {
+    auto currentSize = partitionValues_->size();
+    auto newSize = std::min<vector_size_t>(currentSize * 2, maxPartitions_);
+
+    partitionValues_->resize(newSize);
+    for (auto& child : partitionValues_->children()) {
+      child->resize(newSize);
+    }
+  }
+
+  for (auto i = 0; i < partitionChannels_.size(); ++i) {
+    partitionValues_->childAt(i)->copy(
+        input->childAt(i).get(), partitionId, row, 1);
+  }
+}
+
+void IcebergPartitionIdGenerator::run(
+    const RowVectorPtr& input,
+    raw_vector<uint64_t>& result) {
+  const auto numRows = input->size();
+  result.resize(numRows);
+
+  // Step 1: Apply transforms to partition columns.
+  auto transformedColumns = transformEvaluator_->evaluate(input);
+
+  // Step 2: Create RowVector based on transformed columns.
+  const auto& rowVector = std::make_shared<RowVector>(
+      connectorQueryCtx_->memoryPool(),
+      rowType_,
+      nullptr,
+      numRows,
+      std::move(transformedColumns));
+
+  // Step 3: Compute value IDs, map to sequential partition IDs and save
+  // partition values.
+  computeAndSavePartitionIds(rowVector, result);
+}
+
+std::vector<std::pair<std::string, std::string>>
+IcebergPartitionIdGenerator::extractPartitionKeyValues(
+    const RowVectorPtr& partitionsVector,
+    vector_size_t row) const {
+  std::vector<std::pair<std::string, std::string>> partitionKeyValues;
+  VELOX_DCHECK_EQ(
+      partitionsVector->childrenSize(),
+      partitionSpec_->fields.size(),
+      "Partition values and partition transform does not match.");
+  for (auto i = 0; i < partitionsVector->childrenSize(); i++) {
+    const auto& formatter = std::make_shared<IcebergPartitionPath>(
+        partitionSpec_->fields.at(i).transformType);
+    const auto& column = partitionsVector->childAt(i);
+    partitionKeyValues.push_back(VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        makePartitionKeyValueString,
+        column->typeKind(),
+        formatter,
+        *column->loadedVector(),
+        row,
+        asRowType(partitionsVector->type())->nameOf(i),
+        column->type()));
+  }
+  return partitionKeyValues;
+}
+
+std::string IcebergPartitionIdGenerator::partitionName(
+    uint32_t partitionId) const {
+  auto keyValues = extractPartitionKeyValues(partitionValues_, partitionId);
+  std::ostringstream out;
+
+  for (auto& [key, value] : keyValues) {
+    if (out.tellp() > 0) {
+      out << '/';
+    }
+
+    if (partitionPathAsLowerCase_) {
+      folly::toLowerAscii(key);
+    }
+    std::string encodedKey;
+    std::string encodedValue;
+
+    // Pre-allocate for worst case: every byte is invalid UTF-8.
+    // urlEscape() writes directly into the pre-allocated buffer and
+    // calls resize() at the end to shrink to the actual size used.
+    encodedKey.resize(key.size() * 9);
+    encodedValue.resize(value.size() * 9);
+    functions::detail::urlEscape(encodedKey, key);
+    functions::detail::urlEscape(encodedValue, value);
+    out << encodedKey << '=' << encodedValue;
+  }
+
+  return out.str();
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.h
+++ b/velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/PartitionIdGenerator.h"
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+#include "velox/connectors/hive/iceberg/TransformEvaluator.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Generates partition IDs for writing Iceberg table.
+///
+/// Computes partition keys by applying Iceberg partition transforms
+/// (e.g., bucket, truncate, year, month, day, hour, identity) to source columns
+/// and maps the transformed values to sequential partition IDs. Maintains a
+/// mapping from partition values to partition IDs and generates
+/// Iceberg-compliant partition path names for file organization.
+///
+/// Each unique combination of transformed partition values is assigned
+/// a sequential ID (0, 1, 2, ...) up to a configurable maximum.
+/// Uses TransformEvaluator for batch evaluation of transforms.
+class IcebergPartitionIdGenerator : public PartitionIdGenerator {
+ public:
+  /// @param inputType RowType of the input data. Used to build transform
+  /// expressions once during construction for reuse across multiple input
+  /// batches.
+  /// @param partitionChannels Column indices (0-based) in the input RowVector
+  /// for source columns referenced by each partition field. Must have the same
+  /// size as partitionSpec->fields. partitionChannels[i] specifies which input
+  /// column to use for partitionSpec->fields[i]. The same channel index may
+  /// appear multiple times if multiple transforms are applied to the same
+  /// source column (e.g., both bucket(c1, 16) and truncate(c1, 10)).
+  /// This separate mapping is necessary because partitionSpec field names refer
+  /// to table schema column names, while the input RowVector may use different
+  /// column names (e.g., generated names like c0, c1). Cannot use column names
+  /// in partitionSpec to locate child vector in input RowVector.
+  /// The partitionChannels provide the positional mapping from partition spec
+  /// fields to input RowVector columns.
+  /// @param partitionSpec Iceberg partition specification containing transform
+  /// definitions for each partition field. Each field specifies a source column
+  /// name (matching table schema, not input RowVector names), transform type
+  /// (identity, bucket, truncate, year, etc.), and optional parameters.
+  /// Multiple transforms on the same column are allowed with restrictions
+  /// enforced by IcebergPartitionSpec validation.
+  /// See IcebergPartitionSpec::checkCompatibility for detail.
+  /// @param maxPartitions Maximum number of distinct partitions allowed.
+  /// Exceeding this limit will cause a VeloxUserError.
+  /// @param connectorQueryCtx Connector query context for expression evaluation
+  /// and memory allocation.
+  IcebergPartitionIdGenerator(
+      const RowTypePtr& inputType,
+      std::vector<column_index_t> partitionChannels,
+      IcebergPartitionSpecPtr partitionSpec,
+      uint32_t maxPartitions,
+      const ConnectorQueryCtx* connectorQueryCtx);
+
+  /// Generate sequential partition IDs for all rows in the input vector.
+  ///
+  /// For each row, applies the partition transforms, hashes the transformed
+  /// values, and maps to a sequential partition ID. New partitions are created
+  /// as needed (up to maxPartitions limit). Partition values are stored for
+  /// later partition name generation.
+  ///
+  /// @param input Input RowVector containing all columns. Must have columns
+  /// at indices specified by partitionChannels.
+  /// @param result Output vector of partition IDs, one per input row.
+  /// Resized to match input size. Values are 0-based sequential IDs.
+  void run(const RowVectorPtr& input, raw_vector<uint64_t>& result) override;
+
+  /// Generate the partition name for the given partition ID.
+  ///
+  /// Constructs an Iceberg-compliant partition path string in the format:
+  /// "key1=value1/key2=value2/..." where keys are partition column names for
+  /// identity transform or column_transform for non-identity transforms and
+  /// values are the human-readable string representations of the transformed
+  /// partition values. Special characters are URL-encoded per
+  /// java.net.URLEncoder.encode().
+  ///
+  /// In typical usage (e.g., HiveDataSink::appendWriter), this is called
+  /// once per partition ID when creating a new writer for that partition.
+  /// It performs string formatting and URL encoding on each call, so callers
+  /// should cache the result if the same partition name is needed
+  /// multiple times.
+  ///
+  /// @param partitionId Sequential partition ID (0-based) returned by run().
+  /// Must be less than the number of partitions created so far.
+  /// @return Partition path string suitable for use in file paths.
+  std::string partitionName(uint32_t partitionId) const override;
+
+  /// Returns the RowVector containing transformed partition values.
+  /// Each row in this vector corresponds to a partition ID (row index =
+  /// partition ID). Each column contains the transformed values for that
+  /// partition column.
+  /// The vector grows dynamically as new partitions are discovered, up to
+  /// maxPartitions_.
+  /// Should be called after calling run() method.
+  ///
+  /// @return RowVector with one column per transformed column, columns in same
+  /// order as IcebergPartitionSpec::fields.
+  const RowVectorPtr& partitionKeys() const {
+    return partitionValues_;
+  }
+
+ private:
+  void savePartitionValues(
+      uint32_t partitionId,
+      const RowVectorPtr& input,
+      vector_size_t row) override;
+
+  std::vector<std::pair<std::string, std::string>> extractPartitionKeyValues(
+      const RowVectorPtr& partitionsVector,
+      vector_size_t row) const;
+
+  const IcebergPartitionSpecPtr partitionSpec_;
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  const std::unique_ptr<TransformEvaluator> transformEvaluator_;
+  RowTypePtr rowType_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergPartitionPath.cpp
+++ b/velox/connectors/hive/iceberg/IcebergPartitionPath.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/iceberg/IcebergPartitionPath.h"
+#include "velox/common/encode/Base64.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+constexpr int32_t kEpochYear = 1970;
+
+std::string IcebergPartitionPath::toPartitionString(
+    int32_t value,
+    const TypePtr& type) const {
+  switch (transformType_) {
+    case TransformType::kIdentity: {
+      if (type->isDate()) {
+        return DATE()->toString(value);
+      }
+      return folly::to<std::string>(value);
+    }
+    case TransformType::kDay:
+      return DATE()->toString(value);
+    case TransformType::kYear:
+      return fmt::format("{:04d}", kEpochYear + value);
+    case TransformType::kMonth: {
+      int32_t year = kEpochYear + value / 12;
+      int32_t month = 1 + value % 12;
+      if (month <= 0) {
+        month += 12;
+        year -= 1;
+      }
+      return fmt::format("{:04d}-{:02d}", year, month);
+    }
+    case TransformType::kHour: {
+      int64_t seconds = static_cast<int64_t>(value) * 3600;
+      std::tm tmValue;
+      VELOX_USER_CHECK(
+          Timestamp::epochToCalendarUtc(seconds, tmValue),
+          "Failed to convert seconds to time: {}",
+          seconds);
+      return fmt::format(
+          "{:04d}-{:02d}-{:02d}-{:02d}",
+          tmValue.tm_year + 1900,
+          tmValue.tm_mon + 1,
+          tmValue.tm_mday,
+          tmValue.tm_hour);
+    }
+    default:
+      return folly::to<std::string>(value);
+  }
+}
+
+std::string IcebergPartitionPath::toPartitionString(
+    Timestamp value,
+    const TypePtr& type) const {
+  TimestampToStringOptions options;
+  options.precision = TimestampPrecision::kMilliseconds;
+  options.zeroPaddingYear = true;
+  options.skipTrailingZeros = true;
+  options.leadingPositiveSign = true;
+  return value.toString(options);
+}
+
+std::string IcebergPartitionPath::toPartitionString(
+    StringView value,
+    const TypePtr& type) const {
+  if (type->isVarbinary()) {
+    return encoding::Base64::encode(value.data(), value.size());
+  }
+  return std::string(value);
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergPartitionPath.h
+++ b/velox/connectors/hive/iceberg/IcebergPartitionPath.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/HivePartitionUtil.h"
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+// Converts a partition value to its string representation for use in
+// partition directory path. The format follows the Iceberg specification
+// for partition path encoding.
+class IcebergPartitionPath : public HivePartitionUtil {
+ public:
+  explicit IcebergPartitionPath(TransformType transformType)
+      : transformType_(transformType) {}
+
+  ~IcebergPartitionPath() override = default;
+
+  using HivePartitionUtil::toPartitionString;
+
+  std::string toPartitionString(int32_t value, const TypePtr& type)
+      const override;
+
+  std::string toPartitionString(Timestamp value, const TypePtr& type)
+      const override;
+
+  std::string toPartitionString(StringView value, const TypePtr& type)
+      const override;
+
+ private:
+  const TransformType transformType_;
+};
+
+using IcebergPartitionPathPtr = std::shared_ptr<const IcebergPartitionPath>;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/PartitionSpec.cpp
+++ b/velox/connectors/hive/iceberg/PartitionSpec.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+
+#include <unordered_map>
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+enum class TransformCategory {
+  kIdentity,
+  kTemporal, // Year, Month, Day, Hour.
+  kBucket,
+  kTruncate,
+};
+
+TransformCategory getTransformCategory(TransformType transformType) {
+  switch (transformType) {
+    case TransformType::kIdentity:
+      return TransformCategory::kIdentity;
+    case TransformType::kYear:
+    case TransformType::kMonth:
+    case TransformType::kDay:
+    case TransformType::kHour:
+      return TransformCategory::kTemporal;
+    case TransformType::kBucket:
+      return TransformCategory::kBucket;
+    case TransformType::kTruncate:
+      return TransformCategory::kTruncate;
+    default:
+      VELOX_UNREACHABLE("Unknown transform type");
+  }
+}
+
+bool isValidPartitionType(const TypePtr& type) {
+  return !(
+      type->isRow() || type->isArray() || type->isMap() || type->isDouble() ||
+      type->isReal() || isTimestampWithTimeZoneType(type));
+}
+
+bool canTransform(TransformType transformType, const TypePtr& type) {
+  switch (transformType) {
+    case TransformType::kIdentity:
+      return type->isTinyint() || type->isSmallint() || type->isInteger() ||
+          type->isBigint() || type->isBoolean() || type->isDecimal() ||
+          type->isDate() || type->isTimestamp() || type->isVarchar() ||
+          type->isVarbinary();
+    case TransformType::kYear:
+    case TransformType::kMonth:
+    case TransformType::kDay:
+      return type->isDate() || type->isTimestamp();
+    case TransformType::kHour:
+      return type->isTimestamp();
+    case TransformType::kBucket:
+      return type->isInteger() || type->isBigint() || type->isDecimal() ||
+          type->isVarchar() || type->isVarbinary() || type->isDate() ||
+          type->isTimestamp();
+    case TransformType::kTruncate:
+      return type->isInteger() || type->isBigint() || type->isDecimal() ||
+          type->isVarchar() || type->isVarbinary();
+    default:
+      VELOX_UNREACHABLE("Unsupported partition transform type.");
+  }
+}
+
+const auto& transformTypeNames() {
+  static const folly::F14FastMap<TransformType, std::string_view>
+      kTransformNames = {
+          {TransformType::kIdentity, "identity"},
+          {TransformType::kHour, "hour"},
+          {TransformType::kDay, "day"},
+          {TransformType::kMonth, "month"},
+          {TransformType::kYear, "year"},
+          {TransformType::kBucket, "bucket"},
+          {TransformType::kTruncate, "trunc"},
+      };
+  return kTransformNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(TransformType, transformTypeNames);
+
+void IcebergPartitionSpec::checkCompatibility() const {
+  std::unordered_map<std::string, std::unordered_map<TransformCategory, int>>
+      columnTransformCategories;
+
+  for (const auto& field : fields) {
+    const auto& type = field.type;
+    const auto& name = field.name;
+    if (!isValidPartitionType(type)) {
+      VELOX_USER_FAIL(
+          "Type is not supported as a partition column: {}", type->name());
+    }
+
+    if (!canTransform(field.transformType, type)) {
+      VELOX_USER_FAIL(
+          "Transform is not supported for partition field. Field: '{}', Type: '{}', Transform: '{}'.",
+          name,
+          type->toString(),
+          TransformTypeName::toName(field.transformType));
+    }
+
+    auto category = getTransformCategory(field.transformType);
+    columnTransformCategories[name][category]++;
+
+    // Check if any transform category appears more than once.
+    if (columnTransformCategories[name][category] > 1) {
+      std::string categoryName;
+      switch (category) {
+        case TransformCategory::kIdentity:
+          categoryName = "Identity";
+          break;
+        case TransformCategory::kTemporal:
+          categoryName = "Temporal (Year/Month/Day/Hour)";
+          break;
+        case TransformCategory::kBucket:
+          categoryName = "Bucket";
+          break;
+        case TransformCategory::kTruncate:
+          categoryName = "Truncate";
+          break;
+      }
+      VELOX_USER_FAIL(
+          "Multiple transforms of the same category on a column are not allowed. "
+          "Each transform category can appear at most once per column. Column: '{}', Category: {}.",
+          name,
+          categoryName);
+    }
+  }
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/PartitionSpec.h
+++ b/velox/connectors/hive/iceberg/PartitionSpec.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Partition transform types supported by Iceberg.
+/// Define how source column values are converted into partition values.
+/// Each transform type corresponds to a specific partitioning strategy.
+/// See https://iceberg.apache.org/spec/#partition-transforms.
+enum class TransformType {
+  /// Use the source value as-is (no transformation).
+  kIdentity,
+  /// Extract a timestamp hour, as hours from 1970-01-01 00:00:00.
+  kHour,
+  /// Extract a date or timestamp day, as days from 1970-01-01.
+  kDay,
+  /// Extract a date or timestamp month, as months from 1970-01.
+  kMonth,
+  /// Extract a date or timestamp year, as years from 1970.
+  kYear,
+  /// Hash the value into N buckets for even distribution.
+  kBucket,
+  /// Truncate strings or numbers to a specified width.
+  kTruncate
+};
+
+VELOX_DECLARE_ENUM_NAME(TransformType);
+
+/// Represents how to produce partition data for an Iceberg table.
+///
+/// This structure corresponds to the Iceberg Java PartitionSpec class but
+/// contains only the necessary fields for Velox. Partition data is produced
+/// by transforming columns in a table, where each column can have multiple
+/// transforms applied in sequence.
+///
+/// The upstream engine processes this specification through the Iceberg Java
+/// library to validate column types, detect duplicates, and generate the
+/// partition spec that is passed to Velox.
+///
+/// IMPORTANT: Iceberg spec uses field IDs to identify source columns, but
+/// Velox RowType only supports matching fields by name. Therefore, Velox uses
+/// the partition field name to match against the table schema column names.
+/// Callers must ensure that partition field names exactly match the column
+/// names in the table schema.
+///
+/// Multiple transforms on the same column are allowed, but with restrictions:
+/// - Transforms are organized into 4 categories: Identity, Temporal
+///   (Year/Month/Day/Hour), Bucket, and Truncate.
+/// - Each category can appear at most once per column.
+/// - Example valid specs: ARRAY['truncate(a, 2)', 'bucket(a, 16)', 'a'] or
+///   ARRAY['year(b)', 'bucket(b, 16)', 'b']
+///
+/// The partition spec defines:
+/// - Unique ID for versioning and evolution.
+/// - Which source columns in current table schema to use for partitioning
+/// (identified by field name,
+///   not field ID as in the Iceberg spec).
+/// - What transforms to apply (identity, bucket, truncate etc.).
+/// - Transform parameters (e.g., bucket count, truncate width).
+struct IcebergPartitionSpec {
+  struct Field {
+    /// The field name of this partition field as it appears in the partition
+    /// spec. This is the original Iceberg field name, not the transformed name
+    /// from org.apache.iceberg.PartitionField which includes the transform as a
+    /// suffix.
+    const std::string name;
+
+    /// The source column type.
+    const TypePtr type;
+
+    /// The transform type applied to the source field (e.g., kIdentity,
+    /// kBucket, kTruncate, etc.). Callers must ensure the transform is
+    /// compatible with the source column type.
+    const TransformType transformType;
+
+    /// Optional parameter for transforms that require configuration
+    /// (e.g., bucket count or truncate width).
+    const std::optional<int32_t> parameter;
+
+    /// Returns the result type after applying this transform.
+    TypePtr resultType() const {
+      switch (transformType) {
+        case TransformType::kBucket:
+        case TransformType::kYear:
+        case TransformType::kMonth:
+        case TransformType::kHour:
+          return INTEGER();
+        case TransformType::kDay:
+          return DATE();
+        case TransformType::kIdentity:
+        case TransformType::kTruncate:
+        default:
+          return type;
+      }
+    }
+  };
+
+  const int32_t specId;
+  const std::vector<Field> fields;
+
+  /// Constructor with validation that:
+  /// - Each field's type is supported for partitioning.
+  /// - Each field's transform type is compatible with its data type.
+  /// - No transform category appears more than once per column (Identity,
+  ///   Temporal, Bucket, and Truncate are separate categories).
+  ///
+  /// @param _specId Partition specification ID.
+  /// @param _fields Vector of partition fields. When empty indicates no
+  /// partition.
+  /// @throws VELOX_USER_FAIL if validation fails.
+  IcebergPartitionSpec(int32_t _specId, const std::vector<Field>& _fields)
+      : specId(_specId), fields(_fields) {
+    checkCompatibility();
+  }
+
+ private:
+  /// Validates partition fields for correctness.
+  /// Checks type/transform compatibility and transform combination rules.
+  void checkCompatibility() const;
+};
+
+using IcebergPartitionSpecPtr = std::shared_ptr<const IcebergPartitionSpec>;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformEvaluator.cpp
+++ b/velox/connectors/hive/iceberg/TransformEvaluator.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/TransformEvaluator.h"
+
+#include <mutex>
+
+#include "velox/expression/Expr.h"
+#include "velox/functions/iceberg/Register.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+constexpr char const* kIcebergFunctionPrefix{"iceberg_"};
+
+}
+
+TransformEvaluator::TransformEvaluator(
+    const std::vector<core::TypedExprPtr>& expressions,
+    const ConnectorQueryCtx* connectorQueryCtx)
+    : connectorQueryCtx_(connectorQueryCtx) {
+  VELOX_CHECK_NOT_NULL(connectorQueryCtx_);
+  // Register Iceberg functions once for expression evaluation.
+  static std::once_flag registerFlag;
+  std::call_once(registerFlag, []() {
+    functions::iceberg::registerFunctions(kIcebergFunctionPrefix);
+  });
+
+  exprSet_ = connectorQueryCtx_->expressionEvaluator()->compile(expressions);
+  VELOX_CHECK_NOT_NULL(exprSet_);
+}
+
+std::vector<VectorPtr> TransformEvaluator::evaluate(
+    const RowVectorPtr& input) const {
+  const auto numRows = input->size();
+  const auto numExpressions = exprSet_->exprs().size();
+
+  std::vector<VectorPtr> results(numExpressions);
+  SelectivityVector rows(numRows);
+
+  // Evaluate all expressions in one pass.
+  connectorQueryCtx_->expressionEvaluator()->evaluate(
+      exprSet_.get(), rows, *input, results);
+
+  return results;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformEvaluator.h
+++ b/velox/connectors/hive/iceberg/TransformEvaluator.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Evaluates multiple transforms efficiently using batch expression evaluation.
+/// Compiles expressions once in the constructor and reuses them for multiple
+/// input batches.
+class TransformEvaluator {
+ public:
+  /// Creates an evaluator with the given expressions and connector query
+  /// context. Compiles the expressions once for reuse across multiple
+  /// evaluations.
+  ///
+  /// @param expressions Vector of typed expressions to evaluate. These are
+  /// typically built using TransformExprBuilder::toExpressions() for Iceberg
+  /// partition transforms, but can be any valid Velox expressions. The
+  /// expressions are compiled once during construction.
+  /// @param connectorQueryCtx Connector query context providing access to the
+  /// expression evaluator (for compilation and evaluation) and memory pool.
+  /// Must remain valid for the lifetime of this TransformEvaluator.
+  TransformEvaluator(
+      const std::vector<core::TypedExprPtr>& expressions,
+      const ConnectorQueryCtx* connectorQueryCtx);
+
+  /// Evaluates all expressions on the input data in a single pass.
+  /// Uses the pre-compiled ExprSet from the constructor for efficiency.
+  ///
+  /// The expressions are compiled once in the constructor and reused for all
+  /// subsequent evaluate() calls.
+  ///
+  /// The input RowType must match the RowType used when building the
+  /// expressions (passed to TransformExprBuilder::toExpressions). The column
+  /// positions, names and types must align. Create new TransformEvaluator for
+  /// input that has different RowType with the one when building the
+  /// expressions.
+  ///
+  /// @param input Input row vector containing the source data. Must have the
+  /// same RowType (column positions, names and types) as used when building the
+  /// expressions in the constructor.
+  /// @return Vector of result columns, one for each expression, in the same
+  /// order as the expressions provided to the constructor.
+  std::vector<VectorPtr> evaluate(const RowVectorPtr& input) const;
+
+ private:
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  std::unique_ptr<exec::ExprSet> exprSet_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformExprBuilder.cpp
+++ b/velox/connectors/hive/iceberg/TransformExprBuilder.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+constexpr char const* kBucketFunction{"iceberg_bucket"};
+constexpr char const* kTruncateFunction{"iceberg_truncate"};
+constexpr char const* kYearFunction{"iceberg_years"};
+constexpr char const* kMonthFunction{"iceberg_months"};
+constexpr char const* kDayFunction{"iceberg_days"};
+constexpr char const* kHourFunction{"iceberg_hours"};
+
+} // namespace
+
+core::TypedExprPtr TransformExprBuilder::toExpression(
+    const IcebergPartitionSpec::Field& field,
+    const std::string& inputFieldName) {
+  // For identity transform, just return a field access expression.
+  if (field.transformType == TransformType::kIdentity) {
+    return std::make_shared<core::FieldAccessTypedExpr>(
+        field.type, inputFieldName);
+  }
+
+  // For other transforms, build a CallTypedExpr with the appropriate function.
+  std::string functionName;
+  TypePtr resultType;
+  switch (field.transformType) {
+    case TransformType::kBucket:
+      functionName = kBucketFunction;
+      resultType = INTEGER();
+      break;
+    case TransformType::kTruncate:
+      functionName = kTruncateFunction;
+      resultType = field.type;
+      break;
+    case TransformType::kYear:
+      functionName = kYearFunction;
+      resultType = INTEGER();
+      break;
+    case TransformType::kMonth:
+      functionName = kMonthFunction;
+      resultType = INTEGER();
+      break;
+    case TransformType::kDay:
+      functionName = kDayFunction;
+      resultType = DATE();
+      break;
+    default:
+      functionName = kHourFunction;
+      resultType = INTEGER();
+      break;
+  }
+
+  // Build the expression arguments.
+  std::vector<core::TypedExprPtr> exprArgs;
+  if (field.parameter.has_value()) {
+    exprArgs.emplace_back(
+        std::make_shared<core::ConstantTypedExpr>(
+            INTEGER(), Variant(field.parameter.value())));
+  }
+  exprArgs.emplace_back(
+      std::make_shared<core::FieldAccessTypedExpr>(field.type, inputFieldName));
+
+  return std::make_shared<core::CallTypedExpr>(
+      resultType, std::move(exprArgs), functionName);
+}
+
+std::vector<core::TypedExprPtr> TransformExprBuilder::toExpressions(
+    const IcebergPartitionSpecPtr& partitionSpec,
+    const std::vector<column_index_t>& partitionChannels,
+    const RowTypePtr& inputType) {
+  VELOX_CHECK_EQ(
+      partitionSpec->fields.size(),
+      partitionChannels.size(),
+      "Number of partition fields must match number of partition channels");
+
+  const auto numTransforms = partitionChannels.size();
+  std::vector<core::TypedExprPtr> transformExprs;
+  transformExprs.reserve(numTransforms);
+
+  for (auto i = 0; i < numTransforms; i++) {
+    const auto channel = partitionChannels[i];
+    transformExprs.emplace_back(
+        toExpression(partitionSpec->fields.at(i), inputType->nameOf(channel)));
+  }
+
+  return transformExprs;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformExprBuilder.h
+++ b/velox/connectors/hive/iceberg/TransformExprBuilder.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Converts Iceberg partition specification to Velox expressions.
+class TransformExprBuilder {
+ public:
+  /// Converts a single partition field to a typed expression.
+  ///
+  /// Builds an expression tree for one partition transform. Identity transforms
+  /// become FieldAccessTypedExpr, while other transforms (bucket, truncate,
+  /// year, month, day, hour) become CallTypedExpr with appropriate function
+  /// names and parameters.
+  ///
+  /// @param field Partition field containing transform type, source column
+  /// type, and optional parameter (e.g., bucket count, truncate width).
+  /// @param inputFieldName Name of the source column in the input RowVector.
+  /// @return Typed expression representing the transform.
+  static core::TypedExprPtr toExpression(
+      const IcebergPartitionSpec::Field& field,
+      const std::string& inputFieldName);
+
+  /// Converts partition specification to a list of typed expressions.
+  ///
+  /// @param partitionSpec Iceberg partition specification containing transform
+  /// definitions for each partition field.
+  /// @param partitionChannels Column indices (0-based) in the input RowVector
+  /// that correspond to each partition field. Must have the same size as
+  /// partitionSpec->fields. Provides the positional mapping from partition spec
+  /// fields to input RowVector columns.
+  /// @param inputType The row type of the input data. This is necessary for
+  /// building expressions because the column names in partitionSpec reference
+  /// table schema names, which might not match the column names in inputType
+  /// (e.g., inputType may use generated names like c0, c1, c2). The
+  /// FieldAccessTypedExpr must be built using the actual column names from
+  /// inputType that will be present at runtime. The partitionChannels provide
+  /// the positional mapping to locate the correct columns.
+  /// @return Vector of typed expressions, one for each partition field.
+  static std::vector<core::TypedExprPtr> toExpressions(
+      const IcebergPartitionSpecPtr& partitionSpec,
+      const std::vector<column_index_t>& partitionChannels,
+      const RowTypePtr& inputType);
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_dwio_common_exception
     velox_dwio_common_test_utils
     velox_vector_test_lib
+    velox_vector_fuzzer
     velox_exec
     velox_exec_test_lib
     Folly::folly
@@ -57,7 +58,16 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
   )
 
-  add_executable(velox_hive_iceberg_insert_test IcebergInsertTest.cpp IcebergTestBase.cpp Main.cpp)
+  add_executable(
+    velox_hive_iceberg_insert_test
+    IcebergInsertTest.cpp
+    IcebergPartitionIdGeneratorTest.cpp
+    IcebergTestBase.cpp
+    Main.cpp
+    PartitionSpecTest.cpp
+    TransformE2ETest.cpp
+    TransformTest.cpp
+  )
 
   add_test(velox_hive_iceberg_insert_test velox_hive_iceberg_insert_test)
 
@@ -68,10 +78,15 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_hive_iceberg_splitreader
     velox_vector_fuzzer
     GTest::gtest
+    GTest::gtest_main
   )
 
   if(VELOX_ENABLE_PARQUET)
-    target_link_libraries(velox_hive_iceberg_test velox_dwio_parquet_reader)
+    target_link_libraries(
+      velox_hive_iceberg_test
+      velox_dwio_parquet_writer
+      velox_dwio_parquet_reader
+    )
 
     file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergInsertTest.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -24,25 +26,19 @@ class IcebergInsertTest : public test::IcebergTestBase {
  protected:
   void test(const RowTypePtr& rowType, double nullRatio = 0.0) {
     const auto outputDirectory = exec::test::TempDirectoryPath::create();
-    const auto dataPath = fmt::format("{}", outputDirectory->getPath());
+    const auto dataPath = outputDirectory->getPath();
     constexpr int32_t numBatches = 10;
     constexpr int32_t vectorSize = 5'000;
     const auto vectors =
         createTestData(rowType, numBatches, vectorSize, nullRatio);
-    auto dataSink =
-        createIcebergDataSink(rowType, outputDirectory->getPath(), {});
-
-    for (const auto& vector : vectors) {
-      dataSink->appendData(vector);
-    }
-
-    ASSERT_TRUE(dataSink->finish());
+    const auto& dataSink =
+        createDataSinkAndAppendData(rowType, vectors, dataPath);
     const auto commitTasks = dataSink->close();
-    createDuckDbTable(vectors);
+
     auto splits = createSplitsForDirectory(dataPath);
     ASSERT_EQ(splits.size(), commitTasks.size());
     auto plan = exec::test::PlanBuilder().tableScan(rowType).planNode();
-    assertQuery(plan, splits, "SELECT * FROM tmp");
+    exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
   }
 };
 
@@ -76,6 +72,131 @@ TEST_F(IcebergInsertTest, bigDecimal) {
   test(rowType);
 }
 #endif
+
+TEST_F(IcebergInsertTest, singleColumnPartition) {
+  auto rowType = ROW(
+      {"c1", "c2", "c3", "c4", "c5", "c6"},
+      {BIGINT(), INTEGER(), SMALLINT(), DECIMAL(18, 5), BOOLEAN(), VARCHAR()});
+  for (auto colIndex = 0; colIndex < rowType->size(); colIndex++) {
+    const auto outputDirectory = exec::test::TempDirectoryPath::create();
+    constexpr int32_t numBatches = 2;
+    constexpr int32_t vectorSize = 50;
+    const auto vectors = createTestData(rowType, numBatches, vectorSize, 0.5);
+    std::vector<test::PartitionField> partitionTransforms = {
+        {colIndex, TransformType::kIdentity, std::nullopt}};
+    const auto& dataSink = createDataSinkAndAppendData(
+        rowType, vectors, outputDirectory->getPath(), partitionTransforms);
+    const auto commitTasks = dataSink->close();
+    auto splits = createSplitsForDirectory(outputDirectory->getPath());
+
+    ASSERT_GT(commitTasks.size(), 0);
+    ASSERT_EQ(splits.size(), commitTasks.size());
+
+    for (const auto& task : commitTasks) {
+      auto taskJson = folly::parseJson(task);
+      ASSERT_TRUE(taskJson.count("partitionDataJson") > 0);
+    }
+
+    auto plan = exec::test::PlanBuilder().tableScan(rowType).planNode();
+    exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+  }
+}
+
+TEST_F(IcebergInsertTest, partitionNullColumn) {
+  auto rowType = ROW(
+      {"c1", "c2", "c3", "c4", "c5", "c6"},
+      {BIGINT(), INTEGER(), SMALLINT(), DECIMAL(18, 5), BOOLEAN(), VARCHAR()});
+  for (auto colIndex = 0; colIndex < rowType->size(); colIndex++) {
+    const auto& colName = rowType->nameOf(colIndex);
+    const auto colType = rowType->childAt(colIndex);
+    const auto outputDirectory = exec::test::TempDirectoryPath::create();
+    constexpr int32_t numBatches = 2;
+    constexpr int32_t vectorSize = 100;
+
+    // nullRatio = 1.0
+    const auto vectors = createTestData(rowType, numBatches, vectorSize, 1.0);
+
+    std::vector<test::PartitionField> partitionTransforms = {
+        {colIndex, TransformType::kIdentity, std::nullopt}};
+    const auto& dataSink = createDataSinkAndAppendData(
+        rowType, vectors, outputDirectory->getPath(), partitionTransforms);
+
+    const auto commitTasks = dataSink->close();
+    ASSERT_EQ(1, commitTasks.size());
+    auto taskJson = folly::parseJson(commitTasks.at(0));
+    ASSERT_EQ(1, taskJson.count("partitionDataJson"));
+    auto partitionDataStr = taskJson["partitionDataJson"].asString();
+    auto partitionData = folly::parseJson(partitionDataStr);
+    ASSERT_EQ(1, partitionData.count("partitionValues"));
+    auto partitionValues = partitionData["partitionValues"];
+    ASSERT_TRUE(partitionValues.isArray());
+    ASSERT_TRUE(partitionValues[0].isNull());
+
+    auto files = listFiles(outputDirectory->getPath());
+    ASSERT_EQ(files.size(), 1);
+
+    for (const auto& file : files) {
+      std::vector<std::string> pathComponents;
+      folly::split("/", file, pathComponents);
+      bool foundPartitionDir = false;
+      for (const auto& component : pathComponents) {
+        if (component.find('=') != std::string::npos) {
+          foundPartitionDir = true;
+          std::vector<std::string> parts;
+          folly::split('=', component, parts);
+          ASSERT_EQ(parts.size(), 2);
+          ASSERT_EQ(parts[0], colName);
+          ASSERT_EQ(parts[1], "null");
+        }
+      }
+      ASSERT_TRUE(foundPartitionDir)
+          << "No partition directory found in path: " << file;
+    }
+  }
+}
+
+TEST_F(IcebergInsertTest, partitionMultiColumns) {
+  auto rowType =
+      ROW({"c1", "c2", "c3", "c4", "c5", "c6"},
+          {
+              BIGINT(),
+              INTEGER(),
+              SMALLINT(),
+              DECIMAL(18, 5),
+              BOOLEAN(),
+              VARCHAR(),
+          });
+  std::vector<std::vector<int32_t>> columnCombinations = {
+      {0, 1}, // BIGINT, INTEGER.
+      {2, 1}, // SMALLINT, INTEGER.
+      {2, 3}, // SMALLINT, DECIMAL.
+      {0, 2, 1} // BIGINT, SMALLINT, INTEGER.
+  };
+
+  for (const auto& combination : columnCombinations) {
+    const auto outputDirectory = exec::test::TempDirectoryPath::create();
+    constexpr int32_t numBatches = 2;
+    constexpr int32_t vectorSize = 50;
+    const auto vectors = createTestData(rowType, numBatches, vectorSize);
+    std::vector<test::PartitionField> partitionTransforms;
+    for (auto colIndex : combination) {
+      partitionTransforms.push_back(
+          {colIndex, TransformType::kIdentity, std::nullopt});
+    }
+
+    const auto& dataSink = createDataSinkAndAppendData(
+        rowType, vectors, outputDirectory->getPath(), partitionTransforms);
+
+    const auto commitTasks = dataSink->close();
+    auto splits = createSplitsForDirectory(outputDirectory->getPath());
+
+    ASSERT_GT(commitTasks.size(), 0);
+    ASSERT_EQ(splits.size(), commitTasks.size());
+
+    auto plan = exec::test::PlanBuilder().tableScan(rowType).planNode();
+    exec::test::AssertQueryBuilder(plan).splits(splits).assertResults(vectors);
+  }
+}
 
 } // namespace
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergPartitionIdGeneratorTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergPartitionIdGeneratorTest.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergPartitionIdGenerator.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+using namespace facebook::velox;
+
+namespace {
+
+class IcebergPartitionIdGeneratorTest : public test::IcebergTestBase {
+ protected:
+  // Creates a generator with partition channels [0, 1, 2, ...] corresponding
+  // to the input columns in order. All input vectors must have the same size.
+  //
+  // @param columnNames Names of the partition columns, each name should be
+  // unique.
+  // @param types Data types of the partition columns.
+  // @param transformTypes Transform types to apply to each column (e.g.,
+  // kIdentity, kBucket, kYear).
+  // @param parameters Optional transform parameters (e.g., bucket count for
+  // kBucket, width for kTruncate). If empty or shorter than columnNames,
+  // missing parameters default to std::nullopt.
+  // @return A configured IcebergPartitionIdGenerator with maxPartitions=128.
+  std::unique_ptr<IcebergPartitionIdGenerator> createGenerator(
+      const std::vector<std::string>& columnNames,
+      const std::vector<TypePtr>& types,
+      const std::vector<TransformType>& transformTypes,
+      const std::vector<std::optional<int32_t>>& parameters = {}) {
+    VELOX_CHECK_EQ(columnNames.size(), types.size());
+    VELOX_CHECK_EQ(types.size(), transformTypes.size());
+    VELOX_CHECK(parameters.empty() || parameters.size() == columnNames.size());
+    std::vector<IcebergPartitionSpec::Field> fields;
+    fields.reserve(columnNames.size());
+    std::vector<column_index_t> partitionChannels(columnNames.size());
+    std::iota(partitionChannels.begin(), partitionChannels.end(), 0);
+    for (auto i = 0; i < columnNames.size(); ++i) {
+      auto parameter = parameters.size() > i ? parameters.at(i) : std::nullopt;
+      fields.emplace_back(
+          IcebergPartitionSpec::Field{
+              columnNames[i], types[i], transformTypes[i], parameter});
+    }
+
+    return std::make_unique<IcebergPartitionIdGenerator>(
+        ROW(columnNames, types),
+        partitionChannels,
+        std::make_shared<const IcebergPartitionSpec>(0, fields),
+        /*maxPartitions=*/128,
+        connectorQueryCtx_.get());
+  }
+
+  // Runs the generator on the input rowVector and verifies that the generated
+  // partition paths match the expected paths. Supports two verification modes:
+  // 1. If expectedPaths.size() == rowVector.size(): Verifies each row's
+  //    complete partition path matches the corresponding expected path.
+  // 2. If rowVector.size() == 1: Splits the generated partition path by '/'
+  //    and verifies each component matches the corresponding expected path.
+  //
+  // @param generator The IcebergPartitionIdGenerator to test.
+  // @param rowVector Input data to generate partition IDs from.
+  // @param expectedPaths Expected partition path strings or path components.
+  void verifyPartitionPaths(
+      const std::unique_ptr<IcebergPartitionIdGenerator>& generator,
+      const RowVectorPtr& rowVector,
+      const std::vector<std::string>& expectedPaths) {
+    raw_vector<uint64_t> partitionIds(rowVector->size());
+    generator->run(rowVector, partitionIds);
+
+    if (expectedPaths.size() == rowVector->size()) {
+      for (auto i = 0; i < rowVector->size(); ++i) {
+        std::string partitionName = generator->partitionName(partitionIds[i]);
+        ASSERT_EQ(partitionName, expectedPaths[i]);
+      }
+    } else {
+      ASSERT_EQ(rowVector->size(), 1);
+      std::string partitionName = generator->partitionName(partitionIds[0]);
+      std::vector<std::string> actualPaths;
+      folly::split('/', partitionName, actualPaths);
+      ASSERT_EQ(actualPaths.size(), expectedPaths.size());
+      for (auto i = 0; i < expectedPaths.size(); ++i) {
+        ASSERT_EQ(actualPaths[i], expectedPaths[i]);
+      }
+    }
+  }
+};
+
+TEST_F(IcebergPartitionIdGeneratorTest, identityTransforms) {
+  std::vector<std::string> columnNames = {
+      "c_int",
+      "c_bigint",
+      "c_varchar",
+      "c_varbinary",
+      "c_decimal",
+      "c_bool",
+      "c_date"};
+
+  std::vector<TypePtr> types = {
+      INTEGER(),
+      BIGINT(),
+      VARCHAR(),
+      VARBINARY(),
+      DECIMAL(18, 4),
+      BOOLEAN(),
+      DATE(),
+  };
+  std::vector<TransformType> transformTypes(
+      columnNames.size(), TransformType::kIdentity);
+  const auto& generator = createGenerator(columnNames, types, transformTypes);
+  verifyPartitionPaths(
+      generator,
+      makeRowVector(
+          columnNames,
+          {
+              makeConstant<int32_t>(42, 1),
+              makeConstant<int64_t>(9'876'543'210, 1),
+              makeConstant<StringView>("test string partition column name", 1),
+              makeConstant<StringView>("\x48\x65\x6c\x6c\x6f", 1, VARBINARY()),
+              makeConstant<int64_t>(12'345'678'901'234, 1, DECIMAL(18, 4)),
+              makeConstant<bool>(true, 1),
+              makeConstant<int32_t>(18'262, 1, DATE()),
+          }),
+      {
+          "c_int=42",
+          "c_bigint=9876543210",
+          "c_varchar=test+string+partition+column+name",
+          "c_varbinary=SGVsbG8%3D",
+          "c_decimal=1234567890.1234",
+          "c_bool=true",
+          "c_date=2020-01-01",
+      });
+}
+
+TEST_F(IcebergPartitionIdGeneratorTest, timestampIdentitySpecialValues) {
+  std::vector<Timestamp> timestamps = {
+      Timestamp(253402300800, 100000000), // +10000-01-01T00:00:00.1.
+      Timestamp(-62170000000, 0), // -0001-11-29T19:33:20.
+      Timestamp(-62135577748, 999000000), // 0001-01-01T05:17:32.999.
+      Timestamp(0, 0), // 1970-01-01T00:00.
+      Timestamp(1609459200, 999000000), // 2021-01-01T00:00.
+      Timestamp(1640995200, 500000000), // 2022-01-01T00:00:00.5.
+      Timestamp(1672531200, 123000000), // 2023-01-01T00:00:00.123.
+      Timestamp(-1, 999000000), // 1969-12-31T23:59:59.999.
+      Timestamp(1, 1000000), // 1970-01-01T00:00:01.001.
+      Timestamp(-62167219199, 0), // 0000-01-01T00:00:01.
+      Timestamp(-377716279140, 321000000), // -10000-01-01T01:01:00.321.
+      Timestamp(253402304660, 321000000), // +10000-01-01T01:01:00.321.
+      Timestamp(951782400, 0), // 2000-02-29T00:00:00 (leap year).
+      Timestamp(4107456000, 0), // 2100-02-28T00:00:00.
+      Timestamp(-86400, 0), // 1969-12-31T00:00:00.
+  };
+
+  std::vector<std::string> expectedPartitionNames = {
+      "c_timestamp=%2B10000-01-01T00%3A00%3A00.1",
+      "c_timestamp=-0001-11-29T19%3A33%3A20",
+      "c_timestamp=0001-01-01T05%3A17%3A32.999",
+      "c_timestamp=1970-01-01T00%3A00%3A00",
+      "c_timestamp=2021-01-01T00%3A00%3A00.999",
+      "c_timestamp=2022-01-01T00%3A00%3A00.5",
+      "c_timestamp=2023-01-01T00%3A00%3A00.123",
+      "c_timestamp=1969-12-31T23%3A59%3A59.999",
+      "c_timestamp=1970-01-01T00%3A00%3A01.001",
+      "c_timestamp=0000-01-01T00%3A00%3A01",
+      "c_timestamp=-10000-08-24T19%3A21%3A00.321",
+      "c_timestamp=%2B10000-01-01T01%3A04%3A20.321",
+      "c_timestamp=2000-02-29T00%3A00%3A00",
+      "c_timestamp=2100-02-28T00%3A00%3A00",
+      "c_timestamp=1969-12-31T00%3A00%3A00",
+  };
+
+  std::vector<std::string> columnNames = {"c_timestamp"};
+  const auto& generator =
+      createGenerator(columnNames, {TIMESTAMP()}, {TransformType::kIdentity});
+  verifyPartitionPaths(
+      generator,
+      makeRowVector(columnNames, {makeFlatVector<Timestamp>(timestamps)}),
+      expectedPartitionNames);
+}
+
+TEST_F(IcebergPartitionIdGeneratorTest, nullValues) {
+  std::vector<std::string> columnNames = {"c_int", "c_varchar", "c_decimal"};
+
+  const auto& generator = createGenerator(
+      columnNames,
+      {INTEGER(), VARCHAR(), DECIMAL(18, 3)},
+      {
+          TransformType::kBucket,
+          TransformType::kTruncate,
+          TransformType::kIdentity,
+      },
+      {4, 100, std::nullopt});
+
+  verifyPartitionPaths(
+      generator,
+      makeRowVector(
+          columnNames,
+          {
+              makeConstant<int32_t>(std::nullopt, 1),
+              makeConstant<StringView>(std::nullopt, 1),
+              makeConstant<int64_t>(std::nullopt, 1, DECIMAL(18, 3)),
+          }),
+      {"c_int_bucket=null/c_varchar_trunc=null/c_decimal=null"});
+}
+
+TEST_F(IcebergPartitionIdGeneratorTest, specialChars) {
+  std::vector<std::pair<std::string, std::string>> testCases = {
+      {"space test", "space+test"},
+      {"slash/test", "slash%2Ftest"},
+      {"question?test", "question%3Ftest"},
+      {"percent%test", "percent%25test"},
+      {"hash#test", "hash%23test"},
+      {"ampersand&test", "ampersand%26test"},
+      {"equals=test", "equals%3Dtest"},
+      {"plus+test", "plus%2Btest"},
+      {"comma,test", "comma%2Ctest"},
+      {"semicolon;test", "semicolon%3Btest"},
+      {"at@test", "at%40test"},
+      {"dollar$test", "dollar%24test"},
+      {"backslash\\test", "backslash%5Ctest"},
+      {"quote\"test", "quote%22test"},
+      {"apostrophe'test", "apostrophe%27test"},
+      {"less<than", "less%3Cthan"},
+      {"greater>than", "greater%3Ethan"},
+      {"colon:test", "colon%3Atest"},
+      {"pipe|test", "pipe%7Ctest"},
+      {"bracket[test", "bracket%5Btest"},
+      {"bracket]test", "bracket%5Dtest"},
+      {"brace{test", "brace%7Btest"},
+      {"brace}test", "brace%7Dtest"},
+      {"caret^test", "caret%5Etest"},
+      {"tilde~test", "tilde%7Etest"},
+      {"backtick`test", "backtick%60test"},
+      {"unicode\u00A9test", "unicode%C2%A9test"},
+      {"email@example.com", "email%40example.com"},
+      {"user:password@host:port/path", "user%3Apassword%40host%3Aport%2Fpath"},
+      {"https://github.ibm.com/IBM/velox",
+       "https%3A%2F%2Fgithub.ibm.com%2FIBM%2Fvelox"},
+      {"a+b=c&d=e+f", "a%2Bb%3Dc%26d%3De%2Bf"},
+      {"special!@#$%^&*()_+", "special%21%40%23%24%25%5E%26*%28%29_%2B"},
+  };
+
+  std::vector<std::string> columnNames = {"ColumnWithSpecialChars"};
+  const auto& generator =
+      createGenerator(columnNames, {VARCHAR()}, {TransformType::kIdentity});
+
+  for (const auto& [input, expectedEncoded] : testCases) {
+    std::vector<std::string> expectedPartitionNames = {
+        fmt::format("{}={}", columnNames[0], expectedEncoded)};
+    verifyPartitionPaths(
+        generator,
+        makeRowVector(
+            columnNames, {makeConstant<StringView>(StringView(input), 1)}),
+        expectedPartitionNames);
+  }
+}
+
+TEST_F(IcebergPartitionIdGeneratorTest, multipleRows) {
+  std::vector<std::string> columnNames = {"c_int", "c_varchar"};
+  std::vector<TransformType> transformTypes(
+      columnNames.size(), TransformType::kIdentity);
+  const auto& generator =
+      createGenerator(columnNames, {INTEGER(), VARCHAR()}, transformTypes);
+
+  verifyPartitionPaths(
+      generator,
+      makeRowVector(
+          columnNames,
+          {
+              makeFlatVector<int32_t>({10, 20, 30}),
+              makeFlatVector<StringView>({"value1", "value2", "value3"}),
+          }),
+      {
+          "c_int=10/c_varchar=value1",
+          "c_int=20/c_varchar=value2",
+          "c_int=30/c_varchar=value3",
+      });
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/PartitionSpecTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/PartitionSpecTest.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+TEST(PartitionSpecTest, invalidColumnType) {
+  std::vector<IcebergPartitionSpec::Field> fields1 = {
+      {"col_row",
+       ROW({{"a", INTEGER()}}),
+       TransformType::kIdentity,
+       std::nullopt},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields1),
+      "not supported as a partition column");
+
+  std::vector<IcebergPartitionSpec::Field> fields2 = {
+      {"col_array", ARRAY(INTEGER()), TransformType::kIdentity, std::nullopt},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields2),
+      "not supported as a partition column");
+
+  std::vector<IcebergPartitionSpec::Field> fields3 = {
+      {"col_map",
+       MAP(VARCHAR(), INTEGER()),
+       TransformType::kIdentity,
+       std::nullopt},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields3),
+      "not supported as a partition column");
+
+  std::vector<IcebergPartitionSpec::Field> fields4 = {
+      {"c0",
+       TIMESTAMP_WITH_TIME_ZONE(),
+       TransformType::kIdentity,
+       std::nullopt},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields4),
+      "not supported as a partition column");
+}
+
+TEST(PartitionSpecTest, invalidMultipleTransforms) {
+  std::vector<IcebergPartitionSpec::Field> fields1 = {
+      {"c0", VARCHAR(), TransformType::kIdentity, std::nullopt},
+      {"c0", VARCHAR(), TransformType::kIdentity, std::nullopt},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields1),
+      "Multiple transforms of the same category on a column are not allowed. "
+      "Each transform category can appear at most once per column. "
+      "Column: 'c0', Category: Identity.");
+
+  std::vector<IcebergPartitionSpec::Field> fields2 = {
+      {"c0", VARCHAR(), TransformType::kBucket, 16},
+      {"c0", VARCHAR(), TransformType::kBucket, 32},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields2),
+      "Multiple transforms of the same category on a column are not allowed. "
+      "Each transform category can appear at most once per column. "
+      "Column: 'c0', Category: Bucket.");
+
+  std::vector<IcebergPartitionSpec::Field> fields3 = {
+      {"c0", VARCHAR(), TransformType::kTruncate, 2},
+      {"c0", VARCHAR(), TransformType::kTruncate, 5},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields3),
+      "Multiple transforms of the same category on a column are not allowed. "
+      "Each transform category can appear at most once per column. "
+      "Column: 'c0', Category: Truncate.");
+
+  std::vector<IcebergPartitionSpec::Field> fields4 = {
+      {"c0", DATE(), TransformType::kYear, std::nullopt},
+      {"c0", DATE(), TransformType::kMonth, std::nullopt},
+  };
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields4),
+      "Multiple transforms of the same category on a column are not allowed. "
+      "Each transform category can appear at most once per column. "
+      "Column: 'c0', Category: Temporal (Year/Month/Day/Hour).");
+}
+
+TEST(PartitionSpecTest, validMultipleTransforms) {
+  std::vector<IcebergPartitionSpec::Field> fields1 = {
+      {"c0", VARCHAR(), TransformType::kIdentity, std::nullopt},
+      {"c0", VARCHAR(), TransformType::kBucket, 16},
+      {"c0", VARCHAR(), TransformType::kTruncate, 10},
+  };
+  auto spec = std::make_shared<const IcebergPartitionSpec>(1, fields1);
+  EXPECT_EQ(spec->fields.size(), 3);
+
+  std::vector<IcebergPartitionSpec::Field> fields2 = {
+      {"c0", DATE(), TransformType::kYear, std::nullopt},
+      {"c0", DATE(), TransformType::kBucket, 16},
+      {"c0", DATE(), TransformType::kIdentity, std::nullopt},
+  };
+  spec = std::make_shared<const IcebergPartitionSpec>(1, fields2);
+  EXPECT_EQ(spec->fields.size(), 3);
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
@@ -1,0 +1,661 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/functions/iceberg/Murmur3Hash32.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class TransformE2ETest : public test::IcebergTestBase {
+ protected:
+  static constexpr int32_t kDefaultNumBatches = 2;
+  static constexpr int32_t kDefaultRowsPerBatch = 100;
+
+  std::vector<RowVectorPtr> createTimestampTestData(
+      int32_t numBatches,
+      int32_t rowsPerBatch,
+      RowTypePtr rowType) {
+    std::vector<RowVectorPtr> batches;
+    static const std::vector<Timestamp> timestamps = {
+        Timestamp(0, 0), // 1970-01-01 00:00:00
+        Timestamp(3600, 0), // 1970-01-01 01:00:00
+        Timestamp(86400, 0), // 1970-01-02 00:00:00
+        Timestamp(2592000, 0), // 1970-01-31 00:00:00
+        Timestamp(31536000, 0), // 1971-01-01 00:00:00
+        Timestamp(1609459200, 0), // 2021-01-01 00:00:00
+        Timestamp(1609545600, 0), // 2021-01-02 00:00:00
+        Timestamp(1612224000, 0), // 2021-02-01 00:00:00
+        Timestamp(1640995200, 0), // 2022-01-01 00:00:00
+        Timestamp(1672531200, 0) // 2023-01-01 00:00:00
+    };
+
+    for (auto i = 0; i < numBatches; i++) {
+      auto timestampVector = BaseVector::create<FlatVector<Timestamp>>(
+          TIMESTAMP(), rowsPerBatch, opPool_.get());
+      for (auto j = 0; j < rowsPerBatch; j++) {
+        timestampVector->set(j, timestamps[j % timestamps.size()]);
+      }
+      batches.push_back(makeRowVector(rowType->names(), {timestampVector}));
+    }
+    return batches;
+  }
+
+  std::shared_ptr<TempDirectoryPath> writeBatchesWithTransforms(
+      const std::vector<RowVectorPtr>& batches,
+      RowTypePtr rowType,
+      const std::vector<test::PartitionField>& partitionFields) {
+    int64_t expectedRowCount = 0;
+    for (const auto& batch : batches) {
+      expectedRowCount += batch->size();
+    }
+
+    auto outputDirectory = TempDirectoryPath::create();
+    const auto& dataSink = createDataSinkAndAppendData(
+        rowType, batches, outputDirectory->getPath(), partitionFields);
+    dataSink->close();
+    verifyTotalRowCount(rowType, outputDirectory->getPath(), expectedRowCount);
+    return outputDirectory;
+  }
+
+  std::shared_ptr<TempDirectoryPath> writeTimestampBatchesWithTransform(
+      const std::vector<RowVectorPtr>& batches,
+      TransformType transformType) {
+    auto rowType = ROW({"c_timestamp"}, {TIMESTAMP()});
+    return writeBatchesWithTransforms(
+        batches, rowType, {{0, transformType, std::nullopt}});
+  }
+
+  // Helper function to build expected counts map from timestamp batches.
+  // The key format depends on the granularity:
+  // - Month: "YYYY-MM"
+  // - Day: "YYYY-MM-DD"
+  // - Hour: "YYYY-MM-DD-HH"
+  std::unordered_map<std::string, int32_t> buildExpectedCountsFromTimestamps(
+      const std::vector<RowVectorPtr>& batches,
+      const std::string& granularity) {
+    std::unordered_map<std::string, int32_t> expectedCounts;
+
+    for (const auto& batch : batches) {
+      auto timestampVector = batch->childAt(0)->as<SimpleVector<Timestamp>>();
+      for (auto i = 0; i < batch->size(); i++) {
+        if (!timestampVector->isNullAt(i)) {
+          Timestamp ts = timestampVector->valueAt(i);
+          std::tm tm;
+          if (Timestamp::epochToCalendarUtc(ts.getSeconds(), tm)) {
+            int32_t year = tm.tm_year + 1900;
+            int32_t month = tm.tm_mon + 1;
+            int32_t day = tm.tm_mday;
+            int32_t hour = tm.tm_hour;
+
+            std::string key;
+            if (granularity == "month") {
+              key = fmt::format("{:04d}-{:02d}", year, month);
+            } else if (granularity == "day") {
+              key = fmt::format("{:04d}-{:02d}-{:02d}", year, month, day);
+            } else if (granularity == "hour") {
+              key = fmt::format(
+                  "{:04d}-{:02d}-{:02d}-{:02d}", year, month, day, hour);
+            }
+            expectedCounts[key]++;
+          }
+        }
+      }
+    }
+    return expectedCounts;
+  }
+
+  std::vector<std::string> firstLevelDirectories(const std::string& basePath) {
+    std::vector<std::string> partitionDirs;
+    for (const auto& entry : std::filesystem::directory_iterator(basePath)) {
+      if (entry.is_directory()) {
+        partitionDirs.push_back(entry.path().string());
+      }
+    }
+    return partitionDirs;
+  }
+
+  std::vector<std::string> listDirectoriesRecursively(const std::string& path) {
+    std::vector<std::string> allPartitionDirs;
+    auto firstLevelDirs = firstLevelDirectories(path);
+
+    for (const auto& dir : firstLevelDirs) {
+      if (std::filesystem::is_directory(dir)) {
+        allPartitionDirs.push_back(
+            std::filesystem::path(dir).filename().string());
+        auto subDirs = listDirectoriesRecursively(dir);
+        allPartitionDirs.insert(
+            allPartitionDirs.end(), subDirs.begin(), subDirs.end());
+      }
+    }
+
+    return allPartitionDirs;
+  }
+
+  // Verify the number of partitions and their naming convention.
+  void verifyPartitionCount(
+      const std::string& outputPath,
+      const std::vector<std::string>& partitionTransforms,
+      int32_t expectedPartitionCount) {
+    const auto partitionDirs = firstLevelDirectories(outputPath);
+
+    if (partitionTransforms.empty()) {
+      ASSERT_EQ(partitionDirs.size(), 1)
+          << "Expected 1 directory for no partitioning, got "
+          << partitionDirs.size();
+    } else {
+      ASSERT_EQ(partitionDirs.size(), expectedPartitionCount)
+          << "Expected " << expectedPartitionCount << " partitions, got "
+          << partitionDirs.size();
+
+      for (const auto& dir : partitionDirs) {
+        const auto dirName = std::filesystem::path(dir).filename().string();
+        ASSERT_TRUE(dirName.find('=') != std::string::npos)
+            << "Partition directory " << dirName
+            << " does not follow Iceberg naming convention";
+      }
+    }
+  }
+
+  // Verify the total row count across all partitions.
+  void verifyTotalRowCount(
+      RowTypePtr rowType,
+      const std::string& outputPath,
+      int32_t expectedRowCount) {
+    auto splits = createSplitsForDirectory(outputPath);
+
+    const auto plan = PlanBuilder()
+                          .tableScan(rowType)
+                          .singleAggregation({}, {"count(1)"})
+                          .planNode();
+
+    const auto result =
+        AssertQueryBuilder(plan).splits(splits).copyResults(opPool_.get());
+
+    ASSERT_EQ(result->size(), 1);
+    ASSERT_EQ(
+        result->childAt(0)->asFlatVector<int64_t>()->valueAt(0),
+        expectedRowCount);
+  }
+
+  // Verify data in a specific partition.
+  void verifyPartitionData(
+      RowTypePtr rowType,
+      const std::string& partitionPath,
+      const std::string& partitionFilter,
+      const int32_t expectedRowCount,
+      bool skipRowCountCheck = false) {
+    auto splits = createSplitsForDirectory(partitionPath);
+
+    auto countPlan = PlanBuilder()
+                         .tableScan(rowType)
+                         .singleAggregation({}, {"count(1)"})
+                         .planNode();
+
+    const auto& countResult =
+        AssertQueryBuilder(countPlan).splits(splits).copyResults(opPool_.get());
+
+    ASSERT_EQ(countResult->size(), 1);
+    const auto actualRowCount =
+        countResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+
+    if (!skipRowCountCheck) {
+      ASSERT_EQ(actualRowCount, expectedRowCount);
+    } else {
+      // Just verify that we have some data.
+      ASSERT_GT(actualRowCount, 0);
+    }
+
+    const auto dataPlan = PlanBuilder()
+                              .tableScan(rowType)
+                              .filter(partitionFilter)
+                              .singleAggregation({}, {"count(1)"})
+                              .planNode();
+    const auto& dataResult =
+        AssertQueryBuilder(dataPlan).splits(splits).copyResults(opPool_.get());
+    ASSERT_EQ(dataResult->size(), 1);
+    const auto filteredRowCount =
+        dataResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+    if (!skipRowCountCheck) {
+      ASSERT_EQ(filteredRowCount, expectedRowCount);
+    } else {
+      ASSERT_EQ(filteredRowCount, actualRowCount);
+    }
+  }
+
+  std::pair<std::string, std::string> buildFilter(
+      const std::string& partitionDir) {
+    auto eq = partitionDir.find('=');
+    auto us = partitionDir.rfind('_', eq - 1);
+    auto column = partitionDir.substr(0, us);
+    auto value = partitionDir.substr(eq + 1);
+    return {column, value};
+  }
+
+  int32_t extractBucketNumber(const std::string& dirName) {
+    const auto& eq = dirName.find('=');
+    VELOX_CHECK_NE(
+        eq, std::string::npos, "Invalid partition directory name: {}", dirName);
+    const auto& bucketStr = dirName.substr(eq + 1);
+    return std::stoi(bucketStr);
+  }
+
+  int32_t computeBucketHash(const StringView& value, int32_t numBuckets) {
+    int32_t hash = functions::iceberg::Murmur3Hash32::hashBytes(
+        value.data(), value.size());
+    return ((hash & 0x7FFFFFFF) % numBuckets);
+  }
+};
+
+TEST_F(TransformE2ETest, identity) {
+  constexpr auto rowsPerBatch = 50;
+  auto rowType = ROW({"c_int"}, {INTEGER()});
+  auto vectors = createTestData(rowType, kDefaultNumBatches, rowsPerBatch);
+
+  auto outputDirectory = writeBatchesWithTransforms(
+      vectors, rowType, {{0, TransformType::kIdentity, std::nullopt}});
+
+  verifyPartitionCount(
+      outputDirectory->getPath(), {"c_int"}, kDefaultNumBatches * rowsPerBatch);
+
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+  for (const auto& dir : partitionDirs) {
+    const auto& dirName = std::filesystem::path(dir).filename().string();
+    verifyPartitionData(rowType, dir, dirName, 1);
+  }
+}
+
+TEST_F(TransformE2ETest, partitionNamingConventions) {
+  std::string binaryData = "binary\0data\1\2\3";
+  auto rowVector = makeRowVector(
+      {
+          "c_int",
+          "c_bigint",
+          "c_varchar",
+          "c_varchar2",
+          "c_decimal",
+          "c_varbinary",
+      },
+      {
+          makeConstant(42, 1, INTEGER()),
+          makeConstant(static_cast<int64_t>(9'876'543'210), 1, BIGINT()),
+          makeConstant("test string", 1, VARCHAR()),
+          makeNullConstant(TypeKind::VARCHAR, 1),
+          makeConstant(static_cast<int64_t>(1'234'567'890), 1, DECIMAL(18, 3)),
+          makeConstant(StringView(binaryData), 1, VARBINARY()),
+      });
+
+  std::vector<test::PartitionField> partitionTransforms = {
+      {0, TransformType::kIdentity, std::nullopt}, // c_int.
+      {1, TransformType::kIdentity, std::nullopt}, // c_bigint.
+      {2, TransformType::kIdentity, std::nullopt}, // c_varchar.
+      {4, TransformType::kIdentity, std::nullopt}, // c_decimal.
+      {5, TransformType::kIdentity, std::nullopt}, // c_varbinary.
+      {3, TransformType::kIdentity, std::nullopt}, // c_varchar2.
+  };
+
+  auto outputDirectory = writeBatchesWithTransforms(
+      {rowVector}, asRowType(rowVector->type()), partitionTransforms);
+
+  const auto& actualPartitionNames =
+      listDirectoriesRecursively(outputDirectory->getPath());
+
+  // Build expected partition folder names
+  std::vector<std::string> expectedPartitionNames = {
+      "c_int=42",
+      "c_bigint=9876543210",
+      "c_varchar=test+string",
+      "c_decimal=1234567.890",
+      "c_varbinary=" +
+          encoding::Base64::encode(binaryData.data(), binaryData.size()),
+      "c_varchar2=null",
+  };
+
+  ASSERT_EQ(actualPartitionNames, expectedPartitionNames)
+      << "Partition folder names do not match expected values";
+}
+
+TEST_F(TransformE2ETest, bucket) {
+  constexpr int32_t numBuckets = 4;
+  auto rowType = ROW({"c_varchar"}, {VARCHAR()});
+  auto vectors =
+      createTestData(rowType, kDefaultNumBatches, kDefaultRowsPerBatch);
+
+  auto outputDirectory = writeBatchesWithTransforms(
+      vectors, rowType, {{0, TransformType::kBucket, numBuckets}});
+
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+  ASSERT_LE(partitionDirs.size(), numBuckets);
+
+  int32_t totalRowsInPartitions = 0;
+  for (const auto& dir : partitionDirs) {
+    auto splits = createSplitsForDirectory(dir);
+    auto countPlan = PlanBuilder()
+                         .tableScan(rowType)
+                         .singleAggregation({}, {"count(1)"})
+                         .planNode();
+    auto countResult =
+        AssertQueryBuilder(countPlan).splits(splits).copyResults(opPool_.get());
+
+    auto partitionRowCount =
+        countResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+    totalRowsInPartitions += partitionRowCount;
+    ASSERT_GT(partitionRowCount, 0);
+  }
+
+  ASSERT_EQ(totalRowsInPartitions, kDefaultNumBatches * kDefaultRowsPerBatch);
+
+  std::unordered_map<std::string, int32_t> valueToExpectedBucket;
+
+  for (const auto& dir : partitionDirs) {
+    const auto dirName = std::filesystem::path(dir).filename().string();
+    const int32_t expectedBucket = extractBucketNumber(dirName);
+
+    auto dataPlan =
+        PlanBuilder().tableScan(rowType).project({"c_varchar"}).planNode();
+    const auto& dataResult = AssertQueryBuilder(dataPlan)
+                                 .splits(createSplitsForDirectory(dir))
+                                 .copyResults(opPool_.get());
+
+    auto varcharColumn = dataResult->childAt(0)->asFlatVector<StringView>();
+    for (auto i = 0; i < dataResult->size(); i++) {
+      StringView value = varcharColumn->valueAt(i);
+
+      auto computedBucket = computeBucketHash(value, numBuckets);
+      ASSERT_EQ(computedBucket, expectedBucket)
+          << "Value '" << value << "' in partition " << dirName
+          << " has computed bucket " << computedBucket
+          << " but expected bucket " << expectedBucket;
+
+      // Track the bucket for this value to verify consistency.
+      if (valueToExpectedBucket.find(value) == valueToExpectedBucket.end()) {
+        valueToExpectedBucket[value] = expectedBucket;
+      } else {
+        // Verify that the same value always hashes to the same bucket.
+        ASSERT_EQ(valueToExpectedBucket[value], expectedBucket)
+            << "Value '" << value
+            << "' hashed to different buckets: " << valueToExpectedBucket[value]
+            << " and " << expectedBucket;
+      }
+    }
+  }
+}
+
+TEST_F(TransformE2ETest, truncate) {
+  auto rowType = ROW({"c_int"}, {INTEGER()});
+
+  std::vector<RowVectorPtr> batches;
+  for (auto i = 0; i < kDefaultNumBatches; i++) {
+    std::vector<VectorPtr> columns;
+    columns.push_back(
+        makeFlatVector<int32_t>(50, [](auto row) { return row % 100; }));
+    auto vectors = makeRowVector(rowType->names(), columns);
+    batches.push_back(vectors);
+  }
+
+  auto outputDirectory = writeBatchesWithTransforms(
+      batches, rowType, {{0, TransformType::kTruncate, 10}});
+
+  verifyPartitionCount(outputDirectory->getPath(), {"truncate(c_int, 10)"}, 5);
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+
+  for (const auto& dir : partitionDirs) {
+    const std::string dirName = std::filesystem::path(dir).filename().string();
+    auto [c, v] = buildFilter(dirName);
+    const std::string filter =
+        c + ">=" + v + " AND " + c + "<" + std::to_string(std::stoi(v) + 10);
+    verifyPartitionData(
+        rowType, dir, filter, 20); // 10 values per batch * 2 batches.
+  }
+}
+
+TEST_F(TransformE2ETest, year) {
+  auto rowType = ROW({"c_date"}, {DATE()});
+
+  std::vector<RowVectorPtr> batches;
+  for (auto i = 0; i < kDefaultNumBatches; i++) {
+    auto dateVector = BaseVector::create<FlatVector<int32_t>>(
+        DATE(), kDefaultRowsPerBatch, opPool_.get());
+    for (auto i = 0; i < kDefaultRowsPerBatch; i++) {
+      static const std::vector<int32_t> dates = {
+          18'262, 18'628, 18'993, 19'358, 19'723, 20'181};
+      dateVector->set(i, dates[i % dates.size()]);
+    }
+    batches.emplace_back(makeRowVector(rowType->names(), {dateVector}));
+  }
+
+  auto outputDirectory = writeBatchesWithTransforms(
+      batches, rowType, {{0, TransformType::kYear, std::nullopt}});
+
+  verifyPartitionCount(outputDirectory->getPath(), {"year(c_date)"}, 6);
+
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+  for (int32_t year = 2020; year <= 2025; year++) {
+    const auto expectedDirName = fmt::format("c_date_year={}", year);
+    bool foundPartition = false;
+    auto yearFilter = [](const int32_t year) -> std::string {
+      return fmt::format(
+          "YEAR(DATE '{}-01-01')={}",
+          std::to_string(year),
+          std::to_string(year));
+    };
+
+    for (const auto& dir : partitionDirs) {
+      const auto dirName = std::filesystem::path(dir).filename().string();
+      if (dirName == expectedDirName) {
+        foundPartition = true;
+        auto datePlan = PlanBuilder()
+                            .tableScan(rowType)
+                            .filter(yearFilter(year))
+                            .singleAggregation({}, {"count(1)"})
+                            .planNode();
+
+        auto dateResult = AssertQueryBuilder(datePlan)
+                              .splits(createSplitsForDirectory(dir))
+                              .copyResults(opPool_.get());
+
+        auto partitionRowCount =
+            dateResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+        auto countPlan = PlanBuilder()
+                             .tableScan(rowType)
+                             .singleAggregation({}, {"count(1)"})
+                             .planNode();
+        auto countResult = AssertQueryBuilder(countPlan)
+                               .splits(createSplitsForDirectory(dir))
+                               .copyResults(opPool_.get());
+        auto totalPartitionCount =
+            countResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0);
+        ASSERT_EQ(partitionRowCount, totalPartitionCount);
+        break;
+      }
+    }
+    ASSERT_TRUE(foundPartition)
+        << "Partition for year " << year << " not found";
+  }
+}
+
+TEST_F(TransformE2ETest, month) {
+  auto rowType = ROW({"c_timestamp"}, {TIMESTAMP()});
+  auto batches = createTimestampTestData(
+      kDefaultNumBatches, kDefaultRowsPerBatch, rowType);
+
+  auto outputDirectory =
+      writeTimestampBatchesWithTransform(batches, TransformType::kMonth);
+
+  auto expectedCounts = buildExpectedCountsFromTimestamps(batches, "month");
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+
+  for (const auto& dir : partitionDirs) {
+    const auto dirName = std::filesystem::path(dir).filename().string();
+    auto [c, v] = buildFilter(dirName);
+    size_t dashPos = v.find('-');
+    ASSERT_NE(dashPos, std::string::npos) << "Invalid month format: " << v;
+
+    int32_t year = std::stoi(v.substr(0, dashPos));
+    int32_t month = std::stoi(v.substr(dashPos + 1));
+    std::string filter = fmt::format(
+        "YEAR(c_timestamp) = {} AND MONTH(c_timestamp) = {}", year, month);
+    std::string monthKey = fmt::format("{:04d}-{:02d}", year, month);
+    verifyPartitionData(rowType, dir, filter, expectedCounts[monthKey]);
+  }
+}
+
+TEST_F(TransformE2ETest, day) {
+  auto rowType = ROW({"c_timestamp"}, {TIMESTAMP()});
+  auto batches = createTimestampTestData(
+      kDefaultNumBatches, kDefaultRowsPerBatch, rowType);
+
+  auto outputDirectory =
+      writeTimestampBatchesWithTransform(batches, TransformType::kDay);
+
+  auto expectedCounts = buildExpectedCountsFromTimestamps(batches, "day");
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+
+  for (const auto& dir : partitionDirs) {
+    const auto dirName = std::filesystem::path(dir).filename().string();
+    auto [c, v] = buildFilter(dirName);
+    std::vector<std::string> dateParts;
+    folly::split('-', v, dateParts);
+    ASSERT_EQ(dateParts.size(), 3) << "Invalid day format: " << v;
+
+    int32_t year = std::stoi(dateParts[0]);
+    int32_t month = std::stoi(dateParts[1]);
+    int32_t day = std::stoi(dateParts[2]);
+
+    std::string filter = fmt::format(
+        "YEAR(c_timestamp) = {} AND MONTH(c_timestamp) = {} AND DAY(c_timestamp) = {}",
+        year,
+        month,
+        day);
+    std::string dayKey = fmt::format("{:04d}-{:02d}-{:02d}", year, month, day);
+    verifyPartitionData(rowType, dir, filter, expectedCounts[dayKey]);
+  }
+}
+
+TEST_F(TransformE2ETest, hour) {
+  auto rowType = ROW({"c_timestamp"}, {TIMESTAMP()});
+  auto batches = createTimestampTestData(
+      kDefaultNumBatches, kDefaultRowsPerBatch, rowType);
+
+  auto outputDirectory =
+      writeTimestampBatchesWithTransform(batches, TransformType::kHour);
+
+  auto expectedCounts = buildExpectedCountsFromTimestamps(batches, "hour");
+  const auto& partitionDirs = firstLevelDirectories(outputDirectory->getPath());
+
+  for (const auto& dir : partitionDirs) {
+    const auto dirName = std::filesystem::path(dir).filename().string();
+    auto [c, v] = buildFilter(dirName);
+    std::vector<std::string> dateParts;
+    folly::split('-', v, dateParts);
+    ASSERT_EQ(dateParts.size(), 4) << "Invalid hour format: " << v;
+
+    int32_t year = std::stoi(dateParts[0]);
+    int32_t month = std::stoi(dateParts[1]);
+    int32_t day = std::stoi(dateParts[2]);
+    int32_t hour = std::stoi(dateParts[3]);
+
+    std::string filter = fmt::format(
+        "YEAR(c_timestamp) = {} AND MONTH(c_timestamp) = {} AND "
+        "DAY(c_timestamp) = {} AND HOUR(c_timestamp) = {}",
+        year,
+        month,
+        day,
+        hour);
+    std::string hourKey =
+        fmt::format("{:04d}-{:02d}-{:02d}-{:02d}", year, month, day, hour);
+    verifyPartitionData(rowType, dir, filter, expectedCounts[hourKey]);
+  }
+}
+
+TEST_F(TransformE2ETest, multipleTransformsOnSameColumn) {
+  auto rowType = ROW(
+      {
+          "c_int",
+          "c_bigint",
+      },
+      {
+          INTEGER(),
+          BIGINT(),
+      });
+
+  auto vectors = createTestData(rowType, 2, 20);
+  auto outputDirectory = writeBatchesWithTransforms(
+      vectors,
+      rowType,
+      {
+          {0, TransformType::kIdentity, std::nullopt}, // c_int.
+          {0, TransformType::kTruncate, 10}, // truncate(c_int, 10).
+          {0, TransformType::kBucket, 4}, // bucket(c_int, 4)
+      });
+
+  auto firstLevelDirs = firstLevelDirectories(outputDirectory->getPath());
+  ASSERT_GT(firstLevelDirs.size(), 0);
+  for (const auto& dir : firstLevelDirs) {
+    const auto dirName = std::filesystem::path(dir).filename().string();
+    ASSERT_TRUE(dirName.find("c_int=") != std::string::npos)
+        << "First level directory " << dirName
+        << " should use identity transform";
+
+    auto secondLevelDirs = firstLevelDirectories(dir);
+    ASSERT_GT(secondLevelDirs.size(), 0)
+        << "No second level directories found in " << dir;
+
+    for (const auto& secondDir : secondLevelDirs) {
+      const auto secondDirName =
+          std::filesystem::path(secondDir).filename().string();
+      ASSERT_TRUE(secondDirName.find("c_int_trunc=") != std::string::npos)
+          << "Second level directory " << secondDirName
+          << " should use truncate transform";
+
+      auto thirdLevelDirs = firstLevelDirectories(secondDir);
+      ASSERT_GT(thirdLevelDirs.size(), 0)
+          << "No third level directories found in " << secondDir;
+
+      for (const auto& thirdDir : thirdLevelDirs) {
+        const auto thirdDirName =
+            std::filesystem::path(thirdDir).filename().string();
+        ASSERT_TRUE(thirdDirName.find("c_int_bucket=") != std::string::npos)
+            << "Third level directory " << thirdDirName
+            << " should use bucket transform";
+
+        // Verify the partition has data.
+        auto splits = createSplitsForDirectory(thirdDir);
+        auto countPlan = PlanBuilder()
+                             .tableScan(rowType)
+                             .singleAggregation({}, {"count(1)"})
+                             .planNode();
+        auto countResult =
+            AssertQueryBuilder(countPlan).splits(splits).copyResults(
+                opPool_.get());
+        ASSERT_GT(
+            countResult->childAt(0)->asFlatVector<int64_t>()->valueAt(0), 0)
+            << "Leaf partition directory " << thirdDir << " has no data";
+      }
+    }
+  }
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/TransformTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformTest.cpp
@@ -1,0 +1,362 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+#include "velox/connectors/hive/iceberg/TransformEvaluator.h"
+#include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+class TransformTest : public test::IcebergTestBase {
+ protected:
+  template <typename T>
+  void testIdentityTransform(
+      const IcebergPartitionSpec::Field& field,
+      const std::vector<T>& inputValues,
+      const TypePtr& type = nullptr) {
+    // Convert input values to optional for testTransform
+    std::vector<std::optional<T>> optionalValues;
+    optionalValues.reserve(inputValues.size());
+    for (const auto& value : inputValues) {
+      optionalValues.push_back(value);
+    }
+    testTransform<T, T>(field, optionalValues, optionalValues, type);
+  }
+
+  template <typename IN, typename OUT>
+  void testTransform(
+      const IcebergPartitionSpec::Field& field,
+      const std::vector<std::optional<IN>>& inputValues,
+      const std::vector<std::optional<OUT>>& expectedValues,
+      const TypePtr& type = nullptr) {
+    VectorPtr inputVector;
+    std::vector<IcebergPartitionSpec::Field> fields = {field};
+    const auto& spec = std::make_shared<const IcebergPartitionSpec>(0, fields);
+    std::vector<column_index_t> channels{0};
+
+    if constexpr (std::is_same_v<IN, StringView>) {
+      auto size = inputValues.size();
+      auto vectorType = type ? type : VARCHAR();
+      inputVector = BaseVector::create<FlatVector<StringView>>(
+          vectorType, size, opPool_.get());
+      const auto& flatVector = inputVector->asFlatVector<StringView>();
+      for (vector_size_t i = 0; i < size; i++) {
+        if (inputValues[i].has_value()) {
+          flatVector->set(i, inputValues[i].value());
+        } else {
+          flatVector->setNull(i, true);
+        }
+      }
+    } else {
+      auto size = inputValues.size();
+      inputVector = BaseVector::create<FlatVector<IN>>(
+          type ? type : CppToType<IN>::create(), size, opPool_.get());
+      const auto& flatVector = inputVector->asFlatVector<IN>();
+      for (auto i = 0; i < size; i++) {
+        if (inputValues[i].has_value()) {
+          flatVector->set(i, inputValues[i].value());
+        } else {
+          flatVector->setNull(i, true);
+        }
+      }
+    }
+
+    const auto& rowVector = makeRowVector({field.name}, {inputVector});
+
+    // Build transform expressions from partition spec.
+    auto transformExprs = TransformExprBuilder::toExpressions(
+        spec, channels, asRowType(rowVector->type()));
+
+    // Create evaluator and evaluate expressions.
+    auto transformEvaluator = std::make_unique<TransformEvaluator>(
+        transformExprs, connectorQueryCtx_.get());
+    const auto& resultVector = transformEvaluator->evaluate(rowVector);
+
+    VectorPtr expectedVector;
+    if constexpr (std::is_same_v<OUT, StringView>) {
+      auto size = expectedValues.size();
+      auto vectorType = type ? type : VARCHAR();
+      expectedVector = BaseVector::create<FlatVector<StringView>>(
+          vectorType, size, opPool_.get());
+      const auto& flatVector = expectedVector->asFlatVector<StringView>();
+      for (auto i = 0; i < size; i++) {
+        if (expectedValues[i].has_value()) {
+          flatVector->set(i, expectedValues[i].value());
+        } else {
+          flatVector->setNull(i, true);
+        }
+      }
+    } else {
+      auto size = expectedValues.size();
+      expectedVector = BaseVector::create<FlatVector<OUT>>(
+          CppToType<OUT>::create(), size, opPool_.get());
+      const auto& flatVector = expectedVector->asFlatVector<OUT>();
+      for (auto i = 0; i < size; i++) {
+        if (expectedValues[i].has_value()) {
+          flatVector->set(i, expectedValues[i].value());
+        } else {
+          flatVector->setNull(i, true);
+        }
+      }
+    }
+
+    ASSERT_EQ(resultVector[0]->size(), expectedValues.size());
+    for (auto i = 0; i < resultVector[0]->size(); i++) {
+      if (expectedValues[i].has_value()) {
+        EXPECT_FALSE(resultVector[0]->isNullAt(i));
+        EXPECT_EQ(
+            resultVector[0]->as<SimpleVector<OUT>>()->valueAt(i),
+            expectedVector->as<SimpleVector<OUT>>()->valueAt(i));
+      } else {
+        EXPECT_TRUE(resultVector[0]->isNullAt(i));
+      }
+    }
+  }
+};
+
+TEST_F(TransformTest, identity) {
+  auto partitionSpec = createPartitionSpec(
+      {
+          {0, TransformType::kIdentity, std::nullopt}, // c_int.
+          {1, TransformType::kIdentity, std::nullopt}, // c_bigint.
+          {2, TransformType::kIdentity, std::nullopt}, // c_varchar.
+          {4, TransformType::kIdentity, std::nullopt}, // c_varbinary.
+          {5, TransformType::kIdentity, std::nullopt}, // c_decimal.
+          {6, TransformType::kIdentity, std::nullopt}, // c_timestamp.
+      },
+      ROW(
+          {
+              "c_int",
+              "c_bigint",
+              "c_varchar",
+              "c_date",
+              "c_varbinary",
+              "c_decimal",
+              "c_timestamp",
+          },
+          {
+              INTEGER(),
+              BIGINT(),
+              VARCHAR(),
+              DATE(),
+              VARBINARY(),
+              DECIMAL(18, 3),
+              TIMESTAMP(),
+          }));
+
+  const auto& intTransform = partitionSpec->fields[0];
+  EXPECT_EQ(intTransform.transformType, TransformType::kIdentity);
+  testIdentityTransform<int32_t>(
+      intTransform,
+      {
+          1,
+          0,
+          -1,
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max(),
+      });
+
+  const auto& bigintTransform = partitionSpec->fields[1];
+  EXPECT_EQ(bigintTransform.transformType, TransformType::kIdentity);
+  EXPECT_EQ(bigintTransform.type->kind(), TypeKind::BIGINT);
+  testIdentityTransform<int64_t>(
+      bigintTransform,
+      {
+          1L,
+          0L,
+          -1L,
+          std::numeric_limits<int64_t>::min(),
+          std::numeric_limits<int64_t>::max(),
+      });
+
+  const auto& varcharTransform = partitionSpec->fields[2];
+  EXPECT_EQ(varcharTransform.transformType, TransformType::kIdentity);
+  EXPECT_EQ(varcharTransform.type->kind(), TypeKind::VARCHAR);
+  testIdentityTransform<StringView>(
+      varcharTransform,
+      {
+          StringView("a"),
+          StringView(""),
+          StringView("velox"),
+          StringView(
+              "Velox is a composable execution engine distributed as an open source C++ library. It provides reusable, extensible, and high-performance data processing components that can be (re-)used to build data management systems focused on different analytical workloads, including batch, interactive, stream processing, and AI/ML. Velox was created by Meta and it is currently developed in partnership with IBM/Ahana, Intel, Voltron Data, Microsoft, ByteDance and many other companies."),
+      });
+
+  const auto& varbinaryTransform = partitionSpec->fields[3];
+  EXPECT_EQ(varbinaryTransform.transformType, TransformType::kIdentity);
+  EXPECT_EQ(varbinaryTransform.type->kind(), TypeKind::VARBINARY);
+  testIdentityTransform<StringView>(
+      varbinaryTransform,
+      {
+          StringView("\x01\x02\x03", 3),
+          StringView("\x04\x05\x06\x07", 4),
+          StringView("\x08\x09", 2),
+          StringView("", 0),
+          StringView("\xFF\xFE\xFD\xFC", 4),
+      },
+      VARBINARY());
+
+  const auto& timestampTransform = partitionSpec->fields[5];
+  EXPECT_EQ(timestampTransform.transformType, TransformType::kIdentity);
+  EXPECT_EQ(timestampTransform.type->kind(), TypeKind::TIMESTAMP);
+  testIdentityTransform<Timestamp>(
+      timestampTransform,
+      {
+          Timestamp(0, 0),
+          Timestamp(1609459200, 0),
+          Timestamp(1640995200, 0),
+          Timestamp(1672531200, 0),
+          Timestamp(9223372036854775, 999999999),
+      });
+}
+
+TEST_F(TransformTest, nulls) {
+  auto spec = createPartitionSpec(
+      {{0, TransformType::kIdentity, std::nullopt}},
+      ROW({"c_int"}, {INTEGER()}));
+
+  std::vector<std::optional<int32_t>> intValues = {
+      5, std::nullopt, 15, std::nullopt, 25};
+  testTransform<int32_t, int32_t>(spec->fields[0], intValues, intValues);
+
+  std::vector<std::optional<StringView>> varcharInput = {
+      StringView("abc"),
+      std::nullopt,
+      StringView("def"),
+      std::nullopt,
+      StringView("ghi"),
+  };
+
+  spec = createPartitionSpec(
+      {{0, TransformType::kIdentity, std::nullopt}},
+      ROW({"c_varchar"}, {VARCHAR()}));
+  testTransform<StringView, StringView>(
+      spec->fields[0], varcharInput, varcharInput);
+
+  std::vector<std::optional<StringView>> varbinaryInput = {
+      StringView("\x01\x02\x03", 3),
+      std::nullopt,
+      StringView("\x04\x05\x06", 3),
+      std::nullopt,
+      StringView("\x07\x08\x09", 3),
+  };
+
+  spec = createPartitionSpec(
+      {{0, TransformType::kIdentity, std::nullopt}},
+      ROW({"c_varbinary"}, {VARBINARY()}));
+  testTransform<StringView>(spec->fields[0], varbinaryInput, varbinaryInput);
+}
+
+TEST_F(TransformTest, bucketTransform) {
+  auto rowType =
+      ROW({"c_int", "c_bigint", "c_varchar", "c_varbinary", "c_date"},
+          {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DATE()});
+
+  const auto partitionSpec = createPartitionSpec(
+      {{0, TransformType::kBucket, 4},
+       {1, TransformType::kBucket, 8},
+       {2, TransformType::kBucket, 16},
+       {3, TransformType::kBucket, 32},
+       {4, TransformType::kBucket, 10}},
+      rowType);
+
+  auto& intBucketTransform = partitionSpec->fields[0];
+  EXPECT_EQ(intBucketTransform.transformType, TransformType::kBucket);
+
+  testTransform<int32_t, int32_t>(
+      intBucketTransform,
+      {8,
+       34,
+       0,
+       1,
+       -1,
+       42,
+       100,
+       1000,
+       std::numeric_limits<int32_t>::min(),
+       std::numeric_limits<int32_t>::max()},
+      {3, 3, 0, 0, 0, 2, 0, 0, 0, 2});
+
+  auto& bigintBucketTransform = partitionSpec->fields[1];
+  EXPECT_EQ(bigintBucketTransform.transformType, TransformType::kBucket);
+
+  testTransform<int64_t, int32_t>(
+      bigintBucketTransform,
+      {34L,
+       0L,
+       -34L,
+       -1L,
+       1L,
+       42L,
+       123'456'789L,
+       -123'456'789L,
+       std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()},
+      {3, 4, 5, 0, 4, 6, 1, 4, 5, 7});
+
+  auto& varcharBucketTransform = partitionSpec->fields[2];
+  EXPECT_EQ(varcharBucketTransform.transformType, TransformType::kBucket);
+
+  testTransform<StringView, int32_t>(
+      varcharBucketTransform,
+      {StringView("abcdefg"),
+       StringView("测试"),
+       StringView("测试ping试测"),
+       StringView(""),
+       StringView("🚀🔥"),
+       StringView("a\u0300\u0301"), // Combining characters.
+       StringView("To be or not to be, that is the question.")},
+      {6, 8, 11, 0, 14, 11, 9});
+
+  auto& varbinaryBucketTransform = partitionSpec->fields[3];
+  EXPECT_EQ(varbinaryBucketTransform.transformType, TransformType::kBucket);
+
+  testTransform<StringView, int32_t>(
+      varbinaryBucketTransform,
+      {StringView("abc\0\0", 5),
+       StringView("\x01\x02\x03\x04", 4),
+       StringView("\xFF\xFE\xFD\xFC", 4),
+       StringView("\x00\x00\x00\x00", 4),
+       StringView("\xDE\xAD\xBE\xEF", 4),
+       StringView(std::string(100, 'x').c_str(), 100)},
+      {11, 5, 15, 30, 10, 18},
+      VARBINARY());
+
+  auto& dateBucketTransform = partitionSpec->fields[4];
+  EXPECT_EQ(dateBucketTransform.transformType, TransformType::kBucket);
+
+  testTransform<int32_t, int32_t>(
+      dateBucketTransform,
+      {
+          0, // 1970-01-01.
+          365, // 1971-01-01.
+          18'262, // 2020-01-01.
+          -365, // 1969-01-01.
+          -1, // 1969-12-31.
+          20'181, // 2025-04-03.
+          -36889, // 1869-01-01.
+          18'628 // 2021-01-01.
+      },
+      {6, 1, 3, 6, 2, 5, 9, 0});
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
This is continuous of previous PR https://github.com/facebookincubator/velox/pull/14723.
Implements comprehensive partition transform functionality for
Iceberg tables, enabling data to be partitioned using various transform
functions including identity, bucket, truncate, and temporal transforms
(year, month, day, hour).


