### PR TITLE
feat: Support VeloxQueryRunner in Github Expression Fuzzer (#15483)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -222,6 +222,7 @@ jobs:
             -DVELOX_MONO_LIBRARY=ON
             -DVELOX_BUILD_PYTHON_PACKAGE=ON
             -DVELOX_PYTHON_LEGACY_ONLY=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
             ${{ inputs.extraCMakeFlags }}
         run: |
           make python-venv

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -384,6 +384,13 @@ jobs:
           path: velox/_build/debug/velox/exec/fuzzer/velox_spatial_join_fuzzer
           retention-days: ${{ env.RETENTION }}
 
+      - name: Upload local runner service runner
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: local_runner_service_runner
+          path: velox/_build/debug/velox/exec/fuzzer/velox_local_runner_service_runner
+          retention-days: ${{ env.RETENTION }}
+
   presto-fuzzer-run:
     name: Presto Fuzzer
     if: ${{ needs.compile.outputs.presto_bias  != 'true' }}
@@ -457,6 +464,80 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: presto-fuzzer-failure-artifacts
+          path: |
+            /tmp/fuzzer_repro
+
+  presto-fuzzer-with-local-runner-run:
+    name: Presto Fuzzer with Local Runner
+    runs-on: ubuntu-latest
+    container: ghcr.io/facebookincubator/velox-dev:centos9
+    needs: compile
+    timeout-minutes: 120
+    steps:
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        if: github.event_name == 'pull_request'
+        id: changes
+        with:
+          filters: |
+            presto:
+              - 'velox/expression/!(test)**'
+              - 'velox/exec/!(test)**'
+              - 'velox/common/!(test)**'
+              - 'velox/core/!(test)**'
+              - 'velox/vector/!(test)**'
+
+      - name: Download presto fuzzer
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: presto
+
+      - name: Download local runner service runner
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: local_runner_service_runner
+
+      - name: Run Presto Fuzzer with Local Runner
+        run: |
+          mkdir -p /tmp/fuzzer_repro/logs/
+          chmod -R 777 /tmp/fuzzer_repro
+          chmod +x velox_expression_fuzzer_test
+          chmod +x velox_local_runner_service_runner
+          # Start LocalRunnerService in the background
+          ./velox_local_runner_service_runner > /tmp/fuzzer_repro/logs/local_runner_service.log 2>&1 &
+          LOCAL_RUNNER_PID=$!
+          echo "Started LocalRunnerService with PID: ${LOCAL_RUNNER_PID}"
+          # Sleep for 10 seconds to allow service to start
+          sleep 10
+          random_seed=${RANDOM}
+          echo "Duration: $DURATION"
+          echo "Random seed: ${random_seed}"
+          ./velox_expression_fuzzer_test \
+                --seed ${random_seed} \
+                --enable_variadic_signatures \
+                --velox_fuzzer_enable_complex_types \
+                --velox_fuzzer_enable_decimal_type \
+                --lazy_vector_generation_ratio 0.2 \
+                --common_dictionary_wraps_generation_ratio=0.3 \
+                --velox_fuzzer_enable_column_reuse \
+                --velox_fuzzer_enable_expression_reuse \
+                --max_expression_trees_per_step 2 \
+                --retry_with_try \
+                --enable_dereference \
+                --duration_sec $DURATION \
+                --minloglevel=0 \
+                --stderrthreshold=2 \
+                --log_dir=/tmp/fuzzer_repro/logs \
+                --repro_persist_path=/tmp/fuzzer_repro \
+                --velox_runner_url=http://127.0.0.1:9091 \
+          && echo -e "\n\nFuzzer run finished successfully."
+          # Stop the LocalRunnerService
+          kill $LOCAL_RUNNER_PID || true
+
+      - name: Archive production artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: presto-fuzzer-with-local-runner-failure-artifacts
           path: |
             /tmp/fuzzer_repro
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,11 +658,14 @@ if(${VELOX_BUILD_TESTING})
   velox_resolve_dependency(gRPC)
 endif()
 
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  add_definitions(-DVELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+endif()
+
 # FBThrift is required by remote functions and LocalRunnerService.
 # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
 # requires clients to explicitly install fizz and wangle.
 if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
-  add_definitions(-DVELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ option(VELOX_ENABLE_PARQUET "Enable Parquet support" ON)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_GEO "Enable Geospatial support" ON)
 option(VELOX_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
+option(
+  VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  "Enable LocalRunnerService and VeloxQueryRunner for expression fuzzer regression testing"
+  OFF
+)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 option(VELOX_ENABLE_COMPRESSION_LZ4 "Enable Lz4 compression support." OFF)
 
@@ -653,9 +658,11 @@ if(${VELOX_BUILD_TESTING})
   velox_resolve_dependency(gRPC)
 endif()
 
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
-  # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
-  # requires clients to explicitly install fizz and wangle.
+# FBThrift is required by remote functions and LocalRunnerService.
+# TODO: Move this to use resolve_dependency(). For some reason, FBThrift
+# requires clients to explicitly install fizz and wangle.
+if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  add_definitions(-DVELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -40,10 +40,8 @@ add_library(
   PrestoSql.cpp
 )
 
-# TODO Add VeloxQueryRunner to velox_fuzzer_util to support in
-# ExpressionFuzzerTest. More information can be found here:
-# https://github.com/facebookincubator/velox/issues/15414
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# VeloxQueryRunner requires LocalRunnerService thrift library
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   target_sources(velox_fuzzer_util PRIVATE VeloxQueryRunner.cpp)
   target_link_libraries(velox_fuzzer_util local_runner_service_thrift)
   target_include_directories(velox_fuzzer_util PUBLIC ${CMAKE_CURRENT_BINARY_DIR})

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(presto_sql_test presto_sql_test)
 target_link_libraries(presto_sql_test velox_fuzzer_util velox_presto_types)
 
 # LocalRunnerService Test (requires FBThrift support)
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_executable(local_runner_service_test LocalRunnerServiceTest.cpp)
   add_test(local_runner_service_test local_runner_service_test)
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -18,6 +18,9 @@
 #include <unordered_set>
 
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+#include "velox/exec/fuzzer/VeloxQueryRunner.h"
+#endif
 #include "velox/expression/fuzzer/ArgTypesGenerator.h"
 #include "velox/expression/fuzzer/ArgValuesGenerators.h"
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
@@ -46,6 +49,14 @@ DEFINE_string(
     "Presto coordinator URI along with port. If set, we use Presto as the "
     "source of truth. Otherwise, use the Velox simplified expression evaluation. Example: "
     "--presto_url=http://127.0.0.1:8080");
+
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+DEFINE_string(
+    velox_runner_url,
+    "",
+    "URI for thrift requests to LocalRunnerService. Defaults to localhost on port 9091. "
+    "Example: --velox_runner_url=http://127.0.0.1:9091");
+#endif
 
 DEFINE_uint32(
     req_timeout_ms,
@@ -484,6 +495,8 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "merge_khll(array(khyperloglog)) -> khyperloglog",
 };
 
+std::unordered_set<std::string> skipFunctionsLocalRunner = {};
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
@@ -503,6 +516,7 @@ int main(int argc, char** argv) {
   std::shared_ptr<facebook::velox::memory::MemoryPool> rootPool{
       facebook::velox::memory::memoryManager()->addRootPool()};
   std::shared_ptr<ReferenceQueryRunner> referenceQueryRunner{nullptr};
+  auto shouldAdjustTimestampToSessionTimezone = "true";
 
   if (!FLAGS_presto_url.empty()) {
     // Add additional functions to skip since we are now querying Presto
@@ -515,13 +529,25 @@ int main(int argc, char** argv) {
         "expression_fuzzer",
         static_cast<std::chrono::milliseconds>(FLAGS_req_timeout_ms));
     LOG(INFO) << "Using Presto as the reference DB.";
+#ifdef VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  } else if (!FLAGS_velox_runner_url.empty()) {
+    shouldAdjustTimestampToSessionTimezone = "false";
+    skipFunctions.insert(
+        skipFunctionsLocalRunner.begin(), skipFunctionsLocalRunner.end());
+    referenceQueryRunner = std::make_shared<VeloxQueryRunner>(
+        rootPool.get(),
+        FLAGS_velox_runner_url,
+        std::chrono::milliseconds(FLAGS_req_timeout_ms));
+    LOG(INFO) << "Using LocalQueryRunner as the reference engine.";
+#endif
   }
   FuzzerRunner::runFromGtest(
       initialSeed,
       skipFunctions,
       exprTransformers,
       {{"session_timezone", "America/Los_Angeles"},
-       {"adjust_timestamp_to_session_timezone", "true"}},
+       {"adjust_timestamp_to_session_timezone",
+        shouldAdjustTimestampToSessionTimezone}},
       argTypesGenerators,
       argValuesGenerators,
       referenceQueryRunner,


### PR DESCRIPTION
Summary:

Additionally resolves https://github.com/facebookincubator/velox/issues/15414

Add Regression Fuzzer (i.e. Expression Fuzzer with LocalRunnerService as a source-of-truth) to Fuzzer Job test suite. This fuzzer sends serialized plans to a thrift service build on the base commit to test solely on new changes.

Differential Revision: D86911550


