### PR TITLE
refactor: Move ioStats and fileReadOps to FileStorageContext struct

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -48,6 +48,21 @@
 
 namespace facebook::velox {
 
+struct FileStorageContext {
+  /// Stats for IO operations
+  filesystems::File::IoStats* ioStats{nullptr};
+
+  /// Options for file read operations
+  folly::F14FastMap<std::string, std::string> fileReadOps;
+
+  FileStorageContext() = default;
+
+  FileStorageContext(
+      filesystems::File::IoStats* stats,
+      folly::F14FastMap<std::string, std::string> fileReadOps = {})
+      : ioStats(stats), fileReadOps(std::move(fileReadOps)) {}
+};
+
 // A read-only file.  All methods in this object should be thread safe.
 class ReadFile {
  public:
@@ -55,18 +70,12 @@ class ReadFile {
 
   // Reads the data at [offset, offset + length) into the provided pre-allocated
   // buffer 'buf'. The bytes are returned as a string_view pointing to 'buf'.
-  //
-  // 'stats' is an IoStatistics pointer passed in by the caller to collect stats
-  // for this read operation.
-  //
   // This method should be thread safe.
   virtual std::string_view pread(
       uint64_t offset,
       uint64_t length,
       void* buf,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const = 0;
+      const FileStorageContext& fileStorageContext = {}) const = 0;
 
   // Same as above, but returns owned data directly.
   //
@@ -74,24 +83,16 @@ class ReadFile {
   virtual std::string pread(
       uint64_t offset,
       uint64_t length,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const;
+      const FileStorageContext& fileStorageContext = {}) const;
 
   // Reads starting at 'offset' into the memory referenced by the
   // Ranges in 'buffers'. The buffers are filled left to right. A
   // buffer with nullptr data will cause its size worth of bytes to be skipped.
-  //
-  // 'stats' is an IoStatistics pointer passed in by the caller to collect stats
-  // for this read operation.
-  //
   // This method should be thread safe.
   virtual uint64_t preadv(
       uint64_t /*offset*/,
       const std::vector<folly::Range<char*>>& /*buffers*/,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const;
+      const FileStorageContext& fileStorageContext = {}) const;
 
   // Vectorized read API. Implementations can coalesce and parallelize.
   // The offsets don't need to be sorted.
@@ -102,35 +103,23 @@ class ReadFile {
   // by the preadv.
   // Returns the total number of bytes read, which might be different than the
   // sum of all buffer sizes (for example, if coalescing was used).
-  //
-  // 'stats' is an IoStatistics pointer passed in by the caller to collect stats
-  // for this read operation.
-  //
   // This method should be thread safe.
   virtual uint64_t preadv(
       folly::Range<const common::Region*> regions,
       folly::Range<folly::IOBuf*> iobufs,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const;
+      const FileStorageContext& fileStorageContext = {}) const;
 
   /// Like preadv but may execute asynchronously and returns the read size or
   /// exception via SemiFuture. Use hasPreadvAsync() to check if the
   /// implementation is in fact asynchronous.
-  ///
-  /// 'stats' is an IoStatistics pointer passed in by the caller to collect
-  /// stats for this read operation.
-  ///
   /// This method should be thread safe.
   virtual folly::SemiFuture<uint64_t> preadvAsync(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const {
+      const FileStorageContext& fileStorageContext = {}) const {
     try {
       return folly::SemiFuture<uint64_t>(
-          preadv(offset, buffers, stats, fileReadOps));
+          preadv(offset, buffers, fileStorageContext));
     } catch (const std::exception& e) {
       return folly::makeSemiFuture<uint64_t>(e);
     }
@@ -254,16 +243,12 @@ class InMemoryReadFile : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   uint64_t size() const final {
     return file_.size();
@@ -329,25 +314,19 @@ class LocalReadFile final : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t size() const final;
 
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   folly::SemiFuture<uint64_t> preadvAsync(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   bool hasPreadvAsync() const override {
     return executor_ != nullptr;

--- a/velox/common/file/tests/FaultyFile.cpp
+++ b/velox/common/file/tests/FaultyFile.cpp
@@ -34,8 +34,7 @@ std::string_view FaultyReadFile::pread(
     uint64_t offset,
     uint64_t length,
     void* buf,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+    const FileStorageContext& fileStorageContext) const {
   if (injectionHook_ != nullptr) {
     FaultFileReadOperation op(path_, offset, length, buf);
     injectionHook_(&op);
@@ -43,14 +42,13 @@ std::string_view FaultyReadFile::pread(
       return std::string_view(static_cast<char*>(op.buf), op.length);
     }
   }
-  return delegatedFile_->pread(offset, length, buf, stats, fileReadOps);
+  return delegatedFile_->pread(offset, length, buf, fileStorageContext);
 }
 
 uint64_t FaultyReadFile::preadv(
     uint64_t offset,
     const std::vector<folly::Range<char*>>& buffers,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+    const FileStorageContext& fileStorageContext) const {
   if (injectionHook_ != nullptr) {
     FaultFileReadvOperation op(path_, offset, buffers);
     injectionHook_(&op);
@@ -58,17 +56,16 @@ uint64_t FaultyReadFile::preadv(
       return op.readBytes;
     }
   }
-  return delegatedFile_->preadv(offset, buffers, stats, fileReadOps);
+  return delegatedFile_->preadv(offset, buffers, fileStorageContext);
 }
 
 folly::SemiFuture<uint64_t> FaultyReadFile::preadvAsync(
     uint64_t offset,
     const std::vector<folly::Range<char*>>& buffers,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+    const FileStorageContext& fileStorageContext) const {
   // TODO: add fault injection for async read later.
   if (delegatedFile_->hasPreadvAsync() || executor_ == nullptr) {
-    return delegatedFile_->preadvAsync(offset, buffers, stats, fileReadOps);
+    return delegatedFile_->preadvAsync(offset, buffers, fileStorageContext);
   }
   auto promise = std::make_unique<folly::Promise<uint64_t>>();
   folly::SemiFuture<uint64_t> future = promise->getSemiFuture();
@@ -76,10 +73,9 @@ folly::SemiFuture<uint64_t> FaultyReadFile::preadvAsync(
                   _promise = std::move(promise),
                   _offset = offset,
                   _buffers = buffers,
-                  _stats = stats,
-                  _fileReadOps = fileReadOps]() {
+                  _fileStorageContext = fileStorageContext]() {
     auto delegateFuture =
-        delegatedFile_->preadvAsync(_offset, _buffers, _stats, _fileReadOps);
+        delegatedFile_->preadvAsync(_offset, _buffers, _fileStorageContext);
     _promise->setValue(delegateFuture.wait().value());
   });
   return future;

--- a/velox/common/file/tests/FaultyFile.h
+++ b/velox/common/file/tests/FaultyFile.h
@@ -39,16 +39,12 @@ class FaultyReadFile : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   uint64_t memoryUsage() const override {
     return delegatedFile_->memoryUsage();
@@ -76,9 +72,7 @@ class FaultyReadFile : public ReadFile {
   folly::SemiFuture<uint64_t> preadvAsync(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
  private:
   const std::string path_;

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.cpp
@@ -57,8 +57,7 @@ class AbfsReadFile::Impl {
       uint64_t offset,
       uint64_t length,
       void* buffer,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     preadInternal(offset, length, static_cast<char*>(buffer));
     return {static_cast<char*>(buffer), length};
   }
@@ -66,8 +65,7 @@ class AbfsReadFile::Impl {
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     std::string result(length, 0);
     preadInternal(offset, length, result.data());
     return result;
@@ -76,8 +74,7 @@ class AbfsReadFile::Impl {
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     size_t length = 0;
     auto size = buffers.size();
     for (auto& range : buffers) {
@@ -99,8 +96,7 @@ class AbfsReadFile::Impl {
   uint64_t preadv(
       folly::Range<const common::Region*> regions,
       folly::Range<folly::IOBuf*> iobufs,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     size_t length = 0;
     VELOX_CHECK_EQ(regions.size(), iobufs.size());
     for (size_t i = 0; i < regions.size(); ++i) {
@@ -111,8 +107,7 @@ class AbfsReadFile::Impl {
           region.offset,
           region.length,
           output.writableData(),
-          stats,
-          fileReadOps);
+          fileStorageContext);
       output.append(region.length);
       length += region.length;
     }
@@ -173,33 +168,29 @@ std::string_view AbfsReadFile::pread(
     uint64_t offset,
     uint64_t length,
     void* buffer,
-    File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->pread(offset, length, buffer, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->pread(offset, length, buffer, fileStorageContext);
 }
 
 std::string AbfsReadFile::pread(
     uint64_t offset,
     uint64_t length,
-    File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->pread(offset, length, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->pread(offset, length, fileStorageContext);
 }
 
 uint64_t AbfsReadFile::preadv(
     uint64_t offset,
     const std::vector<folly::Range<char*>>& buffers,
-    File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->preadv(offset, buffers, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->preadv(offset, buffers, fileStorageContext);
 }
 
 uint64_t AbfsReadFile::preadv(
     folly::Range<const common::Region*> regions,
     folly::Range<folly::IOBuf*> iobufs,
-    File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->preadv(regions, iobufs, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->preadv(regions, iobufs, fileStorageContext);
 }
 
 uint64_t AbfsReadFile::size() const {

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsReadFile.h
@@ -35,30 +35,22 @@ class AbfsReadFile final : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t preadv(
       folly::Range<const common::Region*> regions,
       folly::Range<folly::IOBuf*> iobufs,
-      File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t size() const final;
 

--- a/velox/connectors/hive/storage_adapters/gcs/GcsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsReadFile.cpp
@@ -59,8 +59,7 @@ class GcsReadFile::Impl {
       uint64_t length,
       void* buffer,
       std::atomic<uint64_t>& bytesRead,
-      filesystems::File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     preadInternal(offset, length, static_cast<char*>(buffer), bytesRead);
     return {static_cast<char*>(buffer), length};
   }
@@ -69,8 +68,7 @@ class GcsReadFile::Impl {
       uint64_t offset,
       uint64_t length,
       std::atomic<uint64_t>& bytesRead,
-      filesystems::File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     std::string result(length, 0);
     char* position = result.data();
     preadInternal(offset, length, position, bytesRead);
@@ -81,8 +79,7 @@ class GcsReadFile::Impl {
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
       std::atomic<uint64_t>& bytesRead,
-      filesystems::File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     // 'buffers' contains Ranges(data, size)  with some gaps (data = nullptr) in
     // between. This call must populate the ranges (except gap ranges)
     // sequentially starting from 'offset'. If a range pointer is nullptr, the
@@ -161,24 +158,21 @@ std::string_view GcsReadFile::pread(
     uint64_t offset,
     uint64_t length,
     void* buffer,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->pread(offset, length, buffer, bytesRead_, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->pread(offset, length, buffer, bytesRead_, fileStorageContext);
 }
 
 std::string GcsReadFile::pread(
     uint64_t offset,
     uint64_t length,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->pread(offset, length, bytesRead_, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->pread(offset, length, bytesRead_, fileStorageContext);
 }
 uint64_t GcsReadFile::preadv(
     uint64_t offset,
     const std::vector<folly::Range<char*>>& buffers,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->preadv(offset, buffers, bytesRead_, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->preadv(offset, buffers, bytesRead_, fileStorageContext);
 }
 
 uint64_t GcsReadFile::size() const {

--- a/velox/connectors/hive/storage_adapters/gcs/GcsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GcsReadFile.h
@@ -38,23 +38,17 @@ class GcsReadFile : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buffer,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const override;
+      const FileStorageContext& fileStorageContext = {}) const override;
 
   uint64_t size() const override;
 

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.cpp
@@ -107,7 +107,7 @@ class HdfsReadFile::Impl {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     preadInternal(offset, length, static_cast<char*>(buf));
     return {static_cast<char*>(buf), length};
   }
@@ -115,7 +115,7 @@ class HdfsReadFile::Impl {
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     std::string result(length, 0);
     char* pos = result.data();
     preadInternal(offset, length, pos);
@@ -170,17 +170,15 @@ std::string_view HdfsReadFile::pread(
     uint64_t offset,
     uint64_t length,
     void* buf,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return pImpl->pread(offset, length, buf, fileReadOps);
+    const FileStorageContext& fileStorageContext) const {
+  return pImpl->pread(offset, length, buf, fileStorageContext);
 }
 
 std::string HdfsReadFile::pread(
     uint64_t offset,
     uint64_t length,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return pImpl->pread(offset, length, fileReadOps);
+    const FileStorageContext& fileStorageContext) const {
+  return pImpl->pread(offset, length, fileStorageContext);
 }
 
 uint64_t HdfsReadFile::size() const {

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h
@@ -38,16 +38,12 @@ class HdfsReadFile final : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t size() const final;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.cpp
@@ -79,8 +79,7 @@ class S3ReadFile ::Impl {
       uint64_t offset,
       uint64_t length,
       void* buffer,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     preadInternal(offset, length, static_cast<char*>(buffer));
     return {static_cast<char*>(buffer), length};
   }
@@ -88,8 +87,7 @@ class S3ReadFile ::Impl {
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     std::string result(length, 0);
     char* position = result.data();
     preadInternal(offset, length, position);
@@ -99,8 +97,7 @@ class S3ReadFile ::Impl {
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      File::IoStats* stats,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
+      const FileStorageContext& fileStorageContext) const {
     // 'buffers' contains Ranges(data, size)  with some gaps (data = nullptr) in
     // between. This call must populate the ranges (except gap ranges)
     // sequentially starting from 'offset'. AWS S3 GetObject does not support
@@ -188,25 +185,22 @@ std::string_view S3ReadFile::pread(
     uint64_t offset,
     uint64_t length,
     void* buf,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->pread(offset, length, buf, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->pread(offset, length, buf, fileStorageContext);
 }
 
 std::string S3ReadFile::pread(
     uint64_t offset,
     uint64_t length,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->pread(offset, length, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->pread(offset, length, fileStorageContext);
 }
 
 uint64_t S3ReadFile::preadv(
     uint64_t offset,
     const std::vector<folly::Range<char*>>& buffers,
-    filesystems::File::IoStats* stats,
-    const folly::F14FastMap<std::string, std::string>& fileReadOps) const {
-  return impl_->preadv(offset, buffers, stats, {});
+    const FileStorageContext& fileStorageContext) const {
+  return impl_->preadv(offset, buffers, fileStorageContext);
 }
 
 uint64_t S3ReadFile::size() const {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3ReadFile.h
@@ -35,23 +35,17 @@ class S3ReadFile : public ReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   std::string pread(
       uint64_t offset,
       uint64_t length,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t preadv(
       uint64_t offset,
       const std::vector<folly::Range<char*>>& buffers,
-      filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
-      const final;
+      const FileStorageContext& fileStorageContext = {}) const final;
 
   uint64_t size() const final;
 

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -181,7 +181,7 @@ class ReadFileInputStream final : public InputStream {
   }
 
  private:
-  const folly::F14FastMap<std::string, std::string> fileReadOps_;
+  FileStorageContext fileStorageContext_;
   std::shared_ptr<velox::ReadFile> readFile_;
 };
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -42,8 +42,7 @@ class RecordingInputStream : public facebook::velox::InMemoryReadFile {
       uint64_t offset,
       uint64_t length,
       void* buf,
-      facebook::velox::filesystems::File::IoStats* stats = nullptr,
-      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
+      const facebook::velox::FileStorageContext& fileStorageContext = {})
       const override {
     reads_.push_back({offset, length});
     return {static_cast<char*>(buf), length};


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/276

Refactored read operation parameters to use a `ReadOptions` struct instead of separate `ioStats` and `fileReadOps` parameters. This addresses the problem where adding new parameters to read functions requires updating all implementations across the codebase.

Differential Revision: D84112628


