### PR TITLE
feat: Add rewrite for COALESCE special form

### DIFF
--- a/velox/core/ITypedExpr.cpp
+++ b/velox/core/ITypedExpr.cpp
@@ -35,4 +35,14 @@ const auto& exprKindNames() {
 } // namespace
 
 VELOX_DEFINE_ENUM_NAME(ExprKind, exprKindNames);
+
+size_t ITypedExprHasher::operator()(const ITypedExpr* expr) const {
+  return expr->hash();
+}
+
+bool ITypedExprComparer::operator()(
+    const ITypedExpr* lhs,
+    const ITypedExpr* rhs) const {
+  return *lhs == *rhs;
+}
 } // namespace facebook::velox::core

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -38,6 +38,14 @@ class ITypedExprVisitorContext;
 
 using TypedExprPtr = std::shared_ptr<const ITypedExpr>;
 
+struct ITypedExprHasher {
+  size_t operator()(const ITypedExpr* expr) const;
+};
+
+struct ITypedExprComparer {
+  bool operator()(const ITypedExpr* lhs, const ITypedExpr* rhs) const;
+};
+
 /// Strongly-typed expression, e.g. literal, function call, etc.
 class ITypedExpr : public ISerializable {
  public:

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -773,8 +773,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterMap) {
       }
       std::string remainingFilter;
       if (filterColumn == kWholeColumn) {
-        remainingFilter =
-            "coalesce(b, cast(null AS MAP(BIGINT, BIGINT)))[0] == 0";
+        remainingFilter = "coalesce(b, map_concat(b, b))[0] == 0";
       } else {
         remainingFilter = "b[0] == 0";
       }

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -56,6 +56,7 @@ velox_add_library(
   RowConstructor.cpp
   SimpleFunctionRegistry.cpp
   SpecialFormRegistry.cpp
+  CoalesceRewrite.cpp
   ConjunctRewrite.cpp
   SwitchExpr.cpp
   SwitchRewrite.cpp

--- a/velox/expression/CoalesceRewrite.cpp
+++ b/velox/expression/CoalesceRewrite.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <set>
+
+#include "velox/expression/CoalesceRewrite.h"
+#include "velox/expression/ExprConstants.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/expression/ExprUtils.h"
+
+namespace facebook::velox::expression {
+
+core::TypedExprPtr CoalesceRewrite::rewrite(const core::TypedExprPtr& expr) {
+  if (!expr->isCallKind()) {
+    return nullptr;
+  }
+  const auto* callExpr = expr->asUnchecked<core::CallTypedExpr>();
+  if (callExpr->name() != kCoalesce) {
+    return nullptr;
+  }
+
+  // Deduplicate inputs to COALESCE and remove NULL inputs.
+  std::vector<core::TypedExprPtr> flat;
+  utils::flattenInput(expr, kCoalesce, flat);
+  folly::F14FastSet<
+      const core::ITypedExpr*,
+      core::ITypedExprHasher,
+      core::ITypedExprComparer>
+      uniqueInputs;
+  std::vector<core::TypedExprPtr> deduplicatedInputs;
+
+  for (const auto& input : flat) {
+    if (input->isConstantKind()) {
+      const auto* constantExpr = input->asUnchecked<core::ConstantTypedExpr>();
+      if (constantExpr->isNull()) {
+        // Drop NULL constant.
+        continue;
+      }
+
+      if (uniqueInputs.empty()) {
+        // Return first non-NULL constant input.
+        return input;
+      }
+
+      // Drop inputs after non-NULL constant input.
+      uniqueInputs.insert(input.get());
+      deduplicatedInputs.push_back(input);
+      break;
+    } else {
+      if (uniqueInputs.emplace(input.get()).second) {
+        deduplicatedInputs.push_back(input);
+      }
+    }
+  }
+
+  // Return NULL if all inputs to COALESCE are NULL.
+  if (uniqueInputs.empty()) {
+    return flat.front();
+  }
+  // If there is a single input to COALESCE, return this expression.
+  if (uniqueInputs.size() == 1) {
+    return deduplicatedInputs.front();
+  }
+
+  return std::make_shared<core::CallTypedExpr>(
+      expr->type(), std::move(deduplicatedInputs), kCoalesce);
+}
+
+void CoalesceRewrite::registerRewrite() {
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      expression::CoalesceRewrite::rewrite);
+}
+
+} // namespace facebook::velox::expression

