### PR TITLE
fix: Diable array mode for types with custom comparison in hash tables

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -438,6 +438,25 @@ class VectorHasher {
     }
   }
 
+  // Specialization for int128_t: For types with custom comparison (IPADDRESS,
+  // UUID), force hash mode by blocking both range and distinct modes. For other
+  // int128_t types (HUGEINT, DECIMAL), use generic path which may use range
+  // mode for small values.
+  void analyzeValue(int128_t value) {
+    if (type_->providesCustomComparison()) {
+      // Force hash mode by disabling both range and distinct optimizations
+      if (!rangeOverflow_) {
+        setRangeOverflow();
+      }
+      if (!distinctOverflow_) {
+        setDistinctOverflow();
+      }
+    } else {
+      // Use generic analysis for regular int128_t types (HUGEINT, DECIMAL)
+      analyzeValue<int64_t>(toInt64(value));
+    }
+  }
+
   template <typename T>
   bool tryMapToRangeSimd(
       const T* values,


### PR DESCRIPTION
Summary:
For query like 
```
SELECT 
  LEFT_TABLE.ip_addr as ip_left_string, 
  RIGHT_TABLE.ip_addr as ip_right_string, 
  CAST(LEFT_TABLE.ip_addr AS IPADDRESS) as ip_left_ip_address_type, 
  CAST(RIGHT_TABLE.ip_addr AS IPADDRESS) as ip_right_ip_address_type, 
  CAST(LEFT_TABLE.ip_addr AS IPADDRESS) = CAST(RIGHT_TABLE.ip_addr AS IPADDRESS) as are_equal_as_ip_address_type 
FROM 
  (
    VALUES 
      ('2620:10d:c0a8:f0::37'), 
      ('2620:10d:c053:33::37')
  ) AS LEFT_TABLE(ip_addr) 
  INNER JOIN (
    VALUES 
      ('2620:10d:c0a8:f0::37')
  ) AS RIGHT_TABLE(ip_addr) ON CAST(LEFT_TABLE.ip_addr AS IPADDRESS) = CAST(RIGHT_TABLE.ip_addr AS IPADDRESS) 
LIMIT 
  1000
```

it goes through VectorHasher<IPADDRESS> and then into HashTable and check the logic here : https://www.internalfb.com/code/fbsource/[3c9bb6c6ec54aa72fb792b9fdf9045c452b5e11d]/fbcode/velox/exec/HashTable.cpp?lines=1514-1519 . But if rangesWithReserve is smaller than kArrayHashMaxSize, the vector ends up using HashMode::kArray instead of HashMode::kHash. So, even though IPAddress has a hash function defined, it never actually gets called in this case.

Reviewed By: gggrace14

Differential Revision: D84952949


