### PR TITLE
feat: Add biased NULL pattern generation to VectorFuzzer

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -121,6 +121,7 @@ class AggregationFuzzerBase {
     opts.stringVariableLength = true;
     opts.stringLength = 4'000;
     opts.nullRatio = FLAGS_null_ratio;
+    opts.useRandomNullPattern = true;
     opts.timestampPrecision = timestampPrecision;
     return opts;
   }

--- a/velox/exec/fuzzer/JoinFuzzer.cpp
+++ b/velox/exec/fuzzer/JoinFuzzer.cpp
@@ -88,6 +88,7 @@ class JoinFuzzer {
     opts.stringVariableLength = true;
     opts.stringLength = 100;
     opts.nullRatio = FLAGS_null_ratio;
+    opts.useRandomNullPattern = true;
     opts.timestampPrecision =
         VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
     return opts;

--- a/velox/expression/fuzzer/FuzzerRunner.cpp
+++ b/velox/expression/fuzzer/FuzzerRunner.cpp
@@ -171,6 +171,7 @@ VectorFuzzer::Options getVectorFuzzerOptions() {
   opts.stringVariableLength = true;
   opts.stringLength = 100;
   opts.nullRatio = FLAGS_null_ratio;
+  opts.useRandomNullPattern = true;
   opts.timestampPrecision =
       VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
   return opts;

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -79,9 +79,21 @@ class VectorFuzzer {
   struct Options {
     size_t vectorSize{100};
 
-    /// Chance of generating a null value in the output vector (`nullRatio` is a
-    /// double between 0 and 1).
+    /// Controls NULL generation in vectors. This is a probability (0.0-1.0)
+    /// or fraction used by NULL patterns:
+    /// - When useRandomNullPattern=false (default): Uses kRandom pattern only
+    ///   - nullRatio is the probability that each element is NULL
+    /// - When useRandomNullPattern=true: Randomly selects pattern, then:
+    ///   - Random (70%): Probability that each element is NULL
+    ///   - HeadOnly (10%): Fraction of vector that's NULL at beginning
+    ///   - TailOnly (10%): Fraction of vector that's NULL at end
+    ///   - HeadAndTail (10%): Half the fraction at head, half at tail
     double nullRatio{0};
+
+    /// If true, randomly selects NULL patterns (kRandom 70%, kHeadOnly 10%,
+    /// kTailOnly 10%, kHeadAndTail 10%). If false, uses only kRandom pattern.
+    /// Default is false to preserve backward compatibility.
+    bool useRandomNullPattern{false};
 
     /// If false, fuzzer will not generate nulls for elements within containers
     /// (arrays/maps/rows). It might still generate null for the container


### PR DESCRIPTION
Summary:
This diff extends VectorFuzzer with biased NULL distribution patterns to improve fuzzing coverage of edge cases.

**Changes:**
- Updated `fuzzNulls()` to generate NULLs with 4 modes: `kRandom`(70%), `kHeadOnly`(10%), `kTailOnly`(10%), `kHeadAndTail`(10%). 
- Modified `fuzzFlat()` to use the pattern-aware `fuzzNulls()` instead of inline random NULL generation

**Why:**
Random NULL distribution may miss edge cases where NULLs are concentrated at specific positions (beginning, end, or both edges). These patterns can expose bugs emerging from these patterns.

Differential Revision: D89227420


