### PR TITLE
feat: Add TIME support to date_diff function

### DIFF
--- a/velox/functions/lib/DateTimeUtil.h
+++ b/velox/functions/lib/DateTimeUtil.h
@@ -379,8 +379,10 @@ FOLLY_ALWAYS_INLINE Timestamp addToTimestamp(
 /// For units < DAY, the time of day changes.
 /// For units >= DAY, the time of day doesn't change.
 FOLLY_ALWAYS_INLINE int64_t addToTime(int64_t time, int64_t valueInMillis) {
-  VELOX_USER_CHECK_GE(time, 0, "TIME value must be positive");
-  VELOX_USER_CHECK_LT(time, kMillisInDay, "TIME value must be less than 24h");
+  VELOX_USER_CHECK(
+      time >= 0 && time < kMillisInDay,
+      "TIME value {} is out of range [0, 86400000)",
+      time);
 
   if (FOLLY_UNLIKELY(valueInMillis == 0)) {
     return time;

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -276,6 +276,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       Varchar,
       TimestampWithTimezone,
       TimestampWithTimezone>({prefix + "date_diff"});
+  registerFunction<DateDiffFunction, int64_t, Varchar, Time, Time>(
+      {prefix + "date_diff"});
   registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
       {prefix + "date_format"});
   registerFunction<DateFormatFunction, Varchar, TimestampWithTimezone, Varchar>(


### PR DESCRIPTION
Summary:
- added `diffTime()` function that calculates differences between TIME values
- simple millisecond arithmetic with unit conversion (TIME = ms since midnight)
- supports millisecond, second, minute, hour (rejects date-related units)
- `getTimeUnit()` for TIME-specific unit validation
- `initialize()` and `call()` method overloads for `<Time, Time>` parameters
- only allows time-related units, rejects day/month/year

Differential Revision: D84103016


