### PR TITLE
fix: Don't try installing `FindSnappy.cmake`

### DIFF
--- a/CMake/VeloxUtils.cmake
+++ b/CMake/VeloxUtils.cmake
@@ -135,10 +135,10 @@ function(velox_add_library TARGET)
           list(APPEND system_dependencies Snappy zstd)
         endif()
         foreach(system_dependency ${system_dependencies})
-          install(
-            FILES "${PROJECT_SOURCE_DIR}/CMake/Find${system_dependency}.cmake"
-            DESTINATION "${package_cmake_dir}"
-          )
+          set(velox_find_module "${PROJECT_SOURCE_DIR}/CMake/Find${system_dependency}.cmake")
+          if(EXISTS "${velox_find_module}")
+            install(FILES "${velox_find_module}" DESTINATION "${package_cmake_dir}")
+          endif()
         endforeach()
         # TODO: We can enable this once we add version to Velox.
         # set(version_cmake "${PROJECT_BINARY_DIR}/CMake/VeloxConfigVersion.cmake")


### PR DESCRIPTION
GH-14564 removed `FindSnappy.cmake` because it's not necessary.

But our CMake package related code always tries installing `FindSnappy.cmake`:

```text
CMake Error at velox/buffer/cmake_install.cmake:93 (file):
  file INSTALL cannot find
  "CMake/FindSnappy.cmake": No such file or directory.
Call Stack (most recent call first):
  velox/cmake_install.cmake:47 (include)
  cmake_install.cmake:52 (include)
```