### PR TITLE
fix: Add KHLL and SetDigest scalar functions to fuzzer skiplist

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -443,6 +443,22 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "localtime", // localtime cannot be called with paranthesis:
                  // https://github.com/facebookincubator/velox/issues/14937,
     "jarowinkler_similarity", // https://github.com/facebookincubator/velox/issues/15736
+    // Fuzzer and the underlying engine are confused about SetDigest functions
+    // (since SetDigest is a user defined type), and tries to pass a
+    // VARBINARY (since SetDigest's implementation uses an
+    // alias to VARBINARY).
+    "cardinality(setdigest) -> bigint",
+    "intersection_cardinality(setdigest,setdigest) -> bigint",
+    "jaccard_index(setdigest,setdigest) -> double",
+    "hash_counts(setdigest) -> map(bigint,smallint)",
+    // Same with KHyperLogLog functions
+    "cardinality(khyperloglog) -> bigint",
+    "intersection_cardinality(khyperloglog,khyperloglog) -> bigint",
+    "jaccard_index(khyperloglog,khyperloglog) -> double",
+    "reidentification_potential(khyperloglog,bigint) -> double",
+    "uniqueness_distribution(khyperloglog) -> map(bigint,double)",
+    "uniqueness_distribution(khyperloglog,bigint) -> map(bigint,double)",
+    "merge_khll(array(khyperloglog)) -> khyperloglog",
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
https://www.internalfb.com/servicelab/experiment/1929342688008399/trial/1929342874675047/twlogs?logHandle=tsp_atn%2Ftwindtunnel%2Fcogwheel_velox_expression_fuzzer.cogwheel_test.1929342874675047.a&taskHandle=0&file=stderr
is failing. KHLL and SetDigest functions should be enabled in fuzzer after the fuzzer support is merged in. Blocking for now.

Differential Revision: D89303065


