### PR TITLE
feat: Add KHyperloglog Scalar UDFs

### DIFF
--- a/velox/common/hyperloglog/HllAccumulator.h
+++ b/velox/common/hyperloglog/HllAccumulator.h
@@ -31,6 +31,9 @@ namespace facebook::velox::common::hll {
 namespace detail {
 template <typename T, bool HllAsFinalResult>
 inline uint64_t hashOne(const T& value) {
+  if constexpr (std::is_same_v<T, Timestamp>) {
+    return hashOne<int64_t, HllAsFinalResult>(value.toMillis());
+  }
   if constexpr (HllAsFinalResult) {
     if constexpr (std::is_same_v<T, int64_t>) {
       return common::hll::Murmur3Hash128::hash64ForLong(value, 0);
@@ -42,17 +45,6 @@ inline uint64_t hashOne(const T& value) {
   } else {
     return XXH64(&value, sizeof(T), 0);
   }
-}
-
-// Use timestamp.toMillis() to compute hash value.
-template <>
-inline uint64_t hashOne<Timestamp, false>(const Timestamp& value) {
-  return hashOne<int64_t, false>(value.toMillis());
-}
-
-template <>
-inline uint64_t hashOne<Timestamp, true>(const Timestamp& /*value*/) {
-  VELOX_UNREACHABLE("approx_set(timestamp) is not supported.");
 }
 
 template <>
@@ -67,21 +59,62 @@ inline uint64_t hashOne<StringView, true>(const StringView& value) {
 
 } // namespace detail
 
-template <typename T, bool HllAsFinalResult>
+template <
+    typename T,
+    bool HllAsFinalResult,
+    typename TAllocator = HashStringAllocator>
 struct HllAccumulator {
-  explicit HllAccumulator(HashStringAllocator* allocator)
+  explicit HllAccumulator(TAllocator* allocator)
       : sparseHll_{allocator}, denseHll_{allocator} {}
+
+  explicit HllAccumulator(int8_t indexBitLength, TAllocator* allocator)
+      : isSparse_(true),
+        indexBitLength_(indexBitLength),
+        sparseHll_(allocator),
+        denseHll_(allocator) {
+    // Set soft memory limit for sparse HLL to convert to dense when exceeded.
+    sparseHll_.setSoftMemoryLimit(
+        DenseHlls::estimateInMemorySize(indexBitLength_));
+  }
 
   void setIndexBitLength(int8_t indexBitLength) {
     indexBitLength_ = indexBitLength;
     sparseHll_.setSoftMemoryLimit(
-        common::hll::DenseHlls::estimateInMemorySize(indexBitLength_));
+        DenseHlls::estimateInMemorySize(indexBitLength_));
+  }
+
+  /// Creates an HllAccumulator instance from serialized data.
+  static std::unique_ptr<HllAccumulator> deserialize(
+      const char* data,
+      TAllocator* allocator) {
+    if (SparseHlls::canDeserialize(data)) {
+      int8_t indexBitLength = SparseHlls::deserializeIndexBitLength(data);
+      auto wrapper =
+          std::make_unique<HllAccumulator>(indexBitLength, allocator);
+      wrapper->sparseHll_ = SparseHll<TAllocator>(data, allocator);
+      wrapper->sparseHll_.setSoftMemoryLimit(
+          DenseHlls::estimateInMemorySize(indexBitLength));
+      return wrapper;
+    } else if (DenseHlls::canDeserialize(data)) {
+      int8_t indexBitLength = DenseHlls::deserializeIndexBitLength(data);
+      auto wrapper =
+          std::make_unique<HllAccumulator>(indexBitLength, allocator);
+      wrapper->denseHll_ = DenseHll<TAllocator>(data, allocator);
+      wrapper->isSparse_ = false;
+      return wrapper;
+    } else {
+      VELOX_FAIL("Cannot deserialize HyperLogLog");
+    }
   }
 
   void append(T value) {
     const auto hash = detail::hashOne<T, HllAsFinalResult>(value);
+    insertHash(hash);
+  }
 
+  void insertHash(uint64_t hash) {
     if (isSparse_) {
+      // insertHash returns true if soft memory limit exceeded
       if (sparseHll_.insertHash(hash)) {
         toDense();
       }
@@ -94,33 +127,32 @@ struct HllAccumulator {
     return isSparse_ ? sparseHll_.cardinality() : denseHll_.cardinality();
   }
 
-  void mergeWith(StringView serialized, HashStringAllocator* allocator) {
+  void mergeWith(StringView serialized, TAllocator* allocator) {
     auto input = serialized.data();
-    if (common::hll::SparseHlls::canDeserialize(input)) {
-      if (isSparse_) {
-        sparseHll_.mergeWith(input);
-        if (indexBitLength_ < 0) {
-          setIndexBitLength(
-              common::hll::DenseHlls::deserializeIndexBitLength(input));
-        }
-        if (sparseHll_.overLimit()) {
-          toDense();
-        }
-      } else {
-        common::hll::SparseHll<> other{input, allocator};
-        other.toDense(denseHll_);
-      }
-    } else if (common::hll::DenseHlls::canDeserialize(input)) {
-      if (isSparse_) {
-        if (indexBitLength_ < 0) {
-          setIndexBitLength(
-              common::hll::DenseHlls::deserializeIndexBitLength(input));
-        }
-        toDense();
-      }
-      denseHll_.mergeWith(input);
+    if (indexBitLength_ < 0) {
+      // deserializeIndexBitLength is the same between Dense and Sparse HLL
+      setIndexBitLength(DenseHlls::deserializeIndexBitLength(input));
+    }
+
+    if (SparseHlls::canDeserialize(input)) {
+      SparseHll<TAllocator> other{input, allocator};
+      mergeWithSparse(other);
+    } else if (DenseHlls::canDeserialize(input)) {
+      DenseHll<TAllocator> other{input, allocator};
+      mergeWithDense(other);
     } else {
       VELOX_USER_FAIL("Unexpected type of HLL");
+    }
+  }
+
+  void mergeWith(const HllAccumulator& other) {
+    if (indexBitLength_ < 0) {
+      setIndexBitLength(other.indexBitLength_);
+    }
+    if (other.isSparse_) {
+      mergeWithSparse(other.sparseHll_);
+    } else {
+      mergeWithDense(other.denseHll_);
     }
   }
 
@@ -133,6 +165,10 @@ struct HllAccumulator {
                      : denseHll_.serialize(outputBuffer);
   }
 
+  bool isSparse() const {
+    return isSparse_;
+  }
+
  private:
   void toDense() {
     isSparse_ = false;
@@ -141,10 +177,28 @@ struct HllAccumulator {
     sparseHll_.reset();
   }
 
+  void mergeWithSparse(const SparseHll<TAllocator>& other) {
+    if (isSparse_) {
+      sparseHll_.mergeWith(other);
+      if (sparseHll_.overLimit()) {
+        toDense();
+      }
+    } else {
+      other.toDense(denseHll_);
+    }
+  }
+
+  void mergeWithDense(const DenseHll<TAllocator>& other) {
+    if (isSparse_) {
+      toDense();
+    }
+    denseHll_.mergeWith(other);
+  }
+
   bool isSparse_{true};
   int8_t indexBitLength_{-1};
-  common::hll::SparseHll<> sparseHll_;
-  common::hll::DenseHll<> denseHll_;
+  SparseHll<TAllocator> sparseHll_;
+  DenseHll<TAllocator> denseHll_;
 };
 
 template <>
@@ -187,5 +241,4 @@ struct HllAccumulator<bool, false> {
  private:
   int8_t approxDistinctState_{0};
 };
-
 } // namespace facebook::velox::common::hll

--- a/velox/common/hyperloglog/KHyperLogLog.h
+++ b/velox/common/hyperloglog/KHyperLogLog.h
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <map>
+#include <memory>
+
+#include <folly/container/F14Map.h>
+#include "velox/common/hyperloglog/HllAccumulator.h"
+
+namespace facebook::velox::common::hll {
+
+/// See "KHyperLogLog: EstimatingReidentifiability and Joinability of Large Data
+/// at Scale" by Chia et al., 2019.
+/// https://research.google/pubs/khyperloglog-estimating-reidentifiability-and-joinability-of-large-data-at-scale/
+template <typename TUii, typename TAllocator>
+class KHyperLogLog {
+ public:
+  template <typename U>
+  using TStlAllocator = typename TAllocator::template TStlAllocator<U>;
+
+  static constexpr int32_t kDefaultHllBuckets = 256;
+  static constexpr int32_t kDefaultMaxSize = 4096;
+  static constexpr int64_t kDefaultHistogramSize = 256;
+
+  explicit KHyperLogLog(TAllocator* allocator)
+      : KHyperLogLog(kDefaultMaxSize, kDefaultHllBuckets, allocator) {}
+
+  KHyperLogLog(int maxSize, int hllBuckets, TAllocator* allocator)
+      : maxSize_(maxSize),
+        hllBuckets_(hllBuckets),
+        allocator_(allocator),
+        minhash_(
+            TStlAllocator<std::pair<
+                const int64_t,
+                HllAccumulator<TUii, true, TAllocator>>>(allocator)) {
+    VELOX_CHECK(
+        hllBuckets > 0 && (hllBuckets & (hllBuckets - 1)) == 0,
+        "hllBuckets must be a power of 2");
+    // numBuckets = 2^bits
+    indexBitLength_ = static_cast<int8_t>(std::log2(hllBuckets));
+  }
+
+  /// Creates a KHyperLogLog instance from serialized data.
+  static std::unique_ptr<KHyperLogLog<TUii, TAllocator>>
+  deserialize(const char* data, size_t size, TAllocator* allocator);
+
+  /// Serializes the KHyperLogLog state to a varbinary.
+  /// The caller must ensure there is enough space at the buffer location, using
+  /// estimatedSerializedSize(). Note: Not const because DenseHll::serialize()
+  /// may reorder internal overflow arrays for deterministic serialization.
+  void serialize(char* outputBuffer);
+
+  /// Returns an estimate of the size in bytes of the serialized
+  /// representation.
+  size_t estimatedSerializedSize() const;
+
+  /// Convert JoinKey to int64_t, hash, then add with its associated User
+  /// Identifying Information (UII) to the existing KHLL.
+  template <typename TJoinKey>
+  void add(TJoinKey joinKey, TUii uii);
+
+  /// Returns the estimated cardinality (number of distinct join keys).
+  /// When isExact() is true, returns exact count. Otherwise, uses min-hash
+  /// density estimation to extrapolate to the full hash space.
+  int64_t cardinality() const;
+
+  /// Returns whether the KHyperLogLog is in exact mode.
+  /// Exact mode means the number of distinct values is less than maxSize,
+  /// so all values are being tracked exactly without approximation.
+  bool isExact() const;
+
+  size_t minhashSize() const;
+
+  /// Counts the exact number of common join keys between two KHyperLogLogs.
+  /// Both instances must be in exact mode (isExact() == true), otherwise
+  /// throws.
+  static int64_t exactIntersectionCardinality(
+      const KHyperLogLog<TUii, TAllocator>& left,
+      const KHyperLogLog<TUii, TAllocator>& right);
+
+  /// Computes the Jaccard index (similarity coefficient) between two
+  /// KHyperLogLogs. Uses the min-hash approach: looks at the first
+  /// min(|left.minhash|, |right.minhash|) entries in the sorted union of keys
+  /// and calculates the proportion that appear in both sets.
+  static double jaccardIndex(
+      const KHyperLogLog<TUii, TAllocator>& left,
+      const KHyperLogLog<TUii, TAllocator>& right);
+
+  /// Merges two KHyperLogLog instances into a new instance.
+  /// Uses the one with the smaller maxSize as the base to avoid losing
+  /// resolution. Takes ownership of the input unique_ptrs and returns one
+  /// of them to avoid copying.
+  static std::unique_ptr<KHyperLogLog<TUii, TAllocator>> merge(
+      std::unique_ptr<KHyperLogLog<TUii, TAllocator>> left,
+      std::unique_ptr<KHyperLogLog<TUii, TAllocator>> right);
+
+  /// Calculates the reidentification potential, which is the proportion of
+  /// values with cardinality (number of distinct UIIs) at or below the given
+  /// threshold. A higher value indicates more values are highly unique and
+  /// could potentially be used to reidentify individuals.
+  double reidentificationPotential(int64_t threshold) const;
+
+  /// Returns a histogram of the uniqueness distribution with specified number
+  /// of buckets. For each value, determines its cardinality (number of distinct
+  /// UIIs) and increments the corresponding bucket. For hash values larger than
+  /// the histogram size, the cardinality will be added to the last bucket at
+  /// histogramSize.
+  folly::F14FastMap<int64_t, double> uniquenessDistribution(
+      int64_t histogramSize) const;
+
+  /// Merges another KHyperLogLog instance into this one (modifies this
+  /// instance).
+  void mergeWith(const KHyperLogLog<TUii, TAllocator>& other);
+
+  /// Merges another serialized KHyperLogLog into this one.
+  void mergeWith(StringView serialized, TAllocator* allocator) {
+    auto other = common::hll::KHyperLogLog<TUii, TAllocator>::deserialize(
+        serialized.data(), serialized.size(), allocator);
+    mergeWith(*other);
+  }
+
+ private:
+  void update(int64_t hash, TUii uii);
+
+  void removeOverflowEntries();
+
+  void increaseTotalHllSize(HllAccumulator<TUii, true, TAllocator>& hll);
+
+  void decreaseTotalHllSize(HllAccumulator<TUii, true, TAllocator>& hll);
+
+  int64_t maxKey() const {
+    if (minhash_.empty()) {
+      return INT64_MIN;
+    }
+    return minhash_.rbegin()->first;
+  }
+
+  int32_t maxSize_;
+  int32_t hllBuckets_;
+  int8_t indexBitLength_;
+  TAllocator* allocator_;
+
+  std::map<
+      int64_t,
+      HllAccumulator<TUii, true, TAllocator>,
+      std::less<int64_t>,
+      TStlAllocator<
+          std::pair<const int64_t, HllAccumulator<TUii, true, TAllocator>>>>
+      minhash_;
+
+  size_t hllsTotalEstimatedSerializedSize_{0};
+};
+
+} // namespace facebook::velox::common::hll
+
+#include "velox/common/hyperloglog/KHyperLogLogImpl.h"

--- a/velox/common/hyperloglog/KHyperLogLogImpl.h
+++ b/velox/common/hyperloglog/KHyperLogLogImpl.h
@@ -1,0 +1,435 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+#include "velox/common/hyperloglog/Murmur3Hash128.h"
+#include "velox/type/HugeInt.h"
+
+namespace facebook::velox::common::hll {
+
+namespace detail {
+constexpr uint8_t kVersionByte = 1;
+constexpr int64_t kHashOutputHalfRange = INT64_MAX;
+constexpr size_t kHeaderSize = sizeof(uint8_t) // version
+    + 4 * sizeof(int32_t); // maxSize, hllBuckets, minhashSize, hllsTotalSize;
+
+template <typename TJoinKey>
+static int64_t hashKey(TJoinKey joinKey) {
+  int64_t result;
+  if constexpr (std::is_same_v<TJoinKey, Timestamp>) {
+    result = joinKey.toMillis();
+  } else if constexpr (
+      std::is_same_v<TJoinKey, int128_t> ||
+      std::is_same_v<TJoinKey, uint128_t>) {
+    return Murmur3Hash128::hash64(&joinKey, sizeof(joinKey), 0);
+  } else if constexpr (std::is_integral_v<TJoinKey>) {
+    result = static_cast<int64_t>(joinKey);
+  } else if constexpr (std::is_same_v<TJoinKey, float>) {
+    // Cast to double first, then extract bits, based on implicit coercion
+    double dbl = static_cast<double>(joinKey);
+    result = *reinterpret_cast<int64_t*>(&dbl);
+  } else if constexpr (std::is_same_v<TJoinKey, double>) {
+    result = *reinterpret_cast<int64_t*>(&joinKey);
+  } else if constexpr (std::is_same_v<TJoinKey, StringView>) {
+    result =
+        common::hll::Murmur3Hash128::hash64(joinKey.data(), joinKey.size(), 0);
+  } else {
+    VELOX_UNREACHABLE("Unsupported input type: {}", typeid(TJoinKey).name());
+  }
+
+  return Murmur3Hash128::hash64(&result, sizeof(result), 0);
+}
+} // namespace detail
+
+template <typename TUii, typename TAllocator>
+std::unique_ptr<KHyperLogLog<TUii, TAllocator>>
+KHyperLogLog<TUii, TAllocator>::deserialize(
+    const char* data,
+    size_t size,
+    TAllocator* allocator) {
+  VELOX_CHECK_GE(size, sizeof(uint8_t), "Invalid KHyperLogLog data: too small");
+
+  InputByteStream stream(data);
+
+  uint8_t version = stream.read<uint8_t>();
+  VELOX_CHECK_EQ(
+      version, detail::kVersionByte, "Unsupported KHyperLogLog version");
+
+  VELOX_CHECK_GE(
+      size,
+      detail::kHeaderSize,
+      "Invalid KHyperLogLog data: insufficient header size");
+
+  // Header values
+  int32_t maxSize = stream.read<int32_t>();
+  int32_t hllBuckets = stream.read<int32_t>();
+  int32_t minhashSize = stream.read<int32_t>();
+  int32_t totalHllSize = stream.read<int32_t>();
+
+  if (minhashSize == 0) {
+    VELOX_CHECK_EQ(
+        totalHllSize,
+        0,
+        "Invalid KHyperLogLog data: minhashSize is 0 but totalHllSize is not 0");
+    size_t remainingSize = size - stream.offset();
+    VELOX_CHECK_EQ(
+        remainingSize,
+        0,
+        "Invalid KHyperLogLog data: minhashSize is 0 but extra data remains");
+    return std::make_unique<KHyperLogLog<TUii, TAllocator>>(
+        maxSize, hllBuckets, allocator);
+  }
+
+  // Validate remaining size.
+  size_t expectedRemainingSize =
+      minhashSize * (sizeof(int32_t) + sizeof(int64_t)) + totalHllSize;
+  size_t remainingSize = size - stream.offset();
+  VELOX_CHECK_GE(
+      remainingSize,
+      expectedRemainingSize,
+      "Invalid KHyperLogLog data: insufficient data for minhash and HLLs");
+
+  // Read HLL sizes.
+  std::vector<int32_t> hllSizes(minhashSize);
+  stream.copyTo(hllSizes.data(), minhashSize);
+
+  // Read keys.
+  std::vector<int64_t> keys(minhashSize);
+  stream.copyTo(keys.data(), minhashSize);
+
+  // Create KHyperLogLog instance.
+  auto result = std::make_unique<KHyperLogLog<TUii, TAllocator>>(
+      maxSize, hllBuckets, allocator);
+
+  // Deserialize HLLs.
+  const char* hllData = data + stream.offset();
+  remainingSize = size - stream.offset();
+
+  size_t sumOfHllSizes = 0;
+  for (int32_t hllSize : hllSizes) {
+    sumOfHllSizes += hllSize;
+  }
+
+  VELOX_CHECK_GE(
+      remainingSize,
+      sumOfHllSizes,
+      "Invalid KHyperLogLog data: insufficient data for HLLs");
+
+  for (int32_t i = 0; i < minhashSize; ++i) {
+    int32_t hllSize = hllSizes[i];
+    int64_t key = keys[i];
+
+    auto hll =
+        HllAccumulator<TUii, true, TAllocator>::deserialize(hllData, allocator);
+    result->increaseTotalHllSize(*hll);
+    result->minhash_.emplace(key, std::move(*hll));
+
+    hllData += hllSize;
+    remainingSize -= hllSize;
+  }
+
+  return result;
+}
+
+template <typename TUii, typename TAllocator>
+void KHyperLogLog<TUii, TAllocator>::serialize(char* outputBuffer) {
+  OutputByteStream stream(outputBuffer);
+
+  // Write version.
+  stream.appendOne<uint8_t>(detail::kVersionByte);
+
+  // Write header.
+  stream.appendOne<int32_t>(maxSize_);
+  stream.appendOne<int32_t>(hllBuckets_);
+  stream.appendOne<int32_t>(static_cast<int32_t>(minhash_.size()));
+
+  // Write the sum of all HLL sizes.
+  int32_t totalHllSize = 0;
+  for (auto& [key, hll] : minhash_) {
+    totalHllSize += hll.serializedSize();
+  }
+  stream.appendOne<int32_t>(totalHllSize);
+
+  // Write HLL sizes in sorted key order. minHash_ is a sorted map, so no
+  // additional sorting is necessary for deterministic serialization.
+  int32_t maxSerializedSize = 0;
+  for (auto& [key, hll] : minhash_) {
+    int32_t hllSerializedSize = hll.serializedSize();
+    stream.appendOne<int32_t>(hllSerializedSize);
+    maxSerializedSize = std::max(maxSerializedSize, hllSerializedSize);
+  }
+
+  // Write keys in sorted order.
+  for (const auto& [key, hll] : minhash_) {
+    stream.appendOne<int64_t>(key);
+  }
+
+  // Write serialized HLLs in sorted key order.
+  std::string hllBuffer(maxSerializedSize, '\0');
+  for (auto& [key, hll] : minhash_) {
+    const_cast<HllAccumulator<TUii, true, TAllocator>&>(hll).serialize(
+        hllBuffer.data());
+    stream.append(hllBuffer.data(), hll.serializedSize());
+  }
+}
+
+template <typename TUii, typename TAllocator>
+size_t KHyperLogLog<TUii, TAllocator>::estimatedSerializedSize() const {
+  return detail::kHeaderSize + // header: version, maxSize, hllBuckets,
+                               // minhashSize, totalHllSize
+      minhash_.size() * sizeof(int32_t) + // individual HLL sizes +
+      minhash_.size() * sizeof(int64_t) + // minhash keys +
+      hllsTotalEstimatedSerializedSize_; // sum of all HLL serialized sizes
+}
+
+template <typename TUii, typename TAllocator>
+template <typename TJoinKey>
+void KHyperLogLog<TUii, TAllocator>::add(TJoinKey joinKey, TUii uii) {
+  update(detail::hashKey(joinKey), uii);
+}
+
+template <typename TUii, typename TAllocator>
+void KHyperLogLog<TUii, TAllocator>::update(int64_t hash, TUii uii) {
+  auto it = minhash_.end();
+  if (!(isExact() || (minhash_.size() > 0 && hash < maxKey()) ||
+        ((it = minhash_.find(hash)) != minhash_.end()))) {
+    return;
+  }
+
+  // Get or create HLL for this hash.
+  HllAccumulator<TUii, true, TAllocator>* hll;
+  if (it == minhash_.end()) {
+    auto [iterator, inserted] = minhash_.emplace(
+        hash,
+        HllAccumulator<TUii, true, TAllocator>(indexBitLength_, allocator_));
+    hll = &iterator->second;
+  } else {
+    hll = &it->second;
+    decreaseTotalHllSize(*hll);
+  }
+
+  hll->append(uii);
+
+  increaseTotalHllSize(*hll);
+  removeOverflowEntries();
+}
+
+template <typename TUii, typename TAllocator>
+int64_t KHyperLogLog<TUii, TAllocator>::cardinality() const {
+  if (isExact()) {
+    return static_cast<int64_t>(minhash_.size());
+  }
+
+  // Estimate cardinality by calculating the average spacing (density) between
+  // stored hash values, then extrapolating to the full hash space.
+  // The hash range is the full 64-bit hash range (2^64) which does not fit in a
+  // double, so both the hash range and the density are halved to keep
+  // proportions mathematically correct. The "-1" is a statistical bias
+  // correction from "On Synopses for Distinct-Value Estimation Under Multiset
+  // Operations" by Beyer et. al.
+  // Use unsigned arithmetic to avoid overflow for large maxKey values.
+  uint64_t hashesRange =
+      static_cast<uint64_t>(maxKey()) - static_cast<uint64_t>(INT64_MIN);
+  double halfDensity =
+      static_cast<double>(hashesRange) / (minhash_.size() - 1) / 2.0;
+  return static_cast<int64_t>(detail::kHashOutputHalfRange / halfDensity);
+}
+
+template <typename TUii, typename TAllocator>
+bool KHyperLogLog<TUii, TAllocator>::isExact() const {
+  return static_cast<int32_t>(minhash_.size()) < maxSize_;
+}
+
+template <typename TUii, typename TAllocator>
+size_t KHyperLogLog<TUii, TAllocator>::minhashSize() const {
+  return minhash_.size();
+}
+
+template <typename TUii, typename TAllocator>
+int64_t KHyperLogLog<TUii, TAllocator>::exactIntersectionCardinality(
+    const KHyperLogLog<TUii, TAllocator>& left,
+    const KHyperLogLog<TUii, TAllocator>& right) {
+  VELOX_CHECK(
+      left.isExact(),
+      "exactIntersectionCardinality cannot operate on approximate sets");
+  VELOX_CHECK(
+      right.isExact(),
+      "exactIntersectionCardinality cannot operate on approximate sets");
+
+  // Optimize by iterating through the smaller map and checking the larger one.
+  const auto& smaller = left.minhash_.size() <= right.minhash_.size()
+      ? left.minhash_
+      : right.minhash_;
+  const auto& larger = left.minhash_.size() <= right.minhash_.size()
+      ? right.minhash_
+      : left.minhash_;
+
+  // Count intersection of keys.
+  int64_t intersectionCnt = 0;
+  for (const auto& [key, hll] : smaller) {
+    if (larger.contains(key)) {
+      intersectionCnt++;
+    }
+  }
+
+  return intersectionCnt;
+}
+
+template <typename TUii, typename TAllocator>
+double KHyperLogLog<TUii, TAllocator>::jaccardIndex(
+    const KHyperLogLog<TUii, TAllocator>& left,
+    const KHyperLogLog<TUii, TAllocator>& right) {
+  if (left.minhash_.empty() && right.minhash_.empty()) {
+    return 1.0;
+  }
+  auto smallerSize = std::min(left.minhash_.size(), right.minhash_.size());
+
+  if (smallerSize == 0) {
+    return 0.0;
+  }
+
+  auto itA = left.minhash_.begin();
+  auto itB = right.minhash_.begin();
+
+  auto intersectionCnt = 0;
+  auto unionCnt = 0;
+
+  // Merge the two sorted sequences, counting intersection along the way.
+  while (itA != left.minhash_.end() && itB != right.minhash_.end() &&
+         unionCnt < smallerSize) {
+    if (itA->first < itB->first) {
+      ++itA;
+    } else if (itB->first < itA->first) {
+      ++itB;
+    } else {
+      intersectionCnt++;
+      ++itA;
+      ++itB;
+    }
+    unionCnt++;
+  }
+
+  return static_cast<double>(intersectionCnt) / smallerSize;
+}
+
+template <typename TUii, typename TAllocator>
+std::unique_ptr<KHyperLogLog<TUii, TAllocator>>
+KHyperLogLog<TUii, TAllocator>::merge(
+    std::unique_ptr<KHyperLogLog<TUii, TAllocator>> left,
+    std::unique_ptr<KHyperLogLog<TUii, TAllocator>> right) {
+  // The KHLL with the smaller K will be used as base. This is because if a KHLL
+  // with a smaller K is merged into a KHLL with a larger K, the smaller KHLL's
+  // minhash will not cover all of the larger minhash's range. Instead, we want
+  // to keep only the smallest K number of HLLs in the new KHLL.
+  if (left->maxSize_ <= right->maxSize_) {
+    left->mergeWith(*right);
+    return std::move(left);
+  } else {
+    right->mergeWith(*left);
+    return std::move(right);
+  }
+}
+
+template <typename TUii, typename TAllocator>
+void KHyperLogLog<TUii, TAllocator>::mergeWith(
+    const KHyperLogLog<TUii, TAllocator>& other) {
+  for (const auto& [key, otherHll] : other.minhash_) {
+    auto it = minhash_.find(key);
+    if (it != minhash_.end()) {
+      decreaseTotalHllSize(it->second);
+      it->second.mergeWith(otherHll);
+      increaseTotalHllSize(it->second);
+    } else {
+      HllAccumulator<TUii, true, TAllocator> newHll(
+          indexBitLength_, allocator_);
+      newHll.mergeWith(otherHll);
+      increaseTotalHllSize(newHll);
+      minhash_.emplace(key, std::move(newHll));
+    }
+  }
+
+  removeOverflowEntries();
+}
+
+template <typename TUii, typename TAllocator>
+double KHyperLogLog<TUii, TAllocator>::reidentificationPotential(
+    int64_t threshold) const {
+  if (minhash_.empty()) {
+    return 0.0;
+  }
+  int64_t highlyUniqueValues = 0;
+
+  for (const auto& [key, hll] : minhash_) {
+    if (hll.cardinality() <= threshold) {
+      highlyUniqueValues++;
+    }
+  }
+
+  return static_cast<double>(highlyUniqueValues) / minhash_.size();
+}
+
+template <typename TUii, typename TAllocator>
+folly::F14FastMap<int64_t, double>
+KHyperLogLog<TUii, TAllocator>::uniquenessDistribution(
+    int64_t histogramSize) const {
+  folly::F14FastMap<int64_t, double> out;
+
+  for (int64_t i = 1; i <= histogramSize; ++i) {
+    out[i] = 0.0;
+  }
+
+  int64_t size = minhash_.size();
+  if (size == 0) {
+    return out;
+  }
+
+  double bucketScale = 1.0 / static_cast<double>(size);
+  for (const auto& [key, hll] : minhash_) {
+    int64_t cardinality = hll.cardinality();
+    int64_t bucket = std::min(cardinality, histogramSize);
+    out[bucket] += bucketScale;
+  }
+
+  return out;
+}
+
+template <typename TUii, typename TAllocator>
+void KHyperLogLog<TUii, TAllocator>::removeOverflowEntries() {
+  while (static_cast<int32_t>(minhash_.size()) > maxSize_) {
+    auto maxIt = std::prev(minhash_.end());
+    if (maxIt != minhash_.end()) {
+      decreaseTotalHllSize(maxIt->second);
+      minhash_.erase(maxIt);
+    }
+  }
+}
+
+template <typename TUii, typename TAllocator>
+void KHyperLogLog<TUii, TAllocator>::increaseTotalHllSize(
+    HllAccumulator<TUii, true, TAllocator>& hll) {
+  hllsTotalEstimatedSerializedSize_ += hll.serializedSize();
+}
+
+template <typename TUii, typename TAllocator>
+void KHyperLogLog<TUii, TAllocator>::decreaseTotalHllSize(
+    HllAccumulator<TUii, true, TAllocator>& hll) {
+  hllsTotalEstimatedSerializedSize_ -= hll.serializedSize();
+}
+
+} // namespace facebook::velox::common::hll

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
+add_executable(
+  velox_common_hyperloglog_test
+  DenseHllTest.cpp
+  SparseHllTest.cpp
+  HllAccumulatorTest.cpp
+)
 
 add_test(NAME velox_common_hyperloglog_test COMMAND velox_common_hyperloglog_test)
 

--- a/velox/common/hyperloglog/tests/HllAccumulatorTest.cpp
+++ b/velox/common/hyperloglog/tests/HllAccumulatorTest.cpp
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/hyperloglog/HllAccumulator.h"
+
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+
+#include <gtest/gtest-typed-test.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::common::hll;
+
+namespace {
+const int8_t kDefaultIndexBitLength = 11;
+const double kDefaultStandardError =
+    1.04 / std::sqrt(1 << kDefaultIndexBitLength);
+} // namespace
+
+template <typename TAllocator>
+class HllAccumulatorTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    if constexpr (std::is_same_v<TAllocator, HashStringAllocator>) {
+      allocator_ = &hsa_;
+    } else {
+      allocator_ = pool_.get();
+    }
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator hsa_{pool_.get()};
+  TAllocator* allocator_{};
+};
+
+using AllocatorTypes =
+    ::testing::Types<HashStringAllocator, memory::MemoryPool>;
+
+class NameGenerator {
+ public:
+  template <typename TAllocator>
+  static std::string GetName(int) {
+    if constexpr (std::is_same_v<TAllocator, HashStringAllocator>) {
+      return "hsa";
+    } else if constexpr (std::is_same_v<TAllocator, memory::MemoryPool>) {
+      return "pool";
+    } else {
+      VELOX_UNREACHABLE(
+          "Only HashStringAllocator and MemoryPool are supported allocator types.");
+    }
+  }
+};
+
+TYPED_TEST_SUITE(HllAccumulatorTest, AllocatorTypes, NameGenerator);
+
+TYPED_TEST(HllAccumulatorTest, basicInt64) {
+  // Test SparseHLL.
+  HllAccumulator<int64_t, false, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int64_t numValues = 100;
+  for (int64_t i = 0; i < numValues; i++) {
+    accumulator.append(i);
+  }
+
+  // Sparse HLL should be exact.
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+
+  // Test DenseHLL.
+  constexpr int64_t numValuesDense = 10000;
+  for (int64_t i = 0; i < numValuesDense; i++) {
+    accumulator.append(i);
+  }
+  EXPECT_NEAR(
+      accumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, basicDouble) {
+  // Test SparseHLL.
+  HllAccumulator<double, true, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int numValues = 150;
+  for (int i = 0; i < numValues; i++) {
+    accumulator.append(static_cast<double>(i) * 1.5);
+  }
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+
+  // Test DenseHLL.
+  constexpr int numValuesDense = 15000;
+  for (int i = numValues; i < numValuesDense; i++) {
+    accumulator.append(static_cast<double>(i) * 1.5);
+  }
+  EXPECT_NEAR(
+      accumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, basicStringView) {
+  // Test SparseHLL.
+  HllAccumulator<StringView, true, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int numValues = 100;
+  std::vector<std::string> strings;
+  strings.reserve(numValues);
+  for (int i = 0; i < numValues; i++) {
+    strings.push_back("value_" + std::to_string(i));
+  }
+  for (const auto& str : strings) {
+    accumulator.append(StringView(str));
+  }
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+
+  // Test DenseHLL.
+  constexpr int numValuesDense = 10000;
+  for (int i = numValues; i < numValuesDense; i++) {
+    strings.push_back("value_" + std::to_string(i));
+  }
+  for (int i = numValues; i < numValuesDense; i++) {
+    accumulator.append(StringView(strings[i]));
+  }
+  EXPECT_NEAR(
+      accumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, serde) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int64_t numValues = 200;
+  for (int64_t i = 0; i < numValues; i++) {
+    accumulator.append(i);
+  }
+
+  auto size = accumulator.serializedSize();
+  std::string serialized(size, '\0');
+  accumulator.serialize(serialized.data());
+
+  auto deserialized = HllAccumulator<int64_t, false, TypeParam>::deserialize(
+      serialized.data(), this->allocator_);
+
+  EXPECT_EQ(deserialized->cardinality(), numValues);
+
+  // Test round trip
+  std::string reserialized(deserialized->serializedSize(), '\0');
+  deserialized->serialize(reserialized.data());
+  EXPECT_EQ(reserialized, serialized);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithBothSparse) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  // Add non-overlapping values that keep both sparse.
+  for (int64_t i = 0; i < 100; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 100; i < 200; i++) {
+    accumulator2.append(i);
+  }
+
+  accumulator1.mergeWith(accumulator2);
+
+  // Resulting accumulator should be sparse and exact.
+  EXPECT_TRUE(accumulator1.isSparse());
+  EXPECT_EQ(accumulator1.cardinality(), 200);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithBothDense) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  // Add non-overlapping values that trigger dense mode.
+  constexpr int64_t numValues = 10000;
+  for (int64_t i = 0; i < 5000; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 5000; i < numValues; i++) {
+    accumulator2.append(i);
+  }
+
+  accumulator1.mergeWith(accumulator2);
+  EXPECT_FALSE(accumulator1.isSparse());
+
+  EXPECT_NEAR(
+      accumulator1.cardinality(), numValues, numValues * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeSparseWithDense) {
+  HllAccumulator<int64_t, false, TypeParam> sparseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> denseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    sparseAccumulator.append(i);
+  }
+
+  constexpr int64_t numValuesDense = 5000;
+  for (int64_t i = 100; i < numValuesDense; i++) {
+    denseAccumulator.append(i);
+  }
+
+  sparseAccumulator.mergeWith(denseAccumulator);
+
+  // mergeWith should convert any sparse accumulator to dense if either is
+  // dense. Result should be dense and approximate.
+
+  EXPECT_FALSE(sparseAccumulator.isSparse());
+  EXPECT_NEAR(
+      sparseAccumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeDenseWithSparse) {
+  HllAccumulator<int64_t, false, TypeParam> sparseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> denseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    sparseAccumulator.append(i);
+  }
+
+  constexpr int64_t numValuesDense = 5000;
+  for (int64_t i = 100; i < numValuesDense; i++) {
+    denseAccumulator.append(i);
+  }
+
+  denseAccumulator.mergeWith(sparseAccumulator);
+
+  // Result should be dense and approximate.
+  EXPECT_FALSE(denseAccumulator.isSparse());
+  EXPECT_NEAR(
+      denseAccumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithSerializedDataSparse) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 100; i < 200; i++) {
+    accumulator2.append(i);
+  }
+
+  auto size = accumulator2.serializedSize();
+  std::string buffer(size, '\0');
+  accumulator2.serialize(buffer.data());
+
+  // Merge with serialized data (should remain sparse).
+  accumulator1.mergeWith(StringView(buffer), this->allocator_);
+
+  // Should be sparse and exact.
+  EXPECT_TRUE(accumulator1.isSparse());
+  EXPECT_EQ(accumulator1.cardinality(), 200);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithOverlappingDataSparse) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 50; i < 150; i++) {
+    accumulator2.append(i);
+  }
+
+  accumulator1.mergeWith(accumulator2);
+
+  // Sparse HLL should be sparse and exact: union of [0, 100) and [50, 150) =
+  // [0, 150)
+  EXPECT_TRUE(accumulator1.isSparse());
+  EXPECT_EQ(accumulator1.cardinality(), 150);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeUninitializedAccumulator) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator(this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> initialized(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int64_t numValues = 100;
+  for (int64_t i = 0; i < numValues; i++) {
+    initialized.append(i);
+  }
+
+  auto size = initialized.serializedSize();
+  std::string buffer(size, '\0');
+  initialized.serialize(buffer.data());
+
+  accumulator.mergeWith(StringView(buffer), this->allocator_);
+
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+}

--- a/velox/common/hyperloglog/tests/KHyperLogLogTest.cpp
+++ b/velox/common/hyperloglog/tests/KHyperLogLogTest.cpp
@@ -1,0 +1,685 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/common/memory/Memory.h"
+
+#include <folly/Random.h>
+#include <gtest/gtest.h>
+#include <set>
+#include <unordered_set>
+#include "velox/type/Timestamp.h"
+
+using namespace facebook::velox::common::hll;
+using namespace facebook::velox::memory;
+using namespace facebook::velox;
+
+namespace {
+const int32_t kDefaultNumBuckets = 256;
+// Theoretical relative standard error formula from the HyperLogLog paper
+// (Flajolet et al.): 1.04 / sqrt(num buckets)
+const double kDefaultStandardError = 1.04 / std::sqrt(kDefaultNumBuckets);
+} // namespace
+
+class KHyperLogLogTest : public ::testing::Test {
+ public:
+  void SetUp() override {
+    facebook::velox::memory::MemoryManager::initialize({});
+    pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
+    hsa_ = std::make_unique<HashStringAllocator>(pool_.get());
+    allocator_ = hsa_.get();
+  }
+
+  void TearDown() override {
+    // Clean up allocator before pool.
+    hsa_.reset();
+    pool_.reset();
+  }
+
+ protected:
+  std::shared_ptr<MemoryPool> pool_;
+  std::unique_ptr<HashStringAllocator> hsa_;
+  HashStringAllocator* allocator_{};
+
+  // Helper function to generate random values with quadratic distribution.
+  // Squaring a uniform random [0.0, 1.0] heavily skews results toward zero
+  // (e.g., ~70% of values fall in the lower half). This simulates realistic
+  // data where most values have low cardinality and few have high cardinality,
+  // which is critical for testing KHLL's privacy features under conditions
+  // where re-identification risk is highest.
+  int64_t randomLong(int64_t range) {
+    double random = folly::Random::randDouble01();
+    return static_cast<int64_t>(std::pow(random, 2.0) * range);
+  }
+
+  // Creates a KHyperLogLog with specific values for testing.
+  std::unique_ptr<KHyperLogLog<int64_t, HashStringAllocator>> createKHLL(
+      const std::vector<int64_t>& values,
+      const std::vector<int64_t>& uiis) {
+    EXPECT_EQ(values.size(), uiis.size());
+    auto khll = std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(
+        allocator_);
+
+    for (size_t i = 0; i < values.size(); ++i) {
+      khll->add(values[i], uiis[i]);
+    }
+
+    return khll;
+  }
+};
+
+TEST_F(KHyperLogLogTest, basicCardinality) {
+  auto khll =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+
+  // Empty KHLL should have cardinality 0.
+  EXPECT_EQ(0, khll->cardinality());
+  EXPECT_TRUE(khll->isExact());
+
+  // Add some values.
+  for (int64_t i = 0; i < 100; ++i) {
+    khll->add(i, randomLong(100));
+  }
+
+  // Should be exact since it is under the default max size.
+  EXPECT_TRUE(khll->isExact());
+  EXPECT_EQ(100, khll->cardinality());
+}
+
+TEST_F(KHyperLogLogTest, cardinalityAccuracy) {
+  // Test representative precision levels (low and high) to ensure
+  // accuracy across different bucket configurations: 4 (16 buckets) and
+  // 12 (4096 buckets).
+  const int trials = 30;
+
+  for (int indexBits : {4, 12}) {
+    const int numberOfBuckets = 1 << indexBits;
+    const int maxCardinality = numberOfBuckets * 2;
+
+    std::vector<double> errors;
+
+    for (int trial = 0; trial < trials; ++trial) {
+      auto khll = std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(
+          KHyperLogLog<int64_t, HashStringAllocator>::kDefaultMaxSize,
+          numberOfBuckets,
+          allocator_);
+
+      for (int cardinality = 1; cardinality <= maxCardinality; cardinality++) {
+        khll->add(folly::Random::rand64(), 0L);
+
+        // Sample every 20% of bucket count (vs Java's 10%) to reduce test
+        // time
+        if (cardinality % (numberOfBuckets / 5) == 0) {
+          double error =
+              (static_cast<double>(khll->cardinality()) - cardinality) /
+              cardinality;
+          errors.push_back(std::abs(error));
+        }
+      }
+    }
+
+    // Calculate standard deviation
+    double mean = 0.0;
+    for (double error : errors) {
+      mean += error;
+    }
+    mean /= errors.size();
+
+    double variance = 0.0;
+    for (double error : errors) {
+      variance += (error - mean) * (error - mean);
+    }
+    variance /= errors.size();
+    double stdDev = std::sqrt(variance);
+
+    EXPECT_LE(stdDev, kDefaultStandardError)
+        << "Cardinality mismatch at indexBits " << indexBits << ", bucket "
+        << numberOfBuckets;
+  }
+}
+
+TEST_F(KHyperLogLogTest, mergeWith) {
+  auto khll1 = createKHLL(
+      std::vector<int64_t>{0, 1, 2, 3, 4, 5},
+      std::vector<int64_t>{10, 11, 12, 13, 14, 15});
+
+  auto khll2 = createKHLL(
+      std::vector<int64_t>{3, 4, 5, 6, 7, 8},
+      std::vector<int64_t>{13, 14, 15, 16, 17, 18});
+
+  auto expected = createKHLL(
+      std::vector<int64_t>{0, 1, 2, 3, 4, 5, 6, 7, 8},
+      std::vector<int64_t>{10, 11, 12, 13, 14, 15, 16, 17, 18});
+
+  khll1->mergeWith(*khll2);
+
+  EXPECT_EQ(expected->cardinality(), khll1->cardinality());
+  EXPECT_EQ(
+      expected->reidentificationPotential(10),
+      khll1->reidentificationPotential(10));
+}
+
+TEST_F(KHyperLogLogTest, merge) {
+  // Helpers to create a KHLL with given maxSize and data
+  auto createSmaller = [&]() {
+    const auto smallerSize = 5;
+    auto khll = std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(
+        smallerSize, kDefaultNumBuckets, allocator_);
+    for (size_t i = 0; i < smallerSize; ++i) {
+      khll->add(i, i);
+    }
+    return khll;
+  };
+
+  auto createLarger = [&]() {
+    const auto largerSize = 10;
+    auto khll = std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(
+        largerSize, kDefaultNumBuckets, allocator_);
+    for (size_t i = 0; i < largerSize; ++i) {
+      khll->add(i, i);
+    }
+    return khll;
+  };
+
+  // Test merge(left, right)
+  auto smallerFirst = KHyperLogLog<int64_t, HashStringAllocator>::merge(
+      createSmaller(), createLarger());
+
+  // Test merge(right, left) - should produce same result
+  auto largerFist = KHyperLogLog<int64_t, HashStringAllocator>::merge(
+      createLarger(), createSmaller());
+
+  EXPECT_EQ(smallerFirst->cardinality(), largerFist->cardinality());
+
+  // Explicitly merging smaller into larger should produce different results.
+  auto larger = createLarger();
+  larger->mergeWith(*createSmaller());
+  EXPECT_NE(larger->cardinality(), largerFist->cardinality());
+}
+
+TEST_F(KHyperLogLogTest, serde) {
+  // Test small serialization
+  std::vector<int64_t> values;
+  std::vector<int64_t> uiis;
+
+  for (int64_t i = 0; i < 1000; ++i) {
+    values.push_back(i);
+    uiis.push_back(randomLong(100));
+  }
+
+  auto khll = createKHLL(values, uiis);
+
+  size_t totalSize = khll->estimatedSerializedSize();
+  std::string outputBuffer(totalSize, '\0');
+  khll->serialize(outputBuffer.data());
+  auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+      outputBuffer.data(), outputBuffer.size(), allocator_);
+
+  EXPECT_EQ(khll->cardinality(), deserialized->cardinality());
+  EXPECT_EQ(
+      khll->reidentificationPotential(10),
+      deserialized->reidentificationPotential(10));
+
+  // Test round-trip
+  std::string reserializeBuffer(totalSize, '\0');
+  deserialized->serialize(reserializeBuffer.data());
+  EXPECT_EQ(outputBuffer, reserializeBuffer);
+
+  // Test empty KHLL round-trip
+  auto emptyKhll = createKHLL({}, {});
+  size_t emptySize = emptyKhll->estimatedSerializedSize();
+  std::string emptyOutputBuffer(emptySize, '\0');
+  emptyKhll->serialize(emptyOutputBuffer.data());
+  auto deserializedEmpty =
+      KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+          emptyOutputBuffer.data(), emptyOutputBuffer.size(), allocator_);
+  EXPECT_EQ(deserializedEmpty->cardinality(), 0);
+  std::string reserializedEmptyOutputBuffer(emptySize, '\0');
+  deserializedEmpty->serialize(reserializedEmptyOutputBuffer.data());
+  EXPECT_EQ(emptyOutputBuffer, reserializedEmptyOutputBuffer);
+}
+
+TEST_F(KHyperLogLogTest, uniquenessDistribution) {
+  const int histogramSize = 256;
+  const int count = 1000;
+
+  auto khll =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+  std::map<int64_t, std::set<int64_t>> valueToUiis;
+
+  for (int i = 0; i < count; ++i) {
+    int64_t uii = randomLong(histogramSize);
+    int64_t value = randomLong(count);
+    khll->add(value, uii);
+    valueToUiis[value].insert(uii);
+  }
+  auto khllHistogram = khll->uniquenessDistribution(histogramSize);
+
+  // Build the actual histogram
+  std::map<int64_t, double> actualHistogram;
+  int size = valueToUiis.size();
+
+  for (const auto& [value, uiiSet] : valueToUiis) {
+    int64_t bucket = std::min(
+        static_cast<int64_t>(uiiSet.size()),
+        static_cast<int64_t>(histogramSize));
+    actualHistogram[bucket] += 1.0 / size;
+  }
+
+  // Verify histogram accuracy (with some tolerance for approximation)
+  for (int64_t i = 1; i < histogramSize; ++i) {
+    double expected = actualHistogram.count(i) ? actualHistogram[i] : 0.0;
+    double khllEstimated = khllHistogram.count(i) ? khllHistogram[i] : 0.0;
+
+    // Use 10% tolerance since the values of uniqueness distribution are a sum
+    // of 1 / size of minHash, and not the cardinality estimates.
+    EXPECT_NEAR(khllEstimated, expected, expected * 0.1)
+        << "Histogram mismatch at bucket " << i;
+  }
+}
+
+TEST_F(KHyperLogLogTest, reidentificationPotential) {
+  auto khll =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+  std::map<int64_t, std::set<int64_t>> valueToUiis;
+
+  const int count = 1000;
+  for (int i = 0; i < count; ++i) {
+    int64_t uii = randomLong(100);
+    int64_t value = randomLong(count);
+    khll->add(value, uii);
+    valueToUiis[value].insert(uii);
+  }
+
+  // Test different thresholds
+  for (int threshold = 1; threshold < 10; ++threshold) {
+    double khllEstimated = khll->reidentificationPotential(threshold);
+
+    // Calculate the actual reidentification potential
+    int highlyUniqueCount = 0;
+    for (const auto& [value, uiiSet] : valueToUiis) {
+      if (static_cast<int>(uiiSet.size()) <= threshold) {
+        highlyUniqueCount++;
+      }
+    }
+
+    double expected =
+        static_cast<double>(highlyUniqueCount) / valueToUiis.size();
+
+    if (expected > 0) {
+      EXPECT_NEAR(khllEstimated, expected, expected * kDefaultStandardError)
+          << "Reidentification potential mismatch for threshold " << threshold;
+    }
+  }
+}
+
+TEST_F(KHyperLogLogTest, exactIntersectionCardinality) {
+  auto khll1 = createKHLL(
+      std::vector<int64_t>{1, 2, 3, 4, 5},
+      std::vector<int64_t>{10, 20, 30, 40, 50});
+
+  auto khll2 = createKHLL(
+      std::vector<int64_t>{3, 4, 5, 6, 7},
+      std::vector<int64_t>{30, 40, 50, 60, 70});
+
+  EXPECT_TRUE(khll1->isExact());
+  EXPECT_TRUE(khll2->isExact());
+
+  int64_t intersection =
+      KHyperLogLog<int64_t, HashStringAllocator>::exactIntersectionCardinality(
+          *khll1, *khll2);
+  // Values 3, 4, 5 are in both
+  EXPECT_EQ(3, intersection);
+}
+
+TEST_F(KHyperLogLogTest, jaccardIndex) {
+  // Test with larger datasets.
+  // Create two KHLLs where one is a subset of the other
+  const int64_t set1Size = 100000;
+  const int64_t set2Size = 150000;
+
+  auto khll1 =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+  auto khll2 =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+
+  // Add values 0 to 99,999 to khll1
+  for (int64_t i = 0; i < set1Size; ++i) {
+    khll1->add(i, randomLong(100));
+  }
+
+  // Add values 0 to 149,999 to khll2 (includes all of khll1)
+  for (int64_t i = 0; i < set2Size; ++i) {
+    khll2->add(i, randomLong(100));
+  }
+
+  double jaccard =
+      KHyperLogLog<int64_t, HashStringAllocator>::jaccardIndex(*khll1, *khll2);
+
+  // Expected Jaccard = |intersection| / |union|
+  // Intersection: 100,000 (all of set1)
+  // Union: 150,000 (all of set2)
+  // Jaccard = 100,000 / 150,000 = 2/3 ≈ 0.6667
+  double expectedJaccard = static_cast<double>(set1Size) / set2Size;
+
+  EXPECT_NEAR(
+      jaccard, expectedJaccard, expectedJaccard * kDefaultStandardError);
+}
+
+TEST_F(KHyperLogLogTest, largeDataset) {
+  auto khll =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+
+  const int count = 200000;
+  std::unordered_set<int64_t> uniqueValues;
+
+  for (int i = 0; i < count; ++i) {
+    int64_t value = folly::Random::rand64();
+    int64_t uii = randomLong(100);
+    khll->add(value, uii);
+    uniqueValues.insert(value);
+  }
+
+  EXPECT_FALSE(khll->isExact());
+
+  int64_t expected = static_cast<int64_t>(uniqueValues.size());
+  int64_t khllEstimated = khll->cardinality();
+
+  EXPECT_NEAR(expected, khllEstimated, khllEstimated * kDefaultStandardError);
+}
+
+TEST_F(KHyperLogLogTest, minhashSize) {
+  auto khll =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+
+  EXPECT_EQ(0, khll->minhashSize());
+
+  khll->add(1, 10);
+  khll->add(2, 20);
+  khll->add(3, 30);
+
+  EXPECT_EQ(3, khll->minhashSize());
+}
+
+TEST_F(KHyperLogLogTest, estimatedSizes) {
+  auto khll =
+      std::make_unique<KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+
+  size_t initialEstimatedSerSize = khll->estimatedSerializedSize();
+
+  for (int64_t i = 0; i < 100; ++i) {
+    khll->add(i, randomLong(100));
+  }
+
+  size_t finalEstimatedSerSize = khll->estimatedSerializedSize();
+
+  // Sizes should increase after adding data.
+  EXPECT_GT(finalEstimatedSerSize, initialEstimatedSerSize);
+
+  // Verify the estimated size is accurate.
+  std::string serializedBuffer(finalEstimatedSerSize, '\0');
+  khll->serialize(serializedBuffer.data());
+  size_t actualSerSize = serializedBuffer.size();
+
+  EXPECT_LE(actualSerSize, finalEstimatedSerSize)
+      << "Actual serialized size exceeds estimate - potential buffer overflow";
+
+  EXPECT_NEAR(
+      actualSerSize,
+      finalEstimatedSerSize,
+      finalEstimatedSerSize * kDefaultStandardError);
+}
+
+TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
+  // Test different TJoinKey, TUii combinations:
+  // int32_t TJoinKey, int32_t TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<int32_t, HashStringAllocator>>(
+        allocator_);
+    for (int32_t i = 0; i < 100; ++i) {
+      khll->add(i, i);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // uint32_t TJoinKey, uint32_t TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<uint32_t, HashStringAllocator>>(
+        allocator_);
+    for (uint32_t i = 0; i < 100; ++i) {
+      khll->add(i % 10, i);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(10, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // int16_t TJoinKey, int16_t TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<int16_t, HashStringAllocator>>(
+        allocator_);
+    for (int16_t i = 0; i < 10000; ++i) {
+      khll->add(i % 100, i);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // uint16_t TJoinKey, uint16_t TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<uint16_t, HashStringAllocator>>(
+        allocator_);
+    for (uint16_t i = 0; i < 100; ++i) {
+      khll->add(i, i);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // int8_t TJoinKey, int8_t TUii
+  {
+    auto khll =
+        std::make_unique<KHyperLogLog<int8_t, HashStringAllocator>>(allocator_);
+    for (int8_t i = -100; i < 100; ++i) {
+      khll->add(i, i);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(200, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // uint8_t TJoinKey, uint8_t TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<uint8_t, HashStringAllocator>>(
+        allocator_);
+    for (uint8_t i = 0; i < 100; ++i) {
+      khll->add(i, i);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // float TJoinKey, float TUii
+  {
+    auto khll =
+        std::make_unique<KHyperLogLog<float, HashStringAllocator>>(allocator_);
+    for (int i = 0; i < 10; ++i) {
+      khll->add(static_cast<float>(i), static_cast<float>(i));
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(10, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // double TJoinKey, double TUii
+  {
+    auto khll =
+        std::make_unique<KHyperLogLog<double, HashStringAllocator>>(allocator_);
+    for (int i = 0; i < 100; ++i) {
+      khll->add(static_cast<double>(i), static_cast<double>(i));
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // StringView TJoinKey, StringView TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<StringView, HashStringAllocator>>(
+        allocator_);
+    std::vector<std::string> strings;
+    strings.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+      strings.push_back("key_" + std::to_string(i));
+    }
+    for (int i = 0; i < 100; ++i) {
+      khll->add(StringView(strings[i]), StringView(strings[i]));
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // Timestamp TJoinKey, Timestamp TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<Timestamp, HashStringAllocator>>(
+        allocator_);
+    for (int i = 0; i < 100; ++i) {
+      Timestamp ts(i * 1000, 0);
+      khll->add(ts, ts);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+
+  // int128_t TJoinKey, int128_t TUii
+  {
+    auto khll = std::make_unique<KHyperLogLog<int128_t, HashStringAllocator>>(
+        allocator_);
+    for (int i = 0; i < 100; ++i) {
+      // Create 128-bit values with different upper and lower 64 bits
+      int128_t value = (static_cast<int128_t>(i) << 64) | (i + 1000);
+      khll->add(value, value);
+    }
+    EXPECT_TRUE(khll->isExact());
+    EXPECT_EQ(100, khll->cardinality());
+
+    // Test round trip
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+        outputBuffer.data(), outputBuffer.size(), allocator_);
+    std::string reserializeBuffer(totalSize, '\0');
+    deserialized->serialize(reserializeBuffer.data());
+    EXPECT_EQ(outputBuffer, reserializeBuffer);
+  }
+}

--- a/velox/functions/prestosql/KHyperLogLogFunctions.h
+++ b/velox/functions/prestosql/KHyperLogLogFunctions.h
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions {
+
+using KHyperLogLog = common::hll::KHyperLogLog<int64_t, memory::MemoryPool>;
+// hhhh not sure if this is the correct type. i guess since first step is to
+// deserialize..?
+
+class KHyperLogLogCardinalityFunction : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("bigint")
+                .argumentType("khyperloglog")
+                .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->as<FlatVector<int64_t>>();
+
+    exec::LocalDecodedVector khllDecoder(context, *args[0], rows);
+    auto decodedKhll = khllDecoder.get();
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedKhll->isNullAt(row)) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      auto khllData = decodedKhll->valueAt<StringView>(row);
+      auto khllInstance = KHyperLogLog::deserialize(
+          khllData.data(), khllData.size(), context.pool());
+      flatResult->set(row, khllInstance->cardinality());
+    });
+  }
+};
+
+class KHyperLogLogIntersectionCardinalityFunction
+    : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("bigint")
+                .argumentType("khyperloglog")
+                .argumentType("khyperloglog")
+                .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 2);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->as<FlatVector<int64_t>>();
+
+    exec::LocalDecodedVector khll1Decoder(context, *args[0], rows);
+    auto decodedKhll1 = khll1Decoder.get();
+
+    exec::LocalDecodedVector khll2Decoder(context, *args[1], rows);
+    auto decodedKhll2 = khll2Decoder.get();
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedKhll1->isNullAt(row) || decodedKhll2->isNullAt(row)) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      auto khll1Data = decodedKhll1->valueAt<StringView>(row);
+      auto khll2Data = decodedKhll2->valueAt<StringView>(row);
+
+      auto khll1Instance = KHyperLogLog::deserialize(
+          khll1Data.data(), khll1Data.size(), context.pool());
+      auto khll2Instance = KHyperLogLog::deserialize(
+          khll2Data.data(), khll2Data.size(), context.pool());
+
+      // If both khlls are exact, return the exact intersection cardinality.
+      if (khll1Instance->isExact() && khll2Instance->isExact()) {
+        flatResult->set(
+            row,
+            KHyperLogLog::exactIntersectionCardinality(
+                *khll1Instance, *khll2Instance));
+        return;
+      }
+
+      // If either of the khlls are not exact, return an approximation of the
+      // intersection cardinality using the Jaccard Index like a similarity
+      // index between the 2 key sets.
+      int64_t lowestCardinality =
+          std::min(khll1Instance->cardinality(), khll2Instance->cardinality());
+      double jaccard =
+          KHyperLogLog::jaccardIndex(*khll1Instance, *khll2Instance);
+      auto setUnion = KHyperLogLog::merge(*khll1Instance, *khll2Instance);
+      int64_t computedResult =
+          static_cast<int64_t>(std::round(jaccard * setUnion->cardinality()));
+
+      // In a special case where one set is much smaller and almost a true
+      // subset of the other, return the size of the smaller set. For example:
+      // Set1 = {1,2,3,4,5,6}
+      // Set2 = {1,2}
+      // Jaccard Index = 1
+      // Approximated intersection cardinality = 6
+      // This result does not make sense as Set2 does not even have 6
+      // elements. Thus return 2 instead.
+      flatResult->set(row, std::min(computedResult, lowestCardinality));
+    });
+  }
+};
+
+class KHyperLogLogJaccardIndexFunction : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("double")
+                .argumentType("khyperloglog")
+                .argumentType("khyperloglog")
+                .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 2);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->as<FlatVector<double>>();
+
+    exec::LocalDecodedVector khll1Decoder(context, *args[0], rows);
+    auto decodedKhll1 = khll1Decoder.get();
+
+    exec::LocalDecodedVector khll2Decoder(context, *args[1], rows);
+    auto decodedKhll2 = khll2Decoder.get();
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedKhll1->isNullAt(row) || decodedKhll2->isNullAt(row)) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      auto khll1Data = decodedKhll1->valueAt<StringView>(row);
+      auto khll2Data = decodedKhll2->valueAt<StringView>(row);
+
+      auto khll1Instance = KHyperLogLog::deserialize(
+          khll1Data.data(), khll1Data.size(), context.pool());
+      auto khll2Instance = KHyperLogLog::deserialize(
+          khll2Data.data(), khll2Data.size(), context.pool());
+
+      flatResult->set(
+          row, KHyperLogLog::jaccardIndex(*khll1Instance, *khll2Instance));
+    });
+  }
+};
+
+class KHyperLogLogReidentificationPotentialFunction
+    : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("double")
+                .argumentType("khyperloglog")
+                .argumentType("bigint")
+                .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 2);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->as<FlatVector<double>>();
+
+    exec::LocalDecodedVector khllDecoder(context, *args[0], rows);
+    auto decodedKhll = khllDecoder.get();
+
+    exec::LocalDecodedVector thresholdDecoder(context, *args[1], rows);
+    auto decodedThreshold = thresholdDecoder.get();
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedKhll->isNullAt(row) || decodedThreshold->isNullAt(row)) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      auto khllData = decodedKhll->valueAt<StringView>(row);
+      auto threshold = decodedThreshold->valueAt<int64_t>(row);
+
+      auto khllInstance = KHyperLogLog::deserialize(
+          khllData.data(), khllData.size(), context.pool());
+      flatResult->set(row, khllInstance->reidentificationPotential(threshold));
+    });
+  }
+};
+
+class KHyperLogLogUniquenessDistributionFunction : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {
+        exec::FunctionSignatureBuilder()
+            .returnType("map(bigint,double)")
+            .argumentType("khyperloglog")
+            .build(),
+        exec::FunctionSignatureBuilder()
+            .returnType("map(bigint,double)")
+            .argumentType("khyperloglog")
+            .argumentType("bigint")
+            .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK(args.size() == 1 || args.size() == 2);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* mapResult = result->as<MapVector>();
+
+    exec::LocalDecodedVector khllDecoder(context, *args[0], rows);
+    auto decodedKhll = khllDecoder.get();
+
+    // Histogram size is an optional second parameter to the function, with a
+    // default value of 256.
+    std::unique_ptr<exec::LocalDecodedVector> histogramSizeDecoder;
+    DecodedVector* decodedHistogramSize = nullptr;
+    if (args.size() == 2) {
+      histogramSizeDecoder =
+          std::make_unique<exec::LocalDecodedVector>(context, *args[1], rows);
+      decodedHistogramSize = histogramSizeDecoder->get();
+    }
+
+    // Prepare key and value vectors
+    auto mapKeys = mapResult->mapKeys()->asFlatVector<int64_t>();
+    auto mapValues = mapResult->mapValues()->asFlatVector<double>();
+
+    vector_size_t currentOffset = 0;
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedKhll->isNullAt(row)) {
+        mapResult->setNull(row, true);
+        mapResult->setOffsetAndSize(row, 0, 0);
+        return;
+      }
+
+      auto khllData = decodedKhll->valueAt<StringView>(row);
+      auto khllInstance = KHyperLogLog::deserialize(
+          khllData.data(), khllData.size(), context.pool());
+
+      int64_t histogramSize =
+          (decodedHistogramSize && !decodedHistogramSize->isNullAt(row))
+          ? decodedHistogramSize->valueAt<int64_t>(row)
+          : KHyperLogLog::kDefaultHistogramSize;
+
+      auto distribution = khllInstance->uniquenessDistribution(histogramSize);
+
+      // Sort the distribution by key to ensure sorted output
+      std::vector<std::pair<int64_t, double>> sortedDistribution(
+          distribution.begin(), distribution.end());
+      std::sort(
+          sortedDistribution.begin(),
+          sortedDistribution.end(),
+          [](const auto& a, const auto& b) { return a.first < b.first; });
+
+      // Calculate required size
+      vector_size_t mapSize = sortedDistribution.size();
+      vector_size_t newOffset = currentOffset + mapSize;
+
+      // Resize vectors to accommodate new elements
+      mapKeys->resize(newOffset);
+      mapValues->resize(newOffset);
+
+      // Set the offset and size for this row
+      mapResult->setOffsetAndSize(row, currentOffset, mapSize);
+
+      // Fill in the keys and values
+      vector_size_t i = 0;
+      for (const auto& [key, value] : sortedDistribution) {
+        mapKeys->set(currentOffset + i, key);
+        mapValues->set(currentOffset + i, value);
+        ++i;
+      }
+
+      currentOffset = newOffset;
+    });
+  }
+};
+
+class MergeKHyperLogLogFunction : public exec::VectorFunction {
+ public:
+  static std::vector<exec::FunctionSignaturePtr> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("khyperloglog")
+                .argumentType("array(KHYPERLOGLOG)")
+                .build()};
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+
+    context.ensureWritable(rows, outputType, result);
+    auto* flatResult = result->as<FlatVector<StringView>>();
+    exec::LocalDecodedVector arrayDecoder(context, *args[0], rows);
+    auto decodedArray = arrayDecoder.get();
+    auto baseArray = decodedArray->base()->as<ArrayVector>();
+    auto rawSizes = baseArray->rawSizes();
+    auto rawOffsets = baseArray->rawOffsets();
+    auto indices = decodedArray->indices();
+    auto arrayElements = baseArray->elements();
+
+    exec::LocalSelectivityVector allElementsRows(
+        context, arrayElements->size());
+    allElementsRows->setAll();
+    exec::LocalDecodedVector elementsDecoder(
+        context, *arrayElements, *allElementsRows);
+    auto decodedElements = elementsDecoder.get();
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+      if (decodedArray->isNullAt(row)) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      auto arraySize = rawSizes[indices[row]];
+      auto arrayOffset = rawOffsets[indices[row]];
+
+      std::unique_ptr<KHyperLogLog> merged = nullptr;
+
+      for (vector_size_t i = 0; i < arraySize; ++i) {
+        auto elementIndex = arrayOffset + i;
+        if (decodedElements->isNullAt(elementIndex)) {
+          continue;
+        }
+
+        auto khllData = decodedElements->valueAt<StringView>(elementIndex);
+        if (khllData.empty()) {
+          continue;
+        }
+        if (!merged) {
+          // Initialize with first non-null element.
+          merged = KHyperLogLog::deserialize(
+              khllData.data(), khllData.size(), context.pool());
+        } else {
+          auto currentKhll = KHyperLogLog::deserialize(
+              khllData.data(), khllData.size(), context.pool());
+          merged->mergeWith(*currentKhll);
+        }
+      }
+
+      // Return null if all elements were null.
+      if (!merged) {
+        flatResult->setNull(row, true);
+        return;
+      }
+
+      std::string serialized(merged->estimatedSerializedSize(), '\0');
+      merged->serialize(serialized.data());
+
+      char* buffer = flatResult->getRawStringBufferWithSpace(serialized.size());
+      memcpy(buffer, serialized.data(), serialized.size());
+      flatResult->setNoCopy(row, StringView(buffer, serialized.size()));
+    });
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -89,4 +89,5 @@ const char* const kNoisyApproxSetSfm = "noisy_approx_set_sfm";
 const char* const kNoisyApproxDistinctSfm = "noisy_approx_distinct_sfm";
 const char* const kNoisyApproxSetSfmFromIndexAndZeros =
     "noisy_approx_set_sfm_from_index_and_zeros";
