### PR TITLE
Fix segfault during a raw vector pool transfer.

### DIFF
--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -674,6 +674,9 @@ template <>
 VectorPtr FlatVector<StringView>::testingCopyPreserveEncodings(
     velox::memory::MemoryPool* pool) const;
 
+template <>
+void FlatVector<StringView>::transferOrCopyTo(velox::memory::MemoryPool* pool);
+
 template <typename T>
 using FlatVectorPtr = std::shared_ptr<FlatVector<T>>;
 


### PR DESCRIPTION
Summary:
Long strings contain a data pointer, which makes them not eligible for a shallow copy. 

If a pool transfer fails transferOrCopyTo copies the string buffers to the new pool which gives then a new address. Since the StringView still points to the old address this can cause issues as that address no longer has to be valid.

This diff stores the old pointers and rewires the StringView to the new buffers in case a copy occurs.

Differential Revision: D86680882


