### PR TITLE
docs: Move 'task_splits_count' to 'Task Execution' category

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -45,6 +45,9 @@ void registerVeloxMetrics() {
   DEFINE_HISTOGRAM_METRIC(
       kMetricTaskBarrierProcessTimeMs, 1'000, 0, 30'000, 50, 90, 99, 100);
 
+  // Tracks the total number of splits received by all tasks.
+  DEFINE_METRIC(kMetricTaskSplitsCount, facebook::velox::StatType::COUNT);
+
   /// ================== Cache Counters =================
 
   // Tracks hive handle generation latency in range of [0, 100s] and reports
@@ -369,9 +372,6 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricTaskMemoryReclaimWaitTimeoutCount,
       facebook::velox::StatType::COUNT);
-
-  // Tracks the total number of splits received by all tasks.
-  DEFINE_METRIC(kMetricTaskSplitsCount, facebook::velox::StatType::COUNT);
 
   // The number of times that the memory reclaim fails because the operator is
   // executing a non-reclaimable section where it is expected to have reserved

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -100,6 +100,9 @@ Task Execution
      - Histogram
      - Tracks task barrier execution time in range of [0, 30s] with 30 buckets
        and each bucket with time window of 1s. We report P50, P90, P99, and P100.
+   * - task_splits_count
+     - Count
+     - The total number of splits received by all tasks.
 
 Memory Management
 -----------------
@@ -160,9 +163,6 @@ Memory Management
    * - task_memory_reclaim_wait_timeout_count
      - Count
      - The number of times that the task memory reclaim wait timeouts.
-   * - task_splits_count
-     - Count
-     - The total number of splits received by all tasks.
    * - memory_non_reclaimable_count
      - Count
      - The number of times that the memory reclaim fails because the operator is executing a


### PR DESCRIPTION
The "task_splits_count" metric is currently categorized as 
"Memory Management" in the documentation and code. This is incorrect; 
it should be in the "Task Execution" category.