### PR TITLE
Alias native min max scalar functions

### DIFF
--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -39,10 +39,10 @@ void registerFailFunction(const std::vector<std::string>& names) {
 template <typename T>
 void registerGreatestLeastFunction(const std::string& prefix) {
   registerFunction<ParameterBinder<GreatestFunction, T>, T, T, Variadic<T>>(
-      {prefix + "greatest"});
+      {prefix + "greatest", prefix + "max"});
 
   registerFunction<ParameterBinder<LeastFunction, T>, T, T, Variadic<T>>(
-      {prefix + "least"});
+      {prefix + "least", prefix + "min"});
 }
 
 void registerAllGreatestLeastFunctions(const std::string& prefix) {

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -439,3 +439,27 @@ TEST_F(GreatestLeastTest, boolean) {
       {true, true, true, false, std::nullopt, std::nullopt});
   test::assertEqualVectors(expected, result);
 }
+
+TEST_F(GreatestLeastTest, maxMinAliases) {
+  // Test max and min alias to greatest and least for types TINYINT, VARCHAR,
+  // TIMESTAMP.
+
+  runTest<int8_t>("max(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {100, 1, 0});
+  runTest<int8_t>("min(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
+
+  runTest<StringView>(
+      "max(c0, c1)", {{"a"_sv, "b"_sv}, {"z"_sv, "a"_sv}}, {"z"_sv, "b"_sv});
+  runTest<StringView>(
+      "min(c0, c1)", {{"a"_sv, "b"_sv}, {"z"_sv, "a"_sv}}, {"a"_sv, "a"_sv});
+
+  runTest<Timestamp>(
+      "max(c0, c1)",
+      {{Timestamp(0, 0), Timestamp(10, 100)},
+       {Timestamp(1, 0), Timestamp(10, 1)}},
+      {Timestamp(1, 0), Timestamp(10, 100)});
+  runTest<Timestamp>(
+      "min(c0, c1)",
+      {{Timestamp(0, 0), Timestamp(10, 100)},
+       {Timestamp(1, 0), Timestamp(10, 1)}},
+      {Timestamp(0, 0), Timestamp(10, 1)});
+}


### PR DESCRIPTION
Summary:
Add scalar functions - min and max that map to least and greatest respectively.

These exist in Java through function resolution

https://www.internalfb.com/code/fbsource/fbcode/github/presto-trunk/presto-main-base/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java?lines=358

Differential Revision: D83996036


