### PR TITLE
build: Avoid staying in subdir of dependency after it has been installed

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -299,7 +299,7 @@ function install_aws_deps {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
 
   github_checkout $AWS_REPO_NAME "$AWS_SDK_VERSION" --depth 1 --recurse-submodules
-  cmake_install -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management"
+  cmake_install_dir aws-sdk-cpp -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management"
 }
 
 function install_minio {
@@ -329,13 +329,13 @@ function install_gcs-sdk-cpp {
 
   # protobuf
   github_checkout protocolbuffers/protobuf v"${PROTOBUF_VERSION}" --depth 1
-  cmake_install \
+  cmake_install_dir protobuf \
     -Dprotobuf_BUILD_TESTS=OFF \
     -Dprotobuf_ABSL_PROVIDER=package
 
   # grpc
   github_checkout grpc/grpc "${GRPC_VERSION}" --depth 1
-  cmake_install \
+  cmake_install_dir grpc \
     -DgRPC_BUILD_TESTS=OFF \
     -DgRPC_ABSL_PROVIDER=package \
     -DgRPC_ZLIB_PROVIDER=package \
@@ -347,19 +347,19 @@ function install_gcs-sdk-cpp {
 
   # crc32
   github_checkout google/crc32c "${CRC32_VERSION}" --depth 1
-  cmake_install \
+  cmake_install_dir crc32c \
     -DCRC32C_BUILD_TESTS=OFF \
     -DCRC32C_BUILD_BENCHMARKS=OFF \
     -DCRC32C_USE_GLOG=OFF
 
   # nlohmann json
   github_checkout nlohmann/json "${NLOHMAN_JSON_VERSION}" --depth 1
-  cmake_install \
+  cmake_install_dir json \
     -DJSON_BuildTests=OFF
 
   # google-cloud-cpp
   github_checkout googleapis/google-cloud-cpp "${GOOGLE_CLOUD_CPP_VERSION}" --depth 1
-  cmake_install \
+  cmake_install_dir google-cloud-cpp \
     -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
     -DGOOGLE_CLOUD_CPP_ENABLE=storage
 }
@@ -370,6 +370,7 @@ function install_azure-storage-sdk-cpp {
   export AZURE_SDK_DISABLE_AUTO_VCPKG=ON
   vcpkg_commit_id=7a6f366cefd27210f6a8309aed10c31104436509
   github_checkout azure/azure-sdk-for-cpp azure-storage-files-datalake_"${AZURE_SDK_VERSION}"
+  pushd azure-sdk-for-cpp || exit
   sed -i='' "s/set(VCPKG_COMMIT_STRING .*)/set(VCPKG_COMMIT_STRING $vcpkg_commit_id)/" cmake-modules/AzureVcpkg.cmake
 
   azure_core_dir="sdk/core/azure-core"
@@ -406,6 +407,7 @@ function install_azure-storage-sdk-cpp {
     cd sdk/storage/azure-storage-files-datalake || exit
     cmake_install -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" -DBUILD_SHARED_LIBS=OFF
   )
+  popd || exit
 }
 
 function install_hdfs_deps {

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -49,6 +49,7 @@ function prompt {
     done
   ) 2>/dev/null
 }
+
 function github_checkout {
   local REPO=$1
   shift
@@ -69,7 +70,6 @@ function github_checkout {
   if [ ! -d "${DIRNAME}" ]; then
     git clone -q -b "$VERSION" "${GIT_CLONE_PARAMS[@]}" "https://github.com/${REPO}.git"
   fi
-  cd "${DIRNAME}" || exit
 }
 
 # get_cxx_flags [$CPU_ARCH]


### PR DESCRIPTION
In https://github.com/apache/incubator-gluten/pull/10836, we encountered a Velox compilation issue caused by the changes introduced in https://github.com/facebookincubator/velox/pull/14849. The error occurred because ABSOLUTE_SCRIPTDIR was modified.

```
2025-10-09T03:42:02.6189401Z ++ realpath scripts
2025-10-09T03:42:02.6207867Z + ABSOLUTE_SCRIPTDIR=/__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/deps-download/abseil-cpp/scripts
2025-10-09T03:42:02.6210432Z + VELOX_ARROW_CMAKE_PATCH=/__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/deps-download/abseil-cpp/scripts/../CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
2025-10-09T03:42:02.6212114Z + cd /__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/deps-download/arrow
2025-10-09T03:42:02.6213956Z + git apply /__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/deps-download/abseil-cpp/scripts/../CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch
2025-10-09T03:42:02.6230732Z error: can't open patch '/__w/incubator-gluten/incubator-gluten/ep/build-velox/build/velox_ep/deps-download/abseil-cpp/scripts/../CMake/resolve_dependency_modules/arrow/cmake-compatibility.patch': No such file or directory
2025-10-09T03:42:02.6235097Z + exit 1
```