### PR TITLE
refactor: Remove usage of folly::StringPiece in HiveTypeParser

### DIFF
--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -23,10 +23,10 @@
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::type::fbhive {
-
 namespace {
+
 /// Returns true only if 'str' contains digits.
-bool isPositiveInteger(const std::string& str) {
+bool isPositiveInteger(std::string_view str) {
   return !str.empty() &&
       std::find_if(str.begin(), str.end(), [](unsigned char c) {
         return !std::isdigit(c);
@@ -37,6 +37,17 @@ bool isSupportedSpecialChar(char c) {
   static std::unordered_set<char> supported{'_', '$', '#'};
   return supported.count(c) == 1;
 }
+
+/// Returns whether `prefix` is non-empty case-insensitive prefix of `input`.
+bool isPrefix(std::string_view input, std::string_view prefix) {
+  return prefix.size() > 0 && input.size() >= prefix.size() &&
+      std::equal(
+             prefix.begin(),
+             prefix.end(),
+             input.begin(),
+             folly::AsciiCaseInsensitive{});
+}
+
 } // namespace
 
 HiveTypeParser::HiveTypeParser() {
@@ -69,15 +80,15 @@ HiveTypeParser::HiveTypeParser() {
   setupMetadata<TokenType::EndOfStream, TypeKind::INVALID>();
 }
 
-TypePtr HiveTypeParser::parse(const std::string& ser) {
-  remaining_ = folly::StringPiece(ser);
+TypePtr HiveTypeParser::parse(std::string_view input) {
+  remaining_ = input;
   Result result = parseType();
   VELOX_CHECK(
       remaining_.size() == 0 || TokenType::EndOfStream == lookAhead(),
       "Input remaining after parsing the Hive type \"{}\"\n"
       "Remaining: \"{}\"",
-      ser,
-      remaining_.toString());
+      input,
+      remaining_);
   return result.type;
 }
 
@@ -88,8 +99,8 @@ Result HiveTypeParser::parseType() {
   if (!nt.isValidType()) {
     VELOX_FAIL(
         "Unexpected token {} at {}. typeKind = {}",
-        nt.value.toString(),
-        remaining_.toString(),
+        nt.value,
+        remaining_,
         nt.typeKind());
   }
 
@@ -98,12 +109,12 @@ Result HiveTypeParser::parseType() {
       eatToken(TokenType::LeftRoundBracket);
       Token precision = nextToken();
       VELOX_CHECK(
-          isPositiveInteger(precision.value.toString()),
+          isPositiveInteger(precision.value),
           "Decimal precision must be a positive integer");
       eatToken(TokenType::Comma);
       Token scale = nextToken();
       VELOX_CHECK(
-          isPositiveInteger(scale.value.toString()),
+          isPositiveInteger(scale.value),
           "Decimal scale must be a positive integer");
       eatToken(TokenType::RightRoundBracket);
       return Result{DECIMAL(
@@ -119,18 +130,20 @@ Result HiveTypeParser::parseType() {
       eatToken(TokenType::LeftRoundBracket);
       Token length = nextToken();
       VELOX_CHECK(
-          isPositiveInteger(length.value.toString()),
+          isPositiveInteger(length.value),
           "Varchar length must be a positive integer");
       eatToken(TokenType::RightRoundBracket);
     }
     return Result{scalarType};
   } else if (nt.isOpaqueType()) {
     eatToken(TokenType::StartSubType);
-    folly::StringPiece innerTypeName =
+    std::string_view innerTypeName =
         eatToken(TokenType::Identifier, true).value;
     eatToken(TokenType::EndSubType);
 
-    auto typeIndex = getTypeIdForOpaqueTypeAlias(innerTypeName.str());
+    // TODO: `getTypeIdForOpaqueTypeAlias()` should take a std::string_view so
+    // we don't need to needlessly construct a std::string.
+    auto typeIndex = getTypeIdForOpaqueTypeAlias(std::string(innerTypeName));
     auto instance = std::make_shared<const OpaqueType>(typeIndex);
     return Result{instance};
   } else {
@@ -155,7 +168,7 @@ Result HiveTypeParser::parseType() {
         return Result{velox::ARRAY(resultList.typelist.at(0))};
       }
       default:
-        VELOX_FAIL("unsupported kind: " + mapTypeKindToName(nt.typeKind()));
+        VELOX_FAIL("Unsupported kind: '{}'", mapTypeKindToName(nt.typeKind()));
     }
   }
 }
@@ -163,6 +176,7 @@ Result HiveTypeParser::parseType() {
 ResultList HiveTypeParser::parseTypeList(bool hasFieldNames) {
   std::vector<TypePtr> subTypeList{};
   std::vector<std::string> names{};
+
   eatToken(TokenType::StartSubType);
   while (true) {
     if (TokenType::EndSubType == lookAhead()) {
@@ -170,11 +184,11 @@ ResultList HiveTypeParser::parseTypeList(bool hasFieldNames) {
       return ResultList{std::move(subTypeList), std::move(names)};
     }
 
-    folly::StringPiece fieldName;
+    std::string_view fieldName;
     if (hasFieldNames) {
       fieldName = eatToken(TokenType::Identifier, true).value;
       eatToken(TokenType::Colon);
-      names.push_back(fieldName.toString());
+      names.emplace_back(fieldName);
     }
 
     Result result = parseType();
@@ -196,7 +210,7 @@ Token HiveTypeParser::eatToken(TokenType tokenType, bool ignorePredefined) {
     return token;
   }
 
-  VELOX_FAIL("Unexpected token " + token.remaining.toString());
+  VELOX_FAIL("Unexpected token '{}'", token.remaining);
 }
 
 Token HiveTypeParser::nextToken(bool ignorePredefined) {
@@ -206,29 +220,28 @@ Token HiveTypeParser::nextToken(bool ignorePredefined) {
 }
 
 TokenAndRemaining HiveTypeParser::nextToken(
-    folly::StringPiece sp,
+    std::string_view sv,
     bool ignorePredefined) const {
-  while (!sp.empty() && isspace(sp.front())) {
-    sp.advance(1);
+  while (!sv.empty() && isspace(sv.front())) {
+    sv.remove_prefix(1);
   }
 
-  if (sp.empty()) {
-    return makeExtendedToken(getMetadata(TokenType::EndOfStream), sp, 0);
+  if (sv.empty()) {
+    return makeExtendedToken(getMetadata(TokenType::EndOfStream), sv, 0);
   }
 
   if (!ignorePredefined) {
     for (auto& metadata : metadata_) {
       for (auto& token : metadata->tokenString) {
-        folly::StringPiece match(token);
-        if (match.size() > 0 &&
-            sp.startsWith(match, folly::AsciiCaseInsensitive{})) {
-          return makeExtendedToken(metadata.get(), sp, match.size());
+        std::string_view match(token);
+        if (isPrefix(sv, match)) {
+          return makeExtendedToken(metadata.get(), sv, match.size());
         }
       }
     }
   }
 
-  auto iter = sp.cbegin();
+  auto iter = sv.cbegin();
   size_t len = 0;
   while (isalnum(*iter) || isSupportedSpecialChar(*iter)) {
     ++len;
@@ -236,10 +249,10 @@ TokenAndRemaining HiveTypeParser::nextToken(
   }
 
   if (len > 0) {
-    return makeExtendedToken(getMetadata(TokenType::Identifier), sp, len);
+    return makeExtendedToken(getMetadata(TokenType::Identifier), sv, len);
   }
 
-  VELOX_FAIL("Bad Token at " + sp.toString());
+  VELOX_FAIL("Bad Token at '{}'", sv);
 }
 
 TokenType Token::tokenType() const {
@@ -272,15 +285,15 @@ int8_t HiveTypeParser::makeTokenId(TokenType tokenType) const {
 
 TokenAndRemaining HiveTypeParser::makeExtendedToken(
     TokenMetadata* tokenMetadata,
-    folly::StringPiece sp,
+    std::string_view sv,
     size_t len) const {
-  folly::StringPiece spmatch(sp.cbegin(), sp.cbegin() + len);
-  sp.advance(len);
+  std::string_view spmatch{sv.data(), len};
+  sv.remove_prefix(len);
 
   TokenAndRemaining result;
   result.metadata = tokenMetadata;
   result.value = spmatch;
-  result.remaining = sp;
+  result.remaining = sv;
   return result;
 }
 

--- a/velox/type/fbhive/HiveTypeParser.h
+++ b/velox/type/fbhive/HiveTypeParser.h
@@ -22,7 +22,6 @@
 #include <string>
 #include <vector>
 
-#include <folly/Range.h>
 #include "velox/type/Type.h"
 
 namespace facebook::velox::type::fbhive {
@@ -77,7 +76,7 @@ struct TokenMetadata {
 
 struct Token {
   TokenMetadata* metadata;
-  folly::StringPiece value;
+  std::string_view value;
 
   TokenType tokenType() const;
 
@@ -93,7 +92,7 @@ struct Token {
 };
 
 struct TokenAndRemaining : public Token {
-  folly::StringPiece remaining;
+  std::string_view remaining;
 };
 
 struct Result {
@@ -109,7 +108,7 @@ class HiveTypeParser {
  public:
   HiveTypeParser();
 
-  TypePtr parse(const std::string& ser);
+  TypePtr parse(std::string_view input);
 
  private:
   int8_t makeTokenId(TokenType tokenType) const;
@@ -125,12 +124,12 @@ class HiveTypeParser {
   Token nextToken(bool ignorePredefined = false);
 
   TokenAndRemaining nextToken(
-      folly::StringPiece sp,
+      std::string_view sv,
       bool ignorePredefined = false) const;
 
   TokenAndRemaining makeExtendedToken(
       TokenMetadata* tokenMetadata,
-      folly::StringPiece sp,
+      std::string_view sv,
       size_t len) const;
 
   template <TokenType KIND, velox::TypeKind TYPEKIND>
@@ -149,7 +148,7 @@ class HiveTypeParser {
   TokenMetadata* getMetadata(TokenType type) const;
 
   std::vector<std::unique_ptr<TokenMetadata>> metadata_;
-  folly::StringPiece remaining_;
+  std::string_view remaining_;
 };
 
 } // namespace facebook::velox::type::fbhive

--- a/velox/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -128,7 +128,7 @@ TEST(FbHive, badParse) {
       "Unexpected token uniontype at < bigint , int, float");
   VELOX_ASSERT_THROW(parser.parse("badid"), "Unexpected token badid at ");
   VELOX_ASSERT_THROW(
-      parser.parse("struct<int, bigint>"), "Unexpected token  bigint>");
+      parser.parse("struct<int, bigint>"), "Unexpected token ' bigint>'");
   VELOX_ASSERT_THROW(parser.parse("list<>"), "Unexpected token list at <>");
   VELOX_ASSERT_THROW(
       parser.parse("map<>"), "wrong param count for map type def");
@@ -140,7 +140,7 @@ TEST(FbHive, badParse) {
   VELOX_ASSERT_THROW(
       parser.parse("map<int>"), "wrong param count for map type def");
   VELOX_ASSERT_THROW(
-      parser.parse("decimal<20, 10>"), "Unexpected token 20, 10>");
+      parser.parse("decimal<20, 10>"), "Unexpected token '20, 10>'");
   VELOX_ASSERT_THROW(parser.parse("decimal(20, 10>"), "Unexpected token ");
   VELOX_ASSERT_THROW(
       parser.parse("decimal(a, 10)"),


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84209938


