### PR TITLE
feat: Switch to use AsycSource for ParallelUnitLoader

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -56,8 +56,8 @@ class AsyncSource {
 
   ~AsyncSource() {
     VELOX_CHECK(
-        moved_ || closed_,
-        "AsyncSource should be properly consumed or closed.");
+        moved_ || closed_ || (cancelled_ && !making_),
+        "AsyncSource should be properly consumed, closed, or cancelled.");
   }
 
   // Makes an item if it is not already made. To be called on a background
@@ -163,6 +163,18 @@ class AsyncSource {
     return timing_;
   }
 
+  /// Cancels the task if it hasn't started yet.
+  /// If the task has already started, the task will continue but AsyncSource
+  /// is marked as cancelled to allow proper cleanup in destructor.
+  void cancel() {
+    std::lock_guard<std::mutex> l(mutex_);
+    cancelled_ = true;
+    if (make_ == nullptr) {
+      return;
+    }
+    make_ = nullptr;
+  }
+
   /// This function assists the caller in ensuring that resources allocated in
   /// AsyncSource are promptly released:
   /// 1. Waits for the completion of the 'make_' function if it is executing
@@ -217,5 +229,6 @@ class AsyncSource {
   CpuWallTiming timing_;
   bool closed_{false};
   bool moved_{false};
+  bool cancelled_{false};
 };
 } // namespace facebook::velox

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -634,11 +634,6 @@ void configureRowReaderOptions(
         hiveConfig->preserveFlatMapsInMemory(sessionProperties));
     rowReaderOptions.setParallelUnitLoadCount(
         hiveConfig->parallelUnitLoadCount(sessionProperties));
-    // When parallel unit loader is enabled, all units would be loaded by
-    // ParallelUnitLoader, thus disable eagerFirstStripeLoad.
-    if (hiveConfig->parallelUnitLoadCount(sessionProperties) > 0) {
-      rowReaderOptions.setEagerFirstStripeLoad(false);
-    }
   }
   rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -84,6 +84,7 @@ class TestReaderP
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    facebook::velox::common::testutil::TestValue::enable();
   }
 
   folly::Executor* executor() {
@@ -106,6 +107,7 @@ class TestReader : public testing::Test, public VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    facebook::velox::common::testutil::TestValue::enable();
   }
 
   std::vector<VectorPtr> createBatches(
@@ -2855,10 +2857,9 @@ DEBUG_ONLY_TEST_F(TestReader, asyncLoadSurvivesReaderDestruction) {
   std::atomic<int> asyncLoadsCompleted{0};
   folly::Baton<> readerDestroyed;
 
-  facebook::velox::common::testutil::TestValue::enable();
-  facebook::velox::common::testutil::TestValue::set(
+  SCOPED_TESTVALUE_SET(
       "facebook::velox::dwio::common::ParallelUnitLoader::load",
-      std::function<void(std::shared_ptr<LoadUnit>*)>([&](auto*) {
+      std::function<void(void*)>([&](void*) {
         // Only block the second stripe (index 1) - let the first stripe load
         // normally so rowReader->next() can complete
         // fetch_add returns the value before increment: 0 for first, 1 for
@@ -2916,7 +2917,6 @@ DEBUG_ONLY_TEST_F(TestReader, asyncLoadSurvivesReaderDestruction) {
 
   // Clean up
   ioExecutor->join();
-  facebook::velox::common::testutil::TestValue::disable();
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Improve thread efficiency by switching to use AsycSource
- when load() is queued and not running on IOThreadPool, allow caller (driver thread) to directly pick up the work
- when ParallelUnitLoader is destroyed, cancel any load() that hasn't started running

Differential Revision: D87993259


