### PR TITLE
perf: Inline testInt64 and testValues for frequently used filter types

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -438,6 +438,8 @@ class SelectivityIterator {
 template <typename Callable>
 inline void SelectivityVector::applyToSelected(Callable func) const {
   if (isAllSelected()) {
+    // IMPORTANT: Do not remove this line.  Without it the compiler would not be
+    // able to vectorize or unroll the loop.
     const auto end = end_;
     for (vector_size_t row = begin_; row < end; ++row) {
       func(row);


### PR DESCRIPTION
Summary:
These methods are often used in performance sensitive tight loops, and
inlining them can give us benefits including loop unrolling, constant folding,
and auto vectorization.

The implementation is not changed, just moving the code from cpp file to header
file.

Differential Revision: D88273788


