### PR TITLE
fix: Exception handling in cast from JSON

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -1822,3 +1822,18 @@ TEST_F(JsonCastTest, castFromJsonWithEscapingForSpecialUniocodeCharacters) {
   testCast(R"(["\u007F"])", "\u007F");
   testCast(R"(["\u008A"])", "\u008A");
 }
+
+TEST_F(JsonCastTest, uniqueErrorContextMessage) {
+  // Verify that exceptions thrown have the correct error context information.
+  testContextMessageOnThrow(
+      "cast((c0) as DOUBLE)",
+      makeRowVector({makeNullableFlatVector<JsonNativeType>({"\"abc\""_sv})}),
+      "Top-level Expression: cast((c0) as DOUBLE)");
+
+  // Test twice to ensure that the context is correctly generated for each
+  // expression and not cached and reused.
+  testContextMessageOnThrow(
+      "cast((c0) as BIGINT)",
+      makeRowVector({makeNullableFlatVector<JsonNativeType>({"\"abc\""_sv})}),
+      "Top-level Expression: cast((c0) as BIGINT)");
+}

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -251,6 +251,18 @@ TEST_F(JsonFunctionsTest, jsonFormat) {
   velox::test::assertEqualVectors(expected, result);
 }
 
+TEST_F(JsonFunctionsTest, jsonParseErrorContext) {
+  auto data = makeRowVector(
+      {makeFlatVector<StringView>({"1]"}), makeFlatVector<StringView>({"2]"})});
+  // Verify that exceptions thrown have the correct error context information.
+  testContextMessageOnThrow(
+      "json_parse(c0)", data, "Top-level Expression: json_parse(c0)");
+  // Test twice to ensure that the context is correctly generated for each
+  // expression and not cached and reused.
+  testContextMessageOnThrow(
+      "json_parse(c1)", data, "Top-level Expression: json_parse(c1)");
+}
+
 TEST_F(JsonFunctionsTest, jsonParse) {
   const auto jsonParse = [&](std::optional<std::string> value) {
     return evaluateOnce<StringView>("json_parse(c0)", value);

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -393,6 +393,21 @@ class FunctionBaseTest : public testing::Test,
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   parse::ParseOptions options_;
 
+  void testContextMessageOnThrow(
+      const std::string& expression,
+      const RowVectorPtr& data,
+      const std::string& expectedContextMessage) {
+    try {
+      evaluate(expression, data);
+      FAIL() << "Expected an exception";
+    } catch (const VeloxUserError& e) {
+      ASSERT_TRUE(e.context().find(expectedContextMessage) != std::string::npos)
+          << "Expected additional context in error message to contain '"
+          << expectedContextMessage << "', but received '" << e.context()
+          << "'.";
+    }
+  }
+
  private:
   template <typename T>
   std::shared_ptr<T> castEvaluateResult(

--- a/velox/functions/prestosql/types/JsonCastOperator.h
+++ b/velox/functions/prestosql/types/JsonCastOperator.h
@@ -57,8 +57,8 @@ class JsonCastOperator : public exec::CastOperator {
       const SelectivityVector& rows,
       BaseVector& result) const;
 
-  inline static folly::once_flag initializeErrors_;
-  inline static std::exception_ptr errors_[simdjson::NUM_ERROR_CODES];
+  mutable folly::once_flag initializeErrors_;
+  mutable std::exception_ptr errors_[simdjson::NUM_ERROR_CODES];
   mutable std::string paddedInput_;
 };
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
A recent change https://github.com/facebookincubator/velox/pull/14582
made the exception initialization codepath create and maintain a
static list of exceptions shared by all Cast to JSON expressions.
Since Velox error messages add additional context when generated,
the static exception ends up retaining the message which contains
the expression and the top level expression details of the very
first error produced. This then ends up being re-used across
expression objects and across different query plan resulting in
wrong error message being thrown.
This change reverts the original PR to ensure exceptions with the
expected context are thrown.

Test Plan:
Added unit tests for both cast to json and json_parse as both have
similar exception generation pattern.

Differential Revision: D87838044


