### PR TITLE
refactor: Remove usage of folly::StringPiece in common/encode

### DIFF
--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -187,14 +187,13 @@ size_t Base64::calculateEncodedSize(size_t inputSize, bool withPadding) {
 
 // static
 void Base64::encode(const char* input, size_t inputSize, char* output) {
-  encodeImpl(
-      folly::StringPiece(input, inputSize), kBase64Charset, true, output);
+  encodeImpl(std::string_view(input, inputSize), kBase64Charset, true, output);
 }
 
 // static
 void Base64::encodeUrl(const char* input, size_t inputSize, char* output) {
   encodeImpl(
-      folly::StringPiece(input, inputSize), kBase64UrlCharset, true, output);
+      std::string_view(input, inputSize), kBase64UrlCharset, true, output);
 }
 
 // static
@@ -249,13 +248,13 @@ void Base64::encodeImpl(
 }
 
 // static
-std::string Base64::encode(folly::StringPiece text) {
+std::string Base64::encode(std::string_view text) {
   return encodeImpl(text, kBase64Charset, true);
 }
 
 // static
 std::string Base64::encode(const char* input, size_t inputSize) {
-  return encode(folly::StringPiece(input, inputSize));
+  return encode(std::string_view(input, inputSize));
 }
 
 namespace {
@@ -308,7 +307,7 @@ std::string Base64::encode(const folly::IOBuf* inputBuffer) {
 }
 
 // static
-std::string Base64::decode(folly::StringPiece encodedText) {
+std::string Base64::decode(std::string_view encodedText) {
   std::string decodedResult;
   decode(std::make_pair(encodedText.data(), encodedText.size()), decodedResult);
   return decodedResult;
@@ -492,13 +491,13 @@ Expected<size_t> Base64::decodeImpl(
 }
 
 // static
-std::string Base64::encodeUrl(folly::StringPiece text) {
+std::string Base64::encodeUrl(std::string_view text) {
   return encodeImpl(text, kBase64UrlCharset, false);
 }
 
 // static
 std::string Base64::encodeUrl(const char* input, size_t inputSize) {
-  return encodeUrl(folly::StringPiece(input, inputSize));
+  return encodeUrl(std::string_view(input, inputSize));
 }
 
 // static
@@ -521,7 +520,7 @@ Status Base64::decodeUrl(
 }
 
 // static
-std::string Base64::decodeUrl(folly::StringPiece encodedText) {
+std::string Base64::decodeUrl(std::string_view encodedText) {
   std::string decodedOutput;
   decodeUrl(
       std::make_pair(encodedText.data(), encodedText.size()), decodedOutput);

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <folly/Range.h>
 #include <folly/io/IOBuf.h>
 
 #include <array>
@@ -45,7 +44,7 @@ class Base64 {
   static std::string encode(const char* input, size_t inputSize);
 
   /// Encodes the specified text.
-  static std::string encode(folly::StringPiece text);
+  static std::string encode(std::string_view text);
 
   /// Encodes the specified IOBuf data.
   static std::string encode(const folly::IOBuf* inputBuffer);
@@ -60,7 +59,7 @@ class Base64 {
   static std::string encodeUrl(const char* input, size_t inputSize);
 
   /// Encodes the specified text using URL encoding.
-  static std::string encodeUrl(folly::StringPiece text);
+  static std::string encodeUrl(std::string_view text);
 
   /// Encodes the specified IOBuf data using URL encoding.
   static std::string encodeUrl(const folly::IOBuf* inputBuffer);
@@ -72,7 +71,7 @@ class Base64 {
   encodeUrl(const char* input, size_t inputSize, char* outputBuffer);
 
   /// Decodes the input Base64 encoded string.
-  static std::string decode(folly::StringPiece encodedText);
+  static std::string decode(std::string_view encodedText);
 
   /// Decodes the specified encoded payload and writes the result to the
   /// 'output'.
@@ -94,7 +93,7 @@ class Base64 {
       size_t outputSize);
 
   /// Decodes the input Base64 URL encoded string.
-  static std::string decodeUrl(folly::StringPiece encodedText);
+  static std::string decodeUrl(std::string_view encodedText);
 
   /// Decodes the specified URL encoded payload and writes the result to the
   /// 'output'.

--- a/velox/common/encode/ByteStream.h
+++ b/velox/common/encode/ByteStream.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 /**
@@ -26,7 +27,6 @@
 #include <glog/logging.h>
 
 #include <folly/FBString.h>
-#include <folly/Range.h>
 
 namespace facebook::velox::strings {
 
@@ -86,28 +86,28 @@ class ByteSink {
    * append() will return 0).  In particular, this may not be used for
    * non-blocking behavior.
    */
-  virtual size_t append(folly::StringPiece str) = 0;
+  virtual size_t append(std::string_view str) = 0;
   size_t append(const void* data, size_t size) {
-    return append(folly::StringPiece(static_cast<const char*>(data), size));
+    return append(std::string_view(static_cast<const char*>(data), size));
   }
 
   /**
-   * Append the given string to this ByteSink.  The string must remain
+   * Append the given string to this ByteSink. The string must remain
    * allocated (and unchanged) until the ByteSink is destroyed.
    */
-  virtual size_t appendAllocated(folly::StringPiece str) {
+  virtual size_t appendAllocated(std::string_view str) {
     return append(str);
   }
 
   /**
    * Convenience function that appends the bitwise representation of count
-   * objects starting at address obj.  The usual caveats about endianness,
+   * objects starting at address obj. The usual caveats about endianness,
    * padding apply.
    */
   template <class T>
   size_t appendBitwise(const T* obj, size_t count) {
     const size_t sz = count * sizeof(T);
-    return append(folly::StringPiece(reinterpret_cast<const char*>(obj), sz));
+    return append(std::string_view(reinterpret_cast<const char*>(obj), sz));
   }
 
   /**
@@ -185,8 +185,8 @@ class SByteSink : public ByteSink {
  public:
   explicit SByteSink(S* str) : str_(str) {}
 
-  size_t append(folly::StringPiece s) override {
-    str_->append(s.start(), s.size());
+  size_t append(std::string_view s) override {
+    str_->append(s.data(), s.size());
     return s.size();
   }
 
@@ -237,7 +237,7 @@ class ByteSource {
    * next() will return false, but bad() will also return false.  On error,
    * next() returns false, and bad() returns true.
    */
-  virtual bool next(folly::StringPiece* chunk) = 0;
+  virtual bool next(std::string_view* chunk) = 0;
 
   /**
    * Push back the last numBytes returned by the last next() call, so
@@ -316,7 +316,7 @@ class ByteSourceBuffer : public std::basic_streambuf<char> {
 class StringByteSource : public ByteSource {
  public:
   explicit StringByteSource(
-      const folly::StringPiece& str,
+      const std::string_view& str,
       size_t maxBytes = kSizeMax)
       : str_(str),
         offset_(0),
@@ -326,15 +326,17 @@ class StringByteSource : public ByteSource {
   bool bad() const override {
     return false;
   }
-  bool next(folly::StringPiece* chunk) override {
+
+  bool next(std::string_view* chunk) override {
     if (offset_ == str_.size()) {
       return false;
     }
     size_t len = std::min(str_.size() - offset_, maxBytes_);
-    chunk->reset(str_.start() + offset_, len);
+    *chunk = std::string_view(str_.data() + offset_, len);
     offset_ += len;
     return true;
   }
+
   void backUp(size_t numBytes) override {
     CHECK_LE(numBytes, maxBytes_);
     CHECK_GE(offset_, numBytes);
@@ -342,7 +344,7 @@ class StringByteSource : public ByteSource {
   }
 
  private:
-  folly::StringPiece str_;
+  std::string_view str_;
   size_t offset_;
   size_t maxBytes_;
 };

--- a/velox/common/encode/tests/Base64Test.cpp
+++ b/velox/common/encode/tests/Base64Test.cpp
@@ -25,27 +25,20 @@ namespace facebook::velox::encoding {
 class Base64Test : public ::testing::Test {};
 
 TEST_F(Base64Test, fromBase64) {
-  EXPECT_EQ(
-      "Hello, World!",
-      Base64::decode(folly::StringPiece("SGVsbG8sIFdvcmxkIQ==")));
+  EXPECT_EQ("Hello, World!", Base64::decode("SGVsbG8sIFdvcmxkIQ=="));
   EXPECT_EQ(
       "Base64 encoding is fun.",
-      Base64::decode(folly::StringPiece("QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4=")));
-  EXPECT_EQ(
-      "Simple text", Base64::decode(folly::StringPiece("U2ltcGxlIHRleHQ=")));
-  EXPECT_EQ(
-      "1234567890", Base64::decode(folly::StringPiece("MTIzNDU2Nzg5MA==")));
+      Base64::decode("QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4="));
+  EXPECT_EQ("Simple text", Base64::decode("U2ltcGxlIHRleHQ="));
+  EXPECT_EQ("1234567890", Base64::decode("MTIzNDU2Nzg5MA=="));
 
   // Check encoded strings without padding
-  EXPECT_EQ(
-      "Hello, World!",
-      Base64::decode(folly::StringPiece("SGVsbG8sIFdvcmxkIQ")));
+  EXPECT_EQ("Hello, World!", Base64::decode("SGVsbG8sIFdvcmxkIQ"));
   EXPECT_EQ(
       "Base64 encoding is fun.",
-      Base64::decode(folly::StringPiece("QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4")));
-  EXPECT_EQ(
-      "Simple text", Base64::decode(folly::StringPiece("U2ltcGxlIHRleHQ")));
-  EXPECT_EQ("1234567890", Base64::decode(folly::StringPiece("MTIzNDU2Nzg5MA")));
+      Base64::decode("QmFzZTY0IGVuY29kaW5nIGlzIGZ1bi4"));
+  EXPECT_EQ("Simple text", Base64::decode("U2ltcGxlIHRleHQ"));
+  EXPECT_EQ("1234567890", Base64::decode("MTIzNDU2Nzg5MA"));
 }
 
 TEST_F(Base64Test, calculateDecodedSizeProperSize) {


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84229840


