### PR TITLE
feat: Add CustomType comparison support for Time With Timezone

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -42,6 +42,7 @@
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/UuidType.h"
 #include "velox/functions/prestosql/types/parser/TypeParser.h"
@@ -322,8 +323,7 @@ bool PrestoQueryRunner::isConstantExprSupported(
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
         !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&
         !isTDigestType(type) && !isQDigestType(type) && !isBingTileType(type) &&
-        !isSfmSketchType(type);
-    ;
+        !isSfmSketchType(type) && !isTimeWithTimeZone(type);
   }
   return true;
 }

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -412,7 +412,7 @@ struct TimeWithTimezonePlusOneFunction {
   void call(
       out_type<TimeWithTimezone>& out,
       const arg_type<TimeWithTimezone>& input) {
-    out = input + 1;
+    out = *input + 1;
   }
 };
 
@@ -425,7 +425,7 @@ struct ArrayTimeWithTimezoneFunction {
       const arg_type<Array<TimeWithTimezone>>& input) {
     for (int i = 0; i < input.size(); i++) {
       if (input[i].has_value()) {
-        out.push_back(input[i].value());
+        out.push_back(*input[i].value());
       }
     }
   }

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -19,6 +19,8 @@
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixRegistration.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneRegistration.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
@@ -34,6 +36,7 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, TimestampWithTimezone, TimestampWithTimezone>(
       aliases);
   registerFunction<T, TReturn, Time, Time>(aliases);
+  registerFunction<T, TReturn, TimeWithTimezone, TimeWithTimezone>(aliases);
   registerFunction<T, TReturn, IPAddress, IPAddress>(aliases);
 }
 } // namespace
