### PR TITLE
fix(cudf): Fix mergeRowVector when only one vector

### DIFF
--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -38,6 +38,9 @@ RowVectorPtr mergeRowVectors(
     const std::vector<RowVectorPtr>& results,
     velox::memory::MemoryPool* pool) {
   VELOX_NVTX_FUNC_RANGE();
+  if (results.size() == 1) {
+    return results[0];
+  }
   vector_size_t totalCount = 0;
   for (const auto& result : results) {
     totalCount += result->size();


### PR DESCRIPTION
If the source CPU RowVector size is more than GPU batch size, no need to copy it.