### PR TITLE
fix: Avoid string conversions due to TestValue

### DIFF
--- a/velox/common/testutil/TestValue.cpp
+++ b/velox/common/testutil/TestValue.cpp
@@ -20,7 +20,7 @@ namespace facebook::velox::common::testutil {
 
 std::mutex TestValue::mutex_;
 bool TestValue::enabled_ = false;
-std::unordered_map<std::string, TestValue::Callback> TestValue::injectionMap_;
+folly::F14FastMap<std::string, TestValue::Callback> TestValue::injectionMap_;
 
 #ifndef NDEBUG
 void TestValue::enable() {
@@ -38,12 +38,12 @@ bool TestValue::enabled() {
   return enabled_;
 }
 
-void TestValue::clear(const std::string& injectionPoint) {
+void TestValue::clear(std::string_view injectionPoint) {
   std::lock_guard<std::mutex> l(mutex_);
   injectionMap_.erase(injectionPoint);
 }
 
-void TestValue::adjust(const std::string& injectionPoint, void* testData) {
+void TestValue::adjust(std::string_view injectionPoint, void* testData) {
   Callback injectionCb;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -60,7 +60,7 @@ void TestValue::disable() {}
 bool TestValue::enabled() {
   return false;
 }
-void TestValue::clear(const std::string& injectionPoint) {}
+void TestValue::clear(std::string_view injectionPoint) {}
 #endif
 
 } // namespace facebook::velox::common::testutil


### PR DESCRIPTION
Summary:
The API demands a `std::string&`, but some call sites pass a `const char*` literal.   One particularly expensive call site was added in D86994206.

Use `std::string_view` instead, and change the `injectionMap_` to F14, which supports heterogenous lookup.

Reviewed By: kalman5

Differential Revision: D87908637


