### PR TITLE
refactor: Use `re2::StringPiece` for `RE2::FullMatch()`

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -70,7 +70,7 @@ function install_build_prerequisites {
 # Install dependencies from the package managers.
 function install_velox_deps_from_dnf {
   dnf_install libevent-devel \
-    openssl-devel libzstd-devel lz4-devel double-conversion-devel \
+    openssl-devel re2-devel libzstd-devel lz4-devel double-conversion-devel \
     libdwarf-devel elfutils-libelf-devel curl-devel libicu-devel bison flex \
     libsodium-devel zlib-devel gtest-devel gmock-devel xxhash-devel
 
@@ -97,7 +97,6 @@ function install_velox_deps {
   run_and_time install_conda
   run_and_time install_gflags
   run_and_time install_glog
-  run_and_time install_re2
   run_and_time install_snappy
   run_and_time install_boost
   run_and_time install_protobuf

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1936,10 +1936,10 @@ struct ParseDurationFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<IntervalDayTime>& result,
       const arg_type<Varchar>& amountUnit) {
-    absl::string_view valueStr;
-    absl::string_view unit;
+    re2::StringPiece valueStr;
+    re2::StringPiece unit;
     if (!RE2::FullMatch(
-            absl::string_view(amountUnit.data(), amountUnit.size()),
+            re2::StringPiece(amountUnit.data(), amountUnit.size()),
             *durationRegex_,
             &valueStr,
             &unit)) {
@@ -1950,7 +1950,7 @@ struct ParseDurationFunction {
     double value{};
     try {
       size_t pos = 0;
-      // Create temporary string from absl::string_view for stod
+      // Create temporary string from re2::StringPiece for stod
       std::string valueString(valueStr.data(), valueStr.size());
       value = std::stod(valueString, &pos);
       if (pos != valueString.size()) {


### PR DESCRIPTION
`RE2::FullMatch()` uses `absl::string_view` not `std::string_view`:

https://github.com/google/re2/blob/61c4644171ee6b480540bf9e569cba06d9090b4b/re2/re2.h#L411

`absl::string_view` may not be an alias of `std::string_view`. In the case, the following error is reported:

```text
In file included from velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp:18:
velox/functions/prestosql/DateTimeFunctions.h:1939:10: error: no matching function for call to 'FullMatch'
 1939 |     if (!RE2::FullMatch(
      |          ^~~~~~~~~~~~~~
/include/re2/re2.h:411:15: note: candidate function template not viable: no known conversion from 'std::string_view' (aka 'basic_string_view<char>') to 'absl::string_view' for 1st argument
  411 |   static bool FullMatch(absl::string_view text, const RE2& re, A&&... a) {
      |               ^         ~~~~~~~~~~~~~~~~~~~~~~
```

Old RE2 that is provided by CentOS Stream 9 doesn't accept `absl::string_view`.

Old RE2 uses `re2::StringPiece` for `RE2::FullMatch()` and new RE2 provides `re2::StringPiece` as an alias of `absl::string_view`. So we can use `re2::StringPiece` for both of old and new RE2.

We can drop support for old RE2 to always use `absl::string_view` but we use `re2::StringPiece` for now. It seems that RE2 will use `std::string_view` instead of `absl::string_view` eventually. For example, https://github.com/google/re2/commit/2a029e28d3080e4718581649ba9faad5347c3ff9 is a commit to migrate to `std::optional` from `absl::optional`.

We can revisit this after RE2 migrates to `std::string_view`.

Related: GH-15124