### PR TITLE
Fix cuDF MultiThreadedHashJoinTest.semiFilterOverLazyVectors test case failure

### DIFF
--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -17,7 +17,12 @@ add_executable(velox_cudf_assign_unique_id_test Main.cpp AssignUniqueIdTest.cpp)
 add_executable(velox_cudf_config_test Main.cpp ConfigTest.cpp)
 add_executable(velox_cudf_expression_selection_test Main.cpp ExpressionEvaluatorSelectionTest.cpp)
 add_executable(velox_cudf_filter_project_test Main.cpp FilterProjectTest.cpp)
-add_executable(velox_cudf_hash_join_test HashJoinTest.cpp Main.cpp)
+add_executable(
+  velox_cudf_hash_join_test
+  HashJoinTest.cpp
+  Main.cpp
+  utils/CudfHiveConnectorTestBase.cpp
+)
 add_executable(velox_cudf_limit_test Main.cpp LimitTest.cpp)
 add_executable(velox_cudf_local_partition_test Main.cpp LocalPartitionTest.cpp)
 add_executable(velox_cudf_order_by_test Main.cpp OrderByTest.cpp)

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
@@ -47,12 +47,12 @@ class CudfHiveConnectorTestBase
   void resetCudfHiveConnector(
       const std::shared_ptr<const facebook::velox::config::ConfigBase>& config);
 
-  void writeToFile(
+  static void writeToFile(
       const std::string& filePath,
       RowVectorPtr vector,
       std::string prefix = "c");
 
-  void writeToFile(
+  static void writeToFile(
       const std::string& filePath,
       const std::vector<RowVectorPtr>& vectors,
       std::string prefix = "c");


### PR DESCRIPTION
Fix test case failures that were the result of using Hive connectors when cuDF Hive connectors were expected.

Related issue: https://github.com/facebookincubator/velox/issues/15324