### PR TITLE
fix: Reduce memory spike in aggregate window functions

### DIFF
--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -15,6 +15,9 @@
  */
 
 #include "velox/exec/AggregateWindow.h"
+
+#include <utility>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/WindowFunction.h"
@@ -329,6 +332,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
     // Check if we have a valid cached result with matching frame bounds.
     // If cached, all subsequent blocks in this partition can reuse it directly.
     if (cachedSameFrameResult_.has_value() &&
+        cachedSameFrameBounds_.has_value() &&
         cachedSameFrameBounds_->first == firstRow &&
         cachedSameFrameBounds_->second == lastRow) {
       validRows.applyToSelected([&](auto i) {

--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -154,7 +154,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
           resultOffset,
           result);
     } else if (frameMetadata.incrementalAggregation) {
-      vector_size_t startRow;
+      vector_size_t startRow = 0;
       if (frameMetadata.usePreviousAggregate) {
         // If incremental aggregation can be resumed from the previous block,
         // then the argument vectors also can be populated from the previous
@@ -347,6 +347,7 @@ class AggregateWindowFunction : public exec::WindowFunction {
       aggregateInitialized_ = true;
 
       // Process in batches to prevent memory explosion for large partitions.
+      // NOLINTNEXTLINE(altera-id-dependent-backward-branch)
       for (vector_size_t batchStart = firstRow; batchStart <= lastRow;
            batchStart += maxBatchSize_) {
         auto batchEnd = std::min(batchStart + maxBatchSize_ - 1, lastRow);


### PR DESCRIPTION
Reduce memory spike in aggregate window functions when using UNBOUNDED
PRECEDING AND UNBOUNDED FOLLOWING frame.

Previously, for window frames where all rows in a partition have the unbound frame
(e.g., UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), the implementation would
allocate argument vectors for the entire partition at once via `fillArgVectors`.
For large partitions with millions of rows, this single massive allocation
causes a significant memory spike that can lead to OOM.

This change adds a dedicated `sameFrameAggregation` path that:
1. Detects when all rows have identical frames by tracking `allSameFrame` in
   `FrameMetadata`.
2. Processes data in batches (controlled by `maxOutputBatchRows` config)
   instead of allocating one giant vector for the entire partition. This
   significantly reduces peak memory usage.
3. Caches the computed aggregate result after the first block, so subsequent
   output blocks can reuse the cached result without any data loading or
   recomputation.

The fix reduces memory spike for queries like:
```sql
SELECT sum(x) OVER (PARTITION BY p ORDER BY s
                    ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
FROM large_table  -- partition with millions of rows
```

Peak Memory Before (4.2 G)
```
      -- Window[2][STREAMING partition by [n0_1] order by [n0_2 ASC NULLS FIRST] t_10 := last_ignore_null("n0_0") ROWS between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING] -> n0_0:VARCHAR, n0_1:DATE, n0_2:INTEGER, t_10:VARCHAR
         Output: 100000000 rows (6.69GB, 24415 batches), Cpu time: 27.89s, Wall time: 28.08s, Blocked wall time: 0ns, Peak memory: 4.20GB, Memory allocations: 97685, Threads: 1, CPU breakdown: B/I/O/F (112.65ms/6.55s/21.10s/126.12ms)
            runningAddInputWallNanos     sum: 6.57s, count: 1, min: 6.57s, max: 6.57s
            runningFinishWallNanos       sum: 145.55ms, count: 1, min: 145.55ms, max: 145.55ms
            runningGetOutputWallNanos    sum: 21.16s, count: 1, min: 21.16s, max: 21.16s
            spillNotSupported            sum: 2, count: 2, min: 1, max: 1
```
Peak Memory After (2.7 G)
```
      -- Window[2][STREAMING partition by [n0_1] order by [n0_2 ASC NULLS FIRST] t_10 := last_ignore_null("n0_0") ROWS between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING] -> n0_0:VARCHAR, n0_1:DATE, n0_2:INTEGER, t_10:VARCHAR
         Output: 100000000 rows (6.69GB, 24415 batches), Cpu time: 26.81s, Wall time: 27.01s, Blocked wall time: 0ns, Peak memory: 2.70GB, Memory allocations: 97685, Threads: 1, CPU breakdown: B/I/O/F (116.28ms/7.48s/19.09s/127.72ms)
            runningAddInputWallNanos     sum: 7.51s, count: 1, min: 7.51s, max: 7.51s
            runningFinishWallNanos       sum: 146.44ms, count: 1, min: 146.44ms, max: 146.44ms
            runningGetOutputWallNanos    sum: 19.14s, count: 1, min: 19.14s, max: 19.14s
            spillNotSupported            sum: 2, count: 2, min: 1, max: 1
```