### PR TITLE
fix: Use 16-core runner and increase NUM_THREADS to 8

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -209,7 +209,7 @@ jobs:
           cd _build/debug && ctest -j 8 --output-on-failure --no-tests=error
 
   fedora-debug:
-    runs-on: 8-core-ubuntu-22.04
+    runs-on: 16-core-ubuntu
     container: ghcr.io/facebookincubator/velox-dev:fedora
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
@@ -248,7 +248,7 @@ jobs:
           fmt_SOURCE: BUNDLED
           simdjson_SOURCE: BUNDLED
           gRPC_SOURCE: SYSTEM
-          MAKEFLAGS: NUM_THREADS=4 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3
+          MAKEFLAGS: NUM_THREADS=8 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=3
           EXTRA_CMAKE_FLAGS: >-
             -DVELOX_ENABLE_PARQUET=ON
             -DARROW_THRIFT_USE_SHARED=ON


### PR DESCRIPTION
Summary: Reduced NUM_THREADS from 4 to 2 in the linux-build-base GitHub workflow to prevent resource exhaustion during CI builds. This change helps ensure more stable builds by reducing concurrent compilation threads while maintaining the same memory and link job limits.

Differential Revision: D84923538
