### PR TITLE
fix: Install utf8proc headers

### DIFF
--- a/velox/.gitattributes
+++ b/velox/.gitattributes
@@ -1,12 +1,4 @@
 external/**                 -diff -merge
 external/**                 linguist-vendored=true
-external/date/*             -diff -merge
-external/date/*             linguist-vendored=true
-external/duckdb/**          -diff -merge
-external/duckdb/**          linguist-vendored=true
-external/duckdb/tpch/**     -diff -merge
-external/duckdb/tpch/**     linguist-vendored=true
-external/md5/*              -diff -merge
-external/md5/*              linguist-vendored=true
-external/utf8proc/*         -diff -merge
-external/utf8proc/*         linguist-vendored=true
+external/**/CMakeLists.txt  diff merge
+external/**/CMakeLists.txt  linguist-vendored=false

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -26,6 +26,7 @@ add_subdirectory(external/date)
 add_subdirectory(external/tzdb)
 add_subdirectory(external/md5)
 add_subdirectory(external/hdfs)
+add_subdirectory(external/utf8proc)
 #
 
 # examples depend on expression

--- a/velox/external/utf8proc/CMakeLists.txt
+++ b/velox/external/utf8proc/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_install_library_headers()


### PR DESCRIPTION
`velox/functions/lib/string/StringCore.h` includes `utf8procImpl.h`. So we need to install them.

This also updates `velox/.gitattributes`. Don't ignore `CMakeLists.txt` from diff because `external/**/CMakeLists.txt` are written by us.