### PR TITLE
refactor: Remove usage of folly::StringPiece in RowType::findChild()

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -484,7 +484,7 @@ std::string makeFieldNotFoundErrorMessage(
 }
 } // namespace
 
-const TypePtr& RowType::findChild(folly::StringPiece name) const {
+const TypePtr& RowType::findChild(std::string_view name) const {
   if (auto i = getChildIdxIfExists(name)) {
     return children_[*i];
   }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1154,7 +1154,7 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   /// Returns type of the first child with matching name. Throws if child with
   /// this name doesn't exist.
-  const TypePtr& findChild(folly::StringPiece name) const;
+  const TypePtr& findChild(std::string_view name) const;
 
   /// Returns true if child with specified name exists.
   bool containsChild(std::string_view name) const;


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84200887


