### PR TITLE
feat: Add native Myanmar functions

### DIFF
--- a/CMake/resolve_dependency_modules/myanmartools.cmake
+++ b/CMake/resolve_dependency_modules/myanmartools.cmake
@@ -1,0 +1,51 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+# Myanmar-tools is a C++ library for detecting and converting Zawgyi-encoded text
+# Source: https://github.com/google/myanmar-tools
+# Using commit f7efa5761c6aea3f6ab029600c0d296e16bed14c which corresponds to Java v1.1.3 release
+# Note: Myanmar Tools uses language-specific tags (v1.1.3+java, v1.2.0+py, etc.)
+# but doesn't have C++ specific version tags. We use the commit hash instead.
+set(VELOX_MYANMARTOOLS_COMMIT f7efa5761c6aea3f6ab029600c0d296e16bed14c)
+set(VELOX_MYANMARTOOLS_BUILD_SHA256_CHECKSUM
+    cccd1217115e6d2eb54bb62a6e551727ebc44fa2ee518729775b6bb4eefb3e08)
+set(VELOX_MYANMARTOOLS_SOURCE_URL
+    "https://github.com/google/myanmar-tools/archive/${VELOX_MYANMARTOOLS_COMMIT}.tar.gz"
+)
+
+velox_resolve_dependency_url(MYANMARTOOLS)
+
+message(STATUS "Building myanmar-tools from source")
+
+FetchContent_Declare(
+  myanmartools
+  URL ${VELOX_MYANMARTOOLS_SOURCE_URL}
+  URL_HASH SHA256=${VELOX_MYANMARTOOLS_BUILD_SHA256_CHECKSUM})
+
+FetchContent_MakeAvailable(myanmartools)
+
+# The myanmar-tools library builds targets like "myanmar-tools" or similar
+# We need to check the actual CMakeLists.txt in the library to get the correct target name
+# and create an alias
+if(TARGET myanmartools)
+  add_library(myanmartools::myanmartools ALIAS myanmartools)
+elseif(TARGET myanmar-tools)
+  add_library(myanmartools::myanmartools ALIAS myanmar-tools)
+else()
+  message(
+    FATAL_ERROR
+      "Myanmar-tools library target not found. Please check the library's CMakeLists.txt"
+  )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -696,6 +696,9 @@ velox_resolve_dependency(xsimd 10.0.0)
 velox_set_source(stemmer)
 velox_resolve_dependency(stemmer)
 
+velox_set_source(myanmartools)
+velox_resolve_dependency(myanmartools)
+
 if(VELOX_BUILD_TESTING)
   set(BUILD_TESTING ON)
   include(CTest) # include after project() but before add_subdirectory()

--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -328,6 +328,37 @@ String Functions
     If the specified ``lang`` is not supported, this function throws a user error.
 
 
