### PR TITLE
feat: Add map to struct pushdown support to file readers

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -27,6 +27,8 @@
 
 namespace facebook::velox::dwio::common {
 
+using ScanSpec = velox::common::ScanSpec;
+
 /// Generalized representation of a set of distinct values for dictionary
 /// encodings.
 struct DictionaryValues {

--- a/velox/dwio/common/TypeWithId.h
+++ b/velox/dwio/common/TypeWithId.h
@@ -97,4 +97,6 @@ class TypeWithId : public velox::Tree<std::shared_ptr<const TypeWithId>> {
   const std::vector<std::shared_ptr<const TypeWithId>> children_;
 };
 
+using TypeWithIdPtr = std::shared_ptr<const TypeWithId>;
+
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -99,6 +99,10 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
         return createSelectiveFlatMapColumnReader(
             columnReaderOptions, requestedType, fileType, params, scanSpec);
       }
+      if (scanSpec.isFlatMapAsStruct()) {
+        return std::make_unique<SelectiveMapAsStructColumnReader>(
+            columnReaderOptions, requestedType, fileType, params, scanSpec);
+      }
       return std::make_unique<SelectiveMapColumnReader>(
           columnReaderOptions, requestedType, fileType, params, scanSpec);
     case TypeKind::REAL:

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -153,8 +153,6 @@ void MapColumnReader::seekToRowGroup(int64_t index) {
   BufferPtr noBuffer;
   formatData_->as<ParquetData>().setNulls(noBuffer, 0);
   lengths_.setLengths(nullptr);
-  keyReader_->seekToRowGroup(index);
-  elementReader_->seekToRowGroup(index);
 }
 
 void MapColumnReader::skipUnreadLengths() {


### PR DESCRIPTION
Summary: This is a fallback mode to read flatmap as struct.  It is not used in Presto but needed in other ML compute engines.

Differential Revision: D87095482


