### PR TITLE
feat(build): Add `SIMDJSON_SKIPUTF8VALIDATION` option for simdjson in setup script

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -27,6 +27,7 @@ BUILD_GEOS="${BUILD_GEOS:-true}"
 BUILD_FAISS="${BUILD_FAISS:-true}"
 BUILD_DUCKDB="${BUILD_DUCKDB:-true}"
 EXTRA_ARROW_OPTIONS=${EXTRA_ARROW_OPTIONS:-""}
+SIMDJSON_SKIPUTF8VALIDATION=${SIMDJSON_SKIPUTF8VALIDATION:-"OFF"}
 
 USE_CLANG="${USE_CLANG:-false}"
 
@@ -193,7 +194,7 @@ function install_xsimd {
 
 function install_simdjson {
   wget_and_untar https://github.com/simdjson/simdjson/archive/refs/tags/v"${SIMDJSON_VERSION}".tar.gz simdjson
-  cmake_install_dir simdjson -DSIMDJSON_SKIPUTF8VALIDATION=ON
+  cmake_install_dir simdjson -DSIMDJSON_SKIPUTF8VALIDATION=${SIMDJSON_SKIPUTF8VALIDATION}
 }
 
 function install_arrow {


### PR DESCRIPTION
In the existing code below, the `SIMDJSON_SKIPUTF8VALIDATION` option for simdjson is determined through the setting for `VELOX_SIMDJSON_SKIPUTF8VALIDATION`. https://github.com/facebookincubator/velox/blob/13ac97fe4441b983aa19747dde0bf7ae2aef4ea4/CMake/resolve_dependency_modules/simdjson.cmake#L36-L38

For consistency, we should also allow setting this build option in setup script. For Spark users, it must be enabled to allow invalid UTF8 encoding in JSON data, which is necessary for alignment with Spark.
