### PR TITLE
feat: Add TIME - TIME subtraction support

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -565,6 +565,29 @@ struct TimeMinusInterval {
   }
 };
 
+template <typename T>
+struct TimeMinusFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IntervalDayTime>& result,
+      const arg_type<Time>& a,
+      const arg_type<Time>& b) {
+    // Validate inputs are in valid TIME range [0, 86400000)
+    VELOX_USER_CHECK(
+        a >= 0 && a < kMillisInDay,
+        "TIME value {} is out of range [0, 86400000)",
+        a);
+    VELOX_USER_CHECK(
+        b >= 0 && b < kMillisInDay,
+        "TIME value {} is out of range [0, 86400000)",
+        b);
+
+    // Simple subtraction returns interval in milliseconds
+    result = a - b;
+  }
+};
+
 // Optimized vector function for Time +/- IntervalYearMonth
 // This case is special because result = time (identity function), allowing
 // for significant optimizations.

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -160,6 +160,10 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<TimeMinusInterval, Time, Time, IntervalDayTime>(
       {prefix + "minus"});
 
+  // Register Time - Time function (returns IntervalDayTime)
+  registerFunction<TimeMinusFunction, IntervalDayTime, Time, Time>(
+      {prefix + "minus"});
+
   // Use optimized vector function for Time + IntervalYearMonth (identity
   // function)
   exec::registerVectorFunction(


### PR DESCRIPTION
Summary: Implements TIME - TIME subtraction that returns INTERVAL_DAY_TIME to support queries like `SELECT TIME '10:00:00' - TIME '08:00:00'`.

Differential Revision: D88684605


