### PR TITLE
feat: Add NonMaterializedSortBuffer

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -26,8 +26,8 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SortingWriter.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/OperatorUtils.h"
-#include "velox/exec/SortBuffer.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -872,7 +872,7 @@ HiveDataSink::maybeCreateBucketSortWriter(
   }
   auto* sortPool = writerInfo_.back()->sortPool.get();
   VELOX_CHECK_NOT_NULL(sortPool);
-  auto sortBuffer = std::make_unique<exec::SortBuffer>(
+  auto sortBuffer = std::make_unique<exec::MaterializedSortBuffer>(
       getNonPartitionTypes(dataChannels_, inputType_),
       sortColumnIndices_,
       sortCompareFlags_,

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -504,6 +504,10 @@ class QueryConfig {
   static constexpr const char* kPrefixSortMaxStringPrefixLength =
       "prefixsort_max_string_prefix_length";
 
+  /// Enable materialized sort buffer.
+  static constexpr const char* kMaterializedSortBufferEnabled =
+      "materialized_sort_buffer_enabled";
+
   /// Enable query tracing flag.
   static constexpr const char* kQueryTraceEnabled = "query_trace_enabled";
 
@@ -1068,6 +1072,10 @@ class QueryConfig {
   int32_t spillableReservationGrowthPct() const {
     constexpr int32_t kDefaultPct = 10;
     return get<int32_t>(kSpillableReservationGrowthPct, kDefaultPct);
+  }
+
+  bool materializedSortBufferEnabled() const {
+    return get<bool>(kMaterializedSortBufferEnabled, true);
   }
 
   bool queryTraceEnabled() const {

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox::dwio::common {
 SortingWriter::SortingWriter(
     std::unique_ptr<Writer> writer,
-    std::unique_ptr<exec::SortBuffer> sortBuffer,
+    std::unique_ptr<exec::MaterializedSortBuffer> sortBuffer,
     vector_size_t maxOutputRowsConfig,
     uint64_t maxOutputBytesConfig,
     uint64_t outputTimeSliceLimitMs)

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include "velox/dwio/common/Writer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/MemoryReclaimer.h"
-#include "velox/exec/SortBuffer.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -27,7 +27,7 @@ class SortingWriter : public Writer {
  public:
   SortingWriter(
       std::unique_ptr<Writer> writer,
-      std::unique_ptr<exec::SortBuffer> sortBuffer,
+      std::unique_ptr<exec::MaterializedSortBuffer> sortBuffer,
       vector_size_t maxOutputRowsConfig,
       uint64_t maxOutputBytesConfig,
       uint64_t outputTimeSliceLimitMs);
@@ -85,7 +85,7 @@ class SortingWriter : public Writer {
   memory::MemoryPool* const sortPool_;
   const bool canReclaim_;
 
-  std::unique_ptr<exec::SortBuffer> sortBuffer_;
+  std::unique_ptr<exec::MaterializedSortBuffer> sortBuffer_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/SortingWriterTest.cpp
+++ b/velox/dwio/common/tests/SortingWriterTest.cpp
@@ -67,7 +67,7 @@ class SortingWriterTest : public testing::Test,
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  std::unique_ptr<SortBuffer> createSortBuffer() {
+  std::unique_ptr<MaterializedSortBuffer> createSortBuffer() {
     const RowTypePtr inputType =
         ROW({{"c0", BIGINT()}, {"c1", INTEGER()}, {"c2", VARCHAR()}});
 
@@ -80,7 +80,7 @@ class SortingWriterTest : public testing::Test,
         std::numeric_limits<uint32_t>::max(),
         12};
 
-    return std::make_unique<SortBuffer>(
+    return std::make_unique<MaterializedSortBuffer>(
         inputType,
         sortColumnIndices,
         sortCompareFlags,

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -50,12 +50,15 @@ velox_add_library(
   LocalPartition.cpp
   LocalPlanner.cpp
   MarkDistinct.cpp
+  MaterializedSortBuffer.cpp
   MemoryReclaimer.cpp
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp
   NestedLoopJoinBuild.cpp
   NestedLoopJoinProbe.cpp
+  NonMaterializedSortBuffer.cpp
+  SortBufferBase.cpp
   SpatialIndex.cpp
   SpatialJoinBuild.cpp
   SpatialJoinProbe.cpp
@@ -79,7 +82,6 @@ velox_add_library(
   RowsStreamingWindowBuild.cpp
   ScaleWriterLocalPartition.cpp
   ScaledScanController.cpp
-  SortBuffer.cpp
   SortWindowBuild.cpp
   SortedAggregations.cpp
   SpatialJoinBuild.cpp

--- a/velox/exec/MaterializedSortBuffer.cpp
+++ b/velox/exec/MaterializedSortBuffer.cpp
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-#include "SortBuffer.h"
-#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
+#include <vector>
 #include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
 
-SortBuffer::SortBuffer(
-    const RowTypePtr& input,
+MaterializedSortBuffer::MaterializedSortBuffer(
+    const RowTypePtr& inputType,
     const std::vector<column_index_t>& sortColumnIndices,
     const std::vector<CompareFlags>& sortCompareFlags,
     velox::memory::MemoryPool* pool,
@@ -29,48 +29,46 @@ SortBuffer::SortBuffer(
     common::PrefixSortConfig prefixSortConfig,
     const common::SpillConfig* spillConfig,
     folly::Synchronized<velox::common::SpillStats>* spillStats)
-    : input_(input),
-      sortCompareFlags_(sortCompareFlags),
-      pool_(pool),
-      nonReclaimableSection_(nonReclaimableSection),
-      prefixSortConfig_(prefixSortConfig),
-      spillConfig_(spillConfig),
-      spillStats_(spillStats),
-      sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
-  VELOX_CHECK_GE(input_->size(), sortCompareFlags_.size());
-  VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
-  VELOX_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
-  VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
-
+    : SortBufferBase(
+          inputType,
+          sortColumnIndices,
+          sortCompareFlags,
+          pool,
+          nonReclaimableSection,
+          prefixSortConfig,
+          spillConfig,
+          spillStats) {
   std::vector<TypePtr> sortedColumnTypes;
   std::vector<TypePtr> nonSortedColumnTypes;
   std::vector<std::string> sortedSpillColumnNames;
   std::vector<TypePtr> sortedSpillColumnTypes;
   sortedColumnTypes.reserve(sortColumnIndices.size());
-  nonSortedColumnTypes.reserve(input->size() - sortColumnIndices.size());
-  sortedSpillColumnNames.reserve(input->size());
-  sortedSpillColumnTypes.reserve(input->size());
+  nonSortedColumnTypes.reserve(inputType->size() - sortColumnIndices.size());
+  sortedSpillColumnNames.reserve(inputType->size());
+  sortedSpillColumnTypes.reserve(inputType->size());
   std::unordered_set<column_index_t> sortedChannelSet;
   // Sorted key columns.
   for (column_index_t i = 0; i < sortColumnIndices.size(); ++i) {
     columnMap_.emplace_back(IdentityProjection(i, sortColumnIndices.at(i)));
-    sortedColumnTypes.emplace_back(input_->childAt(sortColumnIndices.at(i)));
+    sortedColumnTypes.emplace_back(
+        inputType_->childAt(sortColumnIndices.at(i)));
     sortedSpillColumnTypes.emplace_back(
-        input_->childAt(sortColumnIndices.at(i)));
-    sortedSpillColumnNames.emplace_back(input->nameOf(sortColumnIndices.at(i)));
+        inputType_->childAt(sortColumnIndices.at(i)));
+    sortedSpillColumnNames.emplace_back(
+        inputType->nameOf(sortColumnIndices.at(i)));
     sortedChannelSet.emplace(sortColumnIndices.at(i));
   }
   // Non-sorted key columns.
   for (column_index_t i = 0, nonSortedIndex = sortCompareFlags_.size();
-       i < input_->size();
+       i < inputType_->size();
        ++i) {
     if (sortedChannelSet.count(i) != 0) {
       continue;
     }
     columnMap_.emplace_back(nonSortedIndex++, i);
-    nonSortedColumnTypes.emplace_back(input_->childAt(i));
-    sortedSpillColumnTypes.emplace_back(input_->childAt(i));
-    sortedSpillColumnNames.emplace_back(input->nameOf(i));
+    nonSortedColumnTypes.emplace_back(inputType_->childAt(i));
+    sortedSpillColumnTypes.emplace_back(inputType_->childAt(i));
+    sortedSpillColumnNames.emplace_back(inputType->nameOf(i));
   }
 
   data_ = std::make_unique<RowContainer>(
@@ -79,18 +77,18 @@ SortBuffer::SortBuffer(
       ROW(std::move(sortedSpillColumnNames), std::move(sortedSpillColumnTypes));
 }
 
-SortBuffer::~SortBuffer() {
+MaterializedSortBuffer::~MaterializedSortBuffer() {
   pool_->release();
 }
 
-void SortBuffer::addInput(const VectorPtr& input) {
+void MaterializedSortBuffer::addInput(const VectorPtr& input) {
   velox::common::testutil::TestValue::adjust(
       "facebook::velox::exec::SortBuffer::addInput", this);
 
   VELOX_CHECK(!noMoreInput_);
   ensureInputFits(input);
 
-  SelectivityVector allRows(input->size());
+  const SelectivityVector allRows(input->size());
   std::vector<char*> rows(input->size());
   for (int row = 0; row < input->size(); ++row) {
     rows[row] = data_->newRow();
@@ -107,7 +105,7 @@ void SortBuffer::addInput(const VectorPtr& input) {
   numInputRows_ += allRows.size();
 }
 
-void SortBuffer::noMoreInput() {
+void MaterializedSortBuffer::noMoreInput() {
   velox::common::testutil::TestValue::adjust(
       "facebook::velox::exec::SortBuffer::noMoreInput", this);
   VELOX_CHECK(!noMoreInput_);
@@ -126,13 +124,7 @@ void SortBuffer::noMoreInput() {
   if (inputSpiller_ == nullptr) {
     VELOX_CHECK_EQ(numInputRows_, data_->numRows());
     updateEstimatedOutputRowSize();
-    // Sort the pointers to the rows in RowContainer (data_) instead of sorting
-    // the rows.
-    sortedRows_.resize(numInputRows_);
-    RowContainerIterator iter;
-    data_->listRows(&iter, numInputRows_, sortedRows_.data());
-    PrefixSort::sort(
-        data_.get(), sortCompareFlags_, prefixSortConfig_, pool_, sortedRows_);
+    sortInput(numInputRows_);
   } else {
     // Spill the remaining in-memory state to disk if spilling has been
     // triggered on this sort buffer. This is to simplify query OOM prevention
@@ -147,31 +139,7 @@ void SortBuffer::noMoreInput() {
   pool_->release();
 }
 
-RowVectorPtr SortBuffer::getOutput(vector_size_t maxOutputRows) {
-  SCOPE_EXIT {
-    pool_->release();
-  };
-
-  VELOX_CHECK(noMoreInput_);
-
-  if (numOutputRows_ == numInputRows_) {
-    return nullptr;
-  }
-  VELOX_CHECK_GT(maxOutputRows, 0);
-  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
-  const vector_size_t batchSize =
-      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
-  ensureOutputFits(batchSize);
-  prepareOutput(batchSize);
-  if (hasSpilled()) {
-    getOutputWithSpill();
-  } else {
-    getOutputWithoutSpill();
-  }
-  return output_;
-}
-
-bool SortBuffer::hasSpilled() const {
+bool MaterializedSortBuffer::hasSpilled() const {
   if (inputSpiller_ != nullptr) {
     VELOX_CHECK_NULL(outputSpiller_);
     return true;
@@ -179,121 +147,24 @@ bool SortBuffer::hasSpilled() const {
   return outputSpiller_ != nullptr;
 }
 
-void SortBuffer::spill() {
-  VELOX_CHECK_NOT_NULL(
-      spillConfig_, "spill config is null when SortBuffer spill is called");
-
-  // Check if sort buffer is empty or not, and skip spill if it is empty.
-  if (data_->numRows() == 0) {
-    return;
-  }
-  updateEstimatedOutputRowSize();
-
-  if (sortedRows_.empty()) {
-    spillInput();
-  } else {
-    spillOutput();
-  }
+int64_t MaterializedSortBuffer::estimateFlatInputBytes(
+    const VectorPtr& input) const {
+  return input->estimateFlatSize();
 }
 
-std::optional<uint64_t> SortBuffer::estimateOutputRowSize() const {
+int64_t MaterializedSortBuffer::estimateIncrementalBytes(
+    const VectorPtr& input,
+    uint64_t outOfLineBytes,
+    int64_t flatInputBytes) const {
+  return data_->sizeIncrement(
+      input->size(), outOfLineBytes ? flatInputBytes : 0);
+}
+
+std::optional<uint64_t> MaterializedSortBuffer::estimateOutputRowSize() const {
   return estimatedOutputRowSize_;
 }
 
-void SortBuffer::ensureInputFits(const VectorPtr& input) {
-  // Check if spilling is enabled or not.
-  if (spillConfig_ == nullptr) {
-    return;
-  }
-
-  const int64_t numRows = data_->numRows();
-  if (numRows == 0) {
-    // 'data_' is empty. Nothing to spill.
-    return;
-  }
-
-  auto [freeRows, outOfLineFreeBytes] = data_->freeSpace();
-  const auto outOfLineBytes =
-      data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
-  const int64_t flatInputBytes = input->estimateFlatSize();
-
-  // Test-only spill path.
-  if (numRows > 0 && testingTriggerSpill(pool_->name())) {
-    spill();
-    return;
-  }
-
-  const auto currentMemoryUsage = pool_->usedBytes();
-  const auto minReservationBytes =
-      currentMemoryUsage * spillConfig_->minSpillableReservationPct / 100;
-  const auto availableReservationBytes = pool_->availableReservation();
-  const int64_t estimatedIncrementalBytes =
-      data_->sizeIncrement(input->size(), outOfLineBytes ? flatInputBytes : 0);
-  if (availableReservationBytes > minReservationBytes) {
-    // If we have enough free rows for input rows and enough variable length
-    // free space for the vector's flat size, no need for spilling.
-    if (freeRows > input->size() &&
-        (outOfLineBytes == 0 || outOfLineFreeBytes >= flatInputBytes)) {
-      return;
-    }
-
-    // If the current available reservation in memory pool is 2X the
-    // estimatedIncrementalBytes, no need to spill.
-    if (availableReservationBytes > 2 * estimatedIncrementalBytes) {
-      return;
-    }
-  }
-
-  // Try reserving targetIncrementBytes more in memory pool, if succeed, no
-  // need to spill.
-  const auto targetIncrementBytes = std::max<int64_t>(
-      estimatedIncrementalBytes * 2,
-      currentMemoryUsage * spillConfig_->spillableReservationGrowthPct / 100);
-  {
-    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
-    if (pool_->maybeReserve(targetIncrementBytes)) {
-      return;
-    }
-  }
-  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
-               << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
-}
-
-void SortBuffer::ensureOutputFits(vector_size_t batchSize) {
-  VELOX_CHECK_GT(batchSize, 0);
-  // Check if spilling is enabled or not.
-  if (spillConfig_ == nullptr) {
-    return;
-  }
-
-  // Test-only spill path.
-  if (testingTriggerSpill(pool_->name())) {
-    spill();
-    return;
-  }
-
-  if (!estimatedOutputRowSize_.has_value() || hasSpilled()) {
-    return;
-  }
-
-  const uint64_t outputBufferSizeToReserve =
-      estimatedOutputRowSize_.value() * batchSize * 1.2;
-  {
-    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
-    if (pool_->maybeReserve(outputBufferSizeToReserve)) {
-      return;
-    }
-  }
-  LOG(WARNING) << "Failed to reserve "
-               << succinctBytes(outputBufferSizeToReserve)
-               << " for memory pool " << pool_->name()
-               << ", usage: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes());
-}
-
-void SortBuffer::ensureSortFits() {
+void MaterializedSortBuffer::ensureSortFits() {
   // Check if spilling is enabled or not.
   if (spillConfig_ == nullptr) {
     return;
@@ -309,27 +180,10 @@ void SortBuffer::ensureSortFits() {
     return;
   }
 
-  // The memory for std::vector sorted rows and prefix sort required buffer.
-  uint64_t sortBufferToReserve =
-      numInputRows_ * sizeof(char*) +
-      PrefixSort::maxRequiredBytes(
-          data_.get(), sortCompareFlags_, prefixSortConfig_, pool_);
-  {
-    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
-    if (pool_->maybeReserve(sortBufferToReserve)) {
-      return;
-    }
-  }
-
-  LOG(WARNING) << fmt::format(
-      "Failed to reserve {} for memory pool {}, usage: {}, reservation: {}",
-      succinctBytes(sortBufferToReserve),
-      pool_->name(),
-      succinctBytes(pool_->usedBytes()),
-      succinctBytes(pool_->reservedBytes()));
+  ensureSortFitsImpl();
 }
 
-void SortBuffer::updateEstimatedOutputRowSize() {
+void MaterializedSortBuffer::updateEstimatedOutputRowSize() {
   const auto optionalRowSize = data_->estimateRowSize();
   if (!optionalRowSize.has_value() || optionalRowSize.value() == 0) {
     return;
@@ -343,7 +197,7 @@ void SortBuffer::updateEstimatedOutputRowSize() {
   }
 }
 
-void SortBuffer::spillInput() {
+void MaterializedSortBuffer::spillInput() {
   if (inputSpiller_ == nullptr) {
     VELOX_CHECK(!noMoreInput_);
     const auto sortingKeys = SpillState::makeSortingKeys(sortCompareFlags_);
@@ -354,7 +208,7 @@ void SortBuffer::spillInput() {
   data_->clear();
 }
 
-void SortBuffer::spillOutput() {
+void MaterializedSortBuffer::spillOutput() {
   if (hasSpilled()) {
     // Already spilled.
     return;
@@ -379,14 +233,14 @@ void SortBuffer::spillOutput() {
   finishSpill();
 }
 
-void SortBuffer::prepareOutput(vector_size_t batchSize) {
+void MaterializedSortBuffer::prepareOutput(vector_size_t batchSize) {
   if (output_ != nullptr) {
     VectorPtr output = std::move(output_);
     BaseVector::prepareForReuse(output, batchSize);
     output_ = std::static_pointer_cast<RowVector>(output);
   } else {
     output_ = std::static_pointer_cast<RowVector>(
-        BaseVector::create(input_, batchSize, pool_));
+        BaseVector::create(inputType_, batchSize, pool_));
   }
 
   for (auto& child : output_->children()) {
@@ -403,7 +257,7 @@ void SortBuffer::prepareOutput(vector_size_t batchSize) {
   VELOX_CHECK_LE(output_->size() + numOutputRows_, numInputRows_);
 }
 
-void SortBuffer::getOutputWithoutSpill() {
+void MaterializedSortBuffer::getOutputWithoutSpill() {
   VELOX_DCHECK_EQ(numInputRows_, sortedRows_.size());
   for (const auto& columnProjection : columnMap_) {
     data_->extractColumn(
@@ -415,7 +269,7 @@ void SortBuffer::getOutputWithoutSpill() {
   numOutputRows_ += output_->size();
 }
 
-void SortBuffer::getOutputWithSpill() {
+void MaterializedSortBuffer::getOutputWithSpill() {
   VELOX_CHECK_NOT_NULL(spillMerger_);
   VELOX_DCHECK_EQ(sortedRows_.size(), 0);
 
@@ -460,7 +314,7 @@ void SortBuffer::getOutputWithSpill() {
   numOutputRows_ += output_->size();
 }
 
-void SortBuffer::finishSpill() {
+void MaterializedSortBuffer::finishSpill() {
   VELOX_CHECK_NULL(spillMerger_);
   VELOX_CHECK(spillPartitionSet_.empty());
   VELOX_CHECK_EQ(
@@ -479,7 +333,7 @@ void SortBuffer::finishSpill() {
   VELOX_CHECK_EQ(spillPartitionSet_.size(), 1);
 }
 
-void SortBuffer::prepareOutputWithSpill() {
+void MaterializedSortBuffer::prepareOutputWithSpill() {
   VELOX_CHECK(hasSpilled());
   if (spillMerger_ != nullptr) {
     VELOX_CHECK(spillPartitionSet_.empty());

--- a/velox/exec/NonMaterializedSortBuffer.cpp
+++ b/velox/exec/NonMaterializedSortBuffer.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/NonMaterializedSortBuffer.h"
+
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/exec/Spiller.h"
+#include "velox/expression/VectorReaders.h"
+
+namespace facebook::velox::exec {
+
+NonMaterializedSortBuffer::NonMaterializedSortBuffer(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& sortColumnIndices,
+    const std::vector<CompareFlags>& sortCompareFlags,
+    velox::memory::MemoryPool* pool,
+    tsan_atomic<bool>* nonReclaimableSection,
+    common::PrefixSortConfig prefixSortConfig,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    : SortBufferBase(
+          inputType,
+          sortColumnIndices,
+          sortCompareFlags,
+          pool,
+          nonReclaimableSection,
+          prefixSortConfig,
+          /*spillConfig*/ nullptr,
+          /*spillStats*/ nullptr),
+      sortingKeys_(
+          SpillState::makeSortingKeys(sortColumnIndices, sortCompareFlags)) {
+  // Sorted key columns.
+  std::vector<TypePtr> sortedColumnTypes;
+  sortedColumnTypes.reserve(sortColumnIndices.size());
+  for (column_index_t i = 0; i < sortColumnIndices.size(); ++i) {
+    columnMap_.emplace_back(IdentityProjection(i, sortColumnIndices[i]));
+    sortedColumnTypes.emplace_back(
+        inputType_->childAt(sortColumnIndices.at(i)));
+  }
+
+  // Vector index and row index columns.
+  const auto numSortKeys = columnMap_.size();
+  for (auto i = 0; i < indexType_->size(); ++i) {
+    indexColumnMap_.emplace_back(numSortKeys + i, i);
+  }
+  data_ = std::make_unique<RowContainer>(
+      sortedColumnTypes, indexType_->children(), pool_);
+}
+
+NonMaterializedSortBuffer::~NonMaterializedSortBuffer() {
+  inputs_.clear();
+  rowIndices_.reset();
+  pool_->release();
+}
+
+void NonMaterializedSortBuffer::addInput(const VectorPtr& input) {
+  velox::common::testutil::TestValue::adjust(
+      "facebook::velox::exec::HybridSortBuffer::addInput", this);
+  VELOX_CHECK(!noMoreInput_);
+  const SelectivityVector allRows(input->size());
+  std::vector<char*> rows(input->size());
+  for (int row = 0; row < input->size(); ++row) {
+    rows[row] = data_->newRow();
+  }
+
+  // Stores the sort key columns.
+  auto* inputRow = input->asChecked<RowVector>();
+  for (const auto& columnProjection : columnMap_) {
+    DecodedVector decoded(
+        *inputRow->childAt(columnProjection.outputChannel), allRows);
+    data_->store(
+        decoded,
+        folly::Range(rows.data(), input->size()),
+        columnProjection.inputChannel);
+  }
+
+  // Stores the vector indices column.
+  inputs_.push_back(std::static_pointer_cast<RowVector>(input));
+  const auto vectorIndex = std::make_shared<ConstantVector<int64_t>>(
+      pool(),
+      input->size(),
+      /*isNull*/ false,
+      BIGINT(),
+      inputs_.size() - 1);
+  DecodedVector decoded;
+  decoded.decode(*vectorIndex, allRows);
+  auto indexColumnChannel = columnMap_.size();
+  data_->store(
+      decoded, folly::Range(rows.data(), input->size()), indexColumnChannel++);
+
+  // Stores the row indices column.
+  if (FOLLY_UNLIKELY(rowIndices_ == nullptr)) {
+    rowIndices_ = BaseVector::create<FlatVector<int64_t>>(
+        BIGINT(), input->size(), pool());
+  }
+  BaseVector::prepareForReuse(rowIndices_, input->size());
+  const auto rowIndices = rowIndices_->asUnchecked<FlatVector<int64_t>>();
+  for (int64_t i = 0; i < input->size(); ++i) {
+    rowIndices->mutableRawValues()[i] = i;
+  }
+  decoded.decode(*rowIndices, allRows);
+  data_->store(
+      decoded, folly::Range(rows.data(), input->size()), indexColumnChannel);
+
+  numInputRows_ += allRows.size();
+  numInputBytes_ += input->retainedSize();
+}
+
+void NonMaterializedSortBuffer::noMoreInput() {
+  velox::common::testutil::TestValue::adjust(
+      "facebook::velox::exec::HybridSortBuffer::noMoreInput", this);
+  VELOX_CHECK(!noMoreInput_);
+  noMoreInput_ = true;
+
+  // No data.
+  if (numInputRows_ == 0) {
+    return;
+  }
+  estimatedOutputRowSize_ = numInputBytes_ / numInputRows_;
+
+  VELOX_CHECK_EQ(numInputRows_, data_->numRows());
+  sortInput(numInputRows_);
+
+  // Releases the unused memory reservation after procesing input.
+  pool_->release();
+}
+
+int64_t NonMaterializedSortBuffer::estimateFlatInputBytes(
+    const VectorPtr& input) const {
+  int64_t flatInputBytes{0};
+  const auto inputRowVector = input->asUnchecked<RowVector>();
+  for (const auto identity : columnMap_) {
+    flatInputBytes +=
+        inputRowVector->childAt(identity.outputChannel)->estimateFlatSize();
+  }
+  flatInputBytes += indexColumnMap_.size() * sizeof(int64_t) * input->size();
+  return flatInputBytes;
+}
+
+int64_t NonMaterializedSortBuffer::estimateIncrementalBytes(
+    const VectorPtr& input,
+    uint64_t outOfLineBytes,
+    int64_t flatInputBytes) const {
+  return data_->sizeIncrement(
+             input->size(), outOfLineBytes ? flatInputBytes : 0) +
+      input->retainedSize();
+}
+
+std::optional<uint64_t> NonMaterializedSortBuffer::estimateOutputRowSize()
+    const {
+  return estimatedOutputRowSize_;
+}
+
+void NonMaterializedSortBuffer::prepareOutputVector(
+    RowVectorPtr& output,
+    const RowTypePtr& outputType,
+    vector_size_t outputBatchSize) const {
+  if (output != nullptr) {
+    VectorPtr vector = std::move(output);
+    BaseVector::prepareForReuse(vector, outputBatchSize);
+    output = std::static_pointer_cast<RowVector>(vector);
+  } else {
+    output = std::static_pointer_cast<RowVector>(
+        BaseVector::create(outputType, outputBatchSize, pool_));
+  }
+
+  for (const auto& child : output->children()) {
+    child->resize(outputBatchSize);
+  }
+}
+
+void NonMaterializedSortBuffer::prepareOutput(vector_size_t batchSize) {
+  prepareOutputVector(output_, inputType_, batchSize);
+  prepareOutputVector(indexOutput_, indexType_, batchSize);
+  VELOX_CHECK_GT(output_->size(), 0);
+  VELOX_CHECK_LE(output_->size() + numOutputRows_, numInputRows_);
+}
+
+void NonMaterializedSortBuffer::gatherCopyOutput() {
+  SCOPE_EXIT {
+    numOutputRows_ += output_->size();
+  };
+  VELOX_DCHECK_EQ(numInputRows_, sortedRows_.size());
+  for (const auto& columnProjection : indexColumnMap_) {
+    data_->extractColumn(
+        sortedRows_.data() + numOutputRows_,
+        indexOutput_->size(),
+        columnProjection.inputChannel,
+        indexOutput_->childAt(columnProjection.outputChannel));
+  }
+
+  // Extracts vector indices.
+  std::vector<const RowVector*> sourceVectors;
+  sourceVectors.reserve(indexOutput_->size());
+  const auto* vectorIndices =
+      indexOutput_->childAt(0)->asChecked<FlatVector<int64_t>>();
+  for (auto i = 0; i < indexOutput_->size(); ++i) {
+    sourceVectors.push_back(inputs_[vectorIndices->rawValues()[i]].get());
+  }
+
+  // Extracts row indices.
+  std::vector<vector_size_t> sourceRowIndices;
+  sourceRowIndices.reserve(indexOutput_->size());
+  const auto* rowIndices =
+      indexOutput_->childAt(1)->asChecked<FlatVector<int64_t>>();
+  for (auto i = 0; i < indexOutput_->size(); ++i) {
+    sourceRowIndices.push_back(rowIndices->rawValues()[i]);
+  }
+
+  gatherCopy(
+      output_.get(), 0, output_->size(), sourceVectors, sourceRowIndices);
+}
+
+RowVectorPtr NonMaterializedSortBuffer::getOutput(vector_size_t maxOutputRows) {
+  SCOPE_EXIT {
+    pool_->release();
+  };
+
+  VELOX_CHECK(noMoreInput_);
+  if (numOutputRows_ == numInputRows_) {
+    inputs_.clear();
+    data_->clear();
+    return nullptr;
+  }
+
+  VELOX_CHECK_GT(maxOutputRows, 0);
+  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
+
+  prepareOutput(batchSize);
+  gatherCopyOutput();
+
+  return output_;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/NonMaterializedSortBuffer.h
+++ b/velox/exec/NonMaterializedSortBuffer.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/MaterializedSortBuffer.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/PrefixSort.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/SortBufferBase.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+/// A utility class to accumulate data inside and output the sorted result.
+/// Spilling would be triggered if spilling is enabled and memory usage exceeds
+/// limit.
+///
+/// Uses non-materialize mode to sort input vectors, serializing only the sort
+/// key columns and two additional index columns into the RowContainer. These
+/// index columns are the vector indices and the row indices of each vector.
+/// After sorting, rows are gathered and copied from the input vectors using
+/// these indices.
+class NonMaterializedSortBuffer final : public SortBufferBase {
+ public:
+  NonMaterializedSortBuffer(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& sortColumnIndices,
+      const std::vector<CompareFlags>& sortCompareFlags,
+      velox::memory::MemoryPool* pool,
+      tsan_atomic<bool>* nonReclaimableSection,
+      common::PrefixSortConfig prefixSortConfig,
+      const common::SpillConfig* spillConfig = nullptr,
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+
+  ~NonMaterializedSortBuffer() override;
+
+  void addInput(const VectorPtr& input) override;
+
+  /// Indicates no more input and triggers either of:
+  ///  - In-memory sorting on rows stored in 'data_' if spilling is not enabled.
+  ///  - Finish spilling and setup the sort merge reader for the un-spilling
+  ///  processing for the output.
+  void noMoreInput() override;
+
+  std::optional<uint64_t> estimateOutputRowSize() const override;
+
+  RowVectorPtr getOutput(vector_size_t maxOutputRows) override;
+
+ private:
+  void prepareOutputVector(
+      RowVectorPtr& output,
+      const RowTypePtr& outputType,
+      vector_size_t outputBatchSize) const;
+
+  // Invoked to initialize or reset the reusable output buffer to get output.
+  void prepareOutput(vector_size_t outputBatchSize) override;
+
+  void gatherCopyOutput();
+
+  int64_t estimateFlatInputBytes(const VectorPtr& input) const override;
+
+  int64_t estimateIncrementalBytes(
+      const VectorPtr& input,
+      uint64_t outOfLineBytes,
+      int64_t flatInputBytes) const override;
+
+  const std::vector<SpillSortKey> sortingKeys_;
+
+  // Two index columns materialized in the row container to index each input
+  // row. The first column points to the vector in 'inputs_' and the second
+  // points to the row in the pointed vector.
+  const RowTypePtr indexType_{ROW({BIGINT(), BIGINT()})};
+
+  std::vector<RowVectorPtr> inputs_;
+
+  VectorPtr rowIndices_;
+
+  // The column projection map between 'data_' and 'indexOutput_', containing
+  // two columns: 0 for vector indices and 1 for row indices.
+  std::vector<IdentityProjection> indexColumnMap_;
+
+  // Reusable indices vector.
+  RowVectorPtr indexOutput_;
+
+  // The number of received input bytes.
+  uint64_t numInputBytes_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -16,9 +16,10 @@
 #pragma once
 
 #include "velox/exec/ContainerRowSerde.h"
+#include "velox/exec/MaterializedSortBuffer.h"
+#include "velox/exec/NonMaterializedSortBuffer.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
-#include "velox/exec/SortBuffer.h"
 #include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
@@ -62,7 +63,7 @@ class OrderBy : public Operator {
   void close() override;
 
  private:
-  std::unique_ptr<SortBuffer> sortBuffer_;
+  std::unique_ptr<SortBufferBase> sortBuffer_;
   bool finished_ = false;
   vector_size_t maxOutputRows_;
 };

--- a/velox/exec/SortBufferBase.cpp
+++ b/velox/exec/SortBufferBase.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SortBufferBase.h"
+#include <vector>
+
+namespace facebook::velox::exec {
+SortBufferBase::SortBufferBase(
+    const RowTypePtr& inputType,
+    const std::vector<column_index_t>& sortColumnIndices,
+    const std::vector<CompareFlags>& sortCompareFlags,
+    velox::memory::MemoryPool* pool,
+    tsan_atomic<bool>* nonReclaimableSection,
+    common::PrefixSortConfig prefixSortConfig,
+    const common::SpillConfig* spillConfig,
+    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    : inputType_(inputType),
+      sortCompareFlags_(sortCompareFlags),
+      pool_(pool),
+      nonReclaimableSection_(nonReclaimableSection),
+      prefixSortConfig_(prefixSortConfig),
+      spillConfig_(spillConfig),
+      spillStats_(spillStats),
+      sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
+  VELOX_CHECK_GE(inputType_->size(), sortCompareFlags_.size());
+  VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
+  VELOX_CHECK_EQ(sortColumnIndices.size(), sortCompareFlags_.size());
+  VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
+}
+
+void SortBufferBase::ensureSortFitsImpl() const {
+  // The memory for std::vector sorted rows and prefix sort required buffer.
+  const auto numBytesToReserve =
+      numInputRows_ * sizeof(char*) +
+      PrefixSort::maxRequiredBytes(
+          data_.get(), sortCompareFlags_, prefixSortConfig_, pool_);
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(numBytesToReserve)) {
+      return;
+    }
+  }
+
+  LOG(WARNING) << fmt::format(
+      "Failed to reserve {} for memory pool {}, usage: {}, reservation: {}",
+      succinctBytes(numBytesToReserve),
+      pool_->name(),
+      succinctBytes(pool_->usedBytes()),
+      succinctBytes(pool_->reservedBytes()));
+}
+
+void SortBufferBase::sortInput(uint64_t numRows) {
+  sortedRows_.resize(numRows);
+  RowContainerIterator iter;
+  data_->listRows(&iter, numRows, sortedRows_.data());
+  PrefixSort::sort(
+      data_.get(), sortCompareFlags_, prefixSortConfig_, pool_, sortedRows_);
+}
+
+void SortBufferBase::ensureInputFits(const VectorPtr& input) {
+  // Check if spilling is enabled or not.
+  if (spillConfig_ == nullptr) {
+    return;
+  }
+
+  const int64_t numRows = data_->numRows();
+  if (numRows == 0) {
+    // 'data_' is empty. Nothing to spill.
+    return;
+  }
+
+  auto [freeRows, outOfLineFreeBytes] = data_->freeSpace();
+  const auto outOfLineBytes =
+      data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  const auto flatInputBytes = estimateFlatInputBytes(input);
+
+  // Test-only spill path.
+  if (numRows > 0 && testingTriggerSpill(pool_->name())) {
+    spill();
+    return;
+  }
+
+  const auto currentMemoryUsage = pool_->usedBytes();
+  const auto minReservationBytes =
+      currentMemoryUsage * spillConfig_->minSpillableReservationPct / 100;
+  const auto availableReservationBytes = pool_->availableReservation();
+  const auto estimatedIncrementalBytes =
+      estimateIncrementalBytes(input, outOfLineBytes, flatInputBytes);
+
+  if (availableReservationBytes > minReservationBytes) {
+    // If we have enough free rows for input rows and enough variable length
+    // free space for the vector's flat size, no need for spilling.
+    if (freeRows > input->size() &&
+        (outOfLineBytes == 0 || outOfLineFreeBytes >= flatInputBytes)) {
+      return;
+    }
+
+    // If the current available reservation in memory pool is 2X the
+    // estimatedIncrementalBytes, no need to spill.
+    if (availableReservationBytes > 2 * estimatedIncrementalBytes) {
+      return;
+    }
+  }
+
+  // Try reserving targetIncrementBytes more in memory pool, if succeed, no
+  // need to spill.
+  const auto targetIncrementBytes = std::max<int64_t>(
+      estimatedIncrementalBytes * 2,
+      currentMemoryUsage * spillConfig_->spillableReservationGrowthPct / 100);
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(targetIncrementBytes)) {
+      return;
+    }
+  }
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool()->name()
+               << ", usage: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+}
+
+void SortBufferBase::ensureOutputFits(vector_size_t batchSize) {
+  VELOX_CHECK_GT(batchSize, 0);
+  // Check if spilling is enabled or not.
+  if (spillConfig_ == nullptr) {
+    return;
+  }
+
+  // Test-only spill path.
+  if (testingTriggerSpill(pool_->name())) {
+    spill();
+    return;
+  }
+
+  if (!estimatedOutputRowSize_.has_value() || hasSpilled()) {
+    return;
+  }
+
+  const uint64_t outputBufferSizeToReserve =
+      estimatedOutputRowSize_.value() * batchSize * 1.2;
+  {
+    memory::ReclaimableSectionGuard guard(nonReclaimableSection_);
+    if (pool_->maybeReserve(outputBufferSizeToReserve)) {
+      return;
+    }
+  }
+  LOG(WARNING) << "Failed to reserve "
+               << succinctBytes(outputBufferSizeToReserve)
+               << " for memory pool " << pool_->name()
+               << ", usage: " << succinctBytes(pool_->usedBytes())
+               << ", reservation: " << succinctBytes(pool_->reservedBytes());
+}
+
+void SortBufferBase::spill() {
+  VELOX_CHECK_NOT_NULL(
+      spillConfig_,
+      "spill config is null when HybridSortBuffer spill is called");
+
+  // Check if sort buffer is empty or not, and skip spill if it is empty.
+  if (data_->numRows() == 0) {
+    return;
+  }
+
+  if (sortedRows_.empty()) {
+    spillInput();
+  } else {
+    spillOutput();
+  }
+}
+
+RowVectorPtr SortBufferBase::getOutput(vector_size_t maxOutputRows) {
+  SCOPE_EXIT {
+    pool_->release();
+  };
+
+  VELOX_CHECK(noMoreInput_);
+
+  if (numOutputRows_ == numInputRows_) {
+    // inputs_.clear();
+    // data_->clear();
+    return nullptr;
+  }
+  VELOX_CHECK_GT(maxOutputRows, 0);
+  VELOX_CHECK_GT(numInputRows_, numOutputRows_);
+  const vector_size_t batchSize =
+      std::min<uint64_t>(numInputRows_ - numOutputRows_, maxOutputRows);
+
+  ensureOutputFits(batchSize);
+  prepareOutput(batchSize);
+
+  if (hasSpilled()) {
+    getOutputWithSpill();
+  } else {
+    getOutputWithoutSpill();
+  }
+
+  return output_;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/SortBufferBase.h
+++ b/velox/exec/SortBufferBase.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/PrefixSort.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+class SortBufferBase {
+ public:
+  SortBufferBase(
+      const RowTypePtr& inputType,
+      const std::vector<column_index_t>& sortColumnIndices,
+      const std::vector<CompareFlags>& sortCompareFlags,
+      velox::memory::MemoryPool* pool,
+      tsan_atomic<bool>* nonReclaimableSection,
+      common::PrefixSortConfig prefixSortConfig,
+      const common::SpillConfig* spillConfig = nullptr,
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+
+  virtual ~SortBufferBase() = default;
+
+  virtual void addInput(const VectorPtr& input) = 0;
+
+  virtual void noMoreInput() = 0;
+
+  virtual std::optional<uint64_t> estimateOutputRowSize() const = 0;
+
+  /// Returns the sorted output rows in batch.
+  virtual RowVectorPtr getOutput(vector_size_t maxOutputRows);
+
+  /// Indicates if this sort buffer can spill or not.
+  bool canSpill() const {
+    return spillConfig_ != nullptr;
+  }
+
+  void spill();
+
+  memory::MemoryPool* pool() const {
+    return pool_;
+  }
+
+ protected:
+  // Returns true if the sort buffer has spilled, regardless of during input or
+  // output processing. If spilled() is true, it means the sort buffer is in
+  // minimal memory mode and could not be spilled further.
+  virtual bool hasSpilled() const {
+    return false;
+  }
+
+  virtual int64_t estimateFlatInputBytes(const VectorPtr& input) const = 0;
+
+  virtual int64_t estimateIncrementalBytes(
+      const VectorPtr& input,
+      uint64_t outOfLineBytes,
+      int64_t flatInputBytes) const = 0;
+
+  virtual void prepareOutput(vector_size_t batchSize) = 0;
+
+  virtual void spillInput() {
+    VELOX_UNSUPPORTED("Spill is not supported yet.");
+  }
+
+  virtual void spillOutput() {
+    VELOX_UNSUPPORTED("Spill is not supported yet.");
+  }
+
+  virtual void getOutputWithoutSpill() {
+    VELOX_UNSUPPORTED("Spill is not supported yet.");
+  }
+
+  virtual void getOutputWithSpill() {
+    VELOX_UNSUPPORTED("Spill is not supported yet.");
+  }
+
+  void ensureSortFitsImpl() const;
+
+  // Sort the pointers to the rows in RowContainer (data_) instead of sorting
+  // the rows.
+  //
+  // TODO: Adds offset to make it can do multiple round sorting.
+  void sortInput(uint64_t numRows);
+
+  // Ensures there is sufficient memory reserved to process 'input'.
+  void ensureInputFits(const VectorPtr& input);
+
+  // Reserves memory for output processing. If reservation cannot be increased,
+  // spills enough to make output fit.
+  void ensureOutputFits(vector_size_t batchSize);
+
+  const RowTypePtr inputType_;
+
+  const std::vector<CompareFlags> sortCompareFlags_;
+
+  velox::memory::MemoryPool* const pool_;
+
+  // The flag is passed from the associated operator such as OrderBy or
+  // TableWriter to indicate if this sort buffer object is under non-reclaimable
+  // execution section or not.
+  tsan_atomic<bool>* const nonReclaimableSection_;
+
+  // Configuration settings for prefix-sort.
+  const common::PrefixSortConfig prefixSortConfig_;
+
+  const common::SpillConfig* const spillConfig_;
+  folly::Synchronized<common::SpillStats>* const spillStats_;
+
+  std::vector<char*, memory::StlAllocator<char*>> sortedRows_;
+
+  // The column projection map between 'input_' and 'spillerStoreType_' as sort
+  // buffer stores the sort columns first in 'data_'.
+  std::vector<IdentityProjection> columnMap_;
+
+  // Indicates no more input. Once it is set, addInput() can't be called on this
+  // sort buffer object.
+  bool noMoreInput_ = false;
+
+  // The number of received input rows.
+  uint64_t numInputRows_ = 0;
+
+  // Used to store the input data in row format.
+  std::unique_ptr<RowContainer> data_;
+
+  // Used to merge the sorted runs from in-memory rows and spilled rows on disk.
+  std::unique_ptr<TreeOfLosers<SpillMergeStream>> spillMerger_;
+
+  // Reusable output vector.
+  RowVectorPtr output_;
+
+  // Estimated size of a single output row by using the max
+  // 'data_->estimateRowSize()' across all accumulated data set.
+  std::optional<uint64_t> estimatedOutputRowSize_{};
+
+  // Records the source rows to copy to 'output_' in order.
+  std::vector<const RowVector*> spillSources_;
+
+  std::vector<vector_size_t> spillSourceRows_;
+
+  // The number of rows that has been returned.
+  uint64_t numOutputRows_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -64,12 +64,14 @@ add_executable(
   LocalPartitionTest.cpp
   Main.cpp
   MarkDistinctTest.cpp
+  MaterializedSortBufferTest.cpp
   MemoryReclaimerTest.cpp
   MergeJoinTest.cpp
   MergeTest.cpp
   MergerTest.cpp
   MultiFragmentTest.cpp
   NestedLoopJoinTest.cpp
+  NonMaterializedSortBufferTest.cpp
   OrderByTest.cpp
   OperatorTraceTest.cpp
   OutputBufferManagerTest.cpp
@@ -88,7 +90,6 @@ add_executable(
   RowNumberTest.cpp
   ScaledScanControllerTest.cpp
   ScaleWriterLocalPartitionTest.cpp
-  SortBufferTest.cpp
   SpatialIndexTest.cpp
   SpillerTest.cpp
   SpillTest.cpp

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/common/file/FileSystems.h"
-#include "velox/exec/SortBuffer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -44,7 +44,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
       const size_t maxOutputRows) {
     const VectorFuzzer::Options fuzzerOpts{.vectorSize = maxOutputRows};
     const auto vectors = createVectors(numVectors, inputType_, fuzzerOpts);
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -171,7 +171,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
   std::vector<RowVectorPtr> makeExpectedResults(
       const std::vector<RowVectorPtr>& vectors,
       size_t maxOutputRows) {
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,

--- a/velox/exec/tests/MaterializedSortBufferTest.cpp
+++ b/velox/exec/tests/MaterializedSortBufferTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/exec/SortBuffer.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -49,8 +49,8 @@ class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
 };
 } // namespace
 
-class SortBufferTest : public OperatorTestBase,
-                       public testing::WithParamInterface<bool> {
+class MaterializedSortBufferTest : public OperatorTestBase,
+                                   public testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
     OperatorTestBase::SetUp();
@@ -128,7 +128,7 @@ class SortBufferTest : public OperatorTestBase,
   std::unique_ptr<TestRuntimeStatWriter> statWriter_;
 };
 
-TEST_P(SortBufferTest, singleKey) {
+TEST_P(MaterializedSortBufferTest, singleKey) {
   const RowVectorPtr data = makeRowVector(
       {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
        makeFlatVector<int32_t>(
@@ -181,7 +181,7 @@ TEST_P(SortBufferTest, singleKey) {
   sortColumnIndices_ = {1};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         testData.sortCompareFlags,
@@ -216,8 +216,8 @@ TEST_P(SortBufferTest, singleKey) {
   }
 }
 
-TEST_P(SortBufferTest, multipleKeys) {
-  auto sortBuffer = std::make_unique<SortBuffer>(
+TEST_P(MaterializedSortBufferTest, multipleKeys) {
+  auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
       inputType_,
       sortColumnIndices_,
       sortCompareFlags_,
@@ -277,7 +277,7 @@ TEST_P(SortBufferTest, multipleKeys) {
 }
 
 // TODO: enable it later with test utility to compare the sorted result.
-TEST_P(SortBufferTest, DISABLED_randomData) {
+TEST_P(MaterializedSortBufferTest, DISABLED_randomData) {
   struct {
     RowTypePtr inputType;
     std::vector<column_index_t> sortColumnIndices;
@@ -329,7 +329,7 @@ TEST_P(SortBufferTest, DISABLED_randomData) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         testData.inputType,
         testData.sortColumnIndices,
         testData.sortCompareFlags,
@@ -352,7 +352,7 @@ TEST_P(SortBufferTest, DISABLED_randomData) {
   }
 }
 
-TEST_P(SortBufferTest, batchOutput) {
+TEST_P(MaterializedSortBufferTest, batchOutput) {
   struct {
     bool triggerSpill;
     std::vector<size_t> numInputRows;
@@ -402,7 +402,7 @@ TEST_P(SortBufferTest, batchOutput) {
         "none",
         prefixSortConfig_);
     folly::Synchronized<common::SpillStats> spillStats;
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -445,7 +445,7 @@ TEST_P(SortBufferTest, batchOutput) {
   }
 }
 
-TEST_P(SortBufferTest, spill) {
+TEST_P(MaterializedSortBufferTest, spill) {
   struct {
     bool spillEnabled;
     bool memoryReservationFailure;
@@ -495,7 +495,7 @@ TEST_P(SortBufferTest, spill) {
         "none",
         prefixSortConfig_);
     folly::Synchronized<common::SpillStats> spillStats;
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -560,11 +560,11 @@ TEST_P(SortBufferTest, spill) {
   }
 }
 
-DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringInput) {
+DEBUG_ONLY_TEST_P(MaterializedSortBufferTest, spillDuringInput) {
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   const auto spillConfig = getSpillConfig(spillDirectory->getPath());
   folly::Synchronized<common::SpillStats> spillStats;
-  auto sortBuffer = std::make_unique<SortBuffer>(
+  auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
       inputType_,
       sortColumnIndices_,
       sortCompareFlags_,
@@ -579,14 +579,15 @@ DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringInput) {
   std::atomic_int processedInputs{0};
   SCOPED_TESTVALUE_SET(
       "facebook::velox::exec::SortBuffer::addInput",
-      std::function<void(SortBuffer*)>(([&](SortBuffer* sortBuffer) {
-        if (processedInputs++ != numSpilledInputs) {
-          return;
-        }
-        ASSERT_GT(sortBuffer->pool()->usedBytes(), 0);
-        sortBuffer->spill();
-        ASSERT_EQ(sortBuffer->pool()->usedBytes(), 0);
-      })));
+      std::function<void(MaterializedSortBuffer*)>(
+          ([&](MaterializedSortBuffer* sortBuffer) {
+            if (processedInputs++ != numSpilledInputs) {
+              return;
+            }
+            ASSERT_GT(sortBuffer->pool()->usedBytes(), 0);
+            sortBuffer->spill();
+            ASSERT_EQ(sortBuffer->pool()->usedBytes(), 0);
+          })));
 
   VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool_.get());
 
@@ -614,11 +615,11 @@ DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringInput) {
   }
 }
 
-DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringOutput) {
+DEBUG_ONLY_TEST_P(MaterializedSortBufferTest, spillDuringOutput) {
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   const auto spillConfig = getSpillConfig(spillDirectory->getPath());
   folly::Synchronized<common::SpillStats> spillStats;
-  auto sortBuffer = std::make_unique<SortBuffer>(
+  auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
       inputType_,
       sortColumnIndices_,
       sortCompareFlags_,
@@ -631,11 +632,12 @@ DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringOutput) {
   const int numInputs = 10;
   SCOPED_TESTVALUE_SET(
       "facebook::velox::exec::SortBuffer::noMoreInput",
-      std::function<void(SortBuffer*)>(([&](SortBuffer* sortBuffer) {
-        ASSERT_GT(sortBuffer->pool()->usedBytes(), 0);
-        sortBuffer->spill();
-        ASSERT_EQ(sortBuffer->pool()->usedBytes(), 0);
-      })));
+      std::function<void(MaterializedSortBuffer*)>(
+          ([&](MaterializedSortBuffer* sortBuffer) {
+            ASSERT_GT(sortBuffer->pool()->usedBytes(), 0);
+            sortBuffer->spill();
+            ASSERT_EQ(sortBuffer->pool()->usedBytes(), 0);
+          })));
   VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool_.get());
 
   ASSERT_EQ(memory::spillMemoryPool()->stats().usedBytes, 0);
@@ -662,14 +664,14 @@ DEBUG_ONLY_TEST_P(SortBufferTest, spillDuringOutput) {
   }
 }
 
-DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySortGetOutput) {
+DEBUG_ONLY_TEST_P(MaterializedSortBufferTest, reserveMemorySortGetOutput) {
   for (bool spillEnabled : {false, true}) {
     SCOPED_TRACE(fmt::format("spillEnabled {}", spillEnabled));
 
     auto spillDirectory = exec::test::TempDirectoryPath::create();
     const auto spillConfig = getSpillConfig(spillDirectory->getPath());
     folly::Synchronized<common::SpillStats> spillStats;
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -688,8 +690,10 @@ DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySortGetOutput) {
     std::atomic_bool noMoreInput{false};
     SCOPED_TESTVALUE_SET(
         "facebook::velox::exec::SortBuffer::noMoreInput",
-        std::function<void(SortBuffer*)>(
-            ([&](SortBuffer* sortBuffer) { noMoreInput.store(true); })));
+        std::function<void(MaterializedSortBuffer*)>(
+            ([&](MaterializedSortBuffer* sortBuffer) {
+              noMoreInput.store(true);
+            })));
 
     std::atomic_int numReserves{0};
     SCOPED_TESTVALUE_SET(
@@ -713,7 +717,7 @@ DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySortGetOutput) {
   }
 }
 
-DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySort) {
+DEBUG_ONLY_TEST_P(MaterializedSortBufferTest, reserveMemorySort) {
   struct {
     bool usePrefixSort;
     bool spillEnabled;
@@ -728,7 +732,7 @@ DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySort) {
     auto spillDirectory = exec::test::TempDirectoryPath::create();
     auto spillConfig = getSpillConfig(spillDirectory->getPath(), usePrefixSort);
     folly::Synchronized<common::SpillStats> spillStats;
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -764,13 +768,13 @@ DEBUG_ONLY_TEST_P(SortBufferTest, reserveMemorySort) {
   }
 }
 
-TEST_P(SortBufferTest, emptySpill) {
+TEST_P(MaterializedSortBufferTest, emptySpill) {
   for (bool hasPostSpillData : {false, true}) {
     SCOPED_TRACE(fmt::format("hasPostSpillData {}", hasPostSpillData));
     auto spillDirectory = exec::test::TempDirectoryPath::create();
     auto spillConfig = getSpillConfig(spillDirectory->getPath());
     folly::Synchronized<common::SpillStats> spillStats;
-    auto sortBuffer = std::make_unique<SortBuffer>(
+    auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -791,7 +795,7 @@ TEST_P(SortBufferTest, emptySpill) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    SortBufferTest,
-    SortBufferTest,
+    MaterializedSortBufferTest,
+    MaterializedSortBufferTest,
     testing::ValuesIn({false, true}));
 } // namespace facebook::velox::functions::test

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -16,9 +16,9 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/exec/MaterializedSortBuffer.h"
 #include "velox/exec/Merge.h"
 #include "velox/exec/MergeSource.h"
-#include "velox/exec/SortBuffer.h"
 #include "velox/exec/Spill.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
@@ -47,7 +47,7 @@ class MergerTest : public OperatorTestBase {
       const size_t vectorSize) {
     const VectorFuzzer::Options fuzzerOpts{.vectorSize = vectorSize};
     const auto vectors = createVectors(numVectors, inputType_, fuzzerOpts);
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,
@@ -123,7 +123,7 @@ class MergerTest : public OperatorTestBase {
         flatInputs.emplace_back(vector);
       }
     }
-    const auto sortBuffer = std::make_unique<SortBuffer>(
+    const auto sortBuffer = std::make_unique<MaterializedSortBuffer>(
         inputType_,
         sortColumnIndices_,
         sortCompareFlags_,

--- a/velox/exec/tests/NonMaterializedSortBufferTest.cpp
+++ b/velox/exec/tests/NonMaterializedSortBufferTest.cpp
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/NonMaterializedSortBuffer.h"
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/type/Type.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::functions::test {
+namespace {
+// Class to write runtime stats in the tests to the stats container.
+class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
+ public:
+  explicit TestRuntimeStatWriter(
+      std::unordered_map<std::string, RuntimeMetric>& stats)
+      : stats_{stats} {}
+
+  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+      override {
+    addOperatorRuntimeStats(name, value, stats_);
+  }
+
+ private:
+  std::unordered_map<std::string, RuntimeMetric>& stats_;
+};
+} // namespace
+
+class NonMaterializedSortBufferTest : public OperatorTestBase,
+                                      public testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+    rng_.seed(123);
+    statWriter_ = std::make_unique<TestRuntimeStatWriter>(stats_);
+    setThreadLocalRunTimeStatWriter(statWriter_.get());
+  }
+
+  void TearDown() override {
+    pool_.reset();
+    rootPool_.reset();
+    OperatorTestBase::TearDown();
+  }
+
+  const bool enableSpillPrefixSort_{GetParam()};
+  const velox::common::PrefixSortConfig prefixSortConfig_ =
+      velox::common::PrefixSortConfig{
+          std::numeric_limits<uint32_t>::max(),
+          GetParam() ? 8 : std::numeric_limits<uint32_t>::max(),
+          12};
+
+  const RowTypePtr inputType_ = ROW(
+      {{"c0", BIGINT()},
+       {"c1", INTEGER()},
+       {"c2", SMALLINT()},
+       {"c3", REAL()},
+       {"c4", DOUBLE()},
+       {"c5", VARCHAR()}});
+  // Specifies the sort columns ["c4", "c1"].
+  std::vector<column_index_t> sortColumnIndices_{4, 1};
+  std::vector<CompareFlags> sortCompareFlags_{
+      {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue},
+      {true, true, false, CompareFlags::NullHandlingMode::kNullAsValue}};
+
+  const std::shared_ptr<folly::Executor> executor_{
+      std::make_shared<folly::CPUThreadPoolExecutor>(
+          std::thread::hardware_concurrency())};
+
+  tsan_atomic<bool> nonReclaimableSection_{false};
+  folly::Random::DefaultGenerator rng_;
+  std::unordered_map<std::string, RuntimeMetric> stats_;
+  std::unique_ptr<TestRuntimeStatWriter> statWriter_;
+  const std::shared_ptr<memory::MemoryPool> fuzzerPool_ =
+      memory::memoryManager()->addLeafPool("HybridSortBufferTest");
+};
+
+TEST_P(NonMaterializedSortBufferTest, singleKey) {
+  const RowVectorPtr data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<int32_t>(
+           {17, 16, 15, 14, 13, 10, 8, 7, 4, 3}), // sorted column
+       makeFlatVector<int16_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<float>(
+           {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}),
+       makeFlatVector<double>(
+           {1.1, 2.2, 2.2, 5.5, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}),
+       makeFlatVector<std::string>(
+           {"hello",
+            "world",
+            "today",
+            "is",
+            "great",
+            "hello",
+            "world",
+            "is",
+            "great",
+            "today"})});
+
+  struct {
+    std::vector<CompareFlags> sortCompareFlags;
+    std::vector<int32_t> expectedResult;
+
+    std::string debugString() const {
+      const std::string expectedResultStr = folly::join(",", expectedResult);
+      std::stringstream sortCompareFlagsStr;
+      for (const auto sortCompareFlag : sortCompareFlags) {
+        sortCompareFlagsStr << sortCompareFlag.toString();
+      }
+      return fmt::format(
+          "sortCompareFlags:{}, expectedResult:{}",
+          sortCompareFlagsStr.str(),
+          expectedResultStr);
+    }
+  } testSettings[] = {
+      {{{true,
+         true,
+         false,
+         CompareFlags::NullHandlingMode::kNullAsValue}}, // Ascending
+       {3, 4, 7, 8, 10, 13, 14, 15, 16, 17}},
+      {{{true,
+         false,
+         false,
+         CompareFlags::NullHandlingMode::kNullAsValue}}, // Descending
+       {17, 16, 15, 14, 13, 10, 8, 7, 4, 3}}};
+
+  // Specifies the sort columns ["c1"].
+  sortColumnIndices_ = {1};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto sortBuffer = std::make_unique<NonMaterializedSortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        testData.sortCompareFlags,
+        pool_.get(),
+        &nonReclaimableSection_,
+        prefixSortConfig_);
+
+    sortBuffer->addInput(data);
+    sortBuffer->noMoreInput();
+    auto output = sortBuffer->getOutput(10000);
+    ASSERT_EQ(output->size(), 10);
+    int resultIndex = 0;
+    for (int expectedValue : testData.expectedResult) {
+      ASSERT_EQ(
+          output->childAt(1)->asFlatVector<int32_t>()->valueAt(resultIndex++),
+          expectedValue);
+    }
+    if (GetParam()) {
+      ASSERT_EQ(
+          stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+          sortColumnIndices_.size());
+      ASSERT_EQ(
+          stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+          sortColumnIndices_.size());
+      ASSERT_EQ(
+          stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+          sortColumnIndices_.size());
+    } else {
+      ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+    }
+    stats_.clear();
+  }
+}
+
+TEST_P(NonMaterializedSortBufferTest, multipleKeys) {
+  auto sortBuffer = std::make_unique<NonMaterializedSortBuffer>(
+      inputType_,
+      sortColumnIndices_,
+      sortCompareFlags_,
+      pool_.get(),
+      &nonReclaimableSection_,
+      prefixSortConfig_);
+
+  RowVectorPtr data = makeRowVector(
+      {makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<int32_t>(
+           {15, 12, 9, 8, 7, 6, 5, 4, 3, 1}), // sorted-2 column
+       makeFlatVector<int16_t>({1, 2, 3, 4, 5, 6, 8, 10, 12, 15}),
+       makeFlatVector<float>(
+           {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 10.1}),
+       makeFlatVector<double>(
+           {1.1, 2.2, 2.2, 5.5, 5.5, 7.7, 8.1, 8, 8.1, 8.1, 10.0}), // sorted-1
+                                                                    // column
+       makeFlatVector<std::string>(
+           {"hello",
+            "world",
+            "today",
+            "is",
+            "great",
+            "hello",
+            "world",
+            "is",
+            "sort",
+            "sorted"})});
+
+  sortBuffer->addInput(data);
+  sortBuffer->noMoreInput();
+  auto output = sortBuffer->getOutput(10000);
+  ASSERT_EQ(output->size(), 10);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(0), 15);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(1), 9);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(2), 12);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(3), 7);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(4), 8);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(5), 6);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(6), 4);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(7), 1);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(8), 3);
+  ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(9), 5);
+  if (GetParam()) {
+    ASSERT_EQ(
+        stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+        sortColumnIndices_.size());
+    ASSERT_EQ(
+        stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+        sortColumnIndices_.size());
+    ASSERT_EQ(
+        stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+        sortColumnIndices_.size());
+  } else {
+    ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+  }
+}
+
+TEST_P(NonMaterializedSortBufferTest, batchOutput) {
+  struct {
+    std::vector<size_t> numInputRows;
+    size_t maxOutputRows;
+    std::vector<size_t> expectedOutputRowCount;
+
+    std::string debugString() const {
+      const std::string numInputRowsStr = folly::join(",", numInputRows);
+      const std::string expectedOutputRowCountStr =
+          folly::join(",", expectedOutputRowCount);
+      return fmt::format(
+          "numInputRows:{}, maxOutputRows:{}, expectedOutputRowCount:{}",
+          numInputRowsStr,
+          maxOutputRows,
+          expectedOutputRowCountStr);
+    }
+  } testSettings[] = {
+      {{2, 3, 3}, 1, {1, 1, 1, 1, 1, 1, 1, 1}},
+      {{2, 3, 3}, 1, {1, 1, 1, 1, 1, 1, 1, 1}},
+      {{2000, 2000}, 10000, {4000}},
+      {{2000, 2000}, 10000, {4000}},
+      {{2000, 2000}, 2000, {2000, 2000}},
+      {{2000, 2000}, 2000, {2000, 2000}},
+      {{1024, 1024, 1024}, 1000, {1000, 1000, 1000, 72}},
+      {{1024, 1024, 1024}, 1000, {1000, 1000, 1000, 72}}};
+
+  TestScopedSpillInjection scopedSpillInjection(100);
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto sortBuffer = std::make_unique<NonMaterializedSortBuffer>(
+        inputType_,
+        sortColumnIndices_,
+        sortCompareFlags_,
+        pool_.get(),
+        &nonReclaimableSection_,
+        prefixSortConfig_,
+        nullptr,
+        nullptr);
+    ASSERT_FALSE(sortBuffer->canSpill());
+    std::vector<RowVectorPtr> inputVectors;
+    inputVectors.reserve(testData.numInputRows.size());
+    uint64_t totalNumInput = 0;
+    for (size_t inputRows : testData.numInputRows) {
+      VectorFuzzer fuzzer({.vectorSize = inputRows}, fuzzerPool_.get());
+      RowVectorPtr input = fuzzer.fuzzRow(inputType_);
+      sortBuffer->addInput(input);
+      inputVectors.push_back(input);
+      totalNumInput += inputRows;
+    }
+    sortBuffer->noMoreInput();
+    int expectedOutputBufferIndex = 0;
+    RowVectorPtr output = sortBuffer->getOutput(testData.maxOutputRows);
+    while (output != nullptr) {
+      ASSERT_EQ(
+          output->size(),
+          testData.expectedOutputRowCount[expectedOutputBufferIndex++]);
+      output = sortBuffer->getOutput(testData.maxOutputRows);
+    }
+  }
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    NonMaterializedSortBufferTest,
+    NonMaterializedSortBufferTest,
+    testing::ValuesIn({false, true}));
+} // namespace facebook::velox::functions::test


### PR DESCRIPTION
Add a `NonMaterializedSortBuffer`; it only serializes the sort key columns and
two additional index columns into the RowContainer. These
These index columns are the vector indices and the row indices of each vector.
After sorting, rows are gathered and copied from the input vectors using these indices.