### PR TITLE
Enable `UNION` to process inputs with different column names

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2438,7 +2438,7 @@ class LocalPartitionNode : public PlanNode {
 
     for (size_t i = 1; i < sources_.size(); ++i) {
       VELOX_USER_CHECK(
-          *sources_[i]->outputType() == *sources_[0]->outputType(),
+          sources_[i]->outputType()->equivalent(*sources_[0]->outputType()),
           "All sources of the LocalPartitionedNode must have the same output type: {} vs. {}.",
           sources_[i]->outputType()->toString(),
           sources_[0]->outputType()->toString());

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -299,6 +299,7 @@ RowVectorPtr LocalExchange::getOutput() {
     VELOX_CHECK(!drained);
     auto lockedStats = stats_.wlock();
     lockedStats->addInputVector(data->estimateFlatSize(), data->size());
+    data->setType(outputType_);
     return data;
   }
 


### PR DESCRIPTION
When do union for inputs with different column names but same types in same orders. LocalPartitionNode treat the output types of inputs as different types. So the PR is to enable the local exchange operators to handle this case.