### PR TITLE
fix: Add missing metadataFilter_ transfer for split prefetch

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -505,6 +505,7 @@ void HiveDataSource::setFromDataSource(
   readerOutputType_ = std::move(source->readerOutputType_);
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);
   scanSpec_ = std::move(source->scanSpec_);
+  metadataFilter_ = std::move(source->metadataFilter_);
   splitReader_ = std::move(source->splitReader_);
   splitReader_->setConnectorQueryCtx(connectorQueryCtx_);
   // New io will be accounted on the stats of 'source'. Add the existing


### PR DESCRIPTION
Summary:
We're seeing crash when prefetch is turned on, ASAN log P2022180855
In `setFromDataSource`:

1.  `scanSpec_ = std::move(source->scanSpec_);` - The scanSpec is moved from old source to new one
2.  The `scanSpec_` contains raw pointers*to Filter objects owned by `source->metadataFilter_`
3.  But `metadataFilter_` is **NOT** transferred from source to this
4.  When `sourceUnique` (the old source) is destroyed at the end of the function, `source->metadataFilter_` is destroyed
5.  The `scanSpec_` in the new HiveDataSource now has **dangling pointers** to the destroyed Filters
6.  Later async operations try to use these pointers → heap-use-after-free

Reviewed By: Yuhta

Differential Revision: D86178967


