### PR TITLE
misc: Respect Linux cgroups restrictions when sizing thread pools

### DIFF
--- a/velox/common/base/SpillStats.cpp
+++ b/velox/common/base/SpillStats.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/SpillStats.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/StatsReporter.h"
@@ -24,7 +25,7 @@ namespace facebook::velox::common {
 namespace {
 std::vector<folly::Synchronized<SpillStats>>& allSpillStats() {
   static std::vector<folly::Synchronized<SpillStats>> spillStatsList(
-      std::thread::hardware_concurrency());
+      folly::hardware_concurrency());
   return spillStatsList;
 }
 

--- a/velox/common/base/tests/ConcurrentCounterTest.cpp
+++ b/velox/common/base/tests/ConcurrentCounterTest.cpp
@@ -18,6 +18,7 @@
 
 #include <fmt/format.h>
 #include <folly/Random.h>
+#include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 
@@ -48,7 +49,7 @@ class ConcurrentCounterTest : public testing::TestWithParam<bool> {
 
   void setupCounter() {
     counter_ = std::make_unique<ConcurrentCounter<int64_t>>(
-        std::thread::hardware_concurrency());
+        folly::hardware_concurrency());
   }
 
   const bool useUpdateFn_{GetParam()};
@@ -72,8 +73,8 @@ TEST_P(ConcurrentCounterTest, multithread) {
   const int32_t numUpdatesPerThread = 5'000;
   std::vector<int> numThreads;
   numThreads.push_back(1);
-  numThreads.push_back(std::thread::hardware_concurrency());
-  numThreads.push_back(std::thread::hardware_concurrency() * 2);
+  numThreads.push_back(folly::hardware_concurrency());
+  numThreads.push_back(folly::hardware_concurrency() * 2);
   for (int numThreads : numThreads) {
     SCOPED_TRACE(fmt::format("numThreads: {}", numThreads));
     counter_->testingClear();

--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/file/FileSystems.h"
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/synchronization/CallOnce.h>
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/file/File.h"
 
@@ -90,7 +91,7 @@ class LocalFileSystem : public FileSystem {
                       std::max(
                           1,
                           static_cast<int32_t>(
-                              std::thread::hardware_concurrency() / 2)),
+                              folly::hardware_concurrency() / 2)),
                       std::make_shared<folly::NamedThreadFactory>(
                           "LocalReadahead"))
                 : nullptr) {}

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -16,6 +16,7 @@
 
 #include <fcntl.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/system/HardwareConcurrency.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
@@ -188,9 +189,7 @@ class LocalFileTest : public ::testing::TestWithParam<bool> {
   const bool useFaultyFs_;
   const std::unique_ptr<folly::CPUThreadPoolExecutor> executor_ =
       std::make_unique<folly::CPUThreadPoolExecutor>(
-          std::max(
-              1,
-              static_cast<int32_t>(std::thread::hardware_concurrency() / 2)),
+          std::max(1, static_cast<int32_t>(folly::hardware_concurrency() / 2)),
           std::make_shared<folly::NamedThreadFactory>(
               "LocalFileReadAheadTest"));
 };

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/memory/MallocAllocator.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/memory/Memory.h"
 
 #include <sys/mman.h>
@@ -33,7 +34,7 @@ MallocAllocator::MallocAllocator(size_t capacity, uint32_t reservationByteLimit)
             decrementUsageWithReservationFunc(counter, decrement, lock);
             return true;
           }),
-      reservations_(std::thread::hardware_concurrency()) {}
+      reservations_(folly::hardware_concurrency()) {}
 
 MallocAllocator::~MallocAllocator() {
   // TODO: Remove the check when memory leak issue is resolved.

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/memory/SharedArbitrator.h"
+#include <folly/system/HardwareConcurrency.h>
 #include <folly/system/ThreadName.h>
 #include <pthread.h>
 #include <mutex>
@@ -296,8 +297,7 @@ SharedArbitrator::SharedArbitrator(const Config& config)
       "memoryReclaimThreadsHwMultiplier_ needs to be positive");
 
   const uint64_t numReclaimThreads = std::max<size_t>(
-      1,
-      std::thread::hardware_concurrency() * memoryReclaimThreadsHwMultiplier_);
+      1, folly::hardware_concurrency() * memoryReclaimThreadsHwMultiplier_);
   memoryReclaimExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
       numReclaimThreads,
       std::make_shared<folly::NamedThreadFactory>("MemoryReclaim"));

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
 #include <folly/init/Init.h>
