### PR TITLE
feat: Add iceberg partition specification

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -15,8 +15,9 @@
 velox_add_library(
   velox_hive_iceberg_splitreader
   IcebergDataSink.cpp
-  IcebergSplitReader.cpp
   IcebergSplit.cpp
+  IcebergSplitReader.cpp
+  PartitionSpec.cpp
   PositionalDeleteFileReader.cpp
 )
 

--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/connectors/hive/HiveDataSink.h"
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -32,6 +33,10 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
   /// @param locationHandle Contains the target location information including:
   /// - Base directory path where data files will be written.
   /// - File naming scheme and temporary directory paths.
+  /// @param tableStorageFormat File format to use for writing data files.
+  /// @param partitionSpec Optional partition specification defining how to
+  /// partition the data. If nullptr, the table is unpartitioned and all data
+  /// is written to a single directory.
   /// @param compressionKind Optional compression to apply to data files.
   /// @param serdeParameters Additional serialization/deserialization parameters
   /// for the file format.
@@ -39,8 +44,18 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
       std::vector<HiveColumnHandlePtr> inputColumns,
       LocationHandlePtr locationHandle,
       dwio::common::FileFormat tableStorageFormat,
+      IcebergPartitionSpecPtr partitionSpec,
       std::optional<common::CompressionKind> compressionKind = {},
       const std::unordered_map<std::string, std::string>& serdeParameters = {});
+
+  /// Returns the Iceberg partition specification that defines how the table
+  /// is partitioned.
+  const IcebergPartitionSpecPtr& partitionSpec() const {
+    return partitionSpec_;
+  }
+
+ private:
+  const IcebergPartitionSpecPtr partitionSpec_;
 };
 
 using IcebergInsertTableHandlePtr =

