### PR TITLE
perf: Avoid string copy in IPAddressType

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -433,7 +433,7 @@ TEST_F(PrestoHasherTest, timestampWithTimezone) {
 }
 
 TEST_F(PrestoHasherTest, ipAddress) {
-  auto makeIpAdressFromString = [](const std::string& ipAddr) -> int128_t {
+  auto makeIpAdressFromString = [](std::string_view ipAddr) -> int128_t {
     auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
     return ret.value();
   };

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -1450,7 +1450,7 @@ TEST_F(ComparisonsTest, IPPrefixType) {
 }
 
 TEST_F(ComparisonsTest, IpAddressType) {
-  auto makeIpAdressFromString = [](const std::string& ipAddr) -> int128_t {
+  auto makeIpAdressFromString = [](std::string_view ipAddr) -> int128_t {
     auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
     return ret.value();
   };

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -136,8 +136,9 @@ class IPAddressCastOperator : public exec::CastOperator {
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       const auto ipAddressString = ipAddressStrings->valueAt(row);
-      auto maybeIpAsInt128 =
-          ipaddress::tryGetIPv6asInt128FromString(ipAddressString);
+      // TODO: Remove explicit std::string_view cast.
+      auto maybeIpAsInt128 = ipaddress::tryGetIPv6asInt128FromString(
+          std::string_view(ipAddressString));
 
       if (maybeIpAsInt128.hasError()) {
         if (threadSkipErrorDetails()) {

--- a/velox/functions/prestosql/types/IPAddressType.h
+++ b/velox/functions/prestosql/types/IPAddressType.h
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #pragma once
 
 #include <folly/IPAddress.h>
@@ -21,8 +22,8 @@
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
-
 namespace ipaddress {
+
 constexpr int kIPV4AddressBytes = 4;
 constexpr int kIPV4ToV6FFIndex = 10;
 constexpr int kIPV4ToV6Index = 12;
@@ -31,6 +32,7 @@ constexpr int kIPAddressBytes = 16;
 inline folly::ByteArray16 toIPv6ByteArray(const int128_t& ipAddr) {
   folly::ByteArray16 bytes{{0}};
   memcpy(bytes.data(), &ipAddr, sizeof(ipAddr));
+
   // Reverse because the velox is always on little endian system
   // and the byte array needs to be big endian (network byte order)
   std::reverse(bytes.begin(), bytes.end());
@@ -38,7 +40,7 @@ inline folly::ByteArray16 toIPv6ByteArray(const int128_t& ipAddr) {
 }
 
 inline folly::Expected<int128_t, folly::IPAddressFormatError>
-tryGetIPv6asInt128FromString(const std::string& ipAddressStr) {
+tryGetIPv6asInt128FromString(const std::string_view& ipAddressStr) {
   auto maybeIp = folly::IPAddress::tryFromString(ipAddressStr);
   if (maybeIp.hasError()) {
     return folly::makeUnexpected(maybeIp.error());
@@ -51,6 +53,7 @@ tryGetIPv6asInt128FromString(const std::string& ipAddressStr) {
   memcpy(&intAddr, &addrBytes, kIPAddressBytes);
   return intAddr;
 }
+
 } // namespace ipaddress
 
 class IPAddressType final : public HugeintType {

--- a/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPAddressTypeTest.cpp
@@ -25,7 +25,7 @@ class IPAddressTypeTest : public testing::Test, public TypeTestBase {
     registerIPAddressType();
   }
 
-  int128_t getIPv6asInt128FromStringUnchecked(const std::string& ipAddr) {
+  int128_t getIPv6asInt128FromStringUnchecked(std::string_view ipAddr) {
     auto ret = ipaddress::tryGetIPv6asInt128FromString(ipAddr);
     return ret.value();
   }


### PR DESCRIPTION
Summary: Avoiding unnecessary string copy from StringView to std::string.

Differential Revision: D87908833


