### PR TITLE
perf: Optimize basic numeric upcast

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -107,6 +107,9 @@ target_link_libraries(
 add_executable(velox_cast_benchmark CastBenchmark.cpp)
 target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps} velox_vector_test_lib)
 
+add_executable(velox_numeric_upcast_benchmark NumericUpcastBenchmark.cpp)
+target_link_libraries(velox_numeric_upcast_benchmark ${velox_benchmark_deps} velox_vector_test_lib)
+
 add_executable(velox_format_datetime_benchmark FormatDateTimeBenchmark.cpp)
 target_link_libraries(
   velox_format_datetime_benchmark

--- a/velox/benchmarks/basic/NumericUpcastBenchmark.cpp
+++ b/velox/benchmarks/basic/NumericUpcastBenchmark.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  const vector_size_t vectorSize = 300'000'000;
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+
+  auto tinyIntInputNullable = vectorMaker.flatVector<int8_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int8_t>::max(); },
+      [](auto j) { return j % 5 == 0; });
+  auto tinyIntInput = vectorMaker.flatVector<int8_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int8_t>::max(); },
+      nullptr);
+
+  auto smallIntInputNullable = vectorMaker.flatVector<int16_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int16_t>::max(); },
+      [](auto j) { return j % 5 == 0; });
+  auto smallIntInput = vectorMaker.flatVector<int16_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int16_t>::max(); },
+      nullptr);
+
+  auto integerInputNullable = vectorMaker.flatVector<int32_t>(
+      vectorSize,
+      [](auto j) { return j * 2 + 1; },
+      [](auto j) { return j % 5 == 0; });
+  auto integerInput = vectorMaker.flatVector<int32_t>(
+      vectorSize, [](auto j) { return j * 2 + 1; }, nullptr);
+
+  auto bigintInputNullable = vectorMaker.flatVector<int64_t>(
+      vectorSize,
+      [](auto j) { return j * 2 + 1; },
+      [](auto j) { return j % 5 == 0; });
+  auto bigintInput = vectorMaker.flatVector<int64_t>(
+      vectorSize, [](auto j) { return j * 2 + 1; }, nullptr);
+
+  auto realInputNullable = vectorMaker.flatVector<float>(
+      vectorSize,
+      [](auto j) { return j * 9.9999; },
+      [](auto j) { return j % 5 == 0; });
+  auto realInput = vectorMaker.flatVector<float>(
+      vectorSize, [](auto j) { return j * 9.9999; }, nullptr);
+
+  auto hugeintInputNullable = vectorMaker.flatVector<int128_t>(
+      vectorSize,
+      [](auto j) { return j * 999 + 1; },
+      [](auto j) { return j % 5 == 0; });
+  auto hugeintInput = vectorMaker.flatVector<int128_t>(
+      vectorSize, [](auto j) { return j * 999 + 1; }, nullptr);
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "numeric_upcast",
+          vectorMaker.rowVector(
+              {
+                  "tinyint_column_nullable",
+                  "tinyint_column",
+                  "smallint_column_nullable",
+                  "smallint_column",
+                  "integer_column_nullable",
+                  "integer_column",
+                  "bigint_column_nullable",
+                  "bigint_column",
+                  "real_column_nullable",
+                  "real_column",
+                  "hugeint_column_nullable",
+                  "hugeint_column",
+              },
+              {
+                  tinyIntInputNullable,
+                  tinyIntInput,
+                  smallIntInputNullable,
+                  smallIntInput,
+                  integerInputNullable,
+                  integerInput,
+                  bigintInputNullable,
+                  bigintInput,
+                  realInputNullable,
+                  realInput,
+                  hugeintInputNullable,
+                  hugeintInput,
+              }))
+      // Cast from tinyint.
+      .addExpression(
+          "cast_tinyint_nullable_as_smallint",
+          "cast(tinyint_column_nullable as smallint)")
+      .addExpression(
+          "cast_tinyint_as_smallint", "cast(tinyint_column as smallint)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_integer",
+          "cast(tinyint_column_nullable as integer)")
+      .addExpression(
+          "cast_tinyint_as_integer", "cast(tinyint_column as integer)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_bigint",
+          "cast(tinyint_column_nullable as bigint)")
+      .addExpression("cast_tinyint_as_bigint", "cast(tinyint_column as bigint)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_real",
+          "cast(tinyint_column_nullable as real)")
+      .addExpression("cast_tinyint_as_real", "cast(tinyint_column as real)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_double",
+          "cast(tinyint_column_nullable as double)")
+      .addExpression("cast_tinyint_as_double", "cast(tinyint_column as double)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_hugeint",
+          "cast(tinyint_column_nullable as hugeint)")
+      .addExpression(
+          "cast_tinyint_as_hugeint", "cast(tinyint_column as hugeint)")
+
+      // Cast from smallint.
+      .addExpression(
+          "cast_smallint_nullable_as_integer",
+          "cast(smallint_column_nullable as integer)")
+      .addExpression(
+          "cast_smallint_as_integer", "cast(smallint_column as integer)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_bigint",
+          "cast(smallint_column_nullable as bigint)")
+      .addExpression(
+          "cast_smallint_as_bigint", "cast(smallint_column as bigint)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_real",
+          "cast(smallint_column_nullable as real)")
+      .addExpression("cast_smallint_as_real", "cast(smallint_column as real)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_double",
+          "cast(smallint_column_nullable as double)")
+      .addExpression(
+          "cast_smallint_as_double", "cast(smallint_column as double)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_hugeint",
+          "cast(smallint_column_nullable as hugeint)")
+      .addExpression(
+          "cast_smallint_as_hugeint", "cast(smallint_column as hugeint)")
+
+      // Cast from integer.
+      .addExpression(
+          "cast_integer_nullable_as_bigint",
+          "cast(integer_column_nullable as bigint)")
+      .addExpression("cast_integer_as_bigint", "cast(integer_column as bigint)")
+
+      .addExpression(
+          "cast_integer_nullable_as_real",
+          "cast(integer_column_nullable as real)")
+      .addExpression("cast_integer_as_real", "cast(integer_column as real)")
+
+      .addExpression(
+          "cast_integer_nullable_as_double",
+          "cast(integer_column_nullable as double)")
+      .addExpression("cast_integer_as_double", "cast(integer_column as double)")
+
+      .addExpression(
+          "cast_integer_nullable_as_hugeint",
+          "cast(integer_column_nullable as hugeint)")
+      .addExpression(
+          "cast_integer_as_hugeint", "cast(integer_column as hugeint) ")
+
+      // Cast from bigint.
+      .addExpression(
+          "cast_bigint_nullable_as_real",
+          "cast(bigint_column_nullable as real)")
+      .addExpression("cast_bigint_as_real", "cast(bigint_column as real)")
+
+      .addExpression(
+          "cast_bigint_nullable_as_double",
+          "cast(bigint_column_nullable as double)")
+      .addExpression("cast_bigint_as_double", "cast(bigint_column as double)")
+
+      .addExpression(
+          "cast_bigint_nullable_as_hugeint",
+          "cast(bigint_column_nullable as hugeint)")
+      .addExpression("cast_bigint_as_hugeint", "cast(bigint_column as hugeint)")
+
+      // Cast from hugeint.
+      .addExpression(
+          "cast_hugeint_nullable_as_real",
+          "cast(hugeint_column_nullable as real)")
+      .addExpression("cast_hugeint_as_real", "cast(hugeint_column as real)")
+
+      .addExpression(
+          "cast_hugeint_nullable_as_double",
+          "cast(hugeint_column_nullable as double)")
+      .addExpression("cast_hugeint_as_double", "cast(hugeint_column as double)")
+
+      // Cast from real.
+      .addExpression(
+          "cast_real_nullable_as_double",
+          "cast(real_column_nullable as double)")
+      .addExpression("cast_real_as_double", "cast(real_column as double)")
+      .withIterations(100)
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -314,6 +314,14 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const BaseVector& input);
 
