### PR TITLE
feat: Add support for casting TIME to timestampWithTimezone

### DIFF
--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -44,6 +44,16 @@ class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
     });
   }
 
+  void setQueryTimeZoneAndStartTime(
+      const std::string& timeZone,
+      int64_t startTimeMs) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+        {core::QueryConfig::kSessionStartTime, std::to_string(startTimeMs)},
+    });
+  }
+
   void disableAdjustTimestampToTimezone() {
     queryCtx_->testingOverrideConfigUnsafe({
         {core::QueryConfig::kAdjustTimestampToTimezone, "false"},
@@ -312,6 +322,299 @@ TEST_F(TimestampWithTimeZoneCastTest, fromDate) {
   result =
       evaluate("cast(c0 as timestamp with time zone)", makeRowVector({input}));
   test::assertEqualVectors(expected, result);
+}
+
+TEST_F(TimestampWithTimeZoneCastTest, fromTime) {
+  {
+    // Test casting TIME to TIMESTAMP WITH TIME ZONE with default session start
+    // time (epoch). TIME values represent time since midnight (in milliseconds)
+    auto input = makeFlatVector<int64_t>(
+        {
+            0, // 00:00:00.000 (midnight)
+            3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+                321, // 03:04:05.321
+            12 * kMillisInHour, // 12:00:00.000 (noon)
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999, // 23:59:59.999 (end of day)
+        },
+        TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    auto tzId = tz::getTimeZoneID("America/Los_Angeles");
+    // When session start time is not set (default = 0), uses epoch (1970-01-01)
+    // LA is -8 hours from UTC (PST), so 00:00:00 PST = 08:00:00 UTC
+    auto expected = makeFlatVector<int64_t>(
+        {
+            pack(8 * kMillisInHour, tzId), // 00:00:00.000 PST -> 08:00:00 UTC
+            pack(
+                3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+                    321 + 8 * kMillisInHour,
+                tzId), // 03:04:05.321 PST -> 11:04:05.321 UTC
+            pack(
+                12 * kMillisInHour + 8 * kMillisInHour,
+                tzId), // 12:00:00.000 PST -> 20:00:00 UTC
+            pack(
+                23 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999 + 8 * kMillisInHour,
+                tzId), // 23:59:59.999 PST -> 07:59:59.999 UTC (next day)
+        },
+        TIMESTAMP_WITH_TIME_ZONE());
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)", makeRowVector({input}));
+    test::assertEqualVectors(expected, result);
+  }
+
+  {
+    // Test casting TIME to TIMESTAMP WITH TIME ZONE with session start time set
+    // to 2023-01-15 10:30:00 UTC (1673780400000 ms)
+    // This should use the date from session start time (2023-01-15), not epoch
+    auto input = makeFlatVector<int64_t>(
+        {
+            0, // 00:00:00.000 (midnight)
+            12 * kMillisInHour, // 12:00:00.000 (noon)
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999, // 23:59:59.999
+        },
+        TIME());
+
+    // Session start time: 2023-01-15 10:30:00 UTC = 1673779800000 ms
+    // In LA timezone (PST, -8 hours), this is 2023-01-15 02:30:00 PST
+    // The date portion is 2023-01-15, which is 19372 days from epoch
+    // 2023-01-15 00:00:00 UTC = 19372 * 86400 * 1000 = 1673740800000 ms
+    int64_t sessionStartMs = 1673779800000LL; // 2023-01-15 10:30:00 UTC
+    setQueryTimeZoneAndStartTime("America/Los_Angeles", sessionStartMs);
+
+    auto tzId = tz::getTimeZoneID("America/Los_Angeles");
+    // Date portion: 2023-01-15 in LA timezone = 2023-01-15 00:00:00 PST
+    // = 2023-01-15 08:00:00 UTC = 1673740800000 + 8*3600*1000 = 1673769600000
+    int64_t dateBaseMs = 1673769600000LL; // 2023-01-15 00:00:00 UTC
+    auto expected = makeFlatVector<int64_t>(
+        {
+            pack(
+                dateBaseMs,
+                tzId), // 2023-01-15 00:00:00.000 PST in UTC
+            pack(
+                dateBaseMs + 12 * kMillisInHour,
+                tzId), // 2023-01-15 12:00:00.000 PST in UTC
+            pack(
+                dateBaseMs + 23 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999,
+                tzId), // 2023-01-15 23:59:59.999 PST in UTC
+        },
+        TIMESTAMP_WITH_TIME_ZONE());
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)", makeRowVector({input}));
+    test::assertEqualVectors(expected, result);
+  }
+
+  {
+    // Test with nulls
+    auto input = makeNullableFlatVector<int64_t>(
+        {0,
+         std::nullopt,
+         12 * kMillisInHour,
+         std::nullopt,
+         23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+             999},
+        TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    auto tzId = tz::getTimeZoneID("America/Los_Angeles");
+    auto expected = makeNullableFlatVector<int64_t>(
+        {pack(8 * kMillisInHour, tzId),
+         std::nullopt,
+         pack(12 * kMillisInHour + 8 * kMillisInHour, tzId),
+         std::nullopt,
+         pack(
+             23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                 999 + 8 * kMillisInHour,
+             tzId)},
+        TIMESTAMP_WITH_TIME_ZONE());
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)", makeRowVector({input}));
+    test::assertEqualVectors(expected, result);
+  }
+
+  {
+    // Test with different timezone (Asia/Shanghai, +8 hours from UTC)
+    auto input = makeFlatVector<int64_t>(
+        {
+            0,
+            12 * kMillisInHour,
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999,
+        },
+        TIME());
+
+    setQueryTimeZone("Asia/Shanghai");
+
+    auto tzId = tz::getTimeZoneID("Asia/Shanghai");
+    // Shanghai is +8 hours from UTC, so 00:00:00 Shanghai = 16:00:00 UTC (prev
+    // day)
+    auto expected = makeFlatVector<int64_t>(
+        {
+            pack(
+                -8 * kMillisInHour,
+                tzId), // 00:00:00 CST -> 16:00:00 UTC (prev day)
+            pack(
+                12 * kMillisInHour - 8 * kMillisInHour,
+                tzId), // 12:00:00 CST -> 04:00:00 UTC
+            pack(
+                23 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999 - 8 * kMillisInHour,
+                tzId), // 23:59:59.999 CST -> 15:59:59.999 UTC
+        },
+        TIMESTAMP_WITH_TIME_ZONE());
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)", makeRowVector({input}));
+    test::assertEqualVectors(expected, result);
+  }
+
+  {
+    // Test with adjustTimestampToTimezone disabled
+    // When disabled, TIME values are treated as already in UTC
+    auto input = makeFlatVector<int64_t>(
+        {
+            0,
+            3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond + 321,
+            12 * kMillisInHour,
+        },
+        TIME());
+
+    setQueryTimeZone("Asia/Shanghai");
+    disableAdjustTimestampToTimezone();
+
+    auto tzId = tz::getTimeZoneID("Asia/Shanghai");
+    auto expected = makeFlatVector<int64_t>(
+        {
+            pack(0, tzId),
+            pack(
+                3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+                    321,
+                tzId),
+            pack(12 * kMillisInHour, tzId),
+        },
+        TIMESTAMP_WITH_TIME_ZONE());
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)", makeRowVector({input}));
+    test::assertEqualVectors(expected, result);
+  }
+
+  {
+    // Test constant TIME vector cast to TIMESTAMP WITH TIME ZONE (non-null)
+    // This tests the optimization path for constant vectors
+    auto constantTimeVector = BaseVector::wrapInConstant(
+        1000, 0, makeFlatVector<int64_t>({12 * kMillisInHour}, TIME()));
+
+    setQueryTimeZone("America/New_York");
+
+    auto tzId = tz::getTimeZoneID("America/New_York");
+    // NY is -5 hours from UTC (EST), so 12:00:00 EST = 17:00:00 UTC
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)",
+        makeRowVector({constantTimeVector}));
+
+    // Should return a constant vector with the adjusted value
+    auto expected = BaseVector::wrapInConstant(
+        1000,
+        0,
+        makeFlatVector<int64_t>(
+            {pack(12 * kMillisInHour + 5 * kMillisInHour, tzId)},
+            TIMESTAMP_WITH_TIME_ZONE()));
+
+    test::assertEqualVectors(expected, result);
+    // Verify the result is actually constant-encoded (optimization worked)
+    ASSERT_TRUE(result->isConstantEncoding());
+  }
+
+  {
+    // Test constant TIME vector cast to TIMESTAMP WITH TIME ZONE (null)
+    // This tests the optimization path for null constant vectors
+    auto nullTimeVector = BaseVector::createNullConstant(TIME(), 500, pool());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    auto result = evaluate(
+        "cast(c0 as timestamp with time zone)",
+        makeRowVector({nullTimeVector}));
+
+    // Should return a null constant vector
+    auto expected =
+        BaseVector::createNullConstant(TIMESTAMP_WITH_TIME_ZONE(), 500, pool());
+
+    test::assertEqualVectors(expected, result);
+    // Verify the result is actually constant-encoded (optimization worked)
+    ASSERT_TRUE(result->isConstantEncoding());
+    ASSERT_TRUE(result->isNullAt(0));
+  }
+
+  {
+    // Test constant TIME vector with different sizes
+    // This ensures the optimization correctly handles different vector sizes
+    setQueryTimeZone("America/Los_Angeles");
+    auto tzId = tz::getTimeZoneID("America/Los_Angeles");
+
+    for (auto size : {1, 10, 100, 1000}) {
+      auto constantTimeVector = BaseVector::wrapInConstant(
+          size,
+          0,
+          makeFlatVector<int64_t>(
+              {3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+               321},
+              TIME()));
+
+      auto result = evaluate(
+          "cast(c0 as timestamp with time zone)",
+          makeRowVector({constantTimeVector}));
+
+      auto expected = BaseVector::wrapInConstant(
+          size,
+          0,
+          makeFlatVector<int64_t>(
+              {pack(
+                  3 * kMillisInHour + 4 * kMillisInMinute +
+                      5 * kMillisInSecond + 321 + 8 * kMillisInHour,
+                  tzId)},
+              TIMESTAMP_WITH_TIME_ZONE()));
+
+      test::assertEqualVectors(expected, result);
+      ASSERT_TRUE(result->isConstantEncoding());
+      ASSERT_EQ(result->size(), size);
+    }
+  }
+
+  {
+    // Test try_cast for TIME to TIMESTAMP WITH TIME ZONE
+    auto input =
+        makeFlatVector<int64_t>({0, 12 * kMillisInHour, 86399999}, TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    auto tzId = tz::getTimeZoneID("America/Los_Angeles");
+    auto expected = makeFlatVector<int64_t>(
+        {
+            pack(8 * kMillisInHour, tzId), // 00:00:00 PST -> 08:00:00 UTC
+            pack(
+                12 * kMillisInHour + 8 * kMillisInHour,
+                tzId), // 12:00:00 PST -> 20:00:00 UTC
+            pack(
+                86399999 + 8 * kMillisInHour,
+                tzId), // 23:59:59.999 PST -> 07:59:59.999 UTC (next day)
+        },
+        TIMESTAMP_WITH_TIME_ZONE());
+
+    auto result = evaluate(
+        "try_cast(c0 as timestamp with time zone)", makeRowVector({input}));
+    test::assertEqualVectors(expected, result);
+  }
 }
 
 } // namespace

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -34,6 +34,36 @@ const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
   return tz::locateZone(0); // GMT
 }
 
