### PR TITLE
refactor(exchange): Use recordInputStats() utility in getOutputFromColumnarPages()

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -205,13 +205,15 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
       inputStream_ == nullptr || columnarPageIdx_ < currentPages_.size());
 
   // Iterate through pages
-  for (; columnarPageIdx_ < currentPages_.size();) {
+  while (columnarPageIdx_ < currentPages_.size()) {
     auto& page = currentPages_[columnarPageIdx_];
 
-    // Track raw bytes for stats (only once per page)
     if (!inputStream_) {
+      // NOTE: 'rawInputBytes' only counts bytes from pages processed from the
+      // beginning in this call. If processing resumes from the middle of a
+      // page, that page's bytes are not counted. This ensures each page is
+      // counted only once in 'rawInputBytes' across multiple calls.
       rawInputBytes += page->size();
-      // Create stream for this page
       inputStream_ = page->prepareStreamForDeserialize();
     }
 
@@ -229,16 +231,14 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
       resultOffset = result_->size();
     }
 
-    // If page is fully consumed
     if (inputStream_->atEnd()) {
+      // Page is fully consumed, free memory immediately, and move to the next.
       inputStream_ = nullptr;
-      // free memory immediately
       page.reset();
-      // move to next page
       ++columnarPageIdx_;
     }
 
-    // Stop if accumulated enough rows for this batch
+    // Stop if accumulated enough rows for this batch.
     if (resultOffset >= numRows) {
       break;
     }
@@ -251,19 +251,14 @@ RowVectorPtr Exchange::getOutputFromColumnarPages(VectorSerde* serde) {
       result_->estimateFlatSize() / numOutputRows,
       estimatedRowSize_.value_or(1L));
 
-  // If processed all pages, clear the vector and reset state
+  // If processed all pages, clear the vector and reset state.
   if (columnarPageIdx_ >= currentPages_.size()) {
     VELOX_CHECK_NULL(inputStream_);
     currentPages_.clear();
     columnarPageIdx_ = 0;
   }
 
-  // Record stats
-  auto lockedStats = stats_.wlock();
-  lockedStats->rawInputBytes += rawInputBytes;
-  lockedStats->rawInputPositions += numOutputRows;
-  lockedStats->addInputVector(result_->estimateFlatSize(), numOutputRows);
-
+  recordInputStats(rawInputBytes);
   return result_;
 }
 
@@ -366,13 +361,12 @@ void Exchange::recordExchangeClientStats() {
     lockedStats->runtimeStats.insert({name, value});
   }
 
-  const auto backgroundCpuTimeNanos =
-      exchangeClientStats.find(Operator::kBackgroundCpuTimeNanos);
-  if (backgroundCpuTimeNanos != exchangeClientStats.end()) {
+  const auto iter = exchangeClientStats.find(Operator::kBackgroundCpuTimeNanos);
+  if (iter != exchangeClientStats.end()) {
     const CpuWallTiming backgroundTiming{
-        static_cast<uint64_t>(backgroundCpuTimeNanos->second.count),
+        static_cast<uint64_t>(iter->second.count),
         0,
-        static_cast<uint64_t>(backgroundCpuTimeNanos->second.sum)};
+        static_cast<uint64_t>(iter->second.sum)};
     lockedStats->backgroundTiming.clear();
     lockedStats->backgroundTiming.add(backgroundTiming);
   }


### PR DESCRIPTION
We can use the existing 'recordInputStats()' utility function instead  
of manually updating individual metrics(rawInputBytes,  
rawInputPositions, and addInputVector) in  
Exchange::getOutputFromColumnarPages().  

Also add clarifying comment about how 'rawInputBytes' tracks page  
bytes to prevent double-counting.  

No functional changes.