### PR TITLE
fix: ST_CoordDim failing with wrong return type

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -413,7 +413,7 @@ Accessors
 
     Returns the minimum convex geometry that encloses all input geometries.
 
-.. function:: ST_CoordDim(geometry: Geometry) -> output: integer
+.. function:: ST_CoordDim(geometry: Geometry) -> output: tinyint
 
     Return the coordinate dimension of the geometry.
 

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -1161,12 +1161,12 @@ class StCoordDimFunction : public facebook::velox::exec::VectorFunction {
     // Create a constant vector of value 2, with size equal to the number of
     // rows
     result = facebook::velox::BaseVector::createConstant(
-        outputType, 2, rows.size(), context.pool());
+        outputType, static_cast<int8_t>(2), rows.size(), context.pool());
   }
   static std::vector<std::shared_ptr<facebook::velox::exec::FunctionSignature>>
   signatures() {
     return {facebook::velox::exec::FunctionSignatureBuilder()
-                .returnType("integer")
+                .returnType("tinyint")
                 .argumentType("geometry")
                 .build()};
   }

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -2169,9 +2169,9 @@ TEST_F(GeometryFunctionsTest, testStConvexHull) {
 
 TEST_F(GeometryFunctionsTest, testStCoordDim) {
   const auto testStCoordDimFunc = [&](const std::optional<std::string>& wkt,
-                                      const std::optional<int32_t>& expected) {
-    std::optional<int32_t> result =
-        evaluateOnce<int32_t>("ST_CoordDim(ST_GeometryFromText(c0))", wkt);
+                                      const std::optional<int8_t>& expected) {
+    std::optional<int8_t> result =
+        evaluateOnce<int8_t>("ST_CoordDim(ST_GeometryFromText(c0))", wkt);
 
     if (expected.has_value()) {
       ASSERT_TRUE(result.has_value());


### PR DESCRIPTION
ST_CoordDim return type should be tinyint based on : https://github.com/prestodb/presto/issues/26344