### PR TITLE
feat: Add iceberg column handle

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 velox_add_library(
   velox_hive_iceberg_splitreader
+  IcebergColumnHandle.cpp
   IcebergConnector.cpp
   IcebergDataSink.cpp
   IcebergPartitionName.cpp

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
+#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/type/Subfield.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+IcebergColumnHandle::IcebergColumnHandle(
+    const std::string& name,
+    ColumnType columnType,
+    TypePtr dataType,
+    parquet::ParquetFieldId icebergField,
+    std::vector<common::Subfield> requiredSubfields)
+    : HiveColumnHandle(
+          name,
+          columnType,
+          dataType,
+          dataType,
+          std::move(requiredSubfields)),
+      field_(std::move(icebergField)) {}
+
+const parquet::ParquetFieldId& IcebergColumnHandle::field() const {
+  return field_;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/type/Subfield.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+class IcebergColumnHandle : public HiveColumnHandle {
+ public:
+  IcebergColumnHandle(
+      const std::string& name,
+      ColumnType columnType,
+      TypePtr dataType,
+      parquet::ParquetFieldId icebergField,
+      std::vector<common::Subfield> requiredSubfields = {});
+
+  const parquet::ParquetFieldId& field() const;
+
+ private:
+  const parquet::ParquetFieldId field_;
+};
+
+using IcebergColumnHandlePtr = std::shared_ptr<const IcebergColumnHandle>;
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -19,10 +19,15 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "velox/common/base/Fs.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/TransformExprBuilder.h"
 #include "velox/exec/OperatorUtils.h"
 
@@ -104,14 +109,16 @@ std::string IcebergFileNameGenerator::toString() const {
 } // namespace
 
 IcebergInsertTableHandle::IcebergInsertTableHandle(
-    std::vector<HiveColumnHandlePtr> inputColumns,
+    std::vector<IcebergColumnHandlePtr> inputColumns,
     LocationHandlePtr locationHandle,
     dwio::common::FileFormat tableStorageFormat,
     IcebergPartitionSpecPtr partitionSpec,
     std::optional<common::CompressionKind> compressionKind,
     const std::unordered_map<std::string, std::string>& serdeParameters)
     : HiveInsertTableHandle(
-          std::move(inputColumns),
+          std::vector<HiveColumnHandlePtr>(
+              inputColumns.begin(),
+              inputColumns.end()),
           std::move(locationHandle),
           tableStorageFormat,
           nullptr,

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.h
@@ -17,6 +17,9 @@
 #pragma once
 
 #include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"


### PR DESCRIPTION
Introduces IcebergColumnHandle that extends HiveColumnHandle to capture Iceberg-specific schema metadata, particularly field IDs and nested field structures.
Unlike Hive tables which identify columns by name only, Iceberg tables use unique field IDs to identify columns and nested fields in the schema. These field IDs are critical for schema evolution.

The field IDs will be used in two places during write:
- Write to parquet data file metadata.
- When collecting data file statistics, field id is used as the key when storing the statistics key value map.

For complex types (structs, arrays, maps), Iceberg assigns field IDs not just to top-level columns but to every nested field in the type hierarchy.