### PR TITLE
refactor(geo): Move GeometrySerde to common/geospatial

### DIFF
--- a/velox/common/geospatial/CMakeLists.txt
+++ b/velox/common/geospatial/CMakeLists.txt
@@ -11,4 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+if(VELOX_ENABLE_GEO)
+  velox_add_library(velox_common_geospatial_serde GeometrySerde.cpp)
+  velox_link_libraries(velox_common_geospatial_serde velox_expression GEOS::geos)
+endif()
+
 velox_install_library_headers()
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/common/geospatial/GeometrySerde.cpp
+++ b/velox/common/geospatial/GeometrySerde.cpp
@@ -20,14 +20,20 @@
 #include <geos/geom/Point.h>
 
 #include "velox/common/base/IOUtils.h"
-#include "velox/functions/prestosql/geospatial/GeometrySerde.h"
+#include "velox/common/geospatial/GeometrySerde.h"
 
 using facebook::velox::common::InputByteStream;
-
 using facebook::velox::common::geospatial::EsriShapeType;
 using facebook::velox::common::geospatial::GeometrySerializationType;
 
-namespace facebook::velox::functions::geospatial {
+namespace facebook::velox::common::geospatial {
+
+geos::geom::GeometryFactory* GeometryDeserializer::getGeometryFactory() {
+  thread_local static geos::geom::GeometryFactory::Ptr geometryFactory =
+      geos::geom::GeometryFactory::create();
+  return geometryFactory.get();
+}
+
 std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::readGeometry(
     velox::common::InputByteStream& stream,
     size_t size) {
@@ -236,7 +242,7 @@ std::unique_ptr<geos::geom::Geometry> GeometryDeserializer::readPolygon(
 
     if (multiType) {
       ClockwiseResult clockwiseFlag =
-          isClockwise(coordinates, 0, coordinates->size());
+          GeometrySerializer::isClockwise(coordinates, 0, coordinates->size());
       if (FOLLY_UNLIKELY(clockwiseFlag == ClockwiseResult::ZERO_AREA)) {
         // When serializing a MultiPolygon, we should throw a user error if
         // there is a zero-area ring. This should only get hit due to a bug in
@@ -321,4 +327,4 @@ GeometryDeserializer::readGeometryCollection(
       getGeometryFactory()->createGeometryCollection(rawGeometries));
 }
 
-} // namespace facebook::velox::functions::geospatial
+} // namespace facebook::velox::common::geospatial

--- a/velox/common/geospatial/tests/CMakeLists.txt
+++ b/velox/common/geospatial/tests/CMakeLists.txt
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 if(VELOX_ENABLE_GEO)
-  add_executable(velox_geospatial_test GeometryFunctionsTest.cpp)
+  add_executable(velox_common_geospatial_serde_test GeometrySerdeTest.cpp)
+
+  add_test(velox_common_geospatial_serde_test velox_common_geospatial_serde_test)
+
+  target_link_libraries(
+    velox_common_geospatial_serde_test
+    velox_common_geospatial_serde
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+    GTest::gmock_main
+    GEOS::geos
+  )
 endif()
-
-add_test(velox_geospatial_test velox_geospatial_test)
-
-target_link_libraries(
-  velox_geospatial_test
-  GTest::gtest
-  GTest::gtest_main
-  GTest::gmock
-  GTest::gmock_main
-)

--- a/velox/common/geospatial/tests/GeometrySerdeTest.cpp
+++ b/velox/common/geospatial/tests/GeometrySerdeTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/geospatial/GeometrySerde.h"
+#include "velox/common/geospatial/GeometrySerde.h"
 #include <geos/geom/Geometry.h>
 #include <geos/io/WKTReader.h>
 #include <geos/io/WKTWriter.h>
@@ -23,7 +23,7 @@
 
 using namespace ::testing;
 
-using namespace facebook::velox::functions::geospatial;
+using namespace facebook::velox::common::geospatial;
 
 void assertRoundtrip(const std::string& wkt) {
   geos::io::WKTReader reader;

--- a/velox/functions/prestosql/geospatial/CMakeLists.txt
+++ b/velox/functions/prestosql/geospatial/CMakeLists.txt
@@ -11,6 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(velox_functions_geo GeometrySerde.cpp GeometryUtils.cpp)
+velox_add_library(velox_functions_geo GeometryUtils.cpp)
 
-velox_link_libraries(velox_functions_geo velox_functions_lib GEOS::geos)
+velox_link_libraries(
+  velox_functions_geo
+  velox_common_geospatial_serde
+  velox_functions_lib
+  GEOS::geos
+)

--- a/velox/functions/prestosql/geospatial/GeometryUtils.cpp
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.cpp
@@ -217,12 +217,6 @@ std::vector<const geos::geom::Geometry*> flattenCollection(
   return result;
 }
 
-geos::geom::GeometryFactory* getGeometryFactory() {
-  thread_local static geos::geom::GeometryFactory::Ptr geometryFactory =
-      geos::geom::GeometryFactory::create();
-  return geometryFactory.get();
-}
-
 std::optional<std::string> geometryInvalidReason(
     const geos::geom::Geometry* geometry) {
   if (geometry == nullptr) {

--- a/velox/functions/prestosql/geospatial/GeometryUtils.h
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.h
@@ -67,8 +67,6 @@ class GeometryCollectionIterator {
   std::deque<const geos::geom::Geometry*> geometriesDeque;
 };
 
-geos::geom::GeometryFactory* getGeometryFactory();
-
 FOLLY_ALWAYS_INLINE const
     std::unordered_map<geos::geom::GeometryTypeId, std::string>&
     getGeosTypeToStringIdentifier() {
@@ -148,80 +146,6 @@ FOLLY_ALWAYS_INLINE bool isAtomicType(const geos::geom::Geometry& geometry) {
 
 std::optional<std::string> geometryInvalidReason(
     const geos::geom::Geometry* geometry);
-
-enum ClockwiseResult { CW, CCW, ZERO_AREA };
-
-/// Determines if a ring of coordinates (from `start` to `end`) is oriented
-/// clockwise. A return value of 1 indicates clockwise orientation, 0 indicates
-/// counterclockwise, and -1 represents a polygon which has no orientation due
-/// to having an area of 0.
-FOLLY_ALWAYS_INLINE ClockwiseResult isClockwise(
-    const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
-    size_t start,
-    size_t end) {
-  double sum = 0.0;
-  for (size_t i = start; i < end - 1; i++) {
-    const auto& p1 = coordinates->getAt(i);
-    const auto& p2 = coordinates->getAt(i + 1);
-    sum += (p2.x - p1.x) * (p2.y + p1.y);
-  }
-  if (FOLLY_UNLIKELY(std::abs(sum) < 1e-15)) {
-    return ClockwiseResult::ZERO_AREA;
-  }
-  return sum > 0.0 ? ClockwiseResult::CW : ClockwiseResult::CCW;
-}
-
-/// Reverses the order of coordinates in the sequence between `start` and `end`
-FOLLY_ALWAYS_INLINE void reverse(
-    const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
-    size_t start,
-    size_t end) {
-  for (size_t i = 0; i < (end - start) / 2; ++i) {
-    auto temp = coordinates->getAt(start + i);
-    coordinates->setAt(coordinates->getAt(end - 1 - i), start + i);
-    coordinates->setAt(temp, end - 1 - i);
-  }
-}
-
-/// Ensures that a polygon ring has the canonical orientation:
-/// - Exterior rings (shells) must be clockwise.
-/// - Interior rings (holes) must be counter-clockwise.
-/// A return value of true indicates a zero-area ring was encountered
-FOLLY_ALWAYS_INLINE bool canonicalizePolygonCoordinates(
-    const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
-    size_t start,
-    size_t end,
-    bool isShell) {
-  ClockwiseResult isClockwiseFlag = isClockwise(coordinates, start, end);
-  if (isClockwiseFlag == ClockwiseResult::ZERO_AREA) {
-    return true;
-  }
-
-  if ((isShell && isClockwiseFlag == ClockwiseResult::CCW) ||
-      (!isShell && isClockwiseFlag == ClockwiseResult::CW)) {
-    reverse(coordinates, start, end);
-  }
-  return false;
-}
-
-/// Applies `canonicalizePolygonCoordinates` to all rings in a polygon.
-/// A return value of true indicates at least one zero-area ring was
-/// encountered.
-FOLLY_ALWAYS_INLINE bool canonicalizePolygonCoordinates(
-    const std::unique_ptr<geos::geom::CoordinateSequence>& coordinates,
-    const std::vector<size_t>& partIndexes,
-    const std::vector<bool>& shellPart) {
-  bool zeroAreaRingEncountered = false;
-  for (size_t part = 0; part < partIndexes.size() - 1; part++) {
-    zeroAreaRingEncountered |= canonicalizePolygonCoordinates(
-        coordinates, partIndexes[part], partIndexes[part + 1], shellPart[part]);
-  }
-  if (!partIndexes.empty()) {
-    zeroAreaRingEncountered |= canonicalizePolygonCoordinates(
-        coordinates, partIndexes.back(), coordinates->size(), shellPart.back());
-  }
-  return zeroAreaRingEncountered;
-}
 
 Status validateLatitudeLongitude(double latitude, double longitude);
 

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -21,7 +21,6 @@
 #include "velox/common/testutil/OptionalEmpty.h"
 #include "velox/functions/prestosql/tests/resources/GeometryTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
-#include "velox/functions/prestosql/types/BingTileType.h"
 
 using facebook::velox::functions::test::FunctionBaseTest;
 using namespace facebook::velox;

--- a/velox/functions/prestosql/types/BingTileType.cpp
+++ b/velox/functions/prestosql/types/BingTileType.cpp
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <optional>
 #include <string>
+#include "velox/common/geospatial/GeometryConstants.h"
 
 namespace facebook::velox {
 

--- a/velox/functions/prestosql/types/BingTileType.h
+++ b/velox/functions/prestosql/types/BingTileType.h
@@ -17,7 +17,6 @@
 
 #include <folly/Expected.h>
 #include <cstdint>
-#include "velox/common/geospatial/GeometryConstants.h"
 #include "velox/type/SimpleFunctionApi.h"
 
 namespace facebook::velox {


### PR DESCRIPTION
Summary:
This is a better place to import it from for SpatialJoinBuilder,
which lives in exec.

Differential Revision: D89239583
