### PR TITLE
feat: Add SetDigest library and scalar UDFs

### DIFF
--- a/velox/functions/lib/SetDigest.h
+++ b/velox/functions/lib/SetDigest.h
@@ -1,0 +1,454 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/hyperloglog/DenseHll.h"
+#include "velox/common/hyperloglog/Murmur3Hash128.h"
+#include "velox/common/hyperloglog/SparseHll.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/type/StringView.h"
+
+#include <folly/Bits.h>
+
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <map>
+#include <set>
+
+namespace facebook::velox::functions {
+
+namespace {
+constexpr int8_t kUncompressedFormat = 1;
+} // namespace
+
+/// SetDigest is a probabilistic data structure for estimating set cardinality
+/// and performing set operations. It combines HyperLogLog for cardinality
+/// estimation with MinHash for exact counting and intersection operations.
+class SetDigest {
+ public:
+  static constexpr int32_t kDefaultMaxHashes = 8192;
+  static constexpr int32_t kNumberOfBuckets = 2048;
+  static constexpr int8_t kDefaultIndexBitLength = 11;
+
+  /// Construct a SetDigest with specified parameters.
+  /// @param allocator Memory allocator for internal data structures.
+  /// @param indexBitLength Number of bits for HLL indexing (default 11 = 2048
+  /// buckets). Must be in range (0, 16].
+  /// @param maxHashes Maximum number of hashes to store in MinHash (default
+  /// 8192). When exceeded, digest becomes approximate.
+  explicit SetDigest(
+      HashStringAllocator* allocator,
+      int8_t indexBitLength = kDefaultIndexBitLength,
+      int32_t maxHashes = kDefaultMaxHashes);
+
+  /// Add a new 64-bit integer value to the digest.
+  /// @param value The value to add.
+  void add(int64_t value);
+
+  /// Add a new string value to the digest.
+  /// @param value The string value to add.
+  void add(StringView value);
+
+  /// Merge this digest with another digest.
+  /// @param other The other digest to merge into this one.
+  void mergeWith(const SetDigest& other);
+
+  /// Returns true if the digest is exact (cardinality < maxHashes).
+  /// When exact, cardinality() returns the exact count.
+  bool isExact() const;
+
+  /// Returns the estimated cardinality of the set.
+  /// If isExact() is true, returns the exact count.
+  /// Otherwise, returns HyperLogLog estimate.
+  int64_t cardinality() const;
+
+  /// Calculate the exact intersection cardinality between two digests.
+  /// Both digests must be exact (isExact() == true).
+  /// @param a First digest (must be exact).
+  /// @param b Second digest (must be exact).
+  /// @return The exact number of elements in the intersection.
+  static int64_t exactIntersectionCardinality(
+      const SetDigest& a,
+      const SetDigest& b);
+
+  /// Compute the Jaccard index (similarity coefficient) between two digests.
+  /// Uses MinHash estimation. Returns a value in [0, 1] where 1 means
+  /// identical sets and 0 means disjoint sets.
+  /// @param a First digest.
+  /// @param b Second digest.
+  /// @return Estimated Jaccard index.
+  static double jaccardIndex(const SetDigest& a, const SetDigest& b);
+
+  /// Calculate the size needed for serialization.
+  /// @return The number of bytes needed to serialize this digest.
+  int32_t estimatedSerializedSize() const;
+
+  /// Serialize the digest into bytes. The serialization is versioned and
+  /// compatible with Presto Java.
+  /// @param out Pre-allocated memory at least estimatedSerializedSize() in
+  /// size.
+  void serialize(char* out);
+
+  /// Deserialize a SetDigest from serialized input.
+  /// Serialization produced by Presto Java can be used as input.
+  /// @param data The input serialization.
+  /// @param size The size of the serialization in bytes.
+  void deserialize(const char* data, int32_t size);
+
+  /// Get a copy of the MinHash hash counts.
+  /// Returns a map from hash value to count.
+  /// @return A map of hash values to their counts.
+  std::map<int64_t, int16_t> getHashCounts() const;
+
+ private:
+  void addHash(uint64_t hash);
+  void convertToDense();
+
+  using MinHashAllocator = StlAllocator<std::pair<const int64_t, int16_t>>;
+  std::map<int64_t, int16_t, std::less<int64_t>, MinHashAllocator> minhash_;
+
+  // HyperLogLog: starts as Sparse, converts to Dense when needed
+  common::hll::SparseHll<> sparseHll_;
+  common::hll::DenseHll<> denseHll_;
+  bool isSparse_{true};
+  int8_t indexBitLength_{11}; // Default to 2^11 = 2048 buckets
+  int32_t maxHashes_{kDefaultMaxHashes};
+  HashStringAllocator* allocator_;
+};
+
+inline SetDigest::SetDigest(
+    HashStringAllocator* allocator,
+    int8_t indexBitLength,
+    int32_t maxHashes)
+    : minhash_{MinHashAllocator(allocator)},
+      sparseHll_{allocator},
+      denseHll_{allocator},
+      indexBitLength_{indexBitLength},
+      maxHashes_{maxHashes},
+      allocator_{allocator} {
+  // Validate indexBitLength matches Java validation
+  VELOX_CHECK_GT(indexBitLength, 0, "indexBitLength must be > 0");
+  VELOX_CHECK_LE(indexBitLength, 16, "indexBitLength must be <= 16");
+
+  // Validate maxHashes
+  VELOX_CHECK_GT(maxHashes, 0, "maxHashes must be > 0");
+
+  // Verify default indexBitLength matches kNumberOfBuckets
+  static_assert(
+      (1 << kDefaultIndexBitLength) == kNumberOfBuckets,
+      "Default index bit length must match NUMBER_OF_BUCKETS");
+
+  sparseHll_.setSoftMemoryLimit(
+      common::hll::DenseHlls::estimateInMemorySize(indexBitLength_));
+}
+
+inline bool SetDigest::isExact() const {
+  return static_cast<int32_t>(minhash_.size()) < maxHashes_;
+}
+
+inline void SetDigest::add(int64_t value) {
+  uint64_t hash = common::hll::Murmur3Hash128::hash64ForLong(value, 0);
+
+  addHash(hash);
+
+  if (isSparse_) {
+    if (sparseHll_.insertHash(hash)) {
+      // insertHash returns true when over limit, convert to dense
+      convertToDense();
+    }
+  } else {
+    denseHll_.insertHash(hash);
+  }
+}
+
+inline void SetDigest::add(StringView value) {
+  uint64_t hash =
+      common::hll::Murmur3Hash128::hash64(value.data(), value.size(), 0);
+
+  addHash(hash);
+
+  // Add to HyperLogLog
+  if (isSparse_) {
+    if (sparseHll_.insertHash(hash)) {
+      convertToDense();
+    }
+  } else {
+    denseHll_.insertHash(hash);
+  }
+}
+
+inline void SetDigest::addHash(uint64_t hash) {
+  auto it = minhash_.find(hash);
+  int16_t currentCount = (it != minhash_.end()) ? it->second : 0;
+
+  if (currentCount < std::numeric_limits<int16_t>::max()) {
+    minhash_[hash] = static_cast<int16_t>(currentCount + 1);
+  }
+
+  while (static_cast<int32_t>(minhash_.size()) > maxHashes_) {
+    auto lastIt = minhash_.end();
+    --lastIt;
+    minhash_.erase(lastIt);
+  }
+}
+
+inline void SetDigest::convertToDense() {
+  isSparse_ = false;
+  denseHll_.initialize(indexBitLength_);
+  sparseHll_.toDense(denseHll_);
+  sparseHll_.reset();
+}
+
+namespace setdigest::detail {
+
+static_assert(folly::kIsLittleEndian);
+
+template <typename T>
+void write(T value, char*& out) {
+  folly::storeUnaligned(out, value);
+  out += sizeof(T);
+}
+
+template <typename T>
+void write(const T* values, int count, char*& out) {
+  auto size = sizeof(T) * count;
+  std::memcpy(out, values, size);
+  out += size;
+}
+
+template <typename T>
+T read(const char*& in) {
+  T value = folly::loadUnaligned<T>(in);
+  in += sizeof(T);
+  return value;
+}
+
+} // namespace setdigest::detail
+
+inline int32_t SetDigest::estimatedSerializedSize() const {
+  int32_t hllSize =
+      isSparse_ ? sparseHll_.serializedSize() : denseHll_.serializedSize();
+
+  return sizeof(int8_t) + // format byte
+      sizeof(int32_t) + // HLL length
+      hllSize + // HLL data
+      sizeof(int32_t) + // maxHashes
+      sizeof(int32_t) + // minhash size
+      minhash_.size() * (sizeof(int64_t) + sizeof(int16_t)); // keys + values
+}
+
+inline void SetDigest::serialize(char* out) {
+  const char* oldOut = out;
+
+  setdigest::detail::write(kUncompressedFormat, out);
+
+  int32_t hllSize =
+      isSparse_ ? sparseHll_.serializedSize() : denseHll_.serializedSize();
+  setdigest::detail::write(hllSize, out);
+
+  if (isSparse_) {
+    sparseHll_.serialize(indexBitLength_, out);
+  } else {
+    denseHll_.serialize(out);
+  }
+  out += hllSize;
+
+  setdigest::detail::write(maxHashes_, out);
+
+  int32_t minhashSize = static_cast<int32_t>(minhash_.size());
+  setdigest::detail::write(minhashSize, out);
+
+  for (const auto& entry : minhash_) {
+    setdigest::detail::write(entry.first, out);
+  }
+
+  for (const auto& entry : minhash_) {
+    setdigest::detail::write(entry.second, out);
+  }
+
+  VELOX_CHECK_EQ(out - oldOut, estimatedSerializedSize());
+}
+
+inline void SetDigest::deserialize(const char* data, int32_t size) {
+  VELOX_USER_CHECK_GE(
+      size,
+      sizeof(int8_t) + sizeof(int32_t),
+      "Input too small to be a valid SetDigest");
+
+  const char* in = data;
+
+  int8_t format = setdigest::detail::read<int8_t>(in);
+  VELOX_USER_CHECK_EQ(
+      format, kUncompressedFormat, "Unexpected SetDigest format");
+
+  // Read HLL length
+  int32_t hllLength = setdigest::detail::read<int32_t>(in);
+  VELOX_USER_CHECK_GE(
+      hllLength, 0, "Invalid HLL length in SetDigest serialization");
+  VELOX_USER_CHECK_LE(
+      hllLength,
+      size - (sizeof(int8_t) + sizeof(int32_t)),
+      "HLL length exceeds input size");
+
+  // Deserialize HLL - validate using canDeserialize before constructing.
+  const char* hllData = in;
+
+  if (common::hll::SparseHlls::canDeserialize(hllData)) {
+    indexBitLength_ =
+        common::hll::SparseHlls::deserializeIndexBitLength(hllData);
+    sparseHll_.setSoftMemoryLimit(
+        common::hll::DenseHlls::estimateInMemorySize(indexBitLength_));
+    isSparse_ = true;
+    sparseHll_ = common::hll::SparseHll<>(hllData, allocator_);
+  } else if (common::hll::DenseHlls::canDeserialize(hllData)) {
+    indexBitLength_ =
+        common::hll::DenseHlls::deserializeIndexBitLength(hllData);
+    isSparse_ = false;
+    denseHll_ = common::hll::DenseHll<>(hllData, allocator_);
+  } else {
+    VELOX_USER_FAIL("Cannot deserialize SetDigest: invalid HLL data");
+  }
+  in += hllLength;
+
+  maxHashes_ = setdigest::detail::read<int32_t>(in);
+
+  int32_t minhashSize = setdigest::detail::read<int32_t>(in);
+
+  std::vector<int64_t> keys;
+  keys.reserve(minhashSize);
+  for (int32_t i = 0; i < minhashSize; i++) {
+    keys.push_back(setdigest::detail::read<int64_t>(in));
+  }
+
+  for (int32_t i = 0; i < minhashSize; i++) {
+    int16_t count = setdigest::detail::read<int16_t>(in);
+    minhash_[keys[i]] = count;
+  }
+}
+
+inline void SetDigest::mergeWith(const SetDigest& other) {
+  // Merge HyperLogLog
+  if (other.isSparse_) {
+    if (isSparse_) {
+      sparseHll_.mergeWith(other.sparseHll_);
+      if (sparseHll_.overLimit()) {
+        convertToDense();
+      }
+    } else {
+      other.sparseHll_.toDense(denseHll_);
+    }
+  } else {
+    if (isSparse_) {
+      convertToDense();
+    }
+    denseHll_.mergeWith(other.denseHll_);
+  }
+
+  // Merge minhash maps
+  for (const auto& entry : other.minhash_) {
+    int64_t key = entry.first;
+    int16_t otherCount = entry.second;
+
+    auto it = minhash_.find(key);
+    int16_t currentCount = (it != minhash_.end()) ? it->second : 0;
+
+    // Add counts, saturating at int16_t max
+    int32_t newCount =
+        static_cast<int32_t>(currentCount) + static_cast<int32_t>(otherCount);
+    if (newCount > std::numeric_limits<int16_t>::max()) {
+      minhash_[key] = std::numeric_limits<int16_t>::max();
+    } else {
+      minhash_[key] = static_cast<int16_t>(newCount);
+    }
+  }
+
+  // Remove largest hash values when we exceed maxHashes
+  while (static_cast<int32_t>(minhash_.size()) > maxHashes_) {
+    auto lastIt = minhash_.end();
+    --lastIt;
+    minhash_.erase(lastIt);
+  }
+}
+
+inline int64_t SetDigest::cardinality() const {
+  if (isExact()) {
+    return static_cast<int64_t>(minhash_.size());
+  }
+  return isSparse_ ? sparseHll_.cardinality() : denseHll_.cardinality();
+}
+
+inline int64_t SetDigest::exactIntersectionCardinality(
+    const SetDigest& a,
+    const SetDigest& b) {
+  VELOX_USER_CHECK(
+      a.isExact(), "exact intersection cannot operate on approximate sets");
+  VELOX_USER_CHECK(
+      b.isExact(), "exact intersection cannot operate on approximate sets");
+
+  int64_t count = 0;
+  for (const auto& entry : a.minhash_) {
+    if (b.minhash_.count(entry.first)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+inline double SetDigest::jaccardIndex(const SetDigest& a, const SetDigest& b) {
+  int32_t sizeOfSmallerSet = std::min(
+      static_cast<int32_t>(a.minhash_.size()),
+      static_cast<int32_t>(b.minhash_.size()));
+
+  if (sizeOfSmallerSet == 0) {
+    return (a.minhash_.size() == 0 && b.minhash_.size() == 0) ? 1.0 : 0.0;
+  }
+
+  std::set<int64_t> minUnion;
+  for (const auto& entry : a.minhash_) {
+    minUnion.insert(entry.first);
+  }
+  for (const auto& entry : b.minhash_) {
+    minUnion.insert(entry.first);
+  }
+
+  int32_t intersection = 0;
+  int32_t i = 0;
+  for (int64_t key : minUnion) {
+    if (a.minhash_.count(key) && b.minhash_.count(key)) {
+      intersection++;
+    }
+    i++;
+    if (i >= sizeOfSmallerSet) {
+      break;
+    }
+  }
+
+  return static_cast<double>(intersection) /
+      static_cast<double>(sizeOfSmallerSet);
+}
+
+inline std::map<int64_t, int16_t> SetDigest::getHashCounts() const {
+  std::map<int64_t, int16_t> result;
+  for (const auto& entry : minhash_) {
+    result[entry.first] = entry.second;
+  }
+  return result;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/SetDigestTest.cpp
+++ b/velox/functions/lib/tests/SetDigestTest.cpp
@@ -1,0 +1,736 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/SetDigest.h"
+#include "velox/common/memory/Memory.h"
+
+#include <folly/base64.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <random>
+
+using namespace facebook::velox::functions;
+
+class SetDigestTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    facebook::velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
+    allocator_ =
+        std::make_unique<facebook::velox::HashStringAllocator>(pool_.get());
+  }
+
+  // Helper for Java-equivalent intersection cardinality tests
+  void testIntersectionCardinalityHelper(
+      int32_t maxHashes1,
+      int32_t numBuckets1,
+      int32_t maxHashes2,
+      int32_t numBuckets2);
+
+  std::string decodeBase64(const std::string& encoded) {
+    return folly::base64Decode(encoded);
+  }
+
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
+  std::unique_ptr<facebook::velox::HashStringAllocator> allocator_;
+};
+
+TEST_F(SetDigestTest, roundTripSerialization) {
+  SetDigest digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(1L);
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(2L);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest digest2(allocator_.get());
+  digest2.deserialize(buffer1.data(), size1);
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  ASSERT_EQ(size1, size2) << "Serialized sizes should match after round-trip";
+
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  ASSERT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()))
+      << "Serialized data should match after round-trip";
+
+  ASSERT_EQ(digest1.isExact(), digest2.isExact());
+  ASSERT_EQ(digest1.cardinality(), digest2.cardinality());
+}
+
+TEST_F(SetDigestTest, roundTripWithStrings) {
+  SetDigest digest1(allocator_.get());
+
+  digest1.add(facebook::velox::StringView("apple"));
+  digest1.add(facebook::velox::StringView("banana"));
+  digest1.add(facebook::velox::StringView("apple"));
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest digest2(allocator_.get());
+  digest2.deserialize(buffer1.data(), size1);
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  ASSERT_EQ(size1, size2);
+
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  ASSERT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+}
+
+TEST_F(SetDigestTest, mergeWithRoundTrip) {
+  SetDigest digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(3L);
+
+  SetDigest digest2(allocator_.get());
+  digest2.add(3L);
+  digest2.add(4L);
+  digest2.add(5L);
+
+  digest1.mergeWith(digest2);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest digest3(allocator_.get());
+  digest3.deserialize(buffer1.data(), size1);
+
+  int32_t size2 = digest3.estimatedSerializedSize();
+  ASSERT_EQ(size1, size2);
+
+  std::vector<char> buffer2(size2);
+  digest3.serialize(buffer2.data());
+
+  ASSERT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+
+  ASSERT_TRUE(digest1.isExact());
+  ASSERT_EQ(digest1.cardinality(), 5);
+  ASSERT_EQ(digest3.cardinality(), 5);
+}
+
+TEST_F(SetDigestTest, mergeWithDuplicates) {
+  SetDigest digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(1L);
+  digest1.add(1L);
+
+  SetDigest digest2(allocator_.get());
+  digest2.add(1L);
+  digest2.add(2L);
+
+  digest1.mergeWith(digest2);
+
+  ASSERT_TRUE(digest1.isExact());
+  ASSERT_EQ(digest1.cardinality(), 2);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest digest3(allocator_.get());
+  digest3.deserialize(buffer1.data(), size1);
+
+  int32_t size2 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest3.serialize(buffer2.data());
+
+  ASSERT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+}
+
+TEST_F(SetDigestTest, javaCompatibility) {
+  // Query used: SELECT to_base64(cast(make_set_digest(value) as varbinary))
+  // FROM (VALUES 1, 1, 1, 2, 2) T(value);
+  SetDigest digest(allocator_.get());
+
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(2L);
+  digest.add(2L);
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  std::string base64Output =
+      folly::base64Encode(folly::StringPiece(buffer.data(), size));
+
+  ASSERT_TRUE(digest.isExact());
+  ASSERT_EQ(digest.cardinality(), 2);
+  ASSERT_GT(size, 0);
+}
+
+TEST_F(SetDigestTest, javaCompatibilityEmptyDigest) {
+  // Query: SELECT to_base64(cast(make_set_digest(value) as varbinary))
+  // FROM (SELECT NULL as value WHERE 1=0) T(value);
+  SetDigest digest(allocator_.get());
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  std::string base64Output =
+      folly::base64Encode(folly::StringPiece(buffer.data(), size));
+
+  ASSERT_TRUE(digest.isExact());
+  ASSERT_EQ(digest.cardinality(), 0);
+}
+
+TEST_F(SetDigestTest, cardinality) {
+  SetDigest digest(allocator_.get());
+
+  ASSERT_EQ(digest.cardinality(), 0);
+
+  digest.add(1L);
+  ASSERT_EQ(digest.cardinality(), 1);
+
+  digest.add(1L);
+  ASSERT_EQ(digest.cardinality(), 1);
+
+  digest.add(2L);
+  ASSERT_EQ(digest.cardinality(), 2);
+}
+
+TEST_F(SetDigestTest, exactIntersectionCardinality) {
+  SetDigest digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(3L);
+
+  SetDigest digest2(allocator_.get());
+  digest2.add(2L);
+  digest2.add(3L);
+  digest2.add(4L);
+
+  int64_t intersection =
+      SetDigest::exactIntersectionCardinality(digest1, digest2);
+  ASSERT_EQ(intersection, 2);
+
+  SetDigest digest3(allocator_.get());
+  digest3.add(5L);
+  digest3.add(6L);
+
+  intersection = SetDigest::exactIntersectionCardinality(digest1, digest3);
+  ASSERT_EQ(intersection, 0);
+}
+
+TEST_F(SetDigestTest, jaccardIndex) {
+  SetDigest digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(3L);
+
+  SetDigest digest2(allocator_.get());
+  digest2.add(2L);
+  digest2.add(3L);
+  digest2.add(4L);
+
+  double jaccard = SetDigest::jaccardIndex(digest1, digest2);
+  ASSERT_GE(jaccard, 0.0);
+  ASSERT_LE(jaccard, 1.0);
+
+  // Test identical sets - should always be 1.0
+  SetDigest digest3(allocator_.get());
+  digest3.add(1L);
+  digest3.add(2L);
+  digest3.add(3L);
+
+  jaccard = SetDigest::jaccardIndex(digest1, digest3);
+  ASSERT_NEAR(jaccard, 1.0, 0.001);
+
+  // Test disjoint sets - should be 0.0
+  SetDigest digest4(allocator_.get());
+  digest4.add(10L);
+  digest4.add(20L);
+  digest4.add(30L);
+
+  jaccard = SetDigest::jaccardIndex(digest1, digest4);
+  ASSERT_NEAR(jaccard, 0.0, 0.001);
+}
+
+TEST_F(SetDigestTest, getHashCounts) {
+  SetDigest digest(allocator_.get());
+
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(2L);
+  digest.add(2L);
+
+  auto hashCounts = digest.getHashCounts();
+  ASSERT_EQ(hashCounts.size(), 2) << "Should have 2 unique hash values";
+  int totalCount = 0;
+  for (const auto& entry : hashCounts) {
+    totalCount += entry.second;
+  }
+  ASSERT_EQ(totalCount, 5) << "Total count should be 5";
+}
+
+TEST_F(SetDigestTest, hashCountsJavaCompatibility) {
+  // This test matches the Java TestSetDigest.testHashCounts() test
+  SetDigest digest1(allocator_.get());
+  digest1.add(0L);
+  digest1.add(0L);
+  digest1.add(1L);
+
+  auto hashCounts1 = digest1.getHashCounts();
+  ASSERT_EQ(hashCounts1.size(), 2) << "Should have 2 unique hash values";
+
+  std::set<int16_t> counts1;
+  for (const auto& entry : hashCounts1) {
+    counts1.insert(entry.second);
+  }
+  std::set<int16_t> expected1 = {1, 2};
+  ASSERT_EQ(counts1, expected1)
+      << "Java expects hash counts {1, 2} after adding 0, 0, 1";
+
+  SetDigest digest2(allocator_.get());
+  digest2.add(0L);
+  digest2.add(0L);
+  digest2.add(2L);
+  digest2.add(2L);
+
+  auto hashCounts2 = digest2.getHashCounts();
+  ASSERT_EQ(hashCounts2.size(), 2) << "Should have 2 unique hash values";
+
+  std::set<int16_t> counts2;
+  for (const auto& entry : hashCounts2) {
+    counts2.insert(entry.second);
+  }
+  std::set<int16_t> expected2 = {2, 2};
+  ASSERT_EQ(counts2, expected2)
+      << "Java expects hash counts {2, 2} after adding 0, 0, 2, 2";
+
+  // Merge digest2 into digest1
+  digest1.mergeWith(digest2);
+
+  auto hashCountsMerged = digest1.getHashCounts();
+  ASSERT_EQ(hashCountsMerged.size(), 3)
+      << "After merge should have 3 unique hash values";
+
+  std::set<int16_t> countsMerged;
+  for (const auto& entry : hashCountsMerged) {
+    countsMerged.insert(entry.second);
+  }
+  std::set<int16_t> expectedMerged = {1, 2, 4};
+  // hash(0): 2 + 2 = 4
+  // hash(1): 1 + 0 = 1
+  // hash(2): 0 + 2 = 2
+  ASSERT_EQ(countsMerged, expectedMerged)
+      << "Java expects hash counts {1, 2, 4} after merging";
+}
+
+TEST_F(SetDigestTest, javaSerializationCompatibilityIntegerValues) {
+  SCOPED_TRACE(
+      "SELECT to_base64(cast(make_set_digest(col) as varbinary)) "
+      "FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) AS t(col)");
+
+  // Base64 encoded SetDigest generated by Java Presto for values 1-10
+  auto data = decodeBase64(
+      "ASwAAAACCwoAgANEAEDsyQbAxdQPADQvEoYdNBuBKeEwgtKHOQBYPVsB0hm0gCAI3gAgAAAKAAAAwbZqSBDSGbSowHZsoCAI3krEBfu3A0QAUyYs1XjsyQYbd2yb9sXUD3IeYiw5NC8S5tfq34AdNBuyj38lkynhMHnf8AaM0oc5DItIsjlYPVsBAAEAAQABAAEAAQABAAEAAQABAA==");
+
+  SetDigest digest(allocator_.get());
+  digest.deserialize(data.data(), data.size());
+
+  ASSERT_TRUE(digest.isExact()) << "Digest should be exact for 10 values";
+  ASSERT_EQ(digest.cardinality(), 10) << "Cardinality should be 10";
+
+  SetDigest expectedDigest(allocator_.get());
+  for (int64_t i = 1; i <= 10; i++) {
+    expectedDigest.add(i);
+  }
+  ASSERT_EQ(expectedDigest.cardinality(), 10);
+  ASSERT_TRUE(expectedDigest.isExact());
+
+  int64_t intersection =
+      SetDigest::exactIntersectionCardinality(digest, expectedDigest);
+  ASSERT_EQ(intersection, 10)
+      << "Deserialized digest should contain exactly values 1-10";
+
+  auto hashCounts = digest.getHashCounts();
+  auto expectedHashCounts = expectedDigest.getHashCounts();
+  ASSERT_EQ(hashCounts.size(), expectedHashCounts.size())
+      << "Hash count sizes should match";
+
+  for (const auto& entry : hashCounts) {
+    ASSERT_EQ(entry.second, 1)
+        << "Each value should appear exactly once (count=1)";
+  }
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  ASSERT_EQ(size, data.size())
+      << "Serialized size should match original Java data size";
+  ASSERT_EQ(std::string(buffer.begin(), buffer.end()), data)
+      << "Round-trip serialization should produce identical bytes";
+
+  SetDigest digest2(allocator_.get());
+  digest2.deserialize(buffer.data(), size);
+  ASSERT_EQ(digest2.cardinality(), 10);
+  ASSERT_TRUE(digest2.isExact());
+
+  int64_t intersection2 =
+      SetDigest::exactIntersectionCardinality(digest2, expectedDigest);
+  ASSERT_EQ(intersection2, 10)
+      << "Re-deserialized digest should still contain exactly values 1-10";
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  ASSERT_EQ(std::string(buffer2.begin(), buffer2.end()), data)
+      << "Multiple round-trips should produce identical bytes";
+}
+
+TEST_F(SetDigestTest, javaSerializationCompatibilityStringValues) {
+  SCOPED_TRACE(
+      "SELECT to_base64(cast(make_set_digest(col) as varbinary)) "
+      "FROM (VALUES ('apple'), ('banana'), ('cherry')) AS t(col)");
+
+  SetDigest digest1(allocator_.get());
+  digest1.add(facebook::velox::StringView("apple"));
+  digest1.add(facebook::velox::StringView("banana"));
+  digest1.add(facebook::velox::StringView("cherry"));
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest digest2(allocator_.get());
+  digest2.deserialize(buffer1.data(), size1);
+
+  ASSERT_TRUE(digest2.isExact()) << "Digest should be exact for 3 values";
+  ASSERT_EQ(digest2.cardinality(), 3) << "Cardinality should be 3";
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  ASSERT_EQ(size1, size2) << "Serialized sizes should match";
+  ASSERT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()))
+      << "Round-trip serialization should produce identical bytes";
+
+  SetDigest digest3(allocator_.get());
+  digest3.deserialize(buffer2.data(), size2);
+  int32_t size3 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest3.serialize(buffer3.data());
+
+  ASSERT_EQ(
+      std::string(buffer3.begin(), buffer3.end()),
+      std::string(buffer1.begin(), buffer1.end()))
+      << "Multiple round-trips should produce identical bytes";
+}
+
+TEST_F(SetDigestTest, sparseHllToDenseConversion) {
+  SetDigest digest(allocator_.get());
+
+  // digest is still exact (5000 < 8192 maxHashes)
+  constexpr int32_t kNumValues = 5000;
+  for (int32_t i = 0; i < kNumValues; i++) {
+    digest.add(static_cast<int64_t>(i));
+  }
+
+  ASSERT_TRUE(digest.isExact())
+      << "Digest should be exact for " << kNumValues << " values";
+  ASSERT_EQ(digest.cardinality(), kNumValues)
+      << "Cardinality should be exact count";
+
+  int32_t size1 = digest.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest.serialize(buffer1.data());
+
+  SetDigest digest2(allocator_.get());
+  digest2.deserialize(buffer1.data(), size1);
+
+  ASSERT_TRUE(digest2.isExact()) << "Deserialized digest should still be exact";
+  ASSERT_EQ(digest2.cardinality(), kNumValues)
+      << "Cardinality should be preserved after deserialization";
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  ASSERT_EQ(size1, size2) << "Serialized sizes should match";
+  ASSERT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()))
+      << "Serialization should be stable after sparse-to-dense conversion";
+
+  digest2.add(static_cast<int64_t>(kNumValues));
+  ASSERT_EQ(digest2.cardinality(), kNumValues + 1)
+      << "Should be able to add values after deserialization";
+
+  // add enough values to exceed maxHashes (8192) and become approximate
+  constexpr int32_t kNumAdditionalValues = 5000;
+  for (int32_t i = kNumValues; i < kNumValues + kNumAdditionalValues; i++) {
+    digest.add(static_cast<int64_t>(i));
+  }
+
+  ASSERT_FALSE(digest.isExact())
+      << "Digest should become approximate after exceeding maxHashes";
+
+  int64_t actualCardinality = kNumValues + kNumAdditionalValues;
+  int64_t estimatedCardinality = digest.cardinality();
+  double errorRate =
+      std::abs(static_cast<double>(estimatedCardinality - actualCardinality)) /
+      static_cast<double>(actualCardinality);
+  ASSERT_LT(errorRate, 0.05)
+      << "HLL cardinality estimate should be within 5% of actual. "
+      << "Actual: " << actualCardinality
+      << ", Estimated: " << estimatedCardinality
+      << ", Error: " << (errorRate * 100) << "%";
+
+  int32_t size3 = digest.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest.serialize(buffer3.data());
+
+  SetDigest digest3(allocator_.get());
+  digest3.deserialize(buffer3.data(), size3);
+
+  ASSERT_FALSE(digest3.isExact())
+      << "Deserialized digest should be approximate";
+  ASSERT_EQ(digest3.cardinality(), digest.cardinality())
+      << "Cardinality should be preserved for approximate digest";
+
+  int32_t size4 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer4(size4);
+  digest3.serialize(buffer4.data());
+
+  ASSERT_EQ(size3, size4) << "Approximate digest serialized sizes should match";
+  ASSERT_EQ(
+      std::string(buffer3.begin(), buffer3.end()),
+      std::string(buffer4.begin(), buffer4.end()))
+      << "Approximate digest serialization should be stable";
+}
+
+// Java-equivalent tests matching TestSetDigest.java
+
+TEST_F(SetDigestTest, testIntersectionCardinality) {
+  // Equivalent to Java's testIntersectionCardinality() with default parameters
+  testIntersectionCardinalityHelper(
+      SetDigest::kDefaultMaxHashes,
+      SetDigest::kNumberOfBuckets,
+      SetDigest::kDefaultMaxHashes,
+      SetDigest::kNumberOfBuckets);
+}
+
+TEST_F(SetDigestTest, testUnevenIntersectionCardinality) {
+  // Equivalent to Java's testUnevenIntersectionCardinality()
+  testIntersectionCardinalityHelper(
+      SetDigest::kDefaultMaxHashes / 4,
+      SetDigest::kNumberOfBuckets,
+      SetDigest::kDefaultMaxHashes,
+      SetDigest::kNumberOfBuckets);
+}
+
+void SetDigestTest::testIntersectionCardinalityHelper(
+    int32_t maxHashes1,
+    int32_t numBuckets1,
+    int32_t maxHashes2,
+    int32_t numBuckets2) {
+  std::vector<int32_t> sizes;
+
+  std::mt19937 rand(0); // Same seed as Java for reproducibility
+  // Generate random size from each power of ten in [10, 100,000,000]
+  for (int32_t i = 10; i < 100000000; i *= 10) {
+    std::uniform_int_distribution<int32_t> dist(10, i + 9);
+    sizes.push_back(dist(rand));
+  }
+
+  for (int32_t size : sizes) {
+    int32_t expectedCardinality = 0;
+    SetDigest digest1(
+        allocator_.get(),
+        static_cast<int8_t>(std::log2(numBuckets1)),
+        maxHashes1);
+    SetDigest digest2(
+        allocator_.get(),
+        static_cast<int8_t>(std::log2(numBuckets2)),
+        maxHashes2);
+
+    std::uniform_int_distribution<int64_t> valueDist;
+    std::uniform_real_distribution<double> probDist(0.0, 1.0);
+
+    for (int32_t j = 0; j < size; j++) {
+      int32_t added = 0;
+      int64_t value = valueDist(rand);
+
+      if (probDist(rand) < 0.5) {
+        digest1.add(value);
+        added++;
+      }
+      if (probDist(rand) < 0.5) {
+        digest2.add(value);
+        added++;
+      }
+      if (added == 2) {
+        expectedCardinality++;
+      }
+    }
+
+    // Skip test if expectedCardinality is too small
+    if (expectedCardinality < 10) {
+      continue;
+    }
+
+    // Calculate intersection using C++ implementation
+    int64_t estimatedCardinality;
+    if (digest1.isExact() && digest2.isExact()) {
+      estimatedCardinality =
+          SetDigest::exactIntersectionCardinality(digest1, digest2);
+    } else {
+      // Use Jaccard index for approximate intersection
+      int64_t cardinality1 = digest1.cardinality();
+      int64_t cardinality2 = digest2.cardinality();
+      double jaccard = SetDigest::jaccardIndex(digest1, digest2);
+
+      // Merge to get union cardinality
+      SetDigest tempDigest(
+          allocator_.get(),
+          static_cast<int8_t>(std::log2(numBuckets1)),
+          maxHashes1);
+      tempDigest.mergeWith(digest1);
+      tempDigest.mergeWith(digest2);
+      int64_t unionCardinality = tempDigest.cardinality();
+
+      estimatedCardinality =
+          static_cast<int64_t>(std::round(jaccard * unionCardinality));
+      estimatedCardinality =
+          std::min(estimatedCardinality, std::min(cardinality1, cardinality2));
+    }
+
+    double errorRate = std::abs(expectedCardinality - estimatedCardinality) /
+        static_cast<double>(expectedCardinality);
+    EXPECT_LT(errorRate, 0.10)
+        << "Expected intersection cardinality " << expectedCardinality
+        << " +/- 10%, got " << estimatedCardinality << ", for set of size "
+        << size << " (maxHashes1=" << maxHashes1
+        << ", numBuckets1=" << numBuckets1 << ", maxHashes2=" << maxHashes2
+        << ", numBuckets2=" << numBuckets2 << ")";
+  }
+}
+
+TEST_F(SetDigestTest, testSmallLargeIntersections) {
+  // Equivalent to Java's testSmallLargeIntersections()
+  std::vector<int32_t> sizes;
+
+  std::mt19937 rand(0); // Same seed as Java
+  for (int32_t i = 1000; i < 1000000; i *= 10) {
+    std::uniform_int_distribution<int32_t> dist(10, i + 9);
+    sizes.push_back(dist(rand));
+  }
+
+  for (size_t size1_idx = 0; size1_idx < sizes.size(); ++size1_idx) {
+    int32_t size1 = sizes[size1_idx];
+    SetDigest digest1(allocator_.get());
+    std::vector<std::pair<std::unique_ptr<SetDigest>, int32_t>> smallerSets;
+
+    std::uniform_int_distribution<int64_t> valueDist;
+    std::uniform_real_distribution<double> probDist(0.0, 1.0);
+
+    for (size_t size2_idx = 0; size2_idx < size1_idx; ++size2_idx) {
+      int32_t size2 = sizes[size2_idx];
+
+      for (int32_t overlap = 2; overlap <= 10; overlap += 2) {
+        int32_t expectedCardinality = 0;
+        auto digest2 = std::make_unique<SetDigest>(allocator_.get());
+
+        // Reset rand for this iteration to generate same values for digest1
+        std::mt19937 innerRand(rand());
+
+        for (int32_t j = 0; j < size1; j++) {
+          int64_t value = valueDist(innerRand);
+          digest1.add(value);
+
+          if (probDist(innerRand) < size2 / static_cast<double>(size1)) {
+            if (probDist(innerRand) * 10 < overlap) {
+              digest2->add(value);
+              expectedCardinality++;
+            } else {
+              digest2->add(valueDist(innerRand));
+            }
+          }
+        }
+
+        smallerSets.emplace_back(std::move(digest2), expectedCardinality);
+      }
+    }
+
+    for (const auto& [digest2Ptr, expectedCardinality] : smallerSets) {
+      const SetDigest& digest2 = *digest2Ptr;
+
+      // Calculate estimated intersection
+      int64_t estIntersectionCardinality;
+      if (digest1.isExact() && digest2.isExact()) {
+        estIntersectionCardinality =
+            SetDigest::exactIntersectionCardinality(digest1, digest2);
+      } else {
+        int64_t cardinality1 = digest1.cardinality();
+        int64_t cardinality2 = digest2.cardinality();
+        double jaccard = SetDigest::jaccardIndex(digest1, digest2);
+
+        SetDigest tempDigest(allocator_.get());
+        tempDigest.mergeWith(digest1);
+        tempDigest.mergeWith(digest2);
+        int64_t unionCardinality = tempDigest.cardinality();
+
+        estIntersectionCardinality =
+            static_cast<int64_t>(std::round(jaccard * unionCardinality));
+        estIntersectionCardinality = std::min(
+            estIntersectionCardinality, std::min(cardinality1, cardinality2));
+      }
+
+      int64_t size2 = digest2.cardinality();
+      EXPECT_LE(estIntersectionCardinality, size2)
+          << "Intersection cannot exceed smaller set size";
+
+      double errorRate =
+          std::abs(expectedCardinality - estIntersectionCardinality) /
+          static_cast<double>(size1);
+      EXPECT_LT(errorRate, 0.05)
+          << "Expected intersection cardinality " << expectedCardinality
+          << ", got " << estIntersectionCardinality << " for size1=" << size1
+          << ", size2=" << size2 << ", error rate " << (errorRate * 100) << "%";
+    }
+  }
+}

