### PR TITLE
refactor: Move HllAccumulator to HllUtils

### DIFF
--- a/velox/common/hyperloglog/HllAccumulator.h
+++ b/velox/common/hyperloglog/HllAccumulator.h
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#define XXH_INLINE_ALL
+
+#include <xxhash.h>
+#include <cmath>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/hyperloglog/DenseHll.h"
+#include "velox/common/hyperloglog/Murmur3Hash128.h"
+#include "velox/common/hyperloglog/SparseHll.h"
+#include "velox/common/memory/HashStringAllocator.h"
+
+namespace facebook::velox::common::hll {
+
+namespace detail {
+template <typename T, bool HllAsFinalResult>
+inline uint64_t hashOne(const T& value) {
+  if constexpr (HllAsFinalResult) {
+    if constexpr (std::is_same_v<T, int64_t>) {
+      return common::hll::Murmur3Hash128::hash64ForLong(value, 0);
+    } else if constexpr (std::is_same_v<T, double>) {
+      return common::hll::Murmur3Hash128::hash64ForLong(
+          *reinterpret_cast<const int64_t*>(&value), 0);
+    }
+    return common::hll::Murmur3Hash128::hash64(&value, sizeof(T), 0);
+  } else {
+    return XXH64(&value, sizeof(T), 0);
+  }
+}
+
+// Use timestamp.toMillis() to compute hash value.
+template <>
+inline uint64_t hashOne<Timestamp, false>(const Timestamp& value) {
+  return hashOne<int64_t, false>(value.toMillis());
+}
+
+template <>
+inline uint64_t hashOne<Timestamp, true>(const Timestamp& /*value*/) {
+  VELOX_UNREACHABLE("approx_set(timestamp) is not supported.");
+}
+
+template <>
+inline uint64_t hashOne<StringView, false>(const StringView& value) {
+  return XXH64(value.data(), value.size(), 0);
+}
+
+template <>
+inline uint64_t hashOne<StringView, true>(const StringView& value) {
+  return common::hll::Murmur3Hash128::hash64(value.data(), value.size(), 0);
+}
+
+} // namespace detail
+
+template <typename T, bool HllAsFinalResult>
+struct HllAccumulator {
+  explicit HllAccumulator(HashStringAllocator* allocator)
+      : sparseHll_{allocator}, denseHll_{allocator} {}
+
+  void setIndexBitLength(int8_t indexBitLength) {
+    indexBitLength_ = indexBitLength;
+    sparseHll_.setSoftMemoryLimit(
+        common::hll::DenseHlls::estimateInMemorySize(indexBitLength_));
+  }
+
+  void append(T value) {
+    const auto hash = detail::hashOne<T, HllAsFinalResult>(value);
+
+    if (isSparse_) {
+      if (sparseHll_.insertHash(hash)) {
+        toDense();
+      }
+    } else {
+      denseHll_.insertHash(hash);
+    }
+  }
+
+  int64_t cardinality() const {
+    return isSparse_ ? sparseHll_.cardinality() : denseHll_.cardinality();
+  }
+
+  void mergeWith(StringView serialized, HashStringAllocator* allocator) {
+    auto input = serialized.data();
+    if (common::hll::SparseHlls::canDeserialize(input)) {
+      if (isSparse_) {
+        sparseHll_.mergeWith(input);
+        if (indexBitLength_ < 0) {
+          setIndexBitLength(
+              common::hll::DenseHlls::deserializeIndexBitLength(input));
+        }
+        if (sparseHll_.overLimit()) {
+          toDense();
+        }
+      } else {
+        common::hll::SparseHll<> other{input, allocator};
+        other.toDense(denseHll_);
+      }
+    } else if (common::hll::DenseHlls::canDeserialize(input)) {
+      if (isSparse_) {
+        if (indexBitLength_ < 0) {
+          setIndexBitLength(
+              common::hll::DenseHlls::deserializeIndexBitLength(input));
+        }
+        toDense();
+      }
+      denseHll_.mergeWith(input);
+    } else {
+      VELOX_USER_FAIL("Unexpected type of HLL");
+    }
+  }
+
+  int32_t serializedSize() {
+    return isSparse_ ? sparseHll_.serializedSize() : denseHll_.serializedSize();
+  }
+
+  void serialize(char* outputBuffer) {
+    return isSparse_ ? sparseHll_.serialize(indexBitLength_, outputBuffer)
+                     : denseHll_.serialize(outputBuffer);
+  }
+
+ private:
+  void toDense() {
+    isSparse_ = false;
+    denseHll_.initialize(indexBitLength_);
+    sparseHll_.toDense(denseHll_);
+    sparseHll_.reset();
+  }
+
+  bool isSparse_{true};
+  int8_t indexBitLength_{-1};
+  common::hll::SparseHll<> sparseHll_;
+  common::hll::DenseHll<> denseHll_;
+};
+
+template <>
+struct HllAccumulator<bool, false> {
+  explicit HllAccumulator(HashStringAllocator* /*allocator*/) {}
+
+  void append(bool value) {
+    approxDistinctState_ |= (1 << value);
+  }
+
+  int64_t cardinality() const {
+    return (approxDistinctState_ & 1) + ((approxDistinctState_ & 2) >> 1);
+  }
+
+  void mergeWith(
+      StringView /*serialized*/,
+      HashStringAllocator* /*allocator*/) {
+    VELOX_UNREACHABLE(
+        "APPROX_DISTINCT<BOOLEAN> unsupported mergeWith(StringView, HashStringAllocator*)");
+  }
+
+  void mergeWith(int8_t data) {
+    approxDistinctState_ |= data;
+  }
+
+  int32_t serializedSize() const {
+    return sizeof(int8_t);
+  }
+
+  void serialize(char* /*outputBuffer*/) {
+    VELOX_UNREACHABLE("APPROX_DISTINCT<BOOLEAN> unsupported serialize(char*)");
+  }
+
+  void setIndexBitLength(int8_t /*indexBitLength*/) {}
+
+  int8_t getState() const {
+    return approxDistinctState_;
+  }
+
+ private:
+  int8_t approxDistinctState_{0};
+};
+
+} // namespace facebook::velox::common::hll

