### PR TITLE
refactor: Remove usage of folly::StringPiece in Variant

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -23,7 +23,6 @@
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox {
-
 namespace {
 
 bool dispatchDynamicVariantEquality(
@@ -162,6 +161,7 @@ bool dispatchDynamicVariantEquality(
   return VELOX_DYNAMIC_TYPE_DISPATCH_METHOD(
       VariantEquality, equals<false>, a.kind(), a, b);
 }
+
 } // namespace
 
 std::string encloseWithQuote(std::string str) {

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -32,10 +32,8 @@ namespace facebook::velox {
 // Constant used in comparison of REAL and DOUBLE values.
 constexpr double kEpsilon{0.00001};
 
-// note: while this is not intended for use in real critical code paths,
-//       it's probably worthwhile to make it not completely suck
-// todo(youknowjack): make this class not completely suck
-
+/// NOTE: Variants are not intended to be used in real critical code paths. For
+/// these cases, use Vectors instead.
 class Variant;
 
 namespace detail {
@@ -78,7 +76,7 @@ struct VariantTypeTraits<
     std::enable_if_t<
         KIND == TypeKind::VARCHAR || KIND == TypeKind::VARBINARY,
         void>> {
-  using native_type = folly::StringPiece;
+  using native_type = std::string_view;
   using stored_type =
       TypeStorage<scalar_stored_type<KIND>, KIND, usesCustomComparison>;
   using value_type = scalar_stored_type<KIND>;
@@ -218,7 +216,7 @@ class Variant {
       typename detail::VariantTypeTraits<TypeKind::VARCHAR, false>::native_type
           v)
       : ptr_{new detail::VariantTypeTraits<TypeKind::VARCHAR, false>::
-                 stored_type{v.str()}},
+                 stored_type{std::string(v)}},
         kind_{TypeKind::VARCHAR},
         usesCustomComparison_{false} {}
 
@@ -336,10 +334,10 @@ class Variant {
     }
   }
 
-  // Support construction from StringView as well as StringPiece.
-  /* implicit */ Variant(StringView view) : Variant{folly::StringPiece{view}} {}
+  // Support construction from velox::StringView as well as std::string_view.
+  /* implicit */ Variant(StringView view) : Variant{std::string_view{view}} {}
 
-  // Break ties between implicit conversions to StringView/StringPiece.
+  // Break ties between implicit conversions to StringView/std::string_view.
   /* implicit */ Variant(std::string str)
       : ptr_{new std::string{std::move(str)}},
         kind_{TypeKind::VARCHAR},

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -477,16 +477,15 @@ class DecodedVectorTest : public testing::Test, public VectorTestBase {
 
 template <>
 void DecodedVectorTest::testConstant<StringView>(const StringView& value) {
-  auto val = value.getString();
-  auto constantVector = BaseVector::createConstant(
-      VARCHAR(), folly::StringPiece{val}, 100, pool_.get());
+  auto constantVector =
+      BaseVector::createConstant(VARCHAR(), value, 100, pool_.get());
 
   auto check = [&](auto& decoded) {
     EXPECT_TRUE(decoded.isConstantMapping());
     EXPECT_FALSE(decoded.isIdentityMapping());
     for (int32_t i = 0; i < 100; i++) {
       EXPECT_FALSE(decoded.isNullAt(i));
-      EXPECT_EQ(decoded.template valueAt<StringView>(i).getString(), val);
+      EXPECT_EQ(decoded.template valueAt<StringView>(i).getString(), value);
     }
   };
 


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84223237


