### PR TITLE
Add tests to cover changes in D84879127

### DIFF
--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/P4HyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
@@ -105,6 +106,8 @@ TEST_F(TypeOfTest, customTypes) {
   VarcharEnumParameter otherColorInfo("someColorType", varcharEnumMap);
   EXPECT_EQ("test.enum.color", typeOf(VARCHAR_ENUM(colorInfo)));
   EXPECT_EQ("someColorType", typeOf(VARCHAR_ENUM(otherColorInfo)));
+
+  EXPECT_EQ("ipprefix", typeOf(IPPREFIX()));
 }
 } // namespace
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
This diff is automatically generated by [Devmate for Testing](https://fburl.com/dm4t-diff-time). Help us improve by reviewing the diff!

It adds more tests to cover changes in `TypeOf.cpp` in D84879127. You can find additional information here: P1997594370.

Review this diff as you would review your peer's code.

If the tests are useful to you:
* **To land them as is**, accept the diff. It will be landed automatically when the parent diff is landed.
* **To add them to the original diff D84879127**, run `testcompose get ...` as shown below. This diff will then be auto-abandoned when you land the original diff.
* Alternatively, you can also commandeer the diff, make changes and land it yourself.

https://our.intern.facebook.com/intern/testcompose/merge-diffs/

If the tests are not useful, send the diff **Back to Author**. The diff will then be auto-abandoned.

Write any feedback (positive and negative) about this diff in the comments. Our team uses it to improve the tool.

Read more about the diff-time Devmate for Testing in [the wiki](https://fburl.com/dm4t-diff-time).
Questions and feedback are welcome in [the support group](https://fb.workplace.com/groups/mm4tfeedback).

Reviewed By: pratikpugalia

Differential Revision: D84961056


