### PR TITLE
refactor: Add "Locked" suffix to thread-unsafe methods in AsyncDataCache

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -151,7 +151,7 @@ std::string AsyncDataCacheEntry::toString() const {
       numPins_);
 }
 
-std::unique_ptr<AsyncDataCacheEntry> CacheShard::getFreeEntry() {
+std::unique_ptr<AsyncDataCacheEntry> CacheShard::getFreeEntryLocked() {
   std::unique_ptr<AsyncDataCacheEntry> newEntry;
   if (freeEntries_.empty()) {
     newEntry = std::make_unique<AsyncDataCacheEntry>(this);
@@ -176,7 +176,7 @@ CachePin CacheShard::findOrCreate(
       if (foundEntry->isExclusive()) {
         ++numWaitExclusive_;
         if (wait != nullptr) {
-          *wait = foundEntry->getFuture();
+          *wait = foundEntry->getFutureLocked();
         }
         return CachePin();
       }
@@ -212,7 +212,7 @@ CachePin CacheShard::findOrCreate(
       entryMap_.erase(it);
     }
 
-    auto newEntry = getFreeEntry();
+    auto newEntry = getFreeEntryLocked();
     // Initialize the members that must be set inside 'mutex_'.
     newEntry->numPins_ = AsyncDataCacheEntry::kExclusive;
     newEntry->promise_ = nullptr;
@@ -336,7 +336,7 @@ std::unique_ptr<folly::SharedPromise<bool>> CacheShard::removeEntry(
   removeEntryLocked(entry);
   // After the entry is removed from the hash table, a promise can no longer
   // be made. It is safe to move the promise and realize it.
-  return entry->movePromise();
+  return entry->movePromiseLocked();
 }
 
 void CacheShard::removeEntryLocked(AsyncDataCacheEntry* entry) {
@@ -409,7 +409,7 @@ uint64_t CacheShard::evict(
           eventCounter_ > entries_.size() / 4 ||
           numChecked > entries_.size() / 8) {
         now = accessTime();
-        calibrateThreshold();
+        calibrateThresholdLocked();
         numChecked = 0;
         eventCounter_ = 0;
       }
@@ -490,7 +490,7 @@ void CacheShard::freeAllocations(std::vector<memory::Allocation>& allocations) {
   allocations.clear();
 }
 
-void CacheShard::calibrateThreshold() {
+void CacheShard::calibrateThresholdLocked() {
   auto numSamples = std::min<int32_t>(10, entries_.size());
   auto now = accessTime();
   auto entryIndex = (clockHand_ % entries_.size());

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -263,22 +263,21 @@ class AsyncDataCacheEntry {
   /// Sets access stats so that this is immediately evictable.
   void makeEvictable();
 
-  /// Moves the promise out of 'this'. Used in order to handle the
-  /// promise within the lock of the cache shard, so not within private
-  /// methods of 'this'.
-  std::unique_ptr<folly::SharedPromise<bool>> movePromise() {
-    return std::move(promise_);
-  }
-
   std::string toString() const;
 
  private:
   void release();
   void addReference();
 
+  // Moves the promise out of 'this'. Must be called inside the mutex of
+  // 'shard_'.
+  std::unique_ptr<folly::SharedPromise<bool>> movePromiseLocked() {
+    return std::move(promise_);
+  }
+
   // Returns a future that will be realized when a caller can retry getting
   // 'this'. Must be called inside the mutex of 'shard_'.
-  folly::SemiFuture<bool> getFuture() {
+  folly::SemiFuture<bool> getFutureLocked() {
     if (promise_ == nullptr) {
       promise_ = std::make_unique<folly::SharedPromise<bool>>();
     }
@@ -634,7 +633,7 @@ class CacheShard {
   static constexpr uint32_t kMaxFreeEntries = 1 << 10;
   static constexpr int32_t kNoThreshold = std::numeric_limits<int32_t>::max();
 
-  void calibrateThreshold();
+  void calibrateThresholdLocked();
 
   void removeEntryLocked(AsyncDataCacheEntry* entry);
 
@@ -642,7 +641,7 @@ class CacheShard {
   //
   // TODO: consider to pass a size hint so as to select the a free entry which
   // already has the right amount of memory associated with it.
-  std::unique_ptr<AsyncDataCacheEntry> getFreeEntry();
+  std::unique_ptr<AsyncDataCacheEntry> getFreeEntryLocked();
 
   CachePin initEntry(RawFileCacheKey key, AsyncDataCacheEntry* entry);
 
@@ -880,8 +879,11 @@ class AsyncDataCache : public memory::Cache {
   void clear();
 
  private:
-  static constexpr int32_t kNumShards = 4; // Must be power of 2.
+  // Must be power of 2.
+  static constexpr int32_t kNumShards = 4;
   static constexpr int32_t kShardMask = kNumShards - 1;
+
+  static_assert((kNumShards & kShardMask) == 0);
 
   // True if 'acquired' has more pages than 'numPages' or allocator has space
   // for numPages - acquired pages of more allocation.


### PR DESCRIPTION
This aligns them with the project-wide convention for functions that 
must be called under a lock, improving code consistency and making 
locking requirements more explicit.

The `AsyncDataCacheEntry::movePromiseLocked()` method is only 
accessible to `CacheShard` from outside the class. However, since 
`CacheShard` is a friend of `AsyncDataCacheEntry`, it can be moved to 
the `private` area to prevent others from accidentally calling this 
thread-unsafe method.

No functional changes.