### PR TITLE
feat: Add custom spill base dir support for trace replayer

### DIFF
--- a/velox/tool/trace/AggregationReplayer.h
+++ b/velox/tool/trace/AggregationReplayer.h
@@ -29,6 +29,7 @@ class AggregationReplayer : public OperatorReplayerBase {
       const std::string& taskId,
       const std::string& nodeId,
       const std::string& operatorType,
+      const std::string& spillBaseDir,
       const std::string& driverIds,
       uint64_t queryCapacity,
       folly::Executor* executor)
@@ -38,6 +39,7 @@ class AggregationReplayer : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            spillBaseDir,
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/FilterProjectReplayer.h
+++ b/velox/tool/trace/FilterProjectReplayer.h
@@ -43,6 +43,7 @@ class FilterProjectReplayer : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            "",
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/HashJoinReplayer.h
+++ b/velox/tool/trace/HashJoinReplayer.h
@@ -29,6 +29,7 @@ class HashJoinReplayer final : public OperatorReplayerBase {
       const std::string& taskId,
       const std::string& nodeId,
       const std::string& operatorType,
+      const std::string& spillBaseDir,
       const std::string& driverIds,
       uint64_t queryCapacity,
       folly::Executor* executor)
@@ -38,6 +39,7 @@ class HashJoinReplayer final : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            spillBaseDir,
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/IndexLookupJoinReplayer.h
+++ b/velox/tool/trace/IndexLookupJoinReplayer.h
@@ -38,6 +38,7 @@ class IndexLookupJoinReplayer : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            "",
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -33,11 +33,12 @@ using namespace facebook::velox;
 
 namespace facebook::velox::tool::trace {
 OperatorReplayerBase::OperatorReplayerBase(
-    std::string traceDir,
-    std::string queryId,
-    std::string taskId,
-    std::string nodeId,
-    std::string nodeName,
+    const std::string& traceDir,
+    const std::string& queryId,
+    const std::string& taskId,
+    const std::string& nodeId,
+    const std::string& nodeName,
+    const std::string& spillBaseDir,
     const std::string& driverIds,
     uint64_t queryCapacity,
     folly::Executor* executor)
@@ -48,6 +49,7 @@ OperatorReplayerBase::OperatorReplayerBase(
       taskTraceDir_(
           exec::trace::getTaskTraceDirectory(traceDir, queryId_, taskId_)),
       nodeTraceDir_(exec::trace::getNodeTraceDirectory(taskTraceDir_, nodeId_)),
+      spillBaseDir_(spillBaseDir),
       fs_(filesystems::getFileSystem(taskTraceDir_, nullptr)),
       pipelineIds_(exec::trace::listPipelineIds(nodeTraceDir_, fs_)),
       driverIds_(
@@ -83,15 +85,17 @@ OperatorReplayerBase::OperatorReplayerBase(
 
 RowVectorPtr OperatorReplayerBase::run(bool copyResults) {
   auto queryCtx = createQueryCtx();
-  std::shared_ptr<exec::test::TempDirectoryPath> spillDirectory;
-  if (queryCtx->queryConfig().spillEnabled()) {
-    spillDirectory = exec::test::TempDirectoryPath::create();
+  std::shared_ptr<exec::test::TempDirectoryPath> localSpillDirectory;
+  if (queryCtx->queryConfig().spillEnabled() && spillBaseDir_.empty()) {
+    localSpillDirectory = exec::test::TempDirectoryPath::create();
   }
 
   TraceReplayTaskRunner traceTaskRunner(createPlan(), std::move(queryCtx));
   auto [task, result] =
       traceTaskRunner.maxDrivers(driverIds_.size())
-          .spillDirectory(spillDirectory ? spillDirectory->getPath() : "")
+          .spillDirectory(
+              localSpillDirectory != nullptr ? localSpillDirectory->getPath()
+                                             : spillBaseDir_)
           .run(copyResults);
   printStats(task);
   return result;

--- a/velox/tool/trace/OperatorReplayerBase.h
+++ b/velox/tool/trace/OperatorReplayerBase.h
@@ -29,11 +29,12 @@ namespace facebook::velox::tool::trace {
 class OperatorReplayerBase {
  public:
   OperatorReplayerBase(
-      std::string traceDir,
-      std::string queryId,
-      std::string taskId,
-      std::string nodeId,
-      std::string nodeName,
+      const std::string& traceDir,
+      const std::string& queryId,
+      const std::string& taskId,
+      const std::string& nodeId,
+      const std::string& nodeName,
+      const std::string& spillBaseDir,
       const std::string& driverIds,
       uint64_t queryCapacity,
       folly::Executor* executor);
@@ -63,6 +64,7 @@ class OperatorReplayerBase {
   const std::string nodeName_;
   const std::string taskTraceDir_;
   const std::string nodeTraceDir_;
+  const std::string spillBaseDir_;
   const std::shared_ptr<filesystems::FileSystem> fs_;
   const std::vector<uint32_t> pipelineIds_;
   const std::vector<uint32_t> driverIds_;

--- a/velox/tool/trace/OrderByReplayer.h
+++ b/velox/tool/trace/OrderByReplayer.h
@@ -29,6 +29,7 @@ class OrderByReplayer : public OperatorReplayerBase {
       const std::string& taskId,
       const std::string& nodeId,
       const std::string& operatorType,
+      const std::string& spillBaseDir,
       const std::string& driverIds,
       uint64_t queryCapacity,
       folly::Executor* executor)
@@ -38,6 +39,7 @@ class OrderByReplayer : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            spillBaseDir,
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -121,6 +121,7 @@ PartitionedOutputReplayer::PartitionedOutputReplayer(
           taskId,
           nodeId,
           operatorType,
+          "",
           driverIds,
           queryCapacity,
           executor),

--- a/velox/tool/trace/TableScanReplayer.h
+++ b/velox/tool/trace/TableScanReplayer.h
@@ -42,6 +42,7 @@ class TableScanReplayer final : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            "",
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/TableWriterReplayer.h
+++ b/velox/tool/trace/TableWriterReplayer.h
@@ -42,6 +42,7 @@ class TableWriterReplayer final : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            "",
             driverIds,
             queryCapacity,
             executor),

--- a/velox/tool/trace/TopNRowNumberReplayer.h
+++ b/velox/tool/trace/TopNRowNumberReplayer.h
@@ -29,6 +29,7 @@ class TopNRowNumberReplayer : public OperatorReplayerBase {
       const std::string& taskId,
       const std::string& nodeId,
       const std::string& operatorType,
+      const std::string& spillBaseDir,
       const std::string& driverIds,
       uint64_t queryCapacity,
       folly::Executor* executor)
@@ -38,6 +39,7 @@ class TopNRowNumberReplayer : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            spillBaseDir,
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -108,6 +108,10 @@ DEFINE_string(
     function_prefix,
     "",
     "Prefix for the scalar and aggregate functions.");
+DEFINE_string(
+    spill_directory,
+    "",
+    "Base directory for spilling. If not specified, a local temporary directory will be used.");
 
 namespace facebook::velox::tool::trace {
 namespace {
@@ -335,6 +339,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_task_id,
         FLAGS_node_id,
         traceNodeName,
+        FLAGS_spill_directory,
         FLAGS_driver_ids,
         queryCapacityBytes,
         cpuExecutor_.get());
@@ -389,6 +394,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_task_id,
         FLAGS_node_id,
         traceNodeName,
+        FLAGS_spill_directory,
         FLAGS_driver_ids,
         queryCapacityBytes,
         cpuExecutor_.get());
@@ -419,6 +425,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_task_id,
         FLAGS_node_id,
         traceNodeName,
+        FLAGS_spill_directory,
         FLAGS_driver_ids,
         queryCapacityBytes,
         cpuExecutor_.get());
@@ -429,6 +436,7 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_task_id,
         FLAGS_node_id,
         traceNodeName,
+        FLAGS_spill_directory,
         FLAGS_driver_ids,
         queryCapacityBytes,
         cpuExecutor_.get());

--- a/velox/tool/trace/UnnestReplayer.h
+++ b/velox/tool/trace/UnnestReplayer.h
@@ -38,6 +38,7 @@ class UnnestReplayer : public OperatorReplayerBase {
             taskId,
             nodeId,
             operatorType,
+            "",
             driverIds,
             queryCapacity,
             executor) {}

--- a/velox/tool/trace/tests/AggregationReplayerTest.cpp
+++ b/velox/tool/trace/tests/AggregationReplayerTest.cpp
@@ -271,6 +271,7 @@ TEST_F(AggregationReplayerTest, hashAggregationTest) {
                                        traceNodeId_,
                                        "Aggregation",
                                        "",
+                                       "",
                                        0,
                                        executor_.get())
                                        .run();
@@ -336,6 +337,7 @@ TEST_F(AggregationReplayerTest, streamingAggregateTest) {
                                        task->taskId(),
                                        traceNodeId_,
                                        "Aggregation",
+                                       "",
                                        "",
                                        0,
                                        executor_.get())

--- a/velox/tool/trace/tests/HashJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/HashJoinReplayerTest.cpp
@@ -230,6 +230,7 @@ TEST_F(HashJoinReplayerTest, basic) {
                                    traceNodeId_,
                                    "HashJoin",
                                    "",
+                                   "",
                                    0,
                                    executor_.get())
                                    .run();
@@ -301,6 +302,7 @@ TEST_F(HashJoinReplayerTest, partialDriverIds) {
             task->taskId(),
             traceNodeId_,
             "HashJoin",
+            "",
             "0",
             0,
             executor_.get())
@@ -313,6 +315,7 @@ TEST_F(HashJoinReplayerTest, partialDriverIds) {
       task->taskId(),
       traceNodeId_,
       "HashJoin",
+      "",
       "1,3",
       0,
       executor_.get())
@@ -468,6 +471,7 @@ DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashBuildSpill) {
                                    traceNodeId_,
                                    "HashJoin",
                                    "",
+                                   "",
                                    0,
                                    executor_.get())
                                    .run();
@@ -549,6 +553,7 @@ DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashProbeSpill) {
                                    task->taskId(),
                                    traceNodeId_,
                                    "HashJoin",
+                                   "",
                                    "",
                                    0,
                                    executor_.get())

--- a/velox/tool/trace/tests/OrderByReplayerTest.cpp
+++ b/velox/tool/trace/tests/OrderByReplayerTest.cpp
@@ -148,6 +148,7 @@ TEST_F(OrderByReplayerTest, basic) {
                                    orderById_,
                                    "OrderBy",
                                    "",
+                                   "",
                                    0,
                                    executor_.get())
                                    .run();
@@ -186,6 +187,7 @@ TEST_F(OrderByReplayerTest, partial) {
                                    task->taskId(),
                                    orderById_,
                                    "OrderBy",
+                                   "",
                                    "",
                                    0,
                                    executor_.get())

--- a/velox/tool/trace/tests/TopNRowNumberReplayerTest.cpp
+++ b/velox/tool/trace/tests/TopNRowNumberReplayerTest.cpp
@@ -178,6 +178,7 @@ TEST_F(TopNRowNumberReplayerTest, basic) {
                                    topNRowNumberId_,
                                    "TopNRowNumber",
                                    "",
+                                   "",
                                    0,
                                    executor_.get())
                                    .run();
@@ -217,6 +218,7 @@ TEST_F(TopNRowNumberReplayerTest, withoutRowNumber) {
                                    task->taskId(),
                                    topNRowNumberId_,
                                    "TopNRowNumber",
+                                   "",
                                    "",
                                    0,
                                    executor_.get())
@@ -258,6 +260,7 @@ TEST_F(TopNRowNumberReplayerTest, multiplePartitions) {
                                    topNRowNumberId_,
                                    "TopNRowNumber",
                                    "",
+                                   "",
                                    0,
                                    executor_.get())
                                    .run();
@@ -297,6 +300,7 @@ TEST_F(TopNRowNumberReplayerTest, noPartitionKeys) {
                                    task->taskId(),
                                    topNRowNumberId_,
                                    "TopNRowNumber",
+                                   "",
                                    "",
                                    0,
                                    executor_.get())
@@ -340,6 +344,7 @@ TEST_F(TopNRowNumberReplayerTest, multipleSortingKeys) {
                                    topNRowNumberId_,
                                    "TopNRowNumber",
                                    "",
+                                   "",
                                    0,
                                    executor_.get())
                                    .run();
@@ -379,6 +384,7 @@ TEST_F(TopNRowNumberReplayerTest, limitOne) {
                                    task->taskId(),
                                    topNRowNumberId_,
                                    "TopNRowNumber",
+                                   "",
                                    "",
                                    0,
                                    executor_.get())

--- a/velox/tool/trace/tests/TraceFileToolTest.cpp
+++ b/velox/tool/trace/tests/TraceFileToolTest.cpp
@@ -251,6 +251,7 @@ TEST_F(TraceFileToolTest, basic) {
                                      traceNodeId_,
                                      "HashJoin",
                                      "",
+                                     "",
                                      0,
                                      executor_.get())
                                      .run();


### PR DESCRIPTION
Summary: Replayer currently only support spilling to local. Add feature to spill to custom storage

Reviewed By: xiaoxmeng, zacw7

Differential Revision: D85874574


