### PR TITLE
refactor: Remove backward compatibility code from remote functions

### DIFF
--- a/velox/functions/remote/client/Remote.cpp
+++ b/velox/functions/remote/client/Remote.cpp
@@ -30,7 +30,7 @@ class RemoteThriftFunction : public RemoteVectorFunction {
   RemoteThriftFunction(
       const std::string& functionName,
       const std::vector<exec::VectorFunctionArg>& inputArgs,
-      const RemoteVectorFunctionMetadata& metadata)
+      const RemoteThriftVectorFunctionMetadata& metadata)
       : RemoteVectorFunction(functionName, inputArgs, metadata),
         location_(metadata.location),
         thriftClient_(getThriftClient(location_, &eventBase_)) {}
@@ -57,7 +57,7 @@ std::shared_ptr<exec::VectorFunction> createRemoteFunction(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/,
-    const RemoteVectorFunctionMetadata& metadata) {
+    const RemoteThriftVectorFunctionMetadata& metadata) {
   return std::make_unique<RemoteThriftFunction>(name, inputArgs, metadata);
 }
 
@@ -67,24 +67,6 @@ void registerRemoteFunction(
     const std::string& name,
     std::vector<exec::FunctionSignaturePtr> signatures,
     const RemoteThriftVectorFunctionMetadata& metadata,
-    bool overwrite) {
-  exec::registerStatefulVectorFunction(
-      name,
-      signatures,
-      std::bind(
-          createRemoteFunction,
-          std::placeholders::_1,
-          std::placeholders::_2,
-          std::placeholders::_3,
-          metadata),
-      metadata,
-      overwrite);
-}
-
-void registerRemoteFunction(
-    const std::string& name,
-    std::vector<exec::FunctionSignaturePtr> signatures,
-    const RemoteVectorFunctionMetadata& metadata,
     bool overwrite) {
   exec::registerStatefulVectorFunction(
       name,

--- a/velox/functions/remote/client/Remote.h
+++ b/velox/functions/remote/client/Remote.h
@@ -16,14 +16,17 @@
 
 #pragma once
 
+#include <folly/SocketAddress.h>
 #include "velox/functions/remote/client/RemoteVectorFunction.h"
 
 namespace facebook::velox::functions {
 
 struct RemoteThriftVectorFunctionMetadata
     : public RemoteVectorFunctionMetadata {
-  // TODO: Move `folly::SocketAddress location` and other thrift options here
-  // once call sites are updated.
+  /// Network address of the server to communicate with using a thrift client.
+  /// Note that this can hold a network location (ip/port pair) or a unix domain
+  /// socket path (see SocketAddress::makeFromPath()).
+  folly::SocketAddress location;
 };
 
 /// Registers a new remote function. It will use the meatadata defined in
@@ -38,13 +41,6 @@ void registerRemoteFunction(
     const std::string& name,
     std::vector<exec::FunctionSignaturePtr> signatures,
     const RemoteThriftVectorFunctionMetadata& metadata = {},
-    bool overwrite = true);
-
-// TODO: Remove once call sites are updated.
-void registerRemoteFunction(
-    const std::string& name,
-    std::vector<exec::FunctionSignaturePtr> signatures,
-    const RemoteVectorFunctionMetadata& metadata = {},
     bool overwrite = true);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/remote/client/RemoteVectorFunction.h
+++ b/velox/functions/remote/client/RemoteVectorFunction.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <folly/SocketAddress.h>
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/remote/if/gen-cpp2/RemoteFunction_types.h"
 #include "velox/vector/VectorStream.h"
@@ -27,14 +26,6 @@ struct RemoteVectorFunctionMetadata : public exec::VectorFunctionMetadata {
   /// The serialization format to be used to send batches of data to the remote
   /// process.
   remote::PageFormat serdeFormat{remote::PageFormat::PRESTO_PAGE};
-
-  /// Network address of the server to communicate with using a thrift client.
-  /// Note that this can hold a network location (ip/port pair) or a unix domain
-  /// socket path (see SocketAddress::makeFromPath()).
-  ///
-  /// TODO: Move this to `RemoteThriftVectorFunctionMetadata` once call sites
-  /// are updated.
-  folly::SocketAddress location;
 };
 
 /// Main vector function logic. Needs to be extended with the transport-specific


### PR DESCRIPTION
Summary:
Removing backward compatibility code from remote function refactor,
now that we ensured all users of that code are updated.

Differential Revision: D84776510


