### PR TITLE
feat: Add NonMaterializedSortBuffer 

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -26,8 +26,8 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SortingWriter.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/OperatorUtils.h"
-#include "velox/exec/SortBuffer.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -905,7 +905,7 @@ HiveDataSink::maybeCreateBucketSortWriter(
   }
   auto* sortPool = writerInfo_.back()->sortPool.get();
   VELOX_CHECK_NOT_NULL(sortPool);
-  auto sortBuffer = std::make_unique<exec::SortBuffer>(
+  auto sortBuffer = std::make_unique<exec::MaterializedSortBuffer>(
       getNonPartitionTypes(dataChannels_, inputType_),
       sortColumnIndices_,
       sortCompareFlags_,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -510,6 +510,10 @@ class QueryConfig {
   static constexpr const char* kPrefixSortMaxStringPrefixLength =
       "prefixsort_max_string_prefix_length";
 
+  /// Enable non-materialized sort buffer.
+  static constexpr const char* kNonMaterializedSortBufferEnabled =
+      "non_materialized_sort_buffer_enabled";
+
   /// Enable query tracing flag.
   static constexpr const char* kQueryTraceEnabled = "query_trace_enabled";
 
@@ -1080,6 +1084,10 @@ class QueryConfig {
   int32_t spillableReservationGrowthPct() const {
     constexpr int32_t kDefaultPct = 10;
     return get<int32_t>(kSpillableReservationGrowthPct, kDefaultPct);
+  }
+
+  bool nonMaterializedSortBufferEnabled() const {
+    return get<bool>(kNonMaterializedSortBufferEnabled, false);
   }
 
   bool queryTraceEnabled() const {

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox::dwio::common {
 SortingWriter::SortingWriter(
     std::unique_ptr<Writer> writer,
-    std::unique_ptr<exec::SortBuffer> sortBuffer,
+    std::unique_ptr<exec::MaterializedSortBuffer> sortBuffer,
     vector_size_t maxOutputRowsConfig,
     uint64_t maxOutputBytesConfig,
     uint64_t outputTimeSliceLimitMs)

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include "velox/dwio/common/Writer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/MemoryReclaimer.h"
-#include "velox/exec/SortBuffer.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -27,7 +27,7 @@ class SortingWriter : public Writer {
  public:
   SortingWriter(
       std::unique_ptr<Writer> writer,
-      std::unique_ptr<exec::SortBuffer> sortBuffer,
+      std::unique_ptr<exec::MaterializedSortBuffer> sortBuffer,
       vector_size_t maxOutputRowsConfig,
       uint64_t maxOutputBytesConfig,
       uint64_t outputTimeSliceLimitMs);
@@ -85,7 +85,7 @@ class SortingWriter : public Writer {
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
 
-  std::unique_ptr<exec::SortBuffer> sortBuffer_;
+  std::unique_ptr<exec::MaterializedSortBuffer> sortBuffer_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/SortingWriterTest.cpp
+++ b/velox/dwio/common/tests/SortingWriterTest.cpp
@@ -18,7 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/exec/SortBuffer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox::exec;
@@ -67,7 +67,7 @@ class SortingWriterTest : public testing::Test,
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  std::unique_ptr<SortBuffer> createSortBuffer() {
+  std::unique_ptr<MaterializedSortBuffer> createSortBuffer() {
     const RowTypePtr inputType =
         ROW({{"c0", BIGINT()}, {"c1", INTEGER()}, {"c2", VARCHAR()}});
 
@@ -80,7 +80,7 @@ class SortingWriterTest : public testing::Test,
         std::numeric_limits<uint32_t>::max(),
         12};
 
-    return std::make_unique<SortBuffer>(
+    return std::make_unique<MaterializedSortBuffer>(
         inputType,
         sortColumnIndices,
         sortCompareFlags,

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -50,12 +50,15 @@ velox_add_library(
   LocalPartition.cpp
   LocalPlanner.cpp
   MarkDistinct.cpp
+  MaterializedSortBuffer.cpp
   MemoryReclaimer.cpp
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp
   NestedLoopJoinBuild.cpp
   NestedLoopJoinProbe.cpp
+  NonMaterializedSortBuffer.cpp
+  SortBufferBase.cpp
   SpatialIndex.cpp
   SpatialJoinBuild.cpp
   SpatialJoinProbe.cpp
@@ -80,7 +83,6 @@ velox_add_library(
   RowsStreamingWindowBuild.cpp
   ScaleWriterLocalPartition.cpp
   ScaledScanController.cpp
-  SortBuffer.cpp
   SortWindowBuild.cpp
   SortedAggregations.cpp
   SpatialJoinBuild.cpp

--- a/velox/exec/MaterializedSortBuffer.cpp
+++ b/velox/exec/MaterializedSortBuffer.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "SortBuffer.h"
-#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
+#include <vector>
 #include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
 
-SortBuffer::SortBuffer(
-    const RowTypePtr& input,
+MaterializedSortBuffer::MaterializedSortBuffer(
+    const RowTypePtr& inputType,
     const std::vector<column_index_t>& sortColumnIndices,
     const std::vector<CompareFlags>& sortCompareFlags,
     velox::memory::MemoryPool* pool,
@@ -29,48 +29,45 @@ SortBuffer::SortBuffer(
     common::PrefixSortConfig prefixSortConfig,
     const common::SpillConfig* spillConfig,
     folly::Synchronized<velox::common::SpillStats>* spillStats)
-    : input_(input),
-      sortCompareFlags_(sortCompareFlags),
-      pool_(pool),
-      nonReclaimableSection_(nonReclaimableSection),
-      prefixSortConfig_(prefixSortConfig),
-      spillConfig_(spillConfig),
-      spillStats_(spillStats),
-      sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
-  VELOX_CHECK_GE(input_->children().size(), sortCompareFlags_.size());
-  VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
-  VELOX_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
-  VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
-
+    : SortBufferBase(
+          inputType,
+          sortColumnIndices,
+          sortCompareFlags,
+          pool,
+          nonReclaimableSection,
+          prefixSortConfig,
+          spillConfig,
+          spillStats) {
   std::vector<TypePtr> sortedColumnTypes;
   std::vector<TypePtr> nonSortedColumnTypes;
   std::vector<std::string> sortedSpillColumnNames;
   std::vector<TypePtr> sortedSpillColumnTypes;
   sortedColumnTypes.reserve(sortColumnIndices.size());
-  nonSortedColumnTypes.reserve(input->size() - sortColumnIndices.size());
-  sortedSpillColumnNames.reserve(input->size());
-  sortedSpillColumnTypes.reserve(input->size());
+  nonSortedColumnTypes.reserve(inputType->size() - sortColumnIndices.size());
+  sortedSpillColumnNames.reserve(inputType->size());
+  sortedSpillColumnTypes.reserve(inputType->size());
   std::unordered_set<column_index_t> sortedChannelSet;
   // Sorted key columns.
   for (column_index_t i = 0; i < sortColumnIndices.size(); ++i) {
-    columnMap_.emplace_back(IdentityProjection(i, sortColumnIndices.at(i)));
-    sortedColumnTypes.emplace_back(input_->childAt(sortColumnIndices.at(i)));
+    columnMap_.emplace_back(IdentityProjection(i, sortColumnIndices[i]));
+    sortedColumnTypes.emplace_back(inputType_->childAt(sortColumnIndices[i]));
     sortedSpillColumnTypes.emplace_back(
-        input_->childAt(sortColumnIndices.at(i)));
-    sortedSpillColumnNames.emplace_back(input->nameOf(sortColumnIndices.at(i)));
-    sortedChannelSet.emplace(sortColumnIndices.at(i));
+        inputType_->childAt(sortColumnIndices[i]));
+    sortedSpillColumnNames.emplace_back(
+        inputType->nameOf(sortColumnIndices[i]));
+    sortedChannelSet.emplace(sortColumnIndices[i]);
   }
   // Non-sorted key columns.
   for (column_index_t i = 0, nonSortedIndex = sortCompareFlags_.size();
-       i < input_->size();
+       i < inputType_->size();
        ++i) {
-    if (sortedChannelSet.count(i) != 0) {
+    if (sortedChannelSet.contains(i)) {
       continue;
     }
     columnMap_.emplace_back(nonSortedIndex++, i);
-    nonSortedColumnTypes.emplace_back(input_->childAt(i));
-    sortedSpillColumnTypes.emplace_back(input_->childAt(i));
-    sortedSpillColumnNames.emplace_back(input->nameOf(i));
+    nonSortedColumnTypes.emplace_back(inputType_->childAt(i));
+    sortedSpillColumnTypes.emplace_back(inputType_->childAt(i));
+    sortedSpillColumnNames.emplace_back(inputType->nameOf(i));
   }
 
   data_ = std::make_unique<RowContainer>(
@@ -79,13 +76,13 @@ SortBuffer::SortBuffer(
       ROW(std::move(sortedSpillColumnNames), std::move(sortedSpillColumnTypes));
 }
 
-SortBuffer::~SortBuffer() {
+MaterializedSortBuffer::~MaterializedSortBuffer() {
   pool_->release();
 }
 
-void SortBuffer::addInput(const VectorPtr& input) {
+void MaterializedSortBuffer::addInput(const VectorPtr& input) {
   velox::common::testutil::TestValue::adjust(
-      "facebook::velox::exec::SortBuffer::addInput", this);
+      "facebook::velox::exec::MaterializedSortBuffer::addInput", this);
 
   VELOX_CHECK(!noMoreInput_);
   ensureInputFits(input);
@@ -95,7 +92,7 @@ void SortBuffer::addInput(const VectorPtr& input) {
   for (int row = 0; row < input->size(); ++row) {
     rows[row] = data_->newRow();
   }
-  const auto* inputRow = input->as<RowVector>();
+  const auto* inputRow = input->asChecked<RowVector>();
   for (const auto& columnProjection : columnMap_) {
     DecodedVector decoded(
         *inputRow->childAt(columnProjection.outputChannel), allRows);
@@ -107,9 +104,9 @@ void SortBuffer::addInput(const VectorPtr& input) {
   numInputRows_ += allRows.size();
 }
 
-void SortBuffer::noMoreInput() {
+void MaterializedSortBuffer::noMoreInput() {
   velox::common::testutil::TestValue::adjust(
-      "facebook::velox::exec::SortBuffer::noMoreInput", this);
+      "facebook::velox::exec::MaterializedSortBuffer::noMoreInput", this);
   VELOX_CHECK(!noMoreInput_);
   VELOX_CHECK_NULL(outputSpiller_);
 
@@ -126,13 +123,7 @@ void SortBuffer::noMoreInput() {
   if (inputSpiller_ == nullptr) {
     VELOX_CHECK_EQ(numInputRows_, data_->numRows());
     updateEstimatedOutputRowSize();
-    // Sort the pointers to the rows in RowContainer (data_) instead of sorting
-    // the rows.
-    sortedRows_.resize(numInputRows_);
-    RowContainerIterator iter;
-    data_->listRows(&iter, numInputRows_, sortedRows_.data());
-    PrefixSort::sort(
-        data_.get(), sortCompareFlags_, prefixSortConfig_, pool_, sortedRows_);
+    sortInput(numInputRows_);
   } else {
     // Spill the remaining in-memory state to disk if spilling has been
     // triggered on this sort buffer. This is to simplify query OOM prevention
@@ -147,31 +138,7 @@ void SortBuffer::noMoreInput() {
   pool_->release();
 }
 
-RowVectorPtr SortBuffer::getOutput(vector_size_t maxOutputRows) {
-  SCOPE_EXIT {
-    pool_->release();
-  };
-
-  VELOX_CHECK(noMoreInput_);
-
-  if (numOutputRows_ == numInputRows_) {
-    return nullptr;
-  }
-  VELOX_CHECK_GT(maxOutputRows, 0);
-  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
-  const vector_size_t batchSize =
-      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
-  ensureOutputFits(batchSize);
-  prepareOutput(batchSize);
-  if (hasSpilled()) {
-    getOutputWithSpill();
-  } else {
-    getOutputWithoutSpill();
-  }
-  return output_;
-}
-
-bool SortBuffer::hasSpilled() const {
+bool MaterializedSortBuffer::hasSpilled() const {
   if (inputSpiller_ != nullptr) {
     VELOX_CHECK_NULL(outputSpiller_);
     return true;
@@ -179,121 +146,20 @@ bool SortBuffer::hasSpilled() const {
   return outputSpiller_ != nullptr;
 }
 
-void SortBuffer::spill() {
-  VELOX_CHECK_NOT_NULL(
-      spillConfig_, "spill config is null when SortBuffer spill is called");
-
-  // Check if sort buffer is empty or not, and skip spill if it is empty.
-  if (data_->numRows() == 0) {
-    return;
-  }
-  updateEstimatedOutputRowSize();
-
-  if (sortedRows_.empty()) {
-    spillInput();
-  } else {
-    spillOutput();
-  }
+int64_t MaterializedSortBuffer::estimateFlatInputBytes(
+    const VectorPtr& input) const {
+  return input->estimateFlatSize();
 }
 
-std::optional<uint64_t> SortBuffer::estimateOutputRowSize() const {
-  return estimatedOutputRowSize_;
+int64_t MaterializedSortBuffer::estimateIncrementalBytes(
+    const VectorPtr& input,
+    uint64_t outOfLineBytes,
+    int64_t flatInputBytes) const {
+  return data_->sizeIncrement(
+      input->size(), outOfLineBytes ? flatInputBytes : 0);
 }
 
-void SortBuffer::ensureInputFits(const VectorPtr& input) {
-  // Check if spilling is enabled or not.
-  if (spillConfig_ == nullptr) {
-    return;
-  }
-
-  const int64_t numRows = data_->numRows();
-  if (numRows == 0) {
-    // 'data_' is empty. Nothing to spill.
-    return;
-  }
-
-  auto [freeRows, outOfLineFreeBytes] = data_->freeSpace();
-  const auto outOfLineBytes =
-      data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
-  const int64_t flatInputBytes = input->estimateFlatSize();
-
-  // Test-only spill path.
-  if (numRows > 0 && testingTriggerSpill(pool_->name())) {
-    spill();
-    return;
-  }
-
-  const auto currentMemoryUsage = pool_->usedBytes();
-  const auto minReservationBytes =
-      currentMemoryUsage * spillConfig_->minSpillableReservationPct / 100;
-  const auto availableReservationBytes = pool_->availableReservation();
-  const int64_t estimatedIncrementalBytes =
-      data_->sizeIncrement(input->size(), outOfLineBytes ? flatInputBytes : 0);
-  if (availableReservationBytes > minReservationBytes) {
-    // If we have enough free rows for input rows and enough variable length
-    // free space for the vector's flat size, no need for spilling.
-    if (freeRows > input->size() &&
-        (outOfLineBytes == 0 || outOfLineFreeBytes >= flatInputBytes)) {
-      return;
-    }
-
-    // If the current available reservation in memory pool is 2X the
-    // estimatedIncrementalBytes, no need to spill.
-    if (availableReservationBytes > 2 * estimatedIncrementalBytes) {
-      return;
-    }
-  }
-
-  // Try reserving targetIncrementBytes more in memory pool, if succeed, no
-  // need to spill.
-  const auto targetIncrementBytes = std::max<int64_t>(
-      estimatedIncrementalBytes * 2,
-      currentMemoryUsage * spillConfig_->spillableReservationGrowthPct / 100);
-  {
-    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
-    if (pool_->maybeReserve(targetIncrementBytes)) {
-      return;
-    }
-  }
-  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
-               << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
-}
-
-void SortBuffer::ensureOutputFits(vector_size_t batchSize) {
-  VELOX_CHECK_GT(batchSize, 0);
-  // Check if spilling is enabled or not.
-  if (spillConfig_ == nullptr) {
-    return;
-  }
-
-  // Test-only spill path.
-  if (testingTriggerSpill(pool_->name())) {
-    spill();
-    return;
-  }
-
-  if (!estimatedOutputRowSize_.has_value() || hasSpilled()) {
-    return;
-  }
-
-  const uint64_t outputBufferSizeToReserve =
-      estimatedOutputRowSize_.value() * batchSize * 1.2;
-  {
-    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
-    if (pool_->maybeReserve(outputBufferSizeToReserve)) {
-      return;
-    }
-  }
-  LOG(WARNING) << "Failed to reserve "
-               << succinctBytes(outputBufferSizeToReserve)
-               << " for memory pool " << pool_->name()
-               << ", usage: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes());
-}
-
-void SortBuffer::ensureSortFits() {
+void MaterializedSortBuffer::ensureSortFits() {
   // Check if spilling is enabled or not.
   if (spillConfig_ == nullptr) {
     return;
@@ -309,41 +175,10 @@ void SortBuffer::ensureSortFits() {
     return;
   }
 
-  // The memory for std::vector sorted rows and prefix sort required buffer.
-  const auto sortBufferToReserve =
-      numInputRows_ * sizeof(char*) +
-      PrefixSort::maxRequiredBytes(
-          data_.get(), sortCompareFlags_, prefixSortConfig_, pool_);
-  {
-    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
-    if (pool_->maybeReserve(sortBufferToReserve)) {
-      return;
-    }
-  }
-
-  LOG(WARNING) << fmt::format(
-      "Failed to reserve {} for memory pool {}, usage: {}, reservation: {}",
-      succinctBytes(sortBufferToReserve),
-      pool_->name(),
-      succinctBytes(pool_->usedBytes()),
-      succinctBytes(pool_->reservedBytes()));
+  ensureSortFitsImpl();
 }
 
-void SortBuffer::updateEstimatedOutputRowSize() {
-  const auto optionalRowSize = data_->estimateRowSize();
-  if (!optionalRowSize.has_value() || optionalRowSize.value() == 0) {
-    return;
-  }
-
-  const auto rowSize = optionalRowSize.value();
-  if (!estimatedOutputRowSize_.has_value()) {
-    estimatedOutputRowSize_ = rowSize;
-  } else if (rowSize > estimatedOutputRowSize_.value()) {
-    estimatedOutputRowSize_ = rowSize;
-  }
-}
-
-void SortBuffer::spillInput() {
+void MaterializedSortBuffer::spillInput() {
   if (inputSpiller_ == nullptr) {
     VELOX_CHECK(!noMoreInput_);
     const auto sortingKeys = SpillState::makeSortingKeys(sortCompareFlags_);
@@ -354,7 +189,7 @@ void SortBuffer::spillInput() {
   data_->clear();
 }
 
-void SortBuffer::spillOutput() {
+void MaterializedSortBuffer::spillOutput() {
   if (hasSpilled()) {
     // Already spilled.
     return;
@@ -379,14 +214,14 @@ void SortBuffer::spillOutput() {
   finishSpill();
 }
 
-void SortBuffer::prepareOutput(vector_size_t batchSize) {
+void MaterializedSortBuffer::prepareOutput(vector_size_t batchSize) {
   if (output_ != nullptr) {
     VectorPtr output = std::move(output_);
     BaseVector::prepareForReuse(output, batchSize);
     output_ = std::static_pointer_cast<RowVector>(output);
   } else {
     output_ = std::static_pointer_cast<RowVector>(
-        BaseVector::create(input_, batchSize, pool_));
+        BaseVector::create(inputType_, batchSize, pool_));
   }
 
   for (auto& child : output_->children()) {
@@ -403,7 +238,7 @@ void SortBuffer::prepareOutput(vector_size_t batchSize) {
   VELOX_CHECK_LE(output_->size() + numOutputRows_, numInputRows_);
 }
 
-void SortBuffer::getOutputWithoutSpill() {
+void MaterializedSortBuffer::getOutputWithoutSpill() {
   VELOX_DCHECK_EQ(numInputRows_, sortedRows_.size());
   for (const auto& columnProjection : columnMap_) {
     data_->extractColumn(
@@ -415,7 +250,7 @@ void SortBuffer::getOutputWithoutSpill() {
   numOutputRows_ += output_->size();
 }
 
-void SortBuffer::getOutputWithSpill() {
+void MaterializedSortBuffer::getOutputWithSpill() {
   VELOX_CHECK_NOT_NULL(spillMerger_);
   VELOX_DCHECK_EQ(sortedRows_.size(), 0);
 
@@ -460,7 +295,7 @@ void SortBuffer::getOutputWithSpill() {
   numOutputRows_ += output_->size();
 }
 
-void SortBuffer::finishSpill() {
+void MaterializedSortBuffer::finishSpill() {
   VELOX_CHECK_NULL(spillMerger_);
   VELOX_CHECK(spillPartitionSet_.empty());
   VELOX_CHECK_EQ(
@@ -479,7 +314,7 @@ void SortBuffer::finishSpill() {
   VELOX_CHECK_EQ(spillPartitionSet_.size(), 1);
 }
 
-void SortBuffer::prepareOutputWithSpill() {
+void MaterializedSortBuffer::prepareOutputWithSpill() {
   VELOX_CHECK(hasSpilled());
   if (spillMerger_ != nullptr) {
     VELOX_CHECK(spillPartitionSet_.empty());

--- a/velox/exec/MaterializedSortBuffer.h
+++ b/velox/exec/MaterializedSortBuffer.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/ContainerRowSerde.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/PrefixSort.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/SortBufferBase.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+class SortInputSpiller;
+class SortOutputSpiller;
+
+/// A utility class to accumulate data inside and output the sorted result.
+/// Spilling would be triggered if spilling is enabled and memory usage exceeds
+/// limit.
+class MaterializedSortBuffer final : public SortBufferBase {
+ public:
+  MaterializedSortBuffer(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& sortColumnIndices,
+      const std::vector<CompareFlags>& sortCompareFlags,
+      velox::memory::MemoryPool* pool,
+      tsan_atomic<bool>* nonReclaimableSection,
+      common::PrefixSortConfig prefixSortConfig,
+      const common::SpillConfig* spillConfig = nullptr,
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+
+  ~MaterializedSortBuffer() override;
+
+  void addInput(const VectorPtr& input) override;
+
+  /// Indicates no more input and triggers either of:
+  ///  - In-memory sorting on rows stored in 'data_' if spilling is not enabled.
+  ///  - Finish spilling and setup the sort merge reader for the un-spilling
+  ///  processing for the output.
+  void noMoreInput() override;
+
+ private:
+  // Reserves memory for sort. If reservation cannot be increased, spills enough
+  // to make output fit.
+  void ensureSortFits();
+
+  // Invoked to initialize or reset the reusable output buffer to get output.
+  void prepareOutput(vector_size_t outputBatchSize) override;
+
+  // Invoked to initialize reader to read the spilled data from storage for
+  // output processing.
+  void prepareOutputWithSpill();
+
+  void getOutputWithoutSpill() override;
+
+  void getOutputWithSpill() override;
+
+  // Spill during input stage.
+  void spillInput() override;
+
+  // Spill during output stage.
+  void spillOutput() override;
+
+  // Finish spill, and we shouldn't get any rows from non-spilled partition as
+  // there is only one hash partition for SortBuffer.
+  void finishSpill();
+
+  // Returns true if the sort buffer has spilled, regardless of during input or
+  // output processing. If spilled() is true, it means the sort buffer is in
+  // minimal memory mode and could not be spilled further.
+  bool hasSpilled() const override;
+
+  int64_t estimateFlatInputBytes(const VectorPtr& input) const override;
+
+  int64_t estimateIncrementalBytes(
+      const VectorPtr& input,
+      uint64_t outOfLineBytes,
+      int64_t flatInputBytes) const override;
+
+  // The data type of the rows stored in 'data_' and spilled on disk. The
+  // sort key columns are stored first then the non-sorted data columns.
+  RowTypePtr spillerStoreType_;
+
+  std::unique_ptr<SortInputSpiller> inputSpiller_;
+
+  std::unique_ptr<SortOutputSpiller> outputSpiller_;
+
+  SpillPartitionSet spillPartitionSet_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/NonMaterializedSortBuffer.cpp
+++ b/velox/exec/NonMaterializedSortBuffer.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/NonMaterializedSortBuffer.h"
+
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/Spiller.h"
+#include "velox/expression/VectorReaders.h"
+
+namespace facebook::velox::exec {
+
+NonMaterializedSortBuffer::NonMaterializedSortBuffer(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& sortColumnIndices,
+    const std::vector<CompareFlags>& sortCompareFlags,
+    velox::memory::MemoryPool* pool,
+    tsan_atomic<bool>* nonReclaimableSection,
+    common::PrefixSortConfig prefixSortConfig,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    : SortBufferBase(
+          inputType,
+          sortColumnIndices,
+          sortCompareFlags,
+          pool,
+          nonReclaimableSection,
+          prefixSortConfig,
+          /*spillConfig=*/nullptr,
+          /*spillStats=*/nullptr),
+      sortingKeys_(
+          SpillState::makeSortingKeys(sortColumnIndices, sortCompareFlags)) {
+  // Sorted key columns.
+  std::vector<TypePtr> sortedColumnTypes;
+  sortedColumnTypes.reserve(sortColumnIndices.size());
+  for (column_index_t i = 0; i < sortColumnIndices.size(); ++i) {
+    sortColumnProjections_.emplace_back(
+        IdentityProjection(i, sortColumnIndices[i]));
+    sortedColumnTypes.emplace_back(inputType_->childAt(sortColumnIndices[i]));
+  }
+
+  // Vector index and row index columns.
+  const auto numSortKeys = sortColumnProjections_.size();
+  for (auto i = 0; i < indexType_->size(); ++i) {
+    indexColumnMap_.emplace_back(numSortKeys + i, i);
+  }
+  data_ = std::make_unique<RowContainer>(
+      sortedColumnTypes, indexType_->children(), pool_);
+}
+
+NonMaterializedSortBuffer::~NonMaterializedSortBuffer() {
+  inputs_.clear();
+  rowIndexVec_.reset();
+  pool_->release();
+}
+
+void NonMaterializedSortBuffer::addInput(const VectorPtr& input) {
+  velox::common::testutil::TestValue::adjust(
+      "facebook::velox::exec::HybridSortBuffer::addInput", this);
+  VELOX_CHECK(!noMoreInput_);
+  const SelectivityVector allRows(input->size());
+  std::vector<char*> rows(input->size());
+  for (int row = 0; row < input->size(); ++row) {
+    rows[row] = data_->newRow();
+  }
+
+  // Stores the sort key columns.
+  const auto* inputRow = input->asChecked<RowVector>();
+  for (const auto& columnProjection : sortColumnProjections_) {
+    DecodedVector decoded(
+        *inputRow->childAt(columnProjection.outputChannel), allRows);
+    data_->store(
+        decoded,
+        folly::Range(rows.data(), input->size()),
+        columnProjection.inputChannel);
+  }
+
+  inputs_.push_back(checked_pointer_cast<RowVector>(input));
+
+  // Stores the vector indices column.
+  const auto vectorIndexVec = std::make_shared<ConstantVector<int64_t>>(
+      pool(),
+      input->size(),
+      /*isNull=*/false,
+      BIGINT(),
+      inputs_.size() - 1);
+  DecodedVector decoded;
+  decoded.decode(*vectorIndexVec, allRows);
+  auto indexColumnChannel = sortColumnProjections_.size();
+  data_->store(
+      decoded, folly::Range(rows.data(), input->size()), indexColumnChannel++);
+
+  // Stores the row indices column.
+  prepareRowIndexVector(input);
+  const auto rowIndices = rowIndexVec_->asUnchecked<FlatVector<int64_t>>();
+  for (int64_t i = 0; i < input->size(); ++i) {
+    rowIndices->mutableRawValues()[i] = i;
+  }
+  decoded.decode(*rowIndices, allRows);
+  data_->store(
+      decoded, folly::Range(rows.data(), input->size()), indexColumnChannel);
+
+  numInputRows_ += allRows.size();
+  numInputBytes_ += input->estimateFlatSize();
+}
+
+void NonMaterializedSortBuffer::noMoreInput() {
+  velox::common::testutil::TestValue::adjust(
+      "facebook::velox::exec::NonMaterializedSortBuffer::noMoreInput", this);
+  VELOX_CHECK(!noMoreInput_);
+  noMoreInput_ = true;
+
+  // No data.
+  if (numInputRows_ == 0) {
+    return;
+  }
+  estimatedOutputRowSize_ = numInputBytes_ / numInputRows_;
+
+  VELOX_CHECK_EQ(numInputRows_, data_->numRows());
+  sortInput(numInputRows_);
+
+  // Releases the unused memory reservation after procesing input.
+  pool_->release();
+}
+
+int64_t NonMaterializedSortBuffer::estimateFlatInputBytes(
+    const VectorPtr& input) const {
+  int64_t estimatedInputBytes{0};
+  const auto* inputRowVector = input->asChecked<RowVector>();
+  for (const auto projection : sortColumnProjections_) {
+    estimatedInputBytes +=
+        inputRowVector->childAt(projection.outputChannel)->estimateFlatSize();
+  }
+  estimatedInputBytes +=
+      indexColumnMap_.size() * sizeof(int64_t) * input->size();
+  return estimatedInputBytes;
+}
+
+int64_t NonMaterializedSortBuffer::estimateIncrementalBytes(
+    const VectorPtr& input,
+    uint64_t outOfLineBytes,
+    int64_t flatInputBytes) const {
+  return data_->sizeIncrement(
+             input->size(), outOfLineBytes ? flatInputBytes : 0) +
+      input->estimateFlatSize();
+}
+
+void NonMaterializedSortBuffer::prepareOutputVector(
+    const RowTypePtr& outputType,
+    vector_size_t outputBatchSize,
+    RowVectorPtr& output) const {
+  if (output != nullptr) {
+    VectorPtr vector = std::move(output);
+    BaseVector::prepareForReuse(vector, outputBatchSize);
+    output = std::static_pointer_cast<RowVector>(vector);
+  } else {
+    output = std::static_pointer_cast<RowVector>(
+        BaseVector::create(outputType, outputBatchSize, pool_));
+  }
+
+  for (const auto& child : output->children()) {
+    child->resize(outputBatchSize);
+  }
+}
+
+void NonMaterializedSortBuffer::prepareOutput(vector_size_t batchSize) {
+  prepareOutputVector(inputType_, batchSize, output_);
+  prepareOutputVector(indexType_, batchSize, outputIndex_);
+  VELOX_CHECK_EQ(output_->size(), batchSize);
+}
+
+void NonMaterializedSortBuffer::prepareRowIndexVector(const VectorPtr& input) {
+  if (FOLLY_UNLIKELY(rowIndexVec_ == nullptr)) {
+    rowIndexVec_ = BaseVector::create<FlatVector<int64_t>>(
+        BIGINT(), input->size(), pool());
+  }
+  BaseVector::prepareForReuse(rowIndexVec_, input->size());
+}
+
+void NonMaterializedSortBuffer::gatherCopyOutput() {
+  SCOPE_EXIT {
+    numOutputRows_ += output_->size();
+  };
+  VELOX_DCHECK_EQ(numInputRows_, sortedRows_.size());
+  VELOX_CHECK_NOT_NULL(output_);
+  for (const auto& columnProjection : indexColumnMap_) {
+    data_->extractColumn(
+        sortedRows_.data() + numOutputRows_,
+        outputIndex_->size(),
+        columnProjection.inputChannel,
+        outputIndex_->childAt(columnProjection.outputChannel));
+  }
+
+  // Extracts vector indices.
+  std::vector<const RowVector*> sourceVectors;
+  sourceVectors.reserve(outputIndex_->size());
+  const auto* vectorIndices =
+      outputIndex_->childAt(0)->asChecked<FlatVector<int64_t>>();
+  for (auto i = 0; i < outputIndex_->size(); ++i) {
+    sourceVectors.push_back(inputs_[vectorIndices->rawValues()[i]].get());
+  }
+
+  // Extracts row indices.
+  std::vector<vector_size_t> sourceRowIndices;
+  sourceRowIndices.reserve(outputIndex_->size());
+  const auto* rowIndices =
+      outputIndex_->childAt(1)->asChecked<FlatVector<int64_t>>();
+  for (auto i = 0; i < outputIndex_->size(); ++i) {
+    sourceRowIndices.push_back(rowIndices->rawValues()[i]);
+  }
+
+  gatherCopy(
+      output_.get(), 0, output_->size(), sourceVectors, sourceRowIndices);
+}
+
+RowVectorPtr NonMaterializedSortBuffer::getOutput(vector_size_t maxOutputRows) {
+  SCOPE_EXIT {
+    pool_->release();
+  };
+
+  VELOX_CHECK(noMoreInput_);
+  if (numOutputRows_ == numInputRows_) {
+    inputs_.clear();
+    data_->clear();
+    return nullptr;
+  }
+
+  VELOX_CHECK_GT(maxOutputRows, 0);
+  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
+
+  prepareOutput(batchSize);
+  gatherCopyOutput();
+
+  return output_;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/NonMaterializedSortBuffer.h
+++ b/velox/exec/NonMaterializedSortBuffer.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/MaterializedSortBuffer.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/PrefixSort.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/SortBufferBase.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+/// A utility class to accumulate data inside and output the sorted result.
+/// Spilling would be triggered if spilling is enabled and memory usage exceeds
+/// limit.
+///
+/// Uses non-materialize mode to sort input vectors, serializing only the sort
+/// key columns and two additional index columns into the RowContainer. These
+/// index columns are the vector indices and the row indices of each vector.
+/// After sorting, rows are gathered and copied from the input vectors using
+/// these indices.
+class NonMaterializedSortBuffer final : public SortBufferBase {
+ public:
+  NonMaterializedSortBuffer(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& sortColumnIndices,
+      const std::vector<CompareFlags>& sortCompareFlags,
+      velox::memory::MemoryPool* pool,
+      tsan_atomic<bool>* nonReclaimableSection,
+      common::PrefixSortConfig prefixSortConfig,
+      const common::SpillConfig* spillConfig = nullptr,
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+
+  ~NonMaterializedSortBuffer() override;
+
+  void addInput(const VectorPtr& input) override;
+
+  /// Indicates no more input and triggers either of:
+  ///  - In-memory sorting on rows stored in 'data_' if spilling is not enabled.
+  ///  - Finish spilling and setup the sort merge reader for the un-spilling
+  ///  processing for the output.
+  void noMoreInput() override;
+
+  RowVectorPtr getOutput(vector_size_t maxOutputRows) override;
+
+ private:
+  void prepareOutputVector(
+      const RowTypePtr& outputType,
+      vector_size_t outputBatchSize,
+      RowVectorPtr& output) const;
+
+  // Invoked to initialize or reset the reusable output buffer to get output.
+  void prepareOutput(vector_size_t outputBatchSize) override;
+
+  void gatherCopyOutput();
+
+  int64_t estimateFlatInputBytes(const VectorPtr& input) const override;
+
+  int64_t estimateIncrementalBytes(
+      const VectorPtr& input,
+      uint64_t outOfLineBytes,
+      int64_t flatInputBytes) const override;
+
+  void prepareRowIndexVector(const VectorPtr& input);
+
+  const std::vector<SpillSortKey> sortingKeys_;
+
+  // Two index columns materialized in the row container to index each input
+  // row. The first column points to the vector in 'inputs_' and the second
+  // points to the row in the pointed vector.
+  const RowTypePtr indexType_{ROW({BIGINT(), BIGINT()})};
+
+  // The sort columns projection map between 'input_' and 'sortingKeys_' as sort
+  // buffer stores the sort columns first in 'data_'.
+  std::vector<IdentityProjection> sortColumnProjections_;
+
+  std::vector<RowVectorPtr> inputs_;
+
+  VectorPtr rowIndexVec_;
+
+  // The column projection map between 'data_' and 'indexOutput_', containing
+  // two columns: 0 for vector indices and 1 for row indices.
+  std::vector<IdentityProjection> indexColumnMap_;
+
+  // Reusable indices vector.
+  RowVectorPtr outputIndex_;
+
+  // The number of received input bytes.
+  uint64_t numInputBytes_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -59,15 +59,30 @@ OrderBy::OrderBy(
     sortCompareFlags.push_back(
         fromSortOrderToCompareFlags(orderByNode->sortingOrders()[i]));
   }
-  sortBuffer_ = std::make_unique<SortBuffer>(
-      outputType_,
-      sortColumnIndices,
-      sortCompareFlags,
-      pool(),
-      &nonReclaimableSection_,
-      driverCtx->prefixSortConfig(),
-      spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
-      spillStats_.get());
+
+  const auto nonMaterializedSortBufferEnabled =
+      driverCtx->queryConfig().nonMaterializedSortBufferEnabled();
+  if (nonMaterializedSortBufferEnabled) {
+    sortBuffer_ = std::make_unique<NonMaterializedSortBuffer>(
+        outputType_,
+        sortColumnIndices,
+        sortCompareFlags,
+        pool(),
+        &nonReclaimableSection_,
+        driverCtx->prefixSortConfig(),
+        spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
+        spillStats_.get());
+  } else {
+    sortBuffer_ = std::make_unique<MaterializedSortBuffer>(
+        outputType_,
+        sortColumnIndices,
+        sortCompareFlags,
+        pool(),
+        &nonReclaimableSection_,
+        driverCtx->prefixSortConfig(),
+        spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr,
+        spillStats_.get());
+  }
 }
 
 void OrderBy::addInput(RowVectorPtr input) {

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -16,9 +16,10 @@
 #pragma once
 
 #include "velox/exec/ContainerRowSerde.h"
+#include "velox/exec/MaterializedSortBuffer.h"
+#include "velox/exec/NonMaterializedSortBuffer.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
-#include "velox/exec/SortBuffer.h"
 #include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
@@ -62,7 +63,7 @@ class OrderBy : public Operator {
   void close() override;
 
  private:
-  std::unique_ptr<SortBuffer> sortBuffer_;
+  std::unique_ptr<SortBufferBase> sortBuffer_;
   bool finished_ = false;
   vector_size_t maxOutputRows_;
 };

--- a/velox/exec/SortBufferBase.cpp
+++ b/velox/exec/SortBufferBase.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SortBufferBase.h"
+#include <vector>
+
+namespace facebook::velox::exec {
+SortBufferBase::SortBufferBase(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& sortColumnIndices,
+    const std::vector<CompareFlags>& sortCompareFlags,
+    velox::memory::MemoryPool* pool,
+    tsan_atomic<bool>* nonReclaimableSection,
+    common::PrefixSortConfig prefixSortConfig,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    : inputType_(inputType),
+      sortCompareFlags_(sortCompareFlags),
+      pool_(pool),
+      nonReclaimableSection_(nonReclaimableSection),
+      prefixSortConfig_(prefixSortConfig),
+      spillConfig_(spillConfig),
+      spillStats_(spillStats),
+      sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
+  VELOX_CHECK_GE(inputType_->children().size(), sortCompareFlags_.size());
+  VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
+  VELOX_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
+  VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
+}
+
+void SortBufferBase::updateEstimatedOutputRowSize() {
+  const auto optionalRowSize = data_->estimateRowSize();
+  if (!optionalRowSize.has_value() || optionalRowSize.value() == 0) {
+    return;
+  }
+
+  const auto rowSize = optionalRowSize.value();
+  if (!estimatedOutputRowSize_.has_value()) {
+    estimatedOutputRowSize_ = rowSize;
+  } else if (rowSize > estimatedOutputRowSize_.value()) {
+    estimatedOutputRowSize_ = rowSize;
+  }
+}
+
+void SortBufferBase::ensureSortFitsImpl() const {
+  // The memory for std::vector sorted rows and prefix sort required buffer.
+  const auto numBytesToReserve =
+      numInputRows_ * sizeof(char*) +
+      PrefixSort::maxRequiredBytes(
+          data_.get(), sortCompareFlags_, prefixSortConfig_, pool_);
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(numBytesToReserve)) {
+      return;
+    }
+  }
+
+  LOG(WARNING) << fmt::format(
+      "Failed to reserve {} for memory pool {}, usage: {}, reservation: {}",
+      succinctBytes(numBytesToReserve),
+      pool_->name(),
+      succinctBytes(pool_->usedBytes()),
+      succinctBytes(pool_->reservedBytes()));
+}
+
+void SortBufferBase::sortInput(uint64_t numRows) {
+  sortedRows_.resize(numRows);
+  RowContainerIterator iter;
+  data_->listRows(&iter, numRows, sortedRows_.data());
+  PrefixSort::sort(
+      data_.get(), sortCompareFlags_, prefixSortConfig_, pool_, sortedRows_);
+}
+
+void SortBufferBase::ensureInputFits(const VectorPtr& input) {
+  // Check if spilling is enabled or not.
+  if (spillConfig_ == nullptr) {
+    return;
+  }
+
+  const int64_t numRows = data_->numRows();
+  if (numRows == 0) {
+    // 'data_' is empty. Nothing to spill.
+    return;
+  }
+
+  auto [freeRows, outOfLineFreeBytes] = data_->freeSpace();
+  const auto outOfLineBytes =
+      data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  const auto flatInputBytes = estimateFlatInputBytes(input);
+
+  // Test-only spill path.
+  if (numRows > 0 && testingTriggerSpill(pool_->name())) {
+    spill();
+    return;
+  }
+
+  const auto currentMemoryUsage = pool_->usedBytes();
+  const auto minReservationBytes =
+      currentMemoryUsage * spillConfig_->minSpillableReservationPct / 100;
+  const auto availableReservationBytes = pool_->availableReservation();
+  const auto estimatedIncrementalBytes =
+      estimateIncrementalBytes(input, outOfLineBytes, flatInputBytes);
+
+  if (availableReservationBytes > minReservationBytes) {
+    // If we have enough free rows for input rows and enough variable length
+    // free space for the vector's flat size, no need for spilling.
+    if (freeRows > input->size() &&
+        (outOfLineBytes == 0 || outOfLineFreeBytes >= flatInputBytes)) {
+      return;
+    }
+
+    // If the current available reservation in memory pool is 2X the
+    // estimatedIncrementalBytes, no need to spill.
+    if (availableReservationBytes > 2 * estimatedIncrementalBytes) {
+      return;
+    }
+  }
+
+  // Try reserving targetIncrementBytes more in memory pool, if succeed, no
+  // need to spill.
+  const auto targetIncrementBytes = std::max<int64_t>(
+      estimatedIncrementalBytes * 2,
+      currentMemoryUsage * spillConfig_->spillableReservationGrowthPct / 100);
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(targetIncrementBytes)) {
+      return;
+    }
+  }
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool()->name()
+               << ", usage: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+}
+
+void SortBufferBase::ensureOutputFits(vector_size_t batchSize) {
+  VELOX_CHECK_GT(batchSize, 0);
+  // Check if spilling is enabled or not.
+  if (spillConfig_ == nullptr) {
+    return;
+  }
+
+  // Test-only spill path.
+  if (testingTriggerSpill(pool_->name())) {
+    spill();
+    return;
+  }
+
+  if (!estimatedOutputRowSize_.has_value() || hasSpilled()) {
+    return;
+  }
+
+  const uint64_t outputBufferSizeToReserve =
+      estimatedOutputRowSize_.value() * batchSize * 1.2;
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(outputBufferSizeToReserve)) {
+      return;
+    }
+  }
+  LOG(WARNING) << "Failed to reserve "
+               << succinctBytes(outputBufferSizeToReserve)
+               << " for memory pool " << pool_->name()
+               << ", usage: " << succinctBytes(pool_->usedBytes())
+               << ", reservation: " << succinctBytes(pool_->reservedBytes());
+}
+
+void SortBufferBase::spill() {
+  VELOX_CHECK_NOT_NULL(
+      spillConfig_,
+      "spill config is null when HybridSortBuffer spill is called");
+
+  // Check if sort buffer is empty or not, and skip spill if it is empty.
+  if (data_->numRows() == 0) {
+    return;
+  }
+  updateEstimatedOutputRowSize();
+
+  if (sortedRows_.empty()) {
+    spillInput();
+  } else {
+    spillOutput();
+  }
+}
+
+RowVectorPtr SortBufferBase::getOutput(vector_size_t maxOutputRows) {
+  SCOPE_EXIT {
+    pool_->release();
+  };
+
+  VELOX_CHECK(noMoreInput_);
+
+  if (numOutputRows_ == numInputRows_) {
+    return nullptr;
+  }
+  VELOX_CHECK_GT(maxOutputRows, 0);
+  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
+
+  ensureOutputFits(batchSize);
+  prepareOutput(batchSize);
+
+  if (hasSpilled()) {
+    getOutputWithSpill();
+  } else {
+    getOutputWithoutSpill();
+  }
+
+  return output_;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -64,12 +64,14 @@ add_executable(
   LocalPartitionTest.cpp
   Main.cpp
   MarkDistinctTest.cpp
+  MaterializedSortBufferTest.cpp
   MemoryReclaimerTest.cpp
   MergeJoinTest.cpp
   MergeTest.cpp
   MergerTest.cpp
   MultiFragmentTest.cpp
   NestedLoopJoinTest.cpp
+  NonMaterializedSortBufferTest.cpp
   OrderByTest.cpp
   OperatorTraceTest.cpp
   OutputBufferManagerTest.cpp
@@ -88,7 +90,6 @@ add_executable(
   RowNumberTest.cpp
   ScaledScanControllerTest.cpp
   ScaleWriterLocalPartitionTest.cpp
-  SortBufferTest.cpp
   SpatialIndexTest.cpp
   HilbertIndexTest.cpp
   SpillerTest.cpp

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/file/FileSystems.h"
-#include "velox/exec/SortBuffer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -44,7 +44,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
       const size_t maxOutputRows) {
     const VectorFuzzer::Options fuzzerOpts{.vectorSize = maxOutputRows};
     const auto vectors = createVectors(numVectors, inputType_, fuzzerOpts);
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -171,7 +171,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
   std::vector<RowVectorPtr> makeExpectedResults(
       const std::vector<RowVectorPtr>& vectors,
       size_t maxOutputRows) {
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -16,9 +16,9 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/Merge.h"
 #include "velox/exec/MergeSource.h"
-#include "velox/exec/SortBuffer.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -47,7 +47,7 @@ class MergerTest : public OperatorTestBase {
       const size_t vectorSize) {
     const VectorFuzzer::Options fuzzerOpts{.vectorSize = vectorSize};
     const auto vectors = createVectors(numVectors, inputType_, fuzzerOpts);
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -123,7 +123,7 @@ class MergerTest : public OperatorTestBase {
         flatInputs.emplace_back(vector);
       }
     }
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,

--- a/velox/exec/tests/NonMaterializedSortBufferTest.cpp
+++ b/velox/exec/tests/NonMaterializedSortBufferTest.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/NonMaterializedSortBuffer.h"
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/type/Type.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::functions::test {
+namespace {
+// Class to write runtime stats in the tests to the stats container.
+class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
+ public:
+  explicit TestRuntimeStatWriter(
+      std::unordered_map<std::string, RuntimeMetric>& stats)
+      : stats_{stats} {}
+
+  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+      override {
+    addOperatorRuntimeStats(name, value, stats_);
+  }
+
+ private:
+  std::unordered_map<std::string, RuntimeMetric>& stats_;
+};
+} // namespace
+
+class NonMaterializedSortBufferTest : public OperatorTestBase,
+                                      public testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+    rng_.seed(123);
+    statWriter_ = std::make_unique<TestRuntimeStatWriter>(stats_);
+    setThreadLocalRunTimeStatWriter(statWriter_.get());
+  }
+
+  void TearDown() override {
+    pool_.reset();
+    rootPool_.reset();
+    OperatorTestBase::TearDown();
+    setThreadLocalRunTimeStatWriter(nullptr);
+  }
+
+  const bool enableSpillPrefixSort_{GetParam()};
+  const velox::common::PrefixSortConfig prefixSortConfig_ =
+      velox::common::PrefixSortConfig{
+          std::numeric_limits<uint32_t>::max(),
+          GetParam() ? 8 : std::numeric_limits<uint32_t>::max(),
+          12};
+
+  const RowTypePtr inputType_ = ROW(
+      {{"c0", BIGINT()},
+       {"c1", INTEGER()},
+       {"c2", SMALLINT()},
+       {"c3", REAL()},
+       {"c4", DOUBLE()},
+       {"c5", VARCHAR()}});
+  // Specifies the sort columns ["c4", "c1"].
+  std::vector<column_index_t> sortColumnIndices_{4, 1};
+  std::vector<CompareFlags> sortCompareFlags_{
+      {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue},
+      {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}};
+
+  const std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
+
+  tsan_atomic<bool> nonReclaimableSection_{false};
+  folly::Random::DefaultGenerator rng_;
+  std::unordered_map<std::string, RuntimeMetric> stats_;
+  std::unique_ptr<TestRuntimeStatWriter> statWriter_;
+  const std::shared_ptr<memory::MemoryPool> fuzzerPool_ =
+      memory::memoryManager()->addLeafPool("NonMaterializedSortBufferTest");
+};
+
+TEST_P(NonMaterializedSortBufferTest, singleKey) {
+  const RowVectorPtr data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<int32_t>(
+           {17, 16, 15, 14, 13, 10, 8, 7, 4, 3}), // sorted column
+       makeFlatVector<int16_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<float>(
+           {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}),
+       makeFlatVector<double>(
+           {1.1, 2.2, 2.2, 5.5, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}),
+       makeFlatVector<std::string>(
+           {"hello",
+            "world",
+            "today",
+            "is",
+            "great",
+            "hello",
+            "world",
+            "is",
+            "great",
+            "today"})});
+
+  struct {
+    std::vector<CompareFlags> sortCompareFlags;
+    std::vector<int32_t> expectedResult;
+
+    std::string debugString() const {
+      const std::string expectedResultStr = folly::join(",", expectedResult);
+      std::stringstream sortCompareFlagsStr;
+      for (const auto sortCompareFlag : sortCompareFlags) {
+        sortCompareFlagsStr << sortCompareFlag.toString();
+      }
+      return fmt::format(
+          "sortCompareFlags:{}, expectedResult:{}",
+          sortCompareFlagsStr.str(),
+          expectedResultStr);
+    }
+  } testSettings[] = {
+      {{{true,
+         true,
+         false,
+         CompareFlags::NullHandlingMode::kNullAsValue}}, // Ascending
+       {3, 4, 7, 8, 10, 13, 14, 15, 16, 17}},
+      {{{true,
+         false,
+         false,
+         CompareFlags::NullHandlingMode::kNullAsValue}}, // Descending
+       {17, 16, 15, 14, 13, 10, 8, 7, 4, 3}}};
+
+  // Specifies the sort columns ["c1"].
+  sortColumnIndices_ = {1};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto sortBuffer = std::make_unique<NonMaterializedSortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        testData.sortCompareFlags,
+        pool_.get(),
+        &nonReclaimableSection_,
+        prefixSortConfig_);
+
+    sortBuffer->addInput(data);
+    sortBuffer->noMoreInput();
+    auto output = sortBuffer->getOutput(10000);
+    ASSERT_EQ(output->size(), 10);
+    int resultIndex = 0;
+    for (int expectedValue : testData.expectedResult) {
+      ASSERT_EQ(
+          output->childAt(1)->asFlatVector<int32_t>()->valueAt(resultIndex++),
+          expectedValue);
+    }
+    if (GetParam()) {
+      ASSERT_EQ(
+          stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+          sortColumnIndices_.size());
+      ASSERT_EQ(
+          stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+          sortColumnIndices_.size());
+      ASSERT_EQ(
+          stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+          sortColumnIndices_.size());
+    } else {
+      ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+    }
+    stats_.clear();
+  }
+}
+
+TEST_P(NonMaterializedSortBufferTest, multipleKeys) {
+  auto sortBuffer = std::make_unique<NonMaterializedSortBuffer>(
+      inputType_,
+      sortColumnIndices_,
+      sortCompareFlags_,
+      pool_.get(),
+      &nonReclaimableSection_,
+      prefixSortConfig_);
+
+  RowVectorPtr data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<int32_t>(
+           {15, 12, 9, 8, 7, 6, 5, 4, 3, 1}), // sorted-2 column
+       makeFlatVector<int16_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<float>(
+           {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}),
+       makeFlatVector<double>(
+           {1.1, 2.2, 2.2, 5.5, 5.5, 7.7, 8.1, 8, 8.1, 8.1, 10.0}), // sorted-1
+                                                                    // column
+       makeFlatVector<std::string>(
+           {"hello",
+            "world",
+            "today",
+            "is",
+            "great",
+            "hello",
+            "world",
+            "is",
+            "sort",
+            "sorted"})});
+
+  sortBuffer->addInput(data);
+  sortBuffer->noMoreInput();
+  auto output = sortBuffer->getOutput(10000);
+  ASSERT_EQ(output->size(), 10);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(0), 15);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(1), 9);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(2), 12);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(3), 7);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(4), 8);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(5), 6);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(6), 4);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(7), 1);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(8), 3);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(9), 5);
+  if (GetParam()) {
+    ASSERT_EQ(
+        stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+        sortColumnIndices_.size());
+    ASSERT_EQ(
+        stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+        sortColumnIndices_.size());
+    ASSERT_EQ(
+        stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+        sortColumnIndices_.size());
+  } else {
+    ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+  }
+}
+
+TEST_P(NonMaterializedSortBufferTest, batchOutput) {
+  struct {
+    std::vector<size_t> numInputRows;
+    size_t maxOutputRows;
+    std::vector<size_t> expectedOutputRowCount;
+
+    std::string debugString() const {
+      const std::string numInputRowsStr = folly::join(",", numInputRows);
+      const std::string expectedOutputRowCountStr =
+          folly::join(",", expectedOutputRowCount);
+      return fmt::format(
+          "numInputRows:{}, maxOutputRows:{}, expectedOutputRowCount:{}",
+          numInputRowsStr,
+          maxOutputRows,
+          expectedOutputRowCountStr);
+    }
+  } testSettings[] = {
+      {{2, 3, 3}, 1, {1, 1, 1, 1, 1, 1, 1, 1}},
+      {{2, 3, 3}, 1, {1, 1, 1, 1, 1, 1, 1, 1}},
+      {{2000, 2000}, 10000, {4000}},
+      {{2000, 2000}, 10000, {4000}},
+      {{2000, 2000}, 2000, {2000, 2000}},
+      {{2000, 2000}, 2000, {2000, 2000}},
+      {{1024, 1024, 1024}, 1000, {1000, 1000, 1000, 72}},
+      {{1024, 1024, 1024}, 1000, {1000, 1000, 1000, 72}}};
+
+  TestScopedSpillInjection scopedSpillInjection(100);
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto sortBuffer = std::make_unique<NonMaterializedSortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        prefixSortConfig_,
+        nullptr,
+        nullptr);
+    ASSERT_FALSE(sortBuffer->canSpill());
+    std::vector<RowVectorPtr> inputVectors;
+    inputVectors.reserve(testData.numInputRows.size());
+    uint64_t totalNumInput = 0;
+    for (size_t inputRows : testData.numInputRows) {
+      VectorFuzzer fuzzer({.vectorSize = inputRows}, fuzzerPool_.get());
+      RowVectorPtr input = fuzzer.fuzzRow(inputType_);
+      sortBuffer->addInput(input);
+      inputVectors.push_back(input);
+      totalNumInput += inputRows;
+    }
+    sortBuffer->noMoreInput();
+    int expectedOutputBufferIndex = 0;
+    RowVectorPtr output = sortBuffer->getOutput(testData.maxOutputRows);
+    while (output != nullptr) {
+      ASSERT_EQ(
+          output->size(),
+          testData.expectedOutputRowCount[expectedOutputBufferIndex++]);
+      output = sortBuffer->getOutput(testData.maxOutputRows);
+    }
+  }
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    NonMaterializedSortBufferTest,
+    NonMaterializedSortBufferTest,
+    testing::ValuesIn({false, true}));
+} // namespace facebook::velox::functions::test


### PR DESCRIPTION
Add a NonMaterializedSortBuffer, which materializes only the sort key columns
and additional index columns into a RowContainer for sorting. After the sort, it
uses these indices to gather and copy the corresponding rows from the original
input vectors into the output vector. This reduces the overhead of materializing
payload columns into the RowContainer, which is especially beneficial for wide
table scenarios. Support for spilling will be added in a follow-up PR.