### PR TITLE
fix: Array_flatten can produce an output ArrayVector where the ranges overlap

### DIFF
--- a/velox/functions/prestosql/ArrayFlatten.cpp
+++ b/velox/functions/prestosql/ArrayFlatten.cpp
@@ -106,6 +106,8 @@ class ArrayFlattenFunction : public exec::VectorFunction {
       state.arraySizes = arrayVector->rawSizes();
 
       const auto innerArrayVector = arrayVector->elements();
+      state.flattenElementsConsecutive =
+          innerArrayVector->encoding() == VectorEncoding::Simple::ARRAY;
       state.innerArrayRowSelector =
           std::make_unique<exec::LocalSelectivityVector>(
               context, innerArrayVector->size());


### PR DESCRIPTION
Summary:
array_flatten has an optimization where for each outer array, the elements of the inner arrays
are sequential, it will create the output ArrayVector by simply allocating new offsets and sizes 
and reusing the original elements Vector rather than Dictionary encoding them.

However, if the inner arrays are themselves encoded this can result in arrays getting created
in the output with overlapping ranges. This violates a core assumption in Velox and leads to
issues downstream (e.g. it's common to assume you can map from an element back to the
single array that contains that element).

To fix this I've updated the optimization to only apply when the inner arrays are not encoded.

Differential Revision: D89097376


