### PR TITLE
feat(spilling): Fallback to timsort when allocation of prefix sort buffer memory fails during spilling

### DIFF
--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -361,54 +361,57 @@ bool PrefixSort::sortInternal(
     std::vector<char*, memory::StlAllocator<char*>>& rows) {
   const auto numRows = rows.size();
   const auto entrySize = sortLayout_.entrySize;
-  memory::ContiguousAllocation prefixBufferAlloc;
-  // Allocates prefix sort buffer.
   {
-    const auto numPages =
-        memory::AllocationTraits::numPages(numRows * entrySize);
-    if (!pool_->maybeReserve(memory::AllocationTraits::pageBytes(numPages))) {
-      return false;
+    memory::ContiguousAllocation prefixBufferAlloc;
+    // Allocates prefix sort buffer.
+    {
+      const auto numPages =
+          memory::AllocationTraits::numPages(numRows * entrySize);
+      if (!pool_->maybeReserve(memory::AllocationTraits::pageBytes(numPages))) {
+        return false;
+      }
+      pool_->allocateContiguous(numPages, prefixBufferAlloc);
     }
-    pool_->allocateContiguous(numPages, prefixBufferAlloc);
-  }
-  char* prefixBuffer = prefixBufferAlloc.data<char>();
+    char* prefixBuffer = prefixBufferAlloc.data<char>();
 
-  // Extracts rows, and stores the serialized normalized keys plus the row
-  // address (in row container) to prefix sort buffer.
-  for (auto i = 0; i < rows.size(); ++i) {
-    extractRowAndEncodePrefixKeys(rows[i], prefixBuffer + entrySize * i);
-  }
-
-  // Sort rows with the normalized prefix keys.
-  {
-    const auto swapBuffer = AlignedBuffer::allocate<char>(entrySize, pool_);
-    PrefixSortRunner sortRunner(entrySize, swapBuffer->asMutable<char>());
-    auto* prefixBufferStart = prefixBuffer;
-    auto* prefixBufferEnd = prefixBuffer + numRows * entrySize;
-    if (sortLayout_.numNormalizedKeys > 0) {
-      addThreadLocalRuntimeStat(
-          PrefixSort::kNumPrefixSortKeys,
-          RuntimeCounter(
-              sortLayout_.numNormalizedKeys, RuntimeCounter::Unit::kNone));
+    // Extracts rows, and stores the serialized normalized keys plus the row
+    // address (in row container) to prefix sort buffer.
+    for (auto i = 0; i < rows.size(); ++i) {
+      extractRowAndEncodePrefixKeys(rows[i], prefixBuffer + entrySize * i);
     }
-    if (sortLayout_.hasNonNormalizedKey ||
-        sortLayout_.nonPrefixSortStartIndex < sortLayout_.numNormalizedKeys) {
-      sortRunner.quickSort(
-          prefixBufferStart, prefixBufferEnd, [&](char* lhs, char* rhs) {
-            return comparePartNormalizedKeys(lhs, rhs);
-          });
-    } else {
-      sortRunner.quickSort(
-          prefixBufferStart, prefixBufferEnd, [&](char* lhs, char* rhs) {
-            return compareAllNormalizedKeys(lhs, rhs);
-          });
+
+    // Sort rows with the normalized prefix keys.
+    {
+      const auto swapBuffer = AlignedBuffer::allocate<char>(entrySize, pool_);
+      PrefixSortRunner sortRunner(entrySize, swapBuffer->asMutable<char>());
+      auto* prefixBufferStart = prefixBuffer;
+      auto* prefixBufferEnd = prefixBuffer + numRows * entrySize;
+      if (sortLayout_.numNormalizedKeys > 0) {
+        addThreadLocalRuntimeStat(
+            PrefixSort::kNumPrefixSortKeys,
+            RuntimeCounter(
+                sortLayout_.numNormalizedKeys, RuntimeCounter::Unit::kNone));
+      }
+      if (sortLayout_.hasNonNormalizedKey ||
+          sortLayout_.nonPrefixSortStartIndex < sortLayout_.numNormalizedKeys) {
+        sortRunner.quickSort(
+            prefixBufferStart, prefixBufferEnd, [&](char* lhs, char* rhs) {
+              return comparePartNormalizedKeys(lhs, rhs);
+            });
+      } else {
+        sortRunner.quickSort(
+            prefixBufferStart, prefixBufferEnd, [&](char* lhs, char* rhs) {
+              return compareAllNormalizedKeys(lhs, rhs);
+            });
+      }
+    }
+
+    // Output sorted row addresses.
+    for (auto i = 0; i < rows.size(); ++i) {
+      rows[i] = getRowAddrFromPrefixBuffer(prefixBuffer + i * entrySize);
     }
   }
-
-  // Output sorted row addresses.
-  for (auto i = 0; i < rows.size(); ++i) {
-    rows[i] = getRowAddrFromPrefixBuffer(prefixBuffer + i * entrySize);
-  }
+  pool_->release();
 
   return true;
 }

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -105,7 +105,8 @@ class PrefixSort {
       memory::MemoryPool* pool);
 
   /// Follow the steps below to sort the data in RowContainer:
-  /// 1. Allocate a contiguous block of memory to store normalized keys.
+  /// 1. Allocate a contiguous block of memory to store normalized keys, if
+  /// allocation fails return false.
   /// 2. Extract the sort keys from the RowContainer. If the key can be
   /// normalized, normalize it. For this kind of keys can be normalized，we
   /// combine them with the original row address ptr and store them
@@ -127,7 +128,8 @@ class PrefixSort {
   ///
   /// @param rows The result of RowContainer::listRows(), assuming that the
   /// caller (SortBuffer etc.) has already got the result.
-  FOLLY_ALWAYS_INLINE static void sort(
+  /// @return true if the sort is done, false if the sort fails.
+  FOLLY_ALWAYS_INLINE static bool sort(
       const RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags,
       const velox::common::PrefixSortConfig& config,
@@ -135,7 +137,7 @@ class PrefixSort {
       std::vector<char*, memory::StlAllocator<char*>>& rows) {
     if (rowContainer->numRows() < config.minNumRows) {
       stdSort(rows, rowContainer, compareFlags);
-      return;
+      return true;
     }
     const auto sortLayout =
         generateSortLayout(rowContainer, compareFlags, config);
@@ -143,11 +145,11 @@ class PrefixSort {
     // Putting this outside sort-internal helps with stdSort.
     if (!sortLayout.hasNormalizedKeys) {
       stdSort(rows, rowContainer, compareFlags);
-      return;
+      return true;
     }
 
     PrefixSort prefixSort(rowContainer, sortLayout, pool);
-    prefixSort.sortInternal(rows);
+    return prefixSort.sortInternal(rows);
   }
 
   /// The std::sort won't require bytes while prefix sort may require buffers
@@ -207,7 +209,7 @@ class PrefixSort {
   // swap buffer.
   uint32_t maxRequiredBytes() const;
 
-  void sortInternal(std::vector<char*, memory::StlAllocator<char*>>& rows);
+  bool sortInternal(std::vector<char*, memory::StlAllocator<char*>>& rows);
 
   int compareAllNormalizedKeys(char* left, char* right);
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -230,20 +230,27 @@ void SpillerBase::ensureSorted(SpillRun& run) {
   {
     NanosecondTimer timer(&sortTimeNs);
 
-    if (!state_.prefixSortConfig().has_value()) {
+    bool prefixSortSuccess{false};
+    if (state_.prefixSortConfig().has_value()) {
+      prefixSortSuccess = PrefixSort::sort(
+              container_,
+              compareFlags_,
+              state_.prefixSortConfig().value(),
+              memory::spillMemoryPool(),
+              run.rows);
+      if (!prefixSortSuccess) {
+        LOG(WARNING) << "PrefixSort failed due to memory allocation error, "
+                     << "falling back to TimSort";
+      }
+    }
+
+    if (!prefixSortSuccess) {
       gfx::timsort(
           run.rows.begin(),
           run.rows.end(),
           [&](const char* left, const char* right) {
             return container_->compareRows(left, right, compareFlags_) < 0;
           });
-    } else {
-      PrefixSort::sort(
-          container_,
-          compareFlags_,
-          state_.prefixSortConfig().value(),
-          memory::spillMemoryPool(),
-          run.rows);
     }
 
     run.sorted = true;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -233,11 +233,11 @@ void SpillerBase::ensureSorted(SpillRun& run) {
     bool prefixSortSuccess{false};
     if (state_.prefixSortConfig().has_value()) {
       prefixSortSuccess = PrefixSort::sort(
-              container_,
-              compareFlags_,
-              state_.prefixSortConfig().value(),
-              memory::spillMemoryPool(),
-              run.rows);
+          container_,
+          compareFlags_,
+          state_.prefixSortConfig().value(),
+          memory::spillMemoryPool(),
+          run.rows);
       if (!prefixSortSuccess) {
         LOG(WARNING) << "PrefixSort failed due to memory allocation error, "
                      << "falling back to TimSort";

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -705,10 +705,11 @@ DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySortGetOutput) {
     // Sets an extreme large value to get output once to avoid test flakiness.
     sortBuffer->getOutput(1'000'000);
     if (spillEnabled) {
-      // Reserve memory for sort and getOutput.
-      ASSERT_EQ(numReserves, 2);
+      // Reserve memory for sort and getOutput and when prefix sort.
+      ASSERT_EQ(numReserves, enableSpillPrefixSort_ ? 3 : 2);
     } else {
-      ASSERT_EQ(numReserves, 0);
+      // Reserve memory when prefix sort.
+      ASSERT_EQ(numReserves, enableSpillPrefixSort_ ? 1 : 0);
     }
   }
 }
@@ -745,21 +746,20 @@ DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySort) {
     TestScopedSpillInjection scopedSpillInjection(0);
     sortBuffer->addInput(fuzzer.fuzzRow(inputType_));
 
-    std::atomic_bool hasReserveMemory = false;
+    std::atomic_int numReserves{0};
     // Reserve memory for sort.
     SCOPED_TESTVALUE_SET(
         "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
         std::function<void(memory::MemoryPoolImpl*)>(
-            ([&](memory::MemoryPoolImpl* pool) {
-              hasReserveMemory.store(true);
-            })));
+            ([&](memory::MemoryPoolImpl* pool) { ++numReserves; })));
 
     sortBuffer->noMoreInput();
     if (spillEnabled) {
-      // Reserve memory for sort.
-      ASSERT_TRUE(hasReserveMemory);
+      // Reserve memory for sort and when prefix sort.
+      ASSERT_EQ(numReserves, enableSpillPrefixSort_ ? 2 : 1);
     } else {
-      ASSERT_FALSE(hasReserveMemory);
+      // Reserve memory when prefix sort.
+      ASSERT_EQ(numReserves, enableSpillPrefixSort_ ? 1 : 0);
     }
   }
 }

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -786,9 +786,7 @@ DEBUG_ONLY_TEST_F(WindowTest, reserveMemorySort) {
     SCOPED_TESTVALUE_SET(
         "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
         std::function<void(memory::MemoryPoolImpl*)>(
-            ([&](memory::MemoryPoolImpl* pool) {
-              ++numReserves;
-            })));
+            ([&](memory::MemoryPoolImpl* pool) { ++numReserves; })));
 
     sortWindowBuild->noMoreInput();
     if (spillEnabled) {

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -781,21 +781,22 @@ DEBUG_ONLY_TEST_F(WindowTest, reserveMemorySort) {
     const auto data = usePrefixSort ? prefixSortData : nonPrefixSortData;
     sortWindowBuild->addInput(data);
 
-    std::atomic_bool hasReserveMemory = false;
+    std::atomic_int numReserves{0};
     // Reserve memory for sort.
     SCOPED_TESTVALUE_SET(
         "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
         std::function<void(memory::MemoryPoolImpl*)>(
             ([&](memory::MemoryPoolImpl* pool) {
-              hasReserveMemory.store(true);
+              ++numReserves;
             })));
 
     sortWindowBuild->noMoreInput();
     if (spillEnabled) {
-      // Reserve memory for sort.
-      ASSERT_TRUE(hasReserveMemory);
+      // Reserve memory for sort and when prefix sort.
+      ASSERT_EQ(numReserves, 2);
     } else {
-      ASSERT_FALSE(hasReserveMemory);
+      // Reserve memory when prefix sort.
+      ASSERT_EQ(numReserves, 1);
     }
   }
 }


### PR DESCRIPTION
Allocating prefix sort buffer memory when spilling could lead to `MEM_ALLOC_ERROR`. This PR uses Timsort as a fallback when allocation of prefix sort buffer memory fails during spilling.