### PR TITLE
fix: Fix incorrect scalar optimization in `gatherCopy`

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -103,7 +103,11 @@ void gatherCopy(
     const std::vector<const RowVector*>& sources,
     const std::vector<vector_size_t>& sourceIndices,
     column_index_t sourceChannel) {
-  if (target->isScalar()) {
+  const bool flattenSources =
+      std::all_of(sources.begin(), sources.end(), [](const auto& source) {
+        return source->isFlatEncoding();
+      });
+  if (target->isScalar() && flattenSources) {
     VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
         scalarGatherCopy,
         target->type()->kind(),


### PR DESCRIPTION
The optimized path for scalar targets in `gatherCopy` incorrectly assumed all
source vectors were flat, causing failures with encoded vectors such as `DictionaryVector`.
This PR adds another check to ensure the fast path is now only taken when the target is
scalar and all the sources are flattened.