### PR TITLE
feat: Add geometry and radius fields to SpatialJoinNode

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3968,6 +3968,12 @@ class SpatialJoinNode : public PlanNode {
           right_.has_value(), "SpatialJoinNode right source is not set");
       VELOX_USER_CHECK(
           outputType_.has_value(), "SpatialJoinNode outputType is not set");
+      VELOX_USER_CHECK(
+          probeGeometry_.has_value(),
+          "SpatialJoinNode probe geometry is not set");
+      VELOX_USER_CHECK(
+          buildGeometry_.has_value(),
+          "SpatialJoinNode build geometry is not set");
 
       VELOX_USER_CHECK(
           (probeGeometry_.has_value() && buildGeometry_.has_value()) ||
@@ -3991,6 +3997,9 @@ class SpatialJoinNode : public PlanNode {
           id_.value(),
           joinType_,
           joinCondition_,
+          probeGeometry_.value(),
+          buildGeometry_.value(),
+          radius_,
           left_.value(),
           right_.value(),
           outputType_.value());
@@ -4027,11 +4036,11 @@ class SpatialJoinNode : public PlanNode {
     return joinCondition_;
   }
 
-  const std::optional<FieldAccessTypedExprPtr>& probeGeometry() const {
+  const FieldAccessTypedExprPtr& probeGeometry() const {
     return probeGeometry_;
   }
 
-  const std::optional<FieldAccessTypedExprPtr>& buildGeometry() const {
+  const FieldAccessTypedExprPtr& buildGeometry() const {
     return buildGeometry_;
   }
 
@@ -4057,8 +4066,8 @@ class SpatialJoinNode : public PlanNode {
 
   const JoinType joinType_;
   const TypedExprPtr joinCondition_;
-  const std::optional<FieldAccessTypedExprPtr> probeGeometry_;
-  const std::optional<FieldAccessTypedExprPtr> buildGeometry_;
+  const FieldAccessTypedExprPtr probeGeometry_;
+  const FieldAccessTypedExprPtr buildGeometry_;
   const std::optional<FieldAccessTypedExprPtr> radius_;
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;

--- a/velox/exec/tests/SpatialJoinTest.cpp
+++ b/velox/exec/tests/SpatialJoinTest.cpp
@@ -144,6 +144,9 @@ class SpatialJoinTest : public OperatorTestBase {
                     .localPartition({})
                     .planNode(),
                 predicate,
+                "left_g",
+                "right_g",
+                std::nullopt,
                 {"left_g", "right_g"},
                 joinType)
             .project(
@@ -355,6 +358,9 @@ TEST_F(SpatialJoinTest, failOnGroupedExecution) {
                   .localPartition({})
                   .planNode(),
               "ST_Intersects(left_g, right_g)",
+              "left_g",
+              "right_g",
+              std::nullopt,
               {"left_g", "right_g"},
               core::JoinType::kInner)
           .project(

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1743,20 +1743,35 @@ PlanBuilder& PlanBuilder::nestedLoopJoin(
 PlanBuilder& PlanBuilder::spatialJoin(
     const core::PlanNodePtr& right,
     const std::string& joinCondition,
+    const std::string& probeGeometry,
+    const std::string& buildGeometry,
+    const std::optional<std::string>& radius,
     const std::vector<std::string>& outputLayout,
     core::JoinType joinType) {
   VELOX_CHECK_NOT_NULL(planNode_, "SpatialJoin cannot be the source node");
-  auto resultType = concat(planNode_->outputType(), right->outputType());
+  auto probeType = planNode_->outputType();
+  auto buildType = right->outputType();
+  auto resultType = concat(probeType, buildType);
   auto outputType = extract(resultType, outputLayout);
 
   VELOX_CHECK(!joinCondition.empty(), "SpatialJoin condition cannot be empty");
   core::TypedExprPtr joinConditionExpr =
       parseExpr(joinCondition, resultType, options_, pool_);
 
+  auto probeGeometryField = field(probeType, probeGeometry);
+  auto buildGeometryField = field(buildType, buildGeometry);
+  std::optional<core::FieldAccessTypedExprPtr> radiusField;
+  if (radius.has_value()) {
+    radiusField = field(buildType, radius.value());
+  }
+
   planNode_ = std::make_shared<core::SpatialJoinNode>(
       nextPlanNodeId(),
       joinType,
       std::move(joinConditionExpr),
+      std::move(probeGeometryField),
+      std::move(buildGeometryField),
+      std::move(radiusField),
       std::move(planNode_),
       right,
       outputType);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1317,6 +1317,9 @@ class PlanBuilder {
   PlanBuilder& spatialJoin(
       const core::PlanNodePtr& right,
       const std::string& joinCondition,
+      const std::string& probeGeometry,
+      const std::string& buildGeometry,
+      const std::optional<std::string>& radius,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 


### PR DESCRIPTION
Summary:
In preparation for spatial join using envelope intersection as the
indexing method, let's expose fields for probeGeometry, buildGeometry, and
radius to construct the envelopes.

Differential Revision: D83052835


