### PR TITLE
refactor: Move getVectorSerdeOptions() to a common util location

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/OperatorUtils.h"
+#include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/VectorHasher.h"
 #include "velox/expression/EvalCtx.h"
+#include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/ConstantVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/LazyVector.h"
@@ -569,4 +571,20 @@ std::unique_ptr<Operator> BlockedOperatorFactory::toOperator(
   }
   return nullptr;
 }
+
+std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
+    common::CompressionKind compressionKind,
+    VectorSerde::Kind kind,
+    std::optional<float> minCompressionRatio) {
+  std::unique_ptr<VectorSerde::Options> options =
+      kind == VectorSerde::Kind::kPresto
+      ? std::make_unique<serializer::presto::PrestoVectorSerde::PrestoOptions>()
+      : std::make_unique<VectorSerde::Options>();
+  options->compressionKind = compressionKind;
+  if (minCompressionRatio.has_value()) {
+    options->minCompressionRatio = minCompressionRatio.value();
+  }
+  return options;
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -15,8 +15,11 @@
  */
 #pragma once
 
+#include <optional>
+#include "velox/core/QueryConfig.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/Spiller.h"
+#include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
 
@@ -307,4 +310,12 @@ class BlockedOperatorFactory : public Operator::PlanNodeTranslator {
  private:
   BlockedOperatorCb blockedCb_{nullptr};
 };
+
+/// Creates VectorSerde::Options for the given VectorSerde kind with compression
+/// settings. Optionally configures minimum compression ratio.
+std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
+    common::CompressionKind compressionKind,
+    VectorSerde::Kind kind,
+    std::optional<float> minCompressionRatio = std::nullopt);
+
 } // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -15,24 +15,11 @@
  */
 
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/OperatorUtils.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
-namespace {
-std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
-    const core::QueryConfig& queryConfig,
-    VectorSerde::Kind kind) {
-  std::unique_ptr<VectorSerde::Options> options =
-      kind == VectorSerde::Kind::kPresto
-      ? std::make_unique<serializer::presto::PrestoVectorSerde::PrestoOptions>()
-      : std::make_unique<VectorSerde::Options>();
-  options->compressionKind =
-      common::stringToCompressionKind(queryConfig.shuffleCompressionKind());
-  options->minCompressionRatio = PartitionedOutput::minCompressionRatio();
-  return options;
-}
-} // namespace
 
 namespace detail {
 Destination::Destination(
@@ -203,8 +190,11 @@ PartitionedOutput::PartitionedOutput(
       eagerFlush_(eagerFlush),
       serde_(getNamedVectorSerde(planNode->serdeKind())),
       serdeOptions_(getVectorSerdeOptions(
-          operatorCtx_->driverCtx()->queryConfig(),
-          planNode->serdeKind())) {
+          common::stringToCompressionKind(operatorCtx_->driverCtx()
+                                              ->queryConfig()
+                                              .shuffleCompressionKind()),
+          planNode->serdeKind(),
+          PartitionedOutput::minCompressionRatio())) {
   if (!planNode->isPartitioned()) {
     VELOX_USER_CHECK_EQ(numDestinations_, 1);
   }


### PR DESCRIPTION
Summary: There are a few identical methods to quickly compose a serde option across the codebase. Centralize them for consistency and maintainability.

Differential Revision: D84853981


