### PR TITLE
refactor: Remove usage of folly::StringPiece in dwio

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -1576,7 +1576,7 @@ class StringColumnReadWithVisitorHelper {
       ExtractValues extractValues,
       F readWithVisitor) {
     readWithVisitor(
-        ColumnVisitor<folly::StringPiece, TFilter, ExtractValues, kIsDense>(
+        ColumnVisitor<std::string_view, TFilter, ExtractValues, kIsDense>(
             *static_cast<const TFilter*>(filter),
             &reader_,
             rows_,

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -410,7 +410,7 @@ void SelectiveColumnReader::compactScalarValues<bool, bool>(
   values_->setSize(bits::nbytes(numValues_));
 }
 
-char* SelectiveColumnReader::copyStringValue(folly::StringPiece value) {
+char* SelectiveColumnReader::copyStringValue(std::string_view value) {
   uint64_t size = value.size();
   if (stringBuffers_.empty() || rawStringUsed_ + size > rawStringSize_) {
     auto bytes = std::max(size, kStringBufferSize);
@@ -431,7 +431,7 @@ char* SelectiveColumnReader::copyStringValue(folly::StringPiece value) {
   return rawStringBuffer_ + start;
 }
 
-void SelectiveColumnReader::addStringValue(folly::StringPiece value) {
+void SelectiveColumnReader::addStringValue(std::string_view value) {
   auto copy = copyStringValue(value);
   reinterpret_cast<StringView*>(rawValues_)[numValues_++] =
       StringView(copy, value.size());

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -482,7 +482,7 @@ class SelectiveColumnReader {
     return false;
   }
 
-  StringView copyStringValueIfNeed(folly::StringPiece value) {
+  StringView copyStringValueIfNeed(std::string_view value) {
     if (value.size() <= StringView::kInlineSize) {
       return StringView(value);
     }
@@ -581,11 +581,11 @@ class SelectiveColumnReader {
   // Checks consistency of nulls-related state.
   const uint64_t* shouldMoveNulls(const RowSet& rows);
 
-  void addStringValue(folly::StringPiece value);
+  void addStringValue(std::string_view value);
 
   // Copies 'value' to buffers owned by 'this' and returns the start of the
   // copy.
-  char* copyStringValue(folly::StringPiece value);
+  char* copyStringValue(std::string_view value);
 
   virtual bool hasDeletion() const {
     return false;
@@ -732,7 +732,7 @@ class SelectiveColumnReader {
 };
 
 template <>
-inline void SelectiveColumnReader::addValue(const folly::StringPiece value) {
+inline void SelectiveColumnReader::addValue(const std::string_view value) {
   const uint64_t size = value.size();
   if (size <= StringView::kInlineSize) {
     reinterpret_cast<StringView*>(rawValues_)[numValues_++] =
@@ -766,7 +766,7 @@ struct NoHook final : public ValueHook {
 
   void addValue(vector_size_t /*row*/, double /*value*/) final {}
 
-  void addValue(vector_size_t /*row*/, folly::StringPiece /*value*/) final {}
+  void addValue(vector_size_t /*row*/, std::string_view /*value*/) final {}
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -64,7 +64,7 @@ class TestingHook : public ValueHook {
     }
   }
 
-  void addValue(vector_size_t row, folly::StringPiece value) override {
+  void addValue(vector_size_t row, std::string_view value) override {
     if constexpr (std::is_same_v<T, StringView>) {
       result_->set(row, StringView(value));
     } else {

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -362,20 +362,19 @@ void SelectiveStringDirectColumnReader::skipInDecode(
   lengthIndex_ += numValues;
 }
 
-folly::StringPiece SelectiveStringDirectColumnReader::readValue(
-    int32_t length) {
+std::string_view SelectiveStringDirectColumnReader::readValue(int32_t length) {
   skipBytes(bytesToSkip_, blobStream_.get(), bufferStart_, bufferEnd_);
   bytesToSkip_ = 0;
   // bufferStart_ may be null if length is 0 and this is the first string
   // we're reading.
   if (bufferEnd_ - bufferStart_ >= length) {
     bytesToSkip_ = length;
-    return folly::StringPiece(bufferStart_, length);
+    return std::string_view(bufferStart_, length);
   }
   tempString_.resize(length);
   readBytes(
       length, blobStream_.get(), tempString_.data(), bufferStart_, bufferEnd_);
-  return folly::StringPiece(tempString_);
+  return std::string_view(tempString_);
 }
 
 template <bool kHasNulls, typename Visitor>
@@ -474,7 +473,7 @@ void SelectiveStringDirectColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  prepareRead<folly::StringPiece>(offset, rows, incomingNulls);
+  prepareRead<std::string_view>(offset, rows, incomingNulls);
   auto numRows = rows.back() + 1;
   auto numNulls = nullsInReadRange_
       ? BaseVector::countNulls(nullsInReadRange_, 0, numRows)

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -58,7 +58,7 @@ class SelectiveStringDirectColumnReader
   template <bool hasNulls>
   void skipInDecode(int32_t numValues, int32_t current, const uint64_t* nulls);
 
-  folly::StringPiece readValue(int32_t length);
+  std::string_view readValue(int32_t length);
 
   template <bool hasNulls, typename Visitor>
   void decode(const uint64_t* nulls, Visitor visitor);

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -3524,7 +3524,7 @@ struct StringColumnWriterTestCase {
         postProcess{postProcess},
         repetitionCount{repetitionCount},
         flushCount{flushCount},
-        type{CppToType<folly::StringPiece>::create()} {}
+        type{CppToType<std::string_view>::create()} {}
 
   virtual ~StringColumnWriterTestCase() = default;
 

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -1230,10 +1230,12 @@ uint64_t StringColumnWriter::writeDict(
   size_t strideIndex = strideOffsets_.size() - 1;
   uint64_t rawSize = 0;
   auto processRow = [&](size_t pos) {
-    auto sp = decodedVector.valueAt<StringView>(pos);
-    rows_.unsafeAppend(dictEncoder_.addKey(sp, strideIndex));
-    statsBuilder.addValues(sp);
-    rawSize += sp.size();
+    auto sv = decodedVector.valueAt<StringView>(pos);
+    // TODO: Remove explicit std::string_view cast.
+    rows_.unsafeAppend(dictEncoder_.addKey(std::string_view(sv), strideIndex));
+    // TODO: Remove explicit std::string_view cast.
+    statsBuilder.addValues(std::string_view(sv));
+    rawSize += sv.size();
   };
 
   uint64_t nullCount = 0;
@@ -1274,10 +1276,11 @@ uint64_t StringColumnWriter::writeDirect(
 
   uint64_t rawSize = 0;
   auto processRow = [&](size_t pos) {
-    auto sp = decodedVector.valueAt<StringView>(pos);
-    auto size = sp.size();
-    dataDirect_->write(sp.data(), size);
-    statsBuilder.addValues(sp);
+    auto sv = decodedVector.valueAt<StringView>(pos);
+    auto size = sv.size();
+    dataDirect_->write(sv.data(), size);
+    // TODO: Remove explicit std::string_view cast.
+    statsBuilder.addValues(std::string_view(sv));
     rawSize += size;
     lengths.unsafeAppend(size);
   };

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -21,7 +21,6 @@
 #include "velox/vector/FlatMapVector.h"
 
 namespace facebook::velox::dwrf {
-
 namespace {
 
 template <typename T>
@@ -252,7 +251,7 @@ uint32_t updateKeyStatistics<TypeKind::VARCHAR>(
     StringView value,
     uint64_t count) {
   auto size = value.size();
-  keyStatsBuilder.addValues(folly::StringPiece{value.data(), size}, count);
+  keyStatsBuilder.addValues(std::string_view{value.data(), size}, count);
   return size * count;
 }
 

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.h
@@ -358,7 +358,7 @@ class StringStatisticsBuilder : public StatisticsBuilder,
 
   ~StringStatisticsBuilder() override = default;
 
-  void addValues(folly::StringPiece value, uint64_t count = 1) {
+  void addValues(std::string_view value, uint64_t count = 1) {
     // min_/max_ is not initialized with default that can be compared against
     // easily. So we need to capture whether self is empty and handle
     // differently.
@@ -368,10 +368,10 @@ class StringStatisticsBuilder : public StatisticsBuilder,
       min_ = value;
       max_ = value;
     } else {
-      if (min_.has_value() && value < folly::StringPiece{min_.value()}) {
+      if (min_.has_value() && value < std::string_view{min_.value()}) {
         min_ = value;
       }
-      if (max_.has_value() && value > folly::StringPiece{max_.value()}) {
+      if (max_.has_value() && value > std::string_view{max_.value()}) {
         max_ = value;
       }
     }

--- a/velox/dwio/dwrf/writer/StatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/writer/StatisticsBuilderUtils.cpp
@@ -81,18 +81,18 @@ void StatisticsBuilderUtils::addValues(
     const VectorPtr& vector,
     const common::Ranges& ranges) {
   auto nulls = vector->rawNulls();
-  auto data = vector->asFlatVector<StringView>()->rawValues();
+  auto* data = vector->asFlatVector<StringView>()->rawValues();
   if (vector->mayHaveNulls()) {
     for (auto& pos : ranges) {
       if (bits::isBitNull(nulls, pos)) {
         builder.setHasNull();
       } else {
-        builder.addValues(folly::StringPiece{data[pos]});
+        builder.addValues(std::string_view{data[pos]});
       }
     }
   } else {
     for (auto& pos : ranges) {
-      builder.addValues(folly::StringPiece{data[pos]});
+      builder.addValues(std::string_view{data[pos]});
     }
   }
 }

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -30,6 +30,7 @@
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::dwrf {
+
 using dwio::common::BufferedOutputStream;
 using dwio::common::DataBufferHolder;
 using dwio::common::compression::CompressionBufferPool;
@@ -57,9 +58,7 @@ class WriterContext : public CompressionBufferPool {
     return streams_.at(stream);
   }
 
-  void addBuffer(
-      const DwrfStreamIdentifier& stream,
-      folly::StringPiece buffer) {
+  void addBuffer(const DwrfStreamIdentifier& stream, std::string_view buffer) {
     streams_.at(stream).take(buffer);
   }
 

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -268,7 +268,7 @@ class PageReader {
   template <
       typename Visitor,
       typename std::enable_if<
-          !std::is_same_v<typename Visitor::DataType, folly::StringPiece> &&
+          !std::is_same_v<typename Visitor::DataType, std::string_view> &&
               !std::is_same_v<typename Visitor::DataType, int8_t>,
           int>::type = 0>
   void
@@ -304,7 +304,7 @@ class PageReader {
   template <
       typename Visitor,
       typename std::enable_if<
-          std::is_same_v<typename Visitor::DataType, folly::StringPiece>,
+          std::is_same_v<typename Visitor::DataType, std::string_view>,
           int>::type = 0>
   void
   callDecoder(const uint64_t* nulls, bool& nullsFromFastPath, Visitor visitor) {

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -35,7 +35,7 @@ void StringColumnReader::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  prepareRead<folly::StringPiece>(offset, rows, incomingNulls);
+  prepareRead<std::string_view>(offset, rows, incomingNulls);
   dwio::common::StringColumnReadWithVisitorHelper<true, false>(
       *this, rows)([&](auto visitor) {
     formatData_->as<ParquetData>().readWithVisitor(visitor);
@@ -83,7 +83,7 @@ void StringColumnReader::dedictionarize() {
       }
       auto& view = dict->valueAt(indices[i]);
       numValues_ = i;
-      addStringValue(folly::StringPiece(view.data(), view.size()));
+      addStringValue(std::string_view(view.data(), view.size()));
     }
     numValues_ = numValues;
   }

--- a/velox/dwio/parquet/reader/StringDecoder.h
+++ b/velox/dwio/parquet/reader/StringDecoder.h
@@ -90,15 +90,15 @@ class StringDecoder {
     return *reinterpret_cast<const int32_t*>(buffer);
   }
 
-  folly::StringPiece readString() {
+  std::string_view readString() {
     auto length = lengthAt(bufferStart_);
     bufferStart_ += length + sizeof(int32_t);
-    return folly::StringPiece(bufferStart_ - length, length);
+    return std::string_view(bufferStart_ - length, length);
   }
 
-  folly::StringPiece readFixedString() {
+  std::string_view readFixedString() {
     bufferStart_ += fixedLength_;
-    return folly::StringPiece(bufferStart_ - fixedLength_, fixedLength_);
+    return std::string_view(bufferStart_ - fixedLength_, fixedLength_);
   }
 
   const char* bufferStart_;

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -2250,7 +2250,7 @@ static inline bool applyFilter(TFilter& filter, const std::string& value) {
 }
 
 template <typename TFilter>
-static inline bool applyFilter(TFilter& filter, folly::StringPiece value) {
+static inline bool applyFilter(TFilter& filter, std::string_view value) {
   return filter.testBytes(value.data(), value.size());
 }
 

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -78,7 +78,7 @@ class ValueHook {
     VELOX_UNSUPPORTED();
   }
 
-  virtual void addValue(vector_size_t /*row*/, folly::StringPiece /*value*/) {
+  virtual void addValue(vector_size_t /*row*/, std::string_view /*value*/) {
     VELOX_UNSUPPORTED();
   }
 
@@ -159,7 +159,8 @@ class ValueHook {
       const StringView* values,
       vector_size_t size) {
     for (auto i = 0; i < size; ++i) {
-      addValue(rows[i], values[i]);
+      // TODO: Remove explicit std::string_view cast.
+      addValue(rows[i], std::string_view(values[i]));
     }
   }
 
@@ -167,6 +168,9 @@ class ValueHook {
   void addValueTyped(vector_size_t row, T value) {
     if constexpr (std::is_integral_v<T> && sizeof(T) < sizeof(int64_t)) {
       addValue(row, static_cast<int64_t>(value));
+    } else if constexpr (std::is_same_v<T, StringView>) {
+      // TODO: Remove explicit std::string_view cast.
+      addValue(row, std::string_view(value));
     } else {
       addValue(row, value);
     }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/287

Intermediate step while migrating legacy folly::StringPiece usages to
std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D85061784


