### PR TITLE
fix: Fix ExchangeClient stats reporting

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -78,6 +78,11 @@ void ExchangeClient::close() {
     if (closed_) {
       return;
     }
+
+    // Capture stats BEFORE clearing sources_.
+    // This allows stats() to return meaningful data even after close().
+    stats_ = collectStatsLocked();
+
     closed_ = true;
     sources = std::move(sources_);
     producingSources = std::move(producingSources_);
@@ -91,9 +96,17 @@ void ExchangeClient::close() {
   queue_->close();
 }
 
-folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
-  folly::F14FastMap<std::string, RuntimeMetric> stats;
+folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() {
   std::lock_guard<std::mutex> l(queue_->mutex());
+  if (stats_.empty()) {
+    stats_ = collectStatsLocked();
+  }
+  return stats_;
+}
+
+folly::F14FastMap<std::string, RuntimeMetric>
+ExchangeClient::collectStatsLocked() const {
+  folly::F14FastMap<std::string, RuntimeMetric> stats;
 
   for (const auto& source : sources_) {
     if (source->supportsMetrics()) {

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -91,7 +91,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   // Returns runtime statistics aggregated across all of the exchange sources.
   // ExchangeClient is expected to report background CPU time by including a
   // runtime metric named Operator::kBackgroundCpuTimeNanos.
-  folly::F14FastMap<std::string, RuntimeMetric> stats() const;
+  folly::F14FastMap<std::string, RuntimeMetric> stats();
 
   const std::shared_ptr<ExchangeQueue>& queue() const {
     return queue_;
@@ -163,6 +163,8 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
         sources_.size() == 1;
   }
 
+  folly::F14FastMap<std::string, RuntimeMetric> collectStatsLocked() const;
+
   // Handy for ad-hoc logging.
   const std::string taskId_;
   const int destination_;
@@ -176,6 +178,8 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   std::unordered_set<std::string> remoteTaskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
   bool closed_{false};
+
+  folly::F14FastMap<std::string, RuntimeMetric> stats_;
 
   // The minimum byte size the consumer is expected to consume from
   // the exchange queue.


### PR DESCRIPTION
Summary:
when ExchangeClient::stats() is called after  ExchangeClient::close() have been called, it would return empty stats

Fix it by collecting stats when ExchangeClient::close() is called

Differential Revision: D86713220


