### PR TITLE
fix: Fix StringView remapping in transferOrCopyTo() when string buffers are copied

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -223,6 +223,10 @@ class Buffer {
         sizeof(T), is_pod_like_v<T>, buffer, offset, length);
   }
 
+  /// Transfers this buffer to 'pool'. Returns true if the transfer succeeds, or
+  /// false if the transfer fails. A buffer can be transferred to 'pool' if its
+  /// original pool and 'pool' are from the same MemoryAllocator and the buffer
+  /// is not a BufferView.
   virtual bool transferTo(velox::memory::MemoryPool* /*pool*/) {
     VELOX_NYI("{} unsupported", __FUNCTION__);
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -542,6 +542,11 @@ class BaseVector {
   virtual VectorPtr testingCopyPreserveEncodings(
       velox::memory::MemoryPool* pool = nullptr) const = 0;
 
+  /// Transfer or copy this vector and all its buffers recursively to 'pool'.
+  /// The transfer of a buffer is allowed if its original pool and 'pool' are
+  /// from the same MemoryAllocator and the buffer is not a BufferView. If a
+  /// buffer is not allowed to be transferred, it is copied to pool. After this
+  /// call, this vector and all its buffers are owned by 'pool'.
   virtual void transferOrCopyTo(velox::memory::MemoryPool* pool);
 
   /// Construct a zero-copy slice of the vector with the indicated offset and

--- a/velox/vector/FlatMapVector.cpp
+++ b/velox/vector/FlatMapVector.cpp
@@ -695,17 +695,4 @@ MapVectorPtr FlatMapVector::toMapVector() const {
       sortedKeys_);
 }
 
-void FlatMapVector::transferOrCopyTo(velox::memory::MemoryPool* pool) {
-  BaseVector::transferOrCopyTo(pool);
-  distinctKeys_->transferOrCopyTo(pool);
-  for (auto& mapValue : mapValues_) {
-    mapValue->transferOrCopyTo(pool);
-  }
-  for (auto& inMap : inMaps_) {
-    if (!inMap->transferTo(pool)) {
-      inMap = AlignedBuffer::copy<uint64_t>(inMap, pool);
-    }
-  }
-}
-
 } // namespace facebook::velox

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -337,7 +337,12 @@ class FlatMapVector : public BaseVector {
   /// testing/validation purposes, and not for performance critical paths.
   MapVectorPtr toMapVector() const;
 
-  void transferOrCopyTo(velox::memory::MemoryPool* pool) override;
+  void transferOrCopyTo(velox::memory::MemoryPool* /*pool*/) override {
+    // TODO: enable this after
+    // https://github.com/facebookincubator/velox/issues/15485 is resolved to
+    // allow proper testing.
+    VELOX_NYI("{} unsupported", __FUNCTION__);
+  }
 
  private:
   void setDistinctKeysImpl(VectorPtr distinctKeys) {

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -215,7 +215,7 @@ class SequenceVector : public SimpleVector<T> {
   }
 
   void transferOrCopyTo(velox::memory::MemoryPool* /*pool*/) override {
-    VELOX_UNSUPPORTED("transferTo not defined for SequenceVector");
+    VELOX_NYI("{} unsupported", __FUNCTION__);
   }
 
  private:

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ target_link_libraries(
   velox_presto_types
   velox_temp_path
   velox_type_test_lib
+  velox_common_fuzzer_util
   Boost::atomic
   Boost::context
   Boost::date_time

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -22,6 +22,7 @@
 #include <optional>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/fuzzer/Utils.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/common/testutil/OptionalEmpty.h"
 #include "velox/serializers/PrestoSerializer.h"
@@ -4298,56 +4299,86 @@ TEST_F(VectorTest, estimateFlatSize) {
   arrayVector->prepareForReuse();
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(VectorTest, transferOrCopyTo) {
   auto rootPool = memory::memoryManager()->addRootPool("long-living");
   auto pool = rootPool->addLeafChild("long-living leaf");
+  memory::MemoryManager anotherManager{memory::MemoryManager::Options{}};
 
   VectorPtr vector;
   VectorPtr expected;
 
   // Test primitive type.
-  {
-    auto localRootPool = memory::memoryManager()->addRootPool("short-living");
-    auto localPool = localRootPool->addLeafChild("short-living leaf");
-    test::VectorMaker maker{localPool.get()};
-    vector = maker.flatVector<int64_t>(
-        3, [](auto row) { return row; }, [](auto row) { return row == 2; });
-    expected = BaseVector::copy(*vector, pool.get());
-    vector->transferOrCopyTo(pool.get());
-  }
-  ASSERT_EQ(vector->pool(), pool.get());
-  test::assertEqualVectors(expected, vector);
+  auto testPrimitive = [&](memory::MemoryManager* memoryManager) {
+    std::vector<int64_t> c0;
+    std::vector<std::string> c1;
+    {
+      auto localRootPool = memoryManager->addRootPool("short-living");
+      auto localPool = localRootPool->addLeafChild("short-living leaf");
+      FuzzerGenerator rng{123};
+      std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
+      for (auto i = 0; i < 1000; ++i) {
+        c0.push_back(fuzzer::rand<int64_t>(rng, fuzzer::DataSpec{}));
+        std::string buf;
+        fuzzer::randString(
+            rng,
+            fuzzer::rand<uint64_t>(rng, 0, 100),
+            {fuzzer::UTF8CharList::ASCII,
+             fuzzer::UTF8CharList::UNICODE_CASE_SENSITIVE,
+             fuzzer::UTF8CharList::EXTENDED_UNICODE},
+            buf,
+            converter);
+        c1.push_back(buf);
+      }
+      test::VectorMaker maker{localPool.get()};
+      vector = maker.rowVector(
+          {maker.flatVector<int64_t>(c0), maker.flatVector<std::string>(c1)});
+      vector->transferOrCopyTo(pool.get());
+    }
+    ASSERT_EQ(vector->pool(), pool.get());
+    test::VectorMaker maker{pool.get()};
+    expected = maker.rowVector(
+        {maker.flatVector<int64_t>(c0), maker.flatVector<std::string>(c1)});
+    test::assertEqualVectors(expected, vector);
+  };
+  testPrimitive(memory::memoryManager());
+  testPrimitive(&anotherManager);
 
   // Test complex type.
-  {
-    auto localRootPool = memory::memoryManager()->addRootPool("short-living");
-    auto localPool = localRootPool->addLeafChild("short-living leaf");
-    test::VectorMaker maker{localPool.get()};
-    vector = maker.rowVector(
-        {maker.flatVector<double>(
-             3,
-             [](auto row) { return row; },
-             [](auto row) { return row == 2; }),
-         maker.constantVector<bool>({true, true, true}),
-         maker.dictionaryVector<int64_t>({1, std::nullopt, 1}),
-         maker.arrayVector<int64_t>(
-             3,
-             [](auto row) { return row; },
-             [](auto row) { return row; },
-             [](auto row) { return row == 0; },
-             [](auto row) { return row == 1; }),
-         maker.mapVector<int64_t, int64_t>(
-             3,
-             [](auto row) { return row; },
-             [](auto row) { return row; },
-             [](auto row) { return row + 1; },
-             [](auto row) { return row == 1; },
-             [](auto row) { return row == 2; })});
-    expected = BaseVector::copy(*vector, pool.get());
-    vector->transferOrCopyTo(pool.get());
-  }
-  ASSERT_EQ(vector->pool(), pool.get());
-  test::assertEqualVectors(expected, vector);
+  auto testComplex = [&](memory::MemoryManager* memoryManager) {
+    {
+      auto localRootPool = memoryManager->addRootPool("short-living");
+      auto localPool = localRootPool->addLeafChild("short-living leaf");
+      test::VectorMaker maker{localPool.get()};
+      vector = maker.rowVector(
+          {maker.flatVector<double>(
+               3,
+               [](auto row) { return row; },
+               [](auto row) { return row == 2; }),
+           maker.constantVector<bool>({true, true, true}),
+           maker.dictionaryVector<int64_t>({1, std::nullopt, 1}),
+           maker.arrayVector<int64_t>(
+               3,
+               [](auto row) { return row; },
+               [](auto row) { return row; },
+               [](auto row) { return row == 0; },
+               [](auto row) { return row == 1; }),
+           maker.mapVector<int64_t, int64_t>(
+               3,
+               [](auto row) { return row; },
+               [](auto row) { return row; },
+               [](auto row) { return row + 1; },
+               [](auto row) { return row == 1; },
+               [](auto row) { return row == 2; })});
+      expected = BaseVector::copy(*vector, pool.get());
+      vector->transferOrCopyTo(pool.get());
+    }
+    ASSERT_EQ(vector->pool(), pool.get());
+    test::assertEqualVectors(expected, vector);
+  };
+  testComplex(memory::memoryManager());
+  testComplex(&anotherManager);
 
   // Test with fuzzing.
   // TODO: FlatMapVector doesn't support copy() yet. Add it later when it
@@ -4358,77 +4389,75 @@ TEST_F(VectorTest, transferOrCopyTo) {
       .allowLazyVector = true,
       .allowFlatMapVector = false};
   const int kNumIterations = 500;
-  for (auto i = 0; i < kNumIterations; ++i) {
-    {
-      auto localRootPool = memory::memoryManager()->addRootPool("short-living");
-      auto localPool = localRootPool->addLeafChild("short-living leaf");
+  auto testFuzz = [&](memory::MemoryManager* memoryManager) {
+    for (auto i = 0; i < kNumIterations; ++i) {
+      {
+        auto localRootPool = memoryManager->addRootPool("short-living");
+        auto localPool = localRootPool->addLeafChild("short-living leaf");
 
-      VectorFuzzer fuzzer{options, localPool.get(), 123};
-      auto type = fuzzer.randType();
-      vector = fuzzer.fuzz(type);
-      expected = BaseVector::copy(*vector, pool.get());
-      vector->transferOrCopyTo(pool.get());
+        VectorFuzzer fuzzer{options, localPool.get(), 123};
+        auto type = fuzzer.randType();
+        vector = fuzzer.fuzz(type);
+        expected = BaseVector::copy(*vector, pool.get());
+        vector->transferOrCopyTo(pool.get());
+      }
+      ASSERT_EQ(vector->pool(), pool.get());
+      test::assertEqualVectors(expected, vector);
     }
-    ASSERT_EQ(vector->pool(), pool.get());
-    test::assertEqualVectors(expected, vector);
-  }
+  };
+  testFuzz(memory::memoryManager());
+  testFuzz(&anotherManager);
 
   // Test complex-typed vectors with buffers from different pools.
-  VectorFuzzer fuzzer{options, pool.get(), 123};
-  for (auto i = 0; i < kNumIterations; ++i) {
+  auto testBufferFromDifferentPools =
+      [&](memory::MemoryManager* memoryManager) {
+        VectorFuzzer fuzzer{options, pool.get(), 123};
+        for (auto i = 0; i < kNumIterations; ++i) {
+          {
+            auto localRootPool = memoryManager->addRootPool("short-living");
+            auto localPool = localRootPool->addLeafChild("short-living leaf");
+            VectorFuzzer localFuzzer{options, localPool.get(), 123};
+
+            auto type = fuzzer.randType();
+            auto elements = localFuzzer.fuzz(type);
+            auto arrays = fuzzer.fuzzArray(elements, 70);
+            fuzzer.setOptions({});
+            auto keys = fuzzer.fuzz(BIGINT());
+            fuzzer.setOptions(options);
+            auto maps = localFuzzer.fuzzMap(keys, arrays, 50);
+            vector = localFuzzer.fuzzRow({maps}, 50);
+
+            expected = BaseVector::copy(*vector, pool.get());
+            vector->transferOrCopyTo(pool.get());
+          }
+          ASSERT_EQ(vector->pool(), pool.get());
+          test::assertEqualVectors(expected, vector);
+        }
+      };
+  testBufferFromDifferentPools(memory::memoryManager());
+  testBufferFromDifferentPools(&anotherManager);
+
+  // Test opaque vector.
+  auto testOpaque = [&](memory::MemoryManager* memoryManager) {
     {
-      auto localRootPool = memory::memoryManager()->addRootPool("short-living");
+      auto localRootPool = memoryManager->addRootPool("short-living");
       auto localPool = localRootPool->addLeafChild("short-living leaf");
-      VectorFuzzer localFuzzer{options, localPool.get(), 123};
 
-      auto type = fuzzer.randType();
-      auto elements = localFuzzer.fuzz(type);
-      auto arrays = fuzzer.fuzzArray(elements, 70);
-      fuzzer.setOptions({});
-      auto keys = fuzzer.fuzz(BIGINT());
-      fuzzer.setOptions(options);
-      auto maps = localFuzzer.fuzzMap(keys, arrays, 50);
-      vector = localFuzzer.fuzzRow({maps}, 50);
-
+      auto type = OPAQUE<NonPOD>();
+      auto size = 100;
+      vector = BaseVector::create(type, size, localPool.get());
+      auto opaqueObj = std::make_shared<NonPOD>();
+      for (auto i = 0; i < size; ++i) {
+        vector->as<FlatVector<std::shared_ptr<void>>>()->set(i, opaqueObj);
+      }
       expected = BaseVector::copy(*vector, pool.get());
       vector->transferOrCopyTo(pool.get());
     }
     ASSERT_EQ(vector->pool(), pool.get());
     test::assertEqualVectors(expected, vector);
-  }
-
-  // Test memory pool with different allocator.
-  {
-    memory::MemoryManager anotherManager{memory::MemoryManager::Options{}};
-    auto anotherRootPool = anotherManager.addRootPool("another root pool");
-    auto anotherPool = anotherRootPool->addLeafChild("another leaf pool");
-    VectorFuzzer localFuzzer{options, anotherPool.get(), 789};
-
-    auto type = fuzzer.randType();
-    vector = fuzzer.fuzz(type);
-    expected = BaseVector::copy(*vector, pool.get());
-    vector->transferOrCopyTo(pool.get());
-  }
-  ASSERT_EQ(vector->pool(), pool.get());
-  test::assertEqualVectors(expected, vector);
-
-  // Test opaque vector.
-  {
-    auto localRootPool = memory::memoryManager()->addRootPool("short-living");
-    auto localPool = localRootPool->addLeafChild("short-living leaf");
-
-    auto type = OPAQUE<NonPOD>();
-    auto size = 100;
-    vector = BaseVector::create(type, size, localPool.get());
-    auto opaqueObj = std::make_shared<NonPOD>();
-    for (auto i = 0; i < size; ++i) {
-      vector->as<FlatVector<std::shared_ptr<void>>>()->set(i, opaqueObj);
-    }
-    expected = BaseVector::copy(*vector, pool.get());
-    vector->transferOrCopyTo(pool.get());
-  }
-  ASSERT_EQ(vector->pool(), pool.get());
-  test::assertEqualVectors(expected, vector);
+  };
+  testOpaque(memory::memoryManager());
+  testOpaque(&anotherManager);
 
   auto testMemoryStats = [&options](size_t seed) {
     auto localRoot1 = memory::memoryManager()->addRootPool("local root 1");
@@ -4463,6 +4492,7 @@ TEST_F(VectorTest, transferOrCopyTo) {
     testMemoryStats(kNumIterations * i + i);
   }
 }
+#pragma GCC diagnostic pop
 
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
FlatVector::transferOrCopyTo() and ConstantVector::transferOrCopyTo() may copy the string 
buffers to new ones. However, there was a bug that they didn't udpate the StringViews in the 
vectors afterwards. StringViews must be updated if a string buffer is replaced by its copy, 
because StringViews contain pointers to addresses inside the string buffers.

This diff updates StringViews in FlatVector::transferOrCopyTo() and 
ConstantVector::transferOrCopyTo() when a copy of a string buffer occurs. It also updated the 
unit test to cover these situations. 

In addition, this diff adds documentation of the BaseVector::transferOrCopyTo() API. It also 
removes FlatMapVector::transferOrCopyTo() since it's not covered in the unit test yet.

Differential Revision: D86680882


