### PR TITLE
fix: Trim numeric suffix when casting string to real/double

### DIFF
--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -127,12 +127,14 @@ Expected<T> doCastToFloatingPoint(const StringView& data) {
 
 Expected<float> PrestoCastHooks::castStringToReal(
     const StringView& data) const {
-  return doCastToFloatingPoint<float>(data);
+  auto trimmed = util::trimNumericSuffix(data);
+  return doCastToFloatingPoint<float>(trimmed);
 }
 
 Expected<double> PrestoCastHooks::castStringToDouble(
     const StringView& data) const {
-  return doCastToFloatingPoint<double>(data);
+  auto trimmed = util::trimNumericSuffix(data);
+  return doCastToFloatingPoint<double>(trimmed);
 }
 
 StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -127,14 +127,12 @@ Expected<T> doCastToFloatingPoint(const StringView& data) {
 
 Expected<float> PrestoCastHooks::castStringToReal(
     const StringView& data) const {
-  auto trimmed = util::trimNumericSuffix(data);
-  return doCastToFloatingPoint<float>(trimmed);
+  return doCastToFloatingPoint<float>(util::trimFloatSuffix(data));
 }
 
 Expected<double> PrestoCastHooks::castStringToDouble(
     const StringView& data) const {
-  auto trimmed = util::trimNumericSuffix(data);
-  return doCastToFloatingPoint<double>(trimmed);
+  return doCastToFloatingPoint<double>(util::trimFloatSuffix(data));
 }
 
 StringView PrestoCastHooks::removeWhiteSpaces(const StringView& view) const {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1214,6 +1214,8 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"1.7E308"}, {kInf});
     testCast<std::string, float>("real", {"1."}, {1.0});
     testCast<std::string, float>("real", {"1"}, {1});
+    testCast<std::string, float>("real", {"1.2f"}, {1.2});
+    testCast<std::string, float>("real", {"1.2d"}, {1.2});
     testCast<std::string, float>("real", {"  1  "}, {1});
     testCast<std::string, float>("real", {"-Infinity"}, {-kInf});
     testCast<std::string, float>("real", {"+Infinity"}, {kInf});

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1223,6 +1223,8 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"  NaN  "}, {kNan});
     testCast<std::string, float>("real", {"  -NaN  "}, {kNan});
     testCast<std::string, float>("real", {"  +NaN  "}, {kNan});
+    testCast<std::string, double>("double", {"1.2f"}, {1.2});
+    testCast<std::string, double>("double", {"1.2d"}, {1.2});
   }
 
   // To boolean.

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1215,7 +1215,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"1."}, {1.0});
     testCast<std::string, float>("real", {"1"}, {1});
     testCast<std::string, float>("real", {"1.2f"}, {1.2});
+    testCast<std::string, float>("real", {"1.2F"}, {1.2});
     testCast<std::string, float>("real", {"1.2d"}, {1.2});
+    testCast<std::string, float>("real", {"1.2D"}, {1.2});
     testCast<std::string, float>("real", {"  1  "}, {1});
     testCast<std::string, float>("real", {"-Infinity"}, {-kInf});
     testCast<std::string, float>("real", {"+Infinity"}, {kInf});
@@ -1224,7 +1226,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"  -NaN  "}, {kNan});
     testCast<std::string, float>("real", {"  +NaN  "}, {kNan});
     testCast<std::string, double>("double", {"1.2f"}, {1.2});
+    testCast<std::string, double>("double", {"1.2F"}, {1.2});
     testCast<std::string, double>("double", {"1.2d"}, {1.2});
+    testCast<std::string, double>("double", {"1.2D"}, {1.2});
   }
 
   // To boolean.

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -110,13 +110,25 @@ Expected<int32_t> SparkCastHooks::castStringToDate(
       removeWhiteSpaces(dateString), util::ParseMode::kSparkCast);
 }
 
+StringView trimNumericSuffix(const StringView& v) {
+  if (!v.empty()) {
+    char last = *(v.end() - 1);
+    if (last == 'f' || last == 'F' || last == 'd' || last == 'D') {
+      return StringView(v.data(), v.size() - 1);
+    }
+  }
+  return v;
+}
+
 Expected<float> SparkCastHooks::castStringToReal(const StringView& data) const {
-  return util::Converter<TypeKind::REAL>::tryCast(data);
+  auto trimmed = trimNumericSuffix(data);
+  return util::Converter<TypeKind::REAL>::tryCast(trimmed);
 }
 
 Expected<double> SparkCastHooks::castStringToDouble(
     const StringView& data) const {
-  return util::Converter<TypeKind::DOUBLE>::tryCast(data);
+  auto trimmed = trimNumericSuffix(data);
+  return util::Converter<TypeKind::DOUBLE>::tryCast(trimmed);
 }
 
 StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -111,14 +111,13 @@ Expected<int32_t> SparkCastHooks::castStringToDate(
 }
 
 Expected<float> SparkCastHooks::castStringToReal(const StringView& data) const {
-  auto trimmed = util::trimNumericSuffix(data);
-  return util::Converter<TypeKind::REAL>::tryCast(trimmed);
+  return util::Converter<TypeKind::REAL>::tryCast(util::trimFloatSuffix(data));
 }
 
 Expected<double> SparkCastHooks::castStringToDouble(
     const StringView& data) const {
-  auto trimmed =  util::trimNumericSuffix(data);
-  return util::Converter<TypeKind::DOUBLE>::tryCast(trimmed);
+  return util::Converter<TypeKind::DOUBLE>::tryCast(
+      util::trimFloatSuffix(data));
 }
 
 StringView SparkCastHooks::removeWhiteSpaces(const StringView& view) const {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -110,24 +110,14 @@ Expected<int32_t> SparkCastHooks::castStringToDate(
       removeWhiteSpaces(dateString), util::ParseMode::kSparkCast);
 }
 
