### PR TITLE
fix(cuDF): ExpressionEvaluator was not declared in this scope

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.h
+++ b/velox/experimental/cudf/exec/CudfHashJoin.h
@@ -300,7 +300,7 @@ class CudfHashJoinProbe : public exec::Operator, public NvtxHelper {
       cudf::column_view rightIndicesCol,
       std::function<std::vector<std::unique_ptr<cudf::column>>(
           std::vector<std::unique_ptr<cudf::column>>&&,
-          cudf::mutable_column_view)> func,
+          cudf::column_view)> func,
       rmm::cuda_stream_view stream);
 };
 


### PR DESCRIPTION
This PR fixes the recent CI build
https://github.com/facebookincubator/velox/actions/runs/19030255736/job/54342240691
```
cudf/exec/CudfHashJoin.cpp:626:26: error: 'ExpressionEvaluator' was not declared in this scope;
```
2 PRs were merged around same time and 2 merges together caused an issue.