### PR TITLE
fix(TextReader): Fix incorrect handling of \r not followed by \n

### DIFF
--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -709,6 +709,7 @@ char TextRowReader::getByteUncheckedOptimized(DelimType& delim) {
     if (skipLF) {
       if (v != '\n') {
         pos_--;
+        unreadIdx_--;
         return '\n';
       }
     } else {


### PR DESCRIPTION
When a '\r' character is not followed by '\n', the current code fails to  
properly rewind the buffer index (unreadIdx_), leading to incorrect data  
consumption and potential misalignment in subsequent reads.
 
This PR fixes it.