### PR TITLE
feat: Change SpillPartitionId::kMaxSpillLevel to 7

### DIFF
--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -251,7 +251,7 @@ class ConcatFilesSpillMergeStream final : public SpillMergeStream {
 class SpillPartitionId {
  public:
   /// Maximum spill level supported by 'SpillPartitionId'.
-  static constexpr uint32_t kMaxSpillLevel{3};
+  static constexpr uint32_t kMaxSpillLevel{7};
 
   /// Maximum number of partition bits per spill level supported by
   /// 'SpillPartitionId'.
@@ -329,7 +329,10 @@ class SpillPartitionId {
   //   (3 ~ 5 bits): Represents the partition number at the 2nd level.
   //   (6 ~ 8 bits): Represents the partition number at the 3rd level.
   //   (9 ~ 11 bits): Represents the partition number at the 4th level.
-  //   (12 ~ 28 bits): Unused
+  //   (12 ~ 14 bits): Represents the partition number at the 5th level.
+  //   (15 ~ 17 bits): Represents the partition number at the 6th level.
+  //   (18 ~ 20 bits): Represents the partition number at the 7th level.
+  //   (21 ~ 28 bits): Unused
   //   (29 ~ 31 bits): Represents the current spill level.
   //   <MSB>
   uint32_t encodedId_{kInvalidEncodedId};


### PR DESCRIPTION
Based on the design of [`encodedId_`](https://github.com/facebookincubator/velox/blob/ba52907ede48fa4572590c96845c2cd746e9c74e/velox/exec/Spill.h#L325-L335), `spillLevel` can support up to 7th level (3 bit). I want to change `SpillPartitionId::kMaxSpillLevel` from `3` to `7` to allow `max_spill_level` to be set to a larger value.

closes #15400