### PR TITLE
fix: Max length estimation in DateTimeFormatter

### DIFF
--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -1222,10 +1222,10 @@ uint32_t DateTimeFormatter::maxResultSize(const tz::TimeZone* timezone) const {
         break;
       case DateTimeFormatSpecifier::TIMEZONE:
         if (token.pattern.minRepresentDigits <= 3) {
-          // The longest timezone abbreviation is 6 in the case of negative or
-          // explicitly positive numeric representations (e.g., +01:00, -08:00)
-          // https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
-          size += 6;
+          // The longest timezone abbreviation is 9 in the case of timezones
+          // that do not have an abbreviation and use GMT offset (e.g.,
+          // GMT+01:00, GMT-08:00)
+          size += 9;
         } else {
           // The longest time zone long name is 40, Australian Central Western
           // Standard Time.

--- a/velox/functions/lib/tests/DateTimeFormatterTest.cpp
+++ b/velox/functions/lib/tests/DateTimeFormatterTest.cpp
@@ -1347,7 +1347,7 @@ TEST_F(JodaDateTimeFormatterTest, formatResultSize) {
   EXPECT_EQ(getJodaDateTimeFormatter("CCCCCCCCC")->maxResultSize(timezone), 9);
 
   EXPECT_EQ(
-      getJodaDateTimeFormatter("yyyy-MM-dd z")->maxResultSize(timezone), 23);
+      getJodaDateTimeFormatter("yyyy-MM-dd z")->maxResultSize(timezone), 26);
   EXPECT_EQ(
       getJodaDateTimeFormatter("yyyy-MM-dd Z")->maxResultSize(timezone), 25);
   EXPECT_EQ(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4425,6 +4425,8 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   EXPECT_EQ("+05:30", formatDatetime(parseTimestamp("1970-01-01"), "ZZ"));
   EXPECT_EQ("+0530", formatDatetime(parseTimestamp("1970-01-01"), "Z"));
 
+  // Time zone test cases - 'z'
+  // Timezone that has an abbreviation
   EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "zzz"));
   EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "zz"));
   EXPECT_EQ("IST", formatDatetime(parseTimestamp("1970-01-01"), "z"));
@@ -4433,6 +4435,18 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
       formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
   EXPECT_EQ(
       "India Standard Time",
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzzzzzzzzzzzzzzzzzzzz"));
+
+  // Timezone that has no abbreviations so uses GMT offset
+  setQueryTimeZone("Asia/Atyrau");
+  EXPECT_EQ("GMT+05:00", formatDatetime(parseTimestamp("1970-01-01"), "zzz"));
+  EXPECT_EQ("GMT+05:00", formatDatetime(parseTimestamp("1970-01-01"), "zz"));
+  EXPECT_EQ("GMT+05:00", formatDatetime(parseTimestamp("1970-01-01"), "z"));
+  EXPECT_EQ(
+      "West Kazakhstan Time",
+      formatDatetime(parseTimestamp("1970-01-01"), "zzzz"));
+  EXPECT_EQ(
+      "West Kazakhstan Time",
       formatDatetime(parseTimestamp("1970-01-01"), "zzzzzzzzzzzzzzzzzzzzzz"));
 
   // Test daylight savings.


### PR DESCRIPTION
Summary:
Fixes the maxLength() utility function in DateTimeFormatter for TIMEZONE specifiers that print out the timezone abbreviation, that is, for 'z', 'zz' and 'zzz'. It increases the size for the case where some timezones do not have abbreviations but instead use GMT offsets like `GMT+05:00`.

Originally found by the expression fuzzer.

Differential Revision: D87290122


