### PR TITLE
refactor: FileUtils::makePartName

### DIFF
--- a/velox/dwio/catalog/fbhive/FileUtils.cpp
+++ b/velox/dwio/catalog/fbhive/FileUtils.cpp
@@ -158,46 +158,28 @@ std::string FileUtils::unescapePathName(const std::string& data) {
 
 std::string FileUtils::makePartName(
     const std::vector<std::pair<std::string, std::string>>& entries,
-    bool partitionPathAsLowerCase) {
-  size_t size = 0;
-  size_t escapeCount = 0;
-  std::for_each(entries.begin(), entries.end(), [&](auto& pair) {
-    auto keySize = pair.first.size();
-    VELOX_CHECK_GT(keySize, 0);
-    size += keySize;
-    escapeCount += countEscape(pair.first);
+    bool partitionPathAsLowerCase,
+    bool useDefaultPartitionValue,
+    const EncodeFunction& encodeFunc) {
+  std::ostringstream out;
 
-    auto valSize = pair.second.size();
-    if (valSize == 0) {
-      size += kDefaultPartitionValue.size();
+  for (const auto& [key, value] : entries) {
+    VELOX_CHECK(!key.empty());
+    if (out.tellp() > 0) {
+      out << '/';
+    }
+
+    std::string keyToEncode = partitionPathAsLowerCase ? toLower(key) : key;
+    out << encodeFunc(keyToEncode) << '=';
+
+    if (value.empty() && useDefaultPartitionValue) {
+      out << kDefaultPartitionValue;
     } else {
-      size += valSize;
-      escapeCount += countEscape(pair.second);
+      out << encodeFunc(value);
     }
-  });
+  }
 
-  std::string ret;
-  ret.reserve(size + escapeCount * HEX_WIDTH + entries.size() - 1);
-
-  std::for_each(entries.begin(), entries.end(), [&](auto& pair) {
-    if (ret.size() > 0) {
-      ret += "/";
-    }
-    if (partitionPathAsLowerCase) {
-      ret += escapePathName(toLower(pair.first));
-    } else {
-      ret += escapePathName(pair.first);
-    }
-
-    ret += "=";
-    if (pair.second.size() == 0) {
-      ret += kDefaultPartitionValue;
-    } else {
-      ret += escapePathName(pair.second);
-    }
-  });
-
-  return ret;
+  return out.str();
 }
 
 std::vector<std::pair<std::string, std::string>> FileUtils::parsePartKeyValues(

--- a/velox/dwio/catalog/fbhive/FileUtils.h
+++ b/velox/dwio/catalog/fbhive/FileUtils.h
@@ -29,6 +29,10 @@ namespace fbhive {
 
 class FileUtils {
  public:
+  /// Function type for encoding partition key/value strings.
+  /// Takes a string to encode and returns the encoded string.
+  using EncodeFunction = std::function<std::string(const std::string&)>;
+
   /// Converts the path name to be hive metastore compliant, will do
   /// url-encoding when needed.
   static std::string escapePathName(const std::string& data);
@@ -39,9 +43,18 @@ class FileUtils {
 
   /// Creates the partition directory path from the list of partition key/value
   /// pairs, will do url-encoding when needed.
+  /// @param entries Vector of (key, value) pairs for partition columns
+  /// @param partitionPathAsLowerCase Whether to convert keys to lowercase
+  /// @param useDefaultPartitionValue If true, empty values are replaced with
+  ///        kDefaultPartitionValue. If false, empty values are encoded as-is.
+  ///        Defaults to true for Hive compatibility.
+  /// @param encodeFunc Function to use for encoding keys and values.
+  ///                   Defaults to escapePathName.
   static std::string makePartName(
       const std::vector<std::pair<std::string, std::string>>& entries,
-      bool partitionPathAsLowerCase);
+      bool partitionPathAsLowerCase,
+      bool useDefaultPartitionValue = true,
+      const EncodeFunction& encodeFunc = escapePathName);
 
   /// Converts the hive-metastore-compliant path name back to the corresponding
   /// partition key/value pairs.

--- a/velox/dwio/catalog/fbhive/test/FileUtilsTests.cpp
+++ b/velox/dwio/catalog/fbhive/test/FileUtilsTests.cpp
@@ -22,7 +22,7 @@
 using namespace ::testing;
 using namespace facebook::velox::dwio::catalog::fbhive;
 
-TEST(FileUtilsTests, MakePartName) {
+TEST(FileUtilsTests, makePartName) {
   std::vector<std::pair<std::string, std::string>> pairs{
       {"ds", "2016-01-01"}, {"FOO", ""}, {"a\nb:c", "a#b=c"}};
   ASSERT_EQ(
@@ -33,7 +33,19 @@ TEST(FileUtilsTests, MakePartName) {
       "ds=2016-01-01/FOO=__HIVE_DEFAULT_PARTITION__/a%0Ab%3Ac=a%23b%3Dc");
 }
 
-TEST(FileUtilsTests, ParsePartKeyValues) {
+TEST(FileUtilsTests, makePartNameWithoutDefaultPartitionValue) {
+  std::vector<std::pair<std::string, std::string>> pairs{
+      {"ds", "2016-01-01"}, {"FOO", ""}, {"a\nb:c", "a#b=c"}};
+  // Test with useDefaultPartitionValue = false.
+  ASSERT_EQ(
+      FileUtils::makePartName(pairs, true, false),
+      "ds=2016-01-01/foo=/a%0Ab%3Ac=a%23b%3Dc");
+  ASSERT_EQ(
+      FileUtils::makePartName(pairs, false, false),
+      "ds=2016-01-01/FOO=/a%0Ab%3Ac=a%23b%3Dc");
+}
+
+TEST(FileUtilsTests, parsePartKeyValues) {
   EXPECT_THROW(
       FileUtils::parsePartKeyValues("ds"), facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
@@ -60,7 +72,7 @@ TEST(FileUtilsTests, ParsePartKeyValues) {
           std::make_pair("a\nb:c", "a#b=c/")));
 }
 
-TEST(FileUtilsTests, ExtractPartitionName) {
+TEST(FileUtilsTests, extractPartitionName) {
   struct TestCase {
    public:
     TestCase(const std::string& filePath, const std::string& partitionName)


### PR DESCRIPTION
Refactor FileUtils::makePartName to support Iceberg partition name generation.
1. Add 'useDefaultPartitionValue' parameter to control whether
   empty partition values should be replaced with `__HIVE_DEFAULT_PARTITION__`
2. Add 'encodeFunc' parameter to allow custom encoding functions
   (defaults to escapePathName for Hive compatibility).
3. Add test coverage.