### PR TITLE
refactor: Extract common BaseSerializedPage API

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -34,6 +34,7 @@ velox_add_library(
   ExchangeClient.cpp
   ExchangeQueue.cpp
   ExchangeSource.cpp
+  SerializedPage.cpp
   Expand.cpp
   FilterProject.cpp
   GroupId.cpp

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -44,7 +44,7 @@ void RemoteConnectorSplit::registerSerDe() {
 
 namespace {
 std::unique_ptr<folly::IOBuf> mergePages(
-    std::vector<std::unique_ptr<SerializedPage>>& pages) {
+    std::vector<std::unique_ptr<SerializedPageBase>>& pages) {
   VELOX_CHECK(!pages.empty());
   std::unique_ptr<folly::IOBuf> mergedBufs;
   for (const auto& page : pages) {
@@ -278,7 +278,8 @@ RowVectorPtr Exchange::getOutputFromRowPages(VectorSerde* serde) {
   if (inputStream_ == nullptr) {
     std::unique_ptr<folly::IOBuf> mergedBufs = mergePages(currentPages_);
     rawInputBytes += mergedBufs->computeChainDataLength();
-    mergedRowPage_ = std::make_unique<SerializedPage>(std::move(mergedBufs));
+    mergedRowPage_ =
+        std::make_unique<PrestoSerializedPage>(std::move(mergedBufs));
     inputStream_ = mergedRowPage_->prepareStreamForDeserialize();
   }
 

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -117,13 +117,13 @@ class Exchange : public SourceOperator {
   // Reusable result vector.
   RowVectorPtr result_;
 
-  std::vector<std::unique_ptr<SerializedPage>> currentPages_;
+  std::vector<std::unique_ptr<SerializedPageBase>> currentPages_;
   bool atEnd_{false};
   std::default_random_engine rng_{std::random_device{}()};
 
   // Memory holders for deserialization across 'getOutput' calls.
   // The merged pages for row serialization.
-  std::unique_ptr<SerializedPage> mergedRowPage_;
+  std::unique_ptr<SerializedPageBase> mergedRowPage_;
   std::unique_ptr<RowIterator> rowIterator_;
 
   // State for columnar page deserialization.

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -119,13 +119,13 @@ folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
   return stats;
 }
 
-std::vector<std::unique_ptr<SerializedPage>> ExchangeClient::next(
+std::vector<std::unique_ptr<SerializedPageBase>> ExchangeClient::next(
     int consumerId,
     uint32_t maxBytes,
     bool* atEnd,
     ContinueFuture* future) {
   std::vector<RequestSpec> requestSpecs;
-  std::vector<std::unique_ptr<SerializedPage>> pages;
+  std::vector<std::unique_ptr<SerializedPageBase>> pages;
   ContinuePromise stalePromise = ContinuePromise::makeEmpty();
   {
     std::lock_guard<std::mutex> l(queue_->mutex());

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -106,7 +106,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   ///
   /// The data may be compressed, in which case 'maxBytes' applies to compressed
   /// size.
-  std::vector<std::unique_ptr<SerializedPage>>
+  std::vector<std::unique_ptr<SerializedPageBase>>
   next(int consumerId, uint32_t maxBytes, bool* atEnd, ContinueFuture* future);
 
   std::string toString() const;

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -15,66 +15,9 @@
  */
 #pragma once
 
-#include "velox/common/memory/ByteStream.h"
+#include "velox/exec/SerializedPage.h"
 
 namespace facebook::velox::exec {
-
-/// Corresponds to Presto SerializedPage, i.e. a container for serialize vectors
-/// in Presto wire format.
-class SerializedPage {
- public:
-  /// Construct from IOBuf chain.
-  explicit SerializedPage(
-      std::unique_ptr<folly::IOBuf> iobuf,
-      std::function<void(folly::IOBuf&)> onDestructionCb = nullptr,
-      std::optional<int64_t> numRows = std::nullopt);
-
-  virtual ~SerializedPage();
-
-  /// Returns the size of the serialized data in bytes.
-  uint64_t size() const {
-    return iobufBytes_;
-  }
-
-  std::optional<int64_t> numRows() const {
-    return numRows_;
-  }
-
-  /// Makes 'input' ready for deserializing 'this' with
-  /// VectorStreamGroup::read().
-  std::unique_ptr<ByteInputStream> prepareStreamForDeserialize();
-
-  std::unique_ptr<folly::IOBuf> getIOBuf() const {
-    return iobuf_->clone();
-  }
-
- private:
-  static int64_t chainBytes(folly::IOBuf& iobuf) {
-    int64_t size = 0;
-    for (auto& range : iobuf) {
-      size += range.size();
-    }
-    return size;
-  }
-
-  // Buffers containing the serialized data. The memory is owned by 'iobuf_'.
-  std::vector<ByteRange> ranges_;
-
-  // IOBuf holding the data in 'ranges_.
-  std::unique_ptr<folly::IOBuf> iobuf_;
-
-  // Number of payload bytes in 'iobuf_'.
-  const int64_t iobufBytes_;
-
-  // Number of payload rows, if provided.
-  const std::optional<int64_t> numRows_;
-
-  // Callback that will be called on destruction of the SerializedPage,
-  // primarily used to free externally allocated memory backing folly::IOBuf
-  // from caller. Caller is responsible to pass in proper cleanup logic to
-  // prevent any memory leak.
-  std::function<void(folly::IOBuf&)> onDestructionCb_;
-};
 
 /// Queue of results retrieved from source. Owned by shared_ptr by
 /// Exchange and client threads and registered callbacks waiting
@@ -108,7 +51,7 @@ class ExchangeQueue {
   /// returned in 'promises'. When 'page' is nullptr and the queue is not
   /// completed serving data, no 'promises' will be added and returned.
   void enqueueLocked(
-      std::unique_ptr<SerializedPage>&& page,
+      std::unique_ptr<SerializedPageBase>&& page,
       std::vector<ContinuePromise>& promises);
 
   /// If data is permanently not available, e.g. the source cannot be
@@ -127,7 +70,7 @@ class ExchangeQueue {
   ///
   /// The data may be compressed, in which case 'maxBytes' applies to compressed
   /// size.
-  std::vector<std::unique_ptr<SerializedPage>> dequeueLocked(
+  std::vector<std::unique_ptr<SerializedPageBase>> dequeueLocked(
       int consumerId,
       uint32_t maxBytes,
       bool* atEnd,
@@ -226,7 +169,7 @@ class ExchangeQueue {
   bool atEnd_{false};
 
   std::mutex mutex_;
-  std::deque<std::unique_ptr<SerializedPage>> queue_;
+  std::deque<std::unique_ptr<SerializedPageBase>> queue_;
   // The map from consumer id to the waiting promise
   folly::F14FastMap<int, ContinuePromise> promises_;
 

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -287,7 +287,7 @@ class MergeExchangeSource : public MergeSource {
 
   std::shared_ptr<ExchangeClient> client_;
   std::unique_ptr<ByteInputStream> inputStream_;
-  std::unique_ptr<SerializedPage> currentPage_;
+  std::unique_ptr<SerializedPageBase> currentPage_;
   bool atEnd_ = false;
 };
 } // namespace

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -30,10 +30,10 @@ void ArbitraryBuffer::noMoreData() {
   pages_.push_back(nullptr);
 }
 
-void ArbitraryBuffer::enqueue(std::unique_ptr<SerializedPage> page) {
+void ArbitraryBuffer::enqueue(std::unique_ptr<SerializedPageBase> page) {
   VELOX_CHECK_NOT_NULL(page, "Unexpected null page");
   VELOX_CHECK(!hasNoMoreData(), "Arbitrary buffer has set no more data marker");
-  pages_.push_back(std::shared_ptr<SerializedPage>(page.release()));
+  pages_.push_back(std::shared_ptr<SerializedPageBase>(page.release()));
 }
 
 void ArbitraryBuffer::getAvailablePageSizes(std::vector<int64_t>& out) const {
@@ -45,7 +45,7 @@ void ArbitraryBuffer::getAvailablePageSizes(std::vector<int64_t>& out) const {
   }
 }
 
-std::vector<std::shared_ptr<SerializedPage>> ArbitraryBuffer::getPages(
+std::vector<std::shared_ptr<SerializedPageBase>> ArbitraryBuffer::getPages(
     uint64_t maxBytes) {
   if (maxBytes == 0 && !pages_.empty() && pages_.front() == nullptr) {
     // Always give out an end marker when this buffer is finished and fully
@@ -57,7 +57,7 @@ std::vector<std::shared_ptr<SerializedPage>> ArbitraryBuffer::getPages(
     VELOX_CHECK_EQ(pages_.size(), 1);
     return {nullptr};
   }
-  std::vector<std::shared_ptr<SerializedPage>> pages;
+  std::vector<std::shared_ptr<SerializedPageBase>> pages;
   uint64_t bytesRemoved{0};
   while (bytesRemoved < maxBytes && !pages_.empty()) {
     if (pages_.front() == nullptr) {
@@ -81,7 +81,7 @@ std::string ArbitraryBuffer::toString() const {
       hasNoMoreData());
 }
 
-void DestinationBuffer::Stats::recordEnqueue(const SerializedPage& data) {
+void DestinationBuffer::Stats::recordEnqueue(const SerializedPageBase& data) {
   const auto numRows = data.numRows();
   VELOX_CHECK(numRows.has_value(), "SerializedPage's numRows must be valid");
   bytesBuffered += data.size();
@@ -89,7 +89,8 @@ void DestinationBuffer::Stats::recordEnqueue(const SerializedPage& data) {
   ++pagesBuffered;
 }
 
-void DestinationBuffer::Stats::recordAcknowledge(const SerializedPage& data) {
+void DestinationBuffer::Stats::recordAcknowledge(
+    const SerializedPageBase& data) {
   const auto numRows = data.numRows();
   VELOX_CHECK(numRows.has_value(), "SerializedPage's numRows must be valid");
   const int64_t size = data.size();
@@ -104,7 +105,7 @@ void DestinationBuffer::Stats::recordAcknowledge(const SerializedPage& data) {
   ++pagesSent;
 }
 
-void DestinationBuffer::Stats::recordDelete(const SerializedPage& data) {
+void DestinationBuffer::Stats::recordDelete(const SerializedPageBase& data) {
   recordAcknowledge(data);
 }
 
@@ -185,7 +186,7 @@ DestinationBuffer::Data DestinationBuffer::getData(
   return {std::move(data), std::move(remainingBytes), true};
 }
 
-void DestinationBuffer::enqueue(std::shared_ptr<SerializedPage> data) {
+void DestinationBuffer::enqueue(std::shared_ptr<SerializedPageBase> data) {
   // Drop duplicate end markers.
   if (data == nullptr && !data_.empty() && data_.back() == nullptr) {
     return;
@@ -245,7 +246,7 @@ void DestinationBuffer::loadData(ArbitraryBuffer* buffer, uint64_t maxBytes) {
   }
 }
 
-std::vector<std::shared_ptr<SerializedPage>> DestinationBuffer::acknowledge(
+std::vector<std::shared_ptr<SerializedPageBase>> DestinationBuffer::acknowledge(
     int64_t sequence,
     bool fromGetData) {
   const int64_t numDeleted = sequence - sequence_;
@@ -268,7 +269,7 @@ std::vector<std::shared_ptr<SerializedPage>> DestinationBuffer::acknowledge(
 
   VELOX_CHECK_LE(
       numDeleted, data_.size(), "Ack received for a not yet produced item");
-  std::vector<std::shared_ptr<SerializedPage>> freed;
+  std::vector<std::shared_ptr<SerializedPageBase>> freed;
   for (auto i = 0; i < numDeleted; ++i) {
     if (data_[i] == nullptr) {
       VELOX_CHECK_EQ(i, data_.size() - 1, "null marker found in the middle");
@@ -282,9 +283,9 @@ std::vector<std::shared_ptr<SerializedPage>> DestinationBuffer::acknowledge(
   return freed;
 }
 
-std::vector<std::shared_ptr<SerializedPage>>
+std::vector<std::shared_ptr<SerializedPageBase>>
 DestinationBuffer::deleteResults() {
-  std::vector<std::shared_ptr<SerializedPage>> freed;
+  std::vector<std::shared_ptr<SerializedPageBase>> freed;
   for (auto i = 0; i < data_.size(); ++i) {
     if (data_[i] == nullptr) {
       VELOX_CHECK_EQ(i, data_.size() - 1, "null marker found in the middle");
@@ -314,7 +315,7 @@ namespace {
 // that we do the expensive free outside and only then continue the
 // producers which will allocate more memory.
 void releaseAfterAcknowledge(
-    std::vector<std::shared_ptr<SerializedPage>>& freed,
+    std::vector<std::shared_ptr<SerializedPageBase>>& freed,
     std::vector<ContinuePromise>& promises) {
   freed.clear();
   for (auto& promise : promises) {
@@ -445,7 +446,7 @@ void OutputBuffer::updateTotalBufferedBytesMsLocked() {
 
 bool OutputBuffer::enqueue(
     int destination,
-    std::unique_ptr<SerializedPage> data,
+    std::unique_ptr<SerializedPageBase> data,
     ContinueFuture* future) {
   VELOX_CHECK_NOT_NULL(data);
   VELOX_CHECK(
@@ -492,13 +493,13 @@ bool OutputBuffer::enqueue(
 }
 
 void OutputBuffer::enqueueBroadcastOutputLocked(
-    std::unique_ptr<SerializedPage> data,
+    std::unique_ptr<SerializedPageBase> data,
     std::vector<DataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(isBroadcast());
   VELOX_CHECK_NULL(arbitraryBuffer_);
   VELOX_DCHECK(dataAvailableCbs.empty());
 
-  std::shared_ptr<SerializedPage> sharedData(data.release());
+  std::shared_ptr<SerializedPageBase> sharedData(data.release());
   for (auto& buffer : buffers_) {
     if (buffer != nullptr) {
       buffer->enqueue(sharedData);
@@ -514,7 +515,7 @@ void OutputBuffer::enqueueBroadcastOutputLocked(
 }
 
 void OutputBuffer::enqueueArbitraryOutputLocked(
-    std::unique_ptr<SerializedPage> data,
+    std::unique_ptr<SerializedPageBase> data,
     std::vector<DataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(isArbitrary());
   VELOX_DCHECK_NOT_NULL(arbitraryBuffer_);
@@ -541,7 +542,7 @@ void OutputBuffer::enqueueArbitraryOutputLocked(
 
 void OutputBuffer::enqueuePartitionedOutputLocked(
     int destination,
-    std::unique_ptr<SerializedPage> data,
+    std::unique_ptr<SerializedPageBase> data,
     std::vector<DataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(isPartitioned());
   VELOX_CHECK_NULL(arbitraryBuffer_);
@@ -631,7 +632,7 @@ bool OutputBuffer::isFinishedLocked() {
 }
 
 void OutputBuffer::acknowledge(int destination, int64_t sequence) {
-  std::vector<std::shared_ptr<SerializedPage>> freed;
+  std::vector<std::shared_ptr<SerializedPageBase>> freed;
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -649,7 +650,7 @@ void OutputBuffer::acknowledge(int destination, int64_t sequence) {
 }
 
 void OutputBuffer::updateAfterAcknowledgeLocked(
-    const std::vector<std::shared_ptr<SerializedPage>>& freed,
+    const std::vector<std::shared_ptr<SerializedPageBase>>& freed,
     std::vector<ContinuePromise>& promises) {
   uint64_t freedBytes{0};
   int freedPages{0};
@@ -673,7 +674,7 @@ void OutputBuffer::updateAfterAcknowledgeLocked(
 }
 
 bool OutputBuffer::deleteResults(int destination) {
-  std::vector<std::shared_ptr<SerializedPage>> freed;
+  std::vector<std::shared_ptr<SerializedPageBase>> freed;
   std::vector<ContinuePromise> promises;
   bool isFinished;
   DataAvailable dataAvailable;
@@ -717,7 +718,7 @@ void OutputBuffer::getData(
     DataAvailableCallback notify,
     DataConsumerActiveCheckCallback activeCheck) {
   DestinationBuffer::Data data;
-  std::vector<std::shared_ptr<SerializedPage>> freed;
+  std::vector<std::shared_ptr<SerializedPageBase>> freed;
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(mutex_);

--- a/velox/exec/OutputBufferManager.cpp
+++ b/velox/exec/OutputBufferManager.cpp
@@ -57,7 +57,7 @@ uint64_t OutputBufferManager::numBuffers() const {
 bool OutputBufferManager::enqueue(
     const std::string& taskId,
     int destination,
-    std::unique_ptr<SerializedPage> data,
+    std::unique_ptr<SerializedPageBase> data,
     ContinueFuture* future) {
   return getBuffer(taskId)->enqueue(destination, std::move(data), future);
 }

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -53,7 +53,7 @@ class OutputBufferManager {
   bool enqueue(
       const std::string& taskId,
       int destination,
-      std::unique_ptr<SerializedPage> data,
+      std::unique_ptr<SerializedPageBase> data,
       ContinueFuture* future);
 
   void noMoreData(const std::string& taskId);

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -132,7 +132,7 @@ BlockingReason Destination::flush(
   bool blocked = bufferManager.enqueue(
       taskId_,
       destination_,
-      std::make_unique<SerializedPage>(
+      std::make_unique<PrestoSerializedPage>(
           stream.getIOBuf(bufferReleaseFn), nullptr, flushedRows),
       future);
 

--- a/velox/exec/SerializedPage.cpp
+++ b/velox/exec/SerializedPage.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/SerializedPage.h"
+
+namespace facebook::velox::exec {
+
+PrestoSerializedPage::PrestoSerializedPage(
+    std::unique_ptr<folly::IOBuf> iobuf,
+    std::function<void(folly::IOBuf&)> onDestructionCb,
+    std::optional<int64_t> numRows)
+    : iobuf_(std::move(iobuf)),
+      iobufBytes_(chainBytes(*iobuf_.get())),
+      numRows_(numRows),
+      onDestructionCb_(onDestructionCb) {
+  VELOX_CHECK_NOT_NULL(iobuf_);
+  for (auto& buf : *iobuf_) {
+    int32_t bufSize = buf.size();
+    ranges_.push_back(
+        ByteRange{
+            const_cast<uint8_t*>(reinterpret_cast<const uint8_t*>(buf.data())),
+            bufSize,
+            0});
+  }
+}
+
+PrestoSerializedPage::~PrestoSerializedPage() {
+  if (onDestructionCb_) {
+    onDestructionCb_(*iobuf_.get());
+  }
+}
+
+std::unique_ptr<ByteInputStream>
+PrestoSerializedPage::prepareStreamForDeserialize() {
+  return std::make_unique<BufferInputStream>(std::move(ranges_));
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SerializedPage.h
+++ b/velox/exec/SerializedPage.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/ByteStream.h"
+
+namespace facebook::velox::exec {
+
+/// Interface for serialized pages.
+class SerializedPageBase {
+ public:
+  virtual ~SerializedPageBase() = default;
+
+  /// Returns the size of the serialized data in bytes.
+  virtual uint64_t size() const = 0;
+
+  /// Returns the number of rows if available.
+  virtual std::optional<int64_t> numRows() const = 0;
+
+  /// Makes 'input' ready for deserializing 'this' with
+  /// VectorStreamGroup::read().
+  virtual std::unique_ptr<ByteInputStream> prepareStreamForDeserialize() = 0;
+
+  /// Returns a clone of the IOBuf.
+  virtual std::unique_ptr<folly::IOBuf> getIOBuf() const = 0;
+};
+
+/// Corresponds to Presto SerializedPage, i.e. a container for serialized
+/// vectors in Presto wire format.
+class PrestoSerializedPage : public SerializedPageBase {
+ public:
+  /// Construct from IOBuf chain.
+  explicit PrestoSerializedPage(
+      std::unique_ptr<folly::IOBuf> iobuf,
+      std::function<void(folly::IOBuf&)> onDestructionCb = nullptr,
+      std::optional<int64_t> numRows = std::nullopt);
+
+  ~PrestoSerializedPage() override;
+
+  uint64_t size() const override {
+    return iobufBytes_;
+  }
+
+  std::optional<int64_t> numRows() const override {
+    return numRows_;
+  }
+
+  std::unique_ptr<ByteInputStream> prepareStreamForDeserialize() override;
+
+  std::unique_ptr<folly::IOBuf> getIOBuf() const override {
+    return iobuf_->clone();
+  }
+
+ private:
+  static int64_t chainBytes(folly::IOBuf& iobuf) {
+    int64_t size = 0;
+    for (auto& range : iobuf) {
+      size += range.size();
+    }
+    return size;
+  }
+
+  // Buffers containing the serialized data. The memory is owned by 'iobuf_'.
+  std::vector<ByteRange> ranges_;
+
+  // IOBuf holding the data in 'ranges_.
+  std::unique_ptr<folly::IOBuf> iobuf_;
+
+  // Number of payload bytes in 'iobuf_'.
+  const int64_t iobufBytes_;
+
+  // Number of payload rows, if provided.
+  const std::optional<int64_t> numRows_;
+
+  // Callback that will be called on destruction of the PrestoSerializedPage,
+  // primarily used to free externally allocated memory backing folly::IOBuf
+  // from caller. Caller is responsible to pass in proper cleanup logic to
+  // prevent any memory leak.
+  std::function<void(folly::IOBuf&)> onDestructionCb_;
+};
+
+// TODO: Remove after fully migration to new SerializedPageBase and
+// PrestoSerializedPage API.
+using SerializedPage = PrestoSerializedPage;
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -109,9 +109,9 @@ class ExchangeClientTest
     return pageSize;
   }
 
-  std::vector<std::unique_ptr<SerializedPage>>
+  std::vector<std::unique_ptr<SerializedPageBase>>
   fetchPages(int consumerId, ExchangeClient& client, int32_t numPages) {
-    std::vector<std::unique_ptr<SerializedPage>> allPages;
+    std::vector<std::unique_ptr<SerializedPageBase>> allPages;
     for (auto i = 0; i < numPages; ++i) {
       bool atEnd{false};
       ContinueFuture future;
@@ -139,7 +139,7 @@ class ExchangeClientTest
 
   static void enqueue(
       ExchangeQueue& queue,
-      std::unique_ptr<SerializedPage> page) {
+      std::unique_ptr<SerializedPageBase> page) {
     std::vector<ContinuePromise> promises;
     {
       std::lock_guard<std::mutex> l(queue.mutex());
@@ -150,10 +150,10 @@ class ExchangeClientTest
     }
   }
 
-  static std::unique_ptr<SerializedPage> makePage(uint64_t size) {
+  static std::unique_ptr<SerializedPageBase> makePage(uint64_t size) {
     auto ioBuf = folly::IOBuf::create(size);
     ioBuf->append(size);
-    return std::make_unique<SerializedPage>(std::move(ioBuf), nullptr, 1);
+    return std::make_unique<PrestoSerializedPage>(std::move(ioBuf), nullptr, 1);
   }
 
   folly::Executor* executor() const {

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -116,7 +116,7 @@ class OutputBufferManagerTest : public testing::Test {
     return task;
   }
 
-  std::unique_ptr<SerializedPage> makeSerializedPage(
+  std::unique_ptr<SerializedPageBase> makeSerializedPage(
       RowTypePtr rowType,
       vector_size_t size) {
     auto vector = std::dynamic_pointer_cast<RowVector>(
@@ -1472,7 +1472,7 @@ TEST_P(
   std::memcpy(iobuf->writableData(), payload.data(), payloadSize);
   iobuf->append(payloadSize);
 
-  auto page = std::make_unique<SerializedPage>(std::move(iobuf));
+  auto page = std::make_unique<PrestoSerializedPage>(std::move(iobuf));
 
   auto queue = std::make_shared<ExchangeQueue>(1, 0);
   std::vector<ContinuePromise> promises;

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -90,7 +90,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
       if (data.empty()) {
         sequence = requestedSequence;
       }
-      std::vector<std::unique_ptr<SerializedPage>> pages;
+      std::vector<std::unique_ptr<SerializedPageBase>> pages;
       bool atEnd = false;
       int64_t totalBytes = 0;
       for (auto& inputPage : data) {
@@ -101,7 +101,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
         }
         totalBytes += inputPage->length();
         inputPage->unshare();
-        pages.push_back(std::make_unique<SerializedPage>(std::move(inputPage)));
+        pages.push_back(
+            std::make_unique<PrestoSerializedPage>(std::move(inputPage)));
         inputPage = nullptr;
       }
       numPages_ += pages.size();

--- a/velox/exec/tests/utils/SerializedPageUtil.cpp
+++ b/velox/exec/tests/utils/SerializedPageUtil.cpp
@@ -20,7 +20,7 @@ using namespace facebook::velox;
 
 namespace facebook::velox::exec::test {
 
-std::unique_ptr<SerializedPage> toSerializedPage(
+std::unique_ptr<SerializedPageBase> toSerializedPage(
     const RowVectorPtr& vector,
     VectorSerde::Kind serdeKind,
     const std::shared_ptr<OutputBufferManager>& bufferManager,
@@ -34,7 +34,8 @@ std::unique_ptr<SerializedPage> toSerializedPage(
   auto listener = bufferManager->newListener();
   IOBufOutputStream stream(*pool, listener.get(), data->size());
   data->flush(&stream);
-  return std::make_unique<SerializedPage>(stream.getIOBuf(), nullptr, size);
+  return std::make_unique<PrestoSerializedPage>(
+      stream.getIOBuf(), nullptr, size);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/SerializedPageUtil.h
+++ b/velox/exec/tests/utils/SerializedPageUtil.h
@@ -23,7 +23,7 @@
 namespace facebook::velox::exec::test {
 
 /// Helper function for serializing RowVector to PrestoPage format.
-std::unique_ptr<SerializedPage> toSerializedPage(
+std::unique_ptr<SerializedPageBase> toSerializedPage(
     const RowVectorPtr& vector,
     VectorSerde::Kind serdeKind,
     const std::shared_ptr<OutputBufferManager>& bufferManager,


### PR DESCRIPTION
Summary: There are more use cases integrated with velox that needs SerializedPage to be extensible. Extract interface as BaseSerializedPage and make the current one PrestoSerializedPage. There's no logic change in the codebase.

Differential Revision: D87852061


