### PR TITLE
feat: Report number of lookups to the AsyncDataCache

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -162,6 +162,9 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricMemoryCacheSumEvictScore, facebook::velox::StatType::SUM);
 
+  // Number of lookups since last counter retrieval.
+  DEFINE_METRIC(kMetricMemoryCacheNumLookups, facebook::velox::StatType::SUM);
+
   // Number of hits (saved IO) since last counter retrieval. The first hit to a
   // prefetched entry does not count.
   DEFINE_METRIC(kMetricMemoryCacheNumHits, facebook::velox::StatType::SUM);

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -220,6 +220,9 @@ constexpr std::string_view kMetricMemoryCacheTotalPrefetchBytes{
 constexpr std::string_view kMetricMemoryCacheSumEvictScore{
     "velox.memory_cache_sum_evict_score"};
 
+constexpr std::string_view kMetricMemoryCacheNumLookups{
+    "velox.memory_cache_num_lookups"};
+
 constexpr std::string_view kMetricMemoryCacheNumHits{
     "velox.memory_cache_num_hits"};
 

--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -162,6 +162,7 @@ void PeriodicStatsReporter::reportCacheStats() {
   // Memory cache cumulative stats.
   const auto deltaCacheStats = cacheStats - lastCacheStats_;
 
+  REPORT_IF_NOT_ZERO(kMetricMemoryCacheNumLookups, deltaCacheStats.numLookup);
   REPORT_IF_NOT_ZERO(kMetricMemoryCacheNumHits, deltaCacheStats.numHit);
   REPORT_IF_NOT_ZERO(kMetricMemoryCacheHitBytes, deltaCacheStats.hitBytes);
   REPORT_IF_NOT_ZERO(kMetricMemoryCacheNumNew, deltaCacheStats.numNew);

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -462,6 +462,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(
         counterMap.count(std::string(kMetricMemoryAllocatorTotalUsedBytes)), 1);
     // Check deltas are not reported
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumLookups)), 0);
     ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumHits)), 0);
     ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheHitBytes)), 0);
     ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumNew)), 0);
@@ -542,7 +543,8 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   newSsdStats->readWithoutChecksumChecks = 10;
   newSsdStats->entriesRecovered = 10;
   cache.updateStats(
-      {.numHit = 10,
+      {.numLookup = 10,
+       .numHit = 10,
        .hitBytes = 10,
        .numNew = 10,
        .numEvict = 10,
@@ -565,6 +567,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   // Check delta stats are reported
   {
     std::lock_guard<std::mutex> l(reporter_->m);
+    ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumLookups)), 1);
     ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumHits)), 1);
     ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheHitBytes)), 1);
     ASSERT_EQ(counterMap.count(std::string(kMetricMemoryCacheNumNew)), 1);
@@ -614,7 +617,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
         counterMap.count(std::string(kMetricSsdCacheRecoveredEntries)), 1);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricSsdCacheReadWithoutChecksum)), 1);
-    ASSERT_EQ(counterMap.size(), 58);
+    ASSERT_EQ(counterMap.size(), 59);
   }
 }
 

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -679,6 +679,7 @@ void CacheShard::updateStats(CacheStats& stats) {
     ++stats.numEntries;
     entry->updateDataStats(stats);
   }
+  stats.numLookup += eventCounter_;
   stats.numHit += numHit_;
   stats.hitBytes += hitBytes_;
   stats.numNew += numNew_;
@@ -775,6 +776,7 @@ bool CacheShard::removeFileEntries(
 
 CacheStats CacheStats::operator-(const CacheStats& other) const {
   CacheStats result;
+  result.numLookup = numLookup - other.numLookup;
   result.numHit = numHit - other.numHit;
   result.hitBytes = hitBytes - other.hitBytes;
   result.numNew = numNew - other.numNew;

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -574,6 +574,8 @@ struct CacheStats {
 
   /// ============= Cumulative stats =============
 
+  /// Number of lookups.
+  int64_t numLookup{0};
   /// Number of hits (saved IO). The first hit to a prefetched entry does not
   /// count.
   int64_t numHit{0};

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -330,6 +330,9 @@ Cache
      - Sum
      - Sum of scores of evicted entries. This serves to infer an average lifetime
        for entries in cache.
+   * - memory_cache_num_lookups
+     - Sum
+     - Number of lookups since last counter retrieval.
    * - memory_cache_num_hits
      - Sum
      - Number of hits (saved IO) since last counter retrieval. The first hit to a


### PR DESCRIPTION
Add runtime stats for number of lookups to the AsyncDataCache.

This is to track the total number of lookups to the memory cache. Currently, the existing metrics (memory_cache_num_hits + memory_cache_num_new) would not accurately track this due to memory_cache_num_hits only being incremented after the first entry access.

https://github.com/facebookincubator/velox/blob/main/velox/docs/monitoring/metrics.rst?plain=1#L335 https://github.com/facebookincubator/velox/blob/main/velox/common/caching/AsyncDataCache.cpp#L192