### PR TITLE
fix: ST_NumInteriorRing failing with wrong return type

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -405,7 +405,7 @@ Accessors
     GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POINT (1 1))) ->
     [POINT (0 0), POINT (1 1)], GEOMETRYCOLLECTION EMPTY -> [].
 
-.. function:: ST_NumInteriorRing(geometry: Geometry) -> output: integer
+.. function:: ST_NumInteriorRing(geometry: Geometry) -> output: bigint
 
     Returns the cardinality of the collection of interior rings of a polygon.
 

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -1100,7 +1100,7 @@ struct StNumInteriorRingFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(
-      out_type<int32_t>& result,
+      out_type<int64_t>& result,
       const arg_type<Geometry>& geometry) {
     std::unique_ptr<geos::geom::Geometry> geosGeometry =
         geospatial::GeometryDeserializer::deserialize(geometry);
@@ -1125,7 +1125,7 @@ struct StNumInteriorRingFunction {
       VELOX_USER_FAIL(
           "Number of interior rings exceeds the maximum value of int32");
     }
-    result = static_cast<int32_t>(numInteriorRings);
+    result = static_cast<int64_t>(numInteriorRings);
     return true;
   }
 };

--- a/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeometryFunctionsRegistration.cpp
@@ -126,7 +126,7 @@ void registerAccessors(const std::string& prefix) {
       {{prefix + "ST_InteriorRingN"}});
   registerFunction<StNumGeometriesFunction, int32_t, Geometry>(
       {{prefix + "ST_NumGeometries"}});
-  registerFunction<StNumInteriorRingFunction, int32_t, Geometry>(
+  registerFunction<StNumInteriorRingFunction, int64_t, Geometry>(
       {{prefix + "ST_NumInteriorRing"}});
   registerFunction<StConvexHullFunction, Geometry, Geometry>(
       {{prefix + "ST_ConvexHull"}});

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -2008,8 +2008,8 @@ TEST_F(GeometryFunctionsTest, testStInteriorRingN) {
 TEST_F(GeometryFunctionsTest, testStNumInteriorRing) {
   const auto testStNumInteriorRingFunc =
       [&](const std::optional<std::string>& wkt,
-          const std::optional<int32_t>& expected) {
-        std::optional<int32_t> result = evaluateOnce<int32_t>(
+          const std::optional<int64_t>& expected) {
+        std::optional<int64_t> result = evaluateOnce<int64_t>(
             "ST_NumInteriorRing(ST_GeometryFromText(c0))", wkt);
 
         if (expected.has_value()) {


### PR DESCRIPTION
ST_NumInteriorRing return type should be bigint based on : https://github.com/prestodb/presto/issues/26343