### PR TITLE
perf(spilling): Support serializing rows to avoid extracting it as vector

### DIFF
--- a/velox/common/base/SpillConfig.cpp
+++ b/velox/common/base/SpillConfig.cpp
@@ -36,7 +36,8 @@ SpillConfig::SpillConfig(
     const std::string& _compressionKind,
     std::optional<PrefixSortConfig> _prefixSortConfig,
     const std::string& _fileCreateConfig,
-    uint32_t _windowMinReadBatchRows)
+    uint32_t _windowMinReadBatchRows,
+    bool _serializeRowContainer)
     : getSpillDirPathCb(std::move(_getSpillDirPathCb)),
       updateAndCheckSpillLimitCb(std::move(_updateAndCheckSpillLimitCb)),
       fileNamePrefix(std::move(_fileNamePrefix)),
@@ -56,7 +57,8 @@ SpillConfig::SpillConfig(
       compressionKind(common::stringToCompressionKind(_compressionKind)),
       prefixSortConfig(_prefixSortConfig),
       fileCreateConfig(_fileCreateConfig),
-      windowMinReadBatchRows(_windowMinReadBatchRows) {
+      windowMinReadBatchRows(_windowMinReadBatchRows),
+      serializeRowContainer(_serializeRowContainer) {
   VELOX_USER_CHECK_GE(
       spillableReservationGrowthPct,
       minSpillableReservationPct,

--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -80,7 +80,8 @@ struct SpillConfig {
       const std::string& _compressionKind,
       std::optional<PrefixSortConfig> _prefixSortConfig = std::nullopt,
       const std::string& _fileCreateConfig = {},
-      uint32_t _windowMinReadBatchRows = 1'000);
+      uint32_t _windowMinReadBatchRows = 1'000,
+      bool serializeRowContainer = false);
 
   /// Returns the spilling level with given 'startBitOffset' and
   /// 'numPartitionBits'.
@@ -168,5 +169,9 @@ struct SpillConfig {
 
   /// The minimum number of rows to read when processing spilled window data.
   uint32_t windowMinReadBatchRows;
+
+  /// Directly serialize rows in RowContainer for spilling, or extract them for
+  /// serialization.
+  bool serializeRowContainer;
 };
 } // namespace facebook::velox::common

--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -15,10 +15,10 @@
  */
 
 #include "velox/exec/ContainerRowSerde.h"
+#include "velox/common/memory/HashStringAllocator.h"
 #include "velox/type/FloatingPointUtil.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
-#include "velox/common/memory/HashStringAllocator.h"
 
 namespace facebook::velox::exec {
 
@@ -266,8 +266,7 @@ void deserializeString(
     serializer::presto::VectorStream* out) {
   auto size = in.read<int32_t>();
   out->appendLength(size);
-  auto& hashStringStream =
-      dynamic_cast<HashStringAllocator::InputStream&>(in);
+  auto& hashStringStream = dynamic_cast<HashStringAllocator::InputStream&>(in);
   // No intermediate copy.
   hashStringStream.readBytes(out->getValueSteam(), size);
 }
@@ -424,8 +423,7 @@ void deserializeOne<TypeKind::ARRAY>(
     ByteInputStream& in,
     serializer::presto::VectorStream* out,
     TypePtr type) {
-  const auto arrayType =
-      std::dynamic_pointer_cast<const ArrayType>(type);
+  const auto arrayType = std::dynamic_pointer_cast<const ArrayType>(type);
   auto elementType = arrayType->elementType();
   auto size = in.read<int32_t>();
   out->appendLength(size);
@@ -465,8 +463,7 @@ void deserializeOne<TypeKind::MAP>(
     ByteInputStream& in,
     serializer::presto::VectorStream* out,
     TypePtr type) {
-  const auto mapType =
-      std::dynamic_pointer_cast<const MapType>(type);
+  const auto mapType = std::dynamic_pointer_cast<const MapType>(type);
   auto keyType = mapType->keyType();
   auto valueType = mapType->valueType();
   auto keySize = in.read<int32_t>();

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -18,6 +18,7 @@
 #include "velox/common/memory/ByteStream.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/DecodedVector.h"
+#include "velox/serializers/VectorStream.h"
 
 namespace facebook::velox::exec {
 
@@ -39,6 +40,11 @@ class ContainerRowSerde {
 
   static void
   deserialize(ByteInputStream& in, vector_size_t index, BaseVector* result);
+
+  static void deserialize(
+      ByteInputStream& in,
+      serializer::presto::VectorStream* out,
+      TypePtr type);
 
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. flags.nullHandlingMode can be only NullAsValue

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -16,9 +16,9 @@
 #pragma once
 
 #include "velox/common/memory/ByteStream.h"
+#include "velox/serializers/VectorStream.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/DecodedVector.h"
-#include "velox/serializers/VectorStream.h"
 
 namespace facebook::velox::exec {
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -146,7 +146,8 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
           ? std::optional<common::PrefixSortConfig>(prefixSortConfig())
           : std::nullopt,
       queryConfig.spillFileCreateConfig(),
-      queryConfig.windowSpillMinReadBatchRows());
+      queryConfig.windowSpillMinReadBatchRows(),
+      true);
 }
 
 std::atomic_uint64_t BlockingState::numBlockedDrivers_{0};

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -347,6 +347,10 @@ class HashBuildSpiller : public SpillerBase {
   void extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr)
       override;
 
+  bool hasProbedFlag() const override {
+    return spillProbeFlag_;
+  }
+
   bool needSort() const override {
     return false;
   }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1230,6 +1230,8 @@ class RowContainer {
         stream->appendNonNull();
         if constexpr (std::is_same_v<T, bool>) {
           stream->appendOne<uint8_t>(valueAt<T>(row, offset) ? 1 : 0);
+        } else if constexpr (std::is_same_v<T, StringView>) {
+          extractString(valueAt<StringView>(row, offset), stream);
         } else {
           stream->appendOne(valueAt<T>(row, offset));
         }
@@ -1253,6 +1255,8 @@ class RowContainer {
         stream->appendNonNull();
         if constexpr (std::is_same_v<T, bool>) {
           stream->appendOne<uint8_t>(valueAt<T>(row, offset) ? 1 : 0);
+        } else if constexpr (std::is_same_v<T, StringView>) {
+          extractString(valueAt<StringView>(row, offset), stream);
         } else {
           stream->appendOne(valueAt<T>(row, offset));
         }
@@ -1521,6 +1525,10 @@ class RowContainer {
       StringView value,
       FlatVector<StringView>* values,
       vector_size_t index);
+
+  static void extractString(
+      StringView value,
+      serializer::presto::VectorStream* stream);
 
   static int32_t compareStringAsc(
       StringView left,

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -185,7 +185,9 @@ uint64_t SpillState::appendToPartition(
 uint64_t SpillState::appendToPartition(
     const SpillPartitionId& id,
     const SpillRows& rows,
-    RowContainer* rowContainer) {
+    RowContainer* rowContainer,
+    const RowVectorPtr& vector,
+    bool hasProbedFlag) {
   VELOX_CHECK(
       isPartitionSpilled(id), "Partition {} is not spilled", id.toString());
 
@@ -201,7 +203,7 @@ uint64_t SpillState::appendToPartition(
   validateSpillBytesSize(bytes);
   updateSpilledInputBytes(bytes);
 
-  return partitionWriter(id)->write(rows, rowContainer);
+  return partitionWriter(id)->write(rows, rowContainer, vector, hasProbedFlag);
 }
 
 SpillWriter* SpillState::partitionWriter(const SpillPartitionId& id) const {

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -148,7 +148,7 @@ void SpillState::initPartitionWriter(const SpillPartitionId& id) {
       lockedWriters.emplace(
           id,
           std::make_unique<SpillWriter>(
-              std::static_pointer_cast<const RowType>(type_),
+              type_,
               sortingKeys_,
               compressionKind_,
               fmt::format(

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -33,6 +33,7 @@
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
+class RowContainer;
 class VectorHasher;
 
 /// A source of sorted spilled RowVectors coming either from a file or memory.
@@ -551,6 +552,7 @@ class SpillState {
   /// target size of a single file.  'pool' owns the memory for state and
   /// results.
   SpillState(
+      RowTypePtr type_,
       const common::GetSpillDirectoryPathCB& getSpillDirectoryPath,
       const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
       const std::string& fileNamePrefix,
@@ -606,6 +608,12 @@ class SpillState {
       const SpillPartitionId& id,
       const RowVectorPtr& rows);
 
+  using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;
+  uint64_t appendToPartition(
+      const SpillPartitionId& id,
+      const SpillRows& rows,
+      RowContainer* container);
+
   /// Finishes a sorted run for partition with 'id'. If write is called for
   /// 'partition' again, the data does not have to be sorted relative to the
   /// data written so far.
@@ -645,6 +653,8 @@ class SpillState {
   void updateSpilledInputBytes(uint64_t bytes);
 
   SpillWriter* partitionWriter(const SpillPartitionId& id) const;
+
+  void initPartitionWriter(const SpillPartitionId& id);
 
   const RowTypePtr type_;
 

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -612,7 +612,9 @@ class SpillState {
   uint64_t appendToPartition(
       const SpillPartitionId& id,
       const SpillRows& rows,
-      RowContainer* container);
+      RowContainer* container,
+      const RowVectorPtr& vector,
+      bool hasProbedFlag);
 
   /// Finishes a sorted run for partition with 'id'. If write is called for
   /// 'partition' again, the data does not have to be sorted relative to the

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -117,6 +117,7 @@ uint64_t SpillWriter::write(const SpillRows& rows, RowContainer* container) {
 
   uint64_t timeNs{0};
   {
+    NanosecondTimer timer(&timeNs);
     if (batch_ == nullptr) {
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
       batch_->createStreamTree(type_, rows.size(), serdeOptions_.get());

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -108,9 +108,7 @@ SpillFiles SpillWriter::finish() {
   return spillFiles;
 }
 
-uint64_t SpillWriter::write(
-    const SpillRows& rows,
-    RowContainer* container) {
+uint64_t SpillWriter::write(const SpillRows& rows, RowContainer* container) {
   if (rows.size() == 0) {
     return 0;
   }
@@ -129,7 +127,8 @@ uint64_t SpillWriter::write(
     batch_->appendNumRows(rows.size());
     const auto& types = container->columnTypes();
     for (auto i = 0; i < types.size(); ++i) {
-      container->extractColumn(rows.data(),rows.size(), i, types[i], batch_->streamAt(i));
+      container->extractColumn(
+          rows.data(), rows.size(), i, types[i], batch_->streamAt(i));
     }
   }
   updateAppendStats(rows.size(), timeNs);

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -119,10 +119,7 @@ uint64_t SpillWriter::write(const SpillRows& rows, RowContainer* container) {
   {
     if (batch_ == nullptr) {
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
-      batch_->createStreamTree(
-          std::static_pointer_cast<const RowType>(type_),
-          1'000,
-          serdeOptions_.get());
+      batch_->createStreamTree(type_, 1'000, serdeOptions_.get());
     }
     batch_->appendNumRows(rows.size());
     const auto& types = container->columnTypes();

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -119,7 +119,7 @@ uint64_t SpillWriter::write(const SpillRows& rows, RowContainer* container) {
   {
     if (batch_ == nullptr) {
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
-      batch_->createStreamTree(type_, 1'000, serdeOptions_.get());
+      batch_->createStreamTree(type_, rows.size(), serdeOptions_.get());
     }
     batch_->appendNumRows(rows.size());
     const auto& types = container->columnTypes();

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -33,6 +33,7 @@
 
 namespace facebook::velox::exec {
 using SpillSortKey = std::pair<column_index_t, CompareFlags>;
+class RowContainer;
 
 /// Records info of a finished spill file which is used for read.
 struct SpillFileInfo {
@@ -79,6 +80,13 @@ class SpillWriter : public serializer::SerializedPageFileWriter {
   ///
   /// NOTE: we don't allow write to a spill writer after finish
   SpillFiles finish();
+
+  using serializer::SerializedPageFileWriter::write;
+
+  using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;
+  uint64_t write(
+      const SpillRows& rows,
+      RowContainer* container);
 
   std::vector<std::string> testingSpilledFilePaths() const;
 

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -84,9 +84,7 @@ class SpillWriter : public serializer::SerializedPageFileWriter {
   using serializer::SerializedPageFileWriter::write;
 
   using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;
-  uint64_t write(
-      const SpillRows& rows,
-      RowContainer* container);
+  uint64_t write(const SpillRows& rows, RowContainer* container);
 
   std::vector<std::string> testingSpilledFilePaths() const;
 

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -84,7 +84,11 @@ class SpillWriter : public serializer::SerializedPageFileWriter {
   using serializer::SerializedPageFileWriter::write;
 
   using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;
-  uint64_t write(const SpillRows& rows, RowContainer* container);
+  uint64_t write(
+      const SpillRows& rows,
+      RowContainer* container,
+      const RowVectorPtr& vector,
+      bool hasProbedFlag);
 
   std::vector<std::string> testingSpilledFilePaths() const;
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -207,17 +207,16 @@ std::unique_ptr<SpillerBase::SpillStatus> SpillerBase::writeSpill(
   constexpr int32_t kTargetBatchRows = 64;
 
   RowVectorPtr spillVector;
-  SpillRows spillRows(*memory::spillMemoryPool());
   auto& run = spillRuns_.at(id);
   try {
     ensureSorted(run);
     size_t written = 0;
     while (written < run.rows.size()) {
       if (serializeRowContainer_) {
+        SpillRows spillRows(*memory::spillMemoryPool());
         extractSpillRows(
             run.rows, kTargetBatchRows, kTargetBatchBytes, spillRows, written);
         state_.appendToPartition(id, spillRows, container_);
-        spillRows.clear();
       } else {
         extractSpillVector(
             run.rows,

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -68,8 +68,8 @@ SpillerBase::SpillerBase(
           spillConfig->fileCreateConfig) {
   TestValue::adjust("facebook::velox::exec::SpillerBase", this);
 
-  serializeRowContainer_ =
-      spillConfig->serializeRowContainer && container_->supportSerializeRows();
+  serializeRowContainer_ = spillConfig->serializeRowContainer &&
+      container_ != nullptr && container_->supportSerializeRows();
 }
 
 void SpillerBase::spill(const RowContainerIterator* startRowIter) {

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -156,6 +156,8 @@ class SpillerBase {
   // that one can start reading these back.
   bool finalized_{false};
 
+  bool serializeRowContainer_{false};
+
   SpillState state_;
 
   // Collects the rows to spill for each partition.
@@ -190,6 +192,13 @@ class SpillerBase {
       int32_t maxRows,
       int64_t maxBytes,
       RowVectorPtr& spillVector,
+      size_t& nextBatchIndex);
+
+  int64_t extractSpillRows(
+      SpillRows& rows,
+      int32_t maxRows,
+      int64_t maxBytes,
+      SpillRows& spillRows,
       size_t& nextBatchIndex);
 
   // Invoked to finalize the spiller and flush any buffered spill to disk.

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -74,6 +74,16 @@ class SpillerBase {
   // RowContainerSpillMergeStream.
   virtual void extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr);
 
+  // Extracts accumulators for 'rows' into '*result'.
+  // Creates '*results' in spillPool() if nullptr.
+  virtual void extractNonSerializable(
+      folly::Range<char**> rows,
+      RowVectorPtr& resultPtr);
+
+  virtual bool hasProbedFlag() const {
+    return false;
+  }
+
   virtual bool needSort() const = 0;
 
   virtual std::string type() const = 0;
@@ -158,6 +168,8 @@ class SpillerBase {
 
   bool serializeRowContainer_{false};
 
+  RowTypePtr accumulatorType_;
+
   SpillState state_;
 
   // Collects the rows to spill for each partition.
@@ -199,6 +211,7 @@ class SpillerBase {
       int32_t maxRows,
       int64_t maxBytes,
       SpillRows& spillRows,
+      RowVectorPtr& accumulatorVector,
       size_t& nextBatchIndex);
 
   // Invoked to finalize the spiller and flush any buffered spill to disk.

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -58,8 +58,8 @@ std::unique_ptr<RowContainer> setupSpillContainer(
 }
 } // namespace
 
-void AggregateSpillBenchmarkBase::setUp() {
-  SpillerBenchmarkBase::setUp();
+void AggregateSpillBenchmarkBase::setUp(RowTypePtr rowType, int32_t stringMaxLength) {
+  SpillerBenchmarkBase::setUp(rowType, stringMaxLength);
 
   rowContainer_ = setupSpillContainer(
       rowType_, FLAGS_spiller_benchmark_num_key_columns, pool_);

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -58,7 +58,9 @@ std::unique_ptr<RowContainer> setupSpillContainer(
 }
 } // namespace
 
-void AggregateSpillBenchmarkBase::setUp(RowTypePtr rowType, int32_t stringMaxLength) {
+void AggregateSpillBenchmarkBase::setUp(
+    RowTypePtr rowType,
+    int32_t stringMaxLength) {
   SpillerBenchmarkBase::setUp(rowType, stringMaxLength);
 
   rowContainer_ = setupSpillContainer(

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -23,7 +23,11 @@ class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
       : spillerType_(spillerType) {};
 
   /// Sets up the test.
-  void setUp(RowTypePtr rowType, int32_t stringMaxLength) override;
+  void setUp(
+      RowTypePtr rowType =
+          ROW({"c0", "c1", "c2", "c3", "c4"},
+              {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DOUBLE()}),
+      int32_t stringMaxLength = 10) override;
 
   /// Runs the test.
   void run() override;

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.h
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.h
@@ -23,7 +23,7 @@ class AggregateSpillBenchmarkBase : public SpillerBenchmarkBase {
       : spillerType_(spillerType) {};
 
   /// Sets up the test.
-  void setUp() override;
+  void setUp(RowTypePtr rowType, int32_t stringMaxLength) override;
 
   /// Runs the test.
   void run() override;

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -372,6 +372,31 @@ if(VELOX_ENABLE_BENCHMARKS)
     velox_exec_test_lib
     velox_spiller_aggregate_benchmark_base
   )
+
+  add_library(
+    velox_spiller_sort_benchmark_base
+    SortSpillInputBenchmarkBase.cpp
+    SpillerBenchmarkBase.cpp
+  )
+  target_link_libraries(
+    velox_spiller_sort_benchmark_base
+    velox_exec
+    velox_exec_test_lib
+    velox_memory
+    velox_vector_fuzzer
+    glog::glog
+    gflags::gflags
+    Folly::folly
+    pthread
+  )
+
+  add_executable(velox_spiller_sort_benchmark SpillerSortBenchmarkTest.cpp)
+  target_link_libraries(
+    velox_spiller_sort_benchmark
+    velox_exec
+    velox_exec_test_lib
+    velox_spiller_sort_benchmark_base
+  )
 endif()
 
 add_executable(cpr_http_client_test CprHttpClientTest.cpp)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -396,6 +396,7 @@ if(VELOX_ENABLE_BENCHMARKS)
     velox_exec
     velox_exec_test_lib
     velox_spiller_sort_benchmark_base
+    Folly::follybenchmark
   )
 endif()
 

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -29,8 +29,10 @@ namespace {
 const int numSampleVectors = 100;
 } // namespace
 
-void JoinSpillInputBenchmarkBase::setUp() {
-  SpillerBenchmarkBase::setUp();
+void JoinSpillInputBenchmarkBase::setUp(
+    RowTypePtr rowType,
+    int32_t stringMaxLength) {
+  SpillerBenchmarkBase::setUp(rowType, stringMaxLength);
   common::SpillConfig spillConfig;
   spillConfig.getSpillDirPathCb = [&]() -> std::string_view {
     return spillDir_;

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.h
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.h
@@ -23,7 +23,11 @@ class JoinSpillInputBenchmarkBase : public SpillerBenchmarkBase {
   JoinSpillInputBenchmarkBase() = default;
 
   /// Sets up the test.
-  void setUp() override;
+  void setUp(
+      RowTypePtr rowType =
+          ROW({"c0", "c1", "c2", "c3", "c4"},
+              {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DOUBLE()}),
+      int32_t stringMaxLength = 10) override;
 
   /// Runs the test.
   void run() override;

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -137,6 +137,49 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     testNegativeRowNumbers(container, rows, column, expected);
   }
 
+  std::unique_ptr<ByteInputStream> toByteStream(const std::string& input) {
+    ByteRange byteRange{
+        reinterpret_cast<uint8_t*>(const_cast<char*>(input.data())),
+        (int32_t)input.length(),
+        0};
+    return std::make_unique<BufferInputStream>(
+        std::vector<ByteRange>{{byteRange}});
+  }
+
+  void testSerializeRows(
+      RowContainer& container,
+      const std::vector<char*>& rows,
+      RowTypePtr rowType,
+      const VectorPtr& expected) {
+    std::ostringstream output;
+    serializer::presto::PrestoVectorSerde serde;
+    serializer::presto::PrestoVectorSerde::PrestoOptions options = {
+        false,
+        common::CompressionKind::CompressionKind_LZ4,
+        0.8,
+        /*nullsFirst=*/true};
+    auto batch = std::make_unique<VectorStreamGroup>(pool_.get(), &serde);
+    batch->createStreamTree(rowType, rows.size(), &options);
+    batch->appendNumRows(rows.size());
+    const auto& types = container.columnTypes();
+    for (auto i = 0; i < types.size(); ++i) {
+      container.extractColumn(
+          rows.data(), rows.size(), i, types[i], batch->streamAt(i));
+    }
+
+    facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
+    OStreamOutputStream out(&output, &listener);
+    batch->flush(&out);
+
+    auto str = output.str();
+    auto byteStream = toByteStream(str);
+    RowVectorPtr result;
+    serde.deserialize(
+        byteStream.get(), pool_.get(), rowType, &result, 0, &options);
+
+    assertEqualVectors(expected, result);
+  }
+
   void testExtractColumnAllRows(
       RowContainer& container,
       const std::vector<char*>& rows,
@@ -393,6 +436,28 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     auto rows = store(*rowContainer, decoded, size);
 
     testExtractColumn(*rowContainer, rows, 0, input);
+    return rowContainer;
+  }
+
+  std::unique_ptr<RowContainer> roundTripSerde(const RowVectorPtr& input) {
+    // Create row container.
+    std::vector<TypePtr> types;
+    for (int i = 0; i < input->childrenSize(); ++i) {
+      types.push_back(input->childAt(i)->type());
+    }
+
+    // Store the vector in the rowContainer.
+    auto rowContainer = std::make_unique<RowContainer>(types, pool_.get());
+    auto size = input->size();
+    std::vector<char*> rows(input->size());
+    for (int row = 0; row < input->size(); ++row) {
+      rows[row] = rowContainer->newRow();
+    }
+    for (int i = 0; i < input->childrenSize(); ++i) {
+      DecodedVector decoded(*input->childAt(i));
+      rowContainer->store(decoded, folly::Range(rows.data(), input->size()), i);
+    }
+    testSerializeRows(*rowContainer, rows, input->rowType(), input);
     return rowContainer;
   }
 
@@ -1044,6 +1109,59 @@ TEST_F(RowContainerTest, storeExtractArrayOfVarchar) {
   elements[1].emplace_back(strings[3]);
   auto input = vectorMaker.arrayVector<StringView>(elements);
   roundTrip(input);
+}
+
+TEST_F(RowContainerTest, serialize) {
+  facebook::velox::test::VectorMaker vectorMaker{pool_.get()};
+  int32_t vecSize = 1000;
+  auto input = vectorMaker.rowVector(
+      {"int", "bool", "str", "array", "map", "row"},
+      {vectorMaker.flatVector<int64_t>(
+           vecSize,
+           [&](auto row) { return row; },
+           [](auto j) { return j % 5 == 0; }),
+       vectorMaker.flatVector<bool>(
+           vecSize,
+           [&](auto row) { return row % 2 == 0; },
+           [](auto j) { return j % 5 == 0; }),
+       vectorMaker.flatVector<StringView>(
+           vecSize,
+           [&](auto row) {
+             return row % 2 == 0 ? "inline" : "not-inline-string-aaaaaaaaa";
+           },
+           [](auto j) { return j % 5 == 0; }),
+       vectorMaker.arrayVector<int64_t>(
+           vecSize,
+           [](auto j) { return 7 + (j % 3); },
+           [](auto j) { return j; },
+           [](auto j) { return j % 5 == 0; },
+           [](auto j) { return j % 5 == 0; }),
+       vectorMaker.mapVector<int64_t, bool>(
+           vecSize,
+           [](auto j) { return 7 + (j % 3); },
+           [](auto j) { return j; },
+           [](auto j) { return j % 3 == 0; },
+           [](auto j) { return j % 5 == 0; },
+           [](auto j) { return j % 5 == 0; }),
+       vectorMaker.rowVector(
+           {"int", "str", "arr"},
+           {vectorMaker.flatVector<int64_t>(
+                vecSize, [&](auto row) { return row; }),
+            vectorMaker.flatVector<StringView>(
+                vecSize,
+                [&](auto row) {
+                  return row % 2 == 0 ? "inline"
+                                      : "not-inline-string-aaaaaaaaa";
+                },
+                [](auto j) { return j % 5 == 0; }),
+            vectorMaker.arrayVector<int64_t>(
+                vecSize,
+                [](auto j) { return 7 + (j % 3); },
+                [](auto j) { return j; },
+                [](auto j) { return j % 5 == 0; },
+                [](auto j) { return j % 5 == 0; })})});
+
+  roundTripSerde(input);
 }
 
 TEST_F(RowContainerTest, types) {

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1164,6 +1164,16 @@ TEST_F(RowContainerTest, serialize) {
   roundTripSerde(input);
 }
 
+TEST_F(RowContainerTest, serializeLongString) {
+  facebook::velox::test::VectorMaker vectorMaker{pool_.get()};
+  int32_t vecSize = 1000;
+  auto input = vectorMaker.rowVector(
+      {"str"}, {vectorMaker.flatVector<StringView>(vecSize, [&](auto row) {
+        return "l&1mjT4i6'Y#!&7We|o2YtImnZ},I?R~svBP>/<HcLin:t.7%YCY.:y+*jTRp-MNpo6^N(]M>ky)XYEl5gslT%`#5X%[MBbE&%{`5)~5a]5)wJh[!Um3UKkf3gnji.Z\\\\";
+      })});
+  roundTripSerde(input);
+}
+
 TEST_F(RowContainerTest, types) {
   constexpr int32_t kNumRows = 100;
   auto batch = makeDataset(

--- a/velox/exec/tests/SortSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/SortSpillInputBenchmarkBase.cpp
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) Facebook, Inc. and its affiliates.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "velox/exec/tests/SortSpillInputBenchmarkBase.h"
 #include <gflags/gflags.h>
@@ -28,10 +28,7 @@ std::unique_ptr<RowContainer> makeRowContainer(
     const std::vector<TypePtr>& keyTypes,
     const std::vector<TypePtr>& dependentTypes,
     std::shared_ptr<velox::memory::MemoryPool>& pool) {
-  return std::make_unique<RowContainer>(
-      keyTypes,
-      dependentTypes,
-      pool.get());
+  return std::make_unique<RowContainer>(keyTypes, dependentTypes, pool.get());
 }
 
 std::unique_ptr<RowContainer> setupSpillContainer(
@@ -47,9 +44,12 @@ std::unique_ptr<RowContainer> setupSpillContainer(
   }
   return makeRowContainer(keys, dependents, pool);
 }
-}
+} // namespace
 
-void SortSpillInputBenchmarkBase::setUp(RowTypePtr rowType, bool serializeRowContainer, int32_t stringMaxLength) {
+void SortSpillInputBenchmarkBase::setUp(
+    RowTypePtr rowType,
+    bool serializeRowContainer,
+    int32_t stringMaxLength) {
   SpillerBenchmarkBase::setUp(rowType, stringMaxLength);
   serializeRowContainer_ = serializeRowContainer;
   rowContainer_ = setupSpillContainer(
@@ -84,13 +84,11 @@ void SortSpillInputBenchmarkBase::writeSpillData() {
 
 void SortSpillInputBenchmarkBase::run() {
   MicrosecondTimer timer(&executionTimeUs_);
-  auto sortInputSpiller =
-      dynamic_cast<SortInputSpiller*>(spiller_.get());
+  auto sortInputSpiller = dynamic_cast<SortInputSpiller*>(spiller_.get());
   VELOX_CHECK_NOT_NULL(sortInputSpiller);
   sortInputSpiller->spill();
   rowContainer_->clear();
 }
-
 
 std::unique_ptr<SpillerBase> SortSpillInputBenchmarkBase::makeSpiller() {
   common::SpillConfig spillConfig;
@@ -102,8 +100,7 @@ std::unique_ptr<SpillerBase> SortSpillInputBenchmarkBase::makeSpiller() {
   spillConfig.writeBufferSize = FLAGS_spiller_benchmark_write_buffer_size;
   spillConfig.executor = executor_.get();
 
-  spillConfig.compressionKind =
-      common::CompressionKind::CompressionKind_LZ4;
+  spillConfig.compressionKind = common::CompressionKind::CompressionKind_LZ4;
   spillConfig.prefixSortConfig = PrefixSortConfig();
 
   spillConfig.maxSpillRunRows = 0;
@@ -113,11 +110,7 @@ std::unique_ptr<SpillerBase> SortSpillInputBenchmarkBase::makeSpiller() {
   const auto sortingKeys = SpillState::makeSortingKeys(
       std::vector<CompareFlags>(rowContainer_->keyTypes().size()));
   return std::make_unique<SortInputSpiller>(
-      rowContainer_.get(),
-      rowType_,
-      sortingKeys,
-      &spillConfig,
-      &spillStats_);
+      rowContainer_.get(), rowType_, sortingKeys, &spillConfig, &spillStats_);
 }
 
 void SortSpillInputBenchmarkBase::printStats() const {
@@ -133,4 +126,4 @@ void SortSpillInputBenchmarkBase::printStats() const {
   spiller_->finishSpill(partitionSet);
   VELOX_CHECK_EQ(partitionSet.size(), 1);
 }
-}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/SortSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/SortSpillInputBenchmarkBase.cpp
@@ -1,0 +1,136 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "velox/exec/tests/SortSpillInputBenchmarkBase.h"
+#include <gflags/gflags.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+using namespace facebook::velox::memory;
+using namespace facebook::velox::exec;
+namespace facebook::velox::exec::test {
+
+namespace {
+std::unique_ptr<RowContainer> makeRowContainer(
+    const std::vector<TypePtr>& keyTypes,
+    const std::vector<TypePtr>& dependentTypes,
+    std::shared_ptr<velox::memory::MemoryPool>& pool) {
+  return std::make_unique<RowContainer>(
+      keyTypes,
+      dependentTypes,
+      pool.get());
+}
+
+std::unique_ptr<RowContainer> setupSpillContainer(
+    const RowTypePtr& rowType,
+    uint32_t numKeys,
+    std::shared_ptr<velox::memory::MemoryPool>& pool) {
+  const auto& childTypes = rowType->children();
+  std::vector<TypePtr> keys(childTypes.begin(), childTypes.begin() + numKeys);
+  std::vector<TypePtr> dependents;
+  if (numKeys < childTypes.size()) {
+    dependents.insert(
+        dependents.end(), childTypes.begin() + numKeys, childTypes.end());
+  }
+  return makeRowContainer(keys, dependents, pool);
+}
+}
+
+void SortSpillInputBenchmarkBase::setUp(RowTypePtr rowType, bool serializeRowContainer, int32_t stringMaxLength) {
+  SpillerBenchmarkBase::setUp(rowType, stringMaxLength);
+  serializeRowContainer_ = serializeRowContainer;
+  rowContainer_ = setupSpillContainer(
+      rowType_, FLAGS_spiller_benchmark_num_key_columns, pool_);
+  writeSpillData();
+  spiller_ = makeSpiller();
+}
+
+void SortSpillInputBenchmarkBase::writeSpillData() {
+  vector_size_t numRows = 0;
+  for (const auto& rowVector : rowVectors_) {
+    numRows += rowVector->size();
+  }
+
+  std::vector<char*> rows;
+  rows.resize(numRows);
+  for (int i = 0; i < numRows; ++i) {
+    rows[i] = rowContainer_->newRow();
+  }
+
+  vector_size_t nextRow = 0;
+  for (const auto& rowVector : rowVectors_) {
+    const SelectivityVector allRows(rowVector->size());
+    for (int index = 0; index < rowVector->size(); ++index, ++nextRow) {
+      for (int i = 0; i < rowType_->size(); ++i) {
+        DecodedVector decodedVector(*rowVector->childAt(i), allRows);
+        rowContainer_->store(decodedVector, index, rows[nextRow], i);
+      }
+    }
+  }
+}
+
+void SortSpillInputBenchmarkBase::run() {
+  MicrosecondTimer timer(&executionTimeUs_);
+  auto sortInputSpiller =
+      dynamic_cast<SortInputSpiller*>(spiller_.get());
+  VELOX_CHECK_NOT_NULL(sortInputSpiller);
+  sortInputSpiller->spill();
+  rowContainer_->clear();
+}
+
+
+std::unique_ptr<SpillerBase> SortSpillInputBenchmarkBase::makeSpiller() {
+  common::SpillConfig spillConfig;
+  spillConfig.getSpillDirPathCb = [&]() -> std::string_view {
+    return spillDir_;
+  };
+  spillConfig.updateAndCheckSpillLimitCb = [&](uint64_t) {};
+  spillConfig.fileNamePrefix = FLAGS_spiller_benchmark_name;
+  spillConfig.writeBufferSize = FLAGS_spiller_benchmark_write_buffer_size;
+  spillConfig.executor = executor_.get();
+
+  spillConfig.compressionKind =
+      common::CompressionKind::CompressionKind_LZ4;
+  spillConfig.prefixSortConfig = PrefixSortConfig();
+
+  spillConfig.maxSpillRunRows = 0;
+  spillConfig.fileCreateConfig = {};
+  spillConfig.serializeRowContainer = serializeRowContainer_;
+
+  const auto sortingKeys = SpillState::makeSortingKeys(
+      std::vector<CompareFlags>(rowContainer_->keyTypes().size()));
+  return std::make_unique<SortInputSpiller>(
+      rowContainer_.get(),
+      rowType_,
+      sortingKeys,
+      &spillConfig,
+      &spillStats_);
+}
+
+void SortSpillInputBenchmarkBase::printStats() const {
+  LOG(INFO) << "total execution time: " << succinctMicros(executionTimeUs_);
+  const auto memStats = pool_->stats();
+  LOG(INFO) << numInputVectors_ << " vectors each with " << inputVectorSize_
+            << " rows have been processed";
+  LOG(INFO) << "peak memory usage[" << succinctBytes(memStats.peakBytes)
+            << "] cumulative memory usage["
+            << succinctBytes(memStats.cumulativeBytes) << "]";
+  LOG(INFO) << spiller_->stats().toString();
+  SpillPartitionSet partitionSet;
+  spiller_->finishSpill(partitionSet);
+  VELOX_CHECK_EQ(partitionSet.size(), 1);
+}
+}

--- a/velox/exec/tests/SortSpillInputBenchmarkBase.h
+++ b/velox/exec/tests/SortSpillInputBenchmarkBase.h
@@ -1,48 +1,48 @@
 /*
-* Copyright (c) Facebook, Inc. and its affiliates.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "SpillerBenchmarkBase.h"
 
 namespace facebook::velox::exec::test {
 /// This test measures the spill input overhead in spill join & probe.
 class SortSpillInputBenchmarkBase : public SpillerBenchmarkBase {
-public:
- SortSpillInputBenchmarkBase() = default;
+ public:
+  SortSpillInputBenchmarkBase() = default;
 
- void setUp(RowTypePtr rowType, int32_t stringMaxLength) override {
-   setUp(rowType, false, stringMaxLength);
- };
- /// Sets up the test.
- void setUp(
-     RowTypePtr rowType,
-     bool serializeRowContainer,
-     int32_t stringMaxLength);
+  void setUp(RowTypePtr rowType, int32_t stringMaxLength) override {
+    setUp(rowType, false, stringMaxLength);
+  };
+  /// Sets up the test.
+  void setUp(
+      RowTypePtr rowType,
+      bool serializeRowContainer,
+      int32_t stringMaxLength);
 
- /// Runs the test.
- void run() override;
+  /// Runs the test.
+  void run() override;
 
- void printStats() const override;
+  void printStats() const override;
 
-private:
- void writeSpillData();
- std::unique_ptr<SpillerBase> makeSpiller();
+ private:
+  void writeSpillData();
+  std::unique_ptr<SpillerBase> makeSpiller();
 
- const std::string spillerType_;
- std::unique_ptr<RowContainer> rowContainer_;
- std::shared_ptr<velox::memory::MemoryPool> spillerPool_;
- bool serializeRowContainer_;
+  const std::string spillerType_;
+  std::unique_ptr<RowContainer> rowContainer_;
+  std::shared_ptr<velox::memory::MemoryPool> spillerPool_;
+  bool serializeRowContainer_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/SortSpillInputBenchmarkBase.h
+++ b/velox/exec/tests/SortSpillInputBenchmarkBase.h
@@ -1,0 +1,48 @@
+/*
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#include "SpillerBenchmarkBase.h"
+
+namespace facebook::velox::exec::test {
+/// This test measures the spill input overhead in spill join & probe.
+class SortSpillInputBenchmarkBase : public SpillerBenchmarkBase {
+public:
+ SortSpillInputBenchmarkBase() = default;
+
+ void setUp(RowTypePtr rowType, int32_t stringMaxLength) override {
+   setUp(rowType, false, stringMaxLength);
+ };
+ /// Sets up the test.
+ void setUp(
+     RowTypePtr rowType,
+     bool serializeRowContainer,
+     int32_t stringMaxLength);
+
+ /// Runs the test.
+ void run() override;
+
+ void printStats() const override;
+
+private:
+ void writeSpillData();
+ std::unique_ptr<SpillerBase> makeSpiller();
+
+ const std::string spillerType_;
+ std::unique_ptr<RowContainer> rowContainer_;
+ std::shared_ptr<velox::memory::MemoryPool> spillerPool_;
+ bool serializeRowContainer_;
+};
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -291,7 +291,7 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
     const auto sortingKeys = SpillState::makeSortingKeys(
         compareFlags.empty() ? std::vector<CompareFlags>(1) : compareFlags);
     state_ = std::make_unique<SpillState>(
-        batchesByPartition_[*partitionIds.begin()].back()->rowType(),
+        ROW({"c0"}, {BIGINT()}),
         [&]() -> const std::string& { return tempDir_->getPath(); },
         updateSpilledBytesCb_,
         fileNamePrefix_,
@@ -643,7 +643,8 @@ TEST_P(SpillTest, spillTimestamp) {
   ASSERT_TRUE(state.isPartitionSpilled(partitionId));
   ASSERT_FALSE(
       state.testingNonEmptySpilledPartitionIdSet().contains(partitionId));
-  state.appendToPartition(partitionId, rv);
+  state.appendToPartition(
+      partitionId, rv);
   state.finishFile(partitionId);
   EXPECT_TRUE(
       state.testingNonEmptySpilledPartitionIdSet().contains(partitionId));
@@ -1429,7 +1430,9 @@ TEST_P(SpillTest, validatePerSpillWriteSize) {
   state.setPartitionSpilled(partitionId);
   ASSERT_TRUE(state.isPartitionSpilled(partitionId));
   VELOX_ASSERT_THROW(
-      state.appendToPartition(partitionId, rv), "Spill bytes will overflow");
+      state.appendToPartition(
+          partitionId, rv),
+      "Spill bytes will overflow");
 }
 
 namespace {

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -643,8 +643,7 @@ TEST_P(SpillTest, spillTimestamp) {
   ASSERT_TRUE(state.isPartitionSpilled(partitionId));
   ASSERT_FALSE(
       state.testingNonEmptySpilledPartitionIdSet().contains(partitionId));
-  state.appendToPartition(
-      partitionId, rv);
+  state.appendToPartition(partitionId, rv);
   state.finishFile(partitionId);
   EXPECT_TRUE(
       state.testingNonEmptySpilledPartitionIdSet().contains(partitionId));
@@ -1430,9 +1429,7 @@ TEST_P(SpillTest, validatePerSpillWriteSize) {
   state.setPartitionSpilled(partitionId);
   ASSERT_TRUE(state.isPartitionSpilled(partitionId));
   VELOX_ASSERT_THROW(
-      state.appendToPartition(
-          partitionId, rv),
-      "Spill bytes will overflow");
+      state.appendToPartition(partitionId, rv), "Spill bytes will overflow");
 }
 
 namespace {

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -27,6 +27,7 @@ int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   filesystems::registerLocalFileSystem();
 
   auto spillerType = FLAGS_spiller_benchmark_spiller_type;

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -52,7 +52,7 @@ DEFINE_uint32(
     "The number of vectors for spilling");
 DEFINE_uint32(
     spiller_benchmark_num_key_columns,
-    2,
+    1,
     "The number of key columns");
 DEFINE_uint32(
     spiller_benchmark_spill_executor_size,
@@ -93,7 +93,7 @@ void SpillerBenchmarkBase::setUp(RowTypePtr rowType, int32_t stringMaxLength) {
     options.vectorSize = inputVectorSize_;
     options.nullRatio = 0.1;
     options.stringLength = stringMaxLength;
-    options.stringVariableLength = true;
+    options.stringVariableLength = false;
     vectorFuzzer_ = std::make_unique<VectorFuzzer>(options, pool_.get());
   }
   rowVectors_.reserve(numInputVectors_);

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -79,25 +79,26 @@ using namespace facebook::velox::memory;
 
 namespace facebook::velox::exec::test {
 
-void SpillerBenchmarkBase::setUp() {
+void SpillerBenchmarkBase::setUp(RowTypePtr rowType, int32_t stringMaxLength) {
   rootPool_ =
       memory::memoryManager()->addRootPool(FLAGS_spiller_benchmark_name);
   pool_ = rootPool_->addLeafChild(FLAGS_spiller_benchmark_name);
 
-  rowType_ =
-      ROW({"c0", "c1", "c2", "c3", "c4"},
-          {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DOUBLE()});
+  rowType_ = rowType;
 
   numInputVectors_ = FLAGS_spiller_benchmark_num_spill_vectors;
   inputVectorSize_ = FLAGS_spiller_benchmark_spill_vector_size;
   {
     VectorFuzzer::Options options;
     options.vectorSize = inputVectorSize_;
+    options.nullRatio = 0.1;
+    options.stringLength = stringMaxLength;
+    options.stringVariableLength = true;
     vectorFuzzer_ = std::make_unique<VectorFuzzer>(options, pool_.get());
   }
   rowVectors_.reserve(numInputVectors_);
   for (int i = 0; i < numInputVectors_; ++i) {
-    rowVectors_.push_back(vectorFuzzer_->fuzzRow(rowType_));
+    rowVectors_.push_back(vectorFuzzer_->fuzzRow(rowType));
   }
 
   if (FLAGS_spiller_benchmark_spill_executor_size != 0) {

--- a/velox/exec/tests/SpillerBenchmarkBase.h
+++ b/velox/exec/tests/SpillerBenchmarkBase.h
@@ -45,7 +45,11 @@ class SpillerBenchmarkBase {
   virtual ~SpillerBenchmarkBase() = default;
 
   /// Sets up the test.
-  virtual void setUp() = 0;
+  virtual void setUp(
+      RowTypePtr rowType =
+          ROW({"c0", "c1", "c2", "c3", "c4"},
+              {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DOUBLE()}),
+      int32_t stringMaxLength = 10) = 0;
 
   /// Runs the test.
   virtual void run() = 0;

--- a/velox/exec/tests/SpillerJoinInputBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerJoinInputBenchmarkTest.cpp
@@ -25,6 +25,7 @@ int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   memory::MemoryManager::initialize(memory::MemoryManager::Options{});
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   filesystems::registerLocalFileSystem();
   auto test = std::make_unique<exec::test::JoinSpillInputBenchmarkBase>();
   test->setUp();

--- a/velox/exec/tests/SpillerSortBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerSortBenchmarkTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SortSpillInputBenchmarkBase.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+#include <gflags/gflags.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+bool containsString(TypePtr type) {
+  if (type->kind() == TypeKind::VARCHAR ||
+      type->kind() == TypeKind::VARBINARY) {
+    return true;
+  }
+  for (auto i = 0; i < type->size(); ++i) {
+    if (containsString(type->childAt(i))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void runTest(RowTypePtr rowType, bool serializeRowContainer, int strLength) {
+  auto test = std::make_unique<test::SortSpillInputBenchmarkBase>();
+  test->setUp(rowType, serializeRowContainer, strLength);
+  test->run();
+  test->printStats();
+  test->cleanup();
+}
+
+void doTest(RowTypePtr rowType) {
+  LOG(INFO) << "=====================BENCHMARK===========================";
+  bool conf[] = {false, true};
+  int strLength[] = {10, 50, 100};
+  LOG(INFO) << "row type: " << rowType->toString();
+  for (auto serializeRowContainer : conf) {
+    if (containsString(rowType)) {
+      for (auto length : strLength) {
+        LOG(INFO)
+            << "-----------------------------------------------------------";
+        LOG(INFO) << "serializeRowContainer: "
+                  << (serializeRowContainer ? "true" : "false")
+                  << " string max length: " << length;
+        runTest(rowType, serializeRowContainer, length);
+      }
+    } else {
+      LOG(INFO)
+          << "-----------------------------------------------------------";
+      LOG(INFO) << "serializeRowContainer: "
+                << (serializeRowContainer ? "true" : "false");
+      runTest(rowType, serializeRowContainer, 0);
+    }
+  }
+}
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  filesystems::registerLocalFileSystem();
+
+  RowTypePtr rowTypes[] = {
+      ROW({"c0", "c1", "c2"}, {INTEGER(), BIGINT(), INTEGER()}),
+      ROW({"c0", "c1", "c2"}, {INTEGER(), BIGINT(), VARBINARY()}),
+      ROW({"c0", "c1", "c2"}, {INTEGER(), BIGINT(), ARRAY(INTEGER())}),
+      ROW({"c0", "c1", "c2"}, {INTEGER(), BIGINT(), ARRAY(VARBINARY())}),
+      ROW({"c0", "c1", "c2"},
+          {INTEGER(), BIGINT(), MAP(INTEGER(), VARBINARY())}),
+      ROW({"c0", "c1", "c2"},
+          {INTEGER(),
+           BIGINT(),
+           ROW({"int", "str"}, {INTEGER(), VARBINARY()})})};
+  for (auto rowType : rowTypes) {
+    doTest(rowType);
+  }
+  return 0;
+}

--- a/velox/exec/tests/SpillerSortBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerSortBenchmarkTest.cpp
@@ -34,67 +34,67 @@ void runTest(RowTypePtr rowType, bool serializeRowContainer, int strLength) {
 }
 
 BENCHMARK(integer_type) {
-  runTest(ROW({"c0"}, {INTEGER()}), false, 0);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), INTEGER()}), false, 0);
 }
 
 BENCHMARK_RELATIVE(integer_type_serialize_rows) {
-  runTest(ROW({"c0"}, {INTEGER()}), true, 0);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), INTEGER()}), true, 0);
 }
 
 BENCHMARK(bigint_type) {
-  runTest(ROW({"c0"}, {BIGINT()}), false, 0);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), BIGINT()}), false, 0);
 }
 
 BENCHMARK_RELATIVE(bigint_type_serialize_rows) {
-  runTest(ROW({"c0"}, {BIGINT()}), true, 0);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), BIGINT()}), true, 0);
 }
 
 BENCHMARK(string_type_10bytes) {
-  runTest(ROW({"c0"}, {VARBINARY()}), false, 10);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), VARBINARY()}), false, 10);
 }
 
 BENCHMARK_RELATIVE(string_type_10bytes_serialize_rows) {
-  runTest(ROW({"c0"}, {VARBINARY()}), true, 10);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), VARBINARY()}), true, 10);
 }
 
 BENCHMARK(string_type_50bytes) {
-  runTest(ROW({"c0"}, {VARBINARY()}), false, 50);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), VARBINARY()}), false, 50);
 }
 
 BENCHMARK_RELATIVE(string_type_50bytes_long_serialize_rows) {
-  runTest(ROW({"c0"}, {VARBINARY()}), true, 50);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), VARBINARY()}), true, 50);
 }
 
 BENCHMARK(array_of_integer_type) {
-  runTest(ROW({"c0"}, {ARRAY(INTEGER())}), false, 10);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(INTEGER())}), false, 10);
 }
 
 BENCHMARK_RELATIVE(array_of_integer_type_serialize_rows) {
-  runTest(ROW({"c0"}, {ARRAY(INTEGER())}), true, 10);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(INTEGER())}), true, 10);
 }
 
 BENCHMARK(array_of_10bytes_varbinary_type) {
-  runTest(ROW({"c0"}, {ARRAY(VARBINARY())}), false, 10);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(VARBINARY())}), false, 10);
 }
 
 BENCHMARK_RELATIVE(array_of_10bytes_varbinary_type_serialize_rows) {
-  runTest(ROW({"c0"}, {ARRAY(VARBINARY())}), true, 10);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(VARBINARY())}), true, 10);
 }
 
 BENCHMARK(array_of_50bytes_varbinary_type) {
-  runTest(ROW({"c0"}, {ARRAY(VARBINARY())}), false, 50);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(VARBINARY())}), false, 50);
 }
 
 BENCHMARK_RELATIVE(array_of_50bytes_varbinary_type_serialize_rows) {
-  runTest(ROW({"c0"}, {ARRAY(VARBINARY())}), true, 50);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(VARBINARY())}), true, 50);
 }
 
 BENCHMARK(array_of_100bytes_varbinary_type) {
-  runTest(ROW({"c0"}, {ARRAY(VARBINARY())}), false, 100);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(VARBINARY())}), false, 100);
 }
 
 BENCHMARK_RELATIVE(array_of_100bytes_varbinary_type_serialize_rows) {
-  runTest(ROW({"c0"}, {ARRAY(VARBINARY())}), true, 100);
+  runTest(ROW({"c0", "c1"}, {INTEGER(), ARRAY(VARBINARY())}), true, 100);
 }
 
 int main(int argc, char* argv[]) {

--- a/velox/exec/tests/SpillerSortBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerSortBenchmarkTest.cpp
@@ -14,27 +14,13 @@
  * limitations under the License.
  */
 
-#include "SortSpillInputBenchmarkBase.h"
-#include "velox/serializers/PrestoSerializer.h"
 #include <folly/Benchmark.h>
+#include "SortSpillInputBenchmarkBase.h"
 
 #include <gflags/gflags.h>
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
-
-bool containsString(TypePtr type) {
-  if (type->kind() == TypeKind::VARCHAR ||
-      type->kind() == TypeKind::VARBINARY) {
-    return true;
-  }
-  for (auto i = 0; i < type->size(); ++i) {
-    if (containsString(type->childAt(i))) {
-      return true;
-    }
-  }
-  return false;
-}
 
 void runTest(RowTypePtr rowType, bool serializeRowContainer, int strLength) {
   folly::BenchmarkSuspender suspender;

--- a/velox/serializers/PrestoIterativeVectorSerializer.cpp
+++ b/velox/serializers/PrestoIterativeVectorSerializer.cpp
@@ -40,14 +40,16 @@ PrestoIterativeVectorSerializer::PrestoIterativeVectorSerializer(
 void PrestoIterativeVectorSerializer::append(
     const RowVectorPtr& vector,
     const folly::Range<const IndexRange*>& ranges,
-    Scratch& scratch) {
+    Scratch& scratch,
+    const column_index_t columnStartOffset) {
   const auto numNewRows = rangesTotalSize(ranges);
   if (numNewRows == 0) {
     return;
   }
   numRows_ += numNewRows;
   for (int32_t i = 0; i < vector->childrenSize(); ++i) {
-    serializeColumn(vector->childAt(i), ranges, &streams_[i], scratch);
+    serializeColumn(
+        vector->childAt(i), ranges, &streams_[i + columnStartOffset], scratch);
   }
 }
 

--- a/velox/serializers/PrestoIterativeVectorSerializer.h
+++ b/velox/serializers/PrestoIterativeVectorSerializer.h
@@ -43,7 +43,7 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
     return &streams_[i];
   }
 
-  void appendNumRows(int32_t numRows) {
+  void appendNumRows(int32_t numRows) override {
     numRows_ += numRows;
   }
 

--- a/velox/serializers/PrestoIterativeVectorSerializer.h
+++ b/velox/serializers/PrestoIterativeVectorSerializer.h
@@ -39,6 +39,14 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
       const folly::Range<const vector_size_t*>& rows,
       Scratch& scratch) override;
 
+  VectorStream* getStream(vector_size_t i) override {
+    return &streams_[i];
+  }
+
+  void appendNumRows(int32_t numRows) {
+    numRows_ += numRows;
+  }
+
   size_t maxSerializedSize() const override;
 
   // The SerializedPage layout is:

--- a/velox/serializers/PrestoIterativeVectorSerializer.h
+++ b/velox/serializers/PrestoIterativeVectorSerializer.h
@@ -32,7 +32,8 @@ class PrestoIterativeVectorSerializer : public IterativeVectorSerializer {
   void append(
       const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges,
-      Scratch& scratch) override;
+      Scratch& scratch,
+      const column_index_t columnStartOffset = 0) override;
 
   void append(
       const RowVectorPtr& vector,

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -245,7 +245,8 @@ void PrestoVectorSerde::serializeSingleColumn(
       vector->size(),
       prestoOptions);
   Scratch scratch;
-  detail::serializeColumn(vector, folly::Range(&range, 1), stream.get(), scratch);
+  detail::serializeColumn(
+      vector, folly::Range(&range, 1), stream.get(), scratch);
 
   PrestoOutputStreamListener listener;
   OStreamOutputStream outputStream(output, &listener);

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -237,7 +237,7 @@ void PrestoVectorSerde::serializeSingleColumn(
 
   const IndexRange range{0, vector->size()};
   const auto arena = std::make_unique<StreamArena>(pool);
-  auto stream = std::make_unique<detail::VectorStream>(
+  auto stream = std::make_unique<VectorStream>(
       vector->type(),
       std::nullopt,
       std::nullopt,
@@ -245,7 +245,7 @@ void PrestoVectorSerde::serializeSingleColumn(
       vector->size(),
       prestoOptions);
   Scratch scratch;
-  serializeColumn(vector, folly::Range(&range, 1), stream.get(), scratch);
+  detail::serializeColumn(vector, folly::Range(&range, 1), stream.get(), scratch);
 
   PrestoOutputStreamListener listener;
   OStreamOutputStream outputStream(output, &listener);

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -52,7 +52,8 @@ class RowSerializer : public IterativeVectorSerializer {
   void append(
       const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges,
-      Scratch& /*scratch*/) override {
+      Scratch& /*scratch*/,
+      const column_index_t /*columnStartOffset*/) override {
     size_t totalSize = 0;
     const auto totalRows = std::accumulate(
         ranges.begin(),

--- a/velox/serializers/SerializedPageFile.cpp
+++ b/velox/serializers/SerializedPageFile.cpp
@@ -151,7 +151,7 @@ uint64_t SerializedPageFileWriter::write(
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
       batch_->createStreamTree(
           std::static_pointer_cast<const RowType>(rows->type()),
-          rows->size(),
+          1'000,
           serdeOptions_.get());
     }
     batch_->append(rows, indices);

--- a/velox/serializers/SerializedPageFile.cpp
+++ b/velox/serializers/SerializedPageFile.cpp
@@ -151,7 +151,7 @@ uint64_t SerializedPageFileWriter::write(
       batch_ = std::make_unique<VectorStreamGroup>(pool_, serde_);
       batch_->createStreamTree(
           std::static_pointer_cast<const RowType>(rows->type()),
-          1'000,
+          rows->size(),
           serdeOptions_.get());
     }
     batch_->append(rows, indices);

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -246,4 +246,4 @@ void VectorStream::append(folly::Range<const bool*> values);
 
 template <>
 void VectorStream::append(folly::Range<const int128_t*> values);
-} // namespace facebook::velox::serializer::presto::detail
+} // namespace facebook::velox::serializer::presto

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -19,7 +19,7 @@
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/BaseVector.h"
 
-namespace facebook::velox::serializer::presto::detail {
+namespace facebook::velox::serializer::presto {
 // Appendable container for serialized values. To append a value at a
 // time, call appendNull or appendNonNull first. Then call appendLength if the
 // type has a length. A null value has a length of 0. Then call appendValue if
@@ -147,6 +147,10 @@ class VectorStream {
   template <typename T>
   void appendOne(const T& value) {
     append(folly::Range(&value, 1));
+  }
+
+  ByteOutputStream& getValueSteam() {
+    return values_;
   }
 
   bool isDictionaryStream() const {

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -187,8 +187,9 @@ void VectorStreamGroup::createStreamTree(
 void VectorStreamGroup::append(
     const RowVectorPtr& vector,
     const folly::Range<const IndexRange*>& ranges,
-    Scratch& scratch) {
-  serializer_->append(vector, ranges, scratch);
+    Scratch& scratch,
+    const column_index_t columnStartOffset) {
+  serializer_->append(vector, ranges, scratch, columnStartOffset);
 }
 
 void VectorStreamGroup::append(

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -71,7 +71,8 @@ class IterativeVectorSerializer {
   virtual void append(
       const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges,
-      Scratch& scratch) = 0;
+      Scratch& scratch,
+      const column_index_t columnStartOffset = 0) = 0;
 
   virtual void append(
       const RowVectorPtr& vector,
@@ -446,13 +447,15 @@ class VectorStreamGroup : public StreamArena {
   void append(
       const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges,
-      Scratch& scratch);
+      Scratch& scratch,
+      const column_index_t columnOffset = 0);
 
   void append(
       const RowVectorPtr& vector,
-      const folly::Range<const IndexRange*>& ranges) {
+      const folly::Range<const IndexRange*>& ranges,
+      const column_index_t columnOffset = 0) {
     Scratch scratch;
-    append(vector, ranges, scratch);
+    append(vector, ranges, scratch, columnOffset);
   }
 
   void append(

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -33,6 +33,10 @@ struct IndexRange {
   vector_size_t size;
 };
 
+namespace serializer::presto {
+class VectorStream;
+}
+
 namespace row {
 class CompactRow;
 class UnsafeRowFast;
@@ -80,6 +84,14 @@ class IterativeVectorSerializer {
       const RowVectorPtr& vector,
       const folly::Range<const vector_size_t*>& rows,
       Scratch& scratch) {
+    VELOX_UNSUPPORTED("{}", __FUNCTION__);
+  }
+
+  virtual serializer::presto::VectorStream* getStream(vector_size_t i) {
+    VELOX_UNSUPPORTED("{}", __FUNCTION__);
+  }
+
+  virtual void appendNumRows(int32_t numRows) {
     VELOX_UNSUPPORTED("{}", __FUNCTION__);
   }
 
@@ -449,6 +461,14 @@ class VectorStreamGroup : public StreamArena {
       Scratch& scratch);
 
   void append(const RowVectorPtr& vector);
+
+  serializer::presto::VectorStream* streamAt(vector_size_t i) {
+    return serializer_->getStream(i);
+  }
+
+  void appendNumRows(int32_t numRows) {
+    serializer_->appendNumRows(numRows);
+  }
 
   void append(
       const row::CompactRow& compactRow,


### PR DESCRIPTION
Currently, Velox has to extract rows in RowContainer as vector for serialization when spilling. This PR supports serializing rows to eliminate the cost of extracting and materializing vectors corresponding to `spillExtractVectorTime` metrics.

Below are the benchmark results:
```

============================================================================
[...]ec/tests/SpillerSortBenchmarkTest.cpp     relative  time/iter   iters/s
============================================================================
integer_type                                                 1.00s   996.37m
integer_type_serialize_rows                     100.98%   993.88ms      1.01
bigint_type                                                  1.01s   988.61m
bigint_type_serialize_rows                      100.97%      1.00s   998.16m
string_type_10bytes                                          1.11s   900.35m
string_type_10bytes_serialize_rows              105.15%      1.06s   946.74m
string_type_50bytes                                          1.35s   743.15m
string_type_50bytes_long_serialize_rows         106.23%      1.27s   789.46m
array_of_integer_type                                        1.88s   530.53m
array_of_integer_type_serialize_rows            124.22%      1.52s   659.04m
array_of_10bytes_varbinary_type                              2.60s   384.22m
array_of_10bytes_varbinary_type_serialize_rows  137.72%      1.89s   529.16m
array_of_50bytes_varbinary_type                              3.68s   272.06m
array_of_50bytes_varbinary_type_serialize_rows  143.72%      2.56s   391.01m
array_of_100bytes_varbinary_type                             4.97s   201.02m
array_of_100bytes_varbinary_type_serialize_rows 149.28%      3.33s   300.08m
```

<details>

<summary>benchmark spilling stats details</summary>

```shell
============================================================================
[...]ec/tests/SpillerSortBenchmarkTest.cpp     relative  time/iter   iters/s
============================================================================
spillRuns[1] spilledInputBytes[9.54MB] spilledBytes[6.33MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[298.08ms] spillSortTimeNanos[577.05ms] spillExtractVectorTime[49.48ms] spillSerializationTimeNanos[30.22ms] spillWrites[7] spillFlushTimeNanos[17.91ms] spillWriteTimeNanos[784.38us] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
integer_type                                                 1.00s   996.37m

spillRuns[1] spilledInputBytes[12.40MB] spilledBytes[6.33MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[297.89ms] spillSortTimeNanos[577.48ms] spillExtractVectorTime[11.61ms] spillSerializationTimeNanos[51.17ms] spillWrites[7] spillFlushTimeNanos[17.38ms] spillWriteTimeNanos[832.79us] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
integer_type_serialize_rows                     100.98%   993.88ms      1.01

spillRuns[1] spilledInputBytes[15.26MB] spilledBytes[9.41MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[297.18ms] spillSortTimeNanos[577.24ms] spillExtractVectorTime[50.69ms] spillSerializationTimeNanos[30.16ms] spillWrites[10] spillFlushTimeNanos[25.71ms] spillWriteTimeNanos[1.28ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
bigint_type                                                  1.01s   988.61m

spillRuns[1] spilledInputBytes[16.21MB] spilledBytes[9.41MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[294.63ms] spillSortTimeNanos[575.87ms] spillExtractVectorTime[11.61ms] spillSerializationTimeNanos[54.57ms] spillWrites[10] spillFlushTimeNanos[25.36ms] spillWriteTimeNanos[1.17ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
bigint_type_serialize_rows                      100.97%      1.00s   998.16m

spillRuns[1] spilledInputBytes[26.70MB] spilledBytes[14.77MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[302.08ms] spillSortTimeNanos[577.42ms] spillExtractVectorTime[83.14ms] spillSerializationTimeNanos[76.10ms] spillWrites[15] spillFlushTimeNanos[40.56ms] spillWriteTimeNanos[1.51ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
string_type_10bytes                                          1.11s   900.35m

spillRuns[1] spilledInputBytes[27.66MB] spilledBytes[14.77MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[298.01ms] spillSortTimeNanos[574.23ms] spillExtractVectorTime[20.10ms] spillSerializationTimeNanos[83.73ms] spillWrites[15] spillFlushTimeNanos[39.57ms] spillWriteTimeNanos[1.50ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
string_type_10bytes_serialize_rows              105.15%      1.06s   946.74m

spillRuns[1] spilledInputBytes[757.69MB] spilledBytes[44.08MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[297.01ms] spillSortTimeNanos[570.92ms] spillExtractVectorTime[185.83ms] spillSerializationTimeNanos[129.09ms] spillWrites[47] spillFlushTimeNanos[112.08ms] spillWriteTimeNanos[5.73ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
string_type_50bytes                                          1.35s   743.15m

spillRuns[1] spilledInputBytes[69.36MB] spilledBytes[44.08MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[297.38ms] spillSortTimeNanos[574.21ms] spillExtractVectorTime[19.52ms] spillSerializationTimeNanos[186.17ms] spillWrites[47] spillFlushTimeNanos[118.13ms] spillWriteTimeNanos[19.35ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
string_type_50bytes_long_serialize_rows         106.23%      1.27s   789.46m

spillRuns[1] spilledInputBytes[103.43MB] spilledBytes[23.38MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[299.08ms] spillSortTimeNanos[577.30ms] spillExtractVectorTime[625.65ms] spillSerializationTimeNanos[237.93ms] spillWrites[32] spillFlushTimeNanos[93.37ms] spillWriteTimeNanos[3.34ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_integer_type                                        1.88s   530.53m

spillRuns[1] spilledInputBytes[63.40MB] spilledBytes[23.38MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[299.58ms] spillSortTimeNanos[577.55ms] spillExtractVectorTime[20.12ms] spillSerializationTimeNanos[455.54ms] spillWrites[32] spillFlushTimeNanos[94.09ms] spillWriteTimeNanos[3.36ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_integer_type_serialize_rows            124.22%      1.52s   659.04m

spillRuns[1] spilledInputBytes[370.92MB] spilledBytes[73.02MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[298.38ms] spillSortTimeNanos[576.86ms] spillExtractVectorTime[793.47ms] spillSerializationTimeNanos[590.73ms] spillWrites[97] spillFlushTimeNanos[265.04ms] spillWriteTimeNanos[13.06ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_10bytes_varbinary_type                              2.60s   384.22m

spillRuns[1] spilledInputBytes[121.80MB] spilledBytes[72.81MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[297.92ms] spillSortTimeNanos[571.34ms] spillExtractVectorTime[21.37ms] spillSerializationTimeNanos[666.29ms] spillWrites[97] spillFlushTimeNanos[256.59ms] spillWriteTimeNanos[9.22ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_10bytes_varbinary_type_serialize_rows  137.72%      1.89s   529.16m

spillRuns[1] spilledInputBytes[1.06GB] spilledBytes[253.80MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[297.86ms] spillSortTimeNanos[566.41ms] spillExtractVectorTime[1.00s] spillSerializationTimeNanos[946.97ms] spillWrites[328] spillFlushTimeNanos[725.17ms] spillWriteTimeNanos[35.09ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_50bytes_varbinary_type                              3.68s   272.06m

spillRuns[1] spilledInputBytes[353.89MB] spilledBytes[254.86MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[296.06ms] spillSortTimeNanos[574.13ms] spillExtractVectorTime[20.52ms] spillSerializationTimeNanos[785.47ms] spillWrites[328] spillFlushTimeNanos[728.75ms] spillWriteTimeNanos[45.17ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_50bytes_varbinary_type_serialize_rows  143.72%      2.56s   391.01m

spillRuns[1] spilledInputBytes[1.13GB] spilledBytes[476.34MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[298.18ms] spillSortTimeNanos[571.76ms] spillExtractVectorTime[1.14s] spillSerializationTimeNanos[1.37s] spillWrites[612] spillFlushTimeNanos[1.36s] spillWriteTimeNanos[75.16ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_100bytes_varbinary_type                             4.97s   201.02m

spillRuns[1] spilledInputBytes[643.58MB] spilledBytes[475.49MB] spilledRows[1000000] spilledPartitions[1] spilledFiles[1] spillFillTimeNanos[294.76ms] spillSortTimeNanos[565.68ms] spillExtractVectorTime[19.21ms] spillSerializationTimeNanos[905.35ms] spillWrites[612] spillFlushTimeNanos[1.34s] spillWriteTimeNanos[50.25ms] maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]
array_of_100bytes_varbinary_type_serialize_rows 149.28%      3.33s   300.08m
```

</details>