### PR TITLE
perf: Avoid StringView copy in folly/Conv.h

### DIFF
--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -275,6 +275,16 @@ inline StringView operator""_sv(const char* str, size_t len) {
   return StringView(str, len);
 }
 
+// Specializations needed for string conversion in folly/Conv.h.
+template <class TString>
+inline void toAppend(const StringView& value, TString* result) {
+  result->append(value);
+}
+
+inline size_t estimateSpaceNeeded(const StringView& value) {
+  return value.size();
+}
+
 } // namespace facebook::velox
 
 namespace std {
@@ -287,6 +297,7 @@ struct hash<::facebook::velox::StringView> {
 } // namespace std
 
 namespace folly {
+
 template <>
 struct hasher<::facebook::velox::StringView> {
   size_t operator()(const ::facebook::velox::StringView view) const {


### PR DESCRIPTION
Summary:
StringView's are getting implicitly copied into std::string whenever
StringView is used in folly/Conv.h functions (folly::to() and similar).
Providing a specialization to avoid the implicit copy.

Differential Revision: D87929077


