### PR TITLE
fix: Fix unreachable-break issue in velox

### DIFF
--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -156,22 +156,16 @@ common::CompressionKind thriftCodecToCompressionKind(
   switch (codec) {
     case thrift::CompressionCodec::UNCOMPRESSED:
       return common::CompressionKind::CompressionKind_NONE;
-      break;
     case thrift::CompressionCodec::SNAPPY:
       return common::CompressionKind::CompressionKind_SNAPPY;
-      break;
     case thrift::CompressionCodec::GZIP:
       return common::CompressionKind::CompressionKind_GZIP;
-      break;
     case thrift::CompressionCodec::LZO:
       return common::CompressionKind::CompressionKind_LZO;
-      break;
     case thrift::CompressionCodec::LZ4:
       return common::CompressionKind::CompressionKind_LZ4;
-      break;
     case thrift::CompressionCodec::ZSTD:
       return common::CompressionKind::CompressionKind_ZSTD;
-      break;
     case thrift::CompressionCodec::LZ4_RAW:
       return common::CompressionKind::CompressionKind_LZ4;
     default:

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -1145,16 +1145,12 @@ VectorPtr deserialize(
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
       return deserializeStrings(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::ARRAY:
       return deserializeArrays(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::MAP:
       return deserializeMaps(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::ROW:
       return deserializeRows(type, data, nulls, offsets, pool);
-      break;
     default:
       VELOX_UNREACHABLE("{}", type->toString());
   }

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -1023,16 +1023,12 @@ VectorPtr deserialize(
     case TypeKind::VARCHAR:
     case TypeKind::VARBINARY:
       return deserializeStrings(type, data, nulls, offsets, pool);
-      break;
     case TypeKind::ARRAY:
       return deserializeArrays(type, data, nulls, pool);
-      break;
     case TypeKind::MAP:
       return deserializeMaps(type, data, nulls, pool);
-      break;
     case TypeKind::ROW:
       return deserializeRows(type, data, nulls, offsets, pool);
-      break;
     default:
       VELOX_UNREACHABLE("{}", type->toString());
   }

--- a/velox/tpcds/gen/dsdgen/join.cpp
+++ b/velox/tpcds/gen/dsdgen/join.cpp
@@ -106,7 +106,6 @@ static ds_key_t date_join(
       genrand_integer(
           &nTemp, DIST_UNIFORM, nMin * 2, nMax * 2, 0, from_col, dsdGenContext);
       return (join_count + nTemp);
-      break;
     case WEB_SITE:
     case WEB_PAGE:
       return (web_join(from_col, join_count, dsdGenContext));


### PR DESCRIPTION
Summary:
LLVM has a warning `-Wunreachable-code-break` which identifies `break` statements that cannot be reached. These compromise readability, are misleading, and may identify bugs. This diff removes such statements.

For questions/comments, contact r-barnes.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: Yuhta

Differential Revision: D89225727


