### PR TITLE
fix: TypeParser Enum type name to allow special characters

### DIFF
--- a/velox/functions/prestosql/types/parser/TypeParser.ll
+++ b/velox/functions/prestosql/types/parser/TypeParser.ll
@@ -39,7 +39,7 @@ QUOTED_ID         (['"']([^"\n]|"")*['"'])
 NUMBER            ([[:digit:]]+)
 SIGNED_INT        (-?[[:digit:]]+)
 VARIABLE          (VARCHAR|VARBINARY)
-WORD_WITH_PERIODS ([[:alpha:]_][[:alnum:]_]*)(\.([[:alpha:]_][[:alnum:]_]*))*
+WORD_WITH_SPECIAL_CHAR ([^:({ ,]+)(\.([^:({ ,]+))(\.([^:({ ,]+))
 
 %%
 
@@ -59,7 +59,7 @@ WORD_WITH_PERIODS ([[:alpha:]_][[:alnum:]_]*)(\.([[:alpha:]_][[:alnum:]_]*))*
 {NUMBER}           yylval->build<long long>(folly::to<long long>(YYText())); return Parser::token::NUMBER;
 {SIGNED_INT}       yylval->build<long long>(folly::to<long long>(YYText())); return Parser::token::SIGNED_INT;
 {WORD}             yylval->build<std::string>(YYText()); return Parser::token::WORD;
-{WORD_WITH_PERIODS}             yylval->build<std::string>(YYText()); return Parser::token::WORD_WITH_PERIODS;
+{WORD_WITH_SPECIAL_CHAR}             yylval->build<std::string>(YYText()); return Parser::token::WORD_WITH_SPECIAL_CHAR;
 {QUOTED_ID}        yylval->build<std::string>(YYText()); return Parser::token::QUOTED_ID;
 <<EOF>>            return Parser::token::YYEOF;
 .               /* no action on unmatched input */

--- a/velox/functions/prestosql/types/parser/TypeParser.yy
+++ b/velox/functions/prestosql/types/parser/TypeParser.yy
@@ -34,7 +34,7 @@
 }
 
 %token               LPAREN RPAREN COMMA PERIOD COLON ARRAY MAP ROW FUNCTION DECIMAL LBRACE RBRACE
-%token <std::string> WORD VARIABLE QUOTED_ID WORD_WITH_PERIODS
+%token <std::string> WORD VARIABLE QUOTED_ID WORD_WITH_SPECIAL_CHAR
 %token <long long>   NUMBER SIGNED_INT
 %token YYEOF         0
 
@@ -181,8 +181,7 @@ enum_kind : WORD { if ($1 != "BigintEnum" && $1 != "VarcharEnum" )
                 $$ = $1; }
                 ;
 
-enum_name : WORD_WITH_PERIODS { $$ = $1; }
-          | WORD { $$ = $1; }
+enum_name : WORD_WITH_SPECIAL_CHAR { $$ = $1; }
           ;
 
 enum_type : enum_name COLON enum_kind LPAREN enum_name enum_map_entries_json RPAREN


### PR DESCRIPTION
Summary:
Made some fixes in accordance to Presto Java's TypeSignature.parseTypeSignature for enum types:
- the name should be a 3 part name, which corresponds to a QualifiedObjectName.
- allow the enum name to contain any characters excluding colon, opening brackets, comma, or space - there is no limit on any special characters in the Java implementation, however it is also dependent on the fact that the enum name does not contain any of those few special characters because those are used as delimiters in the parsing logic
- no change for the enum keys as those need to always be wrapped in quotations, hence uses QUOTED_ID

Differential Revision: D84387908


