### PR TITLE
misc: Remove ExchangeClient::kBackgroundCpuTimeMs

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -26,8 +26,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
  public:
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
   static constexpr std::chrono::milliseconds kRequestDataMaxWait{100};
-  // TODO: remove this after Operator::kBackgroundCpuTimeNanos is fully used.
-  static inline const std::string kBackgroundCpuTimeMs = "backgroundCpuTimeMs";
+
   ExchangeClient(
       std::string taskId,
       int destination,


### PR DESCRIPTION
Summary: deprecate the old ExchangeClient::kBackgroundCpuTimeMs

Differential Revision: D87613815


