### PR TITLE
feat(udf): Add remap_keys velox udf

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -94,6 +94,16 @@ Map Functions
         SELECT map_remove_null_values(MAP(ARRAY[1, 2, 3], ARRAY[3, 4, NULL])); -- {1=3, 2=4}
         SELECT map_remove_null_values(NULL); -- NULL
 
+.. function:: remap_keys(map(K,V), array(K), array(K)) -> map(K,V)
+
+      Returns a map with keys remapped according to the oldKeys and newKeys arrays.
+      Unmapped keys remain unchanged. Values are preserved. Null keys are ignored. ::
+
+          SELECT remap_keys(MAP(ARRAY[1, 2, 3], ARRAY[10, 20, 30]), ARRAY[1, 3], ARRAY[100, 300]); -- {100 -> 10, 2 -> 20, 300 -> 30}
+          SELECT remap_keys(MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]), ARRAY['a', 'c'], ARRAY['alpha', 'charlie']); -- {alpha -> 1, b -> 2, charlie -> 3}
+          SELECT remap_keys(MAP(ARRAY[1, 2, 3], ARRAY[10, null, 30]), ARRAY[1, 2], ARRAY[100, 200]); -- {100 -> 10, 200 -> null, 3 -> 30}
+          SELECT remap_keys(MAP(ARRAY[1, 2], ARRAY[10, 20]), ARRAY[], ARRAY[]); -- {1 -> 10, 2 -> 20}
+
 .. function:: map_subset(map(K,V), array(k)) -> map(K,V)
 
     Constructs a map from those entries of ``map`` for which the key is in the array given

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -262,6 +262,7 @@ std::unordered_set<std::string> skipFunctions = {
 
 std::unordered_set<std::string> skipFunctionsSOT = {
     "array_subset", // Velox-only function, not available in Presto
+    "remap_keys", // Velox-only function, not available in Presto
     "noisy_empty_approx_set_sfm", // non-deterministic because of privacy.
     // https://github.com/facebookincubator/velox/issues/11034
     "cast(real) -> varchar",

--- a/velox/functions/prestosql/RemapKeys.h
+++ b/velox/functions/prestosql/RemapKeys.h
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/ComplexViewTypes.h"
+#include "velox/functions/Udf.h"
+#include "velox/type/FloatingPointUtil.h"
+
+namespace facebook::velox::functions {
+
+/// Fast path for constant primitive type keys.
+template <typename TExec, typename Key>
+struct RemapKeysPrimitiveFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void call(
+      out_type<Map<Key, Generic<T1>>>& out,
+      const arg_type<Map<Key, Generic<T1>>>& inputMap,
+      const arg_type<Array<Key>>& oldKeys,
+      const arg_type<Array<Key>>& newKeys) {
+    if (inputMap.empty()) {
+      return;
+    }
+
+    // Build mapping from old keys to new keys
+    folly::F14FastMap<arg_type<Key>, arg_type<Key>> keyMapping;
+
+    // The old and new key arrays don't need to be the same size.
+    // If they differ, we only process up to the shorter array's length.
+    auto oldKeysSize = oldKeys.size();
+    auto newKeysSize = newKeys.size();
+    auto minSize = std::min(oldKeysSize, newKeysSize);
+
+    auto oldIt = oldKeys.begin();
+    auto newIt = newKeys.begin();
+
+    for (size_t i = 0; i < minSize; ++i, ++oldIt, ++newIt) {
+      if (oldIt->has_value() && newIt->has_value()) {
+        keyMapping[oldIt->value()] = newIt->value();
+      }
+    }
+
+    // Iterate through input map and remap keys
+    for (const auto& entry : inputMap) {
+      auto it = keyMapping.find(entry.first);
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        if (it != keyMapping.end()) {
+          keyWriter = it->second;
+        } else {
+          keyWriter = entry.first;
+        }
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        if (it != keyMapping.end()) {
+          keyWriter = it->second;
+        } else {
+          keyWriter = entry.first;
+        }
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+};
+
+/// String version that avoids copy of strings.
+template <typename TExec>
+struct RemapKeysVarcharFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  void call(
+      out_type<Map<Varchar, Generic<T1>>>& out,
+      const arg_type<Map<Varchar, Generic<T1>>>& inputMap,
+      const arg_type<Array<Varchar>>& oldKeys,
+      const arg_type<Array<Varchar>>& newKeys) {
+    if (inputMap.empty()) {
+      return;
+    }
+
+    // Build mapping from old keys to new keys
+    folly::F14FastMap<StringView, StringView> keyMapping;
+
+    auto oldKeysSize = oldKeys.size();
+    auto newKeysSize = newKeys.size();
+    auto minSize = std::min(oldKeysSize, newKeysSize);
+
+    auto oldIt = oldKeys.begin();
+    auto newIt = newKeys.begin();
+
+    for (size_t i = 0; i < minSize; ++i, ++oldIt, ++newIt) {
+      if (oldIt->has_value() && newIt->has_value()) {
+        keyMapping[oldIt->value()] = newIt->value();
+      }
+    }
+
+    // Iterate through input map and remap keys
+    for (const auto& entry : inputMap) {
+      auto it = keyMapping.find(entry.first);
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        if (it != keyMapping.end()) {
+          // Key is remapped - must copy from newKeys array
+          keyWriter.copy_from(it->second);
+        } else {
+          // Key is not remapped - can reuse from inputMap
+          keyWriter.setNoCopy(entry.first);
+        }
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        if (it != keyMapping.end()) {
+          // Key is remapped - must copy from newKeys array
+          keyWriter.copy_from(it->second);
+        } else {
+          // Key is not remapped - can reuse from inputMap
+          keyWriter.setNoCopy(entry.first);
+        }
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+};
+
+struct RemapKeysFunctionEqualComparator {
+  bool operator()(const exec::GenericView& lhs, const exec::GenericView& rhs)
+      const {
+    static constexpr auto kEqualValueAtFlags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+
+    auto result = lhs.compare(rhs, kEqualValueAtFlags);
+
+    VELOX_USER_CHECK(
+        result.has_value(), "Comparison on null elements is not supported");
+
+    return result.value() == 0;
+  }
+};
+
+struct RemapKeysFunctionHasher {
+  size_t operator()(const exec::GenericView& value) const {
+    return value.hash();
+  }
+};
+
+/// Generic implementation for complex types.
+template <typename TExec>
+struct RemapKeysFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  void call(
+      out_type<Map<Generic<T1>, Generic<T2>>>& out,
+      const arg_type<Map<Generic<T1>, Generic<T2>>>& inputMap,
+      const arg_type<Array<Generic<T1>>>& oldKeys,
+      const arg_type<Array<Generic<T1>>>& newKeys) {
+    if (inputMap.empty()) {
+      return;
+    }
+
+    auto oldKeysSize = oldKeys.size();
+    auto newKeysSize = newKeys.size();
+    auto minSize = std::min(oldKeysSize, newKeysSize);
+
+    // Iterate through input map and remap keys
+    for (const auto& entry : inputMap) {
+      std::optional<size_t> matchIndex;
+
+      // Search for matching old key
+      auto oldIt = oldKeys.begin();
+      for (size_t i = 0; i < minSize; ++i, ++oldIt) {
+        if (oldIt->has_value()) {
+          RemapKeysFunctionEqualComparator comparator;
+          if (comparator(entry.first, oldIt->value())) {
+            matchIndex = i;
+            break;
+          }
+        }
+      }
+
+      if (!entry.second.has_value()) {
+        auto& keyWriter = out.add_null();
+        if (matchIndex.has_value()) {
+          auto newIt = newKeys.begin();
+          std::advance(newIt, matchIndex.value());
+          if (newIt->has_value()) {
+            keyWriter.copy_from(newIt->value());
+          } else {
+            keyWriter.copy_from(entry.first);
+          }
+        } else {
+          keyWriter.copy_from(entry.first);
+        }
+      } else {
+        auto [keyWriter, valueWriter] = out.add_item();
+        if (matchIndex.has_value()) {
+          auto newIt = newKeys.begin();
+          std::advance(newIt, matchIndex.value());
+          if (newIt->has_value()) {
+            keyWriter.copy_from(newIt->value());
+          } else {
+            keyWriter.copy_from(entry.first);
+          }
+        } else {
+          keyWriter.copy_from(entry.first);
+        }
+        valueWriter.copy_from(entry.second.value());
+      }
+    }
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -26,6 +26,7 @@
 #include "velox/functions/prestosql/MapTopNKeys.h"
 #include "velox/functions/prestosql/MapTopNValues.h"
 #include "velox/functions/prestosql/MultimapFromEntries.h"
+#include "velox/functions/prestosql/RemapKeys.h"
 
 namespace facebook::velox::functions {
 
@@ -62,6 +63,42 @@ void registerMapSubset(const std::string& prefix) {
       Map<Generic<T1>, Generic<T2>>,
       Map<Generic<T1>, Generic<T2>>,
       Array<Generic<T1>>>({prefix + "map_subset"});
+}
+
+template <typename T>
+void registerRemapKeysPrimitive(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<RemapKeysPrimitiveFunction, T>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T1>>,
+      Array<T>,
+      Array<T>>({prefix + "remap_keys"});
+}
+
+void registerRemapKeys(const std::string& prefix) {
+  registerRemapKeysPrimitive<bool>(prefix);
+  registerRemapKeysPrimitive<int8_t>(prefix);
+  registerRemapKeysPrimitive<int16_t>(prefix);
+  registerRemapKeysPrimitive<int32_t>(prefix);
+  registerRemapKeysPrimitive<int64_t>(prefix);
+  registerRemapKeysPrimitive<float>(prefix);
+  registerRemapKeysPrimitive<double>(prefix);
+  registerRemapKeysPrimitive<Timestamp>(prefix);
+  registerRemapKeysPrimitive<Date>(prefix);
+
+  registerFunction<
+      RemapKeysVarcharFunction,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T1>>,
+      Array<Varchar>,
+      Array<Varchar>>({prefix + "remap_keys"});
+
+  registerFunction<
+      RemapKeysFunction,
+      Map<Generic<T1>, Generic<T2>>,
+      Map<Generic<T1>, Generic<T2>>,
+      Array<Generic<T1>>,
+      Array<Generic<T1>>>({prefix + "remap_keys"});
 }
 
 void registerMapRemoveNullValues(const std::string& prefix) {
@@ -135,6 +172,8 @@ void registerMapFunctions(const std::string& prefix) {
       int64_t>({prefix + "map_top_n_values"});
 
   registerMapSubset(prefix);
+
+  registerRemapKeys(prefix);
 
   registerMapRemoveNullValues(prefix);
 

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ add_executable(
   MapFilterTest.cpp
   MapFromEntriesTest.cpp
   MapNormalizeTest.cpp
+  RemapKeysTest.cpp
   MapTopNTest.cpp
   MapTopNKeysTest.cpp
   MapTopNValuesTest.cpp

--- a/velox/functions/prestosql/tests/RemapKeysTest.cpp
+++ b/velox/functions/prestosql/tests/RemapKeysTest.cpp
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions {
+namespace {
+
+class RemapKeysTest : public test::FunctionBaseTest {
+ protected:
+  void testRemapKeys(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(RemapKeysTest, basicIntegerKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+      {{4, 40}, {5, 50}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2},
+      {4},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 200},
+      {400},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {200, 20}, {3, 30}},
+      {{400, 40}, {5, 50}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, stringKeys) {
+  auto inputMap = makeMapVector<StringView, int32_t>({
+      {{"a", 1}, {"b", 2}, {"c", 3}},
+      {{"x", 10}, {"y", 20}},
+  });
+
+  auto oldKeys = makeArrayVector<StringView>({
+      {"a", "c"},
+      {"x"},
+  });
+
+  auto newKeys = makeArrayVector<StringView>({
+      {"alpha", "charlie"},
+      {"xray"},
+  });
+
+  auto expected = makeMapVector<StringView, int32_t>({
+      {{"alpha", 1}, {"b", 2}, {"charlie", 3}},
+      {{"xray", 10}, {"y", 20}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, emptyMap) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {10, 20},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, emptyOldKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, noMatchingKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {4, 5, 6},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {40, 50, 60},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, mismatchedArrayLengths) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+      {{4, 40}, {5, 50}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 200},
+      {400, 500, 600},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {200, 20}, {3, 30}},
+      {{400, 40}, {500, 50}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, nullValuesInMap) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, std::nullopt}, {3, 30}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 200},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {200, std::nullopt}, {3, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, nullKeysInArrays) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto oldKeys = makeNullableArrayVector<int32_t>({
+      {1, std::nullopt, 3},
+  });
+
+  auto newKeys = makeNullableArrayVector<int32_t>({
+      {100, std::nullopt, 300},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {2, 20}, {300, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, duplicateOldKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 1, 2},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 101, 200},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{101, 10}, {200, 20}, {3, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, floatKeys) {
+  auto inputMap = makeMapVector<float, int32_t>({
+      {{1.5f, 10}, {2.5f, 20}, {3.5f, 30}},
+  });
+
+  auto oldKeys = makeArrayVector<float>({
+      {1.5f, 3.5f},
+  });
+
+  auto newKeys = makeArrayVector<float>({
+      {10.5f, 30.5f},
+  });
+
+  auto expected = makeMapVector<float, int32_t>({
+      {{10.5f, 10}, {2.5f, 20}, {30.5f, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, booleanKeys) {
+  auto inputMap = makeMapVector<bool, int32_t>({
+      {{true, 10}, {false, 20}},
+  });
+
+  auto oldKeys = makeArrayVector<bool>({
+      {true},
+  });
+
+  auto newKeys = makeArrayVector<bool>({
+      {false},
+  });
+
+  auto expected = makeMapVector<bool, int32_t>({
+      {{false, 10}, {false, 20}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, complexValues) {
+  // Test with map of integer keys to array values
+  auto keys = makeFlatVector<int32_t>({0, 1, 2});
+  auto innerArrays = makeArrayVector<int32_t>({
+      {1, 2},
+      {3, 4, 5},
+      {6},
+  });
+
+  auto inputMap = makeMapVector({0}, keys, innerArrays);
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {0, 1},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {10, 11},
+  });
+
+  auto expectedKeys = makeFlatVector<int32_t>({10, 11, 2});
+  auto expectedInnerArrays = makeArrayVector<int32_t>({
+      {1, 2},
+      {3, 4, 5},
+      {6},
+  });
+
+  auto expected = makeMapVector({0}, expectedKeys, expectedInnerArrays);
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, allKeysRemapped) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2, 3},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 200, 300},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {200, 20}, {300, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, partialRemapping) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {2, 4},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {200, 400},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {200, 20}, {3, 30}, {400, 40}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, largeMap) {
+  // Create a map with 10 entries for testing
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{0, 0},
+       {1, 10},
+       {2, 20},
+       {3, 30},
+       {4, 40},
+       {5, 50},
+       {6, 60},
+       {7, 70},
+       {8, 80},
+       {9, 90}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {0, 5, 9},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {1000, 5000, 9000},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{1000, 0},
+       {1, 10},
+       {2, 20},
+       {3, 30},
+       {4, 40},
+       {5000, 50},
+       {6, 60},
+       {7, 70},
+       {8, 80},
+       {9000, 90}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, timestampKeys) {
+  auto inputMap = makeMapVector<Timestamp, int32_t>({
+      {{Timestamp(1, 0), 10}, {Timestamp(2, 0), 20}},
+  });
+
+  auto oldKeys = makeArrayVector<Timestamp>({
+      {Timestamp(1, 0)},
+  });
+
+  auto newKeys = makeArrayVector<Timestamp>({
+      {Timestamp(100, 0)},
+  });
+
+  auto expected = makeMapVector<Timestamp, int32_t>({
+      {{Timestamp(100, 0), 10}, {Timestamp(2, 0), 20}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, oldKeysLongerThanNewKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2, 3, 4, 5},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 200},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {200, 20}, {3, 30}, {4, 40}, {5, 50}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, newKeysLongerThanOldKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100, 200, 300, 400, 500},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {200, 20}, {3, 30}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, significantSizeDifference) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}, {6, 60}, {7, 70}},
+  });
+
+  auto oldKeys = makeArrayVector<int32_t>({
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+  });
+
+  auto newKeys = makeArrayVector<int32_t>({
+      {100},
+  });
+
+  auto expected = makeMapVector<int32_t, int32_t>({
+      {{100, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}, {6, 60}, {7, 70}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+TEST_F(RemapKeysTest, stringKeysWithDifferentSizes) {
+  auto inputMap = makeMapVector<StringView, int32_t>({
+      {{"apple", 1}, {"banana", 2}, {"cherry", 3}, {"date", 4}},
+  });
+
+  auto oldKeys = makeArrayVector<StringView>({
+      {"apple", "banana", "cherry", "date", "elderberry", "fig"},
+  });
+
+  auto newKeys = makeArrayVector<StringView>({
+      {"APPLE", "BANANA"},
+  });
+
+  auto expected = makeMapVector<StringView, int32_t>({
+      {{"APPLE", 1}, {"BANANA", 2}, {"cherry", 3}, {"date", 4}},
+  });
+
+  testRemapKeys(
+      "remap_keys(c0, c1, c2)", {inputMap, oldKeys, newKeys}, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
## Summary

Implemented REMAP_KEYS UDF for Velox following the task requirements in T240490714.

## Function Signature
```
REMAP_KEYS(MAP(K,V), ARRAY[K], ARRAY[K]) -> MAP(K, V)
```

## Key Features

- **Key remapping**: Changes map keys based on old-to-new key mapping arrays
- **Value preservation**: All values remain unchanged, only keys are remapped
- **Null handling**:
  - Null values in maps are preserved
  - Null keys in arrays are ignored
- **Mismatched array lengths**: Uses minimum of both array lengths for mapping
- **Unmapped keys**: Keys not in oldKeys array remain unchanged
- **Optimized implementations**: Three specialized implementations for different types

## Implementation Details

### Core Files Added/Modified:
- `fbcode/velox/functions/prestosql/RemapKeys.h` - Main implementation with 3 optimized variants
- `fbcode/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp` - Function registration
- `fbcode/velox/functions/prestosql/BUCK` - Build configuration
- `fbcode/velox/functions/prestosql/tests/RemapKeysTest.cpp` - Comprehensive test suite
- `fbcode/velox/functions/prestosql/tests/CMakeLists.txt` - Test build configuration
- `fbcode/velox/expression/fuzzer/ExpressionFuzzerTest.cpp` - Fuzzer exclusion

### Implementation Variants:
1. **RemapKeysPrimitiveFunction**: Optimized for primitive types with hash map lookup
2. **RemapKeysVarcharFunction**: String-optimized with zero-copy semantics
3. **RemapKeysFunction**: Generic implementation for complex types

### Behavior Examples:
```sql
SELECT remap_keys(MAP(ARRAY[1, 2, 3], ARRAY[10, 20, 30]), ARRAY[1, 3], ARRAY[100, 300]);
-- MAP(ARRAY[100, 2, 300], ARRAY[10, 20, 30])

SELECT remap_keys(MAP(ARRAY['a', 'b'], ARRAY[1, 2]), ARRAY['a'], ARRAY['alpha']);
-- MAP(ARRAY['alpha', 'b'], ARRAY[1, 2])

SELECT remap_keys(MAP(ARRAY[1, 2], ARRAY[10, null]), ARRAY[1], ARRAY[100]);
-- MAP(ARRAY[100, 2], ARRAY[10, null])
```

## Testing

Comprehensive test coverage including:
- Basic functionality with various data types (int, float, bool, string, timestamp, complex)
- Edge cases (empty maps, empty arrays, no matching keys)
- Null handling (nulls in values, nulls in key arrays)
- Mismatched array lengths
- Duplicate old keys (last occurrence wins)
- Partial and complete key remapping

## Compatibility

- Follows existing Velox UDF patterns (similar to MAP_SUBSET and ARRAY_SUBSET)
- Maintains backward compatibility with existing map functions
- Velox-only function (excluded from Presto fuzzer tests)

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=T240490714-e771fd55-1a8a-411e-acab-2cd2313a8296)

Differential Revision: D83999440


