### PR TITLE
feat: Add SetDigest library

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -57,6 +57,7 @@ velox_link_libraries(
   velox_functions_util
   velox_vector
   velox_type_tz
+  velox_common_hyperloglog
   re2::re2
   Folly::folly
 )

--- a/velox/functions/lib/SetDigest.h
+++ b/velox/functions/lib/SetDigest.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Status.h"
+#include "velox/common/hyperloglog/HllAccumulator.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/type/StringView.h"
+
+#include <cstdint>
+#include <map>
+#include <type_traits>
+
+namespace facebook::velox::functions {
+
+/// SetDigest is a probabilistic data structure for estimating set cardinality
+/// and performing set operations. It combines HyperLogLog for cardinality
+/// estimation with MinHash for exact counting and intersection operations.
+///
+/// Template parameters:
+/// - T: The element type, which must be either int64_t or StringView.
+template <typename T>
+class SetDigest {
+  static_assert(
+      std::is_same_v<T, int64_t> || std::is_same_v<T, StringView>,
+      "SetDigest only supports int64_t or StringView");
+
+ public:
+  template <typename U>
+  using TStlAllocator = HashStringAllocator::TStlAllocator<U>;
+
+  static constexpr int32_t kDefaultMaxHashes = 8192;
+  static constexpr int32_t kNumberOfBuckets = 2048;
+  static constexpr int8_t kDefaultIndexBitLength = 11;
+
+  /// Construct a SetDigest with specified parameters.
+  /// @param allocator Memory allocator for internal data structures.
+  /// @param indexBitLength Number of bits for HLL indexing (default 11 = 2048
+  /// buckets). Must be in range (0, 16].
+  /// @param maxHashes Maximum number of hashes to store in MinHash (default
+  /// 8192). When exceeded, digest becomes approximate.
+  explicit SetDigest(
+      HashStringAllocator* allocator,
+      int8_t indexBitLength = kDefaultIndexBitLength,
+      int32_t maxHashes = kDefaultMaxHashes);
+
+  /// Add a new value to the digest.
+  /// @param value The value to add.
+  void add(T value);
+
+  /// Merge this digest with another digest.
+  /// @param other The other digest to merge into this one.
+  void mergeWith(const SetDigest& other);
+
+  /// Returns true if the digest is exact (cardinality < maxHashes).
+  /// When exact, cardinality() returns the exact count.
+  /// Used in exactIntersectionCardinality().
+  bool isExact() const;
+
+  /// Returns the estimated cardinality of the set.
+  /// If isExact() is true, returns the exact count.
+  /// Otherwise, returns HyperLogLog estimate.
+  int64_t cardinality() const;
+
+  /// Calculate the exact intersection cardinality between two digests.
+  /// Both digests must be exact (isExact() == true).
+  /// @param left First digest (must be exact).
+  /// @param right Second digest (must be exact).
+  /// @return The exact number of elements in the intersection.
+  static int64_t exactIntersectionCardinality(
+      const SetDigest& left,
+      const SetDigest& right);
+
+  /// Compute the Jaccard index (similarity coefficient) between two digests.
+  /// Uses MinHash estimation. Returns a value in [0, 1] where 1 means
+  /// identical sets and 0 means disjoint sets.
+  /// @param left First digest.
+  /// @param right Second digest.
+  /// @return Estimated Jaccard index.
+  static double jaccardIndex(const SetDigest& left, const SetDigest& right);
+
+  /// Calculate the size needed for serialization.
+  /// @return The number of bytes needed to serialize this digest.
+  int32_t estimatedSerializedSize() const;
+
+  /// Serialize the digest into bytes. The serialization is versioned and
+  /// compatible with Presto Java.
+  /// @param out Pre-allocated memory at least estimatedSerializedSize() in
+  /// size.
+  void serialize(char* out) const;
+
+  /// Deserialize a SetDigest from serialized input.
+  /// Serialization produced by Presto Java can be used as input.
+  /// @param data The input serialization.
+  /// @param size The size of the serialization in bytes.
+  /// @return Status::OK() on success, or an error Status on failure.
+  Status deserialize(const char* data, int32_t size);
+
+  /// Get a copy of the MinHash hash counts.
+  /// Returns a map from hash value to count.
+  /// @return A map of hash values to their counts.
+  std::map<int64_t, int16_t> getHashCounts() const;
+
+ private:
+  void addHash(uint64_t hash);
+
+  void increaseTotalHllSize();
+  void decreaseTotalHllSize();
+
+  using MinHashAllocator = TStlAllocator<std::pair<const int64_t, int16_t>>;
+  std::map<int64_t, int16_t, std::less<int64_t>, MinHashAllocator> minhash_;
+
+  common::hll::HllAccumulator<int64_t, true, HashStringAllocator>
+      hllAccumulator_;
+  int32_t maxHashes_{kDefaultMaxHashes};
+  HashStringAllocator* allocator_;
+
+  /// Tracks the HLL serialized size, updated when HLL changes.
+  int32_t hllTotalEstimatedSerializedSize_{0};
+};
+
+} // namespace facebook::velox::functions
+
+#include "velox/functions/lib/SetDigestImpl.h"

