### PR TITLE
feat: Add KHyperLogLog Input Generator

### DIFF
--- a/velox/functions/prestosql/types/KHyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/KHyperLogLogRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
 
 #include "velox/functions/prestosql/types/KHyperLogLogType.h"
+#include "velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -34,10 +35,10 @@ class KHyperLogLogTypeFactory : public CustomTypeFactory {
   }
 
   AbstractInputGeneratorPtr getInputGenerator(
-      const InputGeneratorConfig& /*config*/) const override {
-    // TODO: Implement KHyperLogLogInputGenerator similar to
-    // P4HyperLogLogInputGenerator.
-    return nullptr;
+      const InputGeneratorConfig& config) const override {
+    return std::static_pointer_cast<AbstractInputGenerator>(
+        std::make_shared<fuzzer::KHyperLogLogInputGenerator>(
+            config.seed_, config.nullRatio_, config.pool_));
   }
 };
 } // namespace

--- a/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/CMakeLists.txt
@@ -16,6 +16,7 @@ velox_add_library(
   TimestampWithTimeZoneInputGenerator.cpp
   TimeWithTimezoneInputGenerator.cpp
   HyperLogLogInputGenerator.cpp
+  KHyperLogLogInputGenerator.cpp
   P4HyperLogLogInputGenerator.cpp
   SfmSketchInputGenerator.cpp
 )

