### PR TITLE
perf(exchange): Optimize promise insertion to avoid temporary Promise construction

### DIFF
--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -128,7 +128,7 @@ void ExchangeQueue::addPromiseLocked(
     *stalePromise = std::move(it->second);
     it->second = std::move(promise);
   } else {
-    promises_[consumerId] = std::move(promise);
+    promises_.emplace(consumerId, std::move(promise));
   }
   VELOX_CHECK_LE(promises_.size(), numberOfConsumers_);
 }


### PR DESCRIPTION
X-link: https://github.com/prestodb/presto/issues/26094

`ExchangeQueue::promises_` is a `folly::F14FastMap<int, ContinuePromise>`.
Using the subscript operator:
```
  promises_[consumerId] = std::move(promise);
```
1. Default-construct a empty `ContinuePromise` when inserting a new
   'consumerId' key.
2. However, this temporary promise is then immediately overwritten
   by the move-assignment.

However, for an empty `folly::Promise` object that is expected to be
overwritten, we should use `folly::makeEmpty()` to initialize it (it is
'invalid') instead of the default constructor (it will be 'valid' but
'not fulfilled', assigning to it will cause an exception. Creating an
exception triggers a stack unwind, which can saturate the CPU in
high-concurrency scenarios, **causing significant performance issues**.

In high-concurrency scenarios, I can see a lot of CPU consumption here,
for the reason mentioned above.

This patch replaces the subscript-based insertion with:
```
  promises_.emplace(consumerId, std::move(promise));
```
which constructs the `ContinuePromise` in place and avoids creating and
overwrite a temporary empty promise. This completely eliminates the
redundant expensive `folly::Promise` stack backtrace, and thus, saves
a lot of CPU.