### PR TITLE
feat: Add SimpleSetDigest type for scalar function signatures

### DIFF
--- a/velox/functions/prestosql/types/SetDigestType.h
+++ b/velox/functions/prestosql/types/SetDigestType.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -61,4 +62,14 @@ inline bool isSetDigestType(const TypePtr& type) {
 inline std::shared_ptr<const SetDigestType> SETDIGEST() {
   return SetDigestType::get();
 }
+
+// Type to use for inputs and outputs of simple functions, e.g.
+// arg_type<SetDigest> and out_type<SetDigest>.
+struct SetDigestT {
+  using type = Varbinary;
+  static constexpr const char* typeName = "setdigest";
+};
+
+using SetDigest = CustomType<SetDigestT>;
+
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Add SimpleSetDigest custom type wrapper for use in simple function signatures.
This allows SetDigest functions to be registered with the proper type signature.

Differential Revision: D88801353
