### PR TITLE
feat: Support variant-to-vector for DECIMAL types

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -807,16 +807,6 @@ struct VariantToVector {
   }
 };
 
-template <>
-struct VariantToVector<TypeKind::HUGEINT> {
-  static VectorPtr makeVector(
-      TypePtr type,
-      const std::vector<Variant>& /*data*/,
-      memory::MemoryPool* /*pool*/) {
-    VELOX_NYI("Type not supported: {}", type->toString());
-  }
-};
-
 template <TypeKind KIND>
 struct VariantToVector<
     KIND,

--- a/velox/vector/VariantToVector.h
+++ b/velox/vector/VariantToVector.h
@@ -21,8 +21,7 @@ namespace facebook::velox {
 
 // Converts Variant `value` into a Velox vector using specified type.
 //
-// Supports all primitive types and complex types that do not contain DECIMAL
-// types.
+// Supports all primitive types and complex types.
 //
 // @returns ConstantVector of size 1.
 //

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -85,9 +85,8 @@ TEST_F(VariantToVectorTest, decimal) {
       Variant(arrayData[0]), Variant(arrayData[1]), Variant(arrayData[2])};
   Variant arrayInput = Variant::array(arrayInputData);
 
-  VELOX_ASSERT_THROW(
-      BaseVector::createConstant(ARRAY(type), arrayInput, 1, pool()),
-      "Type not supported: DECIMAL(20, 3)");
+  auto expectedVector = makeArrayVector<int128_t>({arrayData}, type);
+  testValue(ARRAY(type), arrayInput, expectedVector);
 }
 
 TEST_F(VariantToVectorTest, timestamp) {


### PR DESCRIPTION
Previously, variant-to-vector conversion did not support DECIMAL types.
I observed that DECIMAL can be handled the same way as other FixedWidth
types. Therefore, the template specialization for HUGEINT can be
removed, allowing the generic implementation to handle it.