### PR TITLE
refactor: Add SimpleFunction signature with MemoryPool

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -318,7 +318,10 @@ ExprPtr compileCall(
         folly::join(", ", inputTypes));
 
     auto func = simpleFunctionEntry->createFunction()->createVectorFunction(
-        inputTypes, getConstantInputs(inputs), ctx.queryCtx->queryConfig());
+        inputTypes,
+        getConstantInputs(inputs),
+        ctx.queryCtx->queryConfig(),
+        ctx.pool);
     return std::make_shared<Expr>(
         resultType,
         std::move(inputs),

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -166,7 +166,8 @@ class SimpleFunctionAdapterFactory {
   virtual std::unique_ptr<VectorFunction> createVectorFunction(
       const std::vector<TypePtr>& inputTypes,
       const std::vector<VectorPtr>& constantInputs,
-      const core::QueryConfig& config) const = 0;
+      const core::QueryConfig& config,
+      memory::MemoryPool* memoryPool = nullptr) const = 0;
   virtual ~SimpleFunctionAdapterFactory() = default;
 };
 

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -416,4 +416,31 @@ TEST_F(ExprCompilerTest, exprDeduplication) {
       "Non-deterministic expressions should NOT be deduplicated when config is false");
 }
 
+TEST_F(ExprCompilerTest, simpleFunctionMemoryPool) {
+  // Test that MemoryPool is correctly passed through ExprCompiler to
+  // SimpleFunctions that have initialize() with memoryPool parameter.
+  // empty_approx_set() creates an HLL sketch.
+  auto expression = call("empty_approx_set", {});
+  auto exprSet = compile(expression);
+  ASSERT_EQ(exprSet->size(), 1);
+
+  auto input = makeRowVector(ROW({}, {}), 1);
+  SelectivityVector rows(1);
+  EvalCtx evalCtx(execCtx_.get(), exprSet.get(), input.get());
+  std::vector<VectorPtr> results(1);
+  exprSet->eval(rows, evalCtx, results);
+
+  // Verify result - eval should create the vector
+  ASSERT_TRUE(results[0] != nullptr) << "Result vector was not created";
+  ASSERT_EQ(results[0]->size(), 1) << "Result vector has wrong size";
+  ASSERT_FALSE(results[0]->isNullAt(0));
+
+  // empty_approx_set() returns a constant.
+  DecodedVector decoded(*results[0], rows);
+  ASSERT_FALSE(decoded.isNullAt(0)) << "Decoded result is null";
+
+  auto stringView = decoded.valueAt<StringView>(0);
+  ASSERT_GT(stringView.size(), 0) << "HLL sketch is empty";
+}
+
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Add MemoryPool support to SimpleFunction `initialize()` method to enable memory tracking for scalar functions (e.g merge_hll) that use HashStringAllocator.

Some types that require this include Hyperloglog, KHyperloglog, SetDigest, SfmSketch etc. 

**Changes** 
SimpleFunctionMetadata/SimpleFunctionAdapter/VectorFunction
- New function signature with MemoryPool
- Function caller tries method with MemoryPool first then without. 

ExprCompiler
- Gets MemoryPool from Execution Context passes through function factories
- Create MemoryPool reference (with special no-op deleter so it doesn't try to delete memory it doesn't own)

ExprCompilerTest - Added test here

Differential Revision: D87932003


