### PR TITLE
perf: Add noGroupsSpanBatches flag to streaming aggregation for optimize output processing

### DIFF
--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -188,7 +188,8 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
         testData.hasPreAggregation ? preGroupingKeys : emptyPreGroupingKeys,
         testData.isDistinct ? emptyAggregateNames : aggregateNames,
         testData.isDistinct ? emptyAggregates : aggregates,
-        false,
+        /*ignoreNullKeys=*/false,
+        /*noGroupsSpanBatches=*/false,
         valueNode_);
     auto queryCtx = getSpillQueryCtx(
         testData.isSpillEnabled,

--- a/velox/docs/develop/aggregations.rst
+++ b/velox/docs/develop/aggregations.rst
@@ -112,6 +112,27 @@ encounters a row with a different values in pre-grouped keys. This helps reduce
 the total amount of memory used and allows to unblock downstream operators
 faster.
 
+noGroupsSpanBatches Optimization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AggregationNode supports an optional ``noGroupsSpanBatches`` flag that can be set
+to true for streaming aggregations. When enabled, this flag indicates that no
+sort group spans across input batches - each input batch contains complete data
+for its groups, and no group will appear in any subsequent input batch.
+
+This optimization allows the StreamingAggregation operator to immediately produce
+aggregation results for all groups in each input batch without waiting to see if
+more data for those groups will arrive in subsequent batches. This can
+significantly improve output latency and reduce memory usage since the operator
+doesn't need to hold onto partial aggregation state across batches.
+
+The ``noGroupsSpanBatches`` flag can only be set when the aggregation is
+pre-grouped (streaming). Setting it on a non-streaming aggregation will result
+in an error.
+
+This optimization is typically set automatically by query optimizers when they can
+guarantee that the input data meets the required properties.
+
 Push-Down into Table Scan
 -------------------------
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -44,7 +44,8 @@ StreamingAggregation::StreamingAggregation(
       maxOutputBatchBytes_{
           operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes()},
       aggregationNode_{aggregationNode},
-      step_{aggregationNode->step()} {
+      step_{aggregationNode->step()},
+      noGroupsSpanBatches_{aggregationNode_->noGroupsSpanBatches()} {
   if (aggregationNode_->ignoreNullKeys()) {
     VELOX_UNSUPPORTED(
         "Streaming aggregation doesn't support ignoring null keys yet");
@@ -367,21 +368,31 @@ RowVectorPtr StreamingAggregation::getOutput() {
   const bool outputDueToBatchSize = numGroups_ > minOutputBatchSize_;
   const bool outputDueToBatchBytes =
       numGroups_ > 1 && estimatedBatchBytes > maxOutputBatchBytes_;
-  if (numPrevGroups > 0 && (outputDueToBatchSize || outputDueToBatchBytes)) {
+  if ((noGroupsSpanBatches_ || numPrevGroups > 0) &&
+      (outputDueToBatchSize || outputDueToBatchBytes)) {
     size_t numOutputGroups{0};
-    // NOTE: we only want to apply the single group output optimization if
-    // 'minOutputBatchSize_' is set to one for eagerly streaming output
-    // producing.
-    if (!prevGroupAssigned || numPrevGroups == 1 || minOutputBatchSize_ != 1) {
-      numOutputGroups = std::min(numGroups_ - 1, numPrevGroups);
+    if (noGroupsSpanBatches_) {
+      numOutputGroups = numGroups_;
     } else {
-      numOutputGroups = std::min(numGroups_ - 1, numPrevGroups - 1);
-      outputFirstGroup_ = (numGroups_ - numOutputGroups) > 1;
+      // NOTE: we only want to apply the single group output optimization if
+      // 'minOutputBatchSize_' is set to one for eagerly streaming output
+      // producing.
+      if (!prevGroupAssigned || numPrevGroups == 1 ||
+          minOutputBatchSize_ != 1) {
+        numOutputGroups = std::min(numGroups_ - 1, numPrevGroups);
+      } else {
+        numOutputGroups = std::min(numGroups_ - 1, numPrevGroups - 1);
+        outputFirstGroup_ = (numGroups_ - numOutputGroups) > 1;
+      }
     }
     VELOX_CHECK_GT(numOutputGroups, 0);
     output = createOutput(numOutputGroups);
   }
   prevInput_ = input_;
+  if (numGroups_ == 0) {
+    VELOX_CHECK(noGroupsSpanBatches_);
+    prevInput_ = nullptr;
+  }
   input_ = nullptr;
   return output;
 }

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -105,6 +105,11 @@ class StreamingAggregation : public Operator {
 
   const core::AggregationNode::Step step_;
 
+  // When true, indicates that no sort group spans across input batches. Each
+  // input batch contains complete data for its groups. This allows the
+  // streaming aggregation operator to produce all group results for each input.
+  const bool noGroupsSpanBatches_;
+
   std::vector<column_index_t> groupingKeys_;
   std::vector<AggregateInfo> aggregates_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;

--- a/velox/exec/TraceUtil.cpp
+++ b/velox/exec/TraceUtil.cpp
@@ -356,6 +356,7 @@ core::PlanNodePtr getTraceNode(
         aggregationNode->globalGroupingSets(),
         aggregationNode->groupId(),
         aggregationNode->ignoreNullKeys(),
+        aggregationNode->noGroupsSpanBatches(),
         std::make_shared<DummySourceNode>(
             aggregationNode->sources().front()->outputType()));
   }

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -482,7 +482,8 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
               std::vector<core::FieldAccessTypedExprPtr>{},
               std::vector<std::string>{"agg"},
               aggregates,
-              false,
+              /*ignoreNullKeys=*/false,
+              /*noGroupsSpanBatches=*/false,
               std::move(source));
         })
         .planNode();
@@ -543,7 +544,8 @@ TEST_F(AggregationTest, missingLambdaFunction) {
                         std::vector<core::FieldAccessTypedExprPtr>{},
                         std::vector<std::string>{"agg"},
                         aggregates,
-                        false,
+                        /*ignoreNullKeys=*/false,
+                        /*noGroupsSpanBatches=*/false,
                         std::move(source));
                   })
                   .planNode();

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -928,6 +928,7 @@ core::PlanNodePtr PlanBuilder::createIntermediateOrFinalAggregation(
       partialAggNode->aggregateNames(),
       aggregates,
       partialAggNode->ignoreNullKeys(),
+      partialAggNode->noGroupsSpanBatches(),
       planNode_);
   VELOX_CHECK_EQ(
       aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
@@ -1133,6 +1134,7 @@ PlanBuilder& PlanBuilder::aggregation(
       globalGroupingSets,
       groupId,
       ignoreNullKeys,
+      /*noGroupsSpanBatches=*/false,
       planNode_);
   VELOX_CHECK_EQ(
       aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
@@ -1145,7 +1147,8 @@ PlanBuilder& PlanBuilder::streamingAggregation(
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& masks,
     core::AggregationNode::Step step,
-    bool ignoreNullKeys) {
+    bool ignoreNullKeys,
+    bool noGroupsSpanBatches) {
   auto aggregatesAndNames =
       createAggregateExpressionsAndNames(aggregates, masks, step);
   auto aggregationNode = std::make_shared<core::AggregationNode>(
@@ -1156,6 +1159,7 @@ PlanBuilder& PlanBuilder::streamingAggregation(
       aggregatesAndNames.names,
       aggregatesAndNames.aggregates,
       ignoreNullKeys,
+      noGroupsSpanBatches,
       planNode_);
   VELOX_CHECK_EQ(
       aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1049,7 +1049,8 @@ class PlanBuilder {
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& masks,
       core::AggregationNode::Step step,
-      bool ignoreNullKeys);
+      bool ignoreNullKeys,
+      bool noGroupsSpanBatches = false);
 
   /// Add a GroupIdNode using the specified grouping keys, grouping sets,
   /// aggregation inputs and a groupId column name.

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -495,7 +495,8 @@ PlanNodePtr toVeloxPlan(
       std::vector<FieldAccessTypedExprPtr>{}, // preGroupedKeys
       names,
       std::move(aggregates),
-      false, // ignoreNullKeys
+      /*ignoreNullKeys=*/false,
+      /*noGroupsSpanBatches=*/false,
       source);
 }
 


### PR DESCRIPTION
Summary: This change adds a noGroupsSpanBatches flag to streaming aggregation in Velox. When the optimizer knows that no sort group spans across input batches (each input batch contains complete data for its groups), the streaming aggregation operator can immediately produce results for all groups in each batch without waiting to see if more data for those groups will arrive. This optimization improves output latency and reduces memory usage.

Differential Revision: D88054187


