### PR TITLE
refactor(filter): Enable users to move strings in

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -229,7 +229,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeEqualFilter(
     case TypeKind::HUGEINT:
       return equalHugeint(singleValue<int128_t>(value));
     case TypeKind::VARCHAR:
-      return equal(singleValue<StringView>(value));
+      return equal(std::string(singleValue<StringView>(value)));
     case TypeKind::TIMESTAMP:
       return equal(singleValue<Timestamp>(value));
     default:
@@ -261,7 +261,7 @@ ExprToSubfieldFilterParser::makeGreaterThanFilter(
     case TypeKind::REAL:
       return greaterThanFloat(singleValue<float>(lower));
     case TypeKind::VARCHAR:
-      return greaterThan(singleValue<StringView>(lower));
+      return greaterThan(std::string(singleValue<StringView>(lower)));
     case TypeKind::TIMESTAMP:
       return greaterThan(singleValue<Timestamp>(lower));
     default:
@@ -292,7 +292,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeLessThanFilter(
     case TypeKind::REAL:
       return lessThanFloat(singleValue<float>(upper));
     case TypeKind::VARCHAR:
-      return lessThan(singleValue<StringView>(upper));
+      return lessThan(std::string(singleValue<StringView>(upper)));
     case TypeKind::TIMESTAMP:
       return lessThan(singleValue<Timestamp>(upper));
     default:
@@ -324,7 +324,7 @@ ExprToSubfieldFilterParser::makeLessThanOrEqualFilter(
     case TypeKind::REAL:
       return lessThanOrEqualFloat(singleValue<float>(upper));
     case TypeKind::VARCHAR:
-      return lessThanOrEqual(singleValue<StringView>(upper));
+      return lessThanOrEqual(std::string(singleValue<StringView>(upper)));
     case TypeKind::TIMESTAMP:
       return lessThanOrEqual(singleValue<Timestamp>(upper));
     default:
@@ -356,7 +356,7 @@ ExprToSubfieldFilterParser::makeGreaterThanOrEqualFilter(
     case TypeKind::REAL:
       return greaterThanOrEqualFloat(singleValue<float>(lower));
     case TypeKind::VARCHAR:
-      return greaterThanOrEqual(singleValue<StringView>(lower));
+      return greaterThanOrEqual(std::string(singleValue<StringView>(lower)));
     case TypeKind::TIMESTAMP:
       return greaterThanOrEqual(singleValue<Timestamp>(lower));
     default:
@@ -401,7 +401,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeInFilter(
       auto stringElements = elements->as<SimpleVector<StringView>>();
       std::vector<std::string> values;
       for (auto i = 0; i < size; i++) {
-        values.push_back(stringElements->valueAt(offset + i).str());
+        values.push_back(std::string(stringElements->valueAt(offset + i)));
       }
       if (negated) {
         return notIn(values);
@@ -451,10 +451,12 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeBetweenFilter(
     case TypeKind::VARCHAR:
       if (negated) {
         return notBetween(
-            singleValue<StringView>(lower), singleValue<StringView>(upper));
+            std::string(singleValue<StringView>(lower)),
+            std::string(singleValue<StringView>(upper)));
       }
       return between(
-          singleValue<StringView>(lower), singleValue<StringView>(upper));
+          std::string(singleValue<StringView>(lower)),
+          std::string(singleValue<StringView>(upper)));
     case TypeKind::TIMESTAMP:
       return negated
           ? nullptr

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -221,64 +221,58 @@ inline std::unique_ptr<common::BigintRange> equal(
   return std::make_unique<common::BigintRange>(value, value, nullAllowed);
 }
 
-inline std::unique_ptr<common::BytesRange> between(
-    const std::string& min,
-    const std::string& max,
-    bool nullAllowed = false) {
+inline std::unique_ptr<common::BytesRange>
+between(std::string min, std::string max, bool nullAllowed = false) {
   return std::make_unique<common::BytesRange>(
-      min, false, false, max, false, false, nullAllowed);
+      std::move(min), false, false, std::move(max), false, false, nullAllowed);
 }
 
-inline std::unique_ptr<common::BytesRange> betweenExclusive(
-    const std::string& min,
-    const std::string& max,
-    bool nullAllowed = false) {
+inline std::unique_ptr<common::BytesRange>
+betweenExclusive(std::string min, std::string max, bool nullAllowed = false) {
   return std::make_unique<common::BytesRange>(
-      min, false, true, max, false, true, nullAllowed);
+      std::move(min), false, true, std::move(max), false, true, nullAllowed);
 }
 
-inline std::unique_ptr<common::NegatedBytesRange> notBetween(
-    const std::string& min,
-    const std::string& max,
-    bool nullAllowed = false) {
+inline std::unique_ptr<common::NegatedBytesRange>
+notBetween(std::string min, std::string max, bool nullAllowed = false) {
   return std::make_unique<common::NegatedBytesRange>(
-      min, false, false, max, false, false, nullAllowed);
+      std::move(min), false, false, std::move(max), false, false, nullAllowed);
 }
 
 inline std::unique_ptr<common::NegatedBytesRange> notBetweenExclusive(
-    const std::string& min,
-    const std::string& max,
+    std::string min,
+    std::string max,
     bool nullAllowed = false) {
   return std::make_unique<common::NegatedBytesRange>(
-      min, false, true, max, false, true, nullAllowed);
+      std::move(min), false, true, std::move(max), false, true, nullAllowed);
 }
 
 inline std::unique_ptr<common::BytesRange> lessThanOrEqual(
-    const std::string& max,
+    std::string max,
     bool nullAllowed = false) {
   return std::make_unique<common::BytesRange>(
-      "", true, false, max, false, false, nullAllowed);
+      "", true, false, std::move(max), false, false, nullAllowed);
 }
 
 inline std::unique_ptr<common::BytesRange> lessThan(
-    const std::string& max,
+    std::string max,
     bool nullAllowed = false) {
   return std::make_unique<common::BytesRange>(
-      "", true, false, max, false, true, nullAllowed);
+      "", true, false, std::move(max), false, true, nullAllowed);
 }
 
 inline std::unique_ptr<common::BytesRange> greaterThanOrEqual(
-    const std::string& min,
+    std::string min,
     bool nullAllowed = false) {
   return std::make_unique<common::BytesRange>(
-      min, false, false, "", true, false, nullAllowed);
+      std::move(min), false, false, "", true, false, nullAllowed);
 }
 
 inline std::unique_ptr<common::BytesRange> greaterThan(
-    const std::string& min,
+    std::string min,
     bool nullAllowed = false) {
   return std::make_unique<common::BytesRange>(
-      min, false, true, "", true, false, nullAllowed);
+      std::move(min), false, true, "", true, false, nullAllowed);
 }
 
 inline std::unique_ptr<common::Filter> in(

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1684,10 +1684,10 @@ class BytesRange final : public AbstractRange {
   /// the filter.
   /// @param nullAllowed Null values are passing the filter if true.
   BytesRange(
-      const std::string& lower,
+      std::string lower,
       bool lowerUnbounded,
       bool lowerExclusive,
-      const std::string& upper,
+      std::string upper,
       bool upperUnbounded,
       bool upperExclusive,
       bool nullAllowed)
@@ -1698,8 +1698,8 @@ class BytesRange final : public AbstractRange {
             upperExclusive,
             nullAllowed,
             FilterKind::kBytesRange),
-        lower_(lower),
-        upper_(upper),
+        lower_(std::move(lower)),
+        upper_(std::move(upper)),
         singleValue_(
             !lowerExclusive_ && !upperExclusive_ && !lowerUnbounded_ &&
             !upperUnbounded_ && lower_ == upper_) {
@@ -1816,19 +1816,19 @@ class NegatedBytesRange final : public Filter {
   /// the filter.
   /// @param nullAllowed Null values are passing the filter if true.
   NegatedBytesRange(
-      const std::string& lower,
+      std::string lower,
       bool lowerUnbounded,
       bool lowerExclusive,
-      const std::string& upper,
+      std::string upper,
       bool upperUnbounded,
       bool upperExclusive,
       bool nullAllowed)
       : Filter(true, nullAllowed, FilterKind::kNegatedBytesRange) {
     nonNegated_ = std::make_unique<BytesRange>(
-        lower,
+        std::move(lower),
         lowerUnbounded,
         lowerExclusive,
-        upper,
+        std::move(upper),
         upperUnbounded,
         upperExclusive,
         nullAllowed);


### PR DESCRIPTION
Summary:
Changing the constructor APIs to take parameters by value to enable
API users to move strings in, letting them being constructed within the object
directly.

Also making velox::StringView->std::string conversions explicit, for
clarity since they require an allocation and a string copy.

Differential Revision: D85614187


