### PR TITLE
build: Bump Presto version used in Fuzzer tests to 0.295

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     image: ghcr.io/facebookincubator/velox-dev:presto-java
     build:
       args:
-        - PRESTO_VERSION=0.293
+        - PRESTO_VERSION=0.295
       dockerfile: scripts/docker/java.dockerfile
 
   spark-server:

--- a/scripts/docker/java.dockerfile
+++ b/scripts/docker/java.dockerfile
@@ -15,7 +15,7 @@
 
 # Global arg default to share across stages
 ARG SPARK_VERSION=3.5.1
-ARG PRESTO_VERSION=0.293
+ARG PRESTO_VERSION=0.295
 
 #########################
 # Stage: Spark Download #
@@ -40,7 +40,7 @@ ARG PRESTO_VERSION
 RUN wget -O presto-server.tar.gz \
     https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
 RUN wget -O presto-cli \
-    https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar
+    https://github.com/prestodb/presto/releases/download/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar
 
 RUN tar -xzf presto-server.tar.gz
 


### PR DESCRIPTION
This is to help address https://github.com/facebookincubator/velox/issues/15332

It looks like the version of Presto in the docker file currently being used is 0.290.  We need to build a new image, bumping the version kills two birds with one stone by triggering a new image to be built.

Also, fixed where we get the presto-cli executable jar, based on
https://github.com/prestodb/presto/issues/25976