### PR TITLE
feat: Add map_keys_overlap function to Velox

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -137,6 +137,16 @@ Map Functions
         SELECT map_except(MAP(ARRAY[1,2], ARRAY['a','b']), ARRAY[]); -- {1->'a', 2->'b'}
         SELECT map_except(MAP(ARRAY[], ARRAY[]), ARRAY[1,2]); -- {}
 
+.. function:: map_keys_overlap(map(K,V), array(K)) -> boolean
+
+    Returns true if any key in the map matches any element in the given array, false otherwise.
+    Returns false if either the map or array is empty. Null keys in the array are ignored. ::
+
+        SELECT map_keys_overlap(MAP(ARRAY[1, 2, 3], ARRAY[10, 20, 30]), ARRAY[1, 5]); -- true
+        SELECT map_keys_overlap(MAP(ARRAY[1, 2, 3], ARRAY[10, 20, 30]), ARRAY[4, 5]); -- false
+        SELECT map_keys_overlap(MAP(ARRAY['a', 'b'], ARRAY[1, 2]), ARRAY['a']); -- true
+        SELECT map_keys_overlap(MAP(ARRAY[], ARRAY[]), ARRAY[1]); -- false
+
 .. function:: map_top_n(map(K,V), n) -> map(K, V)
 
     Truncates map items. Keeps only the top N elements by value. Keys are used to break ties with the max key being chosen. Both keys and values should be orderable.

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -262,6 +262,7 @@ std::unordered_set<std::string> skipFunctions = {
     "to_geometry",
     "to_spherical_geography",
     "localtime",
+    "map_keys_overlap",
 };
 
 std::unordered_set<std::string> skipFunctionsSOT = {
@@ -271,6 +272,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "array_subset", // Velox-only function, not available in Presto
     "remap_keys", // Velox-only function, not available in Presto
     "map_intersect", // Velox-only function, not available in Presto
+    "map_keys_overlap", // Velox-only function, not available in Presto
     "noisy_empty_approx_set_sfm", // non-deterministic because of privacy.
     // https://github.com/facebookincubator/velox/issues/11034
     "cast(real) -> varchar",

--- a/velox/functions/prestosql/MapKeysOverlap.h
+++ b/velox/functions/prestosql/MapKeysOverlap.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/ComplexViewTypes.h"
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions {
+
+template <typename TExec, typename Key>
+struct MapKeysOverlapPrimitiveFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& out,
+      const arg_type<Map<Key, Generic<T1>>>& inputMap,
+      const arg_type<Array<Key>>& keys) {
+    if (inputMap.empty() || keys.empty()) {
+      out = false;
+      return;
+    }
+
+    folly::F14FastSet<arg_type<Key>> keySet;
+
+    for (const auto& key : keys) {
+      if (key.has_value()) {
+        keySet.insert(key.value());
+      }
+    }
+
+    for (const auto& entry : inputMap) {
+      if (keySet.find(entry.first) != keySet.end()) {
+        out = true;
+        return;
+      }
+    }
+
+    out = false;
+  }
+};
+
+template <typename TExec>
+struct MapKeysOverlapVarcharFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& out,
+      const arg_type<Map<Varchar, Generic<T1>>>& inputMap,
+      const arg_type<Array<Varchar>>& keys) {
+    if (inputMap.empty() || keys.empty()) {
+      out = false;
+      return;
+    }
+
+    folly::F14FastSet<StringView> keySet;
+
+    for (const auto& key : keys) {
+      if (key.has_value()) {
+        keySet.insert(key.value());
+      }
+    }
+
+    for (const auto& entry : inputMap) {
+      if (keySet.find(entry.first) != keySet.end()) {
+        out = true;
+        return;
+      }
+    }
+
+    out = false;
+  }
+};
+
+struct MapKeysOverlapFunctionEqualComparator {
+  bool operator()(const exec::GenericView& lhs, const exec::GenericView& rhs)
+      const {
+    static constexpr auto kEqualValueAtFlags = CompareFlags::equality(
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+
+    auto result = lhs.compare(rhs, kEqualValueAtFlags);
+
+    // If comparison returns indeterminate (null), treat as not equal
+    if (!result.has_value()) {
+      return false;
+    }
+
+    return result.value() == 0;
+  }
+};
+
+template <typename TExec>
+struct MapKeysOverlapFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& out,
+      const arg_type<Map<Generic<T1>, Generic<T2>>>& inputMap,
+      const arg_type<Array<Generic<T1>>>& keys) {
+    if (inputMap.empty() || keys.empty()) {
+      out = false;
+      return;
+    }
+
+    searchKeys_.clear();
+    for (const auto& key : keys) {
+      if (key.has_value()) {
+        searchKeys_.emplace(key.value());
+      }
+    }
+
+    if (searchKeys_.empty()) {
+      out = false;
+      return;
+    }
+
+    for (const auto& entry : inputMap) {
+      if (searchKeys_.contains(entry.first)) {
+        out = true;
+        return;
+      }
+    }
+
+    out = false;
+  }
+
+ private:
+  folly::F14FastSet<
+      exec::GenericView,
+      std::hash<exec::GenericView>,
+      MapKeysOverlapFunctionEqualComparator>
+      searchKeys_;
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -22,6 +22,7 @@
 #include "velox/functions/prestosql/MapFunctions.h"
 #include "velox/functions/prestosql/MapIntersect.h"
 #include "velox/functions/prestosql/MapKeysByTopNValues.h"
