### PR TITLE
[Do not review] perf(Cast) : Optimize simple casts like INTEGER->BIGINT

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -36,6 +36,8 @@ target_link_libraries(
   GTest::gtest_main
 )
 
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
 add_executable(
   velox_exec_test
   AddressableNonNullValueListTest.cpp

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -314,6 +314,12 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const BaseVector& input);
 
+  VectorPtr applyIntegerToBigintCast(
+      const SelectivityVector& rows,
+      const TypePtr& toType,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   bool isTryCast() const {
     return isTryCast_;
   }

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -259,6 +259,11 @@ class EvalCtx {
     return peeledFields_;
   }
 
+  void setDictionaryWrap(BufferPtr wrap, BufferPtr wrapNulls) {
+    wrap_ = std::move(wrap);
+    wrapNulls_ = std::move(wrapNulls);
+  }
+
   /// Used by peelEncodings.
   void saveAndReset(ContextSaver& saver, const SelectivityVector& rows);
 
@@ -353,6 +358,11 @@ class EvalCtx {
       VectorPtr& result);
 
   void deselectErrors(SelectivityVector& rows) const;
+
+  VectorPtr applyDictionaryWrapToPeeledResult(
+      const TypePtr& outputType,
+      VectorPtr peeledResult,
+      const SelectivityVector& rows);
 
   /// Returns the vector of errors or nullptr if no errors. This is
   /// intentionally a raw pointer to signify that the caller may not
@@ -590,6 +600,10 @@ class EvalCtx {
   // Set if peeling was successful, that is, common encodings from inputs were
   // peeled off.
   std::shared_ptr<PeeledEncoding> peeledEncoding_;
+
+  // The dictionary indices used to peel encodings. Only valid for CastExpr.
+  BufferPtr wrap_;
+  BufferPtr wrapNulls_;
 
   // True if nulls in the input vectors were pruned (removed from the current
   // selectivity vector). Only possible is all expressions have default null

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -3993,5 +3993,23 @@ TEST_F(CastExprTest, timeToTimestampCast) {
     assertEqualVectors(expected, result);
   }
 }
+
+TEST_F(CastExprTest, integerToBigintCast) {
+  std::vector<core::TypedExprPtr> inputs = {
+      std::make_shared<const core::FieldAccessTypedExpr>(INTEGER(), "c0")};
+  auto castExpr =
+      std::make_shared<core::CallTypedExpr>(BIGINT(), inputs, "cast");
+
+  testEncodings(
+      castExpr,
+      {makeFlatVector<int32_t>(
+          1'000,
+          [](auto i) { return 1 + 2 * i; },
+          [](auto i) { return i % 2 == 0; })},
+      makeFlatVector<int64_t>(
+          1'000,
+          [](auto i) { return 1 + 2 * i; },
+          [](auto i) { return i % 2 == 0; }));
+}
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
Avoid the overhead of peeling.

This code is for an experiment. The ideal design should enhance PeelEncoding classes to avoid extra vectors for single vector cases like CAST.