### PR TITLE
fix(cudf): Fix cudf expression library does not link velox_core

### DIFF
--- a/velox/experimental/cudf/expression/CMakeLists.txt
+++ b/velox/experimental/cudf/expression/CMakeLists.txt
@@ -22,7 +22,7 @@ add_library(
 target_link_libraries(
   velox_cudf_expression
   PUBLIC cudf::cudf
-  PRIVATE arrow velox_exception velox_common_base velox_core velox_cudf_vector
+  PRIVATE arrow velox_exception velox_common_base velox_expression velox_cudf_vector
 )
 
 target_compile_options(velox_cudf_expression PRIVATE -Wno-missing-field-initializers)


### PR DESCRIPTION
Fix the exception
```
/opt/rh/gcc-toolset-12/root/usr/libexec/gcc/x86_64-redhat-linux/12/ld: /opt/gluten/dev/../ep/build-velox/build/velox_ep/_build/release/velox/experimental/cudf/expression/libvelox_cudf_expression.a(ExpressionEvaluator.cpp.o): in function `facebook::velox::cudf_velox::FunctionExpression::canEvaluate(std::shared_ptr<facebook::velox::core::ITypedExpr const> const&)':
ExpressionEvaluator.cpp:(.text+0x26b8): undefined reference to `facebook::velox::core::ExprKindName::toName(facebook::velox::core::ExprKind)'
collect2: error: ld returned 1 exit status
```