### PR TITLE
refactor: Move map_subset registration logic into MapSubset.cpp

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -40,6 +40,7 @@ velox_add_library(
   MapEntries.cpp
   MapFromEntries.cpp
   MapKeysAndValues.cpp
+  MapSubset.cpp
   MapZipWith.cpp
   Not.cpp
   Reduce.cpp

--- a/velox/functions/prestosql/MapSubset.cpp
+++ b/velox/functions/prestosql/MapSubset.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/MapSubset.h"
+#include "velox/functions/Registerer.h"
+
+namespace facebook::velox::functions {
+template <typename T>
+void registerMapSubsetPrimitive(const std::string& name) {
+  registerFunction<
+      ParameterBinder<MapSubsetPrimitiveFunction, T>,
+      Map<T, Generic<T1>>,
+      Map<T, Generic<T1>>,
+      Array<T>>({name});
+}
+
+void registerMapSubset(const std::string& name) {
+  registerMapSubsetPrimitive<bool>(name);
+  registerMapSubsetPrimitive<int8_t>(name);
+  registerMapSubsetPrimitive<int16_t>(name);
+  registerMapSubsetPrimitive<int32_t>(name);
+  registerMapSubsetPrimitive<int64_t>(name);
+  registerMapSubsetPrimitive<float>(name);
+  registerMapSubsetPrimitive<double>(name);
+  registerMapSubsetPrimitive<Timestamp>(name);
+  registerMapSubsetPrimitive<Date>(name);
+
+  registerFunction<
+      MapSubsetVarcharFunction,
+      Map<Varchar, Generic<T1>>,
+      Map<Varchar, Generic<T1>>,
+      Array<Varchar>>({name});
+
+  registerFunction<
+      MapSubsetFunction,
+      Map<Generic<T1>, Generic<T2>>,
+      Map<Generic<T1>, Generic<T2>>,
+      Array<Generic<T1>>>({name});
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/MapSubset.h
+++ b/velox/functions/prestosql/MapSubset.h
@@ -15,8 +15,9 @@
  */
 #pragma once
 
+#include "velox/core/QueryConfig.h"
 #include "velox/expression/ComplexViewTypes.h"
-#include "velox/functions/Udf.h"
+#include "velox/functions/Macros.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::functions {
@@ -233,5 +234,7 @@ struct MapSubsetFunction {
       MapSubsetFunctionEqualComparator>
       searchKeys_;
 };
+
+void registerMapSubset(const std::string& name);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -31,40 +31,6 @@
 namespace facebook::velox::functions {
 
 namespace {
-
-template <typename T>
-void registerMapSubsetPrimitive(const std::string& prefix) {
-  registerFunction<
-      ParameterBinder<MapSubsetPrimitiveFunction, T>,
-      Map<T, Generic<T1>>,
-      Map<T, Generic<T1>>,
-      Array<T>>({prefix + "map_subset"});
-}
-
-void registerMapSubset(const std::string& prefix) {
-  registerMapSubsetPrimitive<bool>(prefix);
-  registerMapSubsetPrimitive<int8_t>(prefix);
-  registerMapSubsetPrimitive<int16_t>(prefix);
-  registerMapSubsetPrimitive<int32_t>(prefix);
-  registerMapSubsetPrimitive<int64_t>(prefix);
-  registerMapSubsetPrimitive<float>(prefix);
-  registerMapSubsetPrimitive<double>(prefix);
-  registerMapSubsetPrimitive<Timestamp>(prefix);
-  registerMapSubsetPrimitive<Date>(prefix);
-
-  registerFunction<
-      MapSubsetVarcharFunction,
-      Map<Varchar, Generic<T1>>,
-      Map<Varchar, Generic<T1>>,
-      Array<Varchar>>({prefix + "map_subset"});
-
-  registerFunction<
-      MapSubsetFunction,
-      Map<Generic<T1>, Generic<T2>>,
-      Map<Generic<T1>, Generic<T2>>,
-      Array<Generic<T1>>>({prefix + "map_subset"});
-}
-
 template <typename T>
 void registerRemapKeysPrimitive(const std::string& prefix) {
   registerFunction<
@@ -171,7 +137,7 @@ void registerMapFunctions(const std::string& prefix) {
       Map<Orderable<T1>, Orderable<T2>>,
       int64_t>({prefix + "map_top_n_values"});
 
-  registerMapSubset(prefix);
+  registerMapSubset(prefix + "map_subset");
 
   registerRemapKeys(prefix);
 


### PR DESCRIPTION
Summary:
The map_subset function in Presto has several optimized code paths for primitive types and varchars that complicate the registration logic.  I'd like to reuse the UDF in another engine with a different name, but I'd rather not have to maintain that logic in a separate location.

Given that the complicated registration is mostly due to implementation details of MapSubset itself, it makes sense to move it into MapSubset.cpp so that it can be shared wherever it is used. This is very common for other UDFs as well.

Differential Revision: D86125861


