### PR TITLE
fix: Do not rewrite expression if it only has constant inputs

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -467,9 +467,8 @@ ExprPtr compileExpression(
     memory::MemoryPool* pool,
     const std::unordered_set<std::string>& flatteningCandidates,
     bool enableConstantFolding) {
-  auto rewritten = enableConstantFolding
-      ? expression::optimize(expr, queryCtx, pool)
-      : expression::ExprRewriteRegistry::instance().rewrite(expr);
+  auto rewritten =
+      enableConstantFolding ? expression::optimize(expr, queryCtx, pool) : expr;
   if (rewritten.get() != expr.get()) {
     scope->rewrittenExpressions.push_back(rewritten);
   }

--- a/velox/expression/ExprRewriteRegistry.cpp
+++ b/velox/expression/ExprRewriteRegistry.cpp
@@ -28,6 +28,16 @@ void ExprRewriteRegistry::clear() {
 
 core::TypedExprPtr ExprRewriteRegistry::rewrite(
     const core::TypedExprPtr& expr) {
+  const auto& inputs = expr->inputs();
+  VELOX_CHECK(
+      std::any_of(
+          inputs.begin(),
+          inputs.end(),
+          [](const core::TypedExprPtr& input) {
+            return !input->isConstantKind();
+          }),
+      "Expression should have at least one non-constant input.");
+
   core::TypedExprPtr result = expr;
   registry_.withRLock([&](const auto& list) {
     for (const auto& rewrite : list) {

--- a/velox/expression/ExprRewriteRegistry.h
+++ b/velox/expression/ExprRewriteRegistry.h
@@ -38,6 +38,8 @@ class ExprRewriteRegistry {
   /// Clears the registry to remove all registered rewrites.
   void clear();
 
+  /// Rewrites input expression to an equivalent expression. Throws if the
+  /// expression only has constant inputs.
   core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
 
   static ExprRewriteRegistry& instance() {

--- a/velox/expression/tests/ConjunctRewriteTest.cpp
+++ b/velox/expression/tests/ConjunctRewriteTest.cpp
@@ -25,17 +25,6 @@ class ConjunctRewriteTest
     : public expression::test::SpecialFormRewriteTestBase {};
 
 TEST_F(ConjunctRewriteTest, basic) {
-  testRewrite("true and true", "true");
-  testRewrite("false or false", "false");
-  testRewrite("null::boolean and false", "false");
-  testRewrite("true or null::boolean", "true");
-  testRewrite(
-      "null::boolean and null::boolean and null::boolean", "null::boolean");
-  testRewrite(
-      "null::boolean or null::boolean or null::boolean", "null::boolean");
-  testRewrite("null::boolean and true", "null::boolean");
-  testRewrite("false or null::boolean", "null::boolean");
-
   const auto type = ROW({"a", "b"}, {VARCHAR(), BIGINT()});
   testRewrite(
       "null::boolean and a = 'z' and true", "null::boolean and a = 'z'", type);

--- a/velox/expression/tests/ExprRewriteRegistryTest.cpp
+++ b/velox/expression/tests/ExprRewriteRegistryTest.cpp
@@ -27,17 +27,20 @@ TEST_F(ExprRewriteRegistryTest, basic) {
   expression::ExpressionRewrite testRewrite =
       [&](const core::TypedExprPtr& input) {
         return std::make_shared<core::CallTypedExpr>(
-            input->type(), "test_expr", input, input);
+            input->type(), "rewritten_expr", input, input);
       };
   registry.registerRewrite(testRewrite);
 
-  auto input = std::make_shared<core::ConstantTypedExpr>(BIGINT(), 123LL);
+  auto input = std::make_shared<core::CallTypedExpr>(
+      BIGINT(),
+      "original_expr",
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "a"));
   const auto rewritten = registry.rewrite(input);
   ASSERT_TRUE(rewritten->isCallKind());
   ASSERT_TRUE(rewritten->type()->isBigint());
   const auto rewrittenCall = rewritten->asUnchecked<core::CallTypedExpr>();
   ASSERT_EQ(rewrittenCall->inputs().size(), 2);
-  ASSERT_EQ(rewrittenCall->name(), "test_expr");
+  ASSERT_EQ(rewrittenCall->name(), "rewritten_expr");
 
   registry.clear();
   const auto rewriteAfterClear = registry.rewrite(input);

--- a/velox/expression/tests/SwitchRewriteTest.cpp
+++ b/velox/expression/tests/SwitchRewriteTest.cpp
@@ -25,14 +25,6 @@ class SwitchRewriteTest : public expression::test::SpecialFormRewriteTestBase {
 };
 
 TEST_F(SwitchRewriteTest, basic) {
-  testRewrite("if(true, 'hello', 'world')", "'hello'");
-  testRewrite("case when false then 1 when true then 3 end", "3");
-  testRewrite("case when false then 1 when false then 3 end", "null::bigint");
-  testRewrite("case when false then 1 when false then 3 else 2 end", "2");
-  testRewrite(
-      "case when false then 'hello' when false then 'world' when true then 'foo' else 'bar' end",
-      "'foo'");
-
   const auto type = ROW({"a"}, {BIGINT()});
   testRewrite("case when false then 1234 when true then a end", "a", type);
   testRewrite(


### PR DESCRIPTION
Expression rewrite is invoked after constant folding, hence, rewrite should not expect a deterministic input expression with all constant inputs. Adds a check to ExprRewriteRegistry.