### PR TITLE
fix: Register DWRF writer in TopNRowNumberFuzzer

### DIFF
--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -277,7 +277,8 @@ void DuckQueryRunnerToSqlPlanNodeVisitor::visit(
     sql << inputType->nameOf(i);
   }
 
-  sql << ", row_number() OVER (";
+  sql << ", " << core::TopNRowNumberNode::rankFunctionName(node.rankFunction())
+      << "() OVER (";
 
   const auto& partitionKeys = node.partitionKeys();
   if (!partitionKeys.empty()) {

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -291,7 +291,8 @@ void PrestoQueryRunnerToSqlPlanNodeVisitor::visit(
     sql << inputType->nameOf(i);
   }
 
-  sql << ", row_number() OVER (";
+  sql << ", " << core::TopNRowNumberNode::rankFunctionName(node.rankFunction())
+      << "() OVER (";
 
   const auto& partitionKeys = node.partitionKeys();
   if (!partitionKeys.empty()) {

--- a/velox/exec/fuzzer/RowNumberFuzzerBase.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzerBase.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -78,6 +79,7 @@ RowNumberFuzzerBase::RowNumberFuzzerBase(
 void RowNumberFuzzerBase::setupReadWrite() {
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
+  dwrf::registerDwrfWriterFactory();
 
   if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();


### PR DESCRIPTION
i) Register DWRF writer
ii) Use TopNRowNumber rank function name (instead of defaulting to row_number)