### PR TITLE
Use rapidhash rather than a crc32-ish hashing algorithm

### DIFF
--- a/velox/common/base/BitUtil.cpp
+++ b/velox/common/base/BitUtil.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/process/ProcessBase.h"
 
 #include <folly/BenchmarkUtil.h>
+#include <folly/hash/rapidhash.h>
 
 namespace facebook::velox::bits {
 
@@ -175,48 +176,6 @@ void scatterBits(
 }
 
 uint64_t hashBytes(uint64_t seed, const char* data, size_t size) {
-  auto begin = reinterpret_cast<const uint8_t*>(data);
-  const uint64_t kMul = 0x9ddfea08eb382d69ULL;
-  if (size < 8) {
-    auto word = loadPartialWord(begin, size);
-    uint64_t crc = simd::crc32U64(seed, word);
-    uint64_t crc2 = simd::crc32U64(seed, word >> 32);
-    return crc | (crc2 << 32);
-  }
-  uint64_t a0 = seed;
-  uint64_t a1 = seed << 32;
-  uint64_t a2 = seed >> 16;
-  int32_t toGo = size;
-  auto words = reinterpret_cast<const uint64_t*>(data);
-  while (toGo >= 24) {
-    a0 = simd::crc32U64(a0, words[0]);
-    a1 = simd::crc32U64(a1, words[1]);
-    a2 = simd::crc32U64(a2, words[2]);
-    words += 3;
-    toGo -= 24;
-  }
-  if (toGo > 16) {
-    a0 = simd::crc32U64(a0, words[0]);
-    a1 = simd::crc32U64(a1, words[1]);
-    a2 = simd::crc32U64(
-        a2,
-        loadPartialWord(
-            reinterpret_cast<const uint8_t*>(words + 2), toGo - 16));
-  } else if (toGo > 8) {
-    a0 = simd::crc32U64(a0, words[0]);
-    a1 = simd::crc32U64(
-        a1,
-        toGo == 16
-            ? words[1]
-            : loadPartialWord(
-                  reinterpret_cast<const uint8_t*>(words + 1), toGo - 8));
-  } else if (toGo > 0) {
-    a0 = simd::crc32U64(
-        a0,
-        toGo == 8
-            ? words[0]
-            : loadPartialWord(reinterpret_cast<const uint8_t*>(words), toGo));
-  }
-  return a0 ^ ((a1 * kMul)) ^ (a2 * kMul);
+  return folly::hash::rapidhashNano_with_seed(data, size, seed);
 }
 } // namespace facebook::velox::bits

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -290,6 +290,8 @@ inline size_t estimateSpaceNeeded(const StringView& value) {
 namespace std {
 template <>
 struct hash<::facebook::velox::StringView> {
+  using folly_is_avalanching = std::true_type;
+
   size_t operator()(const ::facebook::velox::StringView view) const {
     return facebook::velox::bits::hashBytes(1, view.data(), view.size());
   }
@@ -300,6 +302,8 @@ namespace folly {
 
 template <>
 struct hasher<::facebook::velox::StringView> {
+  using folly_is_avalanching = std::true_type;
+
   size_t operator()(const ::facebook::velox::StringView view) const {
     return facebook::velox::bits::hashBytes(1, view.data(), view.size());
   }


### PR DESCRIPTION
Summary: This should be faster than the crc32 implementation on most platforms, and aligns with a change Folly has already made for F14 tables.

Differential Revision: D87956701


