### PR TITLE
fix: Change columnHandles to filterColumnHandles in HiveTableHandle

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -50,6 +50,19 @@ bool shouldEagerlyMaterialize(
   return false;
 }
 
+void checkColumnHandleConsistent(
+    const HiveColumnHandle& x,
+    const HiveColumnHandle& y) {
+  VELOX_CHECK(
+      x.columnType() == y.columnType(),
+      "Inconsistent column handle: {}",
+      x.name());
+  VELOX_CHECK_EQ(
+      *x.dataType(), *y.dataType(), "Inconsistent column handle: {}", x.name());
+  VELOX_CHECK_EQ(
+      *x.hiveType(), *y.hiveType(), "Inconsistent column handle: {}", x.name());
+}
+
 } // namespace
 
 void HiveDataSource::processColumnHandle(const HiveColumnHandlePtr& handle) {
@@ -91,29 +104,37 @@ HiveDataSource::HiveDataSource(
   VELOX_CHECK_NOT_NULL(
       hiveTableHandle_, "TableHandle must be an instance of HiveTableHandle");
 
-  if (hiveTableHandle_->columnHandles().empty()) {
-    // Column handled keyed on the column alias, the name used in the query.
-    for (const auto& [canonicalizedName, columnHandle] : assignments) {
-      auto handle =
-          std::dynamic_pointer_cast<const HiveColumnHandle>(columnHandle);
-      VELOX_CHECK_NOT_NULL(
-          handle,
-          "ColumnHandle must be an instance of HiveColumnHandle for {}",
-          canonicalizedName);
-      processColumnHandle(handle);
+  folly::F14FastMap<std::string_view, const HiveColumnHandle*> columnHandles;
+  // Column handled keyed on the column alias, the name used in the query.
+  for (const auto& [canonicalizedName, columnHandle] : assignments) {
+    auto handle =
+        std::dynamic_pointer_cast<const HiveColumnHandle>(columnHandle);
+    VELOX_CHECK_NOT_NULL(
+        handle,
+        "ColumnHandle must be an instance of HiveColumnHandle for {}",
+        canonicalizedName);
+    const auto [it, unique] =
+        columnHandles.emplace(handle->name(), handle.get());
+    if (!unique) {
+      // This should not happen normally, but there is some bug in Presto DELETE
+      // queries that sometimes we do get duplicate assignments for partitioning
+      // columns.
+      checkColumnHandleConsistent(*handle, *it->second);
+      VELOX_CHECK(
+          handle->columnType() == HiveColumnHandle::ColumnType::kPartitionKey,
+          "Cannot map from same table column to different outputs in table scan; a project node should be used instead: {}",
+          handle->name());
+      continue;
     }
-  } else {
-    folly::F14FastSet<const connector::ColumnHandle*> assignmentHandles;
-    for (const auto& [_, columnHandle] : assignments) {
-      assignmentHandles.insert(columnHandle.get());
+    processColumnHandle(handle);
+  }
+  for (auto& handle : hiveTableHandle_->filterColumnHandles()) {
+    auto it = columnHandles.find(handle->name());
+    if (it != columnHandles.end()) {
+      checkColumnHandleConsistent(*handle, *it->second);
+      continue;
     }
-    for (auto& handle : hiveTableHandle_->columnHandles()) {
-      assignmentHandles.erase(handle.get());
-      processColumnHandle(handle);
-    }
-    VELOX_CHECK(
-        assignmentHandles.empty(),
-        "Assignments must be a subset of column handles");
+    processColumnHandle(handle);
   }
 
   std::vector<std::string> readColumnNames;

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -112,7 +112,7 @@ HiveTableHandle::HiveTableHandle(
     const core::TypedExprPtr& remainingFilter,
     const RowTypePtr& dataColumns,
     const std::unordered_map<std::string, std::string>& tableParameters,
-    std::vector<HiveColumnHandlePtr> columnHandles)
+    std::vector<HiveColumnHandlePtr> filterColumnHandles)
     : ConnectorTableHandle(std::move(connectorId)),
       tableName_(tableName),
       filterPushdownEnabled_(filterPushdownEnabled),
@@ -120,7 +120,7 @@ HiveTableHandle::HiveTableHandle(
       remainingFilter_(remainingFilter),
       dataColumns_(dataColumns),
       tableParameters_(tableParameters),
-      columnHandles_(std::move(columnHandles)) {}
+      filterColumnHandles_(std::move(filterColumnHandles)) {}
 
 std::string HiveTableHandle::toString() const {
   std::stringstream out;

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -148,7 +148,7 @@ class HiveTableHandle : public ConnectorTableHandle {
       const core::TypedExprPtr& remainingFilter,
       const RowTypePtr& dataColumns = nullptr,
       const std::unordered_map<std::string, std::string>& tableParameters = {},
-      std::vector<HiveColumnHandlePtr> columnHandles = {});
+      std::vector<HiveColumnHandlePtr> filterColumnHandles = {});
 
   const std::string& tableName() const {
     return tableName_;
@@ -191,12 +191,12 @@ class HiveTableHandle : public ConnectorTableHandle {
     return tableParameters_;
   }
 
-  /// Full schema including partitioning columns and data columns.  If this is
-  /// non-empty, it should be a superset of the column handles in data source
-  /// assignments parameter (the shared_ptrs should pointing to the exact same
-  /// objects).
-  const std::vector<HiveColumnHandlePtr> columnHandles() const {
-    return columnHandles_;
+  /// Extra columns that are used in filters and remaining filters, but not in
+  /// the output.  If there is overlap with data source assignments parameter,
+  /// the name and types should be the same (the required subfields are taken
+  /// from assignments).
+  const std::vector<HiveColumnHandlePtr> filterColumnHandles() const {
+    return filterColumnHandles_;
   }
 
   std::string toString() const override;
@@ -216,7 +216,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const core::TypedExprPtr remainingFilter_;
   const RowTypePtr dataColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
-  const std::vector<HiveColumnHandlePtr> columnHandles_;
+  const std::vector<HiveColumnHandlePtr> filterColumnHandles_;
 };
 
 using HiveTableHandlePtr = std::shared_ptr<const HiveTableHandle>;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -287,19 +287,17 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
     }
   }
 
-  RowTypePtr parseType;
-  if (!columnHandles_.empty()) {
-    std::vector<std::string> names;
-    std::vector<TypePtr> types;
-    for (auto& handle : columnHandles_) {
-      names.push_back(handle->name());
-      types.push_back(handle->hiveType());
+  RowTypePtr parseType = dataColumns_ ? dataColumns_ : outputType_;
+  if (!filterColumnHandles_.empty()) {
+    auto names = parseType->names();
+    auto types = parseType->children();
+    for (auto& handle : filterColumnHandles_) {
+      if (!parseType->containsChild(handle->name())) {
+        names.push_back(handle->name());
+        types.push_back(handle->hiveType());
+      }
     }
     parseType = ROW(std::move(names), std::move(types));
-  } else if (dataColumns_) {
-    parseType = dataColumns_;
-  } else {
-    parseType = outputType_;
   }
 
   core::TypedExprPtr filterNodeExpr;
@@ -335,7 +333,7 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
         remainingFilterExpr,
         dataColumns_,
         /*tableParameters=*/std::unordered_map<std::string, std::string>{},
-        columnHandles_);
+        filterColumnHandles_);
   }
   core::PlanNodePtr result = std::make_shared<core::TableScanNode>(
       id, outputType_, tableHandle_, assignments_);

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -323,9 +323,9 @@ class PlanBuilder {
       return *this;
     }
 
-    TableScanBuilder& columnHandles(
-        std::vector<connector::hive::HiveColumnHandlePtr> columnHandles) {
-      columnHandles_ = std::move(columnHandles);
+    TableScanBuilder& filterColumnHandles(
+        std::vector<connector::hive::HiveColumnHandlePtr> filterColumnHandles) {
+      filterColumnHandles_ = std::move(filterColumnHandles);
       return *this;
     }
 
@@ -354,7 +354,7 @@ class PlanBuilder {
     RowTypePtr outputType_;
     core::ExprPtr remainingFilter_;
     RowTypePtr dataColumns_;
-    std::vector<connector::hive::HiveColumnHandlePtr> columnHandles_;
+    std::vector<connector::hive::HiveColumnHandlePtr> filterColumnHandles_;
     std::unordered_map<std::string, std::string> columnAliases_;
     connector::ConnectorTableHandlePtr tableHandle_;
     connector::ColumnHandleMap assignments_;


### PR DESCRIPTION
Summary:
Turns out the requirement to have full schema in column handles and
pointer equality is not pratical for engines.  Change the semantic of the new
field to be extra column handles that are not appearing in assignments already.

Differential Revision: D86209890


