### PR TITLE
feat: Templatize HllAccumulator with TAllocator

### DIFF
--- a/velox/common/hyperloglog/HllAccumulator.h
+++ b/velox/common/hyperloglog/HllAccumulator.h
@@ -31,6 +31,9 @@ namespace facebook::velox::common::hll {
 namespace detail {
 template <typename T, bool HllAsFinalResult>
 inline uint64_t hashOne(const T& value) {
+  if constexpr (std::is_same_v<T, Timestamp>) {
+    return hashOne<int64_t, HllAsFinalResult>(value.toMillis());
+  }
   if constexpr (HllAsFinalResult) {
     if constexpr (std::is_same_v<T, int64_t>) {
       return common::hll::Murmur3Hash128::hash64ForLong(value, 0);
@@ -42,17 +45,6 @@ inline uint64_t hashOne(const T& value) {
   } else {
     return XXH64(&value, sizeof(T), 0);
   }
-}
-
-// Use timestamp.toMillis() to compute hash value.
-template <>
-inline uint64_t hashOne<Timestamp, false>(const Timestamp& value) {
-  return hashOne<int64_t, false>(value.toMillis());
-}
-
-template <>
-inline uint64_t hashOne<Timestamp, true>(const Timestamp& /*value*/) {
-  VELOX_UNREACHABLE("approx_set(timestamp) is not supported.");
 }
 
 template <>
@@ -67,21 +59,62 @@ inline uint64_t hashOne<StringView, true>(const StringView& value) {
 
 } // namespace detail
 
-template <typename T, bool HllAsFinalResult>
+template <
+    typename T,
+    bool HllAsFinalResult,
+    typename TAllocator = HashStringAllocator>
 struct HllAccumulator {
-  explicit HllAccumulator(HashStringAllocator* allocator)
+  explicit HllAccumulator(TAllocator* allocator)
       : sparseHll_{allocator}, denseHll_{allocator} {}
+
+  explicit HllAccumulator(int8_t indexBitLength, TAllocator* allocator)
+      : isSparse_(true),
+        indexBitLength_(indexBitLength),
+        sparseHll_(allocator),
+        denseHll_(allocator) {
+    // Set soft memory limit for sparse HLL to convert to dense when exceeded.
+    sparseHll_.setSoftMemoryLimit(
+        DenseHlls::estimateInMemorySize(indexBitLength_));
+  }
 
   void setIndexBitLength(int8_t indexBitLength) {
     indexBitLength_ = indexBitLength;
     sparseHll_.setSoftMemoryLimit(
-        common::hll::DenseHlls::estimateInMemorySize(indexBitLength_));
+        DenseHlls::estimateInMemorySize(indexBitLength_));
+  }
+
+  /// Creates an HllAccumulator instance from serialized data.
+  static std::unique_ptr<HllAccumulator> deserialize(
+      const char* data,
+      TAllocator* allocator) {
+    if (SparseHlls::canDeserialize(data)) {
+      int8_t indexBitLength = SparseHlls::deserializeIndexBitLength(data);
+      auto wrapper =
+          std::make_unique<HllAccumulator>(indexBitLength, allocator);
+      wrapper->sparseHll_ = SparseHll<TAllocator>(data, allocator);
+      wrapper->sparseHll_.setSoftMemoryLimit(
+          DenseHlls::estimateInMemorySize(indexBitLength));
+      return wrapper;
+    } else if (DenseHlls::canDeserialize(data)) {
+      int8_t indexBitLength = DenseHlls::deserializeIndexBitLength(data);
+      auto wrapper =
+          std::make_unique<HllAccumulator>(indexBitLength, allocator);
+      wrapper->denseHll_ = DenseHll<TAllocator>(data, allocator);
+      wrapper->isSparse_ = false;
+      return wrapper;
+    } else {
+      VELOX_FAIL("Cannot deserialize HyperLogLog");
+    }
   }
 
   void append(T value) {
     const auto hash = detail::hashOne<T, HllAsFinalResult>(value);
+    insertHash(hash);
+  }
 
+  void insertHash(uint64_t hash) {
     if (isSparse_) {
+      // insertHash returns true if soft memory limit exceeded
       if (sparseHll_.insertHash(hash)) {
         toDense();
       }
@@ -94,33 +127,32 @@ struct HllAccumulator {
     return isSparse_ ? sparseHll_.cardinality() : denseHll_.cardinality();
   }
 
-  void mergeWith(StringView serialized, HashStringAllocator* allocator) {
+  void mergeWith(StringView serialized, TAllocator* allocator) {
     auto input = serialized.data();
-    if (common::hll::SparseHlls::canDeserialize(input)) {
-      if (isSparse_) {
-        sparseHll_.mergeWith(input);
-        if (indexBitLength_ < 0) {
-          setIndexBitLength(
-              common::hll::DenseHlls::deserializeIndexBitLength(input));
-        }
-        if (sparseHll_.overLimit()) {
-          toDense();
-        }
-      } else {
-        common::hll::SparseHll<> other{input, allocator};
-        other.toDense(denseHll_);
-      }
-    } else if (common::hll::DenseHlls::canDeserialize(input)) {
-      if (isSparse_) {
-        if (indexBitLength_ < 0) {
-          setIndexBitLength(
-              common::hll::DenseHlls::deserializeIndexBitLength(input));
-        }
-        toDense();
-      }
-      denseHll_.mergeWith(input);
+    if (indexBitLength_ < 0) {
+      // deserializeIndexBitLength is the same between Dense and Sparse HLL
+      setIndexBitLength(DenseHlls::deserializeIndexBitLength(input));
+    }
+
+    if (SparseHlls::canDeserialize(input)) {
+      SparseHll<TAllocator> other{input, allocator};
+      mergeWithSparse(other);
+    } else if (DenseHlls::canDeserialize(input)) {
+      DenseHll<TAllocator> other{input, allocator};
+      mergeWithDense(other);
     } else {
       VELOX_USER_FAIL("Unexpected type of HLL");
+    }
+  }
+
+  void mergeWith(const HllAccumulator& other) {
+    if (indexBitLength_ < 0) {
+      setIndexBitLength(other.indexBitLength_);
+    }
+    if (other.isSparse_) {
+      mergeWithSparse(other.sparseHll_);
+    } else {
+      mergeWithDense(other.denseHll_);
     }
   }
 
@@ -133,6 +165,10 @@ struct HllAccumulator {
                      : denseHll_.serialize(outputBuffer);
   }
 
+  bool isSparse() const {
+    return isSparse_;
+  }
+
  private:
   void toDense() {
     isSparse_ = false;
@@ -141,10 +177,28 @@ struct HllAccumulator {
     sparseHll_.reset();
   }
 
+  void mergeWithSparse(const SparseHll<TAllocator>& other) {
+    if (isSparse_) {
+      sparseHll_.mergeWith(other);
+      if (sparseHll_.overLimit()) {
+        toDense();
+      }
+    } else {
+      other.toDense(denseHll_);
+    }
+  }
+
+  void mergeWithDense(const DenseHll<TAllocator>& other) {
+    if (isSparse_) {
+      toDense();
+    }
+    denseHll_.mergeWith(other);
+  }
+
   bool isSparse_{true};
   int8_t indexBitLength_{-1};
-  common::hll::SparseHll<> sparseHll_;
-  common::hll::DenseHll<> denseHll_;
+  SparseHll<TAllocator> sparseHll_;
+  DenseHll<TAllocator> denseHll_;
 };
 
 template <>
@@ -187,5 +241,4 @@ struct HllAccumulator<bool, false> {
  private:
   int8_t approxDistinctState_{0};
 };
-
 } // namespace facebook::velox::common::hll

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
+add_executable(
+  velox_common_hyperloglog_test
+  DenseHllTest.cpp
+  SparseHllTest.cpp
+  HllAccumulatorTest.cpp
+)
 
 add_test(NAME velox_common_hyperloglog_test COMMAND velox_common_hyperloglog_test)
 

--- a/velox/common/hyperloglog/tests/HllAccumulatorTest.cpp
+++ b/velox/common/hyperloglog/tests/HllAccumulatorTest.cpp
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/hyperloglog/HllAccumulator.h"
+
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+
+#include <gtest/gtest-typed-test.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::common::hll;
+
+namespace {
+const int8_t kDefaultIndexBitLength = 11;
+const double kDefaultStandardError =
+    1.04 / std::sqrt(1 << kDefaultIndexBitLength);
+} // namespace
+
+template <typename TAllocator>
+class HllAccumulatorTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    if constexpr (std::is_same_v<TAllocator, HashStringAllocator>) {
+      allocator_ = &hsa_;
+    } else {
+      allocator_ = pool_.get();
+    }
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  HashStringAllocator hsa_{pool_.get()};
+  TAllocator* allocator_{};
+};
+
+using AllocatorTypes =
+    ::testing::Types<HashStringAllocator, memory::MemoryPool>;
+
+class NameGenerator {
+ public:
+  template <typename TAllocator>
+  static std::string GetName(int) {
+    if constexpr (std::is_same_v<TAllocator, HashStringAllocator>) {
+      return "hsa";
+    } else if constexpr (std::is_same_v<TAllocator, memory::MemoryPool>) {
+      return "pool";
+    } else {
+      VELOX_UNREACHABLE(
+          "Only HashStringAllocator and MemoryPool are supported allocator types.");
+    }
+  }
+};
+
+TYPED_TEST_SUITE(HllAccumulatorTest, AllocatorTypes, NameGenerator);
+
+TYPED_TEST(HllAccumulatorTest, basicInt64) {
+  // Test SparseHLL.
+  HllAccumulator<int64_t, false, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int64_t numValues = 100;
+  for (int64_t i = 0; i < numValues; i++) {
+    accumulator.append(i);
+  }
+
+  // Sparse HLL should be exact.
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+
+  // Test DenseHLL.
+  constexpr int64_t numValuesDense = 10000;
+  for (int64_t i = 0; i < numValuesDense; i++) {
+    accumulator.append(i);
+  }
+  EXPECT_NEAR(
+      accumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, basicDouble) {
+  // Test SparseHLL.
+  HllAccumulator<double, true, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int numValues = 150;
+  for (int i = 0; i < numValues; i++) {
+    accumulator.append(static_cast<double>(i) * 1.5);
+  }
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+
+  // Test DenseHLL.
+  constexpr int numValuesDense = 15000;
+  for (int i = numValues; i < numValuesDense; i++) {
+    accumulator.append(static_cast<double>(i) * 1.5);
+  }
+  EXPECT_NEAR(
+      accumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, basicStringView) {
+  // Test SparseHLL.
+  HllAccumulator<StringView, true, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int numValues = 100;
+  std::vector<std::string> strings;
+  strings.reserve(numValues);
+  for (int i = 0; i < numValues; i++) {
+    strings.push_back("value_" + std::to_string(i));
+  }
+  for (const auto& str : strings) {
+    accumulator.append(StringView(str));
+  }
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+
+  // Test DenseHLL.
+  constexpr int numValuesDense = 10000;
+  for (int i = numValues; i < numValuesDense; i++) {
+    strings.push_back("value_" + std::to_string(i));
+  }
+  for (int i = numValues; i < numValuesDense; i++) {
+    accumulator.append(StringView(strings[i]));
+  }
+  EXPECT_NEAR(
+      accumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, serde) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int64_t numValues = 200;
+  for (int64_t i = 0; i < numValues; i++) {
+    accumulator.append(i);
+  }
+
+  auto size = accumulator.serializedSize();
+  std::string serialized(size, '\0');
+  accumulator.serialize(serialized.data());
+
+  auto deserialized = HllAccumulator<int64_t, false, TypeParam>::deserialize(
+      serialized.data(), this->allocator_);
+
+  EXPECT_EQ(deserialized->cardinality(), numValues);
+
+  // Test round trip
+  std::string reserialized(deserialized->serializedSize(), '\0');
+  deserialized->serialize(reserialized.data());
+  EXPECT_EQ(reserialized, serialized);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithBothSparse) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  // Add non-overlapping values that keep both sparse.
+  for (int64_t i = 0; i < 100; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 100; i < 200; i++) {
+    accumulator2.append(i);
+  }
+
+  accumulator1.mergeWith(accumulator2);
+
+  // Resulting accumulator should be sparse and exact.
+  EXPECT_TRUE(accumulator1.isSparse());
+  EXPECT_EQ(accumulator1.cardinality(), 200);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithBothDense) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  // Add non-overlapping values that trigger dense mode.
+  constexpr int64_t numValues = 10000;
+  for (int64_t i = 0; i < 5000; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 5000; i < numValues; i++) {
+    accumulator2.append(i);
+  }
+
+  accumulator1.mergeWith(accumulator2);
+  EXPECT_FALSE(accumulator1.isSparse());
+
+  EXPECT_NEAR(
+      accumulator1.cardinality(), numValues, numValues * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeSparseWithDense) {
+  HllAccumulator<int64_t, false, TypeParam> sparseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> denseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    sparseAccumulator.append(i);
+  }
+
+  constexpr int64_t numValuesDense = 5000;
+  for (int64_t i = 100; i < numValuesDense; i++) {
+    denseAccumulator.append(i);
+  }
+
+  sparseAccumulator.mergeWith(denseAccumulator);
+
+  // mergeWith should convert any sparse accumulator to dense if either is
+  // dense. Result should be dense and approximate.
+
+  EXPECT_FALSE(sparseAccumulator.isSparse());
+  EXPECT_NEAR(
+      sparseAccumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeDenseWithSparse) {
+  HllAccumulator<int64_t, false, TypeParam> sparseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> denseAccumulator(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    sparseAccumulator.append(i);
+  }
+
+  constexpr int64_t numValuesDense = 5000;
+  for (int64_t i = 100; i < numValuesDense; i++) {
+    denseAccumulator.append(i);
+  }
+
+  denseAccumulator.mergeWith(sparseAccumulator);
+
+  // Result should be dense and approximate.
+  EXPECT_FALSE(denseAccumulator.isSparse());
+  EXPECT_NEAR(
+      denseAccumulator.cardinality(),
+      numValuesDense,
+      numValuesDense * kDefaultStandardError);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithSerializedDataSparse) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 100; i < 200; i++) {
+    accumulator2.append(i);
+  }
+
+  auto size = accumulator2.serializedSize();
+  std::string buffer(size, '\0');
+  accumulator2.serialize(buffer.data());
+
+  // Merge with serialized data (should remain sparse).
+  accumulator1.mergeWith(StringView(buffer), this->allocator_);
+
+  // Should be sparse and exact.
+  EXPECT_TRUE(accumulator1.isSparse());
+  EXPECT_EQ(accumulator1.cardinality(), 200);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeWithOverlappingDataSparse) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator1(
+      kDefaultIndexBitLength, this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> accumulator2(
+      kDefaultIndexBitLength, this->allocator_);
+
+  for (int64_t i = 0; i < 100; i++) {
+    accumulator1.append(i);
+  }
+  for (int64_t i = 50; i < 150; i++) {
+    accumulator2.append(i);
+  }
+
+  accumulator1.mergeWith(accumulator2);
+
+  // Sparse HLL should be sparse and exact: union of [0, 100) and [50, 150) =
+  // [0, 150)
+  EXPECT_TRUE(accumulator1.isSparse());
+  EXPECT_EQ(accumulator1.cardinality(), 150);
+}
+
+TYPED_TEST(HllAccumulatorTest, mergeUninitializedAccumulator) {
+  HllAccumulator<int64_t, false, TypeParam> accumulator(this->allocator_);
+  HllAccumulator<int64_t, false, TypeParam> initialized(
+      kDefaultIndexBitLength, this->allocator_);
+
+  constexpr int64_t numValues = 100;
+  for (int64_t i = 0; i < numValues; i++) {
+    initialized.append(i);
+  }
+
+  auto size = initialized.serializedSize();
+  std::string buffer(size, '\0');
+  initialized.serialize(buffer.data());
+
+  accumulator.mergeWith(StringView(buffer), this->allocator_);
+
+  EXPECT_EQ(accumulator.cardinality(), numValues);
+}


### PR DESCRIPTION
Summary:
Adding some functionalities to HllAccumulator to accomodate KHLL
- mergeWith which takes in a deserialized HllAccumuator
- template typename TAllocator, to allow usage of both HashStringAllocator and MemoryPool, with the default set to use HashStringAllocator (as Sparse and Dense Hll does)

Differential Revision: D87591323


