### PR TITLE
refactor(geo): Add SpatialIndex building to SpatialJoinBuild

### DIFF
--- a/velox/exec/SpatialJoinProbe.cpp
+++ b/velox/exec/SpatialJoinProbe.cpp
@@ -283,7 +283,7 @@ bool SpatialJoinProbe::getBuildData(ContinueFuture* future) {
     return false;
   }
 
-  buildVectors_ = std::move(buildData);
+  buildVectors_ = buildData.value().buildVectors;
   return true;
 }
 


### PR DESCRIPTION
Summary:
As a part of enabling indexed Spatial joins, have SpatialJoinBuild
build an index which is not yet used by SpatialJoinProbe.  SpatialJoinProbe
will use it in the next change.

Depends on  D84263281  D83052835

Differential Revision: D84381734


