### PR TITLE
feat: Add rewrites for SWITCH and IF special forms

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -142,6 +142,12 @@ TypedExprPtr ConstantTypedExpr::create(
   return std::make_shared<ConstantTypedExpr>(restoreVector(dataStream, pool));
 }
 
+// static
+TypedExprPtr ConstantTypedExpr::makeNull(const TypePtr& type) {
+  return std::make_shared<core::ConstantTypedExpr>(
+      type, Variant::null(type->kind()));
+}
+
 std::string ConstantTypedExpr::toString() const {
   if (hasValueVector()) {
     return valueVector_->toString(0);

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -151,6 +151,9 @@ class ConstantTypedExpr : public ITypedExpr {
 
   static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
+  /// Returns a NULL constant expression of given type.
+  static TypedExprPtr makeNull(const TypePtr& type);
+
  private:
   const Variant value_;
   const VectorPtr valueVector_;

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -58,6 +58,7 @@ velox_add_library(
   SpecialFormRegistry.cpp
   ConjunctRewrite.cpp
   SwitchExpr.cpp
+  SwitchRewrite.cpp
   TryExpr.cpp
   VectorFunction.cpp
 )

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -24,6 +24,7 @@
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/SwitchExpr.h"
+#include "velox/expression/SwitchRewrite.h"
 #include "velox/expression/TryExpr.h"
 
 namespace facebook::velox::exec {
@@ -52,5 +53,6 @@ void registerFunctionCallToSpecialForms() {
       std::make_unique<RowConstructorCallToSpecialForm>());
 
   expression::ConjunctRewrite::registerRewrite();
+  expression::SwitchRewrite::registerRewrite();
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchRewrite.cpp
+++ b/velox/expression/SwitchRewrite.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <set>
+
+#include "velox/expression/ExprConstants.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/expression/ExprUtils.h"
+#include "velox/expression/SwitchRewrite.h"
+
+namespace facebook::velox::expression {
+
+core::TypedExprPtr SwitchRewrite::rewrite(const core::TypedExprPtr& expr) {
+  if (!expr->isCallKind()) {
+    return nullptr;
+  }
+  const auto* callExpr = expr->asUnchecked<core::CallTypedExpr>();
+  if (!(callExpr->name() == kSwitch) && !(callExpr->name() == kIf)) {
+    return nullptr;
+  }
+
+  const auto& inputs = expr->inputs();
+  const auto numInputs = inputs.size();
+  std::vector<core::TypedExprPtr> optimizedInputs;
+
+  // Iterate over all `(condition, value)` pairs. Handle `else` value at the
+  // end.
+  for (auto i = 0; i < numInputs - 1; i += 2) {
+    const auto& condition = inputs.at(i);
+    const auto& value = inputs.at(i + 1);
+
+    if (condition->isConstantKind()) {
+      const auto* constCondition =
+          condition->asUnchecked<core::ConstantTypedExpr>();
+      if (auto boolCondition = constCondition->toBool()) {
+        if (boolCondition.value()) {
+          // If this condition is true and all conditions before this are false,
+          // simplify `switch` expression to the corresponding `value`.
+          if (optimizedInputs.empty()) {
+            return value;
+          }
+          // If this condition is true and all conditions before this can only
+          // be evaluated at runtime, make this the new `else` value and stop
+          // checking further conditions.
+          optimizedInputs.push_back(value);
+          break;
+        } else {
+          // Skip false conditions.
+          continue;
+        }
+      } else {
+        // Skip NULL conditions.
+        continue;
+      }
+    } else {
+      optimizedInputs.push_back(condition);
+      optimizedInputs.push_back(value);
+    }
+  }
+
+  // Handle `else` value if present.
+  if (optimizedInputs.size() % 2 == 0 && numInputs % 2 == 1) {
+    const auto elseValue = inputs.at(numInputs - 1);
+    // Return `else` value if there are no conditions.
+    if (optimizedInputs.empty()) {
+      return elseValue;
+    }
+    optimizedInputs.emplace_back(elseValue);
+  }
+  // Return NULL if there are no conditions and `else` value is not present.
+  if (optimizedInputs.empty()) {
+    return core::ConstantTypedExpr::makeNull(expr->type());
+  }
+
+  return std::make_shared<core::CallTypedExpr>(
+      expr->type(), std::move(optimizedInputs), callExpr->name());
+}
+
+void SwitchRewrite::registerRewrite() {
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      expression::SwitchRewrite::rewrite);
+}
+
+} // namespace facebook::velox::expression

--- a/velox/expression/SwitchRewrite.h
+++ b/velox/expression/SwitchRewrite.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::expression {
+
+class SwitchRewrite {
+ public:
+  /// Rewrites SWITCH and IF special form expressions which have the shape
+  /// `SWITCH(condition1, value1, condition2, value2, .., conditionN, valueN, ..
+  /// .., optional<elseValue>)`, and `IF(condition, trueValue, falseValue)`
+  /// respectively. IF expression is rewritten to `trueValue` or `falseValue`
+  /// if `condition` is either true or false respectively. The conditions of
+  /// SWITCH expression are traversed in order and if the condition is:
+  ///  1. false, it is removed from the inputs along with its corresponding
+  ///     value.
+  ///  2. true: If there are no inputs before this, the corresponding value
+  ///     is returned. Otherwise, the corresponding value is the new else value
+  ///     and all subsequent inputs are ignored.
+  ///  3. not a constant boolean and it cannot be evaluated without input data,
+  ///     the condition and its corresponding value are retained in the inputs.
+  /// If there are no conditions in the expression now, the else value is
+  /// returned if it is present; otherwise NULL is returned. The else value is
+  /// added to the inputs otherwise and the optimized SWITCH expression with
+  /// pruned inputs is returned.
+  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+
+  static void registerRewrite();
+};
+
+} // namespace facebook::velox::expression

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -46,6 +46,8 @@ add_executable(
   SimpleFunctionInitTest.cpp
   SimpleFunctionPresetNullsTest.cpp
   SimpleFunctionTest.cpp
+  SpecialFormRewriteTestBase.cpp
+  SwitchRewriteTest.cpp
   ConjunctRewriteTest.cpp
   StringWriterTest.cpp
   TryExprTest.cpp

--- a/velox/expression/tests/ConjunctRewriteTest.cpp
+++ b/velox/expression/tests/ConjunctRewriteTest.cpp
@@ -16,48 +16,13 @@
 
 #include <gtest/gtest.h>
 
-#include "velox/expression/ExprRewriteRegistry.h"
-#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/expression/tests/SpecialFormRewriteTestBase.h"
 
 namespace facebook::velox::expression {
 namespace {
 
-class ConjunctRewriteTest : public functions::test::FunctionBaseTest {
- protected:
-  static void SetUpTestCase() {
-    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
-  }
-
-  void SetUp() override {
-    functions::prestosql::registerAllScalarFunctions("");
-    parse::registerTypeResolver();
-  }
-
-  void TearDown() override {
-    expression::ExprRewriteRegistry::instance().clear();
-  }
-
-  /// Validates special form expression rewrites that can short circuit
-  /// expression evaluation.
-  /// @param expr Input SQL expression to be rewritten.
-  /// @param expected Expected SQL expression after rewriting `expr`.
-  /// @param type Row type containing input fields referenced by `expr`.
-  void testRewrite(
-      const std::string& expr,
-      const std::string& expected,
-      const RowTypePtr& type = ROW({})) {
-    const auto typedExpr = makeTypedExpr(expr, type);
-    const auto rewritten =
-        expression::ExprRewriteRegistry::instance().rewrite(typedExpr);
-    const auto expectedExpr = makeTypedExpr(expected, type);
-    SCOPED_TRACE(fmt::format("Input: {}", typedExpr->toString()));
-    SCOPED_TRACE(fmt::format("Rewritten: {}", rewritten->toString()));
-    SCOPED_TRACE(fmt::format("Expected: {}", expectedExpr->toString()));
-
-    ASSERT_TRUE(*rewritten == *expectedExpr);
-  }
-};
+class ConjunctRewriteTest
+    : public expression::test::SpecialFormRewriteTestBase {};
 
 TEST_F(ConjunctRewriteTest, basic) {
   testRewrite("true and true", "true");

--- a/velox/expression/tests/SpecialFormRewriteTestBase.cpp
+++ b/velox/expression/tests/SpecialFormRewriteTestBase.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/tests/SpecialFormRewriteTestBase.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::expression::test {
+
+void SpecialFormRewriteTestBase::SetUpTestCase() {
+  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+}
+
+void SpecialFormRewriteTestBase::SetUp() {
+  functions::prestosql::registerAllScalarFunctions("");
+  parse::registerTypeResolver();
+}
+
+void SpecialFormRewriteTestBase::TearDown() {
+  expression::ExprRewriteRegistry::instance().clear();
+}
+
+void SpecialFormRewriteTestBase::testRewrite(
+    const std::string& expr,
+    const std::string& expected,
+    const RowTypePtr& type) {
+  const auto typedExpr = makeTypedExpr(expr, type);
+  const auto rewritten =
+      expression::ExprRewriteRegistry::instance().rewrite(typedExpr);
+  const auto expectedExpr = makeTypedExpr(expected, type);
+  if (*rewritten != *expectedExpr) {
+    SCOPED_TRACE(fmt::format("Input: {}", typedExpr->toString()));
+    SCOPED_TRACE(fmt::format("Rewritten: {}", rewritten->toString()));
+    SCOPED_TRACE(fmt::format("Expected: {}", expectedExpr->toString()));
+  }
+
+  ASSERT_TRUE(*rewritten == *expectedExpr);
+}
+
+} // namespace facebook::velox::expression::test

--- a/velox/expression/tests/SpecialFormRewriteTestBase.h
+++ b/velox/expression/tests/SpecialFormRewriteTestBase.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::expression::test {
+
+class SpecialFormRewriteTestBase : public functions::test::FunctionBaseTest {
+ protected:
+  static void SetUpTestCase();
+
+  void SetUp() override;
+
+  void TearDown() override;
+
+  /// Validates special form expression rewrites that can short circuit
+  /// expression evaluation.
+  /// @param expr Input SQL expression to be rewritten.
+  /// @param expected Expected SQL expression after rewriting `expr`.
+  /// @param type Row type containing input fields referenced by `expr`.
+  void testRewrite(
+      const std::string& expr,
+      const std::string& expected,
+      const RowTypePtr& type = ROW({}));
+};
+
+} // namespace facebook::velox::expression::test

--- a/velox/expression/tests/SwitchRewriteTest.cpp
+++ b/velox/expression/tests/SwitchRewriteTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/expression/tests/SpecialFormRewriteTestBase.h"
+
+namespace facebook::velox::expression {
+namespace {
+
+class SwitchRewriteTest : public expression::test::SpecialFormRewriteTestBase {
+};
+
+TEST_F(SwitchRewriteTest, basic) {
+  testRewrite("if(true, 'hello', 'world')", "'hello'");
+  testRewrite("case when false then 1 when true then 3 end", "3");
+  testRewrite("case when false then 1 when false then 3 end", "null::bigint");
+  testRewrite("case when false then 1 when false then 3 else 2 end", "2");
+  testRewrite(
+      "case when false then 'hello' when false then 'world' when true then 'foo' else 'bar' end",
+      "'foo'");
+
+  const auto type = ROW({"a"}, {BIGINT()});
+  testRewrite("case when false then 1234 when true then a end", "a", type);
+  testRewrite(
+      "case when false then 1234 when false then 3456 else a end", "a", type);
+  testRewrite(
+      "case when false then 100 when a > 2 then 200 when a > 4 then 300 else 5678 end",
+      "case when a > 2 then 200 when a > 4 then 300 else 5678 end",
+      type);
+  testRewrite(
+      "case when a < 5 then 1234 when a > 10 then 3456 when true then 6789 else 0 end",
+      "case when a < 5 then 1234 when a > 10 then 3456 else 6789 end",
+      type);
+}
+
+} // namespace
+} // namespace facebook::velox::expression


### PR DESCRIPTION
Rewrites SWITCH and IF special form expressions which have either of the shapes:
1. `SWITCH(condition1, value1, condition2, value2, .., conditionN, valueN, .., optional<defaultValue>)`
2. `IF(condition, trueValue, falseValue)` 

Removes `(conditionN, valueN)` pairs from inputs when `conditionN` is false. 
If `conditionN` is true and all the previous conditions were false, the expression is simplified to `valueN`. 
If `conditionN` is true and there is at least one condition before `conditionN` that can not be evaluated without input data, modifies else clause to `valueN` and prunes rest of the inputs. 
Returns an optimized SWITCH expression with pruned inputs.