### PR TITLE
feat: Add TIME support to xxHash64 function

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1941,6 +1941,21 @@ struct XxHash64TimestampFunction {
   }
 };
 
+/// xxhash64(Time) → bigint
+/// Return a xxhash64 of input Time
+template <typename T>
+struct XxHash64TimeFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE
+  void call(out_type<int64_t>& result, const arg_type<Time>& input) {
+    // TIME is represented as milliseconds since midnight
+    // Convert to big-endian to match Presto's xxhash64 behavior
+    auto bigEndianValue = folly::Endian::big(input);
+    result = XXH64(&bigEndianValue, sizeof(bigEndianValue), 0);
+  }
+};
+
 template <typename T>
 struct ParseDurationFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -325,6 +325,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "xxhash64_internal"});
   registerFunction<XxHash64TimestampFunction, int64_t, Timestamp>(
       {prefix + "xxhash64_internal"});
+  registerFunction<XxHash64TimeFunction, int64_t, Time>(
+      {prefix + "xxhash64_internal"});
 
   registerFunction<ParseDurationFunction, IntervalDayTime, Varchar>(
       {prefix + "parse_duration"});


### PR DESCRIPTION
Summary:
- Added `XxHash64TimeFunction` in `DateTimeFunctions.h` that hashes the TIME value (int64_t milliseconds since midnight) using XXH64
- Registered the function in `DateTimeFunctionsRegistration.cpp`

Differential Revision: D84962427