--- a/velox/functions/prestosql/aggregates/HyperLogLogAggregate.h
+++ b/velox/functions/prestosql/aggregates/HyperLogLogAggregate.h
@@ -18,11 +18,9 @@
 #define XXH_INLINE_ALL
 #include <xxhash.h> // @manual=third-party//xxHash:xxhash
 
-#include "velox/common/hyperloglog/DenseHll.h"
+#include "velox/common/hyperloglog/HllAccumulator.h"
 #include "velox/common/hyperloglog/HllUtils.h"
-#include "velox/common/hyperloglog/Murmur3Hash128.h"
 #include "velox/common/hyperloglog/SparseHll.h"
-#include "velox/common/memory/HashStringAllocator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
@@ -30,163 +28,6 @@
 using facebook::velox::common::hll::SparseHll;
 
 namespace facebook::velox::aggregate::prestosql {
-
-template <typename T, bool HllAsFinalResult>
-inline uint64_t hashOne(T value) {
-  if constexpr (HllAsFinalResult) {
-    if constexpr (std::is_same_v<T, int64_t>) {
-      return common::hll::Murmur3Hash128::hash64ForLong(value, 0);
-    } else if constexpr (std::is_same_v<T, double>) {
-      return common::hll::Murmur3Hash128::hash64ForLong(
-          *reinterpret_cast<int64_t*>(&value), 0);
-    }
-    return common::hll::Murmur3Hash128::hash64(&value, sizeof(T), 0);
-  } else {
-    return XXH64(&value, sizeof(T), 0);
-  }
-}
-
-// Use timestamp.toMillis() to compute hash value.
-template <>
-inline uint64_t hashOne<Timestamp, false>(Timestamp value) {
-  return hashOne<int64_t, false>(value.toMillis());
-}
-
-template <>
-inline uint64_t hashOne<Timestamp, true>(Timestamp /*value*/) {
-  VELOX_UNREACHABLE("approx_set(timestamp) is not supported.");
-}
-
-template <>
-inline uint64_t hashOne<StringView, false>(StringView value) {
-  return XXH64(value.data(), value.size(), 0);
-}
-
-template <>
-inline uint64_t hashOne<StringView, true>(StringView value) {
-  return common::hll::Murmur3Hash128::hash64(value.data(), value.size(), 0);
-}
-
-template <typename T, bool HllAsFinalResult>
-struct HllAccumulator {
-  explicit HllAccumulator(HashStringAllocator* allocator)
-      : sparseHll_{allocator}, denseHll_{allocator} {}
-
-  void setIndexBitLength(int8_t indexBitLength) {
-    indexBitLength_ = indexBitLength;
-    sparseHll_.setSoftMemoryLimit(
-        common::hll::DenseHlls::estimateInMemorySize(indexBitLength_));
-  }
-
-  void append(T value) {
-    const auto hash = hashOne<T, HllAsFinalResult>(value);
-
-    if (isSparse_) {
-      if (sparseHll_.insertHash(hash)) {
-        toDense();
-      }
-    } else {
-      denseHll_.insertHash(hash);
-    }
-  }
-
-  int64_t cardinality() const {
-    return isSparse_ ? sparseHll_.cardinality() : denseHll_.cardinality();
-  }
-
-  void mergeWith(StringView serialized, HashStringAllocator* allocator) {
-    auto input = serialized.data();
-    if (common::hll::SparseHlls::canDeserialize(input)) {
-      if (isSparse_) {
-        sparseHll_.mergeWith(input);
-        if (indexBitLength_ < 0) {
-          setIndexBitLength(
-              common::hll::DenseHlls::deserializeIndexBitLength(input));
-        }
-        if (sparseHll_.overLimit()) {
-          toDense();
-        }
-      } else {
-        common::hll::SparseHll<> other{input, allocator};
-        other.toDense(denseHll_);
-      }
-    } else if (common::hll::DenseHlls::canDeserialize(input)) {
-      if (isSparse_) {
-        if (indexBitLength_ < 0) {
-          setIndexBitLength(
-              common::hll::DenseHlls::deserializeIndexBitLength(input));
-        }
-        toDense();
-      }
-      denseHll_.mergeWith(input);
-    } else {
-      VELOX_USER_FAIL("Unexpected type of HLL");
-    }
-  }
-
-  int32_t serializedSize() {
-    return isSparse_ ? sparseHll_.serializedSize() : denseHll_.serializedSize();
-  }
-
-  void serialize(char* outputBuffer) {
-    return isSparse_ ? sparseHll_.serialize(indexBitLength_, outputBuffer)
-                     : denseHll_.serialize(outputBuffer);
-  }
-
- private:
-  void toDense() {
-    isSparse_ = false;
-    denseHll_.initialize(indexBitLength_);
-    sparseHll_.toDense(denseHll_);
-    sparseHll_.reset();
-  }
-
-  bool isSparse_{true};
-  int8_t indexBitLength_{-1};
-  common::hll::SparseHll<> sparseHll_;
-  common::hll::DenseHll<> denseHll_;
-};
-
-template <>
-struct HllAccumulator<bool, false> {
-  explicit HllAccumulator(HashStringAllocator* /*allocator*/) {}
-
-  void append(bool value) {
-    approxDistinctState_ |= (1 << value);
-  }
-
-  int64_t cardinality() const {
-    return (approxDistinctState_ & 1) + ((approxDistinctState_ & 2) >> 1);
-  }
-
-  void mergeWith(
-      StringView /*serialized*/,
-      HashStringAllocator* /*allocator*/) {
-    VELOX_UNREACHABLE(
-        "APPROX_DISTINCT<BOOLEAN> unsupported mergeWith(StringView, HashStringAllocator*)");
-  }
-
-  void mergeWith(int8_t data) {
-    approxDistinctState_ |= data;
-  }
-
-  int32_t serializedSize() const {
-    return sizeof(int8_t);
-  }
-
-  void serialize(char* /*outputBuffer*/) {
-    VELOX_UNREACHABLE("APPROX_DISTINCT<BOOLEAN> unsupported serialize(char*)");
-  }
-
-  void setIndexBitLength(int8_t /*indexBitLength*/) {}
-
-  int8_t getState() const {
-    return approxDistinctState_;
-  }
-
- private:
-  int8_t approxDistinctState_{0};
-};
 
 template <typename T, bool HllAsFinalResult>
 class HyperLogLogAggregate : public exec::Aggregate {
@@ -201,11 +42,11 @@ class HyperLogLogAggregate : public exec::Aggregate {
         indexBitLength_{common::hll::toIndexBitLength(defaultError)} {}
 
   int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(HllAccumulator<T, HllAsFinalResult>);
+    return sizeof(velox::common::hll::HllAccumulator<T, HllAsFinalResult>);
   }
 
   int32_t accumulatorAlignmentSize() const override {
-    return alignof(HllAccumulator<T, HllAsFinalResult>);
+    return alignof(velox::common::hll::HllAccumulator<T, HllAsFinalResult>);
   }
 
   bool isFixedSize() const override {
@@ -235,7 +76,8 @@ class HyperLogLogAggregate : public exec::Aggregate {
           groups,
           numGroups,
           flatResult,
-          [](HllAccumulator<T, HllAsFinalResult>* accumulator,
+          [](velox::common::hll::HllAccumulator<T, HllAsFinalResult>*
+                 accumulator,
              FlatVector<int64_t>* result,
              vector_size_t index) {
             result->set(index, accumulator->cardinality());
@@ -252,7 +94,8 @@ class HyperLogLogAggregate : public exec::Aggregate {
 
       for (auto i = 0; i < numGroups; ++i) {
         char* group = groups[i];
-        auto* accumulator = value<HllAccumulator<bool, false>>(group);
+        auto* accumulator =
+            value<velox::common::hll::HllAccumulator<bool, false>>(group);
         flatResult->set(i, accumulator->getState());
       }
 
@@ -263,7 +106,8 @@ class HyperLogLogAggregate : public exec::Aggregate {
           groups,
           numGroups,
           flatResult,
-          [&](HllAccumulator<T, HllAsFinalResult>* accumulator,
+          [&](velox::common::hll::HllAccumulator<T, HllAsFinalResult>*
+                  accumulator,
               FlatVector<StringView>* result,
               vector_size_t index) {
             auto size = accumulator->serializedSize();
@@ -299,7 +143,9 @@ class HyperLogLogAggregate : public exec::Aggregate {
 
         auto group = groups[row];
         auto tracker = trackRowSize(group);
-        auto accumulator = value<HllAccumulator<T, HllAsFinalResult>>(group);
+        auto accumulator =
+            value<velox::common::hll::HllAccumulator<T, HllAsFinalResult>>(
+                group);
         clearNull(group);
         accumulator->setIndexBitLength(indexBitLength_);
         accumulator->append(decodedValue_.valueAt<T>(row));
@@ -343,7 +189,9 @@ class HyperLogLogAggregate : public exec::Aggregate {
           return;
         }
 
-        auto accumulator = value<HllAccumulator<T, HllAsFinalResult>>(group);
+        auto accumulator =
+            value<velox::common::hll::HllAccumulator<T, HllAsFinalResult>>(
+                group);
         clearNull(group);
         accumulator->setIndexBitLength(indexBitLength_);
 
@@ -377,24 +225,26 @@ class HyperLogLogAggregate : public exec::Aggregate {
     setAllNulls(groups, indices);
     for (auto i : indices) {
       auto group = groups[i];
-      new (group + offset_) HllAccumulator<T, HllAsFinalResult>(allocator_);
+      new (group + offset_)
+          velox::common::hll::HllAccumulator<T, HllAsFinalResult>(allocator_);
     }
   }
 
   void destroyInternal(folly::Range<char**> groups) override {
-    destroyAccumulators<HllAccumulator<T, HllAsFinalResult>>(groups);
+    destroyAccumulators<
+        velox::common::hll::HllAccumulator<T, HllAsFinalResult>>(groups);
   }
 
  private:
   void mergeToAccumulator(char* group, const vector_size_t row) {
     if constexpr (std::is_same_v<T, bool>) {
       static_assert(!HllAsFinalResult);
-      value<HllAccumulator<bool, false>>(group)->mergeWith(
+      value<velox::common::hll::HllAccumulator<bool, false>>(group)->mergeWith(
           decodedHll_.valueAt<int8_t>(row));
     } else {
       auto serialized = decodedHll_.valueAt<StringView>(row);
-      HllAccumulator<T, HllAsFinalResult>* accumulator =
-          value<HllAccumulator<T, HllAsFinalResult>>(group);
+      velox::common::hll::HllAccumulator<T, HllAsFinalResult>* accumulator =
+          value<velox::common::hll::HllAccumulator<T, HllAsFinalResult>>(group);
       accumulator->mergeWith(serialized, allocator_);
     }
   }
@@ -433,7 +283,9 @@ class HyperLogLogAggregate : public exec::Aggregate {
           bits::clearBit(rawNulls, i);
         }
 
-        auto accumulator = value<HllAccumulator<T, HllAsFinalResult>>(group);
+        auto accumulator =
+            value<velox::common::hll::HllAccumulator<T, HllAsFinalResult>>(
+                group);
         extractFunction(accumulator, result, i);
       }
     }

--- a/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/HyperLogLogInputGenerator.h
@@ -22,7 +22,7 @@
 
 namespace facebook::velox::fuzzer {
 
-using facebook::velox::aggregate::prestosql::HllAccumulator;
+using common::hll::HllAccumulator;
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"


### PR DESCRIPTION
Summary:
Moving HllAccumulator which was part of HyperloglogAggregates to HllUtils, so that it can be reused in Khyperloglog. HllAccumulator provides the functionality to switch between Sparse and Dense HLLs, along with other functions like merge, insertHash, cardinality which also take care of the 2 versions of HLL (sparse and dense), which is also needed for the implementation of KHLL.

Some functions added to HllAccumulator, to accomodate KHLL requirements are:
- mergeWith which takes in a deserialized HllAccumuator
- template typename TAllocator, to allow usage of both HashStringAllocator and MemoryPool, with the default set to use HashStringAllocator (as Sparse and Dense Hll does)

Differential Revision: D87486444


