### PR TITLE
fix: Fix build failure due to undefined symbols registerOrcReaderFactory

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -149,6 +149,7 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_common_exception
   velox_dwio_common_test_utils
+  velox_dwio_orc_reader
   velox_dwio_parquet_reader
   velox_dwio_parquet_writer
   velox_exec


### PR DESCRIPTION
Resolve #15682