### PR TITLE
feat: Add sampling rate to HiveTableHandle

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -167,7 +167,7 @@ HiveDataSource::HiveDataSource(
   for (const auto& [k, v] : hiveTableHandle_->subfieldFilters()) {
     filters_.emplace(k.clone(), v);
   }
-  double sampleRate = 1;
+  double sampleRate = hiveTableHandle_->sampleRate();
   auto remainingFilter = extractFiltersFromRemainingFilter(
       hiveTableHandle_->remainingFilter(),
       expressionEvaluator_,

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -140,6 +140,8 @@ using HiveColumnHandleMap =
 
 class HiveTableHandle : public ConnectorTableHandle {
  public:
+  /// @param sampleRate Sampling rate in (0, 1] range. 0.1 means 10% sampling.
+  /// 1.0 means no sampling. Default is no sampling.
   HiveTableHandle(
       std::string connectorId,
       const std::string& tableName,
@@ -148,7 +150,8 @@ class HiveTableHandle : public ConnectorTableHandle {
       const core::TypedExprPtr& remainingFilter,
       const RowTypePtr& dataColumns = nullptr,
       const std::unordered_map<std::string, std::string>& tableParameters = {},
-      std::vector<HiveColumnHandlePtr> filterColumnHandles = {});
+      std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
+      double sampleRate = 1.0);
 
   const std::string& tableName() const {
     return tableName_;
@@ -172,6 +175,12 @@ class HiveTableHandle : public ConnectorTableHandle {
   /// than subfield filters but supports arbitrary boolean expression.
   const core::TypedExprPtr& remainingFilter() const {
     return remainingFilter_;
+  }
+
+  /// Sampling rate between 0 and 1 (excluding 0). 0.1 means 10%
+  /// sampling. 1.0 means no sampling.
+  double sampleRate() const {
+    return sampleRate_;
   }
 
   /// Subset of schema of the table that we store in file (i.e.,
@@ -214,6 +223,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const bool filterPushdownEnabled_;
   const common::SubfieldFilters subfieldFilters_;
   const core::TypedExprPtr remainingFilter_;
+  const double sampleRate_;
   const RowTypePtr dataColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
   const std::vector<HiveColumnHandlePtr> filterColumnHandles_;

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -657,29 +657,44 @@ TEST_F(PlanNodeSerdeTest, rowNumber) {
 }
 
 TEST_F(PlanNodeSerdeTest, scan) {
-  auto plan = PlanBuilder(pool_.get())
-                  .tableScan(
-                      ROW({"a", "b", "c", "d"},
-                          {BIGINT(), BIGINT(), BOOLEAN(), DOUBLE()}),
-                      {"a < 5", "b = 7", "c = true", "d > 0.01"},
-                      "a + b < 100")
-                  .planNode();
-  testSerde(plan);
+  {
+    auto plan = PlanBuilder(pool_.get())
+                    .tableScan(
+                        ROW({"a", "b", "c", "d"},
+                            {BIGINT(), BIGINT(), BOOLEAN(), DOUBLE()}),
+                        {"a < 5", "b = 7", "c = true", "d > 0.01"},
+                        "a + b < 100")
+                    .planNode();
+    testSerde(plan);
+  }
 
-  plan = PlanBuilder()
-             .startTableScan()
-             .outputType(ROW({"x"}, {BIGINT()}))
-             .assignments(
-                 {{"x", HiveConnectorTestBase::regularColumn("a", BIGINT())}})
-             .dataColumns(ROW({"a", "b"}, {BIGINT(), BIGINT()}))
-             .filterColumnHandles({
-                 HiveConnectorTestBase::partitionKey("ds", VARCHAR()),
-                 HiveConnectorTestBase::regularColumn("a", BIGINT()),
-             })
-             .remainingFilter("length(ds) + a % 2 > 0")
-             .endTableScan()
-             .planNode();
-  testSerde(plan);
+  {
+    auto plan =
+        PlanBuilder()
+            .startTableScan()
+            .outputType(ROW({"x"}, {BIGINT()}))
+            .assignments(
+                {{"x", HiveConnectorTestBase::regularColumn("a", BIGINT())}})
+            .dataColumns(ROW({"a", "b"}, {BIGINT(), BIGINT()}))
+            .filterColumnHandles({
+                HiveConnectorTestBase::partitionKey("ds", VARCHAR()),
+                HiveConnectorTestBase::regularColumn("a", BIGINT()),
+            })
+            .remainingFilter("length(ds) + a % 2 > 0")
+            .endTableScan()
+            .planNode();
+    testSerde(plan);
+  }
+
+  {
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .outputType(ROW({"x"}, {BIGINT()}))
+                    .sampleRate(0.5)
+                    .endTableScan()
+                    .planNode();
+    testSerde(plan);
+  }
 }
 
 TEST_F(PlanNodeSerdeTest, topNRowNumber) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -246,6 +246,11 @@ PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::remainingFilter(
   return *this;
 }
 
+PlanBuilder::TableScanBuilder& PlanBuilder::TableScanBuilder::sampleRate(
+    double sampleRate) {
+  sampleRate_ = sampleRate;
+  return *this;
+}
 namespace {
 void addConjunct(
     const core::TypedExprPtr& conjunct,

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -296,6 +296,8 @@ class PlanBuilder {
     /// AND'ed with all the subfieldFilters.
     TableScanBuilder& remainingFilter(std::string remainingFilter);
 
+    TableScanBuilder& sampleRate(double sampleRate);
+
     /// @param dataColumns can be different from 'outputType' for the purposes
     /// of testing queries using missing columns. It is used, if specified, for
     /// parseExpr call and as 'dataColumns' for the TableHandle. You supply more
@@ -353,6 +355,7 @@ class PlanBuilder {
     std::string connectorId_{kHiveDefaultConnectorId};
     RowTypePtr outputType_;
     core::ExprPtr remainingFilter_;
+    double sampleRate_{1.0};
     RowTypePtr dataColumns_;
     std::vector<connector::hive::HiveColumnHandlePtr> filterColumnHandles_;
     std::unordered_map<std::string, std::string> columnAliases_;


### PR DESCRIPTION
Summary: Axiom optimizer will be able to parse the filter on top of scan to extract not only comparisons of subfields with constants, but also sampling rate (rand() < k). We need a place to store that in the HiveTableHandle.

Differential Revision: D86423635


