### PR TITLE
refactor: Use std::move for std::function in PrestoSerializedPage ctor

### DIFF
--- a/velox/exec/SerializedPage.cpp
+++ b/velox/exec/SerializedPage.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/exec/SerializedPage.h"
 
+#include <utility>
+
 namespace facebook::velox::exec {
 
 PrestoSerializedPage::PrestoSerializedPage(
@@ -24,7 +26,7 @@ PrestoSerializedPage::PrestoSerializedPage(
     : iobuf_(std::move(iobuf)),
       iobufBytes_(chainBytes(*iobuf_.get())),
       numRows_(numRows),
-      onDestructionCb_(onDestructionCb) {
+      onDestructionCb_(std::move(onDestructionCb)) {
   VELOX_CHECK_NOT_NULL(iobuf_);
   for (auto& buf : *iobuf_) {
     int32_t bufSize = buf.size();


### PR DESCRIPTION
This forces an unnecessary and potentially expensive copy of the  
`std::function` object. The cost is particularly high if the underlying  
callable object requires a heap allocation (e.g., a lambda with a  
large capture).  

No functional changes.  