### PR TITLE
feat: Allow customized serialized page

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -67,7 +67,6 @@ class Exchange : public SourceOperator {
  protected:
   virtual VectorSerde* getSerde();
 
- private:
   // When 'estimatedRowSize_' is unset, meaning we haven't materialized
   // and returned any output from this exchange operator, we return this
   // conservative number of output rows, to make sure memory does not grow too

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -29,7 +29,7 @@ class SerializedPage {
       std::function<void(folly::IOBuf&)> onDestructionCb = nullptr,
       std::optional<int64_t> numRows = std::nullopt);
 
-  ~SerializedPage();
+  virtual ~SerializedPage();
 
   /// Returns the size of the serialized data in bytes.
   uint64_t size() const {


### PR DESCRIPTION
Summary: Persistent shuffle might need to extend serialized page to include persistent shuffle specific data structure

Differential Revision: D84527691


