### PR TITLE
test(wave): Disable NimbleReaderTest.TrivialWithCompressionShouldFail

### DIFF
--- a/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTest.cpp
+++ b/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTest.cpp
@@ -312,7 +312,7 @@ TEST_F(NimbleReaderTest, decodeTrivialSingleLevelFloat) {
   test({{input}}, readFactors, compressionOptions);
 }
 
-TEST_F(NimbleReaderTest, TrivialWithCompressionShouldFail) {
+TEST_F(NimbleReaderTest, DISABLED_TrivialWithCompressionShouldFail) {
   using namespace facebook::nimble;
 
   auto c0 = makeFlatVector<double>(17, [](auto row) { return row * 1.1; });


### PR DESCRIPTION
Summary:
This test is expecting failure when compression exists.  Something
changed in Nimble writer that it no longer writes out compression with the
current configuration.  Disable it for now since it is only checking an
exception being thrown and we can enable it later if we find a configuration
that triggers compression.

Differential Revision: D83855747