@@ -42,6 +45,7 @@ void registerComparisonFunctions(const std::string& prefix) {
   // Comparison functions also need TimestampWithTimezoneType,
   // independent of DateTimeFunctions
   registerTimestampWithTimeZoneType();
+  registerTimeWithTimezoneType();
   registerIPAddressType();
   registerIPPrefixType();
 
@@ -97,6 +101,12 @@ void registerComparisonFunctions(const std::string& prefix) {
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, Time, Time, Time>(
       {prefix + "between"});
+  registerFunction<
+      BetweenFunction,
+      bool,
+      TimeWithTimezone,
+      TimeWithTimezone,
+      TimeWithTimezone>({prefix + "between"});
   registerFunction<
       BetweenFunction,
       bool,

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/external/tzdb/zoned_time.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
@@ -5808,6 +5809,155 @@ TEST_F(DateTimeFunctionsTest, timeComparisons) {
   EXPECT_EQ(std::nullopt, between(std::nullopt, 0, 1000));
   EXPECT_EQ(std::nullopt, between(500, std::nullopt, 1000));
   EXPECT_EQ(std::nullopt, between(500, 0, std::nullopt));
+}
+
+TEST_F(DateTimeFunctionsTest, timeWithTimezoneComparisons) {
+  const auto eq = [&](std::optional<int64_t> a, std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 = c1", {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()}, a, b);
+  };
+  const auto neq = [&](std::optional<int64_t> a, std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 != c1", {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()}, a, b);
+  };
+  const auto lt = [&](std::optional<int64_t> a, std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 < c1", {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()}, a, b);
+  };
+  const auto lte = [&](std::optional<int64_t> a, std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 <= c1", {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()}, a, b);
+  };
+  const auto gt = [&](std::optional<int64_t> a, std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 > c1", {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()}, a, b);
+  };
+  const auto gte = [&](std::optional<int64_t> a, std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 >= c1", {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()}, a, b);
+  };
+  const auto between = [&](std::optional<int64_t> value,
+                           std::optional<int64_t> lower,
+                           std::optional<int64_t> upper) {
+    return evaluateOnce<bool>(
+        "c0 between c1 and c2",
+        {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()},
+        value,
+        lower,
+        upper);
+  };
+
+  // test distinct_from - unlike regular comparison operators,
+  // distinct_from treats NULLs as values that can be compared
+  const auto distinctFrom = [&](std::optional<int64_t> a,
+                                std::optional<int64_t> b) {
+    return evaluateOnce<bool>(
+        "c0 is distinct from c1",
+        {TIME_WITH_TIME_ZONE(), TIME_WITH_TIME_ZONE()},
+        a,
+        b);
+  };
+
+  // Helper to parse TIME WITH TIME ZONE from string
+  const auto parse = [](const std::string& timeStr) -> std::optional<int64_t> {
+    auto result =
+        util::fromTimeWithTimezoneString(timeStr.c_str(), timeStr.size());
+    if (result.hasError()) {
+      throw std::runtime_error("Parse error: " + result.error().message());
+    }
+    return result.value();
+  };
+
+  // test equality - same UTC time in different timezones should be equal
+  EXPECT_EQ(true, eq(parse("00:00:00.000+00:00"), parse("01:00:00.000+01:00")));
+  EXPECT_EQ(true, eq(parse("12:30:45.123+00:00"), parse("20:30:45.123+08:00")));
+  EXPECT_EQ(
+      false, eq(parse("00:00:00.000+00:00"), parse("00:00:01.000+00:00")));
+  EXPECT_EQ(std::nullopt, eq(std::nullopt, parse("00:00:00.000+00:00")));
+
+  // test inequality
+  EXPECT_EQ(
+      true, neq(parse("00:00:00.000+00:00"), parse("00:00:00.000+01:00")));
+  EXPECT_EQ(
+      true, neq(parse("00:00:00.000+00:00"), parse("00:00:01.000+00:00")));
+  EXPECT_EQ(
+      true, neq(parse("01:00:00.000+01:00"), parse("01:00:00.000+03:00")));
+
+  // test less than
+  EXPECT_EQ(
+      false, lt(parse("00:00:00.000+00:00"), parse("00:00:00.000+01:00")));
+  EXPECT_EQ(true, lt(parse("00:00:01.000+01:00"), parse("00:00:00.000+00:00")));
+  EXPECT_EQ(
+      false, lt(parse("00:00:01.000+00:00"), parse("00:00:00.000+01:00")));
+  EXPECT_EQ(
+      false, lt(parse("01:00:00.000+01:00"), parse("02:00:00.000+03:00")));
+
+  // test less than or equal
+  EXPECT_EQ(
+      false, lte(parse("00:00:00.000+00:00"), parse("00:00:00.000+01:00")));
+  EXPECT_EQ(
+      false, lte(parse("00:00:01.000+00:00"), parse("00:00:00.000+01:00")));
+
+  // test greater than
+  EXPECT_EQ(true, gt(parse("00:00:00.000+00:00"), parse("00:00:00.000+01:00")));
+  EXPECT_EQ(
+      false, gt(parse("01:00:00.000+03:00"), parse("02:00:00.000+01:00")));
+
+  // test greater than or equal
+  EXPECT_EQ(
+      true, gte(parse("00:00:00.000+00:00"), parse("00:00:00.000+00:00")));
+  EXPECT_EQ(
+      true, gte(parse("00:00:00.000+00:00"), parse("00:00:01.000+01:00")));
+  EXPECT_EQ(
+      true, gte(parse("00:00:01.000+00:00"), parse("00:00:00.000+01:00")));
+
+  // test between
+  EXPECT_EQ(
+      true,
+      between(
+          parse("02:00:00.000+02:00"),
+          parse("00:00:00.000+01:00"),
+          parse("00:00:01.000+00:00")));
+  EXPECT_EQ(
+      std::nullopt,
+      between(
+          parse("00:00:00.500+00:00"),
+          parse("00:00:00.000+01:00"),
+          std::nullopt));
+
+  // test distinct from
+  // Same UTC time in different timezones should not be distinct
+  EXPECT_EQ(
+      false,
+      distinctFrom(parse("01:00:00.000+01:00"), parse("02:00:00.000+02:00")));
+
+  // Different times should be distinct
+  EXPECT_EQ(
+      true,
+      distinctFrom(parse("00:00:00.000+00:00"), parse("00:00:01.000+00:00")));
+  EXPECT_EQ(
+      true,
+      distinctFrom(parse("01:00:00.000+01:00"), parse("02:00:00.000+03:00")));
+
+  // NULL handling: NULL is distinct from non-NULL
+  EXPECT_EQ(true, distinctFrom(std::nullopt, parse("00:00:00.000+00:00")));
+
+  // NULL is NOT distinct from NULL
+  EXPECT_EQ(false, distinctFrom(std::nullopt, std::nullopt));
+
+  // Test edge cases with day wrap-around (normalization logic)
+  EXPECT_EQ(
+      false, eq(parse("01:00:00.000+08:00"), parse("02:00:00.000+00:00")));
+  EXPECT_EQ(
+      false, gt(parse("01:00:00.000+08:00"), parse("02:00:00.000+00:00")));
+
+  EXPECT_EQ(
+      false, eq(parse("23:00:00.000-08:00"), parse("16:00:00.000+08:00")));
+  EXPECT_EQ(true, lt(parse("23:00:00.000-08:00"), parse("18:00:00.000-14:00")));
+
+  EXPECT_EQ(
+      false, eq(parse("00:30:00.000-02:00"), parse("00:30:00.000+02:00")));
+  EXPECT_EQ(true, gt(parse("00:30:00.000-02:00"), parse("00:30:00.000+02:00")));
 }
 
 TEST_F(DateTimeFunctionsTest, castDateToTimestamp) {

--- a/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
@@ -36,7 +36,7 @@ void castToTime(
 
   auto convertToLocalTime = [](int64_t timeWithTimezone) {
     int64_t millisUtc = util::unpackMillisUtc(timeWithTimezone);
-    auto timezoneMinutes = util::unpackZoneKeyId(timeWithTimezone);
+    auto timezoneMinutes = util::unpackZoneOffset(timeWithTimezone);
     int16_t offsetMinutes = util::decodeTimezoneOffset(timezoneMinutes);
     return util::utcToLocalTime(millisUtc, offsetMinutes);
   };

--- a/velox/functions/prestosql/types/TimeWithTimezoneType.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneType.cpp
@@ -50,7 +50,7 @@ StringView TimeWithTimezoneType::valueToString(
   // This represents a range of -14:00 to +14:00, with 0 representing UTC.
   // The range is from -840 to 840 minutes, we thus encode by doing bias
   // encoding and taking 840 as the bias.
-  auto timezoneMinutes = util::unpackZoneKeyId(value);
+  auto timezoneMinutes = util::unpackZoneOffset(value);
 
   VELOX_CHECK_GE(timezoneMinutes, 0, "Timezone offset is less than -14:00");
   VELOX_CHECK_LE(

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/TimeWithTimezoneInputGeneratorTest.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/TimeWithTimezoneInputGeneratorTest.cpp
@@ -44,7 +44,7 @@ TEST(TimeWithTimezoneInputGeneratorTest, generate) {
     EXPECT_LT(timeMillis, util::kMillisInDay);
 
     // Verify timezone offset is in valid bias-encoded range [0, 1680]
-    const auto timezoneOffset = util::unpackZoneKeyId(value);
+    const auto timezoneOffset = util::unpackZoneOffset(value);
     EXPECT_GE(timezoneOffset, 0);
     EXPECT_LE(timezoneOffset, 2 * util::kTimeZoneBias);
   }
@@ -62,7 +62,7 @@ TEST(TimeWithTimezoneInputGeneratorTest, generatesBothOffsetTypes) {
 
   for (int i = 0; i < 100 && (!foundFrequentlyUsed || !foundOther); ++i) {
     auto value = generator.generate().value<TypeKind::BIGINT>();
-    auto encoded = util::unpackZoneKeyId(value);
+    auto encoded = util::unpackZoneOffset(value);
     auto offset = util::decodeTimezoneOffset(encoded);
 
     if (frequentlyUsed.count(offset)) {

--- a/velox/type/Time.h
+++ b/velox/type/Time.h
@@ -63,7 +63,7 @@ inline int64_t unpackMillisUtc(int64_t timeWithTimeZone) {
 }
 
 /// Unpacks the timezone offset from a packed TIME WITH TIME ZONE value
-inline int16_t unpackZoneKeyId(int64_t timeWithTimeZone) {
+inline int16_t unpackZoneOffset(int64_t timeWithTimeZone) {
   return timeWithTimeZone & kTimezoneMask;
 }
 
@@ -91,9 +91,7 @@ inline int16_t biasEncode(int16_t timeZoneOffsetMinutes) {
 /// @param encodedTimezone Bias-encoded timezone [0, 1680]
 /// @return Timezone offset in minutes [-840, 840]
 inline int16_t decodeTimezoneOffset(int16_t encodedTimezone) {
-  return (encodedTimezone >= kTimeZoneBias)
-      ? (encodedTimezone - kTimeZoneBias)
-      : -(kTimeZoneBias - encodedTimezone);
+  return encodedTimezone - kTimeZoneBias;
 }
 
 /// Parse a TIME WITH TIME ZONE string and return packed 64-bit value


### PR DESCRIPTION
Summary:
Added support for Custom comparison for type Time With Timezone

Changes:
- Modifying constructor and setting `providesCustomComparison` as true.
- Adding hash and compare functions
- Registering and/or testing support for  `gt`,`lt`, `gte`, `lte`, `eq`, `neq`, `distinct_from` and `between`

Unrelated Improvements:

- Renamed unpackZoneId to unpackZoneOffset and used correct references in valueToString

Differential Revision: D86255962


