### PR TITLE
fix: Do not wait for async load at ParallelUnitLoader destructor

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -112,7 +112,7 @@ class DwrfRowReader : public StrideIndexProvider,
     stats.footerBufferOverread += getReader().footerBufferOverread();
     stats.numStripes += stripeCeiling_ - firstStripe_;
     stats.columnReaderStatistics.flattenStringDictionaryValues +=
-        columnReaderStatistics_.flattenStringDictionaryValues;
+        columnReaderStatistics_->flattenStringDictionaryValues;
     stats.unitLoaderStats.merge(unitLoadStats_);
   }
 
@@ -218,7 +218,7 @@ class DwrfRowReader : public StrideIndexProvider,
   // instead of next stripe.
   bool recomputeStridesToSkip_{false};
 
-  dwio::common::ColumnReaderStatistics columnReaderStatistics_;
+  std::shared_ptr<dwio::common::ColumnReaderStatistics> columnReaderStatistics_;
 
   std::optional<int64_t> nextRowNumber_;
 

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -18,8 +18,11 @@
 #include <gtest/gtest.h>
 #include "folly/Random.h"
 #include "folly/executors/CPUThreadPoolExecutor.h"
+#include "folly/executors/IOThreadPoolExecutor.h"
 #include "folly/lang/Assume.h"
+#include "folly/synchronization/Baton.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
@@ -27,6 +30,7 @@
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
 #include "velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
@@ -2804,6 +2808,115 @@ TEST_F(TestReader, mapAsStructAllEmpty) {
       makeRowVector({"1"}, {makeNullConstant(TypeKind::BIGINT, 2)}),
   });
   assertEqualVectors(expected, batch);
+}
+
+// Verify DwrfRowReader can be destroyed while ParallelUnitLoader async load()
+// are in progress. This regression test ensures that:
+// 1. ParallelUnitLoader destructor doesn't wait for async load() operations
+// 2. Async load() from DwrfUnit can still function after ParallelUnitLoader
+// destruction and DwrfRowReader destruction, which means all dependencies in
+// DwrfUnit remain valid (eg ReaderBase)
+//
+// If a future change adds an unsafe raw pointer to DwrfUnit's dependencies that
+// would be freed by ParallelUnitLoader or DwrfRowReader's destruction, this
+// test may crash due to use-after-free.
+DEBUG_ONLY_TEST_F(TestReader, asyncLoadSurvivesReaderDestruction) {
+  const int kNumStripes = 2;
+  const int kRowsPerStripe = 100;
+  std::vector<VectorPtr> batches;
+  batches.reserve(kNumStripes);
+  for (int stripe = 0; stripe < kNumStripes; ++stripe) {
+    batches.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            kRowsPerStripe,
+            [stripe](auto row) { return stripe * kRowsPerStripe + row; }),
+    }));
+  }
+
+  // Write the DWRF file - force each batch into its own stripe
+  auto config = std::make_shared<dwrf::Config>();
+
+  auto sink =
+      std::make_unique<MemorySink>(1 << 20, FileSink::Options{.pool = pool()});
+  auto* sinkPtr = sink.get();
+  auto writer = E2EWriterTestUtil::writeData(
+      std::move(sink),
+      asRowType(batches[0]->type()),
+      batches,
+      config,
+      // Force flush after each batch to create separate stripes
+      E2EWriterTestUtil::simpleFlushPolicyFactory(true));
+
+  std::string data(sinkPtr->data(), sinkPtr->size());
+  auto input = std::make_unique<BufferedInput>(
+      std::make_shared<InMemoryReadFile>(std::move(data)), *pool());
+
+  std::atomic<int> asyncLoadsStarted{0};
+  std::atomic<int> asyncLoadsCompleted{0};
+  folly::Baton<> readerDestroyed;
+
+  facebook::velox::common::testutil::TestValue::enable();
+  facebook::velox::common::testutil::TestValue::set(
+      "facebook::velox::dwio::common::ParallelUnitLoader::load",
+      std::function<void(std::shared_ptr<LoadUnit>*)>([&](auto*) {
+        // Only block the second stripe (index 1) - let the first stripe load
+        // normally so rowReader->next() can complete
+        // fetch_add returns the value before increment: 0 for first, 1 for
+        // second, etc.
+        if (asyncLoadsStarted.fetch_add(1) == 1) {
+          // Block here until reader is destroyed
+          readerDestroyed.wait();
+        }
+        asyncLoadsCompleted.fetch_add(1);
+      }));
+
+  auto ioExecutor = std::make_shared<folly::IOThreadPoolExecutor>(2);
+
+  // Make sure ReaderOptions and DwrfRowReader are freed after {} scope
+  {
+    dwio::common::ReaderOptions readerOpts(pool());
+    readerOpts.setFileFormat(FileFormat::DWRF);
+    auto reader = DwrfReader::create(std::move(input), readerOpts);
+
+    // Enable parallel unit load
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setParallelUnitLoadCount(2);
+    rowReaderOpts.setIOExecutor(ioExecutor.get());
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+
+    VectorPtr batch;
+    rowReader->next(50, batch); // Read first stripe
+
+    auto start = std::chrono::steady_clock::now();
+    rowReader.reset();
+    auto duration = std::chrono::steady_clock::now() - start;
+    // Verify destruction was fast (didn't wait for async operations)
+    EXPECT_LT(duration, std::chrono::seconds(1))
+        << "Destruction should not wait for async loads";
+  }
+
+  // Now signal that reader is destroyed
+  readerDestroyed.post();
+
+  // Wait for async loads to complete
+  int maxWaitMs = 2000;
+  int waitedMs = 0;
+  while (asyncLoadsCompleted.load() < 2 && waitedMs < maxWaitMs) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    waitedMs += 100;
+  }
+
+  // Verify that both async loads completed successfully after reader
+  // destruction This proves the fix works: async operations can complete even
+  // after DwrfRowReader is destroyed because LoadUnit is captured as shared_ptr
+  EXPECT_EQ(asyncLoadsCompleted.load(), 2)
+      << "Both async loads should complete even after reader destruction. "
+      << "If this fails, it means async operations are being cancelled or "
+      << "crashing after DwrfRowReader destruction, indicating unsafe pointers.";
+
+  // Clean up
+  ioExecutor->join();
+  facebook::velox::common::testutil::TestValue::disable();
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
**1. DEADLOCK**
We have observed hanging when parallelUnitLoader is turned on ( [stacktrace](https://www.internalfb.com/intern/everpaste/?handle=GGR-SCIae13bMmFZAKsB6AQpWsMJbsIXAAAB&phabricator_paste_number=2015904911)). It hanged because there is a circular dependency when memory arbitration is triggered (P2054964327)
- HashBuild triggers memory arbitration
- It acquires the **arbitration lock** and reclaim memory from TableScan
- That triggers TableScan's destruction which triggers ParallelUnitLoader destruction
- ParallelUnitLoader destructor waits for async load to finish
- the async load triggers memory arbitration again and tries to acquire the same **arbiration lock**

To break the dependency, we no longer wait for asyc load operation at ParallelUnitLoader destruction.

**2. LIFE CYCLE**
To make sure asyc load operation can still function after ParallelUnitLoader destruction and DwrfRowReader destruction:
- Capture DwrfUnit as shared_pointer to keep it alive after ParallelUnitLoader is destroyed
- Make DwrfUnit hold onto the used components:
   - Pass ReaderBase as shared pointer
    - Pass ColumnReaderStatistics as shared pointer
    - Pass columnReaderOptions as copy instead of reference

Differential Revision: D87828770


