### PR TITLE
fix: Relax type comparison requirement

### DIFF
--- a/velox/vector/EncodedVectorCopy.cpp
+++ b/velox/vector/EncodedVectorCopy.cpp
@@ -1067,7 +1067,7 @@ void encodedVectorCopy(
     VELOX_CHECK(source->pool() == options.pool);
   }
   if (target) {
-    VELOX_CHECK(*target->type() == *source->type());
+    VELOX_CHECK(target->type()->equivalent(*source->type()));
     VELOX_CHECK(target->pool() == options.pool);
   }
   VELOX_CHECK(


### PR DESCRIPTION
Summary: The previous check requires the two types to exactly match including the names. However, for this particular call site, we care about the shape, but not the names. So move the logic to the comparison that ignores the names.

Differential Revision: D84364201


