### PR TITLE
feat: Add support for casting TIME to TimeWithTimezone

### DIFF
--- a/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
@@ -34,7 +34,37 @@ inline int64_t getUTCMillis(
       seconds * util::kMillisInSecond + millis;
 }
 
-class TimeWithTimezoneCastTest : public functions::test::CastBaseTest {};
+class TimeWithTimezoneCastTest : public functions::test::CastBaseTest {
+ protected:
+  void setQueryTimeZone(const std::string& timeZone) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+    });
+  }
+
+  void setQueryTimeZoneAndStartTime(
+      const std::string& timeZone,
+      int64_t startTimeMs) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+        {core::QueryConfig::kSessionStartTime, std::to_string(startTimeMs)},
+    });
+  }
+
+  void disableAdjustTimestampToTimezone() {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kAdjustTimestampToTimezone, "false"},
+    });
+  }
+
+  // Helper to pack TIME WITH TIME ZONE value
+  int64_t packTimeWithTZ(int64_t timeMillis, int16_t offsetMinutes) {
+    auto encodedOffset = biasEncode(offsetMinutes);
+    return pack(timeMillis, encodedOffset);
+  }
+};
 
 TEST_F(TimeWithTimezoneCastTest, toVarchar) {
   // Test comprehensive scenarios: various times, timezones, boundary values,
@@ -332,6 +362,408 @@ TEST_F(TimeWithTimezoneCastTest, toTime) {
   auto expectedConstantVector = makeConstant(expectedTime, 10, TIME());
 
   testCast(inputConstantVector, expectedConstantVector);
+}
+
+TEST_F(TimeWithTimezoneCastTest, fromTime) {
+  {
+    // Test casting TIME to TIME WITH TIME ZONE with various times
+    // TIME values are in local time, and get converted to UTC for storage
+    auto input = makeFlatVector<int64_t>(
+        {
+            0, // 00:00:00.000 (midnight) local
+            3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+                321, // 03:04:05.321 local
+            12 * kMillisInHour, // 12:00:00.000 (noon) local
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999, // 23:59:59.999 (end of day) local
+        },
+        TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+    // LA is UTC-8, so offset is -8 * 60 = -480 minutes
+    // Local times are converted to UTC: local - (-8 hours) = local + 8 hours
+    auto expected = makeFlatVector<int64_t>(
+        {
+            // 00:00:00 local -> 08:00:00 UTC
+            packTimeWithTZ(8 * kMillisInHour, -480),
+            // 03:04:05.321 local -> 11:04:05.321 UTC
+            packTimeWithTZ(
+                11 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+                    321,
+                -480),
+            // 12:00:00 local -> 20:00:00 UTC
+            packTimeWithTZ(20 * kMillisInHour, -480),
+            // 23:59:59.999 local -> 07:59:59.999 UTC (next day, wraps to
+            // 07:59:59.999)
+            packTimeWithTZ(
+                7 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999,
+                -480),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test with nulls
+    auto input = makeNullableFlatVector<int64_t>(
+        {0,
+         std::nullopt,
+         12 * kMillisInHour,
+         std::nullopt,
+         23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+             999},
+        TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+    // LA is UTC-8, local times are converted to UTC: local + 8 hours
+
+    auto expected = makeNullableFlatVector<int64_t>(
+        {// 00:00:00 local -> 08:00:00 UTC
+         packTimeWithTZ(8 * kMillisInHour, -480),
+         std::nullopt,
+         // 12:00:00 local -> 20:00:00 UTC
+         packTimeWithTZ(20 * kMillisInHour, -480),
+         std::nullopt,
+         // 23:59:59.999 local -> 07:59:59.999 UTC (wraps to next day)
+         packTimeWithTZ(
+             7 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                 999,
+             -480)},
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test with different timezone (Asia/Shanghai, UTC+8)
+    auto input = makeFlatVector<int64_t>(
+        {
+            0,
+            12 * kMillisInHour,
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999,
+        },
+        TIME());
+
+    setQueryTimeZone("Asia/Shanghai");
+
+    // Shanghai is UTC+8, so offset is 8 * 60 = 480 minutes
+    // Local times are converted to UTC: local - 8 hours
+    auto expected = makeFlatVector<int64_t>(
+        {
+            // 00:00:00 local -> 16:00:00 UTC (previous day, wraps to 16:00)
+            packTimeWithTZ(16 * kMillisInHour, 480),
+            // 12:00:00 local -> 04:00:00 UTC
+            packTimeWithTZ(4 * kMillisInHour, 480),
+            // 23:59:59.999 local -> 15:59:59.999 UTC
+            packTimeWithTZ(
+                15 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999,
+                480),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test with adjustTimestampToTimezone disabled
+    // When disabled, offset should be 0 (UTC)
+    auto input = makeFlatVector<int64_t>(
+        {
+            0,
+            3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond + 321,
+            12 * kMillisInHour,
+        },
+        TIME());
+
+    setQueryTimeZone("Asia/Shanghai");
+    disableAdjustTimestampToTimezone();
+
+    // When adjustTimestampToTimezone is false, offset is 0 (UTC)
+    auto expected = makeFlatVector<int64_t>(
+        {
+            packTimeWithTZ(0, 0),
+            packTimeWithTZ(
+                3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+                    321,
+                0),
+            packTimeWithTZ(12 * kMillisInHour, 0),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test constant TIME vector cast to TIME WITH TIME ZONE (non-null)
+    auto constantTimeVector = BaseVector::wrapInConstant(
+        1000, 0, makeFlatVector<int64_t>({12 * kMillisInHour}, TIME()));
+
+    setQueryTimeZone("America/New_York");
+
+    // NY is UTC-5, so offset is -5 * 60 = -300 minutes
+    // 12:00:00 local -> 17:00:00 UTC
+    auto expected = BaseVector::wrapInConstant(
+        1000,
+        0,
+        makeFlatVector<int64_t>(
+            {packTimeWithTZ(17 * kMillisInHour, -300)}, TIME_WITH_TIME_ZONE()));
+
+    testCast(constantTimeVector, expected);
+  }
+
+  {
+    // Test constant TIME vector cast to TIME WITH TIME ZONE (null)
+    auto nullTimeVector = BaseVector::createNullConstant(TIME(), 500, pool());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    auto expected =
+        BaseVector::createNullConstant(TIME_WITH_TIME_ZONE(), 500, pool());
+
+    testCast(nullTimeVector, expected);
+  }
+
+  {
+    // Test constant TIME vector with different sizes
+    setQueryTimeZone("America/Los_Angeles");
+
+    for (auto size : {1, 10, 100, 1000}) {
+      auto constantTimeVector = BaseVector::wrapInConstant(
+          size,
+          0,
+          makeFlatVector<int64_t>(
+              {3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond +
+               321},
+              TIME()));
+
+      // LA is UTC-8, so offset is -8 * 60 = -480 minutes
+      // 03:04:05.321 local -> 11:04:05.321 UTC
+      auto expected = BaseVector::wrapInConstant(
+          size,
+          0,
+          makeFlatVector<int64_t>(
+              {packTimeWithTZ(
+                  11 * kMillisInHour + 4 * kMillisInMinute +
+                      5 * kMillisInSecond + 321,
+                  -480)},
+              TIME_WITH_TIME_ZONE()));
+
+      testCast(constantTimeVector, expected);
+    }
+  }
+
+  {
+    // Test basic cast for completeness
+    auto input =
+        makeFlatVector<int64_t>({0, 12 * kMillisInHour, 86399999}, TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    // LA is UTC-8, local times are converted to UTC: local + 8 hours
+    auto expected = makeFlatVector<int64_t>(
+        {
+            // 00:00:00 local -> 08:00:00 UTC
+            packTimeWithTZ(8 * kMillisInHour, -480),
+            // 12:00:00 local -> 20:00:00 UTC
+            packTimeWithTZ(20 * kMillisInHour, -480),
+            // 23:59:59.999 local -> 07:59:59.999 UTC (wraps to next day)
+            packTimeWithTZ(
+                7 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999,
+                -480),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test with session start time during DST (summer)
+    // 2023-07-15 12:00:00 UTC (during DST in America/Los_Angeles)
+    // LA is UTC-7 during DST, so offset is -7 * 60 = -420 minutes
+    int64_t sessionStartMs = 1689426000000LL; // 2023-07-15 12:00:00 UTC
+    auto input = makeFlatVector<int64_t>(
+        {
+            0,
+            12 * kMillisInHour,
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999,
+        },
+        TIME());
+
+    setQueryTimeZoneAndStartTime("America/Los_Angeles", sessionStartMs);
+
+    // During DST, LA is UTC-7 (PDT), so offset is -420 minutes
+    // Local times are converted to UTC: local - (-7 hours) = local + 7 hours
+    auto expected = makeFlatVector<int64_t>(
+        {
+            // 00:00:00 local -> 07:00:00 UTC
+            packTimeWithTZ(7 * kMillisInHour, -420),
+            // 12:00:00 local -> 19:00:00 UTC
+            packTimeWithTZ(19 * kMillisInHour, -420),
+            // 23:59:59.999 local -> 06:59:59.999 UTC (next day wraps to
+            // 06:59:59.999)
+            packTimeWithTZ(
+                6 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999,
+                -420),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test with session start time during standard time (winter)
+    // 2023-01-15 12:00:00 UTC (during standard time in America/Los_Angeles)
+    // LA is UTC-8 during standard time, so offset is -8 * 60 = -480 minutes
+    int64_t sessionStartMs = 1673779200000LL; // 2023-01-15 12:00:00 UTC
+    auto input = makeFlatVector<int64_t>(
+        {
+            0,
+            12 * kMillisInHour,
+            23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                999,
+        },
+        TIME());
+
+    setQueryTimeZoneAndStartTime("America/Los_Angeles", sessionStartMs);
+
+    // During standard time, LA is UTC-8 (PST), so offset is -480 minutes
+    // Local times are converted to UTC: local - (-8 hours) = local + 8 hours
+    auto expected = makeFlatVector<int64_t>(
+        {
+            // 00:00:00 local -> 08:00:00 UTC
+            packTimeWithTZ(8 * kMillisInHour, -480),
+            // 12:00:00 local -> 20:00:00 UTC
+            packTimeWithTZ(20 * kMillisInHour, -480),
+            // 23:59:59.999 local -> 07:59:59.999 UTC (next day wraps to
+            // 07:59:59.999)
+            packTimeWithTZ(
+                7 * kMillisInHour + 59 * kMillisInMinute +
+                    59 * kMillisInSecond + 999,
+                -480),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+}
+
+TEST_F(TimeWithTimezoneCastTest, fromTimeVerifyUtcStorage) {
+  // This test verifies that when casting TIME to TIME WITH TIME ZONE,
+  // the time component is stored as UTC milliseconds, not local milliseconds.
+  // TIME WITH TIME ZONE stores:
+  // - Upper 52 bits: UTC milliseconds since midnight
+  // - Lower 12 bits: timezone offset
+
+  {
+    // TIME '14:00:00' in America/Los_Angeles (UTC-8)
+    // Local time: 14:00:00 -> UTC time: 22:00:00
+    auto input = makeFlatVector<int64_t>(
+        {
+            14 * kMillisInHour, // 14:00:00 local
+        },
+        TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+    // LA is UTC-8, so offset is -8 * 60 = -480 minutes
+
+    // Cast TIME to TIME WITH TIME ZONE using testCast
+    auto expected = makeFlatVector<int64_t>(
+        {
+            packTimeWithTZ(22 * kMillisInHour, -480), // Expected: UTC 22:00
+        },
+        TIME_WITH_TIME_ZONE());
+
+    // This will fail with the current buggy implementation
+    testCast(input, expected);
+  }
+
+  {
+    // TIME '06:00:00' in Asia/Shanghai (UTC+8)
+    // Local time: 06:00:00 -> UTC time: 22:00:00 (previous day)
+    auto input = makeFlatVector<int64_t>(
+        {
+            6 * kMillisInHour, // 06:00:00 local
+        },
+        TIME());
+
+    setQueryTimeZone("Asia/Shanghai");
+    // Shanghai is UTC+8, so offset is 8 * 60 = 480 minutes
+
+    auto expected = makeFlatVector<int64_t>(
+        {
+            // BUG: This will fail because current code stores local time
+            // (06:00), not UTC time (22:00)
+            packTimeWithTZ(22 * kMillisInHour, 480), // Expected: UTC 22:00
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, expected);
+  }
+
+  {
+    // Test case 3: Round-trip test
+    // TIME -> TIME WITH TIME ZONE -> TIME should preserve the original value
+    auto input = makeFlatVector<int64_t>(
+        {
+            14 * kMillisInHour + 30 * kMillisInMinute, // 14:30:00
+        },
+        TIME());
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    // First cast TIME to TIME WITH TIME ZONE
+    auto timeWithTzExpected = makeFlatVector<int64_t>(
+        {
+            // UTC time should be 22:30:00 (14:30 - (-8:00) = 22:30)
+            packTimeWithTZ(22 * kMillisInHour + 30 * kMillisInMinute, -480),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    testCast(input, timeWithTzExpected);
+
+    // Then cast back to TIME - should preserve original local time
+    auto timeExpected = makeFlatVector<int64_t>(
+        {
+            14 * kMillisInHour + 30 * kMillisInMinute,
+        },
+        TIME());
+
+    testCast(timeWithTzExpected, timeExpected);
+  }
+
+  {
+    // Verify consistency with fromVarchar
+    // Casting "14:00:00-08:00" from VARCHAR should produce the same result
+    // as casting TIME '14:00:00' with America/Los_Angeles timezone
+
+    setQueryTimeZone("America/Los_Angeles");
+
+    // Cast TIME to TIME WITH TIME ZONE
+    auto timeInput = makeFlatVector<int64_t>({14 * kMillisInHour}, TIME());
+
+    // Cast VARCHAR to TIME WITH TIME ZONE
+    auto varcharInput = makeFlatVector<std::string>({"14:00:00.000-08:00"});
+
+    // Both should produce the same result: UTC 22:00:00 with offset -480
+    auto expected = makeFlatVector<int64_t>(
+        {
+            packTimeWithTZ(22 * kMillisInHour, -480),
+        },
+        TIME_WITH_TIME_ZONE());
+
+    // Test TIME cast
+    testCast(timeInput, expected);
+
+    // Test VARCHAR cast
+    testCast(varcharInput, expected);
+  }
 }
 
 } // namespace

--- a/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
@@ -16,10 +16,12 @@
 #include "velox/functions/prestosql/types/TimeWithTimezoneRegistration.h"
 
 #include "velox/expression/CastExpr.h"
+#include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Time.h"
 #include "velox/type/Type.h"
+#include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox {
@@ -168,28 +170,79 @@ void castFromString(
   });
 }
 
+const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
+  const auto sessionTzName = config.sessionTimezone();
+
+  if (!sessionTzName.empty()) {
+    return tz::locateZone(sessionTzName);
+  }
+
+  return tz::locateZone(0); // GMT
+}
+
+// Calculate timezone offset in minutes at the given timestamp.
+// Since TIME has no date component, we use session start time to determine
+// which DST offset to apply.
+inline int16_t getTimezoneOffsetMinutes(
+    const tz::TimeZone* sessionTimeZone,
+    int64_t sessionStartTimeMs) {
+  if (auto offset = sessionTimeZone->offset()) {
+    return static_cast<int16_t>(offset->count());
+  }
+  auto sysTime = std::chrono::time_point<std::chrono::system_clock>(
+      std::chrono::milliseconds(sessionStartTimeMs));
+  auto info = sessionTimeZone->tz()->get_info(sysTime);
+  auto offsetMinutes =
+      std::chrono::duration_cast<std::chrono::minutes>(info.offset);
+  return static_cast<int16_t>(offsetMinutes.count());
+}
+
+// Pack time (in milliseconds since midnight) and timezone offset minutes
+inline int64_t packTimeWithTimeZone(
+    int64_t timeMillis,
+    int16_t timezoneOffsetMinutes) {
+  auto encodedOffset = util::biasEncode(timezoneOffsetMinutes);
+  return pack(timeMillis, encodedOffset);
+}
+
+void castFromTime(
+    const SimpleVector<int64_t>& inputVector,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    int64_t* rawResults,
+    int16_t offsetMinutes) {
+  context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+    const auto timeMillis = inputVector.valueAt(row);
+    // Convert local time to UTC before packing
+    const auto utcMillis = util::localToUtcTime(timeMillis, offsetMinutes);
+    rawResults[row] = packTimeWithTimeZone(utcMillis, offsetMinutes);
+  });
+}
+
 class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
   TimeWithTimeZoneCastOperator() = default;
 
  public:
-  static std::shared_ptr<const exec::CastOperator> get() {
+  static std::shared_ptr<const CastOperator> get() {
     VELOX_CONSTEXPR_SINGLETON TimeWithTimeZoneCastOperator kInstance;
-    return {std::shared_ptr<const exec::CastOperator>{}, &kInstance};
+    return {std::shared_ptr<const CastOperator>{}, &kInstance};
   }
 
-  bool isSupportedToType(const TypePtr& other) const override {
+  bool isSupportedFromType(const TypePtr& other) const override {
     switch (other->kind()) {
-      case TypeKind::VARCHAR:
-        return true;
       case TypeKind::BIGINT:
         return other->isTime();
+      case TypeKind::VARCHAR:
+        return true;
       default:
         return false;
     }
   }
 
-  bool isSupportedFromType(const TypePtr& other) const override {
+  bool isSupportedToType(const TypePtr& other) const override {
     switch (other->kind()) {
+      case TypeKind::BIGINT:
+        return other->isTime();
       case TypeKind::VARCHAR:
         return true;
       default:
@@ -204,14 +257,53 @@ class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
       const TypePtr& resultType,
       VectorPtr& result) const override {
     context.ensureWritable(rows, resultType, result);
-    switch (input.typeKind()) {
-      case TypeKind::VARCHAR:
-        castFromString(input, context, rows, *result);
-        break;
-      default:
-        VELOX_UNREACHABLE(
-            "Cast to TIME WITH TIME ZONE from {} not yet supported",
-            input.type()->toString());
+
+    // Handle VARCHAR to TIME WITH TIME ZONE
+    if (input.type() == VARCHAR()) {
+      castFromString(input, context, rows, *result);
+      return;
+    }
+
+    if (input.type()->isTime()) {
+      const auto& config = context.execCtx()->queryCtx()->queryConfig();
+      const auto* sessionTimeZone = getTimeZoneFromConfig(config);
+      const auto sessionStartTimeMs = config.sessionStartTimeMs();
+      int16_t offsetMinutes =
+          getTimezoneOffsetMinutes(sessionTimeZone, sessionStartTimeMs);
+
+      if (input.isConstantEncoding()) {
+        auto constantInput = input.as<ConstantVector<int64_t>>();
+        if (constantInput->isNullAt(0)) {
+          result = BaseVector::createNullConstant(
+              resultType, rows.end(), context.pool());
+          return;
+        }
+
+        const auto timeMillis = constantInput->valueAt(0);
+        // Convert local time to UTC before packing
+        const auto utcMillis = util::localToUtcTime(timeMillis, offsetMinutes);
+        auto packedValue = packTimeWithTimeZone(utcMillis, offsetMinutes);
+
+        result = std::make_shared<ConstantVector<int64_t>>(
+            context.pool(),
+            rows.end(),
+            false, // isNull
+            resultType,
+            std::move(packedValue));
+        return;
+      }
+
+      auto* timeWithTzResult = result->asFlatVector<int64_t>();
+      timeWithTzResult->clearNulls(rows);
+      auto* rawResults = timeWithTzResult->mutableRawValues();
+
+      const auto inputVector = input.as<SimpleVector<int64_t>>();
+      castFromTime(*inputVector, context, rows, rawResults, offsetMinutes);
+      return;
+    } else {
+      VELOX_UNSUPPORTED(
+          "Cast from {} to TIME WITH TIME ZONE not yet supported",
+          input.type()->toString());
     }
   }
 
@@ -222,19 +314,24 @@ class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
       const TypePtr& resultType,
       VectorPtr& result) const override {
     context.ensureWritable(rows, resultType, result);
+
     switch (resultType->kind()) {
+      case TypeKind::BIGINT:
+        if (resultType->isTime()) {
+          castToTime(input, context, rows, *result);
+          return;
+        }
+        break;
       case TypeKind::VARCHAR:
         castToString(input, context, rows, *result);
-        break;
-      case TypeKind::BIGINT:
-        VELOX_CHECK(resultType->isTime());
-        castToTime(input, context, rows, *result);
-        break;
+        return;
       default:
-        VELOX_UNREACHABLE(
-            "Cast from TIME WITH TIME ZONE to {} not yet supported",
-            resultType->toString());
+        break;
     }
+
+    VELOX_UNSUPPORTED(
+        "Cast from TIME WITH TIME ZONE to {} not yet supported",
+        resultType->toString());
   }
 };
 
@@ -247,7 +344,6 @@ class TimeWithTimezoneTypeFactory : public CustomTypeFactory {
     return TIME_WITH_TIME_ZONE();
   }
 
-  // Type casting from and to TimestampWithTimezone is not supported yet.
   exec::CastOperatorPtr getCastOperator() const override {
     return TimeWithTimeZoneCastOperator::get();
   }
@@ -257,6 +353,7 @@ class TimeWithTimezoneTypeFactory : public CustomTypeFactory {
     return nullptr;
   }
 };
+
 } // namespace
 
 void registerTimeWithTimezoneType() {

--- a/velox/type/tz/TimeZoneMap.h
+++ b/velox/type/tz/TimeZoneMap.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <chrono>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -165,6 +166,15 @@ class TimeZone {
 
   const tzdb::time_zone* tz() const {
     return tz_;
+  }
+
+  /// Returns the fixed offset for offset-based time zones (e.g., "+05:30").
+  /// Returns std::nullopt for time zones with a tzdb::time_zone pointer.
+  std::optional<std::chrono::minutes> offset() const {
+    if (tz_ == nullptr) {
+      return offset_;
+    }
+    return std::nullopt;
   }
 
   /// Returns the short name (abbreviation) of the time zone for the given

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -254,6 +254,57 @@ TEST(TimeZoneMapTest, getTimeZoneIDFromOffset) {
   VELOX_ASSERT_THROW(getTimeZoneID(-15'000), "Invalid timezone offset");
 }
 
+TEST(TimeZoneMapTest, offset) {
+  // Test offset-based timezones - should return the offset value.
+  {
+    const auto* tz = locateZone("+05:30");
+    ASSERT_NE(tz, nullptr);
+    auto offset = tz->offset();
+    ASSERT_TRUE(offset.has_value());
+    EXPECT_EQ(offset->count(), 330); // 5*60 + 30 = 330 minutes
+  }
+
+  {
+    const auto* tz = locateZone("-08:00");
+    ASSERT_NE(tz, nullptr);
+    auto offset = tz->offset();
+    ASSERT_TRUE(offset.has_value());
+    EXPECT_EQ(offset->count(), -480); // -8*60 = -480 minutes
+  }
+
+  {
+    const auto* tz = locateZone("+00:01");
+    ASSERT_NE(tz, nullptr);
+    auto offset = tz->offset();
+    ASSERT_TRUE(offset.has_value());
+    EXPECT_EQ(offset->count(), 1); // 1 minute
+  }
+
+  // Test named timezones - should return std::nullopt.
+  // Note: UTC is a named timezone with tzdb::time_zone pointer, not
+  // offset-based
+  {
+    const auto* tz = locateZone("UTC");
+    ASSERT_NE(tz, nullptr);
+    auto offset = tz->offset();
+    EXPECT_FALSE(offset.has_value());
+  }
+
+  {
+    const auto* tz = locateZone("America/Los_Angeles");
+    ASSERT_NE(tz, nullptr);
+    auto offset = tz->offset();
+    EXPECT_FALSE(offset.has_value());
+  }
+
+  {
+    const auto* tz = locateZone("Europe/London");
+    ASSERT_NE(tz, nullptr);
+    auto offset = tz->offset();
+    EXPECT_FALSE(offset.has_value());
+  }
+}
+
 TEST(TimeZoneMapTest, invalid) {
   VELOX_ASSERT_THROW(getTimeZoneName(99999999), "Unable to resolve timeZoneID");
   VELOX_ASSERT_THROW(getTimeZoneID("This is a test"), "Unknown time zone");


### PR DESCRIPTION
Summary:
- Added `TimeWithTimeZoneCastOperator`
- Implemented `castFromTime()` function that:
  - Appends timezone offset based on session timezone setting
  - Respects `adjustTimestampToTimezone` config flag
  - Calculates offset using epoch (1970-01-01) for consistency

- Added constant vector optimization
- Handles constant TIME inputs efficiently by returning constant results without iterating through all rows
- Optimizes both null and non-null constant cases

Differential Revision: D84954694


