### PR TITLE
fix(cudf): Replace tryBindWithCoercions call with tryBind

### DIFF
--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -116,9 +116,8 @@ static bool matchCallAgainstSignatures(
     argTypes.push_back(in->type());
   }
   for (const auto& sig : sigs) {
-    std::vector<Coercion> coercions(n);
     exec::SignatureBinder binder(*sig, argTypes);
-    if (!binder.tryBindWithCoercions(coercions)) {
+    if (!binder.tryBind()) {
       continue;
     }
     // binder does not confirm whether positional arguments are


### PR DESCRIPTION
Summary: Velox receives fully resolved typed expressions. No coercions are needed to execute these.

Differential Revision: D89440541


