### PR TITLE
fix: Enable map_keys_overlap for expression fuzzer

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -262,7 +262,6 @@ std::unordered_set<std::string> skipFunctions = {
     "to_geometry",
     "to_spherical_geography",
     "localtime",
-    "map_keys_overlap",
 };
 
 std::unordered_set<std::string> skipFunctionsSOT = {


### PR DESCRIPTION
Summary: Remove map_keys_overlap from skipFunctions to enable fuzzer testing. The function is already correctly skipped from SOT verification since it's Velox-only.

Differential Revision: D88680724
