### PR TITLE
fix: Don't corrupt the FlatVector if resize fails to allocate memory

### DIFF
--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/common/testutil/OptionalEmpty.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
@@ -117,6 +118,7 @@ class VectorTest : public testing::Test, public velox::test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    common::testutil::TestValue::enable();
   }
 
   void SetUp() override {
@@ -295,6 +297,24 @@ class VectorTest : public testing::Test, public velox::test::VectorTestBase {
       flat->resize(size * 2);
       EXPECT_EQ(flat->valueAt(size * 2 - 1).size(), 0);
     }
+
+// This part of the test relies on TestValues to inject a failure, these are
+// only enabled in debug builds.
+#ifndef NDEBUG
+    {
+      // Make a copy so we don't modify the original Vector.
+      const auto slice = flat->slice(0, flat->size());
+
+      const std::string errorMessage = "Simulated failure in memory allocation";
+      SCOPED_TESTVALUE_SET(
+          "facebook::velox::FlatVector::resizeValues",
+          std::function<void(FlatVector<T>*)>(
+              [&](FlatVector<T>*) { VELOX_FAIL(errorMessage); }));
+
+      VELOX_ASSERT_THROW(slice->resize(slice->size() * 2), errorMessage);
+      slice->validate();
+    }
+#endif
 
     // Fill, the values at size * 2 - 1 gets assigned a second time.
     for (int32_t i = 0; i < flat->size(); ++i) {


### PR DESCRIPTION
Summary:
FlatVector::resize currently calls BaseVector::resize first then resizes the values_ Buffer. If we
fail to resize the values_ Buffer (e.g. we run out of memory, or the Driver is shutting down) it
can leave the FlatVector in an invalid state where values_ isn't large enough to hold values_
elements.

This change modifies the logic to only call BaseVector::resize after resizing the values_ Buffer.
This way if we fail at worst we have a values_ Buffer that is larger than length_ which is a valid
state to be in. Note that BaseVector::resize already allocates the nulls Buffer before updating
length_. Also DictionaryVector already allocates the indices Buffer before calling 
BaseVector::resize, and ConstantVector doesn't resize Buffers.

I have validated that after https://github.com/facebookincubator/velox/pull/15487 we no longer
refer to any values from BaseVector that may be modified by resize (e.g. length_) when
resizing the values_ Buffer.

When we can't allocate the Buffer we throw a VeloxRuntimeError, and we make no guarantees
about the validity of objects within the scope of the Driver after a VeloxRuntimeError is
thrown, so this is just a best effort attempt to reduce the risk of undefined behavior when
users attempt to handle VeloxRuntimeErrors incorrectly (e.g. in UDFs).

Differential Revision: D86994206


