### PR TITLE
refactor: Remove usages of folly::StringPiece in dwio/common

### DIFF
--- a/velox/dwio/common/DataBufferHolder.cpp
+++ b/velox/dwio/common/DataBufferHolder.cpp
@@ -21,7 +21,7 @@ using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::dwio::common {
 
-void DataBufferHolder::take(const std::vector<folly::StringPiece>& buffers) {
+void DataBufferHolder::take(const std::vector<std::string_view>& buffers) {
   // compute size
   uint64_t totalSize = 0;
   for (auto& buf : buffers) {

--- a/velox/dwio/common/DataBufferHolder.h
+++ b/velox/dwio/common/DataBufferHolder.h
@@ -47,14 +47,14 @@ class DataBufferHolder {
 
   /// Takes content of the incoming data buffer. It is the caller's
   /// responsibility to resize the buffer (if required).
-  void take(const std::vector<folly::StringPiece>& buffers);
+  void take(const std::vector<std::string_view>& buffers);
 
-  void take(folly::StringPiece buffer) {
-    take(std::vector<folly::StringPiece>{buffer});
+  void take(std::string_view buffer) {
+    take(std::vector<std::string_view>{buffer});
   }
 
   void take(const dwio::common::DataBuffer<char>& buffer) {
-    take(folly::StringPiece{buffer.data(), buffer.size()});
+    take(std::string_view{buffer.data(), buffer.size()});
   }
 
   std::vector<dwio::common::DataBuffer<char>>& getBuffers() {

--- a/velox/dwio/common/OutputStream.h
+++ b/velox/dwio/common/OutputStream.h
@@ -116,7 +116,7 @@ class BufferedOutputStream : public google::protobuf::io::ZeroCopyOutputStream {
       void** buffer,
       int32_t* size,
       uint64_t headerSize,
-      const std::vector<folly::StringPiece>& bufferToFlush) {
+      const std::vector<std::string_view>& bufferToFlush) {
     bufferHolder_.take(bufferToFlush);
     *buffer = buffer_.data() + headerSize;
     *size = static_cast<int32_t>(buffer_.size() - headerSize);

--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -165,7 +165,7 @@ bool PagedInputStream::readOrSkip(const void** data, int32_t* size) {
   // perform decryption
   if (decrypter_) {
     decryptionBuffer_ =
-        decrypter_->decrypt(folly::StringPiece{input, remainingLength_});
+        decrypter_->decrypt(std::string_view{input, remainingLength_});
     input = reinterpret_cast<const char*>(decryptionBuffer_->data());
     remainingLength_ = decryptionBuffer_->length();
     if (data) {

--- a/velox/dwio/common/compression/PagedOutputStream.h
+++ b/velox/dwio/common/compression/PagedOutputStream.h
@@ -64,8 +64,8 @@ class PagedOutputStream : public BufferedOutputStream {
       int32_t strideIndex = -1) const override;
 
  private:
-  // create page using compressor and encryptor
-  std::vector<folly::StringPiece> createPage();
+  // Create page using compressor and encryptor.
+  std::vector<std::string_view> createPage();
 
   void writeHeader(char* buffer, size_t compressedSize, bool original);
 

--- a/velox/dwio/common/encryption/Encryption.h
+++ b/velox/dwio/common/encryption/Encryption.h
@@ -60,7 +60,7 @@ class Encrypter {
   virtual const std::string& getKey() const = 0;
 
   virtual std::unique_ptr<folly::IOBuf> encrypt(
-      folly::StringPiece input) const = 0;
+      std::string_view input) const = 0;
 
   virtual std::unique_ptr<Encrypter> clone() const = 0;
 };
@@ -83,7 +83,7 @@ class Decrypter {
   virtual bool isKeyLoaded() const = 0;
 
   virtual std::unique_ptr<folly::IOBuf> decrypt(
-      folly::StringPiece input) const = 0;
+      std::string_view input) const = 0;
 
   virtual std::unique_ptr<Decrypter> clone() const = 0;
 };
@@ -104,7 +104,7 @@ class DummyDecrypter : public Decrypter {
   }
 
   std::unique_ptr<folly::IOBuf> decrypt(
-      folly::StringPiece /* unused */) const override {
+      std::string_view /* unused */) const override {
     DWIO_RAISE("Failed to access encrypted data");
   }
 

--- a/velox/dwio/common/encryption/TestProvider.h
+++ b/velox/dwio/common/encryption/TestProvider.h
@@ -32,17 +32,17 @@ class TestEncryption {
     return key_;
   }
 
-  std::unique_ptr<folly::IOBuf> encrypt(folly::StringPiece input) const {
+  std::unique_ptr<folly::IOBuf> encrypt(std::string_view input) const {
     ++count_;
     auto encoded = velox::encoding::Base64::encodeUrl(input);
     return folly::IOBuf::copyBuffer(key_ + encoded);
   }
 
-  std::unique_ptr<folly::IOBuf> decrypt(folly::StringPiece input) const {
+  std::unique_ptr<folly::IOBuf> decrypt(std::string_view input) const {
     ++count_;
     std::string key{input.begin(), key_.size()};
     DWIO_ENSURE_EQ(key_, key);
-    auto decoded = velox::encoding::Base64::decodeUrl(folly::StringPiece{
+    auto decoded = velox::encoding::Base64::decodeUrl(std::string_view{
         input.begin() + key_.size(), input.size() - key_.size()});
     return folly::IOBuf::copyBuffer(decoded);
   }
@@ -62,8 +62,7 @@ class TestEncrypter : public TestEncryption, public Encrypter {
     return TestEncryption::getKey();
   }
 
-  std::unique_ptr<folly::IOBuf> encrypt(
-      folly::StringPiece input) const override {
+  std::unique_ptr<folly::IOBuf> encrypt(std::string_view input) const override {
     return TestEncryption::encrypt(input);
   }
 
@@ -84,8 +83,7 @@ class TestDecrypter : public TestEncryption, public Decrypter {
     return !getKey().empty();
   }
 
-  std::unique_ptr<folly::IOBuf> decrypt(
-      folly::StringPiece input) const override {
+  std::unique_ptr<folly::IOBuf> decrypt(std::string_view input) const override {
     return TestEncryption::decrypt(input);
   }
 


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages
to std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D85284482


