### PR TITLE
fix: Fix map_except to handle null elements in complex keys gracefully

### DIFF
--- a/velox/functions/prestosql/MapExcept.h
+++ b/velox/functions/prestosql/MapExcept.h
@@ -143,8 +143,11 @@ struct MapExceptFunctionEqualComparator {
 
     auto result = lhs.compare(rhs, kEqualValueAtFlags);
 
-    VELOX_USER_CHECK(
-        result.has_value(), "Comparison on null elements is not supported");
+    // If comparison returns indeterminate (null), treat as not equal.
+    // This is consistent with SQL semantics where NULL != NULL.
+    if (!result.has_value()) {
+      return false;
+    }
 
     return result.value() == 0;
   }


### PR DESCRIPTION
Summary:
The `map_except` function was throwing an exception when comparing complex keys that contained null descendants. This happened during hash collision resolution in the internal hash set used to track exclusion keys.

The behavior was also inconsistent because the hash set is reused across rows, so whether an exception was thrown depended on previous rows' data (which affected the number of hash buckets and thus the likelihood of hash collisions triggering comparisons).

This fix changes the comparator to return `false` when the comparison result is indeterminate (null), treating null comparisons as "not equal". This is consistent with:
1. SQL semantics where NULL != NULL
2. Other similar functions in the codebase like `MapKeysOverlap` and `MapIntersect`

Differential Revision: D89207005


