### PR TITLE
feat: Add Support for cast from Varchar to Time with Timezone

### DIFF
--- a/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
@@ -17,6 +17,10 @@
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Time.h"
+
+using facebook::velox::util::biasEncode;
+using facebook::velox::util::pack;
 
 namespace facebook::velox {
 namespace {
@@ -32,41 +36,41 @@ TEST_F(TimeWithTimezoneCastTest, toVarchar) {
           pack(
               6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
                   123,
-              TimeWithTimezoneType::biasEncode(0)),
+              biasEncode(0)),
           // Same time with negative offset (EST).
           pack(
               6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
                   123,
-              TimeWithTimezoneType::biasEncode(-5 * 60)),
+              biasEncode(-5 * 60)),
           // Same time with positive offset including half-hour (IST).
           pack(
               6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
                   123,
-              TimeWithTimezoneType::biasEncode(5 * 60 + 30)),
+              biasEncode(5 * 60 + 30)),
           // Boundary: Midnight.
-          pack(0, TimeWithTimezoneType::biasEncode(0)),
+          pack(0, biasEncode(0)),
           // Boundary: Almost end of day.
           pack(
               23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
                   999,
-              TimeWithTimezoneType::biasEncode(0)),
+              biasEncode(0)),
           // Null value.
           std::nullopt,
           // Boundary: Maximum positive timezone offset (+14:00).
-          pack(12 * kMillisInHour, TimeWithTimezoneType::biasEncode(14 * 60)),
+          pack(12 * kMillisInHour, biasEncode(14 * 60)),
           // Boundary: Maximum negative timezone offset (-14:00).
-          pack(12 * kMillisInHour, TimeWithTimezoneType::biasEncode(-14 * 60)),
+          pack(12 * kMillisInHour, biasEncode(-14 * 60)),
           // Edge case: 1 millisecond after midnight.
-          pack(1, TimeWithTimezoneType::biasEncode(0)),
+          pack(1, biasEncode(0)),
           // Various time components with negative offset including minutes.
           pack(
               12 * kMillisInHour + 34 * kMillisInMinute + 56 * kMillisInSecond +
                   789,
-              TimeWithTimezoneType::biasEncode(-4 * 60 - 30)),
+              biasEncode(-4 * 60 - 30)),
           // Time with no milliseconds component.
           pack(
               9 * kMillisInHour + 8 * kMillisInMinute + 7 * kMillisInSecond,
-              TimeWithTimezoneType::biasEncode(5 * 60 + 45)),
+              biasEncode(5 * 60 + 45)),
           // Another null value.
           std::nullopt,
       },
@@ -90,5 +94,208 @@ TEST_F(TimeWithTimezoneCastTest, toVarchar) {
   testCast(input, expected);
 }
 
