### PR TITLE
fix: Add missing include in Iceberg test

### DIFF
--- a/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <filesystem>
+
 #include "velox/connectors/hive/iceberg/tests/IcebergTestBase.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"


### PR DESCRIPTION
The missing include broke builds in a fedora clang17 laptop. 