### PR TITLE
refactor: Support memory pool in expression rewrites

### DIFF
--- a/velox/expression/CoalesceRewrite.cpp
+++ b/velox/expression/CoalesceRewrite.cpp
@@ -22,7 +22,9 @@
 
 namespace facebook::velox::expression {
 
-core::TypedExprPtr CoalesceRewrite::rewrite(const core::TypedExprPtr& expr) {
+core::TypedExprPtr CoalesceRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* /*pool*/) {
   if (!expr->isCallKind()) {
     return nullptr;
   }

--- a/velox/expression/CoalesceRewrite.h
+++ b/velox/expression/CoalesceRewrite.h
@@ -32,7 +32,9 @@ class CoalesceRewrite {
   /// If there is a single input to COALESCE after pruning inputs, COALESCE is
   /// simplified to this expression. Otherwise, returns an optimized COALESCE
   /// expression with pruned inputs.
-  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* /*pool*/);
 
   static void registerRewrite();
 };

--- a/velox/expression/ConjunctRewrite.cpp
+++ b/velox/expression/ConjunctRewrite.cpp
@@ -22,7 +22,9 @@
 
 namespace facebook::velox::expression {
 
-core::TypedExprPtr ConjunctRewrite::rewrite(const core::TypedExprPtr& expr) {
+core::TypedExprPtr ConjunctRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* /*pool*/) {
   if (!expr->isCallKind()) {
     return nullptr;
   }

--- a/velox/expression/ConjunctRewrite.h
+++ b/velox/expression/ConjunctRewrite.h
@@ -28,7 +28,9 @@ class ConjunctRewrite {
   /// is only one input to the conjunct after its inputs are pruned, rewrites
   /// the conjunct expression to this input. Otherwise, returns an optimized
   /// conjunct expression with pruned inputs.
-  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* /*pool*/);
 
   static void registerRewrite();
 };

--- a/velox/expression/ExprOptimizer.cpp
+++ b/velox/expression/ExprOptimizer.cpp
@@ -122,7 +122,7 @@ core::TypedExprPtr optimize(
   if (allInputsConstant) {
     return tryConstantFold(result, queryCtx, pool, makeFailExpr);
   }
-  return ExprRewriteRegistry::instance().rewrite(result);
+  return ExprRewriteRegistry::instance().rewrite(result, pool);
 }
 
 } // namespace facebook::velox::expression

--- a/velox/expression/ExprRewriteRegistry.cpp
+++ b/velox/expression/ExprRewriteRegistry.cpp
@@ -27,7 +27,8 @@ void ExprRewriteRegistry::clear() {
 }
 
 core::TypedExprPtr ExprRewriteRegistry::rewrite(
-    const core::TypedExprPtr& expr) {
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* pool) {
   const auto& inputs = expr->inputs();
   VELOX_CHECK(
       std::any_of(
@@ -42,7 +43,7 @@ core::TypedExprPtr ExprRewriteRegistry::rewrite(
   registry_.withRLock([&](const auto& list) {
     for (const auto& rewrite : list) {
       VELOX_CHECK_NOT_NULL(rewrite);
-      if (auto rewritten = (rewrite)(expr)) {
+      if (auto rewritten = (rewrite)(expr, pool)) {
         result = rewritten;
         break;
       }

--- a/velox/expression/ExprRewriteRegistry.h
+++ b/velox/expression/ExprRewriteRegistry.h
@@ -22,8 +22,8 @@ namespace facebook::velox::expression {
 
 /// An expression re-writer that takes an expression and returns an equivalent
 /// expression or nullptr if re-write is not possible.
-using ExpressionRewrite =
-    std::function<core::TypedExprPtr(const core::TypedExprPtr)>;
+using ExpressionRewrite = std::function<
+    core::TypedExprPtr(const core::TypedExprPtr, memory::MemoryPool*)>;
 
 class ExprRewriteRegistry {
  public:
@@ -40,7 +40,9 @@ class ExprRewriteRegistry {
 
   /// Rewrites input expression to an equivalent expression. Throws if the
   /// expression only has constant inputs.
-  core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* pool);
 
   static ExprRewriteRegistry& instance() {
     static ExprRewriteRegistry kInstance;

--- a/velox/expression/SwitchRewrite.cpp
+++ b/velox/expression/SwitchRewrite.cpp
@@ -22,7 +22,9 @@
 
 namespace facebook::velox::expression {
 
-core::TypedExprPtr SwitchRewrite::rewrite(const core::TypedExprPtr& expr) {
+core::TypedExprPtr SwitchRewrite::rewrite(
+    const core::TypedExprPtr& expr,
+    memory::MemoryPool* /*pool*/) {
   if (!expr->isCallKind()) {
     return nullptr;
   }

--- a/velox/expression/SwitchRewrite.h
+++ b/velox/expression/SwitchRewrite.h
@@ -36,7 +36,9 @@ class SwitchRewrite {
   /// returned if it is present; otherwise NULL is returned. The else value is
   /// added to the inputs otherwise and the optimized SWITCH expression with
   /// pruned inputs is returned.
-  static core::TypedExprPtr rewrite(const core::TypedExprPtr& expr);
+  static core::TypedExprPtr rewrite(
+      const core::TypedExprPtr& expr,
+      memory::MemoryPool* /*pool*/);
 
   static void registerRewrite();
 };

--- a/velox/expression/tests/ExprRewriteRegistryTest.cpp
+++ b/velox/expression/tests/ExprRewriteRegistryTest.cpp
@@ -25,7 +25,7 @@ class ExprRewriteRegistryTest : public testing::Test {};
 TEST_F(ExprRewriteRegistryTest, basic) {
   expression::ExprRewriteRegistry registry;
   expression::ExpressionRewrite testRewrite =
-      [&](const core::TypedExprPtr& input) {
+      [&](const core::TypedExprPtr& input, memory::MemoryPool* /*pool*/) {
         return std::make_shared<core::CallTypedExpr>(
             input->type(), "rewritten_expr", input, input);
       };
@@ -35,7 +35,7 @@ TEST_F(ExprRewriteRegistryTest, basic) {
       BIGINT(),
       "original_expr",
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "a"));
-  const auto rewritten = registry.rewrite(input);
+  const auto rewritten = registry.rewrite(input, nullptr);
   ASSERT_TRUE(rewritten->isCallKind());
   ASSERT_TRUE(rewritten->type()->isBigint());
   const auto rewrittenCall = rewritten->asUnchecked<core::CallTypedExpr>();
@@ -43,7 +43,7 @@ TEST_F(ExprRewriteRegistryTest, basic) {
   ASSERT_EQ(rewrittenCall->name(), "rewritten_expr");
 
   registry.clear();
-  const auto rewriteAfterClear = registry.rewrite(input);
+  const auto rewriteAfterClear = registry.rewrite(input, nullptr);
   ASSERT_TRUE(*rewriteAfterClear == *input);
 }
 

--- a/velox/expression/tests/SpecialFormRewriteTestBase.cpp
+++ b/velox/expression/tests/SpecialFormRewriteTestBase.cpp
@@ -39,7 +39,7 @@ void SpecialFormRewriteTestBase::testRewrite(
     const RowTypePtr& type) {
   const auto typedExpr = makeTypedExpr(expr, type);
   const auto rewritten =
-      expression::ExprRewriteRegistry::instance().rewrite(typedExpr);
+      expression::ExprRewriteRegistry::instance().rewrite(typedExpr, nullptr);
   const auto expectedExpr = makeTypedExpr(expected, type);
   if (*rewritten != *expectedExpr) {
     SCOPED_TRACE(fmt::format("Input: {}", typedExpr->toString()));

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -425,7 +425,9 @@ VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
 
 void registerReduceRewrites(const std::string& prefix) {
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix](const auto& expr) { return rewriteReduce(prefix, expr); });
+      [prefix](const auto& expr, memory::MemoryPool* /*pool*/) {
+        return rewriteReduce(prefix, expr);
+      });
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -182,7 +182,7 @@ void registerArrayFunctions(const std::string& prefix) {
 
   auto checker = std::make_shared<SimpleComparisonChecker>();
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix, checker](const auto& expr) {
+      [prefix, checker](const auto& expr, memory::MemoryPool* /*pool*/) {
         return rewriteArraySortCall(prefix, expr, checker);
       });
 

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -197,7 +197,7 @@ void registerSplitToMap(const std::string& prefix) {
       Varchar,
       bool>({"$internal$split_to_map"});
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix](const auto& expr) {
+      [prefix](const auto& expr, memory::MemoryPool* /*pool*/) {
         return rewriteSplitToMapCall(prefix, expr);
       });
 }

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -226,7 +226,7 @@ void registerArrayFunctions(const std::string& prefix) {
 
   auto checker = std::make_shared<SparkSimpleComparisonChecker>();
   expression::ExprRewriteRegistry::instance().registerRewrite(
-      [prefix, checker](const auto& expr) {
+      [prefix, checker](const auto& expr, memory::MemoryPool* /*pool*/) {
         return rewriteArraySortCall(prefix, expr, checker);
       });
   exec::registerStatefulVectorFunction(


### PR DESCRIPTION
Enables use of memory pool for expression rewrites. Required for https://github.com/facebookincubator/velox/pull/15663.