### PR TITLE
misc: Use folly F14FastMap to filter keys in MakeRowFromMap

### DIFF
--- a/velox/functions/lib/MakeRowFromMap.h
+++ b/velox/functions/lib/MakeRowFromMap.h
@@ -308,6 +308,6 @@ class MakeRowFromMap {
   const bool throwOnDuplicateKeys_{true};
   const std::vector<std::string> outputFieldNames_;
   const TypePtr inputKeyType_;
-  std::unordered_map<KeyType, size_t> keyToIndex_;
+  folly::F14FastMap<KeyType, size_t> keyToIndex_;
 };
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary: Some recent performance investigations revealed that std::unordered_map is 2-10x more expensive in some cases than its folly equivalent. Therefore, switching to folly instead.

Differential Revision: D85993871


