### PR TITLE
fix: Skip `switch` function in Spark expression fuzzer

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -442,7 +442,7 @@ jobs:
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
-                --special_forms="and,or,cast,coalesce,if" \
+                --special_forms="and,or,cast,coalesce" \
                 --enable_dereference \
                 --duration_sec $DURATION \
                 --minloglevel=0 \
@@ -706,6 +706,7 @@ jobs:
                 --retry_with_try \
                 --enable_dereference \
                 --velox_fuzzer_enable_decimal_type \
+                --special_forms="and,or,cast,coalesce" \
                 --duration_sec $DURATION \
                 --minloglevel=0 \
                 --stderrthreshold=2 \


### PR DESCRIPTION
Summary:
The Spark expression fuzzer was failing intermittently due to the `like` function within the SWITCH function generating invalid escape strings (multi-character instead of single character). 

This diff adds `"switch"` to `skipFunctions` in `SparkExpressionFuzzerTest.cpp` to prevent these spurious failures until the underlying issue is resolved. Here we also excluded 'if' from Presto and Spark fuzzer.

Differential Revision: D88753778