+// Helper function to calculate midnight in UTC for the given session start
+// time in the session timezone. This can be called once and reused for all
+// rows in a batch.
+int64_t calculateMidnightUtcMs(
+    int64_t sessionStartTimeMs,
+    const tz::TimeZone* sessionTimeZone) {
+  std::chrono::milliseconds localRepresentation;
+
+  if (sessionStartTimeMs != 0) {
+    // Convert session start time to local time in the timezone
+    localRepresentation = sessionTimeZone->to_local(
+        std::chrono::milliseconds(sessionStartTimeMs));
+  } else {
+    // Special case: when session start time is 0 (epoch), treat it as
+    // local representation of epoch (1970-01-01 00:00:00 in local time),
+    // not as UTC epoch converted to local time
+    localRepresentation = std::chrono::milliseconds(0);
+  }
+
+  // Truncate to start of day (midnight) in local time representation
+  auto localMidnight =
+      std::chrono::floor<std::chrono::days>(localRepresentation);
+
+  // Convert the local midnight representation back to UTC
+  auto utcMidnight = sessionTimeZone->to_sys(
+      std::chrono::duration_cast<std::chrono::milliseconds>(localMidnight));
+
+  return utcMidnight.count();
+}
+
 void castFromTimestamp(
     const SimpleVector<Timestamp>& inputVector,
     exec::EvalCtx& context,
@@ -201,6 +231,8 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
         return true;
       case TypeKind::INTEGER:
         return other->isDate();
+      case TypeKind::BIGINT:
+        return other->isTime();
       default:
         return false;
     }
