### PR TITLE
refactor: Use const_iterator

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -247,10 +247,10 @@ class CallTypedExpr : public ITypedExpr {
       return false;
     }
     return std::equal(
-        this->inputs().begin(),
-        this->inputs().end(),
-        other.inputs().begin(),
-        other.inputs().end(),
+        this->inputs().cbegin(),
+        this->inputs().cend(),
+        other.inputs().cbegin(),
+        other.inputs().cend(),
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
 
@@ -316,10 +316,10 @@ class FieldAccessTypedExpr : public ITypedExpr {
       return false;
     }
     return std::equal(
-        this->inputs().begin(),
-        this->inputs().end(),
-        other.inputs().begin(),
-        other.inputs().end(),
+        this->inputs().cbegin(),
+        this->inputs().cend(),
+        other.inputs().cbegin(),
+        other.inputs().cend(),
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
 
@@ -396,10 +396,10 @@ class DereferenceTypedExpr : public ITypedExpr {
       return false;
     }
     return std::equal(
-        this->inputs().begin(),
-        this->inputs().end(),
-        other.inputs().begin(),
-        other.inputs().end(),
+        this->inputs().cbegin(),
+        this->inputs().cend(),
+        other.inputs().cbegin(),
+        other.inputs().cend(),
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
 
@@ -451,10 +451,10 @@ class ConcatTypedExpr : public ITypedExpr {
       return false;
     }
     return std::equal(
-        this->inputs().begin(),
-        this->inputs().end(),
-        other.inputs().begin(),
-        other.inputs().end(),
+        this->inputs().cbegin(),
+        this->inputs().cend(),
+        other.inputs().cbegin(),
+        other.inputs().cend(),
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
 

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1138,7 +1138,7 @@ std::vector<std::string> allNames(
     const std::vector<std::string>& names,
     const std::vector<std::string>& moreNames) {
   auto result = names;
-  result.insert(result.end(), moreNames.begin(), moreNames.end());
+  result.insert(result.cend(), moreNames.cbegin(), moreNames.cend());
   return result;
 }
 
@@ -1150,7 +1150,7 @@ std::vector<TypedExprPtr> flattenExprs(
     const PlanNodePtr& input) {
   std::vector<TypedExprPtr> result;
   for (auto& group : exprs) {
-    result.insert(result.end(), group.begin(), group.end());
+    result.insert(result.cend(), group.cbegin(), group.cend());
   }
 
   const auto& sourceType = input->outputType();
@@ -2502,7 +2502,7 @@ const char* TopNRowNumberNode::rankFunctionName(
   static const auto kFunctionNames = rankFunctionNames();
   auto it = kFunctionNames.find(function);
   VELOX_CHECK(
-      it != kFunctionNames.end(),
+      it != kFunctionNames.cend(),
       "Invalid rank function {}",
       static_cast<int>(function));
   return it->second.c_str();
@@ -2513,7 +2513,7 @@ TopNRowNumberNode::RankFunction TopNRowNumberNode::rankFunctionFromName(
     std::string_view name) {
   static const auto kFunctionNames = invertMap(rankFunctionNames());
   auto it = kFunctionNames.find(name.data());
-  VELOX_CHECK(it != kFunctionNames.end(), "Invalid rank function {}", name);
+  VELOX_CHECK(it != kFunctionNames.cend(), "Invalid rank function {}", name);
   return it->second;
 }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1301,10 +1301,10 @@ class AggregationNode : public PlanNode {
   bool isPreGrouped() const {
     return !preGroupedKeys_.empty() &&
         std::equal(
-            preGroupedKeys_.begin(),
-            preGroupedKeys_.end(),
-            groupingKeys_.begin(),
-            groupingKeys_.end(),
+            preGroupedKeys_.cbegin(),
+            preGroupedKeys_.cend(),
+            groupingKeys_.cbegin(),
+            groupingKeys_.cend(),
             [](const FieldAccessTypedExprPtr& x,
                const FieldAccessTypedExprPtr& y) -> bool {
               return (*x == *y);

--- a/velox/dwio/common/DataBufferHolder.cpp
+++ b/velox/dwio/common/DataBufferHolder.cpp
@@ -38,7 +38,7 @@ void DataBufferHolder::take(const std::vector<std::string_view>& buffers) {
   auto* data = buf.data();
   for (auto& buffer : buffers) {
     const auto size = buffer.size();
-    ::memcpy(data, buffer.begin(), size);
+    ::memcpy(data, buffer.cbegin(), size);
     data += size;
   }
   // If possibly, write content of the data to output immediately. Otherwise,

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -235,7 +235,7 @@ std::shared_ptr<DirectCoalescedLoad> DirectBufferedInput::coalescedLoad(
   return streamToCoalescedLoad_.withWLock(
       [&](auto& loads) -> std::shared_ptr<DirectCoalescedLoad> {
         auto it = loads.find(stream);
-        if (it == loads.end()) {
+        if (it == loads.cend()) {
           return nullptr;
         }
         auto load = std::move(it->second);
@@ -343,7 +343,7 @@ int32_t DirectCoalescedLoad::getData(
       requests_.begin(), requests_.end(), offset, [](auto& x, auto offset) {
         return x.region.offset < offset;
       });
-  if (it == requests_.end() || it->region.offset != offset) {
+  if (it == requests_.cend() || it->region.offset != offset) {
     return 0;
   }
   data = std::move(it->data);

--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -71,9 +71,10 @@ class DirectCoalescedLoad : public cache::CoalescedLoad {
         pool_(pool) {
     VELOX_DCHECK_NOT_NULL(pool_);
     VELOX_DCHECK(
-        std::is_sorted(requests.begin(), requests.end(), [](auto* x, auto* y) {
-          return x->region.offset < y->region.offset;
-        }));
+        std::is_sorted(
+            requests.cbegin(), requests.cend(), [](auto* x, auto* y) {
+              return x->region.offset < y->region.offset;
+            }));
     requests_.reserve(requests.size());
     for (auto i = 0; i < requests.size(); ++i) {
       requests_.push_back(std::move(*requests[i]));

--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -236,14 +236,14 @@ KeyPredicate<T> prepareKeyPredicate(std::string_view expression) {
   // You cannot mix allow key and reject key.
   VELOX_CHECK(
       modes.empty() ||
-      std::all_of(modes.begin(), modes.end(), [&modes](const auto& v) {
+      std::all_of(modes.cbegin(), modes.cend(), [&modes](const auto& v) {
         return v == modes.front();
       }));
 
   auto mode = modes.empty() ? KeyProjectionMode::ALLOW : modes.front();
 
   return KeyPredicate<T>(
-      mode, typename KeyPredicate<T>::Lookup(keys.begin(), keys.end()));
+      mode, typename KeyPredicate<T>::Lookup(keys.cbegin(), keys.cend()));
 }
 
 } // namespace facebook::velox::dwio::common::flatmap

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -312,8 +312,8 @@ class RowReaderOptions {
           flatmapNodeIdsAsStruct) {
     VELOX_CHECK(
         std::all_of(
-            flatmapNodeIdsAsStruct.begin(),
-            flatmapNodeIdsAsStruct.end(),
+            flatmapNodeIdsAsStruct.cbegin(),
+            flatmapNodeIdsAsStruct.cend(),
             [](const auto& kv) { return !kv.second.empty(); }),
         "To use struct encoding for flatmap, keys to project must be specified");
     flatmapNodeIdAsStruct_ = std::move(flatmapNodeIdsAsStruct);

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -104,8 +104,8 @@ uint64_t ScanSpec::newRead() {
   if (numReads_ == 0 ||
       (!disableStatsBasedFilterReorder_ &&
        !std::is_sorted(
-           children_.begin(),
-           children_.end(),
+           children_.cbegin(),
+           children_.cend(),
            [this](
                const std::shared_ptr<ScanSpec>& left,
                const std::shared_ptr<ScanSpec>& right) {

--- a/velox/dwio/common/StreamUtil.h
+++ b/velox/dwio/common/StreamUtil.h
@@ -144,7 +144,7 @@ inline void readContiguous(
 
 // Returns the number of elements in rows that are < limit.
 inline int32_t numBelow(folly::Range<const int32_t*> rows, int32_t limit) {
-  return std::lower_bound(rows.begin(), rows.end(), limit) - rows.begin();
+  return std::lower_bound(rows.cbegin(), rows.cend(), limit) - rows.cbegin();
 }
 
 template <typename T, typename SingleValue, typename SparseRange>

--- a/velox/dwio/common/encryption/TestProvider.h
+++ b/velox/dwio/common/encryption/TestProvider.h
@@ -40,7 +40,7 @@ class TestEncryption {
 
   std::unique_ptr<folly::IOBuf> decrypt(std::string_view input) const {
     ++count_;
-    std::string key{input.begin(), key_.size()};
+    std::string key{input.cbegin(), key_.size()};
     DWIO_ENSURE_EQ(key_, key);
     auto decoded = velox::encoding::Base64::decodeUrl(
         std::string_view{

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -168,7 +168,7 @@ void E2EFilterTestBase::readWithFilter(
   auto resultBatch = BaseVector::create(rowType_, 1, leafPool_.get());
   resetReadBatchSizes();
   int32_t clearCnt = 0;
-  auto deletedRowsIter = mutationSpec.deletedRows.begin();
+  auto deletedRowsIter = mutationSpec.deletedRows.cbegin();
   while (true) {
     {
       MicrosecondTimer timer(&time);
@@ -182,7 +182,7 @@ void E2EFilterTestBase::readWithFilter(
       auto readSize = rowReader->nextReadSize(nextReadBatchSize());
       std::vector<uint64_t> isDeleted(bits::nwords(readSize));
       bool haveDelete = false;
-      for (; deletedRowsIter != mutationSpec.deletedRows.end();
+      for (; deletedRowsIter != mutationSpec.deletedRows.cend();
            ++deletedRowsIter) {
         auto i = *deletedRowsIter;
         if (i < nextRowNumber) {

--- a/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
+++ b/velox/dwio/common/tests/utils/UnitLoaderTestTools.h
@@ -87,7 +87,7 @@ class ReaderMock {
   void seek(uint64_t rowNumber);
 
   std::vector<bool> unitsLoaded() const {
-    return {unitsLoaded_.begin(), unitsLoaded_.end()};
+    return {unitsLoaded_.cbegin(), unitsLoaded_.cend()};
   }
 
  private:

--- a/velox/dwio/dwrf/common/RLEv1.h
+++ b/velox/dwio/dwrf/common/RLEv1.h
@@ -417,7 +417,7 @@ class RleDecoderV1 : public dwio::common::IntDecoder<isSigned> {
         rows + rowIndex,
         std::min<int32_t>(remainingValues_, numRows - rowIndex));
     const auto endOfRun = currentRow + remainingValues_;
-    const auto bound = std::lower_bound(range.begin(), range.end(), endOfRun);
+    const auto bound = std::lower_bound(range.cbegin(), range.cend(), endOfRun);
     return std::make_pair(bound - range.begin(), bound[-1] - currentRow + 1);
   }
 

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1311,7 +1311,7 @@ void StringDictionaryColumnReader::loadStrideDictionary() {
   if (strideDictCount_ > 0) {
     // seek stride dictionary related streams
     std::vector<uint64_t> pos(
-        positions.begin() + positionOffset_, positions.end());
+        positions.cbegin() + positionOffset_, positions.cend());
     dwio::common::PositionProvider pp(pos);
     strideDictStream_->seekToPosition(pp);
     strideDictLengthDecoder_->seekToRowGroup(pp);

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -100,7 +100,7 @@ class DwrfData : public dwio::common::FormatData {
   static std::vector<uint64_t> toPositionsInner(
       const proto::RowIndexEntry& entry) {
     return std::vector<uint64_t>(
-        entry.positions().begin(), entry.positions().end());
+        entry.positions().cbegin(), entry.positions().cend());
   }
 
   memory::MemoryPool& memoryPool_;

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -156,7 +156,7 @@ void SelectiveStringDictionaryColumnReader::loadStrideDictionary() {
   if (scanState_.dictionary2.numValues > 0) {
     // seek stride dictionary related streams
     std::vector<uint64_t> pos(
-        positions.begin() + positionOffset_, positions.end());
+        positions.cbegin() + positionOffset_, positions.cend());
     PositionProvider pp(pos);
     strideDictStream_->seekToPosition(pp);
     strideDictLengthDecoder_->seekToRowGroup(pp);

--- a/velox/dwio/dwrf/reader/StripeMetadataCache.h
+++ b/velox/dwio/dwrf/reader/StripeMetadataCache.h
@@ -95,7 +95,7 @@ class StripeMetadataCache {
     std::vector<uint32_t> offsets;
     offsets.reserve(footer.stripeCacheOffsetsSize());
     const auto& from = footer.stripeCacheOffsets();
-    offsets.assign(from.begin(), from.end());
+    offsets.assign(from.cbegin(), from.cend());
     return offsets;
   }
 

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -213,7 +213,7 @@ VectorPtr populateBatch(
   auto valuesPtr = values->asMutableRange<T>();
 
   const size_t nulloptCount =
-      std::count(data.begin(), data.end(), std::nullopt);
+      std::count(data.cbegin(), data.cend(), std::nullopt);
   if (nulloptCount == 0) {
     size_t index = 0;
     for (auto val : data) {

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -73,11 +73,11 @@ class ValueTypes {
   }
 
   auto begin() const {
-    return values_.begin();
+    return values_.cbegin();
   }
 
   auto end() const {
-    return values_.end();
+    return values_.cend();
   }
 
   const std::shared_ptr<folly::Executor>& decodingExecutor() const {

--- a/velox/dwio/dwrf/test/EncodingManagerTests.cpp
+++ b/velox/dwio/dwrf/test/EncodingManagerTests.cpp
@@ -34,10 +34,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().begin(),
-        footer.encoding().end()};
-    EXPECT_EQ(footer.encoding().begin(), iter.current_);
-    EXPECT_EQ(footer.encoding().end(), iter.currentEnd_);
+        footer.encoding().cbegin(),
+        footer.encoding().cend()};
+    EXPECT_EQ(footer.encoding().cbegin(), iter.current_);
+    EXPECT_EQ(footer.encoding().cend(), iter.currentEnd_);
   }
   {
     // A valid end iterator.
@@ -45,10 +45,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().end(),
-        footer.encoding().end()};
-    EXPECT_EQ(footer.encoding().end(), iter.current_);
-    EXPECT_EQ(footer.encoding().end(), iter.currentEnd_);
+        footer.encoding().cend(),
+        footer.encoding().cend()};
+    EXPECT_EQ(footer.encoding().cend(), iter.current_);
+    EXPECT_EQ(footer.encoding().cend(), iter.currentEnd_);
   }
   footer.add_encoding();
   // footer [e]
@@ -58,10 +58,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().begin(),
-        footer.encoding().end()};
-    EXPECT_EQ(footer.encoding().begin(), iter.current_);
-    EXPECT_EQ(footer.encoding().end(), iter.currentEnd_);
+        footer.encoding().cbegin(),
+        footer.encoding().cend()};
+    EXPECT_EQ(footer.encoding().cbegin(), iter.current_);
+    EXPECT_EQ(footer.encoding().cend(), iter.currentEnd_);
   }
   {
     // A valid end iterator.
@@ -69,10 +69,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().end(),
-        footer.encoding().end()};
-    EXPECT_EQ(footer.encoding().end(), iter.current_);
-    EXPECT_EQ(footer.encoding().end(), iter.currentEnd_);
+        footer.encoding().cend(),
+        footer.encoding().cend()};
+    EXPECT_EQ(footer.encoding().cend(), iter.current_);
+    EXPECT_EQ(footer.encoding().cend(), iter.currentEnd_);
   }
   proto::StripeEncryptionGroup group1;
   proto::StripeEncryptionGroup group2;
@@ -85,10 +85,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().begin(),
-        footer.encoding().end()};
-    EXPECT_EQ(footer.encoding().begin(), iter.current_);
-    EXPECT_EQ(footer.encoding().end(), iter.currentEnd_);
+        footer.encoding().cbegin(),
+        footer.encoding().cend()};
+    EXPECT_EQ(footer.encoding().cbegin(), iter.current_);
+    EXPECT_EQ(footer.encoding().cend(), iter.currentEnd_);
   }
   {
     // A valid end iterator.
@@ -96,10 +96,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         1,
-        encryptionGroups.at(1).encoding().end(),
-        encryptionGroups.at(1).encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        encryptionGroups.at(1).encoding().cend(),
+        encryptionGroups.at(1).encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   {
     // An adjusted end iterator.
@@ -107,10 +107,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().end(),
-        footer.encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        footer.encoding().cend(),
+        footer.encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   encryptionGroups[1].add_encoding();
   // footer [e]
@@ -120,10 +120,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().begin(),
-        footer.encoding().end()};
-    EXPECT_EQ(footer.encoding().begin(), iter.current_);
-    EXPECT_EQ(footer.encoding().end(), iter.currentEnd_);
+        footer.encoding().cbegin(),
+        footer.encoding().cend()};
+    EXPECT_EQ(footer.encoding().cbegin(), iter.current_);
+    EXPECT_EQ(footer.encoding().cend(), iter.currentEnd_);
   }
   {
     // An adjusted iterator.
@@ -131,10 +131,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().end(),
-        footer.encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().begin(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        footer.encoding().cend(),
+        footer.encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cbegin(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   {
     // An adjusted iterator.
@@ -142,10 +142,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         0,
-        encryptionGroups.at(0).encoding().begin(),
-        encryptionGroups.at(0).encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().begin(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        encryptionGroups.at(0).encoding().cbegin(),
+        encryptionGroups.at(0).encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cbegin(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   {
     // A valid end iterator.
@@ -153,10 +153,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         1,
-        encryptionGroups.at(1).encoding().end(),
-        encryptionGroups.at(1).encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        encryptionGroups.at(1).encoding().cend(),
+        encryptionGroups.at(1).encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   footer.Clear();
   // footer []
@@ -167,10 +167,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().begin(),
-        footer.encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().begin(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        footer.encoding().cbegin(),
+        footer.encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cbegin(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   {
     // An adjusted iterator further back.
@@ -178,10 +178,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().end(),
-        footer.encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().begin(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        footer.encoding().cend(),
+        footer.encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cbegin(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   encryptionGroups.at(1).Clear();
   // footer []
@@ -192,10 +192,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         0,
-        encryptionGroups.at(0).encoding().end(),
-        encryptionGroups.at(0).encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        encryptionGroups.at(0).encoding().cend(),
+        encryptionGroups.at(0).encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
   {
     // An adjusted end iterator further back.
@@ -203,10 +203,10 @@ TEST(TestEncodingIter, Ctor) {
         footer,
         encryptionGroups,
         -1,
-        footer.encoding().end(),
-        footer.encoding().end()};
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.current_);
-    EXPECT_EQ(encryptionGroups.at(1).encoding().end(), iter.currentEnd_);
+        footer.encoding().cend(),
+        footer.encoding().cend()};
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.current_);
+    EXPECT_EQ(encryptionGroups.at(1).encoding().cend(), iter.currentEnd_);
   }
 }
 
@@ -227,15 +227,15 @@ TEST(TestEncodingIter, EncodingIterBeginAndEnd) {
       footer,
       encryptionGroups,
       -1,
-      footer.encoding().begin(),
-      footer.encoding().end()};
+      footer.encoding().cbegin(),
+      footer.encoding().cend()};
   EXPECT_EQ(begin, EncodingIter::begin(footer, encryptionGroups));
   EncodingIter end{
       footer,
       encryptionGroups,
       1,
-      encryptionGroups.at(1).encoding().end(),
-      encryptionGroups.at(1).encoding().end()};
+      encryptionGroups.at(1).encoding().cend(),
+      encryptionGroups.at(1).encoding().cend()};
   EXPECT_EQ(end, EncodingIter::end(footer, encryptionGroups));
 }
 

--- a/velox/dwio/dwrf/test/IndexBuilderTests.cpp
+++ b/velox/dwio/dwrf/test/IndexBuilderTests.cpp
@@ -35,7 +35,7 @@ class IndexBuilderTest : public testing::Test {
       IndexBuilder& builder,
       size_t index) {
     auto& positions = builder.getEntry(index).positions();
-    return std::vector<uint64_t>{positions.begin(), positions.end()};
+    return std::vector<uint64_t>{positions.cbegin(), positions.cend()};
   }
 
   StatisticsBuilderOptions options_{16};

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -1116,7 +1116,7 @@ TEST_F(TestSeek, uncompressedLarge) {
       entry.getCompressed()[i] = static_cast<char>(i);
     }
     written += runSize + kHeaderSize;
-    data.insert(data.end(), entry.data().begin(), entry.data().end());
+    data.insert(data.end(), entry.data().cbegin(), entry.data().cend());
   }
   auto stream = createTestDecompressor(
       CompressionKind_SNAPPY,

--- a/velox/dwio/dwrf/test/TestDwrfColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestDwrfColumnStatistics.cpp
@@ -195,12 +195,12 @@ void checkEntries(
   for (const auto& entry : entries) {
     EXPECT_NE(
         std::find_if(
-            expectedEntries.begin(),
-            expectedEntries.end(),
+            expectedEntries.cbegin(),
+            expectedEntries.cend(),
             [&](const ColumnStatistics& expectedStats) {
               return expectedStats == entry;
             }),
-        expectedEntries.end());
+        expectedEntries.cend());
   }
 }
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -51,7 +51,7 @@ class WriterContext : public CompressionBufferPool {
   ~WriterContext() override;
 
   bool hasStream(const DwrfStreamIdentifier& stream) const {
-    return streams_.find(stream) != streams_.end();
+    return streams_.find(stream) != streams_.cend();
   }
 
   const DataBufferHolder& getStream(const DwrfStreamIdentifier& stream) const {
@@ -114,7 +114,7 @@ class WriterContext : public CompressionBufferPool {
       velox::memory::MemoryPool& dictionaryPool,
       velox::memory::MemoryPool& generalPool) {
     auto result = dictEncoders_.find(encodingKey);
-    if (result == dictEncoders_.end()) {
+    if (result == dictEncoders_.cend()) {
       auto emplaceResult = dictEncoders_.emplace(
           encodingKey,
           std::make_unique<IntegerDictionaryEncoder<T>>(
@@ -232,7 +232,7 @@ class WriterContext : public CompressionBufferPool {
   void removeAllIntDictionaryEncodersOnNode(
       std::function<bool(uint32_t)> predicate) {
     auto iter = dictEncoders_.begin();
-    while (iter != dictEncoders_.end()) {
+    while (iter != dictEncoders_.cend()) {
       if (predicate(iter->first.node())) {
         iter = dictEncoders_.erase(iter);
       } else {

--- a/velox/dwio/orc/test/ReaderTest.cpp
+++ b/velox/dwio/orc/test/ReaderTest.cpp
@@ -390,8 +390,8 @@ TEST_P(
   auto rowReader = reader->createRowReader(rowReaderOptions);
 
   for (std::map<std::string, std::string>::const_iterator itr =
-           GetParam().userMeta.begin();
-       itr != GetParam().userMeta.end();
+           GetParam().userMeta.cbegin();
+       itr != GetParam().userMeta.cend();
        ++itr) {
     ASSERT_EQ(true, reader->hasMetadataValue(itr->first));
     std::string val = reader->getMetadataValue(itr->first);

--- a/velox/dwio/parquet/writer/arrow/Metadata.cpp
+++ b/velox/dwio/parquet/writer/arrow/Metadata.cpp
@@ -1746,8 +1746,8 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
         [&thrift_encodings](
             facebook::velox::parquet::thrift::Encoding::type value) {
           auto it = std::find(
-              thrift_encodings.begin(), thrift_encodings.end(), value);
-          if (it == thrift_encodings.end()) {
+              thrift_encodings.cbegin(), thrift_encodings.cend(), value);
+          if (it == thrift_encodings.cend()) {
             thrift_encodings.push_back(value);
           }
         };

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -226,7 +226,7 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
     ASSERT_EQ(this->values_, this->values_out_);
     std::vector<Encoding::type> encodings_vector = this->metadata_encodings();
     std::set<Encoding::type> encodings(
-        encodings_vector.begin(), encodings_vector.end());
+        encodings_vector.cbegin(), encodings_vector.cend());
 
     if (this->type_num() == Type::BOOLEAN) {
       // Dictionary encoding is not allowed for boolean type

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -464,7 +464,7 @@ class TestStatistics : public PrimitiveTypedTest<TestType> {
       std::vector<int16_t> definitionLevels(batchNullCount, 0);
       definitionLevels.insert(
           definitionLevels.end(), batchNumValues - batchNullCount, 1);
-      auto beg = this->values_.begin() + i * numValues / 2;
+      auto beg = this->values_.cbegin() + i * numValues / 2;
       auto end = beg + batchNumValues;
       std::vector<c_type> batch = GetDeepCopy(std::vector<c_type>(beg, end));
       c_type* batchValuesPtr = GetValuesPointer(batch);


### PR DESCRIPTION
Using cbegin() and cend() helps communicate to the reader that the iterator is not modified.
