### PR TITLE
fix: Remove special form SWITCH from expression fuzzer executions

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -435,6 +435,7 @@ jobs:
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
+                --special_forms="and,or,cast,coalesce,if" \
                 --enable_dereference \
                 --duration_sec $DURATION \
                 --minloglevel=0 \


### PR DESCRIPTION
Summary:
Due to the lengthy investigation performed in https://github.com/facebookincubator/velox/issues/15486 a new behavior was identified as the result of SWITCH special form rewrite. The rewrite (in certain cases) results in two different null propagation behaviors between the common and simplified evaluation (rewritten and original expression, respectively). Currently, the expression fuzzer isn't nuanced enough to recognize this behavior mismatch and will fail, causing flakiness on both OSS PRs and internal diffs.

Let's temporarily remove the SWITCH from runs to avoid false positives from this particular expression fuzzer execution while we investigate a more stable way to avoid these particular cases. The special forms chosen in the below are the default minus SWITCH (effectively only eliminating SWITCH).

Differential Revision: D87671357


