### PR TITLE
feat(ci): Add Clang to CentOS adapters image

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -56,8 +56,8 @@ function install_build_prerequisites {
     dnf config-manager --set-enabled crb
     dnf update -y
   fi
-  dnf_install autoconf automake ccache gcc-toolset-12 gcc-toolset-14 git libtool \
-    ninja-build python3-pip python3-devel wget which
+  dnf_install autoconf automake ccache clang gcc-toolset-12 gcc-toolset-14 git libtool \
+    llvm ninja-build python3-pip python3-devel wget which
 
   install_uv
   uv_install cmake@3.31.1


### PR DESCRIPTION
This installs the OS Clang version into the adapters
image for CentOS.