### PR TITLE
misc: Revert std::move in Driver getOutput

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -444,10 +444,8 @@ inline void addInput(Operator* op, const RowVectorPtr& input) {
 }
 
 inline void getOutput(Operator* op, RowVectorPtr& result) {
-  auto output = op->getOutput();
-  if (FOLLY_LIKELY(!op->shouldDropOutput())) {
-    result = std::move(output); // Use move semantics to avoid ref counting
-  } else {
+  result = op->getOutput();
+  if (FOLLY_UNLIKELY(op->shouldDropOutput())) {
     result = nullptr;
   }
 }


### PR DESCRIPTION
Revert no-op change based on https://github.com/facebookincubator/velox/pull/15089#discussion_r2418317391 as it does not lead to any performance improvement


Differential Revision: D85445121


