### PR TITLE
refactor: Remove last usages of folly::StringPiece in velox/functions

### DIFF
--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -170,7 +170,10 @@ class IPPrefixCastOperator : public exec::CastOperator {
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       auto ipAddressStringView = decoded.valueAt<StringView>(row);
-      auto tryIpPrefix = ipaddress::tryParseIpPrefixString(ipAddressStringView);
+
+      // TODO: Remove explicit std::string_view cast.
+      auto tryIpPrefix = ipaddress::tryParseIpPrefixString(
+          std::string_view(ipAddressStringView));
       if (tryIpPrefix.hasError()) {
         context.setStatus(row, std::move(tryIpPrefix.error()));
         return;

--- a/velox/functions/prestosql/types/IPPrefixType.h
+++ b/velox/functions/prestosql/types/IPPrefixType.h
@@ -23,8 +23,8 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
-
 namespace ipaddress {
+
 constexpr uint8_t kIPV4Bits = 32;
 constexpr uint8_t kIPV6Bits = 128;
 constexpr int kIPPrefixLengthIndex = 16;
@@ -50,7 +50,7 @@ inline folly::Expected<int8_t, Status> tryIpPrefixLengthFromIPAddressType(
 }
 
 inline folly::Expected<std::pair<int128_t, int8_t>, Status>
-tryParseIpPrefixString(folly::StringPiece ipprefixString) {
+tryParseIpPrefixString(std::string_view ipprefixString) {
   // Ensure '/' is present
   if (ipprefixString.find('/') == std::string::npos) {
     return folly::makeUnexpected(
@@ -92,6 +92,7 @@ tryParseIpPrefixString(folly::StringPiece ipprefixString) {
   memcpy(&intAddr, &addrBytes, ipaddress::kIPAddressBytes);
   return std::make_pair(intAddr, prefix);
 }
+
 }; // namespace ipaddress
 
 class IPPrefixType final : public RowType {

--- a/velox/functions/sparksql/String.cpp
+++ b/velox/functions/sparksql/String.cpp
@@ -18,14 +18,12 @@
 #include "velox/functions/lib/string/StringCore.h"
 
 namespace facebook::velox::functions::sparksql {
-
-using namespace stringCore;
 namespace {
 
+using namespace stringCore;
+
 template <bool isAscii>
-int32_t instr(
-    const folly::StringPiece haystack,
-    const folly::StringPiece needle) {
+int32_t instr(const std::string_view haystack, const std::string_view needle) {
   int32_t offset = haystack.find(needle);
   if constexpr (isAscii) {
     return offset + 1;
@@ -58,13 +56,18 @@ class Instr : public exec::VectorFunction {
       selected.applyToSelected([&](vector_size_t row) {
         auto h = haystack->valueAt<StringView>(row);
         auto n = needle->valueAt<StringView>(row);
-        output->set(row, instr<true>(h, n));
+
+        // TODO: Remove explicit std::string_view cast.
+        output->set(row, instr<true>(std::string_view(h), std::string_view(n)));
       });
     } else {
       selected.applyToSelected([&](vector_size_t row) {
         auto h = haystack->valueAt<StringView>(row);
         auto n = needle->valueAt<StringView>(row);
-        output->set(row, instr<false>(h, n));
+
+        // TODO: Remove explicit std::string_view cast.
+        output->set(
+            row, instr<false>(std::string_view(h), std::string_view(n)));
       });
     }
   }


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D84525749


