### PR TITLE
feat(parquet): Allow reading a wider integer as a narrower one

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -759,6 +759,11 @@ TypePtr ReaderBase::convertType(
       "Converted type {} is not allowed for requested type {}";
   const bool isRepeated = schemaElement.__isset.repetition_type &&
       schemaElement.repetition_type == thrift::FieldRepetitionType::REPEATED;
+  const auto isInteger = [](const TypePtr& type) {
+    return type->kind() == TypeKind::TINYINT ||
+        type->kind() == TypeKind::SMALLINT ||
+        type->kind() == TypeKind::INTEGER || type->kind() == TypeKind::BIGINT;
+  };
   if (schemaElement.__isset.converted_type) {
     switch (schemaElement.converted_type) {
       case thrift::ConvertedType::INT_8:
@@ -770,15 +775,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.converted_type);
         VELOX_CHECK(
             !requestedType ||
-                isCompatible(
-                    requestedType,
-                    isRepeated,
-                    [](const TypePtr& type) {
-                      return type->kind() == TypeKind::TINYINT ||
-                          type->kind() == TypeKind::SMALLINT ||
-                          type->kind() == TypeKind::INTEGER ||
-                          type->kind() == TypeKind::BIGINT;
-                    }),
+                isCompatible(requestedType, isRepeated, isInteger),
             kTypeMappingErrorFmtStr,
             "TINYINT",
             requestedType->toString());
@@ -793,14 +790,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.converted_type);
         VELOX_CHECK(
             !requestedType ||
-                isCompatible(
-                    requestedType,
-                    isRepeated,
-                    [](const TypePtr& type) {
-                      return type->kind() == TypeKind::SMALLINT ||
-                          type->kind() == TypeKind::INTEGER ||
-                          type->kind() == TypeKind::BIGINT;
-                    }),
+                isCompatible(requestedType, isRepeated, isInteger),
             kTypeMappingErrorFmtStr,
             "SMALLINT",
             requestedType->toString());
@@ -815,13 +805,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.converted_type);
         VELOX_CHECK(
             !requestedType ||
-                isCompatible(
-                    requestedType,
-                    isRepeated,
-                    [](const TypePtr& type) {
-                      return type->kind() == TypeKind::INTEGER ||
-                          type->kind() == TypeKind::BIGINT;
-                    }),
+                isCompatible(requestedType, isRepeated, isInteger),
             kTypeMappingErrorFmtStr,
             "INTEGER",
             requestedType->toString());
@@ -836,12 +820,7 @@ TypePtr ReaderBase::convertType(
             schemaElement.converted_type);
         VELOX_CHECK(
             !requestedType ||
-                isCompatible(
-                    requestedType,
-                    isRepeated,
-                    [](const TypePtr& type) {
-                      return type->kind() == TypeKind::BIGINT;
-                    }),
+                isCompatible(requestedType, isRepeated, isInteger),
             kTypeMappingErrorFmtStr,
             "BIGINT",
             requestedType->toString());
@@ -1007,13 +986,7 @@ TypePtr ReaderBase::convertType(
       case thrift::Type::type::INT32:
         VELOX_CHECK(
             !requestedType ||
-                isCompatible(
-                    requestedType,
-                    isRepeated,
-                    [](const TypePtr& type) {
-                      return type->kind() == TypeKind::INTEGER ||
-                          type->kind() == TypeKind::BIGINT;
-                    }),
+                isCompatible(requestedType, isRepeated, isInteger),
             kTypeMappingErrorFmtStr,
             "INTEGER",
             requestedType->toString());
@@ -1037,12 +1010,7 @@ TypePtr ReaderBase::convertType(
         }
         VELOX_CHECK(
             !requestedType ||
-                isCompatible(
-                    requestedType,
-                    isRepeated,
-                    [](const TypePtr& type) {
-                      return type->kind() == TypeKind::BIGINT;
-                    }),
+                isCompatible(requestedType, isRepeated, isInteger),
             kTypeMappingErrorFmtStr,
             "BIGINT",
             requestedType->toString());


### PR DESCRIPTION
Reading a wider integer as a narrower one causes unchecked truncation and two’s 
complement reinterpretation, resulting in values INT_MAX becoming -1. This 
behavior is intentional and should be well understood by the query planner.