### PR TITLE
feat(cudf): Support CudfVector childrenSize

### DIFF
--- a/velox/experimental/cudf/vector/CudfVector.cpp
+++ b/velox/experimental/cudf/vector/CudfVector.cpp
@@ -107,7 +107,7 @@ CudfVector::CudfVector(
           std::move(type),
           BufferPtr(nullptr),
           size,
-          std::vector<VectorPtr>(),
+          std::vector<VectorPtr>(table->num_columns()),
           std::nullopt),
       table_{std::move(table)},
       stream_{stream} {


### PR DESCRIPTION
Initialize the children vector with nullptr, then function childrenSize can get correct value.