### PR TITLE
fix: Array concat should require 2 arguments as part of the function signature

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -686,24 +686,22 @@ template <typename TExec, typename T>
 struct ArrayConcatFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec)
 
-  static constexpr int32_t kMinArity = 2;
-  static constexpr int32_t kMaxArity = 254;
+  static constexpr int32_t kMaxArity = 252;
 
   void call(
       out_type<Array<T>>& out,
+      const arg_type<Array<T>>& array1,
+      const arg_type<Array<T>>& array2,
       const arg_type<Variadic<Array<T>>>& arrays) {
-    VELOX_USER_CHECK_GE(
-        arrays.size(),
-        kMinArity,
-        "There must be {} or more arguments to concat",
-        kMinArity);
     VELOX_USER_CHECK_LE(
         arrays.size(), kMaxArity, "Too many arguments for concat function");
-    int64_t elementCount = 0;
+    int64_t elementCount = array1.size() + array2.size();
     for (const auto& array : arrays) {
       elementCount += array.value().size();
     }
     out.reserve(elementCount);
+    out.add_items(array1);
+    out.add_items(array2);
     for (const auto& array : arrays) {
       out.add_items(array.value());
     }

--- a/velox/functions/prestosql/registration/ArrayConcatRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayConcatRegistration.cpp
@@ -34,6 +34,8 @@ inline void registerArrayConcatFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayConcatFunction, T>,
       Array<T>,
+      Array<T>,
+      Array<T>,
       Variadic<Array<T>>>({prefix + "concat"});
 }
 } // namespace

--- a/velox/functions/prestosql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConcatTest.cpp
@@ -124,7 +124,9 @@ TEST_F(ArrayConcatTest, arity) {
       "concat(c0, c1, c2, c3)", {array1, array4, array3, array2}, expected);
 
   testExpressionWithError(
-      "concat(c0)", {array1}, "There must be 2 or more arguments to concat");
+      "concat(c0)",
+      {array1},
+      "Scalar function signature is not supported: concat(ARRAY<BIGINT>).");
 
   std::stringstream expression;
   std::vector<VectorPtr> inputArrayVector;


### PR DESCRIPTION
Summary:
Today ArrayConcat requires a minimum of 2 arguments when taking a variable number of arrays to concat. This requirement is enforced at runtime when executing the function.

This was inherited from Presto Java, but it leads to inconsistent behavior when expression flattening and constant folding are enabled/disabled.

For example,

concat(concat(array[1, 2], array[3, 4]))

When constant folding is enabled, this becomes

concat(array[1, 2, 3, 4])

This throws an exception because the number of arguments to concat is less than 2.

But when constant folding is disabled and flattening is enabled, this becomes

concat(array[1, 2], array[3, 4])

This is valid and returns array[1, 2, 3, 4]

To fix this, I've updated the signature of concat to take 2 arrays explicitly and then a variable 
number of additional array arguments.  This enforces the minimum 2 arguments at the 
signature level and prevents this inconsistency.

String concat faced the same issue and this approach is consistent with what was done there.
https://github.com/facebookincubator/velox/pull/11076

Differential Revision: D89003931