+TEST_F(TimeWithTimezoneCastTest, fromVarchar) {
+  // Test casting VARCHAR to TIME WITH TIME ZONE with various formats.
+  auto input = makeNullableFlatVector<std::string>({
+      // Basic format: H:m:s.SSS+HH:mm
+      "6:11:37.123+00:00",
+      "6:11:37.123-05:00",
+      "6:11:37.123+05:30",
+      // Format without milliseconds: H:m:s+HH:mm
+      "12:34:56+01:00",
+      "12:34:56-08:00",
+      // Compact format: H:m+HH:mm
+      "1:30+05:30",
+      "23:45-07:00",
+      // Format with space before timezone: H:m:s.SSS +HH:mm
+      "14:22:11.456 +02:00",
+      "9:15:30.789 -04:30",
+      // Compact timezone format (no colon): H:m:s+HHmm
+      "3:4:5+0709",
+      "15:45:30-0800",
+      // Short timezone format: H:m:s+HH
+      "8:30:00+05",
+      "16:45:30-08",
+      // Boundary: Midnight with UTC
+      "0:0:0.000+00:00",
+      // Boundary: Almost end of day
+      "23:59:59.999+00:00",
+      // Boundary: Maximum positive timezone offset (+14:00)
+      "12:00:00.000+14:00",
+      // Boundary: Maximum negative timezone offset (-14:00)
+      "12:00:00.000-14:00",
+      // Edge case: 1 millisecond after midnight
+      "0:0:0.001+00:00",
+      // Various valid formats with different hour/minute combinations
+      "9:8:7.000+05:45",
+      "1:2:3+01:30",
+      // Null value
+      std::nullopt,
+      // Compact format with space: H:m +HH
+      "7:30 +03",
+      "18:45 -06",
+      // Double-digit hours and minutes: HH:mm:ss.SSS+HH:mm
+      "06:11:37.123+00:00",
+      "12:34:56.789-04:30",
+  });
+
+  auto expected = makeNullableFlatVector<int64_t>(
+      {
+          // 6:11:37.123+00:00
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              biasEncode(0)),
+          // 6:11:37.123-05:00
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              biasEncode(-5 * 60)),
+          // 6:11:37.123+05:30
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              biasEncode(5 * 60 + 30)),
+          // 12:34:56+01:00
+          pack(
+              12 * kMillisInHour + 34 * kMillisInMinute + 56 * kMillisInSecond,
+              biasEncode(1 * 60)),
+          // 12:34:56-08:00
+          pack(
+              12 * kMillisInHour + 34 * kMillisInMinute + 56 * kMillisInSecond,
+              biasEncode(-8 * 60)),
+          // 1:30+05:30
+          pack(
+              1 * kMillisInHour + 30 * kMillisInMinute,
+              biasEncode(5 * 60 + 30)),
+          // 23:45-07:00
+          pack(23 * kMillisInHour + 45 * kMillisInMinute, biasEncode(-7 * 60)),
+          // 14:22:11.456 +02:00
+          pack(
+              14 * kMillisInHour + 22 * kMillisInMinute + 11 * kMillisInSecond +
+                  456,
+              biasEncode(2 * 60)),
+          // 9:15:30.789 -04:30
+          pack(
+              9 * kMillisInHour + 15 * kMillisInMinute + 30 * kMillisInSecond +
+                  789,
+              biasEncode(-4 * 60 - 30)),
+          // 3:4:5+0709
+          pack(
+              3 * kMillisInHour + 4 * kMillisInMinute + 5 * kMillisInSecond,
+              biasEncode(7 * 60 + 9)),
+          // 15:45:30-0800
+          pack(
+              15 * kMillisInHour + 45 * kMillisInMinute + 30 * kMillisInSecond,
+              biasEncode(-8 * 60)),
+          // 8:30:00+05
+          pack(8 * kMillisInHour + 30 * kMillisInMinute, biasEncode(5 * 60)),
+          // 16:45:30-08
+          pack(
+              16 * kMillisInHour + 45 * kMillisInMinute + 30 * kMillisInSecond,
+              biasEncode(-8 * 60)),
+          // 0:0:0.000+00:00
+          pack(0, biasEncode(0)),
+          // 23:59:59.999+00:00
+          pack(
+              23 * kMillisInHour + 59 * kMillisInMinute + 59 * kMillisInSecond +
+                  999,
+              biasEncode(0)),
+          // 12:00:00.000+14:00
+          pack(12 * kMillisInHour, biasEncode(14 * 60)),
+          // 12:00:00.000-14:00
+          pack(12 * kMillisInHour, biasEncode(-14 * 60)),
+          // 0:0:0.001+00:00
+          pack(1, biasEncode(0)),
+          // 9:8:7.000+05:45
+          pack(
+              9 * kMillisInHour + 8 * kMillisInMinute + 7 * kMillisInSecond,
+              biasEncode(5 * 60 + 45)),
+          // 1:2:3+01:30
+          pack(
+              1 * kMillisInHour + 2 * kMillisInMinute + 3 * kMillisInSecond,
+              biasEncode(1 * 60 + 30)),
+          // Null value
+          std::nullopt,
+          // 7:30 +03
+          pack(7 * kMillisInHour + 30 * kMillisInMinute, biasEncode(3 * 60)),
+          // 18:45 -06
+          pack(18 * kMillisInHour + 45 * kMillisInMinute, biasEncode(-6 * 60)),
+          // 06:11:37.123+00:00
+          pack(
+              6 * kMillisInHour + 11 * kMillisInMinute + 37 * kMillisInSecond +
+                  123,
+              biasEncode(0)),
+          // 12:34:56.789-04:30
+          pack(
+              12 * kMillisInHour + 34 * kMillisInMinute + 56 * kMillisInSecond +
+                  789,
+              biasEncode(-4 * 60 - 30)),
+      },
+      TIME_WITH_TIME_ZONE());
+
+  testCast(input, expected);
+}
+
+TEST_F(TimeWithTimezoneCastTest, fromVarcharInvalid) {
+  // Test invalid VARCHAR inputs that should throw errors.
+  auto testInvalidCast = [&](const std::string& input,
+                             const std::string& expectedError) {
+    VELOX_ASSERT_THROW(
+        evaluateCast(
+            VARCHAR(),
+            TIME_WITH_TIME_ZONE(),
+            makeRowVector({makeFlatVector<std::string>({input})})),
+        expectedError);
+  };
+
+  // Invalid: Missing timezone offset
+  testInvalidCast("12:34:56", "missing timezone offset");
+
+  // Invalid: Hour out of range (25 > 23)
+  testInvalidCast("25:00:00+00:00", "Invalid hour value");
+
+  // Invalid: Minute out of range (60 >= 60)
+  testInvalidCast("12:60:00+00:00", "Invalid minute value");
+
+  // Invalid: Second out of range (60 >= 60)
+  testInvalidCast("12:34:60+00:00", "Invalid second value");
+
+  // Invalid: Microsecond precision not supported (4 digits after decimal)
+  testInvalidCast("12:34:56.1234+00:00", "Microsecond precision not supported");
+
+  // Invalid: Timezone offset out of range (+15:00 > +14:00)
+  testInvalidCast("12:00:00+15:00", "out of range");
+
+  // Invalid: Timezone offset out of range (-15:00 < -14:00)
+  testInvalidCast("12:00:00-15:00", "out of range");
+
+  // Invalid: Missing time component
+  testInvalidCast("+05:00", "missing time component");
+
+  // Invalid: Empty string
+  testInvalidCast("", "empty string");
+
+  // Invalid: Malformed format (missing colon in time)
+  testInvalidCast("1234+00:00", "expected ':' after hour");
+
+  // Invalid: Trailing characters after timezone
+  testInvalidCast("12:34:56+00:00extra", "unexpected trailing characters");
+
+  // Invalid: Number of digits in timezone offset hours is not 2
+  testInvalidCast("12:34:56+1:00", "digits before ':' not equal to 2");
+
+  // Invalid: Number of digits in timezone offset hours is not 2
+  testInvalidCast("12:34:56+01:", "failed to parse minutes after ':'");
+
+  // Invalid: IANA/Named timezones not supported (e.g., America/Los_Angeles)
+  testInvalidCast("12:34:56 America/Los_Angeles", "missing timezone offset");
+
+  // Invalid: IANA/Named timezones not supported (e.g., UTC)
+  testInvalidCast("14:30:45 UTC", "missing timezone offset");
+
+  // Invalid: IANA/Named timezones not supported (e.g., Asia/Tokyo)
+  testInvalidCast("09:15:30.123 Asia/Tokyo", "missing timezone offset");
+}
 } // namespace
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimeWithTimezoneType.h
+++ b/velox/functions/prestosql/types/TimeWithTimezoneType.h
@@ -29,8 +29,6 @@ class TimeWithTimezoneType final : public BigintType {
   TimeWithTimezoneType() = default;
 
  public:
-  static constexpr int16_t kTimeZoneBias = 840;
-  static constexpr int16_t kMinutesInHour = 60;
   static constexpr int16_t kTimeWithTimezoneToVarcharRowSize = 18;
 
   static std::shared_ptr<const TimeWithTimezoneType> get() {
@@ -67,21 +65,6 @@ class TimeWithTimezoneType final : public BigintType {
 
   bool isComparable() const override {
     return true;
-  }
-
-  /// Encodes the timezone offset in the upper bits of the bigint.
-  /// The timezone offset is encoded as an integer in the range [-840, 840]
-  /// representing the number of minutes from UTC. The bias is added to the
-  /// timezone offset to ensure that the timezone offset is positive.
-  /// Typically called before a call to pack which will encode the timezone
-  /// offset along with the time value.
-  static inline int16_t biasEncode(int16_t timeZoneOffsetMinutes) {
-    VELOX_CHECK(
-        -kTimeZoneBias <= timeZoneOffsetMinutes &&
-            timeZoneOffsetMinutes <= kTimeZoneBias,
-        "Timezone offset must be between -840 and 840 minutes. Got: ",
-        timeZoneOffsetMinutes);
-    return timeZoneOffsetMinutes + kTimeZoneBias;
   }
 };
 

--- a/velox/functions/prestosql/types/tests/TimeWithTimezoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimeWithTimezoneTypeTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/TimeWithTimezoneRegistration.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/tests/TypeTestBase.h"
+#include "velox/type/Time.h"
 
 namespace facebook::velox::test {
 
@@ -79,91 +80,91 @@ TEST_F(TimeWithTimezoneTypeTest, valueToString) {
   // Test basic time values - these should work based on the implementation
   // Test midnight (00:00:00.000)
   int64_t timeValue = 0;
-  int16_t timeZone = TimeWithTimezoneType::biasEncode(0); // UTC
-  auto value = pack(timeValue, timeZone);
+  int16_t timeZone = util::biasEncode(0); // UTC
+  auto value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "00:00:00.000+00:00");
 
   // Test 1 hour (01:00:00.000) at UTC
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  value = pack(3600000, timeZone);
+  value = util::pack(3600000, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "01:00:00.000+00:00");
 
   // Test 12:30:45.123 at UTC
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
   timeValue = 12 * 3600000 + 30 * 60000 + 45 * 1000 + 123;
-  value = pack(timeValue, timeZone);
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+00:00");
 
   // Test 12:30:45.123 at PST
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(-480); // PST
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(-480); // PST
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123-08:00");
 
   // Test 12:30:45.123 at EST
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(-300); // EST
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(-300); // EST
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123-05:00");
 
   // Test 12:30:45.123 at GMT
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(0); // GMT
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(0); // GMT
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+00:00");
 
   // Test 12:30:45.123 at BST
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(60); // BST
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(60); // BST
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+01:00");
 
   // Test 12:30:45.123 at JST
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(540); // JST
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(540); // JST
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+09:00");
 
   // Test 12:30:45.123 at AEST
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(600); // AEST
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(600); // AEST
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+10:00");
 
   // Test 12:30:45.123 at AEDT
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(660); // AEDT
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(660); // AEDT
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+11:00");
 
   // Test 12:30:45.123 at NZST
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(780); // NZST
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(780); // NZST
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+13:00");
 
   // Test 12:30:45.123 at NZDT
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(840); // NZDT
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(840); // NZDT
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123+14:00");
 
   // Test 12:30:45.123 at UTC-14:00
   std::memset(
       buffer, 0, TimeWithTimezoneType::kTimeWithTimezoneToVarcharRowSize);
-  timeZone = TimeWithTimezoneType::biasEncode(-840); // UTC-14:00
-  value = pack(timeValue, timeZone);
+  timeZone = util::biasEncode(-840); // UTC-14:00
+  value = util::pack(timeValue, timeZone);
   ASSERT_EQ(type->valueToString(value, buffer), "12:30:45.123-14:00");
 }
 

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -29,6 +29,7 @@ velox_add_library(
   StringView.cpp
   StringView.h
   Subfield.cpp
+  Time.cpp
   Timestamp.cpp
   TimestampConversion.cpp
   Tokenizer.cpp

--- a/velox/type/Time.cpp
+++ b/velox/type/Time.cpp
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/Time.h"
+#include <charconv>
+#include "velox/type/TimestampConversion.h"
+
+namespace facebook::velox::util {
+
+namespace {
+
+// Helper: Parse a number from the given position using std::from_chars
+bool parseNumber(const char* data, size_t size, size_t& pos, int32_t& result) {
+  if (pos >= size) {
+    return false;
+  }
+
+  const char* start = data + pos;
+  const char* end = data + size;
+
+  auto parseResult = std::from_chars(start, end, result);
+  if (parseResult.ec != std::errc{}) {
+    return false;
+  }
+
+  // Update position
+  pos += (parseResult.ptr - start);
+  return true;
+}
+
+// Helper: Parse fractional seconds (milliseconds)
+Expected<int32_t>
+parseFractionalSeconds(const char* data, size_t size, size_t& pos) {
+  if (pos >= size || data[pos] != '.') {
+    return 0; // No fractional part
+  }
+
+  pos++; // Skip the '.'
+
+  if (pos >= size) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid time format: fractional seconds incomplete"));
+  }
+
+  // Parse fractional seconds (milliseconds)
+  int32_t fractionalPart = 0;
+
+  const char* start = data + pos;
+  const char* end = data + size;
+
+  auto parseResult = std::from_chars(start, end, fractionalPart);
+  if (parseResult.ec != std::errc{}) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid time format: failed to parse fractional seconds"));
+  }
+
+  size_t digitCount = parseResult.ptr - start;
+  pos += digitCount;
+
+  // Check that we don't have more than 3 digits (millisecond precision)
+  if (digitCount > 3) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid time format: Microsecond precision not supported"));
+  }
+
+  // Convert to milliseconds by padding with zeros if needed
+  // e.g., .1 -> 100ms, .12 -> 120ms, .123 -> 123ms
+  for (size_t i = digitCount; i < 3; i++) {
+    fractionalPart *= 10;
+  }
+
+  return fractionalPart;
+}
+
+// Helper: Validate time components
+Status validateTimeComponents(const TimeComponents& components) {
+  if (components.hour < 0 || components.hour >= kHoursPerDay) {
+    return Status::UserError("Invalid hour value: {}", components.hour);
+  }
+  if (components.minute < 0 || components.minute >= kMinsPerHour) {
+    return Status::UserError("Invalid minute value: {}", components.minute);
+  }
+  if (components.second < 0 || components.second >= kSecsPerMinute) {
+    return Status::UserError("Invalid second value: {}", components.second);
+  }
+  if (components.millis < 0 || components.millis >= kMsecsPerSec) {
+    return Status::UserError(
+        "Invalid millisecond value: {}", components.millis);
+  }
+  return Status::OK();
+}
+
+// Helper: Convert time components to milliseconds since midnight
+Expected<int64_t> timeComponentsToMillis(const TimeComponents& components) {
+  int64_t result = static_cast<int64_t>(components.hour) * kMillisInHour +
+      static_cast<int64_t>(components.minute) * kMillisInMinute +
+      static_cast<int64_t>(components.second) * kMillisInSecond +
+      static_cast<int64_t>(components.millis);
+
+  // Validate time range (0 to 86399999 ms in a day)
+  if (result < 0 || result >= kMillisInDay) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Time value {} is out of range [0, {})", result, kMillisInDay));
+  }
+
+  return result;
+}
+
+// Helper: Parse time components from string (H:m[:s[.SSS]])
+Expected<TimeComponents> parseTimeComponents(const char* buf, size_t len) {
+  TimeComponents components;
+  size_t pos = 0;
+
+  // Parse hour (required, 1-2 digits)
+  if (!parseNumber(buf, len, pos, components.hour)) {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid time format: failed to parse hour"));
+  }
+
+  // Skip first ':'
+  if (pos >= len || buf[pos] != ':') {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid time format: expected ':' after hour"));
+  }
+  pos++;
+
+  // Parse minute (required, 1-2 digits)
+  if (!parseNumber(buf, len, pos, components.minute)) {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid time format: failed to parse minute"));
+  }
+
+  // Check if there's a second ':' for seconds (OPTIONAL)
+  if (pos < len && buf[pos] == ':') {
+    pos++; // Skip the ':'
+
+    // Parse second (optional, 1-2 digits)
+    if (!parseNumber(buf, len, pos, components.second)) {
+      return folly::makeUnexpected(
+          Status::UserError("Invalid time format: failed to parse second"));
+    }
+
+    // Parse optional fractional seconds
+    auto millisResult = parseFractionalSeconds(buf, len, pos);
+    if (millisResult.hasError()) {
+      return folly::makeUnexpected(millisResult.error());
+    }
+    components.millis = millisResult.value();
+  }
+  // If no second ':', seconds and millis remain at 0 (default)
+
+  // Check for trailing characters
+  if (pos < len) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid time format: unexpected trailing characters at position {}",
+            pos));
+  }
+
+  return components;
+}
+
+} // namespace
+
+Expected<int64_t> fromTimeString(const char* buf, size_t len) {
+  auto componentsResult = parseTimeComponents(buf, len);
+  if (componentsResult.hasError()) {
+    return folly::makeUnexpected(componentsResult.error());
+  }
+
+  auto components = componentsResult.value();
+
+  // Validate all components
+  auto validationStatus = validateTimeComponents(components);
+  if (!validationStatus.ok()) {
+    return folly::makeUnexpected(validationStatus);
+  }
+
+  // Convert to milliseconds since midnight
+  return timeComponentsToMillis(components);
+}
+
+Expected<int16_t> parseTimezoneOffset(const char* buf, size_t len) {
+  if (len < 2) {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid timezone offset: too short"));
+  }
+
+  char sign = buf[0];
+  if (sign != '+' && sign != '-') {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid timezone offset: must start with + or -"));
+  }
+
+  int signMultiplier = (sign == '+') ? 1 : -1;
+
+  // Start parsing after the sign
+  size_t pos = 1;
+  const size_t startPos = pos;
+
+  // Parse offset hours/minutes
+  // Supports three formats:
+  // 1. +HH:mm (e.g., +07:09) - colon separates hours and minutes
+  // 2. +HHmm (e.g., +0709) - exactly 4 digits, no colon
+  // 3. +HH (e.g., +07) - exactly 2 digits, no colon
+
+  int32_t offsetHours = 0;
+  int32_t offsetMinutes = 0;
+
+  // Try to parse as many digits as we can for hours
+  if (!parseNumber(buf, len, pos, offsetHours)) {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid timezone offset: failed to parse hours"));
+  }
+
+  size_t digitsRead = pos - startPos;
+
+  // Check what comes next
+  if (pos < len && buf[pos] == ':') {
+    // Format: +HH:mm
+    // Hours should be 2 digits only when followed by colon
+    if (digitsRead != 2) {
+      return folly::makeUnexpected(
+          Status::UserError(
+              "Invalid timezone offset format: digits before ':' not equal to 2"));
+    }
+    pos++; // Skip ':'
+    if (!parseNumber(buf, len, pos, offsetMinutes)) {
+      return folly::makeUnexpected(
+          Status::UserError(
+              "Invalid timezone offset: failed to parse minutes after ':'"));
+    }
+  } else if (digitsRead == 4) {
+    // Format: +HHmm (e.g., +0709)
+    // Extract last 2 digits as minutes
+    offsetMinutes = offsetHours % 100;
+    offsetHours = offsetHours / 100;
+  } else if (digitsRead != 2) {
+    // Valid : 2
+    //    Format: +HH (e.g., +07)
+    //    Minutes remain 0
+    // Invalid: 1, 3, or 5+ digits without colon
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid timezone offset format: expected +HH:mm, +HHmm, or +HH"));
+  }
+
+  // Check for trailing characters
+  if (pos < len) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid timezone offset: unexpected trailing characters at position {}",
+            pos));
+  }
+
+  // Calculate total offset in minutes
+  auto totalOffsetMinutes =
+      (signMultiplier * (offsetHours * 60 + offsetMinutes));
+
+  // Validate timezone offset range (-840 to 840 minutes, i.e., -14:00 to
+  // +14:00)
+  if (totalOffsetMinutes < -kTimeZoneBias ||
+      totalOffsetMinutes > kTimeZoneBias) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Timezone offset {} minutes is out of range [-840, 840]",
+            totalOffsetMinutes));
+  }
+
+  return static_cast<int16_t>(totalOffsetMinutes);
+}
+
+Expected<int64_t> fromTimeWithTimezoneString(const char* buf, size_t len) {
+  if (len == 0) {
+    return folly::makeUnexpected(
+        Status::UserError("Invalid time with timezone: empty string"));
+  }
+
+  // Find timezone offset marker (+ or -)
+  // Search from right to left for better performance
+  std::string_view sv(buf, len);
+  auto tzPos = sv.find_last_of("+-");
+  int tzStartPos =
+      (tzPos != std::string_view::npos) ? static_cast<int>(tzPos) : -1;
+
+  if (tzStartPos == -1) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid time with timezone: missing timezone offset"));
+  }
+
+  // Extract time component (before timezone, trimming optional space)
+  int timeEndPos = tzStartPos;
+  if (timeEndPos > 0 && buf[timeEndPos - 1] == ' ') {
+    timeEndPos--; // Remove space before timezone
+  }
+
+  if (timeEndPos == 0) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "Invalid time with timezone: missing time component"));
+  }
+
+  // Parse time component
+  auto timeResult = fromTimeString(buf, timeEndPos);
+  if (timeResult.hasError()) {
+    return folly::makeUnexpected(timeResult.error());
+  }
+
+  int64_t millisUtc = timeResult.value();
+
+  // Parse timezone offset
+  auto tzOffsetResult = parseTimezoneOffset(buf + tzStartPos, len - tzStartPos);
+  if (tzOffsetResult.hasError()) {
+    return folly::makeUnexpected(tzOffsetResult.error());
+  }
+
+  int16_t offsetMinutes = tzOffsetResult.value();
+
+  // Encode timezone offset and pack with time
+  int16_t encodedTimezone = biasEncode(offsetMinutes);
+  return pack(millisUtc, encodedTimezone);
+}
+
+} // namespace facebook::velox::util

