### PR TITLE
refactor: Deprecate exec::toSubfieldFilter API

### DIFF
--- a/velox/exec/tests/FilterToExpressionTest.cpp
+++ b/velox/exec/tests/FilterToExpressionTest.cpp
@@ -535,7 +535,8 @@ void FilterToExpressionTest::testRoundTrip(
     if (arrayExpr && arrayExpr->name() == "array_constructor") {
       // Use toSubfieldFilter for array_constructor expressions
       auto [roundTripSubfield, roundTripFilter] =
-          exec::toSubfieldFilter(expr, evaluator());
+          exec::ExprToSubfieldFilterParser::getInstance()->toSubfieldFilter(
+              expr, evaluator());
 
       // Step 3: Verify the round-tripped filter and subfield
       ASSERT_TRUE(roundTripFilter != nullptr);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -211,7 +211,8 @@ PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::subfieldFilters(
     auto filterExpr = core::Expressions::inferTypes(
         untypedExpr, parseType, planBuilder_.pool_);
     auto [subfield, subfieldFilter] =
-        exec::toSubfieldFilter(filterExpr, &evaluator);
+        exec::ExprToSubfieldFilterParser::getInstance()->toSubfieldFilter(
+            filterExpr, &evaluator);
 
     auto it = columnAliases_.find(subfield.toString());
     if (it != columnAliases_.end()) {

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -50,10 +50,6 @@ T singleValue(const VectorPtr& vector) {
   return simpleVector->valueAt(0);
 }
 
-const core::CallTypedExpr* asCall(const core::ITypedExpr* expr) {
-  return dynamic_cast<const core::CallTypedExpr*>(expr);
-}
-
 common::BigintRange* asBigintRange(std::unique_ptr<common::Filter>& filter) {
   return dynamic_cast<common::BigintRange*>(filter.get());
 }
@@ -66,39 +62,6 @@ common::BigintMultiRange* asBigintMultiRange(
 template <typename T, typename U>
 std::unique_ptr<T> asUniquePtr(std::unique_ptr<U> ptr) {
   return std::unique_ptr<T>(static_cast<T*>(ptr.release()));
-}
-
-std::unique_ptr<common::Filter> makeOrFilter(
-    std::unique_ptr<common::Filter> a,
-    std::unique_ptr<common::Filter> b) {
-  if (asBigintRange(a) && asBigintRange(b)) {
-    return bigintOr(
-        asUniquePtr<common::BigintRange>(std::move(a)),
-        asUniquePtr<common::BigintRange>(std::move(b)));
-  }
-
-  if (asBigintRange(a) && asBigintMultiRange(b)) {
-    const auto& ranges = asBigintMultiRange(b)->ranges();
-    std::vector<std::unique_ptr<common::BigintRange>> newRanges;
-    newRanges.emplace_back(asUniquePtr<common::BigintRange>(std::move(a)));
-    for (const auto& range : ranges) {
-      newRanges.emplace_back(asUniquePtr<common::BigintRange>(range->clone()));
-    }
-
-    std::sort(
-        newRanges.begin(), newRanges.end(), [](const auto& a, const auto& b) {
-          return a->lower() < b->lower();
-        });
-
-    return std::make_unique<common::BigintMultiRange>(
-        std::move(newRanges), false);
-  }
-
-  if (asBigintMultiRange(a) && asBigintRange(b)) {
-    return makeOrFilter(std::move(b), std::move(a));
-  }
-
-  return orFilter(std::move(a), std::move(b));
 }
 
 template <typename T>
@@ -118,6 +81,7 @@ std::shared_ptr<ExprToSubfieldFilterParser>
     ExprToSubfieldFilterParser::parser_ =
         std::make_shared<PrestoExprToSubfieldFilterParser>();
 
+// static
 bool ExprToSubfieldFilterParser::toSubfield(
     const core::ITypedExpr* field,
     common::Subfield& subfield) {
@@ -159,6 +123,7 @@ bool ExprToSubfieldFilterParser::toSubfield(
   return true;
 }
 
+// static
 std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
     const core::TypedExprPtr& valueExpr,
     core::ExpressionEvaluator* evaluator) {
@@ -206,6 +171,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeEqualFilter(
     const core::TypedExprPtr& valueExpr,
     core::ExpressionEvaluator* evaluator) {
@@ -235,6 +201,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeEqualFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter>
 ExprToSubfieldFilterParser::makeGreaterThanFilter(
     const core::TypedExprPtr& lowerExpr,
@@ -267,6 +234,7 @@ ExprToSubfieldFilterParser::makeGreaterThanFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeLessThanFilter(
     const core::TypedExprPtr& upperExpr,
     core::ExpressionEvaluator* evaluator) {
@@ -298,6 +266,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeLessThanFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter>
 ExprToSubfieldFilterParser::makeLessThanOrEqualFilter(
     const core::TypedExprPtr& upperExpr,
@@ -330,6 +299,7 @@ ExprToSubfieldFilterParser::makeLessThanOrEqualFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter>
 ExprToSubfieldFilterParser::makeGreaterThanOrEqualFilter(
     const core::TypedExprPtr& lowerExpr,
@@ -362,6 +332,7 @@ ExprToSubfieldFilterParser::makeGreaterThanOrEqualFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeInFilter(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator,
@@ -411,6 +382,7 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeInFilter(
   }
 }
 
+// static
 std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeBetweenFilter(
     const core::TypedExprPtr& lowerExpr,
     const core::TypedExprPtr& upperExpr,
@@ -463,6 +435,40 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeBetweenFilter(
     default:
       return nullptr;
   }
+}
+
+// static
+std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeOrFilter(
+    std::unique_ptr<common::Filter> a,
+    std::unique_ptr<common::Filter> b) {
+  if (asBigintRange(a) && asBigintRange(b)) {
+    return bigintOr(
+        asUniquePtr<common::BigintRange>(std::move(a)),
+        asUniquePtr<common::BigintRange>(std::move(b)));
+  }
+
+  if (asBigintRange(a) && asBigintMultiRange(b)) {
+    const auto& ranges = asBigintMultiRange(b)->ranges();
+    std::vector<std::unique_ptr<common::BigintRange>> newRanges;
+    newRanges.emplace_back(asUniquePtr<common::BigintRange>(std::move(a)));
+    for (const auto& range : ranges) {
+      newRanges.emplace_back(asUniquePtr<common::BigintRange>(range->clone()));
+    }
+
+    std::sort(
+        newRanges.begin(), newRanges.end(), [](const auto& a, const auto& b) {
+          return a->lower() < b->lower();
+        });
+
+    return std::make_unique<common::BigintMultiRange>(
+        std::move(newRanges), false);
+  }
+
+  if (asBigintMultiRange(a) && asBigintRange(b)) {
+    return makeOrFilter(std::move(b), std::move(a));
+  }
+
+  return orFilter(std::move(a), std::move(b));
 }
 
 std::unique_ptr<common::Filter>
@@ -528,10 +534,12 @@ PrestoExprToSubfieldFilterParser::leafCallToSubfieldFilter(
   return nullptr;
 }
 
-std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
+std::pair<common::Subfield, std::unique_ptr<common::Filter>>
+PrestoExprToSubfieldFilterParser::toSubfieldFilter(
     const core::TypedExprPtr& expr,
     core::ExpressionEvaluator* evaluator) {
-  if (auto call = asCall(expr.get())) {
+  if (expr->isCallKind();
+      auto* call = expr->asUnchecked<core::CallTypedExpr>()) {
     if (call->name() == "or") {
       auto left = toSubfieldFilter(call->inputs()[0], evaluator);
       auto right = toSubfieldFilter(call->inputs()[1], evaluator);
@@ -543,15 +551,13 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
     common::Subfield subfield;
     std::unique_ptr<common::Filter> filter;
     if (call->name() == "not") {
-      if (auto* inner = asCall(call->inputs()[0].get())) {
-        filter =
-            ExprToSubfieldFilterParser::getInstance()->leafCallToSubfieldFilter(
-                *inner, subfield, evaluator, true);
+      const auto& input = call->inputs()[0];
+      if (input->isCallKind();
+          auto* inner = input->asUnchecked<core::CallTypedExpr>()) {
+        filter = leafCallToSubfieldFilter(*inner, subfield, evaluator, true);
       }
     } else {
-      filter =
-          ExprToSubfieldFilterParser::getInstance()->leafCallToSubfieldFilter(
-              *call, subfield, evaluator, false);
+      filter = leafCallToSubfieldFilter(*call, subfield, evaluator, false);
     }
     if (filter) {
       return std::make_pair(std::move(subfield), std::move(filter));


### PR DESCRIPTION
Summary:
Part of https://github.com/facebookincubator/velox/issues/15384

exec::toSubfieldFilter API appears language agnostic, but it assumes that function registered under name "not" has semantics of Presto's "not" function. This assumption is not valid and can lead to difficult to debug correctness issues.

The fix is to move that API to ExprToSubfieldFilterParser interface which has language-specific implementations.

Differential Revision: D86244462


