### PR TITLE
refactor: Remove redundant resizing of child vectors

### DIFF
--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -389,10 +389,6 @@ void SortBuffer::prepareOutput(vector_size_t batchSize) {
         BaseVector::create(input_, batchSize, pool_));
   }
 
-  for (auto& child : output_->children()) {
-    child->resize(batchSize);
-  }
-
   if (hasSpilled()) {
     spillSources_.resize(batchSize);
     spillSourceRows_.resize(batchSize);

--- a/velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h
+++ b/velox/functions/lib/aggregates/CentralMomentsAggregatesBase.h
@@ -384,9 +384,6 @@ class CentralMomentsAggregatesBase : public exec::Aggregate {
       override {
     auto rowVector = (*result)->as<RowVector>();
     rowVector->resize(numGroups);
-    for (auto& child : rowVector->children()) {
-      child->resize(numGroups);
-    }
 
     uint64_t* rawNulls = getRawNulls(rowVector);
 

--- a/velox/functions/lib/aggregates/CovarianceAggregatesBase.h
+++ b/velox/functions/lib/aggregates/CovarianceAggregatesBase.h
@@ -350,9 +350,6 @@ class CovarianceAggregate : public exec::Aggregate {
       override {
     auto rowVector = (*result)->as<RowVector>();
     rowVector->resize(numGroups);
-    for (auto& child : rowVector->children()) {
-      child->resize(numGroups);
-    }
 
     uint64_t* rawNulls = getRawNulls(rowVector);
 

--- a/velox/functions/lib/aggregates/VarianceAggregatesBase.h
+++ b/velox/functions/lib/aggregates/VarianceAggregatesBase.h
@@ -87,9 +87,6 @@ class VarianceAggregate : public exec::Aggregate {
     auto m2Vector = rowVector->childAt(kM2Idx)->asFlatVector<double>();
 
     rowVector->resize(numGroups);
-    for (auto& child : rowVector->children()) {
-      child->resize(numGroups);
-    }
     uint64_t* rawNulls = getRawNulls(rowVector);
 
     int64_t* rawCounts = countVector->mutableRawValues();


### PR DESCRIPTION
After fixing the row vector resize issue(https://github.com/facebookincubator/velox/pull/13195), resizing the child vector
after resizing the corresponding row vector is no longer necessary.