-StringView trimNumericSuffix(const StringView& v) {
-  if (!v.empty()) {
-    char last = *(v.end() - 1);
-    if (last == 'f' || last == 'F' || last == 'd' || last == 'D') {
-      return StringView(v.data(), v.size() - 1);
-    }
-  }
-  return v;
-}
-
 Expected<float> SparkCastHooks::castStringToReal(const StringView& data) const {
-  auto trimmed = trimNumericSuffix(data);
+  auto trimmed = util::trimNumericSuffix(data);
   return util::Converter<TypeKind::REAL>::tryCast(trimmed);
 }
 
 Expected<double> SparkCastHooks::castStringToDouble(
     const StringView& data) const {
-  auto trimmed = trimNumericSuffix(data);
+  auto trimmed =  util::trimNumericSuffix(data);
   return util::Converter<TypeKind::DOUBLE>::tryCast(trimmed);
 }
 

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -778,6 +778,10 @@ TEST_F(SparkCastExprTest, fromString) {
       "real", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
   testCast<std::string, double>(
       "double", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
+  testCast<std::string, float>("real", {"123.0f"}, {123.0});
+  testCast<std::string, float>("real", {"123.0d"}, {123.0});
+  testCast<std::string, double>("double", {"123.0f"}, {123.0});
+  testCast<std::string, double>("double", {"123.0d"}, {123.0});
   testCast<std::string, Timestamp>(
       "timestamp",
       {"\n\f\r\t\n\u001F 2000-01-01 12:21:56\u000B\u001C\u001D\u001E"},

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -779,9 +779,13 @@ TEST_F(SparkCastExprTest, fromString) {
   testCast<std::string, double>(
       "double", {"\n\f\r\t\n\u001F 123.0\u000B\u001C\u001D\u001E"}, {123.0});
   testCast<std::string, float>("real", {"123.0f"}, {123.0});
+  testCast<std::string, float>("real", {"123.0F"}, {123.0});
   testCast<std::string, float>("real", {"123.0d"}, {123.0});
+  testCast<std::string, float>("real", {"123.0D"}, {123.0});
   testCast<std::string, double>("double", {"123.0f"}, {123.0});
+  testCast<std::string, double>("double", {"123.0F"}, {123.0});
   testCast<std::string, double>("double", {"123.0d"}, {123.0});
+  testCast<std::string, double>("double", {"123.0D"}, {123.0});
   testCast<std::string, Timestamp>(
       "timestamp",
       {"\n\f\r\t\n\u001F 2000-01-01 12:21:56\u000B\u001C\u001D\u001E"},

--- a/velox/type/Conversions.cpp
+++ b/velox/type/Conversions.cpp
@@ -99,8 +99,9 @@ std::string_view trimWhiteSpace(const char* data, size_t length) {
   return std::string_view(data + startIndex, endIndex - startIndex + charSize);
 }
 
-/// Removes trailing numeric type suffix ('f', 'F', 'd', 'D') from the input.
-StringView trimNumericSuffix(const StringView& view) {
+/// Removes trailing floating-point type suffix ('f', 'F', 'd', 'D') from the
+/// input.
+StringView trimFloatSuffix(const StringView& view) {
   if (!view.empty()) {
     char last = *(view.end() - 1);
     if (last == 'f' || last == 'F' || last == 'd' || last == 'D') {

--- a/velox/type/Conversions.cpp
+++ b/velox/type/Conversions.cpp
@@ -99,4 +99,15 @@ std::string_view trimWhiteSpace(const char* data, size_t length) {
   return std::string_view(data + startIndex, endIndex - startIndex + charSize);
 }
 
+/// Removes trailing numeric type suffix ('f', 'F', 'd', 'D') from the input.
+StringView trimNumericSuffix(const StringView& view) {
+  if (!view.empty()) {
+    char last = *(view.end() - 1);
+    if (last == 'f' || last == 'F' || last == 'd' || last == 'D') {
+      return StringView(view.data(), view.size() - 1);
+    }
+  }
+  return view;
+}
+
 } // namespace facebook::velox::util

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -248,6 +248,9 @@ struct Converter<TypeKind::BOOLEAN, void, TPolicy> {
 /// a StringView of the trimmed string.
 std::string_view trimWhiteSpace(const char* data, size_t length);
 
+/// Removes trailing numeric type suffix ('f', 'F', 'd', 'D') from the input.
+StringView trimNumericSuffix(const StringView& view);
+
 /// To TINYINT, SMALLINT, INTEGER, BIGINT, and HUGEINT converter.
 template <TypeKind KIND, typename TPolicy>
 struct Converter<

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -248,8 +248,9 @@ struct Converter<TypeKind::BOOLEAN, void, TPolicy> {
 /// a StringView of the trimmed string.
 std::string_view trimWhiteSpace(const char* data, size_t length);
 
-/// Removes trailing numeric type suffix ('f', 'F', 'd', 'D') from the input.
-StringView trimNumericSuffix(const StringView& view);
+/// Removes trailing floating-point type suffix ('f', 'F', 'd', 'D') from the
+/// input.
+StringView trimFloatSuffix(const StringView& view);
 
 /// To TINYINT, SMALLINT, INTEGER, BIGINT, and HUGEINT converter.
 template <TypeKind KIND, typename TPolicy>


### PR DESCRIPTION
Makes the result of `casting string with numeric suffix to real/double` consistent with spark.


In Java, when parsing string to float/double, the opt [FfDd]? suffix will be skipped.
https://github.com/openjdk/jdk/blob/f4305923fb6203089fd13cf3387c81e127ae5fe2/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java#L1409-L1412

closes #15533