### PR TITLE
feat(readers): Control knob in row reader option

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -449,8 +449,16 @@ class RowReaderOptions {
     return trackRowSize_;
   }
 
-  void setTrackRowSize(bool value) {
-    trackRowSize_ = value;
+  void setTrackRowSize(bool trackRowSize) {
+    trackRowSize_ = trackRowSize;
+  }
+
+  bool passStringBuffersFromDecoder() const {
+    return passStringBuffersFromDecoder_;
+  }
+
+  void setPassStringBuffersFromDecoder(bool passStringBuffersFromDecoder) {
+    passStringBuffersFromDecoder_ = passStringBuffersFromDecoder;
   }
 
  private:
@@ -513,6 +521,7 @@ class RowReaderOptions {
 
   std::shared_ptr<FormatSpecificOptions> formatSpecificOptions_;
   bool trackRowSize_{false};
+  bool passStringBuffersFromDecoder_{true};
 };
 
 /// Options for creating a Reader.


### PR DESCRIPTION
Summary:
See D88118026 for details on the control knob to branch on the different column reader and encoding behavior.

In order for OSS build to pass, we need to first land the velox PR and then advance velox hash.

Differential Revision: D89134173


