### PR TITLE
fix(type): Fix TIME WITH TIME ZONE UTC and local time conversions

### DIFF
--- a/velox/type/Time.cpp
+++ b/velox/type/Time.cpp
@@ -324,7 +324,7 @@ Expected<int64_t> fromTimeWithTimezoneString(const char* buf, size_t len) {
     return folly::makeUnexpected(timeResult.error());
   }
 
-  int64_t millisUtc = timeResult.value();
+  int64_t millisLocal = timeResult.value();
 
   // Parse timezone offset
   auto tzOffsetResult = parseTimezoneOffset(buf + tzStartPos, len - tzStartPos);
@@ -333,6 +333,11 @@ Expected<int64_t> fromTimeWithTimezoneString(const char* buf, size_t len) {
   }
 
   int16_t offsetMinutes = tzOffsetResult.value();
+
+  // Convert local time to UTC using utility function
+  // Example: 12:00:00+05:30 means the local time is 12:00 in UTC+5:30
+  // To get UTC time, we subtract 5:30, resulting in 06:30:00 UTC
+  int64_t millisUtc = localToUtcTime(millisLocal, offsetMinutes);
 
   // Encode timezone offset and pack with time
   int16_t encodedTimezone = biasEncode(offsetMinutes);


### PR DESCRIPTION
Summary:
Fixed bugs in TIME WITH TIME ZONE conversions. The type's
storage model requires storing time in UTC while displaying/operating
in local timezone, but the implementations were not following this:

1. fromTimeWithTimezoneString: Was not converting local→UTC for storage
2. valueToString: Was displaying UTC time directly, not local time
3. castToTime: Was extracting UTC time instead of local time

Example: Input "1:30+05:30" should store as UTC 20:00 (subtracting
5.5 hours), display as 01:30+05:30, and cast to TIME as 01:30.

Refactored duplicated conversion logic into reusable utility functions:
utcToLocalTime(), localToUtcTime(), decodeTimezoneOffset().

Differential Revision: D86397126


