### PR TITLE
fix: Fix build velox_exec_test

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -151,6 +151,7 @@ target_link_libraries(
   velox_dwio_common_test_utils
   velox_dwio_parquet_reader
   velox_dwio_parquet_writer
+  velox_dwio_orc_reader
   velox_exec
   velox_exec_test_lib
   velox_file_test_utils


### PR DESCRIPTION
When build only velox_exec_test with the command `/Applications/CMake.app/Contents/bin/cmake --build /Users/chengchengjin/code/velox/build --config Debug --target velox_exec_test --`
```
[build] Undefined symbols for architecture arm64:
[build]   "facebook::velox::orc::registerOrcReaderFactory()", referenced from:
[build]       facebook::velox::exec::(anonymous namespace)::TableScanTest::SetUp() in TableScanTest.cpp.o
[build] ld: symbol(s) not found for architecture arm64
[build] clang++: error: linker command failed with exit code 1 (use -v to see invocation)
[build] ninja: build stopped: subcommand failed.
```