### PR TITLE
feat: Coercions for complex and generic types

### DIFF
--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -147,7 +147,7 @@ TypePtr CoalesceCallToSpecialForm::resolveType(
   return resolveTypeInt(argTypes);
 }
 
-TypePtr CoalesceCallToSpecialForm::resolveTypeWithCorsions(
+TypePtr CoalesceCallToSpecialForm::resolveTypeWithCoercions(
     const std::vector<TypePtr>& argTypes,
     std::vector<TypePtr>& coercions) {
   return resolveTypeInt(argTypes, true, coercions);

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -46,7 +46,7 @@ class CoalesceCallToSpecialForm : public FunctionCallToSpecialForm {
   /// argument types are the same.
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
-  TypePtr resolveTypeWithCorsions(
+  TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
       std::vector<TypePtr>& coercions) override;
 

--- a/velox/expression/FunctionCallToSpecialForm.cpp
+++ b/velox/expression/FunctionCallToSpecialForm.cpp
@@ -40,7 +40,7 @@ TypePtr resolveTypeForSpecialFormWithCoercions(
     return nullptr;
   }
 
-  return specialForm->resolveTypeWithCorsions(argTypes, coercions);
+  return specialForm->resolveTypeWithCoercions(argTypes, coercions);
 }
 
 ExprPtr constructSpecialForm(

--- a/velox/expression/FunctionCallToSpecialForm.h
+++ b/velox/expression/FunctionCallToSpecialForm.h
@@ -33,9 +33,9 @@ class FunctionCallToSpecialForm {
   /// Like 'resolveType', but with support for applying type conversions if a
   /// special form signature doesn't match 'argTypes' exactly. Support varies
   /// from special form to special form. By default, no coersions are attempted.
-  virtual TypePtr resolveTypeWithCorsions(
+  virtual TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
-      [[maybe_unused]] std::vector<TypePtr>& coercions) {
+      std::vector<TypePtr>& coercions) {
     coercions.clear();
     coercions.resize(argTypes.size());
     return resolveType(argTypes);

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -156,23 +156,21 @@ class SimpleFunctionRegistry {
   std::optional<ResolvedSimpleFunction> resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes) const {
-    std::vector<TypePtr> coercions;
-    return resolveFunction(name, argTypes, false, coercions);
+    return resolveFunction(name, argTypes, nullptr);
   }
 
   std::optional<ResolvedSimpleFunction> resolveFunctionWithCoercions(
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
       std::vector<TypePtr>& coercions) const {
-    return resolveFunction(name, argTypes, true, coercions);
+    return resolveFunction(name, argTypes, &coercions);
   }
 
  private:
   std::optional<ResolvedSimpleFunction> resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
-      bool allowCoercion,
-      std::vector<TypePtr>& coercions) const;
+      std::vector<TypePtr>* coercions) const;
 
   /// Registers a function with the given name and metadata. If an entry with
   /// the name already exists and 'overwrite' is true, the existing entry is

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -34,7 +34,7 @@ TypePtr resolveTypeInt(
 TypePtr resolveTypeInt(const std::vector<TypePtr>& argTypes) {
   std::vector<TypePtr> coercions;
   return resolveTypeInt(argTypes, false, coercions);
-};
+}
 } // namespace
 
 SwitchExpr::SwitchExpr(
@@ -312,7 +312,7 @@ TypePtr SwitchCallToSpecialForm::resolveType(
   return resolveTypeInt(argTypes);
 }
 
-TypePtr SwitchCallToSpecialForm::resolveTypeWithCorsions(
+TypePtr SwitchCallToSpecialForm::resolveTypeWithCoercions(
     const std::vector<TypePtr>& argTypes,
     std::vector<TypePtr>& coercions) {
   return resolveTypeInt(argTypes, true, coercions);
@@ -338,7 +338,7 @@ TypePtr IfCallToSpecialForm::resolveType(const std::vector<TypePtr>& argTypes) {
   return resolveTypeInt(argTypes);
 }
 
-TypePtr IfCallToSpecialForm::resolveTypeWithCorsions(
+TypePtr IfCallToSpecialForm::resolveTypeWithCoercions(
     const std::vector<TypePtr>& argTypes,
     std::vector<TypePtr>& coercions) {
   VELOX_CHECK_EQ(

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -73,7 +73,7 @@ class SwitchCallToSpecialForm : public FunctionCallToSpecialForm {
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
   /// Supports coercions for odd arguments (then and else branches).
-  TypePtr resolveTypeWithCorsions(
+  TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
       std::vector<TypePtr>& coercions) override;
 
@@ -92,7 +92,7 @@ class IfCallToSpecialForm : public SwitchCallToSpecialForm {
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
   /// Supports coercions for 2nd and 3rd arguments (then and else branches).
-  TypePtr resolveTypeWithCorsions(
+  TypePtr resolveTypeWithCoercions(
       const std::vector<TypePtr>& argTypes,
       std::vector<TypePtr>& coercions) override;
 };

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -86,56 +86,46 @@ TypePtr resolveVectorFunction(
   return nullptr;
 }
 
-namespace {
-bool hasCoercion(const std::vector<Coercion>& coercions) {
-  for (const auto& coercion : coercions) {
-    if (coercion.type != nullptr) {
-      return true;
-    }
-  }
-
-  return false;
-}
-} // namespace
-
 TypePtr resolveVectorFunctionWithCoercions(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes,
     std::vector<TypePtr>& coercions) {
-  coercions.clear();
+  std::vector<Coercion> selectedCoercions;
+  size_t selectedCount = 0;
 
   auto optionalType = applyToVectorFunctionEntry<TypePtr>(
-      functionName,
-      [&](const auto& /*name*/, const auto& entry) -> std::optional<TypePtr> {
-        std::vector<std::pair<std::vector<Coercion>, TypePtr>> candidates;
+      functionName, [&](const auto& /*name*/, const auto& entry) {
+        TypePtr selectedType;
+        auto selectedPriority = kImpossibleCoercionCost;
+        std::vector<Coercion> requiredCoercions;
         for (const auto& signature : entry.signatures) {
           exec::SignatureBinder binder(*signature, argTypes);
-          std::vector<Coercion> requiredCoercions;
-          if (binder.tryBindWithCoercions(requiredCoercions)) {
-            auto type = binder.tryResolveReturnType();
-            if (!hasCoercion(requiredCoercions)) {
-              coercions.resize(argTypes.size(), nullptr);
-              return type;
-            }
-
-            candidates.emplace_back(requiredCoercions, type);
+          if (!binder.tryBind(&requiredCoercions)) {
+            continue;
+          }
+          auto type = binder.tryResolveReturnType();
+          if (!type) {
+            continue;
+          }
+          const auto currentPriority = Coercion::overallCost(requiredCoercions);
+          if (currentPriority < selectedPriority) {
+            std::swap(selectedCoercions, requiredCoercions);
+            selectedType = std::move(type);
+            selectedPriority = currentPriority;
+            selectedCount = 1;
+          } else if (currentPriority == selectedPriority) {
+            ++selectedCount;
           }
         }
-
-        if (auto index = Coercion::pickLowestCost(candidates)) {
-          const auto& requiredCoercions = candidates[index.value()].first;
-          coercions.reserve(requiredCoercions.size());
-          for (const auto& coercion : requiredCoercions) {
-            coercions.push_back(coercion.type);
-          }
-
-          return candidates[index.value()].second;
-        }
-
-        return std::nullopt;
+        return selectedType;
       });
 
-  return optionalType.value_or(nullptr);
+  if (selectedCount != 1) {
+    coercions.clear();
+    return nullptr;
+  }
+  Coercion::convert(selectedCoercions, &coercions);
+  return *optionalType;
 }
 
 std::optional<std::pair<TypePtr, VectorFunctionMetadata>>

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1072,7 +1072,7 @@ TEST_F(SimpleFunctionTest, variadicReuseNoArgs) {
 }
 
 TEST_F(SimpleFunctionTest, variadicReuseNoArgsDifferentType) {
-  std::string functionName = "function_with_variadic";
+  std::string functionName = "function_with_variadic_different_type";
   registerFunction<FunctionWithVariadic, int32_t, Variadic<int64_t>>(
       {functionName});
 

--- a/velox/functions/tests/RegistryTestUtil.h
+++ b/velox/functions/tests/RegistryTestUtil.h
@@ -187,4 +187,26 @@ class VectorFuncFour : public velox::exec::VectorFunction {
   }
 };
 
+class VectorFuncFive : public velox::exec::VectorFunction {
+ public:
+  void apply(
+      const velox::SelectivityVector& /* rows */,
+      std::vector<velox::VectorPtr>& /* args */,
+      const TypePtr& /* outputType */,
+      velox::exec::EvalCtx& /* context */,
+      velox::VectorPtr& /* result */) const override {}
+
+  static std::vector<std::shared_ptr<velox::exec::FunctionSignature>>
+  signatures() {
+    // map(K,V), array(K) -> array(K)
+    return {velox::exec::FunctionSignatureBuilder()
+                .knownTypeVariable("K")
+                .typeVariable("V")
+                .returnType("array(K)")
+                .argumentType("map(K,V)")
+                .argumentType("array(K)")
+                .build()};
+  }
+};
+
 } // namespace facebook::velox

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -23,19 +23,27 @@ namespace {
 
 void testCoercion(const TypePtr& fromType, const TypePtr& toType) {
   auto coercion = TypeCoercer::coerceTypeBase(fromType, toType->name());
-  ASSERT_TRUE(coercion.has_value());
-  VELOX_EXPECT_EQ_TYPES(coercion->type, toType);
+  ASSERT_TRUE(coercion);
+  if (coercion.cost == 0) {
+    ASSERT_FALSE(coercion.type);
+  } else {
+    VELOX_EXPECT_EQ_TYPES(coercion.type, toType);
+  }
 }
 
 void testBaseCoercion(const TypePtr& fromType) {
   auto coercion = TypeCoercer::coerceTypeBase(fromType, fromType->kindName());
-  ASSERT_TRUE(coercion.has_value());
-  VELOX_EXPECT_EQ_TYPES(coercion->type, fromType);
+  ASSERT_TRUE(coercion);
+  if (coercion.cost == 0) {
+    ASSERT_FALSE(coercion.type);
+  } else {
+    VELOX_EXPECT_EQ_TYPES(coercion.type, fromType);
+  }
 }
 
 void testNoCoercion(const TypePtr& fromType, const TypePtr& toType) {
   auto coercion = TypeCoercer::coerceTypeBase(fromType, toType->name());
-  ASSERT_FALSE(coercion.has_value());
+  ASSERT_FALSE(coercion);
 }
 
 TEST(TypeCoercerTest, basic) {


### PR DESCRIPTION
Add support for coercions involving complex types (types with type parameters) and generic types. 
Previously, coercions were only supported for scalar types without parameters. 

### Complex types

Add coercion for type parameters. This enables queries like this where a function taking two arrays of the same type (array_intersect) is called with array(integer) and array(bigint). The argument of type array(integer) is automatically casted to array(bigint).

```
SQL> explain (type logical) select array_intersect(ARRAY[1, 2, 3], ARRAY[CAST(2 AS BIGINT)]);
- Project: -> ROW<expr:ARRAY<BIGINT>>
    expr := array_intersect(CAST(array_constructor(1, 2, 3) AS ARRAY<BIGINT>), array_constructor(CAST(2 AS BIGINT)))
  - Values: 1 rows -> ROW<>
```

Only case that doesn't work is cast unknown to complex type, e.g.
```
SQL> explain (type logical) select array_intersect(null, ARRAY[CAST(2 AS BIGINT)]);
Query failed: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Scalar function signature is not supported: array_intersect(UNKNOWN, ARRAY<BIGINT>).
```

It doesn't work because it's unclear what to do with type parameters, we only have their signature, we don't have actual parameters. To be able produce such implicit case we need to know how to convert parameter from signature to real one without actual type. I know fix for type parameters, but it's ugly and I don't know fix for non-type parameters (needs somehow find default value for them). So I think better to solve this separately.

### Generic types

Add a loop to find common super type for all arguments, then coerce each argument to the common super type. In the following example, there are 4 arguments with types UNKNOWN, INTEGER, UNKNOWN, DOUBLE. The common super type is DOUBLE, so all arguments are casted to DOUBLE.

```
SQL> explain (type logical) select ARRAY[null, 1, null, 2.0];
- Project: -> ROW<expr:ARRAY<DOUBLE>>
    expr := array_constructor(CAST(null AS DOUBLE), CAST(1 AS DOUBLE), CAST(null AS DOUBLE), 2)
  - Values: 1 rows -> ROW<>
```

### Uknown type

Add coercion from UNKNOWN to any type without parameters.

```
SQL> explain (type logical) select null + 1;
- Project: -> ROW<expr:INTEGER>
    expr := plus(CAST(null AS INTEGER), 1)
  - Values: 1 rows -> ROW<>
```

This also works with generic function signatures.

```
SQL> explain (type logical) select null = ARRAY[CAST(2 AS BIGINT)];
- Project: -> ROW<expr:BOOLEAN>
    expr := eq(CAST(null AS ARRAY<BIGINT>), array_constructor(CAST(2 AS BIGINT)))
  - Values: 1 rows -> ROW<>
```

### Precedence rules

Change cost of coercion to prefer generic function without coercions over a function with coercions.

### References
* [Data type precedence (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/data-types/data-type-precedence-transact-sql?view=sql-server-ver17)
* [Postgres: Type Conversion](https://www.postgresql.org/docs/7.3/typeconv.html) 

### Notes
- @mkornaukhov  came across some oddities while working on this PR, please check #15749 (they're related to case when we don't have coercions)

### Follow ups

1. Support implicit casts from unknown to complex types
2. Support implicit casts between types with non-type parameters, e.g. decimal
3. Fix #15749 and `isHomogeneousRow`
4. Support implicit cast registration
5. Support pseudo-types, it's needed for Postgres frontend in SereneDB. Pseudo-types have implicit casts to some types, but if it's generic it's still needed to be cast to some type (e.g. it's varchar for Postgres unknown (type of literal))
6. Optimize pre-existing `O(n^2)` in Switch/If/Coalesce expressions.
7. Find why actual type can be null in some tests: https://github.com/facebookincubator/velox/pull/15734#discussion_r2616567872

