### PR TITLE
perf: Use boost::algorithm::iequals to compare type names

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -287,10 +287,7 @@ bool SignatureBinderBase::tryBind(
 
   // Type is not a variable.
   auto typeName = boost::algorithm::to_upper_copy(baseName);
-  auto actualTypeName =
-      boost::algorithm::to_upper_copy(std::string(actualType->name()));
-
-  if (typeName != actualTypeName) {
+  if (!boost::algorithm::iequals(typeName, actualType->name())) {
     if (allowCoercion) {
       if (auto availableCoercion =
               TypeCoercer::coerceTypeBase(actualType, typeName)) {


### PR DESCRIPTION
Summary: Saves one conversion to upper case.

Differential Revision: D89442253


