### PR TITLE
refactor(dwio): Use nested namespace in 'dwio/common' directory

### DIFF
--- a/velox/dwio/common/ChainedBuffer.h
+++ b/velox/dwio/common/ChainedBuffer.h
@@ -20,10 +20,7 @@
 #include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/DataBuffer.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 namespace {
 
@@ -228,7 +225,4 @@ class ChainedBuffer {
   VELOX_FRIEND_TEST(ChainedBufferTests, testClearAll);
 };
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -23,10 +23,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 template <typename T, typename = std::enable_if_t<std::is_trivial_v<T>>>
 class DataBuffer {
@@ -233,7 +230,5 @@ class DataBuffer {
   // Maximum capacity of items of type T.
   uint64_t capacity_;
 };
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ErrorTolerance.h
+++ b/velox/dwio/common/ErrorTolerance.h
@@ -18,10 +18,7 @@
 
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 /**
  * Error tolerance level for readers
@@ -63,7 +60,4 @@ struct ErrorTolerance {
   }
 };
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/MeasureTime.h
+++ b/velox/dwio/common/MeasureTime.h
@@ -20,10 +20,7 @@
 #include <functional>
 #include <optional>
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 class MeasureTime {
  public:
@@ -61,7 +58,4 @@ inline std::optional<MeasureTime> measureTimeIfCallback(
   return std::nullopt;
 }
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/MetricsLog.h
+++ b/velox/dwio/common/MetricsLog.h
@@ -19,10 +19,7 @@
 #include "velox/dwio/common/FilterNode.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 class MetricsLog {
  public:
@@ -178,7 +175,4 @@ void registerMetricsLogFactory(std::shared_ptr<DwioMetricsLogFactory> factory);
 
 DwioMetricsLogFactory& getMetricsLogFactory();
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/RandGen.h
+++ b/velox/dwio/common/RandGen.h
@@ -19,10 +19,7 @@
 #include <folly/Conv.h>
 #include <random>
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 class RandGen {
  public:
@@ -68,7 +65,4 @@ class RandGen {
   std::uniform_int_distribution<int32_t> dist_;
 };
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Retry.h
+++ b/velox/dwio/common/Retry.h
@@ -28,10 +28,7 @@
 #include "velox/dwio/common/RandGen.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 class retriable_error : public std::runtime_error {
  public:
@@ -229,7 +226,4 @@ class RetryModule {
   }
 };
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -28,8 +28,7 @@
 
 #include <vector>
 
-namespace facebook {
-namespace velox {
+namespace facebook::velox {
 namespace dwio::common {
 class ColumnStatistics;
 }
@@ -512,8 +511,7 @@ bool testFilter(
     const TypePtr& type);
 
 } // namespace common
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox
 
 template <>
 struct fmt::formatter<facebook::velox::common::ScanSpec::ColumnType>

--- a/velox/dwio/common/encryption/Encryption.cpp
+++ b/velox/dwio/common/encryption/Encryption.cpp
@@ -16,19 +16,11 @@
 
 #include "velox/dwio/common/encryption/Encryption.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
-namespace encryption {
+namespace facebook::velox::dwio::common::encryption {
 
 bool operator==(const EncryptionProperties& a, const EncryptionProperties& b) {
   return std::addressof(a) == std::addressof(b) ||
       (typeid(a) == typeid(b) && a.equals(b));
 }
 
-} // namespace encryption
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common::encryption

--- a/velox/dwio/common/encryption/Encryption.h
+++ b/velox/dwio/common/encryption/Encryption.h
@@ -20,11 +20,7 @@
 #include "folly/io/IOBuf.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
-namespace encryption {
+namespace facebook::velox::dwio::common::encryption {
 
 enum class EncryptionProvider { Unknown = 0, CryptoService };
 
@@ -127,8 +123,4 @@ class DummyDecrypterFactory : public DecrypterFactory {
   }
 };
 
-} // namespace encryption
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common::encryption

--- a/velox/dwio/common/encryption/TestProvider.h
+++ b/velox/dwio/common/encryption/TestProvider.h
@@ -20,12 +20,7 @@
 #include "velox/dwio/common/encryption/Encryption.h"
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
-namespace encryption {
-namespace test {
+namespace facebook::velox::dwio::common::encryption::test {
 
 class TestEncryption {
  public:
@@ -144,9 +139,4 @@ class TestDecrypterFactory : public DecrypterFactory {
   }
 };
 
-} // namespace test
-} // namespace encryption
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common::encryption::test

--- a/velox/dwio/common/exception/Exception.cpp
+++ b/velox/dwio/common/exception/Exception.cpp
@@ -17,11 +17,7 @@
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/common/base/Exceptions.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
-namespace exception {
+namespace facebook::velox::dwio::common::exception {
 
 std::unique_ptr<ExceptionLogger>& exceptionLogger() {
   static std::unique_ptr<ExceptionLogger> logger(nullptr);
@@ -40,8 +36,4 @@ ExceptionLogger* getExceptionLogger() {
   return exceptionLogger().get();
 }
 
-} // namespace exception
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common::exception

--- a/velox/dwio/common/exception/Exception.h
+++ b/velox/dwio/common/exception/Exception.h
@@ -18,11 +18,8 @@
 
 #include "velox/common/base/VeloxException.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
-namespace exception {
+namespace facebook::velox::dwio {
+namespace common::exception {
 
 class ExceptionLogger {
  public:
@@ -101,8 +98,7 @@ class LoggedException : public velox::VeloxException {
   }
 };
 
-} // namespace exception
-} // namespace common
+} // namespace common::exception
 
 #define DWIO_WARN_IF(e, ...)                                                \
   ({                                                                        \
@@ -256,6 +252,4 @@ containing information about the file, line, and function where it happened.
       "]: ",                           \
       ##__VA_ARGS__);
 
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio

--- a/velox/dwio/common/exception/Exceptions.cpp
+++ b/velox/dwio/common/exception/Exceptions.cpp
@@ -22,10 +22,7 @@
 #include <cstdio>
 #include <string>
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 void verify_range(uint64_t v, uint64_t rangeMask) {
   auto mv = (v & rangeMask);
@@ -67,7 +64,4 @@ std::string format_error_string(std::string fmt...) {
   return s;
 }
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/exception/Exceptions.h
+++ b/velox/dwio/common/exception/Exceptions.h
@@ -22,10 +22,7 @@
 #include <string>
 #include "velox/dwio/common/exception/Exception.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 class NotImplementedYet : public std::logic_error {
  public:
@@ -117,7 +114,4 @@ using logic_error = exception_error<std::logic_error>;
 using runtime_error = exception_error<std::runtime_error>;
 using EOF_error = exception_error<EOFError>;
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/ChainedBufferTests.cpp
+++ b/velox/dwio/common/tests/ChainedBufferTests.cpp
@@ -23,10 +23,7 @@
 
 using namespace ::testing;
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 class ChainedBufferTests : public Test {
  protected:
@@ -321,7 +318,5 @@ TEST_F(ChainedBufferTests, testClearAll) {
     ASSERT_EQ(buf.pages_.size(), 9);
   }
 }
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -21,10 +21,8 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/DataBuffer.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
+
 using namespace facebook::velox::memory;
 using namespace testing;
 using MemoryPool = facebook::velox::memory::MemoryPool;
@@ -175,7 +173,5 @@ TEST_F(DataBufferTest, Move) {
   }
   ASSERT_EQ(0, pool_->usedBytes());
 }
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+
+} // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Update namespace definitions in 'dwio/common' to use the nested
namespace syntax `namespace facebook::velox::dwio::common` as required
by Velox code style guidelines, which can also achieve better
readability and consistency.

No functional change.