### PR TITLE
fix: CMake CMP0002 issue due to velox_aggregates defined in add_library twice

### DIFF
--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -78,7 +78,7 @@ velox_link_libraries(
 )
 
 if(${VELOX_ENABLE_GEO})
-  velox_add_library(velox_aggregates PRIVATE GeometryAggregate.cpp)
+  velox_sources(velox_aggregates PRIVATE GeometryAggregate.cpp)
   velox_link_libraries(velox_aggregates velox_functions_geo)
 endif()
 


### PR DESCRIPTION
Fix an issue that appears to have been introduced in  [42f1355c5c](https://github.com/facebookincubator/velox/commit/42f1355c5c5a804733ccb4bdf851edaa3f29183c#diff-6e7df483262d1c79b3fe1c392498024ba640e03760cb30feb515b1328029977d) that manifests when `velox` is built with `VELOX_ENABLE_GEO` flag set to `on`. 

The issue shows as
```
#9 73.28 CMake Error at velox/CMake/VeloxUtils.cmake:62 (add_library):
#9 73.28   add_library cannot create target "velox_aggregates" because another target
#9 73.28   with the same name already exists.  The existing target is a static library
#9 73.28   created in source directory
#9 73.28   "/presto_native_staging/presto/velox/velox/functions/prestosql/aggregates".
#9 73.28   See documentation for policy CMP0002 for more details.
#9 73.28 Call Stack (most recent call first):
#9 73.28   velox/CMake/VeloxUtils.cmake:162 (velox_base_add_library)
#9 73.28   velox/velox/functions/prestosql/aggregates/CMakeLists.txt:81 (velox_add_library)
```

The issue occurs due to `velox-aggregates` being defined globally in a `add_library` earlier in the same CMakeLists.txt file.