--- a/velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.h"
+
+#include "velox/common/fuzzer/Utils.h"
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::fuzzer {
+
+KHyperLogLogInputGenerator::KHyperLogLogInputGenerator(
+    const size_t seed,
+    const double nullRatio,
+    memory::MemoryPool* pool,
+    int32_t minNumValues)
+    : AbstractInputGenerator{seed, KHYPERLOGLOG(), nullptr, nullRatio},
+      minNumValues_{minNumValues},
+      pool_{pool} {
+  static const std::vector<TypePtr> kBaseTypes{
+      BIGINT(), VARCHAR(), DOUBLE(), UNKNOWN()};
+  baseType_ = kBaseTypes[rand<int32_t>(rng_, 0, kBaseTypes.size() - 1)];
+
+  maxSize_ = rand<int32_t>(rng_, 100, 5000);
+  static const std::vector<int32_t> kValidBuckets{64, 128, 256, 512, 1024};
+  hllBuckets_ = kValidBuckets[rand<int32_t>(rng_, 0, kValidBuckets.size() - 1)];
+}
+
+// General template for numeric types (double)
+template <typename T>
+variant KHyperLogLogInputGenerator::generateTyped() {
+  HashStringAllocator allocator{pool_};
+  common::hll::KHyperLogLog<int64_t, HashStringAllocator> khll{
+      maxSize_, hllBuckets_, &allocator};
+
+  auto numPairs = rand<int32_t>(rng_, minNumValues_, 10000);
+  for (auto i = 0; i < numPairs; ++i) {
+    auto value = rand<T>(rng_);
+    int64_t joinKey = std::hash<T>{}(value);
+    int64_t uii = rand<int64_t>(rng_);
+    khll.add(joinKey, uii);
+  }
+
+  auto size = khll.estimatedSerializedSize();
+  std::string buff(size, '\0');
+  khll.serialize(buff.data());
+  return variant::binary(std::move(buff));
+}
+
+// Specialization for int64_t
+template <>
+variant KHyperLogLogInputGenerator::generateTyped<int64_t>() {
+  HashStringAllocator allocator{pool_};
+  common::hll::KHyperLogLog<int64_t, HashStringAllocator> khll{
+      maxSize_, hllBuckets_, &allocator};
+
+  auto numPairs = rand<int32_t>(rng_, minNumValues_, 10000);
+  for (auto i = 0; i < numPairs; ++i) {
+    int64_t joinKey = rand<int64_t>(rng_);
+    int64_t uii = rand<int64_t>(rng_);
+    khll.add(joinKey, uii);
+  }
+
+  auto size = khll.estimatedSerializedSize();
+  std::string buff(size, '\0');
+  khll.serialize(buff.data());
+  return variant::binary(std::move(buff));
+}
+
+// Specialization for std::string (VARCHAR)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+template <>
+variant KHyperLogLogInputGenerator::generateTyped<std::string>() {
+  HashStringAllocator allocator{pool_};
+  common::hll::KHyperLogLog<int64_t, HashStringAllocator> khll{
+      maxSize_, hllBuckets_, &allocator};
+
+  static const std::vector<UTF8CharList> encodings{
+      UTF8CharList::ASCII,
+      UTF8CharList::UNICODE_CASE_SENSITIVE,
+      UTF8CharList::EXTENDED_UNICODE,
+      UTF8CharList::MATHEMATICAL_SYMBOLS};
+  std::wstring_convert<std::codecvt_utf8<char16_t>, char16_t> converter;
+
+  auto numPairs = rand<int32_t>(rng_, minNumValues_, 10000);
+  for (auto i = 0; i < numPairs; ++i) {
+    auto size = rand<int32_t>(rng_, 0, 100);
+    std::string result;
+    auto str = randString(rng_, size, encodings, result, converter);
+    int64_t joinKey = std::hash<std::string>{}(str);
+    int64_t uii = rand<int64_t>(rng_);
+    khll.add(joinKey, uii);
+  }
+
+  auto size = khll.estimatedSerializedSize();
+  std::string buff(size, '\0');
+  khll.serialize(buff.data());
+  return variant::binary(std::move(buff));
+}
+#pragma GCC diagnostic pop
+
+// Specialization for UnknownValue (NULL type)
+template <>
+variant KHyperLogLogInputGenerator::generateTyped<UnknownValue>() {
+  HashStringAllocator allocator{pool_};
+  common::hll::KHyperLogLog<int64_t, HashStringAllocator> khll{
+      maxSize_, hllBuckets_, &allocator};
+
+  // UnknownValue represents NULL, so create an empty KHyperLogLog
+  // since KHyperLogLog ignores NULL inputs
+
+  auto size = khll.estimatedSerializedSize();
+  std::string buff(size, '\0');
+  khll.serialize(buff.data());
+  return variant::binary(std::move(buff));
+}
+
+variant KHyperLogLogInputGenerator::generate() {
+  if (coinToss(rng_, nullRatio_)) {
+    return variant::null(type_->kind());
+  }
+
+  if (baseType_->isBigint()) {
+    return generateTyped<int64_t>();
+  } else if (baseType_->isVarchar()) {
+    return generateTyped<std::string>();
+  } else if (baseType_->isDouble()) {
+    return generateTyped<double>();
+  } else {
+    return generateTyped<UnknownValue>();
+  }
+}
+
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.h
+++ b/velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::fuzzer {
+
+// Suppress warnings about deprecated declarations for AbstractInputGenerator
+// interface and std::hash usage in type conversions.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+class KHyperLogLogInputGenerator : public AbstractInputGenerator {
+ public:
+  KHyperLogLogInputGenerator(
+      const size_t seed,
+      const double nullRatio,
+      memory::MemoryPool* pool,
+      int32_t minNumValues = 1);
+
+  variant generate() override;
+
+ private:
+  template <typename T>
+  variant generateTyped();
+
+  TypePtr baseType_;
+  int32_t maxSize_;
+  int32_t hllBuckets_;
+  int32_t minNumValues_;
+  memory::MemoryPool* pool_;
+};
+#pragma GCC diagnostic pop
+
+} // namespace facebook::velox::fuzzer

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   TimestampWithTimeZoneInputGeneratorTest.cpp
   TimeWithTimezoneInputGeneratorTest.cpp
   HyperLogLogInputGeneratorTest.cpp
+  KHyperLogLogInputGeneratorTest.cpp
   P4HyperLogLogInputGeneratorTest.cpp
   SfmSketchInputGeneratorTest.cpp
 )

