### PR TITLE
fix: Do not bind UNKNOWN type to another type

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -192,6 +192,9 @@ TypePtr toVeloxType(LogicalType type, bool fileColumnNamesReadAsLowerCase) {
       if (auto customType = getCustomType(name, {})) {
         return customType;
       }
+      if (name == "OPAQUE<void>") {
+        return OPAQUE<void>();
+      }
       [[fallthrough]];
     }
     default:

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -142,8 +142,7 @@ bool SignatureBinder::tryBind(
       if (actualTypes_.size() > formalArgsCnt) {
         auto& type = actualTypes_[formalArgsCnt - 1];
         for (auto i = formalArgsCnt; i < actualTypes_.size(); i++) {
-          if (!type->equivalent(*actualTypes_[i]) &&
-              actualTypes_[i]->kind() != TypeKind::UNKNOWN) {
+          if (!type->equivalent(*actualTypes_[i])) {
             return false;
           }
         }

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -494,7 +494,7 @@ TEST_F(NullFreeArrayViewTest, materialize) {
 
 TEST_F(NullableArrayViewTest, materialize) {
   auto result = evaluate(
-      "array_constructor(1, 2, NULL, 4, NULL)",
+      "array_constructor(1, 2, null::bigint, 4, null::bigint)",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;
@@ -508,7 +508,7 @@ TEST_F(NullableArrayViewTest, materialize) {
 
 TEST_F(NullableArrayViewTest, materializeNested) {
   auto result = evaluate(
-      "array_constructor(array_constructor(1), array_constructor(1, NULL), NULL)",
+      "array_constructor(array_constructor(1), array_constructor(1, null::bigint), null::bigint[])",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;
@@ -534,7 +534,7 @@ TEST_F(NullableArrayViewTest, materializeArrayWithOpaque) {
   registerFunction<MakeOpaqueFunc, std::shared_ptr<int64_t>>({"make_opaque"});
 
   auto result = evaluate(
-      "array_constructor(make_opaque(), null)",
+      "array_constructor(make_opaque(), null::\"OPAQUE<void>\")",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;
@@ -579,7 +579,7 @@ TEST_F(NullableArrayViewTest, materializeArrayOfCustomTypes) {
   registerFunction<MakeUDTFunc, UDTTypeRegistrar::SimpleType>({"make_udt"});
 
   auto result = evaluate(
-      "array_constructor(make_udt(), null, make_udt(), make_udt())",
+      "array_constructor(make_udt(), null::materializeTestUDT, make_udt(), make_udt())",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;

--- a/velox/expression/tests/ArrayWriterTest.cpp
+++ b/velox/expression/tests/ArrayWriterTest.cpp
@@ -689,7 +689,7 @@ TEST_F(ArrayWriterTest, copyFromNullableArrayView) {
       {"copy_from_nullable"});
 
   auto result = evaluate(
-      "copy_from_nullable(array_constructor(1, null, 3, null, 5))",
+      "copy_from_nullable(array_constructor(1, null::bigint, 3, null::bigint, 5))",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   // Test results.
@@ -712,7 +712,7 @@ TEST_F(ArrayWriterTest, copyFromNestedNullableArrayView) {
       Array<Array<int64_t>>>({"copy_from_nullable_nested"});
 
   auto result = evaluate(
-      "copy_from_nullable_nested(array_constructor(array_constructor(1), array_constructor(3, null, 5)))",
+      "copy_from_nullable_nested(array_constructor(array_constructor(1), array_constructor(3, null::bigint, 5)))",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   // Test results.
@@ -769,7 +769,7 @@ TEST_F(ArrayWriterTest, addItems) {
   {
     // call path.
     auto result = evaluate(
-        "add_items_test(array_constructor(10, null))",
+        "add_items_test(array_constructor(10, null::bigint))",
         makeRowVector({makeFlatVector<int64_t>(1)}));
 
     // Test results.

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -775,7 +775,7 @@ TEST_F(NullFreeMapViewTest, materialize) {
 
 TEST_F(NullableMapViewTest, materialize) {
   auto result = evaluate(
-      "map(array_constructor(1, 2),array_constructor(1, NULL))",
+      "map(array_constructor(1, 2),array_constructor(1, null::bigint))",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;
@@ -789,7 +789,7 @@ TEST_F(NullableMapViewTest, materialize) {
 
 TEST_F(NullableMapViewTest, materializeNested) {
   auto result = evaluate(
-      "map(array_constructor(1, 2), array_constructor(array_constructor(1, null), null))",
+      "map(array_constructor(1, 2), array_constructor(array_constructor(1, null::bigint), null::bigint[]))",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;

--- a/velox/expression/tests/MapWriterTest.cpp
+++ b/velox/expression/tests/MapWriterTest.cpp
@@ -564,7 +564,7 @@ TEST_F(MapWriterTest, copyFromNullableMapView) {
       Map<int64_t, int64_t>>({"copy_from_nullable_map_view"});
 
   auto result = evaluate(
-      "copy_from_nullable_map_view(map(array_constructor(1,2,3),array_constructor(4,null,6)))",
+      "copy_from_nullable_map_view(map(array_constructor(1,2,3),array_constructor(4,null::bigint,6)))",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   // Test results.

--- a/velox/expression/tests/RowViewTest.cpp
+++ b/velox/expression/tests/RowViewTest.cpp
@@ -397,7 +397,7 @@ TEST_F(NullFreeRowViewTest, e2eCompare) {
 
 TEST_F(NullableRowViewTest, materialize) {
   auto result = evaluate(
-      "row_constructor(1, 'hi', array_constructor(1, 2, null))",
+      "row_constructor(1, 'hi', array_constructor(1, 2, null::bigint))",
       makeRowVector({makeFlatVector<int64_t>(1)}));
 
   DecodedVector decoded;

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -100,6 +100,35 @@ void assertCannotResolve(
   ASSERT_TRUE(returnType == nullptr);
 }
 
+TEST(SignatureBinderTest, unknown) {
+  {
+    // (T, T) -> array(T)
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("T")
+                         .returnType("array(T)")
+                         .argumentType("T")
+                         .argumentType("T")
+                         .build();
+
+    testSignatureBinder(signature, {INTEGER(), INTEGER()}, ARRAY(INTEGER()));
+    assertCannotBind(signature, {INTEGER(), UNKNOWN()});
+    assertCannotBind(signature, {UNKNOWN(), INTEGER()});
+  }
+
+  {
+    // (T...) -> array(T)
+    auto signature = exec::FunctionSignatureBuilder()
+                         .typeVariable("T")
+                         .returnType("array(T)")
+                         .variableArity("T")
+                         .build();
+
+    testSignatureBinder(signature, {INTEGER(), INTEGER()}, ARRAY(INTEGER()));
+    assertCannotBind(signature, {INTEGER(), UNKNOWN()});
+    assertCannotBind(signature, {UNKNOWN(), INTEGER()});
+  }
+}
+
 TEST(SignatureBinderTest, decimals) {
   // Decimal Add/Subtract.
   {

--- a/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConstructorTest.cpp
@@ -187,7 +187,8 @@ TEST_F(ArrayConstructorTest, literals) {
 
   // Add null literals.
   result = evaluate(
-      "array_constructor(1, 2, null, 4, null)", makeRowVector(ROW({}), 1));
+      "array_constructor(1, 2, null::bigint, 4, null::bigint)",
+      makeRowVector(ROW({}), 1));
   expected =
       makeNullableArrayVector<int64_t>({{1, 2, std::nullopt, 4, std::nullopt}});
   test::assertEqualVectors(expected, result);


### PR DESCRIPTION
Summary:
SignatureBinder used to unconditionally bind variable arity arguments of type UNKNOWN. This behavior is incorrect.

Fixes https://github.com/facebookincubator/velox/issues/15749

Differential Revision: D89445881


