### PR TITLE
fix: Update clang-format in pre-commit to fix broken CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
         name: CMake formatter
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v18.1.3
+    rev: v21.1.2
     hooks:
       - id: clang-format
         # types_or: [c++, c, cuda, metal, objective-c]


### PR DESCRIPTION
reason: https://github.com/facebookincubator/velox/commit/21af185832a129f6be1da09ea1c44c856739c5aa


same: https://github.com/facebookincubator/axiom/pull/562