### PR TITLE
fix: Nanos validation in Timestamp::tmToStringView

### DIFF
--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -202,7 +202,7 @@ StringView Timestamp::tmToStringView(
     uint64_t nanos,
     const TimestampToStringOptions& options,
     char* const startPosition) {
-  VELOX_DCHECK_LT(nanos, 1'000'000'000);
+  VELOX_CHECK_LT(nanos, 1'000'000'000);
 
   const auto appendDigits = [](const int value,
                                const std::optional<uint32_t> minWidth,


### PR DESCRIPTION
Summary:
VELOX_DCHECK_LT is only enabled in debug builds, which means invalid nanos values (>= 1 billion) could silently produce incorrect timestamp strings in release builds. Upgrading to VELOX_CHECK_LT ensures the invariant is always validated.

The check validates nanos < 1'000'000'000 (If nanos >= 1,000,000,000 that means you have 1 or more full seconds, which should be carried over to the seconds), which is a fundamental invariant that should never be violated by valid Timestamp objects.

Differential Revision: D89328847


