### PR TITLE
perf: Reduce type parameter initialization cost and memory usage

### DIFF
--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -64,11 +64,6 @@ class BingTileType final : public BigintType {
     return "BINGTILE";
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
-    static const std::vector<TypeParameter> kEmpty = {};
-    return kEmpty;
-  }
-
   std::string toString() const override {
     return name();
   }

--- a/velox/functions/prestosql/types/EnumTypeBase.h
+++ b/velox/functions/prestosql/types/EnumTypeBase.h
@@ -43,7 +43,7 @@ class EnumTypeBase : public TPhysical {
     return this == &other;
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
+  std::span<const TypeParameter> parameters() const override {
     return parameters_;
   }
 

--- a/velox/functions/prestosql/types/IPPrefixType.h
+++ b/velox/functions/prestosql/types/IPPrefixType.h
@@ -127,9 +127,8 @@ class IPPrefixType final : public RowType {
     return obj;
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
-    static const std::vector<TypeParameter> kEmpty = {};
-    return kEmpty;
+  std::span<const TypeParameter> parameters() const override {
+    return {};
   }
 };
 

--- a/velox/functions/prestosql/types/QDigestRegistration.cpp
+++ b/velox/functions/prestosql/types/QDigestRegistration.cpp
@@ -37,7 +37,7 @@ class QDigestTypeFactory : public CustomTypeFactory {
   AbstractInputGeneratorPtr getInputGenerator(
       const InputGeneratorConfig& config) const override {
     VELOX_USER_CHECK_NOT_NULL(config.type_, "QDigest Type must be provided");
-    const auto& parameters = config.type_->parameters();
+    auto parameters = config.type_->parameters();
 
     VELOX_USER_CHECK(
         parameters.size() == 1 &&

--- a/velox/functions/prestosql/types/QDigestType.h
+++ b/velox/functions/prestosql/types/QDigestType.h
@@ -48,12 +48,12 @@ class QDigestType final : public VarbinaryType {
     return "QDIGEST";
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
-    return parameters_;
+  std::span<const TypeParameter> parameters() const override {
+    return {&parameter_, 1};
   }
 
   std::string toString() const override {
-    return fmt::format("QDIGEST({})", parameters_[0].type->toString());
+    return fmt::format("QDIGEST({})", parameter_.type->toString());
   }
 
   folly::dynamic serialize() const override {
@@ -61,9 +61,7 @@ class QDigestType final : public VarbinaryType {
     obj["name"] = "Type";
     obj["type"] = name();
     folly::dynamic children = folly::dynamic::array;
-    for (auto& param : parameters_) {
-      children.push_back(param.type->serialize());
-    }
+    children.push_back(parameter_.type->serialize());
     obj["cTypes"] = children;
     return obj;
   }
@@ -73,10 +71,9 @@ class QDigestType final : public VarbinaryType {
   }
 
  private:
-  explicit QDigestType(const TypePtr& dataType)
-      : parameters_({TypeParameter(dataType)}) {}
+  explicit QDigestType(const TypePtr& dataType) : parameter_(dataType) {}
 
-  const std::vector<TypeParameter> parameters_;
+  const TypeParameter parameter_;
 };
 
 inline std::shared_ptr<const QDigestType> QDIGEST(const TypePtr& dataType) {

--- a/velox/functions/prestosql/types/TDigestType.h
+++ b/velox/functions/prestosql/types/TDigestType.h
@@ -39,12 +39,12 @@ class TDigestType final : public VarbinaryType {
     return "TDIGEST";
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
-    return parameters_;
+  std::span<const TypeParameter> parameters() const override {
+    return {&parameter_, 1};
   }
 
   std::string toString() const override {
-    return fmt::format("TDIGEST({})", parameters_[0].type->toString());
+    return fmt::format("TDIGEST({})", parameter_.type->toString());
   }
 
   folly::dynamic serialize() const override {
@@ -52,9 +52,7 @@ class TDigestType final : public VarbinaryType {
     obj["name"] = "Type";
     obj["type"] = name();
     folly::dynamic children = folly::dynamic::array;
-    for (auto& param : parameters_) {
-      children.push_back(param.type->serialize());
-    }
+    children.push_back(parameter_.type->serialize());
     obj["cTypes"] = children;
     return obj;
   }
@@ -64,10 +62,9 @@ class TDigestType final : public VarbinaryType {
   }
 
  private:
-  explicit TDigestType(const TypePtr& dataType)
-      : parameters_({TypeParameter(dataType)}) {}
+  explicit TDigestType(const TypePtr& dataType) : parameter_(dataType) {}
 
-  const std::vector<TypeParameter> parameters_;
+  const TypeParameter parameter_;
 };
 
 inline bool isTDigestType(const TypePtr& type) {

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -88,11 +88,6 @@ class TimestampWithTimeZoneType final : public BigintType {
     return "TIMESTAMP WITH TIME ZONE";
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
-    static const std::vector<TypeParameter> kEmpty = {};
-    return kEmpty;
-  }
-
   std::string toString() const override {
     return name();
   }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -278,7 +278,7 @@ const TypePtr& ArrayType::childAt(uint32_t idx) const {
 }
 
 ArrayType::ArrayType(TypePtr child)
-    : child_{std::move(child)}, parameters_{{TypeParameter(child_)}} {}
+    : child_{std::move(child)}, parameter_{child_} {}
 
 bool ArrayType::equivalent(const Type& other) const {
   if (&other == this) {
@@ -339,7 +339,7 @@ const char* MapType::nameOf(uint32_t idx) const {
 MapType::MapType(TypePtr keyType, TypePtr valueType)
     : keyType_{std::move(keyType)},
       valueType_{std::move(valueType)},
-      parameters_{{TypeParameter(keyType_), TypeParameter(valueType_)}} {}
+      parameters_{TypeParameter(keyType_), TypeParameter(valueType_)} {}
 
 std::string MapType::toString() const {
   return "MAP<" + keyType()->toString() + "," + valueType()->toString() + ">";

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -577,20 +577,21 @@ TEST(TypeTest, rowParametersMultiThreaded) {
   }
   auto type = ROW(std::move(names), std::move(types));
   constexpr int kNumThreads = 72;
-  const std::vector<TypeParameter>* parameters[kNumThreads];
+  std::span<const TypeParameter> parameters[kNumThreads];
   std::vector<std::thread> threads;
   for (int i = 0; i < kNumThreads; ++i) {
-    threads.emplace_back([&, i] { parameters[i] = &type->parameters(); });
+    threads.emplace_back([&, i] { parameters[i] = type->parameters(); });
   }
   for (auto& thread : threads) {
     thread.join();
   }
   for (int i = 1; i < kNumThreads; ++i) {
-    ASSERT_TRUE(parameters[i] == parameters[0]);
+    ASSERT_TRUE(parameters[i].data() == parameters[0].data());
+    ASSERT_TRUE(parameters[i].size() == parameters[0].size());
   }
-  ASSERT_EQ(parameters[0]->size(), type->size());
-  for (int i = 0; i < parameters[0]->size(); ++i) {
-    ASSERT_TRUE((*parameters[0])[i].type.get() == type->childAt(i).get());
+  ASSERT_EQ(parameters[0].size(), type->size());
+  for (int i = 0; i < parameters[0].size(); ++i) {
+    ASSERT_TRUE(parameters[0][i].type.get() == type->childAt(i).get());
   }
 }
 

--- a/velox/type/tests/utils/CustomTypesForTesting.h
+++ b/velox/type/tests/utils/CustomTypesForTesting.h
@@ -54,11 +54,6 @@ class BigintTypeWithCustomComparison final : public BigintType {
     return "BIGINT TYPE WITH CUSTOM COMPARISON";
   }
 
-  const std::vector<TypeParameter>& parameters() const override {
-    static const std::vector<TypeParameter> kEmpty = {};
-    return kEmpty;
-  }
-
   std::string toString() const override {
     return name();
   }
@@ -97,11 +92,6 @@ class BigintTypeWithInvalidCustomComparison final : public BigintType {
 
   const char* name() const override {
     return "BIGINT TYPE WITH INVALID CUSTOM COMPARISON";
-  }
-
-  const std::vector<TypeParameter>& parameters() const override {
-    static const std::vector<TypeParameter> kEmpty = {};
-    return kEmpty;
   }
 
   std::string toString() const override {


### PR DESCRIPTION
Summary: In many cases (e.g. ARRAY and MAP) type parameters are fixed size, we don't need dynamic allocation for this.  This is a visible memory cost when we have a lot of expressions.

Differential Revision: D85052874


