### PR TITLE
fix: Upgrade java version for docker images

### DIFF
--- a/scripts/docker/java.dockerfile
+++ b/scripts/docker/java.dockerfile
@@ -49,7 +49,7 @@ RUN tar -xzf presto-server.tar.gz
 #########################
 FROM ghcr.io/facebookincubator/velox-dev:centos9 AS java-base
 
-RUN dnf install -y -q --setopt=install_weak_deps=False java-11-openjdk less procps tzdata
+RUN dnf install -y -q --setopt=install_weak_deps=False java-17-openjdk less procps tzdata
 
 # We set the timezone to America/Los_Angeles due to issue
 # detailed here : https://github.com/facebookincubator/velox/issues/8127


### PR DESCRIPTION
Upgrading Presto java version also requires us to upgrade the  java version used in the images.