### PR TITLE
refactor: Remove enableConstantFolding flag from ExprCompiler

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -739,7 +739,7 @@ class ExprSet {
   explicit ExprSet(
       const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* execCtx,
-      bool enableConstantFolding = true,
+      bool optimize = true,
       bool lazyDereference = false);
 
   virtual ~ExprSet();
@@ -842,7 +842,7 @@ class ExprSetSimplified : public ExprSet {
   ExprSetSimplified(
       const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* execCtx)
-      : ExprSet(source, execCtx, /*enableConstantFolding*/ false) {}
+      : ExprSet(source, execCtx, /*optimize*/ false) {}
 
   virtual ~ExprSetSimplified() override {}
 

--- a/velox/expression/ExprCompiler.h
+++ b/velox/expression/ExprCompiler.h
@@ -28,7 +28,6 @@ class ExprSet;
 std::vector<std::shared_ptr<Expr>> compileExpressions(
     const std::vector<core::TypedExprPtr>& sources,
     core::ExecCtx* execCtx,
-    ExprSet* exprSet,
-    bool enableConstantFolding = true);
+    ExprSet* exprSet);
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Context:

The ExprSet ctor has enableConstantFolding argument, which controls whether to constant fold input expression.
  
With the addition of ExprOptimizer, the input expression is now optimized with a combination of constant folding and logical rewrites using the ExprOptimizer::optimize() API. The optimization is invoked only when enableConstantFolding = true. 

ExprSet is constructed with enableConstantFolding = false only in exec::tryEvaluateConstantExpression() in order to prevent the infinite loop: ExprOptimizer::optimize() -> tryEvaluateConstantExpression() -> ExprSet() -> ExprCompiler::compileExpressions() -> ExprOptimizer::optimize(). 

Changes:

- Rename enableConstantFolding to optimize for clarity.
- Move enableConstantFolding argument to ExprSet ctor (from ExprCompiler::compileExpressions()). 