### PR TITLE
fix: Do not request data size if there is only  a single source as in persistent shuffle and add query config

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -686,6 +686,12 @@ class QueryConfig {
   static constexpr const char* kStreamingAggregationEagerFlush =
       "streaming_aggregation_eager_flush";
 
+  // If true, skip request data size if there is only single source.
+  // This is used to optimize the Presto-on-Spark use case where each
+  // exchange client has only one shuffle partition source.
+  static constexpr const char* kSkipRequestDataSizeWithSingleSourceEnabled =
+      "skip_request_data_size_with_single_source_enabled";
+
   /// If this is true, then it allows you to get the struct field names
   /// as json element names when casting a row to json.
   static constexpr const char* kFieldNamesInJsonCastEnabled =
@@ -1288,6 +1294,10 @@ class QueryConfig {
 
   int32_t streamingAggregationMinOutputBatchRows() const {
     return get<int32_t>(kStreamingAggregationMinOutputBatchRows, 0);
+  }
+
+  bool singleSourceExchangeOptimizationEnabled() const {
+    return get<bool>(kSkipRequestDataSizeWithSingleSourceEnabled, false);
   }
 
   bool isFieldNamesInJsonCastEnabled() const {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -251,4 +251,33 @@ TEST_F(QueryConfigTest, sessionStartTime) {
   }
 }
 
+TEST_F(QueryConfigTest, singleSourceExchangeOptimizationConfig) {
+  // Test default value (should be false)
+  {
+    auto queryCtx = QueryCtx::create(nullptr, QueryConfig{{}});
+    const QueryConfig& config = queryCtx->queryConfig();
+    EXPECT_FALSE(config.singleSourceExchangeOptimizationEnabled());
+  }
+
+  // Test with optimization enabled
+  {
+    std::unordered_map<std::string, std::string> configData(
+        {{QueryConfig::kSkipRequestDataSizeWithSingleSourceEnabled, "true"}});
+    auto queryCtx =
+        QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+    const QueryConfig& config = queryCtx->queryConfig();
+    EXPECT_TRUE(config.singleSourceExchangeOptimizationEnabled());
+  }
+
+  // Test with optimization explicitly disabled
+  {
+    std::unordered_map<std::string, std::string> configData(
+        {{QueryConfig::kSkipRequestDataSizeWithSingleSourceEnabled, "false"}});
+    auto queryCtx =
+        QueryCtx::create(nullptr, QueryConfig{std::move(configData)});
+    const QueryConfig& config = queryCtx->queryConfig();
+    EXPECT_FALSE(config.singleSourceExchangeOptimizationEnabled());
+  }
+}
+
 } // namespace facebook::velox::core::test

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -106,6 +106,12 @@ Generic Configuration
        client. Enforced approximately, not strictly. A larger size can increase network throughput
        for larger clusters and thus decrease query processing time at the expense of reducing the
        amount of memory available for other usage.
+   * - skip_request_data_size_with_single_source_enabled
+     - bool
+     - false
+     -  If true, skip request data size if there is only single source.
+        This is used to optimize the Presto-on-Spark use case where each exchange client
+        has only one shuffle partition source.
    * - local_merge_source_queue_size
      - integer
      - 2

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -185,7 +185,7 @@ void ExchangeClient::request(std::vector<RequestSpec>&& requestSpecs) {
                 RECORD_METRIC_VALUE(kMetricExchangeDataCount);
               }
 
-              bool pauseCurrentSource = false;
+              bool pauseCurrentSource{false};
               std::vector<RequestSpec> requestSpecs;
               std::shared_ptr<ExchangeSource> currentSource = spec.source;
               {
@@ -231,6 +231,9 @@ std::vector<ExchangeClient::RequestSpec>
 ExchangeClient::pickSourcesToRequestLocked() {
   if (closed_) {
     return {};
+  }
+  if (skipRequestDataSizeWithSingleSource()) {
+    return pickupSingleSourceToRequestLocked();
   }
   std::vector<RequestSpec> requestSpecs;
   while (!emptySources_.empty()) {
@@ -280,6 +283,43 @@ ExchangeClient::pickSourcesToRequestLocked() {
     producingSources_.pop();
     totalPendingBytes_ += requestBytes;
   }
+  return requestSpecs;
+}
+
+std::vector<ExchangeClient::RequestSpec>
+ExchangeClient::pickupSingleSourceToRequestLocked() {
+  VELOX_CHECK_EQ(sources_.size(), 1);
+  VELOX_CHECK(!closed_);
+  if (emptySources_.empty() && producingSources_.empty()) {
+    return {};
+  }
+
+  VELOX_CHECK_EQ(totalPendingBytes_, 0);
+  VELOX_CHECK_LE(!!emptySources_.empty() + !!producingSources_.empty(), 1);
+  const auto requestBytes = maxQueuedBytes_ - queue_->totalBytes();
+
+  if (requestBytes <= 0) {
+    return {};
+  }
+  std::vector<RequestSpec> requestSpecs;
+  SCOPE_EXIT {
+    totalPendingBytes_ += requestBytes;
+  };
+  if (!emptySources_.empty()) {
+    VELOX_CHECK_EQ(emptySources_.size(), 1);
+    auto& source = emptySources_.front();
+    VELOX_CHECK(source->shouldRequestLocked());
+    requestSpecs.push_back({std::move(source), requestBytes});
+    emptySources_.pop();
+    return requestSpecs;
+  }
+
+  VELOX_CHECK_EQ(producingSources_.size(), 1);
+  auto& source = producingSources_.front().source;
+  VELOX_CHECK(source->shouldRequestLocked());
+  VELOX_CHECK(!producingSources_.front().remainingBytes.empty());
+  requestSpecs.push_back({std::move(source), requestBytes});
+  producingSources_.pop();
   return requestSpecs;
 }
 

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -36,7 +36,8 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
       uint64_t minOutputBatchBytes,
       memory::MemoryPool* pool,
       folly::Executor* executor,
-      int32_t requestDataSizesMaxWaitSec = 10)
+      int32_t requestDataSizesMaxWaitSec = 10,
+      bool skipRequestDataSizeWithSingleSource = false)
       : taskId_{std::move(taskId)},
         destination_(destination),
         maxQueuedBytes_{maxQueuedBytes},
@@ -53,7 +54,9 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
         // ExchangeQueue 'minOutputBatchBytes' to be be 0 so that it always
         // unblocks. In short, 0 has a special meaning for ExchangeQueue
         minOutputBatchBytes_(
-            std::max(static_cast<uint64_t>(1), minOutputBatchBytes)) {
+            std::max(static_cast<uint64_t>(1), minOutputBatchBytes)),
+        skipRequestDataSizeWithSingleSource_(
+            skipRequestDataSizeWithSingleSource) {
     VELOX_CHECK_NOT_NULL(pool_);
     VELOX_CHECK_NOT_NULL(executor_);
     // NOTE: the executor is used to run async response callback from the
@@ -132,9 +135,34 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
     std::vector<int64_t> remainingBytes;
   };
 
+  // Selects exchange sources to request data from based on available queue
+  // capacity. Handles multiple sources by first requesting data sizes from all
+  // empty sources, then requesting actual data from producing sources based on
+  // their remaining bytes and available capacity. May initiate out-of-band
+  // transfers for large pages that exceed capacity to avoid deadlock
+  // situations. For single source case, delegates to
+  // pickupSingleSourceToRequestLocked which sets max request bytes based on
+  // available queue space instead of reported remaining bytes from exchange
+  // sources.
   std::vector<RequestSpec> pickSourcesToRequestLocked();
 
+  // Specialized single-source request picker for single-source exchange
+  // clients. Sets the max request bytes based on available space in the queue
+  // rather than the reported remaining bytes from exchange sources. The reason
+  // is that single source has no other alternative so just fetch as much as
+  // possible from that source. Returns a request spec for the single source
+  // when there is available capacity in the queue and no pending requests. If
+  // capacity is unavailable or requests are already pending, returns empty
+  // vector.
+  std::vector<RequestSpec> pickupSingleSourceToRequestLocked();
   void request(std::vector<RequestSpec>&& requestSpecs);
+
+  /// Returns true if skip request data size optimization is enabled for single
+  /// source exchanges.
+  bool skipRequestDataSizeWithSingleSource() const {
+    return skipRequestDataSizeWithSingleSource_ && queue_->hasNoMoreSources() &&
+        sources_.size() == 1;
+  }
 
   // Handy for ad-hoc logging.
   const std::string taskId_;
@@ -153,6 +181,10 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   // The minimum byte size the consumer is expected to consume from
   // the exchange queue.
   const uint64_t minOutputBatchBytes_;
+
+  // Enable single source exchange optimization query config flag
+  // when there is only one exchange source.
+  const bool skipRequestDataSizeWithSingleSource_;
 
   // Total number of bytes in flight.
   int64_t totalPendingBytes_{0};

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -162,6 +162,10 @@ class ExchangeQueue {
 
   void noMoreSources();
 
+  bool hasNoMoreSources() const {
+    return noMoreSources_;
+  }
+
   void close();
 
  private:
@@ -216,7 +220,7 @@ class ExchangeQueue {
 
   int numCompleted_{0};
   int numSources_{0};
-  bool noMoreSources_{false};
+  tsan_atomic<bool> noMoreSources_{false};
   bool atEnd_{false};
 
   std::mutex mutex_;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3427,7 +3427,8 @@ void Task::createExchangeClientLocked(
       queryCtx()->queryConfig().minExchangeOutputBatchBytes(),
       addExchangeClientPool(planNodeId, pipelineId),
       queryCtx()->executor(),
-      queryCtx()->queryConfig().requestDataSizesMaxWaitSec());
+      queryCtx()->queryConfig().requestDataSizesMaxWaitSec(),
+      queryCtx()->queryConfig().singleSourceExchangeOptimizationEnabled());
   exchangeClientByPlanNode_.emplace(planNodeId, exchangeClients_[pipelineId]);
 }
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -589,7 +589,7 @@ TEST_P(ExchangeClientTest, acknowledge) {
   SCOPED_TESTVALUE_SET(
       "facebook::velox::exec::test::LocalExchangeSource::pause",
       std::function<void(void*)>(([&numberOfAcknowledgeRequests](void*) {
-        numberOfAcknowledgeRequests++;
+        ++numberOfAcknowledgeRequests;
       })));
 
   {
@@ -665,7 +665,7 @@ TEST_P(ExchangeClientTest, acknowledge) {
     int attempts = 100;
     bool outputBuffersEmpty;
     while (attempts > 0) {
-      attempts--;
+      --attempts;
       outputBuffersEmpty = bufferManager_->getUtilization(sourceTaskId) == 0;
       if (outputBuffersEmpty) {
         break;
@@ -979,13 +979,116 @@ TEST_P(ExchangeClientTest, minOutputBatchBytesMultipleConsumers) {
   client->close();
 }
 
+TEST_P(ExchangeClientTest, skipRequestDataSizeWithSingleSource) {
+  // Test skipRequestDataSizeWithSingleSource flag behavior
+
+  struct {
+    bool skipEnabled;
+
+    std::string debugString() const {
+      return fmt::format("skipEnabled={}", skipEnabled);
+    }
+  } testSettings[] = {
+      // skip enabled
+      {true},
+      // skip disabled
+      {false}};
+
+  for (const auto& setting : testSettings) {
+    SCOPED_TRACE(setting.debugString());
+
+    auto client = std::make_shared<ExchangeClient>(
+        "test-" + setting.debugString(),
+        17,
+        1024,
+        1,
+        kDefaultMinExchangeOutputBatchBytes,
+        pool(),
+        executor(),
+        10,
+        setting.skipEnabled);
+
+    client->close();
+  }
+}
+
+TEST_P(ExchangeClientTest, skipRequestDataSizeNotTriggeredWithMultipleSources) {
+  // Test that optimization is NOT triggered with multiple sources
+
+  auto data = makeRowVector({makeFlatVector<int64_t>(100, folly::identity)});
+  auto page = test::toSerializedPage(data, serdeKind_, bufferManager_, pool());
+
+  // Client with optimization ENABLED but multiple sources
+  auto client = std::make_shared<ExchangeClient>(
+      "test-multi-source",
+      17,
+      page->size() * 10,
+      1,
+      kDefaultMinExchangeOutputBatchBytes,
+      pool(),
+      executor(),
+      10,
+      // enableSingleSourceOptimization = true (but won't trigger with
+      // multiple sources)
+      true);
+
+  // Setup: Create tasks with TWO sources
+  std::vector<std::shared_ptr<Task>> tasks;
+  for (int i = 0; i < 2; ++i) {
+    auto taskId = fmt::format("local://test-source-{}", i);
+    auto task = makeTask(taskId);
+    bufferManager_->initializeTask(
+        task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
+
+    // Enqueue data
+    for (int j = 0; j < 3; ++j) {
+      enqueue(taskId, 17, data);
+    }
+
+    tasks.push_back(task);
+    client->addRemoteTaskId(taskId);
+  }
+
+  client->noMoreRemoteTasks();
+
+  // Fetch pages - should work with regular path (not single source
+  // optimization)
+  // 3 pages from each of 2 sources
+  auto pages = fetchPages(1, *client, 6);
+  ASSERT_EQ(pages.size(), 6);
+
+  // Cleanup
+  for (auto& task : tasks) {
+    task->requestCancel();
+    bufferManager_->removeTask(task->taskId());
+  }
+
+  client->close();
+}
+
+// Test the new hasNoMoreSources() API
+TEST_P(ExchangeClientTest, hasNoMoreSourcesApi) {
+  auto queue = std::make_shared<ExchangeQueue>(1, 0);
+
+  // Initially, should return false
+  EXPECT_FALSE(queue->hasNoMoreSources());
+
+  // After calling noMoreSources(), should return true
+  queue->noMoreSources();
+
+  EXPECT_TRUE(queue->hasNoMoreSources());
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ExchangeClientTest,
     ExchangeClientTest,
     testing::Values(
         VectorSerde::Kind::kPresto,
         VectorSerde::Kind::kCompactRow,
-        VectorSerde::Kind::kUnsafeRow));
+        VectorSerde::Kind::kUnsafeRow),
+    [](const testing::TestParamInfo<VectorSerde::Kind>& info) {
+      return fmt::format("{}", info.param);
+    });
 
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Sequel of D86278872 and D85647156
This diff's addition:
- implemented cleaner exposure of nomoresources through exchangequeue with api access, tsan fix
- add query config to enable this flag in sapphire velox (default: disabled)
- note that in production this diff won't be in effect as it is disabled unless otherwise enabled in query config

optimization logic in D85647156
no more sources flag setting logic credit D86278872

Differential Revision: D87038056


