### PR TITLE
fix: Make flatmap vector initialization more robust

### DIFF
--- a/velox/dwio/common/FlatMapHelper.cpp
+++ b/velox/dwio/common/FlatMapHelper.cpp
@@ -21,8 +21,17 @@
 namespace facebook::velox::dwio::common::flatmap {
 namespace detail {
 
-void reset(VectorPtr& vector, vector_size_t size, bool hasNulls) {
+void reset(
+    VectorPtr& vector,
+    VectorEncoding::Simple desiredEncoding,
+    vector_size_t size,
+    bool hasNulls) {
   if (!vector) {
+    return;
+  }
+
+  if (vector->encoding() != desiredEncoding) {
+    vector.reset();
     return;
   }
 
@@ -162,7 +171,7 @@ void initializeVectorImpl<TypeKind::ARRAY>(
     }
   }
 
-  detail::reset(vector, size, hasNulls);
+  detail::reset(vector, VectorEncoding::Simple::ARRAY, size, hasNulls);
   VectorPtr origElementsVector;
   if (vector) {
     auto& arrayVector = dynamic_cast<ArrayVector&>(*vector);
@@ -226,7 +235,7 @@ void initializeMapVector(
     size = sizeOverride.value();
   }
 
-  detail::reset(vector, size, hasNulls);
+  detail::reset(vector, VectorEncoding::Simple::MAP, size, hasNulls);
   VectorPtr origKeysVector;
   VectorPtr origValuesVector;
   if (vector) {
@@ -298,7 +307,7 @@ void initializeVectorImpl<TypeKind::ROW>(
     }
   }
 
-  detail::reset(vector, size, hasNulls);
+  detail::reset(vector, VectorEncoding::Simple::ROW, size, hasNulls);
   std::vector<VectorPtr> origChildren;
   if (vector) {
     auto& rowVector = dynamic_cast<RowVector&>(*vector);

--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -24,7 +24,11 @@ namespace facebook::velox::dwio::common::flatmap {
 namespace detail {
 
 // Reset vector with the desired size/hasNulls properties
-void reset(VectorPtr& vector, vector_size_t size, bool hasNulls);
+void reset(
+    VectorPtr& vector,
+    VectorEncoding::Simple desiredEncoding,
+    vector_size_t size,
+    bool hasNulls);
 
 // Reset vector smart pointer if any of the buffers is not single referenced.
 template <typename... T>
@@ -63,7 +67,7 @@ void initializeFlatVector(
     vector_size_t size,
     bool hasNulls,
     std::vector<BufferPtr>&& stringBuffers = {}) {
-  detail::reset(vector, size, hasNulls);
+  detail::reset(vector, VectorEncoding::Simple::FLAT, size, hasNulls);
   if (vector) {
     auto& flatVector = dynamic_cast<FlatVector<T>&>(*vector);
     detail::resetIfNotWritable(vector, flatVector.nulls(), flatVector.values());


### PR DESCRIPTION
Summary: The current logic assumes that the incoming vector is flat/array/map/row, hence doesn't apply additional checks. If this initialization is used in a place where various other encodings may be introduced, we may run into problems. This change added the check on desired encoding and resets the vector if encodings don't match

Differential Revision: D84537735


