### PR TITLE
misc: Backout 'Support decimal as partition key type in Hive write and read'

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -28,46 +28,6 @@ int32_t hashInt64(int64_t value) {
   return ((*reinterpret_cast<uint64_t*>(&value)) >> 32) ^ value;
 }
 
-template <typename T>
-inline int32_t hashDecimal(T value, uint8_t scale) {
-  bool isNegative = value < 0;
-  uint64_t absValue =
-      isNegative ? -static_cast<uint64_t>(value) : static_cast<uint64_t>(value);
-
-  uint32_t high = absValue >> 32;
-  uint32_t low = absValue;
-
-  uint32_t hash = 31 * high + low;
-  if (isNegative) {
-    hash = -hash;
-  }
-
-  return 31 * hash + scale;
-}
-
-// Simulates Hive's hashing function from Hive v1.2.1
-// org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils#hashcode()
-// Returns java BigDecimal#hashCode()
-template <>
-inline int32_t hashDecimal<int128_t>(int128_t value, uint8_t scale) {
-  uint32_t words[4];
-  bool isNegative = value < 0;
-  uint128_t absValue = isNegative ? -value : value;
-  words[0] = absValue >> 96;
-  words[1] = absValue >> 64;
-  words[2] = absValue >> 32;
-  words[3] = absValue;
-
-  uint32_t hash = 0;
-  for (auto i = 0; i < 4; i++) {
-    hash = 31 * hash + words[i];
-  }
-  if (isNegative) {
-    hash = -hash;
-  }
-  return hash * 31 + scale;
-}
-
 #if defined(__has_feature)
 #if __has_feature(__address_sanitizer__)
 __attribute__((no_sanitize("integer")))
