### PR TITLE
fix: FileUtils::makePartName should throw on empty input

### DIFF
--- a/velox/dwio/catalog/fbhive/FileUtils.cpp
+++ b/velox/dwio/catalog/fbhive/FileUtils.cpp
@@ -161,6 +161,7 @@ std::string FileUtils::makePartName(
     bool partitionPathAsLowerCase,
     bool useDefaultPartitionValue,
     const EncodeFunction& encodeFunc) {
+  VELOX_CHECK(!entries.empty());
   std::ostringstream out;
 
   for (const auto& [key, value] : entries) {

--- a/velox/dwio/catalog/fbhive/FileUtils.h
+++ b/velox/dwio/catalog/fbhive/FileUtils.h
@@ -43,7 +43,8 @@ class FileUtils {
 
   /// Creates the partition directory path from the list of partition key/value
   /// pairs, will do url-encoding when needed.
-  /// @param entries Vector of (key, value) pairs for partition columns
+  /// @param entries Vector of (key, value) pairs for partition columns. Cannot
+  ///        be empty.
   /// @param partitionPathAsLowerCase Whether to convert keys to lowercase
   /// @param useDefaultPartitionValue If true, empty values are replaced with
   ///        kDefaultPartitionValue. If false, empty values are encoded as-is.

--- a/velox/dwio/catalog/fbhive/test/FileUtilsTests.cpp
+++ b/velox/dwio/catalog/fbhive/test/FileUtilsTests.cpp
@@ -19,8 +19,10 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/dwio/catalog/fbhive/FileUtils.h"
 
+namespace facebook::velox::dwio::catalog::fbhive {
+namespace {
+
 using namespace ::testing;
-using namespace facebook::velox::dwio::catalog::fbhive;
 
 TEST(FileUtilsTests, makePartName) {
   std::vector<std::pair<std::string, std::string>> pairs{
@@ -31,6 +33,7 @@ TEST(FileUtilsTests, makePartName) {
   ASSERT_EQ(
       FileUtils::makePartName(pairs, false),
       "ds=2016-01-01/FOO=__HIVE_DEFAULT_PARTITION__/a%0Ab%3Ac=a%23b%3Dc");
+  ASSERT_THROW(FileUtils::makePartName({}, false), VeloxException);
 }
 
 TEST(FileUtilsTests, makePartNameWithoutDefaultPartitionValue) {
@@ -100,3 +103,6 @@ TEST(FileUtilsTests, extractPartitionName) {
         FileUtils::extractPartitionName(testCase.filePath));
   }
 }
+
+} // namespace
+} // namespace facebook::velox::dwio::catalog::fbhive


### PR DESCRIPTION
Summary:
Empty input was not allowed before
https://github.com/facebookincubator/velox/pull/15480.  It was not obvious but
there are downstream projects depending on this behavior.  Add the extra check
to ensure we throw in this case.

Differential Revision: D87006275


