### PR TITLE
fix: Remove tsan_lock_guard

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -152,7 +152,8 @@ class AsyncSource {
   // If true, move() will not block. But there is no guarantee that somebody
   // else will not get the item first.
   bool hasValue() const {
-    tsan_lock_guard<std::mutex> l(mutex_);
+    // TODO: Can we do this without a lock?
+    std::lock_guard<std::mutex> l(mutex_);
     return item_ != nullptr || exception_ != nullptr;
   }
 

--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -66,10 +66,6 @@ inline T tsanAtomicValue(const std::atomic<T>& x) {
   return x;
 }
 
-/// Lock guard in tsan build and no-op otherwise.
-template <typename T>
-using tsan_lock_guard = std::lock_guard<T>;
-
 #else
 
 template <typename T>
@@ -79,13 +75,6 @@ template <typename T>
 inline T tsanAtomicValue(T x) {
   return x;
 }
-template <typename T>
-struct TsanEmptyLockGuard {
-  TsanEmptyLockGuard(T& /*ignore*/) {}
-};
-
-template <typename T>
-using tsan_lock_guard = TsanEmptyLockGuard<T>;
 
 #endif
 

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -441,7 +441,8 @@ class CoalescedLoad {
   bool loadOrFuture(folly::SemiFuture<bool>* wait, bool ssdSavable = true);
 
   State state() const {
-    tsan_lock_guard<std::mutex> l(mutex_);
+    // TODO: Can we do this without a lock?
+    std::lock_guard<std::mutex> l(mutex_);
     return state_;
   }
 

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -330,7 +330,8 @@ class SsdFile {
   /// Asserts that the region of 'offset' is pinned. This is called by the pin
   /// holder. The pin count can be read without mutex.
   void checkPinned(uint64_t offset) const {
-    tsan_lock_guard<std::shared_mutex> l(mutex_);
+    // TODO: Can we do this without a lock?
+    std::shared_lock<std::shared_mutex> l(mutex_);
     VELOX_CHECK_GT(regionPins_[regionIndex(offset)], 0);
   }
 

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -439,15 +439,16 @@ MemoryPoolImpl::MemoryPoolImpl(
     std::shared_ptr<MemoryPool> parent,
     std::unique_ptr<MemoryReclaimer> reclaimer,
     const Options& options)
-    : MemoryPool{name, kind, parent, options},
+    : MemoryPool{name, kind, std::move(parent), options},
       manager_{memoryManager},
       allocator_{manager_->allocator()},
       arbitrator_{manager_->arbitrator()},
-      reclaimer_(std::move(reclaimer)),
+      reclaimer_{reclaimer.get()},
       // The memory manager sets the capacity through grow() according to the
       // actually used memory arbitration policy.
-      capacity_(parent_ != nullptr ? kMaxMemory : 0) {
+      capacity_{parent_ != nullptr ? kMaxMemory : 0} {
   VELOX_CHECK(options.threadSafe || isLeaf());
+  std::ignore = reclaimer.release();
 }
 
 MemoryPoolImpl::~MemoryPoolImpl() {
@@ -483,6 +484,8 @@ MemoryPoolImpl::~MemoryPoolImpl() {
   if (destructionCb_ != nullptr) {
     destructionCb_(this);
   }
+
+  delete reclaimer_.load(std::memory_order_relaxed);
 }
 
 MemoryPool::Stats MemoryPoolImpl::stats() const {
@@ -1089,13 +1092,12 @@ void MemoryPoolImpl::setReclaimer(std::unique_ptr<MemoryReclaimer> reclaimer) {
         parent_->name());
   }
   std::lock_guard<std::mutex> l(mutex_);
-  VELOX_CHECK_NULL(reclaimer_);
-  reclaimer_ = std::move(reclaimer);
+  VELOX_CHECK_NULL(reclaimer_.load(std::memory_order_relaxed));
+  reclaimer_.store(reclaimer.release(), std::memory_order_relaxed);
 }
 
 MemoryReclaimer* MemoryPoolImpl::reclaimer() const {
-  tsan_lock_guard<std::mutex> l(mutex_);
-  return reclaimer_.get();
+  return reclaimer_.load(std::memory_order_relaxed);
 }
 
 std::optional<uint64_t> MemoryPoolImpl::reclaimableBytes() const {

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -1036,7 +1036,7 @@ class MemoryPoolImpl : public MemoryPool {
   // object if not null. For example, a memory pool can reclaim the used memory
   // from a spillable operator through disk spilling. If null, we can't reclaim
   // memory from this memory pool.
-  std::unique_ptr<MemoryReclaimer> reclaimer_;
+  std::atomic<MemoryReclaimer*> reclaimer_;
 
   // The memory cap in bytes to enforce.
   tsan_atomic<int64_t> capacity_;


### PR DESCRIPTION
https://github.com/facebookincubator/velox/issues/14985

Code was really strange for these usecases.
Because without tsan `tsan_lock_guard` was just noop.
So in this PR I added more synchronization for build without tsan.
And make it same for tsan vs non-tsan.
So I hope if tsan highlight some issues we will fix this