### PR TITLE
fix: Avoid throw exception in toSubfieldFilter

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -543,7 +543,9 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
       if (!right.second) {
         return {};
       }
-      VELOX_CHECK(left.first == right.first);
+      if (left.first != right.first) {
+        return {};
+      }
       return {
           std::move(left.first),
           makeOrFilter(std::move(left.second), std::move(right.second))};


### PR DESCRIPTION
Why?

Because in Axiom now code written like this
```cpp
    try {
      auto pair = velox::exec::toSubfieldFilter(typedExpr, evaluator);
      if (!pair.second) {
        remainingConjuncts.push_back(std::move(typedExpr));
        continue;
      }
      pushdownConjuncts.push_back(typedExpr);
    } catch (const std::exception&) {
      remainingConjuncts.push_back(std::move(typedExpr));
    }
  }
```

it's not only ineffective, it's inconvenient to debug (you cannot use break on throw, because this function will throw even when everything fine)