### PR TITLE
feat(exchange): Make Exchange client eager fetching behavior configurable

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -735,6 +735,13 @@ class QueryConfig {
   static constexpr const char* kSkipRequestDataSizeWithSingleSourceEnabled =
       "skip_request_data_size_with_single_source_enabled";
 
+  /// If true, exchange clients defer data fetching until next() is called.
+  /// This enables waiter tasks using cached hash tables to skip I/O entirely
+  /// when the table is already cached. If false (default), exchange clients
+  /// start fetching data immediately when remote tasks are added.
+  static constexpr const char* kExchangeLazyFetchingEnabled =
+      "exchange_lazy_fetching_enabled";
+
   /// If this is true, then it allows you to get the struct field names
   /// as json element names when casting a row to json.
   static constexpr const char* kFieldNamesInJsonCastEnabled =
@@ -1375,6 +1382,10 @@ class QueryConfig {
 
   bool singleSourceExchangeOptimizationEnabled() const {
     return get<bool>(kSkipRequestDataSizeWithSingleSourceEnabled, false);
+  }
+
+  bool exchangeLazyFetchingEnabled() const {
+    return get<bool>(kExchangeLazyFetchingEnabled, false);
   }
 
   bool isFieldNamesInJsonCastEnabled() const {

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -53,7 +53,16 @@ void ExchangeClient::addRemoteTaskId(const std::string& remoteTaskId) {
       sources_.push_back(source);
       queue_->addSourceLocked();
       emptySources_.push(source);
-      requestSpecs = pickSourcesToRequestLocked();
+      // When lazyFetching_ is true, I/O will be triggered lazily when next() is
+      // called from Exchange::isBlocked(). This allows waiter tasks using
+      // cached hash tables to skip I/O entirely when the table is already
+      // cached - the HashBuild operator will finish before
+      // Exchange::isBlocked() is ever called, so no unnecessary data fetching
+      // occurs.
+      if (!lazyFetching_) {
+        // Start fetching data immediately.
+        requestSpecs = pickSourcesToRequestLocked();
+      }
     }
   }
 

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -36,7 +36,8 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
       memory::MemoryPool* pool,
       folly::Executor* executor,
       int32_t requestDataSizesMaxWaitSec = 10,
-      bool skipRequestDataSizeWithSingleSource = false)
+      bool skipRequestDataSizeWithSingleSource = false,
+      bool lazyFetching = false)
       : taskId_{std::move(taskId)},
         destination_(destination),
         maxQueuedBytes_{maxQueuedBytes},
@@ -55,7 +56,8 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
         minOutputBatchBytes_(
             std::max(static_cast<uint64_t>(1), minOutputBatchBytes)),
         skipRequestDataSizeWithSingleSource_(
-            skipRequestDataSizeWithSingleSource) {
+            skipRequestDataSizeWithSingleSource),
+        lazyFetching_(lazyFetching) {
     VELOX_CHECK_NOT_NULL(pool_);
     VELOX_CHECK_NOT_NULL(executor_);
     // NOTE: the executor is used to run async response callback from the
@@ -188,6 +190,11 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   // Enable single source exchange optimization query config flag
   // when there is only one exchange source.
   const bool skipRequestDataSizeWithSingleSource_;
+
+  // If true, defer fetching until next() is called.
+  // If false (default), start fetching data immediately when remote tasks are
+  // added.
+  const bool lazyFetching_;
 
   // Total number of bytes in flight.
   int64_t totalPendingBytes_{0};

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3428,7 +3428,8 @@ void Task::createExchangeClientLocked(
       addExchangeClientPool(planNodeId, pipelineId),
       queryCtx()->executor(),
       queryCtx()->queryConfig().requestDataSizesMaxWaitSec(),
-      queryCtx()->queryConfig().singleSourceExchangeOptimizationEnabled());
+      queryCtx()->queryConfig().singleSourceExchangeOptimizationEnabled(),
+      queryCtx()->queryConfig().exchangeLazyFetchingEnabled());
   exchangeClientByPlanNode_.emplace(planNodeId, exchangeClients_[pipelineId]);
 }
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -1066,6 +1066,83 @@ TEST_P(ExchangeClientTest, skipRequestDataSizeNotTriggeredWithMultipleSources) {
   client->close();
 }
 
+// Test that lazyFetching=true defers data fetching until next() is called.
+// When lazyFetching=false (default), fetching starts immediately when remote
+// tasks are added via pickSourcesToRequestLocked(). When lazyFetching=true,
+// pickSourcesToRequestLocked() is not called in addRemoteTaskId(), deferring
+// the fetch until next() is called. This is useful for cached hash table
+// scenarios where waiter tasks may not need the data if the table is already
+// cached.
+TEST_P(ExchangeClientTest, lazyFetching) {
+  auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4, 5})});
+
+  // Test with lazyFetching=false (default behavior).
+  // Verify that fetching starts and we can retrieve pages normally.
+  {
+    auto taskId = "local://eager-fetching-test";
+    auto task = makeTask(taskId);
+
+    bufferManager_->initializeTask(
+        task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
+
+    auto client = std::make_shared<ExchangeClient>(
+        "t",
+        17,
+        ExchangeClient::kDefaultMaxQueuedBytes,
+        1,
+        kDefaultMinExchangeOutputBatchBytes,
+        pool(),
+        executor(),
+        10, // requestDataSizesMaxWaitSec
+        false, // skipRequestDataSizeWithSingleSource
+        false); // lazyFetching=false (default)
+
+    client->addRemoteTaskId(taskId);
+    enqueue(taskId, 17, data);
+
+    auto pages = fetchPages(1, *client, 1);
+    ASSERT_EQ(1, pages.size());
+
+    task->requestCancel();
+    bufferManager_->removeTask(taskId);
+    client->close();
+  }
+
+  // Test with lazyFetching=true.
+  // Verify that we can still retrieve pages (fetch is triggered by next()).
+  {
+    auto taskId = "local://lazy-fetching-test";
+    auto task = makeTask(taskId);
+
+    bufferManager_->initializeTask(
+        task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
+
+    auto client = std::make_shared<ExchangeClient>(
+        "t",
+        17,
+        ExchangeClient::kDefaultMaxQueuedBytes,
+        1,
+        kDefaultMinExchangeOutputBatchBytes,
+        pool(),
+        executor(),
+        10, // requestDataSizesMaxWaitSec
+        false, // skipRequestDataSizeWithSingleSource
+        true); // lazyFetching=true
+
+    client->addRemoteTaskId(taskId);
+    enqueue(taskId, 17, data);
+
+    // Even with lazy fetching, we should be able to retrieve pages
+    // since next() triggers the fetch.
+    auto pages = fetchPages(1, *client, 1);
+    ASSERT_EQ(1, pages.size());
+
+    task->requestCancel();
+    bufferManager_->removeTask(taskId);
+    client->close();
+  }
+}
+
 // Test the new hasNoMoreSources() API
 TEST_P(ExchangeClientTest, hasNoMoreSourcesApi) {
   auto queue = std::make_shared<ExchangeQueue>(1, 0);


### PR DESCRIPTION
Summary:
Currently, Exchange operator upon executing `addRemoteTaskId` will eagerly initiate exchange sources 
to start reading data.
But if the downstream operator is a HashBuild that is going to use a cached HT, this eager request is wasteful 
and can even cause excessive read I/O on the data source.

Adding a flag to turn off this behavior completely in cases when HT caching is going to be enabled.
For batch materialization systems, presto-on-spark for example, the eager exchange source fetching is
not of as much importance either way.

Differential Revision: D88900098


