### PR TITLE
feat(geo): Increase default BingTile zoom shift from 6 to 7

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -817,7 +817,7 @@ class QueryConfig {
   }
 
   uint8_t debugBingTileChildrenMaxZoomShift() const {
-    return get<uint8_t>(kDebugBingTileChildrenMaxZoomShift, 6);
+    return get<uint8_t>(kDebugBingTileChildrenMaxZoomShift, 7);
   }
 
   uint64_t queryMaxMemoryPerNode() const {

--- a/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BingTileFunctionsTest.cpp
@@ -459,8 +459,8 @@ TEST_F(BingTileFunctionsTest, bingTileChildrenZoom) {
   VELOX_ASSERT_USER_THROW(
       testBingTileChildren(0, 0, 2, 1), "Child zoom 1 must be >= tile zoom 2");
   VELOX_ASSERT_USER_THROW(
-      testBingTileChildren(0, 0, 1, 8),
-      "Difference between parent zoom (1) and child zoom (8) must be <= 6");
+      testBingTileChildren(0, 0, 1, 9),
+      "Difference between parent zoom (1) and child zoom (9) must be <= 7");
 
   {
     RowVectorPtr input = makeSingleXYZoomZoomRow(0, 0, 1, 7);


### PR DESCRIPTION
Summary:
The session parameter debug_bing_tile_children_max_zoom_shift controls
the max difference in zoom (zoom shift) between parent bing tile and child.
The number of children scales like `4 ** zoom_shift`, so bounding this prevents
some OOMs.  In production we are finding zoom shift 7 queries running fine, so
increase this shift so they can run.

Differential Revision: D89079085
