### PR TITLE
refactor(geo): Move and rename some variables, make some methods private

### DIFF
--- a/velox/exec/SpatialJoinBuild.h
+++ b/velox/exec/SpatialJoinBuild.h
@@ -65,6 +65,11 @@ class SpatialJoinBuild : public Operator {
     Operator::close();
   }
 
+  static Envelope readEnvelope(
+      const StringView& serializedGeometry,
+      double radius);
+
+ private:
   std::vector<RowVectorPtr> mergeDataVectors() const;
 
   SpatialIndex buildSpatialIndex(
@@ -72,11 +77,6 @@ class SpatialJoinBuild : public Operator {
       column_index_t geometryIdx,
       std::optional<column_index_t> radiusIdx);
 
-  static Envelope readEnvelope(
-      const StringView& serializedGeometry,
-      double radius);
-
- private:
   std::vector<RowVectorPtr> dataVectors_;
 
   // Channel of geometry variable used to build spatial index


### PR DESCRIPTION
Summary:
To clarify the purposes of some variables, rename them.  Also the methods
`mergeDataVectors` and `buildSpatialIndex` were only used internally but were declared
public: make them private.

Differential Revision: D86766663


