### PR TITLE
refactor: Rename createTimeNs_  in TableWriter to reflect its meaning accurately

### DIFF
--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -42,7 +42,7 @@ TableWriter::TableWriter(
       insertTableHandle_(
           tableWriteNode->insertTableHandle()->connectorInsertTableHandle()),
       commitStrategy_(tableWriteNode->commitStrategy()),
-      createTimeUs_(getCurrentTimeNano()) {
+      createTimeNs_(getCurrentTimeNano()) {
   setConnectorMemoryReclaimer();
   if (tableWriteNode->outputType()->size() == 1) {
     VELOX_USER_CHECK(!tableWriteNode->columnStatsSpec().has_value());
@@ -280,7 +280,7 @@ std::string TableWriter::createTableCommitContext(bool lastOutput) {
 
 void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
   const auto currentTimeNs = getCurrentTimeNano();
-  VELOX_CHECK_GE(currentTimeNs, createTimeUs_);
+  VELOX_CHECK_GE(currentTimeNs, createTimeNs_);
   {
     auto lockedStats = stats_.wlock();
     lockedStats->physicalWrittenBytes = stats.numWrittenBytes;
@@ -314,7 +314,7 @@ void TableWriter::updateStats(const connector::DataSink::Stats& stats) {
     lockedStats->addRuntimeStat(
         kRunningWallNanos,
         RuntimeCounter(
-            currentTimeNs - createTimeUs_, RuntimeCounter::Unit::kNanos));
+            currentTimeNs - createTimeNs_, RuntimeCounter::Unit::kNanos));
   }
   if (!stats.spillStats.empty()) {
     *spillStats_->wlock() += stats.spillStats;

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -233,9 +233,9 @@ class TableWriter : public Operator {
   const connector::ConnectorInsertTableHandlePtr insertTableHandle_;
   const connector::CommitStrategy commitStrategy_;
   // Records the writer operator creation time in ns. This is used to record
-  // the running wall time of a writer operator. This can helps to detect the
+  // the running wall time of a writer operator. This can help to detect the
   // slow scaled writer scheduling in Prestissimo.
-  const uint64_t createTimeUs_{0};
+  const uint64_t createTimeNs_{0};
 
   std::unique_ptr<ColumnStatsCollector> statsCollector_;
   std::shared_ptr<connector::Connector> connector_;


### PR DESCRIPTION
Rename createTimeNs_  in TableWriter to reflect its meaning accurately, createTime should be ns instead of us