### PR TITLE
feat: Add TIME support to equal, notEqual, lessThan, lessThanOrEqual, greaterThan, greaterThanOrEqual, between

### DIFF
--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -33,6 +33,7 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
   registerFunction<T, TReturn, TimestampWithTimezone, TimestampWithTimezone>(
       aliases);
+  registerFunction<T, TReturn, Time, Time>(aliases);
   registerFunction<T, TReturn, IPAddress, IPAddress>(aliases);
 }
 } // namespace
@@ -93,6 +94,8 @@ void registerComparisonFunctions(const std::string& prefix) {
   registerFunction<BetweenFunction, bool, Date, Date, Date>(
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, Timestamp, Timestamp, Timestamp>(
+      {prefix + "between"});
+  registerFunction<BetweenFunction, bool, Time, Time, Time>(
       {prefix + "between"});
   registerFunction<
       BetweenFunction,


### PR DESCRIPTION
Summary:
- Added `Time` type registration to `registerNonSimdizableScalar` function for all comparison operators
- Added `Time` type to `BetweenFunction` registration

Differential Revision: D84732349


