### PR TITLE
fuzzer: Adds an API to the vector fuzzer to corrupt data buffers for null rows

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -422,6 +422,16 @@ class VectorFuzzer {
     opaqueTypeGenerators_[std::type_index(typeid(Class))] = generator;
   }
 
+  /// Corrupts the underlying data for row indices that are marked
+  /// as null in a vector. For FlatVectors, this means corrupting the values
+  /// buffer at null row indices; for Array/Map Vectors, it corrupts the
+  /// offsets and sizes; and for DictionaryVectors, it corrupts the indices
+  /// buffer. This is used to generate cases to verify that code correctly
+  /// ignores data at null positions rather than relying on it having valid
+  /// values.
+  /// Its a no-op for constant and RowVectors.
+  void fuzzDataBehindNulls(VectorPtr& vector);
+
   // Maximum values allowed values by Presto for interval types.
   static const int64_t kMaxAllowedIntervalDayTime = 2147483647;
   static const int32_t kMaxAllowedIntervalYearMonth = 178956970;


### PR DESCRIPTION
Summary:
This change introduces logic to deliberately corrupt the underlying
data for row indices that are marked as null in a vector. For
FlatVectors, the values buffer is corrupted at these null positions,
for Array and Map Vectors, the offsets and sizes are affected; and
for DictionaryVectors, the indices buffer is corrupted. For Constant
and RowVectors, this operation is a no-op. The purpose of this is to
generate test cases that ensure code correctly ignores data at null
positions, rather than relying on the assumption that the underlying
values are valid.

Differential Revision: D86273473


