### PR TITLE
test: Increase the default bias factor for biased fuzzer runs

### DIFF
--- a/scripts/ci/signature.py
+++ b/scripts/ci/signature.py
@@ -337,7 +337,7 @@ def parse_args(args):
     bias_command_parser.add_argument("contender", type=str)
     bias_command_parser.add_argument("output_path", type=str)
     bias_command_parser.add_argument(
-        "ticket_value", type=get_tickets, default=10, nargs="?"
+        "ticket_value", type=get_tickets, default=20, nargs="?"
     )
     bias_command_parser.add_argument("error_path", type=str, default="")
 


### PR DESCRIPTION
Summary:
Today, when we create bias runs we give the functions we're biasing 10 tickets by default,
(other functions have 1).  I've seen this result in a little over 1 in 10 queries using the function
we're biasing for.

Bump up the default to get that ratio higher to improve coverage (we've seen things slip
through despite this).

Differential Revision: D89085415


