### PR TITLE
fix: Use connector CPUThreadPool for parallel reader

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -32,7 +32,8 @@ namespace facebook::velox::connector::hive {
 HiveConnector::HiveConnector(
     const std::string& id,
     std::shared_ptr<const config::ConfigBase> config,
-    folly::Executor* ioExecutor)
+    folly::Executor* ioExecutor,
+    folly::Executor* cpuExecutor)
     : Connector(id, std::move(config)),
       hiveConfig_(std::make_shared<HiveConfig>(connectorConfig())),
       fileHandleFactory_(
@@ -41,7 +42,8 @@ HiveConnector::HiveConnector(
                     hiveConfig_->numCacheFileHandles())
               : nullptr,
           std::make_unique<FileHandleGenerator>(hiveConfig_->config())),
-      ioExecutor_(ioExecutor) {
+      ioExecutor_(ioExecutor),
+      cpuExecutor_(cpuExecutor) {
   if (hiveConfig_->isFileHandleCacheEnabled()) {
     LOG(INFO) << "Hive connector " << connectorId()
               << " created with maximum of "
@@ -65,6 +67,7 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
       columnHandles,
       &fileHandleFactory_,
       ioExecutor_,
+      cpuExecutor_,
       connectorQueryCtx,
       hiveConfig_);
 }

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -32,7 +32,8 @@ class HiveConnector : public Connector {
   HiveConnector(
       const std::string& id,
       std::shared_ptr<const config::ConfigBase> config,
-      folly::Executor* executor);
+      folly::Executor* ioExecutor,
+      folly::Executor* cpuExecutor);
 
   bool canAddDynamicFilter() const override {
     return true;
@@ -74,6 +75,7 @@ class HiveConnector : public Connector {
   const std::shared_ptr<HiveConfig> hiveConfig_;
   FileHandleFactory fileHandleFactory_;
   folly::Executor* ioExecutor_;
+  folly::Executor* cpuExecutor_;
 };
 
 class HiveConnectorFactory : public ConnectorFactory {
@@ -90,7 +92,7 @@ class HiveConnectorFactory : public ConnectorFactory {
       std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* ioExecutor = nullptr,
       folly::Executor* cpuExecutor = nullptr) override {
-    return std::make_shared<HiveConnector>(id, config, ioExecutor);
+    return std::make_shared<HiveConnector>(id, config, ioExecutor, cpuExecutor);
   }
 };
 

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -615,6 +615,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
     folly::Executor* const ioExecutor,
+    folly::Executor* const cpuExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions) {
   auto skipRowsIt =
       tableParameters.find(dwio::common::TableParameter::kSkipHeaderLineCount);
@@ -623,6 +624,7 @@ void configureRowReaderOptions(
   }
   rowReaderOptions.setScanSpec(scanSpec);
   rowReaderOptions.setIOExecutor(ioExecutor);
+  rowReaderOptions.setCpuExecutor(cpuExecutor);
   rowReaderOptions.setMetadataFilter(std::move(metadataFilter));
   rowReaderOptions.setRequestedType(rowType);
   rowReaderOptions.range(hiveSplit->start, hiveSplit->length);

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -87,6 +87,7 @@ void configureRowReaderOptions(
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const config::ConfigBase* sessionProperties,
     folly::Executor* ioExecutor,
+    folly::Executor* cpuExecutor,
     dwio::common::RowReaderOptions& rowReaderOptions);
 
 bool testFilters(

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -90,10 +90,12 @@ HiveDataSource::HiveDataSource(
     const connector::ColumnHandleMap& assignments,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* ioExecutor,
+    folly::Executor* cpuExecutor,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<HiveConfig>& hiveConfig)
     : fileHandleFactory_(fileHandleFactory),
       ioExecutor_(ioExecutor),
+      cpuExecutor_(cpuExecutor),
       connectorQueryCtx_(connectorQueryCtx),
       hiveConfig_(hiveConfig),
       pool_(connectorQueryCtx->memoryPool()),
@@ -254,6 +256,7 @@ std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
       fsStats_,
       fileHandleFactory_,
       ioExecutor_,
+      cpuExecutor_,
       scanSpec_);
 }
 

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -40,6 +40,7 @@ class HiveDataSource : public DataSource {
       const connector::ColumnHandleMap& assignments,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* ioExecutor,
+      folly::Executor* cpuExecutor,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<HiveConfig>& hiveConfig);
 
@@ -103,6 +104,7 @@ class HiveDataSource : public DataSource {
 
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const ioExecutor_;
+  folly::Executor* const cpuExecutor_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<HiveConfig> hiveConfig_;
   memory::MemoryPool* const pool_;

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -98,6 +98,7 @@ std::unique_ptr<SplitReader> SplitReader::create(
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* ioExecutor,
+    folly::Executor* cpuExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec) {
   //  Create the SplitReader based on hiveSplit->customSplitInfo["table_format"]
   if (hiveSplit->customSplitInfo.count("table_format") > 0 &&
@@ -113,6 +114,7 @@ std::unique_ptr<SplitReader> SplitReader::create(
         fsStats,
         fileHandleFactory,
         ioExecutor,
+        cpuExecutor,
         scanSpec);
   } else {
     return std::unique_ptr<SplitReader>(new SplitReader(
@@ -126,6 +128,7 @@ std::unique_ptr<SplitReader> SplitReader::create(
         fsStats,
         fileHandleFactory,
         ioExecutor,
+        cpuExecutor,
         scanSpec));
   }
 }
@@ -141,6 +144,7 @@ SplitReader::SplitReader(
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* ioExecutor,
+    folly::Executor* cpuExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec)
     : hiveSplit_(hiveSplit),
       hiveTableHandle_(hiveTableHandle),
@@ -152,6 +156,7 @@ SplitReader::SplitReader(
       fsStats_(fsStats),
       fileHandleFactory_(fileHandleFactory),
       ioExecutor_(ioExecutor),
+      cpuExecutor_(cpuExecutor),
       pool_(connectorQueryCtx->memoryPool()),
       scanSpec_(scanSpec),
       baseReaderOpts_(connectorQueryCtx->memoryPool()),
@@ -399,6 +404,7 @@ void SplitReader::createRowReader(
       hiveConfig_,
       connectorQueryCtx_->sessionProperties(),
       ioExecutor_,
+      cpuExecutor_,
       baseRowReaderOpts_);
   baseRowReaderOpts_.setTrackRowSize(
       rowSizeTrackingEnabled.has_value()

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -97,6 +97,7 @@ class SplitReader {
       const std::shared_ptr<filesystems::File::IoStats>& fsStats,
       FileHandleFactory* fileHandleFactory,
       folly::Executor* ioExecutor,
+      folly::Executor* cpuExecutor,
       const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   virtual ~SplitReader() = default;
@@ -150,7 +151,8 @@ class SplitReader {
       const std::shared_ptr<io::IoStatistics>& ioStats,
       const std::shared_ptr<filesystems::File::IoStats>& fsStats,
       FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
+      folly::Executor* ioExecutor,
+      folly::Executor* cpuExecutor,
       const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   /// Create the dwio::common::Reader object baseReader_, which will be used to
@@ -226,6 +228,7 @@ class SplitReader {
   const std::shared_ptr<filesystems::File::IoStats> fsStats_;
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const ioExecutor_;
+  folly::Executor* const cpuExecutor_;
   memory::MemoryPool* const pool_;
 
   std::shared_ptr<common::ScanSpec> scanSpec_;

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -34,7 +34,8 @@ IcebergSplitReader::IcebergSplitReader(
     const std::shared_ptr<io::IoStatistics>& ioStats,
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* const fileHandleFactory,
-    folly::Executor* executor,
+    folly::Executor* ioExecutor,
+    folly::Executor* cpuExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec)
     : SplitReader(
           hiveSplit,
@@ -46,7 +47,8 @@ IcebergSplitReader::IcebergSplitReader(
           ioStats,
           fsStats,
           fileHandleFactory,
-          executor,
+          ioExecutor,
+          cpuExecutor,
           scanSpec),
       baseReadOffset_(0),
       splitOffset_(0),

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -36,7 +36,8 @@ class IcebergSplitReader : public SplitReader {
       const std::shared_ptr<io::IoStatistics>& ioStats,
       const std::shared_ptr<filesystems::File::IoStats>& fsStats,
       FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
+      folly::Executor* ioExecutor,
+      folly::Executor* cpuExecutor,
       const std::shared_ptr<common::ScanSpec>& scanSpec);
 
   ~IcebergSplitReader() override = default;

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -139,6 +139,7 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
       nullptr,
       nullptr,
       nullptr,
+      nullptr,
       deleteRowReaderOpts);
 
   deleteRowReader_.reset();

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -345,6 +345,7 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
             fsStats,
             &fileHandleFactory,
             nullptr,
+            nullptr,
             scanSpec);
 
     std::shared_ptr<random::RandomSkipTracker> randomSkip;

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -353,6 +353,7 @@ TEST_F(HiveConnectorUtilTest, configureSstRowReaderOptions) {
       /*hiveConfig=*/nullptr,
       /*sessionProperties=*/nullptr,
       /*ioExecutor=*/nullptr,
+      /*cpuExecutor=*/nullptr,
       /*rowReaderOptions=*/rowReaderOpts);
 
   EXPECT_EQ(rowReaderOpts.serdeParameters(), hiveSplit->serdeParameters);
@@ -379,6 +380,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
         /*ioExecutor=*/nullptr,
+        /*cpuExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_FALSE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -405,6 +407,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
         /*ioExecutor=*/nullptr,
+        /*cpuExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -432,6 +435,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
         /*ioExecutor=*/nullptr,
+        /*cpuExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
@@ -460,6 +464,7 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*hiveConfig=*/hiveConfig,
         /*sessionProperties=*/&sessionProperties,
         /*ioExecutor=*/nullptr,
+        /*cpuExecutor=*/nullptr,
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -290,6 +290,14 @@ class RowReaderOptions {
     ioExecutor_ = ioExecutor;
   }
 
+  folly::Executor* cpuExecutor() const {
+    return cpuExecutor_;
+  }
+
+  void setCpuExecutor(folly::Executor* const cpuExecutor) {
+    cpuExecutor_ = cpuExecutor;
+  }
+
   const size_t parallelUnitLoadCount() const {
     return parallelUnitLoadCount_;
   }
@@ -473,6 +481,7 @@ class RowReaderOptions {
   bool preserveFlatMapsInMemory_ = false;
   // Optional io executor to enable parallel unit loader.
   folly::Executor* ioExecutor_{nullptr};
+  folly::Executor* cpuExecutor_{nullptr};
   // Optional executors to enable internal reader parallelism.
   // 'decodingExecutor' allow parallelising the vector decoding process.
   // 'ioExecutor' enables parallelism when performing file system read

--- a/velox/dwio/common/ParallelUnitLoader.h
+++ b/velox/dwio/common/ParallelUnitLoader.h
@@ -26,16 +26,16 @@ namespace facebook::velox::dwio::common {
 class ParallelUnitLoaderFactory : public UnitLoaderFactory {
  public:
   ParallelUnitLoaderFactory(
-      folly::Executor* ioExecutor,
+      folly::Executor* cpuExecutor,
       size_t maxConcurrentLoads)
-      : ioExecutor_(ioExecutor), maxConcurrentLoads_(maxConcurrentLoads) {}
+      : cpuExecutor_(cpuExecutor), maxConcurrentLoads_(maxConcurrentLoads) {}
 
   std::unique_ptr<UnitLoader> create(
       std::vector<std::unique_ptr<LoadUnit>> loadUnits,
       uint64_t rowsToSkip) override;
 
  private:
-  folly::Executor* ioExecutor_;
+  folly::Executor* cpuExecutor_;
   size_t maxConcurrentLoads_;
 };
 

--- a/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
+++ b/velox/dwio/common/tests/ParallelUnitLoaderTest.cpp
@@ -30,10 +30,10 @@ class ParallelUnitLoaderTest
     : public UnitLoaderBaseTest<ParallelUnitLoaderFactory> {
  protected:
   ParallelUnitLoaderFactory createFactory() override {
-    return ParallelUnitLoaderFactory(ioExecutor_.get(), 2);
+    return ParallelUnitLoaderFactory(cpuExecutor_.get(), 2);
   }
 
-  std::unique_ptr<folly::CPUThreadPoolExecutor> ioExecutor_ =
+  std::unique_ptr<folly::CPUThreadPoolExecutor> cpuExecutor_ =
       std::make_unique<folly::CPUThreadPoolExecutor>(10);
 };
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -344,10 +344,10 @@ std::unique_ptr<dwio::common::UnitLoader> DwrfRowReader::getUnitLoader() {
       options_.unitLoaderFactory();
   if (!unitLoaderFactory) {
     if (loadUnits.size() > 1 && options_.parallelUnitLoadCount() > 1 &&
-        options_.ioExecutor() != nullptr) {
+        options_.cpuExecutor() != nullptr) {
       unitLoaderFactory =
           std::make_shared<dwio::common::ParallelUnitLoaderFactory>(
-              options_.ioExecutor(), options_.parallelUnitLoadCount());
+              options_.cpuExecutor(), options_.parallelUnitLoadCount());
     } else {
       unitLoaderFactory =
           std::make_shared<dwio::common::OnDemandUnitLoaderFactory>(

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -41,7 +41,8 @@ void HiveConnectorTestBase::SetUp() {
       kHiveConnectorId,
       std::make_shared<config::ConfigBase>(
           std::unordered_map<std::string, std::string>()),
-      ioExecutor_.get());
+      ioExecutor_.get(),
+      cpuExecutor_.get());
   connector::registerConnector(hiveConnector);
   dwio::common::registerFileSinks();
   dwrf::registerDwrfReaderFactory();
@@ -53,6 +54,7 @@ void HiveConnectorTestBase::TearDown() {
   // Make sure all pending loads are finished or cancelled before unregister
   // connector.
   ioExecutor_.reset();
+  cpuExecutor_.reset();
   dwrf::unregisterDwrfReaderFactory();
   dwrf::unregisterDwrfWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
@@ -65,8 +67,8 @@ void HiveConnectorTestBase::resetHiveConnector(
   connector::unregisterConnector(kHiveConnectorId);
 
   connector::hive::HiveConnectorFactory factory;
-  auto hiveConnector =
-      factory.newConnector(kHiveConnectorId, config, ioExecutor_.get());
+  auto hiveConnector = factory.newConnector(
+      kHiveConnectorId, config, ioExecutor_.get(), cpuExecutor_.get());
   connector::registerConnector(hiveConnector);
 }
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -137,6 +137,7 @@ void OperatorTestBase::SetUp() {
   }
   driverExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(3);
   ioExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(3);
+  cpuExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(3);
   PeriodicStatsReporter::Options options;
   options.allocator = memory::memoryManager()->allocator();
   options.allocatorStatsIntervalMs = 2'000;

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -180,5 +180,8 @@ class OperatorTestBase : public virtual testing::Test,
 
   // Used for IO prefetch and spilling.
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
+
+  // Used for CPU-intensive parallel operations.
+  std::unique_ptr<folly::CPUThreadPoolExecutor> cpuExecutor_;
 };
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
ParallelUnitLoader's load() would be scheduled on IOThreadPool, in load() task, it would 
schedule and **wait** on another task (from CacheInputStream) on the same IOThreadPool.
When IOThreadPool is exhausted, the above situation could have deadlock.

Move ParallelUnitLoader's load() onto CPUThreadPool to break circular dependency.