### PR TITLE
docs: Update Presto functions coverage map

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -70,132 +70,140 @@ for :doc:`all <functions/presto/coverage>` and :doc:`most used
     =================================================  =================================================  =================================================  ==  =================================================  ==  =================================================
     Scalar Functions                                                                                                                                             Aggregate Functions                                    Window Functions
     =======================================================================================================================================================  ==  =================================================  ==  =================================================
-    :func:`$internal$json_string_to_array_cast`        :func:`gt`                                         :func:`sequence`                                       :func:`any_value`                                      :func:`cume_dist`
-    :func:`$internal$json_string_to_map_cast`          :func:`gte`                                        :func:`sha1`                                           :func:`approx_distinct`                                :func:`dense_rank`
-    :func:`$internal$json_string_to_row_cast`          :func:`hamming_distance`                           :func:`sha256`                                         :func:`approx_most_frequent`                           :func:`first_value`
-    :func:`$internal$split_to_map`                     :func:`hmac_md5`                                   :func:`sha512`                                         :func:`approx_percentile`                              :func:`lag`
-    :func:`abs`                                        :func:`hmac_sha1`                                  :func:`shuffle`                                        :func:`approx_set`                                     :func:`last_value`
-    :func:`acos`                                       :func:`hmac_sha256`                                :func:`sign`                                           :func:`arbitrary`                                      :func:`lead`
-    :func:`all_keys_match`                             :func:`hmac_sha512`                                :func:`simplify_geometry`                              :func:`array_agg`                                      :func:`nth_value`
-    :func:`all_match`                                  :func:`hour`                                       :func:`sin`                                            :func:`avg`                                            :func:`ntile`
-    :func:`any_keys_match`                             in                                                 :func:`slice`                                          :func:`bitwise_and_agg`                                :func:`percent_rank`
-    :func:`any_match`                                  :func:`infinity`                                   :func:`split`                                          :func:`bitwise_or_agg`                                 :func:`rank`
-    :func:`any_values_match`                           :func:`inverse_beta_cdf`                           :func:`split_part`                                     :func:`bitwise_xor_agg`                                :func:`row_number`
-    :func:`array_average`                              :func:`inverse_binomial_cdf`                       :func:`split_to_map`                                   :func:`bool_and`
-    :func:`array_constructor`                          :func:`inverse_cauchy_cdf`                         :func:`split_to_multimap`                              :func:`bool_or`
-    :func:`array_cum_sum`                              :func:`inverse_chi_squared_cdf`                    :func:`spooky_hash_v2_32`                              :func:`checksum`
-    :func:`array_distinct`                             :func:`inverse_f_cdf`                              :func:`spooky_hash_v2_64`                              :func:`classification_fall_out`
-    :func:`array_duplicates`                           :func:`inverse_gamma_cdf`                          :func:`sqrt`                                           :func:`classification_miss_rate`
-    :func:`array_except`                               :func:`inverse_laplace_cdf`                        :func:`st_area`                                        :func:`classification_precision`
-    :func:`array_frequency`                            :func:`inverse_normal_cdf`                         :func:`st_asbinary`                                    :func:`classification_recall`
-    :func:`array_has_duplicates`                       :func:`inverse_poisson_cdf`                        :func:`st_astext`                                      :func:`classification_thresholds`
-    :func:`array_intersect`                            :func:`inverse_weibull_cdf`                        :func:`st_boundary`                                    :func:`corr`
-    :func:`array_join`                                 :func:`ip_prefix`                                  :func:`st_buffer`                                      :func:`count`
-    :func:`array_max`                                  :func:`ip_prefix_collapse`                         :func:`st_centroid`                                    :func:`count_if`
-    :func:`array_max_by`                               :func:`ip_prefix_subnets`                          :func:`st_contains`                                    :func:`covar_pop`
-    :func:`array_min`                                  :func:`ip_subnet_max`                              :func:`st_convexhull`                                  :func:`covar_samp`
-    :func:`array_min_by`                               :func:`ip_subnet_min`                              :func:`st_coorddim`                                    :func:`entropy`
-    :func:`array_normalize`                            :func:`ip_subnet_range`                            :func:`st_crosses`                                     :func:`every`
-    :func:`array_position`                             :func:`is_finite`                                  :func:`st_difference`                                  :func:`geometric_mean`
-    :func:`array_remove`                               :func:`is_infinite`                                :func:`st_dimension`                                   :func:`histogram`
-    :func:`array_sort`                                 :func:`is_json_scalar`                             :func:`st_disjoint`                                    :func:`kurtosis`
-    :func:`array_sort_desc`                            :func:`is_nan`                                     :func:`st_distance`                                    :func:`map_agg`
-    :func:`array_sum`                                  :func:`is_null`                                    :func:`st_endpoint`                                    :func:`map_union`
-    :func:`array_sum_propagate_element_null`           :func:`is_private_ip`                              :func:`st_envelope`                                    :func:`map_union_sum`
-    :func:`array_top_n`                                :func:`is_subnet_of`                               :func:`st_envelopeaspts`                               :func:`max`
-    :func:`array_union`                                :func:`json_array_contains`                        :func:`st_equals`                                      :func:`max_by`
-    :func:`arrays_overlap`                             :func:`json_array_get`                             :func:`st_exteriorring`                                :func:`max_data_size_for_stats`
-    :func:`asin`                                       :func:`json_array_length`                          :func:`st_geometries`                                  :func:`merge`
-    :func:`at_timezone`                                :func:`json_extract`                               :func:`st_geometryfromtext`                            :func:`min`
-    :func:`atan`                                       :func:`json_extract_scalar`                        :func:`st_geometryn`                                   :func:`min_by`
-    :func:`atan2`                                      :func:`json_format`                                :func:`st_geometrytype`                                :func:`multimap_agg`
-    :func:`beta_cdf`                                   :func:`json_parse`                                 :func:`st_geomfrombinary`                              :func:`noisy_approx_distinct_sfm`
-    :func:`between`                                    :func:`json_size`                                  :func:`st_interiorringn`                               :func:`noisy_approx_set_sfm`
-    :func:`bing_tile`                                  :func:`laplace_cdf`                                :func:`st_interiorrings`                               :func:`noisy_approx_set_sfm_from_index_and_zeros`
-    :func:`bing_tile_at`                               :func:`last_day_of_month`                          :func:`st_intersection`                                :func:`noisy_avg_gaussian`
-    :func:`bing_tile_children`                         :func:`least`                                      :func:`st_intersects`                                  :func:`noisy_count_gaussian`
-    :func:`bing_tile_coordinates`                      :func:`length`                                     :func:`st_isclosed`                                    :func:`noisy_count_if_gaussian`
-    :func:`bing_tile_parent`                           :func:`levenshtein_distance`                       :func:`st_isempty`                                     :func:`noisy_sum_gaussian`
-    :func:`bing_tile_quadkey`                          :func:`like`                                       :func:`st_isring`                                      :func:`numeric_histogram`
-    :func:`bing_tile_zoom_level`                       :func:`line_interpolate_point`                     :func:`st_issimple`                                    :func:`qdigest_agg`
-    :func:`bing_tiles_around`                          :func:`line_locate_point`                          :func:`st_isvalid`                                     :func:`reduce_agg`
-    :func:`binomial_cdf`                               :func:`ln`                                         :func:`st_length`                                      :func:`regr_avgx`
-    :func:`bit_count`                                  :func:`log10`                                      :func:`st_numgeometries`                               :func:`regr_avgy`
-    :func:`bitwise_and`                                :func:`log2`                                       :func:`st_numinteriorring`                             :func:`regr_count`
-    :func:`bitwise_arithmetic_shift_right`             :func:`lower`                                      :func:`st_numpoints`                                   :func:`regr_intercept`
-    :func:`bitwise_left_shift`                         :func:`lpad`                                       :func:`st_overlaps`                                    :func:`regr_r2`
-    :func:`bitwise_logical_shift_right`                :func:`lt`                                         :func:`st_point`                                       :func:`regr_slope`
-    :func:`bitwise_not`                                :func:`lte`                                        :func:`st_pointn`                                      :func:`regr_sxx`
-    :func:`bitwise_or`                                 :func:`ltrim`                                      :func:`st_points`                                      :func:`regr_sxy`
-    :func:`bitwise_right_shift`                        :func:`map`                                        :func:`st_polygon`                                     :func:`regr_syy`
-    :func:`bitwise_right_shift_arithmetic`             :func:`map_concat`                                 :func:`st_relate`                                      :func:`set_agg`
-    :func:`bitwise_shift_left`                         :func:`map_entries`                                :func:`st_startpoint`                                  :func:`set_union`
-    :func:`bitwise_xor`                                :func:`map_filter`                                 :func:`st_symdifference`                               :func:`skewness`
-    :func:`cardinality`                                :func:`map_from_entries`                           :func:`st_touches`                                     :func:`stddev`
-    :func:`cauchy_cdf`                                 :func:`map_key_exists`                             :func:`st_union`                                       :func:`stddev_pop`
-    :func:`cbrt`                                       :func:`map_keys`                                   :func:`st_within`                                      :func:`stddev_samp`
-    :func:`ceil`                                       :func:`map_keys_by_top_n_values`                   :func:`st_x`                                           :func:`sum`
-    :func:`ceiling`                                    :func:`map_normalize`                              :func:`st_xmax`                                        :func:`sum_data_size_for_stats`
-    :func:`chi_squared_cdf`                            :func:`map_remove_null_values`                     :func:`st_xmin`                                        :func:`tdigest_agg`
-    :func:`chr`                                        :func:`map_subset`                                 :func:`st_y`                                           :func:`var_pop`
-    :func:`clamp`                                      :func:`map_top_n`                                  :func:`st_ymax`                                        :func:`var_samp`
-    :func:`codepoint`                                  :func:`map_top_n_keys`                             :func:`st_ymin`                                        :func:`variance`
-    :func:`combinations`                               :func:`map_top_n_values`                           :func:`starts_with`
-    :func:`combine_hash_internal`                      :func:`map_values`                                 :func:`strpos`
-    :func:`concat`                                     :func:`map_zip_with`                               :func:`strrpos`
-    :func:`construct_tdigest`                          :func:`md5`                                        :func:`subscript`
-    :func:`contains`                                   :func:`merge_sfm`                                  :func:`substr`
-    :func:`cos`                                        :func:`merge_tdigest`                              :func:`substring`
-    :func:`cosh`                                       :func:`millisecond`                                :func:`tan`
-    :func:`cosine_similarity`                          :func:`minus`                                      :func:`tanh`
-    :func:`crc32`                                      :func:`minute`                                     :func:`timezone_hour`
-    :func:`current_date`                               :func:`mod`                                        :func:`timezone_minute`
-    :func:`date`                                       :func:`month`                                      :func:`to_base`
-    :func:`date_add`                                   :func:`multimap_from_entries`                      :func:`to_base64`
-    :func:`date_diff`                                  :func:`multiply`                                   :func:`to_base64url`
-    :func:`date_format`                                :func:`murmur3_x64_128`                            :func:`to_big_endian_32`
-    :func:`date_parse`                                 :func:`nan`                                        :func:`to_big_endian_64`
-    :func:`date_trunc`                                 :func:`negate`                                     :func:`to_hex`
-    :func:`day`                                        :func:`neq`                                        :func:`to_ieee754_32`
-    :func:`day_of_month`                               :func:`ngrams`                                     :func:`to_ieee754_64`
-    :func:`day_of_week`                                :func:`no_keys_match`                              :func:`to_iso8601`
-    :func:`day_of_year`                                :func:`no_values_match`                            :func:`to_milliseconds`
-    :func:`degrees`                                    :func:`noisy_empty_approx_set_sfm`                 :func:`to_unixtime`
-    :func:`destructure_tdigest`                        :func:`none_match`                                 :func:`to_utf8`
-    :func:`distinct_from`                              :func:`normal_cdf`                                 :func:`trail`
-    :func:`divide`                                     :func:`normalize`                                  :func:`transform`
-    :func:`dot_product`                                not                                                :func:`transform_keys`
-    :func:`dow`                                        :func:`parse_datetime`                             :func:`transform_values`
-    :func:`doy`                                        :func:`parse_duration`                             :func:`trim`
-    :func:`e`                                          :func:`parse_presto_data_size`                     :func:`trim_array`
-    :func:`element_at`                                 :func:`pi`                                         :func:`trimmed_mean`
-    :func:`empty_approx_set`                           :func:`plus`                                       :func:`truncate`
-    :func:`ends_with`                                  :func:`poisson_cdf`                                :func:`typeof`
-    :func:`eq`                                         :func:`pow`                                        :func:`upper`
-    :func:`exp`                                        :func:`power`                                      :func:`url_decode`
-    :func:`f_cdf`                                      :func:`quantile_at_value`                          :func:`url_encode`
-    :func:`fail`                                       :func:`quantiles_at_values`                        :func:`url_extract_fragment`
-    :func:`filter`                                     :func:`quarter`                                    :func:`url_extract_host`
-    :func:`find_first`                                 :func:`radians`                                    :func:`url_extract_parameter`
-    :func:`find_first_index`                           :func:`rand`                                       :func:`url_extract_path`
-    :func:`flatten`                                    :func:`random`                                     :func:`url_extract_port`
-    :func:`flatten_geometry_collections`               :func:`reduce`                                     :func:`url_extract_protocol`
-    :func:`floor`                                      :func:`regexp_extract`                             :func:`url_extract_query`
-    :func:`format_datetime`                            :func:`regexp_extract_all`                         :func:`uuid`
-    :func:`from_base`                                  :func:`regexp_like`                                :func:`value_at_quantile`
-    :func:`from_base64`                                :func:`regexp_replace`                             :func:`values_at_quantiles`
-    :func:`from_base64url`                             :func:`regexp_split`                               :func:`week`
-    :func:`from_big_endian_32`                         :func:`remove_nulls`                               :func:`week_of_year`
-    :func:`from_big_endian_64`                         :func:`repeat`                                     :func:`weibull_cdf`
-    :func:`from_hex`                                   :func:`replace`                                    :func:`width_bucket`
-    :func:`from_ieee754_32`                            :func:`replace_first`                              :func:`wilson_interval_lower`
-    :func:`from_ieee754_64`                            :func:`reverse`                                    :func:`wilson_interval_upper`
-    :func:`from_iso8601_date`                          :func:`round`                                      :func:`word_stem`
-    :func:`from_iso8601_timestamp`                     :func:`rpad`                                       :func:`xxhash64`
-    :func:`from_unixtime`                              :func:`rtrim`                                      :func:`xxhash64_internal`
-    :func:`from_utf8`                                  :func:`scale_qdigest`                              :func:`year`
-    :func:`gamma_cdf`                                  :func:`scale_tdigest`                              :func:`year_of_week`
-    :func:`geometry_invalid_reason`                    :func:`second`                                     :func:`yow`
-    :func:`geometry_nearest_points`                    :func:`secure_rand`                                :func:`zip`
-    :func:`greatest`                                   :func:`secure_random`                              :func:`zip_with`
+    :func:`$internal$json_string_to_array_cast`        :func:`geometry_to_dissolved_bing_tiles`           :func:`secure_rand`                                    :func:`any_value`                                      :func:`cume_dist`
+    :func:`$internal$json_string_to_map_cast`          :func:`geometry_union`                             :func:`secure_random`                                  :func:`approx_distinct`                                :func:`dense_rank`
+    :func:`$internal$json_string_to_row_cast`          :func:`great_circle_distance`                      :func:`sequence`                                       :func:`approx_most_frequent`                           :func:`first_value`
+    :func:`$internal$split_to_map`                     :func:`greatest`                                   :func:`sha1`                                           :func:`approx_percentile`                              :func:`lag`
+    :func:`abs`                                        :func:`gt`                                         :func:`sha256`                                         :func:`approx_set`                                     :func:`last_value`
+    :func:`acos`                                       :func:`gte`                                        :func:`sha512`                                         :func:`arbitrary`                                      :func:`lead`
+    :func:`all_keys_match`                             :func:`hamming_distance`                           :func:`shuffle`                                        :func:`array_agg`                                      :func:`nth_value`
+    :func:`all_match`                                  :func:`hmac_md5`                                   :func:`sign`                                           :func:`avg`                                            :func:`ntile`
+    :func:`any_keys_match`                             :func:`hmac_sha1`                                  :func:`simplify_geometry`                              :func:`bitwise_and_agg`                                :func:`percent_rank`
+    :func:`any_match`                                  :func:`hmac_sha256`                                :func:`sin`                                            :func:`bitwise_or_agg`                                 :func:`rank`
+    :func:`any_values_match`                           :func:`hmac_sha512`                                :func:`slice`                                          :func:`bitwise_xor_agg`                                :func:`row_number`
+    :func:`array_average`                              :func:`hour`                                       :func:`split`                                          :func:`bool_and`
+    :func:`array_constructor`                          in                                                 :func:`split_part`                                     :func:`bool_or`
+    :func:`array_cum_sum`                              :func:`infinity`                                   :func:`split_to_map`                                   :func:`checksum`
+    :func:`array_distinct`                             :func:`inverse_beta_cdf`                           :func:`split_to_multimap`                              :func:`classification_fall_out`
+    :func:`array_duplicates`                           :func:`inverse_binomial_cdf`                       :func:`spooky_hash_v2_32`                              :func:`classification_miss_rate`
+    :func:`array_except`                               :func:`inverse_cauchy_cdf`                         :func:`spooky_hash_v2_64`                              :func:`classification_precision`
+    :func:`array_frequency`                            :func:`inverse_chi_squared_cdf`                    :func:`sqrt`                                           :func:`classification_recall`
+    :func:`array_has_duplicates`                       :func:`inverse_f_cdf`                              :func:`st_area`                                        :func:`classification_thresholds`
+    :func:`array_intersect`                            :func:`inverse_gamma_cdf`                          :func:`st_asbinary`                                    :func:`corr`
+    :func:`array_join`                                 :func:`inverse_laplace_cdf`                        :func:`st_astext`                                      :func:`count`
+    :func:`array_max`                                  :func:`inverse_normal_cdf`                         :func:`st_boundary`                                    :func:`count_if`
+    :func:`array_max_by`                               :func:`inverse_poisson_cdf`                        :func:`st_buffer`                                      :func:`covar_pop`
+    :func:`array_min`                                  :func:`inverse_t_cdf`                              :func:`st_centroid`                                    :func:`covar_samp`
+    :func:`array_min_by`                               :func:`inverse_weibull_cdf`                        :func:`st_contains`                                    :func:`entropy`
+    :func:`array_normalize`                            :func:`ip_prefix`                                  :func:`st_convexhull`                                  :func:`every`
+    :func:`array_position`                             :func:`ip_prefix_collapse`                         :func:`st_coorddim`                                    :func:`geometric_mean`
+    :func:`array_remove`                               :func:`ip_prefix_subnets`                          :func:`st_crosses`                                     :func:`histogram`
+    :func:`array_sort`                                 :func:`ip_subnet_max`                              :func:`st_difference`                                  :func:`kurtosis`
+    :func:`array_sort_desc`                            :func:`ip_subnet_min`                              :func:`st_dimension`                                   :func:`map_agg`
+    :func:`array_subset`                               :func:`ip_subnet_range`                            :func:`st_disjoint`                                    :func:`map_union`
+    :func:`array_sum`                                  :func:`is_finite`                                  :func:`st_distance`                                    :func:`map_union_sum`
+    :func:`array_sum_propagate_element_null`           :func:`is_infinite`                                :func:`st_endpoint`                                    :func:`max`
+    :func:`array_top_n`                                :func:`is_json_scalar`                             :func:`st_envelope`                                    :func:`max_by`
+    :func:`array_union`                                :func:`is_nan`                                     :func:`st_envelopeaspts`                               :func:`max_data_size_for_stats`
+    :func:`arrays_overlap`                             :func:`is_null`                                    :func:`st_equals`                                      :func:`merge`
+    :func:`asin`                                       :func:`is_private_ip`                              :func:`st_exteriorring`                                :func:`min`
+    :func:`at_timezone`                                :func:`is_subnet_of`                               :func:`st_geometries`                                  :func:`min_by`
+    :func:`atan`                                       :func:`json_array_contains`                        :func:`st_geometryfromtext`                            :func:`multimap_agg`
+    :func:`atan2`                                      :func:`json_array_get`                             :func:`st_geometryn`                                   :func:`noisy_approx_distinct_sfm`
+    :func:`beta_cdf`                                   :func:`json_array_length`                          :func:`st_geometrytype`                                :func:`noisy_approx_set_sfm`
+    :func:`between`                                    :func:`json_extract`                               :func:`st_geomfrombinary`                              :func:`noisy_approx_set_sfm_from_index_and_zeros`
+    :func:`bing_tile`                                  :func:`json_extract_scalar`                        :func:`st_interiorringn`                               :func:`noisy_avg_gaussian`
+    :func:`bing_tile_at`                               :func:`json_format`                                :func:`st_interiorrings`                               :func:`noisy_count_gaussian`
+    :func:`bing_tile_children`                         :func:`json_parse`                                 :func:`st_intersection`                                :func:`noisy_count_if_gaussian`
+    :func:`bing_tile_coordinates`                      :func:`json_size`                                  :func:`st_intersects`                                  :func:`noisy_sum_gaussian`
+    :func:`bing_tile_parent`                           :func:`laplace_cdf`                                :func:`st_isclosed`                                    :func:`numeric_histogram`
+    :func:`bing_tile_polygon`                          :func:`last_day_of_month`                          :func:`st_isempty`                                     :func:`qdigest_agg`
+    :func:`bing_tile_quadkey`                          :func:`least`                                      :func:`st_isring`                                      :func:`reduce_agg`
+    :func:`bing_tile_zoom_level`                       :func:`length`                                     :func:`st_issimple`                                    :func:`regr_avgx`
+    :func:`bing_tiles_around`                          :func:`levenshtein_distance`                       :func:`st_isvalid`                                     :func:`regr_avgy`
+    :func:`binomial_cdf`                               :func:`like`                                       :func:`st_length`                                      :func:`regr_count`
+    :func:`bit_count`                                  :func:`line_interpolate_point`                     :func:`st_linefromtext`                                :func:`regr_intercept`
+    :func:`bit_length`                                 :func:`line_locate_point`                          :func:`st_linestring`                                  :func:`regr_r2`
+    :func:`bitwise_and`                                :func:`ln`                                         :func:`st_multipoint`                                  :func:`regr_slope`
+    :func:`bitwise_arithmetic_shift_right`             :func:`localtime`                                  :func:`st_numgeometries`                               :func:`regr_sxx`
+    :func:`bitwise_left_shift`                         :func:`log10`                                      :func:`st_numinteriorring`                             :func:`regr_sxy`
+    :func:`bitwise_logical_shift_right`                :func:`log2`                                       :func:`st_numpoints`                                   :func:`regr_syy`
+    :func:`bitwise_not`                                :func:`longest_common_prefix`                      :func:`st_overlaps`                                    :func:`set_agg`
+    :func:`bitwise_or`                                 :func:`lower`                                      :func:`st_point`                                       :func:`set_union`
+    :func:`bitwise_right_shift`                        :func:`lpad`                                       :func:`st_pointn`                                      :func:`skewness`
+    :func:`bitwise_right_shift_arithmetic`             :func:`lt`                                         :func:`st_points`                                      :func:`stddev`
+    :func:`bitwise_shift_left`                         :func:`lte`                                        :func:`st_polygon`                                     :func:`stddev_pop`
+    :func:`bitwise_xor`                                :func:`ltrim`                                      :func:`st_relate`                                      :func:`stddev_samp`
+    :func:`cardinality`                                :func:`map`                                        :func:`st_startpoint`                                  :func:`sum`
+    :func:`cauchy_cdf`                                 :func:`map_concat`                                 :func:`st_symdifference`                               :func:`sum_data_size_for_stats`
+    :func:`cbrt`                                       :func:`map_entries`                                :func:`st_touches`                                     :func:`tdigest_agg`
+    :func:`ceil`                                       :func:`map_filter`                                 :func:`st_union`                                       :func:`var_pop`
+    :func:`ceiling`                                    :func:`map_from_entries`                           :func:`st_within`                                      :func:`var_samp`
+    :func:`chi_squared_cdf`                            :func:`map_intersect`                              :func:`st_x`                                           :func:`variance`
+    :func:`chr`                                        :func:`map_key_exists`                             :func:`st_xmax`
+    :func:`clamp`                                      :func:`map_keys`                                   :func:`st_xmin`
+    :func:`codepoint`                                  :func:`map_keys_by_top_n_values`                   :func:`st_y`
+    :func:`combinations`                               :func:`map_normalize`                              :func:`st_ymax`
+    :func:`combine_hash_internal`                      :func:`map_remove_null_values`                     :func:`st_ymin`
+    :func:`concat`                                     :func:`map_subset`                                 :func:`starts_with`
+    :func:`construct_tdigest`                          :func:`map_top_n`                                  :func:`strpos`
+    :func:`contains`                                   :func:`map_top_n_keys`                             :func:`strrpos`
+    :func:`cos`                                        :func:`map_top_n_values`                           :func:`subscript`
+    :func:`cosh`                                       :func:`map_values`                                 :func:`substr`
+    :func:`cosine_similarity`                          :func:`map_zip_with`                               :func:`substring`
+    :func:`crc32`                                      :func:`md5`                                        :func:`t_cdf`
+    :func:`current_date`                               :func:`merge_hll`                                  :func:`tan`
+    :func:`date`                                       :func:`merge_sfm`                                  :func:`tanh`
+    :func:`date_add`                                   :func:`merge_tdigest`                              :func:`timezone_hour`
+    :func:`date_diff`                                  :func:`millisecond`                                :func:`timezone_minute`
+    :func:`date_format`                                :func:`minus`                                      :func:`to_base`
+    :func:`date_parse`                                 :func:`minute`                                     :func:`to_base64`
+    :func:`date_trunc`                                 :func:`mod`                                        :func:`to_base64url`
+    :func:`day`                                        :func:`month`                                      :func:`to_big_endian_32`
+    :func:`day_of_month`                               :func:`multimap_from_entries`                      :func:`to_big_endian_64`
+    :func:`day_of_week`                                :func:`multiply`                                   :func:`to_hex`
+    :func:`day_of_year`                                :func:`murmur3_x64_128`                            :func:`to_ieee754_32`
+    :func:`degrees`                                    :func:`nan`                                        :func:`to_ieee754_64`
+    :func:`destructure_tdigest`                        :func:`negate`                                     :func:`to_iso8601`
+    :func:`distinct_from`                              :func:`neq`                                        :func:`to_milliseconds`
+    :func:`divide`                                     :func:`ngrams`                                     :func:`to_unixtime`
+    :func:`dot_product`                                :func:`no_keys_match`                              :func:`to_utf8`
+    :func:`dow`                                        :func:`no_values_match`                            :func:`trail`
+    :func:`doy`                                        :func:`noisy_empty_approx_set_sfm`                 :func:`transform`
+    :func:`e`                                          :func:`none_match`                                 :func:`transform_keys`
+    :func:`element_at`                                 :func:`normal_cdf`                                 :func:`transform_values`
+    :func:`empty_approx_set`                           :func:`normalize`                                  :func:`trim`
+    :func:`ends_with`                                  not                                                :func:`trim_array`
+    :func:`enum_key`                                   :func:`parse_datetime`                             :func:`trimmed_mean`
+    :func:`eq`                                         :func:`parse_duration`                             :func:`truncate`
+    :func:`exp`                                        :func:`parse_presto_data_size`                     :func:`typeof`
+    :func:`expand_envelope`                            :func:`pi`                                         :func:`upper`
+    :func:`f_cdf`                                      :func:`plus`                                       :func:`url_decode`
+    :func:`fail`                                       :func:`poisson_cdf`                                :func:`url_encode`
+    :func:`filter`                                     :func:`pow`                                        :func:`url_extract_fragment`
+    :func:`find_first`                                 :func:`power`                                      :func:`url_extract_host`
+    :func:`find_first_index`                           :func:`quantile_at_value`                          :func:`url_extract_parameter`
+    :func:`flatten`                                    :func:`quantiles_at_values`                        :func:`url_extract_path`
+    :func:`flatten_geometry_collections`               :func:`quarter`                                    :func:`url_extract_port`
+    :func:`floor`                                      :func:`radians`                                    :func:`url_extract_protocol`
+    :func:`format_datetime`                            :func:`rand`                                       :func:`url_extract_query`
+    :func:`from_base`                                  :func:`random`                                     :func:`uuid`
+    :func:`from_base32`                                :func:`reduce`                                     :func:`value_at_quantile`
+    :func:`from_base64`                                :func:`regexp_extract`                             :func:`values_at_quantiles`
+    :func:`from_base64url`                             :func:`regexp_extract_all`                         :func:`week`
+    :func:`from_big_endian_32`                         :func:`regexp_like`                                :func:`week_of_year`
+    :func:`from_big_endian_64`                         :func:`regexp_replace`                             :func:`weibull_cdf`
+    :func:`from_hex`                                   :func:`regexp_split`                               :func:`width_bucket`
+    :func:`from_ieee754_32`                            :func:`remap_keys`                                 :func:`wilson_interval_lower`
+    :func:`from_ieee754_64`                            :func:`remove_nulls`                               :func:`wilson_interval_upper`
+    :func:`from_iso8601_date`                          :func:`repeat`                                     :func:`word_stem`
+    :func:`from_iso8601_timestamp`                     :func:`replace`                                    :func:`xxhash64`
+    :func:`from_unixtime`                              :func:`replace_first`                              :func:`xxhash64_internal`
+    :func:`from_utf8`                                  :func:`reverse`                                    :func:`year`
+    :func:`gamma_cdf`                                  :func:`round`                                      :func:`year_of_week`
+    :func:`geometry_as_geojson`                        :func:`rpad`                                       :func:`yow`
+    :func:`geometry_from_geojson`                      :func:`rtrim`                                      :func:`zip`
+    :func:`geometry_invalid_reason`                    :func:`scale_qdigest`                              :func:`zip_with`
+    :func:`geometry_nearest_points`                    :func:`scale_tdigest`
+    :func:`geometry_to_bing_tiles`                     :func:`second`
     =================================================  =================================================  =================================================  ==  =================================================  ==  =================================================

--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -108,6 +108,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(15) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(7) {background-color: #6BA81E;}
@@ -117,7 +118,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(17) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
@@ -158,24 +159,24 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(25) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(29) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(4) {background-color: #6BA81E;}
@@ -184,6 +185,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(3) {background-color: #6BA81E;}
@@ -193,9 +195,9 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(33) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(34) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(34) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
@@ -204,6 +206,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(36) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(36) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(3) {background-color: #6BA81E;}
@@ -225,8 +228,8 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(40) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(40) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(4) {background-color: #6BA81E;}
@@ -236,6 +239,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(42) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(2) {background-color: #6BA81E;}
@@ -250,6 +254,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(44) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(45) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
@@ -260,11 +265,12 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(46) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(47) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(48) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(5) {background-color: #6BA81E;}
@@ -277,21 +283,25 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(49) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(50) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(51) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(51) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(51) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(52) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(53) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(3) {background-color: #6BA81E;}
@@ -299,7 +309,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(54) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(5) {background-color: #6BA81E;}
@@ -311,29 +320,29 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(56) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(57) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(59) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(60) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(61) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(7) {background-color: #6BA81E;}
@@ -349,22 +358,23 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(63) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(64) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(65) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(66) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(67) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(67) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(67) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(68) td:nth-child(1) {background-color: #6BA81E;}
@@ -374,7 +384,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(68) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(69) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(7) {background-color: #6BA81E;}
@@ -391,6 +400,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(71) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(72) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(72) td:nth-child(7) {background-color: #6BA81E;}
@@ -402,10 +412,10 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(73) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(74) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(75) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(4) {background-color: #6BA81E;}
@@ -418,17 +428,25 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(76) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(77) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(77) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(78) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(78) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(79) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(79) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(80) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(80) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(80) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(80) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(81) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(81) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(81) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(81) td:nth-child(4) {background-color: #6BA81E;}
     </style>
 
 .. table::
@@ -438,83 +456,85 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions                           Window Functions
     ================================================================================================================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`abs`                               :func:`date_diff`                         :func:`ip_subnet_range`                   :func:`random`                            :func:`st_numgeometries`                      :func:`approx_distinct`                       :func:`cume_dist`
-    :func:`acos`                              :func:`date_format`                       :func:`is_finite`                         :func:`reduce`                            :func:`st_numinteriorring`                    :func:`approx_most_frequent`                  :func:`dense_rank`
-    :func:`all_match`                         :func:`date_parse`                        :func:`is_infinite`                       :func:`regexp_extract`                    :func:`st_numpoints`                          :func:`approx_percentile`                     :func:`first_value`
-    :func:`any_keys_match`                    :func:`date_trunc`                        :func:`is_json_scalar`                    :func:`regexp_extract_all`                :func:`st_overlaps`                           :func:`approx_set`                            :func:`lag`
-    :func:`any_match`                         :func:`day`                               :func:`is_nan`                            :func:`regexp_like`                       :func:`st_point`                              :func:`arbitrary`                             :func:`last_value`
-    :func:`any_values_match`                  :func:`day_of_month`                      :func:`is_private_ip`                     :func:`regexp_replace`                    :func:`st_pointn`                             :func:`array_agg`                             :func:`lead`
-    :func:`array_average`                     :func:`day_of_week`                       :func:`is_subnet_of`                      :func:`regexp_split`                      :func:`st_points`                             :func:`avg`                                   :func:`nth_value`
-    :func:`array_cum_sum`                     :func:`day_of_year`                       jaccard_index                             regress                                   :func:`st_polygon`                            :func:`bitwise_and_agg`                       :func:`ntile`
-    :func:`array_distinct`                    :func:`degrees`                           :func:`json_array_contains`               reidentification_potential                :func:`st_relate`                             :func:`bitwise_or_agg`                        :func:`percent_rank`
-    :func:`array_duplicates`                  :func:`dow`                               :func:`json_array_get`                    :func:`remove_nulls`                      :func:`st_startpoint`                         :func:`bool_and`                              :func:`rank`
-    :func:`array_except`                      :func:`doy`                               :func:`json_array_length`                 render                                    :func:`st_symdifference`                      :func:`bool_or`                               :func:`row_number`
-    :func:`array_frequency`                   :func:`e`                                 :func:`json_extract`                      :func:`repeat`                            :func:`st_touches`                            :func:`checksum`
-    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_extract_scalar`               :func:`replace`                           :func:`st_union`                              :func:`classification_fall_out`
-    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_format`                       :func:`replace_first`                     :func:`st_within`                             :func:`classification_miss_rate`
-    :func:`array_join`                        :func:`ends_with`                         :func:`json_parse`                        :func:`reverse`                           :func:`st_x`                                  :func:`classification_precision`
-    array_least_frequent                      enum_key                                  :func:`json_size`                         rgb                                       :func:`st_xmax`                               :func:`classification_recall`
-    :func:`array_max`                         :func:`exp`                               key_sampling_percent                      :func:`round`                             :func:`st_xmin`                               :func:`classification_thresholds`
-    :func:`array_max_by`                      expand_envelope                           :func:`laplace_cdf`                       :func:`rpad`                              :func:`st_y`                                  convex_hull_agg
-    :func:`array_min`                         :func:`f_cdf`                             :func:`last_day_of_month`                 :func:`rtrim`                             :func:`st_ymax`                               :func:`corr`
-    :func:`array_min_by`                      features                                  :func:`least`                             :func:`scale_qdigest`                     :func:`st_ymin`                               :func:`count`
-    :func:`array_normalize`                   :func:`filter`                            :func:`length`                            :func:`second`                            :func:`starts_with`                           :func:`count_if`
-    :func:`array_position`                    :func:`filter`                            :func:`levenshtein_distance`              :func:`secure_rand`                       :func:`strpos`                                :func:`covar_pop`
-    :func:`array_remove`                      :func:`find_first`                        :func:`line_interpolate_point`            :func:`secure_random`                     :func:`strrpos`                               :func:`covar_samp`
-    :func:`array_sort`                        :func:`find_first_index`                  :func:`line_locate_point`                 :func:`sequence`                          :func:`substr`                                differential_entropy
-    :func:`array_sort_desc`                   :func:`flatten`                           :func:`ln`                                :func:`sha1`                              :func:`tan`                                   :func:`entropy`
-    array_split_into_chunks                   :func:`flatten_geometry_collections`      localtime                                 :func:`sha256`                            :func:`tanh`                                  evaluate_classifier_predictions
-    :func:`array_sum`                         :func:`floor`                             localtimestamp                            :func:`sha512`                            tdigest_agg                                   :func:`every`
-    :func:`array_top_n`                       fnv1_32                                   :func:`log10`                             :func:`shuffle`                           :func:`timezone_hour`                         :func:`geometric_mean`
-    :func:`array_union`                       fnv1_64                                   :func:`log2`                              :func:`sign`                              :func:`timezone_minute`                       geometry_union_agg
-    :func:`arrays_overlap`                    fnv1a_32                                  :func:`lower`                             :func:`simplify_geometry`                 :func:`to_base`                               :func:`histogram`
-    :func:`asin`                              fnv1a_64                                  :func:`lpad`                              :func:`sin`                               to_base32                                     khyperloglog_agg
-    :func:`atan`                              :func:`format_datetime`                   :func:`ltrim`                             sketch_kll_quantile                       :func:`to_base64`                             :func:`kurtosis`
-    :func:`atan2`                             :func:`from_base`                         :func:`map`                               sketch_kll_rank                           :func:`to_base64url`                          learn_classifier
-    bar                                       from_base32                               :func:`map_concat`                        :func:`slice`                             :func:`to_big_endian_32`                      learn_libsvm_classifier
-    :func:`beta_cdf`                          :func:`from_base64`                       :func:`map_entries`                       spatial_partitions                        :func:`to_big_endian_64`                      learn_libsvm_regressor
-    :func:`bing_tile`                         :func:`from_base64url`                    :func:`map_filter`                        :func:`split`                             to_geometry                                   learn_regressor
-    :func:`bing_tile_at`                      :func:`from_big_endian_32`                :func:`map_from_entries`                  :func:`split_part`                        :func:`to_hex`                                make_set_digest
-    :func:`bing_tile_children`                :func:`from_big_endian_64`                :func:`map_keys`                          :func:`split_to_map`                      :func:`to_ieee754_32`                         :func:`map_agg`
-    :func:`bing_tile_coordinates`             :func:`from_hex`                          :func:`map_keys_by_top_n_values`          :func:`split_to_multimap`                 :func:`to_ieee754_64`                         :func:`map_union`
-    :func:`bing_tile_parent`                  :func:`from_ieee754_32`                   :func:`map_normalize`                     :func:`spooky_hash_v2_32`                 :func:`to_iso8601`                            :func:`map_union_sum`
-    bing_tile_polygon                         :func:`from_ieee754_64`                   :func:`map_remove_null_values`            :func:`spooky_hash_v2_64`                 :func:`to_milliseconds`                       :func:`max`
-    :func:`bing_tile_quadkey`                 :func:`from_iso8601_date`                 :func:`map_subset`                        :func:`sqrt`                              to_spherical_geography                        :func:`max_by`
-    :func:`bing_tile_zoom_level`              :func:`from_iso8601_timestamp`            :func:`map_top_n`                         :func:`st_area`                           :func:`to_unixtime`                           :func:`merge`
-    :func:`bing_tiles_around`                 :func:`from_unixtime`                     :func:`map_top_n_keys`                    :func:`st_asbinary`                       :func:`to_utf8`                               merge_set_digest
-    :func:`binomial_cdf`                      :func:`from_utf8`                         map_top_n_keys_by_value                   :func:`st_astext`                         :func:`trail`                                 :func:`min`
-    :func:`bit_count`                         :func:`gamma_cdf`                         :func:`map_top_n_values`                  :func:`st_boundary`                       :func:`transform`                             :func:`min_by`
-    :func:`bitwise_and`                       geometry_as_geojson                       :func:`map_values`                        :func:`st_buffer`                         :func:`transform_keys`                        :func:`multimap_agg`
-    :func:`bitwise_arithmetic_shift_right`    geometry_from_geojson                     :func:`map_zip_with`                      :func:`st_centroid`                       :func:`transform_values`                      :func:`noisy_avg_gaussian`
-    :func:`bitwise_left_shift`                :func:`geometry_invalid_reason`           :func:`md5`                               :func:`st_contains`                       :func:`trim`                                  :func:`noisy_count_gaussian`
-    :func:`bitwise_logical_shift_right`       :func:`geometry_nearest_points`           merge_hll                                 :func:`st_convexhull`                     :func:`trim_array`                            :func:`noisy_count_if_gaussian`
-    :func:`bitwise_not`                       geometry_to_bing_tiles                    merge_khll                                :func:`st_coorddim`                       :func:`truncate`                              :func:`noisy_sum_gaussian`
-    :func:`bitwise_or`                        geometry_to_dissolved_bing_tiles          :func:`millisecond`                       :func:`st_crosses`                        :func:`typeof`                                :func:`numeric_histogram`
-    :func:`bitwise_right_shift`               geometry_union                            :func:`minute`                            :func:`st_difference`                     uniqueness_distribution                       :func:`qdigest_agg`
-    :func:`bitwise_right_shift_arithmetic`    great_circle_distance                     :func:`mod`                               :func:`st_dimension`                      :func:`upper`                                 :func:`reduce_agg`
-    :func:`bitwise_shift_left`                :func:`greatest`                          :func:`month`                             :func:`st_disjoint`                       :func:`url_decode`                            :func:`regr_avgx`
-    :func:`bitwise_xor`                       :func:`hamming_distance`                  :func:`multimap_from_entries`             :func:`st_distance`                       :func:`url_encode`                            :func:`regr_avgy`
-    :func:`cardinality`                       hash_counts                               :func:`murmur3_x64_128`                   :func:`st_endpoint`                       :func:`url_extract_fragment`                  :func:`regr_count`
-    :func:`cauchy_cdf`                        :func:`hmac_md5`                          myanmar_font_encoding                     :func:`st_envelope`                       :func:`url_extract_host`                      :func:`regr_intercept`
-    :func:`cbrt`                              :func:`hmac_sha1`                         myanmar_normalize_unicode                 :func:`st_envelopeaspts`                  :func:`url_extract_parameter`                 :func:`regr_r2`
-    :func:`ceil`                              :func:`hmac_sha256`                       :func:`nan`                               :func:`st_equals`                         :func:`url_extract_path`                      :func:`regr_slope`
-    :func:`ceiling`                           :func:`hmac_sha512`                       :func:`ngrams`                            :func:`st_exteriorring`                   :func:`url_extract_port`                      :func:`regr_sxx`
-    :func:`chi_squared_cdf`                   :func:`hour`                              :func:`no_keys_match`                     :func:`st_geometries`                     :func:`url_extract_protocol`                  :func:`regr_sxy`
-    :func:`chr`                               :func:`infinity`                          :func:`no_values_match`                   :func:`st_geometryfromtext`               :func:`url_extract_query`                     :func:`regr_syy`
-    classify                                  intersection_cardinality                  :func:`none_match`                        :func:`st_geometryn`                      :func:`uuid`                                  reservoir_sample
-    :func:`codepoint`                         :func:`inverse_beta_cdf`                  :func:`normal_cdf`                        :func:`st_geometrytype`                   :func:`value_at_quantile`                     :func:`set_agg`
-    color                                     :func:`inverse_binomial_cdf`              :func:`normalize`                         :func:`st_geomfrombinary`                 :func:`values_at_quantiles`                   :func:`set_union`
-    :func:`combinations`                      :func:`inverse_cauchy_cdf`                now                                       :func:`st_interiorringn`                  :func:`week`                                  sketch_kll
-    :func:`concat`                            :func:`inverse_chi_squared_cdf`           :func:`parse_datetime`                    :func:`st_interiorrings`                  :func:`week_of_year`                          sketch_kll_with_k
-    :func:`contains`                          :func:`inverse_f_cdf`                     :func:`parse_duration`                    :func:`st_intersection`                   :func:`weibull_cdf`                           :func:`skewness`
-    :func:`cos`                               :func:`inverse_gamma_cdf`                 :func:`parse_presto_data_size`            :func:`st_intersects`                     :func:`width_bucket`                          spatial_partitioning
-    :func:`cosh`                              :func:`inverse_laplace_cdf`               :func:`pi`                                :func:`st_isclosed`                       :func:`wilson_interval_lower`                 :func:`stddev`
-    :func:`cosine_similarity`                 :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            :func:`st_isempty`                        :func:`wilson_interval_upper`                 :func:`stddev_pop`
-    :func:`crc32`                             :func:`inverse_poisson_cdf`               :func:`poisson_cdf`                       :func:`st_isring`                         :func:`word_stem`                             :func:`stddev_samp`
-    :func:`current_date`                      :func:`inverse_weibull_cdf`               :func:`pow`                               :func:`st_issimple`                       :func:`xxhash64`                              :func:`sum`
-    current_time                              :func:`ip_prefix`                         :func:`power`                             :func:`st_isvalid`                        :func:`year`                                  :func:`tdigest_agg`
-    current_timestamp                         :func:`ip_prefix_collapse`                :func:`quantile_at_value`                 :func:`st_length`                         :func:`year_of_week`                          :func:`var_pop`
-    current_timezone                          :func:`ip_prefix_subnets`                 :func:`quarter`                           st_linefromtext                           :func:`yow`                                   :func:`var_samp`
-    :func:`date`                              :func:`ip_subnet_max`                     :func:`radians`                           st_linestring                             :func:`zip`                                   :func:`variance`
-    :func:`date_add`                          :func:`ip_subnet_min`                     :func:`rand`                              st_multipoint                             :func:`zip_with`
+    :func:`abs`                               :func:`date_format`                       :func:`ip_subnet_range`                   :func:`random`                            :func:`st_numpoints`                          :func:`approx_distinct`                       :func:`cume_dist`
+    :func:`acos`                              :func:`date_parse`                        :func:`is_finite`                         :func:`reduce`                            :func:`st_overlaps`                           :func:`approx_most_frequent`                  :func:`dense_rank`
+    :func:`all_match`                         :func:`date_trunc`                        :func:`is_infinite`                       :func:`regexp_extract`                    :func:`st_point`                              :func:`approx_percentile`                     :func:`first_value`
+    :func:`any_keys_match`                    :func:`day`                               :func:`is_json_scalar`                    :func:`regexp_extract_all`                :func:`st_pointn`                             :func:`approx_set`                            :func:`lag`
+    :func:`any_match`                         :func:`day_of_month`                      :func:`is_nan`                            :func:`regexp_like`                       :func:`st_points`                             :func:`arbitrary`                             :func:`last_value`
+    :func:`any_values_match`                  :func:`day_of_week`                       :func:`is_private_ip`                     :func:`regexp_replace`                    :func:`st_polygon`                            :func:`array_agg`                             :func:`lead`
+    :func:`array_average`                     :func:`day_of_year`                       :func:`is_subnet_of`                      :func:`regexp_split`                      :func:`st_relate`                             :func:`avg`                                   :func:`nth_value`
+    :func:`array_cum_sum`                     :func:`degrees`                           jaccard_index                             regress                                   :func:`st_startpoint`                         :func:`bitwise_and_agg`                       :func:`ntile`
+    :func:`array_distinct`                    :func:`dot_product`                       :func:`json_array_contains`               reidentification_potential                :func:`st_symdifference`                      :func:`bitwise_or_agg`                        :func:`percent_rank`
+    :func:`array_duplicates`                  :func:`dow`                               :func:`json_array_get`                    :func:`remove_nulls`                      :func:`st_touches`                            :func:`bool_and`                              :func:`rank`
+    :func:`array_except`                      :func:`doy`                               :func:`json_array_length`                 render                                    :func:`st_union`                              :func:`bool_or`                               :func:`row_number`
+    :func:`array_frequency`                   :func:`e`                                 :func:`json_extract`                      :func:`repeat`                            :func:`st_within`                             :func:`checksum`
+    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_extract_scalar`               :func:`replace`                           :func:`st_x`                                  :func:`classification_fall_out`
+    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_format`                       :func:`replace_first`                     :func:`st_xmax`                               :func:`classification_miss_rate`
+    :func:`array_join`                        :func:`ends_with`                         :func:`json_parse`                        :func:`reverse`                           :func:`st_xmin`                               :func:`classification_precision`
+    array_least_frequent                      :func:`enum_key`                          :func:`json_size`                         rgb                                       :func:`st_y`                                  :func:`classification_recall`
+    :func:`array_max`                         :func:`exp`                               key_sampling_percent                      :func:`round`                             :func:`st_ymax`                               :func:`classification_thresholds`
+    :func:`array_max_by`                      :func:`expand_envelope`                   l2_squared                                :func:`rpad`                              :func:`st_ymin`                               convex_hull_agg
+    :func:`array_min`                         :func:`f_cdf`                             :func:`laplace_cdf`                       :func:`rtrim`                             :func:`starts_with`                           :func:`corr`
+    :func:`array_min_by`                      features                                  :func:`last_day_of_month`                 :func:`scale_qdigest`                     :func:`strpos`                                :func:`count`
+    :func:`array_normalize`                   :func:`filter`                            :func:`least`                             :func:`second`                            :func:`strrpos`                               :func:`count_if`
+    :func:`array_position`                    :func:`filter`                            :func:`length`                            :func:`secure_rand`                       :func:`substr`                                :func:`covar_pop`
+    :func:`array_remove`                      :func:`find_first`                        :func:`levenshtein_distance`              :func:`secure_random`                     :func:`tan`                                   :func:`covar_samp`
+    :func:`array_sort`                        :func:`find_first_index`                  :func:`line_interpolate_point`            :func:`sequence`                          :func:`tanh`                                  differential_entropy
+    :func:`array_sort_desc`                   :func:`flatten`                           :func:`line_locate_point`                 :func:`sha1`                              tdigest_agg                                   :func:`entropy`
+    array_split_into_chunks                   :func:`flatten_geometry_collections`      :func:`ln`                                :func:`sha256`                            :func:`timezone_hour`                         evaluate_classifier_predictions
+    :func:`array_sum`                         :func:`floor`                             :func:`localtime`                         :func:`sha512`                            :func:`timezone_minute`                       :func:`every`
+    :func:`array_top_n`                       fnv1_32                                   localtimestamp                            :func:`shuffle`                           :func:`to_base`                               :func:`geometric_mean`
+    :func:`array_union`                       fnv1_64                                   :func:`log10`                             :func:`sign`                              to_base32                                     geometry_union_agg
+    :func:`arrays_overlap`                    fnv1a_32                                  :func:`log2`                              :func:`simplify_geometry`                 :func:`to_base64`                             :func:`histogram`
+    :func:`asin`                              fnv1a_64                                  :func:`longest_common_prefix`             :func:`sin`                               :func:`to_base64url`                          khyperloglog_agg
+    :func:`atan`                              :func:`format_datetime`                   :func:`lower`                             sketch_kll_quantile                       :func:`to_big_endian_32`                      :func:`kurtosis`
+    :func:`atan2`                             :func:`from_base`                         :func:`lpad`                              sketch_kll_rank                           :func:`to_big_endian_64`                      learn_classifier
+    bar                                       :func:`from_base32`                       :func:`ltrim`                             :func:`slice`                             to_geometry                                   learn_libsvm_classifier
+    :func:`beta_cdf`                          :func:`from_base64`                       :func:`map`                               spatial_partitions                        :func:`to_hex`                                learn_libsvm_regressor
+    :func:`bing_tile`                         :func:`from_base64url`                    :func:`map_concat`                        :func:`split`                             :func:`to_ieee754_32`                         learn_regressor
+    :func:`bing_tile_at`                      :func:`from_big_endian_32`                :func:`map_entries`                       :func:`split_part`                        :func:`to_ieee754_64`                         make_set_digest
+    :func:`bing_tile_children`                :func:`from_big_endian_64`                :func:`map_filter`                        :func:`split_to_map`                      :func:`to_iso8601`                            :func:`map_agg`
+    :func:`bing_tile_coordinates`             :func:`from_hex`                          :func:`map_from_entries`                  :func:`split_to_multimap`                 :func:`to_milliseconds`                       :func:`map_union`
+    :func:`bing_tile_parent`                  :func:`from_ieee754_32`                   :func:`map_keys`                          :func:`spooky_hash_v2_32`                 to_spherical_geography                        :func:`map_union_sum`
+    :func:`bing_tile_polygon`                 :func:`from_ieee754_64`                   :func:`map_keys_by_top_n_values`          :func:`spooky_hash_v2_64`                 :func:`to_unixtime`                           :func:`max`
+    :func:`bing_tile_quadkey`                 :func:`from_iso8601_date`                 :func:`map_normalize`                     :func:`sqrt`                              :func:`to_utf8`                               :func:`max_by`
+    :func:`bing_tile_zoom_level`              :func:`from_iso8601_timestamp`            :func:`map_remove_null_values`            :func:`st_area`                           :func:`trail`                                 :func:`merge`
+    :func:`bing_tiles_around`                 :func:`from_unixtime`                     :func:`map_subset`                        :func:`st_asbinary`                       :func:`transform`                             merge_set_digest
+    :func:`binomial_cdf`                      :func:`from_utf8`                         :func:`map_top_n`                         :func:`st_astext`                         :func:`transform_keys`                        :func:`min`
+    :func:`bit_count`                         :func:`gamma_cdf`                         :func:`map_top_n_keys`                    :func:`st_boundary`                       :func:`transform_values`                      :func:`min_by`
+    :func:`bit_length`                        :func:`geometry_as_geojson`               map_top_n_keys_by_value                   :func:`st_buffer`                         :func:`trim`                                  :func:`multimap_agg`
+    :func:`bitwise_and`                       :func:`geometry_from_geojson`             :func:`map_top_n_values`                  :func:`st_centroid`                       :func:`trim_array`                            :func:`noisy_avg_gaussian`
+    :func:`bitwise_arithmetic_shift_right`    :func:`geometry_invalid_reason`           :func:`map_values`                        :func:`st_contains`                       :func:`truncate`                              :func:`noisy_count_gaussian`
+    :func:`bitwise_left_shift`                :func:`geometry_nearest_points`           :func:`map_zip_with`                      :func:`st_convexhull`                     :func:`typeof`                                :func:`noisy_count_if_gaussian`
+    :func:`bitwise_logical_shift_right`       :func:`geometry_to_bing_tiles`            :func:`md5`                               :func:`st_coorddim`                       uniqueness_distribution                       :func:`noisy_sum_gaussian`
+    :func:`bitwise_not`                       :func:`geometry_to_dissolved_bing_tiles`  :func:`merge_hll`                         :func:`st_crosses`                        :func:`upper`                                 :func:`numeric_histogram`
+    :func:`bitwise_or`                        :func:`geometry_union`                    merge_khll                                :func:`st_difference`                     :func:`url_decode`                            :func:`qdigest_agg`
+    :func:`bitwise_right_shift`               google_polyline_decode                    :func:`millisecond`                       :func:`st_dimension`                      :func:`url_encode`                            :func:`reduce_agg`
+    :func:`bitwise_right_shift_arithmetic`    google_polyline_encode                    :func:`minute`                            :func:`st_disjoint`                       :func:`url_extract_fragment`                  :func:`regr_avgx`
+    :func:`bitwise_shift_left`                :func:`great_circle_distance`             :func:`mod`                               :func:`st_distance`                       :func:`url_extract_host`                      :func:`regr_avgy`
+    :func:`bitwise_xor`                       :func:`greatest`                          :func:`month`                             :func:`st_endpoint`                       :func:`url_extract_parameter`                 :func:`regr_count`
+    :func:`cardinality`                       :func:`hamming_distance`                  :func:`multimap_from_entries`             :func:`st_envelope`                       :func:`url_extract_path`                      :func:`regr_intercept`
+    :func:`cauchy_cdf`                        hash_counts                               :func:`murmur3_x64_128`                   :func:`st_envelopeaspts`                  :func:`url_extract_port`                      :func:`regr_r2`
+    :func:`cbrt`                              :func:`hmac_md5`                          myanmar_font_encoding                     :func:`st_equals`                         :func:`url_extract_protocol`                  :func:`regr_slope`
+    :func:`ceil`                              :func:`hmac_sha1`                         myanmar_normalize_unicode                 :func:`st_exteriorring`                   :func:`url_extract_query`                     :func:`regr_sxx`
+    :func:`ceiling`                           :func:`hmac_sha256`                       :func:`nan`                               :func:`st_geometries`                     :func:`uuid`                                  :func:`regr_sxy`
+    :func:`chi_squared_cdf`                   :func:`hmac_sha512`                       :func:`ngrams`                            :func:`st_geometryfromtext`               :func:`value_at_quantile`                     :func:`regr_syy`
+    :func:`chr`                               :func:`hour`                              :func:`no_keys_match`                     :func:`st_geometryn`                      :func:`values_at_quantiles`                   reservoir_sample
+    classify                                  :func:`infinity`                          :func:`no_values_match`                   :func:`st_geometrytype`                   :func:`week`                                  :func:`set_agg`
+    :func:`codepoint`                         intersection_cardinality                  :func:`none_match`                        :func:`st_geomfrombinary`                 :func:`week_of_year`                          :func:`set_union`
+    color                                     :func:`inverse_beta_cdf`                  :func:`normal_cdf`                        :func:`st_interiorringn`                  :func:`weibull_cdf`                           sketch_kll
+    :func:`combinations`                      :func:`inverse_binomial_cdf`              :func:`normalize`                         :func:`st_interiorrings`                  :func:`width_bucket`                          sketch_kll_with_k
+    :func:`concat`                            :func:`inverse_cauchy_cdf`                now                                       :func:`st_intersection`                   :func:`wilson_interval_lower`                 :func:`skewness`
+    :func:`contains`                          :func:`inverse_chi_squared_cdf`           :func:`parse_datetime`                    :func:`st_intersects`                     :func:`wilson_interval_upper`                 spatial_partitioning
+    :func:`cos`                               :func:`inverse_f_cdf`                     :func:`parse_duration`                    :func:`st_isclosed`                       :func:`word_stem`                             :func:`stddev`
+    :func:`cosh`                              :func:`inverse_gamma_cdf`                 :func:`parse_presto_data_size`            :func:`st_isempty`                        :func:`xxhash64`                              :func:`stddev_pop`
+    :func:`cosine_similarity`                 :func:`inverse_laplace_cdf`               :func:`pi`                                :func:`st_isring`                         :func:`year`                                  :func:`stddev_samp`
+    :func:`crc32`                             :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            :func:`st_issimple`                       :func:`year_of_week`                          :func:`sum`
+    :func:`current_date`                      :func:`inverse_poisson_cdf`               :func:`poisson_cdf`                       :func:`st_isvalid`                        :func:`yow`                                   :func:`tdigest_agg`
+    current_time                              :func:`inverse_weibull_cdf`               :func:`pow`                               :func:`st_length`                         :func:`zip`                                   :func:`var_pop`
+    current_timestamp                         :func:`ip_prefix`                         :func:`power`                             :func:`st_linefromtext`                   :func:`zip_with`                              :func:`var_samp`
+    current_timezone                          :func:`ip_prefix_collapse`                :func:`quantile_at_value`                 :func:`st_linestring`                                                                   :func:`variance`
+    :func:`date`                              :func:`ip_prefix_subnets`                 :func:`quarter`                           :func:`st_multipoint`
+    :func:`date_add`                          :func:`ip_subnet_max`                     :func:`radians`                           :func:`st_numgeometries`
+    :func:`date_diff`                         :func:`ip_subnet_min`                     :func:`rand`                              :func:`st_numinteriorring`
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
@@ -44,6 +44,7 @@ bing_tile_zoom_level
 bing_tiles_around
 binomial_cdf
 bit_count
+bit_length
 bitwise_and
 bitwise_arithmetic_shift_right
 bitwise_left_shift
@@ -86,6 +87,7 @@ day_of_month
 day_of_week
 day_of_year
 degrees
+dot_product
 dow
 doy
 e
@@ -130,6 +132,8 @@ geometry_nearest_points
 geometry_to_bing_tiles
 geometry_to_dissolved_bing_tiles
 geometry_union
+google_polyline_decode
+google_polyline_encode
 great_circle_distance
 greatest
 hamming_distance
@@ -173,6 +177,7 @@ json_format
 json_parse
 json_size
 key_sampling_percent
+l2_squared
 laplace_cdf
 last_day_of_month
 least
@@ -185,6 +190,7 @@ localtime
 localtimestamp
 log10
 log2
+longest_common_prefix
 lower
 lpad
 ltrim


### PR DESCRIPTION
Updated the complete list of Presto scalar functions using output from ```SHOW
FUNCTIONS``` command. 

Re-generated coverage maps using instructions from
```velox/functions/prestosql/coverage/README.md```.