### PR TITLE
fix: Prevent integer overflow in PrefixSort memory estimation

### DIFF
--- a/velox/exec/PrefixSort.cpp
+++ b/velox/exec/PrefixSort.cpp
@@ -310,7 +310,7 @@ void PrefixSort::extractRowAndEncodePrefixKeys(char* row, char* prefixBuffer) {
 }
 
 // static.
-uint32_t PrefixSort::maxRequiredBytes(
+uint64_t PrefixSort::maxRequiredBytes(
     const RowContainer* rowContainer,
     const std::vector<CompareFlags>& compareFlags,
     const velox::common::PrefixSortConfig& config,
@@ -345,7 +345,7 @@ void PrefixSort::stdSort(
       });
 }
 
-uint32_t PrefixSort::maxRequiredBytes() const {
+uint64_t PrefixSort::maxRequiredBytes() const {
   const auto numRows = rowContainer_->numRows();
   const auto numPages =
       memory::AllocationTraits::numPages(numRows * sortLayout_.entrySize);

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -153,7 +153,7 @@ class PrefixSort {
   /// The std::sort won't require bytes while prefix sort may require buffers
   /// such as prefix data. The logic is similar to the above function
   /// PrefixSort::sort but returns the maximum buffer the sort may need.
-  static uint32_t maxRequiredBytes(
+  static uint64_t maxRequiredBytes(
       const RowContainer* rowContainer,
       const std::vector<CompareFlags>& compareFlags,
       const velox::common::PrefixSortConfig& config,
@@ -205,7 +205,7 @@ class PrefixSort {
 
   // Estimates the memory required for prefix sort such as prefix buffer and
   // swap buffer.
-  uint32_t maxRequiredBytes() const;
+  uint64_t maxRequiredBytes() const;
 
   void sortInternal(std::vector<char*, memory::StlAllocator<char*>>& rows);
 


### PR DESCRIPTION
Fix an integer overflow bug in `PrefixSort::maxRequiredBytes()` that causes
incorrect memory estimation, preventing spill from triggering and leading to OOM.

**Problem**
The return type of `PrefixSort::maxRequiredBytes()` is `uint32_t`, which can only
represent up to ~4GB. When sorting large datasets (e.g., 1 billion rows), the
actual memory requirement (~24GB for prefix buffer) overflows, returning a much
smaller value (~2.35GB).

This causes `ensureSortFits()` to underestimate memory needs. The reservation
succeeds with the incorrect small value, so spill is not triggered. When
`PrefixSort::sort()` later attempts to allocate the actual memory required,
the operator is already outside the `ReclaimableSectionGuard` scope and cannot
be reclaimed, resulting in OOM.

**Fix**
Change the return type of `PrefixSort::maxRequiredBytes()` from `uint32_t` to
`uint64_t`.