+#include <folly/system/HardwareConcurrency.h>
 #include <re2/re2.h>
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -73,7 +74,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
     setupMemoryPools();
 
     spillExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
-        std::thread::hardware_concurrency());
+        folly::hardware_concurrency());
   }
 
   void TearDown() override {

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -23,13 +23,13 @@
 #include "velox/dwio/dwrf/RegisterDwrfReader.h"
 #include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/Task.h"
-#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 
 #include <folly/init/Init.h>
+#include <folly/system/HardwareConcurrency.h>
 #include <algorithm>
 
 using namespace facebook::velox;
@@ -125,7 +125,7 @@ int main(int argc, char** argv) {
 
   std::shared_ptr<folly::Executor> executor(
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency()));
+          folly::hardware_concurrency()));
 
   // Task is the top-level execution concept. A task needs a taskId (as a
   // string), the plan fragment to execute, a destination (only used for

--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/Cursor.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/file/FileSystems.h"
 
 #include <filesystem>
@@ -214,7 +215,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
       : TaskCursorBase(
             params,
             std::make_shared<folly::CPUThreadPoolExecutor>(
-                std::thread::hardware_concurrency())),
+                folly::hardware_concurrency())),
         maxDrivers_{params.maxDrivers},
         numConcurrentSplitGroups_{params.numConcurrentSplitGroups},
         numSplitGroups_{params.numSplitGroups} {

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -18,6 +18,7 @@
 #include <boost/random/uniform_int_distribution.hpp>
 
 #include <folly/concurrency/ConcurrentHashMap.h>
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
 #include "velox/common/fuzzer/Utils.h"
@@ -272,7 +273,7 @@ class MemoryArbitrationFuzzer {
   VectorFuzzer vectorFuzzer_;
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   folly::Synchronized<Stats> stats_;
 };
 

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/SortBuffer.h"
 #include "velox/exec/Spill.h"
@@ -21,7 +22,6 @@
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 #include "velox/type/Type.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
-#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
 
@@ -200,7 +200,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
        {"c3", VARCHAR()}});
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   const std::vector<column_index_t> sortColumnIndices_{0, 2};
   const std::vector<CompareFlags> sortCompareFlags_{
       CompareFlags{},

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/Merge.h"
@@ -294,7 +295,7 @@ class MergerTest : public OperatorTestBase {
   const RowTypePtr inputType_ = ROW({{"c0", BIGINT()}, {"c1", SMALLINT()}});
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   const std::vector<column_index_t> sortColumnIndices_{0, 1};
   const std::vector<CompareFlags> sortCompareFlags_{
       CompareFlags{.ascending = true},

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/OutputBufferManager.h"
+#include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 #include "folly/experimental/EventCount.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -437,7 +438,7 @@ class OutputBufferManagerTest : public testing::Test {
   const VectorSerde::Kind serdeKind_;
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::shared_ptr<OutputBufferManager> bufferManager_;
   RowTypePtr rowType_;

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/SortBuffer.h"
+#include <folly/system/HardwareConcurrency.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
@@ -119,7 +120,7 @@ class SortBufferTest : public OperatorTestBase,
 
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   const std::shared_ptr<memory::MemoryPool> fuzzerPool_ =
       memory::memoryManager()->addLeafPool("SortBufferTest");
 

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/system/HardwareConcurrency.h>
 #include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <filesystem>
@@ -56,7 +57,7 @@ DEFINE_uint32(
     "The number of key columns");
 DEFINE_uint32(
     spiller_benchmark_spill_executor_size,
-    std::thread::hardware_concurrency(),
+    folly::hardware_concurrency(),
     "The spiller executor size in number of threads");
 DEFINE_uint32(
     spiller_benchmark_spill_vector_size,

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 #include <folly/init/Init.h>
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/tpch/TpchConnector.h"
 #include "velox/connectors/tpch/TpchConnectorSplit.h"
-#include "velox/core/Expressions.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/expression/Expr.h"
@@ -101,7 +101,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   std::shared_ptr<core::QueryCtx> queryCtx_{
       core::QueryCtx::create(executor_.get())};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/Window.h"
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
@@ -69,7 +70,7 @@ class WindowTest : public OperatorTestBase {
 
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
 
   tsan_atomic<bool> nonReclaimableSection_{false};
 };

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <folly/system/HardwareConcurrency.h>
 #include "velox/exec/tests/utils/QueryAssertions.h"
 
 namespace facebook::velox::exec::test {
@@ -206,7 +207,7 @@ class AssertQueryBuilder {
 
   static std::unique_ptr<folly::Executor> newExecutor() {
     return std::make_unique<folly::CPUThreadPoolExecutor>(
-        std::thread::hardware_concurrency());
+        folly::hardware_concurrency());
   }
 
   // Used by the created task as the default driver executor.

--- a/velox/python/runner/runner.cpp
+++ b/velox/python/runner/runner.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <folly/system/HardwareConcurrency.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "velox/python/init/PyInit.h"
@@ -32,7 +33,7 @@ PYBIND11_MODULE(runner, m) {
   // is about to exit.
   static auto rootPool = velox::memory::memoryManager()->addRootPool();
   static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
-      std::thread::hardware_concurrency());
+      folly::hardware_concurrency());
 
   // execute() returns an iterator to Vectors.
   py::module::import("pyvelox.vector");

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/system/HardwareConcurrency.h>
 #include <utility>
 
 #include "velox/core/PlanNode.h"
@@ -66,7 +67,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       exec::OutputBufferManager::getInstanceRef()};
   const std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency(),
+          folly::hardware_concurrency(),
           std::make_shared<folly::NamedThreadFactory>("Driver"))};
   const ConsumerCallBack consumerCb_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> consumerExecutor_;

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/tool/trace/TraceReplayRunner.h"
+#include <folly/system/HardwareConcurrency.h>
 
 #include <gflags/gflags.h>
 
@@ -24,7 +25,6 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
-#include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
@@ -242,13 +242,13 @@ void printSummary(
 TraceReplayRunner::TraceReplayRunner()
     : cpuExecutor_(
           std::make_unique<folly::CPUThreadPoolExecutor>(
-              std::thread::hardware_concurrency() *
+              folly::hardware_concurrency() *
                   FLAGS_driver_cpu_executor_hw_multiplier,
               std::make_shared<folly::NamedThreadFactory>(
                   "TraceReplayCpuConnector"))),
       ioExecutor_(
           std::make_unique<folly::IOThreadPoolExecutor>(
-              std::thread::hardware_concurrency() *
+              folly::hardware_concurrency() *
                   FLAGS_hive_connector_executor_hw_multiplier,
               std::make_shared<folly::NamedThreadFactory>(
                   "TraceReplayIoConnector"))) {}

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -17,6 +17,7 @@
 
 #include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/system/HardwareConcurrency.h>
 
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/vector/FlatVector.h"
@@ -848,10 +849,10 @@ class VectorTestBase {
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          std::thread::hardware_concurrency())};
+          folly::hardware_concurrency())};
 };
 
 class TestRuntimeStatWriter : public BaseRuntimeStatWriter {


### PR DESCRIPTION
Summary:
This change replaces uses of std::thread::hardware_concurrency with
folly::available_concurrency the latter of which always respects
container restrictions while the former does not.  This ensures that
when running inside of a Linux container with restrictions on the
available processors, thread pools and other data structures will not
be over-provisioned.

Differential Revision: D87811255