@@ -226,6 +258,51 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
       const TypePtr& resultType,
       VectorPtr& result) const override {
     context.ensureWritable(rows, resultType, result);
+
+    if (input.typeKind() == TypeKind::BIGINT && input.type()->isTime()) {
+      const auto& config = context.execCtx()->queryCtx()->queryConfig();
+      const auto* sessionTimeZone = getTimeZoneFromConfig(config);
+      const auto sessionStartTimeMs = config.sessionStartTimeMs();
+
+      // Calculate midnight in UTC once (shared by both constant and
+      // non-constant paths)
+      const auto midnightUtcMs =
+          calculateMidnightUtcMs(sessionStartTimeMs, sessionTimeZone);
+
+      if (input.isConstantEncoding()) {
+        // Optimization for constant TIME input vectors
+        auto constantInput = input.as<ConstantVector<int64_t>>();
+        if (constantInput->isNullAt(0)) {
+          result = BaseVector::createNullConstant(
+              resultType, rows.end(), context.pool());
+          return;
+        }
+
+        const auto timeMillis = constantInput->valueAt(0);
+        auto packedValue =
+            pack(midnightUtcMs + timeMillis, sessionTimeZone->id());
+        result = std::make_shared<ConstantVector<int64_t>>(
+            context.pool(),
+            rows.end(),
+            false, // isNull
+            resultType,
+            std::move(packedValue));
+        return;
+      } else {
+        // Non-constant TIME input
+        auto* timestampWithTzResult = result->asFlatVector<int64_t>();
+        timestampWithTzResult->clearNulls(rows);
+        auto* rawResults = timestampWithTzResult->mutableRawValues();
+
+        const auto inputVector = input.as<SimpleVector<int64_t>>();
+        context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+          const auto timeMillis = inputVector->valueAt(row);
+          const auto utcTimestampMs = midnightUtcMs + timeMillis;
+          rawResults[row] = pack(utcTimestampMs, sessionTimeZone->id());
+        });
+        return;
+      }
+    }
 
     auto* timestampWithTzResult = result->asFlatVector<int64_t>();
     timestampWithTzResult->clearNulls(rows);


### PR DESCRIPTION
Summary:
- Added `castFromTime()` function that treats TIME values as wall-clock time in the session timezone and converts to UTC
- Respects `adjustTimestampToTimezone` configuration flag:
  - When enabled (default): Converts TIME from session timezone to UTC
  - When disabled: Treats TIME values as already in UTC
- Implemented constant vector optimization for the common case where input is a constant TIME vector (null or non-null)

Differential Revision: D84947052


