### PR TITLE
fix: Cleanup code to make it Clang20 compatible

### DIFF
--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -48,10 +48,10 @@ struct FileOptions {
   /// etc.
   static constexpr folly::StringPiece kFileCreateConfig{"file-create-config"};
 
-  std::unordered_map<std::string, std::string> values;
+  std::unordered_map<std::string, std::string> values{};
   memory::MemoryPool* pool{nullptr};
   /// If specified then can be trusted to be the file size.
-  std::optional<int64_t> fileSize;
+  std::optional<int64_t> fileSize{};
 
   /// Whether to create parent directories if they don't exist.
   ///

--- a/velox/common/memory/Scratch.h
+++ b/velox/common/memory/Scratch.h
@@ -79,14 +79,17 @@ class Scratch {
     // stringop-overflow warning when 'newCapacity' is 0.
     folly::assume(capacity_ >= 0);
     if (newCapacity > capacity_) {
-      Item* newItems =
-          reinterpret_cast<Item*>(::malloc(sizeof(Item) * newCapacity));
+      auto* newItems =
+          reinterpret_cast<uint8_t*>(::malloc(sizeof(Item) * newCapacity));
       if (fill_ > 0) {
         ::memcpy(newItems, items_, fill_ * sizeof(Item));
       }
-      ::memset(newItems + fill_, 0, (newCapacity - fill_) * sizeof(Item));
+      ::memset(
+          newItems + fill_ * sizeof(Item),
+          0,
+          (newCapacity - fill_) * sizeof(Item));
       ::free(items_);
-      items_ = newItems;
+      items_ = reinterpret_cast<Item*>(newItems);
       capacity_ = newCapacity;
     }
     fill_ = std::min(fill_, newCapacity);

--- a/velox/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
@@ -37,6 +37,8 @@ target_link_libraries(
   velox_gcs
   velox_hive_config
   velox_core
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsFileSystemTest.cpp
@@ -60,8 +60,8 @@ TEST_F(GcsFileSystemTest, readFile) {
   EXPECT_EQ(size, ref_size);
   EXPECT_EQ(readFile->pread(0, size), kLoremIpsum);
 
-  char buffer1[size];
-  ASSERT_EQ(readFile->pread(0, size, &buffer1), kLoremIpsum);
+  std::vector<char> buffer1(size);
+  ASSERT_EQ(readFile->pread(0, size, buffer1.data()), kLoremIpsum);
   ASSERT_EQ(readFile->size(), ref_size);
 
   char buffer2[50];

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
@@ -37,6 +37,9 @@ add_test(velox_hdfs_insert_test velox_hdfs_insert_test)
 
 target_link_libraries(
   velox_hdfs_insert_test
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
+  velox_hdfs
   velox_exec_test_lib
   velox_exec
   GTest::gtest

--- a/velox/experimental/wave/common/HashTable.h
+++ b/velox/experimental/wave/common/HashTable.h
@@ -81,7 +81,7 @@ struct AllocationRange {
         firstRowOffset(roundUp64(capacity / rowSize) / 8),
         rowOffset(firstRowOffset),
         stringOffset(capacity) {
-    ::memset(reinterpret_cast<char*>(base), 0, firstRowOffset);
+    ::memset(reinterpret_cast<uint8_t*>(base), 0, firstRowOffset);
   }
 
   AllocationRange(AllocationRange&& other) {
@@ -92,7 +92,7 @@ struct AllocationRange {
 
   void operator=(AllocationRange&& other) {
     *this = other;
-    memset(&other, 0, sizeof(AllocationRange));
+    memset(reinterpret_cast<uint8_t*>(&other), 0, sizeof(AllocationRange));
   }
 
   int64_t availableFixed() {

--- a/velox/expression/signature_parser/Scanner.h
+++ b/velox/expression/signature_parser/Scanner.h
@@ -36,6 +36,9 @@ class Scanner : public yyFlexLexer {
       : yyFlexLexer(&arg_yyin, &arg_yyout),
         outputType_(outputType),
         input_(input) {}
+
+  ~Scanner() = default;
+
   int lex(Parser::semantic_type* yylval);
 
   void setTypeSignature(TypeSignaturePtr type) {

--- a/velox/external/date/date.h
+++ b/velox/external/date/date.h
@@ -973,8 +973,8 @@ operator<<(std::basic_ostream<CharT, Traits>& os, const year_month_weekday_last&
 inline namespace literals
 {
 
-CONSTCD11 date::day  operator "" _d(unsigned long long d) NOEXCEPT;
-CONSTCD11 date::year operator "" _y(unsigned long long y) NOEXCEPT;
+CONSTCD11 date::day  operator ""_d(unsigned long long d) NOEXCEPT;
+CONSTCD11 date::year operator ""_y(unsigned long long y) NOEXCEPT;
 
 }  // inline namespace literals
 #endif // !defined(_MSC_VER) || (_MSC_VER >= 1900)
@@ -1883,7 +1883,7 @@ inline namespace literals
 CONSTCD11
 inline
 date::day
-operator "" _d(unsigned long long d) NOEXCEPT
+operator ""_d(unsigned long long d) NOEXCEPT
 {
     return date::day{static_cast<unsigned>(d)};
 }
@@ -1891,7 +1891,7 @@ operator "" _d(unsigned long long d) NOEXCEPT
 CONSTCD11
 inline
 date::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return date::year(static_cast<int>(y));
 }

--- a/velox/external/date/iso_week.h
+++ b/velox/external/date/iso_week.h
@@ -343,7 +343,7 @@ inline namespace literals
 CONSTCD11
 inline
 date::year
-operator "" _y(unsigned long long y) NOEXCEPT
+operator ""_y(unsigned long long y) NOEXCEPT
 {
     return date::year(static_cast<int64_t>(y));
 }
@@ -351,7 +351,7 @@ operator "" _y(unsigned long long y) NOEXCEPT
 CONSTCD11
 inline
 iso_week::weeknum
-operator "" _w(unsigned long long wn) NOEXCEPT
+operator ""_w(unsigned long long wn) NOEXCEPT
 {
     return iso_week::weeknum(static_cast<unsigned>(wn));
 }

--- a/velox/tpcds/gen/dsdgen/dist.cpp
+++ b/velox/tpcds/gen/dsdgen/dist.cpp
@@ -371,7 +371,7 @@ int load_dists() {
   read_ptr = tpcds_idx + tpcds_idx_len - (entry_count * IDX_SIZE);
   for (int i = 0; i < entry_count; i++) {
     d_idx_t entry;
-    memset(&entry, 0, sizeof(const d_idx_t));
+    memset(reinterpret_cast<uint8_t*>(&entry), 0, sizeof(const d_idx_t));
     memcpy(entry.name, read_ptr, D_NAME_LEN);
     read_ptr += D_NAME_LEN;
     entry.name[D_NAME_LEN] = '\0';

--- a/velox/type/parser/Scanner.h
+++ b/velox/type/parser/Scanner.h
@@ -40,6 +40,8 @@ class Scanner : public yyFlexLexer {
         outputType_(outputType),
         input_(input) {}
 
+  ~Scanner() = default;
+
   int lex(Parser::semantic_type* yylval);
 
   void setType(TypePtr type) {


### PR DESCRIPTION
When compiling with Clang20 (default in Centos9)
various compile errors occurred that are fixed by these changes.

For example,
call to 'memset' is a pointer to non-trivially copyable type 'type'.