### PR TITLE
fix: Fix flaky test SharedArbitrationTestWithParallelExecutionModeOnly.concurrentArbitration/parallel

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -1379,6 +1379,7 @@ TEST_P(
           if (e.errorCode() != error_code::kMemCapExceeded.c_str() &&
               e.errorCode() != error_code::kMemAborted.c_str() &&
               e.errorCode() != error_code::kMemAllocError.c_str() &&
+              e.errorCode() != error_code::kMemArbitrationTimeout.c_str() &&
               (e.message() != "Aborted for external error")) {
             std::rethrow_exception(std::current_exception());
           }

--- a/velox/exec/tests/utils/ArbitratorTestUtil.h
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.h
@@ -112,7 +112,7 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
 std::unique_ptr<memory::MemoryManager> createMemoryManager(
     int64_t arbitratorCapacity = kMemoryCapacity,
     uint64_t memoryPoolInitCapacity = kMemoryPoolInitCapacity,
-    uint64_t maxReclaimWaitMs = 5 * 60 * 1'000,
+    uint64_t maxReclaimWaitMs = 60 * 1'000,
     uint64_t fastExponentialGrowthCapacityLimit = 0,
     double slowCapacityGrowPct = 0);
 


### PR DESCRIPTION
Summary:
Test can flake when we're running with `arbitratorCapacity=16MB` but memory pool `queryCapacity =128MB` - basically no participant can ever be spilled since they're all too small to hit that threshold.

The issue is the head of line blocking in resumeGlobalArbitrationWaitersLocked(). Say we have waiters [id=8 requestBytes=8MB, id=10 requestBytes=1MB, ..., id=20...] , and arbitrator has freeNonReserved=7.98MB. The  resume funcs tries waiter 8, gets `allocatedBytes=0` from `allocateCapacityLocked()`, then just breaks out without even trying waiter 10. So even though we could satisfy the 1MB request, we don't - everything gets blocked by the first waiter. 
These two issues combined create a livelock: can't satisfy first waiter, can't reclaim memory (no victims hit minReclaimBytes=128MB), can't satisfy other waiters due to HOL blocker. After `kMemoryPoolAbortCapacityLimit=2.5 mins` timeout it started aborting.
The first time it gets unstuck by aborting some queries, but when it gets stuck again the second time, `checkIfTimeout()` fires when `op.hasTimeout()` returns true and we failed as timeout

1. Accept Timeout-Based Abort as Temporary Unblock Mechanism
The head-of-line blocking situation is very complicated, and the current abort-by-timeout is actually working as an unblock procedure. We might revisit the fairness vs. best-effort tradeoff later, but for now, let's keep it as it is. We can treat the timeout and cascading abort behavior as expected in these scenarios.

2. Reduce Timeout from 5 Minutes to 1 Minute
The 5-minute timeout is too generous. In most cases, when arbitration is not able to move forward, continuing to wait is just a waste of time due to the stuck situratoin. 1 minute is large enough.

Differential Revision: D87905815


