### PR TITLE
misc(fuzzer): Skip $internal$split_to_map in expression fuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -415,6 +415,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     // https://github.com/prestodb/presto/pull/25521
     "xxhash64(varbinary,bigint) -> varbinary",
     "map_keys_by_top_n_values", // https://github.com/facebookincubator/velox/issues/14374
+    "$internal$split_to_map",
     "$internal$canonicalize",
     "$internal$contains",
     "localtime", // localtime cannot be called with paranthesis:


### PR DESCRIPTION
Summary:
Add $internal$split_to_map to the skip function list in expression fuzzer when using Presto SOT, 
because this function doesn't exist in Presto.

Differential Revision: D87596970


