### PR TITLE
perf(decimal): Add helper for extracting decimal components efficiently

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -417,15 +417,17 @@ VectorPtr CastExpr::applyDecimalToIntegralCast(
   const auto scaleFactor = DecimalUtil::kPowersOfTen[precisionScale.second];
   if (hooks_->truncate()) {
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-      resultBuffer[row] =
-          static_cast<To>(simpleInput->valueAt(row) / scaleFactor);
+      auto value = simpleInput->valueAt(row);
+      auto integralPart =
+          DecimalUtil::getDecimalParts(value, precisionScale.second).first;
+      resultBuffer[row] = static_cast<To>(integralPart);
     });
   } else {
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
       auto value = simpleInput->valueAt(row);
-      auto integralPart = value / scaleFactor;
+      auto [integralPart, fractionPart] =
+          DecimalUtil::getDecimalParts(value, precisionScale.second);
       if (hooks_->getPolicy() != SparkTryCastPolicy) {
-        auto fractionPart = value % scaleFactor;
         auto sign = value >= 0 ? 1 : -1;
         bool needsRoundUp =
             (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));


### PR DESCRIPTION
Move the logic for extracting integral and fractional parts from decimals to its own function with separate code paths for each scale. This lets the compiler apply strength reduction to division by the constant scale factors.

This improves the performance of the decimal cast basic benchmarks like cast_decimal_as_bigint and cast_decimal_to_inline_string.