### PR TITLE
fix: Fix hash probe caused stuck driver issue

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1176,6 +1176,13 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
     numOut = evalFilter(numOut);
 
     if (numOut == 0) {
+      // The hash probe might get stuck in the output loop if the filter is
+      // highly selective. This does not apply if the call is made during
+      // spilling, because we cannot break out and resume when the operator is
+      // undergoing spilling.
+      if (!toSpillOutput && shouldYield()) {
+        return nullptr;
+      }
       continue;
     }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -8307,5 +8307,191 @@ TEST_F(HashJoinTest, arrayBasedLookupCustomComparisonType) {
   EXPECT_EQ(result->size(), 1'024);
 }
 
+DEBUG_ONLY_TEST_F(
+    HashJoinTest,
+    hashProbeShouldYieldWhenFilterConsistentlyRejectAll) {
+  const uint32_t kProbeSize = 100;
+  const uint32_t kBuildSize = 10'000;
+  const uint64_t kDriverCpuTimeSliceLimitMs = 1'000;
+  const std::string kLargeBatchSize =
+      folly::to<std::string>(kProbeSize * kBuildSize);
+
+  struct {
+    uint32_t numGetOutputCalls;
+    bool hasDelay;
+    std::string debugString() const {
+      return fmt::format(
+          "numGetOutputCalls: {}, hasDelay: {}", numGetOutputCalls, hasDelay);
+    }
+  } testSettings[] = {{0, false}, {0, true}};
+
+  // Create probe data with keys 0-99 and an additional filter column
+  const auto probeData = makeRowVector(
+      {"t_k1", "t_filter"},
+      {
+          makeFlatVector<int32_t>(kProbeSize, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              kProbeSize,
+              [](/*row=*/auto) { return 1; }), // All rows have value 1
+      });
+
+  const auto buildData = makeRowVector(
+      {"u_k1"},
+      {
+          makeFlatVector<int32_t>(kBuildSize, [](auto row) { return row; }),
+      });
+
+  createDuckDbTable("t", {probeData});
+  createDuckDbTable("u", {buildData});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeData})
+          .hashJoin(
+              {"t_k1"},
+              {"u_k1"},
+              PlanBuilder(planNodeIdGenerator).values({buildData}).planNode(),
+              // Filter that DOES find join matches but then rejects all of them
+              // This ensures numOut > 0 after listJoinResults, but == 0 after
+              // evalFilter All probe rows have t_filter=1, so the condition
+              // t_filter > 100000 rejects all
+              "t_filter > 100000",
+              {"t_k1", "u_k1"},
+              core::JoinType::kInner)
+          .planNode();
+
+  for (auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    std::atomic_int hashProbeGetOutputCalls{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::getOutput",
+        std::function<void(Operator*)>([&](Operator* op) {
+          if (op->operatorType() == "HashProbe") {
+            // Inject delay on the 2nd getOutput call when hasDelay is true
+            // This simulates the scenario where:
+            // 1. First getOutput: Probe data added via addInput
+            // 2. Second getOutput: Join finds matches, filter rejects all
+            //    During this call, we inject delay INSIDE the processing
+            //    to simulate CPU-intensive work in the loop
+            if (hashProbeGetOutputCalls.fetch_add(1) == 1 &&
+                testData.hasDelay) {
+              std::this_thread::sleep_for(
+                  std::chrono::milliseconds(2 * kDriverCpuTimeSliceLimitMs));
+            }
+          }
+        }));
+
+    auto queryCtx = core::QueryCtx::create(
+        executor_.get(),
+        core::QueryConfig({
+            {core::QueryConfig::kDriverCpuTimeSliceLimitMs,
+             folly::to<std::string>(kDriverCpuTimeSliceLimitMs)},
+            {core::QueryConfig::kPreferredOutputBatchRows, kLargeBatchSize},
+        }));
+
+    AssertQueryBuilder(planNode, duckDbQueryRunner_)
+        .queryCtx(queryCtx)
+        .maxDrivers(1)
+        .assertResults(
+            "SELECT t_k1, u_k1 FROM t, u WHERE t_k1 = u_k1 AND t_filter > 100000");
+    testData.numGetOutputCalls = hashProbeGetOutputCalls.load();
+  }
+  ASSERT_LT(
+      testSettings[0].numGetOutputCalls, testSettings[1].numGetOutputCalls);
+}
+
+// This test validates that when spillOutput() is running (toSpillOutput=true),
+// the operator should NOT yield even when shouldYield() returns true. This is
+// critical because yielding during spillOutput would break the spilling loop.
+DEBUG_ONLY_TEST_F(
+    HashJoinTest,
+    spillOutputShouldNotYieldWhenFilterConsistentlyRejectAll) {
+  const uint32_t kProbeSize = 100;
+  const uint32_t kBuildSize = 10'000;
+  const uint64_t driverCpuTimeSliceLimitMs = 1'000;
+  const std::string largeBatchSize =
+      folly::to<std::string>(kProbeSize * kBuildSize);
+
+  // Create probe data with keys 0-99 and an additional filter column
+  const auto probeData = makeRowVector(
+      {"t_k1", "t_filter"},
+      {
+          makeFlatVector<int32_t>(kProbeSize, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              kProbeSize,
+              [](/*row=*/auto) { return 1; }), // All rows have value 1
+      });
+
+  const auto buildData = makeRowVector(
+      {"u_k1"},
+      {
+          makeFlatVector<int32_t>(kBuildSize, [](auto row) { return row; }),
+      });
+
+  createDuckDbTable("t", {probeData});
+  createDuckDbTable("u", {buildData});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto planNode =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeData})
+          .hashJoin(
+              {"t_k1"},
+              {"u_k1"},
+              PlanBuilder(planNodeIdGenerator).values({buildData}).planNode(),
+              // Filter that DOES find join matches but then rejects all of them
+              // This ensures numOut > 0 after listJoinResults, but == 0 after
+              // evalFilter. All probe rows have t_filter=1, so the condition
+              // t_filter > 100000 rejects all
+              "t_filter > 100000",
+              {"t_k1", "u_k1"},
+              core::JoinType::kInner)
+          .planNode();
+
+  std::atomic_bool spillTriggered{false};
+  ::facebook ::velox ::common ::testutil ::ScopedTestValue _scopedTestValue5200(
+      "facebook::velox::exec::Driver::runInternal::getOutput",
+      std::function<void(Operator*)>([&](Operator* op) {
+        if (spillTriggered.load() || op->operatorType() != "HashProbe" ||
+            !op->testingHasInput()) {
+          return;
+        }
+        spillTriggered = true;
+        testingRunArbitration(op->pool());
+      }));
+
+  // We inject delay in reclaim to trigger shouldYield().
+  // The test verifies that the query completes successfully despite
+  // shouldYield() returning true, which would only happen if the
+  // !toSpillOutput check prevents early return.
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::HashProbe::reclaim",
+      std::function<void(HashProbe*)>([&](HashProbe* probe) {
+        if (!spillTriggered.load()) {
+          return;
+        }
+        // Inject delay once to trigger shouldYield()
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(2 * driverCpuTimeSliceLimitMs));
+      }));
+
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  AssertQueryBuilder(planNode, duckDbQueryRunner_)
+      .queryCtx(core::QueryCtx::create(driverExecutor_.get()))
+      .maxDrivers(1)
+      .spillDirectory(spillDirectory->getPath())
+      .config(core::QueryConfig::kSpillEnabled, true)
+      .config(core::QueryConfig::kJoinSpillEnabled, true)
+      .config(core::QueryConfig::kSpillStartPartitionBit, 29)
+      .config(
+          core::QueryConfig::kDriverCpuTimeSliceLimitMs,
+          driverCpuTimeSliceLimitMs)
+      .config(core::QueryConfig::kPreferredOutputBatchRows, largeBatchSize)
+      .assertResults(
+          "SELECT t_k1, u_k1 FROM t, u WHERE t_k1 = u_k1 AND t_filter > 100000");
+
+  ASSERT_TRUE(spillTriggered.load());
+}
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
This is a forward fix on the previous revert https://github.com/facebookincubator/velox/pull/15428

The fix makes sure that during spilling, we don't yield in the getOutputInternal() as it is unnecessary.

Differential Revision: D86478196


