### PR TITLE
feat: S2 presto functions (#15511)

### DIFF
--- a/CMake/resolve_dependency_modules/README.md
+++ b/CMake/resolve_dependency_modules/README.md
@@ -41,6 +41,7 @@ by Velox. See details on bundling below.
 | DuckDB (testing)  | 0.8.1           | Yes      ||
 | arrow             | 15.0.0          | Yes      ||
 | geos              | 3.10.7          | Yes      ||
+| s2geometry        | 0.12.0          | Yes      ||
 | fast_float        | v8.0.2          | Yes      ||
 | xxhash            | default         | No       ||
 | thrift            | 0.16            | No       ||

--- a/CMake/resolve_dependency_modules/s2geometry.cmake
+++ b/CMake/resolve_dependency_modules/s2geometry.cmake
@@ -1,0 +1,54 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/s2geometry)
+
+# This creates a separate scope so any changed variables don't affect
+# the rest of the build.
+block()
+  set(VELOX_S2GEOMETRY_BUILD_VERSION 0.12.0)
+  set(
+    VELOX_S2GEOMETRY_BUILD_SHA256_CHECKSUM
+    c09ec751c3043965a0d441e046a73c456c995e6063439a72290f661c1054d611
+  )
+  string(
+    CONCAT
+    VELOX_S2GEOMETRY_SOURCE_URL
+    "https://github.com/google/s2geometry/archive/refs/tags/"
+    "v${VELOX_S2GEOMETRY_BUILD_VERSION}.tar.gz"
+  )
+
+  velox_resolve_dependency_url(S2GEOMETRY)
+
+  FetchContent_Declare(
+    s2geometry
+    URL ${VELOX_S2GEOMETRY_SOURCE_URL}
+    URL_HASH ${VELOX_S2GEOMETRY_BUILD_SHA256_CHECKSUM}
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+    EXCLUDE_FROM_ALL
+    PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/s2geometry/s2geometry-gcc12-max.patch
+  )
+
+  list(APPEND CMAKE_MODULE_PATH "${s2geometry_SOURCE_DIR}/cmake")
+  set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_TESTING OFF)
+  set(BUILD_TESTS OFF)
+  set(CMAKE_BUILD_TYPE Release)
+
+  FetchContent_MakeAvailable(s2geometry)
+
+  add_library(s2::s2 ALIAS s2)
+endblock()

--- a/CMake/resolve_dependency_modules/s2geometry/Finds2geometry.cmake
+++ b/CMake/resolve_dependency_modules/s2geometry/Finds2geometry.cmake
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Find the s2geometry library installed on the system.
+# s2geometry installs its CMake config as "s2Config.cmake" with the s2::s2
+# target. This shim bridges the package name difference so that
+# find_package(s2geometry) works.
+
+find_package(s2 CONFIG QUIET)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(s2geometry DEFAULT_MSG s2_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -762,4 +762,10 @@ if(VELOX_ENABLE_GEO)
   velox_resolve_dependency(geos)
 endif()
 
+if(VELOX_ENABLE_GEO)
+  list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake/resolve_dependency_modules/s2geometry)
+  velox_set_source(s2geometry)
+  velox_resolve_dependency(s2geometry)
+endif()
+
 add_subdirectory(velox)

--- a/velox/common/geospatial/GeometrySerde.cpp
+++ b/velox/common/geospatial/GeometrySerde.cpp
@@ -62,6 +62,15 @@ std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::readGeometry(
   }
 }
 
