### PR TITLE
misc(BE): Throw User Error for CLOSED vs. RUNNING DWIO Writer Check

### DIFF
--- a/velox/dwio/common/Writer.cpp
+++ b/velox/dwio/common/Writer.cpp
@@ -80,6 +80,13 @@ bool Writer::isFinishing() const {
 }
 
 void Writer::checkRunning() const {
+  // Typically represents writer misuse.
+  VELOX_USER_CHECK_NE(
+      state_,
+      State::kClosed,
+      "Writer is not running: {}. Write operations are not allowed on a closed writer.",
+      Writer::stateString(state_));
+
   VELOX_CHECK_EQ(
       state_,
       State::kRunning,


### PR DESCRIPTION
Summary: This typically indicates writer misuse. It is currently logged as a SYSTEM error introducing noise to our alerts. Logging as a USER error is more likely to indicate to the user that a fix is required from their end.

Differential Revision: D85291637


