### PR TITLE
feat: Add localtimestamp Presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -161,6 +161,10 @@ Date and Time Functions
     using ``hours`` and ``minutes`` for the time zone offset.
     The offset must be in [-14:00, 14:00] range.
 
+.. function:: localtimestamp -> timestamp
+
+    Returns the timestamp as of the start of the query.
+
 .. function:: to_iso8601(x) -> varchar
 
     Formats ``x`` as an ISO 8601 string. Supported types for ``x`` are:

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -454,6 +454,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "$internal$contains",
     "localtime", // localtime cannot be called with paranthesis:
                  // https://github.com/facebookincubator/velox/issues/14937,
+    "localtimestamp", // localtimestamp cannot be called with parenthesis
     "jarowinkler_similarity", // https://github.com/facebookincubator/velox/issues/15736
     // Fuzzer and the underlying engine are confused about SetDigest functions
     // (since KHLL is a user defined type), and tries to pass a

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -2113,4 +2113,22 @@ struct LocalTimeFunction {
   int64_t localTimeSinceMidnight_;
 };
 
+template <typename T>
+struct LocalTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config) {
+    ts_ = Timestamp::fromMillis(config.sessionStartTimeMs());
+  }
+
+  FOLLY_ALWAYS_INLINE void call(out_type<Timestamp>& result) {
+    result = ts_;
+  }
+
+ private:
+  Timestamp ts_;
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -346,6 +346,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "parse_duration"});
 
   registerFunction<LocalTimeFunction, Time>({prefix + "localtime"});
+  registerFunction<LocalTimestampFunction, Timestamp>(
+      {prefix + "localtimestamp"});
 }
 } // namespace
 


### PR DESCRIPTION
In the past, we were not implementing functions like localtimestamp that returned constants in Velox. This was because Presto Java would infer the constant value at the co-ordinator and fold it, so the worker was never passed this function in execution.

However, with recent changes for side-car and worker based constant folding implementation, we need native implementations for functions like localtimestamp, so adding to Velox as well.