### PR TITLE
fix: ST_NumPoints failing with wrong return type

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -253,7 +253,7 @@ Accessors
    Returns an array of points in a geometry. Empty or null inputs
    return null.
 
-.. function:: ST_NumPoints(geometry: Geometry) -> points: integer
+.. function:: ST_NumPoints(geometry: Geometry) -> points: bigint
 
    Returns the number of points in a geometry. This is an extension
    to the SQL/MM ``ST_NumPoints`` function which only applies to

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -1375,7 +1375,7 @@ struct StNumPointsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(
-      out_type<int32_t>& result,
+      out_type<int64_t>& result,
       const arg_type<Geometry>& geometry) {
     auto geosGeometry = geospatial::GeometryDeserializer::deserialize(geometry);
 

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -149,7 +149,7 @@ void registerAccessors(const std::string& prefix) {
       std::make_unique<StCoordDimFunction>());
   registerFunction<StPointsFunction, Array<Geometry>, Geometry>(
       {{prefix + "ST_Points"}});
-  registerFunction<StNumPointsFunction, int32_t, Geometry>(
+  registerFunction<StNumPointsFunction, int64_t, Geometry>(
       {{prefix + "ST_NumPoints"}});
   registerFunction<StInteriorRingsFunction, Array<Geometry>, Geometry>(
       {{prefix + "ST_InteriorRings"}});

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -2485,9 +2485,9 @@ TEST_F(GeometryFunctionsTest, testStEnvelopeAsPts) {
 
 TEST_F(GeometryFunctionsTest, testStNumPoints) {
   const auto testStNumPointsFunc = [&](const std::optional<std::string>& wkt,
-                                       const std::optional<int32_t>& expected) {
-    std::optional<int32_t> result =
-        evaluateOnce<int32_t>("ST_NumPoints(ST_GeometryFromText(c0))", wkt);
+                                       const std::optional<int64_t>& expected) {
+    std::optional<int64_t> result =
+        evaluateOnce<int64_t>("ST_NumPoints(ST_GeometryFromText(c0))", wkt);
 
     if (expected.has_value()) {
       ASSERT_TRUE(result.has_value());


### PR DESCRIPTION
ST_NumPoints return type should be bigint based on : https://github.com/prestodb/presto/issues/26282