### PR TITLE
refactor(stats-reporter): Add default method implementation

### DIFF
--- a/velox/common/base/StatsReporter.h
+++ b/velox/common/base/StatsReporter.h
@@ -63,7 +63,7 @@ enum class StatType {
   HISTOGRAM,
 };
 
-inline std::string statTypeString(StatType stat) {
+inline std::string_view statTypeString(StatType stat) {
   switch (stat) {
     case StatType::AVG:
       return "Avg";
@@ -75,8 +75,6 @@ inline std::string statTypeString(StatType stat) {
       return "Count";
     case StatType::HISTOGRAM:
       return "Histogram";
-    default:
-      return fmt::format("UNKNOWN: {}", static_cast<int>(stat));
   }
 }
 
@@ -84,17 +82,17 @@ inline std::string statTypeString(StatType stat) {
 /// different implementations.
 class BaseStatsReporter {
  public:
-  virtual ~BaseStatsReporter() {}
+  virtual ~BaseStatsReporter() = default;
 
   /// Register a stat of the given stat type.
   /// @param key The key to identify the stat.
   /// @param statType How the stat is aggregated.
   virtual void registerMetricExportType(const char* key, StatType statType)
-      const = 0;
+      const {}
 
   virtual void registerMetricExportType(
       folly::StringPiece key,
-      StatType statType) const = 0;
+      StatType statType) const {}
 
   /// Register a histogram with a list of percentiles defined.
   /// @param key The key to identify the histogram.
@@ -107,14 +105,14 @@ class BaseStatsReporter {
       int64_t bucketWidth,
       int64_t min,
       int64_t max,
-      const std::vector<int32_t>& pcts) const = 0;
+      const std::vector<int32_t>& pcts) const {}
 
   virtual void registerHistogramMetricExportType(
       folly::StringPiece key,
       int64_t bucketWidth,
       int64_t min,
       int64_t max,
-      const std::vector<int32_t>& pcts) const = 0;
+      const std::vector<int32_t>& pcts) const {}
 
   /// Register a quantile metric for quantile stats with export types,
   /// quantiles, and sliding window periods.
@@ -127,13 +125,13 @@ class BaseStatsReporter {
       const char* key,
       const std::vector<StatType>& statTypes,
       const std::vector<double>& pcts,
-      const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
+      const std::vector<size_t>& slidingWindowsSeconds = {60}) const {}
 
   virtual void registerQuantileMetricExportType(
       folly::StringPiece key,
       const std::vector<StatType>& statTypes,
       const std::vector<double>& pcts,
-      const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
+      const std::vector<size_t>& slidingWindowsSeconds = {60}) const {}
 
   /// Register a dynamic quantile metric with a template key pattern that
   /// supports runtime substitution.
@@ -145,60 +143,60 @@ class BaseStatsReporter {
       const char* keyPattern,
       const std::vector<StatType>& statTypes,
       const std::vector<double>& pcts,
-      const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
+      const std::vector<size_t>& slidingWindowsSeconds = {60}) const {}
 
   virtual void registerDynamicQuantileMetricExportType(
       folly::StringPiece keyPattern,
       const std::vector<StatType>& statTypes,
       const std::vector<double>& pcts,
-      const std::vector<size_t>& slidingWindowsSeconds = {60}) const = 0;
+      const std::vector<size_t>& slidingWindowsSeconds = {60}) const {}
 
   /// Add the given value to the stat.
-  virtual void addMetricValue(const std::string& key, size_t value = 1)
-      const = 0;
+  virtual void addMetricValue(const std::string& key, size_t value = 1) const {}
 
-  virtual void addMetricValue(const char* key, size_t value = 1) const = 0;
+  virtual void addMetricValue(const char* key, size_t value = 1) const {}
 
-  virtual void addMetricValue(folly::StringPiece key, size_t value = 1)
-      const = 0;
+  virtual void addMetricValue(folly::StringPiece key, size_t value = 1) const {}
 
   /// Add the given value to the histogram.
   virtual void addHistogramMetricValue(const std::string& key, size_t value)
-      const = 0;
+      const {}
 
-  virtual void addHistogramMetricValue(const char* key, size_t value) const = 0;
+  virtual void addHistogramMetricValue(const char* key, size_t value) const {}
 
   virtual void addHistogramMetricValue(folly::StringPiece key, size_t value)
-      const = 0;
+      const {}
 
   /// Add the given value to a quantile metric.
   virtual void addQuantileMetricValue(const std::string& key, size_t value = 1)
-      const = 0;
+      const {}
 
-  virtual void addQuantileMetricValue(const char* key, size_t value = 1)
-      const = 0;
+  virtual void addQuantileMetricValue(const char* key, size_t value = 1) const {
+  }
 
   virtual void addQuantileMetricValue(folly::StringPiece key, size_t value = 1)
-      const = 0;
+      const {}
 
   /// Add the given value to a quantile metric.
   virtual void addDynamicQuantileMetricValue(
       const std::string& key,
       folly::Range<const folly::StringPiece*> subkeys,
-      size_t value = 1) const = 0;
+      size_t value = 1) const {}
 
   virtual void addDynamicQuantileMetricValue(
       const char* key,
       folly::Range<const folly::StringPiece*> subkeys,
-      size_t value = 1) const = 0;
+      size_t value = 1) const {}
 
   virtual void addDynamicQuantileMetricValue(
       folly::StringPiece key,
       folly::Range<const folly::StringPiece*> subkeys,
-      size_t value = 1) const = 0;
+      size_t value = 1) const {}
 
   /// Return the aggregated metrics in a serialized string format.
