### PR TITLE
feat: Add a new run-time stat for index lookup join

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -649,6 +649,10 @@ void registerVeloxMetrics() {
   DEFINE_HISTOGRAM_METRIC(
       kMetricIndexLookupBlockedWaitTimeMs, 32, 0, 16L << 10, 50, 90, 99, 100);
 
+  // The number of index lookup results with error.
+  DEFINE_METRIC(
+      kMetricIndexLookupErrorResultCount, facebook::velox::StatType::COUNT);
+
   /// ================== Table Scan Counters =================
   // Tracks the averaged table scan batch processing time in milliseconds.
   DEFINE_METRIC(

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -384,6 +384,9 @@ constexpr folly::StringPiece kMetricIndexLookupWaitTimeMs{
 constexpr folly::StringPiece kMetricIndexLookupBlockedWaitTimeMs{
     "velox.index_lookup_blocked_wait_time_ms"};
 
+constexpr folly::StringPiece kMetricIndexLookupErrorResultCount{
+    "velox.index_lookup_error_result_count"};
+
 constexpr folly::StringPiece kMetricTableScanBatchProcessTimeMs{
     "velox.table_scan_batch_process_time_ms"};
 

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -622,6 +622,9 @@ Index Join
      - The distribution of index lookup result bytes in range of [0, 128MB] with
        128 buckets. It is configured to report the capacity at P50, P90, P99, and
        P100 percentiles.
+   * - index_lookup_error_result_count
+     - Count
+     - The number of results with error.
 
 Table Scan
 ----------

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -78,6 +78,9 @@ class IndexLookupJoin : public Operator {
   /// the raw data received from the remote storage lookup.
   static inline const std::string kClientLookupResultSize{
       "clientLookupResultSize"};
+  /// The number of lookup results received from remote storage with error.
+  static inline const std::string kClientNumErrorResults{
+      "clientNumErrorResults"};
 
  private:
   using LookupResultIter = connector::IndexSource::LookupResultIterator;


### PR DESCRIPTION
Summary: adding 'clientNumErrorResults' as a new run-time stat for index lookup join

Differential Revision: D84778370


