### PR TITLE
feat: Support specififying options for Velox Trace directory

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -565,6 +565,12 @@ class QueryConfig {
   static constexpr const char* kOpTraceDirectoryCreateConfig =
       "op_trace_directory_create_config";
 
+  /// Config used to create task trace directory. This config is provided to
+  /// underlying file system and the config is free form. The form should be
+  /// defined by the underlying file system.
+  static constexpr const char* kTaskTraceDirectoryCreateConfig =
+      "task_trace_directory_create_config";
+
   /// Disable optimization in expression evaluation to peel common dictionary
   /// layer from inputs.
   static constexpr const char* kDebugDisableExpressionWithPeeling =
@@ -1151,6 +1157,10 @@ class QueryConfig {
 
   std::string opTraceDirectoryCreateConfig() const {
     return get<std::string>(kOpTraceDirectoryCreateConfig, "");
+  }
+
+  std::string taskTraceDirectoryCreateConfig() const {
+    return get<std::string>(kTaskTraceDirectoryCreateConfig, "");
   }
 
   bool prestoArrayAggIgnoreNulls() const {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3501,7 +3501,9 @@ void Task::maybeInitTrace() {
     return;
   }
 
-  trace::createTraceDirectory(traceConfig_->queryTraceDir);
+  trace::createTraceDirectory(
+      traceConfig_->queryTraceDir,
+      queryCtx_->queryConfig().taskTraceDirectoryCreateConfig());
   const auto metadataWriter = std::make_unique<trace::TaskTraceMetadataWriter>(
       traceConfig_->queryTraceDir, memory::traceMemoryPool());
   auto traceNode =


### PR DESCRIPTION
Summary:

Pull Request resolved: https://github.com/facebookincubator/velox/pull/15735

Introduces `taskTraceDirectoryCreateConfig`, which is passed the trace directory created in `Task.cpp`.

This mirrors the existing `opTraceDirectoryCreateConfig`, which is passed to the trace directory created in `Operator.cpp`.

---

Note: IMO it's not worth having separate configs for these separate use cases. However, the existing config is clearly specific to just `Operator`. I'd rather not make a breaking change by generalizing that. Therefore, I opted to create a new, separate config.

Differential Revision: D87584575