--- a/velox/functions/lib/SetDigestImpl.h
+++ b/velox/functions/lib/SetDigestImpl.h
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/IOUtils.h"
+#include "velox/common/hyperloglog/Murmur3Hash128.h"
+
+#include <limits>
+#include <vector>
+
+namespace facebook::velox::functions {
+
+namespace detail {
+constexpr int8_t kUncompressedFormat = 1;
+
+inline uint64_t computeHash(int64_t value) {
+  return common::hll::Murmur3Hash128::hash64ForLong(value, 0);
+}
+
+inline uint64_t computeHash(StringView value) {
+  return common::hll::Murmur3Hash128::hash64(value.data(), value.size(), 0);
+}
+} // namespace detail
+
+template <typename T>
+SetDigest<T>::SetDigest(
+    HashStringAllocator* allocator,
+    int8_t indexBitLength,
+    int32_t maxHashes)
+    : minhash_{MinHashAllocator(allocator)},
+      hllAccumulator_{indexBitLength, allocator},
+      maxHashes_{maxHashes},
+      allocator_{allocator},
+      hllTotalEstimatedSerializedSize_{0} {
+  // Validate indexBitLength matches Java validation
+  VELOX_CHECK_GT(indexBitLength, 0, "indexBitLength must be > 0");
+  VELOX_CHECK_LE(indexBitLength, 16, "indexBitLength must be <= 16");
+
+  // Validate maxHashes
+  VELOX_CHECK_GT(maxHashes, 0, "maxHashes must be > 0");
+
+  // Verify default indexBitLength matches kNumberOfBuckets
+  static_assert(
+      (1 << SetDigest<T>::kDefaultIndexBitLength) ==
+          SetDigest<T>::kNumberOfBuckets,
+      "Default index bit length must match NUMBER_OF_BUCKETS");
+
+  // Initialize HLL size after HLL is constructed
+  increaseTotalHllSize();
+}
+
+template <typename T>
+bool SetDigest<T>::isExact() const {
+  return static_cast<int32_t>(minhash_.size()) < maxHashes_;
+}
+
+template <typename T>
+void SetDigest<T>::add(T value) {
+  uint64_t hash = detail::computeHash(value);
+  addHash(hash);
+  decreaseTotalHllSize();
+  hllAccumulator_.insertHash(hash);
+  increaseTotalHllSize();
+}
+
+template <typename T>
+void SetDigest<T>::addHash(uint64_t hash) {
+  int64_t signedHash = static_cast<int64_t>(hash);
+  auto it = minhash_.find(signedHash);
+  int16_t currentCount = (it != minhash_.end()) ? it->second : 0;
+
+  if (currentCount < std::numeric_limits<int16_t>::max()) {
+    minhash_[signedHash] = static_cast<int16_t>(currentCount + 1);
+  }
+
+  while (static_cast<int32_t>(minhash_.size()) > maxHashes_) {
+    minhash_.erase(std::prev(minhash_.end()));
+  }
+}
+
+template <typename T>
+inline void SetDigest<T>::increaseTotalHllSize() {
+  hllTotalEstimatedSerializedSize_ += hllAccumulator_.serializedSize();
+}
+
+template <typename T>
+inline void SetDigest<T>::decreaseTotalHllSize() {
+  hllTotalEstimatedSerializedSize_ -= hllAccumulator_.serializedSize();
+}
+
+template <typename T>
+int32_t SetDigest<T>::estimatedSerializedSize() const {
+  return static_cast<int32_t>(
+      sizeof(int8_t) + // format byte
+      sizeof(int32_t) + // HLL length
+      hllTotalEstimatedSerializedSize_ + // HLL data
+      sizeof(int32_t) + // maxHashes
+      sizeof(int32_t) + // minhash size
+      minhash_.size() * (sizeof(int64_t) + sizeof(int16_t))); // keys + values
+}
+
+template <typename T>
+void SetDigest<T>::serialize(char* out) const {
+  common::OutputByteStream stream(out);
+
+  stream.appendOne(detail::kUncompressedFormat);
+  stream.appendOne(hllTotalEstimatedSerializedSize_);
+
+  // Use const_cast because HllAccumulator::serialize() is not const,
+  // but serialization does not logically modify the object.
+  const_cast<common::hll::HllAccumulator<int64_t, true, HashStringAllocator>&>(
+      hllAccumulator_)
+      .serialize(out + stream.offset());
+  stream = common::OutputByteStream(
+      out, stream.offset() + hllTotalEstimatedSerializedSize_);
+
+  stream.appendOne(maxHashes_);
+  stream.appendOne(static_cast<int32_t>(minhash_.size()));
+
+  for (const auto& entry : minhash_) {
+    stream.appendOne(entry.first);
+  }
+
+  for (const auto& entry : minhash_) {
+    stream.appendOne(entry.second);
+  }
+
+  VELOX_CHECK_EQ(stream.offset(), estimatedSerializedSize());
+}
+
+template <typename T>
+Status SetDigest<T>::deserialize(const char* data, int32_t size) {
+  if (size < static_cast<int32_t>(sizeof(int8_t) + sizeof(int32_t))) {
+    return Status::UserError("Input too small to be a valid SetDigest");
+  }
+
+  common::InputByteStream stream(data);
+
+  int8_t format = stream.read<int8_t>();
+  if (format != detail::kUncompressedFormat) {
+    return Status::UserError(
+        "Unexpected SetDigest format: expected {}, got {}",
+        detail::kUncompressedFormat,
+        format);
+  }
+
+  // Read HLL length
+  int32_t hllLength = stream.read<int32_t>();
+  if (hllLength < 0) {
+    return Status::UserError("Invalid HLL length in SetDigest serialization");
+  }
+  if (hllLength >
+      size - static_cast<int32_t>(sizeof(int8_t) + sizeof(int32_t))) {
+    return Status::UserError("HLL length exceeds input size");
+  }
+
+  // Deserialize HLL using HllAccumulator
+  auto deserializedHll =
+      common::hll::HllAccumulator<int64_t, true, HashStringAllocator>::
+          deserialize(data + stream.offset(), allocator_);
+  decreaseTotalHllSize();
+  hllAccumulator_ = std::move(*deserializedHll);
+  increaseTotalHllSize();
+
+  stream = common::InputByteStream(data + stream.offset() + hllLength);
+
+  // Calculate remaining bytes after HLL data
+  int32_t bytesConsumed = sizeof(int8_t) + sizeof(int32_t) + hllLength;
+  int32_t remainingBytes = size - bytesConsumed;
+
+  if (remainingBytes < static_cast<int32_t>(2 * sizeof(int32_t))) {
+    return Status::UserError(
+        "Input too small to contain maxHashes and minhash size");
+  }
+
+  maxHashes_ = stream.read<int32_t>();
+  if (maxHashes_ <= 0) {
+    return Status::UserError("maxHashes must be > 0");
+  }
+
+  int32_t minhashSize = stream.read<int32_t>();
+  if (minhashSize < 0) {
+    return Status::UserError("minhash size cannot be negative");
+  }
+
+  // Validate that there's enough data for the minhash entries
+  int32_t expectedMinhashBytes =
+      minhashSize * (sizeof(int64_t) + sizeof(int16_t));
+  if (remainingBytes - 2 * static_cast<int32_t>(sizeof(int32_t)) <
+      expectedMinhashBytes) {
+    return Status::UserError("Input too small to contain minhash entries");
+  }
+
+  std::vector<int64_t> keys;
+  keys.reserve(minhashSize);
+  for (int32_t i = 0; i < minhashSize; i++) {
+    keys.push_back(stream.read<int64_t>());
+  }
+
+  for (int32_t i = 0; i < minhashSize; i++) {
+    int16_t count = stream.read<int16_t>();
+    minhash_[keys[i]] = count;
+  }
+
+  return Status::OK();
+}
+
+template <typename T>
+void SetDigest<T>::mergeWith(const SetDigest& other) {
+  // Merge HyperLogLog using HllAccumulator
+  decreaseTotalHllSize();
+  hllAccumulator_.mergeWith(other.hllAccumulator_);
+  increaseTotalHllSize();
+
+  // Merge minhash maps
+  for (const auto& entry : other.minhash_) {
+    int64_t key = entry.first;
+    int16_t otherCount = entry.second;
+
+    auto it = minhash_.find(key);
+    int16_t currentCount = (it != minhash_.end()) ? it->second : 0;
+
+    // Add counts, saturating at int16_t max
+    int32_t newCount =
+        static_cast<int32_t>(currentCount) + static_cast<int32_t>(otherCount);
+    if (newCount > std::numeric_limits<int16_t>::max()) {
+      minhash_[key] = std::numeric_limits<int16_t>::max();
+    } else {
+      minhash_[key] = static_cast<int16_t>(newCount);
+    }
+  }
+
+  // Remove largest hash values when we exceed maxHashes
+  while (static_cast<int32_t>(minhash_.size()) > maxHashes_) {
+    minhash_.erase(std::prev(minhash_.end()));
+  }
+}
+
+template <typename T>
+int64_t SetDigest<T>::cardinality() const {
+  if (isExact()) {
+    return static_cast<int64_t>(minhash_.size());
+  }
+  return hllAccumulator_.cardinality();
+}
+
+template <typename T>
+int64_t SetDigest<T>::exactIntersectionCardinality(
+    const SetDigest& left,
+    const SetDigest& right) {
+  VELOX_USER_CHECK(
+      left.isExact(), "exact intersection cannot operate on approximate sets");
+  VELOX_USER_CHECK(
+      right.isExact(), "exact intersection cannot operate on approximate sets");
+
+  const auto& [smaller, larger] = left.minhash_.size() <= right.minhash_.size()
+      ? std::tie(left, right)
+      : std::tie(right, left);
+
+  int64_t count = 0;
+  for (const auto& entry : smaller.minhash_) {
+    if (larger.minhash_.count(entry.first)) {
+      count++;
+    }
+  }
+  return count;
+}
+
+template <typename T>
+double SetDigest<T>::jaccardIndex(
+    const SetDigest& left,
+    const SetDigest& right) {
+  if (left.minhash_.empty() && right.minhash_.empty()) {
+    return 1.0;
+  }
+
+  int32_t sizeOfSmallerSet = std::min(
+      static_cast<int32_t>(left.minhash_.size()),
+      static_cast<int32_t>(right.minhash_.size()));
+
+  if (sizeOfSmallerSet == 0) {
+    return 0.0;
+  }
+
+  auto itLeft = left.minhash_.begin();
+  auto itRight = right.minhash_.begin();
+
+  int32_t intersectionCnt = 0;
+  int32_t unionCnt = 0;
+
+  while (itLeft != left.minhash_.end() && itRight != right.minhash_.end() &&
+         unionCnt < sizeOfSmallerSet) {
+    if (itLeft->first < itRight->first) {
+      ++itLeft;
+    } else if (itRight->first < itLeft->first) {
+      ++itRight;
+    } else {
+      intersectionCnt++;
+      ++itLeft;
+      ++itRight;
+    }
+    unionCnt++;
+  }
+
+  return static_cast<double>(intersectionCnt) /
+      static_cast<double>(sizeOfSmallerSet);
+}
+
+template <typename T>
+std::map<int64_t, int16_t> SetDigest<T>::getHashCounts() const {
+  std::map<int64_t, int16_t> result;
+  for (const auto& entry : minhash_) {
+    result[entry.first] = entry.second;
+  }
+  return result;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/SetDigestTest.cpp
+++ b/velox/functions/lib/tests/SetDigestTest.cpp
@@ -1,0 +1,717 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/SetDigest.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/type/StringView.h"
+
+#include <folly/base64.h>
+#include <gtest/gtest.h>
+#include <cmath>
+#include <random>
+
+using namespace facebook::velox::functions;
+using facebook::velox::HashStringAllocator;
+using facebook::velox::StringView;
+
+namespace {
+// SetDigest uses HllAccumulator with 2048 buckets.
+// The theoretical relative standard error formula from the HyperLogLog paper
+// (Flajolet et al.) is: 1.04 / sqrt(num_buckets)
+const double kStandardError =
+    1.04 / std::sqrt(SetDigest<int64_t>::kNumberOfBuckets);
+} // namespace
+
+class SetDigestTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    facebook::velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
+    allocator_ =
+        std::make_unique<facebook::velox::HashStringAllocator>(pool_.get());
+  }
+
+  // Helper for Java-equivalent intersection cardinality tests
+  void testIntersectionCardinalityHelper(
+      int32_t maxHashes1,
+      int32_t numBuckets1,
+      int32_t maxHashes2,
+      int32_t numBuckets2);
+
+  std::string decodeBase64(const std::string& encoded) {
+    return folly::base64Decode(encoded);
+  }
+
+  std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
+  std::unique_ptr<facebook::velox::HashStringAllocator> allocator_;
+};
+
+TEST_F(SetDigestTest, roundTripSerialization) {
+  SetDigest<int64_t> digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(1L);
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(2L);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  ASSERT_TRUE(digest2.deserialize(buffer1.data(), size1).ok());
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  EXPECT_EQ(size1, size2);
+
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  EXPECT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+
+  EXPECT_EQ(digest1.isExact(), digest2.isExact());
+  EXPECT_EQ(digest1.cardinality(), digest2.cardinality());
+}
+
+TEST_F(SetDigestTest, roundTripWithStrings) {
+  SetDigest<StringView> digest1(allocator_.get());
+
+  digest1.add(facebook::velox::StringView("apple"));
+  digest1.add(facebook::velox::StringView("banana"));
+  digest1.add(facebook::velox::StringView("apple"));
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest<StringView> digest2(allocator_.get());
+  ASSERT_TRUE(digest2.deserialize(buffer1.data(), size1).ok());
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  EXPECT_EQ(size1, size2);
+
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  EXPECT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+}
+
+TEST_F(SetDigestTest, mergeWithRoundTrip) {
+  SetDigest<int64_t> digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(3L);
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  digest2.add(3L);
+  digest2.add(4L);
+  digest2.add(5L);
+
+  digest1.mergeWith(digest2);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest<int64_t> digest3(allocator_.get());
+  ASSERT_TRUE(digest3.deserialize(buffer1.data(), size1).ok());
+
+  int32_t size2 = digest3.estimatedSerializedSize();
+  EXPECT_EQ(size1, size2);
+
+  std::vector<char> buffer2(size2);
+  digest3.serialize(buffer2.data());
+
+  EXPECT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+
+  EXPECT_TRUE(digest1.isExact());
+  EXPECT_EQ(digest1.cardinality(), 5);
+  EXPECT_EQ(digest3.cardinality(), 5);
+}
+
+TEST_F(SetDigestTest, mergeWithDuplicates) {
+  SetDigest<int64_t> digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(1L);
+  digest1.add(1L);
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  digest2.add(1L);
+  digest2.add(2L);
+
+  digest1.mergeWith(digest2);
+
+  EXPECT_TRUE(digest1.isExact());
+  EXPECT_EQ(digest1.cardinality(), 2);
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest<int64_t> digest3(allocator_.get());
+  ASSERT_TRUE(digest3.deserialize(buffer1.data(), size1).ok());
+
+  int32_t size2 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest3.serialize(buffer2.data());
+
+  EXPECT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+}
+
+TEST_F(SetDigestTest, javaCompatibility) {
+  // Query used: SELECT to_base64(cast(make_set_digest(value) as varbinary))
+  // FROM (VALUES 1, 1, 1, 2, 2) T(value);
+  SetDigest<int64_t> digest(allocator_.get());
+
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(2L);
+  digest.add(2L);
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  std::string base64Output =
+      folly::base64Encode(folly::StringPiece(buffer.data(), size));
+
+  EXPECT_TRUE(digest.isExact());
+  EXPECT_EQ(digest.cardinality(), 2);
+  EXPECT_GT(size, 0);
+}
+
+TEST_F(SetDigestTest, javaCompatibilityEmptyDigest) {
+  // Query: SELECT to_base64(cast(make_set_digest(value) as varbinary))
+  // FROM (SELECT NULL as value WHERE 1=0) T(value);
+  SetDigest<int64_t> digest(allocator_.get());
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  std::string base64Output =
+      folly::base64Encode(folly::StringPiece(buffer.data(), size));
+
+  EXPECT_TRUE(digest.isExact());
+  EXPECT_EQ(digest.cardinality(), 0);
+}
+
+TEST_F(SetDigestTest, cardinality) {
+  SetDigest<int64_t> digest(allocator_.get());
+
+  EXPECT_EQ(digest.cardinality(), 0);
+
+  digest.add(1L);
+  EXPECT_EQ(digest.cardinality(), 1);
+
+  digest.add(1L);
+  EXPECT_EQ(digest.cardinality(), 1);
+
+  digest.add(2L);
+  EXPECT_EQ(digest.cardinality(), 2);
+}
+
+TEST_F(SetDigestTest, exactIntersectionCardinality) {
+  SetDigest<int64_t> digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(3L);
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  digest2.add(2L);
+  digest2.add(3L);
+  digest2.add(4L);
+
+  int64_t intersection =
+      SetDigest<int64_t>::exactIntersectionCardinality(digest1, digest2);
+  EXPECT_EQ(intersection, 2);
+
+  SetDigest<int64_t> digest3(allocator_.get());
+  digest3.add(5L);
+  digest3.add(6L);
+
+  intersection =
+      SetDigest<int64_t>::exactIntersectionCardinality(digest1, digest3);
+  EXPECT_EQ(intersection, 0);
+}
+
+TEST_F(SetDigestTest, jaccardIndex) {
+  SetDigest<int64_t> digest1(allocator_.get());
+  digest1.add(1L);
+  digest1.add(2L);
+  digest1.add(3L);
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  digest2.add(2L);
+  digest2.add(3L);
+  digest2.add(4L);
+
+  double jaccard = SetDigest<int64_t>::jaccardIndex(digest1, digest2);
+  EXPECT_GE(jaccard, 0.0);
+  EXPECT_LE(jaccard, 1.0);
+
+  // Test identical sets - should always be 1.0
+  SetDigest<int64_t> digest3(allocator_.get());
+  digest3.add(1L);
+  digest3.add(2L);
+  digest3.add(3L);
+
+  jaccard = SetDigest<int64_t>::jaccardIndex(digest1, digest3);
+  EXPECT_NEAR(jaccard, 1.0, 0.001);
+
+  // Test disjoint sets - should be 0.0
+  SetDigest<int64_t> digest4(allocator_.get());
+  digest4.add(10L);
+  digest4.add(20L);
+  digest4.add(30L);
+
+  jaccard = SetDigest<int64_t>::jaccardIndex(digest1, digest4);
+  EXPECT_NEAR(jaccard, 0.0, 0.001);
+}
+
+TEST_F(SetDigestTest, getHashCounts) {
+  SetDigest<int64_t> digest(allocator_.get());
+
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(1L);
+  digest.add(2L);
+  digest.add(2L);
+
+  auto hashCounts = digest.getHashCounts();
+  EXPECT_EQ(hashCounts.size(), 2);
+  int totalCount = 0;
+  for (const auto& entry : hashCounts) {
+    totalCount += entry.second;
+  }
+  EXPECT_EQ(totalCount, 5);
+}
+
+TEST_F(SetDigestTest, hashCountsJavaCompatibility) {
+  // This test matches the Java TestSetDigest.testHashCounts() test
+  SetDigest<int64_t> digest1(allocator_.get());
+  digest1.add(0L);
+  digest1.add(0L);
+  digest1.add(1L);
+
+  auto hashCounts1 = digest1.getHashCounts();
+  EXPECT_EQ(hashCounts1.size(), 2);
+
+  std::set<int16_t> counts1;
+  for (const auto& entry : hashCounts1) {
+    counts1.insert(entry.second);
+  }
+  std::set<int16_t> expected1 = {1, 2};
+  EXPECT_EQ(counts1, expected1);
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  digest2.add(0L);
+  digest2.add(0L);
+  digest2.add(2L);
+  digest2.add(2L);
+
+  auto hashCounts2 = digest2.getHashCounts();
+  EXPECT_EQ(hashCounts2.size(), 2);
+
+  std::set<int16_t> counts2;
+  for (const auto& entry : hashCounts2) {
+    counts2.insert(entry.second);
+  }
+  std::set<int16_t> expected2 = {2, 2};
+  EXPECT_EQ(counts2, expected2);
+
+  // Merge digest2 into digest1
+  digest1.mergeWith(digest2);
+
+  auto hashCountsMerged = digest1.getHashCounts();
+  EXPECT_EQ(hashCountsMerged.size(), 3);
+
+  std::set<int16_t> countsMerged;
+  for (const auto& entry : hashCountsMerged) {
+    countsMerged.insert(entry.second);
+  }
+  std::set<int16_t> expectedMerged = {1, 2, 4};
+  // hash(0): 2 + 2 = 4
+  // hash(1): 1 + 0 = 1
+  // hash(2): 0 + 2 = 2
+  EXPECT_EQ(countsMerged, expectedMerged);
+}
+
+TEST_F(SetDigestTest, javaSerializationCompatibilityIntegerValues) {
+  SCOPED_TRACE(
+      "SELECT to_base64(cast(make_set_digest(col) as varbinary)) "
+      "FROM (VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10)) AS t(col)");
+
+  // Base64 encoded SetDigest generated by Java Presto for values 1-10
+  auto data = decodeBase64(
+      "ASwAAAACCwoAgANEAEDsyQbAxdQPADQvEoYdNBuBKeEwgtKHOQBYPVsB0hm0gCAI3gAgAAAKAAAAwbZqSBDSGbSowHZsoCAI3krEBfu3A0QAUyYs1XjsyQYbd2yb9sXUD3IeYiw5NC8S5tfq34AdNBuyj38lkynhMHnf8AaM0oc5DItIsjlYPVsBAAEAAQABAAEAAQABAAEAAQABAA==");
+
+  SetDigest<int64_t> digest(allocator_.get());
+  ASSERT_TRUE(digest.deserialize(data.data(), data.size()).ok());
+
+  EXPECT_TRUE(digest.isExact());
+  EXPECT_EQ(digest.cardinality(), 10);
+
+  SetDigest<int64_t> expectedDigest(allocator_.get());
+  for (int64_t i = 1; i <= 10; i++) {
+    expectedDigest.add(i);
+  }
+  EXPECT_EQ(expectedDigest.cardinality(), 10);
+  EXPECT_TRUE(expectedDigest.isExact());
+
+  int64_t intersection =
+      SetDigest<int64_t>::exactIntersectionCardinality(digest, expectedDigest);
+  EXPECT_EQ(intersection, 10);
+
+  auto hashCounts = digest.getHashCounts();
+  auto expectedHashCounts = expectedDigest.getHashCounts();
+  EXPECT_EQ(hashCounts.size(), expectedHashCounts.size());
+
+  for (const auto& entry : hashCounts) {
+    EXPECT_EQ(entry.second, 1);
+  }
+
+  int32_t size = digest.estimatedSerializedSize();
+  std::vector<char> buffer(size);
+  digest.serialize(buffer.data());
+
+  EXPECT_EQ(size, data.size());
+  EXPECT_EQ(std::string(buffer.begin(), buffer.end()), data);
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  ASSERT_TRUE(digest2.deserialize(buffer.data(), size).ok());
+  EXPECT_EQ(digest2.cardinality(), 10);
+  EXPECT_TRUE(digest2.isExact());
+
+  int64_t intersection2 =
+      SetDigest<int64_t>::exactIntersectionCardinality(digest2, expectedDigest);
+  EXPECT_EQ(intersection2, 10);
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  EXPECT_EQ(std::string(buffer2.begin(), buffer2.end()), data);
+}
+
+TEST_F(SetDigestTest, javaSerializationCompatibilityStringValues) {
+  SCOPED_TRACE(
+      "SELECT to_base64(cast(make_set_digest(col) as varbinary)) "
+      "FROM (VALUES ('apple'), ('banana'), ('cherry')) AS t(col)");
+
+  SetDigest<StringView> digest1(allocator_.get());
+  digest1.add(StringView("apple"));
+  digest1.add(StringView("banana"));
+  digest1.add(StringView("cherry"));
+
+  int32_t size1 = digest1.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest1.serialize(buffer1.data());
+
+  SetDigest<StringView> digest2(allocator_.get());
+  ASSERT_TRUE(digest2.deserialize(buffer1.data(), size1).ok());
+
+  EXPECT_TRUE(digest2.isExact());
+  EXPECT_EQ(digest2.cardinality(), 3);
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  EXPECT_EQ(size1, size2);
+  EXPECT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+
+  SetDigest<StringView> digest3(allocator_.get());
+  ASSERT_TRUE(digest3.deserialize(buffer2.data(), size2).ok());
+  int32_t size3 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest3.serialize(buffer3.data());
+
+  EXPECT_EQ(
+      std::string(buffer3.begin(), buffer3.end()),
+      std::string(buffer1.begin(), buffer1.end()));
+}
+
+TEST_F(SetDigestTest, sparseHllToDenseConversion) {
+  SetDigest<int64_t> digest(allocator_.get());
+
+  // digest is still exact (5000 < 8192 maxHashes)
+  constexpr int32_t kNumValues = 5000;
+  for (int32_t i = 0; i < kNumValues; i++) {
+    digest.add(static_cast<int64_t>(i));
+  }
+
+  EXPECT_TRUE(digest.isExact());
+  EXPECT_EQ(digest.cardinality(), kNumValues);
+
+  int32_t size1 = digest.estimatedSerializedSize();
+  std::vector<char> buffer1(size1);
+  digest.serialize(buffer1.data());
+
+  SetDigest<int64_t> digest2(allocator_.get());
+  ASSERT_TRUE(digest2.deserialize(buffer1.data(), size1).ok());
+
+  EXPECT_TRUE(digest2.isExact());
+  EXPECT_EQ(digest2.cardinality(), kNumValues);
+
+  int32_t size2 = digest2.estimatedSerializedSize();
+  std::vector<char> buffer2(size2);
+  digest2.serialize(buffer2.data());
+
+  EXPECT_EQ(size1, size2);
+  EXPECT_EQ(
+      std::string(buffer1.begin(), buffer1.end()),
+      std::string(buffer2.begin(), buffer2.end()));
+
+  digest2.add(static_cast<int64_t>(kNumValues));
+  EXPECT_EQ(digest2.cardinality(), kNumValues + 1);
+
+  // add enough values to exceed maxHashes (8192) and become approximate
+  constexpr int32_t kNumAdditionalValues = 5000;
+  for (int32_t i = kNumValues; i < kNumValues + kNumAdditionalValues; i++) {
+    digest.add(static_cast<int64_t>(i));
+  }
+
+  EXPECT_FALSE(digest.isExact());
+
+  int64_t actualCardinality = kNumValues + kNumAdditionalValues;
+  int64_t estimatedCardinality = digest.cardinality();
+
+  // The error bound relates to HyperLogLog cardinality estimation.
+  // Theoretical standard error: 1.04 / sqrt(2048 buckets) ≈ 2.3%
+  // Use 3x standard error for 99.7% confidence (3-sigma rule).
+  EXPECT_NEAR(
+      estimatedCardinality,
+      actualCardinality,
+      actualCardinality * 3 * kStandardError);
+
+  int32_t size3 = digest.estimatedSerializedSize();
+  std::vector<char> buffer3(size3);
+  digest.serialize(buffer3.data());
+
+  SetDigest<int64_t> digest3(allocator_.get());
+  ASSERT_TRUE(digest3.deserialize(buffer3.data(), size3).ok());
+
+  EXPECT_FALSE(digest3.isExact());
+  EXPECT_EQ(digest3.cardinality(), digest.cardinality());
+
+  int32_t size4 = digest3.estimatedSerializedSize();
+  std::vector<char> buffer4(size4);
+  digest3.serialize(buffer4.data());
+
+  EXPECT_EQ(size3, size4);
+  EXPECT_EQ(
+      std::string(buffer3.begin(), buffer3.end()),
+      std::string(buffer4.begin(), buffer4.end()));
+}
+
+// Java-equivalent tests matching TestSetDigest.java
+
+TEST_F(SetDigestTest, testIntersectionCardinality) {
+  // Equivalent to Java's testIntersectionCardinality() with default parameters
+  testIntersectionCardinalityHelper(
+      SetDigest<int64_t>::kDefaultMaxHashes,
+      SetDigest<int64_t>::kNumberOfBuckets,
+      SetDigest<int64_t>::kDefaultMaxHashes,
+      SetDigest<int64_t>::kNumberOfBuckets);
+}
+
+TEST_F(SetDigestTest, testUnevenIntersectionCardinality) {
+  // Equivalent to Java's testUnevenIntersectionCardinality()
+  testIntersectionCardinalityHelper(
+      SetDigest<int64_t>::kDefaultMaxHashes / 4,
+      SetDigest<int64_t>::kNumberOfBuckets,
+      SetDigest<int64_t>::kDefaultMaxHashes,
+      SetDigest<int64_t>::kNumberOfBuckets);
+}
+
+void SetDigestTest::testIntersectionCardinalityHelper(
+    int32_t maxHashes1,
+    int32_t numBuckets1,
+    int32_t maxHashes2,
+    int32_t numBuckets2) {
+  std::vector<int32_t> sizes;
+
+  std::mt19937 rand(0); // Same seed as Java for reproducibility
+  // Generate random size from each power of ten in [10, 100,000,000]
+  for (int32_t i = 10; i < 100000000; i *= 10) {
+    std::uniform_int_distribution<int32_t> dist(10, i + 9);
+    sizes.push_back(dist(rand));
+  }
+
+  for (int32_t size : sizes) {
+    int32_t expectedCardinality = 0;
+    SetDigest<int64_t> digest1(
+        allocator_.get(),
+        static_cast<int8_t>(std::log2(numBuckets1)),
+        maxHashes1);
+    SetDigest<int64_t> digest2(
+        allocator_.get(),
+        static_cast<int8_t>(std::log2(numBuckets2)),
+        maxHashes2);
+
+    std::uniform_int_distribution<int64_t> valueDist;
+    std::uniform_real_distribution<double> probDist(0.0, 1.0);
+
+    for (int32_t j = 0; j < size; j++) {
+      int32_t added = 0;
+      int64_t value = valueDist(rand);
+
+      if (probDist(rand) < 0.5) {
+        digest1.add(value);
+        added++;
+      }
+      if (probDist(rand) < 0.5) {
+        digest2.add(value);
+        added++;
+      }
+      if (added == 2) {
+        expectedCardinality++;
+      }
+    }
+
+    // Skip test if expectedCardinality is too small
+    if (expectedCardinality < 10) {
+      continue;
+    }
+
+    // Calculate intersection using C++ implementation
+    int64_t estimatedCardinality;
+    if (digest1.isExact() && digest2.isExact()) {
+      estimatedCardinality =
+          SetDigest<int64_t>::exactIntersectionCardinality(digest1, digest2);
+    } else {
+      // Use Jaccard index for approximate intersection
+      int64_t cardinality1 = digest1.cardinality();
+      int64_t cardinality2 = digest2.cardinality();
+      double jaccard = SetDigest<int64_t>::jaccardIndex(digest1, digest2);
+
+      // Merge to get union cardinality
+      SetDigest<int64_t> tempDigest(
+          allocator_.get(),
+          static_cast<int8_t>(std::log2(numBuckets1)),
+          maxHashes1);
+      tempDigest.mergeWith(digest1);
+      tempDigest.mergeWith(digest2);
+      int64_t unionCardinality = tempDigest.cardinality();
+
+      estimatedCardinality =
+          static_cast<int64_t>(std::round(jaccard * unionCardinality));
+      estimatedCardinality =
+          std::min(estimatedCardinality, std::min(cardinality1, cardinality2));
+    }
+
+    double errorRate = std::abs(expectedCardinality - estimatedCardinality) /
+        static_cast<double>(expectedCardinality);
+    EXPECT_LT(errorRate, 0.10);
+  }
+}
+
+TEST_F(SetDigestTest, testSmallLargeIntersections) {
+  // Equivalent to Java's testSmallLargeIntersections()
+  std::vector<int32_t> sizes;
+
+  std::mt19937 rand(0); // Same seed as Java
+  for (int32_t i = 1000; i < 1000000; i *= 10) {
+    std::uniform_int_distribution<int32_t> dist(10, i + 9);
+    sizes.push_back(dist(rand));
+  }
+
+  for (size_t size1_idx = 0; size1_idx < sizes.size(); ++size1_idx) {
+    int32_t size1 = sizes[size1_idx];
+    SetDigest<int64_t> digest1(allocator_.get());
+    std::vector<std::pair<std::unique_ptr<SetDigest<int64_t>>, int32_t>>
+        smallerSets;
+
+    std::uniform_int_distribution<int64_t> valueDist;
+    std::uniform_real_distribution<double> probDist(0.0, 1.0);
+
+    for (size_t size2_idx = 0; size2_idx < size1_idx; ++size2_idx) {
+      int32_t size2 = sizes[size2_idx];
+
+      for (int32_t overlap = 2; overlap <= 10; overlap += 2) {
+        int32_t expectedCardinality = 0;
+        auto digest2 = std::make_unique<SetDigest<int64_t>>(allocator_.get());
+
+        // Reset rand for this iteration to generate same values for digest1
+        std::mt19937 innerRand(rand());
+
+        for (int32_t j = 0; j < size1; j++) {
+          int64_t value = valueDist(innerRand);
+          digest1.add(value);
+
+          if (probDist(innerRand) < size2 / static_cast<double>(size1)) {
+            if (probDist(innerRand) * 10 < overlap) {
+              digest2->add(value);
+              expectedCardinality++;
+            } else {
+              digest2->add(valueDist(innerRand));
+            }
+          }
+        }
+
+        smallerSets.emplace_back(std::move(digest2), expectedCardinality);
+      }
+    }
+
+    for (const auto& [digest2Ptr, expectedCardinality] : smallerSets) {
+      const SetDigest<int64_t>& digest2 = *digest2Ptr;
+
+      // Calculate estimated intersection
+      int64_t estIntersectionCardinality;
+      if (digest1.isExact() && digest2.isExact()) {
+        estIntersectionCardinality =
+            SetDigest<int64_t>::exactIntersectionCardinality(digest1, digest2);
+      } else {
+        int64_t cardinality1 = digest1.cardinality();
+        int64_t cardinality2 = digest2.cardinality();
+        double jaccard = SetDigest<int64_t>::jaccardIndex(digest1, digest2);
+
+        SetDigest<int64_t> tempDigest(allocator_.get());
+        tempDigest.mergeWith(digest1);
+        tempDigest.mergeWith(digest2);
+        int64_t unionCardinality = tempDigest.cardinality();
+
+        estIntersectionCardinality =
+            static_cast<int64_t>(std::round(jaccard * unionCardinality));
+        estIntersectionCardinality = std::min(
+            estIntersectionCardinality, std::min(cardinality1, cardinality2));
+      }
+
+      int64_t size2 = digest2.cardinality();
+      EXPECT_LE(estIntersectionCardinality, size2);
+
+      double errorRate =
+          std::abs(expectedCardinality - estIntersectionCardinality) /
+          static_cast<double>(size1);
+      EXPECT_LT(errorRate, 0.05);
+    }
+  }
+}


