### PR TITLE
refactor: Use PrestoBatchSerializer for LocalRunnerService Thrift serialization

### DIFF
--- a/velox/exec/fuzzer/LocalRunnerService.h
+++ b/velox/exec/fuzzer/LocalRunnerService.h
@@ -32,42 +32,15 @@
 #include <thrift/lib/cpp2/server/ThriftServer.h>
 
 #include "velox/exec/fuzzer/if/gen-cpp2/LocalRunnerService.h"
-#include "velox/expression/EvalCtx.h"
+#include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::runner {
 
-/// Extracts a scalar (primitive) value from a Velox vector at the specified
-/// row. This function handles all primitive types supported by Velox, such as:
-/// TINYINT, INTEGER, BIGINT, etc.
-ScalarValue getScalarValue(const VectorPtr& vector, vector_size_t rowIdx);
-
-/// Extracts a complex (nested) value from a Velox vector at the specified row.
-/// This function handles all complex types supported by Velox: ARRAY, MAP and
-/// ROW. The function recursively converts nested structures.
-ComplexValue getComplexValue(
-    const VectorPtr& vector,
-    vector_size_t rowIdx,
-    const exec::EvalCtx& evalCtx);
-
-/// Converts a Velox vector value at a specific row to a Thrift Value and serves
-/// as the entry point for value conversion that can be either primitive or
-/// complex. Output value can either be a scalar or complex value (as mentioned,
-/// using the above). This is where NULL is also defined.
-Value convertValue(
-    const VectorPtr& vector,
-    vector_size_t rowIdx,
-    const exec::EvalCtx& evalCtx);
-
-/// Converts a Velox vector into a corresponding Thrift struct vector.
-std::vector<Value> convertVector(
-    const VectorPtr& vector,
-    vector_size_t size,
-    const exec::EvalCtx& evalCtx);
-
-/// Converts a collection of Velox RowVectors into Thrift Batches.
+/// Converts a collection of Velox RowVectors into Thrift Batches using
+/// binary serialization.
 std::vector<Batch> convertToBatches(
     const std::vector<RowVectorPtr>& rowVectors,
-    const exec::EvalCtx& evalCtx);
+    memory::MemoryPool* pool);
 
 /// Thrift service handler for executing Velox query plans.
 /// Executes a serialized Velox query plan. This method deserializes the plan


### PR DESCRIPTION
Summary:
Refactor LocalRunnerService to use PrestoBatchSerializer instead of crafting output values manually using Thrift structs.

This is not just a much cleaner solution but is much faster as well.

Differential Revision: D84964586


