### PR TITLE
fix: Revert refactor: Remove enableConstantFolding flag from ExprCompiler"

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -739,7 +739,7 @@ class ExprSet {
   explicit ExprSet(
       const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* execCtx,
-      bool optimize = true,
+      bool enableConstantFolding = true,
       bool lazyDereference = false);
 
   virtual ~ExprSet();
@@ -842,7 +842,7 @@ class ExprSetSimplified : public ExprSet {
   ExprSetSimplified(
       const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* execCtx)
-      : ExprSet(source, execCtx, /*optimize*/ false) {}
+      : ExprSet(source, execCtx, /*enableConstantFolding*/ false) {}
 
   virtual ~ExprSetSimplified() override {}
 

--- a/velox/expression/ExprCompiler.h
+++ b/velox/expression/ExprCompiler.h
@@ -28,6 +28,7 @@ class ExprSet;
 std::vector<std::shared_ptr<Expr>> compileExpressions(
     const std::vector<core::TypedExprPtr>& sources,
     core::ExecCtx* execCtx,
-    ExprSet* exprSet);
+    ExprSet* exprSet,
+    bool enableConstantFolding = true);
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Queries fails with

```
VeloxUserError:  Scalar function presto.default.array_sort not registered with arguments: (ARRAY<ROW<numerator_metric_values:MAP<INTEGER,DOUBLE>,denominator_metric_values:MAP<INTEGER,DOUBLE>>>, FUNCTION<ROW<numerator_metric_values:MAP<INTEGER,DOUBLE>,denominator_metric_values:MAP<INTEGER,DOUBLE>>, ROW<numerator_metric_values:MAP<INTEGER,DOUBLE>,denominator_metric_values:MAP<INTEGER,DOUBLE>>, INTEGER>). Found function registered with the following signatures:
((array(T)) -> array(T))
((array(T),constant function(T,U)) -> array(T))
((array(T),constant function(T,T,bigint)) -> array(T))
```

Query shape
```
  SELECT 
    "transform_values"(
      "transform_values"(
        "multimap_agg"(
          metric_dimensions, 
          ROW (
            metric_dimensions_bitmap, pre_metric_stats
          )
        ), 
        (k, v) -> "array_sort"(
          "remove_nulls"(v), 
          (u, w) -> IF(
            (
              "json_format"(
                CAST(u AS json)
              ) > "json_format"(
                CAST(w AS json)
              )
            ), 
            -1, 
            IF(
              (
                "json_format"(
                  CAST(u AS json)
                ) = "json_format"(
                  CAST(w AS json)
                )
              ), 
              0, 
              1
            )
          )
        )
      ), 
      (k, v) -> "map_from_entries"(v)
    ) pre_metric_stats_map 
  FROM 
    pre_metric_stats 
  WHERE 
    (metric_dimensions IS NOT NULL)
```

Original commit changeset: 63f1556253f7

Original Phabricator Diff: D87495859

Differential Revision: D87887320


