### PR TITLE
feat(geo): Increase bing tile max zoom shift to 6

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -791,7 +791,7 @@ class QueryConfig {
   }
 
   uint8_t debugBingTileChildrenMaxZoomShift() const {
-    return get<uint8_t>(kDebugBingTileChildrenMaxZoomShift, 5);
+    return get<uint8_t>(kDebugBingTileChildrenMaxZoomShift, 6);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -459,8 +459,8 @@ TEST_F(BingTileFunctionsTest, bingTileChildrenZoom) {
   VELOX_ASSERT_USER_THROW(
       testBingTileChildren(0, 0, 2, 1), "Child zoom 1 must be >= tile zoom 2");
   VELOX_ASSERT_USER_THROW(
-      testBingTileChildren(0, 0, 1, 7),
-      "Difference between parent zoom (1) and child zoom (7) must be <= 5");
+      testBingTileChildren(0, 0, 1, 8),
+      "Difference between parent zoom (1) and child zoom (8) must be <= 6");
 
   {
     RowVectorPtr input = makeSingleXYZoomZoomRow(0, 0, 1, 7);
@@ -473,7 +473,7 @@ TEST_F(BingTileFunctionsTest, bingTileChildrenZoom) {
         evaluate("bing_tile_children(bing_tile(c0, c1, c2), c3)", input),
         "Difference between parent zoom (1) and child zoom (15) must be <= 10");
     queryCtx_->testingOverrideConfigUnsafe(
-        {{core::QueryConfig::kDebugBingTileChildrenMaxZoomShift, "5"}});
+        {{core::QueryConfig::kDebugBingTileChildrenMaxZoomShift, "6"}});
   }
 }
 

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ add_executable(
   ArgTypesGeneratorTest.cpp
   BinaryFunctionsTest.cpp
   BingTileCastTest.cpp
+  BingTileFunctionsTest.cpp
   BitwiseTest.cpp
   CardinalityTest.cpp
   CeilFloorTest.cpp


### PR DESCRIPTION
Summary:
To protect against exponentially growing numbers of bing tiles,
we put a max zoom shift of 5.  This constrained a bing tile to be
shifted only 5 zoom levels, which increases the number by `4**5 == 2**10`.
When rolling out this feature, a user is getting errors because they were
using a shift of 6, previously allowed.

This makes the default 6, so one bing tile becomes `4**6 == 2**12`.

Differential Revision: D85278103


