### PR TITLE
feat: PartitionedOutputNode must distinguish the root of a plan

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2895,7 +2895,8 @@ PartitionedOutputNode::PartitionedOutputNode(
     PartitionFunctionSpecPtr partitionFunctionSpec,
     RowTypePtr outputType,
     VectorSerde::Kind serdeKind,
-    PlanNodePtr source)
+    PlanNodePtr source,
+    bool rootFragment)
     : PlanNode(id),
       kind_(kind),
       sources_{{std::move(source)}},
@@ -2904,7 +2905,8 @@ PartitionedOutputNode::PartitionedOutputNode(
       replicateNullsAndAny_(replicateNullsAndAny),
       partitionFunctionSpec_(std::move(partitionFunctionSpec)),
       serdeKind_(serdeKind),
-      outputType_(std::move(outputType)) {
+      outputType_(std::move(outputType)),
+      rootFragment_(rootFragment) {
   VELOX_USER_CHECK_GT(numPartitions_, 0);
   if (numPartitions_ == 1) {
     VELOX_USER_CHECK(
@@ -2967,7 +2969,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::single(
     const PlanNodeId& id,
     RowTypePtr outputType,
     VectorSerde::Kind serdeKind,
-    PlanNodePtr source) {
+    PlanNodePtr source,
+    bool rootFragment) {
   std::vector<TypedExprPtr> noKeys;
   return std::make_shared<PartitionedOutputNode>(
       id,
@@ -2978,7 +2981,8 @@ std::shared_ptr<PartitionedOutputNode> PartitionedOutputNode::single(
       std::make_shared<GatherPartitionFunctionSpec>(),
       std::move(outputType),
       serdeKind,
-      std::move(source));
+      std::move(source),
+      rootFragment);
 }
 
 void EnforceSingleRowNode::addDetails(std::stringstream& /* stream */) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2587,7 +2587,8 @@ class PartitionedOutputNode : public PlanNode {
       PartitionFunctionSpecPtr partitionFunctionSpec,
       RowTypePtr outputType,
       VectorSerde::Kind serdeKind,
-      PlanNodePtr source);
+      PlanNodePtr source,
+      bool rootFragment = false);
 
   static std::shared_ptr<PartitionedOutputNode> broadcast(
       const PlanNodeId& id,
@@ -2606,7 +2607,8 @@ class PartitionedOutputNode : public PlanNode {
       const PlanNodeId& id,
       RowTypePtr outputType,
       VectorSerde::Kind VectorSerde,
-      PlanNodePtr source);
+      PlanNodePtr source,
+      bool rootFragment = false);
 
   class Builder {
    public:
@@ -2721,6 +2723,10 @@ class PartitionedOutputNode : public PlanNode {
     return outputType_;
   }
 
+  const bool isRootFragment() const {
+    return rootFragment_;
+  }
+
   const std::vector<PlanNodePtr>& sources() const override {
     return sources_;
   }
@@ -2796,6 +2802,7 @@ class PartitionedOutputNode : public PlanNode {
   const PartitionFunctionSpecPtr partitionFunctionSpec_;
   const VectorSerde::Kind serdeKind_;
   const RowTypePtr outputType_;
+  const bool rootFragment_;
 };
 
 using PartitionedOutputNodePtr = std::shared_ptr<const PartitionedOutputNode>;


### PR DESCRIPTION
Currently when we translate a Presto plan to a Velox plan fragment, we do not have a way later on at the Velox layer to detect if a particular PartitionedOutputNode will be read by the coordinator as the final output of a plan or will be read by other workers.

This patch adds a new field to PartitionedOutputNode so we can signal this during plan translation inside Prestissimo.

In my particular case, This is needed to order to support exchange translation decisions in the cuDF exchange (coming in via a later PR), where the last PartitionedOutputNode has a single partition and will be read by the Presto coordinator, but all other PartitionedOutputNodes will be actually read by other workers via special, hardware accelerated Exchange. Without this change we have no way to distinguish these two at the pure Velox DriverAdapter translation level.