### PR TITLE
fix: FlatVector::resizeValues can lose existing values for opaque types

### DIFF
--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -574,10 +574,11 @@ class FlatVector final : public SimpleVector<T> {
       const vector_size_t* toSourceRow);
 
   // Ensures that the values buffer has space for 'newSize' elements and is
-  // mutable. Sets elements between the old and new sizes to 'initialValue' if
-  // the new size > old size.
+  // mutable. Sets elements between the previous and new sizes to 'initialValue'
+  // if the new size > previous size.
   void resizeValues(
       vector_size_t newSize,
+      vector_size_t previousSize,
       const std::optional<T>& initialValue);
 
   // Check string buffers. Keep at most one singly-referenced buffer if it is

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -749,14 +749,17 @@ class VectorTest : public testing::Test, public velox::test::VectorTestBase {
       // immutable. This is true for a slice since it creates buffer views over
       // the buffers of the original vector that it sliced.
       auto newSize = slice->size() * 2;
+      auto sliceCopy = BaseVector::copy(*slice);
       slice->resize(newSize);
       EXPECT_EQ(slice->size(), newSize);
+      slice->resize(sliceCopy->size());
+      test::assertEqualVectors(slice, sliceCopy);
     }
   }
 
   static void testSlices(const VectorPtr& slice, int level = 2) {
     for (vector_size_t offset : {0, 16, 17}) {
-      for (vector_size_t length : {0, 1, 83}) {
+      for (vector_size_t length : {0, 1, 83, 100}) {
         if (offset + length <= slice->size()) {
           testSlice(slice, level, offset, length);
         }


### PR DESCRIPTION
Summary:
There is a bug in FlatVector::resizeValues where for non-POD types (I think this is just opaque 
types) if the Buffer is immutable, there's a typo where it copies values from the new Buffer
into itself, losing the existing values.

Fixing this bug exposes another bug that FlatVector::resizeValues uses BaseVector::length_
as the previous size, however, by this point BaseVector::resize has already been invoked, so it
should be equal to new size (leading to reading off the end of the Buffer after the fix for the
first issue).

To address this I pass the previous size to FlatVector::resizeValues as relying on the order of 
invoking this function and BaseVector::resize seems error prone.

Another option would be to rely on the Buffer sizes, but then we may be copying more values
than necessary. Along these lines I updated the logic for POD types (other types) to use the
Vector size to determine how many values to copy over (any other values would have been set
to initialValue already if one is needed).

I noticed a similar bug in the bool template specialization of FlatVector::resizeValues where it
was using BaseVector::length_ for deciding how many values to set to initialValue if we are
just updating the size of an existing Buffer with sufficient capacity. I opted to just delete this
code since it is in a private function and there is no invocation that passes an initialValue for a
bool, and it's inconsistent with the base implementation of FlatVector::resizeValues which only
sets values to initialValue if the Buffer is reallocated.

Differential Revision: D86920858


