### PR TITLE
    feat: In the str_to_map Spark function, entryDelimiter and keyValueDelimiter are supported for more characters

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -399,12 +399,14 @@ String Functions
 
     Returns a map by splitting ``string`` into entries with ``entryDelimiter`` and splitting
     each entry into key/value with ``keyValueDelimiter``.
-    ``entryDelimiter`` and ``keyValueDelimiter`` must be constant strings with single ascii
-    character. Allows ``keyValueDelimiter`` not found when splitting an entry. Throws exception
+    ``entryDelimiter`` and ``keyValueDelimiter`` can be constant strings with some ascii
+    characters. Allows ``keyValueDelimiter`` not found when splitting an entry. Throws exception
     when duplicate map keys are found for single row's result, consistent with Spark's default
     behavior. ::
 
         SELECT str_to_map('a:1,b:2,c:3', ',', ':'); -- {"a":"1","b":"2","c":"3"}
+        SELECT str_to_map('a:1,,b:2,,c:3', ',,', ':'); -- {"a":"1","b":"2","c":"3"}
+        SELECT str_to_map('a::1,,b::2,,c::3', ',,', '::'); -- {"a":"1","b":"2","c":"3"}
         SELECT str_to_map('a', ',', ':'); -- {"a":NULL}
         SELECT str_to_map('', ',', ':'); -- {"":NULL}
         SELECT str_to_map('a:1,b:2,c:3', ',', ','); -- {"a:1":NULL,"b:2":NULL,"c:3":NULL}

--- a/velox/functions/sparksql/StringToMap.h
+++ b/velox/functions/sparksql/StringToMap.h
@@ -32,11 +32,15 @@ struct StringToMapFunction {
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& entryDelimiter,
       const arg_type<Varchar>& keyValueDelimiter) {
-    VELOX_USER_CHECK_EQ(
-        entryDelimiter.size(), 1, "entryDelimiter's size should be 1.");
-    VELOX_USER_CHECK_EQ(
-        keyValueDelimiter.size(), 1, "keyValueDelimiter's size should be 1.");
-
+    VELOX_USER_CHECK_GT(
+        entryDelimiter.size(),
+        0,
+        "entryDelimiter's size should be greater than 0.");
+    VELOX_USER_CHECK_GT(
+        keyValueDelimiter.size(),
+        0,
+        "keyValueDelimiter's size "
+        "should be greater than 0.");
     callImpl(
         out,
         toStringView(input),
@@ -65,7 +69,7 @@ struct StringToMapFunction {
           keyValueDelimiter,
           keys);
 
-      pos = nextEntryPos + 1;
+      pos = nextEntryPos + entryDelimiter.size();
       nextEntryPos = input.find(entryDelimiter, pos);
     }
 
@@ -91,7 +95,8 @@ struct StringToMapFunction {
     VELOX_USER_CHECK(
         keys.insert(key).second, "Duplicate keys are not allowed: '{}'.", key);
     const auto value = StringView(
-        entry.data() + delimiterPos + 1, entry.size() - delimiterPos - 1);
+        entry.data() + delimiterPos + keyValueDelimiter.size(),
+        entry.size() - delimiterPos - keyValueDelimiter.size());
 
     auto [keyWriter, valueWriter] = out.add_item();
     keyWriter.setNoCopy(StringView(key));

--- a/velox/functions/sparksql/tests/StringToMapTest.cpp
+++ b/velox/functions/sparksql/tests/StringToMapTest.cpp
@@ -63,29 +63,25 @@ TEST_F(StringToMapTest, basic) {
       {"a:1_b:2_c:3", "_", "_"},
       {{"a:1", std::nullopt}, {"b:2", std::nullopt}, {"c:3", std::nullopt}});
 
+  testStringToMap(
+      {"a:1,,b:2,,c:3", ",,", ":"}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
+  testStringToMap(
+      {"a::1,,b::2,,c::3", ",,", "::"}, {{"a", "1"}, {"b", "2"}, {"c", "3"}});
   // Exception for illegal delimiters.
   // Empty string is used.
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2", "", ":"}),
-      "entryDelimiter's size should be 1.");
+      "entryDelimiter's size should be greater than 0.");
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2", ",", ""}),
-      "keyValueDelimiter's size should be 1.");
+      "keyValueDelimiter's size should be greater than 0.");
   // Delimiter's length > 1.
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", ";;", ":"}),
-      "entryDelimiter's size should be 1.");
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", ",", "::"}),
-      "keyValueDelimiter's size should be 1.");
-  // Unicode character is used.
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", "å", ":"}),
-      "entryDelimiter's size should be 1.");
-  VELOX_ASSERT_THROW(
-      evaluateStringToMap({"a:1,b:2", ",", "æ"}),
-      "keyValueDelimiter's size should be 1.");
-
+  testStringToMap({"a:1,b:2", ";;", ":"}, {{"a", "1,b:2"}});
+  testStringToMap(
+      {"a:1,b:2", ",", "::"}, {{"a:1", std::nullopt}, {"b:2", std::nullopt}});
+  testStringToMap({"a:1,b:2", "å", ":"}, {{"a", "1,b:2"}});
+  testStringToMap(
+      {"a:1,b:2", ",", "æ"}, {{"a:1", std::nullopt}, {"b:2", std::nullopt}});
   // Exception for duplicated keys.
   VELOX_ASSERT_THROW(
       evaluateStringToMap({"a:1,b:2,a:3", ",", ":"}),


### PR DESCRIPTION
The str_to_map function in spark, the entryDelimiter and keyValueDelimiter are supported for more characters. https://spark.apache.org/docs/latest/api/sql/index.html#str_to_map

```sql
CREATE TABLE your_tab (
  str STRING
)
USING PARQUET;

INSERT INTO your_tab VALUES
  ('a::1,b::2,c::3'),
  ('x::9,y::8'),
  ('k::10');

SELECT
  str_to_map(str, ',', '::') AS map_col
FROM your_tab;
```
The spark output:

```sql
{"a":"1","b":"2","c":"3"}
{"x":"9","y":"8"}
{"k":"10"}
{"a":"1","b":"2","c":"3"}
{"x":"9","y":"8"}
{"k":"10"}
```
Fixes https://github.com/facebookincubator/velox/issues/15115