### PR DESCRIPTION
Summary:
## Main Methods

| **Java Method**                                   | **C++ Method**                                   | **Description**                                                        |
|---------------------------------------------------|--------------------------------------------------|-----------------------------------------------------------------------|
| `SetDigest()`                                     | `SetDigest(HashStringAllocator*)`                | Constructor - Java uses default params, C++ requires allocator        |
| `void add(long)`                                  | `void add(int64_t)`                              | Add integer value to digest                                           |
| `void add(Slice)`                                 | `void add(StringView)`                           | Add string/binary value to digest                                     |
| `Slice serialize()`                               | `void serialize(char*)`                          | Serialize to bytes (Java returns Slice, C++ writes to buffer)         |
| `static SetDigest newInstance(Slice)`             | `void deserialize(const char*, int32_t)`         | Deserialize from bytes (Java static factory, C++ instance method)     |
| `void mergeWith(SetDigest)`                       | `void mergeWith(const SetDigest&)`               | Merge two digests                                                     |
| `boolean isExact()`                              | `bool isExact() const`                           | Check if digest is exact or approximate                               |
| `long cardinality()`                              | `int64_t cardinality() const`                    | Get distinct element count                                            |
| `static long exactIntersectionCardinality(...)`    | `static int64_t exactIntersectionCardinality(...)`| Calculate exact intersection size                                     |
| `static double jaccardIndex(...)`                 | `static double jaccardIndex(...)`                | Calculate Jaccard similarity coefficient                              |
| `Map<Long, Short> getHashCounts()`                | `std::map<int64_t, int16_t> getHashCounts() const`| Get MinHash map                                                      |

---

## Size Estimation Functions

| **Java Method**                  | **C++ Method**                        |
|----------------------------------|---------------------------------------|
| `int estimatedSerializedSize()`  | n/a  |
| `int estimatedInMemorySize()`    | `int32_t estimatedInMemorySize() const`|

---

## Additional Methods

| **Java Only**                                 | **C++ Only**                        |
|-----------------------------------------------|-------------------------------------|
| `HyperLogLog getHll()`                        | `void setIndexBitLength(int8_t)`    |
| `SetDigest(int, int)` constructor             |                                     |
| `void convertToDense()` (private)             |                                     |
| `SetDigest(int, HLL, Map)` constructor        |                                     |

Differential Revision: D87376975


