### PR TITLE
feat: Support matchRowFieldsByName in CastHooks

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -594,8 +594,7 @@ VectorPtr CastExpr::applyRow(
 
   // Extract the flag indicating matching of children must be done by
   // name or position
-  auto matchByName =
-      context.execCtx()->queryCtx()->queryConfig().isMatchStructByName();
+  auto matchByName = hooks_->matchRowFieldsByName();
 
   // Cast each row child to its corresponding output child
   std::vector<VectorPtr> newChildren;

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -76,5 +76,8 @@ class CastHooks {
 
   /// Converts boolean to timestamp type.
   virtual Expected<Timestamp> castBooleanToTimestamp(bool seconds) const = 0;
+
+  /// Returns whether to match struct fields by name when casting rows.
+  virtual bool matchRowFieldsByName() const = 0;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -27,7 +27,9 @@
 namespace facebook::velox::exec {
 
 PrestoCastHooks::PrestoCastHooks(const core::QueryConfig& config)
-    : CastHooks(), legacyCast_(config.isLegacyCast()) {
+    : CastHooks(),
+      legacyCast_(config.isLegacyCast()),
+      matchRowFieldsByName_(config.isMatchStructByName()) {
   if (!legacyCast_) {
     options_.zeroPaddingYear = true;
     options_.dateTimeSeparator = ' ';

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -67,8 +67,13 @@ class PrestoCastHooks : public CastHooks {
 
   PolicyType getPolicy() const override;
 
+  bool matchRowFieldsByName() const override {
+    return matchRowFieldsByName_;
+  }
+
  private:
   const bool legacyCast_;
+  const bool matchRowFieldsByName_;
   TimestampToStringOptions options_ = {
       .precision = TimestampToStringOptions::Precision::kMilliseconds};
 };

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -23,8 +23,12 @@ namespace facebook::velox::functions::sparksql {
 
 SparkCastHooks::SparkCastHooks(
     const velox::core::QueryConfig& config,
-    bool allowOverflow)
-    : config_(config), allowOverflow_(allowOverflow) {
+    bool allowOverflow,
+    bool matchRowFieldsByName)
+    : config_(config),
+      allowOverflow_(allowOverflow),
+      matchRowFieldsByName_(
+          matchRowFieldsByName || config.isMatchStructByName()) {
   const auto sessionTzName = config.sessionTimezone();
   if (!sessionTzName.empty()) {
     timestampToStringOptions_.timeZone = tz::locateZone(sessionTzName);

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include "velox/core/QueryCtx.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/expression/CastHooks.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -26,7 +26,8 @@ class SparkCastHooks : public exec::CastHooks {
  public:
   explicit SparkCastHooks(
       const velox::core::QueryConfig& config,
-      bool allowOverflow);
+      bool allowOverflow,
+      bool matchRowFieldsByName = false);
 
   // TODO: Spark hook allows more string patterns than Presto.
   Expected<Timestamp> castStringToTimestamp(
@@ -78,6 +79,10 @@ class SparkCastHooks : public exec::CastHooks {
 
   exec::PolicyType getPolicy() const override;
 
+  bool matchRowFieldsByName() const override {
+    return matchRowFieldsByName_;
+  }
+
  private:
   // Casts a number to a timestamp. The number is treated as the number of
   // seconds since the epoch (1970-01-01 00:00:00 UTC).
@@ -89,6 +94,9 @@ class SparkCastHooks : public exec::CastHooks {
 
   // If true, the cast will truncate the overflow value to fit the target type.
   const bool allowOverflow_;
+
+  // If true, struct fields will be matched by name when casting rows.
+  const bool matchRowFieldsByName_;
 
   /// 1) Does not follow 'isLegacyCast'. 2) The conversion precision is
   /// microsecond. 3) Does not append trailing zeros. 4) Adds a positive

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(
   SizeTest.cpp
   SortArrayTest.cpp
   SparkCastExprTest.cpp
+  SparkCastHooksTest.cpp
   SparkPartitionIdTest.cpp
   SplitTest.cpp
   StringTest.cpp

--- a/velox/functions/sparksql/tests/SparkCastHooksTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastHooksTest.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+TEST(SparkCastHooksTest, matchRowFieldsByName) {
+  // Test that matchRowFieldsByName() returns the correct value based on
+  // the constructor param and the value in the QueryConfig.
+
+  auto testMatchRowFieldsByName = [](bool queryConfigValue,
+                                     bool castHooksValue,
+                                     bool expected) {
+    core::QueryConfig queryConfig(
+        {{core::QueryConfig::kCastMatchStructByName,
+          folly::to<std::string>(queryConfigValue)}});
+
+    EXPECT_EQ(
+        expected,
+        SparkCastHooks(queryConfig, false /* allowOverflow */, castHooksValue)
+            .matchRowFieldsByName());
+  };
+
+  // If either is set to true, matchRowFieldsByName should return true.
+  testMatchRowFieldsByName(false, false, false);
+  testMatchRowFieldsByName(true, false, true);
+  testMatchRowFieldsByName(false, true, true);
+  testMatchRowFieldsByName(true, true, true);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Summary:
Currently, CastExpr determines whether to map row fields by name or by position when
casting between row types, based on a setting in the QueryConfig. This means that it must
apply uniformly to all CastExprs in a query.

We have a use case in Spark where the engine supports cast mapping row fields by position
by default, but a custom UDF enables casting mapping row fields by name. To enable this I'm
adding a function to the CastHooks interface that we check to determine how to map
fields. For PrestoCastHooks this defaults to the value from QueryConfig so there's no change
in behavior. For SparkCastHooks it looks at the value from the QueryConfig as well as a
constructor parameter and OR's them, preserving the existing behavior unless we explicitly
set the new behavior when constructing the instance of SparkCastHooks.

I changed the name in the CastHooks to matchRowFieldsByName instead of 
matchStructByName because we're matching the fields not the struct, and we refer to the
type as row in Velox not struct. Note that matchStructByName is hardcoded in the config
name string, so to not break backwards compatibility I did not change it there.

Differential Revision: D87371309


