### PR TITLE
Fix unreachable-fallthrough issue in velox/functions/sparksql/aggregates/SumAggregate.cpp +1

### DIFF
--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -206,7 +206,6 @@ exec::AggregateRegistrationResult registerSum(
                 inputType->childAt(0),
                 inputType->childAt(0));
           }
-            [[fallthrough]];
           default:
             VELOX_UNREACHABLE(
                 "Unknown input type for {} aggregation {}",


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-fallthrough` which we treat as an error because fallthroughs should only be specified when they are actually meant. To do otherwise compromises code readabiiity and maintainability, and can lead to bugs.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D84428636