--- a/velox/type/Time.h
+++ b/velox/type/Time.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "velox/common/base/Status.h"
+#include "velox/type/StringView.h"
+
+namespace facebook::velox::util {
+
+// Constants for time calculations (aligned with TimestampConversion.h)
+constexpr const int64_t kMillisInSecond = 1000;
+constexpr const int64_t kMillisInMinute = 60 * kMillisInSecond;
+constexpr const int64_t kMillisInHour = 60 * kMillisInMinute;
+constexpr const int64_t kMillisInDay = 24 * kMillisInHour;
+
+/// Represents parsed time components
+struct TimeComponents {
+  int32_t hour = 0;
+  int32_t minute = 0;
+  int32_t second = 0;
+  int32_t millis = 0;
+};
+
+/// Parse a TIME string (H:m[:s[.SSS]] format)
+/// Supports formats:
+/// - "H:m" -> "1:30"
+/// - "H:m:s" -> "1:30:45"
+/// - "H:m:s.SSS" -> "1:30:45.123"
+///
+/// Returns milliseconds since midnight (0 to 86399999)
+/// Returns Unexpected with UserError status if parsing fails
+Expected<int64_t> fromTimeString(const char* buf, size_t len);
+
+inline Expected<int64_t> fromTimeString(const StringView& str) {
+  return fromTimeString(str.data(), str.size());
+}
+
+// Constants for TIME WITH TIME ZONE encoding
+constexpr int32_t kMillisShift = 12;
+constexpr int32_t kTimezoneMask = (1 << kMillisShift) - 1;
+constexpr int16_t kTimeZoneBias = 840;
+constexpr int16_t kMinutesInHour = 60;
+
+/// Unpacks the milliseconds since midnight from a packed TIME WITH TIME ZONE
+/// value
+inline int64_t unpackMillisUtc(int64_t timeWithTimeZone) {
+  return timeWithTimeZone >> kMillisShift;
+}
+
+/// Unpacks the timezone offset from a packed TIME WITH TIME ZONE value
+inline int16_t unpackZoneKeyId(int64_t timeWithTimeZone) {
+  return timeWithTimeZone & kTimezoneMask;
+}
+
+/// Packs milliseconds since midnight and timezone offset into a 64-bit value
+/// The packed value stores time in the upper bits and timezone in the lower 12
+/// bits
+inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
+  return (millisUtc << kMillisShift) | (timeZoneKey & kTimezoneMask);
+}
+
+/// Encodes timezone offset using bias encoding to ensure positive values
+/// Converts timezone offset from range [-840, 840] to [0, 1680]
+inline int16_t biasEncode(int16_t timeZoneOffsetMinutes) {
+  VELOX_CHECK(
+      -kTimeZoneBias <= timeZoneOffsetMinutes &&
+          timeZoneOffsetMinutes <= kTimeZoneBias,
+      "Timezone offset must be between -840 and 840 minutes. Got: {}",
+      timeZoneOffsetMinutes);
+  return timeZoneOffsetMinutes + kTimeZoneBias;
+}
+
+/// Parse a TIME WITH TIME ZONE string and return packed 64-bit value
+/// Supports formats (with optional space before timezone):
+/// - "H:m+HH:mm" or "H:m +HH:mm" -> "1:30+05:30" or "1:30 +05:30"
+/// - "H:m:s+HH:mm" or "H:m:s +HH:mm" -> "1:30:45+05:30"
+/// - "H:m:s.SSS+HH:mm" -> "1:30:45.123+05:30"
+/// - "H:m+HHmm" -> "1:30+0530"
+/// - "H:m+HH" or "H:m +HH" -> "1:30+05" or "1:30 +05"
+/// - "H:m:s+HH" -> "1:30:45+05"
+/// - "H:m:s.SSS+HH" -> "1:30:45.123+05"
+///
+/// Returns a packed 64-bit value where the upper bits contain milliseconds
+/// since midnight and the lower 12 bits contain the bias-encoded timezone
+/// offset.
+///
+/// Returns Unexpected with UserError status if parsing fails
+Expected<int64_t> fromTimeWithTimezoneString(const char* buf, size_t len);
+
+inline Expected<int64_t> fromTimeWithTimezoneString(const StringView& str) {
+  return fromTimeWithTimezoneString(str.data(), str.size());
+}
+
+/// Parse timezone offset from string
+/// Supports formats:
+/// - "+HH:mm" or "-HH:mm" -> "+05:30", "-08:00"
+/// - "+HHmm" or "-HHmm" -> "+0530", "-0800"
+/// - "+HH" or "-HH" -> "+05", "-08"
+///
+/// Returns timezone offset in minutes (-840 to 840)
+/// Returns Unexpected with UserError status if parsing fails
+Expected<int16_t> parseTimezoneOffset(const char* buf, size_t len);
+
+inline Expected<int16_t> parseTimezoneOffset(const StringView& str) {
+  return parseTimezoneOffset(str.data(), str.size());
+}
+
+} // namespace facebook::velox::util


### PR DESCRIPTION
Summary:
This diff adds support for casting from `varchar` to `time with timezone`. Also moved common logic for `varchar` to `time` to a common util.

Varchar formats supported for TIME WITH TIMEZONE include:

*   `H:m:s.SSS+HH:mm`, `H:m:s+HH:mm`, `H:m+HH:mm` (with colon-separated timezone)
*   `H:m:s.SSS+HHmm`, `H:m:s+HHmm`, `H:m+HHmm` (compact timezone format)
*   `H:m:s.SSS+HH`, `H:m:s+HH`, `H:m+HH` (hours-only timezone)
*   All formats support optional space before timezone (e.g., `14:30 +05:30`)


Also fixes Issue [#15256](https://github.com/facebookincubator/velox/issues/15256) as part of this to ensure that seconds becomes optional in parsing of time from varchar

Differential Revision: D85396888


