### PR TITLE
fix: Unregister special forms SWITCH rewrite

### DIFF
--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -25,7 +25,6 @@
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/SwitchExpr.h"
-#include "velox/expression/SwitchRewrite.h"
 #include "velox/expression/TryExpr.h"
 
 namespace facebook::velox::exec {
@@ -55,6 +54,5 @@ void registerFunctionCallToSpecialForms() {
 
   expression::CoalesceRewrite::registerRewrite();
   expression::ConjunctRewrite::registerRewrite();
-  expression::SwitchRewrite::registerRewrite();
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/SwitchRewriteTest.cpp
+++ b/velox/expression/tests/SwitchRewriteTest.cpp
@@ -25,25 +25,36 @@ class SwitchRewriteTest : public expression::test::SpecialFormRewriteTestBase {
 };
 
 TEST_F(SwitchRewriteTest, basic) {
-  testRewrite("if(true, 'hello', 'world')", "'hello'");
-  testRewrite("case when false then 1 when true then 3 end", "3");
-  testRewrite("case when false then 1 when false then 3 end", "null::bigint");
-  testRewrite("case when false then 1 when false then 3 else 2 end", "2");
+  testRewrite("if(true, 'hello', 'world')", "if(true, 'hello', 'world')");
+  testRewrite(
+      "case when false then 1 when true then 3 end",
+      "case when false then 1 when true then 3 end");
+  testRewrite(
+      "case when false then 1 when false then 3 end",
+      "case when false then 1 when false then 3 end");
+  testRewrite(
+      "case when false then 1 when false then 3 else 2 end",
+      "case when false then 1 when false then 3 else 2 end");
   testRewrite(
       "case when false then 'hello' when false then 'world' when true then 'foo' else 'bar' end",
-      "'foo'");
+      "case when false then 'hello' when false then 'world' when true then 'foo' else 'bar' end");
 
   const auto type = ROW({"a"}, {BIGINT()});
-  testRewrite("case when false then 1234 when true then a end", "a", type);
   testRewrite(
-      "case when false then 1234 when false then 3456 else a end", "a", type);
+      "case when false then 1234 when true then a end",
+      "case when false then 1234 when true then a end",
+      type);
+  testRewrite(
+      "case when false then 1234 when false then 3456 else a end",
+      "case when false then 1234 when false then 3456 else a end",
+      type);
   testRewrite(
       "case when false then 100 when a > 2 then 200 when a > 4 then 300 else 5678 end",
-      "case when a > 2 then 200 when a > 4 then 300 else 5678 end",
+      "case when false then 100 when a > 2 then 200 when a > 4 then 300 else 5678 end",
       type);
   testRewrite(
       "case when a < 5 then 1234 when a > 10 then 3456 when true then 6789 else 0 end",
-      "case when a < 5 then 1234 when a > 10 then 3456 else 6789 end",
+      "case when a < 5 then 1234 when a > 10 then 3456 when true then 6789 else 0 end",
       type);
 }
 


### PR DESCRIPTION
Summary:
SWITCH rewrite has correctness issues identified by expression fuzzer and causes behavior mismatch.

More information and investigation can be found here: https://github.com/facebookincubator/velox/issues/15486

Differential Revision: D87355432


