### PR TITLE
feat(plan_builder): Alias support for expression builder

### DIFF
--- a/velox/exec/tests/ExpressionBuilderTest.cpp
+++ b/velox/exec/tests/ExpressionBuilderTest.cpp
@@ -170,6 +170,19 @@ TEST(ExpressionBuilderTest, casts) {
       "try_cast(\"c0\" as VARBINARY)");
 }
 
+TEST(ExpressionBuilderTest, alias) {
+  EXPECT_EQ(lit("str").alias("col"), parseSql("'str' as col"));
+  EXPECT_EQ(col("c1").alias("col"), parseSql("c1 as col"));
+  EXPECT_EQ((col("c1") > 1.1).alias("col"), parseSql("c1 > 1.1 as col"));
+
+  EXPECT_EQ(
+      col("c1").between(1L, 10L).alias("my_col"),
+      parseSql("c1 between 1 and 10 as my_col"));
+
+  // As a free function.
+  EXPECT_EQ(alias(col("c1") == "bla", "col"), parseSql("c1 = 'bla' as col"));
+}
+
 TEST(ExpressionBuilderTest, lambdas) {
   EXPECT_EQ(lambda("x", 1L), parseSql("x -> 1"));
   EXPECT_EQ(lambda({"x"}, 1L), parseSql("x -> 1"));

--- a/velox/exec/tests/utils/ExpressionBuilder.h
+++ b/velox/exec/tests/utils/ExpressionBuilder.h
@@ -182,6 +182,14 @@ class ExprWrapper {
     return expr_;
   }
 
+  /// Add an alias to the current expression:
+  ///
+  /// > col("c0").alias("my_column");
+  ExprWrapper& alias(const std::string& newAlias) {
+    expr_ = expr_->withAlias(newAlias);
+    return *this;
+  }
+
   /// Add a "subfield" expression to enable access of subfields in
   /// rows/structs:
   ///
@@ -393,6 +401,12 @@ inline detail::ExprWrapper operator!(detail::ExprWrapper expr) {
 template <typename T>
 inline detail::ExprWrapper isNull(const T& expr) {
   return detail::toExprWrapper(expr).isNull();
+}
+
+/// "alias" as a free function.
+template <typename TInput>
+inline detail::ExprWrapper alias(TInput lhs, const std::string& newAlias) {
+  return detail::toExprWrapper(lhs).alias(newAlias);
 }
 
 /// "cast" as a free function.

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -79,6 +79,10 @@ class FieldAccessExpr : public IExpr {
         name_, alias(), std::move(newInputs));
   }
 
+  ExprPtr withAlias(const std::string& alias) const override {
+    return std::make_shared<FieldAccessExpr>(name_, alias, inputs());
+  }
+
   ExprPtr dropAlias() const override {
     return std::make_shared<FieldAccessExpr>(name_, std::nullopt, inputs());
   }
@@ -116,6 +120,10 @@ class CallExpr : public IExpr {
         folly::copy(name()), std::move(newInputs), alias());
   }
 
+  ExprPtr withAlias(const std::string& alias) const override {
+    return std::make_shared<CallExpr>(name(), inputs(), alias);
+  }
+
   ExprPtr dropAlias() const override {
     return std::make_shared<CallExpr>(name(), inputs(), std::nullopt);
   }
@@ -151,6 +159,10 @@ class ConstantExpr : public IExpr,
   ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const override {
     VELOX_CHECK_EQ(newInputs.size(), 0);
     return std::make_shared<ConstantExpr>(type(), value(), alias());
+  }
+
+  ExprPtr withAlias(const std::string& alias) const override {
+    return std::make_shared<ConstantExpr>(type(), value(), alias);
   }
 
   ExprPtr dropAlias() const override {
@@ -193,6 +205,10 @@ class CastExpr : public IExpr, public std::enable_shared_from_this<CastExpr> {
     VELOX_CHECK_EQ(newInputs.size(), 1);
     return std::make_shared<CastExpr>(
         type(), newInputs[0], isTryCast_, alias());
+  }
+
+  ExprPtr withAlias(const std::string& alias) const override {
+    return std::make_shared<CastExpr>(type(), input(), isTryCast_, alias);
   }
 
   ExprPtr dropAlias() const override {
@@ -254,4 +270,5 @@ class LambdaExpr : public IExpr,
   const std::vector<std::string> arguments_;
   const ExprPtr body_;
 };
+
 } // namespace facebook::velox::core

--- a/velox/parse/IExpr.h
+++ b/velox/parse/IExpr.h
@@ -85,6 +85,14 @@ class IExpr {
   /// Returns a copy of this expression with the given inputs.
   virtual ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const = 0;
 
+  /// Returns a copy of this expression with the the new alias added.
+  ///
+  /// The last alias added will win if called multiple times. Throws in case the
+  /// subclass does not implement it.
+  virtual ExprPtr withAlias(const std::string& alias) const {
+    VELOX_FAIL("Unable to add alias to expression '{}'", *this);
+  }
+
   /// Returns a copy of this expression with the alias removed.
   virtual ExprPtr dropAlias() const = 0;
 


### PR DESCRIPTION
Summary:
Adding support for alias() and .alias() in expression builder. It
requires a new API in IExpr because IExpr are always immutable.

Differential Revision: D87737347


