### PR TITLE
fix: Improve serde behavior for zero-area polygons

### DIFF
--- a/velox/functions/prestosql/geospatial/GeometrySerde.h
+++ b/velox/functions/prestosql/geospatial/GeometrySerde.h
@@ -315,7 +315,12 @@ class GeometrySerializer {
     }
 
     auto coordinates = geometry.getCoordinates();
-    canonicalizePolygonCoordinates(coordinates, partIndexes, shellPart);
+    bool zeroAreaRingEncountered =
+        canonicalizePolygonCoordinates(coordinates, partIndexes, shellPart);
+    if (FOLLY_UNLIKELY(zeroAreaRingEncountered && multiType)) {
+      VELOX_USER_FAIL(
+          "Input MultiPolygon contains one or more zero-area rings.");
+    }
     writeCoordinates(coordinates, writer);
   }
 

--- a/velox/functions/prestosql/geospatial/GeometryUtils.h
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.h
@@ -149,9 +149,13 @@ FOLLY_ALWAYS_INLINE bool isAtomicType(const geos::geom::Geometry& geometry) {
 std::optional<std::string> geometryInvalidReason(
     const geos::geom::Geometry* geometry);
 
+enum ClockwiseResult { CW, CCW, ZERO_AREA };
+
 /// Determines if a ring of coordinates (from `start` to `end`) is oriented
-/// clockwise.
-FOLLY_ALWAYS_INLINE bool isClockwise(
+/// clockwise. A return value of 1 indicates clockwise orientation, 0 indicates
+/// counterclockwise, and -1 represents a polygon which has no orientation due
+/// to having an area of 0.
+FOLLY_ALWAYS_INLINE ClockwiseResult isClockwise(
     const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
     size_t start,
     size_t end) {
@@ -161,7 +165,10 @@ FOLLY_ALWAYS_INLINE bool isClockwise(
     const auto& p2 = coordinates->getAt(i + 1);
     sum += (p2.x - p1.x) * (p2.y + p1.y);
   }
-  return sum > 0.0;
+  if (FOLLY_UNLIKELY(sum == 0.0)) {
+    return ClockwiseResult::ZERO_AREA;
+  }
+  return sum > 0.0 ? ClockwiseResult::CW : ClockwiseResult::CCW;
 }
 
 /// Reverses the order of coordinates in the sequence between `start` and `end`
@@ -179,31 +186,41 @@ FOLLY_ALWAYS_INLINE void reverse(
 /// Ensures that a polygon ring has the canonical orientation:
 /// - Exterior rings (shells) must be clockwise.
 /// - Interior rings (holes) must be counter-clockwise.
-FOLLY_ALWAYS_INLINE void canonicalizePolygonCoordinates(
+/// A return value of true indicates a zero-area ring was encountered
+FOLLY_ALWAYS_INLINE bool canonicalizePolygonCoordinates(
     const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
     size_t start,
     size_t end,
     bool isShell) {
-  bool isClockwiseFlag = isClockwise(coordinates, start, end);
+  ClockwiseResult isClockwiseFlag = isClockwise(coordinates, start, end);
+  if (isClockwiseFlag == ClockwiseResult::ZERO_AREA) {
+    return true;
+  }
 
-  if ((isShell && !isClockwiseFlag) || (!isShell && isClockwiseFlag)) {
+  if ((isShell && isClockwiseFlag == ClockwiseResult::CCW) ||
+      (!isShell && isClockwiseFlag == ClockwiseResult::CW)) {
     reverse(coordinates, start, end);
   }
+  return false;
 }
 
 /// Applies `canonicalizePolygonCoordinates` to all rings in a polygon.
-FOLLY_ALWAYS_INLINE void canonicalizePolygonCoordinates(
+/// A return value of true indicates at least one zero-area ring was
+/// encountered.
+FOLLY_ALWAYS_INLINE bool canonicalizePolygonCoordinates(
     const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
     const std::vector<size_t>& partIndexes,
     const std::vector<bool>& shellPart) {
+  bool zeroAreaRingEncountered = false;
   for (size_t part = 0; part < partIndexes.size() - 1; part++) {
-    canonicalizePolygonCoordinates(
+    zeroAreaRingEncountered |= canonicalizePolygonCoordinates(
         coordinates, partIndexes[part], partIndexes[part + 1], shellPart[part]);
   }
   if (!partIndexes.empty()) {
-    canonicalizePolygonCoordinates(
+    zeroAreaRingEncountered |= canonicalizePolygonCoordinates(
         coordinates, partIndexes.back(), coordinates->size(), shellPart.back());
   }
+  return zeroAreaRingEncountered;
 }
 
 Status validateLatitudeLongitude(double latitude, double longitude);


### PR DESCRIPTION
Summary:
Today there is an inconsistency Java and C++ with polygon serde related to orientation. A polygon ring's orientation, that is, if the edges run clockwise(CW) or counterclockwise(CCW), is sometimes used to determine if the polygon is an exterior ring (shell) or interior ring (hole). During Esri Java and C++ serialization, we try to 'canonicalize' orientation of polygons to fit this rule. Canonicalization means reversing any shells that are CCW or holes that are CW. However, some polygons have exactly zero area, which are considered CCW before and after reversal. This causes problems after serialization and deserialization, which relies on orientation to determine if a ring is a shell or hole: zero-area polygon shells can be misinterpreted as holes.

This issue is further exacerbated due to Java having 2 serde paths, with C++ serde mirroring the JTS serde path. Esri serde path in Java does not have the same polygon orientation checks. This results in the following behavior:

Fails with `shell is empty but holes are not` in Java:
```
select st_area(st_geometryfromtext('POLYGON((-135 85, -45 85, 45 85, 135 85, -135 85))'))
```

Succeeds in Java:
```
select st_area(to_spherical_geography(st_geometryfromtext('POLYGON((-135 85, -45 85, 45 85, 135 85, -135 85))')))
```

Succeeds in Java, but incorrectly reconstructs the MultiPolygon as `MULTIPOLYGON (((1 1, 2 2, 2 1, 1 1), (1 1, 2 2, 3 3, 2 2, 1 1)))`:
```
select st_astext(st_geometryfromtext('MULTIPOLYGON (((1 1, 2 1, 2 2, 1 1)), ((1 1, 2 2, 3 3, 2 2, 1 1)))'))
```

After this change:

-For polygons which have zero area shells or holes, we simply leave them alone. The first ring is *always* a shell, all further rings are *always* holes. This means no more failing with `shells are empty but holes are not`

-We no longer reverse all zero-area shells. Previously, zero-area shells would try to 'canonicalize' and reverse the shell, leaving a (still zero-area) reversed orientation. Serde will leave zero-area shells alone.

-For MultiPolygons, we *always* fail when encountering zero-area rings. We could theoretically allow zero-area holes, open to discussion here. But I think it's a simpler contract if MultiPolygons can never have any zero-area rings.

Differential Revision: D87384761