--- a/velox/connectors/hive/iceberg/PartitionSpec.cpp
+++ b/velox/connectors/hive/iceberg/PartitionSpec.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+TransformCategory getTransformCategory(TransformType transformType) {
+  switch (transformType) {
+    case TransformType::kIdentity:
+      return TransformCategory::kIdentity;
+    case TransformType::kYear:
+    case TransformType::kMonth:
+    case TransformType::kDay:
+    case TransformType::kHour:
+      return TransformCategory::kTemporal;
+    case TransformType::kBucket:
+      return TransformCategory::kBucket;
+    case TransformType::kTruncate:
+      return TransformCategory::kTruncate;
+    default:
+      VELOX_UNREACHABLE("Unknown transform type");
+  }
+}
+
+bool isValidPartitionType(const TypePtr& type) {
+  return !(
+      type->isRow() || type->isArray() || type->isMap() || type->isDouble() ||
+      type->isReal() || isTimestampWithTimeZoneType(type));
+}
+
+bool canTransform(TransformType transformType, const TypePtr& type) {
+  switch (transformType) {
+    case TransformType::kIdentity:
+      return type->isTinyint() || type->isSmallint() || type->isInteger() ||
+          type->isBigint() || type->isBoolean() || type->isDecimal() ||
+          type->isDate() || type->isTimestamp() || type->isVarchar() ||
+          type->isVarbinary();
+    case TransformType::kYear:
+    case TransformType::kMonth:
+    case TransformType::kDay:
+      return type->isDate() || type->isTimestamp();
+    case TransformType::kHour:
+      return type->isTimestamp();
+    case TransformType::kBucket:
+      return type->isInteger() || type->isBigint() || type->isDecimal() ||
+          type->isVarchar() || type->isVarbinary() || type->isDate() ||
+          type->isTimestamp();
+    case TransformType::kTruncate:
+      return type->isInteger() || type->isBigint() || type->isDecimal() ||
+          type->isVarchar() || type->isVarbinary();
+    default:
+      VELOX_UNREACHABLE("Unsupported partition transform type.");
+  }
+}
+
+const auto& transformTypeNames() {
+  static const folly::F14FastMap<TransformType, std::string_view>
+      kTransformNames = {
+          {TransformType::kIdentity, "identity"},
+          {TransformType::kHour, "hour"},
+          {TransformType::kDay, "day"},
+          {TransformType::kMonth, "month"},
+          {TransformType::kYear, "year"},
+          {TransformType::kBucket, "bucket"},
+          {TransformType::kTruncate, "trunc"},
+      };
+  return kTransformNames;
+}
+
+const auto& transformCategoryNames() {
+  static const folly::F14FastMap<TransformCategory, std::string_view>
+      kTransformCategoryNames = {
+          {TransformCategory::kIdentity, "Identity"},
+          {TransformCategory::kBucket, "Bucket"},
+          {TransformCategory::kTruncate, "Truncate"},
+          {TransformCategory::kTemporal, "Temporal"},
+      };
+  return kTransformCategoryNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(TransformType, transformTypeNames);
+
+VELOX_DEFINE_ENUM_NAME(TransformCategory, transformCategoryNames);
+
+void IcebergPartitionSpec::checkCompatibility() const {
+  folly::F14FastMap<std::string_view, std::vector<TransformType>>
+      columnTransforms;
+
+  for (const auto& field : fields) {
+    const auto& type = field.type;
+    const auto& name = field.name;
+    VELOX_USER_CHECK(
+        isValidPartitionType(type),
+        "Type is not supported as a partition column: {}",
+        type->name());
+
+    VELOX_USER_CHECK(
+        canTransform(field.transformType, type),
+        "Transform is not supported for partition column. Column: '{}', Type: '{}', Transform: '{}'.",
+        name,
+        type->name(),
+        TransformTypeName::toName(field.transformType));
+
+    columnTransforms[name].emplace_back(field.transformType);
+  }
+
+  // Check for duplicate transform categories per column.
+  std::vector<std::string> errors;
+  for (const auto& [columnName, transforms] : columnTransforms) {
+    folly::F14FastSet<TransformCategory> seenCategories;
+    for (const auto& transform : transforms) {
+      auto category = getTransformCategory(transform);
+      if (!seenCategories.insert(category).second) {
+        std::vector<std::string> transformNames;
+        for (const auto& t : transforms) {
+          transformNames.emplace_back(
+              std::string(TransformTypeName::toName(t)));
+        }
+        errors.emplace_back(
+            fmt::format(
+                "Column: '{}', Category: {}, Transforms: [{}]",
+                columnName,
+                TransformCategoryName::toName(category),
+                folly::join(", ", transformNames)));
+        break;
+      }
+    }
+  }
+
+  VELOX_USER_CHECK(
+      errors.empty(),
+      "Multiple transforms of the same category on a column are not allowed. "
+      "Each transform category can appear at most once per column. {}",
+      folly::join("; ", errors));
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/PartitionSpec.h
+++ b/velox/connectors/hive/iceberg/PartitionSpec.h
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Partition transform types.
+/// Defines how source column values are converted into partition keys.
+/// See https://iceberg.apache.org/spec/#partition-transforms.
+enum class TransformType {
+  /// Use the source value as-is (no transformation).
+  kIdentity,
+  /// Extract a timestamp hour, as hours from 1970-01-01 00:00:00.
+  kHour,
+  /// Extract a date or timestamp day, as days from 1970-01-01.
+  kDay,
+  /// Extract a date or timestamp month, as months from 1970-01.
+  kMonth,
+  /// Extract a date or timestamp year, as years from 1970.
+  kYear,
+  /// Hash the value into N buckets for even distribution. Requires an integer
+  /// parameter specifying the bucket count.
+  kBucket,
+  /// Truncate strings or numbers to a specified width. Requires an integer
+  /// parameter specifying the truncate width.
+  kTruncate
+};
+
+VELOX_DECLARE_ENUM_NAME(TransformType);
+
+/// A single column can be used to produce multiple partition keys, but with
+/// following restrictions:
+/// - Transforms are organized into 4 categories: Identity, Temporal,
+///   Bucket, and Truncate.
+/// - Each category can appear at most once per column.
+/// - Sample valid specs on same column: ['truncate(a,2)', 'bucket(a,16)', 'a']
+///   or ['year(b)', 'bucket(b, 16)', 'b']
+enum class TransformCategory {
+  kIdentity,
+  /// Year/Month/Day/Hour
+  kTemporal,
+  kBucket,
+  kTruncate,
+};
+
+VELOX_DECLARE_ENUM_NAME(TransformCategory);
+
+/// Represents how to produce partition data for an Iceberg table.
+///
+/// This structure corresponds to the Iceberg Java PartitionSpec class but
+/// contains only the necessary fields for Velox. Partition keys are computed
+/// by transforming columns in a table.
+///
+/// The upstream engine processes this specification through the Iceberg Java
+/// library to validate column types, detect duplicates, and generate the
+/// partition spec that is passed to Velox.
+///
+/// IMPORTANT: Iceberg spec uses field IDs to identify source columns, but
+/// Velox RowType only supports matching fields by name. Therefore, Velox uses
+/// the partition field name to match against the table schema column names.
+/// Callers must ensure that partition field names exactly match the column
+/// names in the table schema.
+///
+/// The partition spec contains:
+/// - Unique ID for versioning and evolution.
+/// - Which source columns in current table schema to use for partitioning
+/// (identified by field name, not field ID as in the Iceberg spec).
+/// - What transforms to apply (identity, bucket, truncate etc.).
+/// - Transform parameters (e.g., bucket count, truncate width).
+struct IcebergPartitionSpec {
+  struct Field {
+    /// Column name as defined in table schema. This column's value is used to
+    /// compute partition key by applying 'transformType' transformation.
+    const std::string name;
+
+    /// Column type.
+    const TypePtr type;
+
+    /// Transform to apply. Callers must ensure the transform is compatible with
+    /// the column type.
+    const TransformType transformType;
+
+    /// Optional parameter for transforms that require configuration.
+    const std::optional<int32_t> parameter;
+
+    /// Returns the result type after applying this transform.
+    TypePtr resultType() const {
+      switch (transformType) {
+        case TransformType::kBucket:
+        case TransformType::kYear:
+        case TransformType::kMonth:
+        case TransformType::kHour:
+          return INTEGER();
+        case TransformType::kDay:
+          return DATE();
+        case TransformType::kIdentity:
+        case TransformType::kTruncate:
+          return type;
+      }
+    }
+  };
+
+  const int32_t specId;
+  const std::vector<Field> fields;
+
+  /// Constructor with validation that:
+  /// - Each field's type is supported for partitioning.
+  /// - Each field's transform type is compatible with its data type.
+  /// - No transform category appears more than once per column (Identity,
+  ///   Temporal, Bucket, and Truncate are separate categories).
+  ///
+  /// @param _specId Partition specification ID.
+  /// @param _fields Vector of partition fields. When empty indicates no
+  /// partition.
+  /// @throws VeloxUserError if validation fails.
+  IcebergPartitionSpec(int32_t _specId, std::vector<Field> _fields)
+      : specId(_specId), fields(std::move(_fields)) {
+    checkCompatibility();
+  }
+
+ private:
+  // Validates partition fields for correctness.
+  // Checks type/transform compatibility and transform combination rules.
+  void checkCompatibility() const;
+};
+
+using IcebergPartitionSpecPtr = std::shared_ptr<const IcebergPartitionSpec>;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -57,7 +57,13 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
   )
 
-  add_executable(velox_hive_iceberg_insert_test IcebergInsertTest.cpp IcebergTestBase.cpp Main.cpp)
+  add_executable(
+    velox_hive_iceberg_insert_test
+    IcebergInsertTest.cpp
+    IcebergTestBase.cpp
+    Main.cpp
+    PartitionSpecTest.cpp
+  )
 
   add_test(velox_hive_iceberg_insert_test velox_hive_iceberg_insert_test)
 
@@ -68,6 +74,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_hive_iceberg_splitreader
     velox_vector_fuzzer
     GTest::gtest
+    GTest::gtest_main
   )
 
   if(VELOX_ENABLE_PARQUET)

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -29,6 +29,13 @@
 
 namespace facebook::velox::connector::hive::iceberg::test {
 
+struct PartitionField {
+  // 0-based column index.
+  int32_t id;
+  TransformType type;
+  std::optional<int32_t> parameter;
+};
+
 class IcebergTestBase : public exec::test::HiveConnectorTestBase {
  protected:
   void SetUp() override;
@@ -41,22 +48,33 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
       vector_size_t rowsPerBatch,
       double nullRatio = 0.0);
 
-  std::shared_ptr<IcebergDataSink> createIcebergDataSink(
+  std::shared_ptr<IcebergDataSink> createDataSink(
       const RowTypePtr& rowType,
       const std::string& outputDirectoryPath,
-      const std::vector<std::string>& partitionTransforms = {});
+      const std::vector<PartitionField>& partitionFields = {});
+
+  std::shared_ptr<IcebergDataSink> createDataSinkAndAppendData(
+      const RowTypePtr& rowType,
+      const std::vector<RowVectorPtr>& vectors,
+      const std::string& dataPath,
+      const std::vector<PartitionField>& partitionFields = {});
 
   std::vector<std::shared_ptr<ConnectorSplit>> createSplitsForDirectory(
       const std::string& directory);
 
   std::vector<std::string> listFiles(const std::string& dirPath);
 
+  std::shared_ptr<IcebergPartitionSpec> createPartitionSpec(
+      const std::vector<PartitionField>& partitionFields,
+      const RowTypePtr& rowType);
+
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
 
  private:
-  IcebergInsertTableHandlePtr createIcebergInsertTableHandle(
+  IcebergInsertTableHandlePtr createInsertTableHandle(
       const RowTypePtr& rowType,
-      const std::string& outputDirectoryPath);
+      const std::string& outputDirectoryPath,
+      const std::vector<PartitionField>& partitionFields = {});
 
   std::vector<std::string> listPartitionDirectories(
       const std::string& dataPath);

--- a/velox/connectors/hive/iceberg/tests/PartitionSpecTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/PartitionSpecTest.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+TEST(PartitionSpecTest, invalidColumnType) {
+  auto makeSpec = [](const TypePtr& type) {
+    std::vector<IcebergPartitionSpec::Field> fields = {
+        {"c0", type, TransformType::kIdentity, std::nullopt},
+    };
+    return std::make_shared<const IcebergPartitionSpec>(1, fields);
+  };
+
+  VELOX_ASSERT_USER_THROW(
+      makeSpec(ROW({{"a", INTEGER()}})),
+      "Type is not supported as a partition column: ROW");
+  VELOX_ASSERT_USER_THROW(
+      makeSpec(ARRAY(INTEGER())),
+      "Type is not supported as a partition column: ARRAY");
+  VELOX_ASSERT_USER_THROW(
+      makeSpec(MAP(VARCHAR(), INTEGER())),
+      "Type is not supported as a partition column: MAP");
+  VELOX_ASSERT_USER_THROW(
+      makeSpec(TIMESTAMP_WITH_TIME_ZONE()),
+      "Type is not supported as a partition column: TIMESTAMP WITH TIME ZONE");
+}
+
+TEST(PartitionSpecTest, invalidMultipleTransforms) {
+  {
+    std::vector<IcebergPartitionSpec::Field> fields = {
+        {"c0", VARCHAR(), TransformType::kIdentity, std::nullopt},
+        {"c0", VARCHAR(), TransformType::kIdentity, std::nullopt},
+    };
+    VELOX_ASSERT_USER_THROW(
+        std::make_shared<const IcebergPartitionSpec>(1, fields),
+        "Column: 'c0', Category: Identity, Transforms: [identity, identity]");
+  }
+
+  {
+    std::vector<IcebergPartitionSpec::Field> fields = {
+        {"c0", VARCHAR(), TransformType::kBucket, 16},
+        {"c0", VARCHAR(), TransformType::kBucket, 32},
+    };
+    VELOX_ASSERT_USER_THROW(
+        std::make_shared<const IcebergPartitionSpec>(1, fields),
+        "Column: 'c0', Category: Bucket, Transforms: [bucket, bucket]");
+  }
+
+  {
+    std::vector<IcebergPartitionSpec::Field> fields = {
+        {"c0", VARCHAR(), TransformType::kTruncate, 2},
+        {"c0", VARCHAR(), TransformType::kTruncate, 5},
+    };
+    VELOX_ASSERT_USER_THROW(
+        std::make_shared<const IcebergPartitionSpec>(1, fields),
+        "Column: 'c0', Category: Truncate, Transforms: [trunc, trunc]");
+  }
+
+  {
+    std::vector<IcebergPartitionSpec::Field> fields4 = {
+        {"c0", TIMESTAMP(), TransformType::kYear, std::nullopt},
+        {"c0", TIMESTAMP(), TransformType::kMonth, std::nullopt},
+        {"c0", TIMESTAMP(), TransformType::kDay, std::nullopt},
+        {"c0", TIMESTAMP(), TransformType::kHour, std::nullopt},
+    };
+    VELOX_ASSERT_USER_THROW(
+        std::make_shared<const IcebergPartitionSpec>(1, fields4),
+        "Column: 'c0', Category: Temporal, Transforms: [year, month, day, hour]");
+  }
+}
+
+TEST(PartitionSpecTest, invalidMultipleTransformsMultipleColumns) {
+  std::vector<IcebergPartitionSpec::Field> fields = {
+      {"c0", DATE(), TransformType::kYear, std::nullopt},
+      {"c0", DATE(), TransformType::kMonth, std::nullopt},
+      {"c1", VARCHAR(), TransformType::kBucket, 16},
+      {"c1", VARCHAR(), TransformType::kBucket, 32},
+  };
+  // order may vary due to map iteration.
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields),
+      "Column: 'c0', Category: Temporal, Transforms: [year, month]");
+  VELOX_ASSERT_USER_THROW(
+      std::make_shared<const IcebergPartitionSpec>(1, fields),
+      "Column: 'c1', Category: Bucket, Transforms: [bucket, bucket]");
+}
+
+TEST(PartitionSpecTest, validMultipleTransforms) {
+  {
+    std::vector<IcebergPartitionSpec::Field> fields = {
+        {"c0", VARCHAR(), TransformType::kIdentity, std::nullopt},
+        {"c0", VARCHAR(), TransformType::kBucket, 16},
+        {"c0", VARCHAR(), TransformType::kTruncate, 10},
+    };
+    auto spec = std::make_shared<const IcebergPartitionSpec>(1, fields);
+    EXPECT_EQ(spec->fields.size(), 3);
+  }
+
+  {
+    std::vector<IcebergPartitionSpec::Field> fields = {
+        {"c0", DATE(), TransformType::kYear, std::nullopt},
+        {"c0", DATE(), TransformType::kBucket, 16},
+        {"c0", DATE(), TransformType::kIdentity, std::nullopt},
+    };
+    auto spec = std::make_shared<const IcebergPartitionSpec>(1, fields);
+    EXPECT_EQ(spec->fields.size(), 3);
+  }
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Implements the IcebergPartitionSpec structure that contains how to produce partition key for Iceberg tables.
The partition spec specifies which source columns to use for partitioning and what transforms to apply (e.g., identity, bucket, truncate, year, month, day, hour) to compute the partition key.

Implements validation logic to ensure:
1. Column types are valid for partitioning (excludes complex types, doubles, floats, timestamp with timezone)
2. Transform types are compatible with column data types
3. No duplicate transform categories per column (e.g., can't have both year and month on same column)

Added unit tests covering validation rules.

Context: https://iceberg.apache.org/docs/latest/partitioning/