--- a/velox/expression/CoalesceRewrite.h
+++ b/velox/expression/CoalesceRewrite.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::expression {
+
+class CoalesceRewrite {
+ public:
+  /// Rewrites COALESCE special form expression. Nested COALESCE expressions are
+  /// first flattened in a recursive manner, eg: COALESCE(a, COALESCE(b, c)) ->
+  /// COALESCE(a, b, c). The inputs to COALESCE are then traversed in order and:
+  ///  1. If the input is constant:
+  ///     a. and it is NULL, the input is removed.
+  ///     b. and if there are no inputs before this, the COALESCE expression is
+  ///        simplified to this constant input.
+  ///     c. otherwise, all subsequent inputs after this are removed.
+  ///  2. Otherwise, if the same input is seen before, it is removed i.e non
+  ///     constant inputs to COALESCE are deduplicated.
+  /// If there is a single input to COALESCE after pruning inputs, COALESCE is
+  /// simplified to this expression. Otherwise, returns an optimized COALESCE
+  /// expression with pruned inputs.
+  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+
+  static void registerRewrite();
+};
+
+} // namespace facebook::velox::expression

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -33,24 +33,12 @@ namespace {
 using core::ITypedExpr;
 using core::TypedExprPtr;
 
-struct ITypedExprHasher {
-  size_t operator()(const ITypedExpr* expr) const {
-    return expr->hash();
-  }
-};
-
-struct ITypedExprComparer {
-  bool operator()(const ITypedExpr* lhs, const ITypedExpr* rhs) const {
-    return *lhs == *rhs;
-  }
-};
-
 // Map for deduplicating ITypedExpr trees.
 using ExprDedupMap = folly::F14FastMap<
     const ITypedExpr*,
     std::shared_ptr<Expr>,
-    ITypedExprHasher,
-    ITypedExprComparer>;
+    core::ITypedExprHasher,
+    core::ITypedExprComparer>;
 
 /// Represents a lexical scope. A top level scope corresponds to a top
 /// level Expr and is shared among the Exprs of the ExprSet. Each

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -19,6 +19,7 @@
 
 #include "velox/expression/CastExpr.h"
 #include "velox/expression/CoalesceExpr.h"
+#include "velox/expression/CoalesceRewrite.h"
 #include "velox/expression/ConjunctExpr.h"
 #include "velox/expression/ConjunctRewrite.h"
 #include "velox/expression/RowConstructor.h"
@@ -52,6 +53,7 @@ void registerFunctionCallToSpecialForms() {
       expression::kRowConstructor,
       std::make_unique<RowConstructorCallToSpecialForm>());
 
+  expression::CoalesceRewrite::registerRewrite();
   expression::ConjunctRewrite::registerRewrite();
   expression::SwitchRewrite::registerRewrite();
 }

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(
   SimpleFunctionTest.cpp
   SpecialFormRewriteTestBase.cpp
   SwitchRewriteTest.cpp
+  CoalesceRewriteTest.cpp
   ConjunctRewriteTest.cpp
   StringWriterTest.cpp
   TryExprTest.cpp

--- a/velox/expression/tests/CoalesceRewriteTest.cpp
+++ b/velox/expression/tests/CoalesceRewriteTest.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/expression/tests/SpecialFormRewriteTestBase.h"
+
+namespace facebook::velox::expression {
+namespace {
+
+class CoalesceRewriteTest
+    : public expression::test::SpecialFormRewriteTestBase {};
+
+TEST_F(CoalesceRewriteTest, basic) {
+  auto type = ROW({"a", "b"}, {BIGINT(), BIGINT()});
+  testRewrite("coalesce(null::bigint, 1, a)", "1", type);
+  testRewrite(
+      "coalesce(null::bigint, 6 * a, 5 * b, 1, null::bigint)",
+      "coalesce(6 * a, 5 * b, 1)",
+      type);
+  testRewrite(
+      "coalesce(null::bigint, coalesce(null::bigint, a, coalesce(1, b)))",
+      "coalesce(a, 1)",
+      type);
+  testRewrite("coalesce(a, null::bigint, a)", "a", type);
+  testRewrite(
+      "coalesce(a, b, a, coalesce(coalesce(b, a), b))", "coalesce(a, b)", type);
+  testRewrite(
+      "coalesce(a, coalesce(2, coalesce(b, a)), b)", "coalesce(a, 2)", type);
+}
+
+} // namespace
+} // namespace facebook::velox::expression


### PR DESCRIPTION
Rewrites `COALESCE` special form expression. First, flattens nested `COALESCE` expressions in a recursive manner, `eg: COALESCE(a, COALESCE(b, c)) -> COALESCE(a, b, c)`. 

The inputs to `COALESCE` are then traversed in order and:
1. If the input is constant:    
a. and it is `NULL`, the input is removed.    
b. and if there are no inputs before this, the `COALESCE` expression is simplified to this constant input.    
c. otherwise, all subsequent inputs after this are removed. 
2. Otherwise, if the same input is seen before, it is removed i.e non-constant inputs to `COALESCE` are deduplicated.

If there is a single input to `COALESCE` after pruning inputs, `COALESCE` is simplified to this expression. 
Otherwise, returns an optimized `COALESCE` expression with pruned inputs.