### PR TITLE
fix: Change encoding of TimeZone to match Presto

### DIFF
--- a/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimeWithTimezoneCastTest.cpp
@@ -72,6 +72,13 @@ TEST_F(TimeWithTimezoneCastTest, toVarchar) {
   // UTC time to local time by adding the timezone offset.
   auto input = makeNullableFlatVector<int64_t>(
       {
+          // Constant values to test any regressions
+          // in pack and biasEncode functions.
+          58755883008,
+          // 11:31:37.123 UTC with timezone +05:30 -> displays as 17:01:37.123
+          169972216978,
+          // 11:31:37.123 UTC with timezone -05:00 -> displays as 06:31:37.123
+          169972216349,
           // UTC time 06:11:37.123 with UTC timezone -> displays as
           // 06:11:37.123+00:00
           pack(getUTCMillis(6, 11, 37, 123), biasEncode(0)),
@@ -107,6 +114,9 @@ TEST_F(TimeWithTimezoneCastTest, toVarchar) {
       TIME_WITH_TIME_ZONE());
 
   auto expected = makeNullableFlatVector<std::string>({
+      "03:59:04.698+00:00",
+      "17:01:37.123+05:30",
+      "06:31:37.123-05:00",
       "06:11:37.123+00:00",
       "01:11:37.123-05:00",
       "11:41:37.123+05:30",
@@ -169,6 +179,9 @@ TEST_F(TimeWithTimezoneCastTest, fromVarchar) {
       // Double-digit hours and minutes: HH:mm:ss.SSS+HH:mm
       "06:11:37.123+00:00",
       "12:34:56.789-04:30", // Local 12:34:56.789 in UTC-4:30 = 17:04:56.789 UTC
+      "03:59:04.698+00:00",
+      "17:01:37.123+05:30",
+      "06:31:37.123-05:00",
   });
 
   auto expected = makeNullableFlatVector<int64_t>(
@@ -223,6 +236,13 @@ TEST_F(TimeWithTimezoneCastTest, fromVarchar) {
           pack(getUTCMillis(6, 11, 37, 123), biasEncode(0)),
           // "12:34:56.789-04:30" -> UTC 17:04:56.789
           pack(getUTCMillis(17, 4, 56, 789), biasEncode(-4 * 60 - 30)),
+          // Constant values to test any regressions
+          // in pack and biasEncode functions.
+          58755883008,
+          // 11:31:37.123 UTC with timezone +05:30 -> displays as 17:01:37.123
+          169972216978,
+          // 11:31:37.123 UTC with timezone -05:00 -> displays as 06:31:37.123
+          169972216349,
       },
       TIME_WITH_TIME_ZONE());
 

--- a/velox/type/Time.h
+++ b/velox/type/Time.h
@@ -75,22 +75,43 @@ inline int64_t pack(int64_t millisUtc, int16_t timeZoneKey) {
 }
 
 /// Encodes timezone offset using bias encoding to ensure positive values
+/// This aligns with the bias encoding used in Presto for offsets
 /// Converts timezone offset from range [-840, 840] to [0, 1680]
+/// 0 -> 0
+/// [-840, -1] -> [1, 840]
+/// [1, 840] -> [841, 1680]
 inline int16_t biasEncode(int16_t timeZoneOffsetMinutes) {
   VELOX_CHECK(
       -kTimeZoneBias <= timeZoneOffsetMinutes &&
           timeZoneOffsetMinutes <= kTimeZoneBias,
       "Timezone offset must be between -840 and 840 minutes. Got: {}",
       timeZoneOffsetMinutes);
+
+  if (timeZoneOffsetMinutes == 0) {
+    return 0;
+  }
+  if (timeZoneOffsetMinutes < 0) {
+    return timeZoneOffsetMinutes + kTimeZoneBias + 1;
+  }
   return timeZoneOffsetMinutes + kTimeZoneBias;
 }
 
 /// Decode timezone offset from bias-encoded value
 /// Converts from bias-encoded range [0, 1680] to signed offset [-840, 840]
+/// This is the inverse of biasEncode():
+///   - 0 → 0 (UTC)
+///   - [1, 840] → [-840, -1] (negative offsets)
+///   - [841, 1680] → [1, 840] (positive offsets)
 ///
 /// @param encodedTimezone Bias-encoded timezone [0, 1680]
 /// @return Timezone offset in minutes [-840, 840]
 inline int16_t decodeTimezoneOffset(int16_t encodedTimezone) {
+  if (encodedTimezone == 0) {
+    return 0;
+  }
+  if (encodedTimezone <= kTimeZoneBias) {
+    return encodedTimezone - kTimeZoneBias - 1;
+  }
   return encodedTimezone - kTimeZoneBias;
 }
 


### PR DESCRIPTION
Summary:
Fix timezone offset encoding mismatch between Velox and Presto that caused incorrect cast results for TIME WITH TIME ZONE values. The previous encoding used simple offset+840 bias which mapped UTC to index 840. Presto's TimeZoneKey system expects UTC at index 0, with negative offsets at indices 1-840 and positive offsets at 841-1680. This mismatch caused incorrect timezone display when Presto coordinator formatted Velox-computed values.

Updated both biasEncode and decodeTimezoneOffset functions to use the Presto-compatible encoding scheme.

Differential Revision: D88459082


