### PR TITLE
refactor(python): Avoid copy on ROW type construction

### DIFF
--- a/velox/python/type/PyType.h
+++ b/velox/python/type/PyType.h
@@ -43,9 +43,11 @@ class PyType {
   // Factory functions:
 
   static PyType createRowType(
-      const std::vector<std::string>& names,
+      std::vector<std::string> names,
       const std::vector<PyType>& pyTypes) {
     std::vector<TypePtr> types;
+    types.reserve(pyTypes.size());
+
     for (const auto& pyType : pyTypes) {
       types.emplace_back(pyType.type());
     }
@@ -53,7 +55,7 @@ class PyType {
     if (names.empty()) {
       return PyType{ROW(std::move(types))};
     }
-    return PyType{ROW(folly::copy(names), std::move(types))};
+    return PyType{ROW(std::move(names), std::move(types))};
   }
 
   static PyType createMapType(const PyType& keyType, const PyType& valueType) {


### PR DESCRIPTION
Summary:
Avoiding copying the vector of names on ROW type construction, if the
API client moves it in.

Differential Revision: D84852651


