### PR TITLE
fix: Fix memory accounting of buffer mode in LocalPartition

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/LocalPartition.h"
+#include "velox/common/Casts.h"
 #include "velox/exec/Task.h"
 #include "velox/vector/EncodedVectorCopy.h"
 
@@ -438,51 +439,133 @@ void LocalPartition::copy(
   target->copyRanges(input.get(), ranges);
 }
 
-RowVectorPtr LocalPartition::processPartition(
+void LocalPartition::populatePartitionBuffer(
     const RowVectorPtr& input,
-    vector_size_t size,
-    int partition,
-    const BufferPtr& indices,
-    const vector_size_t* rawIndices) {
+    const vector_size_t numPartitionRows,
+    const size_t partition,
+    const vector_size_t* rawIndices,
+    uint64_t& totalPartitionBufferSizeExcludingString,
+    uint64_t& totalPartitionStringBufferSize) {
+  VELOX_CHECK_GT(singlePartitionBufferSize_, 0);
+  copyRanges_.resize(numPartitionRows);
+
+  auto& partitionBuffer = partitionBuffers_[partition];
+  auto targetIndex = 0;
+  if (partitionBuffer) {
+    targetIndex = partitionBuffer->size();
+  }
+  for (int i = 0; i < numPartitionRows; i++) {
+    copyRanges_[i] = {rawIndices[i], targetIndex, 1};
+    targetIndex++;
+  }
+
+  copy(input, copyRanges_, partitionBuffer);
+
+  if (partitionBuffer) {
+    uint64_t stringBufferSize{0};
+    auto totalSize = partitionBuffer->retainedSize(stringBufferSize);
+    totalPartitionBufferSizeExcludingString += totalSize - stringBufferSize;
+    totalPartitionStringBufferSize += stringBufferSize;
+  }
+}
+
+RowVectorPtr LocalPartition::createPartition(
+    const RowVectorPtr& input,
+    const vector_size_t numPartitionRows,
+    const size_t partition,
+    const BufferPtr& indices) {
   RowVectorPtr partitionData{nullptr};
   if (singlePartitionBufferSize_ > 0) {
-    if (partitionBuffers_.empty()) {
-      partitionBuffers_.resize(numPartitions_);
-    }
-    if (copyRanges_.size() < size) {
-      copyRanges_.resize(size);
-    }
-
     auto& partitionBuffer = partitionBuffers_[partition];
-    auto targetIndex = 0;
     if (partitionBuffer) {
-      targetIndex = partitionBuffer->size();
-    }
-    for (int i = 0; i < size; i++) {
-      copyRanges_[i] = {rawIndices[i], targetIndex, 1};
-      targetIndex++;
-    }
-
-    copy(
-        input,
-        folly::Range{copyRanges_.data(), static_cast<size_t>(size)},
-        partitionBuffer);
-
-    if (partitionBuffer &&
-        partitionBuffer->retainedSize() >= singlePartitionBufferSize_) {
-      partitionData = std::dynamic_pointer_cast<RowVector>(partitionBuffer);
-      VELOX_CHECK(partitionData);
+      partitionData =
+          checkedPointerCast<RowVector, BaseVector>(partitionBuffer);
       partitionBuffers_[partition] = nullptr;
     }
-  } else {
-    partitionData =
-        wrapChildren(input, size, indices, queues_[partition]->getVector());
+  } else if (numPartitionRows > 0) {
+    partitionData = wrapChildren(
+        input, numPartitionRows, indices, queues_[partition]->getVector());
   }
   return partitionData;
 }
 
+void LocalPartition::populateAndEnqueuePartitions(
+    RowVectorPtr input,
+    const std::vector<vector_size_t>& numRowsPerPartition,
+    const std::vector<BufferPtr>& indexBuffers,
+    const std::vector<vector_size_t*>& rawIndicesBuffers) {
+  uint64_t totalPartitionBufferSizeExcludingString = 0;
+  uint64_t totalPartitionStringBufferSize = 0;
+  uint16_t nonEmptyPartitionCount = 0;
+
+  // Populate partition buffers if in buffer mode.
+  if (singlePartitionBufferSize_ > 0) {
+    if (partitionBuffers_.empty()) {
+      partitionBuffers_.resize(numPartitions_);
+    }
+    for (auto partition = 0; partition < numPartitions_; partition++) {
+      populatePartitionBuffer(
+          input,
+          numRowsPerPartition[partition],
+          partition,
+          rawIndicesBuffers[partition],
+          totalPartitionBufferSizeExcludingString,
+          totalPartitionStringBufferSize);
+      if (partitionBuffers_[partition]) {
+        nonEmptyPartitionCount++;
+      }
+    }
+  } else {
+    nonEmptyPartitionCount = numPartitions_ -
+        std::count(numRowsPerPartition.begin(), numRowsPerPartition.end(), 0);
+  }
+  VELOX_CHECK_GT(
+      nonEmptyPartitionCount,
+      0,
+      "Input rows should be assigned to at least one partition");
+
+  // Calculate the partition buffer size across all partitions with amortized
+  // string buffer sizes.
+  auto balancedTotalPartitionBufferSize =
+      totalPartitionBufferSizeExcludingString +
+      (totalPartitionStringBufferSize / nonEmptyPartitionCount);
+  auto inputRetainedSize = input->retainedSize();
+
+  // Enqueue all partitions if one of the following conditions is met:
+  // 1. This operator is not in buffer mode.
+  // 2. This operator is in buffer mode and the total buffer size across all
+  // partitions exceeds 'singlePartitionBufferSize_ * numPartitions_'.
+  if (singlePartitionBufferSize_ == 0 ||
+      balancedTotalPartitionBufferSize >=
+          singlePartitionBufferSize_ * numPartitions_) {
+    auto perPartitionAmortizedSize =
+        (singlePartitionBufferSize_ > 0 ? balancedTotalPartitionBufferSize
+                                        : inputRetainedSize) /
+        nonEmptyPartitionCount;
+    for (auto partition = 0; partition < numPartitions_; partition++) {
+      auto partitionSize = numRowsPerPartition[partition];
+      auto partitionData = createPartition(
+          input, partitionSize, partition, indexBuffers[partition]);
+      if (!partitionData) {
+        continue;
+      }
+
+      ContinueFuture future;
+      auto reason = queues_[partition]->enqueue(
+          std::move(partitionData), perPartitionAmortizedSize, &future);
+      if (reason != BlockingReason::kNotBlocked) {
+        blockingReasons_.push_back(reason);
+        futures_.push_back(std::move(future));
+      }
+    }
+  }
+}
+
 void LocalPartition::addInput(RowVectorPtr input) {
   prepareForInput(input);
+  if (input->size() == 0) {
+    return;
+  }
 
   const auto singlePartition = numPartitions_ == 1
       ? 0
@@ -512,31 +595,7 @@ void LocalPartition::addInput(RowVectorPtr input) {
     ++maxIndex[partition];
   }
 
-  const int64_t totalSize = input->retainedSize();
-  for (auto partition = 0; partition < numPartitions_; partition++) {
-    auto partitionSize = maxIndex[partition];
-    if (partitionSize == 0) {
-      // Do not enqueue empty partitions.
-      continue;
-    }
-
-    auto partitionData = processPartition(
-        input,
-        partitionSize,
-        partition,
-        indexBuffers_[partition],
-        rawIndices_[partition]);
-
-    if (partitionData) {
-      ContinueFuture future;
-      auto reason = queues_[partition]->enqueue(
-          partitionData, totalSize * partitionSize / numInput, &future);
-      if (reason != BlockingReason::kNotBlocked) {
-        blockingReasons_.push_back(reason);
-        futures_.push_back(std::move(future));
-      }
-    }
-  }
+  populateAndEnqueuePartitions(input, maxIndex, indexBuffers_, rawIndices_);
 }
 
 void LocalPartition::prepareForInput(RowVectorPtr& input) {
@@ -566,19 +625,36 @@ BlockingReason LocalPartition::isBlocked(ContinueFuture* future) {
 void LocalPartition::noMoreInput() {
   Operator::noMoreInput();
   if (!partitionBuffers_.empty()) {
+    uint64_t totalPartitionBufferSizeExcludingString = 0;
+    uint64_t totalPartitionStringBufferSize = 0;
+    uint16_t nonEmptyPartitionCount = 0;
     for (auto partition = 0; partition < numPartitions_; partition++) {
-      if (partitionBuffers_[partition] &&
-          partitionBuffers_[partition]->size() > 0) {
-        auto partitionData =
-            std::dynamic_pointer_cast<RowVector>(partitionBuffers_[partition]);
-        VELOX_CHECK(partitionData);
-        ContinueFuture future;
-        queues_[partition]->enqueue(
-            partitionData,
-            partitionBuffers_[partition]->retainedSize(),
-            &future);
+      if (partitionBuffers_[partition]) {
+        uint64_t stringBufferSize{0};
+        auto totalSize =
+            partitionBuffers_[partition]->retainedSize(stringBufferSize);
+        totalPartitionBufferSizeExcludingString += totalSize - stringBufferSize;
+        totalPartitionStringBufferSize += stringBufferSize;
+        nonEmptyPartitionCount++;
       }
-      partitionBuffers_[partition] = nullptr;
+    }
+    if (nonEmptyPartitionCount > 0) {
+      auto balancedPartitionBufferSize =
+          totalPartitionBufferSizeExcludingString +
+          (totalPartitionStringBufferSize / nonEmptyPartitionCount);
+      for (auto partition = 0; partition < numPartitions_; partition++) {
+        if (partitionBuffers_[partition]) {
+          auto partitionData = checkedPointerCast<RowVector, BaseVector>(
+              partitionBuffers_[partition]);
+          ContinueFuture future;
+
+          queues_[partition]->enqueue(
+              partitionData,
+              balancedPartitionBufferSize / nonEmptyPartitionCount,
+              &future);
+        }
+        partitionBuffers_[partition] = nullptr;
+      }
     }
     partitionBuffers_.resize(0);
     copyRanges_.resize(0);

--- a/velox/exec/ScaleWriterLocalPartition.cpp
+++ b/velox/exec/ScaleWriterLocalPartition.cpp
@@ -174,28 +174,11 @@ void ScaleWriterPartitioningLocalPartition::addInput(RowVectorPtr input) {
                                              row;
     }
 
-    for (auto i = 0; i < numPartitions_; ++i) {
-      const auto writerRowCount = writerAssignmentCounts_[i];
-      if (writerRowCount == 0) {
-        continue;
-      }
-
-      auto writerInput = processPartition(
-          input,
-          writerRowCount,
-          i,
-          std::move(writerAssignmmentIndicesBuffers_[i]),
-          rawWriterAssignmmentIndicesBuffers_[i]);
-      if (writerInput != nullptr) {
-        ContinueFuture future;
-        auto reason = queues_[i]->enqueue(
-            writerInput, totalInputBytes * writerRowCount / numInput, &future);
-        if (reason != BlockingReason::kNotBlocked) {
-          blockingReasons_.push_back(reason);
-          futures_.push_back(std::move(future));
-        }
-      }
-    }
+    populateAndEnqueuePartitions(
+        input,
+        writerAssignmentCounts_,
+        writerAssignmmentIndicesBuffers_,
+        rawWriterAssignmmentIndicesBuffers_);
   }
 
   // Only update the scaling state if the memory used is below the


### PR DESCRIPTION
Summary:
LocalPartition in buffer-mode appends input rows to the corresponding partition buffer vectors and 
flush the buffer vectors to LocalExchangeQueue when their sizes exceeds a limit. This diff fixes two 
problem with the buffer-mode:
1. When a string buffer is referenced by multiple partition buffer vectors, the entire string buffer 
size is counted once per partition buffer vector. This makes the sizes of partition buffer vectors over 
estimated and prevents the buffer-mode from effectively reducing the number of vectors flushed to LocalExchangeQueues. This diff addresses this problem by amortizing the string buffer size when 
calculating the sizes of partition buffer vectors.
2. LocalPartition checks individual partition buffer vector size and decide whether to flush it. After 
we amortize the string buffer size, this could cause the partition buffers that have few rows to hold 
reference to string buffers for too long, hence not able to release the string buffers to reduce 
memory usage. This diff changes LocalPartition to check the total size of all partition buffers and 
flush all buffers once the total size exceeds the memory limit.

Differential Revision: D87805165


