### PR TITLE
fix: Remove resolveAggregateFunction API

### DIFF
--- a/velox/exec/AggregateFunctionRegistry.cpp
+++ b/velox/exec/AggregateFunctionRegistry.cpp
@@ -21,29 +21,6 @@
 
 namespace facebook::velox::exec {
 
-std::pair<TypePtr, TypePtr> resolveAggregateFunction(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes) {
-  if (auto signatures = getAggregateFunctionSignatures(name)) {
-    for (const auto& signature : signatures.value()) {
-      SignatureBinder binder(*signature, argTypes);
-      if (binder.tryBind()) {
-        return std::make_pair(
-            binder.tryResolveReturnType(),
-            binder.tryResolveType(signature->intermediateType()));
-      }
-    }
-
-    std::stringstream error;
-    error << "Aggregate function signature is not supported: "
-          << toString(name, argTypes)
-          << ". Supported signatures: " << toString(signatures.value()) << ".";
-    VELOX_USER_FAIL(error.str());
-  } else {
-    VELOX_USER_FAIL("Aggregate function not registered: {}", name);
-  }
-}
-
 TypePtr resolveResultType(
     const std::string& name,
     const std::vector<TypePtr>& argTypes) {

--- a/velox/exec/AggregateFunctionRegistry.h
+++ b/velox/exec/AggregateFunctionRegistry.h
@@ -22,15 +22,6 @@
 
 namespace facebook::velox::exec {
 
-/// Given a name of aggregate function and argument types, returns a pair of the
-/// return type and intermediate type if the function exists. Throws if function
-/// doesn't exist or doesn't support specified argument types.
-///
-/// @return a pair of {finalType, intermediateType}
-std::pair<TypePtr, TypePtr> resolveAggregateFunction(
-    const std::string& name,
-    const std::vector<TypePtr>& argTypes);
-
 /// Given a name of aggregate function and argument types, returns the result
 /// type if the function exists. Throws if function doesn't exist or doesn't
 /// support specified argument types. Since aggregate functions can be

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -46,17 +46,6 @@ class AggregateFunctionRegistryTest : public testing::Test {
     EXPECT_EQ(*intermediateType, *expectedIntermediateType);
   }
 
-  void testResolveCombined(
-      const std::string& name,
-      const std::vector<TypePtr>& argTypes,
-      const TypePtr& expectedFinalType,
-      const TypePtr& expectedIntermediateType) {
-    auto [finalType, intermediateType] =
-        resolveAggregateFunction(name, argTypes);
-    EXPECT_EQ(*finalType, *expectedFinalType);
-    EXPECT_EQ(*intermediateType, *expectedIntermediateType);
-  }
-
   void clearRegistry() {
     aggregateFunctions().withWLock(
         [](auto& aggregationFunctionMap) { aggregationFunctionMap.clear(); });
@@ -74,19 +63,6 @@ TEST_F(AggregateFunctionRegistryTest, basic) {
       ARRAY(BOOLEAN()),
       ARRAY(ARRAY(BOOLEAN())));
   testResolve("aggregate_func", {}, DATE(), DATE());
-}
-
-TEST_F(AggregateFunctionRegistryTest, combinedAPI) {
-  testResolveCombined(
-      "aggregate_func", {BIGINT(), DOUBLE()}, BIGINT(), ARRAY(BIGINT()));
-  testResolveCombined(
-      "aggregate_func", {DOUBLE(), DOUBLE()}, DOUBLE(), ARRAY(DOUBLE()));
-  testResolveCombined(
-      "aggregate_func",
-      {ARRAY(BOOLEAN()), ARRAY(BOOLEAN())},
-      ARRAY(BOOLEAN()),
-      ARRAY(ARRAY(BOOLEAN())));
-  testResolveCombined("aggregate_func", {}, DATE(), DATE());
 }
 
 TEST_F(AggregateFunctionRegistryTest, wrongFunctionName) {
@@ -107,28 +83,6 @@ TEST_F(AggregateFunctionRegistryTest, wrongArgType) {
       "Aggregate function signature is not supported");
   VELOX_ASSERT_THROW(
       resolveResultType("aggregate_func", {BIGINT(), BIGINT(), BIGINT()}),
-      "Aggregate function signature is not supported");
-}
-
-TEST_F(AggregateFunctionRegistryTest, wrongFunctionNameCombinedAPI) {
-  VELOX_ASSERT_THROW(
-      resolveAggregateFunction("aggregate_func_nonexist", {BIGINT(), BIGINT()}),
-      "Aggregate function not registered: aggregate_func_nonexist");
-  VELOX_ASSERT_THROW(
-      resolveAggregateFunction("aggregate_func_nonexist", {}),
-      "Aggregate function not registered: aggregate_func_nonexist");
-}
-
-TEST_F(AggregateFunctionRegistryTest, wrongArgTypeCombinedAPI) {
-  VELOX_ASSERT_THROW(
-      resolveAggregateFunction("aggregate_func", {DOUBLE(), BIGINT()}),
-      "Aggregate function signature is not supported");
-  VELOX_ASSERT_THROW(
-      resolveAggregateFunction("aggregate_func", {BIGINT()}),
-      "Aggregate function signature is not supported");
-  VELOX_ASSERT_THROW(
-      resolveAggregateFunction(
-          "aggregate_func", {BIGINT(), BIGINT(), BIGINT()}),
       "Aggregate function signature is not supported");
 }
 


### PR DESCRIPTION
Summary:
Removed the existing `resolveAggregateFunction` API that returned both result and intermediate types as a pair in favor of the new split APIs:
- `resolveResultType`: Returns only the final type
- `resolveIntermediateType`: Returns only the intermediate type

Differential Revision: D85456269


