### PR TITLE
misc: Add null checks for trace node lookups

### DIFF
--- a/velox/exec/TaskTraceReader.cpp
+++ b/velox/exec/TaskTraceReader.cpp
@@ -71,6 +71,8 @@ std::string TaskTraceMetadataReader::nodeName(const std::string& nodeId) const {
              << tracePlanNode_->toString(true, true);
   const auto* traceNode =
       core::PlanNode::findNodeById(tracePlanNode_.get(), nodeId);
+  VELOX_CHECK_NOT_NULL(
+      traceNode, "trace node id {} not found in the trace plan", nodeId);
   return std::string(traceNode->name());
 }
 
@@ -78,6 +80,11 @@ std::optional<std::string> TaskTraceMetadataReader::connectorId(
     const std::string& nodeId) const {
   const auto* traceNode =
       core::PlanNode::findNodeById(tracePlanNode_.get(), nodeId);
+  VELOX_CHECK_NOT_NULL(
+      traceNode,
+      "trace node id {} not found in the trace plan: {}",
+      nodeId,
+      tracePlanNode_->toString(true, true));
 
   if (const auto* indexLookupJoinNode =
           dynamic_cast<const core::IndexLookupJoinNode*>(traceNode)) {


### PR DESCRIPTION
Summary: The check tells you exactly which node id failed, making debugging much easier vs. hunting through a crash dump.

Differential Revision: D89397658


