### PR TITLE
refactor: Remove unused 'velox_memory_pool_debug_enabled' flag

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -41,7 +41,6 @@
 #include "velox/common/memory/MemoryPool.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
-DECLARE_bool(velox_memory_pool_debug_enabled);
 DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
 
 namespace facebook::velox::memory {

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -29,7 +29,6 @@
 #include "velox/common/memory/MemoryArbitrator.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
-DECLARE_bool(velox_memory_pool_debug_enabled);
 DECLARE_bool(velox_memory_pool_capacity_transfer_across_tasks);
 
 namespace facebook::velox::exec {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -31,7 +31,6 @@
 #include "velox/common/testutil/TestValue.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
-DECLARE_bool(velox_memory_pool_debug_enabled);
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 
 using namespace ::testing;
@@ -2531,7 +2530,6 @@ TEST_P(MemoryPoolTest, concurrentUpdateToDifferentPools) {
 }
 
 TEST_P(MemoryPoolTest, concurrentUpdatesToTheSamePool) {
-  FLAGS_velox_memory_pool_debug_enabled = true;
   if (!isLeafThreadSafe_) {
     return;
   }
@@ -2717,7 +2715,6 @@ TEST(MemoryPoolTest, visitChildren) {
 }
 
 TEST(MemoryPoolTest, debugMode) {
-  FLAGS_velox_memory_pool_debug_enabled = true;
   constexpr int64_t kMaxMemory = 10 * GB;
   constexpr int64_t kNumIterations = 100;
   const std::vector<int64_t> kAllocSizes = {128, 8 * KB, 2 * MB};
@@ -2915,7 +2912,6 @@ TEST(MemoryPoolTest, debugModeWithFilter) {
 }
 
 TEST_P(MemoryPoolTest, debugModeWrapCapException) {
-  FLAGS_velox_memory_pool_debug_enabled = true;
   const uint64_t kMaxCap = 128L * MB;
   MemoryManager::Options options;
   options.allocatorCapacity = kMaxCap;

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -100,11 +100,6 @@ DEFINE_bool(
     false,
     "If true, check fails on any memory leaks in memory pool and memory manager");
 
-DEFINE_bool(
-    velox_memory_pool_debug_enabled,
-    false,
-    "If true, 'MemoryPool' will be running in debug mode to track the allocation and free call sites to detect the source of memory leak for testing purpose");
-
 // TODO: deprecate this after solves all the use cases that can cause
 // significant performance regression by memory usage tracking.
 DEFINE_bool(


### PR DESCRIPTION
The 'velox_memory_pool_debug_enabled' flag is no longer used in the
codebase.  Memory pool debugging is now controlled through the
`MemoryPool::DebugOptions` struct which allows for more granular
control of debugging features per memory pool.

This change completely removes its declaration from the code.