### PR TITLE
Batch serialization with preserve encoding option support in remote functions

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.h
+++ b/velox/functions/remote/client/RemoteVectorFunction.h
@@ -26,6 +26,10 @@ struct RemoteVectorFunctionMetadata : public exec::VectorFunctionMetadata {
   /// The serialization format to be used to send batches of data to the remote
   /// process.
   remote::PageFormat serdeFormat{remote::PageFormat::PRESTO_PAGE};
+
+  /// Whether to preserve the input vector encoding in the request sent to
+  /// remote service.
+  bool preserveEncoding{false};
 };
 
 /// Main vector function logic. Needs to be extended with the transport-specific
@@ -64,6 +68,7 @@ class RemoteVectorFunction : public exec::VectorFunction {
   const std::string functionName_;
 
   remote::PageFormat serdeFormat_;
+  bool preserveEncoding_;
   std::unique_ptr<VectorSerde> serde_;
 
   // Structures we construct once to cache:

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -313,6 +313,23 @@ folly::IOBuf rowVectorToIOBuf(
   return std::move(*stream.getIOBuf());
 }
 
+folly::IOBuf rowVectorToIOBufUsingBatchSerializer(
+    const RowVectorPtr& rowVector,
+    memory::MemoryPool& pool,
+    VectorSerde* serde,
+    const VectorSerde::Options* options) {
+  // Use BatchVectorSerializer with provided options (e.g., preserveEncodings)
+  // to maintain encoding through serialization
+  auto serializer = serde->createBatchSerializer(&pool, options);
+
+  IOBufOutputStream stream(pool);
+  IndexRange range{0, rowVector->size()};
+  Scratch scratch;
+  serializer->serialize(rowVector, folly::Range(&range, 1), scratch, &stream);
+
+  return std::move(*stream.getIOBuf());
+}
+
 RowVectorPtr IOBufToRowVector(
     const folly::IOBuf& ioBuf,
     const RowTypePtr& outputType,

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -507,6 +507,12 @@ folly::IOBuf rowVectorToIOBuf(
     memory::MemoryPool& pool,
     VectorSerde* serde = nullptr);
 
+folly::IOBuf rowVectorToIOBufUsingBatchSerializer(
+    const RowVectorPtr& rowVector,
+    memory::MemoryPool& pool,
+    VectorSerde* serde = nullptr,
+    const VectorSerde::Options* options = nullptr);
+
 /// Convenience function to deserialize an IOBuf into a rowVector. If `serde` is
 /// nullptr, use the default installed serializer.
 RowVectorPtr IOBufToRowVector(


### PR DESCRIPTION
Summary:
I noticed that the constant encodings were not preserved when we are receiving thrift request from Presto for remote function calls. We use a lot of constant parameters in our remote funciton udf and if we don't preserve the constant encoding, it will more than double the payload size.
After debugging the issue, the fix is to use batch serializer (instead of iterative serializer) which preserves the encoding correctly. I noticed 60% reduced in payload size after testing this change locally for our remote function udf. This is just a simple case, in other cases we will have even more savings (more than 3x reduction in payload size).

Differential Revision: D87873415