+Myanmar/Burmese Functions
+--------------------------
+
+.. note::
+
+    Text written in Myanmar uses primarily the Zawgyi font encoding, which is not
+    compatible with Unicode. These functions provide utilities for comparing content
+    in Myanmar despite the font encoding differences.
+
+    See http://www.unicode.org/faq/myanmar.html for more information.
+
+.. function:: myanmar_font_encoding(string) -> varchar
+
+    Returns the font encoding for ``string`` written in Myanmar. Returns one of the
+    following values:
+
+    - ``unicode`` if the string uses Unicode encoding
+    - ``zawgyi`` if the string uses Zawgyi encoding
+
+    Returns ``NULL`` if ``string`` is ``NULL``.
+
+.. function:: myanmar_normalize_unicode(string) -> varchar
+
+    Converts ``string`` written in Myanmar from Zawgyi encoding to Unicode encoding.
+    This function processes the input line-by-line, converting only the lines that
+    are detected as Zawgyi-encoded while preserving Unicode lines unchanged. This allows
+    handling of mixed-encoding content.
+
+    Returns ``NULL`` if ``string`` is ``NULL``.
+
+
 Unicode Functions
 -----------------
 

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -41,6 +41,7 @@ velox_add_library(
   MapFromEntries.cpp
   MapKeysAndValues.cpp
   MapZipWith.cpp
+  MyanmarFunctions.cpp
   Not.cpp
   Reduce.cpp
   Reverse.cpp
@@ -76,6 +77,7 @@ velox_link_libraries(
   velox_functions_util
   Folly::folly
   stemmer::stemmer
+  myanmartools::myanmartools
 )
 
 if(VELOX_ENABLE_FAISS)

--- a/velox/functions/prestosql/MyanmarFunctions.cpp
+++ b/velox/functions/prestosql/MyanmarFunctions.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/MyanmarFunctions.h"
+#include <vector>
+#include "myanmartools/detector.h"
+#include "myanmartools/translit_z2u.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+
+namespace facebook::velox::functions {
+
+// Zawgyi probability threshold matching Java implementation
+constexpr double ZAWGYI_PROBABILITY_THRESHOLD = 0.9;
+
+template <typename T>
+struct MyanmarFontEncodingFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    std::string text(input.data(), input.size());
+
+    // Use myanmar-tools ZawgyiDetector (same as Java)
+    static myanmartools::ZawgyiDetector detector;
+    double probability = detector.GetZawgyiProbability(text);
+
+    if (probability > ZAWGYI_PROBABILITY_THRESHOLD) {
+      result.copy_from("zawgyi");
+    } else {
+      result.copy_from("unicode");
+    }
+  }
+};
+
+template <typename T>
+struct MyanmarNormalizeUnicodeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input) {
+    std::string text(input.data(), input.size());
+
+    // Match Java logic: split by newlines, transliterate Zawgyi pieces, rejoin
+    std::vector<std::string> pieces;
+    std::vector<std::string> normalizedPieces;
+
+    size_t start = 0;
+    size_t end = text.find('\n');
+
+    while (end != std::string::npos) {
+      pieces.push_back(text.substr(start, end - start));
+      start = end + 1;
+      end = text.find('\n', start);
+    }
+    pieces.push_back(text.substr(start));
+
+    // Process each piece using myanmar-tools (same as Java)
+    static myanmartools::ZawgyiDetector detector;
+    static myanmartools::TranslitZ2U transliterator;
+
+    for (const auto& piece : pieces) {
+      double probability = detector.GetZawgyiProbability(piece);
+      if (probability > ZAWGYI_PROBABILITY_THRESHOLD) {
+        normalizedPieces.push_back(transliterator.Transliterate(piece));
+      } else {
+        normalizedPieces.push_back(piece);
+      }
+    }
+
+    // Join with newlines
+    std::string normalized;
+    for (size_t i = 0; i < normalizedPieces.size(); ++i) {
+      if (i > 0) {
+        normalized += '\n';
+      }
+      normalized += normalizedPieces[i];
+    }
+
+    result.copy_from(normalized);
+  }
+};
+
+void registerMyanmarFontEncoding(const std::string& name) {
+  registerFunction<MyanmarFontEncodingFunction, Varchar, Varchar>({name});
+}
+
+void registerMyanmarNormalizeUnicode(const std::string& name) {
+  registerFunction<MyanmarNormalizeUnicodeFunction, Varchar, Varchar>({name});
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/MyanmarFunctions.h
+++ b/velox/functions/prestosql/MyanmarFunctions.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::functions {
+
+void registerMyanmarFontEncoding(const std::string& name);
+void registerMyanmarNormalizeUnicode(const std::string& name);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -16,6 +16,7 @@
 #include "velox/expression/ExprRewriteRegistry.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/Re2Functions.h"
+#include "velox/functions/prestosql/MyanmarFunctions.h"
 #include "velox/functions/prestosql/RegexpReplace.h"
 #include "velox/functions/prestosql/RegexpSplit.h"
 #include "velox/functions/prestosql/SplitPart.h"
@@ -241,5 +242,9 @@ void registerStringFunctions(const std::string& prefix) {
   registerFunction<WordStemFunction, Varchar, Varchar>({prefix + "word_stem"});
   registerFunction<WordStemFunction, Varchar, Varchar, Varchar>(
       {prefix + "word_stem"});
+
+  // Myanmar functions
+  registerMyanmarFontEncoding(prefix + "myanmar_font_encoding");
+  registerMyanmarNormalizeUnicode(prefix + "myanmar_normalize_unicode");
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/MyanmarFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/MyanmarFunctionsTest.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/MyanmarFunctions.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+class MyanmarFunctionsTest : public test::FunctionBaseTest {
+ protected:
+  void SetUp() override {
+    test::FunctionBaseTest::SetUp();
+    registerMyanmarFontEncoding("myanmar_font_encoding");
+    registerMyanmarNormalizeUnicode("myanmar_normalize_unicode");
+  }
+};
+
+TEST_F(MyanmarFunctionsTest, myanmarFontEncoding) {
+  const auto fontEncoding = [&](std::optional<std::string> value) {
+    return evaluateOnce<std::string>("myanmar_font_encoding(c0)", value);
+  };
+
+  EXPECT_EQ(std::nullopt, fontEncoding(std::nullopt));
+  EXPECT_EQ("unicode", fontEncoding("english string"));
+  EXPECT_EQ("zawgyi", fontEncoding("\u1095"));
+  EXPECT_EQ(
+      "zawgyi", fontEncoding("\u1021\u101E\u1004\u1039\u1038\u1019\u103D"));
+  EXPECT_EQ(
+      "unicode",
+      fontEncoding("\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A"));
+}
+
+TEST_F(MyanmarFunctionsTest, myanmarNormalizeUnicode) {
+  const auto normalize = [&](std::optional<std::string> value) {
+    return evaluateOnce<std::string>("myanmar_normalize_unicode(c0)", value);
+  };
+
+  EXPECT_EQ(std::nullopt, normalize(std::nullopt));
+  EXPECT_EQ("english string", normalize("english string"));
+  EXPECT_EQ(
+      "\u1021\u101E\u1004\u103A\u1038\u1019\u103E",
+      normalize("\u1021\u101E\u1004\u1039\u1038\u1019\u103D"));
+  EXPECT_EQ(
+      "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A",
+      normalize("\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A"));
+  EXPECT_EQ(
+      "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A\n\u1021\u101E\u1004\u103A\u1038\u1019\u103E",
+      normalize(
+          "\u1000\u103B\u103D\u1014\u103A\u102F\u1015\u103A\n\u1021\u101E\u1004\u1039\u1038\u1019\u103D"));
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary: Add native Myanmar functions
- myanmar_font_encoding
- myanmar_normalize_unicode

Differential Revision: D84526971

Requires external library - https://github.com/google/myanmar-tools/tags
Presto Java uses 1.1.3