--- a/velox/functions/prestosql/types/fuzzer_utils/tests/KHyperLogLogInputGeneratorTest.cpp
+++ b/velox/functions/prestosql/types/fuzzer_utils/tests/KHyperLogLogInputGeneratorTest.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/fuzzer_utils/KHyperLogLogInputGenerator.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/hyperloglog/KHyperLogLog.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/types/KHyperLogLogType.h"
+
+namespace facebook::velox::fuzzer::test {
+
+class KHyperLogLogInputGeneratorTest
+    : public functions::test::FunctionBaseTest {};
+
+TEST_F(KHyperLogLogInputGeneratorTest, generate) {
+  KHyperLogLogInputGenerator generator(1, 0.0, pool());
+
+  for (int i = 0; i < 10; ++i) {
+    auto result = generator.generate();
+    ASSERT_FALSE(result.isNull());
+    ASSERT_EQ(result.kind(), TypeKind::VARBINARY);
+
+    // Verify deserialization works
+    const auto& serialized = result.value<TypeKind::VARBINARY>();
+    HashStringAllocator allocator{pool()};
+    auto khll =
+        common::hll::KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+            serialized.data(), serialized.size(), &allocator);
+    ASSERT_TRUE(khll.hasValue())
+        << "Deserialization failed: " << khll.error().message();
+    ASSERT_NE(*khll, nullptr);
+    ASSERT_GE((*khll)->cardinality(), 0);
+  }
+}
+
+TEST_F(KHyperLogLogInputGeneratorTest, generateWithNulls) {
+  KHyperLogLogInputGenerator generator(1, 0.5, pool());
+
+  int nullCount = 0;
+  int nonNullCount = 0;
+
+  for (int i = 0; i < 100; ++i) {
+    auto result = generator.generate();
+    if (result.isNull()) {
+      nullCount++;
+    } else {
+      nonNullCount++;
+      ASSERT_EQ(result.kind(), TypeKind::VARBINARY);
+
+      // Verify deserialization works
+      const auto& serialized = result.value<TypeKind::VARBINARY>();
+      HashStringAllocator allocator{pool()};
+      auto khll =
+          common::hll::KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+              serialized.data(), serialized.size(), &allocator);
+      ASSERT_TRUE(khll.hasValue())
+          << "Deserialization failed: " << khll.error().message();
+    }
+  }
+
+  // With null ratio 0.5, we should have roughly half nulls
+  ASSERT_GT(nullCount, 0);
+  ASSERT_GT(nonNullCount, 0);
+}
+
+TEST_F(KHyperLogLogInputGeneratorTest, generateDifferentSeeds) {
+  KHyperLogLogInputGenerator generator1(1, 0.0, pool());
+  KHyperLogLogInputGenerator generator2(2, 0.0, pool());
+
+  auto result1 = generator1.generate();
+  auto result2 = generator2.generate();
+
+  ASSERT_FALSE(result1.isNull());
+  ASSERT_FALSE(result2.isNull());
+  ASSERT_EQ(result1.kind(), TypeKind::VARBINARY);
+  ASSERT_EQ(result2.kind(), TypeKind::VARBINARY);
+
+  // Different seeds should produce different results
+  const auto& serialized1 = result1.value<TypeKind::VARBINARY>();
+  const auto& serialized2 = result2.value<TypeKind::VARBINARY>();
+  ASSERT_NE(serialized1, serialized2);
+}
+
+} // namespace facebook::velox::fuzzer::test


### PR DESCRIPTION
Summary:
- Add input generator for KHLL type to support fuzzer testing in Velox for KHLL functions
- Creates valid KHyperLogLog sketches with random data for various base types (BIGINT, VARCHAR, DOUBLE, UNKNOWN)

- The implementation follows the same pattern as P4HyperLogLogInputGenerator
- Configurable parameters (maxSize, hllBuckets) randomly selected within valid ranges

Differential Revision: D87950763
