### PR TITLE
misc: Use consistent thread pool name

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -39,7 +39,7 @@ class HiveDataSource : public DataSource {
       const connector::ConnectorTableHandlePtr& tableHandle,
       const connector::ColumnHandleMap& assignments,
       FileHandleFactory* fileHandleFactory,
-      folly::Executor* executor,
+      folly::Executor* ioExecutor,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<HiveConfig>& hiveConfig);
 


### PR DESCRIPTION
Summary: To keep consistent name as callstack and its implementation function signature

Reviewed By: xiaoxmeng

Differential Revision: D86323515


