### PR TITLE
refactor: Remove unused 'cache_load_quantum' flag

### DIFF
--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -27,8 +27,6 @@
 #include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/InputStream.h"
 
-DECLARE_int32(cache_load_quantum);
-
 namespace facebook::velox::dwio::common {
 
 struct CacheRequest {


### PR DESCRIPTION
The 'cache_load_quantum' gflag is not used anywhere, so we should 
remove its declaration.