### PR TITLE
feat(dwio): Enable row size tracking for metalake separately

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -27,6 +27,7 @@
 #include "velox/common/file/TokenProvider.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/core/ExpressionEvaluator.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/type/Filter.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -517,11 +518,11 @@ class ConnectorQueryCtx {
     selectiveNimbleReaderEnabled_ = value;
   }
 
-  bool rowSizeTrackingEnabled() const {
+  core::QueryConfig::RowSizeTrackingMode rowSizeTrackingMode() const {
     return rowSizeTrackingEnabled_;
   }
 
-  void setRowSizeTrackingEnabled(bool value) {
+  void setRowSizeTrackingMode(core::QueryConfig::RowSizeTrackingMode value) {
     rowSizeTrackingEnabled_ = value;
   }
 
@@ -547,7 +548,8 @@ class ConnectorQueryCtx {
   const folly::CancellationToken cancellationToken_;
   const std::shared_ptr<filesystems::TokenProvider> fsTokenProvider_;
   bool selectiveNimbleReaderEnabled_{false};
-  bool rowSizeTrackingEnabled_{true};
+  core::QueryConfig::RowSizeTrackingMode rowSizeTrackingEnabled_{
+      core::QueryConfig::RowSizeTrackingMode::ENABLED_FOR_ALL};
 };
 
 class Connector;

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -399,7 +399,8 @@ void SplitReader::createRowReader(
   baseRowReaderOpts_.setTrackRowSize(
       rowSizeTrackingEnabled.has_value()
           ? *rowSizeTrackingEnabled
-          : connectorQueryCtx_->rowSizeTrackingEnabled());
+          : connectorQueryCtx_->rowSizeTrackingMode() !=
+              core::QueryConfig::RowSizeTrackingMode::DISABLED);
   baseRowReader_ = baseReader_->createRowReader(baseRowReaderOpts_);
 }
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -716,17 +716,36 @@ class QueryConfig {
   /// username.
   static constexpr const char* kClientTags = "client_tags";
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   /// Enable (reader) row size tracker as a fallback to file level row size
   /// estimates.
   static constexpr const char* kRowSizeTrackingEnabled =
       "row_size_tracking_enabled";
+#endif
+
+  /// Enable (reader) row size tracker as a fallback to file level row size
+  /// estimates.
+  static constexpr const char* kRowSizeTrackingMode = "row_size_tracking_mode";
+
+  enum class RowSizeTrackingMode {
+    DISABLED = 0,
+    EXCLUDE_DELTA_SPLITS = 1,
+    ENABLED_FOR_ALL = 2,
+  };
 
   bool selectiveNimbleReaderEnabled() const {
     return get<bool>(kSelectiveNimbleReaderEnabled, false);
   }
 
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   bool rowSizeTrackingEnabled() const {
     return get<bool>(kRowSizeTrackingEnabled, true);
+  }
+#endif
+
+  RowSizeTrackingMode rowSizeTrackingMode() const {
+    return get<RowSizeTrackingMode>(
+        kRowSizeTrackingMode, RowSizeTrackingMode::ENABLED_FOR_ALL);
   }
 
   bool debugDisableExpressionsWithPeeling() const {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -72,8 +72,8 @@ OperatorCtx::createConnectorQueryCtx(
       task->queryCtx()->fsTokenProvider());
   connectorQueryCtx->setSelectiveNimbleReaderEnabled(
       driverCtx_->queryConfig().selectiveNimbleReaderEnabled());
-  connectorQueryCtx->setRowSizeTrackingEnabled(
-      driverCtx_->queryConfig().rowSizeTrackingEnabled());
+  connectorQueryCtx->setRowSizeTrackingMode(
+      driverCtx_->queryConfig().rowSizeTrackingMode());
   return connectorQueryCtx;
 }
 


### PR DESCRIPTION
Summary:
Due to extra integration uncertainty in the metalake path and some previous QB signals, we decide to separately control row size tracking for metalake with the session property.

Instead of adding an additional session property, we decide to extend the current one. However, due to changing the session property type breaking backward compatibility, we still ended up introducing a new query config. We will delete the deprecated bool session property as the 3rd diff in the stack.

Differential Revision: D84228406


