### PR TITLE
feat: Add rewrite for IN special form

### DIFF
--- a/velox/common/base/CompareFlags.h
+++ b/velox/common/base/CompareFlags.h
@@ -84,7 +84,7 @@ struct CompareFlags {
     ///       ex: (null, 1) = (null, 1) is indeterminate.
     ///
     ///       - If all fields compare results are true, then result is true.
-    ///       ex: (1, 1) = (1, 1) is indeterminate.
+    ///       ex: (1, 1) = (1, 1) is true.
     ///
     ///   4. Maps:
     ///     - Keys are compared first, if keys are not equal values are not

--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -341,6 +341,28 @@ bool ConstantTypedExpr::equals(const ITypedExpr& other) const {
   return this->value_ == casted->value_;
 }
 
+std::optional<bool> ConstantTypedExpr::equals(
+    const ITypedExpr& other,
+    CompareFlags::NullHandlingMode nullHandlingMode,
+    memory::MemoryPool* pool) const {
+  const auto* casted = dynamic_cast<const ConstantTypedExpr*>(&other);
+  if (!casted) {
+    return false;
+  }
+  if (*this->type() != *casted->type()) {
+    return false;
+  }
+
+  const auto valueVector = this->hasValueVector()
+      ? this->valueVector_
+      : this->toConstantVector(pool);
+  const auto castedValueVector = casted->hasValueVector()
+      ? casted->valueVector_
+      : casted->toConstantVector(pool);
+  return valueVector->equalValueAt(
+      castedValueVector.get(), 0, 0, nullHandlingMode);
+}
+
 namespace {
 
 uint64_t hashImpl(const TypePtr& type, const Variant& value);

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -139,6 +139,25 @@ class ConstantTypedExpr : public ITypedExpr {
 
   bool equals(const ITypedExpr& other) const;
 
+  /// Compares this constant expression with another for equality using the
+  /// specified null handling mode.
+  ///
+  /// @param other The expression to compare with.
+  /// @param nullHandlingMode Determines how nulls are compared.
+  ///   - kNullAsValue: null == null is true, null == value is false.
+  ///   - kNullAsIndeterminate: null comparison may be indeterminate and could
+  ///     return std::nullopt.
+  /// @param pool Memory pool used to convert constant expressions with variant
+  ///     to a constant vector for comparison with nullHandlingMode.
+  /// TODO: Add support for comparing Variants with kNullAsIndeterminate null
+  ///  comparison mode.
+  /// @return true if expressions are equal, false if not equal, std::nullopt
+  ///     if the result is indeterminate (only with kNullAsIndeterminate mode).
+  std::optional<bool> equals(
+      const ITypedExpr& other,
+      CompareFlags::NullHandlingMode nullHandlingMode,
+      memory::MemoryPool* pool) const;
+
   bool operator==(const ITypedExpr& other) const final {
     return this->equals(other);
   }

--- a/velox/expression/CoalesceRewrite.cpp
+++ b/velox/expression/CoalesceRewrite.cpp
@@ -22,7 +22,9 @@
 
 namespace facebook::velox::expression {
 
-core::TypedExprPtr CoalesceRewrite::rewrite(const core::TypedExprPtr& expr) {
+core::TypedExprPtr CoalesceRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* /*pool*/) {
   if (!expr->isCallKind()) {
     return nullptr;
   }

--- a/velox/expression/CoalesceRewrite.h
+++ b/velox/expression/CoalesceRewrite.h
@@ -32,7 +32,9 @@ class CoalesceRewrite {
   /// If there is a single input to COALESCE after pruning inputs, COALESCE is
   /// simplified to this expression. Otherwise, returns an optimized COALESCE
   /// expression with pruned inputs.
-  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* /*pool*/);
 
   static void registerRewrite();
 };

--- a/velox/expression/ConjunctRewrite.cpp
+++ b/velox/expression/ConjunctRewrite.cpp
@@ -22,7 +22,9 @@
 
 namespace facebook::velox::expression {
 
-core::TypedExprPtr ConjunctRewrite::rewrite(const core::TypedExprPtr& expr) {
+core::TypedExprPtr ConjunctRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* /*pool*/) {
   if (!expr->isCallKind()) {
     return nullptr;
   }

--- a/velox/expression/ConjunctRewrite.h
+++ b/velox/expression/ConjunctRewrite.h
@@ -28,7 +28,9 @@ class ConjunctRewrite {
   /// is only one input to the conjunct after its inputs are pruned, rewrites
   /// the conjunct expression to this input. Otherwise, returns an optimized
   /// conjunct expression with pruned inputs.
-  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* /*pool*/);
 
   static void registerRewrite();
 };

--- a/velox/expression/ExprOptimizer.cpp
+++ b/velox/expression/ExprOptimizer.cpp
@@ -122,7 +122,7 @@ core::TypedExprPtr optimize(
   if (allInputsConstant) {
     return tryConstantFold(result, queryCtx, pool, makeFailExpr);
   }
-  return ExprRewriteRegistry::instance().rewrite(result);
+  return ExprRewriteRegistry::instance().rewrite(result, pool);
 }
 
 } // namespace facebook::velox::expression

--- a/velox/expression/ExprRewriteRegistry.cpp
+++ b/velox/expression/ExprRewriteRegistry.cpp
@@ -27,7 +27,8 @@ void ExprRewriteRegistry::clear() {
 }
 
 core::TypedExprPtr ExprRewriteRegistry::rewrite(
-    const core::TypedExprPtr& expr) {
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* pool) {
   const auto& inputs = expr->inputs();
   VELOX_CHECK(
       std::any_of(
@@ -42,7 +43,7 @@ core::TypedExprPtr ExprRewriteRegistry::rewrite(
   registry_.withRLock([&](const auto& list) {
     for (const auto& rewrite : list) {
       VELOX_CHECK_NOT_NULL(rewrite);
-      if (auto rewritten = (rewrite)(expr)) {
+      if (auto rewritten = (rewrite)(expr, pool)) {
         result = rewritten;
         break;
       }

--- a/velox/expression/ExprRewriteRegistry.h
+++ b/velox/expression/ExprRewriteRegistry.h
@@ -22,8 +22,8 @@ namespace facebook::velox::expression {
 
 /// An expression re-writer that takes an expression and returns an equivalent
 /// expression or nullptr if re-write is not possible.
-using ExpressionRewrite =
-    std::function<core::TypedExprPtr(const core::TypedExprPtr)>;
+using ExpressionRewrite = std::function<
+    core::TypedExprPtr(const core::TypedExprPtr, memory::MemoryPool*)>;
 
 class ExprRewriteRegistry {
  public:
@@ -40,7 +40,9 @@ class ExprRewriteRegistry {
 
   /// Rewrites input expression to an equivalent expression. Throws if the
   /// expression only has constant inputs.
-  core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* pool);
 
   static ExprRewriteRegistry& instance() {
     static ExprRewriteRegistry kInstance;

--- a/velox/expression/SwitchRewrite.cpp
+++ b/velox/expression/SwitchRewrite.cpp
@@ -22,7 +22,9 @@
 
 namespace facebook::velox::expression {
 
-core::TypedExprPtr SwitchRewrite::rewrite(const core::TypedExprPtr& expr) {
+core::TypedExprPtr SwitchRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* /*pool*/) {
   if (!expr->isCallKind()) {
     return nullptr;
   }

--- a/velox/expression/SwitchRewrite.h
+++ b/velox/expression/SwitchRewrite.h
@@ -36,7 +36,9 @@ class SwitchRewrite {
   /// returned if it is present; otherwise NULL is returned. The else value is
   /// added to the inputs otherwise and the optimized SWITCH expression with
   /// pruned inputs is returned.
-  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* /*pool*/);
 
   static void registerRewrite();
 };

--- a/velox/expression/tests/ExprRewriteRegistryTest.cpp
+++ b/velox/expression/tests/ExprRewriteRegistryTest.cpp
@@ -25,7 +25,7 @@ class ExprRewriteRegistryTest : public testing::Test {};
 TEST_F(ExprRewriteRegistryTest, basic) {
   expression::ExprRewriteRegistry registry;
   expression::ExpressionRewrite testRewrite =
-      [&](const core::TypedExprPtr& input) {
+      [&](const core::TypedExprPtr& input, memory::MemoryPool* /*pool*/) {
         return std::make_shared<core::CallTypedExpr>(
             input->type(), "rewritten_expr", input, input);
       };
@@ -35,7 +35,7 @@ TEST_F(ExprRewriteRegistryTest, basic) {
       BIGINT(),
       "original_expr",
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "a"));
-  const auto rewritten = registry.rewrite(input);
+  const auto rewritten = registry.rewrite(input, nullptr);
   ASSERT_TRUE(rewritten->isCallKind());
   ASSERT_TRUE(rewritten->type()->isBigint());
   const auto rewrittenCall = rewritten->asUnchecked<core::CallTypedExpr>();
@@ -43,7 +43,7 @@ TEST_F(ExprRewriteRegistryTest, basic) {
   ASSERT_EQ(rewrittenCall->name(), "rewritten_expr");
 
   registry.clear();
-  const auto rewriteAfterClear = registry.rewrite(input);
+  const auto rewriteAfterClear = registry.rewrite(input, nullptr);
   ASSERT_TRUE(*rewriteAfterClear == *input);
 }
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2612,6 +2612,60 @@ TEST_F(ExprTest, constantEqualsNullConsistency) {
   EXPECT_TRUE(nullVariantToExpr->equals(*nullBaseVectorToExpr));
 }
 
+TEST_F(ExprTest, constantEqualsNullHandlingMode) {
+  // {1: null} == {1: null} is
+  //  - indeterminate for kNullAsIndeterminate mode.
+  //  - true for kNullAsValue mode.
+  const auto type = MAP(BIGINT(), BIGINT());
+  auto assertNullComparison = [this](
+                                  const core::ConstantTypedExprPtr& a,
+                                  const core::ConstantTypedExprPtr& b) {
+    EXPECT_EQ(
+        a->equals(
+            *b, CompareFlags::NullHandlingMode::kNullAsIndeterminate, pool()),
+        std::nullopt);
+    EXPECT_EQ(
+        a->equals(*b, CompareFlags::NullHandlingMode::kNullAsValue, pool()),
+        true);
+  };
+
+  // Test Variant - Variant comparison.
+  auto mapVariant =
+      Variant::map({{Variant(1LL), Variant::null(TypeKind::BIGINT)}});
+  auto a = std::make_shared<core::ConstantTypedExpr>(type, mapVariant);
+  auto b = std::make_shared<core::ConstantTypedExpr>(type, mapVariant);
+  assertNullComparison(a, b);
+
+  // Test Vector - Vector comparison.
+  auto mapVector = BaseVector::wrapInConstant(
+      1, 0, makeMapVectorFromJson<int64_t, int64_t>({"{1: null}"}));
+  a = std::make_shared<core::ConstantTypedExpr>(mapVector);
+  b = std::make_shared<core::ConstantTypedExpr>(mapVector);
+  assertNullComparison(a, b);
+
+  // Test Variant - Vector comparison.
+  a = std::make_shared<core::ConstantTypedExpr>(type, mapVariant);
+  b = std::make_shared<core::ConstantTypedExpr>(mapVector);
+  assertNullComparison(a, b);
+
+  // {1: null, 2: 2} = {1: null, 2: 3} is false for both kNullAsValue and
+  // kNullAsIndeterminate modes.
+  a = std::make_shared<core::ConstantTypedExpr>(
+      type,
+      Variant::map(
+          {{Variant(1LL), Variant::null(TypeKind::BIGINT)}, {2LL, 2LL}}));
+  mapVector = BaseVector::wrapInConstant(
+      1, 0, makeMapVectorFromJson<int32_t, int32_t>({"{1: null, 2: 3}"}));
+  b = std::make_shared<core::ConstantTypedExpr>(mapVector);
+  EXPECT_EQ(
+      a->equals(
+          *b, CompareFlags::NullHandlingMode::kNullAsIndeterminate, pool()),
+      false);
+  EXPECT_EQ(
+      a->equals(*b, CompareFlags::NullHandlingMode::kNullAsValue, pool()),
+      false);
+}
+
 // Verify consistency of ConstantTypeExpr::toString/hash/equals APIs. The
 // outcome should not depend on whether expression was created using a Variant
 // of a Vector.

--- a/velox/expression/tests/SpecialFormRewriteTestBase.cpp
+++ b/velox/expression/tests/SpecialFormRewriteTestBase.cpp
@@ -39,7 +39,7 @@ void SpecialFormRewriteTestBase::testRewrite(
     const RowTypePtr& type) {
   const auto typedExpr = makeTypedExpr(expr, type);
   const auto rewritten =
-      expression::ExprRewriteRegistry::instance().rewrite(typedExpr);
+      expression::ExprRewriteRegistry::instance().rewrite(typedExpr, nullptr);
   const auto expectedExpr = makeTypedExpr(expected, type);
   if (*rewritten != *expectedExpr) {
     SCOPED_TRACE(fmt::format("Input: {}", typedExpr->toString()));

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -35,6 +35,7 @@ velox_add_library(
   FindFirst.cpp
   FromUtf8.cpp
   InPredicate.cpp
+  InRewrite.cpp
   JsonFunctions.cpp
   Map.cpp
   MapEntries.cpp

--- a/velox/functions/prestosql/InRewrite.cpp
+++ b/velox/functions/prestosql/InRewrite.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/InRewrite.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+
+namespace facebook::velox::functions {
+
+core::TypedExprPtr InRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* pool) {
+  // IN expression with a non-NULL constant value can be rewritten.
+  if (expr->inputs().empty() || !expr->inputs()[0]->isConstantKind()) {
+    return nullptr;
+  }
+
+  if (!expr->isCallKind()) {
+    return nullptr;
+  }
+  static const char* kIn = "in";
+  const auto* callExpr = expr->asUnchecked<core::CallTypedExpr>();
+  if (callExpr->name() != kIn) {
+    return nullptr;
+  }
+
+  const auto& valueExpr = callExpr->inputs().at(0);
+  const auto* constValueExpr =
+      valueExpr->asUnchecked<core::ConstantTypedExpr>();
+  const auto& inputs = callExpr->inputs();
+  const auto numInputs = inputs.size();
+  std::vector<core::TypedExprPtr> optimizedInputs;
+  optimizedInputs.emplace_back(valueExpr);
+
+  for (auto i = 1; i < numInputs; i++) {
+    const auto& input = inputs[i];
+    if (input->isConstantKind()) {
+      // Ensure comparison of constants follows Presto's semantics for NULL
+      // comparison and accounts for indeterminate result.
+      static constexpr auto kNullAsIndeterminate =
+          CompareFlags::NullHandlingMode::kNullAsIndeterminate;
+      const auto* constInput = input->asUnchecked<core::ConstantTypedExpr>();
+      auto compareResult =
+          constInput->equals(*constValueExpr, kNullAsIndeterminate, pool);
+
+      if UNLIKELY (!compareResult.has_value()) {
+        optimizedInputs.push_back(input);
+      } else if (compareResult.value()) {
+        return std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true);
+      }
+    } else {
+      optimizedInputs.push_back(input);
+    }
+  }
+
+  VELOX_CHECK(!optimizedInputs.empty(), "No inputs to IN after rewrite.");
+  return std::make_shared<core::CallTypedExpr>(
+      expr->type(), std::move(optimizedInputs), callExpr->name());
+}
+
+void InRewrite::registerRewrite() {
+  expression::ExprRewriteRegistry::instance().registerRewrite(
+      functions::InRewrite::rewrite);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/InRewrite.h
+++ b/velox/functions/prestosql/InRewrite.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::functions {
+
+class InRewrite {
+ public:
+  /// Rewrites IN special form function when the `value` being searched for is
+  /// a non-NULL constant and the IN-list is not constant. Returns `true` if
+  /// `value` is in the IN-list. Removes constant expressions from IN-list that
+  /// are not equal to `value`.
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* pool);
+
+  static void registerRewrite();
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -425,7 +425,9 @@ VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
 
 void registerReduceRewrites(const std::string& prefix) {
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix](const auto& expr) { return rewriteReduce(prefix, expr); });
+      [prefix](const auto& expr, memory::MemoryPool* /*pool*/) {
+        return rewriteReduce(prefix, expr);
+      });
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -182,7 +182,7 @@ void registerArrayFunctions(const std::string& prefix) {
 
   auto checker = std::make_shared<SimpleComparisonChecker>();
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix, checker](const auto& expr) {
+      [prefix, checker](const auto& expr, memory::MemoryPool* /*pool*/) {
         return rewriteArraySortCall(prefix, expr, checker);
       });
 

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/Fail.h"
 #include "velox/functions/prestosql/GreatestLeast.h"
 #include "velox/functions/prestosql/InPredicate.h"
+#include "velox/functions/prestosql/InRewrite.h"
 #include "velox/functions/prestosql/Reduce.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
@@ -79,6 +80,8 @@ void registerAllSpecialFormGeneralFunctions() {
       bool,
       Generic<T1>,
       Variadic<Generic<T1>>>({"in"});
+  InRewrite::registerRewrite();
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, expression::kRowConstructor);
   registerIsNullFunction("is_null");
 }

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -197,7 +197,7 @@ void registerSplitToMap(const std::string& prefix) {
       Varchar,
       bool>({"$internal$split_to_map"});
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix](const auto& expr) {
+      [prefix](const auto& expr, memory::MemoryPool* /*pool*/) {
         return rewriteSplitToMapCall(prefix, expr);
       });
 }

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -74,6 +74,7 @@ add_executable(
   P4HyperLogLogCastTest.cpp
   SetDigestCastTest.cpp
   InPredicateTest.cpp
+  InRewriteTest.cpp
   IntegerFunctionsTest.cpp
   IPAddressCastTest.cpp
   IPPrefixCastTest.cpp

--- a/velox/functions/prestosql/tests/InRewriteTest.cpp
+++ b/velox/functions/prestosql/tests/InRewriteTest.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/core/Expressions.h"
+#include "velox/expression/ExprRewriteRegistry.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+class InRewriteTest : public functions::test::FunctionBaseTest {
+ protected:
+  static core::TypedExprPtr constant(
+      const TypePtr& type,
+      const Variant& value) {
+    return std::make_shared<core::ConstantTypedExpr>(type, value);
+  }
+
+  static core::TypedExprPtr field(
+      const TypePtr& type,
+      const std::string& name) {
+    return std::make_shared<core::FieldAccessTypedExpr>(type, name);
+  }
+
+  static core::TypedExprPtr makeIn(
+      std::initializer_list<core::TypedExprPtr> inputs) {
+    return std::make_shared<core::CallTypedExpr>(BOOLEAN(), "in", inputs);
+  }
+
+  bool testInRewrite(
+      const core::TypedExprPtr& expr,
+      const core::TypedExprPtr& expected) {
+    const auto rewritten =
+        expression::ExprRewriteRegistry::instance().rewrite(expr, pool());
+    return *rewritten == *expected;
+  }
+};
+
+TEST_F(InRewriteTest, basic) {
+  // 1234 in (2, a, b, 1234) -> true
+  auto in = makeIn(
+      {constant(INTEGER(), 1234),
+       constant(INTEGER(), 2),
+       field(INTEGER(), "a"),
+       field(INTEGER(), "b"),
+       constant(INTEGER(), 1234)});
+  auto expected = constant(BOOLEAN(), true);
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // 81 in (2, 4, a, b, 9) -> 81 in (a, b)
+  in = makeIn(
+      {constant(INTEGER(), 81),
+       constant(INTEGER(), 2),
+       field(INTEGER(), "a"),
+       constant(INTEGER(), 4),
+       field(INTEGER(), "b"),
+       constant(INTEGER(), 9)});
+  expected = makeIn(
+      {constant(INTEGER(), 81), field(INTEGER(), "a"), field(INTEGER(), "b")});
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // 5 in (NULL, a, 5) -> true
+  in = makeIn(
+      {constant(BIGINT(), 5LL),
+       constant(BIGINT(), variant::null(TypeKind::BIGINT)),
+       field(BIGINT(), "a"),
+       constant(BIGINT(), 5LL)});
+  expected = constant(BOOLEAN(), true);
+  ASSERT_TRUE(testInRewrite(in, expected));
+
+  // 'hello' in ('foo', NULL, 'bar', a, b) -> 'hello' in (NULL, a, b)
+  in = makeIn(
+      {constant(VARCHAR(), "hello"),
+       constant(VARCHAR(), "foo"),
+       constant(VARCHAR(), variant::null(TypeKind::VARCHAR)),
+       constant(VARCHAR(), "bar"),
+       field(VARCHAR(), "a"),
+       field(VARCHAR(), "b")});
+  expected = makeIn(
+      {constant(VARCHAR(), "hello"),
+       constant(VARCHAR(), variant::null(TypeKind::VARCHAR)),
+       field(VARCHAR(), "a"),
+       field(VARCHAR(), "b")});
+  ASSERT_TRUE(testInRewrite(in, expected));
+}
+
+TEST_F(InRewriteTest, nullAsIndeterminate) {
+  // NULL in (5, NULL, a) -> NULL in (5, NULL, a)
+  auto in = makeIn(
+      {constant(BIGINT(), variant::null(TypeKind::BIGINT)),
+       constant(BIGINT(), 5LL),
+       constant(BIGINT(), variant::null(TypeKind::BIGINT)),
+       field(BIGINT(), "a")});
+  ASSERT_TRUE(testInRewrite(in, in));
+
+  // NULL in ('foo', a, 'bar', NULL) -> NULL in ('foo', a, 'bar', NULL)
+  in = makeIn(
+      {constant(VARCHAR(), variant::null(TypeKind::VARCHAR)),
+       constant(VARCHAR(), "foo"),
+       field(VARCHAR(), "a"),
+       constant(VARCHAR(), "bar"),
+       constant(VARCHAR(), variant::null(TypeKind::VARCHAR))});
+  ASSERT_TRUE(testInRewrite(in, in));
+
+  // {0: null} IN ({0: 1}, c2) -> {0: null} IN ({0: 1}, c2)
+  auto c0 = BaseVector::wrapInConstant(
+      1, 0, makeMapVectorFromJson<int32_t, int32_t>({"{0: null}"}));
+  auto c1 = BaseVector::wrapInConstant(
+      1, 0, makeMapVectorFromJson<int32_t, int32_t>({"{0: 1}"}));
+  auto c2 = makeMapVectorFromJson<int32_t, int32_t>({"{0: 1, 10: 2}"});
+  in = makeIn(
+      {std::make_shared<core::ConstantTypedExpr>(c0),
+       std::make_shared<core::ConstantTypedExpr>(c1),
+       std::make_shared<core::FieldAccessTypedExpr>(c2->type(), "c2")});
+  ASSERT_TRUE(testInRewrite(in, in));
+
+  // Result of {0: null} == {0: 1} is indeterminate; {0: null} IN ({0: 1}, c2)
+  // should not be simplified by rewrite and should evaluate to null.
+  auto result = evaluate(in, makeRowVector({"c0", "c1", "c2"}, {c0, c1, c2}));
+  velox::test::assertEqualVectors(
+      makeNullConstant(TypeKind::BOOLEAN, 1), result);
+}
+
+} // namespace
+} // namespace facebook::velox::functions

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -226,7 +226,7 @@ void registerArrayFunctions(const std::string& prefix) {
 
   auto checker = std::make_shared<SparkSimpleComparisonChecker>();
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix, checker](const auto& expr) {
+      [prefix, checker](const auto& expr, memory::MemoryPool* /*pool*/) {
         return rewriteArraySortCall(prefix, expr, checker);
       });
   exec::registerStatefulVectorFunction(


### PR DESCRIPTION
Rewrites IN special form when the `value` being searched for is constant. 

- Returns `true` if `value` is in the `IN-list`. 
- Removes constant elements from `IN-list` that do not match with `value`. 

Constant expression comparison for these 2 rules uses null-as-indeterminate null comparison mode in order to maintain consistency with the function implementation of IN predicate. 
Tests are added to ensure the correctness issue from https://github.com/facebookincubator/velox/issues/15648 is resolved.

Examples:

- 5 IN (NULL, a, 5) ==> true
- 5 IN (1, 2, a, b) ==> 5 IN (a, b)

Cherry-picked from https://github.com/facebookincubator/velox/pull/15488.

Depends on https://github.com/facebookincubator/velox/pull/15705, https://github.com/facebookincubator/velox/pull/15726.