### PR TITLE
refactor: Remove usage of folly::StringPiece in JsonExtractor

### DIFF
--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * This file tests the performance of each JsonXXXFunction.call() with
- * expression framework and Velox vectors.
- */
+
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 #include "velox/functions/Registerer.h"
@@ -26,10 +23,15 @@
 #include "velox/functions/prestosql/types/JsonRegistration.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 
+/// This file tests the performance of each JsonXXXFunction.call() with
+/// expression framework and Velox vectors.
+
 namespace facebook::velox::functions {
+
 void registerJsonVectorFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_extract, "json_extract");
 }
+
 } // namespace facebook::velox::functions
 
 namespace facebook::velox::functions::prestosql {
@@ -59,10 +61,9 @@ struct FollyJsonExtractScalarFunction {
       out_type<Varchar>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
-    const folly::StringPiece& jsonStringPiece = json;
-    const folly::StringPiece& jsonPathStringPiece = jsonPath;
+    // TODO: Remove explicit std::string_view cast.
     auto extractResult =
-        jsonExtractScalar(jsonStringPiece, jsonPathStringPiece);
+        jsonExtractScalar(std::string_view(json), std::string_view(jsonPath));
     if (extractResult.has_value()) {
       UDFOutputString::assign(result, *extractResult);
       return true;
@@ -80,8 +81,9 @@ struct FollyJsonExtractFunction {
       out_type<Json>& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
+    // TODO: Remove explicit std::string_view cast.
     auto extractResult =
-        jsonExtract(folly::StringPiece(json), folly::StringPiece(jsonPath));
+        jsonExtract(std::string_view(json), std::string_view(jsonPath));
     if (!extractResult.has_value() || extractResult.value().isNull()) {
       return false;
     }
@@ -159,9 +161,9 @@ struct FollyJsonSizeFunction {
       int64_t& result,
       const arg_type<Json>& json,
       const arg_type<Varchar>& jsonPath) {
-    const folly::StringPiece& jsonStringPiece = json;
-    const folly::StringPiece& jsonPathStringPiece = jsonPath;
-    auto extractResult = jsonExtract(jsonStringPiece, jsonPathStringPiece);
+    // TODO: Remove explicit std::string_view cast.
+    auto extractResult =
+        jsonExtract(std::string_view(json), std::string_view(jsonPath));
     if (!extractResult.has_value()) {
       return false;
     }

--- a/velox/functions/prestosql/json/JsonExtractor.cpp
+++ b/velox/functions/prestosql/json/JsonExtractor.cpp
@@ -27,7 +27,6 @@
 #include "velox/functions/prestosql/json/JsonPathTokenizer.h"
 
 namespace facebook::velox::functions {
-
 namespace {
 
 using JsonVector = std::vector<const folly::dynamic*>;
@@ -35,9 +34,9 @@ using JsonVector = std::vector<const folly::dynamic*>;
 class JsonExtractor {
  public:
   // Use this method to get an instance of JsonExtractor given a json path.
-  static JsonExtractor& getInstance(folly::StringPiece path) {
+  static JsonExtractor& getInstance(std::string_view path) {
     // Pre-process
-    auto trimedPath = folly::trimWhitespace(path).str();
+    std::string trimedPath = folly::trimWhitespace(path).str();
 
     std::shared_ptr<JsonExtractor> op;
     if (kExtractorCache.count(trimedPath)) {
@@ -184,8 +183,8 @@ bool isScalarType(const std::optional<folly::dynamic>& json) {
 } // namespace
 
 std::optional<folly::dynamic> jsonExtract(
-    folly::StringPiece json,
-    folly::StringPiece path) {
+    std::string_view json,
+    std::string_view path) {
   try {
     // If extractor fails to parse the path, this will throw a VeloxUserError,
     // and we want to let this exception bubble up to the client. We only catch
@@ -201,15 +200,9 @@ std::optional<folly::dynamic> jsonExtract(
   return std::nullopt;
 }
 
-std::optional<folly::dynamic> jsonExtract(
-    const std::string& json,
-    const std::string& path) {
-  return jsonExtract(folly::StringPiece(json), folly::StringPiece(path));
-}
-
-std::optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtractFromDynamic(
     const folly::dynamic& json,
-    folly::StringPiece path) {
+    std::string_view path) {
   try {
     return JsonExtractor::getInstance(path).extract(json);
   } catch (const folly::json::parse_error&) {
@@ -218,8 +211,8 @@ std::optional<folly::dynamic> jsonExtract(
 }
 
 std::optional<std::string> jsonExtractScalar(
-    folly::StringPiece json,
-    folly::StringPiece path) {
+    std::string_view json,
+    std::string_view path) {
   auto res = jsonExtract(json, path);
   // Not a scalar value
   if (isScalarType(res)) {
@@ -230,15 +223,6 @@ std::optional<std::string> jsonExtractScalar(
     }
   }
   return std::nullopt;
-}
-
-std::optional<std::string> jsonExtractScalar(
-    const std::string& json,
-    const std::string& path) {
-  folly::StringPiece jsonPiece{json};
-  folly::StringPiece pathPiece{path};
-
-  return jsonExtractScalar(jsonPiece, pathPiece);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/JsonExtractor.h
+++ b/velox/functions/prestosql/json/JsonExtractor.h
@@ -18,57 +18,46 @@
 
 #include <string>
 
-#include "folly/Range.h"
 #include "folly/dynamic.h"
 
 namespace facebook::velox::functions {
 
-/**
- * Extract a json object from path
- * @param json: A json object
- * @param path: Path to locate a json object. Following operators are supported
- *              "$"      Root member of a json structure no matter it's an
- *                       object or an array
- *              "./[]"   Child operator to get a children object
- *              "[]"     Subscript operator for array and map
- *              "*"      Wildcard for [], get all the elements of an array
- * @return Return json string object on success.
- *         On invalid json path, returns std::nullopt (not json null) value
- *         On non-json value, returns the original value.
- * Example:
- * For the following example: ,
- * "{\"store\":,
- *   {\"fruit\":\\[{\"weight\":8,\"type\":\"apple\"},
- *                 {\"weight\":9,\"type\":\"pear\"}],
- *    \"bicycle\":{\"price\":19.95,\"color\":\"red\"}
- *   },
- *  \"email\":\"amy@only_for_json_udf_test.net\",
- *  \"owner\":\"amy\",
- * }",
- * jsonExtract(json, "$.owner") = "amy",
- * jsonExtract(json, "$.store.fruit[0]") =
- *    "{\"weight\":8,\"type\":\"apple\"}",
- * jsonExtract(json, "$.non_exist_key") = NULL
- * jsonExtract(json, "$.store.fruit[*].type") = "[\"apple\", \"pear\"]"
- */
+/// Extract a json object from path
+/// @param json: A json object
+/// @param path: Path to locate a json object. Following operators are supported
+///              "$"      Root member of a json structure no matter it's an
+///                       object or an array
+///              "./[]"   Child operator to get a children object
+///              "[]"     Subscript operator for array and map
+///              "*"      Wildcard for [], get all the elements of an array
+/// @return Return json string object on success.
+///         On invalid json path, returns std::nullopt (not json null) value
+///         On non-json value, returns the original value.
+/// Example:
+/// For the following example: ,
+/// "{\"store\":,
+///   {\"fruit\":\\[{\"weight\":8,\"type\":\"apple\"},
+///                 {\"weight\":9,\"type\":\"pear\"}],
+///    \"bicycle\":{\"price\":19.95,\"color\":\"red\"}
+///   },
+///  \"email\":\"amy@only_for_json_udf_test.net\",
+///  \"owner\":\"amy\",
+/// }",
+/// jsonExtract(json, "$.owner") = "amy",
+/// jsonExtract(json, "$.store.fruit[0]") =
+///    "{\"weight\":8,\"type\":\"apple\"}",
+/// jsonExtract(json, "$.non_exist_key") = NULL
+/// jsonExtract(json, "$.store.fruit[*].type") = "[\"apple\", \"pear\"]"
 std::optional<folly::dynamic> jsonExtract(
-    folly::StringPiece json,
-    folly::StringPiece path);
+    std::string_view json,
+    std::string_view path);
 
-std::optional<folly::dynamic> jsonExtract(
+std::optional<folly::dynamic> jsonExtractFromDynamic(
     const folly::dynamic& json,
-    folly::StringPiece path);
+    std::string_view path);
 
 std::optional<std::string> jsonExtractScalar(
-    folly::StringPiece json,
-    folly::StringPiece path);
-
-std::optional<folly::dynamic> jsonExtract(
-    const std::string& json,
-    const std::string& path);
-
-std::optional<std::string> jsonExtractScalar(
-    const std::string& json,
-    const std::string& path);
+    std::string_view json,
+    std::string_view path);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/JsonExtractorTest.cpp
@@ -20,9 +20,6 @@
 #include "gtest/gtest.h"
 #include "velox/common/base/VeloxException.h"
 
-using facebook::velox::VeloxUserError;
-using facebook::velox::functions::jsonExtract;
-using facebook::velox::functions::jsonExtractScalar;
 using folly::json::parse_error;
 using namespace std::string_literals;
 
@@ -36,27 +33,30 @@ using namespace std::string_literals;
 #define EXPECT_SCALAR_VALUE_NULL(json, path) \
   EXPECT_FALSE(jsonExtractScalar(json, path).has_value())
 
-#define EXPECT_JSON_VALUE_EQ(json, path, ret)        \
-  {                                                  \
-    auto val = json_format(jsonExtract(json, path)); \
-    EXPECT_TRUE(val.has_value());                    \
-    EXPECT_EQ(val.value(), ret);                     \
+#define EXPECT_JSON_VALUE_EQ(json, path, ret)       \
+  {                                                 \
+    auto val = jsonFormat(jsonExtract(json, path)); \
+    EXPECT_TRUE(val.has_value());                   \
+    EXPECT_EQ(val.value(), ret);                    \
   }
 
 #define EXPECT_JSON_VALUE_NULL(json, path) \
-  EXPECT_FALSE(json_format(jsonExtract(json, path)).has_value())
+  EXPECT_FALSE(jsonFormat(jsonExtract(json, path)).has_value())
 
 #define EXPECT_THROW_INVALID_ARGUMENT(json, path) \
   EXPECT_THROW(jsonExtract(json, path), VeloxUserError)
 
+namespace facebook::velox::functions::test {
 namespace {
-std::optional<std::string> json_format(
+
+std::optional<std::string> jsonFormat(
     const std::optional<folly::dynamic>& json) {
   if (json.has_value()) {
     return folly::toJson(json.value());
   }
   return std::nullopt;
 }
+
 } // namespace
 
 TEST(JsonExtractorTest, generalJsonTest) {
@@ -92,60 +92,60 @@ TEST(JsonExtractorTest, generalJsonTest) {
         "owner":"amy"})DELIM";
   // clang-format on
   std::replace(json.begin(), json.end(), '\'', '\"');
-  auto res = json_format(jsonExtract(json, "$.store.fruit[0].weight"s));
+  auto res = jsonFormat(jsonExtract(json, "$.store.fruit[0].weight"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("8", res.value());
-  res = json_format(jsonExtract(json, "$.store.fruit[1].weight"s));
+  res = jsonFormat(jsonExtract(json, "$.store.fruit[1].weight"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("9", res.value());
   EXPECT_FALSE(
-      json_format(jsonExtract(json, "$.store.fruit[2].weight"s)).has_value());
-  res = json_format(jsonExtract(json, "$.store.fruit[*].weight"s));
+      jsonFormat(jsonExtract(json, "$.store.fruit[2].weight"s)).has_value());
+  res = jsonFormat(jsonExtract(json, "$.store.fruit[*].weight"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("[8,9]", res.value());
-  res = json_format(jsonExtract(json, "$.store.fruit[*].type"s));
+  res = jsonFormat(jsonExtract(json, "$.store.fruit[*].type"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("[\"apple\",\"pear\"]", res.value());
-  res = json_format(jsonExtract(json, "$.store.book[0].price"s));
+  res = jsonFormat(jsonExtract(json, "$.store.book[0].price"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("8.95", res.value());
-  res = json_format(jsonExtract(json, "$.store.book[2].category"s));
+  res = jsonFormat(jsonExtract(json, "$.store.book[2].category"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("\"fiction\"", res.value());
-  res = json_format(jsonExtract(json, "$.store.basket[1]"s));
+  res = jsonFormat(jsonExtract(json, "$.store.basket[1]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("[3,4]", res.value());
-  res = json_format(jsonExtract(json, "$.store.basket[0]"s));
+  res = jsonFormat(jsonExtract(json, "$.store.basket[0]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ(
       folly::parseJson("[1,2,{\"a\":\"x\",\"b\":\"y\"}]"),
       folly::parseJson(res.value()));
   EXPECT_FALSE(
-      json_format(jsonExtract(json, "$.store.baskets[1]"s)).has_value());
-  res = json_format(jsonExtract(json, "$[\"e mail\"]"s));
+      jsonFormat(jsonExtract(json, "$.store.baskets[1]"s)).has_value());
+  res = jsonFormat(jsonExtract(json, "$[\"e mail\"]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("\"amy@only_for_json_udf_test.net\"", res.value());
-  res = json_format(jsonExtract(json, "$.owner"s));
+  res = jsonFormat(jsonExtract(json, "$.owner"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("\"amy\"", res.value());
-  res = json_format(
+  res = jsonFormat(
       jsonExtract("[[1.1,[2.1,2.2]],2,{\"a\":\"b\"}]"s, "$[0][1][1]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("2.2", res.value());
-  res = json_format(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[1]"s));
+  res = jsonFormat(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[1]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("2", res.value());
-  res = json_format(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[2]"s));
+  res = jsonFormat(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[2]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("{\"a\":\"b\"}", res.value());
   EXPECT_FALSE(
-      json_format(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[3]"s)).has_value());
-  res = json_format(jsonExtract("[{\"a\":\"b\"}]"s, "$[0]"s));
+      jsonFormat(jsonExtract("[1,2,{\"a\":\"b\"}]"s, "$[3]"s)).has_value());
+  res = jsonFormat(jsonExtract("[{\"a\":\"b\"}]"s, "$[0]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("{\"a\":\"b\"}", res.value());
   EXPECT_FALSE(
-      json_format(jsonExtract("[{\"a\":\"b\"}]"s, "$[2]"s)).has_value());
-  res = json_format(jsonExtract("{\"a\":\"b\"}"s, " $ "s));
+      jsonFormat(jsonExtract("[{\"a\":\"b\"}]"s, "$[2]"s)).has_value());
+  res = jsonFormat(jsonExtract("{\"a\":\"b\"}"s, " $ "s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("{\"a\":\"b\"}", res.value());
 
@@ -161,7 +161,7 @@ TEST(JsonExtractorTest, generalJsonTest) {
   expected.append("[{\"key\":3,\"value\":6},{\"key\":4,\"value\":8},")
       .append("{\"key\":5,\"value\":10}]]");
   auto expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*]"s));
+  res = jsonFormat(jsonExtract(json2, "$[*]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
 
@@ -170,31 +170,31 @@ TEST(JsonExtractorTest, generalJsonTest) {
       .append("{\"key\":3,\"value\":6},")
       .append("{\"key\":4,\"value\":8},{\"value\":10,\"key\":5}]");
   expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*][*]"s));
+  res = jsonFormat(jsonExtract(json2, "$[*][*]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
 
-  res = json_format(jsonExtract(json2, "$[*][*].key"s));
+  res = jsonFormat(jsonExtract(json2, "$[*][*].key"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("[1,2,3,4,5]", res.value());
 
   expected = "[{\"key\":1,\"value\":2},{\"key\":3,\"value\":6}]";
   expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*][0]"s));
+  res = jsonFormat(jsonExtract(json2, "$[*][0]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
 
   expected = "{\"key\":5,\"value\":10}";
   expectedJson = folly::parseJson(expected);
-  res = json_format(jsonExtract(json2, "$[*][2]"s));
+  res = jsonFormat(jsonExtract(json2, "$[*][2]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ(expectedJson, folly::parseJson(res.value()));
 
   // TEST WiteSpaces in Path and Json
-  res = json_format(jsonExtract(json2, "$[*][*].key"s));
+  res = jsonFormat(jsonExtract(json2, "$[*][*].key"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("[1,2,3,4,5]", res.value());
-  res = json_format(
+  res = jsonFormat(
       jsonExtract(" [ [1.1,[2.1,2.2]],2, {\"a\": \"b\"}]"s, " $[0][1][1]"s));
   EXPECT_TRUE(res.has_value());
   EXPECT_EQ("2.2", res.value());
@@ -476,10 +476,13 @@ TEST(JsonExtractorTest, reextractJsonTest) {
         "e mail":"amy@only_for_json_udf_test.net",
         "owner":"amy"})DELIM";
   auto originalJsonObj = jsonExtract(json, "$");
-  // extract the same json json by giving the root path
-  auto reExtractedJsonObj = jsonExtract(originalJsonObj.value(), "$");
+
+  // Extract the same json json by giving the root path.
+  auto reExtractedJsonObj =
+      jsonExtractFromDynamic(originalJsonObj.value(), "$");
   ASSERT_TRUE(reExtractedJsonObj.has_value());
-  // expect the re-extracted json object to be the same as the original jsonObj
+
+  // Expect the re-extracted json object to be the same as the original jsonObj.
   EXPECT_EQ(originalJsonObj.value(), reExtractedJsonObj.value());
 }
 
@@ -515,7 +518,9 @@ TEST(JsonExtractorTest, jsonMultipleExtractsTest) {
         "owner":"amy"})DELIM";
   auto extract1 = jsonExtract(json, "$.store");
   ASSERT_TRUE(extract1.has_value());
-  auto extract2 = jsonExtract(extract1.value(), "$.fruit");
+  auto extract2 = jsonExtractFromDynamic(extract1.value(), "$.fruit");
   ASSERT_TRUE(extract2.has_value());
   EXPECT_EQ(jsonExtract(json, "$.store.fruit").value(), extract2.value());
 }
+
+} // namespace facebook::velox::functions::test


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84436547


