### PR TITLE
perf: Use FMT_COMPILE for float to string casting

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -223,7 +223,7 @@ void CastExpr::applyCastKernel(
       return;
     }
 
-    const auto output = castResult.value();
+    const auto& output = castResult.value();
 
     if constexpr (
         ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <fmt/compile.h>
 #include <folly/Conv.h>
 #include <folly/Expected.h>
 #include <cctype>
@@ -596,14 +597,18 @@ struct Converter<TypeKind::VARCHAR, void, TPolicy> {
       }
       if ((val > -10'000'000 && val <= -0.001) ||
           (val >= 0.001 && val < 10'000'000) || val == 0.0) {
-        auto str = fmt::format("{}", val);
+        auto str = fmt::format(FMT_COMPILE("{}"), val);
         normalizeStandardNotation(str);
         return str;
       }
       // Precision of float is at most 8 significant decimal digits. Precision
       // of double is at most 17 significant decimal digits.
-      auto str =
-          fmt::format(std::is_same_v<T, float> ? "{:.7E}" : "{:.16E}", val);
+      std::string str;
+      if constexpr (std::is_same_v<T, float>) {
+        str = fmt::format(FMT_COMPILE("{:.7E}"), val);
+      } else {
+        str = fmt::format(FMT_COMPILE("{:.16E}"), val);
+      }
       normalizeScientificNotation(str);
       return str;
     }


### PR DESCRIPTION
Make the float to string casts use FMT_COMPILE, to avoid parsing the format string on every call. Also take a reference to the expected result, to avoid copying the string on every cast.

Together, these improve the performance of the basic benchmarks for real and double to scientific/standard notation casts.