### PR TITLE
perf:  Batch serialization with preserve encoding option support in remote functions

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.h
+++ b/velox/functions/remote/client/RemoteVectorFunction.h
@@ -64,6 +64,7 @@ class RemoteVectorFunction : public exec::VectorFunction {
   const std::string functionName_;
 
   remote::PageFormat serdeFormat_;
+  std::unique_ptr<VectorSerde::Options> serdeOptions_;
   std::unique_ptr<VectorSerde> serde_;
 
   // Structures we construct once to cache:

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -498,14 +498,16 @@ class VectorStreamGroup : public StreamArena {
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     memory::MemoryPool& pool,
-    VectorSerde* serde = nullptr);
+    VectorSerde* serde = nullptr,
+    const VectorSerde::Options* options = nullptr);
 
 /// Same as above but serializes up until row `rangeEnd`.
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     vector_size_t rangeEnd,
     memory::MemoryPool& pool,
-    VectorSerde* serde = nullptr);
+    VectorSerde* serde = nullptr,
+    const VectorSerde::Options* options = nullptr);
 
 /// Convenience function to deserialize an IOBuf into a rowVector. If `serde` is
 /// nullptr, use the default installed serializer.


### PR DESCRIPTION
Summary:

I noticed that the constant encodings were not preserved when we are receiving thrift request from Presto for remote function calls. We use a lot of constant parameters in our remote funciton udf and if we don't preserve the constant encoding, it will more than double the payload size.
After debugging the issue, the fix is to use batch serializer (instead of iterative serializer) which preserves the encoding correctly. I noticed 60% reduced in payload size after testing this change locally for our remote function udf. This is just a simple case, in other cases we will have even more savings (more than 3x reduction in payload size).

Differential Revision: D87873415
