### PR TITLE
feat(vector): Add retainedSize(totalStringBufferSize) API to return total size of all string buffers

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -1187,7 +1187,7 @@ uint64_t BaseVector::estimateFlatSize() const {
     const auto& leafType = leaf->type();
     return length_ *
         (leafType->isFixedWidth() ? leafType->cppSizeInBytes() : 0) +
-        BaseVector::retainedSize();
+        BaseVector::retainedSizeImpl();
   }
 
   auto avgRowSize = 1.0 * leaf->retainedSize() / leaf->size();

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -798,8 +798,17 @@ class BaseVector {
   }
 
   /// Returns the byte size of memory that is kept live through 'this'.
-  virtual uint64_t retainedSize() const {
-    return nulls_ ? nulls_->capacity() : 0;
+  uint64_t retainedSize() const {
+    uint64_t totalStringBufferSize{0};
+    return retainedSizeImpl(totalStringBufferSize);
+  }
+
+  /// Returns the byte size of memory that is kept live through 'this'. Also add
+  /// the total size of all string buffers recursively carried by 'this' to
+  /// totalStringBufferSize. To get the total size of all string buffers, set
+  /// the initial value of totalStringBufferSize to 0 when calling this method.
+  uint64_t retainedSize(uint64_t& totalStringBufferSize) const {
+    return retainedSizeImpl(totalStringBufferSize);
   }
 
   /// Returns an estimate of the 'retainedSize' of a flat representation of the
@@ -970,6 +979,13 @@ class BaseVector {
 
   BufferPtr sliceNulls(vector_size_t offset, vector_size_t length) const {
     return nulls_ ? Buffer::slice<bool>(nulls_, offset, length, pool_) : nulls_;
+  }
+
+  virtual uint64_t retainedSizeImpl(
+      uint64_t& /*totalStringBufferSize*/) const = 0;
+
+  uint64_t retainedSizeImpl() const {
+    return nulls_ ? nulls_->capacity() : 0;
   }
 
   TypePtr type_;

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -146,10 +146,6 @@ class BiasVector : public SimpleVector<T> {
     return valueType_;
   }
 
-  uint64_t retainedSize() const override {
-    return BaseVector::retainedSize() + values_->capacity();
-  }
-
   /**
    * Returns a shared_ptr to the underlying arrow array holding the values for
    * this vector. This is used during execution to process over the subset of
@@ -198,6 +194,11 @@ class BiasVector : public SimpleVector<T> {
     return xsimd::batch<T>::load_unaligned(mem);
   }
 #endif
+
+  uint64_t retainedSizeImpl(
+      uint64_t& /*totalStringBufferSize*/) const override {
+    return BaseVector::retainedSizeImpl() + values_->capacity();
+  }
 
   TypeKind valueType_;
   BufferPtr values_;

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -428,7 +428,7 @@ void RowVector::transferOrCopyTo(velox::memory::MemoryPool* pool) {
 }
 
 uint64_t RowVector::estimateFlatSize() const {
-  uint64_t total = BaseVector::retainedSize();
+  uint64_t total = BaseVector::retainedSizeImpl();
   for (const auto& child : children_) {
     if (child) {
       total += child->estimateFlatSize();
@@ -1221,7 +1221,7 @@ void ArrayVector::transferOrCopyTo(velox::memory::MemoryPool* pool) {
 }
 
 uint64_t ArrayVector::estimateFlatSize() const {
-  return BaseVector::retainedSize() + offsets_->capacity() +
+  return BaseVector::retainedSizeImpl() + offsets_->capacity() +
       sizes_->capacity() + elements_->estimateFlatSize();
 }
 
@@ -1547,7 +1547,7 @@ void MapVector::transferOrCopyTo(velox::memory::MemoryPool* pool) {
 }
 
 uint64_t MapVector::estimateFlatSize() const {
-  return BaseVector::retainedSize() + offsets_->capacity() +
+  return BaseVector::retainedSizeImpl() + offsets_->capacity() +
       sizes_->capacity() + keys_->estimateFlatSize() +
       values_->estimateFlatSize();
 }

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -152,11 +152,6 @@ class DictionaryVector : public SimpleVector<T> {
     return indices_;
   }
 
-  uint64_t retainedSize() const override {
-    return BaseVector::retainedSize() + dictionaryValues_->retainedSize() +
-        indices_->capacity();
-  }
-
   bool isScalar() const override {
     return dictionaryValues_->isScalar();
   }
@@ -270,6 +265,12 @@ class DictionaryVector : public SimpleVector<T> {
   }
 
   void setInternalState();
+
+  uint64_t retainedSizeImpl(uint64_t& totalStringBufferSize) const override {
+    return BaseVector::retainedSizeImpl() +
+        dictionaryValues_->retainedSize(totalStringBufferSize) +
+        indices_->capacity();
+  }
 
   BufferPtr indices_;
   const vector_size_t* rawIndices_ = nullptr;

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -407,6 +407,15 @@ class FlatMapVector : public BaseVector {
       vector_size_t wrappedOtherIndex,
       CompareFlags flags) const;
 
+  uint64_t retainedSizeImpl(
+      uint64_t& /*totalStringBufferSize*/) const override {
+    // TODO: since FlatMapVector didn't override BaseVector::retainedSize(),
+    // this override of retainedSizeImpl keeps the original behavior of
+    // FlatMapVector::retainedSize(). We should update this method to reflect
+    // the actual memory usage of FlatMapVector.
+    return BaseVector::retainedSizeImpl();
+  }
+
   // Vector containing the distinct map keys.
   VectorPtr distinctKeys_;
 

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -207,6 +207,11 @@ class FunctionVector : public BaseVector {
   }
 
  private:
+  uint64_t retainedSizeImpl(
+      uint64_t& /*totalStringBufferSize*/) const override {
+    VELOX_UNREACHABLE("retainedSize should not be called on FunctionVector");
+  }
+
   std::vector<std::shared_ptr<Callable>> functions_;
   std::vector<SelectivityVector> rowSets_;
 };

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -366,11 +366,6 @@ class LazyVector : public BaseVector {
     return loadedVector()->containsNullAt(index);
   }
 
-  uint64_t retainedSize() const override {
-    return isLoaded() ? loadedVector()->retainedSize()
-                      : BaseVector::retainedSize();
-  }
-
   /// Returns zero if vector has not been loaded yet.
   uint64_t estimateFlatSize() const override {
     return isLoaded() ? loadedVector()->estimateFlatSize() : 0;
@@ -431,6 +426,11 @@ class LazyVector : public BaseVector {
       SelectivityVector& baseRows);
 
   void loadVectorInternal() const;
+
+  uint64_t retainedSizeImpl(uint64_t& totalStringBufferSize) const override {
+    return isLoaded() ? loadedVector()->retainedSize(totalStringBufferSize)
+                      : BaseVector::retainedSizeImpl();
+  }
 
   std::unique_ptr<VectorLoader> loader_;
 

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -148,10 +148,6 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceLengths_;
   }
 
-  uint64_t retainedSize() const override {
-    return sequenceValues_->retainedSize() + sequenceLengths_->capacity();
-  }
-
   bool isScalar() const override {
     return sequenceValues_->isScalar();
   }
@@ -223,6 +219,11 @@ class SequenceVector : public SimpleVector<T> {
   void setInternalState();
 
   bool checkLoadRange(size_t idx, size_t count) const;
+
+  uint64_t retainedSizeImpl(uint64_t& totalStringBufferSize) const override {
+    return sequenceValues_->retainedSize(totalStringBufferSize) +
+        sequenceLengths_->capacity();
+  }
 
   VectorPtr sequenceValues_;
   SimpleVector<T>* scalarSequenceValues_ = nullptr;

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   VectorPoolTest.cpp
   VectorPrepareForReuseTest.cpp
   VectorPrinterTest.cpp
+  VectorRetainedSizeTest.cpp
   VectorSaverTest.cpp
   VectorStreamTest.cpp
   VectorStreamGroupTest.cpp

--- a/velox/vector/tests/VectorRetainedSizeTest.cpp
+++ b/velox/vector/tests/VectorRetainedSizeTest.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+namespace {
+
+class VectorRetainedSizeTest : public testing::Test,
+                               public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  uint64_t getTotalStringBufferSize(const VectorPtr& vector) {
+    auto* flatVector = vector->asFlatVector<StringView>();
+    VELOX_CHECK_NOT_NULL(flatVector, nullptr);
+    return flatVector->stringBufferSize();
+  }
+};
+
+} // namespace
+
+TEST_F(VectorRetainedSizeTest, flatNoStrings) {
+  auto vector = makeFlatVector<int32_t>(1'000, folly::identity);
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = vector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(totalStringBufferSize, 0);
+  EXPECT_EQ(retainedSize, vector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, flatInlinedStrings) {
+  auto vector = makeFlatVector<std::string>(
+      1'000, [](auto row) { return std::string(row % 3, '.'); });
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = vector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(totalStringBufferSize, 0);
+  EXPECT_EQ(retainedSize, vector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, flatMultipleStringBuffers) {
+  auto vector = makeFlatVector<StringView>({});
+  vector->resize(3);
+
+  std::vector<BufferPtr> buffers;
+  for (auto i = 1; i <= 3; ++i) {
+    vector->getBufferWithSpace(i * 100);
+    // Update buffers to hold a shared pointer to every existing string buffer,
+    // so that the next getBufferWithSpace call will create a new buffer.
+    buffers = vector->stringBuffers();
+  }
+  EXPECT_EQ(vector->stringBuffers().size(), 3);
+
+  for (auto& buffer : buffers) {
+    std::string str(100, 'a');
+    memcpy(buffer->asMutable<char>(), str.data(), str.size());
+    vector->setNoCopy(0, StringView(buffer->as<char>(), str.size()));
+  }
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = vector->retainedSize(totalStringBufferSize);
+  uint64_t expectedBufferSize = getTotalStringBufferSize(vector);
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, vector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, constantWithStringBuffer) {
+  auto vector = makeConstant(std::string(100, 'a'), 50);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = vector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(
+      totalStringBufferSize,
+      vector->as<ConstantVector<StringView>>()->getStringBuffer()->capacity());
+  EXPECT_EQ(retainedSize, vector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, constantWithInlinedString) {
+  auto vector = makeConstant("short", 100);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = vector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(totalStringBufferSize, 0);
+  EXPECT_EQ(retainedSize, vector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, constantWithValueVector) {
+  auto valueVector = makeFlatVector<std::string>(
+      10, [&](auto /*row*/) { return std::string(100, 'a'); });
+  auto vector =
+      std::make_shared<ConstantVector<StringView>>(pool(), 100, 5, valueVector);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = vector->retainedSize(totalStringBufferSize);
+
+  auto stringBuffer =
+      vector->as<ConstantVector<StringView>>()->getStringBuffer();
+  EXPECT_TRUE(stringBuffer != nullptr);
+  EXPECT_EQ(totalStringBufferSize, stringBuffer->capacity());
+  EXPECT_EQ(retainedSize, vector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, dictionaryWithStrings) {
+  auto baseVector = makeFlatVector<std::string>(
+      1'000, [&](auto /*row*/) { return std::string(100, 'a'); });
+  auto indices = makeIndices(100, folly::identity);
+  auto dictVector = wrapInDictionary(indices, 100, baseVector);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = dictVector->retainedSize(totalStringBufferSize);
+
+  uint64_t expectedBufferSize = getTotalStringBufferSize(baseVector);
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, dictVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, dictionaryNoStrings) {
+  auto baseVector = makeFlatVector<int32_t>(1'000, folly::identity);
+  auto indices = makeIndices(100, folly::identity);
+  auto dictVector = wrapInDictionary(indices, 100, baseVector);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = dictVector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(totalStringBufferSize, 0);
+  EXPECT_EQ(retainedSize, dictVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, rowVectorMultipleStringChildren) {
+  auto longStringAt = [&](auto /*row*/) { return std::string(100, 'a'); };
+
+  auto rowVector = makeRowVector({
+      makeFlatVector<std::string>(1'000, longStringAt),
+      makeFlatVector<int32_t>(1'000, folly::identity),
+      makeFlatVector<std::string>(1'000, longStringAt),
+  });
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = rowVector->retainedSize(totalStringBufferSize);
+  uint64_t expectedBufferSize =
+      getTotalStringBufferSize(rowVector->childAt(0)) +
+      getTotalStringBufferSize(rowVector->childAt(2));
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, rowVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, arrayWithStringElements) {
+  auto arrayVector = makeArrayVector<std::string>(
+      1'000,
+      [](auto /*row*/) { return 3; },
+      [&](auto /*row*/) { return std::string(100, 'a'); });
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = arrayVector->retainedSize(totalStringBufferSize);
+  uint64_t expectedBufferSize =
+      getTotalStringBufferSize(arrayVector->elements());
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, arrayVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, arrayNoStrings) {
+  auto arrayVector = makeArrayVector<int32_t>(
+      1'000,
+      [](auto /*row*/) { return 3; },
+      [](auto row, auto index) { return row + index; });
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = arrayVector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(totalStringBufferSize, 0);
+  EXPECT_EQ(retainedSize, arrayVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, mapWithStringKeysAndValues) {
+  auto longStringAt = [&](auto /*row*/) { return std::string(100, 'a'); };
+
+  auto mapVector = makeMapVector<std::string, std::string>(
+      1'000, [](auto /*row*/) { return 2; }, longStringAt, longStringAt);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = mapVector->retainedSize(totalStringBufferSize);
+  uint64_t expectedBufferSize = getTotalStringBufferSize(mapVector->mapKeys()) +
+      getTotalStringBufferSize(mapVector->mapValues());
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, mapVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, nestedComplexWithStrings) {
+  auto innerArray = makeArrayVector<std::string>(
+      1'000,
+      [](auto /*row*/) { return 2; },
+      [&](auto /*row*/) { return std::string(100, 'a'); });
+
+  auto outerArray = makeArrayVector({0, 10, 20}, innerArray);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = outerArray->retainedSize(totalStringBufferSize);
+  uint64_t expectedBufferSize = getTotalStringBufferSize(
+      outerArray->elements()->as<ArrayVector>()->elements());
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, outerArray->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, lazyNotLoaded) {
+  auto lazyVector = std::make_shared<LazyVector>(
+      pool(),
+      VARCHAR(),
+      100,
+      std::make_unique<test::SimpleVectorLoader>([&](auto /*rows*/) {
+        return makeFlatVector<std::string>(
+            100, [&](auto /*row*/) { return std::string(100, 'a'); });
+      }));
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = lazyVector->retainedSize(totalStringBufferSize);
+
+  EXPECT_EQ(totalStringBufferSize, 0);
+  EXPECT_EQ(retainedSize, lazyVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, lazyLoaded) {
+  auto lazyVector = std::make_shared<LazyVector>(
+      pool(),
+      VARCHAR(),
+      100,
+      std::make_unique<test::SimpleVectorLoader>([&](auto /*rows*/) {
+        return makeFlatVector<std::string>(
+            100, [&](auto /*row*/) { return std::string(100, 'a'); });
+      }));
+
+  SelectivityVector rows(100);
+  LazyVector::ensureLoadedRows(lazyVector, rows);
+
+  uint64_t totalStringBufferSize = 0;
+  auto retainedSize = lazyVector->retainedSize(totalStringBufferSize);
+  uint64_t expectedBufferSize =
+      getTotalStringBufferSize(lazyVector->loadedVectorShared());
+
+  EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+  EXPECT_EQ(retainedSize, lazyVector->retainedSize());
+}
+
+TEST_F(VectorRetainedSizeTest, sharedStringBuffers) {
+  auto baseVector = makeFlatVector<std::string>(
+      1'000, [&](auto /*row*/) { return std::string(100, 'a'); });
+
+  auto indices = makeIndices(100, folly::identity);
+  std::vector<VectorPtr> dictionaries;
+  dictionaries.emplace_back(wrapInDictionary(indices, 100, baseVector));
+  dictionaries.emplace_back(wrapInDictionary(indices, 100, baseVector));
+
+  auto expectedBufferSize = getTotalStringBufferSize(baseVector);
+  for (auto& dictVector : dictionaries) {
+    uint64_t totalStringBufferSize = 0;
+    auto retainedSize = dictVector->retainedSize(totalStringBufferSize);
+
+    EXPECT_EQ(totalStringBufferSize, expectedBufferSize);
+    EXPECT_EQ(retainedSize, dictVector->retainedSize());
+  }
+}
+
+} // namespace facebook::velox::test

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -679,7 +679,7 @@ class VectorTestBase {
       vector_size_t size,
       const TypePtr& type = CppToType<EvalType<T>>::create()) {
     return std::make_shared<ConstantVector<EvalType<T>>>(
-        pool(), size, false, type, std::move(value));
+        pool(), size, false, type, EvalType<T>(value));
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
This diff adds a new API `uint64_t retainedSize(uint64_t& totalStringBufferSize)` in BaseVector 
to return total size of all string buffers recursively carried by the vector through the out 
parameter, in addition to the total size of all buffers.

This is needed when the string buffers are multiply referenced and we want to amortize the size, 
such as in the buffer mode in LocalPartition.

Differential Revision: D87505861


