### PR TITLE
feat: Add fuzzer type transform for KHLL

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -39,6 +39,7 @@
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
@@ -323,9 +324,10 @@ bool PrestoQueryRunner::isConstantExprSupported(
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
         !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&
-        !isTDigestType(type) && !isQDigestType(type) &&
-        !isSetDigestType(type) && !isBingTileType(type) &&
-        !isSfmSketchType(type) && !isTimeWithTimeZone(type);
+        !isKHyperLogLogType(type) && !isTDigestType(type) &&
+        !isQDigestType(type) && !isSetDigestType(type) &&
+        !isBingTileType(type) && !isSfmSketchType(type) &&
+        !isTimeWithTimeZone(type);
   }
   return true;
 }

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -22,6 +22,7 @@
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/SfmSketchType.h"
@@ -52,6 +53,9 @@ intermediateTypeTransforms() {
           {HYPERLOGLOG(),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                HYPERLOGLOG(), VARBINARY())},
+          {KHYPERLOGLOG(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               KHYPERLOGLOG(), VARBINARY())},
           {TDIGEST(DOUBLE()),
            std::make_shared<IntermediateTypeTransformUsingCast>(
                TDIGEST(DOUBLE()), VARBINARY())},

--- a/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
+++ b/velox/exec/fuzzer/tests/PrestoSqlTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/fuzzer/PrestoSql.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
 #include "velox/functions/prestosql/types/SetDigestType.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
@@ -43,6 +44,7 @@ TEST(PrestoSqlTest, toTypeSql) {
   EXPECT_EQ(toTypeSql(QDIGEST(BIGINT())), "QDIGEST(BIGINT)");
   EXPECT_EQ(toTypeSql(QDIGEST(REAL())), "QDIGEST(REAL)");
   EXPECT_EQ(toTypeSql(SETDIGEST()), "SETDIGEST");
+  EXPECT_EQ(toTypeSql(KHYPERLOGLOG()), "KHYPERLOGLOG");
   EXPECT_EQ(toTypeSql(DATE()), "DATE");
   EXPECT_EQ(toTypeSql(TIMESTAMP_WITH_TIME_ZONE()), "TIMESTAMP WITH TIME ZONE");
   EXPECT_EQ(toTypeSql(ARRAY(BOOLEAN())), "ARRAY(BOOLEAN)");

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -228,6 +228,7 @@ add_executable(
   PrestoQueryRunnerIntermediateTypeTransformTestBase.cpp
   PrestoQueryRunnerTDigestTransformTest.cpp
   PrestoQueryRunnerQDigestTransformTest.cpp
+  PrestoQueryRunnerKHyperLogLogTransformTest.cpp
   PrestoQueryRunnerSetDigestTransformTest.cpp
   PrestoQueryRunnerJsonTransformTest.cpp
   PrestoQueryRunnerIntervalTransformTest.cpp

--- a/velox/exec/tests/PrestoQueryRunnerKHyperLogLogTransformTest.cpp
+++ b/velox/exec/tests/PrestoQueryRunnerKHyperLogLogTransformTest.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.h"
+#include "velox/exec/tests/PrestoQueryRunnerIntermediateTypeTransformTestBase.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class PrestoQueryRunnerKHyperLogLogTransformTest
+    : public PrestoQueryRunnerIntermediateTypeTransformTestBase {};
+
+TEST_F(PrestoQueryRunnerKHyperLogLogTransformTest, isIntermediateOnlyType) {
+  ASSERT_TRUE(isIntermediateOnlyType(KHYPERLOGLOG()));
+  ASSERT_TRUE(isIntermediateOnlyType(ARRAY(KHYPERLOGLOG())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(KHYPERLOGLOG(), SMALLINT())));
+  ASSERT_TRUE(isIntermediateOnlyType(MAP(VARBINARY(), KHYPERLOGLOG())));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW({KHYPERLOGLOG(), SMALLINT()})));
+  ASSERT_TRUE(isIntermediateOnlyType(ROW(
+      {SMALLINT(),
+       TIMESTAMP(),
+       ARRAY(ROW({MAP(VARCHAR(), KHYPERLOGLOG())}))})));
+}
+
+TEST_F(PrestoQueryRunnerKHyperLogLogTransformTest, transform) {
+  test(KHYPERLOGLOG());
+}
+
+TEST_F(PrestoQueryRunnerKHyperLogLogTransformTest, transformArray) {
+  testArray(KHYPERLOGLOG());
+}
+
+TEST_F(PrestoQueryRunnerKHyperLogLogTransformTest, transformMap) {
+  testMap(KHYPERLOGLOG());
+}
+
+TEST_F(PrestoQueryRunnerKHyperLogLogTransformTest, transformRow) {
+  testRow(KHYPERLOGLOG());
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Add intermediate type transform for KHyperLogLog to enable fuzzer testing.

**Change**
Adds KHyperLogLog <-> VARBINARY transform for Presto Java compatibility. KHLL is an intermediate type only (used for computation). Storage in hive column tables is as VARBINARY.

Also excludes KHLL from isConstantExprSupported() since it cannot be used as a constant literal in SQL (e.g., WHERE column = KHYPERLOGLOG X'...').

Follows the same pattern as SetDigest (D87554118)

Differential Revision: D87946570


