### PR TITLE
fix(build): Ambiguity caused by long literal

### DIFF
--- a/velox/exec/tests/utils/ExpressionBuilder.h
+++ b/velox/exec/tests/utils/ExpressionBuilder.h
@@ -166,6 +166,9 @@ class ExprWrapper;
 template <typename T>
 inline ExprWrapper toExprWrapper(T value);
 
+// Specialization for long to avoid ambiguity.
+inline ExprWrapper toExprWrapper(long value);
+
 template <>
 inline ExprWrapper toExprWrapper<ExprWrapper>(ExprWrapper expr);
 
@@ -459,6 +462,10 @@ namespace detail {
 template <typename T>
 inline ExprWrapper toExprWrapper(T value) {
   return lit(value);
+}
+
+inline ExprWrapper toExprWrapper(long value) {
+  return lit(static_cast<int64_t>(value));
 }
 
 template <>


### PR DESCRIPTION
Fixes the below compilation exception caused by long ambiguity.

```
velox/exec/tests/utils/ExpressionBuilder.h:463:10: error: call to 'lit' is ambiguous
  463 |   return lit(value);
      |          ^~~
```

Error log: https://github.com/facebookincubator/velox/actions/runs/19849127249/job/56872221626?pr=15536