### PR TITLE
build: Fix CI builds

### DIFF
--- a/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/exec/ExpressionEvaluator.cpp
@@ -1465,9 +1465,7 @@ std::reference_wrapper<const cudf::ast::expression> buildBigintRangeExpr(
       return tree.push(Operation{Op::EQUAL, columnRef, columnRef});
     }
   } else {
-    VELOX_FAIL(
-        "Unsupported type for buildBigintRangeExpr: {}",
-        mapTypeKindToName(Kind));
+    VELOX_FAIL("Unsupported type for buildBigintRangeExpr: {}", Kind);
   }
 }
 
@@ -1592,9 +1590,7 @@ std::reference_wrapper<const cudf::ast::expression> buildIntegerInListExpr(
     }
     return std::ref(*result);
   } else {
-    VELOX_FAIL(
-        "Unsupported type for buildIntegerInListExpr: {}",
-        mapTypeKindToName(Kind));
+    VELOX_FAIL("Unsupported type for buildIntegerInListExpr: {}", Kind);
   }
 }
 

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -649,8 +649,7 @@ TEST_P(IntInListParamTest, InListParam) {
     }
   }
   EXPECT_EQ(scalars.size(), expectedScalars)
-      << "Scalar count mismatch for IN list with kind "
-      << mapTypeKindToName(p.kind);
+      << "Scalar count mismatch for IN list with kind " << p.kind;
 
   auto vec = makeTestVector(rowType, 100);
   testFilterExecution(rowType, columnName, *filter, vec, expr);


### PR DESCRIPTION
Summary:
Fixing CI builds broken by conflict when landing removal of
mapTypeKindToName() in https://github.com/facebookincubator/velox/pull/14337

Differential Revision: D85406615


