### PR TITLE
refactor: Move background time declaration to Operator.h

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -365,14 +365,13 @@ void Exchange::recordExchangeClientStats() {
     lockedStats->runtimeStats.insert({name, value});
   }
 
-  const auto backgroundCpuTimeMs =
-      exchangeClientStats.find(ExchangeClient::kBackgroundCpuTimeMs);
-  if (backgroundCpuTimeMs != exchangeClientStats.end()) {
+  const auto backgroundCpuTimeNanos =
+      exchangeClientStats.find(Operator::kBackgroundCpuTimeNanos);
+  if (backgroundCpuTimeNanos != exchangeClientStats.end()) {
     const CpuWallTiming backgroundTiming{
-        static_cast<uint64_t>(backgroundCpuTimeMs->second.count),
+        static_cast<uint64_t>(backgroundCpuTimeNanos->second.count),
         0,
-        static_cast<uint64_t>(backgroundCpuTimeMs->second.sum) *
-            Timestamp::kNanosecondsInMillisecond};
+        static_cast<uint64_t>(backgroundCpuTimeNanos->second.sum)};
     lockedStats->backgroundTiming.clear();
     lockedStats->backgroundTiming.add(backgroundTiming);
   }

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -26,8 +26,8 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
  public:
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
   static constexpr std::chrono::milliseconds kRequestDataMaxWait{100};
+  // TODO: remove this after Operator::kBackgroundCpuTimeNanos is fully used.
   static inline const std::string kBackgroundCpuTimeMs = "backgroundCpuTimeMs";
-
   ExchangeClient(
       std::string taskId,
       int destination,
@@ -91,7 +91,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
 
   // Returns runtime statistics aggregated across all of the exchange sources.
   // ExchangeClient is expected to report background CPU time by including a
-  // runtime metric named ExchangeClient::kBackgroundCpuTimeMs.
+  // runtime metric named Operator::kBackgroundCpuTimeNanos.
   folly::F14FastMap<std::string, RuntimeMetric> stats() const;
 
   const std::shared_ptr<ExchangeQueue>& queue() const {

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -106,7 +106,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
 
   // Returns runtime statistics. ExchangeSource is expected to report
   // background CPU time by including a runtime metric named
-  // ExchangeClient::kBackgroundCpuTimeMs.
+  // Operator::kBackgroundCpuTimeNanos.
   virtual folly::F14FastMap<std::string, int64_t> stats() const {
     VELOX_UNREACHABLE();
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -152,6 +152,11 @@ class Operator : public BaseRuntimeStatWriter {
     }
   };
 
+  /// The name for background cpu time metric if operator has background cpu
+  /// usages outside its driver thread.
+  static inline const std::string kBackgroundCpuTimeNanos =
+      "backgroundCpuTimeNanos";
+
   /// The name of the runtime spill stats collected and reported by operators
   /// that support spilling.
 

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -258,7 +258,7 @@ class MultiFragmentTest : public HiveConnectorTestBase,
         exchangeStats.at("localExchangeSource.numPages").count);
     ASSERT_EQ(
         expectedBackgroundCpuCount,
-        exchangeStats.at(ExchangeClient::kBackgroundCpuTimeMs).count);
+        exchangeStats.at(Operator::kBackgroundCpuTimeNanos).count);
     ASSERT_EQ(
         expectedBackgroundCpuCount, taskStats.at("0").backgroundTiming.count);
   }

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -17,7 +17,7 @@
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <atomic>
 #include "velox/common/testutil/TestValue.h"
-#include "velox/exec/ExchangeClient.h"
+#include "velox/exec/Operator.h"
 #include "velox/exec/OutputBufferManager.h"
 
 namespace facebook::velox::exec::test {
@@ -190,7 +190,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
         {"localExchangeSource.numPages", RuntimeMetric(numPages_)},
         {"localExchangeSource.totalBytes",
          RuntimeMetric(totalBytes_, RuntimeCounter::Unit::kBytes)},
-        {ExchangeClient::kBackgroundCpuTimeMs,
+        {Operator::kBackgroundCpuTimeNanos,
          RuntimeMetric(123 * 1000000, RuntimeCounter::Unit::kNanos)},
     };
   }


### PR DESCRIPTION
Summary: kBackgroundCpuTimeMs is now commonly used by multiple operators beyond only exchange. Move it to Operator class and make the unit Nanos.

Differential Revision: D87611459


