### PR TITLE
feat(readers): Control knob for string optimization in selective reader

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -449,8 +449,16 @@ class RowReaderOptions {
     return trackRowSize_;
   }
 
-  void setTrackRowSize(bool value) {
-    trackRowSize_ = value;
+  void setTrackRowSize(bool trackRowSize) {
+    trackRowSize_ = trackRowSize;
+  }
+
+  bool passStringBuffersFromDecoder() const {
+    return passStringBuffersFromDecoder_;
+  }
+
+  void setPassStringBuffersFromDecoder(bool passStringBuffersFromDecoder) {
+    passStringBuffersFromDecoder_ = passStringBuffersFromDecoder;
   }
 
  private:
@@ -513,6 +521,7 @@ class RowReaderOptions {
 
   std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;
   bool trackRowSize_{false};
+  bool passStringBuffersFromDecoder_{true};
 };
 
 /// Options for creating a Reader.


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/363

Use a flag in row reader option to control the encoding flavor in nimble selective reader, as a feature switch for future Encoding optimizations.

We will need a future presto PR for the prestissimo kill switch.

Differential Revision: D88118026


