### PR TITLE
feat: Add support for timeMinusIntervalDayToSecond and timeMinusIntervalYearToMonth

### DIFF
--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -154,11 +154,22 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<IntervalPlusTime, Time, IntervalDayTime, Time>(
       {prefix + "plus"});
 
+  // Register Time - Interval function
+  registerFunction<TimeMinusInterval, Time, Time, IntervalDayTime>(
+      {prefix + "minus"});
+
   // Use optimized vector function for Time + IntervalYearMonth (identity
   // function)
   exec::registerVectorFunction(
       prefix + "plus",
-      TimeIntervalYearMonthVectorFunction::signatures(),
+      TimeIntervalYearMonthVectorFunction::signaturesPlus(),
+      std::make_unique<TimeIntervalYearMonthVectorFunction>());
+
+  // Use optimized vector function for Time - IntervalYearMonth (identity
+  // function). Only supports (time, interval), not (interval, time).
+  exec::registerVectorFunction(
+      prefix + "minus",
+      TimeIntervalYearMonthVectorFunction::signaturesMinus(),
       std::make_unique<TimeIntervalYearMonthVectorFunction>());
 
   registerFunction<


### PR DESCRIPTION
Summary:
This diff adds support for the timeMinusIntervalDayToSecond and timeMinusIntervalYearToMonth functions in Velox.

Changes include reusing the identity vector function for TimeMinusIntervalYearToMonth and reusing the utility function addToTime with a negated interval for timeMinusIntervalDayToSecond

Differential Revision: D84395742


