### PR TITLE
refactor: Make wrapper for protobuf Arena allocation method

### DIFF
--- a/velox/dwio/common/Arena.h
+++ b/velox/dwio/common/Arena.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <google/protobuf/arena.h>
+
+namespace facebook::velox::dwio::common {
+
+/// Wrapper over protobuf's arena allocation.  The API changes from
+/// CreateMessage() to Create() in newer protobuf versions.
+template <class T, class... Args>
+T* ArenaCreate(google::protobuf::Arena* arena, Args&&... args) {
+#if PROTOBUF_VERSION >= 5030000
+  return google::protobuf::Arena::Create<T>(arena, std::forward<Args>(args)...);
+#else
+  return google::protobuf::Arena::CreateMessage<T>(
+      arena, std::forward<Args>(args)...);
+#endif
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -19,12 +19,14 @@
 #include <fmt/format.h>
 
 #include "velox/common/process/TraceContext.h"
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/functions/lib/string/StringImpl.h"
 
 namespace facebook::velox::dwrf {
 
+using dwio::common::ArenaCreate;
 using dwio::common::ColumnStatistics;
 using dwio::common::FileFormat;
 using dwio::common::LogType;
@@ -96,7 +98,7 @@ template <typename T>
 std::unique_ptr<FooterWrapper> parseFooter(
     dwio::common::SeekableInputStream* input,
     google::protobuf::Arena* arena) {
-  auto* impl = google::protobuf::Arena::CreateMessage<T>(arena);
+  auto* impl = ArenaCreate<T>(arena);
   VELOX_CHECK(impl->ParseFromZeroCopyStream(input));
   return std::make_unique<FooterWrapper>(impl);
 }

--- a/velox/dwio/dwrf/reader/StripeReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.cpp
@@ -16,8 +16,11 @@
 
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 
+#include "velox/dwio/common/Arena.h"
+
 namespace facebook::velox::dwrf {
 
+using dwio::common::ArenaCreate;
 using dwio::common::LogType;
 
 // preload is not considered or mutated if stripe has already been fetched. e.g.
@@ -95,9 +98,7 @@ std::unique_ptr<const StripeMetadata> StripeReaderBase::fetchStripe(
   };
 
   if (fileFooter.format() == DwrfFormat::kDwrf) {
-    auto* rawFooter =
-        google::protobuf::Arena::CreateMessage<proto::StripeFooter>(
-            arena.get());
+    auto* rawFooter = ArenaCreate<proto::StripeFooter>(arena.get());
     ProtoUtils::readProtoInto(
         reader_->createDecompressedStream(
             std::move(footerStream), streamDebugInfo),
@@ -110,9 +111,7 @@ std::unique_ptr<const StripeMetadata> StripeReaderBase::fetchStripe(
 
     return createStripeMetadata(std::move(stripeFooter));
   } else {
-    auto* rawFooter =
-        google::protobuf::Arena::CreateMessage<proto::orc::StripeFooter>(
-            arena.get());
+    auto* rawFooter = ArenaCreate<proto::orc::StripeFooter>(arena.get());
     ProtoUtils::readProtoInto(
         reader_->createDecompressedStream(
             std::move(footerStream), streamDebugInfo),

--- a/velox/dwio/dwrf/test/ColumnStatisticsBase.h
+++ b/velox/dwio/dwrf/test/ColumnStatisticsBase.h
@@ -18,10 +18,14 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
 namespace facebook::velox::dwrf {
+
+using dwio::common::ArenaCreate;
+
 class ColumnStatisticsBase {
  public:
   ColumnStatisticsBase()
@@ -752,8 +756,7 @@ class ColumnStatisticsBase {
 
       if (format == DwrfFormat::kDwrf) {
         auto columnStatistics =
-            google::protobuf::Arena::CreateMessage<proto::ColumnStatistics>(
-                arena_.get());
+            ArenaCreate<proto::ColumnStatistics>(arena_.get());
         if (from == State::kFalse) {
           columnStatistics->set_hasnull(false);
         } else if (from == State::kTrue) {
@@ -762,8 +765,8 @@ class ColumnStatisticsBase {
         target.merge(*buildColumnStatisticsFromProto(
             ColumnStatisticsWrapper(columnStatistics), context()));
       } else {
-        auto columnStatistics = google::protobuf::Arena::CreateMessage<
-            proto::orc::ColumnStatistics>(arena_.get());
+        auto columnStatistics =
+            ArenaCreate<proto::orc::ColumnStatistics>(arena_.get());
         if (from == State::kFalse) {
           columnStatistics->set_hasnull(false);
         } else if (from == State::kTrue) {

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -16,7 +16,9 @@
 
 #include <gtest/gtest.h>
 #include <cstring>
+
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/common/exception/Exception.h"
@@ -72,8 +74,7 @@ class EncryptedStatsTest : public Test {
     TestEncrypter encrypter;
     HiveTypeParser parser;
     auto type = parser.parse("struct<a:int,b:struct<a:int,b:int>,c:int,d:int>");
-    auto footer =
-        google::protobuf::Arena::CreateMessage<proto::Footer>(&arena_);
+    auto footer = ArenaCreate<proto::Footer>(&arena_);
     auto footerWrapper = FooterWriteWrapper(footer);
     // add empty stats to the file
     for (size_t i = 0; i < 7; ++i) {

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
@@ -158,7 +159,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 TEST_P(StripeStreamFormatTypeTest, planReads) {
   google::protobuf::Arena arena;
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   auto footerWrapper = FooterWriteWrapper(footer);
   footerWrapper.setRowIndexStride(100);
   auto type = HiveTypeParser().parse("struct<a:int,b:float>");
@@ -248,7 +249,7 @@ TEST_P(StripeStreamFormatTypeTest, planReads) {
 
 TEST_F(StripeStreamTest, filterSequences) {
   google::protobuf::Arena arena;
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   auto footerWrapper = FooterWriteWrapper(footer);
   footerWrapper.setRowIndexStride(100);
   auto type = HiveTypeParser().parse("struct<a:map<int,float>>");
@@ -313,7 +314,7 @@ TEST_F(StripeStreamTest, filterSequences) {
 
 TEST_P(StripeStreamFormatTypeTest, zeroLength) {
   google::protobuf::Arena arena;
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   auto footerWrapper = FooterWriteWrapper(footer);
   footerWrapper.setRowIndexStride(100);
   auto type = HiveTypeParser().parse("struct<a:int>");
@@ -440,7 +441,7 @@ TEST_P(StripeStreamFormatTypeTest, planReadsIndex) {
   index.SerializeToOstream(&buffer);
 
   // build footer
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   auto footerWrapper = FooterWriteWrapper(footer);
   footerWrapper.setRowIndexStride(100);
   footerWrapper.addStripeCacheOffsets(0);
@@ -600,7 +601,7 @@ TEST_F(StripeStreamTest, readEncryptedStreams) {
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
   ps.set_compressionblocksize(256 * 1024);
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   auto footerWrapper = FooterWriteWrapper(footer);
   // a: not encrypted, projected
   // encryption group 1: b, c. projected b.
@@ -694,7 +695,7 @@ TEST_F(StripeStreamTest, schemaMismatch) {
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
   ps.set_compressionblocksize(256 * 1024);
-  auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
+  auto footer = ArenaCreate<proto::Footer>(&arena);
   auto footerWrapper = FooterWriteWrapper(footer);
   // a: not encrypted, has schema change
   // b: encrypted

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunner.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunner.cpp
@@ -26,6 +26,7 @@
 #include "arrow/status.h"
 #include "grpc/grpc.h" // @manual
 #include "velox/common/base/Fs.h"
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
@@ -40,6 +41,9 @@
 using namespace spark::connect;
 
 namespace facebook::velox::functions::sparksql::fuzzer {
+
+using dwio::common::ArenaCreate;
+
 namespace {
 
 void writeToFile(
@@ -178,21 +182,20 @@ SparkQueryRunner::executeAndReturnVector(const core::PlanNodePtr& plan) {
 
 std::vector<RowVectorPtr> SparkQueryRunner::execute(
     const std::string& content) {
-  auto sql = google::protobuf::Arena::CreateMessage<SQL>(&arena_);
+  auto sql = ArenaCreate<SQL>(&arena_);
   sql->set_query(content);
 
-  auto relation = google::protobuf::Arena::CreateMessage<Relation>(&arena_);
+  auto relation = ArenaCreate<Relation>(&arena_);
   relation->set_allocated_sql(sql);
 
-  auto plan = google::protobuf::Arena::CreateMessage<Plan>(&arena_);
+  auto plan = ArenaCreate<Plan>(&arena_);
   plan->set_allocated_root(relation);
 
-  auto context = google::protobuf::Arena::CreateMessage<UserContext>(&arena_);
+  auto context = ArenaCreate<UserContext>(&arena_);
   context->set_user_id(userId_);
   context->set_user_name(userName_);
 
-  auto request =
-      google::protobuf::Arena::CreateMessage<ExecutePlanRequest>(&arena_);
+  auto request = ArenaCreate<ExecutePlanRequest>(&arena_);
   request->set_session_id(sessionId_);
   request->set_allocated_user_context(context);
   request->set_allocated_plan(plan);


### PR DESCRIPTION
Summary:
It's called CreateMessage() in older versions of protobuf and Create() in newer ones.

CreateMessage() was deleted in https://github.com/protocolbuffers/protobuf/commit/d83a5365d16cff4be7da7d9a34eef14b24cc8733

Differential Revision: D85457019


