### PR TITLE
feat(geo): Add HilbertIndex

### DIFF
--- a/velox/exec/HilbertIndex.h
+++ b/velox/exec/HilbertIndex.h
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Based off of https://threadlocalmutex.com/?p=126
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::exec {
+
+class HilbertIndex {
+ public:
+  /// Construct a Hilber index. If a min value is greater than the max value,
+  /// this will panic.
+  HilbertIndex(float minX, float minY, float maxX, float maxY)
+      : minX_(minX), minY_(minY), maxX_(maxX), maxY_(maxY) {
+    VELOX_CHECK(minX_ <= maxX_);
+    VELOX_CHECK(minY_ <= maxY_);
+
+    float deltaX = maxX_ - minX_;
+    // Subnormals cause numerical instability.
+    // NOLINTNEXTLINE(facebook-hte-FloatingPointMin)
+    if (deltaX < std::numeric_limits<float>::min()) {
+      xScale_ = 0;
+    } else {
+      xScale_ = kHilbertMax / deltaX;
+    }
+
+    float deltaY = maxY_ - minY_;
+    // Subnormals cause numerical instability.
+    // NOLINTNEXTLINE(facebook-hte-FloatingPointMin)
+    if (deltaY < std::numeric_limits<float>::min()) {
+      yScale_ = 0;
+    } else {
+      yScale_ = kHilbertMax / deltaY;
+    }
+  }
+
+  uint32_t inline indexOf(float x, float y) const {
+    if (!(x >= minX_ && x <= maxX_ && y >= minY_ && y <= maxY_)) {
+      // Put things outside the bounds at the end of the Hilbert curve.
+      // Negation handles NaNs
+      return std::numeric_limits<uint32_t>::max();
+    }
+
+    float maxFloat = static_cast<float>(std::numeric_limits<uint32_t>::max());
+
+    uint32_t xInt = static_cast<uint32_t>(
+        std::clamp(xScale_ * (x - minX_), 0.0f, maxFloat));
+    uint32_t yInt = static_cast<uint32_t>(
+        std::clamp(yScale_ * (y - minY_), 0.0f, maxFloat));
+    return discreteIndexOf(xInt, yInt);
+  }
+
+ private:
+  static inline uint32_t interleave(uint32_t x) {
+    x = (x | (x << 8)) & 0x00FF00FF;
+    x = (x | (x << 4)) & 0x0F0F0F0F;
+    x = (x | (x << 2)) & 0x33333333;
+    x = (x | (x << 1)) & 0x55555555;
+    return x;
+  }
+
+  static inline uint32_t discreteIndexOf(uint32_t x, uint32_t y) {
+    uint32_t A, B, C, D;
+
+    // Initial prefix scan round, prime with x and y
+    {
+      uint32_t a = x ^ y;
+      uint32_t b = 0xFFFF ^ a;
+      uint32_t c = 0xFFFF ^ (x | y);
+      uint32_t d = x & (y ^ 0xFFFF);
+
+      A = a | (b >> 1);
+      B = (a >> 1) ^ a;
+
+      C = ((c >> 1) ^ (b & (d >> 1))) ^ c;
+      D = ((a & (c >> 1)) ^ (d >> 1)) ^ d;
+    }
+
+    {
+      uint32_t a = A;
+      uint32_t b = B;
+      uint32_t c = C;
+      uint32_t d = D;
+
+      A = ((a & (a >> 2)) ^ (b & (b >> 2)));
+      B = ((a & (b >> 2)) ^ (b & ((a ^ b) >> 2)));
+
+      C ^= ((a & (c >> 2)) ^ (b & (d >> 2)));
+      D ^= ((b & (c >> 2)) ^ ((a ^ b) & (d >> 2)));
+    }
+
+    {
+      uint32_t a = A;
+      uint32_t b = B;
+      uint32_t c = C;
+      uint32_t d = D;
+
+      A = ((a & (a >> 4)) ^ (b & (b >> 4)));
+      B = ((a & (b >> 4)) ^ (b & ((a ^ b) >> 4)));
+
+      C ^= ((a & (c >> 4)) ^ (b & (d >> 4)));
+      D ^= ((b & (c >> 4)) ^ ((a ^ b) & (d >> 4)));
+    }
+
+    // Final round and projection
+    {
+      uint32_t a = A;
+      uint32_t b = B;
+      uint32_t c = C;
+      uint32_t d = D;
+
+      C ^= ((a & (c >> 8)) ^ (b & (d >> 8)));
+      D ^= ((b & (c >> 8)) ^ ((a ^ b) & (d >> 8)));
+    }
+
+    // Undo transformation prefix scan
+    uint32_t a = C ^ (C >> 1);
+    uint32_t b = D ^ (D >> 1);
+
+    // Recover index bits
+    uint32_t i0 = x ^ y;
+    uint32_t i1 = b | (0xFFFF ^ (i0 | a));
+
+    return (interleave(i1) << 1) | interleave(i0);
+  }
+
+  static const int8_t kHilbertBits = 16;
+  static constexpr float kHilbertMax = (1 << kHilbertBits) - 1;
+
+  const float minX_;
+  const float minY_;
+  const float maxX_;
+  const float maxY_;
+  float xScale_;
+  float yScale_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(
   ScaleWriterLocalPartitionTest.cpp
   SortBufferTest.cpp
   SpatialIndexTest.cpp
+  HilbertIndexTest.cpp
   SpillerTest.cpp
   SpillTest.cpp
   SplitListenerTest.cpp

--- a/velox/exec/tests/HilbertIndexTest.cpp
+++ b/velox/exec/tests/HilbertIndexTest.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/HilbertIndex.h"
+#include <gtest/gtest.h>
+#include <limits>
+
+using namespace ::testing;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+
+class HilbertIndexTest : public virtual testing::Test {};
+
+TEST_F(HilbertIndexTest, testOrder) {
+  HilbertIndex hilbert(0, 0, 4, 4);
+
+  uint32_t h0 = hilbert.indexOf(0.0, 0.0);
+  uint32_t h1 = hilbert.indexOf(1.0, 1.0);
+  uint32_t h2 = hilbert.indexOf(1.0, 3.0);
+  uint32_t h3 = hilbert.indexOf(3.0, 3.0);
+  uint32_t h4 = hilbert.indexOf(3.0, 1.0);
+
+  ASSERT_LT(h0, h1);
+  ASSERT_LT(h1, h2);
+  ASSERT_LT(h2, h3);
+  ASSERT_LT(h3, h4);
+}
+
+TEST_F(HilbertIndexTest, testOutOfBounds) {
+  HilbertIndex hilbert(0, 0, 1, 1);
+
+  ASSERT_EQ(hilbert.indexOf(2.0, 2.0), std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(HilbertIndexTest, testDegenerateRectangle) {
+  HilbertIndex hilbert(0, 0, 0, 0);
+
+  ASSERT_EQ(hilbert.indexOf(0.0, 0.0), 0);
+  ASSERT_EQ(hilbert.indexOf(2.0, 2.0), std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(HilbertIndexTest, testDegenerateHorizontalRectangle) {
+  HilbertIndex hilbert(0, 0, 4, 0);
+
+  ASSERT_EQ(hilbert.indexOf(0.0, 0.0), 0);
+  ASSERT_LT(hilbert.indexOf(1.0, 0.0), hilbert.indexOf(2.0, 0.0));
+  ASSERT_EQ(hilbert.indexOf(0.0, 2.0), std::numeric_limits<uint32_t>::max());
+  ASSERT_EQ(hilbert.indexOf(2.0, 2.0), std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(HilbertIndexTest, testDegenerateVerticalRectangle) {
+  HilbertIndex hilbert(0, 0, 0, 4);
+
+  ASSERT_EQ(hilbert.indexOf(0.0, 0.0), 0);
+  ASSERT_LT(hilbert.indexOf(0.0, 1.0), hilbert.indexOf(0.0, 2.0));
+  ASSERT_EQ(hilbert.indexOf(2.0, 0.0), std::numeric_limits<uint32_t>::max());
+  ASSERT_EQ(hilbert.indexOf(2.0, 2.0), std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(HilbertIndexTest, testNegativeCoordinates) {
+  HilbertIndex hilbert(-10, -10, 10, 10);
+
+  uint32_t h0 = hilbert.indexOf(-5.0, -5.0);
+  uint32_t h1 = hilbert.indexOf(0.0, 0.0);
+  uint32_t h2 = hilbert.indexOf(5.0, 5.0);
+
+  ASSERT_LT(h0, h1);
+  ASSERT_LT(h1, h2);
+
+  ASSERT_EQ(
+      hilbert.indexOf(-15.0, -15.0), std::numeric_limits<uint32_t>::max());
+  ASSERT_EQ(hilbert.indexOf(15.0, 15.0), std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(HilbertIndexTest, testFloatingPointPrecision) {
+  HilbertIndex hilbert(0, 0, 1, 1);
+
+  uint32_t h1 = hilbert.indexOf(0.1, 0.1);
+  uint32_t h2 = hilbert.indexOf(0.2, 0.2);
+  uint32_t h3 = hilbert.indexOf(0.9, 0.9);
+
+  ASSERT_LT(h1, h2);
+  ASSERT_LT(h2, h3);
+}
+
+TEST_F(HilbertIndexTest, testBoundaryPoints) {
+  HilbertIndex hilbert(0, 0, 10, 10);
+
+  uint32_t h0 = hilbert.indexOf(0.0, 0.0);
+  uint32_t h1 = hilbert.indexOf(10.0, 10.0);
+  uint32_t h2 = hilbert.indexOf(0.0, 10.0);
+  // Bottom-right corner is at the end of the range, so may be MAX
+
+  ASSERT_NE(h0, std::numeric_limits<uint32_t>::max());
+  ASSERT_NE(h1, std::numeric_limits<uint32_t>::max());
+  ASSERT_NE(h2, std::numeric_limits<uint32_t>::max());
+}
+
+TEST_F(HilbertIndexTest, testLargeCoordinates) {
+  HilbertIndex hilbert(0, 0, 1000000, 1000000);
+
+  uint32_t h1 = hilbert.indexOf(100000, 100000);
+  uint32_t h2 = hilbert.indexOf(500000, 500000);
+  uint32_t h3 = hilbert.indexOf(900000, 900000);
+
+  ASSERT_LT(h1, h2);
+  ASSERT_LT(h2, h3);
+}
+
+TEST_F(HilbertIndexTest, testDensityInSmallRegion) {
+  HilbertIndex hilbert(0, 0, 100, 100);
+
+  std::vector<uint32_t> indices;
+  for (int i = 0; i < 10; ++i) {
+    for (int j = 0; j < 10; ++j) {
+      indices.push_back(hilbert.indexOf(i * 10.0f + 5.0f, j * 10.0f + 5.0f));
+    }
+  }
+
+  std::set<uint32_t> uniqueIndices(indices.begin(), indices.end());
+  ASSERT_EQ(indices.size(), 100);
+  ASSERT_GT(uniqueIndices.size(), 90);
+}
+
+TEST_F(HilbertIndexTest, testSpatialLocality) {
+  HilbertIndex hilbert(0, 0, 100, 100);
+
+  uint32_t h1 = hilbert.indexOf(50.0, 50.0);
+  uint32_t h2 = hilbert.indexOf(50.1, 50.1);
+  uint32_t h3 = hilbert.indexOf(50.2, 50.2);
+  uint32_t h4 = hilbert.indexOf(90.0, 90.0);
+
+  uint32_t diff12 = std::abs(static_cast<int32_t>(h1 - h2));
+  uint32_t diff23 = std::abs(static_cast<int32_t>(h2 - h3));
+  uint32_t diff14 = std::abs(static_cast<int32_t>(h1 - h4));
+
+  ASSERT_LT(diff12, diff14);
+  ASSERT_LT(diff23, diff14);
+}
+
+TEST_F(HilbertIndexTest, testIdenticalPoints) {
+  HilbertIndex hilbert(0, 0, 10, 10);
+
+  uint32_t h1 = hilbert.indexOf(5.0, 5.0);
+  uint32_t h2 = hilbert.indexOf(5.0, 5.0);
+
+  ASSERT_EQ(h1, h2);
+}
+
+TEST_F(HilbertIndexTest, testExtremelySmallBounds) {
+  HilbertIndex hilbert(0, 0, 0.001, 0.001);
+
+  uint32_t h1 = hilbert.indexOf(0.0, 0.0);
+  uint32_t h2 = hilbert.indexOf(0.0005, 0.0005);
+
+  ASSERT_NE(h1, std::numeric_limits<uint32_t>::max());
+  ASSERT_NE(h2, std::numeric_limits<uint32_t>::max());
+}
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
This will allow us to order Envelopes along a [space-filling curve](https://en.wikipedia.org/wiki/Hilbert_curve),
which will will use to order an RTree for the SpatialIndex.

Differential Revision: D86127953


