### PR TITLE
perf: Use Folly implementation of memcpy and memset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -626,6 +626,7 @@ velox_resolve_dependency(FastFloat)
 
 velox_set_source(folly)
 velox_resolve_dependency(folly)
+add_definitions(-DFOLLY_MEMCPY_IS_MEMCPY -DFOLLY_MEMSET_IS_MEMSET)
 
 if(${VELOX_BUILD_TESTING})
   # Spark query runner depends on absl, gRPC.


### PR DESCRIPTION
Summary:
We observe 30% CPU reduction on some queries using Folly's
implementations.  Ensure we use it in Velox by default.

Differential Revision: D87346461


