### PR TITLE
feat(python): Add expression fluent API

### DIFF
--- a/python/test/test_expression_authoring.py
+++ b/python/test/test_expression_authoring.py
@@ -1,0 +1,101 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pyvelox.expression import col, lit
+
+
+class TestPyVeloxExpressionAuthoring(unittest.TestCase):
+    def test_expression_authoring(self):
+        # Column references.
+        c0 = col("c0")
+        c1 = col("c1")
+
+        self.assertEqual(str(c0), "\"c0\"")
+        self.assertEqual(str(c1), "\"c1\"")
+
+        # Literals.
+        li = lit(42)
+        ld = lit(0.42)
+        ls = lit("my str")
+
+        l_false = lit(False)
+        l_true = lit(True)
+        l_none = lit(None)
+
+        self.assertEqual(str(li), "42")
+        self.assertEqual(str(ld), "0.42")
+        self.assertEqual(str(ls), "my str")
+        self.assertEqual(str(l_false), "false")
+        self.assertEqual(str(l_true), "true")
+        self.assertEqual(str(l_none), "null")
+
+        # Arithmetics.
+        self.assertEqual(str(c0 + c1), "plus(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 + li), "plus(\"c0\",42)")
+        self.assertEqual(str(c0 + 42), "plus(\"c0\",42)")
+        self.assertEqual(str(42 + c0), "plus(42,\"c0\")")
+
+        self.assertEqual(str(c0 - c1), "minus(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 - li), "minus(\"c0\",42)")
+        self.assertEqual(str(c0 - 42), "minus(\"c0\",42)")
+        self.assertEqual(str(42 - c0), "minus(42,\"c0\")")
+
+        self.assertEqual(str(c0 * c1), "multiply(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 * li), "multiply(\"c0\",42)")
+        self.assertEqual(str(c0 * 42), "multiply(\"c0\",42)")
+        self.assertEqual(str(42 * c0), "multiply(42,\"c0\")")
+
+        self.assertEqual(str(c0 / c1), "divide(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 / li), "divide(\"c0\",42)")
+        self.assertEqual(str(c0 / 42), "divide(\"c0\",42)")
+        self.assertEqual(str(42 / c0), "divide(42,\"c0\")")
+
+        # Comparisons.
+        self.assertEqual(str(c0 > c1), "gt(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 > 19.2), "gt(\"c0\",19.2)")
+        self.assertEqual(str("asd" > c0), "lt(\"c0\",asd)")
+
+        self.assertEqual(str(c0 < c1), "lt(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 < 1), "lt(\"c0\",1)")
+        self.assertEqual(str(1 < c1), "gt(\"c1\",1)")
+
+        self.assertEqual(str(c0 <= c1), "lte(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 <= 1), "lte(\"c0\",1)")
+        self.assertEqual(str(1 <= c1), "gte(\"c1\",1)")
+
+        self.assertEqual(str(c0 >= c1), "gte(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 >= 1), "gte(\"c0\",1)")
+        self.assertEqual(str(1 >= c1), "lte(\"c1\",1)")
+
+        self.assertEqual(str(c0 == c1), "eq(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 == 1), "eq(\"c0\",1)")
+        self.assertEqual(str(1 == c1), "eq(\"c1\",1)")
+
+        self.assertEqual(str(c0 != c1), "neq(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 != 1), "neq(\"c0\",1)")
+        self.assertEqual(str(1 != c1), "neq(\"c1\",1)")
+
+        # Conjuncts
+        self.assertEqual(str(c0 & c1), "and(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 & True), "and(\"c0\",true)")
+        self.assertEqual(str(True & c0), "and(true,\"c0\")")
+
+        self.assertEqual(str(c0 | c1), "or(\"c0\",\"c1\")")
+        self.assertEqual(str(c0 | True), "or(\"c0\",true)")
+        self.assertEqual(str(True | c0), "or(true,\"c0\")")
+
+        self.assertEqual(str(~c0), "not(\"c0\")")
+        self.assertEqual(str(c0 & (c1 | ~c0)), "and(\"c0\",or(\"c1\",not(\"c0\")))")

--- a/velox/python/CMakeLists.txt
+++ b/velox/python/CMakeLists.txt
@@ -54,6 +54,10 @@ target_link_libraries(velox_py_type_lib velox_type pybind11::module)
 pyvelox_add_module(type MODULE type/type.cpp)
 target_link_libraries(type PRIVATE velox_py_type_lib)
 
+# pyvelox.expression library:
+pyvelox_add_module(expression MODULE expression/expression.cpp)
+target_link_libraries(expression PRIVATE velox_type velox_parse_expression pybind11::module)
+
 # pyvelox.file library:
 add_library(velox_py_file_lib file/PyFile.cpp)
 target_link_libraries(velox_py_file_lib velox_dwio_common velox_py_init pybind11::module)

--- a/velox/python/expression/PyExpression.h
+++ b/velox/python/expression/PyExpression.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "velox/parse/Expressions.h"
+#include "velox/parse/IExpr.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox::py {
+
+/// A thin wrapper around Velox untyped expressions.
+class PyExpr {
+ public:
+  explicit PyExpr(const core::ExprPtr expr = nullptr) : expr_(expr) {}
+
+  std::string toString() const {
+    if (!expr_) {
+      return "[nullptr]";
+    }
+    return expr_->toString();
+  }
+
+  core::ExprPtr expr() const {
+    return expr_;
+  }
+
+  static PyExpr createFieldAccess(const std::string& field) {
+    return PyExpr{std::make_shared<core::FieldAccessExpr>(field, std::nullopt)};
+  }
+
+  static PyExpr createConstant(const TypePtr& type, const Variant& value) {
+    return PyExpr{
+        std::make_shared<core::ConstantExpr>(type, value, std::nullopt)};
+  }
+
+  static PyExpr createCall(
+      const std::string& name,
+      std::vector<core::ExprPtr> args) {
+    return PyExpr{
+        std::make_shared<core::CallExpr>(name, std::move(args), std::nullopt)};
+  }
+
+ private:
+  core::ExprPtr expr_;
+};
+
+} // namespace facebook::velox::py

--- a/velox/python/expression/expression.cpp
+++ b/velox/python/expression/expression.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <pybind11/operators.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "velox/python/expression/PyExpression.h"
+#include "velox/type/Variant.h"
+
+namespace py = pybind11;
+namespace {
+
+using namespace facebook;
+
+/// Converts a given Python object into a Velox constant expression. Throws
+/// TypeError if it cannot convert.
+velox::py::PyExpr toConstantExpr(const py::object& arg) {
+  // Bool (True|False).
+  if (py::isinstance<py::bool_>(arg)) {
+    return velox::py::PyExpr::createConstant(
+        velox::BOOLEAN(), velox::Variant(arg.cast<bool>()));
+  }
+  // None.
+  else if (py::isinstance<py::none>(arg)) {
+    return velox::py::PyExpr::createConstant(
+        velox::UNKNOWN(), velox::Variant::null(velox::TypeKind::UNKNOWN));
+  }
+  // Integers. For now we assume always bigint (64 bits).
+  else if (py::isinstance<py::int_>(arg)) {
+    return velox::py::PyExpr::createConstant(
+        velox::BIGINT(), velox::Variant(arg.cast<int64_t>()));
+  }
+  // Floats. Assume always double (64 bits) for now.
+  else if (py::isinstance<py::float_>(arg)) {
+    return velox::py::PyExpr::createConstant(
+        velox::DOUBLE(), velox::Variant(arg.cast<double>()));
+  }
+  // Strings.
+  else if (py::isinstance<py::str>(arg)) {
+    return velox::py::PyExpr::createConstant(
+        velox::VARCHAR(), velox::Variant(arg.cast<std::string>()));
+  }
+  // TODO: Support container types (arrays/list, maps, and structs).
+  throw py::type_error(
+      fmt::format("Unsupported PyVelox literal type: {}", py::type::of(arg)));
+}
+
+velox::py::PyExpr toExpr(const py::object& arg) {
+  // If the object is already an expression, just return it.
+  if (py::isinstance<velox::py::PyExpr>(arg)) {
+    return arg.cast<velox::py::PyExpr>();
+  }
+  // Otherwise, try to convert to a literal/constant.
+  return toConstantExpr(arg);
+}
+
+} // namespace
+
+PYBIND11_MODULE(expression, m) {
+  using velox::py::PyExpr;
+
+  py::class_<PyExpr>(m, "Expr")
+      .def("__str__", &PyExpr::toString)
+      // Binary arithmetic operators.
+      .def(
+          "__add__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "plus", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__radd__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "plus", {toExpr(arg).expr(), self.expr()});
+          })
+      .def(
+          "__sub__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "minus", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__rsub__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "minus", {toExpr(arg).expr(), self.expr()});
+          })
+      .def(
+          "__mul__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "multiply", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__rmul__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "multiply", {toExpr(arg).expr(), self.expr()});
+          })
+      .def(
+          "__truediv__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "divide", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__rtruediv__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall(
+                "divide", {toExpr(arg).expr(), self.expr()});
+          })
+      // Conjunts.
+      .def(
+          "__and__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("and", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__rand__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("and", {toExpr(arg).expr(), self.expr()});
+          })
+      .def(
+          "__or__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("or", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__ror__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("or", {toExpr(arg).expr(), self.expr()});
+          })
+      .def(
+          "__invert__",
+          [](const PyExpr& self) {
+            return PyExpr::createCall("not", {self.expr()});
+          })
+      // Comparisons don't need a "right-hand" version of the method as python
+      // assumes them to be perfectly symmetrical.
+      .def(
+          "__gt__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("gt", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__lt__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("lt", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__ge__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("gte", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__le__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("lte", {self.expr(), toExpr(arg).expr()});
+          })
+      .def(
+          "__eq__",
+          [](const PyExpr& self, const py::object& arg) {
+            return PyExpr::createCall("eq", {self.expr(), toExpr(arg).expr()});
+          })
+      .def("__ne__", [](const PyExpr& self, const py::object& arg) {
+        return PyExpr::createCall("neq", {self.expr(), toExpr(arg).expr()});
+      });
+
+  // TODO: Add more arithmetics binary and unary operators.
+
+  m.def("col", &PyExpr::createFieldAccess, py::doc(R"(
+    Create a reference to a column. To be used when building expressions.
+  )"));
+  m.def("lit", &toConstantExpr, py::doc(R"(
+    Create a literal to be used when building expressions.
+  )"));
+}

--- a/velox/python/expression/expression.pyi
+++ b/velox/python/expression/expression.pyi
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pyre-unsafe
+
+class Expr:
+    pass
+
+def col(str) -> Expr: ...
+
+def lit(int) -> Expr: ...
+def lit(float) -> Expr: ...
+def lit(str) -> Expr: ...
+def lit(bool) -> Expr: ...


### PR DESCRIPTION
Summary:
Adding a fluent Python API to enable users to build expression without
having to necessarily rely on SQL. Following PySpark's syntax and philosophy,
where possible.

Differential Revision: D87718840