+std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::deserializeNonEmpty(
+    const StringView& geometry) {
+  auto envelope = deserializeEnvelope(geometry);
+  if (envelope->isNull()) {
+    return nullptr;
+  }
+  return deserialize(geometry);
+}
+
 const std::unique_ptr<geos::geom::Envelope>
 GeometryDeserializer::deserializeEnvelope(const StringView& geometry) {
   velox::common::InputByteStream inputStream(geometry.data());

--- a/velox/common/geospatial/GeometrySerde.h
+++ b/velox/common/geospatial/GeometrySerde.h
@@ -409,6 +409,11 @@ class GeometryDeserializer {
   static const std::unique_ptr<geos::geom::Envelope> deserializeEnvelope(
       const StringView& geometry);
 
+  /// Deserializes a geometry, returning nullptr for empty geometries
+  /// (those with null envelopes).
+  static std::unique_ptr<geos::geom::Geometry> deserializeNonEmpty(
+      const StringView& geometry);
+
   template <typename T>
   static std::unique_ptr<geos::geom::CoordinateArraySequence>
   deserializePointsToCoordinate(

--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -625,5 +625,90 @@ for more details.
     For example, if the non-dissolved covering is [“00”, “01”, “02”, “03”, “10”],
     the dissolved covering would be [“0”, “10”]. Zoom levels from 0 to 23 are supported.
 
+S2 Cell Functions
+-----------------
+
+`S2 Geometry <http://s2geometry.io/>`_ is a library for spherical geometry that
+decomposes the Earth's surface into a hierarchy of cells. Unlike planar tiling
+systems (e.g., Bing Tiles), S2 cells have near-uniform area across all latitudes.
+
+Each cell is identified by a 64-bit **cell ID** (stored as ``BIGINT``), which
+encodes both the cell's position and level in the hierarchy. Cells are organized
+in 31 levels (0–30), where level 0 cells are the largest (covering roughly 1/6
+of Earth's surface) and level 30 cells are the smallest (sub-centimeter).
+
+Cells can also be represented as compact hexadecimal **tokens** (e.g.,
+``'8085808b'``), which are shorter and human-readable. Use
+``s2_cell_from_token`` and ``s2_cell_to_token`` to convert between the two
+representations.
+
+All functions operate on cell IDs (``BIGINT``) rather than tokens because cell
+IDs support direct integer comparison, efficient equi-joins and GROUP BY, and
+compose without casting (e.g., ``s2_cell_contains(s2_cell_parent(id, 10), id)``).
+Tokens are useful for human-readable output and interop with external systems
+that use the token format.
+
+
+.. function:: s2_cell_area_sq_km(cell_id: bigint) -> area: double
+
+    Returns the area of the S2 cell in square kilometers.
+    Returns an error if the cell ID is invalid.
+
+.. function:: s2_cell_contains(parent_cell_id: bigint, child_cell_id: bigint) -> boolean
+
+    Returns ``true`` if the first S2 cell contains the second. Containment is
+    hierarchical: a cell contains all of its descendants at finer levels.
+    Returns an error if either cell ID is invalid.
+
+.. function:: s2_cell_from_token(cell_token: varchar) -> cell_id: bigint
+
+    Returns the 64-bit S2 cell ID for the given cell token. The
+    ``cell_token`` is a compact hexadecimal representation of the S2 cell.
+    Returns an error if the cell token is invalid.
+
+.. function:: s2_cell_level(cell_id: bigint) -> level: integer
+
+    Returns the level of the S2 cell, from 0 (coarsest) to 30 (finest).
+    Returns an error if the cell ID is invalid.
+
+.. function:: s2_cell_parent(cell_id: bigint, level: integer) -> parent_id: bigint
+
+    Returns the parent S2 cell ID at the given ``level``. If the cell is
+    already at or above the given level, returns the same cell ID. The
+    ``level`` must be in the ``[0, 30]`` range. Returns an error if the cell
+    ID is invalid or the level is out of range.
+
+.. function:: s2_cell_to_token(cell_id: bigint) -> cell_token: varchar
+
+    Returns the compact hexadecimal token representation of the S2 cell.
+    Returns an error if the cell ID is invalid.
+
+.. function:: s2_cells(geometry: Geometry, level: integer) -> cell_ids: array(bigint)
+
+    Returns the set of S2 cell IDs that cover the given geometry at a fixed
+    ``level``. All returned cells are at the same level. Supports Point,
+    LineString, Polygon, and their Multi variants. Empty geometries return an
+    empty array, null geometries return null. The ``level`` must be in the
+    ``[0, 30]`` range.
+
+.. function:: s2_cells(geometry: Geometry, min_level: integer, max_level: integer, max_cells: integer) -> cell_ids: array(bigint)
+
+    Returns a compact set of S2 cell IDs at mixed levels that cover the given
+    geometry, similar to ``geometry_to_dissolved_bing_tiles``. The coverer uses
+    large cells (at ``min_level``) for interiors and small cells (up to
+    ``max_level``) for boundaries, targeting at most ``max_cells`` cells. This
+    is useful for compact spatial indexing of regions like cities or countries.
+    Both levels must be in the ``[0, 30]`` range with ``min_level <= max_level``,
+    and ``max_cells`` must be >= 1. Empty geometries return an empty array,
+    null geometries return null.
+
+    Note: ``max_cells`` is a soft limit. Up to 6 cells may be returned
+    regardless of ``max_cells`` if the region intersects multiple cube faces
+    of the S2 projection. ``min_level`` takes priority over ``max_cells`` —
+    cells below ``min_level`` are never used even if this causes more cells
+    to be returned. If ``max_cells`` is less than 4, the covering area may be
+    significantly larger than the original region. A value of 8 or higher is
+    recommended for a reasonable approximation.
+
 .. _OpenGIS Specifications: https://www.ogc.org/standards/ogcapi-features/
 .. _SQL/MM Part 3: Spatial: https://www.iso.org/standard/31369.html

--- a/velox/expression/fuzzer/ArgValuesGenerators.cpp
+++ b/velox/expression/fuzzer/ArgValuesGenerators.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/common/fuzzer/Utils.h"
 #include "velox/core/Expressions.h"
+#include "velox/functions/prestosql/S2CellOperations.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -639,4 +640,67 @@ std::vector<core::TypedExprPtr> SetDigestArgValuesGenerator::generate(
   }
   return inputExpressions;
 }
+namespace {
+
+// Generates a random valid S2 cell ID.
+// Picks random face (0-5), level (0-30), and Hilbert curve position.
+// S2CellId::FromFacePosLevel clamps the position, so any uint64_t is safe.
+int64_t randomS2CellId(FuzzerGenerator& rng) {
+  auto face = static_cast<int>(rand<uint64_t>(rng, 0, 5));
+  auto level = static_cast<int>(rand<uint64_t>(rng, 0, 30));
+  auto position = rand<uint64_t>(rng);
+  return functions::S2CellOp::cellIdFromFacePositionLevel(
+      face, position, level);
+}
+
+} // namespace
+
+std::vector<core::TypedExprPtr> S2CellIdArgValuesGenerator::generate(
+    const CallableSignature& signature,
+    const VectorFuzzer::Options& /*options*/,
+    FuzzerGenerator& rng,
+    ExpressionFuzzerState& state) {
+  VELOX_CHECK_GE(signature.args.size(), 1);
+  populateInputTypesAndNames(signature, state);
+
+  std::vector<core::TypedExprPtr> inputExpressions{
+      signature.args.size(), nullptr};
+  VELOX_CHECK(!inputExpressions.empty());
+
+  // Generate valid constants for each argument based on type:
+  // BIGINT arguments are cell IDs, INTEGER arguments are levels (0-30).
+  for (size_t i = 0; i < inputExpressions.size(); ++i) {
+    state.customInputGenerators_.emplace_back(nullptr);
+    if (signature.args.at(i)->kind() == TypeKind::BIGINT) {
+      inputExpressions[i] = std::make_shared<core::ConstantTypedExpr>(
+          BIGINT(), variant(randomS2CellId(rng)));
+    } else if (signature.args.at(i)->kind() == TypeKind::INTEGER) {
+      auto level = static_cast<int32_t>(rand<uint64_t>(rng, 0, 30));
+      inputExpressions[i] =
+          std::make_shared<core::ConstantTypedExpr>(INTEGER(), variant(level));
+    }
+  }
+
+  return inputExpressions;
+}
+
+std::vector<core::TypedExprPtr> S2CellTokenArgValuesGenerator::generate(
+    const CallableSignature& signature,
+    const VectorFuzzer::Options& /*options*/,
+    FuzzerGenerator& rng,
+    ExpressionFuzzerState& state) {
+  VELOX_CHECK_EQ(signature.args.size(), 1);
+  populateInputTypesAndNames(signature, state);
+
+  std::vector<core::TypedExprPtr> inputExpressions{1, nullptr};
+
+  // Generate a random valid cell ID, then convert to token.
+  auto token = functions::S2CellOp::toToken(randomS2CellId(rng));
+  state.customInputGenerators_.emplace_back(nullptr);
+  inputExpressions[0] =
+      std::make_shared<core::ConstantTypedExpr>(VARCHAR(), variant(token));
+
+  return inputExpressions;
+}
+
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ArgValuesGenerators.h
+++ b/velox/expression/fuzzer/ArgValuesGenerators.h
@@ -205,4 +205,32 @@ class SetDigestArgValuesGenerator : public ArgValuesGenerator {
  private:
   std::string functionName_;
 };
+/// Generates valid S2 cell ID arguments for s2_cell_* functions.
+/// Picks random face, position, and level to construct valid cell IDs via
+/// S2CellOp::cellIdFromFacePositionLevel. Also constrains the level
+/// argument to [0, 30] when present.
+class S2CellIdArgValuesGenerator : public ArgValuesGenerator {
+ public:
+  ~S2CellIdArgValuesGenerator() override = default;
+
+  std::vector<core::TypedExprPtr> generate(
+      const CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      FuzzerGenerator& rng,
+      ExpressionFuzzerState& state) override;
+};
+
+/// Generates valid hex token arguments for s2_cell_from_token.
+/// Constructs a random valid cell ID, then converts it to a token string.
+class S2CellTokenArgValuesGenerator : public ArgValuesGenerator {
+ public:
+  ~S2CellTokenArgValuesGenerator() override = default;
+
+  std::vector<core::TypedExprPtr> generate(
+      const CallableSignature& signature,
+      const VectorFuzzer::Options& options,
+      FuzzerGenerator& rng,
+      ExpressionFuzzerState& state) override;
+};
+
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -64,6 +64,8 @@ using facebook::velox::fuzzer::FuzzerRunner;
 using facebook::velox::fuzzer::JsonExtractArgValuesGenerator;
 using facebook::velox::fuzzer::JsonParseArgValuesGenerator;
 using facebook::velox::fuzzer::QDigestArgValuesGenerator;
+using facebook::velox::fuzzer::S2CellIdArgValuesGenerator;
+using facebook::velox::fuzzer::S2CellTokenArgValuesGenerator;
 using facebook::velox::fuzzer::SetDigestArgValuesGenerator;
 using facebook::velox::fuzzer::TDigestArgValuesGenerator;
 using facebook::velox::fuzzer::UnifiedDigestArgValuesGenerator;
@@ -136,7 +138,14 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
          std::make_shared<SetDigestArgValuesGenerator>("jaccard_index")},
         {"intersection_cardinality",
          std::make_shared<SetDigestArgValuesGenerator>(
-             "intersection_cardinality")}};
+             "intersection_cardinality")},
+        {"s2_cell_area_sq_km", std::make_shared<S2CellIdArgValuesGenerator>()},
+        {"s2_cell_contains", std::make_shared<S2CellIdArgValuesGenerator>()},
+        {"s2_cell_level", std::make_shared<S2CellIdArgValuesGenerator>()},
+        {"s2_cell_parent", std::make_shared<S2CellIdArgValuesGenerator>()},
+        {"s2_cell_to_token", std::make_shared<S2CellIdArgValuesGenerator>()},
+        {"s2_cell_from_token",
+         std::make_shared<S2CellTokenArgValuesGenerator>()}};
 
 // TODO: List of the functions that at some point crash or fail and need to
 // be fixed before we can enable.
