### PR TITLE
feat: Add rewrite for IN special form

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_add_library(
   FindFirst.cpp
   FromUtf8.cpp
   InPredicate.cpp
+  InRewrite.cpp
   JsonFunctions.cpp
   Map.cpp
   MapEntries.cpp

--- a/velox/functions/prestosql/InRewrite.cpp
+++ b/velox/functions/prestosql/InRewrite.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <set>
+
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/expression/ExprUtils.h"
+#include "velox/functions/prestosql/InRewrite.h"
+
+namespace facebook::velox::functions {
+
+core::TypedExprPtr InRewrite::rewrite(const core::TypedExprPtr& expr) {
+  // IN expression with a constant value can be rewritten.
+  if (expr->inputs().empty() || !expr->inputs()[0]->isConstantKind()) {
+    return nullptr;
+  }
+
+  if (!expr->isCallKind()) {
+    return nullptr;
+  }
+  static const char* kIn = "in";
+  const auto* callExpr = expr->asUnchecked<core::CallTypedExpr>();
+  if (callExpr->name() != kIn) {
+    return nullptr;
+  }
+
+  const auto& valueExpr = callExpr->inputs().at(0);
+  const auto* constValueExpr =
+      valueExpr->asUnchecked<core::ConstantTypedExpr>();
+  if (constValueExpr->isNull()) {
+    return core::ConstantTypedExpr::makeNull(BOOLEAN());
+  }
+
+  const auto& inputs = callExpr->inputs();
+  const auto numInputs = inputs.size();
+  bool hasNullInput = false;
+  std::vector<core::TypedExprPtr> optimizedInputs;
+  optimizedInputs.emplace_back(valueExpr);
+
+  for (auto i = 1; i < numInputs; i++) {
+    const auto& input = inputs[i];
+    if (input->isConstantKind()) {
+      const auto* constInput = input->asUnchecked<core::ConstantTypedExpr>();
+      if (constInput->isNull()) {
+        if (!hasNullInput) {
+          optimizedInputs.push_back(input);
+          hasNullInput = true;
+        }
+      } else if (*constInput == *constValueExpr) {
+        return std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true);
+      }
+    } else {
+      optimizedInputs.push_back(input);
+    }
+  }
+
+  VELOX_CHECK(!optimizedInputs.empty(), "No inputs to IN after rewrite.");
+  return std::make_shared<core::CallTypedExpr>(
+      expr->type(), std::move(optimizedInputs), callExpr->name());
+}
+
+void InRewrite::registerRewrite() {
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      functions::InRewrite::rewrite);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/InRewrite.h
+++ b/velox/functions/prestosql/InRewrite.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::functions {
+
+class InRewrite {
+ public:
+  /// Rewrites IN special form function when the `value` being searched for is
+  /// constant and the IN-list is not constant. Returns `true` if `value` is in
+  /// the IN-list. Returns NULL if the IN-list contains a NULL. Removes constant
+  /// expressions from IN-list that are not equal to `value`.
+  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+
+  static void registerRewrite();
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/Fail.h"
 #include "velox/functions/prestosql/GreatestLeast.h"
 #include "velox/functions/prestosql/InPredicate.h"
+#include "velox/functions/prestosql/InRewrite.h"
 #include "velox/functions/prestosql/Reduce.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -79,6 +80,8 @@ void registerAllSpecialFormGeneralFunctions() {
       bool,
       Generic<T1>,
       Variadic<Generic<T1>>>({"in"});
+  InRewrite::registerRewrite();
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, expression::kRowConstructor);
   registerIsNullFunction("is_null");
 }

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(
   P4HyperLogLogCastTest.cpp
   SetDigestCastTest.cpp
   InPredicateTest.cpp
+  InRewriteTest.cpp
   IntegerFunctionsTest.cpp
   IPAddressCastTest.cpp
   IPPrefixCastTest.cpp

--- a/velox/functions/prestosql/tests/InRewriteTest.cpp
+++ b/velox/functions/prestosql/tests/InRewriteTest.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/core/Expressions.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+class InRewriteTest : public functions::test::FunctionBaseTest {
+ protected:
+  static core::TypedExprPtr constant(
+      const TypePtr& type,
+      const Variant& value) {
+    return std::make_shared<core::ConstantTypedExpr>(type, value);
+  }
+
+  static core::TypedExprPtr field(
+      const TypePtr& type,
+      const std::string& name) {
+    return std::make_shared<core::FieldAccessTypedExpr>(type, name);
+  }
+
+  static core::TypedExprPtr makeIn(
+      std::initializer_list<core::TypedExprPtr> inputs) {
+    return std::make_shared<core::CallTypedExpr>(BOOLEAN(), "in", inputs);
+  }
+
+  bool testInRewrite(
+      const core::TypedExprPtr& expr,
+      const core::TypedExprPtr& expected) {
+    const auto rewritten =
+        expression::ExprRewriteRegistry::instance().rewrite(expr);
+    return *rewritten == *expected;
+  }
+};
+
+TEST_F(InRewriteTest, basic) {
+  // 1234 in (2, a, b, 1234) -> true.
+  auto in = makeIn(
+      {constant(INTEGER(), 1234),
+       constant(INTEGER(), 2),
+       field(INTEGER(), "a"),
+       field(INTEGER(), "b"),
+       constant(INTEGER(), 1234)});
+  auto expected = constant(BOOLEAN(), true);
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // 81 in (2, 4, a, b, 9) -> 81 in (a, b)
+  in = makeIn(
+      {constant(INTEGER(), 81),
+       constant(INTEGER(), 2),
+       field(INTEGER(), "a"),
+       constant(INTEGER(), 4),
+       field(INTEGER(), "b"),
+       constant(INTEGER(), 1234)});
+  expected = makeIn(
+      {constant(INTEGER(), 81), field(INTEGER(), "a"), field(INTEGER(), "b")});
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // 5 in (NULL, a, 5) -> true
+  in = makeIn(
+      {constant(BIGINT(), 5LL),
+       constant(BIGINT(), variant::null(TypeKind::BIGINT)),
+       field(BIGINT(), "a"),
+       constant(BIGINT(), 5LL)});
+  expected = constant(BOOLEAN(), true);
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // NULL in (5, NULL, a) -> NULL
+  in = makeIn(
+      {constant(BIGINT(), variant::null(TypeKind::BIGINT)),
+       constant(BIGINT(), 5LL),
+       constant(BIGINT(), variant::null(TypeKind::BIGINT)),
+       field(BIGINT(), "a")});
+  expected = constant(BOOLEAN(), variant::null(TypeKind::BOOLEAN));
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // NULL in ('foo', 'bar', a) -> NULL
+  in = makeIn(
+      {constant(VARCHAR(), variant::null(TypeKind::VARCHAR)),
+       constant(VARCHAR(), "foo"),
+       constant(VARCHAR(), "bar"),
+       field(VARCHAR(), "a")});
+  expected = constant(BOOLEAN(), variant::null(TypeKind::BOOLEAN));
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // 'hello' in ('foo', NULL, 'bar', a, NULL) -> 'hello' in (NULL, a)
+  in = makeIn(
+      {constant(VARCHAR(), "hello"),
+       constant(VARCHAR(), "foo"),
+       constant(VARCHAR(), variant::null(TypeKind::VARCHAR)),
+       constant(VARCHAR(), "bar"),
+       field(VARCHAR(), "a"),
+       constant(VARCHAR(), variant::null(TypeKind::VARCHAR))});
+  expected = makeIn(
+      {constant(VARCHAR(), "hello"),
+       constant(VARCHAR(), variant::null(TypeKind::VARCHAR)),
+       field(VARCHAR(), "a")});
+  ASSERT_TRUE(testInRewrite(in, expected));
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Rewrites IN special form when the `value` being searched for is constant. 

- Returns `true` if `value` is in the `IN-list`. 
- Returns NULL if the value is NULL. 
- Deduplicates NULLs from the `IN-list`. 
- Removes constant elements from `IN-list` that do not match with `value`.

Examples:

- 5 IN (a, 5) ==> true
- NULL IN (5, a, b) ==> NULL
- 5 IN (NULL, a, NULL) ==> 5 IN (a, NULL)
- 5 IN (1, 2, a, b) ==> 5 IN (a, b)