### PR TITLE
fix: Respect preferredOutputBatchBytes in StreamingAggregation

### DIFF
--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -96,6 +96,10 @@ class StreamingAggregation : public Operator {
   // Maximum number of rows in the output batch.
   const vector_size_t minOutputBatchSize_;
 
+  // If the size of the data in the RowContainer exceeds this value, we will
+  // output a batch regardless of the number of rows.
+  const uint64_t maxOutputBatchBytes_;
+
   // Used at initialize() and gets reset() afterward.
   std::shared_ptr<const core::AggregationNode> aggregationNode_;
 

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -27,8 +27,14 @@ namespace {
 
 using namespace facebook::velox::exec::test;
 
-class StreamingAggregationTest : public HiveConnectorTestBase,
-                                 public testing::WithParamInterface<int32_t> {
+struct TestParams {
+  int32_t streamingMinOutputBatchSize;
+  uint64_t preferredOutputBatchBytes;
+};
+
+class StreamingAggregationTest
+    : public HiveConnectorTestBase,
+      public testing::WithParamInterface<TestParams> {
  protected:
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
@@ -36,7 +42,11 @@ class StreamingAggregationTest : public HiveConnectorTestBase,
   }
 
   int32_t flushRows() {
-    return GetParam();
+    return GetParam().streamingMinOutputBatchSize;
+  }
+
+  uint64_t preferredOutputBatchBytes() {
+    return GetParam().preferredOutputBatchBytes;
   }
 
   AssertQueryBuilder& config(
@@ -48,7 +58,10 @@ class StreamingAggregationTest : public HiveConnectorTestBase,
             std::to_string(outputBatchSize))
         .config(
             core::QueryConfig::kStreamingAggregationMinOutputBatchRows,
-            std::to_string(flushRows()));
+            std::to_string(flushRows()))
+        .config(
+            core::QueryConfig::kPreferredOutputBatchBytes,
+            std::to_string(preferredOutputBatchBytes()));
   }
 
   void testAggregation(
@@ -593,13 +606,32 @@ class StreamingAggregationTest : public HiveConnectorTestBase,
 VELOX_INSTANTIATE_TEST_SUITE_P(
     StreamingAggregationTest,
     StreamingAggregationTest,
-    testing::ValuesIn({0, 1, 64, std::numeric_limits<int32_t>::max()}),
-    [](const testing::TestParamInfo<int32_t>& info) {
+    testing::Values(
+        TestParams{0, 1},
+        TestParams{0, 1024},
+        TestParams{0, std::numeric_limits<uint64_t>::max()},
+        TestParams{1, 1},
+        TestParams{1, 1024},
+        TestParams{1, std::numeric_limits<uint64_t>::max()},
+        TestParams{64, 1},
+        TestParams{64, 1024},
+        TestParams{64, std::numeric_limits<uint64_t>::max()},
+        TestParams{std::numeric_limits<int32_t>::max(), 1},
+        TestParams{std::numeric_limits<int32_t>::max(), 1024},
+        TestParams{
+            std::numeric_limits<int32_t>::max(),
+            std::numeric_limits<uint64_t>::max()}),
+    [](const testing::TestParamInfo<TestParams>& info) {
       return fmt::format(
-          "streamingMinOutputBatchSize_{}",
-          info.param == std::numeric_limits<int32_t>::max()
+          "streamingMinOutputBatchSize_{}_preferredOutputBatchBytes_{}",
+          info.param.streamingMinOutputBatchSize ==
+                  std::numeric_limits<int32_t>::max()
               ? "inf"
-              : std::to_string(info.param));
+              : std::to_string(info.param.streamingMinOutputBatchSize),
+          info.param.preferredOutputBatchBytes ==
+                  std::numeric_limits<uint64_t>::max()
+              ? "inf"
+              : std::to_string(info.param.preferredOutputBatchBytes));
     });
 
 TEST_P(StreamingAggregationTest, smallInputBatches) {
@@ -1141,6 +1173,55 @@ TEST_P(StreamingAggregationTest, constantInput) {
   });
   config(AssertQueryBuilder(plan), 1).assertResults(expected);
   config(AssertQueryBuilder(plan), 10).assertResults(expected);
+}
+
+TEST_P(StreamingAggregationTest, preferredOutputBatchBytes) {
+  // Use grouping keys that span one or more batches.
+  std::vector<VectorPtr> keys = {
+      makeNullableFlatVector<int32_t>({1, 1, std::nullopt, 2, 2}),
+      makeFlatVector<int32_t>({2, 3, 3, 4}),
+      makeFlatVector<int32_t>({5, 6, 6, 6}),
+      makeFlatVector<int32_t>({6, 6, 6, 6}),
+      makeFlatVector<int32_t>({6, 7, 8}),
+  };
+
+  auto data = addPayload(keys, 1);
+
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .partialStreamingAggregation(
+                      {"c0"},
+                      {"count(1)",
+                       "min(c1)",
+                       "max(c1)",
+                       "sum(c1)",
+                       "sumnonpod(1)",
+                       "sum(cast(NULL as INT))"})
+                  .finalAggregation()
+                  .planNode();
+
+  auto results =
+      config(AssertQueryBuilder(plan), 1024).copyResultBatches(pool_.get());
+
+  // If streamingMinOutputBatchSize is set to 1, we expect an output batch for:
+  // {1, NULL}, {2}, {3, 4}, {5}, {6}, {7, 8}.
+  // Otherwise, we expect the output batches to be determined by
+  // preferredOutputBatchBytes.
+  size_t expectedOutputBatches;
+  if (GetParam().streamingMinOutputBatchSize == 1) {
+    expectedOutputBatches = 6;
+  } else if (GetParam().preferredOutputBatchBytes == 1) {
+    expectedOutputBatches = 5;
+  } else if (GetParam().preferredOutputBatchBytes == 1024) {
+    expectedOutputBatches = 2;
+  } else {
+    ASSERT_EQ(
+        GetParam().preferredOutputBatchBytes,
+        std::numeric_limits<uint64_t>::max());
+    expectedOutputBatches = 1;
+  }
+
+  ASSERT_EQ(results.size(), expectedOutputBatches);
 }
 
 namespace {

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -266,6 +266,25 @@ RowVectorPtr AssertQueryBuilder::copyResults(
   return copy;
 }
 
+std::vector<RowVectorPtr> AssertQueryBuilder::copyResultBatches(
+    memory::MemoryPool* pool) {
+  auto [cursor, results] = readCursor();
+
+  if (results.empty()) {
+    return results;
+  }
+
+  std::vector<RowVectorPtr> copies;
+  copies.reserve(results.size());
+  for (const auto& result : results) {
+    copies.push_back(
+        BaseVector::create<RowVector>(result->type(), result->size(), pool));
+    copies.back()->copy(result.get(), 0, 0, result->size());
+  }
+
+  return copies;
+}
+
 uint64_t AssertQueryBuilder::runWithoutResults(std::shared_ptr<Task>& task) {
   auto [cursor, results] = readCursor();
   uint64_t count = 0;

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -182,14 +182,16 @@ class AssertQueryBuilder {
       const TypePtr& expectedType,
       vector_size_t expectedNumRows);
 
-  /// Run the query and collect all results into a single vector. Throws if
-  /// query returns empty result.
+  /// Run the query and collect all results into a single vector.
   RowVectorPtr copyResults(memory::MemoryPool* pool);
 
   /// Similar to above method and also returns the task.
   RowVectorPtr copyResults(
       memory::MemoryPool* pool,
       std::shared_ptr<Task>& task);
+
+  /// Run the query and copy the result Vectors as their original batches.
+  std::vector<RowVectorPtr> copyResultBatches(memory::MemoryPool* pool);
 
   /// Run the query and return the number of result rows.
   uint64_t runWithoutResults(std::shared_ptr<Task>& task);


### PR DESCRIPTION
Summary:
Today StreamingAggregation only looks at the number of groups (output rows) when deciding when to flush to the output Vector. This can lead to OOMs when the output rows are very wide, e.g. when using an aggregation that can grow very large depending on the input like ARRAY_AGG in Presto or COLLECT_LIST in Spark.

This change updates StreamingAggregation to look at the size in bytes of the rows in the RowContainer and compare that to preferredOutputBatchBytes as another trigger to output a Vector, allowing us to better control the memory usage and prevent OOMs.

Differential Revision: D85276743


