### PR TITLE
feat(cudf): Implement and default to automatic GPU detection

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1133,10 +1133,10 @@ Note: These configurations are experimental and subject to change.
      - Type
      - Default Value
      - Description
-   * - cudf.enabled
-     - bool
-     - true
-     - If true, enable cuDF. By default, it is enabled if compiled with cuDF.
+   * - cudf.disabled
+     - string
+     - unset
+     - Controls cuDF usage. When unset (default), auto-detects GPU availability. Set to "false" to require cuDF enabled (fails if no GPU detected), or "true" to force disable cuDF.
    * - cudf.memory_resource
      - string
      - async

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -23,7 +23,7 @@ namespace facebook::velox::cudf_velox {
 
 struct CudfConfig {
   /// Keys used by the initialize() method.
-  static constexpr const char* kCudfEnabled{"cudf.enabled"};
+  static constexpr const char* kCudfDisabled{"cudf.disabled"};
   static constexpr const char* kCudfDebugEnabled{"cudf.debug_enabled"};
   static constexpr const char* kCudfMemoryResource{"cudf.memory_resource"};
   static constexpr const char* kCudfMemoryPercent{"cudf.memory_percent"};
@@ -43,9 +43,12 @@ struct CudfConfig {
   /// Initialize from a map with the above keys.
   void initialize(std::unordered_map<std::string, std::string>&&);
 
-  /// Enable cudf by default.
-  /// Clients can disable here and enable it via the QueryConfig as well.
-  bool enabled{true};
+  /// Controls cuDF usage. When unset (default), auto-detects GPU availability.
+  /// Set to "false" to require cuDF enabled (fails if no GPU detected).
+  /// Set to "true" to force disable cuDF.
+  /// This field defaults to false and is set by initialize() based on config.
+  /// Clients can control this via QueryConfig.
+  bool disabled{false};
 
   /// Enable debug printing.
   bool debugEnabled{false};

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -64,6 +64,18 @@ bool isAnyOf(const Base* p) {
   return ((dynamic_cast<const Deriveds*>(p) != nullptr) || ...);
 }
 
+bool detectGpuAvailable() {
+  int deviceCount = 0;
+  auto error = cudaGetDeviceCount(&deviceCount);
+
+  if (error != cudaSuccess || deviceCount == 0) {
+    cudaGetLastError();
+    return false;
+  }
+
+  return true;
+}
+
 } // namespace
 
 bool CompileState::compile(bool allowCpuFallback) {
@@ -420,8 +432,8 @@ struct CudfDriverAdapter {
 
   // Call operator needed by DriverAdapter
   bool operator()(const exec::DriverFactory& factory, exec::Driver& driver) {
-    if (!driver.driverCtx()->queryConfig().get<bool>(
-            CudfConfig::kCudfEnabled, CudfConfig::getInstance().enabled) &&
+    if (driver.driverCtx()->queryConfig().get<bool>(
+            CudfConfig::kCudfDisabled, CudfConfig::getInstance().disabled) &&
         allowCpuFallback_) {
       return false;
     }
@@ -490,8 +502,21 @@ CudfConfig& CudfConfig::getInstance() {
 
 void CudfConfig::initialize(
     std::unordered_map<std::string, std::string>&& config) {
-  if (config.find(kCudfEnabled) != config.end()) {
-    enabled = folly::to<bool>(config[kCudfEnabled]);
+  if (config.find(kCudfDisabled) != config.end()) {
+    std::string value = config[kCudfDisabled];
+    disabled = folly::to<bool>(value);
+
+    // When explicitly set to false (cuDF required), verify GPU is available
+    if (!disabled && !detectGpuAvailable()) {
+      VELOX_FAIL(
+          "cuDF explicitly required (cudf.disabled=false) but no GPU detected. "
+          "Remove cudf.disabled config for automatic detection or ensure GPU is available.");
+    }
+  } else {
+    // Default: auto-detect GPU availability
+    disabled = !detectGpuAvailable();
+    LOG(INFO) << "cuDF auto-detection: GPU "
+              << (!disabled ? "detected, enabling" : "not detected, disabling");
   }
   if (config.find(kCudfDebugEnabled) != config.end()) {
     debugEnabled = folly::to<bool>(config[kCudfDebugEnabled]);

--- a/velox/experimental/cudf/tests/ConfigTest.cpp
+++ b/velox/experimental/cudf/tests/ConfigTest.cpp
@@ -22,7 +22,7 @@ namespace facebook::velox::cudf_velox::test {
 
 TEST(ConfigTest, CudfConfig) {
   std::unordered_map<std::string, std::string> options = {
-      {CudfConfig::kCudfEnabled, "false"},
+      {CudfConfig::kCudfDisabled, "true"},
       {CudfConfig::kCudfDebugEnabled, "true"},
       {CudfConfig::kCudfMemoryResource, "arena"},
       {CudfConfig::kCudfMemoryPercent, "25"},
@@ -31,7 +31,7 @@ TEST(ConfigTest, CudfConfig) {
 
   CudfConfig config;
   config.initialize(std::move(options));
-  ASSERT_EQ(config.enabled, false);
+  ASSERT_EQ(config.disabled, true);
   ASSERT_EQ(config.debugEnabled, true);
   ASSERT_EQ(config.memoryResource, "arena");
   ASSERT_EQ(config.memoryPercent, 25);


### PR DESCRIPTION
Instead of providing an enabled configuration option, we're explicitly enabling cuDF with "auto" mode.

New behavior:
- unset (default): auto-detect GPU availability, enable cuDF if GPU is present
- cudf.disabled=false: require cuDF, fail if no GPU is present
- cudf.disabled=true: force disable cuDF

This is a QoL improvement for mixed cluster deployments and enables
shipping a single image that works on systems with and without a GPU.