### PR TITLE
misc: Updated MEM_POOL_CAP_EXCEEDED error message

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -897,13 +897,16 @@ void SharedArbitrator::growCapacity(ArbitrationOperation& op) {
   RETURN_IF_TRUE(maybeGrowFromSelf(op));
 
   if (!ensureCapacity(op)) {
+    const auto maxCapacity = op.participant()->maxCapacity();
     MEM_POOL_CAP_EXCEEDED(
         fmt::format(
-            "Can't grow {} capacity with {}. This will exceed its max capacity "
+            "Can't grow {} capacity with {}. This will exceed its {} "
             "{}, current capacity {}.",
             op.participant()->name(),
             succinctBytes(op.requestBytes()),
-            succinctBytes(op.participant()->maxCapacity()),
+            capacity_ < maxCapacity ? "arbitrator capacity"
+                                    : "memory pool capacity",
+            succinctBytes(std::min(capacity_, maxCapacity)),
             succinctBytes(op.participant()->capacity())),
         op.participant()->pool());
   }

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -69,7 +69,7 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
   // why).
   std::vector<std::string> expectedTexts = {
       "Can't grow ",
-      "capacity with 2.00MB. This will exceed its max capacity 5.00MB, current "
+      "capacity with 2.00MB. This will exceed its memory pool capacity 5.00MB, current "
       "capacity 5.00MB.\n"
       "ARBITRATOR[SHARED CAPACITY[6.00GB] STATS[numRequests 1 numRunning 1 "
       "numSucceded 0 numAborted 0 numFailures 0 numNonReclaimableAttempts 0 "


### PR DESCRIPTION
Summary:
The error message can be misleading when op.participant()->maxCapacity()) > Arbitrator's capacity_
 
e.g,
[2025-11-22T14:46:29.718-08:00] E1122 14:41:27.973918 1762211 Exceptions.h:53] Line: fbcode/velox/common/memory/SharedArbitrator.cpp:1070, Function: growCapacity, Expression: Exceeded memory pool capacity. Can't grow default_root_7 capacity **with 27.00MB. This will exceed its max capacity 128.00MB, current capacity 11.00MB.**

Differential Revision: D87829034


