### PR TITLE
feat: InputGenerator Support For Time with Time zone (#15416)

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/TypeResolver.h"
@@ -69,6 +70,9 @@ intermediateTypeTransforms() {
           {TIME(),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                TIME(), VARCHAR())},
+          {TIME_WITH_TIME_ZONE(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               TIME_WITH_TIME_ZONE(), VARCHAR())},
           {BINGTILE(),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                BINGTILE(), BIGINT())},

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -32,6 +32,7 @@ velox_add_library(
   TDigestRegistration.cpp
   TimestampWithTimeZoneRegistration.cpp
   TimeWithTimezoneRegistration.cpp
+  TimeWithTimezoneType.cpp
   SetDigestRegistration.cpp
   UuidRegistration.cpp
   VarcharEnumRegistration.cpp

--- a/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
@@ -18,84 +18,13 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.h"
 #include "velox/type/Time.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox {
-
-folly::dynamic TimeWithTimezoneType::serialize() const {
-  folly::dynamic obj = folly::dynamic::object;
-  obj["name"] = "Type";
-  obj["type"] = name();
-  return obj;
-}
-
-StringView TimeWithTimezoneType::valueToString(
-    int64_t value,
-    char* const startPos) const {
-  // TIME WITH TIME ZONE is encoded similarly to TIMESTAMP WITH TIME ZONE
-  // with the most significnat 52 bits representing the time component and the
-  // least 12 bits representing the timezone minutes. This is different from
-  // TIMESTAMP WITH TIMEZONE where the last 12 bits represent the timezone
-  // offset. The timezone offset minutes are stored by value, encoded in the
-  // type itself. This allows the type to be used in a timezone-agnostic manner.
-  //
-  // The time component is a 52 bit value representing the number of
-  // milliseconds since midnight in UTC.
-
-  int64_t millisUtc = util::unpackMillisUtc(value);
-
-  // Ensure time component is within valid range
-  VELOX_CHECK_GE(millisUtc, 0, "Time component is negative");
-  VELOX_CHECK_LE(millisUtc, util::kMillisInDay, "Time component is too large");
-
-  // TimeZone's are encoded as a 12 bit value.
-  // This represents a range of -14:00 to +14:00, with 0 representing UTC.
-  // The range is from -840 to 840 minutes, we thus encode by doing bias
-  // encoding and taking 840 as the bias.
-  auto timezoneMinutes = util::unpackZoneKeyId(value);
-
-  VELOX_CHECK_GE(timezoneMinutes, 0, "Timezone offset is less than -14:00");
-  VELOX_CHECK_LE(
-      timezoneMinutes, 1680, "Timezone offset is greater than +14:00");
-
-  // Decode timezone offset from bias-encoded value
-  int16_t offsetMinutes = util::decodeTimezoneOffset(timezoneMinutes);
-  auto decodedMinutes = std::abs(offsetMinutes);
-
-  const auto isBehindUTCString = (offsetMinutes >= 0) ? "+" : "-";
-
-  // Convert UTC time to local time using utility function
-  // Example: If UTC time is 06:30:00 and timezone is +05:30,
-  // the local time is 12:00:00
-  int64_t millisLocal = util::utcToLocalTime(millisUtc, offsetMinutes);
-
-  int64_t hours = millisLocal / util::kMillisInHour;
-  int64_t remainingMs = millisLocal % util::kMillisInHour;
-  int64_t minutes = remainingMs / util::kMillisInMinute;
-  remainingMs = remainingMs % util::kMillisInMinute;
-  int64_t seconds = remainingMs / util::kMillisInSecond;
-  int64_t millis = remainingMs % util::kMillisInSecond;
-
-  int16_t offsetHours = decodedMinutes / util::kMinutesInHour;
-  int16_t remainingOffsetMinutes = decodedMinutes % util::kMinutesInHour;
-
-  fmt::format_to_n(
-      startPos,
-      kTimeWithTimezoneToVarcharRowSize,
-      "{:02d}:{:02d}:{:02d}.{:03d}{}{:02d}:{:02d}",
-      hours,
-      minutes,
-      seconds,
-      millis,
-      isBehindUTCString,
-      offsetHours,
-      remainingOffsetMinutes);
-  return StringView{startPos, kTimeWithTimezoneToVarcharRowSize};
-}
 
 namespace {
 void castToTime(
@@ -202,7 +131,7 @@ inline int64_t packTimeWithTimeZone(
     int64_t timeMillis,
     int16_t timezoneOffsetMinutes) {
   auto encodedOffset = util::biasEncode(timezoneOffsetMinutes);
-  return pack(timeMillis, encodedOffset);
+  return util::pack(timeMillis, encodedOffset);
 }
 
 void castFromTime(
@@ -350,7 +279,8 @@ class TimeWithTimezoneTypeFactory : public CustomTypeFactory {
 
   AbstractInputGeneratorPtr getInputGenerator(
       const InputGeneratorConfig& config) const override {
-    return nullptr;
+    return std::make_shared<fuzzer::TimeWithTimezoneInputGenerator>(
+        config.seed_, config.nullRatio_);
   }
 };
 

--- a/velox/functions/prestosql/types/TimeWithTimezoneType.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneType.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
+
+#include "velox/type/Time.h"
+
+namespace facebook::velox {
+
+folly::dynamic TimeWithTimezoneType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "Type";
+  obj["type"] = name();
+  return obj;
+}
+
+StringView TimeWithTimezoneType::valueToString(
+    int64_t value,
+    char* const startPos) const {
+  // TIME WITH TIME ZONE is encoded similarly to TIMESTAMP WITH TIME ZONE
+  // with the most significnat 52 bits representing the time component and the
+  // least 12 bits representing the timezone minutes. This is different from
+  // TIMESTAMP WITH TIMEZONE where the last 12 bits represent the timezone
+  // offset. The timezone offset minutes are stored by value, encoded in the
+  // type itself. This allows the type to be used in a timezone-agnostic manner.
+  //
+  // The time component is a 52 bit value representing the number of
+  // milliseconds since midnight in UTC.
+
+  int64_t millisUtc = util::unpackMillisUtc(value);
+
+  // Ensure time component is within valid range
+  VELOX_CHECK_GE(millisUtc, 0, "Time component is negative");
+  VELOX_CHECK_LE(millisUtc, util::kMillisInDay, "Time component is too large");
+
+  // TimeZone's are encoded as a 12 bit value.
+  // This represents a range of -14:00 to +14:00, with 0 representing UTC.
+  // The range is from -840 to 840 minutes, we thus encode by doing bias
+  // encoding and taking 840 as the bias.
+  auto timezoneMinutes = util::unpackZoneKeyId(value);
+
+  VELOX_CHECK_GE(timezoneMinutes, 0, "Timezone offset is less than -14:00");
+  VELOX_CHECK_LE(
+      timezoneMinutes, 1680, "Timezone offset is greater than +14:00");
+
+  // Decode timezone offset from bias-encoded value
+  int16_t offsetMinutes = util::decodeTimezoneOffset(timezoneMinutes);
+  auto decodedMinutes = std::abs(offsetMinutes);
+
+  const auto isBehindUTCString = (offsetMinutes >= 0) ? "+" : "-";
+
+  // Convert UTC time to local time using utility function
+  // Example: If UTC time is 06:30:00 and timezone is +05:30,
+  // the local time is 12:00:00
+  int64_t millisLocal = util::utcToLocalTime(millisUtc, offsetMinutes);
+
+  int64_t hours = millisLocal / util::kMillisInHour;
+  int64_t remainingMs = millisLocal % util::kMillisInHour;
+  int64_t minutes = remainingMs / util::kMillisInMinute;
+  remainingMs = remainingMs % util::kMillisInMinute;
+  int64_t seconds = remainingMs / util::kMillisInSecond;
+  int64_t millis = remainingMs % util::kMillisInSecond;
+
+  int16_t offsetHours = decodedMinutes / util::kMinutesInHour;
+  int16_t remainingOffsetMinutes = decodedMinutes % util::kMinutesInHour;
+
+  fmt::format_to_n(
+      startPos,
+      kTimeWithTimezoneToVarcharRowSize,
+      "{:02d}:{:02d}:{:02d}.{:03d}{}{:02d}:{:02d}",
+      hours,
+      minutes,
+      seconds,
+      millis,
+      isBehindUTCString,
+      offsetHours,
+      remainingOffsetMinutes);
+  return StringView{startPos, kTimeWithTimezoneToVarcharRowSize};
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -14,6 +14,7 @@
 velox_add_library(
   velox_presto_types_fuzzer_utils
   TimestampWithTimeZoneInputGenerator.cpp
+  TimeWithTimezoneInputGenerator.cpp
   HyperLogLogInputGenerator.cpp
   P4HyperLogLogInputGenerator.cpp
   SfmSketchInputGenerator.cpp

--- a/velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.h"
+
+#include "velox/common/fuzzer/Utils.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
+#include "velox/type/Time.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::fuzzer {
+
+TimeWithTimezoneInputGenerator::TimeWithTimezoneInputGenerator(
+    size_t seed,
+    double nullRatio)
+    : AbstractInputGenerator(
+          seed,
+          TIME_WITH_TIME_ZONE(),
+          nullptr /*leafGenerator*/,
+          nullRatio) {}
+
+variant TimeWithTimezoneInputGenerator::generate() {
+  if (coinToss(rng_, nullRatio_)) {
+    return variant::null(type_->kind());
+  }
+
+  const int64_t timeMillis = rand<int64_t>(rng_, 0, util::kMillisInDay - 1);
+
+  int16_t timezoneOffsetMinutes;
+  // 25% of the time, pick from frequently used timezone offsets
+  if (coinToss(rng_, 0.25)) {
+    timezoneOffsetMinutes = kFrequentlyUsedOffsets[rand<size_t>(
+        rng_, 0, kFrequentlyUsedOffsets.size() - 1)];
+  } else {
+    // rest, pick a random timezone offset for variety
+    timezoneOffsetMinutes =
+        rand<int16_t>(rng_, -util::kTimeZoneBias, util::kTimeZoneBias);
+  }
+
+  const int16_t biasEncodedTimezone = util::biasEncode(timezoneOffsetMinutes);
+  return util::pack(timeMillis, biasEncodedTimezone);
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox::fuzzer {
+
+/// Input generator for TIME WITH TIME ZONE type.
+/// Generates valid TIME WITH TIME ZONE values by combining:
+/// - Time component: milliseconds since midnight (0 to 86399999)
+/// - Timezone offset: bias-encoded minutes (-840 to 840 -> 0 to 1680)
+/// Biases selection toward US timezone offsets (including DST) for better
+/// coverage of DST-related edge cases.
+class TimeWithTimezoneInputGenerator : public AbstractInputGenerator {
+ public:
+  // Frequently used timezone offsets in minutes (US timezones including DST)
+  static constexpr std::array<int16_t, 7> kFrequentlyUsedOffsets = {
+      -240, // EDT (Eastern Daylight Time)
+      -300, // EST (Eastern Standard Time) / CDT (Central Daylight Time)
+      -360, // CST (Central Standard Time) / MDT (Mountain Daylight Time)
+      -420, // MST (Mountain Standard Time) / PDT (Pacific Daylight Time)
+      -480, // PST (Pacific Standard Time) / AKDT (Alaska Daylight Time)
+      -540, // AKST (Alaska Standard Time) / HDT (Hawaii-Aleutian Daylight Time)
+      -600, // HST (Hawaii-Aleutian Standard Time)
+  };
+
+  TimeWithTimezoneInputGenerator(size_t seed, double nullRatio);
+
+  Variant generate() override;
+};
+
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_presto_types_fuzzer_utils_test
   TimestampWithTimeZoneInputGeneratorTest.cpp
+  TimeWithTimezoneInputGeneratorTest.cpp
   HyperLogLogInputGeneratorTest.cpp
   P4HyperLogLogInputGeneratorTest.cpp
   SfmSketchInputGeneratorTest.cpp

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/TimeWithTimezoneInputGeneratorTest.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/TimeWithTimezoneInputGeneratorTest.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.h"
+
+#include <gtest/gtest.h>
+#include <unordered_set>
+
+#include "velox/type/Time.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::fuzzer::test {
+
+TEST(TimeWithTimezoneInputGeneratorTest, generate) {
+  TimeWithTimezoneInputGenerator generator(123456, 0.1);
+
+  size_t numTrials = 100;
+  for (size_t i = 0; i < numTrials; ++i) {
+    variant generated = generator.generate();
+
+    if (generated.isNull()) {
+      continue;
+    }
+
+    generated.checkIsKind(TypeKind::BIGINT);
+    const auto value = generated.value<TypeKind::BIGINT>();
+
+    // Verify time component is in valid range [0, kMillisInDay)
+    const auto timeMillis = util::unpackMillisUtc(value);
+    EXPECT_GE(timeMillis, 0);
+    EXPECT_LT(timeMillis, util::kMillisInDay);
+
+    // Verify timezone offset is in valid bias-encoded range [0, 1680]
+    const auto timezoneOffset = util::unpackZoneKeyId(value);
+    EXPECT_GE(timezoneOffset, 0);
+    EXPECT_LE(timezoneOffset, 2 * util::kTimeZoneBias);
+  }
+}
+
+TEST(TimeWithTimezoneInputGeneratorTest, generatesBothOffsetTypes) {
+  TimeWithTimezoneInputGenerator generator(12345, 0.0); // Fixed seed, no nulls
+
+  std::unordered_set<int16_t> frequentlyUsed(
+      TimeWithTimezoneInputGenerator::kFrequentlyUsedOffsets.begin(),
+      TimeWithTimezoneInputGenerator::kFrequentlyUsedOffsets.end());
+
+  bool foundFrequentlyUsed = false;
+  bool foundOther = false;
+
+  for (int i = 0; i < 100 && (!foundFrequentlyUsed || !foundOther); ++i) {
+    auto value = generator.generate().value<TypeKind::BIGINT>();
+    auto encoded = util::unpackZoneKeyId(value);
+    auto offset = util::decodeTimezoneOffset(encoded);
+
+    if (frequentlyUsed.count(offset)) {
+      foundFrequentlyUsed = true;
+    } else {
+      foundOther = true;
+    }
+  }
+
+  EXPECT_TRUE(foundFrequentlyUsed);
+  EXPECT_TRUE(foundOther);
+}
+
+} // namespace facebook::velox::fuzzer::test


### PR DESCRIPTION
Summary:

Add fuzzer input generation support for TIME WITH TIME ZONE type and move type implementation to resolve circular dependency.

Changes
-------

*   Add input generation support for TIME WITH TIME ZONE type
    *   New `TimeWithTimezoneInputGenerator` class generates valid packed time+timezone values
    *   New `TimeWithTimezoneInputGeneratorTest` for validation
*   Refactor `TimeWithTimezoneType` to break circular dependency
    *   Move `serialize()` and `valueToString()` implementations to new `TimeWithTimezoneType.cpp`
    *   Allows fuzzer_utils to use correct type (TIME_WITH_TIME_ZONE)
*   Enable intermediate type transform to varchar in Time With Timezone for prestoQueryRunner

Differential Revision: D86822113


