### PR TITLE
feat: Add sanity checks for function signatures with variable arity argument

### DIFF
--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -173,6 +173,43 @@ TEST_F(FunctionSignatureBuilderTest, homogeneousRowInReturn) {
       "Homogeneous row cannot appear in return type");
 }
 
+TEST_F(FunctionSignatureBuilderTest, variableArity) {
+  // .variableArity() requires at least one argument.
+  VELOX_ASSERT_USER_THROW(
+      exec::FunctionSignatureBuilder()
+          .returnType("bigint")
+          .variableArity()
+          .build(),
+      "Variable arity requires at least one argument");
+
+  // .variableArity() can be used only once.
+  VELOX_ASSERT_USER_THROW(
+      exec::FunctionSignatureBuilder()
+          .returnType("bigint")
+          .variableArity("bigint")
+          .variableArity("integer")
+          .build(),
+      "Cannot add arguments after variable arity argument");
+
+  VELOX_ASSERT_USER_THROW(
+      exec::FunctionSignatureBuilder()
+          .returnType("bigint")
+          .argumentType("bigint")
+          .variableArity()
+          .variableArity()
+          .build(),
+      "Only one variable arity argument is allowed");
+
+  // No arguments can be added after calling .variableArity().
+  VELOX_ASSERT_USER_THROW(
+      exec::FunctionSignatureBuilder()
+          .returnType("bigint")
+          .variableArity("bigint")
+          .argumentType("boolean")
+          .build(),
+      "Cannot add arguments after variable arity argument");
+}
+
 TEST_F(FunctionSignatureBuilderTest, scalarConstantFlags) {
   {
     auto signature = FunctionSignatureBuilder()

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -332,21 +332,22 @@ class FunctionSignatureBuilder {
   }
 
   FunctionSignatureBuilder& argumentType(const std::string& type) {
-    argumentTypes_.emplace_back(parseTypeSignature(type));
-    constantArguments_.push_back(false);
-    return *this;
+    return addArgument(type, /*constant=*/false, /*variableArity=*/false);
   }
 
   FunctionSignatureBuilder& constantArgumentType(const std::string& type) {
-    argumentTypes_.emplace_back(parseTypeSignature(type));
-    constantArguments_.push_back(true);
-    return *this;
+    return addArgument(type, /*constant=*/true, /*variableArity=*/false);
   }
 
   /// Variable arity arguments can appear only at the end of the argument list
   /// and their types must match the type specified in the last entry of
   /// 'argumentTypes'. Variable arity arguments can appear zero or more times.
   FunctionSignatureBuilder& variableArity() {
+    VELOX_USER_CHECK(
+        !variableArity_, "Only one variable arity argument is allowed.");
+    VELOX_USER_CHECK(
+        !argumentTypes_.empty(),
+        "Variable arity requires at least one argument");
     variableArity_ = true;
     return *this;
   }
@@ -354,24 +355,33 @@ class FunctionSignatureBuilder {
   /// Variable arity arguments can appear only at the end of the argument list
   /// and can appear zero or more times.
   FunctionSignatureBuilder& variableArity(const std::string& type) {
-    argumentTypes_.emplace_back(parseTypeSignature(type));
-    constantArguments_.push_back(false);
-    variableArity_ = true;
-    return *this;
+    return addArgument(type, /*constant=*/false, /*variableArity=*/true);
   }
 
   /// Variable arity arguments can appear only at the end of the argument list
   /// and can appear zero or more times.
   FunctionSignatureBuilder& constantVariableArity(const std::string& type) {
-    argumentTypes_.emplace_back(parseTypeSignature(type));
-    constantArguments_.push_back(true);
-    variableArity_ = true;
-    return *this;
+    return addArgument(type, /*constant=*/true, /*variableArity=*/true);
   }
 
   FunctionSignaturePtr build();
 
  private:
+  FunctionSignatureBuilder&
+  addArgument(const std::string& type, bool constant, bool variableArity) {
+    VELOX_USER_CHECK(
+        !variableArity_, "Cannot add arguments after variable arity argument");
+
+    argumentTypes_.emplace_back(parseTypeSignature(type));
+    constantArguments_.push_back(constant);
+
+    if (variableArity) {
+      this->variableArity();
+    }
+
+    return *this;
+  }
+
   std::unordered_map<std::string, SignatureVariable> variables_;
   std::optional<TypeSignature> returnType_;
   std::vector<TypeSignature> argumentTypes_;


### PR DESCRIPTION
Summary: Ensure that there is only one variable-arity argument and it is the last one.

Differential Revision: D89442073


