### PR TITLE
feat: Add HiveTableHandle::columnHandles

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -37,7 +37,7 @@ class HiveDataSource : public DataSource {
   HiveDataSource(
       const RowTypePtr& outputType,
       const connector::ConnectorTableHandlePtr& tableHandle,
-      const connector::ColumnHandleMap& columnHandles,
+      const connector::ColumnHandleMap& assignments,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* executor,
       const ConnectorQueryCtx* connectorQueryCtx,
@@ -146,6 +146,10 @@ class HiveDataSource : public DataSource {
     }
     return emptyOutput_;
   }
+
+  // Add the information from column handle to the corresponding fields in this
+  // object.
+  void processColumnHandle(const HiveColumnHandlePtr& handle);
 
   // The row type for the data source output, not including filter-only columns
   const RowTypePtr outputType_;

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -111,14 +111,16 @@ HiveTableHandle::HiveTableHandle(
     common::SubfieldFilters subfieldFilters,
     const core::TypedExprPtr& remainingFilter,
     const RowTypePtr& dataColumns,
-    const std::unordered_map<std::string, std::string>& tableParameters)
+    const std::unordered_map<std::string, std::string>& tableParameters,
+    std::vector<HiveColumnHandlePtr> columnHandles)
     : ConnectorTableHandle(std::move(connectorId)),
       tableName_(tableName),
       filterPushdownEnabled_(filterPushdownEnabled),
       subfieldFilters_(std::move(subfieldFilters)),
       remainingFilter_(remainingFilter),
       dataColumns_(dataColumns),
-      tableParameters_(tableParameters) {}
+      tableParameters_(tableParameters),
+      columnHandles_(std::move(columnHandles)) {}
 
 std::string HiveTableHandle::toString() const {
   std::stringstream out;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -316,6 +316,12 @@ class PlanBuilder {
       return *this;
     }
 
+    TableScanBuilder& columnHandles(
+        std::vector<connector::hive::HiveColumnHandlePtr> columnHandles) {
+      columnHandles_ = std::move(columnHandles);
+      return *this;
+    }
+
     /// @param assignments Optional ColumnHandles.
     /// outputType names should match the keys in the 'assignments' map. The
     /// 'assignments' map may contain more columns than 'outputType' if some
@@ -341,6 +347,7 @@ class PlanBuilder {
     RowTypePtr outputType_;
     core::ExprPtr remainingFilter_;
     RowTypePtr dataColumns_;
+    std::vector<connector::hive::HiveColumnHandlePtr> columnHandles_;
     std::unordered_map<std::string, std::string> columnAliases_;
     connector::ConnectorTableHandlePtr tableHandle_;
     connector::ColumnHandleMap assignments_;


### PR DESCRIPTION
Summary:
Currently if a partitioning column is not projected out, but used in remaining filter, the engine still adds it to assignments in order for the connector to recognize it.  This is a hack and we should pass the full column handles inside the table handle.

Fix https://github.com/facebookincubator/velox/issues/15348

Differential Revision: D85979627


