### PR TITLE
feat: Add s3 OCI endpoint region inference when region is not specified in the config

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -32,6 +32,9 @@
 
 namespace facebook::velox::filesystems {
 
+constexpr std::string_view kAWSHostSuffix{".amazonaws.com"};
+constexpr std::string_view kOCIHostSuffix{".oraclecloud.com"};
+
 namespace {
 static std::string_view kSep{"/"};
 // AWS S3 EMRFS, Hadoop block storage filesystem on-top of Amazon S3 buckets.
@@ -193,13 +196,17 @@ std::string getHttpProxyEnvVar();
 std::string getHttpsProxyEnvVar();
 std::string getNoProxyEnvVar();
 
+bool isAWSEndpoint(const std::string_view& endpoint);
+bool isOCIEndpoint(const std::string_view& endpoint);
+
 // Adopted from the AWS Java SDK
-// Endpoint can be 'service.[region].amazonaws.com' or
+// For AWS, endpoint can be 'service.[region].amazonaws.com' or
 // 'bucket.s3-[region].amazonaws.com' or bucket.s3.[region].amazonaws.com'
+// For OCI, endpoint can be 'service.[region].oraclecloud.com' or
+// 'namespace.compat.objectstorage.[region].oraclecloud.com'.
 // Return value is a region string value if present.
 // The endpoint may contain a trailing '/' that is handled.
-std::optional<std::string> parseAWSStandardRegionName(
-    std::string_view endpoint);
+std::optional<std::string> parseStandardRegionName(std::string_view endpoint);
 
 class S3ProxyConfigurationBuilder {
  public:

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -129,23 +129,44 @@ TEST(S3UtilTest, isDomainExcludedFromProxy) {
 
 TEST(S3UtilTest, parseAWSRegion) {
   // bucket.s3.[region]
-  EXPECT_EQ(
-      parseAWSStandardRegionName("foo.s3.region.amazonaws.com"), "region");
-  EXPECT_EQ(
-      parseAWSStandardRegionName("foo.s3.region.amazonaws.com/"), "region");
+  EXPECT_EQ(parseStandardRegionName("foo.s3.region.amazonaws.com"), "region");
+  EXPECT_EQ(parseStandardRegionName("foo.s3.region.amazonaws.com/"), "region");
   // bucket.s3-[region]
-  EXPECT_EQ(
-      parseAWSStandardRegionName("foo.s3-region.amazonaws.com"), "region");
-  EXPECT_EQ(
-      parseAWSStandardRegionName("foo.s3-region.amazonaws.com/"), "region");
+  EXPECT_EQ(parseStandardRegionName("foo.s3-region.amazonaws.com"), "region");
+  EXPECT_EQ(parseStandardRegionName("foo.s3-region.amazonaws.com/"), "region");
   // service.[region]
-  EXPECT_EQ(parseAWSStandardRegionName("foo.a3-reg.amazonaws.com"), "a3-reg");
-  EXPECT_EQ(parseAWSStandardRegionName("foo.a3-reg.amazonaws.com/"), "a3-reg");
+  EXPECT_EQ(parseStandardRegionName("foo.a3-reg.amazonaws.com"), "a3-reg");
+  EXPECT_EQ(parseStandardRegionName("foo.a3-reg.amazonaws.com/"), "a3-reg");
   // Not the right suffix
+  EXPECT_EQ(parseStandardRegionName("foo.a3-region.amazon.com"), std::nullopt);
+  EXPECT_EQ(parseStandardRegionName(""), std::nullopt);
+  EXPECT_EQ(parseStandardRegionName("velox"), std::nullopt);
+}
+
+TEST(S3UtilTest, parseOCIRegion) {
   EXPECT_EQ(
-      parseAWSStandardRegionName("foo.a3-region.amazon.com"), std::nullopt);
-  EXPECT_EQ(parseAWSStandardRegionName(""), std::nullopt);
-  EXPECT_EQ(parseAWSStandardRegionName("velox"), std::nullopt);
+      parseStandardRegionName("foo.objectstorage.uk-london.oraclecloud.com"),
+      "uk-london");
+  EXPECT_EQ(
+      parseStandardRegionName("foo.objectstorage.uk-london.oraclecloud.com/"),
+      "uk-london");
+  EXPECT_EQ(
+      parseStandardRegionName(
+          "bar.baz.objectstorage.ca-toronto-1.oraclecloud.com"),
+      "ca-toronto-1");
+  EXPECT_EQ(
+      parseStandardRegionName(
+          "bar.baz.objectstorage.ca-toronto-1.oraclecloud.com/"),
+      "ca-toronto-1");
+  EXPECT_EQ(
+      parseStandardRegionName(
+          "service.subservice.objectstorage.us-ashburn-1.oraclecloud.com"),
+      "us-ashburn-1");
+  EXPECT_EQ(
+      parseStandardRegionName("foo.objectstorage.us-ashburn-1.oracle.com"),
+      std::nullopt);
+  EXPECT_EQ(parseStandardRegionName(""), std::nullopt);
+  EXPECT_EQ(parseStandardRegionName("velox"), std::nullopt);
 }
 
 TEST(S3UtilTest, isIpExcludedFromProxy) {


### PR DESCRIPTION
Add s3 OCI endpoint region inference when region is not provided in the config. Also sets path-style-access=true for when OCI endpoint is detected.

The Oracle Cloud Infrastucture's (OCI) S3 object storage requires the region to be provided and set path-style-access=true in order for it to work. 

Currently, there is only implementation for inferring region from the endpoint for AWS S3 when region is not provided in the config. This PR will implement region inference from endpoint for OCI S3 just like how it's inferred for AWS when region is not explicitly provided in the config.