### PR TITLE
refactor: Mark ExprToSubfieldFilterParser::toSubfieldFilter API as test-only

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -541,6 +541,7 @@ PrestoExprToSubfieldFilterParser::toSubfieldFilter(
   if (expr->isCallKind();
       auto* call = expr->asUnchecked<core::CallTypedExpr>()) {
     if (call->name() == "or") {
+      VELOX_CHECK_EQ(call->inputs().size(), 2);
       auto left = toSubfieldFilter(call->inputs()[0], evaluator);
       auto right = toSubfieldFilter(call->inputs()[1], evaluator);
       VELOX_CHECK(left.first == right.first);
@@ -548,6 +549,7 @@ PrestoExprToSubfieldFilterParser::toSubfieldFilter(
           std::move(left.first),
           makeOrFilter(std::move(left.second), std::move(right.second))};
     }
+
     common::Subfield subfield;
     std::unique_ptr<common::Filter> filter;
     if (call->name() == "not") {

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -424,6 +424,8 @@ class ExprToSubfieldFilterParser {
     parser_ = std::move(parser);
   }
 
+  /// Test-only API. Do not use in production code.
+  ///
   /// Analyzes 'expr' to determine if it can be expressed as a subfield filter.
   /// Returns a pair of subfield and filter if so. Otherwise, throws.
   ///


### PR DESCRIPTION
Summary:
ExprToSubfieldFilterParser::toSubfieldFilter is used only in PlanBuilder and in velox/exec/tests/FilterToExpressionTest.cpp. 

It would be nice to move this API into PlanBuilder and remove its usage from FilterToExpressionTest.

The implementation had a bug where it would drop disjuncts from an OR that has > 2 inputs. Added a check to fail in this case instead of producing wrong results.

Differential Revision: D87343576


