### PR TITLE
refactor: Address more usage of Arena::CreateMessage in dwrf/writer

### DIFF
--- a/velox/dwio/dwrf/writer/IndexBuilder.h
+++ b/velox/dwio/dwrf/writer/IndexBuilder.h
@@ -16,12 +16,14 @@
 
 #pragma once
 
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
 namespace facebook::velox::dwrf {
 
+using dwio::common::ArenaCreate;
 using dwio::common::BufferedOutputStream;
 using dwio::common::PositionRecorder;
 
@@ -40,11 +42,8 @@ class IndexBuilder : public PositionRecorder {
       dwio::common::FileFormat fileFormat = dwio::common::FileFormat::DWRF)
       : out_{std::move(out)},
         arena_(std::make_unique<google::protobuf::Arena>()) {
-    auto rowIndex =
-        google::protobuf::Arena::CreateMessage<proto::RowIndex>(arena_.get());
-    auto rowIndexEntry =
-        google::protobuf::Arena::CreateMessage<proto::RowIndexEntry>(
-            arena_.get());
+    auto rowIndex = ArenaCreate<proto::RowIndex>(arena_.get());
+    auto rowIndexEntry = ArenaCreate<proto::RowIndexEntry>(arena_.get());
 
     index_ = std::make_unique<RowIndexWriteWrapper>(rowIndex);
     entry_ = std::make_unique<RowIndexEntryWriteWrapper>(rowIndexEntry);

--- a/velox/dwio/dwrf/writer/LayoutPlanner.cpp
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.cpp
@@ -16,7 +16,11 @@
 
 #include "velox/dwio/dwrf/writer/LayoutPlanner.h"
 
+#include "velox/dwio/common/Arena.h"
+
 namespace facebook::velox::dwrf {
+
+using dwio::common::ArenaCreate;
 
 StreamList getStreamList(WriterContext& context) {
   StreamList streams;
@@ -128,8 +132,7 @@ EncodingManager::EncodingManager(
     : encryptionHandler_{encryptionHandler},
       arena_{std::make_unique<google::protobuf::Arena>()} {
   initEncryptionGroups();
-  auto dwrfStripeFooter =
-      google::protobuf::Arena::CreateMessage<proto::StripeFooter>(arena_.get());
+  auto dwrfStripeFooter = ArenaCreate<proto::StripeFooter>(arena_.get());
   footer_ = std::make_unique<StripeFooterWriteWrapper>(dwrfStripeFooter);
 }
 

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.cpp
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.cpp
@@ -16,7 +16,11 @@
 
 #include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
 
+#include "velox/dwio/common/Arena.h"
+
 namespace facebook::velox::dwrf {
+
+using dwio::common::ArenaCreate;
 
 namespace {
 
@@ -118,9 +122,7 @@ void StatisticsBuilder::toProto(ColumnStatisticsWriteWrapper& stats) const {
 
 std::unique_ptr<dwio::common::ColumnStatistics> StatisticsBuilder::build()
     const {
-  auto columnStatistics =
-      google::protobuf::Arena::CreateMessage<proto::ColumnStatistics>(
-          arena_.get());
+  auto columnStatistics = ArenaCreate<proto::ColumnStatistics>(arena_.get());
   auto stats = ColumnStatisticsWriteWrapper(columnStatistics);
   toProto(stats);
 

--- a/velox/dwio/dwrf/writer/WriterBase.cpp
+++ b/velox/dwio/dwrf/writer/WriterBase.cpp
@@ -58,8 +58,7 @@ void WriterBase::writeFooter(const Type& type) {
 
   // write postscript
   pos = writerSink_->size();
-  auto dwrfPostScript =
-      google::protobuf::Arena::CreateMessage<proto::PostScript>(arena_.get());
+  auto dwrfPostScript = ArenaCreate<proto::PostScript>(arena_.get());
   std::unique_ptr<PostScriptWriteWrapper> ps =
       std::make_unique<PostScriptWriteWrapper>(dwrfPostScript);
   ps->setWriterVersion(writerVersion);

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -17,10 +17,13 @@
 #pragma once
 
 #include "velox/common/base/GTestMacros.h"
+#include "velox/dwio/common/Arena.h"
 #include "velox/dwio/dwrf/writer/WriterContext.h"
 #include "velox/dwio/dwrf/writer/WriterSink.h"
 
 namespace facebook::velox::dwrf {
+
+using dwio::common::ArenaCreate;
 
 class WriterBase {
  public:
@@ -89,8 +92,7 @@ class WriterBase {
         *sink_,
         context_->getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM),
         context_->getConfigs());
-    auto dwrfFooter_ =
-        google::protobuf::Arena::CreateMessage<proto::Footer>(arena_.get());
+    auto dwrfFooter_ = ArenaCreate<proto::Footer>(arena_.get());
     footer_ = std::make_unique<FooterWriteWrapper>(dwrfFooter_);
   }
 


### PR DESCRIPTION
Summary:
This works around supporting multiple versions of protobuf.  The older protobuf
calls it `Arena::CreateMessage()` and newer ones call it `Arena::Create()`.  Use
the `ArenaCreate()` wrapper in velox/dwio/common/Arena.h.

Differential Revision: D86129557


