### PR TITLE
feat: Support merge join in trace/replay tool

### DIFF
--- a/velox/exec/CallbackSink.h
+++ b/velox/exec/CallbackSink.h
@@ -26,8 +26,9 @@ class CallbackSink : public Operator {
       int32_t operatorId,
       DriverCtx* driverCtx,
       Consumer consumeCb,
-      std::function<BlockingReason(ContinueFuture*)> startedCb = nullptr)
-      : Operator(driverCtx, nullptr, operatorId, "N/A", "CallbackSink"),
+      std::function<BlockingReason(ContinueFuture*)> startedCb = nullptr,
+      const std::string& planNodeId = "N/A")
+      : Operator(driverCtx, nullptr, operatorId, planNodeId, "CallbackSink"),
         startedCb_{std::move(startedCb)},
         consumeCb_{std::move(consumeCb)} {}
 

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -203,7 +203,15 @@ OperatorSupplier makeOperatorSupplier(
               return source->enqueue(std::move(input), future);
             }
           };
-      return std::make_unique<CallbackSink>(operatorId, ctx, consumer);
+      // NOTE: Pass planNodeId to associate CallbackSink with the MergeJoin
+      // node for proper operator identification and input collection.
+      // Operator::maybeSetTracer() uses this to enable tracing.
+      return std::make_unique<CallbackSink>(
+          operatorId,
+          ctx,
+          consumer,
+          nullptr,
+          ctx->queryConfig().queryTraceEnabled() ? planNodeId : "N/A");
     };
   }
 

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -244,10 +244,12 @@ std::vector<uint32_t> extractDriverIds(const std::string& driverIds) {
 bool canTrace(const std::string& operatorType) {
   static const std::unordered_set<std::string> kSupportedOperatorTypes{
       "Aggregation",
+      "CallbackSink",
       "FilterProject",
       "HashBuild",
       "HashProbe",
       "IndexLookupJoin",
+      "MergeJoin",
       "OrderBy",
       "PartialAggregation",
       "PartitionedOutput",
@@ -281,6 +283,21 @@ core::PlanNodePtr getTraceNode(
         std::make_shared<DummySourceNode>(
             hashJoinNode->sources()[1]->outputType()),
         hashJoinNode->outputType());
+  }
+
+  if (const auto* mergeJoinNode =
+          dynamic_cast<const core::MergeJoinNode*>(traceNode)) {
+    return std::make_shared<core::MergeJoinNode>(
+        nodeId,
+        mergeJoinNode->joinType(),
+        mergeJoinNode->leftKeys(),
+        mergeJoinNode->rightKeys(),
+        mergeJoinNode->filter(),
+        std::make_shared<DummySourceNode>(
+            mergeJoinNode->sources()[0]->outputType()),
+        std::make_shared<DummySourceNode>(
+            mergeJoinNode->sources()[1]->outputType()),
+        mergeJoinNode->outputType());
   }
 
   if (const auto* filterNode =

--- a/velox/tool/trace/CMakeLists.txt
+++ b/velox/tool/trace/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   FilterProjectReplayer.cpp
   HashJoinReplayer.cpp
   IndexLookupJoinReplayer.cpp
+  MergeJoinReplayer.cpp
   OperatorReplayerBase.cpp
   OrderByReplayer.cpp
   PartitionedOutputReplayer.cpp

--- a/velox/tool/trace/MergeJoinReplayer.cpp
+++ b/velox/tool/trace/MergeJoinReplayer.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/tool/trace/MergeJoinReplayer.h"
+#include "velox/exec/TraceUtil.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::tool::trace {
+core::PlanNodePtr MergeJoinReplayer::createPlanNode(
+    const core::PlanNode* node,
+    const core::PlanNodeId& nodeId,
+    const core::PlanNodePtr& source) const {
+  const auto* mergeJoinNode = dynamic_cast<const core::MergeJoinNode*>(node);
+  return std::make_shared<core::MergeJoinNode>(
+      nodeId,
+      mergeJoinNode->joinType(),
+      mergeJoinNode->leftKeys(),
+      mergeJoinNode->rightKeys(),
+      mergeJoinNode->filter(),
+      source,
+      PlanBuilder(planNodeIdGenerator_)
+          .traceScan(
+              nodeTraceDir_,
+              pipelineIds_.at(1), // Right side
+              driverIds_,
+              exec::trace::getDataType(planFragment_, nodeId_, 1))
+          .planNode(),
+      mergeJoinNode->outputType());
+}
+} // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/MergeJoinReplayer.h
+++ b/velox/tool/trace/MergeJoinReplayer.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/tool/trace/OperatorReplayerBase.h"
+
+namespace facebook::velox::tool::trace {
+/// The replayer to replay the traced 'MergeJoin' operator.
+class MergeJoinReplayer final : public OperatorReplayerBase {
+ public:
+  MergeJoinReplayer(
+      const std::string& rootDir,
+      const std::string& queryId,
+      const std::string& taskId,
+      const std::string& nodeId,
+      const std::string& operatorType,
+      const std::string& spillBaseDir,
+      const std::string& driverIds,
+      uint64_t queryCapacity,
+      folly::Executor* executor)
+      : OperatorReplayerBase(
+            rootDir,
+            queryId,
+            taskId,
+            nodeId,
+            operatorType,
+            spillBaseDir,
+            driverIds,
+            queryCapacity,
+            executor) {}
+
+ private:
+  core::PlanNodePtr createPlanNode(
+      const core::PlanNode* node,
+      const core::PlanNodeId& nodeId,
+      const core::PlanNodePtr& source) const override;
+};
+} // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -64,7 +64,7 @@ OperatorReplayerBase::OperatorReplayerBase(
   VELOX_USER_CHECK(!taskId_.empty());
   VELOX_USER_CHECK(!nodeId_.empty());
   VELOX_USER_CHECK(!nodeName_.empty());
-  if (nodeName_ == "HashJoin") {
+  if (nodeName_ == "HashJoin" || nodeName_ == "MergeJoin") {
     VELOX_USER_CHECK_EQ(pipelineIds_.size(), 2);
   } else {
     VELOX_USER_CHECK_EQ(pipelineIds_.size(), 1);

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -45,6 +45,7 @@
 #include "velox/tool/trace/FilterProjectReplayer.h"
 #include "velox/tool/trace/HashJoinReplayer.h"
 #include "velox/tool/trace/IndexLookupJoinReplayer.h"
+#include "velox/tool/trace/MergeJoinReplayer.h"
 #include "velox/tool/trace/OperatorReplayerBase.h"
 #include "velox/tool/trace/OrderByReplayer.h"
 #include "velox/tool/trace/PartitionedOutputReplayer.h"
@@ -405,6 +406,17 @@ TraceReplayRunner::createReplayer() const {
         FLAGS_task_id,
         FLAGS_node_id,
         traceNodeName,
+        FLAGS_driver_ids,
+        queryCapacityBytes,
+        cpuExecutor_.get());
+  } else if (traceNodeName == "MergeJoin") {
+    replayer = std::make_unique<tool::trace::MergeJoinReplayer>(
+        FLAGS_root_dir,
+        FLAGS_query_id,
+        FLAGS_task_id,
+        FLAGS_node_id,
+        traceNodeName,
+        FLAGS_spill_directory,
         FLAGS_driver_ids,
         queryCapacityBytes,
         cpuExecutor_.get());

--- a/velox/tool/trace/tests/CMakeLists.txt
+++ b/velox/tool/trace/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   FilterProjectReplayerTest.cpp
   HashJoinReplayerTest.cpp
   IndexLookupJoinReplayerTest.cpp
+  MergeJoinReplayerTest.cpp
   OrderByReplayerTest.cpp
   PartitionedOutputReplayerTest.cpp
   TableScanReplayerTest.cpp

--- a/velox/tool/trace/tests/HashJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/HashJoinReplayerTest.cpp
@@ -229,9 +229,9 @@ TEST_F(HashJoinReplayerTest, basic) {
                                    task->taskId(),
                                    traceNodeId_,
                                    "HashJoin",
-                                   "",
-                                   "",
-                                   0,
+                                   /*spillBaseDir=*/"",
+                                   /*driverIds=*/"",
+                                   /*queryCapacity=*/0,
                                    executor_.get())
                                    .run();
   assertEqualResults({result}, {replayingResult});

--- a/velox/tool/trace/tests/MergeJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/MergeJoinReplayerTest.cpp
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/OperatorTraceReader.h"
+#include "velox/exec/PartitionFunction.h"
+#include "velox/exec/TraceUtil.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/tool/trace/MergeJoinReplayer.h"
+#include "velox/tool/trace/TraceReplayRunner.h"
+
+// using namespace facebook::velox;
+// using namespace facebook::velox::core;
+// using namespace facebook::velox::common;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+// using namespace facebook::velox::connector;
+// using namespace facebook::velox::connector::hive;
+// using namespace facebook::velox::dwio::common;
+// using namespace facebook::velox::common::testutil;
+// using namespace facebook::velox::common::hll;
+
+namespace facebook::velox::tool::trace::test {
+class MergeJoinReplayerTest : public HiveConnectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    HiveConnectorTestBase::SetUpTestCase();
+    if (!isRegisteredVectorSerde()) {
+      serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    }
+    Type::registerSerDe();
+    common::Filter::registerSerDe();
+    connector::hive::HiveConnector::registerSerDe();
+    core::PlanNode::registerSerDe();
+    velox::exec::trace::registerDummySourceSerDe();
+    core::ITypedExpr::registerSerDe();
+    registerPartitionFunctionSerDe();
+  }
+
+  void TearDown() override {
+    probeInput_.clear();
+    buildInput_.clear();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  struct PlanWithSplits {
+    core::PlanNodePtr plan;
+    core::PlanNodeId probeScanId;
+    core::PlanNodeId buildScanId;
+    std::unordered_map<core::PlanNodeId, std::vector<exec::Split>> splits;
+
+    explicit PlanWithSplits(
+        const core::PlanNodePtr& _plan,
+        const core::PlanNodeId& _probeScanId = "",
+        const core::PlanNodeId& _buildScanId = "",
+        const std::unordered_map<
+            core::PlanNodeId,
+            std::vector<velox::exec::Split>>& _splits = {})
+        : plan(_plan),
+          probeScanId(_probeScanId),
+          buildScanId(_buildScanId),
+          splits(_splits) {}
+  };
+
+  RowTypePtr concat(const RowTypePtr& a, const RowTypePtr& b) {
+    std::vector<std::string> names = a->names();
+    std::vector<TypePtr> types = a->children();
+
+    for (auto i = 0; i < b->size(); ++i) {
+      names.push_back(b->nameOf(i));
+      types.push_back(b->childAt(i));
+    }
+
+    return ROW(std::move(names), std::move(types));
+  }
+
+  std::vector<RowVectorPtr>
+  makeVectors(int32_t count, int32_t rowsPerVector, const RowTypePtr& rowType) {
+    std::vector<RowVectorPtr> vectors;
+    vectors.reserve(count);
+
+    for (int32_t i = 0; i < count; ++i) {
+      const int32_t startRow = i * rowsPerVector;
+      std::vector<VectorPtr> children;
+
+      for (int32_t col = 0; col < rowType->size(); ++col) {
+        const auto& type = rowType->childAt(col);
+
+        // First column is the join key and must be sorted
+        if (col == 0) {
+          if (type->kind() == TypeKind::BIGINT) {
+            children.push_back(
+                makeFlatVector<int64_t>(rowsPerVector, [startRow](auto row) {
+                  return startRow + row;
+                }));
+          } else {
+            VELOX_FAIL("Unsupported join key type: {}", type->toString());
+          }
+        } else {
+          // Other columns can have random data using BatchMaker
+          children.push_back(VELOX_DYNAMIC_TYPE_DISPATCH(
+              velox::test::BatchMaker::createVector,
+              type->kind(),
+              type,
+              rowsPerVector,
+              *pool()));
+        }
+      }
+
+      vectors.push_back(makeRowVector(rowType->names(), children));
+    }
+
+    return vectors;
+  }
+
+  std::vector<Split> makeSplits(
+      const std::vector<RowVectorPtr>& inputs,
+      const std::string& path,
+      memory::MemoryPool* writerPool) {
+    std::vector<Split> splits;
+    for (auto i = 0; i < 4; ++i) {
+      const std::string filePath = fmt::format("{}/{}", path, i);
+      writeToFile(filePath, inputs);
+      splits.emplace_back(makeHiveConnectorSplit(filePath));
+    }
+
+    return splits;
+  }
+
+  PlanWithSplits createPlan(
+      const std::string& tableDir,
+      core::JoinType joinType,
+      const std::vector<std::string>& probeKeys,
+      const std::vector<std::string>& buildKeys,
+      const std::vector<RowVectorPtr>& probeInput,
+      const std::vector<RowVectorPtr>& buildInput) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const std::vector<Split> probeSplits =
+        makeSplits(probeInput, fmt::format("{}/probe", tableDir), pool());
+    const std::vector<Split> buildSplits =
+        makeSplits(buildInput, fmt::format("{}/build", tableDir), pool());
+    core::PlanNodeId probeScanId;
+    core::PlanNodeId buildScanId;
+    const auto outputColumns = concat(
+                                   asRowType(buildInput_[0]->type()),
+                                   asRowType(probeInput_[0]->type()))
+                                   ->names();
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(probeType_)
+                    .capturePlanNodeId(probeScanId)
+                    .mergeJoin(
+                        probeKeys,
+                        buildKeys,
+                        PlanBuilder(planNodeIdGenerator)
+                            .tableScan(buildType_)
+                            .capturePlanNodeId(buildScanId)
+                            .planNode(),
+                        /*filter=*/"",
+                        outputColumns,
+                        joinType)
+                    .capturePlanNodeId(traceNodeId_)
+                    .planNode();
+    return PlanWithSplits{
+        plan,
+        probeScanId,
+        buildScanId,
+        {{probeScanId, probeSplits}, {buildScanId, buildSplits}}};
+  }
+
+  core::PlanNodeId traceNodeId_;
+  RowTypePtr probeType_{
+      ROW({"t0", "t1", "t2", "t3"}, {BIGINT(), VARCHAR(), SMALLINT(), REAL()})};
+
+  RowTypePtr buildType_{
+      ROW({"u0", "u1", "u2", "u3"},
+          {BIGINT(), INTEGER(), SMALLINT(), VARCHAR()})};
+  std::vector<RowVectorPtr> probeInput_ = makeVectors(5, 100, probeType_);
+  std::vector<RowVectorPtr> buildInput_ = makeVectors(3, 100, buildType_);
+
+  const std::vector<std::string> probeKeys_{"t0"};
+  const std::vector<std::string> buildKeys_{"u0"};
+  const std::shared_ptr<TempDirectoryPath> testDir_ =
+      TempDirectoryPath::create();
+  const std::string tableDir_ =
+      fmt::format("{}/{}", testDir_->getPath(), "table");
+};
+
+TEST_F(MergeJoinReplayerTest, basic) {
+  const auto planWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+  AssertQueryBuilder builder(planWithSplits.plan);
+  for (const auto& [planNodeId, nodeSplits] : planWithSplits.splits) {
+    builder.splits(planNodeId, nodeSplits);
+  }
+  const auto result = builder.copyResults(pool());
+
+  const auto traceRoot =
+      fmt::format("{}/{}/traceRoot/", testDir_->getPath(), "basic");
+  std::shared_ptr<Task> task;
+  auto tracePlanWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+  AssertQueryBuilder traceBuilder(tracePlanWithSplits.plan);
+  traceBuilder.config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_);
+  for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
+    traceBuilder.splits(planNodeId, nodeSplits);
+  }
+  auto traceResult = traceBuilder.copyResults(pool(), task);
+
+  assertEqualResults({result}, {traceResult});
+
+  const auto taskId = task->taskId();
+  const auto replayingResult = MergeJoinReplayer(
+                                   traceRoot,
+                                   task->queryCtx()->queryId(),
+                                   task->taskId(),
+                                   traceNodeId_,
+                                   "MergeJoin",
+                                   /*spillBaseDir=*/"",
+                                   /*driverIds=*/"",
+                                   /*queryCapacity=*/0,
+                                   executor_.get())
+                                   .run();
+  assertEqualResults({result}, {replayingResult});
+}
+
+TEST_F(MergeJoinReplayerTest, runner) {
+  const auto testDir = TempDirectoryPath::create();
+  const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
+  std::shared_ptr<Task> task;
+  auto tracePlanWithSplits = createPlan(
+      tableDir_,
+      core::JoinType::kInner,
+      probeKeys_,
+      buildKeys_,
+      probeInput_,
+      buildInput_);
+  AssertQueryBuilder traceBuilder(tracePlanWithSplits.plan);
+  traceBuilder.config(core::QueryConfig::kEnableOperatorBatchSizeStats, true)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+      .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+      .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+      .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_);
+  for (const auto& [planNodeId, nodeSplits] : tracePlanWithSplits.splits) {
+    traceBuilder.splits(planNodeId, nodeSplits);
+  }
+  auto traceResult = traceBuilder.copyResults(pool(), task);
+
+  const auto taskTraceDir =
+      exec::trace::getTaskTraceDirectory(traceRoot, *task);
+  const auto leftOperatorTraceDir = exec::trace::getOpTraceDirectory(
+      taskTraceDir,
+      traceNodeId_,
+      /*pipelineId=*/0,
+      /*driverId=*/0);
+  const auto leftSummary =
+      exec::trace::OperatorTraceSummaryReader(leftOperatorTraceDir, pool())
+          .read();
+  ASSERT_EQ(leftSummary.opType, "MergeJoin");
+  ASSERT_GT(leftSummary.peakMemory, 0);
+  ASSERT_GT(leftSummary.inputRows, 0);
+  // NOTE: the input bytes is 0 because of the lazy materialization.
+  ASSERT_EQ(leftSummary.inputBytes, 0);
+  ASSERT_EQ(leftSummary.rawInputRows, 0);
+  ASSERT_EQ(leftSummary.rawInputBytes, 0);
+
+  const auto rightOperatorTraceDir = exec::trace::getOpTraceDirectory(
+      taskTraceDir,
+      traceNodeId_,
+      /*pipelineId=*/1,
+      /*driverId=*/0);
+  const auto rightSummary =
+      exec::trace::OperatorTraceSummaryReader(rightOperatorTraceDir, pool())
+          .read();
+  ASSERT_EQ(rightSummary.opType, "CallbackSink");
+  // NOTE: CallbackSink does not have its own memory pool.
+  ASSERT_EQ(rightSummary.peakMemory, 0);
+  ASSERT_GT(rightSummary.inputRows, 0);
+  // NOTE: the input bytes is 0 because of the lazy materialization.
+  ASSERT_EQ(rightSummary.inputBytes, 0);
+  ASSERT_EQ(rightSummary.rawInputRows, 0);
+  ASSERT_EQ(rightSummary.rawInputBytes, 0);
+
+  FLAGS_root_dir = traceRoot;
+  FLAGS_query_id = task->queryCtx()->queryId();
+  FLAGS_task_id = task->taskId();
+  FLAGS_node_id = traceNodeId_;
+  FLAGS_summary = true;
+  {
+    TraceReplayRunner runner;
+    runner.init();
+    runner.run();
+  }
+
+  FLAGS_task_id = task->taskId();
+  FLAGS_driver_ids = "";
+  FLAGS_summary = false;
+  {
+    TraceReplayRunner runner;
+    runner.init();
+    runner.run();
+  }
+}
+} // namespace facebook::velox::tool::trace::test


### PR DESCRIPTION
Summary: This change adds support for merge join in the trace/replay tool by introducing a new replayer class `MergeJoinReplayer`.

Differential Revision: D86459412


