### PR TITLE
feat: Add TypeOf support for TIME and TIME WITH TIMEZONE

### DIFF
--- a/velox/functions/prestosql/TypeOf.cpp
+++ b/velox/functions/prestosql/TypeOf.cpp
@@ -15,140 +15,103 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
-#include "velox/functions/prestosql/types/BingTileType.h"
-#include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
-#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
-#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/P4HyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
-#include "velox/functions/prestosql/types/UuidType.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
 
 namespace facebook::velox::functions {
 namespace {
 
+// Converts a TypePtr to its string representation. Handles most types by
+// default, but provides special handling for types with mixed casing, custom
+// names, or complex formatting.
 std::string typeName(const TypePtr& type) {
-  switch (type->kind()) {
-    case TypeKind::BOOLEAN:
-      return "boolean";
-    case TypeKind::TINYINT:
-      return "tinyint";
-    case TypeKind::SMALLINT:
-      return "smallint";
-    case TypeKind::INTEGER:
-      if (type->isDate()) {
-        return "date";
-      }
-      if (type->isIntervalYearMonth()) {
-        return "interval year to month";
-      }
-      return "integer";
-    case TypeKind::BIGINT:
-      if (isTimestampWithTimeZoneType(type)) {
-        return "timestamp with time zone";
-      }
-      if (type->isIntervalDayTime()) {
-        return "interval day to second";
-      }
-      if (type->isDecimal()) {
-        const auto& shortDecimal = type->asShortDecimal();
-        return fmt::format(
-            "decimal({},{})", shortDecimal.precision(), shortDecimal.scale());
-      }
-      if (isBingTileType(type)) {
-        return "bingtile";
-      }
-      if (isBigintEnumType(*type)) {
-        return asBigintEnum(type)->enumName();
-      }
-      return "bigint";
-
-    case TypeKind::HUGEINT: {
-      if (isUuidType(type)) {
-        return "uuid";
-      } else if (isIPAddressType(type)) {
-        return "ipaddress";
-      }
-      VELOX_USER_CHECK(
-          type->isDecimal(),
-          "Expected decimal type. Got: {}",
-          type->toString());
-      const auto& longDecimal = type->asLongDecimal();
-      return fmt::format(
-          "decimal({},{})", longDecimal.precision(), longDecimal.scale());
-    }
-    case TypeKind::REAL:
-      return "real";
-    case TypeKind::DOUBLE:
-      return "double";
-    case TypeKind::VARCHAR:
-      if (isJsonType(type)) {
-        return "json";
-      }
-      if (isVarcharEnumType(*type)) {
-        return asVarcharEnum(type)->enumName();
-      }
-      return "varchar";
-    case TypeKind::VARBINARY:
-      if (isHyperLogLogType(type)) {
-        return "HyperLogLog";
-      }
-      if (isP4HyperLogLogType(type)) {
-        return "P4HyperLogLog";
-      }
-      if (isGeometryType(type)) {
-        return "geometry";
-      }
-      if (*type == *TDIGEST(DOUBLE())) {
-        return "tdigest(double)";
-      }
-      if (*type == *QDIGEST(BIGINT())) {
-        return "qdigest(bigint)";
-      }
-      if (*type == *QDIGEST(REAL())) {
-        return "qdigest(real)";
-      }
-      if (*type == *QDIGEST(DOUBLE())) {
-        return "qdigest(double)";
-      }
-      return "varbinary";
-    case TypeKind::TIMESTAMP:
-      return "timestamp";
-    case TypeKind::ARRAY:
-      return fmt::format("array({})", typeName(type->childAt(0)));
-    case TypeKind::MAP:
-      return fmt::format(
-          "map({}, {})",
-          typeName(type->childAt(0)),
-          typeName(type->childAt(1)));
-    case TypeKind::ROW: {
-      if (isIPPrefixType(type)) {
-        return "ipprefix";
-      }
-      const auto& rowType = type->asRow();
-      std::ostringstream out;
-      out << "row(";
-      for (auto i = 0; i < type->size(); ++i) {
-        if (i > 0) {
-          out << ", ";
-        }
-        if (!rowType.nameOf(i).empty()) {
-          out << "\"" << rowType.nameOf(i) << "\" ";
-        }
-        out << typeName(type->childAt(i));
-      }
-      out << ")";
-      return out.str();
-    }
-    case TypeKind::UNKNOWN:
-      return "unknown";
-    default:
-      VELOX_UNSUPPORTED("Unsupported type: {}", type->toString());
+  // Handle decimal types with precision and scale
+  if (type->isDecimal()) {
+    auto precision = type->isShortDecimal() ? type->asShortDecimal().precision()
+                                            : type->asLongDecimal().precision();
+    auto scale = type->isShortDecimal() ? type->asShortDecimal().scale()
+                                        : type->asLongDecimal().scale();
+    return fmt::format("decimal({},{})", precision, scale);
   }
+
+  // Handle complex types with recursive formatting
+  if (type->kind() == TypeKind::ARRAY) {
+    return fmt::format("array({})", typeName(type->childAt(0)));
+  }
+
+  if (type->kind() == TypeKind::MAP) {
+    return fmt::format(
+        "map({}, {})", typeName(type->childAt(0)), typeName(type->childAt(1)));
+  }
+
+  if (type->kind() == TypeKind::ROW) {
+    if (isIPPrefixType(type)) {
+      return "ipprefix";
+    }
+    const auto& rowType = type->asRow();
+    std::ostringstream out;
+    out << "row(";
+    for (auto i = 0; i < type->size(); ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      if (!rowType.nameOf(i).empty()) {
+        out << "\"" << rowType.nameOf(i) << "\" ";
+      }
+      out << typeName(type->childAt(i));
+    }
+    out << ")";
+    return out.str();
+  }
+
+  // Handle enum types that have custom names
+  if (isBigintEnumType(*type)) {
+    return asBigintEnum(type)->enumName();
+  }
+  if (isVarcharEnumType(*type)) {
+    return asVarcharEnum(type)->enumName();
+  }
+
+  // Handle HyperLogLog types that use mixed case
+  if (isHyperLogLogType(type)) {
+    return "HyperLogLog";
+  }
+  if (isP4HyperLogLogType(type)) {
+    return "P4HyperLogLog";
+  }
+
+  // Handle special digest types that need parameter formatting
+  if (*type == *TDIGEST(DOUBLE())) {
+    return "tdigest(double)";
+  }
+  if (*type == *QDIGEST(BIGINT())) {
+    return "qdigest(bigint)";
+  }
+  if (*type == *QDIGEST(REAL())) {
+    return "qdigest(real)";
+  }
+  if (*type == *QDIGEST(DOUBLE())) {
+    return "qdigest(double)";
+  }
+
+  if (type->kind() == TypeKind::UNKNOWN) {
+    return "unknown";
+  }
+
+  // Handle unsupported types
+  if (type->kind() == TypeKind::OPAQUE || type->kind() == TypeKind::FUNCTION ||
+      type->kind() == TypeKind::INVALID) {
+    VELOX_UNSUPPORTED("Unsupported type: {}", type->toString());
+  }
+
+  // Default: use type->name() and lowercase it
+  std::string name = type->name();
+  folly::toLowerAscii(name);
+  return name;
 }
 
 class TypeOfFunction : public exec::VectorFunction {

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/P4HyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
 
@@ -58,6 +59,7 @@ TEST_F(TypeOfTest, basic) {
 
   EXPECT_EQ("timestamp", typeOf(TIMESTAMP()));
   EXPECT_EQ("date", typeOf(DATE()));
+  EXPECT_EQ("time", typeOf(TIME()));
 
   EXPECT_EQ("unknown", typeOf(UNKNOWN()));
 
@@ -75,6 +77,7 @@ TEST_F(TypeOfTest, basic) {
 
 TEST_F(TypeOfTest, customTypes) {
   EXPECT_EQ("timestamp with time zone", typeOf(TIMESTAMP_WITH_TIME_ZONE()));
+  EXPECT_EQ("time with time zone", typeOf(TIME_WITH_TIME_ZONE()));
   EXPECT_EQ("bingtile", typeOf(BINGTILE()));
   EXPECT_EQ("geometry", typeOf(GEOMETRY()));
 


### PR DESCRIPTION
Summary: This diff changes TypeOf for new types to be implicitly supported such as TIME and TIME WITH TIMEZONE. Apart from having types that require custom typeOf handling all other types should be supported by lower(type->name())

Differential Revision: D84879127


