### PR TITLE
feat: Add CastTo Varchar support for TIME WITH TIMEZONE

### DIFF
--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -110,6 +110,7 @@ add_executable(
   SplitToMultiMapTest.cpp
   StringFunctionsTest.cpp
   TimestampWithTimeZoneCastTest.cpp
+  TimeWithTimezoneCastTest.cpp
   TransformKeysTest.cpp
   TransformTest.cpp
   TransformValuesTest.cpp

--- a/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+namespace facebook::velox {
+namespace {
+
+class TimeWithTimezoneCastTest : public functions::test::CastBaseTest {};
+
+TEST_F(TimeWithTimezoneCastTest, toVarchar) {
+  // Test comprehensive scenarios: various times, timezones, boundary values,
+  // and nulls.
+  auto input = makeNullableFlatVector<int64_t>(
+      {
+          // Basic time with UTC.
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              TimeWithTimezoneType::biasEncode(0)),
+          // Same time with negative offset (EST).
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              TimeWithTimezoneType::biasEncode(-5 * 60)),
+          // Same time with positive offset including half-hour (IST).
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              TimeWithTimezoneType::biasEncode(5 * 60 + 30)),
+          // Boundary: Midnight.
+          pack(0, TimeWithTimezoneType::biasEncode(0)),
+          // Boundary: Almost end of day.
+          pack(
+              23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                  999,
+              TimeWithTimezoneType::biasEncode(0)),
+          // Null value.
+          std::nullopt,
+          // Boundary: Maximum positive timezone offset (+14:00).
+          pack(12 * kMillisInHour, TimeWithTimezoneType::biasEncode(14 * 60)),
+          // Boundary: Maximum negative timezone offset (-14:00).
+          pack(12 * kMillisInHour, TimeWithTimezoneType::biasEncode(-14 * 60)),
+          // Edge case: 1 millisecond after midnight.
+          pack(1, TimeWithTimezoneType::biasEncode(0)),
+          // Various time components with negative offset including minutes.
+          pack(
+              12 * kMillisInHour + 34 * kMillisInMinute + 56 * kMillisInSecond +
+                  789,
+              TimeWithTimezoneType::biasEncode(-4 * 60 - 30)),
+          // Time with no milliseconds component.
+          pack(
+              9 * kMillisInHour + 8 * kMillisInMinute + 7 * kMillisInSecond,
+              TimeWithTimezoneType::biasEncode(5 * 60 + 45)),
+          // Another null value.
+          std::nullopt,
+      },
+      TIME_WITH_TIME_ZONE());
+
+  auto expected = makeNullableFlatVector<std::string>({
+      "06:11:37.123+00:00",
+      "06:11:37.123-05:00",
+      "06:11:37.123+05:30",
+      "00:00:00.000+00:00",
+      "23:59:59.999+00:00",
+      std::nullopt,
+      "12:00:00.000+14:00",
+      "12:00:00.000-14:00",
+      "00:00:00.001+00:00",
+      "12:34:56.789-04:30",
+      "09:08:07.000+05:45",
+      std::nullopt,
+  });
+
+  testCast(input, expected);
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimeWithTimezoneType.h
+++ b/velox/functions/prestosql/types/TimeWithTimezoneType.h
@@ -31,6 +31,7 @@ class TimeWithTimezoneType final : public BigintType {
  public:
   static constexpr int16_t kTimeZoneBias = 840;
   static constexpr int16_t kMinutesInHour = 60;
+  static constexpr int16_t kTimeWithTimezoneToVarcharRowSize = 18;
 
   static std::shared_ptr<const TimeWithTimezoneType> get() {
     VELOX_CONSTEXPR_SINGLETON TimeWithTimezoneType kInstance;
@@ -52,7 +53,7 @@ class TimeWithTimezoneType final : public BigintType {
 
   /// Returns the time with timezone 'value' formatted as HH:MM:SS.mmmZZ
   /// where the timezone offset is included in the representation.
-  std::string valueToString(int64_t value) const;
+  StringView valueToString(int64_t value, char* const startPos) const;
 
   folly::dynamic serialize() const override;
 

--- a/velox/functions/prestosql/types/tests/TimeWithTimezoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimeWithTimezoneTypeTest.cpp
@@ -72,72 +72,99 @@ TEST_F(TimeWithTimezoneTypeTest, properties) {
 // Test value to string conversion (if implemented)
 TEST_F(TimeWithTimezoneTypeTest, valueToString) {
   auto type = TIME_WITH_TIME_ZONE();
+  char buffer[TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize];
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
 
   // Test basic time values - these should work based on the implementation
   // Test midnight (00:00:00.000)
   int64_t timeValue = 0;
   int16_t timeZone = TimeWithTimezoneType::biasEncode(0); // UTC
   auto value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "00:00:00.000+00:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "00:00:00.000+00:00");
 
   // Test 1 hour (01:00:00.000) at UTC
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   value = pack(3600000, timeZone);
-  ASSERT_EQ(type->valueToString(value), "01:00:00.000+00:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "01:00:00.000+00:00");
 
   // Test 12:30:45.123 at UTC
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeValue = 12 * 3600000 + 30 * 60000 + 45 * 1000 + 123;
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+00:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+00:00");
 
   // Test 12:30:45.123 at PST
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(-480); // PST
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123-08:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123-08:00");
 
   // Test 12:30:45.123 at EST
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(-300); // EST
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123-05:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123-05:00");
 
   // Test 12:30:45.123 at GMT
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(0); // GMT
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+00:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+00:00");
 
   // Test 12:30:45.123 at BST
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(60); // BST
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+01:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+01:00");
 
   // Test 12:30:45.123 at JST
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(540); // JST
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+09:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+09:00");
 
   // Test 12:30:45.123 at AEST
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(600); // AEST
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+10:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+10:00");
 
   // Test 12:30:45.123 at AEDT
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(660); // AEDT
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+11:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+11:00");
 
   // Test 12:30:45.123 at NZST
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(780); // NZST
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+13:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+13:00");
 
   // Test 12:30:45.123 at NZDT
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(840); // NZDT
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123+14:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+14:00");
 
   // Test 12:30:45.123 at UTC-14:00
+  std::memset(
+      buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeZone = TimeWithTimezoneType::biasEncode(-840); // UTC-14:00
   value = pack(timeValue, timeZone);
-  ASSERT_EQ(type->valueToString(value), "12:30:45.123-14:00");
+  ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123-14:00");
 }
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Add Support for castTo Varchar and basic scaffolding for  CastOperator for Time With Timezone.

Also changed valueToString to return StringView instead to std::string to reuse the function for casting to varchar and hence avoid copying of temporary std::string

Differential Revision: D84879449