@@ -155,34 +115,6 @@ void hashPrimitive(
     const SelectivityVector& rows,
     bool mix,
     std::vector<uint32_t>& hashes) {
-  const auto& type = values.base()->type();
-  if constexpr (kind == TypeKind::BIGINT || kind == TypeKind::HUGEINT) {
-    if (type->isDecimal()) {
-      const auto scale = getDecimalPrecisionScale(*type).second;
-      if (rows.isAllSelected()) {
-        vector_size_t numRows = rows.size();
-        for (auto i = 0; i < numRows; ++i) {
-          const uint32_t hash = values.isNullAt(i)
-              ? 0
-              : hashDecimal(
-                    values.valueAt<typename TypeTraits<kind>::NativeType>(i),
-                    scale);
-          mergeHash(mix, hash, hashes[i]);
-        }
-      } else {
-        rows.applyToSelected([&](auto row) INLINE_LAMBDA {
-          const uint32_t hash = values.isNullAt(row)
-              ? 0
-              : hashDecimal(
-                    values.valueAt<typename TypeTraits<kind>::NativeType>(row),
-                    scale);
-          mergeHash(mix, hash, hashes[row]);
-        });
-      }
-      return;
-    }
-  }
-
   if (rows.isAllSelected()) {
     // The compiler seems to be a little fickle with optimizations.
     // Although rows.applyToSelected should do roughly the same thing, doing
@@ -277,16 +209,6 @@ void HivePartitionFunction::hashTyped<TypeKind::BIGINT>(
     std::vector<uint32_t>& hashes,
     size_t /* poolIndex */) {
   hashPrimitive<TypeKind::BIGINT>(values, rows, mix, hashes);
-}
-
-template <>
-void HivePartitionFunction::hashTyped<TypeKind::HUGEINT>(
-    const DecodedVector& values,
-    const SelectivityVector& rows,
-    bool mix,
-    std::vector<uint32_t>& hashes,
-    size_t /* poolIndex */) {
-  hashPrimitive<TypeKind::HUGEINT>(values, rows, mix, hashes);
 }
 
 template <>

--- a/velox/connectors/hive/HivePartitionUtil.cpp
+++ b/velox/connectors/hive/HivePartitionUtil.cpp
@@ -27,7 +27,6 @@ namespace facebook::velox::connector::hive {
       case TypeKind::SMALLINT:                                                 \
       case TypeKind::INTEGER:                                                  \
       case TypeKind::BIGINT:                                                   \
-      case TypeKind::HUGEINT:                                                  \
       case TypeKind::VARCHAR:                                                  \
       case TypeKind::VARBINARY:                                                \
       case TypeKind::TIMESTAMP:                                                \
@@ -90,22 +89,6 @@ std::pair<std::string, std::string> makePartitionKeyValueString(
         DATE()->toString(
             partitionVector->as<SimpleVector<int32_t>>()->valueAt(row)));
   }
-  if constexpr (Kind == TypeKind::BIGINT || Kind == TypeKind::HUGEINT) {
-    if (partitionVector->type()->isDecimal()) {
-      auto [precision, scale] =
-          getDecimalPrecisionScale(*partitionVector->type());
-      const auto maxStringSize =
-          DecimalUtil::maxStringViewSize(precision, scale);
-      std::vector<char> maxString(maxStringSize);
-      const auto size = DecimalUtil::castToString(
-          partitionVector->as<SimpleVector<T>>()->valueAt(row),
-          scale,
-          maxStringSize,
-          maxString.data());
-      return std::make_pair(name, std::string(maxString.data(), size));
-    }
-  }
-
   return std::make_pair(
       name,
       makePartitionValueString(

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -52,18 +52,6 @@ VectorPtr newConstantFromStringImpl(
         pool, 1, false, type, std::move(days));
   }
 
-  if constexpr (std::is_same_v<T, int64_t> || std::is_same_v<T, int128_t>) {
-    if (type->isDecimal()) {
-      auto [precision, scale] = getDecimalPrecisionScale(*type);
-      T result;
-      const auto status = DecimalUtil::castFromString<T>(
-          StringView(value.value()), precision, scale, result);
-      VELOX_USER_CHECK(status.ok(), status.message());
-      return std::make_shared<ConstantVector<T>>(
-          pool, 1, false, type, std::move(result));
-    }
-  }
-
   if constexpr (std::is_same_v<T, StringView>) {
     return std::make_shared<ConstantVector<StringView>>(
         pool, 1, false, type, StringView(value.value()));

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -55,7 +55,7 @@ namespace facebook::velox::connector::hive {
 /// converted to their appropriate types.
 ///
 /// @param type The target Velox type for the constant vector. Supports all
-/// scalar types including primitives, dates, timestamps, and decimals.
+/// scalar types including primitives, dates, timestamps.
 /// @param value The string representation of the value to convert, formatted
 /// the same way as CAST(x as VARCHAR). Date values must be formatted using ISO
 /// 8601 as YYYY-MM-DD. If nullopt, creates a null constant vector.

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -124,58 +124,6 @@ TEST_F(HivePartitionFunctionTest, bigint) {
   assertPartitionsWithConstChannel(values, 997);
 }
 
-TEST_F(HivePartitionFunctionTest, shortDecimal) {
-  auto values = makeNullableFlatVector<int64_t>(
-      {std::nullopt,
-       300'000'000'000,
-       123456789,
-       DecimalUtil::kShortDecimalMin / 100,
-       DecimalUtil::kShortDecimalMax / 100},
-      DECIMAL(18, 2));
-
-  assertPartitions(values, 1, {0, 0, 0, 0, 0});
-  assertPartitions(values, 2, {0, 1, 1, 1, 1});
-  assertPartitions(values, 500, {0, 471, 313, 115, 37});
-  assertPartitions(values, 997, {0, 681, 6, 982, 502});
-
-  assertPartitionsWithConstChannel(values, 1);
-  assertPartitionsWithConstChannel(values, 2);
-  assertPartitionsWithConstChannel(values, 500);
-  assertPartitionsWithConstChannel(values, 997);
-
-  values = makeFlatVector<int64_t>(
-      {123456789, DecimalUtil::kShortDecimalMin, DecimalUtil::kShortDecimalMax},
-      DECIMAL(18, 0));
-  assertPartitions(values, 500, {311, 236, 412});
-}
-
-TEST_F(HivePartitionFunctionTest, longDecimal) {
-  auto values = makeNullableFlatVector<int128_t>(
-      {std::nullopt,
-       300'000'000'000,
-       HugeInt::parse("12345678901234567891"),
-       DecimalUtil::kLongDecimalMin / 100,
-       DecimalUtil::kLongDecimalMax / 100},
-      DECIMAL(38, 2));
-
-  assertPartitions(values, 1, {0, 0, 0, 0, 0});
-  assertPartitions(values, 2, {0, 1, 1, 1, 1});
-  assertPartitions(values, 500, {0, 471, 99, 49, 103});
-  assertPartitions(values, 997, {0, 681, 982, 481, 6});
-
-  assertPartitionsWithConstChannel(values, 1);
-  assertPartitionsWithConstChannel(values, 2);
-  assertPartitionsWithConstChannel(values, 500);
-  assertPartitionsWithConstChannel(values, 997);
-
-  values = makeNullableFlatVector<int128_t>(
-      {HugeInt::parse("1234567890123456789112345678"),
-       DecimalUtil::kLongDecimalMin,
-       DecimalUtil::kLongDecimalMax},
-      DECIMAL(38, 0));
-  assertPartitions(values, 997, {51, 835, 645});
-}
-
 TEST_F(HivePartitionFunctionTest, varchar) {
   auto values = makeNullableFlatVector<std::string>(
       {std::nullopt,

--- a/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
@@ -74,9 +74,7 @@ TEST_F(HivePartitionUtilTest, partitionName) {
          "flat_bigint_col",
          "dict_string_col",
          "const_date_col",
-         "flat_timestamp_col",
-         "short_decimal_col",
-         "long_decimal_col"},
+         "flat_timestamp_col"},
         {makeFlatVector<bool>(std::vector<bool>{false}),
          makeFlatVector<int8_t>(std::vector<int8_t>{10}),
          makeFlatVector<int16_t>(std::vector<int16_t>{100}),
@@ -85,10 +83,7 @@ TEST_F(HivePartitionUtilTest, partitionName) {
          makeDictionary<StringView>(std::vector<StringView>{"str1000"}),
          makeConstant<int32_t>(10000, 1, DATE()),
          makeFlatVector<Timestamp>(
-             std::vector<Timestamp>{Timestamp::fromMillis(1577836800000)}),
-         makeConstant<int64_t>(10000, 1, DECIMAL(12, 2)),
-         makeConstant<int128_t>(
-             DecimalUtil::kLongDecimalMin / 100, 1, DECIMAL(38, 2))});
+             std::vector<Timestamp>{Timestamp::fromMillis(1577836800000)})});
 
     std::vector<std::string> expectedPartitionKeyValues{
         "flat_bool_col=false",
@@ -98,9 +93,7 @@ TEST_F(HivePartitionUtilTest, partitionName) {
         "flat_bigint_col=10000",
         "dict_string_col=str1000",
         "const_date_col=1997-05-19",
-        "flat_timestamp_col=2019-12-31 16%3A00%3A00.0",
-        "short_decimal_col=100.00",
-        "long_decimal_col=-" + std::string(34, '9') + ".99"};
+        "flat_timestamp_col=2019-12-31 16%3A00%3A00.0"};
 
     std::vector<column_index_t> partitionChannels;
     for (auto i = 1; i <= expectedPartitionKeyValues.size(); i++) {
@@ -147,9 +140,7 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
       "flat_bigint_col",
       "flat_string_col",
       "const_date_col",
-      "flat_timestamp_col",
-      "short_decimal_col",
-      "long_decimal_col"};
+      "flat_timestamp_col"};
 
   RowVectorPtr input = makeRowVector(
       partitionColumnNames,
@@ -160,9 +151,7 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
        makeNullableFlatVector<int64_t>({std::nullopt}),
        makeNullableFlatVector<StringView>({std::nullopt}),
        makeConstant<int32_t>(std::nullopt, 1, DATE()),
-       makeNullableFlatVector<Timestamp>({std::nullopt}),
-       makeConstant<int64_t>(std::nullopt, 1, DECIMAL(12, 2)),
-       makeConstant<int128_t>(std::nullopt, 1, DECIMAL(38, 2))});
+       makeNullableFlatVector<Timestamp>({std::nullopt})});
 
   for (auto i = 0; i < partitionColumnNames.size(); i++) {
     std::vector<column_index_t> partitionChannels = {(column_index_t)i};

--- a/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
+++ b/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
@@ -322,9 +322,8 @@ TEST_F(PartitionIdGeneratorTest, supportedPartitionKeyTypes) {
             INTEGER(),
             BIGINT(),
             TIMESTAMP(),
-            DECIMAL(20, 2),
         }),
