### PR TITLE
refactor(geo): Calculate envelop bounds for spatial index outside of index

### DIFF
--- a/velox/exec/SpatialIndex.cpp
+++ b/velox/exec/SpatialIndex.cpp
@@ -22,7 +22,8 @@
 
 namespace facebook::velox::exec {
 
-SpatialIndex::SpatialIndex(std::vector<Envelope> envelopes) {
+SpatialIndex::SpatialIndex(Envelope bounds, std::vector<Envelope> envelopes)
+    : bounds_(std::move(bounds)) {
   std::ranges::sort(envelopes, {}, &Envelope::minX);
 
   minXs_.reserve(envelopes.size());
@@ -32,10 +33,6 @@ SpatialIndex::SpatialIndex(std::vector<Envelope> envelopes) {
   rowIndices_.reserve(envelopes.size());
 
   for (const auto& env : envelopes) {
-    bounds_.maxX = std::max(bounds_.maxX, env.maxX);
-    bounds_.maxY = std::max(bounds_.maxY, env.maxY);
-    bounds_.minX = std::min(bounds_.minX, env.minX);
-    bounds_.minY = std::min(bounds_.minY, env.minY);
     minXs_.push_back(env.minX);
     minYs_.push_back(env.minY);
     maxXs_.push_back(env.maxX);

--- a/velox/exec/tests/SpatialIndexTest.cpp
+++ b/velox/exec/tests/SpatialIndexTest.cpp
@@ -28,7 +28,8 @@ class SpatialIndexTest : public virtual testing::Test {
   SpatialIndex index_;
 
   void makeIndex(std::vector<Envelope> envelopes) {
-    index_ = SpatialIndex(std::move(envelopes));
+    Envelope bounds = Envelope::of(envelopes);
+    index_ = SpatialIndex(std::move(bounds), std::move(envelopes));
   }
 
   Envelope indexBounds() const {
@@ -83,6 +84,22 @@ TEST_F(SpatialIndexTest, testNaNHandling) {
   Envelope envWithNaN5{
       .minX = nan, .minY = nan, .maxX = nan, .maxY = nan, .rowIndex = 0};
   ASSERT_TRUE(envWithNaN5.isEmpty());
+}
+
+TEST_F(SpatialIndexTest, testEnvelopeMerge) {
+  Envelope env = Envelope::empty();
+
+  env.merge(Envelope{.minX = 0, .minY = 10, .maxX = 1, .maxY = 11});
+  ASSERT_EQ(env.minX, 0.0);
+  ASSERT_EQ(env.minY, 10.0);
+  ASSERT_EQ(env.maxX, 1.0);
+  ASSERT_EQ(env.maxY, 11.0);
+
+  env.merge(Envelope{.minX = 5, .minY = 1, .maxX = 6, .maxY = 2});
+  ASSERT_EQ(env.minX, 0.0);
+  ASSERT_EQ(env.minY, 1.0);
+  ASSERT_EQ(env.maxX, 6.0);
+  ASSERT_EQ(env.maxY, 11.0);
 }
 
 TEST_F(SpatialIndexTest, testEmptyIndex) {


### PR DESCRIPTION
Summary:
The RTreeSpatialIndex will require the overall bounds in order to calculate
the Hilbert index of each envelope. This can be done in the constructor, but will
require an additional iteration through all the envelopes. However, we've already
iterated through the envelopes when reading them, so we can construct the bounds
during that process, and pass it to the spatial index in the constructor.

This is more efficient, but it does create the possibility that SpatialJoinBuilder
calculates incorrect bounds.  We can guard against this by having some asserts in the
loop that constructs the spatial index if we want to make it a bit slower but safer.

Differential Revision: D86127951


