### PR TITLE
fix: TIME support to fuzzer intermediate type transforms

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -191,6 +191,7 @@ const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
       VARCHAR(),
       VARBINARY(),
       TIMESTAMP(),
+      TIME(),
       TIMESTAMP_WITH_TIME_ZONE(),
   };
   return kScalarTypes;
@@ -199,7 +200,7 @@ const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
 // static
 bool PrestoQueryRunner::isSupportedDwrfType(const TypePtr& type) {
   if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown() ||
-      isGeometryType(type)) {
+      type->isTime() || isGeometryType(type)) {
     return false;
   }
 

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerIntervalTransform.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerJsonTransform.h"
+#include "velox/exec/fuzzer/PrestoQueryRunnerTimeTransform.h"
 #include "velox/exec/fuzzer/PrestoQueryRunnerTimestampWithTimeZoneTransform.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
@@ -66,9 +67,7 @@ intermediateTypeTransforms() {
            std::make_shared<IntermediateTypeTransformUsingCast>(
                SFMSKETCH(), VARBINARY())},
           {JSON(), std::make_shared<JsonTransform>()},
-          {TIME(),
-           std::make_shared<IntermediateTypeTransformUsingCast>(
-               TIME(), BIGINT())},
+          {TIME(), std::make_shared<TimeTransform>()},
           {BINGTILE(),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                BINGTILE(), BIGINT())},

--- a/velox/exec/fuzzer/PrestoQueryRunnerTimeTransform.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerTimeTransform.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerTimeTransform.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::velox::exec::test {
+
+// Converts TIME values to BIGINT (milliseconds since start of day)
+core::ExprPtr TimeTransform::projectToTargetType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  // TIME values are stored as milliseconds since midnight
+  // Convert BIGINT back to TIME by casting
+  return std::make_shared<core::CastExpr>(
+      TIME(), inputExpr, false, columnAlias);
+}
+
+// Converts BIGINT (milliseconds) back to TIME values
+core::ExprPtr TimeTransform::projectToIntermediateType(
+    const core::ExprPtr& inputExpr,
+    const std::string& columnAlias) const {
+  // Extract milliseconds from TIME and store as BIGINT
+  return std::make_shared<core::CastExpr>(
+      BIGINT(), inputExpr, false, columnAlias);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/fuzzer/PrestoQueryRunnerTimeTransform.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerTimeTransform.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+
+namespace facebook::velox::exec::test {
+class TimeTransform : public IntermediateTypeTransformUsingCast {
+ public:
+  TimeTransform() : IntermediateTypeTransformUsingCast(TIME(), BIGINT()) {}
+
+  core::ExprPtr projectToIntermediateType(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
+
+  core::ExprPtr projectToTargetType(
+      const core::ExprPtr& inputExpr,
+      const std::string& columnAlias) const override;
+};
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary: Previously TIME is interdemidate type that fuzzer cannot directly interact with. Now changed to BIGINT for the correct logic. This fix corrects fuzzer's interpretation for unsupported TIME type (target) as BIGINT (intermediate)

Differential Revision: D83985841


