### PR TITLE
fix(s3): Make the MinioServer instance only be initialized once

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -29,21 +29,22 @@ namespace {
 
 class S3FileSystemTest : public S3Test {
  protected:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
+    S3Test::SetUpTestSuite();
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
-  }
-
-  void SetUp() override {
-    S3Test::SetUp();
-    auto hiveConfig = minioServer_->hiveConfig({});
     filesystems::initializeS3("Info", kLogLocation_);
   }
 
   static void TearDownTestSuite() {
     filesystems::finalizeS3();
+    S3Test::TearDownTestSuite();
   }
 
-  std::string_view kLogLocation_ = "/tmp/foobar/";
+  void SetUp() override {
+    S3Test::SetUp();
+  }
+
+  static constexpr std::string_view kLogLocation_ = "/tmp/foobar/";
 };
 
 class MyCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
@@ -57,23 +58,107 @@ class MyCredentialsProvider : public Aws::Auth::AWSCredentialsProvider {
 
 } // namespace
 
-TEST_F(S3FileSystemTest, writeAndRead) {
-  /// The hive config used for Minio defaults to turning
-  /// off using proxy settings if the environment provides them.
-  setenv("HTTP_PROXY", "http://test:test@127.0.0.1:8888", 1);
-  const char* bucketName = "data";
-  const char* file = "test.txt";
+TEST_F(S3FileSystemTest, mkdirAndRename) {
+  const auto bucketName = "mkdir";
+  const auto file = "mkdir-test.txt";
+  const auto s3File = s3URI(bucketName, file);
+  addBucket(bucketName);
+
+  auto hiveConfig = minioServer_->hiveConfig();
+  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+
+  ASSERT_FALSE(s3fs.exists(s3File));
+  s3fs.mkdir(s3File);
+  ASSERT_TRUE(s3fs.exists(s3File));
+
+  // Rename test
+  const auto renameFile = "rename-test.txt";
+  const auto s3RenameFile = s3URI(bucketName, renameFile);
+  s3fs.rename(s3File, s3RenameFile);
+  ASSERT_TRUE(s3fs.exists(s3RenameFile));
+  ASSERT_FALSE(s3fs.exists(s3File));
+}
+
+TEST_F(S3FileSystemTest, writeFileAndRead) {
+  const auto bucketName = "writedata";
+  const auto file = "test.txt";
   const auto filename = localPath(bucketName) + "/" + file;
   const auto s3File = s3URI(bucketName, file);
   addBucket(bucketName);
-  {
-    LocalWriteFile writeFile(filename);
-    writeData(&writeFile);
-  }
+
   auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
+  auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
+  auto writeFile =
+      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
+  auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
+  std::string dataContent =
+      "Dance me to your beauty with a burning violin"
+      "Dance me through the panic till I'm gathered safely in"
+      "Lift me like an olive branch and be my homeward dove"
+      "Dance me to the end of love";
+
+  EXPECT_EQ(writeFile->size(), 0);
+  std::int64_t contentSize = dataContent.length();
+  // dataContent length is 178.
+  EXPECT_EQ(contentSize, 178);
+
+  // Append and flush a small batch of data.
+  writeFile->append(dataContent.substr(0, 10));
+  EXPECT_EQ(writeFile->size(), 10);
+  writeFile->append(dataContent.substr(10, contentSize - 10));
+  EXPECT_EQ(writeFile->size(), contentSize);
+  writeFile->flush();
+  // No parts must have been uploaded.
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
+
+  // Append data 178 * 100'000 ~ 16MiB.
+  // Should have 1 part in total with kUploadPartSize = 10MiB.
+  for (int i = 0; i < 100'000; ++i) {
+    writeFile->append(dataContent);
+  }
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 1);
+  EXPECT_EQ(writeFile->size(), 100'001 * contentSize);
+
+  // Append a large data buffer 178 * 150'000 ~ 25MiB (2 parts).
+  std::vector<char> largeBuffer(contentSize * 150'000);
+  for (int i = 0; i < 150'000; ++i) {
+    memcpy(
+        largeBuffer.data() + (i * contentSize),
+        dataContent.data(),
+        contentSize);
+  }
+
+  writeFile->append({largeBuffer.data(), largeBuffer.size()});
+  EXPECT_EQ(writeFile->size(), 250'001 * contentSize);
+  // Total data = ~41 MB = 5 parts.
+  // But parts uploaded will be 4.
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 4);
+
+  // Upload the last part.
+  writeFile->close();
+  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 5);
+
+  VELOX_ASSERT_THROW(
+      writeFile->append(dataContent.substr(0, 10)), "File is closed");
+
   auto readFile = s3fs.openFileForRead(s3File);
-  readData(readFile.get());
+  ASSERT_EQ(readFile->size(), contentSize * 250'001);
+  // Sample and verify every 1'000 dataContent chunks.
+  for (int i = 0; i < 250; ++i) {
+    ASSERT_EQ(
+        readFile->pread(i * (1'000 * contentSize), contentSize), dataContent);
+  }
+  // Verify the last chunk.
+  ASSERT_EQ(readFile->pread(contentSize * 250'000, contentSize), dataContent);
+
+  // Verify the S3 list function.
+  auto result = s3fs.list(s3File);
+
+  ASSERT_EQ(result.size(), 1);
+  ASSERT_TRUE(result[0] == file);
+
+  ASSERT_TRUE(s3fs.exists(s3File));
 }
 
 TEST_F(S3FileSystemTest, invalidCredentialsConfig) {
@@ -217,108 +302,6 @@ TEST_F(S3FileSystemTest, logLocation) {
   // It does not change with a new config.
   config["hive.s3.log-location"] = "/home/foobar";
   checkLogPrefix(expected);
-}
-
-TEST_F(S3FileSystemTest, mkdirAndRename) {
-  const auto bucketName = "mkdir";
-  const auto file = "mkdir-test.txt";
-  const auto s3File = s3URI(bucketName, file);
-  addBucket(bucketName);
-
-  auto hiveConfig = minioServer_->hiveConfig();
-  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
-
-  ASSERT_FALSE(s3fs.exists(s3File));
-  s3fs.mkdir(s3File);
-  ASSERT_TRUE(s3fs.exists(s3File));
-
-  // Rename test
-  const auto renameFile = "rename-test.txt";
-  const auto s3RenameFile = s3URI(bucketName, renameFile);
-  s3fs.rename(s3File, s3RenameFile);
-  ASSERT_TRUE(s3fs.exists(s3RenameFile));
-  ASSERT_FALSE(s3fs.exists(s3File));
-}
-
-TEST_F(S3FileSystemTest, writeFileAndRead) {
-  const auto bucketName = "writedata";
-  const auto file = "test.txt";
-  const auto filename = localPath(bucketName) + "/" + file;
-  const auto s3File = s3URI(bucketName, file);
-
-  auto hiveConfig = minioServer_->hiveConfig();
-  filesystems::S3FileSystem s3fs(bucketName, hiveConfig);
-  auto pool = memory::memoryManager()->addLeafPool("S3FileSystemTest");
-  auto writeFile =
-      s3fs.openFileForWrite(s3File, {{}, pool.get(), std::nullopt});
-  auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
-  std::string dataContent =
-      "Dance me to your beauty with a burning violin"
-      "Dance me through the panic till I'm gathered safely in"
-      "Lift me like an olive branch and be my homeward dove"
-      "Dance me to the end of love";
-
-  EXPECT_EQ(writeFile->size(), 0);
-  std::int64_t contentSize = dataContent.length();
-  // dataContent length is 178.
-  EXPECT_EQ(contentSize, 178);
-
-  // Append and flush a small batch of data.
-  writeFile->append(dataContent.substr(0, 10));
-  EXPECT_EQ(writeFile->size(), 10);
-  writeFile->append(dataContent.substr(10, contentSize - 10));
-  EXPECT_EQ(writeFile->size(), contentSize);
-  writeFile->flush();
-  // No parts must have been uploaded.
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 0);
-
-  // Append data 178 * 100'000 ~ 16MiB.
-  // Should have 1 part in total with kUploadPartSize = 10MiB.
-  for (int i = 0; i < 100'000; ++i) {
-    writeFile->append(dataContent);
-  }
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 1);
-  EXPECT_EQ(writeFile->size(), 100'001 * contentSize);
-
-  // Append a large data buffer 178 * 150'000 ~ 25MiB (2 parts).
-  std::vector<char> largeBuffer(contentSize * 150'000);
-  for (int i = 0; i < 150'000; ++i) {
-    memcpy(
-        largeBuffer.data() + (i * contentSize),
-        dataContent.data(),
-        contentSize);
-  }
-
-  writeFile->append({largeBuffer.data(), largeBuffer.size()});
-  EXPECT_EQ(writeFile->size(), 250'001 * contentSize);
-  // Total data = ~41 MB = 5 parts.
-  // But parts uploaded will be 4.
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 4);
-
-  // Upload the last part.
-  writeFile->close();
-  EXPECT_EQ(s3WriteFile->numPartsUploaded(), 5);
-
-  VELOX_ASSERT_THROW(
-      writeFile->append(dataContent.substr(0, 10)), "File is closed");
-
-  auto readFile = s3fs.openFileForRead(s3File);
-  ASSERT_EQ(readFile->size(), contentSize * 250'001);
-  // Sample and verify every 1'000 dataContent chunks.
-  for (int i = 0; i < 250; ++i) {
-    ASSERT_EQ(
-        readFile->pread(i * (1'000 * contentSize), contentSize), dataContent);
-  }
-  // Verify the last chunk.
-  ASSERT_EQ(readFile->pread(contentSize * 250'000, contentSize), dataContent);
-
-  // Verify the S3 list function.
-  auto result = s3fs.list(s3File);
-
-  ASSERT_EQ(result.size(), 1);
-  ASSERT_TRUE(result[0] == file);
-
-  ASSERT_TRUE(s3fs.exists(s3File));
 }
 
 TEST_F(S3FileSystemTest, invalidConnectionSettings) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
@@ -26,7 +26,8 @@ namespace {
 
 class S3InsertTest : public S3Test, public test::InsertTest {
  protected:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
+    S3Test::SetUpTestSuite();
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -38,10 +38,15 @@ namespace {
 
 class S3MultipleEndpoints : public S3Test, public ::test::VectorTestBase {
  public:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
+    S3Test::SetUpTestSuite();
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
-  static void TearDownTestCase() {
+
+  static void TearDownTestSuite() {
+    parquet::unregisterParquetReaderFactory();
+    parquet::unregisterParquetWriterFactory();
+    S3Test::TearDownTestSuite();
     filesystems::finalizeS3FileSystem();
   }
 
@@ -73,12 +78,6 @@ class S3MultipleEndpoints : public S3Test, public ::test::VectorTestBase {
         ioExecutor_.get());
     connector::registerConnector(hiveConnector1);
     connector::registerConnector(hiveConnector2);
-  }
-
-  void TearDown() override {
-    parquet::unregisterParquetReaderFactory();
-    parquet::unregisterParquetWriterFactory();
-    S3Test::TearDown();
   }
 
   folly::dynamic writeData(

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ReadTest.cpp
@@ -33,7 +33,8 @@ namespace {
 
 class S3ReadTest : public S3Test, public ::test::VectorTestBase {
  protected:
-  static void SetUpTestCase() {
+  static void SetUpTestSuite() {
+    S3Test::SetUpTestSuite();
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 


### PR DESCRIPTION
The free port is not truly available, and a race condition still exists as described in [ISSUE](https://github.com/facebookincubator/velox/issues/15304) and [code](https://github.com/facebookincubator/velox/blob/56a0190ca75ed4a14e7ca18975074b64be681999/velox/exec/tests/utils/PortUtil.h#L25-L27). So we need to ensure that the port usage is shared across multiple S3FileSystemTest instances. This PR moves the `MinioServer` initialization into the `SetUpTestSuite` method, ensuring it is initialized only once, which can help to eliminate the race condition and improves test stability.