### PR TITLE
fix: Call prepareReuse on argVectors in AggregateWindow to clear string buffers

### DIFF
--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -257,10 +257,10 @@ class AggregateWindowFunction : public exec::WindowFunction {
   void fillArgVectors(vector_size_t firstRow, vector_size_t lastRow) {
     vector_size_t numFrameRows = lastRow + 1 - firstRow;
     for (int i = 0; i < argIndices_.size(); i++) {
-      // Without the following call to `prepareForReuse`, if the type of `argVectors_[i]`
-      // is VARCHAR, then the string buffers will accumulate across calculations.
-      // As a result, memory consumption will increase over time. So we call
-      // `prepareForReuse` to clear string buffers timely.
+      // Without the following call to `prepareForReuse`, if the type of
+      // `argVectors_[i]` is VARCHAR, then the string buffers will accumulate
+      // across calculations. As a result, memory consumption will increase over
+      // time. So we call `prepareForReuse` to clear string buffers timely.
       argVectors_[i]->prepareForReuse();
       argVectors_[i]->resize(numFrameRows);
       // Only non-constant field argument vectors need to be populated. The

--- a/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
+++ b/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
@@ -109,7 +109,8 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     SparkWindowTest,
     testing::ValuesIn(getSparkWindowTestParams()));
 
-class SparkAggregateWindowLimitMemoryTest : public exec::test::OperatorTestBase {
+class SparkAggregateWindowLimitMemoryTest
+    : public exec::test::OperatorTestBase {
  public:
   static void SetUpTestCase() {
     OperatorTestBase::SetUpTestCase();
@@ -136,9 +137,11 @@ class SparkAggregateWindowLimitMemoryTest : public exec::test::OperatorTestBase 
 // the limit and cause failure.
 // The capacity is calculated as:
 //   1. size of input data: 1 rows * 32KB (the length of the string) = 32KB
-//   2. size of RowContainer: ((1,024 rows * 32KB (data) + 1,024 rows * 32KB (Accumulators))) * 3 = 192MB
+//   2. size of RowContainer: ((1,024 rows * 32KB (data) + 1,024 rows * 32KB
+//      (Accumulators))) * 3 = 192MB
 //      (Accumulators won't be destroyed now)
-//   3. size of results: 10 rows * 32KB * 2 (column 'd' and the result column) = 640KB
+//   3. size of results: 10 rows * 32KB * 2 (column 'd' and the result column) =
+//      640KB
 //   4. other overheads
 //    Total: ~ 192MB
 // If we don't clear the string buffers in time, the size of the string buffers
@@ -149,18 +152,16 @@ TEST_F(SparkAggregateWindowLimitMemoryTest, clearStringBuffersInTime) {
   constexpr vector_size_t size = 1'024 * 3;
   constexpr vector_size_t resultSize = 10;
   // For this test, it is important to create a single-row partition.
-  // When we process a new partition, we will call 'fillArgVectors' in 'AggregateWindow'.
-  // Single-row partition can let us call 'fillArgVectors' as many as possible.
-  // If we don't call 'prepareForReuse' in 'fillArgVectors', the string buffers
-  // will accumulate and cause high memory usage.
+  // When we process a new partition, we will call 'fillArgVectors' in
+  // 'AggregateWindow'. Single-row partition can let us call 'fillArgVectors' as
+  // many as possible. If we don't call 'prepareForReuse' in 'fillArgVectors',
+  // the string buffers will accumulate and cause high memory usage.
   auto data = makeRowVector(
       {"d", "p"},
-      {
-          // Payload Data.
-          makeConstant(std::string(32 * 1024, 'a'), size),
-          // Partition key.
-          makeFlatVector<int16_t>(size, [](auto row) { return row; })
-      });
+      {// Payload Data.
+       makeConstant(std::string(32 * 1024, 'a'), size),
+       // Partition key.
+       makeFlatVector<int16_t>(size, [](auto row) { return row; })});
 
   createDuckDbTable({data});
 
@@ -169,27 +170,31 @@ TEST_F(SparkAggregateWindowLimitMemoryTest, clearStringBuffersInTime) {
                   .streamingWindow({"first(d) over (partition by p)"})
                   // We use LIMIT clause here to limit the result size to limit
                   // the memory consumed by results.
-                  // Besides, we set offset to 'size - resultSize' to make the Window operator
-                  // process all window partitions. In this way, if we don't clear
-                  // the string buffers during the window function processing,
-                  // the string buffers would accumulate to cause high memory usage.
+                  // Besides, we set offset to 'size - resultSize' to make the
+                  // Window operator process all window partitions. In this way,
+                  // if we don't clear the string buffers during the window
+                  // function processing, the string buffers would accumulate to
+                  // cause high memory usage.
                   // TODO: remove the use of LIMIT clause
-                  // after fixing https://github.com/facebookincubator/velox/issues/16210
+                  // after fixing
+                  // https://github.com/facebookincubator/velox/issues/16210
                   .limit(size - resultSize, resultSize, true)
                   .planNode();
 
-  const auto realResultSize = AssertQueryBuilder(plan)
-      .serialExecution(true)
-      // Because we set offset to 'size - resultSize' in the LIMIT clause,
-      // the Window operator will produce intermediate results that will be
-      // discarded by LIMIT clause.
-      // Set preferred output batch rows to 10 to limit the memory
-      // consumed by these intermediate results.
-      // By limiting the memory consumed by input and intermediate results,
-      // we can know that the reason why we can pass this test is that we clear
-      // the string buffers in time during the window function processing.
-      .config(core::QueryConfig::kPreferredOutputBatchRows, resultSize)
-      .countResults();
+  const auto realResultSize =
+      AssertQueryBuilder(plan)
+          .serialExecution(true)
+          // Because we set offset to 'size - resultSize' in the LIMIT clause,
+          // the Window operator will produce intermediate results that will be
+          // discarded by LIMIT clause.
+          // Set preferred output batch rows to 10 to limit the memory
+          // consumed by these intermediate results.
+          // By limiting the memory consumed by input and intermediate results,
+          // we can know that the reason why we can pass this test is that we
+          // clear the string buffers in time during the window function
+          // processing.
+          .config(core::QueryConfig::kPreferredOutputBatchRows, resultSize)
+          .countResults();
   ASSERT_EQ(realResultSize, resultSize);
 }
 


### PR DESCRIPTION
Currently, after processing one window, `AggregateWindow` will only call `resize` on `argVectors_` and [resize](https://github.com/facebookincubator/velox/blob/main/velox/vector/FlatVector-inl.h#L449) does not clear string buffers if the new size is not 0. As a result, `AggregateWindow` may consume a large amount of memory over time.

This PR fixes the issue by calling `prepareReuse` on `argVectors_` when resetting a new partition to clear the string buffers.