### PR TITLE
fix(build): Literal overload for long on macOS

### DIFF
--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -323,7 +323,7 @@ TEST_F(PlanBuilderTest, filter) {
   VELOX_CHECK_EQ(
       PlanBuilder()
           .tableScan("tmp", data)
-          .filter(col("c0") + 10L > 100L)
+          .filter(col("c0") + 10LL > 100LL)
           .planNode()
           ->toString(true, false),
       expectation);


### PR DESCRIPTION
PR #15615 added a test that uses the literal "10L" that on macOS resolves to the long integral type and for which there was no "lit" function overload resulting in ambiguous usage of lit.