### PR TITLE
fix: Greatest/least custom comparison; add Time/TimeWithTimezone support

### DIFF
--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/InPredicate.h"
 #include "velox/functions/prestosql/Reduce.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::functions {
@@ -60,6 +61,8 @@ void registerAllGreatestLeastFunctions(const std::string& prefix) {
   registerGreatestLeastFunction<Timestamp>(prefix);
   registerGreatestLeastFunction<TimestampWithTimezone>(prefix);
   registerGreatestLeastFunction<IPAddress>(prefix);
+  registerGreatestLeastFunction<Time>(prefix);
+  registerGreatestLeastFunction<TimeWithTimezone>(prefix);
 }
 } // namespace
 


### PR DESCRIPTION
Summary:
The greatest/least functions were extracting raw values (int64_t, int128_t) early and comparing them with standard operators, bypassing custom comparison logic. This caused incorrect results for types like IPAddress:

- IPAddress: Used signed int128_t comparison instead of unsigned byte-by-byte comparison (memcmp), causing addresses with high bit set (e.g., ffff::1) to compare as less than addresses starting with 0x00

The fix collects all arguments in a vector (preserving wrapper types) and compares them directly using their operator< and operator>, which trigger the custom compare() methods. The raw value is extracted only from the winning element at the end and hence fixes [#15620](https://github.com/facebookincubator/velox/issues/15620)

Additionally, this diff adds support for Time and TimeWithTimezone types in greatest/least functions (registration + tests), which also benefit from the custom comparison fix.

Differential Revision: D87961025
