### PR TITLE
fix(geo): Correct out-of-bounds index error in spatial join

### DIFF
--- a/velox/exec/SpatialJoinProbe.cpp
+++ b/velox/exec/SpatialJoinProbe.cpp
@@ -468,19 +468,21 @@ std::vector<int32_t> SpatialJoinProbe::querySpatialIndex() {
 
 BufferPtr SpatialJoinProbe::makeBuildVectorIndices(vector_size_t vectorSize) {
   // Find the slice of candidates that are in this build vector.
-  size_t endIndex = candidateIndex_;
+  vector_size_t endIndex = candidateIndex_;
   for (; endIndex < candidateBuildRows_.size(); ++endIndex) {
     if (relativeBuildRow(endIndex) >= vectorSize) {
       break;
     }
   }
 
+  // Make an index vector to fit the candidates.  Populate each entry with its
+  // relative build row.
   vector_size_t indexCount =
       static_cast<vector_size_t>(endIndex - candidateIndex_);
   auto rowIndices = allocateIndices(indexCount, operatorCtx_->pool());
   auto rawIndices = rowIndices->asMutable<vector_size_t>();
-  for (size_t idx = candidateIndex_; idx < endIndex; ++idx) {
-    rawIndices[idx] = relativeBuildRow(idx);
+  for (vector_size_t idx = 0; idx < indexCount; ++idx) {
+    rawIndices[idx] = relativeBuildRow(idx + candidateIndex_);
   }
 
   return rowIndices;

--- a/velox/exec/tests/SpatialJoinTest.cpp
+++ b/velox/exec/tests/SpatialJoinTest.cpp
@@ -74,7 +74,7 @@ class SpatialJoinTest : public OperatorTestBase {
       const std::vector<std::optional<std::string_view>>& expectedLeftWkts,
       const std::vector<std::optional<std::string_view>>& expectedRightWkts) {
     for (bool separateProbeBatches : {false, true}) {
-      for (size_t maxBatchSize : {1024, 1}) {
+      for (size_t maxBatchSize : {128, 3, 2, 1}) {
         for (int32_t maxDrivers : {1, 4}) {
           runTestWithConfig(
               probeWkts,
@@ -669,6 +669,59 @@ TEST_F(SpatialJoinTest, failOnGroupedExecution) {
 
   VELOX_ASSERT_THROW(
       task->start(1), "Spatial joins do not support grouped execution.");
+}
+
+TEST_F(SpatialJoinTest, testLargeJoinSize) {
+  size_t numRows = 64;
+  size_t maxCoord = 17;
+  std::vector<std::string> buildWkts;
+  buildWkts.reserve(numRows);
+  std::vector<std::string> probeWkts;
+  probeWkts.reserve(numRows);
+  for (size_t i = 0; i < numRows; ++i) {
+    buildWkts.push_back(
+        fmt::format("POINT ({} {})", (i + 1) % maxCoord, (i + 2) % maxCoord));
+    probeWkts.push_back(
+        fmt::format("POINT ({} {})", i % maxCoord, (i + 1) % maxCoord));
+  }
+
+  std::vector<std::optional<std::string_view>> buildWktsView;
+  buildWktsView.reserve(numRows);
+  std::vector<std::optional<std::string_view>> probeWktsView;
+  probeWktsView.reserve(numRows);
+  for (size_t i = 0; i < numRows; ++i) {
+    buildWktsView.push_back(buildWkts[i]);
+    probeWktsView.push_back(probeWkts[i]);
+  }
+
+  std::vector<std::optional<std::string_view>> expectedLeftWkts;
+  expectedLeftWkts.reserve(numRows * numRows / maxCoord);
+  std::vector<std::optional<std::string_view>> expectedRightWkts;
+  expectedRightWkts.reserve(numRows * numRows / maxCoord);
+  for (size_t innerIdx = 0; innerIdx < numRows; ++innerIdx) {
+    for (size_t outerIdx = 0; outerIdx < numRows; ++outerIdx) {
+      if (probeWkts[outerIdx] == buildWkts[innerIdx]) {
+        expectedLeftWkts.push_back(probeWkts[outerIdx]);
+        expectedRightWkts.push_back(buildWkts[innerIdx]);
+      }
+    }
+  }
+
+  for (bool separateProbeBatches : {false, true}) {
+    for (size_t maxBatchSize : {64, 13, 7, 5, 3, 2, 1}) {
+      runTestWithConfig(
+          buildWktsView,
+          probeWktsView,
+          std::nullopt,
+          "ST_Equals(left_g, right_g)",
+          core::JoinType::kInner,
+          expectedLeftWkts,
+          expectedRightWkts,
+          1,
+          maxBatchSize,
+          separateProbeBatches);
+    }
+  }
 }
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
We used candidateIndex_ (which indexes over all build side candidates)
into `decodedFilterResult_`, which just has rows for candidates for _this_
build vector. This caused array-out-of-bounds errors for large build sizes.
Similarily in `makeBuildVectorIndices`, we incorrectly indexed into rawIndices.

Our unit tests did not pick this up because they only tested batch sizes 1024 and 1.
1024 resulted in only one build side batch, and 1 meant that for vectors of size 1 default
initialization of indices to 0 meant that it was aways the right index.

Differential Revision: D86773251


