### PR TITLE
Fix: Remove unused exception parameter from velox/type/Type.cpp

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -1701,7 +1701,7 @@ int64_t TimeType::valueToTime(
     utcTime = timeZone->to_sys(
         std::chrono::milliseconds{localSystemTime},
         tz::TimeZone::TChoose::kEarliest);
-  } catch (const facebook::velox::tzdb::nonexistent_local_time& error) {
+  } catch (const facebook::velox::tzdb::nonexistent_local_time&) {
     // If the time does not exist during DST spring-forward, fail the
     // conversion.
     VELOX_USER_FAIL(


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Differential Revision: D84732654


