### PR TITLE
feat: Add current_time Presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -184,6 +184,10 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+.. function:: current_time() -> time with time zone
+
+    Returns the current time since midnight with the session timezoneReturns the current time since midnight with the session timezone, based on the query session start time.
+
 .. function:: current_timezone() -> varchar
 
     Returns the current session time zone as a varchar.

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -457,7 +457,8 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "$internal$split_to_map",
     "$internal$canonicalize",
     "$internal$contains",
-    "localtime", // localtime cannot be called with paranthesis:
+    "current_time", // current_time cannot be called with parenthesis
+    "localtime", // localtime cannot be called with parenthesis:
                  // https://github.com/facebookincubator/velox/issues/14937,
     "localtimestamp", // localtimestamp cannot be called with parenthesis
     "jarowinkler_similarity", // https://github.com/facebookincubator/velox/issues/15736

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -90,6 +90,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "to_unixtime"});
 
   registerFromUnixtime(prefix + "from_unixtime");
+  registerFunction<CurrentTimeFunction, TimeWithTimezone>(
+      {prefix + "current_time"});
   registerFunction<CurrentTimezoneFunction, Varchar>(
       {prefix + "current_timezone"});
   registerFunction<CurrentTimestampFunction, TimestampWithTimezone>(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -7076,6 +7076,31 @@ TEST_F(DateTimeFunctionsTest, dateAddDateVariableUnit) {
   assertEqualVectors(expected, result);
 }
 
+TEST_F(DateTimeFunctionsTest, currentTime) {
+  auto testCurrentTime = [&](int64_t sessionStartTime,
+                             const std::string& zone,
+                             int64_t expectedMillis,
+                             int16_t expectedOffset) {
+    setSessionStartTimeAndTimeZone(sessionStartTime, zone);
+
+    auto packed = evaluateOnce<int64_t>(
+        "current_time()",
+        makeRowVector(ROW({}), 1),
+        std::nullopt,
+        TIME_WITH_TIME_ZONE());
+
+    ASSERT_TRUE(packed.has_value());
+
+    EXPECT_EQ(util::unpackMillisUtc(packed.value()), expectedMillis);
+    EXPECT_EQ(util::unpackZoneOffset(packed.value()), expectedOffset);
+  };
+
+  testCurrentTime(1710064800000, "UTC", 36000000, 0);
+  testCurrentTime(1710064800000, "Asia/Kolkata", 55800000, 1170);
+  testCurrentTime(1705312800000, "America/Los_Angeles", 7200000, 361);
+  testCurrentTime(1717243200000, "America/Los_Angeles", 18000000, 421);
+}
+
 TEST_F(DateTimeFunctionsTest, currentTimezone) {
   {
     setQueryTimeZone("Asia/Kolkata");


### PR DESCRIPTION
In the past, we were not implementing functions like current_time that returned constants in Velox. This was because Presto Java would infer the constant value at the co-ordinator and fold it, so the worker was never passed this function in execution.

However, with recent changes for side-car and worker based constant folding implementation, we need native implementations for functions like current_time, so adding to Velox as well.