### PR TITLE
refactor: Remove usages of folly::StringPiece in Counters.h

### DIFF
--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -23,379 +23,368 @@ namespace facebook::velox {
 /// Velox metrics Registration.
 void registerVeloxMetrics();
 
-constexpr folly::StringPiece kMetricHiveFileHandleGenerateLatencyMs{
+constexpr std::string_view kMetricHiveFileHandleGenerateLatencyMs{
     "velox.hive_file_handle_generate_latency_ms"};
 
-constexpr folly::StringPiece kMetricCacheShrinkCount{
-    "velox.cache_shrink_count"};
+constexpr std::string_view kMetricCacheShrinkCount{"velox.cache_shrink_count"};
 
-constexpr folly::StringPiece kMetricCacheShrinkTimeMs{"velox.cache_shrink_ms"};
+constexpr std::string_view kMetricCacheShrinkTimeMs{"velox.cache_shrink_ms"};
 
-constexpr folly::StringPiece kMetricMaxSpillLevelExceededCount{
+constexpr std::string_view kMetricMaxSpillLevelExceededCount{
     "velox.spill_max_level_exceeded_count"};
 
-constexpr folly::StringPiece kMetricQueryMemoryReclaimTimeMs{
+constexpr std::string_view kMetricQueryMemoryReclaimTimeMs{
     "velox.query_memory_reclaim_time_ms"};
 
-constexpr folly::StringPiece kMetricQueryMemoryReclaimedBytes{
+constexpr std::string_view kMetricQueryMemoryReclaimedBytes{
     "velox.query_memory_reclaim_bytes"};
 
-constexpr folly::StringPiece kMetricQueryMemoryReclaimCount{
+constexpr std::string_view kMetricQueryMemoryReclaimCount{
     "velox.query_memory_reclaim_count"};
 
-constexpr folly::StringPiece kMetricTaskMemoryReclaimCount{
+constexpr std::string_view kMetricTaskMemoryReclaimCount{
     "velox.task_memory_reclaim_count"};
 
-constexpr folly::StringPiece kMetricTaskMemoryReclaimWaitTimeMs{
+constexpr std::string_view kMetricTaskMemoryReclaimWaitTimeMs{
     "velox.task_memory_reclaim_wait_ms"};
 
-constexpr folly::StringPiece kMetricTaskMemoryReclaimExecTimeMs{
+constexpr std::string_view kMetricTaskMemoryReclaimExecTimeMs{
     "velox.task_memory_reclaim_exec_ms"};
 
-constexpr folly::StringPiece kMetricTaskMemoryReclaimWaitTimeoutCount{
+constexpr std::string_view kMetricTaskMemoryReclaimWaitTimeoutCount{
     "velox.task_memory_reclaim_wait_timeout_count"};
 
-constexpr folly::StringPiece kMetricTaskSplitsCount{"velox.task_splits_count"};
+constexpr std::string_view kMetricTaskSplitsCount{"velox.task_splits_count"};
 
-constexpr folly::StringPiece kMetricOpMemoryReclaimTimeMs{
+constexpr std::string_view kMetricOpMemoryReclaimTimeMs{
     "velox.op_memory_reclaim_time_ms"};
 
-constexpr folly::StringPiece kMetricOpMemoryReclaimedBytes{
+constexpr std::string_view kMetricOpMemoryReclaimedBytes{
     "velox.op_memory_reclaim_bytes"};
 
-constexpr folly::StringPiece kMetricOpMemoryReclaimCount{
+constexpr std::string_view kMetricOpMemoryReclaimCount{
     "velox.op_memory_reclaim_count"};
 
-constexpr folly::StringPiece kMetricMemoryNonReclaimableCount{
+constexpr std::string_view kMetricMemoryNonReclaimableCount{
     "velox.memory_non_reclaimable_count"};
 
-constexpr folly::StringPiece kMetricMemoryPoolInitialCapacityBytes{
+constexpr std::string_view kMetricMemoryPoolInitialCapacityBytes{
     "velox.memory_pool_initial_capacity_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryPoolCapacityGrowCount{
+constexpr std::string_view kMetricMemoryPoolCapacityGrowCount{
     "velox.memory_pool_capacity_growth_count"};
 
-constexpr folly::StringPiece kMetricMemoryPoolUsageLeakBytes{
+constexpr std::string_view kMetricMemoryPoolUsageLeakBytes{
     "velox.memory_pool_usage_leak_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryPoolReservationLeakBytes{
+constexpr std::string_view kMetricMemoryPoolReservationLeakBytes{
     "velox.memory_pool_reservation_leak_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryAllocatorDoubleFreeCount{
+constexpr std::string_view kMetricMemoryAllocatorDoubleFreeCount{
     "velox.memory_allocator_double_free_count"};
 
-constexpr folly::StringPiece kMetricArbitratorLocalArbitrationCount{
+constexpr std::string_view kMetricArbitratorLocalArbitrationCount{
     "velox.arbitrator_local_arbitration_count"};
 
-constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationCount{
+constexpr std::string_view kMetricArbitratorGlobalArbitrationCount{
     "velox.arbitrator_global_arbitration_count"};
 
-constexpr folly::StringPiece
-    kMetricArbitratorGlobalArbitrationNumReclaimVictims{
-        "velox.arbitrator_global_arbitration_num_reclaim_victims"};
+constexpr std::string_view kMetricArbitratorGlobalArbitrationNumReclaimVictims{
+    "velox.arbitrator_global_arbitration_num_reclaim_victims"};
 
-constexpr folly::StringPiece
-    kMetricArbitratorGlobalArbitrationFailedVictimCount{
-        "velox.arbitrator_global_arbitration_failed_victim_count"};
+constexpr std::string_view kMetricArbitratorGlobalArbitrationFailedVictimCount{
+    "velox.arbitrator_global_arbitration_failed_victim_count"};
 
-constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationBytes{
+constexpr std::string_view kMetricArbitratorGlobalArbitrationBytes{
     "velox.arbitrator_global_arbitration_bytes"};
 
-constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationTimeMs{
+constexpr std::string_view kMetricArbitratorGlobalArbitrationTimeMs{
     "velox.arbitrator_global_arbitration_time_ms"};
 
-constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationWaitCount{
+constexpr std::string_view kMetricArbitratorGlobalArbitrationWaitCount{
     "velox.arbitrator_global_arbitration_wait_count"};
 
-constexpr folly::StringPiece kMetricArbitratorGlobalArbitrationWaitTimeMs{
+constexpr std::string_view kMetricArbitratorGlobalArbitrationWaitTimeMs{
     "velox.arbitrator_global_arbitration_wait_time_ms"};
 
-constexpr folly::StringPiece kMetricArbitratorAbortedCount{
+constexpr std::string_view kMetricArbitratorAbortedCount{
     "velox.arbitrator_aborted_count"};
 
-constexpr folly::StringPiece kMetricArbitratorFailuresCount{
+constexpr std::string_view kMetricArbitratorFailuresCount{
     "velox.arbitrator_failures_count"};
 
-constexpr folly::StringPiece kMetricArbitratorOpExecTimeMs{
+constexpr std::string_view kMetricArbitratorOpExecTimeMs{
     "velox.arbitrator_op_exec_time_ms"};
 
-constexpr folly::StringPiece kMetricArbitratorFreeCapacityBytes{
+constexpr std::string_view kMetricArbitratorFreeCapacityBytes{
     "velox.arbitrator_free_capacity_bytes"};
 
-constexpr folly::StringPiece kMetricArbitratorFreeReservedCapacityBytes{
+constexpr std::string_view kMetricArbitratorFreeReservedCapacityBytes{
     "velox.arbitrator_free_reserved_capacity_bytes"};
 
-constexpr folly::StringPiece kMetricDriverYieldCount{
-    "velox.driver_yield_count"};
+constexpr std::string_view kMetricDriverYieldCount{"velox.driver_yield_count"};
 
-constexpr folly::StringPiece kMetricDriverQueueTimeMs{
+constexpr std::string_view kMetricDriverQueueTimeMs{
     "velox.driver_queue_time_ms"};
 
-constexpr folly::StringPiece kMetricDriverExecTimeMs{
-    "velox.driver_exec_time_ms"};
+constexpr std::string_view kMetricDriverExecTimeMs{"velox.driver_exec_time_ms"};
 
-constexpr folly::StringPiece kMetricSpilledInputBytes{
-    "velox.spill_input_bytes"};
+constexpr std::string_view kMetricSpilledInputBytes{"velox.spill_input_bytes"};
 
-constexpr folly::StringPiece kMetricSpilledBytes{"velox.spill_bytes"};
+constexpr std::string_view kMetricSpilledBytes{"velox.spill_bytes"};
 
-constexpr folly::StringPiece kMetricSpilledRowsCount{"velox.spill_rows_count"};
+constexpr std::string_view kMetricSpilledRowsCount{"velox.spill_rows_count"};
 
-constexpr folly::StringPiece kMetricSpilledFilesCount{
-    "velox.spill_files_count"};
+constexpr std::string_view kMetricSpilledFilesCount{"velox.spill_files_count"};
 
-constexpr folly::StringPiece kMetricSpillFillTimeMs{"velox.spill_fill_time_ms"};
+constexpr std::string_view kMetricSpillFillTimeMs{"velox.spill_fill_time_ms"};
 
-constexpr folly::StringPiece kMetricSpillSortTimeMs{"velox.spill_sort_time_ms"};
+constexpr std::string_view kMetricSpillSortTimeMs{"velox.spill_sort_time_ms"};
 
-constexpr folly::StringPiece kMetricSpillExtractVectorTimeMs{
+constexpr std::string_view kMetricSpillExtractVectorTimeMs{
     "velox.spill_extract_vector_time_ms"};
 
-constexpr folly::StringPiece kMetricSpillSerializationTimeMs{
+constexpr std::string_view kMetricSpillSerializationTimeMs{
     "velox.spill_serialization_time_ms"};
 
-constexpr folly::StringPiece kMetricSpillWritesCount{
-    "velox.spill_writes_count"};
+constexpr std::string_view kMetricSpillWritesCount{"velox.spill_writes_count"};
 
-constexpr folly::StringPiece kMetricSpillFlushTimeMs{
-    "velox.spill_flush_time_ms"};
+constexpr std::string_view kMetricSpillFlushTimeMs{"velox.spill_flush_time_ms"};
 
-constexpr folly::StringPiece kMetricSpillWriteTimeMs{
-    "velox.spill_write_time_ms"};
+constexpr std::string_view kMetricSpillWriteTimeMs{"velox.spill_write_time_ms"};
 
-constexpr folly::StringPiece kMetricSpillMemoryBytes{
-    "velox.spill_memory_bytes"};
+constexpr std::string_view kMetricSpillMemoryBytes{"velox.spill_memory_bytes"};
 
-constexpr folly::StringPiece kMetricSpillPeakMemoryBytes{
+constexpr std::string_view kMetricSpillPeakMemoryBytes{
     "velox.spill_peak_memory_bytes"};
 
-constexpr folly::StringPiece kMetricFileWriterEarlyFlushedRawBytes{
+constexpr std::string_view kMetricFileWriterEarlyFlushedRawBytes{
     "velox.file_writer_early_flushed_raw_bytes"};
 
-constexpr folly::StringPiece kMetricHiveSortWriterFinishTimeMs{
+constexpr std::string_view kMetricHiveSortWriterFinishTimeMs{
     "velox.hive_sort_writer_finish_time_ms"};
 
-constexpr folly::StringPiece kMetricArbitratorRequestsCount{
+constexpr std::string_view kMetricArbitratorRequestsCount{
     "velox.arbitrator_requests_count"};
 
-constexpr folly::StringPiece kMetricMemoryAllocatorMappedBytes{
+constexpr std::string_view kMetricMemoryAllocatorMappedBytes{
     "velox.memory_allocator_mapped_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryAllocatorExternalMappedBytes{
+constexpr std::string_view kMetricMemoryAllocatorExternalMappedBytes{
     "velox.memory_allocator_external_mapped_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryAllocatorAllocatedBytes{
+constexpr std::string_view kMetricMemoryAllocatorAllocatedBytes{
     "velox.memory_allocator_allocated_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryAllocatorTotalUsedBytes{
+constexpr std::string_view kMetricMemoryAllocatorTotalUsedBytes{
     "velox.memory_allocator_total_used_bytes"};
 
-constexpr folly::StringPiece kMetricMmapAllocatorDelegatedAllocatedBytes{
+constexpr std::string_view kMetricMmapAllocatorDelegatedAllocatedBytes{
     "velox.mmap_allocator_delegated_allocated_bytes"};
 
-constexpr folly::StringPiece kMetricCacheMaxAgeSecs{"velox.cache_max_age_secs"};
+constexpr std::string_view kMetricCacheMaxAgeSecs{"velox.cache_max_age_secs"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumTinyEntries{
+constexpr std::string_view kMetricMemoryCacheNumTinyEntries{
     "velox.memory_cache_num_tiny_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumLargeEntries{
+constexpr std::string_view kMetricMemoryCacheNumLargeEntries{
     "velox.memory_cache_num_large_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumEmptyEntries{
+constexpr std::string_view kMetricMemoryCacheNumEmptyEntries{
     "velox.memory_cache_num_empty_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumSharedEntries{
+constexpr std::string_view kMetricMemoryCacheNumSharedEntries{
     "velox.memory_cache_num_shared_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumExclusiveEntries{
+constexpr std::string_view kMetricMemoryCacheNumExclusiveEntries{
     "velox.memory_cache_num_exclusive_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumPrefetchedEntries{
+constexpr std::string_view kMetricMemoryCacheNumPrefetchedEntries{
     "velox.memory_cache_num_prefetched_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheTotalTinyBytes{
+constexpr std::string_view kMetricMemoryCacheTotalTinyBytes{
     "velox.memory_cache_total_tiny_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryCacheTotalLargeBytes{
+constexpr std::string_view kMetricMemoryCacheTotalLargeBytes{
     "velox.memory_cache_total_large_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryCacheTotalTinyPaddingBytes{
+constexpr std::string_view kMetricMemoryCacheTotalTinyPaddingBytes{
     "velox.memory_cache_total_tiny_padding_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryCacheTotalLargePaddingBytes{
+constexpr std::string_view kMetricMemoryCacheTotalLargePaddingBytes{
     "velox.memory_cache_total_large_padding_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryCacheTotalPrefetchBytes{
+constexpr std::string_view kMetricMemoryCacheTotalPrefetchBytes{
     "velox.memory_cache_total_prefetched_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryCacheSumEvictScore{
+constexpr std::string_view kMetricMemoryCacheSumEvictScore{
     "velox.memory_cache_sum_evict_score"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumHits{
+constexpr std::string_view kMetricMemoryCacheNumHits{
     "velox.memory_cache_num_hits"};
 
-constexpr folly::StringPiece kMetricMemoryCacheHitBytes{
+constexpr std::string_view kMetricMemoryCacheHitBytes{
     "velox.memory_cache_hit_bytes"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumNew{
+constexpr std::string_view kMetricMemoryCacheNumNew{
     "velox.memory_cache_num_new"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumEvicts{
+constexpr std::string_view kMetricMemoryCacheNumEvicts{
     "velox.memory_cache_num_evicts"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumSavableEvicts{
+constexpr std::string_view kMetricMemoryCacheNumSavableEvicts{
     "velox.memory_cache_num_savable_evicts"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumEvictChecks{
+constexpr std::string_view kMetricMemoryCacheNumEvictChecks{
     "velox.memory_cache_num_evict_checks"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumWaitExclusive{
+constexpr std::string_view kMetricMemoryCacheNumWaitExclusive{
     "velox.memory_cache_num_wait_exclusive"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumAllocClocks{
+constexpr std::string_view kMetricMemoryCacheNumAllocClocks{
     "velox.memory_cache_num_alloc_clocks"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumAgedOutEntries{
+constexpr std::string_view kMetricMemoryCacheNumAgedOutEntries{
     "velox.memory_cache_num_aged_out_entries"};
 
-constexpr folly::StringPiece kMetricMemoryCacheNumStaleEntries{
+constexpr std::string_view kMetricMemoryCacheNumStaleEntries{
     "velox.memory_cache_num_stale_entries"};
 
-constexpr folly::StringPiece kMetricSsdCacheCachedRegions{
+constexpr std::string_view kMetricSsdCacheCachedRegions{
     "velox.ssd_cache_cached_regions"};
 
-constexpr folly::StringPiece kMetricSsdCacheCachedEntries{
+constexpr std::string_view kMetricSsdCacheCachedEntries{
     "velox.ssd_cache_cached_entries"};
 
-constexpr folly::StringPiece kMetricSsdCacheCachedBytes{
+constexpr std::string_view kMetricSsdCacheCachedBytes{
     "velox.ssd_cache_cached_bytes"};
 
-constexpr folly::StringPiece kMetricSsdCacheReadEntries{
+constexpr std::string_view kMetricSsdCacheReadEntries{
     "velox.ssd_cache_read_entries"};
 
-constexpr folly::StringPiece kMetricSsdCacheReadBytes{
+constexpr std::string_view kMetricSsdCacheReadBytes{
     "velox.ssd_cache_read_bytes"};
 
-constexpr folly::StringPiece kMetricSsdCacheWrittenEntries{
+constexpr std::string_view kMetricSsdCacheWrittenEntries{
     "velox.ssd_cache_written_entries"};
 
-constexpr folly::StringPiece kMetricSsdCacheWrittenBytes{
+constexpr std::string_view kMetricSsdCacheWrittenBytes{
     "velox.ssd_cache_written_bytes"};
 
-constexpr folly::StringPiece kMetricSsdCacheAgedOutEntries{
+constexpr std::string_view kMetricSsdCacheAgedOutEntries{
     "velox.ssd_cache_aged_out_entries"};
 
-constexpr folly::StringPiece kMetricSsdCacheAgedOutRegions{
+constexpr std::string_view kMetricSsdCacheAgedOutRegions{
     "velox.ssd_cache_aged_out_regions"};
 
-constexpr folly::StringPiece kMetricSsdCacheOpenSsdErrors{
+constexpr std::string_view kMetricSsdCacheOpenSsdErrors{
     "velox.ssd_cache_open_ssd_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheOpenCheckpointErrors{
+constexpr std::string_view kMetricSsdCacheOpenCheckpointErrors{
     "velox.ssd_cache_open_checkpoint_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheOpenLogErrors{
+constexpr std::string_view kMetricSsdCacheOpenLogErrors{
     "velox.ssd_cache_open_log_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheMetaFileDeleteErrors{
+constexpr std::string_view kMetricSsdCacheMetaFileDeleteErrors{
     "velox.ssd_cache_delete_meta_file_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheGrowFileErrors{
+constexpr std::string_view kMetricSsdCacheGrowFileErrors{
     "velox.ssd_cache_grow_file_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheWriteSsdErrors{
+constexpr std::string_view kMetricSsdCacheWriteSsdErrors{
     "velox.ssd_cache_write_ssd_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheWriteSsdDropped{
+constexpr std::string_view kMetricSsdCacheWriteSsdDropped{
     "velox.ssd_cache_write_ssd_dropped"};
 
-constexpr folly::StringPiece kMetricSsdCacheWriteCheckpointErrors{
+constexpr std::string_view kMetricSsdCacheWriteCheckpointErrors{
     "velox.ssd_cache_write_checkpoint_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheReadCorruptions{
+constexpr std::string_view kMetricSsdCacheReadCorruptions{
     "velox.ssd_cache_read_corruptions"};
 
-constexpr folly::StringPiece kMetricSsdCacheReadSsdErrors{
+constexpr std::string_view kMetricSsdCacheReadSsdErrors{
     "velox.ssd_cache_read_ssd_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheReadCheckpointErrors{
+constexpr std::string_view kMetricSsdCacheReadCheckpointErrors{
     "velox.ssd_cache_read_checkpoint_errors"};
 
-constexpr folly::StringPiece kMetricSsdCacheReadWithoutChecksum{
+constexpr std::string_view kMetricSsdCacheReadWithoutChecksum{
     "velox.ssd_cache_read_without_checksum"};
 
-constexpr folly::StringPiece kMetricSsdCacheCheckpointsRead{
+constexpr std::string_view kMetricSsdCacheCheckpointsRead{
     "velox.ssd_cache_checkpoints_read"};
 
-constexpr folly::StringPiece kMetricSsdCacheCheckpointsWritten{
+constexpr std::string_view kMetricSsdCacheCheckpointsWritten{
     "velox.ssd_cache_checkpoints_written"};
 
-constexpr folly::StringPiece kMetricSsdCacheRegionsEvicted{
+constexpr std::string_view kMetricSsdCacheRegionsEvicted{
     "velox.ssd_cache_regions_evicted"};
 
-constexpr folly::StringPiece kMetricSsdCacheRecoveredEntries{
+constexpr std::string_view kMetricSsdCacheRecoveredEntries{
     "velox.ssd_cache_recovered_entries"};
 
-constexpr folly::StringPiece kMetricExchangeTransactionCreateDelay{
+constexpr std::string_view kMetricExchangeTransactionCreateDelay{
     "velox.exchange.transaction_create_delay_ms"};
 
-constexpr folly::StringPiece kMetricExchangeDataTimeMs{
+constexpr std::string_view kMetricExchangeDataTimeMs{
     "velox.exchange_data_time_ms"};
 
-constexpr folly::StringPiece kMetricExchangeDataBytes{
+constexpr std::string_view kMetricExchangeDataBytes{
     "velox.exchange_data_bytes"};
 
-constexpr folly::StringPiece kMetricExchangeDataSize{
-    "velox.exchange_data_size"};
+constexpr std::string_view kMetricExchangeDataSize{"velox.exchange_data_size"};
 
-constexpr folly::StringPiece kMetricExchangeDataCount{
+constexpr std::string_view kMetricExchangeDataCount{
     "velox.exchange_data_count"};
 
-constexpr folly::StringPiece kMetricExchangeDataSizeTimeMs{
+constexpr std::string_view kMetricExchangeDataSizeTimeMs{
     "velox.exchange_data_size_time_ms"};
 
-constexpr folly::StringPiece kMetricExchangeDataSizeCount{
+constexpr std::string_view kMetricExchangeDataSizeCount{
     "velox.exchange_data_size_count"};
 
-constexpr folly::StringPiece kMetricStorageThrottledDurationMs{
+constexpr std::string_view kMetricStorageThrottledDurationMs{
     "velox.storage_throttled_duration_ms"};
 
-constexpr folly::StringPiece kMetricStorageLocalThrottled{
+constexpr std::string_view kMetricStorageLocalThrottled{
     "velox.storage_local_throttled_count"};
 
-constexpr folly::StringPiece kMetricStorageGlobalThrottled{
+constexpr std::string_view kMetricStorageGlobalThrottled{
     "velox.storage_global_throttled_count"};
 
-constexpr folly::StringPiece kMetricStorageNetworkThrottled{
+constexpr std::string_view kMetricStorageNetworkThrottled{
     "velox.storage_network_throttled_count"};
 
-constexpr folly::StringPiece kMetricIndexLookupResultRawBytes{
+constexpr std::string_view kMetricIndexLookupResultRawBytes{
     "velox.index_lookup_result_raw_bytes"};
 
-constexpr folly::StringPiece kMetricIndexLookupResultBytes{
+constexpr std::string_view kMetricIndexLookupResultBytes{
     "velox.index_lookup_result_bytes"};
 
-constexpr folly::StringPiece kMetricIndexLookupTimeMs{
+constexpr std::string_view kMetricIndexLookupTimeMs{
     "velox.index_lookup_time_ms"};
 
-constexpr folly::StringPiece kMetricIndexLookupWaitTimeMs{
+constexpr std::string_view kMetricIndexLookupWaitTimeMs{
     "velox.index_lookup_wait_time_ms"};
 
-constexpr folly::StringPiece kMetricIndexLookupBlockedWaitTimeMs{
+constexpr std::string_view kMetricIndexLookupBlockedWaitTimeMs{
     "velox.index_lookup_blocked_wait_time_ms"};
 
-constexpr folly::StringPiece kMetricIndexLookupErrorResultCount{
+constexpr std::string_view kMetricIndexLookupErrorResultCount{
     "velox.index_lookup_error_result_count"};
 
-constexpr folly::StringPiece kMetricTableScanBatchProcessTimeMs{
+constexpr std::string_view kMetricTableScanBatchProcessTimeMs{
     "velox.table_scan_batch_process_time_ms"};
 
-constexpr folly::StringPiece kMetricTableScanBatchBytes{
+constexpr std::string_view kMetricTableScanBatchBytes{
     "velox.table_scan_batch_bytes"};
 
-constexpr folly::StringPiece kMetricTaskBatchProcessTimeMs{
+constexpr std::string_view kMetricTaskBatchProcessTimeMs{
     "velox.task_batch_process_time_ms"};
 
-constexpr folly::StringPiece kMetricTaskBarrierProcessTimeMs{
+constexpr std::string_view kMetricTaskBarrierProcessTimeMs{
     "velox.task_barrier_process_time_ms"};
+
 } // namespace facebook::velox

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -65,7 +65,7 @@ void verifyVeloxException(
     std::function<void()> f,
     const std::string& messagePrefix) {
   verifyException<VeloxException>(f, [&messagePrefix](const auto& e) {
-    EXPECT_TRUE(folly::StringPiece{e.what()}.startsWith(messagePrefix))
+    EXPECT_TRUE(std::string_view{e.what()}.starts_with(messagePrefix))
         << "\nException message prefix mismatch.\n\nExpected prefix: "
         << messagePrefix << "\n\nActual message: " << e.what();
   });
@@ -1015,6 +1015,6 @@ TEST(ExceptionTest, exceptionMacroInlining) {
   try {
     VELOX_USER_FAIL(errorStr, "definitely");
   } catch (const std::exception& e) {
-    ASSERT_TRUE(folly::StringPiece{e.what()}.startsWith("argument not found"));
+    ASSERT_TRUE(std::string_view{e.what()}.starts_with("argument not found"));
   }
 }

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -409,69 +409,104 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   const auto& counterMap = reporter_->counterMap;
   {
     std::lock_guard<std::mutex> l(reporter_->m);
-    ASSERT_EQ(counterMap.count(kMetricArbitratorFreeCapacityBytes.str()), 1);
     ASSERT_EQ(
-        counterMap.count(kMetricArbitratorFreeReservedCapacityBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumTinyEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumLargeEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEmptyEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumSharedEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumExclusiveEntries.str()), 1);
+        counterMap.count(std::string(kMetricArbitratorFreeCapacityBytes)), 1);
     ASSERT_EQ(
-        counterMap.count(kMetricMemoryCacheNumPrefetchedEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheTotalTinyBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheTotalLargeBytes.str()), 1);
+        counterMap.count(
+            std::string(kMetricArbitratorFreeReservedCapacityBytes)),
+        1);
     ASSERT_EQ(
-        counterMap.count(kMetricMemoryCacheTotalTinyPaddingBytes.str()), 1);
+        counterMap.count(std::string(kMetricMemoryCacheNumTinyEntries)), 1);
     ASSERT_EQ(
-        counterMap.count(kMetricMemoryCacheTotalLargePaddingBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheTotalPrefetchBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCachedEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCachedRegions.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCachedBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricCacheMaxAgeSecs.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryAllocatorMappedBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryAllocatorAllocatedBytes.str()), 1);
+        counterMap.count(std::string(kMetricMemoryCacheNumLargeEntries)), 1);
     ASSERT_EQ(
-        counterMap.count(kMetricMmapAllocatorDelegatedAllocatedBytes.str()), 1);
+        counterMap.count(std::string(kMetricMemoryCacheNumEmptyEntries)), 1);
     ASSERT_EQ(
-        counterMap.count(kMetricMemoryAllocatorExternalMappedBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSpillMemoryBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSpillPeakMemoryBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryAllocatorTotalUsedBytes.str()), 1);
+        counterMap.count(std::string(kMetricMemoryCacheNumSharedEntries)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumExclusiveEntries)),
+        1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumPrefetchedEntries)),
+        1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheTotalTinyBytes)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheTotalLargeBytes)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheTotalTinyPaddingBytes)),
+        1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheTotalLargePaddingBytes)),
+        1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheTotalPrefetchBytes)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheCachedEntries)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheCachedRegions)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheCachedBytes)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricCacheMaxAgeSecs)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryAllocatorMappedBytes)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryAllocatorAllocatedBytes)), 1);
+    ASSERT_EQ(
+        counterMap.count(
+            std::string(kMetricMmapAllocatorDelegatedAllocatedBytes)),
+        1);
+    ASSERT_EQ(
+        counterMap.count(
+            std::string(kMetricMemoryAllocatorExternalMappedBytes)),
+        1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSpillMemoryBytes)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSpillPeakMemoryBytes)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryAllocatorTotalUsedBytes)), 1);
     // Check deltas are not reported
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumHits.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheHitBytes.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumNew.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvicts.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumSavableEvicts.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvictChecks.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumWaitExclusive.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumAllocClocks.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumAgedOutEntries.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheSumEvictScore.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadEntries.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadBytes.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWrittenEntries.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWrittenBytes.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheOpenSsdErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheOpenCheckpointErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheOpenLogErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheMetaFileDeleteErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheGrowFileErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteSsdErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteSsdDropped.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteCheckpointErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadSsdErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCorruptions.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCheckpointErrors.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsRead.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsWritten.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheRegionsEvicted.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutEntries.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutRegions.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheRecoveredEntries.str()), 0);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadWithoutChecksum.str()), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumHits)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheHitBytes)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumNew)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumEvicts)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumSavableEvicts)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumEvictChecks)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumWaitExclusive)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumAllocClocks)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumAgedOutEntries)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheSumEvictScore)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadEntries)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadBytes)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWrittenEntries)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWrittenBytes)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheOpenSsdErrors)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheOpenCheckpointErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheOpenLogErrors)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheMetaFileDeleteErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheGrowFileErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdDropped)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheWriteCheckpointErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadSsdErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadCorruptions)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheReadCheckpointErrors)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheCheckpointsRead)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheCheckpointsWritten)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheRegionsEvicted)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheAgedOutEntries)), 0);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheAgedOutRegions)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheRecoveredEntries)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheReadWithoutChecksum)), 0);
     ASSERT_EQ(counterMap.size(), 24);
   }
 
@@ -523,38 +558,51 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   // Check delta stats are reported
   {
     std::lock_guard<std::mutex> l(reporter_->m);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumHits.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheHitBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumNew.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvicts.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumSavableEvicts.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumEvictChecks.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumWaitExclusive.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumAllocClocks.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheNumAgedOutEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricMemoryCacheSumEvictScore.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWrittenEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWrittenBytes.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheOpenSsdErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheOpenCheckpointErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheOpenLogErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheMetaFileDeleteErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheGrowFileErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteSsdErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteSsdDropped.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheWriteCheckpointErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadSsdErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCorruptions.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadCheckpointErrors.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsRead.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheCheckpointsWritten.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheRegionsEvicted.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheAgedOutRegions.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheRecoveredEntries.str()), 1);
-    ASSERT_EQ(counterMap.count(kMetricSsdCacheReadWithoutChecksum.str()), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumHits)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheHitBytes)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumNew)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumEvicts)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumSavableEvicts)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumEvictChecks)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumWaitExclusive)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumAllocClocks)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheNumAgedOutEntries)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheSumEvictScore)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadEntries)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadBytes)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWrittenEntries)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWrittenBytes)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheOpenSsdErrors)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheOpenCheckpointErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheOpenLogErrors)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheMetaFileDeleteErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheGrowFileErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdDropped)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheWriteCheckpointErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadSsdErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheReadCorruptions)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheReadCheckpointErrors)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheCheckpointsRead)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheCheckpointsWritten)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheRegionsEvicted)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheAgedOutEntries)), 1);
+    ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheAgedOutRegions)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheRecoveredEntries)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheReadWithoutChecksum)), 1);
     ASSERT_EQ(counterMap.size(), 56);
   }
 }


### PR DESCRIPTION
Summary:
Intermediate step while migrating legacy folly::StringPiece usages
to std::string_view.

Part of https://github.com/facebookincubator/velox/issues/14456

Differential Revision: D85371290


