### PR TITLE
][be] Attach file path to VeloxExceptions thrown from DWRF reader ctor, Nimble tablet and file reader ctors

### DIFF
--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -111,6 +111,16 @@ ReaderBase::ReaderBase(
       fileLength_(input_->getReadFile()->size()),
       arena_(std::make_unique<google::protobuf::Arena>()) {
   process::TraceContext trace("ReaderBase::ReaderBase");
+
+  // Attach the path to VeloxException if an exception is thrown in the
+  // constructor.
+  auto exceptionContextMsg =
+      fmt::format("Reader path {}", input_->getReadFile()->getName());
+  ExceptionContextSetter exceptionContext(
+      {[](VeloxException::Type /*exceptionType*/, auto* debugString) {
+         return *static_cast<std::string*>(debugString);
+       },
+       &exceptionContextMsg});
   // TODO: make a config
   DWIO_ENSURE(fileLength_ > 0, "ORC file is empty");
   VELOX_CHECK_GE(fileLength_, 4, "File size too small");


### PR DESCRIPTION
Summary:
VeloxException has a mechanism to attach scope bound context to VeloxExceptions thrown out of scope. Let's leverage it to add the file path to exceptions thrown from:
* DWRF batch reader constructor
* Nimble tablet reader constructor
* Nimble batch file reader constructor

Later we can also add the file path to the reader::next method.

Differential Revision: D85173751


