### PR TITLE
misc(dwrf): Clarify some flat-/map writer errors

### DIFF
--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -2032,8 +2032,14 @@ uint64_t MapColumnWriter::write(
     auto begin = offsets[pos];
     auto end = begin + lengths[pos];
     if (end > begin) {
-      VELOX_CHECK_LE(end, mapSlice->mapKeys()->size());
-      VELOX_CHECK_LE(end, mapSlice->mapValues()->size());
+      VELOX_CHECK_LE(
+          end,
+          mapSlice->mapKeys()->size(),
+          "Malformed input vector. Size of map keys vector is less than the expected size.");
+      VELOX_CHECK_LE(
+          end,
+          mapSlice->mapValues()->size(),
+          "Malformed input vector. Size of map values vector is less than the expected size.");
       childRanges.add(begin, end);
     }
     nonNullLengths.unsafeAppend(end - begin);

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -393,8 +393,14 @@ uint64_t FlatMapColumnWriter<K>::writeMap(
                         const auto& keysVector) {
     auto begin = offsets[offsetIndex];
     auto end = begin + lengths[offsetIndex];
-    DWIO_ENSURE_LE(end, mapSlice->mapKeys()->size());
-    DWIO_ENSURE_LE(end, mapSlice->mapValues()->size());
+    DWIO_ENSURE_LE(
+        end,
+        mapSlice->mapKeys()->size(),
+        "Malformed input vector. Size of map keys vector is less than the expected size.");
+    DWIO_ENSURE_LE(
+        end,
+        mapSlice->mapValues()->size(),
+        "Malformed input vector. Size of map values vector is less than the expected size.");
 
     for (auto i = begin; i < end; ++i) {
       auto key = keysVector.valueAt(i);


### PR DESCRIPTION
Summary: Make the writer error message when input vector is malformed more human friendly.

Differential Revision: D86217639


