### PR TITLE
perf: Improve expr to subfield filters

### DIFF
--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -308,7 +308,8 @@ class CustomExprToSubfieldFilterParser : public ExprToSubfieldFilterParser {
  public:
   std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
       const core::TypedExprPtr& expr,
-      core::ExpressionEvaluator* evaluator) override {
+      core::ExpressionEvaluator* evaluator,
+      bool negated = false) override {
     if (expr->isCallKind();
         auto* call = expr->asUnchecked<core::CallTypedExpr>()) {
       if (call->name() == "or") {
@@ -324,10 +325,11 @@ class CustomExprToSubfieldFilterParser : public ExprToSubfieldFilterParser {
       if (call->name() == "not") {
         if (auto* inner =
                 call->inputs()[0]->asUnchecked<core::CallTypedExpr>()) {
-          filter = leafCallToSubfieldFilter(*inner, subfield, evaluator, true);
+          filter =
+              leafCallToSubfieldFilter(*inner, subfield, evaluator, !negated);
         }
       } else {
-        filter = leafCallToSubfieldFilter(*call, subfield, evaluator, false);
+        filter = leafCallToSubfieldFilter(*call, subfield, evaluator, negated);
       }
       if (filter) {
         return std::make_pair(std::move(subfield), std::move(filter));


### PR DESCRIPTION
What is done?

Different handling of `"and"`, `"or"`, `"not"`
Different `makeOr`
Use real `notEqual` in more cases


Why is it good?

See Axiom tpch q19

Before

```
Executable Velox plan:

Fragment 0:  numWorkers=0:
-- Aggregation[5][SINGLE revenue := sum("dt1.__p121")] -> revenue:DOUBLE
  -- Project[4][expressions: (dt1.__p121:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p121":DOUBLE
    -- Filter[0][expression: or(and(between(cast("p_size" as BIGINT),1,15),and(lte("l_quantity",30),and(gte("l_quantity",20),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))))),or(and(between(cast("p_size" as BIGINT),1,5),and(lte("l_quantity",11),and(gte("l_quantity",1),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))))),and(between(cast("p_size" as BIGINT),1,10),and(lte("l_quantity",20),and(gte("l_quantity",10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))))] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
      -- HashJoin[3][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
        -- TableScan[1][table: lineitem, range filters: [(l_shipinstruct, Filter(BytesValues, deterministic, null not allowed)), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], remaining filter: (or(and(gte("l_quantity",20),lte("l_quantity",30)),or(and(gte("l_quantity",1),lte("l_quantity",11)),and(gte("l_quantity",10),lte("l_quantity",20))))), data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
        -- TableScan[2][table: part, remaining filter: (or(and(between(cast("p_size" as BIGINT),1,15),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))),or(and(between(cast("p_size" as BIGINT),1,5),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))),and(between(cast("p_size" as BIGINT),1,10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
```
After
```
Executable Velox plan:

Fragment 0:  numWorkers=0:
-- Aggregation[5][SINGLE revenue := sum("dt1.__p121")] -> revenue:DOUBLE
  -- Project[4][expressions: (dt1.__p121:DOUBLE, multiply("l_extendedprice",minus(1,"l_discount")))] -> "dt1.__p121":DOUBLE
    -- Filter[0][expression: or(and(between(cast("p_size" as BIGINT),1,15),and(lte("l_quantity",30),and(gte("l_quantity",20),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))))),or(and(between(cast("p_size" as BIGINT),1,5),and(lte("l_quantity",11),and(gte("l_quantity",1),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))))),and(between(cast("p_size" as BIGINT),1,10),and(lte("l_quantity",20),and(gte("l_quantity",10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))))] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
      -- HashJoin[3][INNER l_partkey=p_partkey] -> l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
        -- TableScan[1][table: lineitem, range filters: [(l_quantity, Filter(MultiRange, deterministic, null not allowed)), (l_shipinstruct, Filter(BytesValues, deterministic, null not allowed)), (l_shipmode, Filter(BytesValues, deterministic, null not allowed))], data columns: ROW<l_orderkey:BIGINT,l_partkey:BIGINT,l_suppkey:BIGINT,l_linenumber:INTEGER,l_quantity:DOUBLE,l_extendedprice:DOUBLE,l_discount:DOUBLE,l_tax:DOUBLE,l_returnflag:VARCHAR,l_linestatus:VARCHAR,l_shipdate:DATE,l_commitdate:DATE,l_receiptdate:DATE,l_shipinstruct:VARCHAR,l_shipmode:VARCHAR,l_comment:VARCHAR>] -> l_partkey:BIGINT, l_quantity:DOUBLE, l_extendedprice:DOUBLE, l_discount:DOUBLE
        -- TableScan[2][table: part, remaining filter: (or(and(between(cast("p_size" as BIGINT),1,15),and(eq("p_brand",Brand#34),in("p_container",{LG CASE, LG BOX, LG PACK, LG PKG}))),or(and(between(cast("p_size" as BIGINT),1,5),and(eq("p_brand",Brand#12),in("p_container",{SM CASE, SM BOX, SM PACK, SM PKG}))),and(between(cast("p_size" as BIGINT),1,10),and(eq("p_brand",Brand#23),in("p_container",{MED BAG, MED BOX, MED PKG, MED PACK})))))), data columns: ROW<p_partkey:BIGINT,p_name:VARCHAR,p_mfgr:VARCHAR,p_brand:VARCHAR,p_type:VARCHAR,p_size:INTEGER,p_container:VARCHAR,p_retailprice:DOUBLE,p_comment:VARCHAR>] -> p_partkey:BIGINT, p_brand:VARCHAR, p_size:INTEGER, p_container:VARCHAR
```