### PR TITLE
feat: Add match ratio statistics to MergeJoin operator

### DIFF
--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -632,5 +632,11 @@ class MergeJoin : public Operator {
 
   bool leftHasDrained_{false};
   bool rightHasDrained_{false};
+
+  // Stats for tracking matched rows from the left side
+  uint64_t matchedLeftRows_{0};
+
+  // Stats for tracking matched rows from the right side
+  uint64_t matchedRightRows_{0};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -1310,6 +1311,160 @@ TEST_F(MergeJoinTest, antiJoinWithTwoJoinKeys) {
   AssertQueryBuilder(plan, duckDbQueryRunner_)
       .assertResults(
           "SELECT * FROM t WHERE NOT exists (select * from u where t.a = u.c and t.b < u.d)");
+}
+
+TEST_F(MergeJoinTest, matchRatioStats) {
+  // Test match ratio statistics for different join scenarios.
+
+  // Inner join with full match (all rows match).
+  {
+    auto left = makeRowVector(
+        {"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 3, 4, 5})});
+    auto right = makeRowVector(
+        {"u0"}, {makeNullableFlatVector<int64_t>({1, 2, 3, 4, 5})});
+
+    createDuckDbTable("t", {left});
+    createDuckDbTable("u", {right});
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId mergeJoinNodeId;
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .mergeJoin(
+                {"t0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+                "",
+                {"t0", "u0"},
+                core::JoinType::kInner)
+            .capturePlanNodeId(mergeJoinNodeId)
+            .planNode();
+
+    auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                    .assertResults("SELECT t0, u0 FROM t, u WHERE t0 = u0");
+
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(stats.at(mergeJoinNodeId).outputRows, 5);
+
+    auto runtimeStats = stats.at(mergeJoinNodeId).customStats;
+    ASSERT_EQ(runtimeStats.at("matchedLeftRows").sum, 5);
+    ASSERT_EQ(runtimeStats.at("matchedRightRows").sum, 5);
+  }
+
+  // Inner join with partial match.
+  {
+    auto left = makeRowVector(
+        {"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8})});
+    auto right = makeRowVector(
+        {"u0"}, {makeNullableFlatVector<int64_t>({2, 4, 6, 10, 12})});
+
+    createDuckDbTable("t", {left});
+    createDuckDbTable("u", {right});
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId mergeJoinNodeId;
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .mergeJoin(
+                {"t0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+                "",
+                {"t0", "u0"},
+                core::JoinType::kInner)
+            .capturePlanNodeId(mergeJoinNodeId)
+            .planNode();
+
+    auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                    .assertResults("SELECT t0, u0 FROM t, u WHERE t0 = u0");
+
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(stats.at(mergeJoinNodeId).outputRows, 3);
+
+    auto runtimeStats = stats.at(mergeJoinNodeId).customStats;
+    // Only 3 left rows match (2, 4, 6).
+    ASSERT_EQ(runtimeStats.at("matchedLeftRows").sum, 3);
+    // Only 3 right rows match (2, 4, 6).
+    ASSERT_EQ(runtimeStats.at("matchedRightRows").sum, 3);
+  }
+
+  // Left join - all left rows appear in output.
+  {
+    auto left = makeRowVector(
+        {"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 3, 4, 5})});
+    auto right =
+        makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({2, 4})});
+
+    createDuckDbTable("t", {left});
+    createDuckDbTable("u", {right});
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId mergeJoinNodeId;
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .mergeJoin(
+                {"t0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+                "",
+                {"t0", "u0"},
+                core::JoinType::kLeft)
+            .capturePlanNodeId(mergeJoinNodeId)
+            .planNode();
+
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .assertResults("SELECT t0, u0 FROM t LEFT JOIN u ON t0 = u0");
+
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(stats.at(mergeJoinNodeId).outputRows, 5);
+
+    auto runtimeStats = stats.at(mergeJoinNodeId).customStats;
+    // Only 2 left rows match (2, 4).
+    ASSERT_EQ(runtimeStats.at("matchedLeftRows").sum, 2);
+    ASSERT_EQ(runtimeStats.at("matchedRightRows").sum, 2);
+  }
+
+  // Join with duplicate keys (cartesian product).
+  {
+    auto left = makeRowVector(
+        {"t0"}, {makeNullableFlatVector<int64_t>({1, 1, 1, 2, 2})});
+    auto right = makeRowVector(
+        {"u0"}, {makeNullableFlatVector<int64_t>({1, 1, 2, 2, 2})});
+
+    createDuckDbTable("t", {left});
+    createDuckDbTable("u", {right});
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    core::PlanNodeId mergeJoinNodeId;
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values({left})
+            .mergeJoin(
+                {"t0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+                "",
+                {"t0", "u0"},
+                core::JoinType::kInner)
+            .capturePlanNodeId(mergeJoinNodeId)
+            .planNode();
+
+    auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                    .assertResults("SELECT t0, u0 FROM t, u WHERE t0 = u0");
+
+    auto stats = toPlanStats(task->taskStats());
+    ASSERT_EQ(stats.at(mergeJoinNodeId).outputRows, 12);
+
+    auto runtimeStats = stats.at(mergeJoinNodeId).customStats;
+    // 3 left rows with key=1 and 2 left rows with key=2.
+    ASSERT_EQ(runtimeStats.at("matchedLeftRows").sum, 5);
+    // 2 right rows with key=1 and 3 right rows with key=2.
+    ASSERT_EQ(runtimeStats.at("matchedRightRows").sum, 5);
+  }
 }
 
 TEST_F(MergeJoinTest, antiJoinWithUniqueJoinKeys) {


### PR DESCRIPTION
Summary:
Track and report the number of input rows and matched rows for both left
and right sides of the join. This enables calculating match ratios to
understand join efficiency and selectivity.

Differential Revision: D85612995


