### PR TITLE
fix: Make KHLL deserialize return Status instead of throwing

### DIFF
--- a/velox/common/hyperloglog/KHyperLogLog.h
+++ b/velox/common/hyperloglog/KHyperLogLog.h
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include <folly/container/F14Map.h>
+#include "velox/common/base/Status.h"
 #include "velox/common/hyperloglog/HllAccumulator.h"
 
 namespace facebook::velox::common::hll {
@@ -55,7 +56,8 @@ class KHyperLogLog {
   }
 
   /// Creates a KHyperLogLog instance from serialized data.
-  static std::unique_ptr<KHyperLogLog<TUii, TAllocator>>
+  /// Returns an error status if the data is invalid.
+  static Expected<std::unique_ptr<KHyperLogLog<TUii, TAllocator>>>
   deserialize(const char* data, size_t size, TAllocator* allocator);
 
   /// Serializes the KHyperLogLog state to a varbinary.
@@ -127,10 +129,12 @@ class KHyperLogLog {
   void mergeWith(const KHyperLogLog<TUii, TAllocator>& other);
 
   /// Merges another serialized KHyperLogLog into this one.
+  /// The serialized data is assumed to be valid.
   void mergeWith(StringView serialized, TAllocator* allocator) {
     auto other = common::hll::KHyperLogLog<TUii, TAllocator>::deserialize(
         serialized.data(), serialized.size(), allocator);
-    mergeWith(*other);
+    VELOX_CHECK(other.hasValue(), "Failed to deserialize KHyperLogLog");
+    mergeWith(*other.value());
   }
 
  private:

--- a/velox/common/hyperloglog/tests/KHyperLogLogTest.cpp
+++ b/velox/common/hyperloglog/tests/KHyperLogLogTest.cpp
@@ -224,8 +224,11 @@ TEST_F(KHyperLogLogTest, serde) {
   size_t totalSize = khll->estimatedSerializedSize();
   std::string outputBuffer(totalSize, '\0');
   khll->serialize(outputBuffer.data());
-  auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
-      outputBuffer.data(), outputBuffer.size(), allocator_);
+  auto deserializedResult =
+      KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+          outputBuffer.data(), outputBuffer.size(), allocator_);
+  ASSERT_TRUE(deserializedResult.hasValue());
+  auto& deserialized = deserializedResult.value();
 
   EXPECT_EQ(khll->cardinality(), deserialized->cardinality());
   EXPECT_EQ(
@@ -242,9 +245,11 @@ TEST_F(KHyperLogLogTest, serde) {
   size_t emptySize = emptyKhll->estimatedSerializedSize();
   std::string emptyOutputBuffer(emptySize, '\0');
   emptyKhll->serialize(emptyOutputBuffer.data());
-  auto deserializedEmpty =
+  auto deserializedEmptyResult =
       KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
           emptyOutputBuffer.data(), emptyOutputBuffer.size(), allocator_);
+  ASSERT_TRUE(deserializedEmptyResult.hasValue());
+  auto& deserializedEmpty = deserializedEmptyResult.value();
   EXPECT_EQ(deserializedEmpty->cardinality(), 0);
   std::string reserializedEmptyOutputBuffer(emptySize, '\0');
   deserializedEmpty->serialize(reserializedEmptyOutputBuffer.data());
@@ -458,8 +463,11 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     size_t totalSize = khll->estimatedSerializedSize();
     std::string outputBuffer(totalSize, '\0');
     khll->serialize(outputBuffer.data());
-    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
-        outputBuffer.data(), outputBuffer.size(), allocator_);
+    auto deserializedResult =
+        KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+            outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserializedResult.hasValue());
+    auto& deserialized = deserializedResult.value();
     std::string reserializeBuffer(totalSize, '\0');
     deserialized->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
@@ -479,8 +487,11 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     size_t totalSize = khll->estimatedSerializedSize();
     std::string outputBuffer(totalSize, '\0');
     khll->serialize(outputBuffer.data());
-    auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
-        outputBuffer.data(), outputBuffer.size(), allocator_);
+    auto deserializedResult =
+        KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
+            outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserializedResult.hasValue());
+    auto& deserialized = deserializedResult.value();
     std::string reserializeBuffer(totalSize, '\0');
     deserialized->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
@@ -502,8 +513,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -523,8 +535,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -544,8 +557,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -565,8 +579,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -586,8 +601,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -607,8 +623,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -633,8 +650,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -655,8 +673,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 
@@ -678,8 +697,9 @@ TEST_F(KHyperLogLogTest, differentJoinKeyUIITypes) {
     khll->serialize(outputBuffer.data());
     auto deserialized = KHyperLogLog<int64_t, HashStringAllocator>::deserialize(
         outputBuffer.data(), outputBuffer.size(), allocator_);
+    ASSERT_TRUE(deserialized.hasValue());
     std::string reserializeBuffer(totalSize, '\0');
-    deserialized->serialize(reserializeBuffer.data());
+    deserialized.value()->serialize(reserializeBuffer.data());
     EXPECT_EQ(outputBuffer, reserializeBuffer);
   }
 }


### PR DESCRIPTION
Summary: As title, `deserialize` does some checks for invalid data. Instead of throwing VELOX_ERROR, use EXPECTED, so that later when it is used in simple scalar functions, the scalar function can check for deserialized.hasError() and return Status.

Differential Revision: D88897304


