### PR TITLE
fix: Error propagation in element_at UDF

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -266,6 +266,7 @@ class EvalCtx {
 
   // @param status Must indicate an error. Cannot be "ok".
   void setStatus(vector_size_t index, const Status& status);
+  void setStatuses(const SelectivityVector& rows, const Status& status);
 
   // If exceptionPtr is known to be a VeloxException use setVeloxExceptionError
   // instead.

--- a/velox/functions/lib/SubscriptUtil.cpp
+++ b/velox/functions/lib/SubscriptUtil.cpp
@@ -352,47 +352,6 @@ VectorPtr MapSubscript::applyMap(
         rows, mapArg, indexArg, context, triggerCaching, lookupTable_);
   }
 }
-
-namespace {
-std::exception_ptr makeZeroSubscriptError() {
-  try {
-    VELOX_USER_FAIL("SQL array indices start at 1");
-  } catch (const std::exception&) {
-    return std::current_exception();
-  }
-}
-
-std::exception_ptr makeBadSubscriptError() {
-  try {
-    VELOX_USER_FAIL("Array subscript out of bounds.");
-  } catch (const std::exception&) {
-    return std::current_exception();
-  }
-}
-
-std::exception_ptr makeNegativeSubscriptError() {
-  try {
-    VELOX_USER_FAIL("Array subscript is negative.");
-  } catch (const std::exception&) {
-    return std::current_exception();
-  }
-}
-} // namespace
-
-const std::exception_ptr& zeroSubscriptError() {
-  static std::exception_ptr error = makeZeroSubscriptError();
-  return error;
-}
-
-const std::exception_ptr& badSubscriptError() {
-  static std::exception_ptr error = makeBadSubscriptError();
-  return error;
-}
-
-const std::exception_ptr& negativeSubscriptError() {
-  static std::exception_ptr error = makeNegativeSubscriptError();
-  return error;
-}
 } // namespace detail
 
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -31,10 +31,8 @@
 namespace facebook::velox::functions {
 
 namespace detail {
-// Below functions return a stock instance of each of the possible errors in
-// SubscriptImpl
-const std::exception_ptr& zeroSubscriptError();
-const std::exception_ptr& badSubscriptError();
+constexpr static inline std::string_view kZeroSubscriptErrorMsg =
+    "SQL array indices start at 1. Got 0.";
 const std::exception_ptr& negativeSubscriptError();
 
 // A flat vector of map keys, an index into that vector and an index into
@@ -336,17 +334,25 @@ class SubscriptImpl : public exec::Subscript {
       bool allFailed = false;
       // If index is invalid, capture the error and mark all rows as failed.
       bool isZeroSubscriptError = false;
+      const I originalIndex = decodedIndices->valueAt<I>(0);
       const auto adjustedIndex =
-          adjustIndex(decodedIndices->valueAt<I>(0), isZeroSubscriptError);
+          adjustIndex(originalIndex, isZeroSubscriptError);
       if (isZeroSubscriptError) {
-        context.setErrors(rows, detail::zeroSubscriptError());
+        context.setStatuses(
+            rows, Status::UserError(detail::kZeroSubscriptErrorMsg));
         allFailed = true;
       }
 
       if (!allFailed) {
         rows.applyToSelected([&](auto row) {
           const auto elementIndex = getIndex(
-              adjustedIndex, row, rawSizes, rawOffsets, arrayIndices, context);
+              originalIndex,
+              adjustedIndex,
+              row,
+              rawSizes,
+              rawOffsets,
+              arrayIndices,
+              context);
           rawIndices[row] = elementIndex;
           if (elementIndex == -1) {
             nullsBuilder.setNull(row);
@@ -355,16 +361,23 @@ class SubscriptImpl : public exec::Subscript {
       }
     } else {
       rows.applyToSelected([&](auto row) {
-        const auto originalIndex = decodedIndices->valueAt<I>(row);
+        const I originalIndex = decodedIndices->valueAt<I>(row);
         bool isZeroSubscriptError = false;
         const auto adjustedIndex =
             adjustIndex(originalIndex, isZeroSubscriptError);
         if (isZeroSubscriptError) {
-          context.setVeloxExceptionError(row, detail::zeroSubscriptError());
+          context.setStatus(
+              row, Status::UserError(detail::kZeroSubscriptErrorMsg));
           return;
         }
         const auto elementIndex = getIndex(
-            adjustedIndex, row, rawSizes, rawOffsets, arrayIndices, context);
+            originalIndex,
+            adjustedIndex,
+            row,
+            rawSizes,
+            rawOffsets,
+            arrayIndices,
+            context);
         rawIndices[row] = elementIndex;
         if (elementIndex == -1) {
           nullsBuilder.setNull(row);
@@ -416,7 +429,8 @@ class SubscriptImpl : public exec::Subscript {
   // above).
   template <typename I>
   vector_size_t getIndex(
-      I index,
+      I originalIndex,
+      vector_size_t index,
       vector_size_t row,
       const vector_size_t* rawSizes,
       const vector_size_t* rawOffsets,
@@ -433,7 +447,11 @@ class SubscriptImpl : public exec::Subscript {
           index += arraySize;
         }
       } else {
-        context.setVeloxExceptionError(row, detail::negativeSubscriptError());
+        context.setStatus(
+            row,
+            Status::UserError(
+                "Array subscript index cannot be negative, Index: {}",
+                originalIndex));
         return -1;
       }
     }
@@ -444,7 +462,12 @@ class SubscriptImpl : public exec::Subscript {
       if constexpr (allowOutOfBound) {
         return -1;
       } else {
-        context.setVeloxExceptionError(row, detail::badSubscriptError());
+        context.setStatus(
+            row,
+            Status::UserError(
+                "Array subscript index out of bounds, Index: {} Array size: {}",
+                originalIndex,
+                arraySize));
         return -1;
       }
     }

--- a/velox/functions/prestosql/tests/RegexpReplaceTest.cpp
+++ b/velox/functions/prestosql/tests/RegexpReplaceTest.cpp
@@ -157,7 +157,7 @@ TEST_F(RegexpReplaceTest, lambda) {
       (evaluate(
           "regexp_replace(c0, '\\w(\\w*)', x -> (concat(upper(x[1]), lower(x[2]))))",
           input)),
-      "Array subscript out of bounds");
+      "Array subscript index out of bounds, Index: 2 Array size: 1");
 
   result = evaluate(
       "regexp_replace(c0, '\\w(\\w*)', x -> try(concat(upper(x[1]), lower(x[2]))))",
@@ -211,7 +211,7 @@ TEST_F(RegexpReplaceTest, lambda) {
       (evaluate(
           "regexp_replace(c0, '(\\w)(\\w*)', x -> if (x[1] = 's', x[10], concat(upper(x[1]), lower(x[2]))))",
           input)),
-      "Array subscript out of bounds");
+      "Array subscript index out of bounds, Index: 10 Array size: 2");
 
   result = evaluate(
       "regexp_replace(c0, '(\\w)(\\w*)', x -> try(if (x[1] = 's', x[10], concat(upper(x[1]), lower(x[2])))))",


### PR DESCRIPTION
Summary:
Currently the UDF statically caches error messages to be re-used
whenever it needs to throw. However, since Velox error messages
add additional context when generated, the cached exception also
ends up re-using the message which contains the expression and
the top level expression details of the very first error produced
since process start. The original intention of that caching was
to mitigate perf impact when running under try where exceptions
are regularly expected. However, since we now have a mechanism
to handle that using Status objects, we employ that mechanism
to the UDF to fix the aforementioned issue.

Also updated the error messages to provide more details.
Updated unit tests and fixed a copy-paste error in one of the unit
tests which was testing the wrong input.

Differential Revision: D84308956