-        {0, 1, 2, 3, 4, 5, 6, 7, 8},
+        {0, 1, 2, 3, 4, 5, 6, 7},
         100,
         pool(),
         true);
@@ -342,9 +341,7 @@ TEST_F(PartitionIdGeneratorTest, supportedPartitionKeyTypes) {
          makeNullableFlatVector<Timestamp>(
              {std::nullopt,
               Timestamp::fromMillis(1639426440001),
-              Timestamp::fromMillis(1639426440002)}),
-         makeNullableFlatVector<int128_t>(
-             {std::nullopt, 1, DecimalUtil::kLongDecimalMin})});
+              Timestamp::fromMillis(1639426440002)})});
 
     raw_vector<uint64_t> ids;
     idGenerator.run(input, ids);

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -41,9 +41,6 @@ namespace facebook::velox::exec {
       case TypeKind::BIGINT: {                                              \
         return TEMPLATE_FUNC<TypeKind::BIGINT>(__VA_ARGS__);                \
       }                                                                     \
-      case TypeKind::HUGEINT: {                                             \
-        return TEMPLATE_FUNC<TypeKind::HUGEINT>(__VA_ARGS__);               \
-      }                                                                     \
       case TypeKind::VARCHAR:                                               \
       case TypeKind::VARBINARY: {                                           \
         return TEMPLATE_FUNC<TypeKind::VARCHAR>(__VA_ARGS__);               \
@@ -739,7 +736,6 @@ void extendRange(
       extendRange<int32_t>(reserve, min, max);
       break;
     case TypeKind::BIGINT:
-    case TypeKind::HUGEINT:
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
     case TypeKind::TIMESTAMP:

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -291,7 +291,6 @@ class VectorHasher {
       case TypeKind::SMALLINT:
       case TypeKind::INTEGER:
       case TypeKind::BIGINT:
-      case TypeKind::HUGEINT:
       case TypeKind::VARCHAR:
       case TypeKind::VARBINARY:
       case TypeKind::TIMESTAMP:

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1870,15 +1870,6 @@ TEST_F(TableScanTest, partitionedTableDoubleKey) {
   testPartitionedTable(filePath->getPath(), DOUBLE(), "3.5");
 }
 
-TEST_F(TableScanTest, partitionedTableDecimalKey) {
-  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
-  auto vectors = makeVectors(10, 1'000, rowType);
-  auto filePath = TempFilePath::create();
-  writeToFile(filePath->getPath(), vectors);
-  createDuckDbTable(vectors);
-  testPartitionedTable(filePath->getPath(), DECIMAL(20, 4), "3.5123");
-}
-
 TEST_F(TableScanTest, partitionedTableDateKey) {
   auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
   auto vectors = makeVectors(10, 1'000, rowType);

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -721,11 +721,6 @@ TEST_F(VectorHasherTest, merge) {
   EXPECT_EQ(numDistinct - 1, ids.size());
 }
 
-TEST_F(VectorHasherTest, computeValueIdsHugeInt) {
-  testComputeValueIds<int128_t>(false);
-  testComputeValueIds<int128_t>(true);
-}
-
 TEST_F(VectorHasherTest, computeValueIdsBigint) {
   testComputeValueIds<int64_t>(false);
   testComputeValueIds<int64_t>(true);

--- a/velox/exec/tests/utils/TableScanTestBase.cpp
+++ b/velox/exec/tests/utils/TableScanTestBase.cpp
@@ -173,11 +173,6 @@ void TableScanTestBase::testPartitionedTableImpl(
   std::string partitionValueStr;
   partitionValueStr =
       partitionValue.has_value() ? "'" + *partitionValue + "'" : "null";
-  if (partitionValue.has_value() && partitionType->isDecimal()) {
-    auto [p, s] = getDecimalPrecisionScale(*partitionType);
-    partitionValueStr =
-        fmt::format("CAST({} AS DECIMAL({}, {}))", partitionValueStr, p, s);
-  }
   assertQuery(
       op, split, fmt::format("SELECT {}, * FROM tmp", partitionValueStr));
 


### PR DESCRIPTION
Summary: This change revert's #12910 , as per [issue 15309](https://github.com/facebookincubator/velox/issues/15309) .

Differential Revision: D85714403


