### PR TITLE
fix: Skip jaworinkler_similarity UDF in Facebook Presto SOT

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -424,7 +424,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "$internal$contains",
     "localtime", // localtime cannot be called with paranthesis:
                  // https://github.com/facebookincubator/velox/issues/14937,
-    "jarowinkler_similarity",
+    "jarowinkler_similarity", // https://github.com/facebookincubator/velox/issues/15736
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary: Skip jaworinkler_similarity skip in Facebook Presto SOT, as it is skipped in OSS Presto SOT

Reviewed By: peterenescu

Differential Revision: D88755137


