### PR TITLE
fix: HiveDataSink nonReclaimableSection bug with multiple writers

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -808,10 +808,11 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
     options->spillConfig = spillConfig_;
   }
 
-  if (options->nonReclaimableSection == nullptr) {
-    options->nonReclaimableSection =
-        writerInfo_.back()->nonReclaimableSectionHolder.get();
-  }
+  // Always set nonReclaimableSection to the current writer's holder.
+  // Since insertTableHandle_->writerOptions() returns a shared_ptr, we need
+  // to ensure each writer has its own nonReclaimableSection pointer.
+  options->nonReclaimableSection =
+      writerInfo_.back()->nonReclaimableSectionHolder.get();
 
   if (options->memoryReclaimerFactory == nullptr ||
       options->memoryReclaimerFactory() == nullptr) {


### PR DESCRIPTION
Summary:
Fix `NON_RECLAIMABLE_SECTION_CHECK()` failure when writing with both bucketing and partitioning.

The bug occurred because multiple writers shared the same nonReclaimableSection
pointer when writerOptions() returned a shared object. Changed appendWriter() to
always set each writer's nonReclaimableSection to its own holder instead of only
setting it the first time around (when writerOptions->nonReclaimableSection == nullptr)

Added tests for bucketed writes with multiple writers.

Reviewed By: xiaoxmeng

Differential Revision: D84387027


