### PR TITLE
fix: Remove unused-but-set variables in velox

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzer.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzer.cpp
@@ -654,9 +654,8 @@ core::TypedExprPtr ExpressionFuzzer::generateArgFunction(const TypePtr& arg) {
   for (const auto& functionName : baseList) {
     if (findConcreteSignature(args, returnType, functionName)) {
       eligible.push_back(functionName);
-    } else if (
-        auto* signatureTemplate =
-            findSignatureTemplate(args, returnType, baseType, functionName)) {
+    } else if (findSignatureTemplate(
+                   args, returnType, baseType, functionName)) {
       eligible.push_back(functionName);
     }
   }

--- a/velox/tpcds/gen/dsdgen/scaling.cpp
+++ b/velox/tpcds/gen/dsdgen/scaling.cpp
@@ -217,7 +217,8 @@ ds_key_t getIDCount(int nTable, DSDGenContext& dsdGenContext) {
  */
 ds_key_t get_rowcount(int table, DSDGenContext& dsdGenContext) {
   static double nScale;
-  int nTable, nMultiplier, i, nBadScale = 0, nRowcountOffset = 0;
+  int nTable, nMultiplier, i, nRowcountOffset = 0;
+  // int nBadScale = 0;
   tdef* pTdef;
 
   if (!dsdGenContext.get_rowcount_init) {
@@ -270,7 +271,7 @@ ds_key_t get_rowcount(int table, DSDGenContext& dsdGenContext) {
               dsdGenContext);
           break;
         case 300:
-          nBadScale = QERR_BAD_SCALE;
+          // nBadScale = QERR_BAD_SCALE;
           dsdGenContext.arRowcount[nTable].kBaseRowcount = dist_weight(
               NULL,
               "rowcounts",
@@ -279,7 +280,7 @@ ds_key_t get_rowcount(int table, DSDGenContext& dsdGenContext) {
               dsdGenContext);
           break;
         case 100:
-          nBadScale = QERR_BAD_SCALE;
+          // nBadScale = QERR_BAD_SCALE;
           dsdGenContext.arRowcount[nTable].kBaseRowcount = dist_weight(
               NULL,
               "rowcounts",
@@ -288,7 +289,7 @@ ds_key_t get_rowcount(int table, DSDGenContext& dsdGenContext) {
               dsdGenContext);
           break;
         case 10:
-          nBadScale = QERR_BAD_SCALE;
+          // nBadScale = QERR_BAD_SCALE;
           dsdGenContext.arRowcount[nTable].kBaseRowcount = dist_weight(
               NULL,
               "rowcounts",
@@ -297,7 +298,7 @@ ds_key_t get_rowcount(int table, DSDGenContext& dsdGenContext) {
               dsdGenContext);
           break;
         case 1:
-          nBadScale = QERR_QUALIFICATION_SCALE;
+          // nBadScale = QERR_QUALIFICATION_SCALE;
           dsdGenContext.arRowcount[nTable].kBaseRowcount = dist_weight(
               NULL,
               "rowcounts",
@@ -306,7 +307,7 @@ ds_key_t get_rowcount(int table, DSDGenContext& dsdGenContext) {
               dsdGenContext);
           break;
         default:
-          nBadScale = QERR_BAD_SCALE;
+          // nBadScale = QERR_BAD_SCALE;
           int mem =
               dist_member(NULL, "rowcounts", nTable + 1, 3, dsdGenContext);
           switch (mem) {

--- a/velox/tpcds/gen/dsdgen/scd.cpp
+++ b/velox/tpcds/gen/dsdgen/scd.cpp
@@ -143,8 +143,7 @@ int setSCDKeys(
 ds_key_t
 scd_join(int tbl, int col, ds_key_t jDate, DSDGenContext& dsdGenContext) {
   ds_key_t res, kRowcount;
-  static int jMinimumDataDate, jMaximumDataDate, jH1DataDate, jT1DataDate,
-      jT2DataDate;
+  static int jMinimumDataDate, jMaximumDataDate, jT1DataDate, jT2DataDate;
   date_t dtTemp;
 
   if (!dsdGenContext.scd_join_init) {
@@ -152,7 +151,6 @@ scd_join(int tbl, int col, ds_key_t jDate, DSDGenContext& dsdGenContext) {
     jMinimumDataDate = dtTemp.julian;
     strtodt(&dtTemp, DATA_END_DATE);
     jMaximumDataDate = dtTemp.julian;
-    jH1DataDate = jMinimumDataDate + (jMaximumDataDate - jMinimumDataDate) / 2;
     jT2DataDate = (jMaximumDataDate - jMinimumDataDate) / 3;
     jT1DataDate = jMinimumDataDate + jT2DataDate;
     jT2DataDate += jT1DataDate;

--- a/velox/tpcds/gen/dsdgen/w_call_center.cpp
+++ b/velox/tpcds/gen/dsdgen/w_call_center.cpp
@@ -70,8 +70,8 @@ int mk_w_call_center(
     void* info_arr,
     ds_key_t index,
     DSDGenContext& dsdGenContext) {
-  int32_t jDateStart, nDaysPerRevision;
-  int32_t nSuffix, bFirstRecord = 0, nFieldChangeFlags, jDateEnd, nDateRange;
+  int32_t jDateStart;
+  int32_t nSuffix, bFirstRecord = 0, nFieldChangeFlags;
   char *cp = nullptr, *sName1 = nullptr, *sName2 = nullptr;
   decimal_t dMinTaxPercentage, dMaxTaxPercentage;
   tdef* pTdef = getSimpleTdefsByNumber(CALL_CENTER, dsdGenContext);
@@ -85,10 +85,6 @@ int mk_w_call_center(
 
   strtodt(&dTemp, DATA_START_DATE);
   jDateStart = dttoj(&dTemp) - WEB_SITE;
-  strtodt(&dTemp, DATA_END_DATE);
-  jDateEnd = dttoj(&dTemp);
-  nDateRange = jDateEnd - jDateStart + 1;
-  nDaysPerRevision = nDateRange / pTdef->nParam + 1;
   nScale = get_dbl("SCALE", dsdGenContext);
 
   r->cc_division_id = -1;
@@ -130,8 +126,9 @@ int mk_w_call_center(
         dsdGenContext);
     if (nSuffix > 0) {
       snprintf(r->cc_name, RS_CC_NAME + 1, "%s_%d", cp, nSuffix);
-    } else
+    } else {
       strcpy(r->cc_name, cp);
+    }
 
     mk_address(&r->cc_address, CC_ADDRESS, dsdGenContext);
     bFirstRecord = 1;

--- a/velox/tpcds/gen/dsdgen/w_customer.cpp
+++ b/velox/tpcds/gen/dsdgen/w_customer.cpp
@@ -61,7 +61,6 @@ int mk_w_customer(
     DSDGenContext& dsdGenContext) {
   int nTemp;
 
-  int nBaseDate;
   /* begin locals declarations */
   int nNameIndex, nGender;
   struct W_CUSTOMER_TBL* r;
@@ -69,10 +68,6 @@ int mk_w_customer(
   date_t dtBirthMin, dtBirthMax, dtToday, dt1YearAgo, dt10YearsAgo;
   tdef* pT = getSimpleTdefsByNumber(CUSTOMER, dsdGenContext);
   r = &dsdGenContext.g_w_customer;
-
-  date_t min_date;
-  strtodt(&min_date, DATE_MINIMUM);
-  nBaseDate = dttoj(&min_date);
 
   strtodt(&dtBirthMax, "1992-12-31");
   strtodt(&dtBirthMin, "1924-01-01");

--- a/velox/tpcds/gen/dsdgen/w_promotion.cpp
+++ b/velox/tpcds/gen/dsdgen/w_promotion.cpp
@@ -63,7 +63,6 @@ int mk_w_promotion(
 
   /* begin locals declarations */
   date_t start_date;
-  ds_key_t nTemp;
   int nFlags;
   tdef* pTdef = getSimpleTdefsByNumber(PROMOTION, dsdGenContext);
 
@@ -80,7 +79,6 @@ int mk_w_promotion(
   nullSet(&pTdef->kNullBitMap, P_NULLS, dsdGenContext);
   r->p_promo_sk = index;
   mk_bkey(&r->p_promo_id[0], index, P_PROMO_ID);
-  nTemp = index;
   r->p_start_date_id = start_date.julian +
       genrand_integer(NULL,
                       DIST_UNIFORM,

--- a/velox/tpcds/gen/dsdgen/w_store.cpp
+++ b/velox/tpcds/gen/dsdgen/w_store.cpp
@@ -55,7 +55,7 @@ int mk_w_store(void* info_arr, ds_key_t index, DSDGenContext& dsdGenContext) {
   /* begin locals declarations */
   static decimal_t dRevMin, dRevMax;
   char *sName1 = nullptr, *sName2 = nullptr, *szTemp = nullptr;
-  int32_t nHierarchyTotal, nStoreType, nPercentage, nDaysOpen, nMin, nMax;
+  int32_t nStoreType, nPercentage, nDaysOpen, nMin, nMax;
   static date_t tDate;
   static decimal_t min_rev_growth, max_rev_growth, dMinTaxPercentage,
       dMaxTaxPercentage;
@@ -65,8 +65,6 @@ int mk_w_store(void* info_arr, ds_key_t index, DSDGenContext& dsdGenContext) {
   r = &dsdGenContext.g_w_store;
 
   if (!dsdGenContext.mk_w_store_init) {
-    nHierarchyTotal = static_cast<int>(get_rowcount(DIVISIONS, dsdGenContext));
-    nHierarchyTotal *= static_cast<int>(get_rowcount(COMPANY, dsdGenContext));
     strtodt(&tDate, DATE_MINIMUM);
     strtodec(&min_rev_growth, STORE_MIN_REV_GROWTH);
     strtodec(&max_rev_growth, STORE_MAX_REV_GROWTH);

--- a/velox/tpcds/gen/dsdgen/w_store_sales.cpp
+++ b/velox/tpcds/gen/dsdgen/w_store_sales.cpp
@@ -54,14 +54,12 @@ W_STORE_SALES_TBL* mk_master_store_sales(
     ds_key_t index,
     DSDGenContext& dsdGenContext) {
   decimal_t dMin, dMax;
-  int nMaxItemCount;
   struct W_STORE_SALES_TBL* r;
   r = &dsdGenContext.g_w_store_sales;
 
   if (!dsdGenContext.mk_master_store_sales_init) {
     strtodec(&dMin, "1.00");
     strtodec(&dMax, "100000.00");
-    nMaxItemCount = 20;
     dsdGenContext.pStoreSalesItemPermutation = makePermutation(
         dsdGenContext.nStoreSalesItemCount =
             static_cast<int>(getIDCount(ITEM, dsdGenContext)),

--- a/velox/tpcds/gen/dsdgen/w_web_page.cpp
+++ b/velox/tpcds/gen/dsdgen/w_web_page.cpp
@@ -66,7 +66,6 @@ int mk_w_web_page(
     DSDGenContext& dsdGenContext) {
   int32_t bFirstRecord = 0, nFieldChangeFlags;
   date_t dToday;
-  ds_key_t nConcurrent, nRevisions;
 
   /* begin locals declarations */
   int32_t nTemp, nAccess;
@@ -86,10 +85,6 @@ int mk_w_web_page(
       CURRENT_DAY);
   strtodt(&dToday, szTemp.data());
   /* set up for the SCD handling */
-  nConcurrent =
-      static_cast<int>(get_rowcount(CONCURRENT_WEB_SITES, dsdGenContext));
-  nRevisions =
-      static_cast<int>(get_rowcount(WEB_PAGE, dsdGenContext) / nConcurrent);
 
   nullSet(&pT->kNullBitMap, WP_NULLS, dsdGenContext);
   r->wp_page_sk = index;


### PR DESCRIPTION
Summary:
This diff removes a variable that was set, but which was not used.

LLVM-15 has a warning `-Wunused-but-set-variable` which we treat as an error because it's so often diagnostic of a code issue. Unused but set variables often indicate a programming mistake, but can also just be unnecessary cruft that harms readability and performance.

Removing this variable will not change how your code works, but the unused variable may indicate your code isn't working the way you thought it was. If you feel the diff needs changes before landing, **please commandeer** and make appropriate changes: there are hundreds of these and responding to them individually is challenging.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D89094087


