### PR TITLE
fix: HiveColumnHandle serde support for RowId special column

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -26,6 +26,7 @@ columnTypeNames() {
       {HiveColumnHandle::ColumnType::kRegular, "Regular"},
       {HiveColumnHandle::ColumnType::kSynthesized, "Synthesized"},
       {HiveColumnHandle::ColumnType::kRowIndex, "RowIndex"},
+      {HiveColumnHandle::ColumnType::kRowId, "RowId"},
   };
 }
 

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -25,6 +25,8 @@ namespace facebook::velox::connector::hive {
 
 class HiveColumnHandle : public ColumnHandle {
  public:
+  /// NOTE: Make sure to update the mapping in columnTypeNames() when modifying
+  /// this.
   enum class ColumnType {
     kPartitionKey,
     kRegular,

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -154,6 +154,7 @@ TEST_F(HiveConnectorSerDeTest, hiveColumnHandle) {
       HiveColumnHandle::ColumnType::kRegular,
       HiveColumnHandle::ColumnType::kSynthesized,
       HiveColumnHandle::ColumnType::kRowIndex,
+      HiveColumnHandle::ColumnType::kRowId,
   };
 
   for (auto columnHandleType : columnHandleTypes) {


### PR DESCRIPTION
Summary:
We are missing the columnTypeName entry for RowId special column which causes failure during plan serialization when it is present.

Added a note on the enum to make sure we don't miss again in the future.

Differential Revision: D84392666