+const char* const kKHyperLogLogAgg = "khyperloglog_agg";
 } // namespace facebook::velox::aggregate

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -32,6 +32,7 @@ velox_add_library(
   EntropyAggregates.cpp
   GeometricMeanAggregate.cpp
   HistogramAggregate.cpp
+  KHyperLogLogAggregate.cpp
   MapAggAggregate.cpp
   MapUnionAggregate.cpp
   MapUnionSumAggregate.cpp

--- a/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+
+using namespace facebook::velox::aggregate;
+
+namespace facebook::velox::aggregate::prestosql {
+namespace {
+
+template <TypeKind TValueKind, TypeKind TUiiKind>
+std::unique_ptr<exec::Aggregate> createKHyperLogLogAggregate(
+    const TypePtr& resultType) {
+  using TValue = typename TypeTraits<TValueKind>::NativeType;
+  using TUii = typename TypeTraits<TUiiKind>::NativeType;
+  return std::make_unique<KHyperLogLogAggregate<TValue, TUii>>(resultType);
+}
+
+template <TypeKind TJoinKeyKind>
+std::unique_ptr<exec::Aggregate> dispatchOnUiiType(
+    TypeKind uiiKind,
+    const TypePtr& resultType) {
+  return VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+      createKHyperLogLogAggregate, TJoinKeyKind, uiiKind, resultType);
+}
+
+/// Registration for khyperloglog_agg aggregate function.
+exec::AggregateRegistrationResult registerKHyperLogLogAgg(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+
+  // Register all physical types for both JoinKey and UII.
+  std::vector<std::string> inputTypes = {
+      "boolean",
+      "tinyint",
+      "smallint",
+      "integer",
+      "bigint",
+      "real",
+      "double",
+      "varchar",
+      "varbinary",
+      "timestamp",
+      "date"};
+
+  // Generate all combinations of (joinKeyType, uiiType)
+  for (const auto& valueType : inputTypes) {
+    for (const auto& uiiType : inputTypes) {
+      signatures.push_back(
+          exec::AggregateFunctionSignatureBuilder()
+              .returnType("khyperloglog")
+              .intermediateType("khyperloglog")
+              .argumentType(valueType)
+              .argumentType(uiiType)
+              .build());
+    }
+  }
+
+  return exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(
+            argTypes.size(), 2, "{}: unexpected number of arguments", name);
+
+        auto joinKeyKind = argTypes[0]->kind();
+        auto uiiKind = argTypes[1]->kind();
+
+        // First dispatch on JoinKey type, then on UII type.
+        return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            dispatchOnUiiType, joinKeyKind, uiiKind, resultType);
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+} // namespace
+
+void registerKHyperLogLogAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerKHyperLogLogAgg(
+      prefix + kKHyperLogLogAgg, withCompanionFunctions, overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h
+++ b/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+template <typename TValue, typename TUii>
+class KHyperLogLogAggregate : public exec::Aggregate {
+  using KHllAccumulator = common::hll::KHyperLogLog<TUii, HashStringAllocator>;
+
+ public:
+  explicit KHyperLogLogAggregate(const TypePtr& resultType)
+      : exec::Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(KHllAccumulator);
+  }
+
+  int32_t accumulatorAlignmentSize() const override {
+    return alignof(KHllAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractAccumulators(groups, numGroups, result);
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK(result);
+    auto* flatResult = (*result)->asFlatVector<StringView>();
+    flatResult->resize(numGroups);
+
+    BufferPtr& nulls = flatResult->mutableNulls(flatResult->size());
+    uint64_t* rawNulls = nulls->asMutable<uint64_t>();
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        bits::clearBit(rawNulls, i);
+
+        auto* accumulator = value<KHllAccumulator>(group);
+        size_t size = accumulator->estimatedSerializedSize();
+
+        StringView serialized;
+        if (StringView::isInline(size)) {
+          std::string buffer(size, '\0');
+          accumulator->serialize(buffer.data());
+          serialized = StringView::makeInline(buffer);
+        } else {
+          char* rawBuffer = flatResult->getRawStringBufferWithSpace(size);
+          accumulator->serialize(rawBuffer);
+          serialized = StringView(rawBuffer, size);
+        }
+        flatResult->setNoCopy(i, serialized);
+      }
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedValue_.decode(*args[0], rows, true);
+    decodedUii_.decode(*args[1], rows, true);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedValue_.isNullAt(row) || decodedUii_.isNullAt(row)) {
+        return;
+      }
+
+      auto group = groups[row];
+      auto tracker = trackRowSize(group);
+      auto* accumulator = value<KHllAccumulator>(group);
+      clearNull(group);
+
+      auto val = decodedValue_.valueAt<TValue>(row);
+      auto uii = decodedUii_.valueAt<TUii>(row);
+      accumulator->add(val, uii);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedIntermediate_.decode(*args[0], rows, true);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedIntermediate_.isNullAt(row)) {
+        return;
+      }
+
+      auto group = groups[row];
+      auto tracker = trackRowSize(group);
+      clearNull(group);
+
+      auto serialized = decodedIntermediate_.valueAt<StringView>(row);
+      auto* accumulator = value<KHllAccumulator>(group);
+      accumulator->mergeWith(serialized, allocator_);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto tracker = trackRowSize(group);
+
+    decodedValue_.decode(*args[0], rows, true);
+    decodedUii_.decode(*args[1], rows, true);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedValue_.isNullAt(row) || decodedUii_.isNullAt(row)) {
+        return;
+      }
+
+      auto* accumulator = value<KHllAccumulator>(group);
+      clearNull(group);
+
+      auto val = decodedValue_.valueAt<TValue>(row);
+      auto uii = decodedUii_.valueAt<TUii>(row);
+      accumulator->add(val, uii);
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedIntermediate_.decode(*args[0], rows, true);
+
+    auto tracker = trackRowSize(group);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedIntermediate_.isNullAt(row)) {
+        return;
+      }
+
+      clearNull(group);
+
+      auto serialized = decodedIntermediate_.valueAt<StringView>(row);
+      auto* accumulator = value<KHllAccumulator>(group);
+      accumulator->mergeWith(serialized, allocator_);
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      auto group = groups[i];
+      new (group + offset_) KHllAccumulator(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<KHllAccumulator>(groups);
+  }
+
+ private:
+  DecodedVector decodedValue_;
+  DecodedVector decodedUii_;
+  DecodedVector decodedIntermediate_;
+};
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MergeKHyperLogLogAggregate.h
+++ b/velox/functions/prestosql/aggregates/MergeKHyperLogLogAggregate.h
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+class MergeKHyperLogLogAggregate : public exec::Aggregate {
+  using MergeKHllAccumulator =
+      common::hll::KHyperLogLog<int64_t, HashStringAllocator>;
+
+ public:
+  explicit MergeKHyperLogLogAggregate(const TypePtr& resultType)
+      : exec::Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(MergeKHllAccumulator);
+  }
+
+  int32_t accumulatorAlignmentSize() const override {
+    return alignof(MergeKHllAccumulator);
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return true;
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const final {
+    singleInputAsIntermediate(rows, args, result);
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractAccumulators(groups, numGroups, result);
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK(result);
+    auto* flatResult = (*result)->asFlatVector<StringView>();
+    flatResult->resize(numGroups);
+
+    uint64_t* rawNulls = nullptr;
+    if (flatResult->mayHaveNulls()) {
+      BufferPtr& nulls = flatResult->mutableNulls(flatResult->size());
+      rawNulls = nulls->asMutable<uint64_t>();
+    }
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        flatResult->setNull(i, true);
+      } else {
+        if (rawNulls) {
+          bits::clearBit(rawNulls, i);
+        }
+
+        auto* accumulator = value<MergeKHllAccumulator>(group);
+        auto size = accumulator->estimatedSerializedSize();
+
+        StringView serialized;
+        if (StringView::isInline(size)) {
+          std::string buffer(size, '\0');
+          accumulator->serialize(buffer.data());
+          serialized = StringView::makeInline(buffer);
+        } else {
+          char* rawBuffer = flatResult->getRawStringBufferWithSpace(size);
+          accumulator->serialize(rawBuffer);
+          serialized = StringView(rawBuffer, size);
+        }
+        flatResult->setNoCopy(i, serialized);
+      }
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addIntermediateResults(groups, rows, args, false);
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedKHll_.decode(*args[0], rows, true);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedKHll_.isNullAt(row)) {
+        return;
+      }
+
+      auto group = groups[row];
+      auto tracker = trackRowSize(group);
+      clearNull(group);
+
+      auto serialized = decodedKHll_.valueAt<StringView>(row);
+      auto* accumulator = value<MergeKHllAccumulator>(group);
+      accumulator->mergeWith(serialized, allocator_);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addSingleGroupIntermediateResults(group, rows, args, false);
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedKHll_.decode(*args[0], rows, true);
+
+    auto tracker = trackRowSize(group);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedKHll_.isNullAt(row)) {
+        return;
+      }
+
+      clearNull(group);
+
+      auto serialized = decodedKHll_.valueAt<StringView>(row);
+      auto* accumulator = value<MergeKHllAccumulator>(group);
+      accumulator->mergeWith(serialized, allocator_);
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      auto group = groups[i];
+      new (group + offset_) MergeKHllAccumulator(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<MergeKHllAccumulator>(groups);
+  }
+
+ private:
+  DecodedVector decodedKHll_;
+};
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -32,6 +32,7 @@
 #include "velox/functions/prestosql/aggregates/EntropyAggregates.h"
 #include "velox/functions/prestosql/aggregates/GeometricMeanAggregate.h"
 #include "velox/functions/prestosql/aggregates/HistogramAggregate.h"