--- a/velox/functions/prestosql/SetDigestFunctions.h
+++ b/velox/functions/prestosql/SetDigestFunctions.h
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/SetDigest.h"
+
+namespace facebook::velox::functions {
+
+/// Scalar function: cardinality(setdigest) -> bigint
+/// Returns the estimated cardinality of the set digest.
+template <typename T>
+struct CardinalitySetDigestFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& input) {
+    auto pool = memory::memoryManager()->addLeafPool();
+    HashStringAllocator allocator(pool.get());
+
+    SetDigest digest(&allocator);
+    digest.deserialize(input.data(), input.size());
+
+    result = digest.cardinality();
+    return true;
+  }
+};
+
+/// Scalar function: intersection_cardinality(setdigest, setdigest) -> bigint
+/// Returns the intersection cardinality between two set digests.
+/// - If both digests are exact: returns exact intersection count
+/// - If either digest is approximate: returns estimated intersection using
+/// Jaccard index
+template <typename T>
+struct IntersectionCardinalityFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& input1,
+      const arg_type<Varbinary>& input2) {
+    auto pool = memory::memoryManager()->addLeafPool();
+    HashStringAllocator allocator(pool.get());
+
+    SetDigest digest1(&allocator);
+    digest1.deserialize(input1.data(), input1.size());
+
+    SetDigest digest2(&allocator);
+    digest2.deserialize(input2.data(), input2.size());
+
+    // If both are exact, use exact intersection
+    if (digest1.isExact() && digest2.isExact()) {
+      result = SetDigest::exactIntersectionCardinality(digest1, digest2);
+      return true;
+    }
+
+    // Otherwise, estimate using Jaccard index (matching Java behavior)
+    int64_t cardinality1 = digest1.cardinality();
+    int64_t cardinality2 = digest2.cardinality();
+    double jaccard = SetDigest::jaccardIndex(digest1, digest2);
+    digest1.mergeWith(digest2);
+    int64_t estimatedIntersection =
+        std::llround(jaccard * digest1.cardinality());
+
+    // When one set is much smaller and approaches being a subset of the other,
+    // the computed cardinality may exceed the smaller set's cardinality.
+    // In this case, the smaller cardinality is a better estimate.
+    result =
+        std::min(estimatedIntersection, std::min(cardinality1, cardinality2));
+    return true;
+  }
+};
+
+/// Scalar function: jaccard_index(setdigest, setdigest) -> double
+/// Returns the Jaccard index (similarity coefficient) between two set digests.
+/// The Jaccard index is a value in [0, 1] where:
+/// - 1.0 means the sets are identical
+/// - 0.0 means the sets are disjoint (no overlap)
+/// Uses MinHash estimation for efficient computation.
+template <typename T>
+struct JaccardIndexFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<double>& result,
+      const arg_type<Varbinary>& input1,
+      const arg_type<Varbinary>& input2) {
+    auto pool = memory::memoryManager()->addLeafPool();
+    HashStringAllocator allocator(pool.get());
+
+    SetDigest digest1(&allocator);
+    digest1.deserialize(input1.data(), input1.size());
+
+    SetDigest digest2(&allocator);
+    digest2.deserialize(input2.data(), input2.size());
+
+    result = SetDigest::jaccardIndex(digest1, digest2);
+    return true;
+  }
+};
+
+/// Scalar function: hash_counts(setdigest) -> map(bigint, smallint)
+/// Returns a map of hash values to their occurrence counts.
+/// This exposes the MinHash component of the SetDigest, showing which
+/// hash values were tracked and how many times each value was added.
+/// Only available when the digest is exact (cardinality < maxHashes).
+template <typename T>
+struct HashCountsFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Map<int64_t, int16_t>>& result,
+      const arg_type<Varbinary>& input) {
+    auto pool = memory::memoryManager()->addLeafPool();
+    HashStringAllocator allocator(pool.get());
+
+    SetDigest digest(&allocator);
+    digest.deserialize(input.data(), input.size());
+
+    auto hashCounts = digest.getHashCounts();
+    result.reserve(hashCounts.size());
+
+    for (const auto& [key, value] : hashCounts) {
+      auto item = result.add_item();
+      std::get<0>(item) = key;
+      std::get<1>(item) = value;
+    }
+
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_add_library(
   MathematicalOperatorsRegistration.cpp
   ProbabilityTrigonometricFunctionsRegistration.cpp
   RegistrationFunctions.cpp
+  SetDigestFunctionsRegistration.cpp
   SfmSketchFunctionsRegistration.cpp
   StringFunctionsRegistration.cpp
   TDigestFunctionsRegistration.cpp

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -17,7 +17,6 @@
 #include "velox/functions/prestosql/IPAddressFunctions.h"
 #include "velox/functions/prestosql/UuidFunctions.h"
 #include "velox/functions/prestosql/types/P4HyperLogLogRegistration.h"
-#include "velox/functions/prestosql/types/SetDigestRegistration.h"
 
 namespace facebook::velox::functions {
 
@@ -33,6 +32,7 @@ extern void registerGeneralFunctions(const std::string& prefix);
 extern void registerHyperLogFunctions(const std::string& prefix);
 extern void registerTDigestFunctions(const std::string& prefix);
 extern void registerQDigestFunctions(const std::string& prefix);
+extern void registerSetDigestFunctions(const std::string& prefix);
 extern void registerSfmSketchFunctions(const std::string& prefix);
 extern void registerEnumFunctions(const std::string& prefix);
 extern void registerIntegerFunctions(const std::string& prefix);
@@ -148,9 +148,6 @@ void registerBitwiseFunctions(const std::string& prefix) {
 
 void registerAllScalarFunctions(const std::string& prefix) {
   registerP4HyperLogLogType();
-  // TODO: Remove type registration after SetDigestFunctionsRegistration.cpp
-  // is created.
-  registerSetDigestType();
   registerArithmeticFunctions(prefix);
   registerCheckedArithmeticFunctions(prefix);
   registerComparisonFunctions(prefix);
@@ -161,6 +158,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerTDigestFunctions(prefix);
   registerQDigestFunctions(prefix);
   registerSfmSketchFunctions(prefix);
+  registerSetDigestFunctions(prefix);
   registerEnumFunctions(prefix);
   registerIntegerFunctions(prefix);
   registerFloatingPointFunctions(prefix);

--- a/velox/functions/prestosql/registration/SetDigestFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/SetDigestFunctionsRegistration.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/SetDigestFunctions.h"
+#include "velox/functions/prestosql/types/SetDigestRegistration.h"
+
+namespace facebook::velox::functions {
+
+void registerSetDigestFunctions(const std::string& prefix) {
+  facebook::velox::registerSetDigestType();
+
+  // Register cardinality(setdigest) -> bigint
+  registerFunction<CardinalitySetDigestFunction, int64_t, Varbinary>(
+      {prefix + "cardinality"});
+
+  // Register intersection_cardinality(setdigest, setdigest) -> bigint
+  registerFunction<
+      IntersectionCardinalityFunction,
+      int64_t,
+      Varbinary,
+      Varbinary>({prefix + "intersection_cardinality"});
+
+  // Register jaccard_index(setdigest, setdigest) -> double
+  registerFunction<JaccardIndexFunction, double, Varbinary, Varbinary>(
+      {prefix + "jaccard_index"});
+
+  // Register hash_counts(setdigest) -> map(bigint, smallint)
+  registerFunction<HashCountsFunction, Map<int64_t, int16_t>, Varbinary>(
+      {prefix + "hash_counts"});
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/SetDigestFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/SetDigestFunctionsTest.cpp
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/base64.h>
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/lib/SetDigest.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/SetDigestRegistration.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::test;
+
+class SetDigestFunctionsTest : public FunctionBaseTest {
+ protected:
+  void SetUp() override {
+    FunctionBaseTest::SetUp();
+    registerSetDigestType();
+  }
+};
+
+TEST_F(SetDigestFunctionsTest, testCardinality) {
+  const auto cardinality = [&](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("cardinality(c0)", VARBINARY(), input);
+  };
+
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+  facebook::velox::functions::SetDigest digest(&allocator);
+
+  std::vector<int64_t> values;
+  for (int64_t i = 1; i <= 100; i++) {
+    digest.add(i);
+    values.push_back(i);
+  }
+
+  int64_t expectedCardinality = digest.cardinality();
+  ASSERT_EQ(100, expectedCardinality);
+
+  int32_t serializedSize = digest.estimatedSerializedSize();
+  std::vector<char> buffer(serializedSize);
+  digest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  auto result = cardinality(serializedDigest);
+  ASSERT_EQ(expectedCardinality, result.value());
+
+  // Test with duplicates - should not increase cardinality
+  facebook::velox::functions::SetDigest digestWithDuplicates(&allocator);
+  digestWithDuplicates.add(1L);
+  digestWithDuplicates.add(1L);
+  digestWithDuplicates.add(1L);
+  digestWithDuplicates.add(2L);
+  digestWithDuplicates.add(2L);
+
+  expectedCardinality = digestWithDuplicates.cardinality();
+  ASSERT_EQ(2, expectedCardinality);
+
+  serializedSize = digestWithDuplicates.estimatedSerializedSize();
+  buffer.resize(serializedSize);
+  digestWithDuplicates.serialize(buffer.data());
+  serializedDigest = std::string(buffer.begin(), buffer.end());
+
+  result = cardinality(serializedDigest);
+  ASSERT_EQ(expectedCardinality, result.value());
+}
+
+TEST_F(SetDigestFunctionsTest, testIntersectionCardinality) {
+  const auto intersectionCardinality =
+      [&](const std::optional<std::string>& input1,
+          const std::optional<std::string>& input2) {
+        return evaluateOnce<int64_t>(
+            "intersection_cardinality(c0, c1)",
+            {VARBINARY(), VARBINARY()},
+            input1,
+            input2);
+      };
+
+  // Create two SetDigest objects in C++ with known overlap
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+
+  facebook::velox::functions::SetDigest digest1(&allocator);
+  for (int64_t i = 1; i <= 10; i++) {
+    digest1.add(i);
+  }
+
+  facebook::velox::functions::SetDigest digest2(&allocator);
+  for (int64_t i = 5; i <= 15; i++) {
+    digest2.add(i);
+  }
+
+  int64_t expectedIntersection =
+      facebook::velox::functions::SetDigest::exactIntersectionCardinality(
+          digest1, digest2);
+  ASSERT_EQ(6, expectedIntersection);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+  std::string serialized1(buffer1.begin(), buffer1.end());
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+  std::string serialized2(buffer2.begin(), buffer2.end());
+
+  auto result = intersectionCardinality(serialized1, serialized2);
+  ASSERT_EQ(expectedIntersection, result.value());
+
+  // Test with no overlap
+  facebook::velox::functions::SetDigest digest3(&allocator);
+  for (int64_t i = 100; i <= 110; i++) {
+    digest3.add(i);
+  }
+
+  expectedIntersection =
+      facebook::velox::functions::SetDigest::exactIntersectionCardinality(
+          digest1, digest3);
+  ASSERT_EQ(0, expectedIntersection);
+
+  int32_t size3 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest3.serialize(buffer3.data());
+  std::string serialized3(buffer3.begin(), buffer3.end());
+
+  result = intersectionCardinality(serialized1, serialized3);
+  ASSERT_EQ(expectedIntersection, result.value());
+
+  // Test with full overlap (same digest)
+  expectedIntersection =
+      facebook::velox::functions::SetDigest::exactIntersectionCardinality(
+          digest1, digest1);
+  result = intersectionCardinality(serialized1, serialized1);
+  ASSERT_EQ(expectedIntersection, result.value());
+
+  // Test with null inputs.
+  result = intersectionCardinality(std::nullopt, serialized1);
+  ASSERT_FALSE(result.has_value());
+
+  result = intersectionCardinality(serialized1, std::nullopt);
+  ASSERT_FALSE(result.has_value());
+
+  result = intersectionCardinality(std::nullopt, std::nullopt);
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(SetDigestFunctionsTest, testHashCounts) {
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+  facebook::velox::functions::SetDigest digest(&allocator);
+
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(2L);
+  digest.add(2L);
+  digest.add(3L);
+
+  auto expectedHashCounts = digest.getHashCounts();
+  ASSERT_EQ(3, expectedHashCounts.size());
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  auto inputVector = BaseVector::create(VARBINARY(), 1, execCtx_.pool());
+  auto flatVector = inputVector->as<FlatVector<StringView>>();
+  flatVector->set(0, StringView(buffer.data(), size));
+
+  auto result = evaluate("hash_counts(c0)", makeRowVector({inputVector}));
+
+  ASSERT_EQ(result->size(), 1);
+  auto mapVector = result->as<MapVector>();
+  ASSERT_NE(mapVector, nullptr);
+
+  ASSERT_EQ(mapVector->sizeAt(0), expectedHashCounts.size());
+
+  auto keys = mapVector->mapKeys()->as<SimpleVector<int64_t>>();
+  auto values = mapVector->mapValues()->as<SimpleVector<int16_t>>();
+
+  auto offset = mapVector->offsetAt(0);
+  auto mapSize = mapVector->sizeAt(0);
+
+  for (auto i = 0; i < mapSize; i++) {
+    auto key = keys->valueAt(offset + i);
+    auto value = values->valueAt(offset + i);
+
+    ASSERT_TRUE(expectedHashCounts.count(key) > 0);
+    ASSERT_EQ(expectedHashCounts.at(key), value);
+  }
+}
+
+TEST_F(SetDigestFunctionsTest, testHashCountsWithMerge) {
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+  facebook::velox::functions::SetDigest digest1(&allocator);
+  digest1.add(0L);
+  digest1.add(0L);
+  digest1.add(1L);
+
+  facebook::velox::functions::SetDigest digest2(&allocator);
+  digest2.add(0L);
+  digest2.add(0L);
+  digest2.add(2L);
+  digest2.add(2L);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  auto inputVector1 = BaseVector::create(VARBINARY(), 1, execCtx_.pool());
+  auto flatVector1 = inputVector1->as<FlatVector<StringView>>();
+  flatVector1->set(0, StringView(buffer1.data(), size1));
+
+  auto result1 = evaluate("hash_counts(c0)", makeRowVector({inputVector1}));
+  auto mapVector1 = result1->as<MapVector>();
+  ASSERT_NE(mapVector1, nullptr);
+
+  // Extract count values from digest1 (should be {1, 2})
+  auto values1 = mapVector1->mapValues()->as<SimpleVector<int16_t>>();
+  auto offset1 = mapVector1->offsetAt(0);
+  auto mapSize1 = mapVector1->sizeAt(0);
+
+  std::set<int16_t> countValues1;
+  for (auto i = 0; i < mapSize1; i++) {
+    countValues1.insert(values1->valueAt(offset1 + i));
+  }
+
+  std::set<int16_t> expected1 = {1, 2}; // hash(0)→2, hash(1)→1
+  ASSERT_EQ(countValues1, expected1);
+
+  digest1.mergeWith(digest2);
+
+  // Test hash_counts after merge
+  int32_t sizeMerged = digest1.estimatedSerializedSize();
+  std::vector<char> bufferMerged(sizeMerged);
+  digest1.serialize(bufferMerged.data());
+
+  auto inputVectorMerged = BaseVector::create(VARBINARY(), 1, execCtx_.pool());
+  auto flatVectorMerged = inputVectorMerged->as<FlatVector<StringView>>();
+  flatVectorMerged->set(0, StringView(bufferMerged.data(), sizeMerged));
+
+  auto resultMerged =
+      evaluate("hash_counts(c0)", makeRowVector({inputVectorMerged}));
+  auto mapVectorMerged = resultMerged->as<MapVector>();
+  ASSERT_NE(mapVectorMerged, nullptr);
+
+  // Extract count values from merged digest (should be {1, 2, 4})
+  auto valuesMerged = mapVectorMerged->mapValues()->as<SimpleVector<int16_t>>();
+  auto offsetMerged = mapVectorMerged->offsetAt(0);
+  auto mapSizeMerged = mapVectorMerged->sizeAt(0);
+
+  std::set<int16_t> countValuesMerged;
+  for (auto i = 0; i < mapSizeMerged; i++) {
+    countValuesMerged.insert(valuesMerged->valueAt(offsetMerged + i));
+  }
+
+  std::set<int16_t> expectedMerged = {
+      1, 2, 4}; // hash(0)→4, hash(1)→1, hash(2)→2
+  ASSERT_EQ(countValuesMerged, expectedMerged);
+}
+
+TEST_F(SetDigestFunctionsTest, testIntersectionCardinalityApproximate) {
+  const auto intersectionCardinality =
+      [&](const std::optional<std::string>& input1,
+          const std::optional<std::string>& input2) {
+        return evaluateOnce<int64_t>(
+            "intersection_cardinality(c0, c1)",
+            {VARBINARY(), VARBINARY()},
+            input1,
+            input2);
+      };
+
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+
+  // Test 1: Both digests approximate
+  // Approximate digest 1: values 0-9999 (10000 elements)
+  facebook::velox::functions::SetDigest approximateDigest1(&allocator);
+  for (int64_t i = 0; i < 10000; i++) {
+    approximateDigest1.add(i);
+  }
+  ASSERT_FALSE(approximateDigest1.isExact());
+
+  // Approximate digest 2: values 5000-14999 (10000 elements)
+  // Intersection: 5000-9999 (5000 elements)
+  // Union: 0-14999 (15000 elements)
+  // Expected Jaccard: 5000/15000 = 0.333
+  facebook::velox::functions::SetDigest approximateDigest2(&allocator);
+  for (int64_t i = 5000; i < 15000; i++) {
+    approximateDigest2.add(i);
+  }
+  ASSERT_FALSE(approximateDigest2.isExact());
+
+  int32_t approx1Size = approximateDigest1.estimatedSerializedSize();
+  std::vector<char> approx1Buffer(approx1Size);
+  approximateDigest1.serialize(approx1Buffer.data());
+  std::string serializedApprox1(approx1Buffer.begin(), approx1Buffer.end());
+
+  int32_t approx2Size = approximateDigest2.estimatedSerializedSize();
+  std::vector<char> approx2Buffer(approx2Size);
+  approximateDigest2.serialize(approx2Buffer.data());
+  std::string serializedApprox2(approx2Buffer.begin(), approx2Buffer.end());
+
+  // Test approximate mode with both digests being approximate
+  // approximateDigest1: 0-9999, approximateDigest2: 5000-14999
+  // Expected intersection: 5000 values (5000-9999)
+  auto result = intersectionCardinality(serializedApprox1, serializedApprox2);
+  ASSERT_TRUE(result.has_value());
+  // Allow reasonable margin of error for HyperLogLog and MinHash estimation
+  EXPECT_GE(result.value(), 3500);
+  EXPECT_LE(result.value(), 6500);
+
+  // Test approximate mode with same digest (self-intersection)
+  // Should return cardinality of the digest
+  result = intersectionCardinality(serializedApprox1, serializedApprox1);
+  ASSERT_TRUE(result.has_value());
+  int64_t cardinality = approximateDigest1.cardinality();
+  EXPECT_EQ(result.value(), cardinality);
+
+  // Test 2: Mixed mode - Exact digest (1000 elements) with Approximate digest
+  // This tests that MinHash can detect overlap when exact set is reasonably
+  // sized. Exact digest: values 0-999 (1000 elements, stays exact since < 8192)
+  facebook::velox::functions::SetDigest exactDigest(&allocator);
+  for (int64_t i = 0; i < 1000; i++) {
+    exactDigest.add(i);
+  }
+  ASSERT_TRUE(exactDigest.isExact());
+
+  // Approximate digest 3: values 0-9999 (10000 elements)
+  // Contains all elements from exactDigest
+  // Intersection: 0-999 (1000 elements)
+  // Union: 0-9999 (10000 elements)
+  // Expected Jaccard: 1000/10000 = 0.1
+  facebook::velox::functions::SetDigest approximateDigest3(&allocator);
+  for (int64_t i = 0; i < 10000; i++) {
+    approximateDigest3.add(i);
+  }
+  ASSERT_FALSE(approximateDigest3.isExact());
+
+  int32_t exactSize = exactDigest.estimatedSerializedSize();
+  std::vector<char> exactBuffer(exactSize);
+  exactDigest.serialize(exactBuffer.data());
+  std::string serializedExact(exactBuffer.begin(), exactBuffer.end());
+
+  int32_t approx3Size = approximateDigest3.estimatedSerializedSize();
+  std::vector<char> approx3Buffer(approx3Size);
+  approximateDigest3.serialize(approx3Buffer.data());
+  std::string serializedApprox3(approx3Buffer.begin(), approx3Buffer.end());
+
+  // Test mixed mode: exact (1000) ∩ approximate (10000 containing all exact)
+  result = intersectionCardinality(serializedExact, serializedApprox3);
+  ASSERT_TRUE(result.has_value());
+  // With 1000 elements, MinHash should be able to estimate the overlap
+  // Expected ~1000, but allow wider margin due to MinHash estimation variance
+  EXPECT_GE(result.value(), 600);
+  EXPECT_LE(result.value(), 1400);
+}
+
+TEST_F(SetDigestFunctionsTest, testJaccardIndex) {
+  const auto jaccardIndex = [&](const std::optional<std::string>& input1,
+                                const std::optional<std::string>& input2) {
+    return evaluateOnce<double>(
+        "jaccard_index(c0, c1)", {VARBINARY(), VARBINARY()}, input1, input2);
+  };
+
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+
+  // Test 1: Identical sets - Jaccard index should be 1.0
+  facebook::velox::functions::SetDigest digest1(&allocator);
+  for (int64_t i = 1; i <= 100; i++) {
+    digest1.add(i);
+  }
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+  std::string serialized1(buffer1.begin(), buffer1.end());
+
+  auto result = jaccardIndex(serialized1, serialized1);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 1.0);
+
+  // Test 2: Disjoint sets - Jaccard index should be 0.0
+  facebook::velox::functions::SetDigest digest2(&allocator);
+  for (int64_t i = 101; i <= 200; i++) {
+    digest2.add(i);
+  }
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+  std::string serialized2(buffer2.begin(), buffer2.end());
+
+  result = jaccardIndex(serialized1, serialized2);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 0.0);
+
+  // Test 3: Partially overlapping sets
+  // digest1: 1-100, digest3: 50-150
+  // Intersection: 50-100 (51 elements)
+  // Union: 1-150 (150 elements)
+  // Expected Jaccard: 51/150 ≈ 0.34
+  facebook::velox::functions::SetDigest digest3(&allocator);
+  for (int64_t i = 50; i <= 150; i++) {
+    digest3.add(i);
+  }
+
+  int32_t size3 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest3.serialize(buffer3.data());
+  std::string serialized3(buffer3.begin(), buffer3.end());
+
+  result = jaccardIndex(serialized1, serialized3);
+  ASSERT_TRUE(result.has_value());
+  // Exact expected value: 51/150 = 0.34
+  double expectedJaccard = 51.0 / 150.0;
+  EXPECT_NEAR(result.value(), expectedJaccard, 0.05);
+
+  // Test 4: One set is a subset of the other
+  // digest1: 1-100, digest4: 25-75 (subset of digest1)
+  // Intersection: 25-75 (51 elements)
+  // Union: 1-100 (100 elements)
+  // Expected Jaccard: 51/100 = 0.51
+  facebook::velox::functions::SetDigest digest4(&allocator);
+  for (int64_t i = 25; i <= 75; i++) {
+    digest4.add(i);
+  }
+
+  int32_t size4 = digest4.estimatedSerializedSize();
+  std::vector<char> buffer4(size4);
+  digest4.serialize(buffer4.data());
+  std::string serialized4(buffer4.begin(), buffer4.end());
+
+  result = jaccardIndex(serialized1, serialized4);
+  ASSERT_TRUE(result.has_value());
+  expectedJaccard = 51.0 / 100.0;
+  EXPECT_NEAR(result.value(), expectedJaccard, 0.05);
+
+  // Test 5: Small overlap
+  // digest1: 1-100, digest5: 95-200
+  // Intersection: 95-100 (6 elements)
+  // Union: 1-200 (200 elements)
+  // Expected Jaccard: 6/200 = 0.03
+  facebook::velox::functions::SetDigest digest5(&allocator);
+  for (int64_t i = 95; i <= 200; i++) {
+    digest5.add(i);
+  }
+
+  int32_t size5 = digest5.estimatedSerializedSize();
+  std::vector<char> buffer5(size5);
+  digest5.serialize(buffer5.data());
+  std::string serialized5(buffer5.begin(), buffer5.end());
+
+  result = jaccardIndex(serialized1, serialized5);
+  ASSERT_TRUE(result.has_value());
+  expectedJaccard = 6.0 / 200.0;
+  EXPECT_NEAR(result.value(), expectedJaccard, 0.05);
+
+  // Test with null inputs.
+  result = jaccardIndex(std::nullopt, serialized1);
+  ASSERT_FALSE(result.has_value());
+
+  result = jaccardIndex(serialized1, std::nullopt);
+  ASSERT_FALSE(result.has_value());
+
+  result = jaccardIndex(std::nullopt, std::nullopt);
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(SetDigestFunctionsTest, testJaccardIndexApproximate) {
+  const auto jaccardIndex = [&](const std::optional<std::string>& input1,
+                                const std::optional<std::string>& input2) {
+    return evaluateOnce<double>(
+        "jaccard_index(c0, c1)", {VARBINARY(), VARBINARY()}, input1, input2);
+  };
+
+  auto pool = memory::memoryManager()->addLeafPool();
+  HashStringAllocator allocator(pool.get());
+
+  // Create large approximate digests
+  // digest1: 0-14999 (15000 elements)
+  facebook::velox::functions::SetDigest digest1(&allocator);
+  for (int64_t i = 0; i < 15000; i++) {
+    digest1.add(i);
+  }
+  ASSERT_FALSE(digest1.isExact());
+
+  // digest2: 5000-19999 (15000 elements)
+  // Intersection: 5000-14999 (10000 elements)
+  // Union: 0-19999 (20000 elements)
+  // Expected Jaccard: 10000/20000 = 0.5
+  facebook::velox::functions::SetDigest digest2(&allocator);
+  for (int64_t i = 5000; i < 20000; i++) {
+    digest2.add(i);
+  }
+  ASSERT_FALSE(digest2.isExact());
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+  std::string serialized1(buffer1.begin(), buffer1.end());
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+  std::string serialized2(buffer2.begin(), buffer2.end());
+
+  auto result = jaccardIndex(serialized1, serialized2);
+  ASSERT_TRUE(result.has_value());
+  // Expected value is 0.5, allow reasonable margin for approximation
+  EXPECT_GE(result.value(), 0.0);
+  EXPECT_LE(result.value(), 1.0);
+  EXPECT_NEAR(result.value(), 0.5, 0.15);
+
+  // Test with same approximate digest (self-similarity)
+  result = jaccardIndex(serialized1, serialized1);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result.value(), 1.0);
+
+  // Test with disjoint approximate sets
+  // digest3: 30000-44999 (15000 elements, no overlap with digest1)
+  facebook::velox::functions::SetDigest digest3(&allocator);
+  for (int64_t i = 30000; i < 45000; i++) {
+    digest3.add(i);
+  }
+  ASSERT_FALSE(digest3.isExact());
+
+  int32_t size3 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest3.serialize(buffer3.data());
+  std::string serialized3(buffer3.begin(), buffer3.end());
+
+  result = jaccardIndex(serialized1, serialized3);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result.value(), 0.0, 0.1);
+}


### PR DESCRIPTION
Summary:
## Main Methods

| **Java Method**                                   | **C++ Method**                                   | **Description**                                                        |
|---------------------------------------------------|--------------------------------------------------|-----------------------------------------------------------------------|
| `SetDigest()`                                     | `SetDigest(HashStringAllocator*)`                | Constructor - Java uses default params, C++ requires allocator        |
| `void add(long)`                                  | `void add(int64_t)`                              | Add integer value to digest                                           |
| `void add(Slice)`                                 | `void add(StringView)`                           | Add string/binary value to digest                                     |
| `Slice serialize()`                               | `void serialize(char*)`                          | Serialize to bytes (Java returns Slice, C++ writes to buffer)         |
| `static SetDigest newInstance(Slice)`             | `void deserialize(const char*, int32_t)`         | Deserialize from bytes (Java static factory, C++ instance method)     |
| `void mergeWith(SetDigest)`                       | `void mergeWith(const SetDigest&)`               | Merge two digests                                                     |
| `boolean isExact()`                              | `bool isExact() const`                           | Check if digest is exact or approximate                               |
| `long cardinality()`                              | `int64_t cardinality() const`                    | Get distinct element count                                            |
| `static long exactIntersectionCardinality(...)`    | `static int64_t exactIntersectionCardinality(...)`| Calculate exact intersection size                                     |
| `static double jaccardIndex(...)`                 | `static double jaccardIndex(...)`                | Calculate Jaccard similarity coefficient                              |
| `Map<Long, Short> getHashCounts()`                | `std::map<int64_t, int16_t> getHashCounts() const`| Get MinHash map                                                      |

---

## Size Estimation Functions

| **Java Method**                  | **C++ Method**                        |
|----------------------------------|---------------------------------------|
| `int estimatedSerializedSize()`  | `int32_t serializedByteSize() const`  |
| `int estimatedInMemorySize()`    | `int32_t estimatedInMemorySize() const`|

---

## Additional Methods

| **Java Only**                                 | **C++ Only**                        |
|-----------------------------------------------|-------------------------------------|
| `HyperLogLog getHll()`                        | `void setIndexBitLength(int8_t)`    |
| `SetDigest(int, int)` constructor             |                                     |
| `void convertToDense()` (private)             |                                     |
| `SetDigest(int, HLL, Map)` constructor        |                                     |

Differential Revision: D85713719


