### PR TITLE
feat: Support row iterator to control memory usage for deserialization

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -68,11 +68,11 @@ class Exchange : public SourceOperator {
   virtual VectorSerde* getSerde();
 
  private:
-  // When 'estimatedCompactRowSize_' is unset, meaning we haven't materialized
+  // When 'estimatedRowSize_' is unset, meaning we haven't materialized
   // and returned any output from this exchange operator, we return this
   // conservative number of output rows, to make sure memory does not grow too
   // much.
-  static constexpr uint64_t kInitialOutputCompactRows = 64;
+  static constexpr uint64_t kInitialOutputRows = 64;
 
   // Invoked to create exchange client for remote tasks. The function shuffles
   // the source task ids first to randomize the source tasks we fetch data from.
@@ -94,9 +94,7 @@ class Exchange : public SourceOperator {
 
   void recordInputStats(uint64_t rawInputBytes);
 
-  RowVectorPtr getOutputFromCompactRows(VectorSerde* serde);
-
-  RowVectorPtr getOutputFromUnsafeRows(VectorSerde* serde);
+  RowVectorPtr getOutputFromRows(VectorSerde* serde);
 
   const uint64_t preferredOutputBatchBytes_;
 
@@ -125,15 +123,15 @@ class Exchange : public SourceOperator {
   bool atEnd_{false};
   std::default_random_engine rng_{std::random_device{}()};
 
-  // Memory holders needed by compact row serde to perform cursor like reads
-  // across 'getOutputFromCompactRows' calls.
-  std::unique_ptr<SerializedPage> compactRowPages_;
-  std::unique_ptr<ByteInputStream> compactRowInputStream_;
-  std::unique_ptr<RowIterator> compactRowIterator_;
+  // Memory holders needed by row serde to perform cursor like reads
+  // across 'getOutputFromRows' calls.
+  std::unique_ptr<SerializedPage> rowPages_;
+  std::unique_ptr<ByteInputStream> rowInputStream_;
+  std::unique_ptr<RowIterator> rowIterator_;
 
   // The estimated bytes per row of the output of this exchange operator
   // computed from the last processed output.
-  std::optional<uint64_t> estimatedCompactRowSize_;
+  std::optional<uint64_t> estimatedRowSize_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -2925,8 +2925,8 @@ TEST_P(MultiFragmentTest, mergeSmallBatchesInExchange) {
   } else {
     test(1, 1'000);
     test(1'000, 72);
-    test(10'000, 7);
-    test(100'000, 1);
+    test(10'000, 8);
+    test(100'000, 2);
   }
 }
 

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -44,6 +44,15 @@ class UnsafeRowVectorSerde : public VectorSerde {
       RowVectorPtr* result,
       const Options* options) override;
 
+  void deserialize(
+      ByteInputStream* source,
+      std::unique_ptr<RowIterator>& sourceRowIterator,
+      uint64_t maxRows,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      velox::memory::MemoryPool* pool,
+      const Options* options = nullptr) override;
+
   static void registerVectorSerde();
   static void registerNamedVectorSerde();
 };

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -325,6 +325,14 @@ TEST_P(CompactRowSerializerTest, fuzz) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     CompactRowSerializerTest,
     CompactRowSerializerTest,
-    testing::ValuesIn(CompactRowSerializerTest::getTestParams()));
+    testing::ValuesIn(CompactRowSerializerTest::getTestParams()),
+    [](const testing::TestParamInfo<TestParam>& info) {
+      return fmt::format(
+          "{}_{}_{}",
+          compressionKindToString(info.param.compressionKind),
+          info.param.appendRow ? "append" : "batch",
+          info.param.microBatchDeserialize ? "rowDeserialize"
+                                           : "batchDeserialize");
+    });
 } // namespace
 } // namespace facebook::velox::serializer


### PR DESCRIPTION
Summary: Add row-level deserialization support for unsafe row to consolidate the batch deserialization procedure in exchange for non-append mode. This also simplify non-oss serde cosco integration.

Differential Revision: D84236862