+#include "velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h"
 #include "velox/functions/prestosql/aggregates/MapAggAggregate.h"
 #include "velox/functions/prestosql/aggregates/MapUnionAggregate.h"
 #include "velox/functions/prestosql/aggregates/MapUnionSumAggregate.h"
@@ -54,6 +55,7 @@
 #include "velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h"
 #include "velox/functions/prestosql/aggregates/VarianceAggregates.h"
 #include "velox/functions/prestosql/types/JsonRegistration.h"
+#include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
 #include "velox/functions/prestosql/types/TDigestRegistration.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -190,6 +192,15 @@ extern void registerVarianceAggregates(
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerTDigestAggregate(const std::string& prefix, bool overwrite);
+extern void registerKHyperLogLogAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerTDigestAggregate(const std::string& prefix, bool overwrite);
+extern void registerKHyperLogLogAggregates(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
 
 void registerAllAggregateFunctions(
     const std::string& prefix,
@@ -198,6 +209,7 @@ void registerAllAggregateFunctions(
     bool overwrite) {
   registerJsonType();
   registerTDigestType();
+  registerKHyperLogLogType();
   registerApproxDistinctAggregates(prefix, withCompanionFunctions, overwrite);
   registerApproxMostFrequentAggregate(
       prefix, withCompanionFunctions, overwrite);
@@ -246,6 +258,7 @@ void registerAllAggregateFunctions(
   registerTDigestAggregate(prefix, overwrite);
   registerNoisyApproxSfmAggregate(prefix, withCompanionFunctions, overwrite);
   registerNumericHistogramAggregate(prefix, withCompanionFunctions, overwrite);
+  registerKHyperLogLogAggregates(prefix, withCompanionFunctions, overwrite);
 }
 
 void registerInternalAggregateFunctions(const std::string& prefix) {

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   EntropyAggregationTest.cpp
   GeometricMeanTest.cpp
   HistogramTest.cpp
+  KHyperLogLogAggregateTest.cpp
   Main.cpp
   MapAccumulatorTest.cpp
   MapAggTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/KHyperLogLogAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/KHyperLogLogAggregateTest.cpp
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::aggregate::test {
+namespace {
+class KHyperLogLogAggregateTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    registerKHyperLogLogType();
+    pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
+    hsa_ = std::make_unique<HashStringAllocator>(pool_.get());
+    allocator_ = hsa_.get();
+  }
+  void TearDown() override {
+    // Clean up allocator before pool.
+    hsa_.reset();
+    pool_.reset();
+  }
+
+  // Helper to create KHLL with test data
+  std::string createKHLL(
+      const std::vector<int64_t>& values,
+      const std::vector<int64_t>& uiis) {
+    EXPECT_EQ(values.size(), uiis.size());
+    auto khll = std::make_unique<
+        common::hll::KHyperLogLog<int64_t, HashStringAllocator>>(allocator_);
+
+    for (size_t i = 0; i < values.size(); ++i) {
+      khll->add(values[i], uiis[i]);
+    }
+
+    std::string serialized(khll->estimatedSerializedSize(), '\0');
+    khll->serialize(serialized.data());
+    return serialized;
+  }
+
+  // Extract cardinality from KHLL varbinary.
+  int64_t getCardinality(const StringView& khllData) {
+    auto khll = common::hll::KHyperLogLog<int32_t, MemoryPool>::deserialize(
+        khllData.data(), khllData.size(), pool_.get());
+    return khll->cardinality();
+  }
+
+  // Verify aggregation results have expected cardinalities.
+  void testAggregationWithCardinality(
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::vector<int64_t>& expectedCardinalities) {
+    auto result = AssertQueryBuilder(
+                      PlanBuilder()
+                          .values(data)
+                          .singleAggregation(groupingKeys, aggregates)
+                          .planNode())
+                      .copyResults(pool_.get());
+
+    ASSERT_EQ(result->size(), expectedCardinalities.size());
+    auto khllVector =
+        result->childAt(groupingKeys.size())->as<FlatVector<StringView>>();
+
+    for (size_t i = 0; i < expectedCardinalities.size(); ++i) {
+      if (!khllVector->isNullAt(i)) {
+        auto khllData = khllVector->valueAt(i);
+        EXPECT_EQ(getCardinality(khllData), expectedCardinalities[i]);
+      }
+    }
+  }
+
+ protected:
+  std::shared_ptr<MemoryPool> pool_;
+  std::unique_ptr<HashStringAllocator> hsa_;
+  HashStringAllocator* allocator_{};
+};
+
+TEST_F(KHyperLogLogAggregateTest, globalAggIntegers) {
+  vector_size_t size = 1'000;
+  auto values =
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 17; });
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({values, uii})}, {}, {"khyperloglog_agg(c0, c1)"}, {17});
+
+  // Test high cardinality
+  values = makeFlatVector<int64_t>(size, [](auto row) { return row; });
+  uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({values, uii})}, {}, {"khyperloglog_agg(c0, c1)"}, {1000});
+}
+
+TEST_F(KHyperLogLogAggregateTest, globalAggIntegersWithNulls) {
+  testAggregationWithCardinality(
+      {makeRowVector({
+          makeNullableFlatVector<int64_t>({1, 2, std::nullopt, 4, 5}),
+          makeNullableFlatVector<int64_t>({10, 10, 20, std::nullopt, 30}),
+      })},
+      {},
+      {"khyperloglog_agg(c0, c1)"},
+      {3});
+
+  // All nulls
+  auto expected = makeRowVector({makeNullConstant(TypeKind::VARBINARY, 1)});
+  testAggregations(
+      {makeRowVector({
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, std::nullopt, std::nullopt}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, std::nullopt, std::nullopt}),
+      })},
+      {},
+      {"khyperloglog_agg(c0, c1)"},
+      {expected});
+}
+
+TEST_F(KHyperLogLogAggregateTest, globalAggStrings) {
+  vector_size_t size = 1'000;
+  static const std::vector<std::string> kFruits = {
+      "apple",
+      "banana",
+      "cherry",
+      "unknown fruit with a long name",
+      "watermelon"};
+
+  auto values = makeFlatVector<StringView>(size, [&](auto row) {
+    return StringView(kFruits[row % kFruits.size()]);
+  });
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({values, uii})},
+      {},
+      {"khyperloglog_agg(c0, c1)"},
+      {static_cast<int64_t>(kFruits.size())});
+}
+
+TEST_F(KHyperLogLogAggregateTest, globalAggVarbinary) {
+  vector_size_t size = 1'000;
+  static const std::vector<std::string> kFruits = {
+      "apple", "banana", "unknown fruit with a long name", "watermelon"};
+
+  auto values = makeFlatVector<std::string>(
+      size,
+      [&](auto row) { return kFruits[row % kFruits.size()]; },
+      nullptr,
+      VARBINARY());
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({values, uii})},
+      {},
+      {"khyperloglog_agg(c0, c1)"},
+      {static_cast<int64_t>(kFruits.size())});
+}
+
+TEST_F(KHyperLogLogAggregateTest, globalAggTimeStamp) {
+  auto data = makeFlatVector<Timestamp>(
+      1'000, [](auto row) { return Timestamp::fromMillis(row); });
+  auto uii = makeFlatVector<int64_t>(1'000, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({data, uii})}, {}, {"khyperloglog_agg(c0, c1)"}, {1000});
+}
+
+TEST_F(KHyperLogLogAggregateTest, globalAggBoolean) {
+  vector_size_t size = 2'000;
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  auto values =
+      makeFlatVector<bool>(size, [](auto row) { return row % 2 == 0; });
+  testAggregationWithCardinality(
+      {makeRowVector({values, uii})}, {}, {"khyperloglog_agg(c0, c1)"}, {2});
+}
+
+TEST_F(KHyperLogLogAggregateTest, groupByIntegers) {
+  vector_size_t size = 1'000;
+  auto keys = makeFlatVector<int32_t>(size, [](auto row) { return row % 2; });
+  auto values = makeFlatVector<int64_t>(
+      size, [](auto row) { return row % 2 == 0 ? row % 17 : row % 23; });
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({keys, values, uii})},
+      {"c0"},
+      {"khyperloglog_agg(c1, c2)"},
+      {17, 23});
+}
+
+TEST_F(KHyperLogLogAggregateTest, groupByHighCardinalityIntegers) {
+  vector_size_t size = 1'000;
+  auto keys = makeFlatVector<int32_t>(size, [](auto row) { return row % 2; });
+  auto values = makeFlatVector<int64_t>(size, [](auto row) { return row; });
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  testAggregationWithCardinality(
+      {makeRowVector({keys, values, uii})},
+      {"c0"},
+      {"khyperloglog_agg(c1, c2)"},
+      {500, 500});
+}
+
+TEST_F(KHyperLogLogAggregateTest, groupByAllNulls) {
+  vector_size_t size = 1'000;
+  auto keys = makeFlatVector<int32_t>(size, [](auto row) { return row % 2; });
+  auto values = makeFlatVector<int32_t>(
+      size, [](auto row) { return row % 2 == 0 ? 27 : row % 3; }, nullEvery(2));
+  auto uii = makeFlatVector<int64_t>(size, [](auto /*row*/) { return 1; });
+
+  auto vectors = makeRowVector({keys, values, uii});
+
+  // When a group has all nulls, khyperloglog_agg returns NULL, not KHLL with
+  // cardinality 0
+  auto result = AssertQueryBuilder(
+                    PlanBuilder()
+                        .values({vectors})
+                        .singleAggregation({"c0"}, {"khyperloglog_agg(c1, c2)"})
+                        .planNode())
+                    .copyResults(pool_.get());
+
+  ASSERT_EQ(result->size(), 2);
+  auto khllVector = result->childAt(1)->as<FlatVector<StringView>>();
+
+  // At group 0, all values are null, so result is NULL.
+  ASSERT_TRUE(khllVector->isNullAt(0));
+
+  // Group 1 should have (0, 1, 2)
+  ASSERT_FALSE(khllVector->isNullAt(1));
+  EXPECT_EQ(getCardinality(khllVector->valueAt(1)), 3);
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/KHyperLogLogAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/KHyperLogLogAggregateTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/hyperloglog/KHyperLogLog.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
@@ -249,6 +250,41 @@ TEST_F(KHyperLogLogAggregateTest, groupByAllNulls) {
   // Group 1 should have (0, 1, 2)
   ASSERT_FALSE(khllVector->isNullAt(1));
   EXPECT_EQ(getCardinality(khllVector->valueAt(1)), 3);
+}
+
+TEST_F(KHyperLogLogAggregateTest, mergeKHyperLogLog) {
+  // Create two separate KHLL sketches
+  auto khll1 = createKHLL({1, 2, 3, 4, 5}, {1, 1, 1, 1, 1});
+  auto khll2 = createKHLL({6, 7, 8, 9, 10}, {1, 1, 1, 1, 1});
+
+  auto khllData = makeFlatVector<StringView>(
+      {StringView(khll1), StringView(khll2)}, KHYPERLOGLOG());
+
+  // Merge the two sketches - should have cardinality 10
+  testAggregationWithCardinality(
+      {makeRowVector({khllData})}, {}, {"merge(c0)"}, {10});
+}
+
+TEST_F(KHyperLogLogAggregateTest, toIntermediate) {
+  constexpr int kSize = 1000;
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>(kSize, folly::identity),
+      makeFlatVector<int64_t>(kSize, [](auto /*row*/) { return 1; }),
+      makeFlatVector<int64_t>(kSize, [](auto /*row*/) { return 1; }),
+  });
+
+  // Create KHLL sketches per group
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .singleAggregation({"c0"}, {"khyperloglog_agg(c1, c2)"})
+                  .planNode();
+
+  auto digests = split(AssertQueryBuilder(plan).copyResults(pool()), 2);
+
+  // Merge the split digests - each group should still have cardinality 1
+  std::vector<int64_t> expectedCardinalities(kSize, 1);
+  testAggregationWithCardinality(
+      digests, {"c0"}, {"merge(a0)"}, expectedCardinalities);
 }
 
 } // namespace

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -28,6 +28,7 @@ velox_add_library(
   GeneralFunctionsRegistration.cpp
   HyperLogFunctionsRegistration.cpp
   IntegerFunctionsRegistration.cpp
+  KHyperLogLogFunctionsRegistration.cpp
   FloatingPointFunctionsRegistration.cpp
   JsonFunctionsRegistration.cpp
   MapFunctionsRegistration.cpp

--- a/velox/functions/prestosql/registration/KHyperLogLogFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/KHyperLogLogFunctionsRegistration.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/KHyperLogLogFunctions.h"
+#include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
+
+namespace facebook::velox::functions {
+
+void registerKHyperLogLogFunctions(const std::string& prefix) {
+  registerKHyperLogLogType();
+
+  // These scalar functions are registered as vector functions, rather than
+  // using the simple function api, so that MemoryPool can be used as the
+  // allocator.
+  exec::registerVectorFunction(
+      prefix + "cardinality",
+      KHyperLogLogCardinalityFunction::signatures(),
+      std::make_unique<KHyperLogLogCardinalityFunction>());
+
+  exec::registerVectorFunction(
+      prefix + "intersection_cardinality",
+      KHyperLogLogIntersectionCardinalityFunction::signatures(),
+      std::make_unique<KHyperLogLogIntersectionCardinalityFunction>());
+
+  exec::registerVectorFunction(
+      prefix + "jaccard_index",
+      KHyperLogLogJaccardIndexFunction::signatures(),
+      std::make_unique<KHyperLogLogJaccardIndexFunction>());
+
+  exec::registerVectorFunction(
+      prefix + "reidentification_potential",
+      KHyperLogLogReidentificationPotentialFunction::signatures(),
+      std::make_unique<KHyperLogLogReidentificationPotentialFunction>());
+
+  exec::registerVectorFunction(
+      prefix + "uniqueness_distribution",
+      KHyperLogLogUniquenessDistributionFunction::signatures(),
+      std::make_unique<KHyperLogLogUniquenessDistributionFunction>());
+
+  exec::registerVectorFunction(
+      prefix + "merge_khll",
+      MergeKHyperLogLogFunction::signatures(),
+      std::make_unique<MergeKHyperLogLogFunction>());
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -31,6 +31,7 @@ extern void registerComparisonFunctions(const std::string& prefix);
 extern void registerDateTimeFunctions(const std::string& prefix);
 extern void registerGeneralFunctions(const std::string& prefix);
 extern void registerHyperLogFunctions(const std::string& prefix);
+extern void registerKHyperLogLogFunctions(const std::string& prefix);
 extern void registerTDigestFunctions(const std::string& prefix);
 extern void registerQDigestFunctions(const std::string& prefix);
 extern void registerSfmSketchFunctions(const std::string& prefix);
@@ -158,6 +159,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerArrayFunctions(prefix);
   registerJsonFunctions(prefix);
   registerHyperLogFunctions(prefix);
+  registerKHyperLogLogFunctions(prefix);
   registerTDigestFunctions(prefix);
   registerQDigestFunctions(prefix);
   registerSfmSketchFunctions(prefix);

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -33,6 +33,8 @@ void registerJsonFunctions(const std::string& prefix = "");
 
 void registerHyperLogFunctions(const std::string& prefix = "");
 
+void registerKHyperLogLogFunctions(const std::string& prefix = "");
+
 void registerTDigestFunctions(const std::string& prefix = "");
 
 void registerQDigestFunctions(const std::string& prefix = "");

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ add_executable(
   HyperLogLogCastTest.cpp
   HyperLogLogFunctionsTest.cpp
   KHyperLogLogCastTest.cpp
+  KHyperLogLogFunctionsTest.cpp
   P4HyperLogLogCastTest.cpp
   SetDigestCastTest.cpp
   InPredicateTest.cpp

--- a/velox/functions/prestosql/tests/KHyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/KHyperLogLogFunctionsTest.cpp
@@ -1,0 +1,689 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::common::hll;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions {
+namespace {
+
+class KHyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
+ protected:
+  void SetUp() override {
+    FunctionBaseTest::SetUp();
+  }
+
+  // Helper to create a KHLL with specific value-UII pairs.
+  std::string createKHLL(
+      const std::vector<std::pair<int64_t, int64_t>>& valueUiiPairs) {
+    auto pool = memory::memoryManager()->addLeafPool();
+    auto khll =
+        std::make_unique<KHyperLogLog<int64_t, memory::MemoryPool>>(pool.get());
+
+    for (const auto& [value, uii] : valueUiiPairs) {
+      khll->add(value, uii);
+    }
+
+    size_t totalSize = khll->estimatedSerializedSize();
+    std::string outputBuffer(totalSize, '\0');
+    khll->serialize(outputBuffer.data());
+    return outputBuffer;
+  }
+
+  // Helper to create array of KHLLs for merge_khll SQL function.
+  VectorPtr createKHLLArray(const std::vector<std::string>& serializedKHLLs) {
+    return makeArrayVector<std::string>({serializedKHLLs}, KHYPERLOGLOG());
+  }
+  // Build a map from the result vector for easier verification.
+  std::map<int64_t, double> createResultMap(MapVector* mapVector) {
+    auto mapSize = mapVector->sizeAt(0);
+
+    auto offset = mapVector->offsetAt(0);
+    auto keys = mapVector->mapKeys()->as<SimpleVector<int64_t>>();
+    auto values = mapVector->mapValues()->as<SimpleVector<double>>();
+
+    std::map<int64_t, double> resultMap;
+    for (vector_size_t i = 0; i < mapSize; ++i) {
+      resultMap[keys->valueAt(offset + i)] = values->valueAt(offset + i);
+    }
+    return resultMap;
+  }
+};
+
+TEST_F(KHyperLogLogFunctionsTest, cardinalityBasic) {
+  auto serialized = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+  auto input =
+      makeFlatVector<StringView>({StringView(serialized)}, KHYPERLOGLOG());
+  auto result = evaluate("cardinality(c0)", makeRowVector({input}));
+  auto expected = makeFlatVector<int64_t>({3});
+
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(KHyperLogLogFunctionsTest, mergeKhll) {
+  // Merge KHLLs with completely disjoint key sets.
+  {
+    auto khll1 = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+    auto khll2 = createKHLL({{3, 13}, {4, 14}, {5, 15}});
+    auto khll3 = createKHLL({{6, 16}, {7, 17}, {8, 18}});
+
+    auto arrayInput = createKHLLArray({khll1, khll2, khll3});
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+    EXPECT_FALSE(result->isNullAt(0));
+    EXPECT_EQ(result->type(), KHYPERLOGLOG());
+
+    auto cardinalityResult =
+        evaluate("cardinality(c0)", makeRowVector({result}));
+    auto expected = makeFlatVector<int64_t>({9});
+    assertEqualVectors(expected, cardinalityResult);
+  }
+
+  // Merge KHLLs with overlapping key sets.
+  {
+    auto khll1 = createKHLL({{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}});
+    auto khll2 = createKHLL({{3, 13}, {4, 14}, {5, 15}, {6, 16}, {7, 17}});
+
+    auto arrayInput = createKHLLArray({khll1, khll2});
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+
+    auto cardinalityResult =
+        evaluate("cardinality(c0)", makeRowVector({result}));
+    auto expected = makeFlatVector<int64_t>({8});
+    assertEqualVectors(expected, cardinalityResult);
+  }
+
+  // Merge KHLL with single element.
+  {
+    auto khll = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+    auto arrayInput = createKHLLArray({khll});
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+
+    auto cardinalityResult =
+        evaluate("cardinality(c0)", makeRowVector({result}));
+    auto expected = makeFlatVector<int64_t>({3});
+    assertEqualVectors(expected, cardinalityResult);
+  }
+
+  // Merge same KHLL multiple times.
+  {
+    auto khll = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+    auto arrayInput = createKHLLArray({khll, khll, khll});
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+
+    // Cardinality should still be 3.
+    auto cardinalityResult =
+        evaluate("cardinality(c0)", makeRowVector({result}));
+    auto expected = makeFlatVector<int64_t>({3});
+    assertEqualVectors(expected, cardinalityResult);
+  }
+
+  // Empty array
+  {
+    auto elements = makeFlatVector<StringView>({}, KHYPERLOGLOG());
+    auto arrayInput = makeArrayVector({0}, elements);
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+
+    EXPECT_TRUE(result->isNullAt(0));
+  }
+
+  // Array with nulls
+  {
+    auto khll = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+
+    std::vector<std::string> serializedData;
+    serializedData.push_back(khll);
+
+    auto elements = makeNullableFlatVector<StringView>(
+        {StringView(serializedData[0]),
+         std::nullopt,
+         StringView(serializedData[0])},
+        KHYPERLOGLOG());
+    auto arrayInput = makeArrayVector({0}, elements, {3});
+
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+
+    EXPECT_FALSE(result->isNullAt(0));
+
+    auto cardinalityResult =
+        evaluate("cardinality(c0)", makeRowVector({result}));
+    auto expected = makeFlatVector<int64_t>({3});
+    assertEqualVectors(expected, cardinalityResult);
+  }
+
+  // All nulls in array
+  {
+    auto elements = makeNullableFlatVector<StringView>(
+        {std::nullopt, std::nullopt, std::nullopt}, KHYPERLOGLOG());
+    auto arrayInput = makeArrayVector({0}, elements, {3});
+    auto result = evaluate("merge_khll(c0)", makeRowVector({arrayInput}));
+
+    EXPECT_TRUE(result->isNullAt(0));
+  }
+
+  // Null array
+  {
+    auto nullArray =
+        makeNullableFlatVector<int64_t>({std::nullopt}, ARRAY(KHYPERLOGLOG()));
+    auto result = evaluate("merge_khll(c0)", makeRowVector({nullArray}));
+
+    EXPECT_TRUE(result->isNullAt(0));
+  }
+}
+
+TEST_F(KHyperLogLogFunctionsTest, intersectionCardinalityExact) {
+  {
+    auto khll1 = createKHLL({{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}});
+    auto khll2 = createKHLL({{3, 13}, {4, 14}, {5, 15}, {6, 16}, {7, 17}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll2)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<int64_t>({2});
+    assertEqualVectors(expected, result);
+  }
+
+  // Intersection cardinality of completely overlapping KHLLs.
+  {
+    auto khll = createKHLL({{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<int64_t>({5});
+    assertEqualVectors(expected, result);
+  }
+
+  // Intersection cardinality of empty sets.
+  {
+    auto emptyKhll = createKHLL({});
+    auto nonEmptyKhll = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(emptyKhll)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(nonEmptyKhll)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<int64_t>({0});
+    assertEqualVectors(expected, result);
+
+    // Test in reverse order.
+    result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input2, input1}));
+    assertEqualVectors(expected, result);
+  }
+
+  {
+    auto emptyKhll1 = createKHLL({});
+    auto emptyKhll2 = createKHLL({});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(emptyKhll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(emptyKhll2)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<int64_t>({0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Intersection cardinality of completely disjoint sets
+  {
+    auto khll1 = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+    auto khll2 = createKHLL({{100, 110}, {101, 111}, {102, 112}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll2)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<int64_t>({0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Intersection where one is a subset of the other.
+  {
+    auto khll1 = createKHLL(
+        {{0, 10},
+         {1, 11},
+         {2, 12},
+         {3, 13},
+         {4, 14},
+         {5, 15},
+         {6, 16},
+         {7, 17},
+         {8, 18},
+         {9, 19}});
+    auto khll2 = createKHLL({{2, 12}, {3, 13}, {4, 14}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll2)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<int64_t>({3});
+    assertEqualVectors(expected, result);
+  }
+}
+
+TEST_F(KHyperLogLogFunctionsTest, intersectionCardinalityApproximate) {
+  auto pool = memory::memoryManager()->addLeafPool();
+
+  // KHLL1: 0-4999 (5000 values), KHLL2: 2500-5499 (3000 values).
+  // Expected intersection: 2500-4999 (2500 elements).
+  {
+    auto khll1 =
+        std::make_unique<KHyperLogLog<int64_t, memory::MemoryPool>>(pool.get());
+    auto khll2 =
+        std::make_unique<KHyperLogLog<int64_t, memory::MemoryPool>>(pool.get());
+
+    for (int64_t i = 0; i < 5000; ++i) {
+      khll1->add(i, 100);
+    }
+
+    for (int64_t i = 2500; i < 5500; ++i) {
+      khll2->add(i, 100);
+    }
+
+    std::string serialized1(khll1->estimatedSerializedSize(), '\0');
+    khll1->serialize(serialized1.data());
+
+    std::string serialized2(khll2->estimatedSerializedSize(), '\0');
+    khll2->serialize(serialized2.data());
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(serialized1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(serialized2)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+
+    // Allow 5% error for approximation
+    auto actualResult = result->as<FlatVector<int64_t>>()->valueAt(0);
+    EXPECT_NEAR(actualResult, 2500, 2500 * 0.05);
+  }
+
+  {
+    auto khll =
+        std::make_unique<KHyperLogLog<int64_t, memory::MemoryPool>>(pool.get());
+
+    for (int64_t i = 0; i < 5000; ++i) {
+      khll->add(i, 100);
+    }
+
+    std::string serialized(khll->estimatedSerializedSize(), '\0');
+    khll->serialize(serialized.data());
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(serialized)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(serialized)}, KHYPERLOGLOG());
+
+    auto result = evaluate(
+        "intersection_cardinality(c0, c1)", makeRowVector({input1, input2}));
+
+    auto actualResult = result->as<FlatVector<int64_t>>()->valueAt(0);
+    EXPECT_NEAR(actualResult, 5000, 5000 * 0.05);
+  }
+}
+
+TEST_F(KHyperLogLogFunctionsTest, uniquenessDistribution) {
+  auto serialized = createKHLL(
+      {{0, 0}, {1, 0}, {1, 1}, {2, 0}, {2, 1}, {3, 0}, {3, 1}, {3, 2}});
+  auto input =
+      makeFlatVector<StringView>({StringView(serialized)}, KHYPERLOGLOG());
+
+  // Uniqueness distribution with default histogram size of 256.
+  {
+    auto result =
+        evaluate("uniqueness_distribution(c0)", makeRowVector({input}));
+
+    EXPECT_FALSE(result->isNullAt(0));
+    EXPECT_EQ(result->type()->kind(), TypeKind::MAP);
+
+    auto mapVector = result->as<MapVector>();
+    auto mapSize = mapVector->sizeAt(0);
+    EXPECT_EQ(mapSize, 256);
+
+    auto resultMap = createResultMap(mapVector);
+
+    std::map<int64_t, double> expected;
+    for (int i = 1; i <= mapSize; ++i) {
+      expected[i] = 0;
+    }
+    expected[1] = 0.25;
+    expected[2] = 0.5;
+    expected[3] = 0.25;
+
+    EXPECT_EQ(resultMap, expected);
+  }
+
+  // Uniqueness distribution with custom histogram size.
+  {
+    auto histSize = makeFlatVector<int64_t>({128});
+    auto result = evaluate(
+        "uniqueness_distribution(c0, c1)", makeRowVector({input, histSize}));
+
+    EXPECT_FALSE(result->isNullAt(0));
+    EXPECT_EQ(result->type()->kind(), TypeKind::MAP);
+
+    auto mapVector = result->as<MapVector>();
+    auto mapSize = mapVector->sizeAt(0);
+    EXPECT_EQ(mapSize, 128);
+
+    auto resultMap = createResultMap(mapVector);
+
+    std::map<int64_t, double> expected;
+    for (int i = 1; i <= mapSize; ++i) {
+      expected[i] = 0;
+    }
+    expected[1] = 0.25;
+    expected[2] = 0.5;
+    expected[3] = 0.25;
+
+    EXPECT_EQ(resultMap, expected);
+  }
+
+  // Uniqueness distribution with empty KHLL (returns map with all histogram
+  // buckets set to 0.0).
+  {
+    auto emptyKhll = createKHLL({});
+    auto emptyInput =
+        makeFlatVector<StringView>({StringView(emptyKhll)}, KHYPERLOGLOG());
+    auto result =
+        evaluate("uniqueness_distribution(c0)", makeRowVector({emptyInput}));
+
+    EXPECT_FALSE(result->isNullAt(0));
+    auto mapVector = result->as<MapVector>();
+    auto mapSize = mapVector->sizeAt(0);
+    EXPECT_EQ(mapSize, 256);
+    auto resultMap = createResultMap(mapVector);
+
+    std::map<int64_t, double> expected;
+    for (int i = 1; i <= mapSize; ++i) {
+      expected[i] = 0;
+    }
+    EXPECT_EQ(resultMap, expected);
+  }
+
+  // Null inputs
+  {
+    auto nullKhll =
+        makeNullableFlatVector<StringView>({std::nullopt}, KHYPERLOGLOG());
+    auto result =
+        evaluate("uniqueness_distribution(c0)", makeRowVector({nullKhll}));
+    EXPECT_TRUE(result->isNullAt(0));
+    auto nullHistSize = makeNullableFlatVector<int64_t>({std::nullopt});
+    result = evaluate(
+        "uniqueness_distribution(c0, c1)",
+        makeRowVector({input, nullHistSize}));
+    EXPECT_TRUE(result->isNullAt(0));
+  }
+}
+
+TEST_F(KHyperLogLogFunctionsTest, jaccardIndex) {
+  // Jaccard index with identical sets.
+  {
+    auto khll = createKHLL({{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}});
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+
+    auto result =
+        evaluate("jaccard_index(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<double>({1.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Jaccard index with completely disjoint sets.
+  {
+    auto khll1 = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+    auto khll2 = createKHLL({{100, 110}, {101, 111}, {102, 112}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll2)}, KHYPERLOGLOG());
+
+    auto result =
+        evaluate("jaccard_index(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<double>({0.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Jaccard index with some overlapping elements.
+  {
+    auto khll1 = createKHLL({{0, 10}, {1, 11}, {2, 12}, {3, 13}, {4, 14}});
+    auto khll2 = createKHLL({{3, 13}, {4, 14}, {5, 15}, {6, 16}, {7, 17}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll2)}, KHYPERLOGLOG());
+
+    auto result =
+        evaluate("jaccard_index(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<double>({0.2});
+    assertEqualVectors(expected, result);
+  }
+
+  {
+    auto khll1 = createKHLL(
+        {{0, 10},
+         {1, 11},
+         {2, 12},
+         {3, 13},
+         {4, 14},
+         {5, 15},
+         {6, 16},
+         {7, 17},
+         {8, 18},
+         {9, 19}});
+    auto khll2 = createKHLL({{2, 12}, {3, 13}, {4, 14}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(khll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(khll2)}, KHYPERLOGLOG());
+
+    auto result =
+        evaluate("jaccard_index(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<double>({0.6666666666666666});
+    assertEqualVectors(expected, result);
+  }
+
+  // Jaccard index with both sets empty. Jaccard index of two empty sets is
+  // defined as 1.0
+  {
+    auto emptyKhll1 = createKHLL({});
+    auto emptyKhll2 = createKHLL({});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(emptyKhll1)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(emptyKhll2)}, KHYPERLOGLOG());
+
+    auto result =
+        evaluate("jaccard_index(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<double>({1.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Jaccard index with an empty and non empty set.
+  {
+    auto emptyKhll = createKHLL({});
+    auto nonEmptyKhll = createKHLL({{0, 10}, {1, 11}, {2, 12}});
+
+    auto input1 =
+        makeFlatVector<StringView>({StringView(emptyKhll)}, KHYPERLOGLOG());
+    auto input2 =
+        makeFlatVector<StringView>({StringView(nonEmptyKhll)}, KHYPERLOGLOG());
+
+    auto result =
+        evaluate("jaccard_index(c0, c1)", makeRowVector({input1, input2}));
+    auto expected = makeFlatVector<double>({0.0});
+    assertEqualVectors(expected, result);
+
+    // Test in reverse order
+    result = evaluate("jaccard_index(c0, c1)", makeRowVector({input2, input1}));
+    assertEqualVectors(expected, result);
+  }
+}
+
+TEST_F(KHyperLogLogFunctionsTest, reidentificationPotential) {
+  // Different reidentification potential cases
+  {
+    auto khll = createKHLL({{0, 0}, {1, 0}, {2, 0}});
+    auto input = makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({2});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, threshold}));
+    auto expected = makeFlatVector<double>({1.0});
+    assertEqualVectors(expected, result);
+  }
+
+  {
+    auto khll = createKHLL({
+        {0, 0},
+        {0, 1},
+        {0, 2},
+        {0, 3},
+        {0, 4}, // Value 0: 5 UIIs
+        {1, 0},
+        {1, 1},
+        {1, 2},
+        {1, 3}, // Value 1: 4 UIIs
+        {2, 0},
+        {2, 1},
+        {2, 2} // Value 2: 3 UIIs
+    });
+    auto input = makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({2});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, threshold}));
+    auto expected = makeFlatVector<double>({0.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // 2 out of 3 values at risk.
+  {
+    auto khll = createKHLL({
+        {0, 0},
+        {0, 1}, // Value 0: 2 UIIs
+        {1, 0},
+        {1, 1},
+        {1, 2}, // Value 1: 3 UIIs
+        {2, 0} // Value 2: 1 UII
+    });
+    auto input = makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({2});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, threshold}));
+    auto expected = makeFlatVector<double>({0.6666666666666666});
+    assertEqualVectors(expected, result);
+  }
+
+  // Reidentification potential with threshold of 0.
+  {
+    auto khll = createKHLL({{0, 0}, {1, 0}, {2, 0}});
+    auto input = makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({0});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, threshold}));
+    auto expected = makeFlatVector<double>({0.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Reidentification potential with empty KHLL
+  {
+    auto emptyKhll = createKHLL({});
+    auto input =
+        makeFlatVector<StringView>({StringView(emptyKhll)}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({2});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, threshold}));
+    auto expected = makeFlatVector<double>({0.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Reidentification potential with single value with multiple UIIs.
+  {
+    auto khll = createKHLL({{0, 0}, {0, 1}, {0, 2}});
+    auto input = makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({2});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, threshold}));
+    auto expected = makeFlatVector<double>({0.0});
+    assertEqualVectors(expected, result);
+  }
+
+  // Null inputs
+  {
+    auto nullKhll =
+        makeNullableFlatVector<StringView>({std::nullopt}, KHYPERLOGLOG());
+    auto threshold = makeFlatVector<int64_t>({2});
+
+    auto result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({nullKhll, threshold}));
+    EXPECT_TRUE(result->isNullAt(0));
+
+    auto khll = createKHLL({{0, 0}, {1, 0}});
+    auto input = makeFlatVector<StringView>({StringView(khll)}, KHYPERLOGLOG());
+    auto nullThreshold = makeNullableFlatVector<int64_t>({std::nullopt});
+    result = evaluate(
+        "reidentification_potential(c0, c1)",
+        makeRowVector({input, nullThreshold}));
+    EXPECT_TRUE(result->isNullAt(0));
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
@@ -16,16 +16,12 @@
 #include "FunctionBaseTest.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
 #include "velox/parse/TypeResolver.h"
 
 namespace facebook::velox::functions::test {
 
 void FunctionBaseTest::SetUpTestCase() {
   parse::registerTypeResolver();
-  // TODO: remove the registration of KHyperLogLog here once it is registered
-  // through registerAllScalarFunctions().
-  registerKHyperLogLogType();
   functions::prestosql::registerAllScalarFunctions();
   memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
 }

--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -55,6 +55,7 @@ velox_link_libraries(
   velox_functions_lib_date_time_formatter
   velox_constrained_input_generators
   velox_presto_types_fuzzer_utils
+  velox_common_hyperloglog
 )
 
 if(${VELOX_BUILD_TESTING})


### PR DESCRIPTION
Summary:
Adds the scalar udfs of the khyperloglog type, based on the utils from https://github.com/facebookincubator/velox/pull/15429

Java implementation: https://github.com/prestodb/presto/blob/master/presto-main-base/src/main/java/com/facebook/presto/type/khyperloglog/KHyperLogLogFunctions.java
Presto docs: https://prestodb.io/docs/current/functions/khyperloglog.html

Differential Revision: D87008234


