### PR TITLE
feat: Add rewrites for AND and OR special forms

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/Casts.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/vector/ComplexVector.h"
+#include "velox/vector/ConstantVector.h"
 #include "velox/vector/SimpleVector.h"
 #include "velox/vector/VectorSaver.h"
 
@@ -85,6 +86,19 @@ TypedExprPtr InputTypedExpr::create(const folly::dynamic& obj, void* context) {
   auto type = core::deserializeType(obj, context);
 
   return std::make_shared<InputTypedExpr>(std::move(type));
+}
+
+std::optional<bool> ConstantTypedExpr::toBool() const {
+  VELOX_CHECK(
+      this->type()->isBoolean(),
+      "Expected boolean expression, but got {}",
+      this->type()->toString());
+
+  if (!isNull()) {
+    return valueVector_ ? valueVector_->as<ConstantVector<bool>>()->valueAt(0)
+                        : value_.value<TypeKind::BOOLEAN>();
+  }
+  return std::nullopt;
 }
 
 void ConstantTypedExpr::accept(

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -114,6 +114,10 @@ class ConstantTypedExpr : public ITypedExpr {
     return BaseVector::createConstant(type(), value_, 1, pool);
   }
 
+  /// Returns value of boolean expression, std::nullopt for null booleans.
+  /// Throws an error if expression is not of boolean type.
+  std::optional<bool> toBool() const;
+
   const std::vector<TypedExprPtr>& inputs() const {
     static const std::vector<TypedExprPtr> kEmpty{};
     return kEmpty;

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -56,6 +56,7 @@ velox_add_library(
   RowConstructor.cpp
   SimpleFunctionRegistry.cpp
   SpecialFormRegistry.cpp
+  ConjunctRewrite.cpp
   SwitchExpr.cpp
   TryExpr.cpp
   VectorFunction.cpp

--- a/velox/expression/ConjunctRewrite.cpp
+++ b/velox/expression/ConjunctRewrite.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <set>
+
+#include "velox/expression/ConjunctRewrite.h"
+#include "velox/expression/ExprConstants.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/expression/ExprUtils.h"
+
+namespace facebook::velox::expression {
+
+core::TypedExprPtr ConjunctRewrite::rewrite(const core::TypedExprPtr& expr) {
+  if (!expr->isCallKind()) {
+    return nullptr;
+  }
+
+  const auto* callExpr = expr->asUnchecked<core::CallTypedExpr>();
+  const bool conjunct = callExpr->name() == kAnd;
+  const bool disjunct = callExpr->name() == kOr;
+  if (!conjunct && !disjunct) {
+    return nullptr;
+  }
+
+  std::vector<core::TypedExprPtr> flat;
+  utils::flattenInput(expr, callExpr->name(), flat);
+  std::vector<core::TypedExprPtr> optimizedInputs;
+  bool nullInput = false;
+
+  for (const auto& input : flat) {
+    if (input->isConstantKind()) {
+      const auto* constInput = input->asUnchecked<core::ConstantTypedExpr>();
+      if (auto boolInput = constInput->toBool()) {
+        if (!boolInput.value() && conjunct) {
+          return input;
+        }
+        if (boolInput.value() && disjunct) {
+          return input;
+        }
+      } else if (!nullInput) {
+        nullInput = true;
+        optimizedInputs.push_back(input);
+      }
+    } else {
+      optimizedInputs.push_back(input);
+    }
+  }
+
+  // optimizedInputs can be empty for expressions like `true OR true`, returns
+  // the first input in this case.
+  if (optimizedInputs.empty()) {
+    return expr->inputs().front();
+  }
+  if (optimizedInputs.size() == 1) {
+    return optimizedInputs.front();
+  }
+  return std::make_shared<core::CallTypedExpr>(
+      expr->type(), std::move(optimizedInputs), callExpr->name());
+}
+
+void ConjunctRewrite::registerRewrite() {
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      expression::ConjunctRewrite::rewrite);
+}
+
+} // namespace facebook::velox::expression

--- a/velox/expression/ConjunctRewrite.h
+++ b/velox/expression/ConjunctRewrite.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::expression {
+
+class ConjunctRewrite {
+ public:
+  /// Rewrites special forms AND and OR. First, nested AND, OR special forms
+  /// are flattened recursively, eg: a AND (b AND (c AND d)) -> AND(a, b, c, d).
+  /// Then, tries to short circuit expression evaluation by rewriting AND and OR
+  /// special forms to `false` and `true` respectively if this is one of
+  /// the inputs. If expression could not be short-circuited, inputs to AND and
+  /// OR conjuncts that are `true` and `false` respectively are pruned. If there
+  /// is only one input to the conjunct after its inputs are pruned, rewrites
+  /// the conjunct expression to this input. Otherwise, returns an optimized
+  /// conjunct expression with pruned inputs.
+  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+
+  static void registerRewrite();
+};
+
+} // namespace facebook::velox::expression

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -20,8 +20,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/ConjunctExpr.h"
-#include "velox/expression/ExprConstants.h"
-#include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/ConjunctRewrite.h"
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/SwitchExpr.h"
@@ -51,6 +50,7 @@ void registerFunctionCallToSpecialForms() {
   registerFunctionCallToSpecialForm(
       expression::kRowConstructor,
       std::make_unique<RowConstructorCallToSpecialForm>());
-}
 
+  expression::ConjunctRewrite::registerRewrite();
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -46,6 +46,7 @@ add_executable(
   SimpleFunctionInitTest.cpp
   SimpleFunctionPresetNullsTest.cpp
   SimpleFunctionTest.cpp
+  ConjunctRewriteTest.cpp
   StringWriterTest.cpp
   TryExprTest.cpp
   VariadicViewTest.cpp

--- a/velox/expression/tests/ConjunctRewriteTest.cpp
+++ b/velox/expression/tests/ConjunctRewriteTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::expression {
+namespace {
+
+class ConjunctRewriteTest : public functions::test::FunctionBaseTest {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions("");
+    parse::registerTypeResolver();
+  }
+
+  void TearDown() override {
+    expression::ExprRewriteRegistry::instance().clear();
+  }
+
+  /// Validates special form expression rewrites that can short circuit
+  /// expression evaluation.
+  /// @param expr Input SQL expression to be rewritten.
+  /// @param expected Expected SQL expression after rewriting `expr`.
+  /// @param type Row type containing input fields referenced by `expr`.
+  void testRewrite(
+      const std::string& expr,
+      const std::string& expected,
+      const RowTypePtr& type = ROW({})) {
+    const auto typedExpr = makeTypedExpr(expr, type);
+    const auto rewritten =
+        expression::ExprRewriteRegistry::instance().rewrite(typedExpr);
+    const auto expectedExpr = makeTypedExpr(expected, type);
+    SCOPED_TRACE(fmt::format("Input: {}", typedExpr->toString()));
+    SCOPED_TRACE(fmt::format("Rewritten: {}", rewritten->toString()));
+    SCOPED_TRACE(fmt::format("Expected: {}", expectedExpr->toString()));
+
+    ASSERT_TRUE(*rewritten == *expectedExpr);
+  }
+};
+
+TEST_F(ConjunctRewriteTest, basic) {
+  testRewrite("true and true", "true");
+  testRewrite("false or false", "false");
+  testRewrite("null::boolean and false", "false");
+  testRewrite("true or null::boolean", "true");
+  testRewrite(
+      "null::boolean and null::boolean and null::boolean", "null::boolean");
+  testRewrite(
+      "null::boolean or null::boolean or null::boolean", "null::boolean");
+  testRewrite("null::boolean and true", "null::boolean");
+  testRewrite("false or null::boolean", "null::boolean");
+
+  const auto type = ROW({"a", "b"}, {VARCHAR(), BIGINT()});
+  testRewrite(
+      "null::boolean and a = 'z' and true", "null::boolean and a = 'z'", type);
+  testRewrite(
+      "a = 'z' or null::boolean or false", "a = 'z' or null::boolean", type);
+  testRewrite("true and a = 'z' and true", "a = 'z'", type);
+  testRewrite("false or a = 'z' or false", "a = 'z'", type);
+  testRewrite("a = 'z' and b = 2 and false", "false", type);
+  testRewrite("((a = 'z' and b = 2) and false)", "false", type);
+  testRewrite("a = 'z' or b = 2 or true", "true", type);
+  testRewrite("(a = 'z' or (b = 2 or true))", "true", type);
+}
+
+} // namespace
+} // namespace facebook::velox::expression

--- a/velox/expression/tests/ExprOptimizerTest.cpp
+++ b/velox/expression/tests/ExprOptimizerTest.cpp
@@ -144,8 +144,8 @@ TEST_F(ExprOptimizerTest, constantFolding) {
       "concat(substr(a, 4), substr(b, 6))",
       ROW({"a", "b"}, {VARCHAR(), VARCHAR()}));
   testExpression(
-      "a = 'z' and b = (1 + 1) or c = (5 - 1) * 3 or 2 * 3 = 6 / 1 and abs(-4) = 2 * 2",
-      "a = 'z' and b = 2 or c = 12 or true",
+      "a = 'z' and b = (1 + 1) or c = (5 - 1) * 3",
+      "a = 'z' and b = 2 or c = 12",
       ROW({"a", "b", "c"}, {VARCHAR(), BIGINT(), INTEGER()}));
 }
 
@@ -197,6 +197,19 @@ TEST_F(ExprOptimizerTest, rewritesWithConstantFolding) {
       "reduce(c0, length(concat('abc', 'xyz')) * 3, (s, x) -> s + (abs(-2) + (5 - 4)) - x, s -> s)",
       "18 + cast(array_sum_propagate_element_null(transform(c0, x -> 3 - x)) AS BIGINT)",
       ROW({"c0"}, {ARRAY(TINYINT())}));
+
+  // Conjunct rewrites with constant folding.
+  type = ROW({"a"}, {ARRAY(BIGINT())});
+  testExpression("if(array_position(a, 1) > 10 and false, 0, 1)", "1", type);
+  testExpression("if(cardinality(a) > 10 or true, 0, 1)", "0", type);
+  testExpression(
+      "filter(a, x -> (2 * 3) = x and abs(-4) = (3 - 1))",
+      "filter(a, x -> false)",
+      type);
+  testExpression(
+      "filter(a, x -> (2 * 3) = x or (8 / 2) = (3 + 1))",
+      "filter(a, x -> true)",
+      type);
 }
 
 /// Test to ensure session queryCtx is used during expression optimization.

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3657,10 +3657,10 @@ TEST_P(ParameterizedExprTest, applyFunctionNoResult) {
   // not.  Conjuncts have the nice property that they set throwOnError to
   // false and don't check if the result VectorPtr is nullptr.
   assertError(
-      "always_throws_vector_function(c0) AND true",
+      "always_throws_vector_function(c0) AND (c0 = 1)",
       makeFlatVector<int32_t>({1, 2, 3}),
       "always_throws_vector_function(c0)",
-      "Top-level Expression: and(always_throws_vector_function(c0), true:BOOLEAN)",
+      "Top-level Expression: and(always_throws_vector_function(c0), eq(cast((c0) as BIGINT), 1:BIGINT))",
       TestingAlwaysThrowsVectorFunction::kVeloxErrorMessage);
 
   exec::registerVectorFunction(
@@ -3669,10 +3669,10 @@ TEST_P(ParameterizedExprTest, applyFunctionNoResult) {
       std::make_unique<NoOpVectorFunction>());
 
   assertError(
-      "no_op(c0) AND true",
+      "no_op(c0) AND (c0 = 2)",
       makeFlatVector<int32_t>({1, 2, 3}),
       "no_op(c0)",
-      "Top-level Expression: and(no_op(c0), true:BOOLEAN)",
+      "Top-level Expression: and(no_op(c0), eq(cast((c0) as BIGINT), 2:BIGINT))",
       "Function neither returned results nor threw exception.");
 }
 


### PR DESCRIPTION
Adds logical rewrites for special form expressions `AND`, `OR`. The rewrites follow this logic to short-circuit conjunct expression evaluation:

1. Flatten inputs to `AND`, `OR`; eg: `a AND (b AND (c AND d))` -> `AND(a, b, c, d)` first.
2. If any input to `AND` expression is `false`, rewrite conjunct expression `AND` to constant expression `false`. Similarly, If any input to `OR` expression is `true`, rewrite conjunct expression `OR` to constant expression `true`. 
3. Prune inputs to `AND` and `OR` expressions that are `true` and `false` respectively. 
4. If there is only one input left after pruning, simplify the conjunct expression to this input.

`NULL`s in inputs are handled with following logic: https://prestodb.io/docs/current/functions/logical.html#effect-of-null-on-logical-operators.