### PR TITLE
fix: String buffer ownership transfer in side table reader

### DIFF
--- a/velox/dwio/common/FlatMapHelper.cpp
+++ b/velox/dwio/common/FlatMapHelper.cpp
@@ -48,6 +48,9 @@ void reset(
     }
   }
   vector->resize(size);
+  // Reside BaseVector::length_ as it will be updated in the subsequent copy()
+  // calls.
+  vector->BaseVector::resize(0);
 }
 
 void initializeStringVector(
@@ -368,8 +371,9 @@ vector_size_t copyNulls(
   vector_size_t nulls = 0;
   // it's assumed that initVector is called before calling this method to
   // properly allocate/clear nulls buffer. So we only need to check against
-  // target vector here.
-  target.resize(targetIndex + count, false);
+  // target vector here.  We only call BaseVector::resize here to make sure
+  // BaseVector::size() is only updated.
+  target.BaseVector::resize(targetIndex + count, false);
   if (target.mayHaveNulls()) {
     auto tgtNulls = const_cast<uint64_t*>(target.rawNulls());
     if (source.isConstantEncoding()) {
@@ -494,7 +498,10 @@ vector_size_t copyOffsets(
     vector_size_t sourceIndex,
     vector_size_t count,
     vector_size_t& childOffset) {
-  target.resize(targetIndex + count);
+  // Its expected that initVector is called before calling this method so the
+  // offsets and sizes buffers are properly allocated. We only call
+  // BaseVector::resize here to make sure BaseVector::size() is only updated.
+  target.BaseVector::resize(targetIndex + count);
   auto tgtOffsets = const_cast<vector_size_t*>(target.rawOffsets());
   auto tgtSizes = const_cast<vector_size_t*>(target.rawSizes());
   auto srcSizes = source.rawSizes();
@@ -710,8 +717,9 @@ bool copyNull(
     vector_size_t sourceIndex) {
   // it's assumed that initVector is called before calling this method to
   // properly allocate/clear nulls buffer. So we only need to check against
-  // target vector here.
-  target.resize(targetIndex + 1, false);
+  // target vector here. We only call BaseVector::resize here to make sure
+  // BaseVector::size() is only updated.
+  target.BaseVector::resize(targetIndex + 1, false);
   if (target.mayHaveNulls()) {
     bool srcIsNull =
         (source.isConstantEncoding() ||
@@ -801,7 +809,10 @@ vector_size_t copyOffset(
     const T& source,
     vector_size_t sourceIndex,
     vector_size_t& childOffset) {
-  target.resize(targetIndex + 1);
+  // Its expected that initVector is called before calling this method so the
+  // offsets and sizes buffers are properly allocated. We only call
+  // BaseVector::resize here to make sure BaseVector::size() is only updated.
+  target.BaseVector::resize(targetIndex + 1);
   auto tgtSizes = const_cast<vector_size_t*>(target.rawSizes());
   childOffset = nextChildOffset(target, targetIndex);
   const_cast<vector_size_t*>(target.rawOffsets())[targetIndex] = childOffset;


### PR DESCRIPTION
Summary:
During side table merging, if the merged column is a MAP, an output MapVector is initialized and them filled in with values from the base and the side table. When the map contains string types (VARCHAR or VARBINARY), the initialize step also copies over the stringBuffers from the children vectors of the base and the side table so that during the copy phase, it only has the copy the StringView values. This change fixes a bug during the copy phase where if the first row of the first map being copied is empty, then a vector resize() with size 0 is called that clears the stringBuffers. This causes the output map to lose ownership of the string buffers that its values point to. This can result in garbage values being read if those buffers are released.
This change replaces vector resize() with BaseVector::resize(), which only updates nulls buffers and length_, preserving stringBuffers. The merge codepath is responsible for correctly setting vector state as needed.
Discussed and aligned on solution with zzhao0.

Reviewed By: zzhao0

Differential Revision: D89101304


