### PR TITLE
fix: Fix sxtream failed test by supporting task cancellation in test

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1441,6 +1441,15 @@ void waitForAllTasksToBeDeleted(uint64_t maxWaitUs) {
       folly::join("\n", pendingTaskStats));
 }
 
+void cancelAllTasks() {
+  std::vector<std::shared_ptr<Task>> pendingTasks = Task::getRunningTasks();
+  for (const auto& task : pendingTasks) {
+    if (!task->isRunning()) {
+      task->requestCancel();
+    }
+  }
+}
+
 std::shared_ptr<Task> assertQuery(
     const core::PlanNodePtr& plan,
     std::function<void(exec::TaskCursor*)> addSplits,

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -221,6 +221,11 @@ bool waitForTaskStateChange(
 /// during this wait call. This is for testing purpose for now.
 void waitForAllTasksToBeDeleted(uint64_t maxWaitUs = 3'000'000);
 
+/// Cancels all currently running tasks across all available task managers.
+/// This is primarily used in testing scenarios to clean up active tasks
+/// and ensure test isolation between test cases.
+void cancelAllTasks();
+
 std::shared_ptr<Task> assertQuery(
     const core::PlanNodePtr& plan,
     const std::string& duckDbSql,


### PR DESCRIPTION
Summary: xstream runtime doesn't cleanup the non-started velox task. A quick fix from test is to add task cancellation for this.

Differential Revision: D83944606


