### PR TITLE
perf(expr): Do exact reserve before sequence of pushes in ArrayView::materialize()

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -599,6 +599,7 @@ class ArrayView {
 
   materialize_t materialize() const {
     materialize_t result;
+    result.reserve(size_);
 
     for (const auto& element : *this) {
       if constexpr (returnsOptionalValues) {


### PR DESCRIPTION
Reviewed By: yfeldblum

Differential Revision: D85773353


