### PR TITLE
fix(CI): Add setup file changes trigger for macOS

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,6 +22,9 @@ on:
       - CMakeLists.txt
       - CMake/**
       - scripts/setup-macos.sh
+      - scripts/setup-common.sh
+      - scripts/setup-versions.sh
+      - scripts/setup-helper-functions.sh
       - .github/workflows/macos.yml
 
   pull_request:
@@ -31,6 +34,9 @@ on:
       - CMakeLists.txt
       - CMake/**
       - scripts/setup-macos.sh
+      - scripts/setup-common.sh
+      - scripts/setup-versions.sh
+      - scripts/setup-helper-functions.sh
       - .github/workflows/macos.yml
 
 permissions:


### PR DESCRIPTION
On the macOS CI changes to various files would not trigger a rebuild. Some dependencies used in the CI don’t come from the bundling and thus have missing coverage which is now closed.