### PR TITLE
feat: Add support for timePlusIntervalDayToSecond and timePlusIntervalMonthToYear

### DIFF
--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -147,6 +147,17 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerTimestampPlusInterval<TimestampWithTimezone>({prefix + "plus"});
   registerTimestampMinusInterval<TimestampWithTimezone>({prefix + "minus"});
 
+  // Register Time + Interval and Interval + Time functions
+  registerFunction<TimePlusInterval, Time, Time, IntervalDayTime>(
+      {prefix + "plus"});
+
+  // Use optimized vector function for Time + IntervalYearMonth (identity
+  // function)
+  exec::registerVectorFunction(
+      prefix + "plus",
+      TimePlusIntervalYearMonthVectorFunction::signatures(),
+      std::make_unique<TimePlusIntervalYearMonthVectorFunction>());
+
   registerFunction<
       TimestampMinusFunction,
       IntervalDayTime,


### PR DESCRIPTION
Summary:
This diff adds support for two new functions in Velox: `timePlusIntervalDayToSecond` and `timePlusIntervalMonthToYear` as part of adding support for Time.

These functions allow for the addition of an interval to a `TIME` value, handling 24-hour wraparound.

Overflow/Underflow are handled separately leveraging modulo properties.

Differential Revision: D83791421


