### PR TITLE
fix: Fix the uninitialized executor_ pointer

### DIFF
--- a/velox/common/file/tests/FaultyFileSystem.h
+++ b/velox/common/file/tests/FaultyFileSystem.h
@@ -176,7 +176,7 @@ class FaultyFileSystem : public FileSystem {
   mutable std::mutex mu_;
   std::optional<FileInjections> fileInjections_;
   std::optional<FileSystemInjections> fsInjections_;
-  folly::Executor* executor_;
+  folly::Executor* executor_{nullptr};
 };
 
 /// Registers the faulty filesystem.


### PR DESCRIPTION
Summary:
Fix a crash in  folly::SemiFuture<uint64_t> FaultyReadFile::preadvAsync 
The executor is no appropriated initialized, so executor_ contains random garbage from memory

```
if (delegatedFile_->hasPreadvAsync() || executor_ == nullptr) {
    return delegatedFile_->preadvAsync(offset, buffers, fileStorageContext);
  }
...
 executor_->add([this causing crash

Differential Revision: D88204034


