### PR TITLE
fix: Make implicit int64_t -> double conversion explicit

### DIFF
--- a/velox/common/hyperloglog/KHyperLogLogImpl.h
+++ b/velox/common/hyperloglog/KHyperLogLogImpl.h
@@ -250,7 +250,8 @@ int64_t KHyperLogLog<TUii, TAllocator>::cardinality() const {
       static_cast<uint64_t>(maxKey()) - static_cast<uint64_t>(INT64_MIN);
   double halfDensity =
       static_cast<double>(hashesRange) / (minhash_.size() - 1) / 2.0;
-  return static_cast<int64_t>(detail::kHashOutputHalfRange / halfDensity);
+  return static_cast<int64_t>(
+      static_cast<double>(detail::kHashOutputHalfRange) / halfDensity);
 }
 
 template <typename TUii, typename TAllocator>


### PR DESCRIPTION
Summary:
Fixes this error:
/__w/presto/presto/presto-native-execution/velox/velox/common/hyperloglog/KHyperLogLogImpl.h:253:31: error: implicit conversion from 'const int64_t' (aka 'const long') to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-const-int-float-conversion]
  return static_cast<int64_t>(detail::kHashOutputHalfRange / halfDensity);
                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~

Differential Revision: D89159405


