### PR TITLE
feat: Batch IndexLookupJoin output when splitOutput is disabled

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -373,6 +373,11 @@ class IndexSource {
    public:
     virtual ~LookupResultIterator() = default;
 
+    /// Invoked to check if there are more lookup results available to fetch.
+    /// Returns true if there are more results, false otherwise. This allows
+    /// the caller to determine whether to continue calling 'next()'.
+    virtual bool hasNext() = 0;
+
     /// Invoked to fetch up to 'size' number of output rows. Returns nullptr if
     /// all the lookup results have been fetched. Returns std::nullopt and sets
     /// the 'future' if started asynchronous work and needs to wait for it to

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3521,7 +3521,7 @@ class IndexLookupJoinNode : public AbstractJoinNode {
 
    private:
     std::vector<IndexLookupConditionPtr> joinConditions_;
-    bool hasMarker_;
+    bool hasMarker_{false};
   };
 
   bool supportsBarrier() const override {

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -140,6 +140,7 @@ IndexLookupJoin::IndexLookupJoin(
           operatorId,
           joinNode->id(),
           "IndexLookupJoin"),
+      splitOutput_{driverCtx->queryConfig().indexLookupJoinSplitOutput()},
       // TODO: support to update output batch size with output size stats during
       // the lookup processing.
       outputBatchSize_{
@@ -575,6 +576,111 @@ void IndexLookupJoin::prepareLookup(InputBatchState& batch) {
   }
 }
 
+void IndexLookupJoin::mergeLookupResults(InputBatchState& batch) {
+  VELOX_CHECK(!batch.partialOutputs.empty());
+  VELOX_CHECK_NULL(batch.lookupResult);
+
+  if (batch.partialOutputs.size() == 1) {
+    batch.lookupResult = std::move(batch.partialOutputs[0]);
+    SCOPE_EXIT {
+      VELOX_CHECK_NOT_NULL(batch.lookupResult);
+      batch.partialOutputs.clear();
+    };
+    return;
+  }
+
+  // Calculate total size.
+  vector_size_t totalSize = 0;
+  for (const auto& result : batch.partialOutputs) {
+    totalSize += static_cast<vector_size_t>(result->size());
+  }
+
+  // Merge inputHits buffers.
+  auto mergedInputHits = allocateIndices(totalSize, pool());
+  auto* rawMergedInputHits = mergedInputHits->asMutable<vector_size_t>();
+  vector_size_t offset = 0;
+  for (const auto& result : batch.partialOutputs) {
+    std::memcpy(
+        rawMergedInputHits + offset,
+        result->inputHits->as<const vector_size_t>(),
+        result->size() * sizeof(vector_size_t));
+    offset += static_cast<vector_size_t>(result->size());
+  }
+
+  // Merge output RowVectors.
+  // NOTE: Uncommon path for connectors that do not respect output batch size
+  // properly
+  auto mergedOutput = BaseVector::create<RowVector>(
+      batch.partialOutputs[0]->output->type(), totalSize, pool());
+  vector_size_t outputOffset = 0;
+  for (const auto& result : batch.partialOutputs) {
+    mergedOutput->copy(result->output.get(), outputOffset, 0, result->size());
+    outputOffset += static_cast<vector_size_t>(result->size());
+  }
+
+  batch.lookupResult = std::make_unique<connector::IndexSource::LookupResult>(
+      std::move(mergedInputHits), std::move(mergedOutput));
+  batch.partialOutputs.clear();
+}
+
+bool IndexLookupJoin::getLookupResults(InputBatchState& batch) {
+  VELOX_CHECK_NOT_NULL(batch.lookupInput);
+  VELOX_CHECK_NOT_NULL(batch.lookupResultIter);
+  VELOX_CHECK(!batch.lookupFuture.valid());
+
+  // Result is ready.
+  if (batch.lookupResult != nullptr) {
+    return true;
+  }
+
+  // Fetch the first result if not already fetched.
+  if (batch.lookupResult == nullptr && batch.partialOutputs.empty()) {
+    auto lookupResultOr =
+        batch.lookupResultIter->next(outputBatchSize_, batch.lookupFuture);
+    if (!lookupResultOr.has_value()) {
+      VELOX_CHECK(batch.lookupFuture.valid());
+      return false;
+    }
+    VELOX_CHECK(!batch.lookupFuture.valid());
+
+    // Either splitOutput_ is true, or no more results, or first result is null.
+    if (splitOutput_ || !lookupResultOr.has_value() ||
+        !batch.lookupResultIter->hasNext()) {
+      batch.lookupResult = std::move(lookupResultOr).value();
+      return true;
+    }
+
+    // Otherwise start accumulating results.
+    batch.partialOutputs.push_back(std::move(lookupResultOr).value());
+  }
+
+  // Continue accumulating remaining results when splitOutput_ is false.
+  // This handles both initial accumulation and resuming after async
+  // interruption.
+  VELOX_CHECK(!splitOutput_);
+  VELOX_CHECK(!batch.partialOutputs.empty());
+  VELOX_CHECK_NULL(batch.lookupResult);
+
+  while (batch.lookupResultIter->hasNext()) {
+    auto nextResultOr =
+        batch.lookupResultIter->next(outputBatchSize_, batch.lookupFuture);
+    if (!nextResultOr.has_value()) {
+      // Need to wait for async operation.
+      VELOX_CHECK(batch.lookupFuture.valid());
+      return false;
+    }
+    VELOX_CHECK(!batch.lookupFuture.valid());
+    auto nextResult = std::move(nextResultOr).value();
+    if (nextResult != nullptr) {
+      batch.partialOutputs.push_back(std::move(nextResult));
+    }
+  }
+
+  // All results accumulated, merge them.
+  mergeLookupResults(batch);
+  return true;
+}
+
 void IndexLookupJoin::decodeAndDetectNonNullKeys(InputBatchState& batch) {
   const auto numRows = batch.input->size();
   batch.nonNullInputRows.resize(numRows);
@@ -610,16 +716,11 @@ void IndexLookupJoin::startLookup(InputBatchState& batch) {
     return;
   }
 
+  // Create the lookup result iterator.
   batch.lookupResultIter = indexSource_->lookup(
       connector::IndexSource::LookupRequest{batch.lookupInput});
-  auto lookupResultOr =
-      batch.lookupResultIter->next(outputBatchSize_, batch.lookupFuture);
-  if (!lookupResultOr.has_value()) {
-    VELOX_CHECK(batch.lookupFuture.valid());
-    return;
-  }
-  VELOX_CHECK(!batch.lookupFuture.valid());
-  batch.lookupResult = std::move(lookupResultOr).value();
+
+  getLookupResults(batch);
 }
 
 RowVectorPtr IndexLookupJoin::getOutputFromLookupResult(
@@ -632,26 +733,23 @@ RowVectorPtr IndexLookupJoin::getOutputFromLookupResult(
     return produceRemainingOutput(batch);
   }
 
-  VELOX_CHECK_NOT_NULL(batch.lookupResultIter);
+  if (!getLookupResults(batch)) {
+    // Async operation pending, need to wait.
+    VELOX_CHECK(batch.lookupFuture.valid());
+    return nullptr;
+  }
+
+  VELOX_CHECK(!batch.lookupFuture.valid());
+  VELOX_CHECK(batch.partialOutputs.empty());
 
   if (batch.lookupResult == nullptr) {
-    auto resultOptional =
-        batch.lookupResultIter->next(outputBatchSize_, batch.lookupFuture);
-    if (!resultOptional.has_value()) {
-      VELOX_CHECK(batch.lookupFuture.valid());
-      return nullptr;
+    if (hasRemainingOutputForLeftJoin(batch)) {
+      return produceRemainingOutputForLeftJoin(batch);
     }
-    VELOX_CHECK(!batch.lookupFuture.valid());
-
-    batch.lookupResult = std::move(resultOptional).value();
-    if (batch.lookupResult == nullptr) {
-      if (hasRemainingOutputForLeftJoin(batch)) {
-        return produceRemainingOutputForLeftJoin(batch);
-      }
-      finishInput(batch);
-      return nullptr;
-    }
+    finishInput(batch);
+    return nullptr;
   }
+
   prepareLookupResult(batch);
   VELOX_CHECK_NOT_NULL(batch.lookupResult);
 

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -344,6 +344,16 @@ TestIndexSource::ResultIterator::ResultIterator(
   lookupResultIter_->reset(*lookupResult_);
 }
 
+bool TestIndexSource::ResultIterator::hasNext() {
+  // If we have an async result ready, we have more to return.
+  if (asyncResult_.has_value()) {
+    return true;
+  }
+
+  // If the iterator is not at end, there are more results to fetch.
+  return !lookupResultIter_->atEnd();
+}
+
 std::optional<std::unique_ptr<connector::IndexSource::LookupResult>>
 TestIndexSource::ResultIterator::next(
     vector_size_t size,

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -194,6 +194,8 @@ class TestIndexSource : public connector::IndexSource,
         std::unique_ptr<HashLookup> lookupResult,
         folly::Executor* executor);
 
+    bool hasNext() override;
+
     std::optional<std::unique_ptr<LookupResult>> next(
         vector_size_t size,
         ContinueFuture& future) override;


### PR DESCRIPTION
Summary: When splitOutput is disabled, IndexLookupJoin now accumulates all lookup results from an iterator into a single output batch instead of splitting them across multiple batches.

Differential Revision: D87889936


