### PR TITLE
fix: Handle NULL values in comparison filter generation

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -136,6 +136,9 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
   if (!value) {
     return nullptr;
   }
+  if (value->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
 
   auto lessThanFilter = makeLessThanFilter(valueExpr, evaluator);
   if (!lessThanFilter) {
@@ -180,6 +183,9 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeEqualFilter(
   if (!value) {
     return nullptr;
   }
+  if (value->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
   switch (value->typeKind()) {
     case TypeKind::BOOLEAN:
       return boolEqual(singleValue<bool>(value));
@@ -210,6 +216,9 @@ ExprToSubfieldFilterParser::makeGreaterThanFilter(
   auto lower = toConstant(lowerExpr, evaluator);
   if (!lower) {
     return nullptr;
+  }
+  if (lower->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
   }
   switch (lower->typeKind()) {
     case TypeKind::TINYINT:
@@ -242,6 +251,9 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeLessThanFilter(
   auto upper = toConstant(upperExpr, evaluator);
   if (!upper) {
     return nullptr;
+  }
+  if (upper->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
   }
   switch (upper->typeKind()) {
     case TypeKind::TINYINT:
@@ -276,6 +288,9 @@ ExprToSubfieldFilterParser::makeLessThanOrEqualFilter(
   if (!upper) {
     return nullptr;
   }
+  if (upper->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
+  }
   switch (upper->typeKind()) {
     case TypeKind::TINYINT:
       return lessThanOrEqual(singleValue<int8_t>(upper));
@@ -308,6 +323,9 @@ ExprToSubfieldFilterParser::makeGreaterThanOrEqualFilter(
   auto lower = toConstant(lowerExpr, evaluator);
   if (!lower) {
     return nullptr;
+  }
+  if (lower->isNullAt(0)) {
+    return std::make_unique<common::AlwaysFalse>();
   }
   switch (lower->typeKind()) {
     case TypeKind::TINYINT:

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -354,6 +354,164 @@ TEST_F(ExprToSubfieldFilterTest, makeOrFilterFloat) {
   }
 }
 
+// Test NULL comparison handling - comparisons with NULL should return
+// AlwaysFalse as per SQL three-valued logic
+TEST_F(ExprToSubfieldFilterTest, eqNull) {
+  auto call = parseCallExpr("a = cast(null as bigint)", ROW("a", BIGINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, eqNullVarchar) {
+  auto call = parseCallExpr("a = cast(null as varchar)", ROW("a", VARCHAR()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, eqNullTimestamp) {
+  auto call =
+      parseCallExpr("a = cast(null as timestamp)", ROW("a", TIMESTAMP()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, neqNull) {
+  auto call = parseCallExpr("a <> cast(null as bigint)", ROW("a", BIGINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, ltNull) {
+  auto call = parseCallExpr("a < cast(null as bigint)", ROW("a", BIGINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, ltNullDouble) {
+  auto call = parseCallExpr("a < cast(null as double)", ROW("a", DOUBLE()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, ltNullVarchar) {
+  auto call = parseCallExpr("a < cast(null as varchar)", ROW("a", VARCHAR()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, lteNull) {
+  auto call = parseCallExpr("a <= cast(null as bigint)", ROW("a", BIGINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, lteNullReal) {
+  auto call = parseCallExpr("a <= cast(null as real)", ROW("a", REAL()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, gtNull) {
+  auto call = parseCallExpr("a > cast(null as bigint)", ROW("a", BIGINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, gtNullInteger) {
+  auto call = parseCallExpr("a > cast(null as integer)", ROW("a", INTEGER()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, gteNull) {
+  auto call = parseCallExpr("a >= cast(null as bigint)", ROW("a", BIGINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, gteNullSmallint) {
+  auto call =
+      parseCallExpr("a >= cast(null as smallint)", ROW("a", SMALLINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
+TEST_F(ExprToSubfieldFilterTest, gteNullTinyint) {
+  auto call = parseCallExpr("a >= cast(null as tinyint)", ROW("a", TINYINT()));
+  auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+  ASSERT_TRUE(filter);
+  validateSubfield(subfield, {"a"});
+
+  auto expected = std::make_unique<common::AlwaysFalse>();
+  VELOX_ASSERT_FILTER(expected, filter);
+}
+
 } // namespace
 } // namespace facebook::velox::exec
 


### PR DESCRIPTION
## Summary
This PR fixes an issue discovered in https://github.com/apache/spark/pull/45202 where Spark pushes down predicates like `b > null` to Velox.

## Problem
The `ExprToSubfieldFilterParser` currently does not check whether constant expressions are NULL. When NULL values are encountered, they are converted to default values, resulting in incorrect filter generation.

## Solution
If the constant value is NULL, return AlwaysFalse filter instead of nullptr.

This change correctly implements SQL three-valued logic: comparisons with NULL always result in NULL, which in filter context means no rows match. Returning AlwaysFalse explicitly represents this semantic, allowing optimizers to recognize and optimize away these conditions.

## Affected Operators
Comparison operators: =, !=, <, <=, >, >=

## Modified Functions
Modified functions in ExprToSubfieldFilterParser:
- makeNotEqualFilter
- makeEqualFilter
- makeGreaterThanFilter
- makeLessThanFilter
- makeLessThanOrEqualFilter
- makeGreaterThanOrEqualFilter