### PR TITLE
fix: Refresh Map Vector pointers after reallocation

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -49,6 +49,10 @@ class VectorWriterBase {
   }
   virtual void commit(bool isSet) = 0;
   virtual void ensureSize(vector_size_t size) = 0;
+  // Resizes the vector to exactly the specified size. Unlike ensureSize(),
+  // this can shrink the vector. Implementations should update internal
+  // pointers after resize to ensure they remain valid.
+  virtual void resizeTo(vector_size_t size) = 0;
   virtual void finish() {}
   // Implementations that write variable length data or complex types should
   // override this to reset their state and that of their children.
@@ -789,6 +793,7 @@ class MapWriter {
     auto index = indexOfLast();
     if constexpr (!requires_commit<K>) {
       VELOX_DCHECK(provide_std_interface<K>);
+      keysVector_->setNull(index, false);
       return keysWriter_->data_[index];
     } else {
       keyNeedsCommit_ = true;


### PR DESCRIPTION
Summary:
Fix stale pointer issue in MapWriter causing segfault in FB-internal UDF.

When a UDF calls add_item() repeatedly on a Map result writer, the underlying vector may reallocate to a larger memory location when full. However, MapWriter retains pointers to the old memory location, causing subsequent writes to access freed memory and segfault.
Fix involves refreshing
valuesVector_ = new vector location
data_ = new memory pointer
So next add_item() adds to correct location.

```
      for (const auto& [timestamp, value] : timeValues) {
        int64_t timestampMs = timestamp * 1000; // Convert to milliseconds
        auto [keyWriter, valueWriter] = result.add_item();
        keyWriter = Timestamp::fromMillis(timestampMs);
        valueWriter = value; <<<< HERE
      }
```


Differential Revision: D85692836


