### PR TITLE
fix(build): Fix Gcc Fedora debug build due to template-id in constructor

### DIFF
--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -115,7 +115,7 @@ struct ConstantVectorReader {
 
   std::optional<exec_in_t> value;
 
-  explicit ConstantVectorReader<T>(ConstantVector<exec_in_t>& vector) {
+  explicit ConstantVectorReader(ConstantVector<exec_in_t>& vector) {
     if (!vector.isNullAt(0)) {
       value = *vector.rawValues();
     }
@@ -160,7 +160,7 @@ struct FlatVectorReader {
   const exec_in_t* values;
   FlatVector<exec_in_t>* vector;
 
-  explicit FlatVectorReader<T>(FlatVector<exec_in_t>& baseVector)
+  explicit FlatVectorReader(FlatVector<exec_in_t>& baseVector)
       : values(baseVector.rawValues()), vector(&baseVector) {}
 
   exec_in_t operator[](vector_size_t offset) const {


### PR DESCRIPTION
Summary: This diff fixes this build issue in GitHub CI: https://github.com/facebookincubator/velox/actions/runs/18572972421/job/52951226145

Differential Revision: D84949333


