### PR TITLE
refactor: Move folly::StringPiece::endsWith() usage to C++20

### DIFF
--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -452,11 +452,11 @@ uint64_t HashJoinMemoryReclaimer::reclaim(
 }
 
 bool isHashBuildMemoryPool(const memory::MemoryPool& pool) {
-  return folly::StringPiece(pool.name()).endsWith("HashBuild");
+  return pool.name().ends_with("HashBuild");
 }
 
 bool isHashProbeMemoryPool(const memory::MemoryPool& pool) {
-  return folly::StringPiece(pool.name()).endsWith("HashProbe");
+  return pool.name().ends_with("HashProbe");
 }
 
 bool needRightSideJoin(core::JoinType joinType) {

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -1822,7 +1822,7 @@ TEST_P(AllTableWriterTest, tableWriteOutputCheck) {
         ASSERT_EQ(writeFileName, targetFileName);
       } else {
         const std::string kParquetSuffix = ".parquet";
-        if (folly::StringPiece(targetFileName).endsWith(kParquetSuffix)) {
+        if (targetFileName.ends_with(kParquetSuffix)) {
           // Remove the .parquet suffix.
           auto trimmedFilename = targetFileName.substr(
               0, targetFileName.size() - kParquetSuffix.size());

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -465,7 +465,7 @@ core::AggregationNode::Step getCompanionStep(
     std::string const& kind,
     core::AggregationNode::Step step) {
   for (const auto& [k, v] : companionStep) {
-    if (folly::StringPiece(kind).endsWith(k)) {
+    if (kind.ends_with(k)) {
       step = v;
       break;
     }
@@ -475,7 +475,7 @@ core::AggregationNode::Step getCompanionStep(
 
 std::string getOriginalName(std::string const& kind) {
   for (const auto& [k, v] : companionStep) {
-    if (folly::StringPiece(kind).endsWith(k)) {
+    if (kind.ends_with(k)) {
       return kind.substr(0, kind.length() - k.length());
     }
   }
@@ -485,7 +485,7 @@ std::string getOriginalName(std::string const& kind) {
 bool hasFinalAggs(
     std::vector<core::AggregationNode::Aggregate> const& aggregates) {
   return std::any_of(aggregates.begin(), aggregates.end(), [](auto const& agg) {
-    return folly::StringPiece(agg.call->name()).endsWith("_merge_extract");
+    return agg.call->name().ends_with("_merge_extract");
   });
 }
 


### PR DESCRIPTION
Summary:
String in C++20 support ends_with() method. Using that instead to
remove usages of folly::StringPiece.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84370184


