### PR TITLE
opt: Optimize the sapphire cosco shuffle deserialization with batch processing with no data copy from cosco raw package

### DIFF
--- a/velox/serializers/RowSerializer.cpp
+++ b/velox/serializers/RowSerializer.cpp
@@ -85,7 +85,7 @@ bool RowIteratorImpl::hasNext() const {
   return source_->tellp() < endOffset_;
 }
 
-std::unique_ptr<std::string> RowIteratorImpl::next() {
+std::unique_ptr<std::string> RowIteratorImpl::nextRow() {
   const auto rowSize = readRowSize();
   auto serializedBuffer = std::make_unique<std::string>();
   serializedBuffer->reserve(rowSize);

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -190,7 +190,13 @@ class RowIterator {
 
   virtual bool hasNext() const = 0;
 
-  virtual std::unique_ptr<std::string> next() = 0;
+  virtual std::unique_ptr<std::string> nextRow() = 0;
+
+  /// Returns a batch of serialized rows as string views. Reads up to maxRows
+  /// from the source stream. The returned views are valid until the next call
+  /// to nextBatch or object destruction. This method provides better
+  /// performance for bulk operations compared to repeated nextRow() calls.
+  virtual std::vector<std::string_view> nextBatch(size_t maxRows) = 0;
 
  protected:
   ByteInputStream* const source_;


### PR DESCRIPTION
Summary: This diff optimize the sapphire shuffle deserialization from cosco raw package. Instead of one row at a time with copy, it fetch a group of rows without copy and see ~20% cpu time reduction

Reviewed By: shrinidhijoshi, tanjialiang

Differential Revision: D84266650


