### PR TITLE
perf: Reserve space for holders_ in DecodedArgs constructor

### DIFF
--- a/velox/expression/DecodedArgs.h
+++ b/velox/expression/DecodedArgs.h
@@ -36,6 +36,7 @@ class DecodedArgs {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       exec::EvalCtx& context) {
+    holders_.reserve(args.size());
     for (auto& arg : args) {
       holders_.emplace_back(context, *arg, rows);
     }


### PR DESCRIPTION
Summary:
The DecodedArgs constructor was populating the holders_ vector without
pre-allocating space, which could cause multiple reallocations as the
vector grows. This adds a reserve() call before the loop to allocate
space upfront for all elements, improving performance by avoiding
unnecessary allocations and copies.

Differential Revision: D86366246


