### PR TITLE
feat: Add support for intervalDayToSecondPlusTime and intervalMonthToYearPlusTime

### DIFF
--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -151,12 +151,15 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<TimePlusInterval, Time, Time, IntervalDayTime>(
       {prefix + "plus"});
 
+  registerFunction<IntervalPlusTime, Time, IntervalDayTime, Time>(
+      {prefix + "plus"});
+
   // Use optimized vector function for Time + IntervalYearMonth (identity
   // function)
   exec::registerVectorFunction(
       prefix + "plus",
-      TimePlusIntervalYearMonthVectorFunction::signatures(),
-      std::make_unique<TimePlusIntervalYearMonthVectorFunction>());
+      TimeIntervalYearMonthVectorFunction::signatures(),
+      std::make_unique<TimeIntervalYearMonthVectorFunction>());
 
   registerFunction<
       TimestampMinusFunction,


### PR DESCRIPTION
Summary:
This diff adds support for the intervalDayToSecondPlusTime and intervalMonthToYearPlusTime functions in Velox.

The code changes include modifying the TimePlusIntervalYearMonthVectorFunction class to support IntervalPlusTimeYearMonth. Also adds a separate function for IntervalDayToSecondPlusTime using the existing api

Differential Revision: D84292978


