### PR TITLE
refactor(dwio): Return StringView in valueInDictionary()

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -1419,7 +1419,7 @@ class StringDictionaryColumnVisitor
     }
   }
 
-  folly::StringPiece valueInDictionary(int64_t index) {
+  StringView valueInDictionary(int64_t index) {
     auto stripeDictSize = DictSuper::state_.dictionary.numValues;
     if (index < stripeDictSize) {
       return reinterpret_cast<const StringView*>(


### PR DESCRIPTION
Summary:
Small cleanup to return StringView directly intead of converting it
to folly::StringPiece. The purpose is to remove all legacy folly::StringPiece usages.

Differential Revision: D84882280