-  virtual std::string fetchMetrics() = 0;
+  virtual std::string fetchMetrics() {
+    return "";
+  }
 
   static bool registered;
 };

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -28,7 +28,7 @@
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/memory/MmapAllocator.h"
 
-namespace facebook::velox {
+namespace facebook::velox::test {
 
 struct QuantileConfig {
   std::vector<StatType> statTypes;
@@ -904,7 +904,7 @@ folly::Singleton<BaseStatsReporter> reporter([]() {
   return new TestReporter();
 });
 
-} // namespace facebook::velox
+} // namespace facebook::velox::test
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/velox/common/base/tests/StatsReporterUtils.h
+++ b/velox/common/base/tests/StatsReporterUtils.h
@@ -26,13 +26,11 @@
 #include <vector>
 #include "velox/common/base/StatsReporter.h"
 
-namespace facebook::velox {
+namespace facebook::velox::test {
 
-/**
- * A test implementation of BaseStatsReporter for use in unit tests.
- * This class provides a mock implementation that captures all metric
- * registrations and values for verification in tests.
- */
+/// A test implementation of BaseStatsReporter for use in unit tests.
+/// This class provides a mock implementation that captures all metric
+/// registrations and values for verification in tests.
 class TestReporter : public BaseStatsReporter {
  public:
   mutable std::mutex m;
@@ -239,10 +237,8 @@ class TestReporter : public BaseStatsReporter {
     return ss.str();
   }
 
-  /**
-   * Get the current counter value for a specific key.
-   * Returns 0 if the key doesn't exist.
-   */
+  // Get the current counter value for a specific key.
+  // Returns 0 if the key doesn't exist.
   size_t getCounterValue(const std::string& key) const {
     std::lock_guard<std::mutex> l(m);
     auto it = counterMap.find(key);
@@ -250,4 +246,4 @@ class TestReporter : public BaseStatsReporter {
   }
 };
 
-} // namespace facebook::velox
+} // namespace facebook::velox::test

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemMetricsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemMetricsTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include <folly/init/Init.h>
 #include <functional>
 
@@ -24,8 +25,9 @@
 
 #include <gtest/gtest.h>
 
-namespace facebook::velox::filesystems {
+namespace facebook::velox::filesystems::test {
 namespace {
+
 class S3TestReporter : public BaseStatsReporter {
  public:
   mutable std::mutex m;
@@ -40,6 +42,7 @@ class S3TestReporter : public BaseStatsReporter {
     statTypeMap.clear();
     histogramPercentilesMap.clear();
   }
+
   void registerMetricExportType(const char* key, StatType statType)
       const override {
     statTypeMap[key] = statType;
@@ -67,18 +70,6 @@ class S3TestReporter : public BaseStatsReporter {
       const std::vector<int32_t>& pcts) const override {
     histogramPercentilesMap[key.str()] = pcts;
   }
-
-  void registerQuantileMetricExportType(
-      const char* /* key */,
-      const std::vector<StatType>& /* statTypes */,
-      const std::vector<double>& /* pcts */,
-      const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
-
-  void registerQuantileMetricExportType(
-      folly::StringPiece /* key */,
-      const std::vector<StatType>& /* statTypes */,
-      const std::vector<double>& /* pcts */,
-      const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
 
   void addMetricValue(const std::string& key, const size_t value)
       const override {
@@ -109,42 +100,6 @@ class S3TestReporter : public BaseStatsReporter {
       const override {
     counterMap[key.str()] = std::max(counterMap[key.str()], value);
   }
-
-  void addQuantileMetricValue(const std::string& /* key */, size_t /* value */)
-      const override {}
-
-  void addQuantileMetricValue(const char* /* key */, size_t /* value */)
-      const override {}
-
-  void addQuantileMetricValue(folly::StringPiece /* key */, size_t /* value */)
-      const override {}
-
-  void registerDynamicQuantileMetricExportType(
-      const char* /* keyPattern */,
-      const std::vector<StatType>& /* statTypes */,
-      const std::vector<double>& /* pcts */,
-      const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
-
-  void registerDynamicQuantileMetricExportType(
-      folly::StringPiece /* keyPattern */,
-      const std::vector<StatType>& /* statTypes */,
-      const std::vector<double>& /* pcts */,
-      const std::vector<size_t>& /* slidingWindowsSeconds */) const override {}
-
-  void addDynamicQuantileMetricValue(
-      const std::string& /* key */,
-      folly::Range<const folly::StringPiece*> /* subkeys */,
-      size_t /* value */) const override {}
-
-  void addDynamicQuantileMetricValue(
-      const char* /* key */,
-      folly::Range<const folly::StringPiece*> /* subkeys */,
-      size_t /* value */) const override {}
-
-  void addDynamicQuantileMetricValue(
-      folly::StringPiece /* key */,
-      folly::Range<const folly::StringPiece*> /* subkeys */,
-      size_t /* value */) const override {}
 
   std::string fetchMetrics() override {
     std::stringstream ss;
@@ -217,7 +172,7 @@ TEST_F(S3FileSystemMetricsTest, metrics) {
   EXPECT_EQ(1, s3Reporter->counterMap[std::string{kMetricS3GetObjectCalls}]);
 }
 
-} // namespace facebook::velox::filesystems
+} // namespace facebook::velox::filesystems::test
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Summary:
Adding default implementation for the virtual methods in
BaseStatsReporter. The purpose here is two-fold:
* Minimize boilerplate code for specializations, so they don't need to provide
  an empty body for each virtual method on the API
* Reduce the amount of symbols leaked to downstream dependencies of this API.

Also removing unnecessary string allocation in `statTypeString()`

Differential Revision: D84781701


