### PR TITLE
fix: ConnectorSplit dataSource must be closed explicitly if present

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -81,7 +81,11 @@ struct ConnectorSplit : public ISerializable {
     return 0;
   }
 
-  virtual ~ConnectorSplit() {}
+  virtual ~ConnectorSplit() {
+    if (dataSource) {
+      dataSource->close();
+    }
+  }
 
   virtual std::string toString() const {
     return fmt::format(


### PR DESCRIPTION
`connectorSplit->dataSource` is an AsyncSource.
An AsyncSource must be explicitly closed or moved before being destroyed.
Internally, at IBM, we encountered a core dump in Presto C++ during a task cancellation and cleanup.
The `connectorSplit->dataSource` is set during `TableScan::preload` and might not be consumed if the task is cancelled.
