### PR TITLE
build(gcc): Bypass `stringop-overflow` GCC false positive

### DIFF
--- a/velox/common/time/CpuWallTimer.h
+++ b/velox/common/time/CpuWallTimer.h
@@ -18,6 +18,7 @@
 #include <fmt/format.h>
 #include <chrono>
 
+#include "velox/common/base/Macros.h"
 #include "velox/common/base/SuccinctPrinter.h"
 #include "velox/common/process/ProcessBase.h"
 
@@ -32,7 +33,10 @@ struct CpuWallTiming {
   auto operator<=>(const CpuWallTiming&) const = default;
 
   void add(const CpuWallTiming& other) {
+    // Suppress spurious warnings in GCC 13.
+    VELOX_SUPPRESS_STRINGOP_OVERFLOW_WARNING
     count += other.count;
+    VELOX_UNSUPPRESS_STRINGOP_OVERFLOW_WARNING
     cpuNanos += other.cpuNanos;
     wallNanos += other.wallNanos;
   }


### PR DESCRIPTION
Using Velox macros that bypass GCC stringop-overflow warning, which is known to be buggy in older gcc versions (<13).