### PR TITLE
feat: Optimize the buffer isView check

### DIFF
--- a/velox/buffer/Buffer.cpp
+++ b/velox/buffer/Buffer.cpp
@@ -18,6 +18,21 @@
 
 namespace facebook::velox {
 
+std::string Buffer::typeString(Type type) {
+  switch (type) {
+    case Type::kPOD:
+      return "kPOD";
+    case Type::kNonPOD:
+      return "kNonPOD";
+    case Type::kPODView:
+      return "kPODView";
+    case Type::kNonPODView:
+      return "kNonPODView";
+    default:
+      return fmt::format("Unknown({})", static_cast<int>(type));
+  }
+}
+
 namespace {
 struct BufferReleaser {
   explicit BufferReleaser(const BufferPtr& parent) : parent_(parent) {}

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -549,5 +549,34 @@ TEST_F(BufferTest, sliceBooleanBuffer) {
       Buffer::slice<bool>(bufferPtr, 5, 6, nullptr), "Pool must not be null.");
 }
 
+TEST_F(BufferTest, testType) {
+  // Test AlignedBuffer type
+  auto alignedBuffer = AlignedBuffer::allocate<char>(100, pool_.get());
+  EXPECT_EQ(alignedBuffer->type(), Buffer::Type::kPOD);
+  EXPECT_TRUE(alignedBuffer->isPOD());
+  EXPECT_FALSE(alignedBuffer->isView());
+
+  // Test NonPODAlignedBuffer type
+  auto nonPODBuffer = AlignedBuffer::allocate<NonPOD>(10, pool_.get());
+  EXPECT_EQ(nonPODBuffer->type(), Buffer::Type::kNonPOD);
+  EXPECT_FALSE(nonPODBuffer->isPOD());
+  EXPECT_FALSE(nonPODBuffer->isView());
+
+  // Test BufferView type
+  MockCachePin pin;
+  const char* data = "test data";
+  auto podBufferView = BufferView<MockCachePin&>::create(
+      reinterpret_cast<const uint8_t*>(data), 9, pin);
+  EXPECT_EQ(podBufferView->type(), Buffer::Type::kPODView);
+  EXPECT_TRUE(podBufferView->isPOD());
+  EXPECT_TRUE(podBufferView->isView());
+
+  auto nonPodBufferView = BufferView<MockCachePin&>::create(
+      reinterpret_cast<const uint8_t*>(data), 9, pin, false);
+  EXPECT_EQ(nonPodBufferView->type(), Buffer::Type::kNonPODView);
+  EXPECT_FALSE(nonPodBufferView->isPOD());
+  EXPECT_TRUE(nonPodBufferView->isView());
+}
+
 } // namespace velox
 } // namespace facebook


### PR DESCRIPTION
Summary: Buffer isView is virtual method which is expensive and show at least 10% of cosco shuffle read operator which mostly come from compact row deserializer. This diff makes this check using a buffer type

Differential Revision: D84329308


