### PR TITLE
fix: HashJoins and HashAggregations may produce incorrect results on types that support custom comparison

### DIFF
--- a/velox/connectors/hive/PartitionIdGenerator.cpp
+++ b/velox/connectors/hive/PartitionIdGenerator.cpp
@@ -38,16 +38,15 @@ PartitionIdGenerator::PartitionIdGenerator(
   for (auto channel : partitionChannels_) {
     hashers_.emplace_back(
         exec::VectorHasher::create(inputType->childAt(channel), channel));
+    VELOX_USER_CHECK(
+        hashers_.back()->typeSupportsValueIds(),
+        "Unsupported partition type: {}.",
+        inputType->childAt(channel)->toString());
   }
 
   std::vector<TypePtr> partitionKeyTypes;
   std::vector<std::string> partitionKeyNames;
   for (auto channel : partitionChannels_) {
-    VELOX_USER_CHECK(
-        exec::VectorHasher::typeKindSupportsValueIds(
-            inputType->childAt(channel)->kind()),
-        "Unsupported partition type: {}.",
-        inputType->childAt(channel)->toString());
     partitionKeyTypes.push_back(inputType->childAt(channel));
     partitionKeyNames.push_back(inputType->nameOf(channel));
   }

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -131,8 +131,15 @@ class VectorHasher {
   static constexpr int32_t kNoLimit = -1;
 
   VectorHasher(TypePtr type, column_index_t channel)
-      : channel_(channel), type_(std::move(type)), typeKind_(type_->kind()) {
-    if (typeKind_ == TypeKind::BOOLEAN) {
+      : channel_(channel),
+        type_(std::move(type)),
+        typeKind_(type_->kind()),
+        typeProvidesCustomComparison_(type_->providesCustomComparison()) {
+    if (!typeSupportsValueIds()) {
+      // Ensure any range or unique value based hashing is disabled.
+      setRangeOverflow();
+      setDistinctOverflow();
+    } else if (typeKind_ == TypeKind::BOOLEAN) {
       // We do not need samples to know the cardinality or limits of a bool
       // vector.
       hasRange_ = true;
@@ -235,9 +242,10 @@ class VectorHasher {
       ScratchMemory& scratchMemory,
       raw_vector<uint64_t>& result) const;
 
-  // Returns true if either range or distinct values have not overflowed.
+  // Returns true if either range or distinct values have not overflowed and the
+  // type doesn't support custom comparison.
   bool mayUseValueIds() const {
-    return hasRange_ || !distinctOverflow_;
+    return typeSupportsValueIds() && (hasRange_ || !distinctOverflow_);
   }
 
   // Returns an instance of the filter corresponding to a set of unique values.
@@ -284,8 +292,12 @@ class VectorHasher {
     return isRange_;
   }
 
-  static bool typeKindSupportsValueIds(TypeKind kind) {
-    switch (kind) {
+  bool typeSupportsValueIds() const {
+    if (typeProvidesCustomComparison_) {
+      return false;
+    }
+
+    switch (typeKind_) {
       case TypeKind::BOOLEAN:
       case TypeKind::TINYINT:
       case TypeKind::SMALLINT:
@@ -438,25 +450,6 @@ class VectorHasher {
     }
   }
 
-  // Specialization for int128_t: For types with custom comparison (IPADDRESS,
-  // UUID), force hash mode by blocking both range and distinct modes. For other
-  // int128_t types (HUGEINT, DECIMAL), use generic path which may use range
-  // mode for small values.
-  void analyzeValue(int128_t value) {
-    if (type_->providesCustomComparison()) {
-      // Force hash mode by disabling both range and distinct optimizations
-      if (!rangeOverflow_) {
-        setRangeOverflow();
-      }
-      if (!distinctOverflow_) {
-        setDistinctOverflow();
-      }
-    } else {
-      // Use generic analysis for regular int128_t types (HUGEINT, DECIMAL)
-      analyzeValue<int64_t>(toInt64(value));
-    }
-  }
-
   template <typename T>
   bool tryMapToRangeSimd(
       const T* values,
@@ -555,6 +548,13 @@ class VectorHasher {
 
   void setRangeOverflow();
 
+  inline void checkTypeSupportsValueIds() const {
+    VELOX_DCHECK(
+        typeSupportsValueIds(),
+        "Value IDs cannot be used, the type {} is not supported.",
+        type_->toString());
+  }
+
   static inline bool
   isNullAt(const char* group, int32_t nullByte, uint8_t nullMask) {
     return (group[nullByte] & nullMask) != 0;
@@ -571,6 +571,7 @@ class VectorHasher {
   const column_index_t channel_;
   const TypePtr type_;
   const TypeKind typeKind_;
+  const bool typeProvidesCustomComparison_;
 
   DecodedVector decoded_;
   raw_vector<uint64_t> cachedHashes_;

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -248,7 +248,7 @@ class WriterFuzzer {
   };
 
   // Supported partition key column types
-  // According to VectorHasher::typeKindSupportsValueIds and
+  // According to VectorHasher::typeSupportsValueIds and
   // https://github.com/prestodb/presto/blob/10143be627beb2c61aba5b3d36af473d2a8ef65e/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java#L593
   const std::vector<TypePtr> kPartitionKeyTypes_{
       BOOLEAN(),

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -38,6 +38,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/SumNonPODAggregate.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/type/tests/utils/CustomTypesForTesting.h"
 
 namespace facebook::velox::exec::test {
 
@@ -4112,6 +4113,42 @@ TEST_F(AggregationTest, nanKeys) {
   auto testDistinctAgg = [&](std::vector<std::string> aggKeys,
                              std::vector<VectorPtr> inputCols,
                              std::vector<VectorPtr> expectedCols) {
+    auto plan = PlanBuilder()
+                    .values({makeRowVector(inputCols)})
+                    .singleAggregation(aggKeys, {}, {})
+                    .planNode();
+    AssertQueryBuilder(plan).assertResults(makeRowVector(expectedCols));
+  };
+
+  // Test with a primitive type key.
+  testDistinctAgg({"c0"}, {c0}, {e0});
+  // Multiple key columns.
+  testDistinctAgg({"c0", "c1"}, {c0, c1}, {e0, e1});
+
+  // Test with a complex type key.
+  testDistinctAgg({"c0"}, {makeRowVector({c0, c1})}, {makeRowVector({e0, e1})});
+  // Multiple key columns.
+  testDistinctAgg(
+      {"c0", "c1"},
+      {makeRowVector({c0, c1}), c1},
+      {makeRowVector({e0, e1}), e1});
+}
+
+TEST_F(AggregationTest, keysProvideCustomComparison) {
+  // Columns reused across test cases.
+  auto c0 = makeFlatVector<int64_t>(
+      {0, 1, 256, 257, 512, 513},
+      velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON());
+  auto c1 = makeFlatVector<int32_t>({1, 2, 1, 2, 1, 2});
+  // Expected result columns reused across test cases. A deduplicated version of
+  // c0 and c1.
+  auto e0 = makeFlatVector<int64_t>(
+      {0, 1}, velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON());
+  auto e1 = makeFlatVector<int32_t>({1, 2});
+
+  auto testDistinctAgg = [&](const std::vector<std::string>& aggKeys,
+                             const std::vector<VectorPtr>& inputCols,
+                             const std::vector<VectorPtr>& expectedCols) {
     auto plan = PlanBuilder()
                     .values({makeRowVector(inputCols)})
                     .singleAggregation(aggKeys, {}, {})

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -571,8 +571,8 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     for (auto row : rows) {
       ASSERT_EQ(
           expected[index],
-          rowContainer->equals<canHandleNulls>(
-              row, rowContainer->columnAt(0), rhsDecoded, index))
+          rowContainer->compare<canHandleNulls>(
+              row, rowContainer->columnAt(0), rhsDecoded, index) == 0)
           << fmt::format(
                  "Mismatch at index {} with canHandleNulls {}",
                  index,
@@ -1178,11 +1178,13 @@ TEST_F(RowContainerTest, types) {
       EXPECT_EQ(source->hashValueAt(i), hashes[i]);
       // Test non-null and nullable variants of equals.
       if (column < keys.size()) {
-        EXPECT_TRUE(
-            data->equals<false>(rows[i], data->columnAt(column), decoded, i));
+        EXPECT_EQ(
+            data->compare<false>(rows[i], data->columnAt(column), decoded, i),
+            0);
       } else if (!columnType->isMap()) {
-        EXPECT_TRUE(
-            data->equals<true>(rows[i], data->columnAt(column), decoded, i));
+        EXPECT_EQ(
+            data->compare<true>(rows[i], data->columnAt(column), decoded, i),
+            0);
       }
       // Non-key map columns are not comparable, as the map keys are not sorted.
       if (columnType->isMap() && column >= keys.size()) {
@@ -1869,8 +1871,10 @@ TEST_F(RowContainerTest, unknown) {
   }
 
   for (size_t row = 0; row < size; ++row) {
-    ASSERT_TRUE(rowContainer->equals<false>(
-        rows[row], rowContainer->columnAt(0), decoded, row));
+    ASSERT_EQ(
+        rowContainer->compare</*mayHaveNulls=*/true>(
+            rows[row], rowContainer->columnAt(0), decoded, row),
+        0);
   }
 
   {
@@ -1951,8 +1955,10 @@ TEST_F(RowContainerTest, nans) {
 
   // Verify that they are considered equal.
   for (size_t row = 0; row < size; ++row) {
-    ASSERT_TRUE(rowContainer->equals<false>(
-        rows[row], rowContainer->columnAt(0), decoded, row));
+    ASSERT_EQ(
+        rowContainer->compare<false>(
+            rows[row], rowContainer->columnAt(0), decoded, row),
+        0);
   }
   ASSERT_EQ(rowContainer->compare(rows[0], rows[1], 0, {}), 0);
 }

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -1203,3 +1203,84 @@ TEST_F(VectorHasherTest, customComparisonRow) {
               {std::nullopt, 0, 1, 0, 1, 0, 1},
               velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())}));
 }
+
+TEST_F(VectorHasherTest, customComparisonValueIds) {
+  // Test that VectorHasher created with custom comparison type
+  // has value IDs disabled (distinctOverflow_ and rangeOverflow_ set).
+  auto vectorHasher = exec::VectorHasher::create(
+      velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(), 1);
+
+  // Test that types with custom comparison do not support value IDs.
+  EXPECT_FALSE(vectorHasher->typeSupportsValueIds());
+
+  // Verify that mayUseValueIds() returns false for custom comparison types.
+  EXPECT_FALSE(vectorHasher->mayUseValueIds());
+}
+
+DEBUG_ONLY_TEST_F(VectorHasherTest, customComparisonNoValueIds) {
+  // Test that custom comparison types cannot use value IDs for optimization.
+  auto data = makeRowVector({makeNullableFlatVector<int64_t>(
+      {0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+      velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON())});
+
+  auto hasher = exec::VectorHasher::create(
+      velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(), 0);
+
+  SelectivityVector allRows(data->size());
+  raw_vector<uint64_t> result(data->size());
+  std::fill(result.begin(), result.end(), 0);
+
+  hasher->decode(*data->childAt(0), allRows);
+
+  VELOX_ASSERT_THROW(
+      hasher->computeValueIds(allRows, result), "Value IDs cannot be used");
+  VectorHasher::ScratchMemory scratchMemory;
+  VELOX_ASSERT_THROW(
+      hasher->lookupValueIds(*data->childAt(0), allRows, scratchMemory, result),
+      "Value IDs cannot be used");
+  EXPECT_EQ(nullptr, hasher->getFilter(true));
+  VELOX_ASSERT_THROW(
+      hasher->enableValueRange(1, 50), "Value IDs cannot be used");
+  VELOX_ASSERT_THROW(
+      hasher->enableValueRange(1, 50), "Value IDs cannot be used");
+}
+
+DEBUG_ONLY_TEST_F(VectorHasherTest, computeValueIdsForRowsCustomComparison) {
+  // Test that computeValueIdsForRows throws an exception for types with custom
+  // comparison.
+  auto hasher = exec::VectorHasher::create(
+      velox::test::BIGINT_TYPE_WITH_CUSTOM_COMPARISON(), 0);
+
+  constexpr int32_t kNumGroups = 5;
+  constexpr int32_t kRowSize = 16;
+  constexpr int32_t kValueOffset = 0;
+  constexpr int32_t kNullByte = 8;
+  constexpr uint8_t kNullMask = 1;
+
+  // Allocate memory for row-wise data.
+  std::vector<std::vector<char>> rowData(kNumGroups);
+  std::vector<char*> groups(kNumGroups);
+
+  for (int i = 0; i < kNumGroups; ++i) {
+    rowData[i].resize(kRowSize, 0);
+    groups[i] = rowData[i].data();
+
+    // Set values for all rows (no nulls for simplicity).
+    *reinterpret_cast<int64_t*>(groups[i] + kValueOffset) = i * 256;
+  }
+
+  raw_vector<uint64_t> result(kNumGroups);
+  std::fill(result.begin(), result.end(), 0);
+
+  // computeValueIdsForRows should throw an exception for types with custom
+  // comparison.
+  VELOX_ASSERT_THROW(
+      hasher->computeValueIdsForRows(
+          groups.data(),
+          kNumGroups,
+          kValueOffset,
+          kNullByte,
+          kNullMask,
+          result),
+      "Value IDs cannot be used");
+}


### PR DESCRIPTION
Summary:
HashJoins and HashAggregations use HashTable to track values. The HashTable can use 3 
different hash modes: hash, array, normalizedKey.  For the latter two, it relies on 
VectorHasher to map values to a unique int64 (unlike hash this can't have collisions). 
VectorHasher decides if it is able to do this based on the TypeKind (physical type).

This leads to bugs when the logical type supports custom comparison. In this case, the 
TypeKind may indicate that value IDs can be produced, but the logic for doing this mapping 
may map two different values which are equal using the Type's custom comparison to 
different int64s at which point we lose the ability to identify equivalent values.

Furthermore, in HashJoin there is an additional issue with hash mode, where when it hits a 
collision or does a lookup in the HashTable, it calls RowContainer's equals method which is 
missing support for custom comparison. So values that should be equal so again we lose the 
ability to identify equivalent values.

This change fixes these issues by:
1) In VectorHasher I changed typeSupportsValueIds to return false if the type supports 
custom comparison
2) In VectorHasher I updated the constructor to explicitly disable range and unique value 
(array/normalizedKey) based hashes if the type supports custom comparison.
3) I updated all functions in VectorHasher that rely on value IDs to do a DCHECK that the 
type supports value IDs or handle them if possible. DCHECK because the code is 
performance sensitive.
4) I removed the equals function from RowContainer. This was only used in one place in the 
code and the logic is equivalent to compare == 0. It did have one optimization to skip null 
checks if we know there are no nulls which I ported to compare.

Note that I removed the special handling for int128_t in VectorHasher's analyzeValue. That 
was compensating for the issues I identify here in some cases, but did not fix the general 
issue with types that are physically 128 bit integers being used as value IDs.  That fix is 
coming separately.

Differential Revision: D85291290


