### PR TITLE
perf: Optimize Presto's cast(string as double/float) by switching to fast_float library

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -56,6 +56,7 @@ velox_add_library(
   RowConstructor.cpp
   SimpleFunctionRegistry.cpp
   SpecialFormRegistry.cpp
+  StringToFloatParser.cpp
   ConjunctRewrite.cpp
   SwitchExpr.cpp
   TryExpr.cpp
@@ -70,8 +71,7 @@ velox_link_libraries(
   velox_expression_functions
   velox_functions_util
   velox_type_tz
-  double-conversion::double-conversion
-  Folly::folly
+  FastFloat::fast_float
 )
 
 add_subdirectory(type_calculation)

--- a/velox/expression/StringToFloatParser.cpp
+++ b/velox/expression/StringToFloatParser.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/StringToFloatParser.h"
+
+#include <cmath>
+
+#include <fast_float/fast_float.h>
+#include <folly/Likely.h>
+
+#include "velox/functions/lib/string/StringImpl.h"
+
+namespace facebook::velox {
+inline bool isAllWhitespace(const char* first, const char* last) {
+  return std::all_of(first, last, [](char c) {
+    return functions::stringImpl::isAsciiWhiteSpace(c);
+  });
+}
+
+template <typename T>
+Status parseInfinityOrNaN(const std::string_view str, T& out) {
+  const size_t length = str.length();
+  if (length == 0) {
+    return Status::Invalid("Empty input string");
+  }
+
+  size_t i = 0;
+  bool negative = false;
+
+  // Handle leading '+' or '-'
+  if (str[i] == '-') {
+    negative = true;
+    i++;
+  } else if (str[i] == '+') {
+    i++;
+  }
+
+  // Find the last non-space character
+  size_t j = length - 1;
+  while (j >= i && functions::stringImpl::isAsciiWhiteSpace(str[j])) {
+    j--;
+  }
+
+  // Extract the meaningful part (no leading/trailing spaces, no signs handled)
+  auto data = str.substr(i, j - i + 1);
+  if (data == "Infinity") {
+    out = negative ? -INFINITY : INFINITY;
+    return Status::OK();
+  }
+
+  if (data == "NaN") {
+    out = negative ? -NAN : NAN;
+    return Status::OK();
+  }
+
+  return Status::Invalid("Invalid input string: {}", str);
+}
+
+template <typename T>
+Status StringToFloatParser::parse(const std::string_view str, T& out) {
+  if (str.empty()) {
+    return Status::Invalid("Empty input string");
+  }
+
+  // move through leading whitespace characters
+  auto* end = str.end();
+  auto* begin = std::find_if_not(str.begin(), end, [](char c) {
+    return functions::stringImpl::isAsciiWhiteSpace(c);
+  });
+
+  if (begin == end) {
+    return Status::Invalid("Empty input string");
+  }
+
+  fast_float::parse_options options{
+      fast_float::chars_format::general |
+      fast_float::chars_format::allow_leading_plus |
+      fast_float::chars_format::no_infnan};
+  auto [ptr, ec] = fast_float::from_chars_advanced(begin, end, out, options);
+  auto isOutOfRange{ec == std::errc::result_out_of_range};
+  auto isOk{ec == std::errc()};
+  if ((!isOk && !isOutOfRange) || !isAllWhitespace(ptr, end)) {
+    // handle "[+/-]Infinity" "[+/-]NaN", case sensitive
+    return parseInfinityOrNaN(std::string_view(begin, end - begin), out);
+  }
+
+  return Status::OK();
+}
+
+template Status StringToFloatParser::parse<float>(
+    const std::string_view str,
+    float& out);
+template Status StringToFloatParser::parse<double>(
+    const std::string_view str,
+    double& out);
+} // namespace facebook::velox

--- a/velox/expression/StringToFloatParser.h
+++ b/velox/expression/StringToFloatParser.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Status.h"
+
+namespace facebook::velox {
+class StringToFloatParser {
+ public:
+  /// Converts a string to a double/float precision floating point value.
+  /// Returns UserError/Invalid status if the data is invalid.
+  ///
+  /// Leading and trailing whitespace characters in str are ignored.
+  /// Whitespace is removed as if by the java's String#trim method.
+  /// that is, both ASCII space and control characters are removed.
+  ///
+  /// The supported string formats is:
+  /// ([\\x00-\\x20]*                 - Optional leading whitespace.
+  /// [+-]?(                          - Optional sign character.
+  /// NaN|"                           - "NaN" string, case sensitive.
+  /// Infinity|                       - "Infinity" string, case sensitive.
+  /// (((Digits(\\.)?(Digits?)(Exp)?)|
+  /// (\\.(Digits)(Exp)?)))
+  /// [\\x00-\\x20]*)                 - Optional trailing whitespace.
+  ///
+  /// @tparam T Either float or double.
+  /// @param str A string to convert.
+  /// @param out The double/float precision value to be output.
+  template <typename T>
+  static Status parse(const std::string_view str, T& out);
+};
+} // namespace facebook::velox


### PR DESCRIPTION
Convert the underlying double-conversion library used by Presto's Cast(varchar as real/double) function to the fast_float library.

BEFORE:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_varchar_as_double_fast_float##cast_string_           123.98ms      8.07
cast_varchar_as_double_fast_float##cast_string_           133.33ms      7.50
----------------------------------------------------------------------------

```
AFTER:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_varchar_as_double_fast_float##cast_string_            46.48ms     21.52
cast_varchar_as_double_fast_float##cast_string_            51.18ms     19.54
----------------------------------------------------------------------------
```
