### PR TITLE
refactor: Remove more usages of folly::StringPiece in dwio

### DIFF
--- a/velox/dwio/common/MetricsLog.h
+++ b/velox/dwio/common/MetricsLog.h
@@ -24,7 +24,7 @@ namespace facebook::velox::dwio::common {
 class MetricsLog {
  public:
   static constexpr std::string_view LIB_VERSION_STRING{"1.1"};
-  static constexpr folly::StringPiece WRITE_OPERATION{"WRITE"};
+  static constexpr std::string_view WRITE_OPERATION{"WRITE"};
 
   enum class MetricsType {
     HEADER,

--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -29,11 +29,11 @@
 namespace facebook::velox::dwrf {
 
 // Writer version
-constexpr folly::StringPiece WRITER_NAME_KEY{"orc.writer.name"};
-constexpr folly::StringPiece WRITER_VERSION_KEY{"orc.writer.version"};
-constexpr folly::StringPiece WRITER_HOSTNAME_KEY{"orc.writer.host"};
-constexpr folly::StringPiece kDwioWriter{"dwio"};
-constexpr folly::StringPiece kPrestoWriter{"presto"};
+constexpr std::string_view kWriterNameKey{"orc.writer.name"};
+constexpr std::string_view kWriterVersionKey{"orc.writer.version"};
+constexpr std::string_view kWriterHostnameKey{"orc.writer.host"};
+constexpr std::string_view kDwioWriter{"dwio"};
+constexpr std::string_view kPrestoWriter{"presto"};
 
 enum class DwrfFormat : uint8_t {
   kDwrf = 0,

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -130,7 +130,7 @@ Config::Entry<const std::vector<uint32_t>> Config::MAP_FLAT_COLS(
     [](const std::string& /* key */, const std::string& val) {
       std::vector<uint32_t> result;
       if (!val.empty()) {
-        std::vector<folly::StringPiece> pieces;
+        std::vector<std::string_view> pieces;
         folly::split(',', val, pieces, true);
         for (const auto& p : pieces) {
           const auto& trimmedCol = folly::trimWhitespace(p);

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -199,7 +199,7 @@ class ReaderBase {
   const std::string& writerName() const {
     for (int32_t index = 0; index < footer_->metadataSize(); ++index) {
       auto entry = footer_->metadata(index);
-      if (entry.name() == WRITER_NAME_KEY) {
+      if (entry.name() == kWriterNameKey) {
         return entry.value();
       }
     }

--- a/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
+++ b/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
@@ -22,7 +22,9 @@
 using namespace testing;
 using namespace facebook::velox::memory;
 
-namespace facebook::velox::dwrf {
+namespace facebook::velox::dwrf::test {
+namespace {
+
 class DictionaryEncodingUtilsTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
@@ -36,7 +38,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringGetSortedIndexLookupTable) {
         bool sort,
         std::function<bool(const StringDictionaryEncoder&, size_t, size_t)>
             ordering,
-        const std::vector<folly::StringPiece>& addKeySequence,
+        const std::vector<std::string_view>& addKeySequence,
         const std::vector<uint32_t>& lookupTable)
         : sort{sort},
           ordering{ordering},
@@ -45,7 +47,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringGetSortedIndexLookupTable) {
     bool sort;
     std::function<bool(const StringDictionaryEncoder&, size_t, size_t)>
         ordering;
-    std::vector<folly::StringPiece> addKeySequence;
+    std::vector<std::string_view> addKeySequence;
     std::vector<uint32_t> lookupTable;
   };
 
@@ -151,7 +153,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
         bool sort,
         std::function<bool(const StringDictionaryEncoder&, size_t, size_t)>
             ordering,
-        const std::vector<folly::StringPiece>& addKeySequence,
+        const std::vector<std::string_view>& addKeySequence,
         const std::vector<uint32_t>& lookupTable,
         const std::vector<bool>& inDict,
         size_t finalDictSize,
@@ -166,7 +168,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
     bool sort;
     std::function<bool(const StringDictionaryEncoder&, size_t, size_t)>
         ordering;
-    std::vector<folly::StringPiece> addKeySequence;
+    std::vector<std::string_view> addKeySequence;
     std::vector<uint32_t> lookupTable;
     std::vector<bool> inDict;
     size_t finalDictSize;
@@ -315,7 +317,7 @@ TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
     dwio::common::DataBuffer<uint32_t> strideDictSizes{
         *pool, rowCount / kStrideSize + 1};
 
-    std::vector<folly::StringPiece> expected{testCase.finalDictSize};
+    std::vector<std::string_view> expected{testCase.finalDictSize};
     std::vector<uint32_t> expectedSize(testCase.finalDictSize);
     for (size_t i = 0; i < testCase.lookupTable.size(); ++i) {
       if (testCase.inDict[i]) {
@@ -368,4 +370,5 @@ TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
   }
 }
 
-} // namespace facebook::velox::dwrf
+} // namespace
+} // namespace facebook::velox::dwrf::test

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -20,8 +20,6 @@
 
 DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
 
-using namespace facebook::velox::memory;
-
 namespace facebook::velox::dwrf {
 
 class TestStringDictionaryEncoder : public ::testing::Test {
@@ -35,10 +33,10 @@ class TestStringDictionaryEncoder : public ::testing::Test {
 TEST_F(TestStringDictionaryEncoder, AddKey) {
   struct TestCase {
     explicit TestCase(
-        const std::vector<folly::StringPiece>& addKeySequence,
+        const std::vector<std::string_view>& addKeySequence,
         const std::vector<size_t>& encodedSequence)
         : addKeySequence{addKeySequence}, encodedSequence{encodedSequence} {}
-    std::vector<folly::StringPiece> addKeySequence;
+    std::vector<std::string_view> addKeySequence;
     std::vector<size_t> encodedSequence;
   };
 
@@ -50,7 +48,7 @@ TEST_F(TestStringDictionaryEncoder, AddKey) {
       TestCase{{"doe", "sow", "sow", "doe", "sow"}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = memoryManager()->addLeafPool();
+    auto pool = memory::memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -63,14 +61,14 @@ TEST_F(TestStringDictionaryEncoder, AddKey) {
 TEST_F(TestStringDictionaryEncoder, GetIndex) {
   struct TestCase {
     explicit TestCase(
-        const std::vector<folly::StringPiece>& addKeySequence,
-        const std::vector<folly::StringPiece>& getIndexSequence,
+        const std::vector<std::string_view>& addKeySequence,
+        const std::vector<std::string_view>& getIndexSequence,
         const std::vector<size_t>& encodedSequence)
         : addKeySequence{addKeySequence},
           getIndexSequence{getIndexSequence},
           encodedSequence{encodedSequence} {}
-    std::vector<folly::StringPiece> addKeySequence;
-    std::vector<folly::StringPiece> getIndexSequence;
+    std::vector<std::string_view> addKeySequence;
+    std::vector<std::string_view> getIndexSequence;
     std::vector<size_t> encodedSequence;
   };
 
@@ -94,7 +92,7 @@ TEST_F(TestStringDictionaryEncoder, GetIndex) {
           {0, 3, 4, 2, 1, 3, 2, 4, 2, 0, 1, 0, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = memoryManager()->addLeafPool();
+    auto pool = memory::memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -111,14 +109,14 @@ TEST_F(TestStringDictionaryEncoder, GetIndex) {
 TEST_F(TestStringDictionaryEncoder, GetCount) {
   struct TestCase {
     explicit TestCase(
-        const std::vector<folly::StringPiece>& addKeySequence,
-        const std::vector<folly::StringPiece>& getCountSequence,
+        const std::vector<std::string_view>& addKeySequence,
+        const std::vector<std::string_view>& getCountSequence,
         const std::vector<size_t>& countSequence)
         : addKeySequence{addKeySequence},
           getCountSequence{getCountSequence},
           countSequence{countSequence} {}
-    std::vector<folly::StringPiece> addKeySequence;
-    std::vector<folly::StringPiece> getCountSequence;
+    std::vector<std::string_view> addKeySequence;
+    std::vector<std::string_view> getCountSequence;
     std::vector<size_t> countSequence;
   };
 
@@ -143,7 +141,7 @@ TEST_F(TestStringDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = memoryManager()->addLeafPool();
+    auto pool = memory::memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -161,15 +159,14 @@ TEST_F(TestStringDictionaryEncoder, GetCount) {
 TEST_F(TestStringDictionaryEncoder, GetStride) {
   struct TestCase {
     explicit TestCase(
-        const std::vector<std::pair<folly::StringPiece, size_t>>&
-            addKeySequence,
-        const std::vector<folly::StringPiece>& getStrideSequence,
+        const std::vector<std::pair<std::string_view, size_t>>& addKeySequence,
+        const std::vector<std::string_view>& getStrideSequence,
         const std::vector<size_t>& strideSequence)
         : addKeySequence{addKeySequence},
           getStrideSequence{getStrideSequence},
           strideSequence{strideSequence} {}
-    std::vector<std::pair<folly::StringPiece, size_t>> addKeySequence;
-    std::vector<folly::StringPiece> getStrideSequence;
+    std::vector<std::pair<std::string_view, size_t>> addKeySequence;
+    std::vector<std::string_view> getStrideSequence;
     std::vector<size_t> strideSequence;
   };
 
@@ -197,7 +194,7 @@ TEST_F(TestStringDictionaryEncoder, GetStride) {
           {1, 1, 6, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = memoryManager()->addLeafPool();
+    auto pool = memory::memoryManager()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& kv : testCase.addKeySequence) {
       stringDictEncoder.addKey(kv.first, kv.second);
@@ -220,7 +217,7 @@ std::string genPaddedIntegerString(size_t integer, size_t length) {
 }
 
 TEST_F(TestStringDictionaryEncoder, Clear) {
-  auto pool = memoryManager()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 2500; ++i) {
@@ -242,7 +239,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
 }
 
 TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
-  auto pool = memoryManager()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 10000; ++i) {
@@ -253,15 +250,15 @@ TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
 }
 
 TEST_F(TestStringDictionaryEncoder, Limit) {
-  auto pool = memoryManager()->addLeafPool();
+  auto pool = memory::memoryManager()->addLeafPool();
   StringDictionaryEncoder encoder{*pool, *pool};
-  encoder.addKey(folly::StringPiece{"abc"}, 0);
+  encoder.addKey(std::string_view{"abc"}, 0);
   dwio::common::DataBuffer<char> buf{*pool};
   buf.resize(std::numeric_limits<uint32_t>::max());
 
   ASSERT_THROW(
       encoder.addKey(
-          folly::StringPiece{
+          std::string_view{
               buf.data(), std::numeric_limits<uint32_t>::max() - 3},
           0),
       dwio::common::exception::LoggedException);

--- a/velox/dwio/dwrf/test/WriterTest.cpp
+++ b/velox/dwio/dwrf/test/WriterTest.cpp
@@ -262,11 +262,11 @@ TEST_P(SupportedCompressionTest, WriteFooter) {
   ASSERT_EQ(footer.metadataSize(), 5);
   for (size_t i = 0; i < 4; ++i) {
     auto item = footer.metadata(i);
-    if (item.name() == WRITER_NAME_KEY) {
+    if (item.name() == kWriterNameKey) {
       ASSERT_EQ(item.value(), kDwioWriter);
-    } else if (item.name() == WRITER_VERSION_KEY) {
+    } else if (item.name() == kWriterVersionKey) {
       ASSERT_EQ(item.value(), folly::to<std::string>(reader->writerVersion()));
-    } else if (item.name() == WRITER_HOSTNAME_KEY) {
+    } else if (item.name() == kWriterHostnameKey) {
       ASSERT_EQ(item.value(), process::getHostName());
     } else {
       ASSERT_EQ(

--- a/velox/dwio/dwrf/writer/WriterBase.cpp
+++ b/velox/dwio/dwrf/writer/WriterBase.cpp
@@ -80,10 +80,10 @@ void WriterBase::writeFooter(const Type& type) {
 
 void WriterBase::writeUserMetadata(uint32_t writerVersion) {
   // add writer version
-  userMetadata_[std::string{WRITER_NAME_KEY}] = kDwioWriter;
-  userMetadata_[std::string{WRITER_VERSION_KEY}] =
+  userMetadata_[std::string{kWriterNameKey}] = kDwioWriter;
+  userMetadata_[std::string{kWriterVersionKey}] =
       folly::to<std::string>(writerVersion);
-  userMetadata_[std::string{WRITER_HOSTNAME_KEY}] = process::getHostName();
+  userMetadata_[std::string{kWriterHostnameKey}] = process::getHostName();
   std::for_each(userMetadata_.begin(), userMetadata_.end(), [&](auto& pair) {
     auto item = footer_.add_metadata();
     item->set_name(pair.first);


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages
to std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Reviewed By: sdruzkin

Differential Revision: D85157908


