### PR TITLE
fix: The processing logic of the testStringToMap method of StringToMapTest

### DIFF
--- a/velox/functions/sparksql/tests/StringToMapTest.cpp
+++ b/velox/functions/sparksql/tests/StringToMapTest.cpp
@@ -33,9 +33,9 @@ class StringToMapTest : public SparkFunctionBaseTest {
       const std::vector<StringView>& inputs,
       const std::vector<std::pair<StringView, std::optional<StringView>>>&
           expect) {
-    auto result = evaluateStringToMap(inputs);
+    auto actualVector = evaluateStringToMap(inputs);
     auto expectVector = makeMapVector<StringView, StringView>({expect});
-    assertEqualVectors(result, expectVector);
+    assertEqualVectors(expectVector, actualVector);
   }
 };
 


### PR DESCRIPTION
The assertEqualVectors function of StringToMapTest  is  used to  compare two vectors for equality.

 * This function checks if the size, type, and values of the `expected` and
 * `actual` vectors are identical. If any mismatch is found, an assertion
 * failure is triggered.
 *
 * @param expected the vector containing the expected values.
 * @param actual the vector to compare against the expected vector.
 
So we should match the expected and actual with the parameters of the function.