### PR TITLE
misc: Change task termination log level to VLOG

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2452,9 +2452,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
       cancellationSource_.requestCancellation();
     }
 
-    LOG(INFO) << "Terminating task " << taskId() << " with state "
-              << taskStateString(state_) << " after running for "
-              << succinctMillis(timeSinceStartMsLocked());
+    VLOG(1) << "Terminating task " << taskId() << " with state "
+            << taskStateString(state_) << " after running for "
+            << succinctMillis(timeSinceStartMsLocked());
 
     taskCompletionNotifier.activate(
         std::move(taskCompletionPromises_), [&]() { onTaskCompletion(); });


### PR DESCRIPTION
Summary: Reduce log spam when running tasks at high QPS and also to keep it consistent with other driver removal logs in the file.

Differential Revision: D86894626


