### PR TITLE
misc(test/utils): Expose assertEqualResults for comparing two multisets.

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -312,6 +312,13 @@ bool assertEqualResults(
     const core::PlanNodePtr& plan1,
     const core::PlanNodePtr& plan2);
 
+bool assertEqualResults(
+    const MaterializedRowMultiset& expectedRows,
+    const TypePtr& expectedType,
+    const MaterializedRowMultiset& actualRows,
+    const TypePtr& actualType,
+    const std::string& message);
+
 /// Ensure both datasets have the same type and number of rows.
 void assertEqualTypeAndNumRows(
     const TypePtr& expectedType,


### PR DESCRIPTION
Summary: Expand header to include existing method that's used internally that I'd like to use from DPP.

Differential Revision: D83879150


