### PR TITLE
refactor: Use standard C/C++ integer types instead of protobuf ones

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -142,8 +142,8 @@ bool CacheInputStream::SkipInt64(int64_t count) {
   return false;
 }
 
-google::protobuf::int64 CacheInputStream::ByteCount() const {
-  return static_cast<google::protobuf::int64>(position_);
+int64_t CacheInputStream::ByteCount() const {
+  return static_cast<int64_t>(position_);
 }
 
 void CacheInputStream::seekToPosition(PositionProvider& seekPosition) {

--- a/velox/dwio/common/CacheInputStream.h
+++ b/velox/dwio/common/CacheInputStream.h
@@ -51,7 +51,7 @@ class CacheInputStream : public SeekableInputStream {
   bool Next(const void** data, int* size) override;
   void BackUp(int count) override;
   bool SkipInt64(int64_t count) override;
-  google::protobuf::int64 ByteCount() const override;
+  int64_t ByteCount() const override;
   void seekToPosition(PositionProvider& position) override;
   std::string getName() const override;
   size_t positionSize() const override;

--- a/velox/dwio/common/DirectInputStream.cpp
+++ b/velox/dwio/common/DirectInputStream.cpp
@@ -91,8 +91,8 @@ bool DirectInputStream::SkipInt64(int64_t count) {
   return false;
 }
 
-google::protobuf::int64 DirectInputStream::ByteCount() const {
-  return static_cast<google::protobuf::int64>(offsetInRegion_);
+int64_t DirectInputStream::ByteCount() const {
+  return static_cast<int64_t>(offsetInRegion_);
 }
 
 void DirectInputStream::seekToPosition(PositionProvider& seekPosition) {

--- a/velox/dwio/common/DirectInputStream.h
+++ b/velox/dwio/common/DirectInputStream.h
@@ -44,7 +44,7 @@ class DirectInputStream : public SeekableInputStream {
   bool Next(const void** data, int* size) override;
   void BackUp(int count) override;
   bool SkipInt64(int64_t count) override;
-  google::protobuf::int64 ByteCount() const override;
+  int64_t ByteCount() const override;
 
   void seekToPosition(PositionProvider& position) override;
   std::string getName() const override;

--- a/velox/dwio/common/OutputStream.h
+++ b/velox/dwio/common/OutputStream.h
@@ -47,8 +47,8 @@ class BufferedOutputStream : public google::protobuf::io::ZeroCopyOutputStream {
 
   void BackUp(int32_t count) override;
 
-  google::protobuf::int64 ByteCount() const override {
-    return static_cast<google::protobuf::int64>(size());
+  int64_t ByteCount() const override {
+    return static_cast<int64_t>(size());
   }
 
   bool WriteAliasedRaw(const void* /* unused */, int32_t /* unused */)

--- a/velox/dwio/common/SeekableInputStream.cpp
+++ b/velox/dwio/common/SeekableInputStream.cpp
@@ -163,8 +163,8 @@ bool SeekableArrayInputStream::SkipInt64(int64_t count) {
   return false;
 }
 
-google::protobuf::int64 SeekableArrayInputStream::ByteCount() const {
-  return static_cast<google::protobuf::int64>(position_);
+int64_t SeekableArrayInputStream::ByteCount() const {
+  return static_cast<int64_t>(position_);
 }
 
 void SeekableArrayInputStream::seekToPosition(PositionProvider& position) {
@@ -241,8 +241,8 @@ bool SeekableFileInputStream::SkipInt64(int64_t signedCount) {
   return position_ < length_;
 }
 
-google::protobuf::int64 SeekableFileInputStream::ByteCount() const {
-  return static_cast<google::protobuf::int64>(position_);
+int64_t SeekableFileInputStream::ByteCount() const {
+  return static_cast<int64_t>(position_);
 }
 
 void SeekableFileInputStream::seekToPosition(PositionProvider& location) {

--- a/velox/dwio/common/SeekableInputStream.h
+++ b/velox/dwio/common/SeekableInputStream.h
@@ -79,7 +79,7 @@ class SeekableArrayInputStream : public SeekableInputStream {
   virtual bool Next(const void** data, int32_t* size) override;
   virtual void BackUp(int32_t count) override;
   virtual bool SkipInt64(int64_t count) override;
-  virtual google::protobuf::int64 ByteCount() const override;
+  virtual int64_t ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;
   virtual size_t positionSize() const override;
@@ -120,7 +120,7 @@ class SeekableFileInputStream : public SeekableInputStream {
   virtual bool Next(const void** data, int32_t* size) override;
   virtual void BackUp(int32_t count) override;
   virtual bool SkipInt64(int64_t count) override;
-  virtual google::protobuf::int64 ByteCount() const override;
+  virtual int64_t ByteCount() const override;
   virtual void seekToPosition(PositionProvider& position) override;
   virtual std::string getName() const override;
   virtual size_t positionSize() const override;

--- a/velox/dwio/common/compression/PagedInputStream.h
+++ b/velox/dwio/common/compression/PagedInputStream.h
@@ -56,7 +56,7 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // NOTE: This always returns true.
   bool SkipInt64(int64_t count) override;
 
-  google::protobuf::int64 ByteCount() const override {
+  int64_t ByteCount() const override {
     return bytesReturned_ + pendingSkip_;
   }
 

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -1065,8 +1065,8 @@ class TestingSeekableInputStream : public SeekableInputStream {
     return true;
   }
 
-  google::protobuf::int64 ByteCount() const override {
-    return position_;
+  int64_t ByteCount() const override {
+    return static_cast<int64_t>(position_);
   }
 
   void seekToPosition(PositionProvider& position) override {


### PR DESCRIPTION
Summary:
These are only available on an older version of protobuf.  Use the standard
sized types so that this code runs across different protobuf versions.

Differential Revision: D85344025


