### PR TITLE
Fix int128 serde

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -682,7 +682,9 @@ folly::dynamic Variant::serialize() const {
       break;
     }
     case TypeKind::HUGEINT: {
-      objValue = value<TypeKind::HUGEINT>();
+      auto& val = value<TypeKind::HUGEINT>();
+      const std::string str(reinterpret_cast<const char*>(&val), sizeof(val));
+      objValue = encoding::Base64::encode(str);
       break;
     }
     case TypeKind::BOOLEAN: {
@@ -787,8 +789,11 @@ Variant Variant::create(const folly::dynamic& variantobj) {
       return Variant::create<TypeKind::INTEGER>(obj.asInt());
     case TypeKind::BIGINT:
       return Variant::create<TypeKind::BIGINT>(obj.asInt());
-    case TypeKind::HUGEINT:
-      return Variant::create<TypeKind::HUGEINT>(obj.asInt());
+    case TypeKind::HUGEINT: {
+      auto str = encoding::Base64::decode(obj.asString());
+      auto result = *reinterpret_cast<int128_t*>(str.data());
+      return Variant::create<TypeKind::HUGEINT>(result);
+    }
     case TypeKind::BOOLEAN: {
       return Variant(obj.asBool());
     }

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -381,6 +381,7 @@ TEST(VariantTest, serialize) {
   testSerDe(Variant(static_cast<int16_t>(1234)));
   testSerDe(Variant(static_cast<int32_t>(12345)));
   testSerDe(Variant(static_cast<int64_t>(1234567)));
+  testSerDe(Variant(static_cast<int128_t>(12345678901234567890ULL) * 1234ULL));
   testSerDe(Variant(static_cast<float>(1.2f)));
   testSerDe(Variant(static_cast<double>(1.234)));
   testSerDe(Variant("This is a test."));


### PR DESCRIPTION
In our use cases, we need to serialize/deserialize 128 bit decimals which don't fit in 64 bits. But the current serde approach just treat int128 as int64 which doesn't work when there are more than 64 significant bits. Instead, int128 is treated as binary in this PR, which works for both `folly::dynamic` and JSON.