+#include "velox/functions/prestosql/MapKeysOverlap.h"
 #include "velox/functions/prestosql/MapNormalize.h"
 #include "velox/functions/prestosql/MapSubset.h"
 #include "velox/functions/prestosql/MapTopN.h"
@@ -135,6 +136,39 @@ void registerMapExcept(const std::string& prefix) {
       Array<Generic<T1>>>({prefix + "map_except"});
 }
 
+template <typename T>
+void registerMapKeysOverlapPrimitive(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<MapKeysOverlapPrimitiveFunction, T>,
+      bool,
+      Map<T, Generic<T1>>,
+      Array<T>>({prefix + "map_keys_overlap"});
+}
+
+void registerMapKeysOverlap(const std::string& prefix) {
+  registerMapKeysOverlapPrimitive<bool>(prefix);
+  registerMapKeysOverlapPrimitive<int8_t>(prefix);
+  registerMapKeysOverlapPrimitive<int16_t>(prefix);
+  registerMapKeysOverlapPrimitive<int32_t>(prefix);
+  registerMapKeysOverlapPrimitive<int64_t>(prefix);
+  registerMapKeysOverlapPrimitive<float>(prefix);
+  registerMapKeysOverlapPrimitive<double>(prefix);
+  registerMapKeysOverlapPrimitive<Timestamp>(prefix);
+  registerMapKeysOverlapPrimitive<Date>(prefix);
+
+  registerFunction<
+      MapKeysOverlapVarcharFunction,
+      bool,
+      Map<Varchar, Generic<T1>>,
+      Array<Varchar>>({prefix + "map_keys_overlap"});
+
+  registerFunction<
+      MapKeysOverlapFunction,
+      bool,
+      Map<Generic<T1>, Generic<T2>>,
+      Array<Generic<T1>>>({prefix + "map_keys_overlap"});
+}
+
 void registerMapRemoveNullValues(const std::string& prefix) {
   registerFunction<
       MapRemoveNullValues,
@@ -212,6 +246,8 @@ void registerMapFunctions(const std::string& prefix) {
   registerMapIntersect(prefix);
 
   registerMapExcept(prefix);
+
+  registerMapKeysOverlap(prefix);
 
   registerMapRemoveNullValues(prefix);
 

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(
   MapFilterTest.cpp
   MapFromEntriesTest.cpp
   MapIntersectTest.cpp
+  MapKeysOverlapTest.cpp
   MapNormalizeTest.cpp
   RemapKeysTest.cpp
   MapTopNTest.cpp

--- a/velox/functions/prestosql/tests/MapKeysOverlapTest.cpp
+++ b/velox/functions/prestosql/tests/MapKeysOverlapTest.cpp
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions {
+namespace {
+
+class MapKeysOverlapTest : public test::FunctionBaseTest {
+ protected:
+  void testMapKeysOverlap(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(MapKeysOverlapTest, basicIntegerKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+      {{4, 40}, {5, 50}},
+      {{6, 60}, {7, 70}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {1, 5},
+      {4},
+      {8, 9},
+  });
+
+  auto expected = makeFlatVector<bool>({true, true, false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, stringKeys) {
+  auto inputMap = makeMapVector<StringView, int32_t>({
+      {{"a", 1}, {"b", 2}, {"c", 3}},
+      {{"x", 10}, {"y", 20}},
+      {{"p", 100}, {"q", 200}},
+  });
+
+  auto keys = makeArrayVector<StringView>({
+      {"a", "d"},
+      {"z"},
+      {"p"},
+  });
+
+  auto expected = makeFlatVector<bool>({true, false, true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, emptyMap) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {},
+      {{1, 10}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {1, 2},
+      {1},
+  });
+
+  auto expected = makeFlatVector<bool>({false, true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, emptyKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {},
+      {},
+  });
+
+  auto expected = makeFlatVector<bool>({false, false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, noMatchingKeys) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+      {{4, 40}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {4, 5, 6},
+      {1, 2, 3},
+  });
+
+  auto expected = makeFlatVector<bool>({false, false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, allKeysMatch) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {1, 2, 3},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, partialMatch) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {3, 5, 6, 7},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, nullValuesInMap) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, std::nullopt}, {3, 30}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {2},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, nullKeysInArray) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  std::vector<std::vector<std::optional<int32_t>>> keyData = {
+      {std::nullopt, 4, 5},
+  };
+  auto keys = makeNullableArrayVector<int32_t>(keyData);
+
+  auto expected = makeFlatVector<bool>({false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, nullKeysMatchInArray) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  std::vector<std::vector<std::optional<int32_t>>> keyData = {
+      {1, std::nullopt, 4},
+  };
+  auto keys = makeNullableArrayVector<int32_t>(keyData);
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, floatKeys) {
+  auto inputMap = makeMapVector<float, int32_t>({
+      {{1.5f, 10}, {2.5f, 20}, {3.5f, 30}},
+  });
+
+  auto keys = makeArrayVector<float>({
+      {1.5f, 10.5f},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, doubleKeys) {
+  auto inputMap = makeMapVector<double, int32_t>({
+      {{1.5, 10}, {2.5, 20}},
+  });
+
+  auto keys = makeArrayVector<double>({
+      {3.5, 4.5},
+  });
+
+  auto expected = makeFlatVector<bool>({false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, booleanKeys) {
+  auto inputMap = makeMapVector<bool, int32_t>({
+      {{true, 10}, {false, 20}},
+      {{true, 30}},
+  });
+
+  auto keys = makeArrayVector<bool>({
+      {true},
+      {false},
+  });
+
+  auto expected = makeFlatVector<bool>({true, false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, timestampKeys) {
+  auto inputMap = makeMapVector<Timestamp, int32_t>({
+      {{Timestamp(1, 0), 10}, {Timestamp(2, 0), 20}},
+  });
+
+  auto keys = makeArrayVector<Timestamp>({
+      {Timestamp(1, 0), Timestamp(100, 0)},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, complexValues) {
+  auto mapKeys = makeFlatVector<int32_t>({0, 1, 2});
+  auto innerArrays = makeArrayVector<int32_t>({
+      {1, 2},
+      {3, 4, 5},
+      {6},
+  });
+
+  auto inputMap = makeMapVector({0}, mapKeys, innerArrays);
+
+  auto keys = makeArrayVector<int32_t>({
+      {0, 5},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, largeMap) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{0, 0},
+       {1, 10},
+       {2, 20},
+       {3, 30},
+       {4, 40},
+       {5, 50},
+       {6, 60},
+       {7, 70},
+       {8, 80},
+       {9, 90}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {5, 15, 25},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, largeMapNoMatch) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{0, 0},
+       {1, 10},
+       {2, 20},
+       {3, 30},
+       {4, 40},
+       {5, 50},
+       {6, 60},
+       {7, 70},
+       {8, 80},
+       {9, 90}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {15, 25, 35},
+  });
+
+  auto expected = makeFlatVector<bool>({false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, multipleRows) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}, {4, 40}},
+      {{5, 50}, {6, 60}},
+      {{7, 70}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {2, 3},
+      {1, 2},
+      {5},
+      {8, 9},
+  });
+
+  auto expected = makeFlatVector<bool>({true, false, true, false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, longStringKeys) {
+  auto inputMap = makeMapVector<StringView, int32_t>({
+      {{"very_long_key_name_1", 1},
+       {"very_long_key_name_2", 2},
+       {"very_long_key_name_3", 3}},
+  });
+
+  auto keys = makeArrayVector<StringView>({
+      {"very_long_key_name_2", "very_long_key_name_4"},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, singleKeyMatch) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}, {4, 40}, {5, 50}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {3},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, duplicateKeysInArray) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto keys = makeArrayVector<int32_t>({
+      {1, 1, 1, 4, 5},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, varcharEmptyStrings) {
+  auto inputMap = makeMapVector<StringView, int32_t>({
+      {{"", 1}, {"a", 2}, {"b", 3}},
+  });
+
+  auto keys = makeArrayVector<StringView>({
+      {"", "c"},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, allNullKeysInArray) {
+  auto inputMap = makeMapVector<int32_t, int32_t>({
+      {{1, 10}, {2, 20}},
+  });
+
+  std::vector<std::vector<std::optional<int32_t>>> keyData = {
+      {std::nullopt, std::nullopt},
+  };
+  auto keys = makeNullableArrayVector<int32_t>(keyData);
+
+  auto expected = makeFlatVector<bool>({false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, int8Keys) {
+  auto inputMap = makeMapVector<int8_t, int32_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+
+  auto keys = makeArrayVector<int8_t>({
+      {2, 5},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, int16Keys) {
+  auto inputMap = makeMapVector<int16_t, int32_t>({
+      {{100, 10}, {200, 20}},
+  });
+
+  auto keys = makeArrayVector<int16_t>({
+      {300, 400},
+  });
+
+  auto expected = makeFlatVector<bool>({false});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+TEST_F(MapKeysOverlapTest, int64Keys) {
+  auto inputMap = makeMapVector<int64_t, int32_t>({
+      {{1000000000, 10}, {2000000000, 20}},
+  });
+
+  auto keys = makeArrayVector<int64_t>({
+      {1000000000},
+  });
+
+  auto expected = makeFlatVector<bool>({true});
+
+  testMapKeysOverlap("map_keys_overlap(c0, c1)", {inputMap, keys}, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
This diff implements the `map_keys_overlap(map(K,V), array(K)) -> boolean` function for Velox, which returns true if any key in the map matches any element in the given array, and false otherwise.

The function handles various key types through specialized implementations:
- Primitive types (bool, int8, int16, int32, int64, float, double, timestamp, date) use `MapKeysOverlapPrimitiveFunction` with `folly::F14FastSet` for efficient lookups
- Varchar keys use `MapKeysOverlapVarcharFunction` with optimized `StringView` comparisons
- Generic/complex key types use `MapKeysOverlapFunction` with custom equality comparator

Key behaviors:
- Returns false if either the map or array is empty
- Null keys in the array are ignored (not matched)
- Map values can be null (only keys are compared)
- Early returns true on first matching key

The function is excluded from Presto fuzzer tests as it's a Velox-only function not available in Presto.

Differential Revision: D87098829