+  // Casts basic numeric types to wider types.
+  template <TypeKind ToKind, TypeKind FromKind>
+  VectorPtr applyNumericUpcast(
+      const SelectivityVector& rows,
+      const TypePtr& toType,
+      exec::EvalCtx& context,
+      const BaseVector& input);
+
   bool isTryCast() const {
     return isTryCast_;
   }


### PR DESCRIPTION
When the row size is large (e.g., around 300,000,000), casting from a narrower 
integer type to a wider one—such as cast(integer as bigint)—can become time-
consuming.

This PR optimizes the numeric upcast by performing the cast directly on the 
raw values within loops, and drops the try-catch used for potential error handing. 
Since upcasts guarantee that the source value fits within the target type, overflow
handling is unnecessary in this case.

The performance gains are likely attributed to:
1) Eliminating try-catch blocks when error handling is unnecessary.
2) Improved auto-vectorization and lower function call overhead after replacing
`valueAt` and `set` with direct access.
3) Avoiding overflow checks.

Optimized conversions include: 
```
CAST(tinyint AS smallint)
CAST(tinyint AS integer)
CAST(tinyint AS bigint)
CAST(tinyint AS real)
CAST(tinyint AS double)
CAST(tinyint AS hugeint)

CAST(smallint AS integer)
CAST(smallint AS bigint)
CAST(smallint AS real)
CAST(smallint AS double)
CAST(smallint AS hugeint)

CAST(integer AS bigint)
CAST(integer AS real)
CAST(integer AS double)
CAST(integer AS hugeint)

CAST(bigint AS real)
CAST(bigint AS double)
CAST(bigint AS hugeint)

CAST(hugeint AS real)
CAST(hugeint AS double)

CAST(real AS double)
```

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
numeric_upcast##cast_tinyint_nullable_as_smalli            1.05min    15.86m
numeric_upcast##cast_tinyint_as_smallint                   1.02min    16.28m
numeric_upcast##cast_tinyint_nullable_as_intege            1.17min    14.23m
numeric_upcast##cast_tinyint_as_integer                    1.08min    15.38m
numeric_upcast##cast_tinyint_nullable_as_bigint            1.70min     9.82m
numeric_upcast##cast_tinyint_as_bigint                     1.37min    12.20m
numeric_upcast##cast_tinyint_nullable_as_real              2.10min     7.93m
numeric_upcast##cast_tinyint_as_real                       2.18min     7.63m
numeric_upcast##cast_tinyint_nullable_as_double            2.49min     6.70m
numeric_upcast##cast_tinyint_as_double                     2.32min     7.18m
numeric_upcast##cast_tinyint_nullable_as_hugein            2.46min     6.78m
numeric_upcast##cast_tinyint_as_hugeint                    2.31min     7.21m
numeric_upcast##cast_smallint_nullable_as_integ            1.20min    13.94m
numeric_upcast##cast_smallint_as_integer                   1.09min    15.34m
numeric_upcast##cast_smallint_nullable_as_bigin            1.66min    10.05m
numeric_upcast##cast_smallint_as_bigint                    1.37min    12.17m
numeric_upcast##cast_smallint_nullable_as_real             2.20min     7.57m
numeric_upcast##cast_smallint_as_real                      2.31min     7.21m
numeric_upcast##cast_smallint_nullable_as_doubl            2.46min     6.78m
numeric_upcast##cast_smallint_as_double                    2.31min     7.22m
numeric_upcast##cast_smallint_nullable_as_hugei            2.59min     6.45m
numeric_upcast##cast_smallint_as_hugeint                   2.31min     7.21m
numeric_upcast##cast_integer_nullable_as_bigint            1.70min     9.83m
numeric_upcast##cast_integer_as_bigint                     1.37min    12.14m
numeric_upcast##cast_integer_nullable_as_real              1.72min     9.72m
numeric_upcast##cast_integer_as_real                       1.81min     9.19m
numeric_upcast##cast_integer_nullable_as_double            2.09min     7.98m
numeric_upcast##cast_integer_as_double                     1.94min     8.61m
numeric_upcast##cast_integer_nullable_as_hugein            2.09min     7.98m
numeric_upcast##cast_integer_as_hugeint                    1.94min     8.60m
numeric_upcast##cast_bigint_nullable_as_real               1.72min     9.67m
numeric_upcast##cast_bigint_as_real                        1.82min     9.16m
numeric_upcast##cast_bigint_nullable_as_double             2.09min     7.96m
numeric_upcast##cast_bigint_as_double                      1.94min     8.57m
numeric_upcast##cast_bigint_nullable_as_hugeint            2.08min     8.00m
numeric_upcast##cast_bigint_as_hugeint                     1.95min     8.56m
numeric_upcast##cast_hugeint_nullable_as_real              2.78min     6.00m
numeric_upcast##cast_hugeint_as_real                       2.49min     6.70m
numeric_upcast##cast_hugeint_nullable_as_double            2.57min     6.48m
numeric_upcast##cast_hugeint_as_double                     2.31min     7.21m
numeric_upcast##cast_real_nullable_as_double               2.20min     7.59m
numeric_upcast##cast_real_as_double                        1.92min     8.70m
----------------------------------------------------------------------------
```
After:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
numeric_upcast##cast_tinyint_nullable_as_smalli             25.15s    39.76m
numeric_upcast##cast_tinyint_as_smallint                    14.28s    70.05m
numeric_upcast##cast_tinyint_nullable_as_intege             36.05s    27.74m
numeric_upcast##cast_tinyint_as_integer                     18.55s    53.91m
numeric_upcast##cast_tinyint_nullable_as_bigint             54.77s    18.26m
numeric_upcast##cast_tinyint_as_bigint                      26.45s    37.81m
numeric_upcast##cast_tinyint_nullable_as_real               33.12s    30.19m
numeric_upcast##cast_tinyint_as_real                        20.59s    48.56m
numeric_upcast##cast_tinyint_nullable_as_double             55.68s    17.96m
numeric_upcast##cast_tinyint_as_double                      28.26s    35.38m
numeric_upcast##cast_tinyint_nullable_as_hugein             54.93s    18.21m
numeric_upcast##cast_tinyint_as_hugeint                     28.21s    35.45m
numeric_upcast##cast_smallint_nullable_as_integ             33.92s    29.48m
numeric_upcast##cast_smallint_as_integer                    18.45s    54.21m
numeric_upcast##cast_smallint_nullable_as_bigin             56.99s    17.55m
numeric_upcast##cast_smallint_as_bigint                     26.37s    37.92m
numeric_upcast##cast_smallint_nullable_as_real              32.48s    30.79m
numeric_upcast##cast_smallint_as_real                       19.67s    50.83m
numeric_upcast##cast_smallint_nullable_as_doubl             53.93s    18.54m
numeric_upcast##cast_smallint_as_double                     28.79s    34.73m
numeric_upcast##cast_smallint_nullable_as_hugei             53.07s    18.84m
numeric_upcast##cast_smallint_as_hugeint                    28.49s    35.10m
numeric_upcast##cast_integer_nullable_as_bigint            1.01min    16.51m
numeric_upcast##cast_integer_as_bigint                      27.04s    36.98m
numeric_upcast##cast_integer_nullable_as_real               35.55s    28.13m
numeric_upcast##cast_integer_as_real                        20.14s    49.66m
numeric_upcast##cast_integer_nullable_as_double             56.62s    17.66m
numeric_upcast##cast_integer_as_double                      28.39s    35.23m
numeric_upcast##cast_integer_nullable_as_hugein             57.36s    17.43m
numeric_upcast##cast_integer_as_hugeint                     28.49s    35.10m
numeric_upcast##cast_bigint_nullable_as_real                35.33s    28.31m
numeric_upcast##cast_bigint_as_real                         20.35s    49.14m
numeric_upcast##cast_bigint_nullable_as_double              56.84s    17.59m
numeric_upcast##cast_bigint_as_double                       28.41s    35.20m
numeric_upcast##cast_bigint_nullable_as_hugeint             58.48s    17.10m
numeric_upcast##cast_bigint_as_hugeint                      28.41s    35.20m
numeric_upcast##cast_hugeint_nullable_as_real              2.08min     8.01m
numeric_upcast##cast_hugeint_as_real                       2.01min     8.28m
numeric_upcast##cast_hugeint_nullable_as_double            1.89min     8.83m
numeric_upcast##cast_hugeint_as_double                     1.37min    12.13m
numeric_upcast##cast_real_nullable_as_double                59.15s    16.91m
numeric_upcast##cast_real_as_double                         29.15s    34.30m

----------------------------------------------------------------------------
```
