### PR TITLE
fix: Make RowType::hashKind() thread-safe on AArch64

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -570,11 +570,12 @@ bool RowType::equals(const Type& other) const {
 }
 
 size_t RowType::hashKind() const {
-  if (!hashKindComputed_.load(std::memory_order_relaxed)) {
-    hashKind_ = TypeBase<TypeKind::ROW>::hashKind();
-    hashKindComputed_ = true;
+  auto hashKind = hashKind_.load(std::memory_order_relaxed);
+  if (hashKind == 0) {
+    hashKind = TypeBase<TypeKind::ROW>::hashKind();
+    hashKind_.store(hashKind, std::memory_order_relaxed);
   }
-  return hashKind_;
+  return hashKind;
 }
 
 void RowType::printChildren(std::stringstream& ss, std::string_view delimiter)

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1218,8 +1218,7 @@ class RowType : public TypeBase<TypeKind::ROW> {
   const std::vector<TypePtr> children_;
   mutable std::atomic<std::vector<TypeParameter>*> parameters_{nullptr};
   mutable std::atomic<NameToIndex*> nameToIndex_{nullptr};
-  mutable std::atomic_bool hashKindComputed_{false};
-  mutable std::atomic_size_t hashKind_;
+  mutable std::atomic_size_t hashKind_{0};
 };
 
 using RowTypePtr = std::shared_ptr<const RowType>;


### PR DESCRIPTION
fix(type): Make RowType::hashKind() thread-safe on AArch64
    
    The lazy cache added in 6b5a5f155860 (“Optimize RowType::hashKind”) used a
    relaxed load of the “computed” flag and left the cached value uninitialized.
    On weakly ordered CPUs (ARM/AArch64) a reader can observe `hashKindComputed_`
    == true before the write to `hashKind_` is visible, returning a stale/garbage
    value. This manifested as a deterministic failure of:
      TypeTest.rowHashKindMultiThreaded when run with multiple cores.
    
    Even though `hashKind_` and `hashKindComputed_` are stored in a sequentially-consistent
    order, the loading of them in the reader thread are not sequentially-consistent,
    because of the relaxed load. Using acquire–release would fix this,
    but there’s an even cheaper simplification.
    
    Fix: remove the flag and use a single atomic with a zero sentinel:
      - hashKind_ is std::atomic_size_t initialized to 0 (0 = “not computed”)
      - readers do: load(relaxed); if nonzero, return it
      - first thread computes v and store(relaxed) v into hashKind_
    Relaxed accesses are sufficient here because all synchronization is confined to
    the same atomic object (no cross-atomic publish/subscribe needed). Multiple
    threads may compute v concurrently, but they produce the same value and one
    store wins—benign.
    
    Result: removes the race on ARM, keeps sizeof(RowType) smaller, and makes the
    hot path a single relaxed load + branch. No functional API changes.