### PR TITLE
feat(fuzzer): Add type transform for SetDigest

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -40,6 +40,7 @@
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
+#include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
@@ -322,7 +323,8 @@ bool PrestoQueryRunner::isConstantExprSupported(
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
         !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&
-        !isTDigestType(type) && !isQDigestType(type) && !isBingTileType(type) &&
+        !isTDigestType(type) && !isQDigestType(type) &&
+        !isSetDigestType(type) && !isBingTileType(type) &&
         !isSfmSketchType(type) && !isTimeWithTimeZone(type);
   }
   return true;

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
+#include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
@@ -63,6 +64,9 @@ intermediateTypeTransforms() {
           {QDIGEST(REAL()),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                QDIGEST(REAL()), VARBINARY())},
+          {SETDIGEST(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               SETDIGEST(), VARBINARY())},
           {SFMSKETCH(),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                SFMSKETCH(), VARBINARY())},

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/exec/fuzzer/PrestoSql.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
+#include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
@@ -41,6 +42,7 @@ TEST(PrestoSqlTest, toTypeSql) {
   EXPECT_EQ(toTypeSql(QDIGEST(DOUBLE())), "QDIGEST(DOUBLE)");
   EXPECT_EQ(toTypeSql(QDIGEST(BIGINT())), "QDIGEST(BIGINT)");
   EXPECT_EQ(toTypeSql(QDIGEST(REAL())), "QDIGEST(REAL)");
+  EXPECT_EQ(toTypeSql(SETDIGEST()), "SETDIGEST");
   EXPECT_EQ(toTypeSql(DATE()), "DATE");
   EXPECT_EQ(toTypeSql(TIMESTAMP_WITH_TIME_ZONE()), "TIMESTAMP WITH TIME ZONE");
   EXPECT_EQ(toTypeSql(ARRAY(BOOLEAN())), "ARRAY(BOOLEAN)");

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -228,6 +228,7 @@ add_executable(
   PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
   PrestoQueryRunnerTDigestTransformTest.cpp
   PrestoQueryRunnerQDigestTransformTest.cpp
+  PrestoQueryRunnerSetDigestTransformTest.cpp
   PrestoQueryRunnerJsonTransformTest.cpp
   PrestoQueryRunnerIntervalTransformTest.cpp
   PrestoQueryRunnerTimeTransformTest.cpp

--- a/velox/exec/tests/PrestoQueryRunnerSetDigestTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerSetDigestTransformTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+#include "velox/functions/prestosql/types/SetDigestType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class PrestoQueryRunnerSetDigestTransformTest
+    : public PrestoQueryRunnerIntermediateTypeTransformTestBase {};
+
+TEST_F(PrestoQueryRunnerSetDigestTransformTest, isIntermediateOnlyType) {
+  ASSERT_TRUE(isIntermediateOnlyType(SETDIGEST()));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(SETDIGEST())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(SETDIGEST(), SMALLINT())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(VARBINARY(), SETDIGEST())));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({SETDIGEST(), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW(
+      {SMALLINT(), TIMESTAMP(), ARRAY(ROW({MAP(VARCHAR(), SETDIGEST())}))})));
+}
+
+TEST_F(PrestoQueryRunnerSetDigestTransformTest, transform) {
+  test(SETDIGEST());
+}
+
+TEST_F(PrestoQueryRunnerSetDigestTransformTest, transformArray) {
+  testArray(SETDIGEST());
+}
+
+TEST_F(PrestoQueryRunnerSetDigestTransformTest, transformMap) {
+  testMap(SETDIGEST());
+}
+
+TEST_F(PrestoQueryRunnerSetDigestTransformTest, transformRow) {
+  testRow(SETDIGEST());
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Fuzzer is not recognizing SetDigest type but go for its physical type Varbinary, and pass that type to Java which is not supposed to happen. This diff adds
the intermediate type transform for SetDigest type to unblock these functions in
fuzzers.

Reviewed By: natashasehgal

Differential Revision: D87554118