@@ -297,6 +306,7 @@ std::unordered_set<std::string> skipFunctions = {
     "convex_hull_agg",
     "geometry_union_agg",
     "localtime",
+    "s2_cells",
 };
 
 std::unordered_set<std::string> skipFunctionsSOT = {
@@ -483,6 +493,13 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "uniqueness_distribution(khyperloglog,bigint) -> map(bigint,double)",
     "merge_khll(array(khyperloglog)) -> khyperloglog",
     "pmod", // Not available in Presto
+    // S2 functions are not registered in the Presto instance used for fuzzing.
+    "s2_cell_area_sq_km",
+    "s2_cell_contains",
+    "s2_cell_from_token",
+    "s2_cell_level",
+    "s2_cell_parent",
+    "s2_cell_to_token",
 };
 
 int main(int argc, char** argv) {

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -117,6 +117,7 @@ velox_add_library(
   RegexpReplace.h
   RegexpSplit.h
   RemapKeys.h
+  S2Functions.h
   SetDigestFunctions.h
   SfmSketchFunctions.h
   SplitPart.h
@@ -153,7 +154,14 @@ endif()
 
 if(VELOX_ENABLE_GEO)
   add_subdirectory(geospatial)
-  velox_link_libraries(velox_functions_prestosql_impl velox_functions_geo)
+
+  # S2 cell operations are isolated in a separate library to prevent a
+  # nallocx symbol conflict between s2geometry's malloc_extension.h and
+  # folly's MallocImpl.h.
+  velox_add_library(velox_s2_cell_operations S2CellOperations.cpp HEADERS S2CellOperations.h)
+  velox_link_libraries(velox_s2_cell_operations s2::s2 GEOS::geos)
+
+  velox_link_libraries(velox_functions_prestosql_impl velox_functions_geo velox_s2_cell_operations)
 endif()
 
 if(NOT VELOX_MONO_LIBRARY)

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -1951,14 +1951,14 @@ struct GeometryToBingTilesFunction {
     if (zoom < 0 || zoom > 23) {
       return Status::UserError("Zoom level must be between 0 and 23");
     }
-    auto envelope =
-        common::geospatial::GeometryDeserializer::deserializeEnvelope(geometry);
-    if (envelope->isNull()) {
+    auto geom =
+        common::geospatial::GeometryDeserializer::deserializeNonEmpty(geometry);
+    if (!geom) {
       return Status::OK();
     }
 
     std::vector<int64_t> covering;
-    auto geom = common::geospatial::GeometryDeserializer::deserialize(geometry);
+    const auto* envelope = geom->getEnvelopeInternal();
 
     if (geom->getGeometryTypeId() == geos::geom::GeometryTypeId::GEOS_POINT) {
       covering = geospatial::getMinimalTilesCoveringGeometry(*envelope, zoom);

--- a/velox/functions/prestosql/S2CellOperations.cpp
+++ b/velox/functions/prestosql/S2CellOperations.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/S2CellOperations.h"
+
+#include <memory>
+
+#include <vector>
+
+#include <geos/geom/Geometry.h>
+#include <geos/geom/LineString.h>
+#include <geos/geom/LinearRing.h>
+#include <geos/geom/Polygon.h>
+#include <s2/s2cell.h>
+#include <s2/s2cell_id.h>
+#include <s2/s2earth.h>
+#include <s2/s2latlng.h>
+#include <s2/s2loop.h>
+#include <s2/s2point.h>
+#include <s2/s2polygon.h>
+#include <s2/s2polyline.h>
+#include <s2/s2region_coverer.h>
+
+namespace facebook::velox::functions {
+
+namespace {
+
+// Maps a GEOS coordinate (x=longitude, y=latitude) to a point on the
+// unit sphere.
+S2Point toS2Point(const geos::geom::Coordinate& coord) {
+  return S2LatLng::FromDegrees(coord.y, coord.x).ToPoint();
+}
+
+// Converts a GEOS linear ring to an S2Loop. Skips the closing vertex
+// (GEOS rings repeat the first vertex; S2 loops are implicitly closed).
+// Normalizes the loop so it encloses the smaller of the two spherical
+// regions it defines.
+std::unique_ptr<S2Loop> toS2Loop(const geos::geom::LinearRing& ring) {
+  auto coords = ring.getCoordinates();
+  auto numVertices = coords->getSize() - 1;
+  std::vector<S2Point> points;
+  points.reserve(numVertices);
+  for (size_t i = 0; i < numVertices; ++i) {
+    points.push_back(toS2Point(coords->getAt(i)));
+  }
+  auto loop = std::make_unique<S2Loop>(points);
+  loop->Normalize();
+  return loop;
+}
+
+// Converts a GEOS geometry to S2 objects and appends the cell covering.
+// A polygon valid in GEOS can be invalid on the sphere (e.g.,
+// self-intersecting edges after geodesic projection), which is why we
+// check S2Polygon::IsValid().
+std::string appendCovering(
+    const geos::geom::Geometry& geom,
+    int32_t level,
+    S2RegionCoverer& coverer,
+    std::vector<uint64_t>& result) {
+  if (geom.isEmpty()) {
+    return {};
+  }
+
+  auto typeId = geom.getGeometryTypeId();
+
+  if (typeId == geos::geom::GeometryTypeId::GEOS_POINT) {
+    result.push_back(
+        S2CellId(toS2Point(*geom.getCoordinate())).parent(level).id());
+
+  } else if (typeId == geos::geom::GeometryTypeId::GEOS_LINESTRING) {
+    auto coords = geom.getCoordinates();
+    if (coords->getSize() < 2) {
+      return "LineString must have at least 2 points";
+    }
+    std::vector<S2Point> points;
+    points.reserve(coords->getSize());
+    for (size_t i = 0; i < coords->getSize(); ++i) {
+      points.push_back(toS2Point(coords->getAt(i)));
+    }
+    S2Polyline polyline(points);
+    std::vector<S2CellId> covering;
+    coverer.GetCovering(polyline, &covering);
+    for (const auto& cellId : covering) {
+      result.push_back(cellId.id());
+    }
+
+  } else if (typeId == geos::geom::GeometryTypeId::GEOS_POLYGON) {
+    const auto& polygon = static_cast<const geos::geom::Polygon&>(geom);
+
+    auto* exteriorRing = polygon.getExteriorRing();
+    if (exteriorRing->getNumPoints() < 4) {
+      return "Polygon ring must have at least 4 points";
+    }
+
+    // Build S2Polygon from exterior ring and holes. The S2Polygon
+    // constructor determines hole nesting automatically.
+    std::vector<std::unique_ptr<S2Loop>> loops;
+    loops.reserve(1 + polygon.getNumInteriorRing());
+    loops.push_back(toS2Loop(*exteriorRing));
+    for (size_t i = 0; i < polygon.getNumInteriorRing(); ++i) {
+      loops.push_back(toS2Loop(*polygon.getInteriorRingN(i)));
+    }
+
+    S2Polygon s2polygon(std::move(loops));
+    if (!s2polygon.IsValid()) {
+      return "Polygon is not valid on the sphere";
+    }
+    std::vector<S2CellId> covering;
+    coverer.GetCovering(s2polygon, &covering);
+    for (const auto& cellId : covering) {
+      result.push_back(cellId.id());
+    }
+
+  } else {
+    for (size_t i = 0; i < geom.getNumGeometries(); ++i) {
+      auto error =
+          appendCovering(*geom.getGeometryN(i), level, coverer, result);
+      if (!error.empty()) {
+        return error;
+      }
+    }
+  }
+
+  return {};
+}
+
+} // namespace
+
+namespace {
+
+S2CellId s2CellId(int64_t cellId) {
+  return S2CellId(static_cast<uint64_t>(cellId));
+}
+
+int64_t fromS2CellId(S2CellId cellId) {
+  return static_cast<int64_t>(cellId.id());
+}
+
+} // namespace
+
+bool S2CellOp::isValid(int64_t cellId) {
+  return s2CellId(cellId).is_valid();
+}
+
+double S2CellOp::areaSqKm(int64_t cellId) {
+  return S2Earth::SteradiansToSquareKm(::S2Cell{s2CellId(cellId)}.ExactArea());
+}
+
+int S2CellOp::level(int64_t cellId) {
+  return s2CellId(cellId).level();
+}
+
+int64_t S2CellOp::parent(int64_t cellId, int level) {
+  return fromS2CellId(s2CellId(cellId).parent(level));
+}
+
+bool S2CellOp::contains(int64_t parent, int64_t child) {
+  return s2CellId(parent).contains(s2CellId(child));
+}
+
+int64_t S2CellOp::fromToken(std::string_view token) {
+  return fromS2CellId(S2CellId::FromToken(token));
+}
+
+std::string S2CellOp::toToken(int64_t cellId) {
+  return s2CellId(cellId).ToToken();
+}
+
+int64_t
+S2CellOp::cellIdFromFacePositionLevel(int face, uint64_t position, int level) {
+  // Start with a valid face cell and descend to the target level by picking
+  // a child (0-3) at each step, determined by successive 2-bit groups of
+  // 'position'.
+  auto cellId = S2CellId::FromFace(face);
+  for (int i = 0; i < level; ++i) {
+    cellId = cellId.child(static_cast<int>(position & 3));
+    position >>= 2;
+  }
+  return fromS2CellId(cellId);
+}
+
+S2Covering S2CellOp::tryCovering(
+    const geos::geom::Geometry& geom,
+    int32_t level) {
+  S2RegionCoverer::Options options;
+  options.set_min_level(level);
+  options.set_max_level(level);
+  S2RegionCoverer coverer(options);
+
+  std::vector<uint64_t> cellIds;
+  auto error = appendCovering(geom, level, coverer, cellIds);
+  if (!error.empty()) {
+    return {{}, std::move(error)};
+  }
+  return {std::vector<int64_t>(cellIds.begin(), cellIds.end()), {}};
+}
+
+S2Covering S2CellOp::tryDissolvedCovering(
+    const geos::geom::Geometry& geom,
+    int32_t minLevel,
+    int32_t maxLevel,
+    int32_t maxCells) {
+  S2RegionCoverer::Options options;
+  options.set_min_level(minLevel);
+  options.set_max_level(maxLevel);
+  options.set_max_cells(maxCells);
+  S2RegionCoverer coverer(options);
+
+  std::vector<uint64_t> cellIds;
+  auto error = appendCovering(geom, maxLevel, coverer, cellIds);
+  if (!error.empty()) {
+    return {{}, std::move(error)};
+  }
+  return {std::vector<int64_t>(cellIds.begin(), cellIds.end()), {}};
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/S2CellOperations.h
+++ b/velox/functions/prestosql/S2CellOperations.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Build isolation layer for s2geometry. s2geometry's malloc_extension.h
+// and folly's MallocImpl.h both define `nallocx` with incompatible types
+// (function declaration vs function pointer). This header exposes S2
+// operations through primitive types so that no translation unit needs
+// to include both s2geometry and folly headers.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace geos::geom {
+class Geometry;
+} // namespace geos::geom
+
+namespace facebook::velox::functions {
+
+/// Result of an S2 covering operation. Empty 'error' indicates success.
+struct S2Covering {
+  std::vector<int64_t> cellIds;
+  std::string error;
+};
+
+/// Wraps s2geometry operations, isolated from folly headers.
+/// All methods are static — no instance state. Cell IDs are int64_t
+/// (reinterpreted from unsigned S2 cell IDs) to match the SQL BIGINT type.
+///
+/// Unless otherwise noted, methods that accept a cell ID require it to be
+/// valid (as determined by isValid()). Passing an invalid cell ID results
+/// in undefined behavior. Callers should validate via isValid() first.
+struct S2CellOp {
+  /// Returns true if 'cellId' is a valid S2 cell identifier.
+  /// Safe to call with any int64_t value.
+  static bool isValid(int64_t cellId);
+
+  /// Returns the area of the cell in square kilometers.
+  static double areaSqKm(int64_t cellId);
+
+  /// Returns the level (0–30) of the cell.
+  static int level(int64_t cellId);
+
+  /// Returns the ancestor cell at the given level.
+  static int64_t parent(int64_t cellId, int level);
+
+  /// Returns true if 'parent' contains 'child'.
+  static bool contains(int64_t parent, int64_t child);
+
+  /// Converts a hex token string to a cell identifier. The returned cell ID
+  /// may be invalid if the token is malformed; callers should check with
+  /// isValid().
+  static int64_t fromToken(std::string_view token);
+
+  /// Converts a cell identifier to a hex token string.
+  static std::string toToken(int64_t cellId);
+
+  /// Constructs a valid cell ID by starting from a face cell (0–5) and
+  /// descending to the given level (0–30). At each level, the next child
+  /// (0–3) is selected from successive 2-bit groups of 'position'
+  /// (bits [1:0] for level 1, bits [3:2] for level 2, etc.). Any uint64_t
+  /// value is safe — extra bits beyond 2*level are ignored.
+  static int64_t
+  cellIdFromFacePositionLevel(int face, uint64_t position, int level);
+
+  /// Converts a GEOS geometry to S2 objects and returns the cell covering.
+  /// GEOS uses planar (straight-line) edges; S2 uses geodesic (great-circle)
+  /// edges. For small geometries the difference is negligible; for large ones
+  /// (country-sized) the S2 covering follows Earth's curvature.
+  static S2Covering tryCovering(
+      const geos::geom::Geometry& geom,
+      int32_t level);
+
+  /// Returns a compact mixed-level covering, similar to
+  /// geometry_to_dissolved_bing_tiles. Uses large cells for interiors and
+  /// small cells for boundaries.
+  static S2Covering tryDissolvedCovering(
+      const geos::geom::Geometry& geom,
+      int32_t minLevel,
+      int32_t maxLevel,
+      int32_t maxCells);
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/S2Functions.h
+++ b/velox/functions/prestosql/S2Functions.h
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include <folly/CPortability.h>
+#include "velox/common/base/Status.h"
+#include "velox/common/geospatial/GeometrySerde.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/S2CellOperations.h"
+#include "velox/functions/prestosql/types/GeometryType.h"
+
+namespace facebook::velox::functions {
+
+namespace detail {
+
+template <typename... Args>
+Status userError(std::string_view format, Args&&... args) {
+  if (threadSkipErrorDetails()) {
+    return Status::UserError();
+  }
+  return Status::UserError(format, std::forward<Args>(args)...);
+}
+
+inline Status validateCellId(int64_t cellId, std::string_view functionName) {
+  if (!S2CellOp::isValid(cellId)) {
+    return userError("{}: Invalid cell ID: {}", functionName, cellId);
+  }
+  return Status::OK();
+}
+
+inline Status validateLevel(int32_t level, std::string_view functionName) {
+  if (level < 0 || level > 30) {
+    return userError(
+        "{}: Level must be in [0, 30] range, got {}", functionName, level);
+  }
+  return Status::OK();
+}
+
+} // namespace detail
+
+/// Implements the s2_cell_area_sq_km SQL function.
+template <typename TExec>
+struct S2CellAreaSqKmFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status
+  call(double& result, const arg_type<int64_t>& cellId) {
+    VELOX_RETURN_NOT_OK(detail::validateCellId(cellId, "s2_cell_area_sq_km"));
+    result = S2CellOp::areaSqKm(cellId);
+    return Status::OK();
+  }
+};
+
+/// Implements the s2_cell_contains SQL function.
+template <typename TExec>
+struct S2CellContainsFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      bool& result,
+      const arg_type<int64_t>& parent,
+      const arg_type<int64_t>& child) {
+    VELOX_RETURN_NOT_OK(detail::validateCellId(parent, "s2_cell_contains"));
+    VELOX_RETURN_NOT_OK(detail::validateCellId(child, "s2_cell_contains"));
+    result = S2CellOp::contains(parent, child);
+    return Status::OK();
+  }
+};
+
+/// Implements the s2_cell_from_token SQL function.
+template <typename TExec>
+struct S2CellFromTokenFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status
+  call(int64_t& result, const arg_type<Varchar>& token) {
+    if (token.empty()) {
+      return detail::userError("s2_cell_from_token: Empty cell token");
+    }
+    result = S2CellOp::fromToken({token.data(), token.size()});
+    if (!S2CellOp::isValid(result)) {
+      return detail::userError(
+          "s2_cell_from_token: Invalid cell token: {}",
+          std::string_view(token.data(), token.size()));
+    }
+    return Status::OK();
+  }
+};
+
+/// Implements the s2_cell_level SQL function.
+template <typename TExec>
+struct S2CellLevelFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status
+  call(int32_t& result, const arg_type<int64_t>& cellId) {
+    VELOX_RETURN_NOT_OK(detail::validateCellId(cellId, "s2_cell_level"));
+    result = S2CellOp::level(cellId);
+    return Status::OK();
+  }
+};
+
+/// Implements the s2_cell_parent SQL function.
+template <typename TExec>
+struct S2CellParentFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      int64_t& result,
+      const arg_type<int64_t>& cellId,
+      const arg_type<int32_t>& level) {
+    VELOX_RETURN_NOT_OK(detail::validateLevel(level, "s2_cell_parent"));
+    VELOX_RETURN_NOT_OK(detail::validateCellId(cellId, "s2_cell_parent"));
+
+    if (S2CellOp::level(cellId) <= level) {
+      result = cellId;
+      return Status::OK();
+    }
+    result = S2CellOp::parent(cellId, level);
+    return Status::OK();
+  }
+};
+
+/// Implements the s2_cell_to_token SQL function.
+template <typename TExec>
+struct S2CellToTokenFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status
+  call(out_type<Varchar>& result, const arg_type<int64_t>& cellId) {
+    VELOX_RETURN_NOT_OK(detail::validateCellId(cellId, "s2_cell_to_token"));
+    result = S2CellOp::toToken(cellId);
+    return Status::OK();
+  }
+};
+
+/// Implements the fixed-level s2_cells(geometry, level) SQL function.
+template <typename TExec>
+struct S2CellsFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<Array<int64_t>>& result,
+      const arg_type<Geometry>& geometry,
+      const arg_type<int32_t>& level) {
+    VELOX_RETURN_NOT_OK(detail::validateLevel(level, "s2_cells"));
+
+    auto geom =
+        common::geospatial::GeometryDeserializer::deserializeNonEmpty(geometry);
+    if (!geom) {
+      return Status::OK();
+    }
+    auto covering = S2CellOp::tryCovering(*geom, level);
+    if (!covering.error.empty()) {
+      return detail::userError("s2_cells: {}", covering.error);
+    }
+    for (auto cellId : covering.cellIds) {
+      result.add_item() = cellId;
+    }
+    return Status::OK();
+  }
+};
+
+/// Implements the dissolved s2_cells(geometry, minLevel, maxLevel, maxCells)
+/// SQL function.
+template <typename TExec>
+struct S2CellsDissolvedFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  FOLLY_ALWAYS_INLINE Status call(
+      out_type<Array<int64_t>>& result,
+      const arg_type<Geometry>& geometry,
+      const arg_type<int32_t>& minLevel,
+      const arg_type<int32_t>& maxLevel,
+      const arg_type<int32_t>& maxCells) {
+    VELOX_RETURN_NOT_OK(detail::validateLevel(minLevel, "s2_cells"));
+    VELOX_RETURN_NOT_OK(detail::validateLevel(maxLevel, "s2_cells"));
+    if (minLevel > maxLevel) {
+      return detail::userError(
+          "s2_cells: min_level ({}) must be <= max_level ({})",
+          minLevel,
+          maxLevel);
+    }
+    if (maxCells < 1) {
+      return detail::userError(
+          "s2_cells: max_cells must be >= 1, got {}", maxCells);
+    }
+
+    auto geom =
+        common::geospatial::GeometryDeserializer::deserializeNonEmpty(geometry);
+    if (!geom) {
+      return Status::OK();
+    }
+    auto covering =
+        S2CellOp::tryDissolvedCovering(*geom, minLevel, maxLevel, maxCells);
+    if (!covering.error.empty()) {
+      return detail::userError("s2_cells: {}", covering.error);
+    }
+    for (auto cellId : covering.cellIds) {
+      result.add_item() = cellId;
+    }
+    return Status::OK();
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
@@ -260,6 +260,13 @@ rgb
 round
 rpad
 rtrim
+s2_cell_area_sq_km
+s2_cell_contains
+s2_cell_from_token
+s2_cell_level
+s2_cell_parent
+s2_cell_to_token
+s2_cells
 scale_qdigest
 second
 secure_rand

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -51,7 +51,10 @@ if(VELOX_ENABLE_GEO)
   velox_compile_definitions(velox_functions_prestosql PRIVATE VELOX_ENABLE_GEO)
   velox_sources(
     velox_functions_prestosql
-    PRIVATE GeometryFunctionsRegistration.cpp SphericalGeographyFunctionsRegistration.cpp
+    PRIVATE
+      GeometryFunctionsRegistration.cpp
+      S2FunctionsRegistration.cpp
+      SphericalGeographyFunctionsRegistration.cpp
   )
 endif()
 

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -52,6 +52,9 @@ extern void registerBingTileFunctions(const std::string& prefix);
 extern void registerGeometryFunctions(const std::string& prefix);
 extern void registerSphericalGeographyFunctions();
 #endif
+#ifdef VELOX_ENABLE_GEO
+extern void registerS2Functions(const std::string& prefix);
+#endif
 extern void registerInternalArrayFunctions();
 
 namespace prestosql {
@@ -121,6 +124,10 @@ void registerGeometryFunctions(const std::string& prefix) {
 void registerSphericalGeographyFunctions() {
   functions::registerSphericalGeographyFunctions();
 }
+
+void registerS2Functions(const std::string& prefix) {
+  functions::registerS2Functions(prefix);
+}
 #endif
 
 void registerGeneralFunctions(const std::string& prefix) {
@@ -168,6 +175,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
 #ifdef VELOX_ENABLE_GEO
   registerGeometryFunctions(prefix);
   registerSphericalGeographyFunctions();
+  registerS2Functions(prefix);
 #endif
   registerGeneralFunctions(prefix);
   registerDateTimeFunctions(prefix);

--- a/velox/functions/prestosql/registration/S2FunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/S2FunctionsRegistration.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/S2Functions.h"
+#include "velox/type/SimpleFunctionApi.h"
+
+namespace facebook::velox::functions {
+
+using namespace facebook::velox;
+
+void registerS2Functions(const std::string& prefix) {
+  registerFunction<S2CellAreaSqKmFunction, double, int64_t>(
+      {prefix + "s2_cell_area_sq_km"});
+  registerFunction<S2CellContainsFunction, bool, int64_t, int64_t>(
+      {prefix + "s2_cell_contains"});
+  registerFunction<S2CellFromTokenFunction, int64_t, Varchar>(
+      {prefix + "s2_cell_from_token"});
+  registerFunction<S2CellLevelFunction, int32_t, int64_t>(
+      {prefix + "s2_cell_level"});
+  registerFunction<S2CellParentFunction, int64_t, int64_t, int32_t>(
+      {prefix + "s2_cell_parent"});
+  registerFunction<S2CellToTokenFunction, Varchar, int64_t>(
+      {prefix + "s2_cell_to_token"});
+  // Two overloads of s2_cells: fixed-level and dissolved (mixed-level).
+  registerFunction<S2CellsFunction, Array<int64_t>, Geometry, int32_t>(
+      {prefix + "s2_cells"});
+  registerFunction<
+      S2CellsDissolvedFunction,
+      Array<int64_t>,
+      Geometry,
+      int32_t,
+      int32_t,
+      int32_t>({prefix + "s2_cells"});
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -145,7 +145,7 @@ add_executable(
 )
 
 if(VELOX_ENABLE_GEO)
-  target_sources(velox_functions_test PRIVATE GeometryFunctionsTest.cpp)
+  target_sources(velox_functions_test PRIVATE GeometryFunctionsTest.cpp S2FunctionsTest.cpp)
 endif()
 
 if(VELOX_ENABLE_FAISS)

--- a/velox/functions/prestosql/tests/S2FunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/S2FunctionsTest.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// A level-0 face cell covering approximately 1/6 of Earth's surface.
+constexpr int64_t kLevel0CellId{
+    static_cast<int64_t>(5'764'607'523'034'234'880ULL)};
+
+// A level-14 cell. kLevel20CellId is a level-20 descendant of this cell, so
+// s2_cell_parent(kLevel20CellId, 14) == kLevel14CellId.
+constexpr int64_t kLevel14CellId{
+    static_cast<int64_t>(9'260'949'543'246'102'528ULL)};
+
+// A level-20 descendant of kLevel14CellId.
+constexpr int64_t kLevel20CellId{
+    static_cast<int64_t>(9'260'949'539'409'362'944ULL)};
+
+// Hex tokens corresponding to the cell IDs above.
+constexpr std::string_view kLevel14Token{"8085808b"};
+constexpr std::string_view kLevel20Token{"8085808a1b5"};
+
+class S2FunctionsTest : public test::FunctionBaseTest {
+ protected:
+  // Evaluates s2_cells at a fixed level and returns the cell IDs.
+  std::vector<int64_t> cells(const std::string& wkt, int32_t level) {
+    return evaluate(
+               "s2_cells(ST_GeometryFromText(c0), c1)",
+               makeRowVector({
+                   makeFlatVector({wkt}),
+                   makeFlatVector<int32_t>({level}),
+               }))
+        ->variantAt(0)
+        .array<int64_t>();
+  }
+
+  // Evaluates dissolved s2_cells and returns the cell IDs.
+  std::vector<int64_t> cells(
+      const std::string& wkt,
+      int32_t minLevel,
+      int32_t maxLevel,
+      int32_t maxCells) {
+    return evaluate(
+               "s2_cells(ST_GeometryFromText(c0), c1, c2, c3)",
+               makeRowVector({
+                   makeFlatVector({wkt}),
+                   makeFlatVector<int32_t>({minLevel}),
+                   makeFlatVector<int32_t>({maxLevel}),
+                   makeFlatVector<int32_t>({maxCells}),
+               }))
+        ->variantAt(0)
+        .array<int64_t>();
+  }
+
+  // Returns the number of cells for convenience assertions.
+  size_t countCells(const std::string& wkt, int32_t level) {
+    return cells(wkt, level).size();
+  }
+
+  size_t countCells(
+      const std::string& wkt,
+      int32_t minLevel,
+      int32_t maxLevel,
+      int32_t maxCells) {
+    return cells(wkt, minLevel, maxLevel, maxCells).size();
+  }
+};
+
+TEST_F(S2FunctionsTest, parent) {
+  auto test = [&](int64_t cellId, int32_t level, int64_t expected) {
+    auto result = evaluateOnce<int64_t>(
+        "s2_cell_parent(c0, c1)", std::optional(cellId), std::optional(level));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(expected, result.value());
+  };
+
+  test(kLevel20CellId, 14, kLevel14CellId);
+
+  // Same level returns same cell ID.
+  test(kLevel14CellId, 14, kLevel14CellId);
+
+  // Higher level returns same cell ID.
+  test(kLevel14CellId, 15, kLevel14CellId);
+
+  // Invalid level.
+  auto testThrows = [&](int32_t level, std::string_view message) {
+    VELOX_ASSERT_USER_THROW(
+        evaluateOnce<int64_t>(
+            "s2_cell_parent(c0, c1)",
+            std::optional(kLevel14CellId),
+            std::optional(level)),
+        message);
+  };
+  testThrows(-1, "s2_cell_parent: Level must be in [0, 30] range, got -1");
+  testThrows(31, "s2_cell_parent: Level must be in [0, 30] range, got 31");
+}
+
+TEST_F(S2FunctionsTest, areaSqKm) {
+  auto test = [&](int64_t cellId, double expected, double tolerance) {
+    auto result =
+        evaluateOnce<double>("s2_cell_area_sq_km(c0)", std::optional(cellId));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_NEAR(expected, result.value(), tolerance);
+  };
+
+  // Level 0 cell (1/6 of Earth's surface).
+  test(kLevel0CellId, 85011012.18633142, 0.000001);
+
+  // Level 14 cell.
+  test(kLevel14CellId, 0.263649755299609, 0.000001);
+}
+
+TEST_F(S2FunctionsTest, fromToken) {
+  auto test = [&](std::string_view token, int64_t expected) {
+    auto result = evaluateOnce<int64_t>(
+        "s2_cell_from_token(c0)", std::optional(std::string(token)));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(expected, result.value());
+  };
+
+  test(kLevel20Token, kLevel20CellId);
+  test(kLevel14Token, kLevel14CellId);
+
+  auto testThrows = [&](std::string_view token, std::string_view message) {
+    VELOX_ASSERT_USER_THROW(
+        evaluateOnce<int64_t>(
+            "s2_cell_from_token(c0)", std::optional(std::string(token))),
+        message);
+  };
+
+  // Invalid token.
+  testThrows("invalid", "s2_cell_from_token: Invalid cell token: invalid");
+
+  // Empty token.
+  testThrows("", "s2_cell_from_token: Empty cell token");
+}
+
+TEST_F(S2FunctionsTest, contains) {
+  // Level 14 cell contains its level 20 descendant.
+  auto contains = evaluateOnce<bool>(
+      "s2_cell_contains(c0, c1)",
+      std::optional(kLevel14CellId),
+      std::optional(kLevel20CellId));
+  ASSERT_TRUE(contains.has_value());
+  EXPECT_TRUE(contains.value());
+
+  // Reverse is false.
+  auto notContains = evaluateOnce<bool>(
+      "s2_cell_contains(c0, c1)",
+      std::optional(kLevel20CellId),
+      std::optional(kLevel14CellId));
+  ASSERT_TRUE(notContains.has_value());
+  EXPECT_FALSE(notContains.value());
+
+  // A cell contains itself.
+  auto containsSelf = evaluateOnce<bool>(
+      "s2_cell_contains(c0, c1)",
+      std::optional(kLevel14CellId),
+      std::optional(kLevel14CellId));
+  ASSERT_TRUE(containsSelf.has_value());
+  EXPECT_TRUE(containsSelf.value());
+
+  // Composes with s2_cell_from_token without casting.
+  auto composedResult = evaluateOnce<bool>(
+      "s2_cell_contains(s2_cell_from_token(c0), s2_cell_from_token(c1))",
+      std::optional(std::string(kLevel14Token)),
+      std::optional(std::string(kLevel20Token)));
+  ASSERT_TRUE(composedResult.has_value());
+  EXPECT_TRUE(composedResult.value());
+}
+
+TEST_F(S2FunctionsTest, level) {
+  auto level0 =
+      evaluateOnce<int32_t>("s2_cell_level(c0)", std::optional(kLevel0CellId));
+  ASSERT_TRUE(level0.has_value());
+  EXPECT_EQ(0, level0.value());
+
+  auto level14 =
+      evaluateOnce<int32_t>("s2_cell_level(c0)", std::optional(kLevel14CellId));
+  ASSERT_TRUE(level14.has_value());
+  EXPECT_EQ(14, level14.value());
+}
+
+TEST_F(S2FunctionsTest, toToken) {
+  auto test = [&](int64_t cellId, std::string_view expected) {
+    auto result = evaluateOnce<std::string>(
+        "s2_cell_to_token(c0)", std::optional(cellId));
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(expected, result.value());
+  };
+
+  test(kLevel20CellId, kLevel20Token);
+  test(kLevel14CellId, kLevel14Token);
+}
+
+TEST_F(S2FunctionsTest, cells) {
+  // A point produces exactly one cell.
+  EXPECT_EQ(1, countCells("POINT (0 0)", 10));
+
+  // A polygon produces multiple cells.
+  EXPECT_GT(countCells("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 10), 1);
+
+  // Empty geometries produce an empty array.
+  EXPECT_EQ(0, countCells("GEOMETRYCOLLECTION EMPTY", 10));
+  EXPECT_EQ(0, countCells("POLYGON EMPTY", 10));
+
+  // Non-empty GeometryCollection produces cells for each sub-geometry.
+  EXPECT_GT(countCells("GEOMETRYCOLLECTION (POINT (0 0), POINT (1 1))", 10), 0);
+
+  // LineString produces multiple cells.
+  EXPECT_GT(countCells("LINESTRING (0 0, 1 1)", 10), 1);
+
+  // MultiPoint produces one cell per point.
+  EXPECT_EQ(3, countCells("MULTIPOINT (0 0, 10 10, 20 20)", 10));
+
+  // Round-trip: level-10 cell contains level-20 cell for same point.
+  auto level10Cells = cells("POINT (40.7128 -74.006)", 10);
+  auto level20Cells = cells("POINT (40.7128 -74.006)", 20);
+  ASSERT_EQ(1, level10Cells.size());
+  ASSERT_EQ(1, level20Cells.size());
+  auto containsResult = evaluateOnce<bool>(
+      "s2_cell_contains(c0, c1)",
+      std::optional(level10Cells[0]),
+      std::optional(level20Cells[0]));
+  ASSERT_TRUE(containsResult.has_value());
+  EXPECT_TRUE(containsResult.value());
+
+  // Level 0 and 30 edge cases.
+  for (int32_t level : {0, 30}) {
+    EXPECT_EQ(1, countCells("POINT (40.7128 -74.006)", level));
+  }
+
+  // Invalid levels.
+  for (int32_t level : {-1, 31}) {
+    VELOX_ASSERT_USER_THROW(
+        cells("POINT (0 0)", level),
+        "s2_cells: Level must be in [0, 30] range");
+  }
+}
+
+TEST_F(S2FunctionsTest, cellsDissolved) {
+  // Dissolved covering should produce fewer cells than fixed-level.
+  auto dissolvedCells =
+      cells("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 4, 14, 100);
+  EXPECT_GT(dissolvedCells.size(), 0);
+  EXPECT_LE(dissolvedCells.size(), 100);
+  EXPECT_LT(
+      dissolvedCells.size(),
+      countCells("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))", 14));
+
+  // All cells should have levels within [min_level, max_level].
+  for (auto cellId : dissolvedCells) {
+    auto cellLevel =
+        evaluateOnce<int32_t>("s2_cell_level(c0)", std::optional(cellId));
+    ASSERT_TRUE(cellLevel.has_value());
+    EXPECT_GE(cellLevel.value(), 4);
+    EXPECT_LE(cellLevel.value(), 14);
+  }
+
+  // Point produces exactly 1 cell.
+  EXPECT_EQ(1, countCells("POINT (0 0)", 0, 20, 100));
+
+  // Empty geometry produces an empty array.
+  EXPECT_EQ(0, countCells("GEOMETRYCOLLECTION EMPTY", 0, 20, 100));
+
+  // min_level > max_level.
+  VELOX_ASSERT_USER_THROW(
+      cells("POINT (0 0)", 15, 10, 100),
+      "s2_cells: min_level (15) must be <= max_level (10)");
+
+  // max_cells < 1.
+  VELOX_ASSERT_USER_THROW(
+      cells("POINT (0 0)", 0, 20, 0), "s2_cells: max_cells must be >= 1");
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:

S2 Geometry (http://s2geometry.io/) is a library for spherical geometry that decomposes the Earth's surface into a hierarchy of cells. Unlike planar tiling systems (e.g., Bing Tiles), S2 cells have near-uniform area across all latitudes and support 31 levels of hierarchical resolution, making them well-suited for spatial indexing, containment checks, and compact region coverings.

New S2 cell functions:

| Function | Signature | Description |
|---|---|---|
| `s2_cell_area_sq_km` | `(bigint) -> double` | Surface area of a cell in km² |
| `s2_cell_contains` | `(bigint, bigint) -> boolean` | Hierarchical containment check |
| `s2_cell_from_token` | `(varchar) -> bigint` | Convert hex token to cell ID |
| `s2_cell_level` | `(bigint) -> integer` | Get level (0-30) of a cell |
| `s2_cell_parent` | `(bigint, integer) -> bigint` | Get ancestor at a given level |
| `s2_cell_to_token` | `(bigint) -> varchar` | Convert cell ID to hex token |
| `s2_cells` | `(Geometry, integer) -> array(bigint)` | Cover geometry at fixed level |
| `s2_cells` | `(Geometry, integer, integer, integer) -> array(bigint)` | Compact mixed-level covering (similar to `geometry_to_dissolved_bing_tiles`) |

Design: all functions operate on cell IDs (BIGINT). Token conversion is
explicit via `s2_cell_from_token`/`s2_cell_to_token`. Level parameters and
return values use INTEGER consistently.

Build isolation:
S2 cell operations are isolated in a separate translation unit (`S2CellOperations.cpp`) to prevent a symbol conflict between s2geometry's `malloc_extension.h` and folly's `MallocImpl.h` — both define `nallocx` with incompatible types (function declaration vs function pointer). The isolation header (`S2CellOperations.h`) exposes only primitive-type wrappers, keeping s2geometry headers out of any translation unit that includes folly.

Dependencies: Adds a bundled dependency on s2geometry 0.12.0 (the first version to remove the glog dependency). Includes a one-line patch (`s2geometry-gcc12-max.patch`) to fix a `std::max` template deduction failure with GCC 12 in `s2cell_id.cc`, where `absl::bit_width` returns `unsigned long` but the other argument is `int`. s2geometry 0.13.1 was considered but requires abseil APIs (`absl::byteswap`, `absl::endian`, `SpinLock`) not present in Velox's bundled abseil `20240116` — upgrading s2geometry will be a simple version bump once Velox upgrades abseil. Includes a
one-line patch for a `std::max` template deduction failure with GCC 12.

All S2 functionality is gated behind `VELOX_ENABLE_GEO`.

Reviewed By: Sullivan-Patrick, pratikpugalia

Differential Revision: D78041102
