### PR TITLE
misc: Back out batch serialization with preserve encoding option support in remote functions (#15703)

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.cpp
+++ b/velox/functions/remote/client/RemoteVectorFunction.cpp
@@ -18,7 +18,6 @@
 
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/remote/if/GetSerde.h"
-#include "velox/serializers/PrestoSerializer.h"
 #include "velox/type/fbhive/HiveTypeSerializer.h"
 
 namespace facebook::velox::functions {
@@ -29,16 +28,6 @@ std::string serializeType(const TypePtr& type) {
   return type::fbhive::HiveTypeSerializer::serialize(type);
 }
 
-std::unique_ptr<VectorSerde::Options> getOptions(remote::PageFormat format) {
-  if (format == remote::PageFormat::PRESTO_PAGE) {
-    auto options = std::make_unique<
-        serializer::presto::PrestoVectorSerde::PrestoOptions>();
-    options->preserveEncodings = true;
-    return options;
-  }
-  return std::make_unique<VectorSerde::Options>();
-}
-
 } // namespace
 
 RemoteVectorFunction::RemoteVectorFunction(
@@ -47,7 +36,6 @@ RemoteVectorFunction::RemoteVectorFunction(
     const RemoteVectorFunctionMetadata& metadata)
     : functionName_(functionName),
       serdeFormat_(metadata.serdeFormat),
-      serdeOptions_(getOptions(serdeFormat_)),
       serde_(getSerde(serdeFormat_)) {
   std::vector<TypePtr> types;
   types.reserve(inputArgs.size());
@@ -104,7 +92,7 @@ void RemoteVectorFunction::applyRemote(
 
   // TODO: serialize only active rows.
   requestInputs->payload_ref() = rowVectorToIOBuf(
-      remoteRowVector, *context.pool(), serde_.get(), serdeOptions_.get());
+      remoteRowVector, rows.end(), *context.pool(), serde_.get());
 
   std::unique_ptr<remote::RemoteFunctionResponse> remoteResponse;
 

--- a/velox/functions/remote/client/RemoteVectorFunction.h
+++ b/velox/functions/remote/client/RemoteVectorFunction.h
@@ -64,7 +64,6 @@ class RemoteVectorFunction : public exec::VectorFunction {
   const std::string functionName_;
 
   remote::PageFormat serdeFormat_;
-  std::unique_ptr<VectorSerde::Options> serdeOptions_;
   std::unique_ptr<VectorSerde> serde_;
 
   // Structures we construct once to cache:

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -292,27 +292,24 @@ void VectorStreamGroup::read(
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     memory::MemoryPool& pool,
-    VectorSerde* serde,
-    const VectorSerde::Options* options) {
-  return rowVectorToIOBuf(rowVector, rowVector->size(), pool, serde, options);
+    VectorSerde* serde) {
+  return rowVectorToIOBuf(rowVector, rowVector->size(), pool, serde);
 }
 
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     vector_size_t rangeEnd,
     memory::MemoryPool& pool,
-    VectorSerde* serde,
-    const VectorSerde::Options* options) {
-  // Use BatchVectorSerializer with provided options (e.g., preserveEncodings).
-  // If serde is null, use the default registered serde.
-  auto* serdeToUse = serde != nullptr ? serde : getVectorSerde();
-  auto serializer = serdeToUse->createBatchSerializer(&pool, options);
+    VectorSerde* serde) {
+  auto streamGroup = std::make_unique<VectorStreamGroup>(&pool, serde);
+  streamGroup->createStreamTree(asRowType(rowVector->type()), rangeEnd);
 
-  IOBufOutputStream stream(pool);
   IndexRange range{0, rangeEnd};
   Scratch scratch;
-  serializer->serialize(rowVector, folly::Range(&range, 1), scratch, &stream);
+  streamGroup->append(rowVector, folly::Range<IndexRange*>(&range, 1), scratch);
 
+  IOBufOutputStream stream(pool);
+  streamGroup->flush(&stream);
   return std::move(*stream.getIOBuf());
 }
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -498,16 +498,14 @@ class VectorStreamGroup : public StreamArena {
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     memory::MemoryPool& pool,
-    VectorSerde* serde = nullptr,
-    const VectorSerde::Options* options = nullptr);
+    VectorSerde* serde = nullptr);
 
 /// Same as above but serializes up until row `rangeEnd`.
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     vector_size_t rangeEnd,
     memory::MemoryPool& pool,
-    VectorSerde* serde = nullptr,
-    const VectorSerde::Options* options = nullptr);
+    VectorSerde* serde = nullptr);
 
 /// Convenience function to deserialize an IOBuf into a rowVector. If `serde` is
 /// nullptr, use the default installed serializer.


### PR DESCRIPTION
Summary:

Original commit changeset: 9976c4af1fc5

Original Phabricator Diff: D87873415

We are seeing crashes in both LogarithmLeafService and LogarithmFrontend P2067237549

Differential Revision: D88425172


