### PR TITLE
refactor: HivePartitionUtil for better extensibility

### DIFF
--- a/velox/connectors/hive/HivePartitionUtil.cpp
+++ b/velox/connectors/hive/HivePartitionUtil.cpp
@@ -15,42 +15,75 @@
  */
 
 #include "velox/connectors/hive/HivePartitionUtil.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox::connector::hive {
 
-#define PARTITION_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                  \
-  [&]() {                                                                      \
-    switch (typeKind) {                                                        \
-      case TypeKind::BOOLEAN:                                                  \
-      case TypeKind::TINYINT:                                                  \
-      case TypeKind::SMALLINT:                                                 \
-      case TypeKind::INTEGER:                                                  \
-      case TypeKind::BIGINT:                                                   \
-      case TypeKind::VARCHAR:                                                  \
-      case TypeKind::VARBINARY:                                                \
-      case TypeKind::TIMESTAMP:                                                \
-        return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(                             \
-            TEMPLATE_FUNC, typeKind, __VA_ARGS__);                             \
-      default:                                                                 \
-        VELOX_UNSUPPORTED(                                                     \
-            "Unsupported partition type: {}", TypeKindName::toName(typeKind)); \
-    }                                                                          \
-  }()
-
 namespace {
+
 template <typename T>
-inline std::string makePartitionValueString(T value) {
+std::string formatDecimal(T value, const TypePtr& type) {
+  const auto& [p, s] = getDecimalPrecisionScale(*type);
+  const auto& maxSize = DecimalUtil::maxStringViewSize(p, s);
+  std::string buffer(maxSize, '\0');
+  const auto& actualSize =
+      DecimalUtil::castToString(value, s, maxSize, buffer.data());
+  buffer.resize(actualSize);
+  return buffer;
+}
+
+template <TypeKind Kind>
+std::pair<std::string, std::string> makePartitionKeyValueString(
+    const HivePartitionUtilPtr& formatter,
+    const BaseVector* partitionVector,
+    vector_size_t row,
+    const std::string& name,
+    const TypePtr& type) {
+  using T = typename TypeTraits<Kind>::NativeType;
+  if (partitionVector->as<SimpleVector<T>>()->isNullAt(row)) {
+    return std::make_pair(name, "");
+  }
+
+  return std::make_pair(
+      name,
+      formatter->toPartitionString(
+          partitionVector->as<SimpleVector<T>>()->valueAt(row), type));
+}
+
+} // namespace
+
+std::string HivePartitionUtil::toPartitionString(
+    int32_t value,
+    const TypePtr& type) const {
+  if (type->isDate()) {
+    return formatDate(value);
+  }
   return folly::to<std::string>(value);
 }
 
-template <>
-inline std::string makePartitionValueString(bool value) {
-  return value ? "true" : "false";
+std::string HivePartitionUtil::toPartitionString(
+    int64_t value,
+    const TypePtr& type) const {
+  if (type->isShortDecimal()) {
+    return formatDecimal(value, type);
+  }
+  return folly::to<std::string>(value);
 }
 
-template <>
-inline std::string makePartitionValueString(Timestamp value) {
+std::string HivePartitionUtil::toPartitionString(
+    int128_t value,
+    const TypePtr& type) const {
+  if (type->isLongDecimal()) {
+    return formatDecimal(value, type);
+  }
+  return folly::to<std::string>(value);
+}
+
+std::string HivePartitionUtil::toPartitionString(
+    Timestamp value,
+    const TypePtr& type) const {
   value.toTimezone(Timestamp::defaultTimezone());
   TimestampToStringOptions options;
   options.dateTimeSeparator = ' ';
@@ -73,42 +106,40 @@ inline std::string makePartitionValueString(Timestamp value) {
   return result;
 }
 
-template <TypeKind Kind>
-std::pair<std::string, std::string> makePartitionKeyValueString(
-    const BaseVector* partitionVector,
-    vector_size_t row,
-    const std::string& name,
-    bool isDate) {
-  using T = typename TypeTraits<Kind>::NativeType;
-  if (partitionVector->as<SimpleVector<T>>()->isNullAt(row)) {
-    return std::make_pair(name, "");
-  }
-  if (isDate) {
-    return std::make_pair(
-        name,
-        DATE()->toString(
-            partitionVector->as<SimpleVector<int32_t>>()->valueAt(row)));
-  }
-  return std::make_pair(
-      name,
-      makePartitionValueString(
-          partitionVector->as<SimpleVector<T>>()->valueAt(row)));
-}
+#define PARTITION_TYPE_DISPATCH(TEMPLATE_FUNC, typeKind, ...)                  \
+  [&]() {                                                                      \
+    switch (typeKind) {                                                        \
+      case TypeKind::BOOLEAN:                                                  \
+      case TypeKind::TINYINT:                                                  \
+      case TypeKind::SMALLINT:                                                 \
+      case TypeKind::INTEGER:                                                  \
+      case TypeKind::BIGINT:                                                   \
+      case TypeKind::VARCHAR:                                                  \
+      case TypeKind::VARBINARY:                                                \
+      case TypeKind::TIMESTAMP:                                                \
+        return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(                             \
+            TEMPLATE_FUNC, typeKind, __VA_ARGS__);                             \
+      default:                                                                 \
+        VELOX_UNSUPPORTED(                                                     \
+            "Unsupported partition type: {}", TypeKindName::toName(typeKind)); \
+    }                                                                          \
+  }()
 
-} // namespace
-
-std::vector<std::pair<std::string, std::string>> extractPartitionKeyValues(
+std::vector<std::pair<std::string, std::string>>
+HivePartitionUtil::extractPartitionKeyValues(
     const RowVectorPtr& partitionsVector,
     vector_size_t row) {
+  const auto& formatter = std::make_shared<HivePartitionUtil>();
   std::vector<std::pair<std::string, std::string>> partitionKeyValues;
   for (auto i = 0; i < partitionsVector->childrenSize(); i++) {
     partitionKeyValues.push_back(PARTITION_TYPE_DISPATCH(
         makePartitionKeyValueString,
         partitionsVector->childAt(i)->typeKind(),
+        formatter,
         partitionsVector->childAt(i)->loadedVector(),
         row,
         asRowType(partitionsVector->type())->nameOf(i),
-        partitionsVector->childAt(i)->type()->isDate()));
+        partitionsVector->childAt(i)->type()));
   }
   return partitionKeyValues;
 }

--- a/velox/connectors/hive/HivePartitionUtil.h
+++ b/velox/connectors/hive/HivePartitionUtil.h
@@ -15,12 +15,63 @@
  */
 #pragma once
 
+#include <memory>
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::connector::hive {
 
-std::vector<std::pair<std::string, std::string>> extractPartitionKeyValues(
-    const RowVectorPtr& partitionsVector,
-    vector_size_t row);
+FOLLY_ALWAYS_INLINE std::string formatDate(int32_t value) {
+  return DATE()->toString(value);
+}
+
+/// Converting partition values to their string representations.
+/// Provides virtual methods for formatting different data types
+/// according to Hive partitioning conventions.
+class HivePartitionUtil {
+ public:
+  virtual ~HivePartitionUtil() = default;
+
+  /// Generic template for formatting simple types that just need string
+  /// conversion. Specialized/overloaded for types that need special handling.
+  template <typename T>
+  FOLLY_ALWAYS_INLINE std::string toPartitionString(
+      T value,
+      const TypePtr& type) const {
+    return folly::to<std::string>(value);
+  }
+
+  FOLLY_ALWAYS_INLINE std::string toPartitionString(
+      bool value,
+      const TypePtr& type) const {
+    return value ? "true" : "false";
+  }
+
+  std::string toPartitionString(int64_t value, const TypePtr& type) const;
+
+  std::string toPartitionString(int128_t value, const TypePtr& type) const;
+
+  virtual std::string toPartitionString(StringView value, const TypePtr& type)
+      const {
+    return folly::to<std::string>(value);
+  }
+
+  virtual std::string toPartitionString(int32_t value, const TypePtr& type)
+      const;
+
+  virtual std::string toPartitionString(Timestamp value, const TypePtr& type)
+      const;
+
+  /// Extract partition key-value pairs from a row vector at a specific row.
+  ///
+  /// @param partitionsVector A row vector containing partition columns.
+  /// @param row The row index to extract partition values from.
+  /// @return A vector of (column_name, formatted_value) pairs.
+  static std::vector<std::pair<std::string, std::string>>
+  extractPartitionKeyValues(
+      const RowVectorPtr& partitionsVector,
+      vector_size_t row);
+};
+
+using HivePartitionUtilPtr = std::shared_ptr<const HivePartitionUtil>;
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/PartitionIdGenerator.cpp
+++ b/velox/connectors/hive/PartitionIdGenerator.cpp
@@ -99,7 +99,8 @@ void PartitionIdGenerator::run(
 
 std::string PartitionIdGenerator::partitionName(uint64_t partitionId) const {
   return FileUtils::makePartName(
-      extractPartitionKeyValues(partitionValues_, partitionId),
+      HivePartitionUtil::extractPartitionKeyValues(
+          partitionValues_, partitionId),
       partitionPathAsLowerCase_);
 }
 

--- a/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionUtilTest.cpp
@@ -102,7 +102,7 @@ TEST_F(HivePartitionUtilTest, partitionName) {
 
       EXPECT_EQ(
           FileUtils::makePartName(
-              extractPartitionKeyValues(
+              HivePartitionUtil::extractPartitionKeyValues(
                   makePartitionsVector(input, partitionChannels), 0),
               true),
           folly::join(
@@ -124,7 +124,7 @@ TEST_F(HivePartitionUtilTest, partitionName) {
 
     VELOX_ASSERT_THROW(
         FileUtils::makePartName(
-            extractPartitionKeyValues(
+            HivePartitionUtil::extractPartitionKeyValues(
                 makePartitionsVector(input, partitionChannels), 0),
             true),
         "Unsupported partition type: MAP");
@@ -155,7 +155,7 @@ TEST_F(HivePartitionUtilTest, partitionNameForNull) {
 
   for (auto i = 0; i < partitionColumnNames.size(); i++) {
     std::vector<column_index_t> partitionChannels = {(column_index_t)i};
-    auto partitionEntries = extractPartitionKeyValues(
+    auto partitionEntries = HivePartitionUtil::extractPartitionKeyValues(
         makePartitionsVector(input, partitionChannels), 0);
     EXPECT_EQ(1, partitionEntries.size());
     EXPECT_EQ(partitionColumnNames[i], partitionEntries[0].first);
@@ -195,7 +195,7 @@ TEST_F(HivePartitionUtilTest, timestampPartitionValueFormatting) {
   auto partitionsVector = makePartitionsVector(input, partitionChannels);
 
   for (size_t i = 0; i < timestamps.size(); i++) {
-    auto partitionEntries = extractPartitionKeyValues(
+    auto partitionEntries = HivePartitionUtil::extractPartitionKeyValues(
         partitionsVector, static_cast<vector_size_t>(i));
 
     EXPECT_EQ(1, partitionEntries.size());


### PR DESCRIPTION
Refactor HivePartitionUtil to use class-based design for extensibility

This PR refactors the partition value formatting logic from standalone
template functions to a class-based design, enabling better code reuse and
extensibility for different table formats (e.g., Iceberg).

