### PR TITLE
feat: Add owner metadata field to Velox functions for error attribution

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -216,6 +216,38 @@ An example of such function is rand():
     }
   };
 
+Function Owner
+^^^^^^^^^^^^^^
+
+Functions can specify an owner (team or individual) responsible for the function.
+This information is included in exception context messages to help with error
+attribution and debugging. By default, no owner is set.
+
+To specify a custom owner, define a static ``owner`` variable in your function class:
+
+.. code-block:: c++
+
+  template <typename TExec>
+  struct MyFunction {
+    VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+    // Specify the team or individual responsible for this function.
+    static constexpr std::string_view owner = "my-team";
+
+    FOLLY_ALWAYS_INLINE bool call(int64_t& result, const int64_t& input) {
+      result = input * 2;
+      return true;
+    }
+  };
+
+When an exception occurs during function evaluation, the error context will
+include the owner information (if specified), making it easier to identify which team should
+investigate the issue. For example, an error message might look like:
+
+.. code-block:: text
+
+  Owner: my-team. Expression: my_function(c0)
+
 All-ASCII Fast Path
 ^^^^^^^^^^^^^^^^^^^
 
@@ -870,12 +902,31 @@ Use exec::registerVectorFunction to register a stateless vector function.
 exec::registerVectorFunction takes a name, a list of supported signatures
 and unique_ptr to an instance of the function. It takes an optional 'metadata'
 parameter that specifies whether a function is deterministic, has default null
-behavior, and other properties. A helper VectorFunctionMetadataBuilder class
+behavior, owner, and other properties. A helper VectorFunctionMetadataBuilder class
 allows to easily construct 'metadata'. For example,
 
 .. code-block:: c++
 
     VectorFunctionMetadataBuilder().defaultNullBehavior(false).build();
+
+To specify a custom owner for a vector function, use the owner() method of
+VectorFunctionMetadataBuilder:
+
+.. code-block:: c++
+
+    VectorFunctionMetadataBuilder()
+        .defaultNullBehavior(false)
+        .owner("my-team")
+        .build();
+
+The owner information is included in exception context messages to help with
+error attribution and debugging. By default, no owner is set.
+When an exception occurs during function evaluation, the error message will
+include the owner (if specified), for example:
+
+.. code-block:: text
+
+    Owner: my-team. Expression: my_vector_function(c0)
 
 
 An optional “overwrite” flag specifies whether to overwrite a function if a function

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -695,16 +695,35 @@ std::string onTopLevelException(VeloxException::Type exceptionType, void* arg) {
   if (strlen(basePath) == 0 && exceptionType == VeloxException::Type::kSystem) {
     basePath = FLAGS_velox_save_input_on_expression_system_failure_path.c_str();
   }
+
+  const auto& owner = context->expr()->vectorFunctionMetadata().owner;
   if (strlen(basePath) == 0) {
-    return fmt::format("Top-level Expression: {}", context->expr()->toString());
+    if (owner.empty()) {
+      return fmt::format(
+          "Top-level Expression: {}", context->expr()->toString());
+    }
+    return fmt::format(
+        "Owner: {}. Top-level Expression: {}",
+        owner,
+        context->expr()->toString());
   }
 
   // Save input vector to a file.
   context->persistDataAndSql(basePath);
 
+  if (owner.empty()) {
+    return fmt::format(
+        "Top-level Expression: {}. Input data: {}. SQL expression: {}."
+        " All SQL expressions: {}. ",
+        context->expr()->toString(),
+        context->dataPath(),
+        context->sqlPath(),
+        context->allExprSqlPath());
+  }
   return fmt::format(
-      "Top-level Expression: {}. Input data: {}. SQL expression: {}."
+      "Owner: {}. Top-level Expression: {}. Input data: {}. SQL expression: {}."
       " All SQL expressions: {}. ",
+      owner,
       context->expr()->toString(),
       context->dataPath(),
       context->sqlPath(),
@@ -715,7 +734,12 @@ std::string onTopLevelException(VeloxException::Type exceptionType, void* arg) {
 /// sub-expression. Returns the output of Expr::toString() for the
 /// sub-expression.
 std::string onException(VeloxException::Type /*exceptionType*/, void* arg) {
-  return static_cast<Expr*>(arg)->toString();
+  auto* expr = static_cast<Expr*>(arg);
+  const auto& owner = expr->vectorFunctionMetadata().owner;
+  if (owner.empty()) {
+    return static_cast<Expr*>(arg)->toString();
+  }
+  return fmt::format("Owner: {}. Expression: {}", owner, expr->toString());
 }
 } // namespace
 

--- a/velox/expression/FunctionMetadata.h
+++ b/velox/expression/FunctionMetadata.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 namespace facebook::velox::exec {
 
 struct VectorFunctionMetadata {
@@ -43,6 +45,10 @@ struct VectorFunctionMetadata {
 
   /// Indicates if this is a companion function.
   bool companionFunction{false};
+
+  /// The owner/team responsible for this function. Used for logging and
+  /// attribution.
+  std::string_view owner{""};
 };
 
 class VectorFunctionMetadataBuilder {
@@ -64,6 +70,11 @@ class VectorFunctionMetadataBuilder {
 
   VectorFunctionMetadataBuilder& companionFunction(bool companionFunction) {
     metadata_.companionFunction = companionFunction;
+    return *this;
+  }
+
+  VectorFunctionMetadataBuilder& owner(std::string_view owner) {
+    metadata_.owner = owner;
     return *this;
   }
 

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -145,7 +145,9 @@ class SimpleFunctionRegistry {
       return VectorFunctionMetadata{
           false,
           functionEntry_.getMetadata().isDeterministic(),
-          functionEntry_.getMetadata().defaultNullBehavior()};
+          functionEntry_.getMetadata().defaultNullBehavior(),
+          false,
+          functionEntry_.getMetadata().owner()};
     }
 
    private:


### PR DESCRIPTION
Summary:
Add an "owner" metadata field to both simple functions and vector functions in Velox.
This enables better error attribution by including the function owner in exception
context messages, helping teams quickly identify ownership when debugging
expression evaluation failures.

Differential Revision: D89347702


