### PR TITLE
feat: Add support for evaluating Iceberg partition transforms

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -21,6 +21,7 @@
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/functions/iceberg/Register.h"
 
 #include <boost/lexical_cast.hpp>
 #include <memory>
@@ -42,6 +43,7 @@ HiveConnector::HiveConnector(
               : nullptr,
           std::make_unique<FileHandleGenerator>(hiveConfig_->config())),
       ioExecutor_(ioExecutor) {
+  iceberg::registerIcebergFunctions();
   if (hiveConfig_->isFileHandleCacheEnabled()) {
     LOG(INFO) << "Hive connector " << connectorId()
               << " created with maximum of "

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -19,6 +19,15 @@ velox_add_library(
   IcebergSplitReader.cpp
   PartitionSpec.cpp
   PositionalDeleteFileReader.cpp
+  TransformEvaluator.cpp
+  TransformExprBuilder.cpp
+)
+
+velox_link_libraries(
+  velox_hive_iceberg_splitreader
+  velox_connector
+  velox_functions_iceberg
+  Folly::folly
 )
 
 velox_link_libraries(velox_hive_iceberg_splitreader velox_connector Folly::folly)

--- a/velox/connectors/hive/iceberg/PartitionSpec.cpp
+++ b/velox/connectors/hive/iceberg/PartitionSpec.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/hive/iceberg/PartitionSpec.h"
 
+#include "velox/functions/iceberg/Register.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -101,6 +102,14 @@ const auto& transformCategoryNames() {
 VELOX_DEFINE_ENUM_NAME(TransformType, transformTypeNames);
 
 VELOX_DEFINE_ENUM_NAME(TransformCategory, transformCategoryNames);
+
+void registerIcebergFunctions() {
+  static std::once_flag registerFlag;
+
+  std::call_once(registerFlag, []() {
+    functions::iceberg::registerFunctions(kIcebergFunctionPrefix);
+  });
+}
 
 void IcebergPartitionSpec::checkCompatibility() const {
   folly::F14FastMap<std::string_view, std::vector<TransformType>>

--- a/velox/connectors/hive/iceberg/PartitionSpec.h
+++ b/velox/connectors/hive/iceberg/PartitionSpec.h
@@ -20,6 +20,25 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
+inline constexpr char const* kIcebergFunctionPrefix{"iceberg_"};
+
+inline const std::string kBucketFunction =
+    std::string(kIcebergFunctionPrefix) + "bucket";
+inline const std::string kTruncateFunction =
+    std::string(kIcebergFunctionPrefix) + "truncate";
+inline const std::string kYearFunction =
+    std::string(kIcebergFunctionPrefix) + "years";
+inline const std::string kMonthFunction =
+    std::string(kIcebergFunctionPrefix) + "months";
+inline const std::string kDayFunction =
+    std::string(kIcebergFunctionPrefix) + "days";
+inline const std::string kHourFunction =
+    std::string(kIcebergFunctionPrefix) + "hours";
+
+/// Registers Iceberg partition transform functions with prefix
+/// kIcebergFunctionPrefix.
+void registerIcebergFunctions();
+
 /// Partition transform types.
 /// Defines how source column values are converted into partition keys.
 /// See https://iceberg.apache.org/spec/#partition-transforms.
@@ -113,6 +132,7 @@ struct IcebergPartitionSpec {
         case TransformType::kTruncate:
           return type;
       }
+      VELOX_UNREACHABLE("Unknown transform type");
     }
   };
 

--- a/velox/connectors/hive/iceberg/TransformEvaluator.cpp
+++ b/velox/connectors/hive/iceberg/TransformEvaluator.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/TransformEvaluator.h"
+
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+TransformEvaluator::TransformEvaluator(
+    const std::vector<core::TypedExprPtr>& expressions,
+    const ConnectorQueryCtx* connectorQueryCtx)
+    : connectorQueryCtx_(connectorQueryCtx) {
+  VELOX_CHECK_NOT_NULL(connectorQueryCtx_);
+  exprSet_ = connectorQueryCtx_->expressionEvaluator()->compile(expressions);
+  VELOX_CHECK_NOT_NULL(exprSet_);
+}
+
+std::vector<VectorPtr> TransformEvaluator::evaluate(
+    const RowVectorPtr& input) const {
+  const auto numRows = input->size();
+  const auto numExpressions = exprSet_->exprs().size();
+
+  std::vector<VectorPtr> results(numExpressions);
+  SelectivityVector rows(numRows);
+
+  // Evaluate all expressions in one pass.
+  connectorQueryCtx_->expressionEvaluator()->evaluate(
+      exprSet_.get(), rows, *input, results);
+
+  return results;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformEvaluator.h
+++ b/velox/connectors/hive/iceberg/TransformEvaluator.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/core/QueryCtx.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Evaluates multiple expressions efficiently using batch evaluation.
+/// Expressions are compiled once in the constructor and reused across multiple
+/// input batches.
+class TransformEvaluator {
+ public:
+  /// Creates an evaluator with the given expressions and connector query
+  /// context. Compiles the expressions once for reuse across multiple
+  /// evaluations.
+  ///
+  /// @param expressions Vector of typed expressions to evaluate. These are
+  /// typically built using TransformExprBuilder::toExpressions() for Iceberg
+  /// partition transforms, but can be any valid Velox expressions. The
+  /// expressions are compiled once during construction.
+  /// @param connectorQueryCtx Connector query context providing access to the
+  /// expression evaluator (for compilation and evaluation) and memory pool.
+  /// Must remain valid for the lifetime of this TransformEvaluator.
+  TransformEvaluator(
+      const std::vector<core::TypedExprPtr>& expressions,
+      const ConnectorQueryCtx* connectorQueryCtx);
+
+  /// Evaluates all expressions on the input data in a single pass.
+  /// Uses the pre-compiled ExprSet from the constructor for efficiency.
+  ///
+  /// The input RowType must match the RowType used when building the
+  /// expressions (passed to TransformExprBuilder::toExpressions). The column
+  /// positions, names and types must align. Create new TransformEvaluator for
+  /// input that has different RowType with the one when building the
+  /// expressions.
+  ///
+  /// @param input Input row vector containing the source data. Must have the
+  /// same RowType (column positions, names and types) as used when building the
+  /// expressions in the constructor.
+  /// @return Vector of result columns, one for each expression, in the same
+  /// order as the expressions provided to the constructor.
+  std::vector<VectorPtr> evaluate(const RowVectorPtr& input) const;
+
+ private:
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  std::unique_ptr<exec::ExprSet> exprSet_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformExprBuilder.cpp
+++ b/velox/connectors/hive/iceberg/TransformExprBuilder.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+/// Converts a single partition field to a typed expression.
+///
+/// Builds an expression tree for one partition transform. Identity transforms
+/// become FieldAccessTypedExpr, while other transforms (bucket, truncate,
+/// year, month, day, hour) become CallTypedExpr with appropriate function
+/// names and parameters.
+///
+/// @param field Partition field containing transform type, source column
+/// type, and optional parameter (e.g., bucket count, truncate width).
+/// @param inputFieldName Name of the source column in the input RowVector.
+/// @return Typed expression representing the transform.
+core::TypedExprPtr toExpression(
+    const IcebergPartitionSpec::Field& field,
+    const std::string& inputFieldName) {
+  // For identity transform, just return a field access expression.
+  if (field.transformType == TransformType::kIdentity) {
+    return std::make_shared<core::FieldAccessTypedExpr>(
+        field.type, inputFieldName);
+  }
+
+  // For other transforms, build a CallTypedExpr with the appropriate function.
+  std::string functionName;
+  switch (field.transformType) {
+    case TransformType::kBucket:
+      functionName = kBucketFunction;
+      break;
+    case TransformType::kTruncate:
+      functionName = kTruncateFunction;
+      break;
+    case TransformType::kYear:
+      functionName = kYearFunction;
+      break;
+    case TransformType::kMonth:
+      functionName = kMonthFunction;
+      break;
+    case TransformType::kDay:
+      functionName = kDayFunction;
+      break;
+    case TransformType::kHour:
+      functionName = kHourFunction;
+      break;
+    case TransformType::kIdentity:
+      break;
+  }
+
+  // Build the expression arguments.
+  std::vector<core::TypedExprPtr> exprArgs;
+  if (field.parameter.has_value()) {
+    exprArgs.emplace_back(
+        std::make_shared<core::ConstantTypedExpr>(
+            INTEGER(), Variant(field.parameter.value())));
+  }
+  exprArgs.emplace_back(
+      std::make_shared<core::FieldAccessTypedExpr>(field.type, inputFieldName));
+
+  return std::make_shared<core::CallTypedExpr>(
+      field.resultType(), std::move(exprArgs), functionName);
+}
+
+} // namespace
+
+std::vector<core::TypedExprPtr> TransformExprBuilder::toExpressions(
+    const IcebergPartitionSpecPtr& partitionSpec,
+    const std::vector<column_index_t>& partitionChannels,
+    const RowTypePtr& inputType) {
+  VELOX_CHECK_EQ(
+      partitionSpec->fields.size(),
+      partitionChannels.size(),
+      "Number of partition fields must match number of partition channels");
+
+  const auto numTransforms = partitionChannels.size();
+  std::vector<core::TypedExprPtr> transformExprs;
+  transformExprs.reserve(numTransforms);
+
+  for (auto i = 0; i < numTransforms; i++) {
+    const auto channel = partitionChannels[i];
+    transformExprs.emplace_back(
+        toExpression(partitionSpec->fields.at(i), inputType->nameOf(channel)));
+  }
+
+  return transformExprs;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/TransformExprBuilder.h
+++ b/velox/connectors/hive/iceberg/TransformExprBuilder.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Converts Iceberg partition specification to Velox expressions.
+class TransformExprBuilder {
+ public:
+  /// Converts partition specification to a list of typed expressions.
+  ///
+  /// @param partitionSpec Iceberg partition specification containing transform
+  /// definitions for each partition field.
+  /// @param partitionChannels Column indices (0-based) in the input RowVector
+  /// that correspond to each partition field. Must have the same size as
+  /// partitionSpec->fields. Provides the positional mapping from partition spec
+  /// fields to input RowVector columns.
+  /// @param inputType The row type of the input data. This is necessary for
+  /// building expressions because the column names in partitionSpec reference
+  /// table schema names, which might not match the column names in inputType
+  /// (e.g., inputType may use generated names like c0, c1, c2). The
+  /// FieldAccessTypedExpr must be built using the actual column names from
+  /// inputType that will be present at runtime. The partitionChannels provide
+  /// the positional mapping to locate the correct columns.
+  /// @return Vector of typed expressions, one for each partition field.
+  static std::vector<core::TypedExprPtr> toExpressions(
+      const IcebergPartitionSpecPtr& partitionSpec,
+      const std::vector<column_index_t>& partitionChannels,
+      const RowTypePtr& inputType);
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     IcebergTestBase.cpp
     Main.cpp
     PartitionSpecTest.cpp
+    TransformTest.cpp
   )
 
   add_test(velox_hive_iceberg_insert_test velox_hive_iceberg_insert_test)

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -65,10 +65,12 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
   std::vector<std::string> listFiles(const std::string& dirPath);
 
   std::shared_ptr<IcebergPartitionSpec> createPartitionSpec(
-      const std::vector<PartitionField>& partitionFields,
-      const RowTypePtr& rowType);
+      const RowTypePtr& rowType,
+      const std::vector<PartitionField>& partitionFields);
 
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
+  std::shared_ptr<memory::MemoryPool> opPool_;
+  std::unique_ptr<ConnectorQueryCtx> connectorQueryCtx_;
 
  private:
   IcebergInsertTableHandlePtr createInsertTableHandle(
@@ -82,13 +84,12 @@ class IcebergTestBase : public exec::test::HiveConnectorTestBase {
   void setupMemoryPools();
 
   std::shared_ptr<memory::MemoryPool> root_;
-  std::shared_ptr<memory::MemoryPool> opPool_;
   std::shared_ptr<memory::MemoryPool> connectorPool_;
   std::shared_ptr<config::ConfigBase> connectorSessionProperties_;
   std::shared_ptr<HiveConfig> connectorConfig_;
-  std::unique_ptr<ConnectorQueryCtx> connectorQueryCtx_;
   VectorFuzzer::Options fuzzerOptions_;
   std::unique_ptr<VectorFuzzer> fuzzer_;
+  std::shared_ptr<core::QueryCtx> queryCtx_;
 };
 
 } // namespace facebook::velox::connector::hive::iceberg::test

--- a/velox/connectors/hive/iceberg/tests/TransformTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformTest.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/encode/Base64.h"
+#include "velox/connectors/hive/iceberg/PartitionSpec.h"
+#include "velox/connectors/hive/iceberg/TransformEvaluator.h"
+#include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
+#include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+class TransformTest : public test::IcebergTestBase {
+ protected:
+  void testTransform(
+      const IcebergPartitionSpecPtr& spec,
+      const RowVectorPtr& input,
+      const RowVectorPtr& expected) const {
+    std::vector<column_index_t> partitionChannels;
+    for (const auto& field : spec->fields) {
+      partitionChannels.push_back(input->rowType()->getChildIdx(field.name));
+    }
+    // Build and evaluate transform expressions.
+    auto transformExprs = TransformExprBuilder::toExpressions(
+        spec, partitionChannels, input->rowType());
+    auto transformEvaluator = std::make_unique<TransformEvaluator>(
+        transformExprs, connectorQueryCtx_.get());
+    auto result = transformEvaluator->evaluate(input);
+
+    ASSERT_EQ(result.size(), expected->childrenSize());
+    for (auto i = 0; i < result.size(); ++i) {
+      velox::test::assertEqualVectors(expected->childAt(i), result[i]);
+    }
+  }
+};
+
+TEST_F(TransformTest, identity) {
+  const auto& rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4"},
+          {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), TIMESTAMP()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kIdentity, std::nullopt},
+          {1, TransformType::kIdentity, std::nullopt},
+          {2, TransformType::kIdentity, std::nullopt},
+          {3, TransformType::kIdentity, std::nullopt},
+          {4, TransformType::kIdentity, std::nullopt},
+      });
+
+  const std::vector<VectorPtr> input = {
+      makeFlatVector<int32_t>({1, -1}),
+      makeFlatVector<int64_t>({1L, -1L}),
+      makeFlatVector<std::string>({("test data"), ("")}),
+      makeFlatVector<std::string>({("\x01\x02\x03"), ("")}, VARBINARY()),
+      makeFlatVector<Timestamp>({Timestamp(0, 0), Timestamp(1609459200, 0)}),
+  };
+
+  testTransform(partitionSpec, makeRowVector(input), makeRowVector(input));
+}
+
+TEST_F(TransformTest, nulls) {
+  const auto& rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5", "c6"},
+          {INTEGER(),
+           VARCHAR(),
+           VARBINARY(),
+           DATE(),
+           TIMESTAMP(),
+           TIMESTAMP(),
+           TIMESTAMP()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kIdentity, std::nullopt},
+          {1, TransformType::kBucket, 8},
+          {2, TransformType::kTruncate, 16},
+          {3, TransformType::kYear, std::nullopt},
+          {4, TransformType::kMonth, std::nullopt},
+          {5, TransformType::kDay, std::nullopt},
+          {6, TransformType::kHour, std::nullopt},
+      });
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeNullableFlatVector<int32_t>({std::nullopt}),
+          makeNullableFlatVector<std::string>({std::nullopt}),
+          makeNullableFlatVector<std::string>({std::nullopt}, VARBINARY()),
+          makeNullableFlatVector<int32_t>({std::nullopt}, DATE()),
+          makeNullableFlatVector<Timestamp>({std::nullopt}),
+          makeNullableFlatVector<Timestamp>({std::nullopt}),
+          makeNullableFlatVector<Timestamp>({std::nullopt}),
+      }),
+      makeRowVector({
+          makeNullableFlatVector<int32_t>({std::nullopt}),
+          makeNullableFlatVector<int32_t>({std::nullopt}),
+          makeNullableFlatVector<std::string>({std::nullopt}, VARBINARY()),
+          makeNullableFlatVector<int32_t>({std::nullopt}),
+          makeNullableFlatVector<int32_t>({std::nullopt}),
+          makeNullableFlatVector<int32_t>({std::nullopt}, DATE()),
+          makeNullableFlatVector<int32_t>({std::nullopt}),
+      }));
+}
+
+TEST_F(TransformTest, bucket) {
+  const auto& rowType =
+      ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
+          {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DATE(), TIMESTAMP()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kBucket, 4},
+          {1, TransformType::kBucket, 8},
+          {2, TransformType::kBucket, 16},
+          {3, TransformType::kBucket, 32},
+          {4, TransformType::kBucket, 10},
+          {5, TransformType::kBucket, 8},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeFlatVector<int32_t>({8, 34, 0}),
+          makeFlatVector<int64_t>({34L, 0L, -34L}),
+          makeFlatVector<std::string>({"abcdefg", "测试", ""}),
+          makeFlatVector<std::string>(
+              {"\x61\x62\x64\x00\x00", "\x01\x02\x03\x04", "\x00"},
+              VARBINARY()),
+          makeFlatVector<int32_t>({0, 365, 18'262}),
+          makeFlatVector<Timestamp>(
+              {Timestamp(0, 0),
+               Timestamp(-31536000, 0),
+               Timestamp(1612224000, 0)}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({3, 3, 0}),
+          makeFlatVector<int32_t>({3, 4, 5}),
+          makeFlatVector<int32_t>({6, 8, 0}),
+          makeFlatVector<int32_t>({26, 5, 0}),
+          makeFlatVector<int32_t>({6, 1, 3}),
+          makeFlatVector<int32_t>({4, 3, 5}),
+      }));
+}
+
+TEST_F(TransformTest, year) {
+  const auto& rowType = ROW({"c0", "c1"}, {DATE(), TIMESTAMP()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kYear, std::nullopt},
+          {1, TransformType::kYear, std::nullopt},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 18'262, -365}),
+          makeFlatVector<Timestamp>(
+              {Timestamp(0, 0),
+               Timestamp(31536000, 0),
+               Timestamp(-31536000, 0)}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 50, -1}),
+          makeFlatVector<int32_t>({0, 1, -1}),
+      }));
+}
+
+TEST_F(TransformTest, month) {
+  const auto& rowType = ROW({"c0", "c1"}, {DATE(), TIMESTAMP()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kMonth, std::nullopt},
+          {1, TransformType::kMonth, std::nullopt},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 18'262, -365}),
+          makeFlatVector<Timestamp>(
+              {Timestamp(0, 0),
+               Timestamp(31536000, 0),
+               Timestamp(-2678400, 0)}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 600, -12}),
+          makeFlatVector<int32_t>({0, 12, -1}),
+      }));
+}
+
+TEST_F(TransformTest, day) {
+  const auto& rowType = ROW({"c0", "c1"}, {DATE(), TIMESTAMP()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kDay, std::nullopt},
+          {1, TransformType::kDay, std::nullopt},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 17532, -1}, DATE()),
+          makeFlatVector<Timestamp>(
+              {Timestamp(0, 0),
+               Timestamp(1514764800, 0),
+               Timestamp(-86400, 0)}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 17532, -1}, DATE()),
+          makeFlatVector<int32_t>({0, 17532, -1}, DATE()),
+      }));
+}
+
+TEST_F(TransformTest, hour) {
+  const auto& partitionSpec = createPartitionSpec(
+      ROW({"c0"}, {TIMESTAMP()}), {{0, TransformType::kHour, std::nullopt}});
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({makeFlatVector<Timestamp>({
+          Timestamp(0, 0),
+          Timestamp(3600, 0),
+          Timestamp(-3600, 0),
+      })}),
+      makeRowVector({makeFlatVector<int32_t>({0, 1, -1})}));
+}
+
+TEST_F(TransformTest, truncate) {
+  const auto& rowType = ROW(
+      {"c0", "c1", "c2", "c3"}, {INTEGER(), BIGINT(), VARCHAR(), VARBINARY()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kTruncate, 10},
+          {1, TransformType::kTruncate, 100},
+          {2, TransformType::kTruncate, 5},
+          {3, TransformType::kTruncate, 3},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeFlatVector<int32_t>({11, -11, 5}),
+          makeFlatVector<int64_t>({123L, -123L, 50L}),
+          makeFlatVector<std::string>({"abcdefg", "测试data", "x"}),
+          makeFlatVector<std::string>(
+              {"abcdefg", "\x01\x02\x03\x04", "\x05"}, VARBINARY()),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({10, -20, 0}),
+          makeFlatVector<int64_t>({100L, -200L, 0L}),
+          makeFlatVector<std::string>({"abcde", "测试dat", "x"}),
+          makeFlatVector<std::string>(
+              {"abc", "\x01\x02\x03", "\x05"}, VARBINARY()),
+      }));
+}
+
+TEST_F(TransformTest, multipleTransforms) {
+  const auto& rowType = ROW({"c0", "c1", "c2"}, {INTEGER(), DATE(), VARCHAR()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kBucket, 4},
+          {1, TransformType::kYear, std::nullopt},
+          {2, TransformType::kTruncate, 3},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector({
+          makeFlatVector<int32_t>({8, 34}),
+          makeFlatVector<int32_t>({0, 17532}),
+          makeFlatVector<std::string>({"abcdefg", "ab c"}),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>({3, 3}),
+          makeFlatVector<int32_t>({0, 48}),
+          makeFlatVector<std::string>({"abc", "ab "}),
+      }));
+}
+
+TEST_F(TransformTest, multipleTransformsOnSameColumn) {
+  const auto& rowType = ROW({"c0", "c1"}, {DATE(), VARCHAR()});
+  const auto& partitionSpec = createPartitionSpec(
+      rowType,
+      {
+          {0, TransformType::kYear, std::nullopt},
+          {0, TransformType::kBucket, 10},
+          {1, TransformType::kTruncate, 5},
+          {1, TransformType::kBucket, 8},
+      });
+
+  testTransform(
+      partitionSpec,
+      makeRowVector(
+          rowType->names(),
+          {
+              makeFlatVector<int32_t>({0, 17532}),
+              makeFlatVector<std::string>({"abcdefg", "test"}),
+          }),
+      makeRowVector({
+          makeFlatVector<int32_t>({0, 48}),
+          makeFlatVector<int32_t>({6, 7}),
+          makeFlatVector<std::string>({"abcde", "test"}),
+          makeFlatVector<int32_t>({6, 3}),
+      }));
+}
+
+} // namespace
+
+} // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Introduce infrastructure for evaluating Iceberg partition transforms.
- TransformExprBuilder converts Iceberg partition specifications into Velox expressions
- TransformEvaluator evaluates multiple transform expressions in a single pass using compiled ExprSet. 
