### PR TITLE
refactor: Refactor SignatureBinder to use pointer for coercions and update related methods

### DIFF
--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -118,7 +118,7 @@ static bool matchCallAgainstSignatures(
   for (const auto& sig : sigs) {
     std::vector<Coercion> coercions(n);
     exec::SignatureBinder binder(*sig, argTypes);
-    if (!binder.tryBindWithCoercions(coercions)) {
+    if (!binder.tryBind(&coercions)) {
       continue;
     }
     // binder does not confirm whether positional arguments are

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -152,7 +152,8 @@ void validate(
     const TypeSignature& returnType,
     const std::vector<TypeSignature>& argumentTypes,
     const std::vector<bool>& constantArguments,
-    const std::vector<TypeSignature>& additionalTypes = {}) {
+    const std::vector<TypeSignature>& additionalTypes,
+    bool variableArity) {
   std::unordered_set<std::string> usedVariables;
   // Validate the additional types, and collect the used variables.
   for (const auto& type : additionalTypes) {
@@ -185,6 +186,10 @@ void validate(
       argumentTypes.size(),
       constantArguments.size(),
       "Argument types size is not equal to constant flags");
+
+  if (variableArity) {
+    VELOX_USER_CHECK_GE(argumentTypes.size(), 1);
+  }
 }
 
 } // namespace
@@ -224,7 +229,13 @@ FunctionSignature::FunctionSignature(
       argumentTypes_{std::move(argumentTypes)},
       constantArguments_{std::move(constantArguments)},
       variableArity_{variableArity} {
-  validate(variables_, returnType_, argumentTypes_, constantArguments_);
+  validate(
+      variables_,
+      returnType_,
+      argumentTypes_,
+      constantArguments_,
+      {},
+      variableArity_);
 }
 
 FunctionSignature::FunctionSignature(
@@ -244,7 +255,8 @@ FunctionSignature::FunctionSignature(
       returnType_,
       argumentTypes_,
       constantArguments_,
-      additionalTypes);
+      additionalTypes,
+      variableArity_);
 }
 
 std::string AggregateFunctionSignature::toString() const {

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -29,20 +29,15 @@ class SignatureBinderBase {
   /// Return true if actualType can bind to typeSignature and update bindings_
   /// accordingly. The number of parameters in typeSignature and actualType
   /// must match. Return false otherwise.
+  /// Non-null 'coercion' allows implicit type conversion if actualType
+  /// doesn't match typeSignature exactly.
+  /// @param coercion Type coercion necessary to bind actualType to
+  /// typeSignature if there is no exact match. 'coercion->type' is null if
+  /// there is exact match.
   bool tryBind(
       const exec::TypeSignature& typeSignature,
-      const TypePtr& actualType);
-
-  /// Like 'tryBind', but allows implicit type conversion if actualType
-  /// doesn't match typeSignature exactly.
-  ///
-  /// @param coercion Type coercion necessary to bind actualType to
-  /// typeSignature if there is no exact match. 'coercion.type' is null if
-  /// there is exact match.
-  bool tryBindWithCoercion(
-      const exec::TypeSignature& typeSignature,
       const TypePtr& actualType,
-      Coercion& coercion);
+      Coercion* coercion = nullptr);
 
   // Return the variables of the signature.
   auto& variables() const {
@@ -84,12 +79,6 @@ class SignatureBinderBase {
   bool tryBindIntegerParameters(
       const std::vector<exec::TypeSignature>& parameters,
       const TypePtr& actualType);
-
-  bool tryBind(
-      const exec::TypeSignature& typeSignature,
-      const TypePtr& actualType,
-      bool allowCoercion,
-      Coercion& coercion);
 };
 
 /// Resolves generic type names in the function signature using actual input
@@ -109,14 +98,12 @@ class SignatureBinder : private SignatureBinderBase {
       : SignatureBinderBase{signature}, actualTypes_{actualTypes} {}
 
   /// Returns true if successfully resolved all generic type names.
-  bool tryBind();
-
-  /// Like 'tryBind', but allows implicit type conversion if actualTypes don't
+  /// Allows implicit type conversion if actualTypes don't
   /// match the signature exactly.
   /// @param coercions Type coercions necessary to bind actualTypes to the
   /// signature. There is one entry per argument. Coercion.type is null if no
   /// coercion is required for that argument.
-  bool tryBindWithCoercions(std::vector<Coercion>& coercions);
+  bool tryBind(std::vector<Coercion>* coercions = nullptr);
 
   /// Returns concrete return type or nullptr if couldn't fully resolve.
   TypePtr tryResolveReturnType() {
@@ -184,8 +171,6 @@ class SignatureBinder : private SignatureBinderBase {
           varcharEnumVariablesBindings);
 
  private:
-  bool tryBind(bool allowCoercions, std::vector<Coercion>& coercions);
-
   const std::vector<TypePtr>& actualTypes_;
 };
 

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -156,23 +156,21 @@ class SimpleFunctionRegistry {
   std::optional<ResolvedSimpleFunction> resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes) const {
-    std::vector<TypePtr> coercions;
-    return resolveFunction(name, argTypes, false, coercions);
+    return resolveFunction(name, argTypes, nullptr);
   }
 
   std::optional<ResolvedSimpleFunction> resolveFunctionWithCoercions(
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
       std::vector<TypePtr>& coercions) const {
-    return resolveFunction(name, argTypes, true, coercions);
+    return resolveFunction(name, argTypes, &coercions);
   }
 
  private:
   std::optional<ResolvedSimpleFunction> resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes,
-      bool allowCoercion,
-      std::vector<TypePtr>& coercions) const;
+      std::vector<TypePtr>* coercions) const;
 
   /// Registers a function with the given name and metadata. If an entry with
   /// the name already exists and 'overwrite' is true, the existing entry is

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -111,7 +111,7 @@ TypePtr resolveVectorFunctionWithCoercions(
         for (const auto& signature : entry.signatures) {
           exec::SignatureBinder binder(*signature, argTypes);
           std::vector<Coercion> requiredCoercions;
-          if (binder.tryBindWithCoercions(requiredCoercions)) {
+          if (binder.tryBind(&requiredCoercions)) {
             auto type = binder.tryResolveReturnType();
             if (!hasCoercion(requiredCoercions)) {
               coercions.resize(argTypes.size(), nullptr);

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -51,7 +51,7 @@ void testSignatureBinder(
   ASSERT_TRUE(binder.tryBind());
 
   std::vector<Coercion> coercions;
-  ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+  ASSERT_TRUE(binder.tryBind(&coercions));
 
   ASSERT_EQ(coercions.size(), actualTypes.size());
   for (const auto& coercion : coercions) {
@@ -75,7 +75,7 @@ void assertCannotBind(
 
   if (allowCoercion) {
     std::vector<Coercion> coercions;
-    ASSERT_FALSE(binder.tryBindWithCoercions(coercions));
+    ASSERT_FALSE(binder.tryBind(&coercions));
   }
 }
 
@@ -89,7 +89,7 @@ void assertCannotResolve(
   ASSERT_TRUE(binder.tryBind());
 
   std::vector<Coercion> coercions;
-  ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+  ASSERT_TRUE(binder.tryBind(&coercions));
 
   ASSERT_EQ(coercions.size(), actualTypes.size());
   for (const auto& coercion : coercions) {
@@ -1078,7 +1078,7 @@ void testCoercions(
   ASSERT_FALSE(binder.tryBind());
 
   std::vector<Coercion> coercions;
-  ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+  ASSERT_TRUE(binder.tryBind(&coercions));
 
   ASSERT_EQ(expectedCoercions.size(), coercions.size());
   for (auto i = 0; i < expectedCoercions.size(); ++i) {
@@ -1114,7 +1114,7 @@ void testNoCoercions(
     exec::SignatureBinder binder(*signature, actualTypes);
 
     std::vector<Coercion> coercions;
-    ASSERT_TRUE(binder.tryBindWithCoercions(coercions));
+    ASSERT_TRUE(binder.tryBind(&coercions));
 
     auto returnType = binder.tryResolveReturnType();
     ASSERT_TRUE(returnType != nullptr);

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -19,10 +19,12 @@
 
 namespace facebook::velox {
 
+using CallableCost = uint64_t;
+
 /// Type coercion necessary to bind a type to a signature.
 struct Coercion {
   TypePtr type;
-  int32_t cost{0};
+  CallableCost cost = 0;
 
   std::string toString() const {
     if (type == nullptr) {
@@ -38,7 +40,7 @@ struct Coercion {
   }
 
   /// Returns overall cost of a list of coercions by adding up individual costs.
-  static int64_t overallCost(const std::vector<Coercion>& coercions);
+  static CallableCost overallCost(const std::vector<Coercion>& coercions);
 
   /// Returns an index of the lowest cost coercion in 'candidates' or nullptr if
   /// 'candidates' is empty or there is a tie.


### PR DESCRIPTION
This PR refactors the SignatureBinder API to use optional pointer parameters for coercions instead of separate methods, and updates the type system to use CallableCost (uint64_t) instead of mixed integer types for cost tracking. The changes consolidate two separate methods (tryBind and tryBindWithCoercions) into a single method with an optional pointer parameter.

Key changes:
- Introduced CallableCost type alias (uint64_t) for consistent cost representation across the type coercion system
- Refactored SignatureBinder::tryBind to accept an optional std::vector<Coercion>* parameter instead of having separate methods
- Updated SimpleFunctionRegistry to use the new pointer-based API pattern
- Enhanced function signature validation to check that variadic signatures have at least one argument
