### PR TITLE
feat: Add metrics iceberg.numSplits and iceberg.numDeletes

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -348,7 +348,7 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     output_ = BaseVector::create(readerOutputType_, 0, pool_);
   }
 
-  const auto rowsScanned = splitReader_->next(size, output_);
+  const auto rowsScanned = splitReader_->next(size, output_, runtimeStats_);
   completedRows_ += rowsScanned;
   if (rowsScanned == 0) {
     splitReader_->updateRuntimeStats(runtimeStats_);

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -261,7 +261,10 @@ void SplitReader::applyBucketConversion(
   output = std::move(filtered);
 }
 
-uint64_t SplitReader::next(uint64_t size, VectorPtr& output) {
+uint64_t SplitReader::next(
+    uint64_t size,
+    VectorPtr& output,
+    dwio::common::RuntimeStatistics& runtimeStats) {
   uint64_t numScanned;
   if (!baseReaderOpts_.randomSkip()) {
     numScanned = baseRowReader_->next(size, output);

--- a/velox/connectors/hive/SplitReader.h
+++ b/velox/connectors/hive/SplitReader.h
@@ -114,7 +114,21 @@ class SplitReader {
       dwio::common::RuntimeStatistics& runtimeStats,
       const folly::F14FastMap<std::string, std::string>& fileReadOps = {});
 
-  virtual uint64_t next(uint64_t size, VectorPtr& output);
+  /// Reads the next batch of rows from the split.
+  ///
+  /// @param size Maximum number of rows to read
+  /// @param output Output vector to store the read data
+  /// @param runtimeStats Runtime statistics collector for tracking metrics
+  ///        during split reading. Currently used by IcebergSplitReader to
+  ///        collect Iceberg-specific statistics:
+  ///        - "iceberg.numDeletes": Number of deleted rows encountered during
+  ///          reading (collected via runtimeStats.unitLoaderStats.addCounter)
+  ///
+  /// @return Number of rows actually read
+  virtual uint64_t next(
+      uint64_t size,
+      VectorPtr& output,
+      dwio::common::RuntimeStatistics& runtimeStats);
 
   void resetFilterCaches();
 

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -101,5 +101,7 @@ class IcebergSplitReader : public SplitReader {
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;
   BufferPtr deleteBitmap_;
+  // Pointer to runtime stats for tracking iceberg metrics
+  dwio::common::RuntimeStatistics* runtimeStats_{nullptr};
 };
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -47,7 +47,10 @@ class IcebergSplitReader : public SplitReader {
       const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
       override;
 
-  uint64_t next(uint64_t size, VectorPtr& output) override;
+  uint64_t next(
+      uint64_t size,
+      VectorPtr& output,
+      dwio::common::RuntimeStatistics& runtimeStats) override;
 
  private:
   /// Adapts the data file schema to match the table schema expected by the
@@ -101,7 +104,5 @@ class IcebergSplitReader : public SplitReader {
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;
   BufferPtr deleteBitmap_;
-  // Pointer to runtime stats for tracking iceberg metrics
-  dwio::common::RuntimeStatistics* runtimeStats_{nullptr};
 };
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -933,7 +933,7 @@ TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
 TEST_F(HiveIcebergTest, icebergMetrics) {
   folly::SingletonVault::singleton()->registrationComplete();
 
-  // Helper function to aggregate a runtime metric across all pipelines and operators
+  // Helper function to aggregate a runtime metric across all pipelines and operators.
   auto getAggregatedRuntimeMetric = [](const exec::TaskStats& taskStats, const std::string& metricName) -> int64_t {
     int64_t total = 0;
     for (const auto& pipelineStats : taskStats.pipelineStats) {
@@ -947,7 +947,7 @@ TEST_F(HiveIcebergTest, icebergMetrics) {
     return total;
   };
 
-  // Test case 1: Single split with 3 deletes
+  // Test case 1: Single split with 3 deletes.
   std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
       {"data_file_1", {100, 85}}};
   std::unordered_map<
@@ -962,7 +962,7 @@ TEST_F(HiveIcebergTest, icebergMetrics) {
   ASSERT_EQ(getAggregatedRuntimeMetric(taskStats, "iceberg.numSplits"), 1);
   ASSERT_EQ(getAggregatedRuntimeMetric(taskStats, "iceberg.numDeletes"), 3);
 
-  // Test case 2: Multiple data files (2 data files = 2 splits) with deletes
+  // Test case 2: Multiple data files (2 data files = 2 splits) with deletes.
   // data_file_1 has 4 deletes
   // data_file_2 has 3 deletes
   // Total: 2 splits, 7 deletes
@@ -978,7 +978,7 @@ TEST_F(HiveIcebergTest, icebergMetrics) {
   ASSERT_EQ(getAggregatedRuntimeMetric(taskStats2, "iceberg.numSplits"), 2);
   ASSERT_EQ(getAggregatedRuntimeMetric(taskStats2, "iceberg.numDeletes"), 7);
 
-  // Test case 3: Multiple data files each split into multiple splits (splitCount=3)
+  // Test case 3: Multiple data files each split into multiple splits (splitCount=3).
   // This tests that metrics aggregate correctly across multiple splits from multiple files.
   // data_file_1 split into 3 splits, with 4 deletes
   // data_file_2 split into 3 splits, with 3 deletes

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/TaskStats.h"
 
 #ifdef VELOX_ENABLE_PARQUET
 #include "velox/dwio/parquet/RegisterParquetReader.h"
@@ -197,7 +198,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
   /// positions for data_file_1 and data_file_2. THere are 3 RowGroups in this
   /// delete file, the first two contain positions for data_file_1, and the last
   /// contain positions for data_file_2
-  void assertPositionalDeletes(
+  std::shared_ptr<exec::Task> assertPositionalDeletes(
       const std::map<std::string, std::vector<int64_t>>& rowGroupSizesForFiles,
       const std::unordered_map<
           std::string,
@@ -262,8 +263,11 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     auto planStats = toPlanStats(task->taskStats());
 
     auto it = planStats.find(plan->id());
-    ASSERT_TRUE(it != planStats.end());
-    ASSERT_TRUE(it->second.peakMemoryBytes > 0);
+    EXPECT_TRUE(it != planStats.end());
+    if (it != planStats.end()) {
+      EXPECT_TRUE(it->second.peakMemoryBytes > 0);
+    }
+    return task;
   }
 
   const static int rowCount = 20000;
@@ -925,4 +929,70 @@ TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
       0);
 }
 #endif
+
+TEST_F(HiveIcebergTest, icebergMetrics) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  // Helper function to aggregate a runtime metric across all pipelines and operators
+  auto getAggregatedRuntimeMetric = [](const exec::TaskStats& taskStats, const std::string& metricName) -> int64_t {
+    int64_t total = 0;
+    for (const auto& pipelineStats : taskStats.pipelineStats) {
+      for (const auto& operatorStats : pipelineStats.operatorStats) {
+        auto it = operatorStats.runtimeStats.find(metricName);
+        if (it != operatorStats.runtimeStats.end()) {
+          total += it->second.sum;
+        }
+      }
+    }
+    return total;
+  };
+
+  // Test case 1: Single split with 3 deletes
+  std::map<std::string, std::vector<int64_t>> rowGroupSizesForFiles = {
+      {"data_file_1", {100, 85}}};
+  std::unordered_map<
+      std::string,
+      std::multimap<std::string, std::vector<int64_t>>>
+      deleteFilesForBaseDatafiles;
+  deleteFilesForBaseDatafiles["delete_file_1"] = {{"data_file_1", {0, 1, 99}}};
+  auto task =
+      assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+  const auto& taskStats = task->taskStats();
+
+  ASSERT_EQ(getAggregatedRuntimeMetric(taskStats, "iceberg.numSplits"), 1);
+  ASSERT_EQ(getAggregatedRuntimeMetric(taskStats, "iceberg.numDeletes"), 3);
+
+  // Test case 2: Multiple data files (2 data files = 2 splits) with deletes
+  // data_file_1 has 4 deletes
+  // data_file_2 has 3 deletes
+  // Total: 2 splits, 7 deletes
+  rowGroupSizesForFiles = {
+      {"data_file_1", {100, 85}}, {"data_file_2", {99, 1}}};
+  deleteFilesForBaseDatafiles.clear();
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
+  task =
+      assertPositionalDeletes(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
+  const auto& taskStats2 = task->taskStats();
+
+  ASSERT_EQ(getAggregatedRuntimeMetric(taskStats2, "iceberg.numSplits"), 2);
+  ASSERT_EQ(getAggregatedRuntimeMetric(taskStats2, "iceberg.numDeletes"), 7);
+
+  // Test case 3: Multiple data files each split into multiple splits (splitCount=3)
+  // This tests that metrics aggregate correctly across multiple splits from multiple files.
+  // data_file_1 split into 3 splits, with 4 deletes
+  // data_file_2 split into 3 splits, with 3 deletes
+  // Total: 6 splits (2 files × 3 splits each), 7 deletes
+  rowGroupSizesForFiles = {
+      {"data_file_1", {100, 85}}, {"data_file_2", {99, 1}}};
+  deleteFilesForBaseDatafiles.clear();
+  deleteFilesForBaseDatafiles["delete_file_1"] = {
+      {"data_file_1", {0, 100, 102, 184}}, {"data_file_2", {1, 98, 99}}};
+  task = assertPositionalDeletes(
+      rowGroupSizesForFiles, deleteFilesForBaseDatafiles, 0, 3);
+  const auto& taskStats3 = task->taskStats();
+
+  ASSERT_EQ(getAggregatedRuntimeMetric(taskStats3, "iceberg.numSplits"), 6);
+  ASSERT_EQ(getAggregatedRuntimeMetric(taskStats3, "iceberg.numDeletes"), 7);
+}
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -236,8 +236,8 @@ int IcebergSplitReaderBenchmark::read(
   int resultSize = 0;
   auto result = BaseVector::create(rowType, 0, leafPool_.get());
   while (true) {
-    bool hasData = icebergSplitReader->next(nextSize, result);
-    if (!hasData) {
+    auto rowsScanned = icebergSplitReader->next(nextSize, result, runtimeStats_);
+    if (rowsScanned == 0) {
       break;
     }
     auto rowsRemaining = result->size();

--- a/velox/docs/develop/debugging/print-plan-with-stats.rst
+++ b/velox/docs/develop/debugging/print-plan-with-stats.rst
@@ -283,3 +283,14 @@ TableScan operator shows how many rows were processed by pushing down aggregatio
 .. code-block::
 
     loadedToValueHook          sum: 50000, count: 5, min: 10000, max: 10000
+
+For Iceberg tables, TableScan operator reports Iceberg-specific statistics:
+
+.. code-block::
+
+   -> TableScan[Table: iceberg_table]
+          iceberg.numSplits     sum: 2, count: 1, min: 2, max: 2
+          iceberg.numDeletes    sum: 7, count: 1, min: 7, max: 7
+
+The `iceberg.numSplits` metric shows the total number of Iceberg splits processed,
+while `iceberg.numDeletes` shows the total number of rows deleted.


### PR DESCRIPTION
## Summary

This PR adds two new runtime metrics for Iceberg table scans to help monitor and debug Iceberg delete operations:
- `iceberg.numSplits` - tracks the number of Iceberg splits processed
- `iceberg.numDeletes` - tracks the number of rows deleted

These metrics originate from [Iceberg's custom metrics](https://iceberg.apache.org/javadoc/nightly/org/apache/iceberg/spark/source/metrics/package-summary.html)

## Related Issues

- https://github.com/apache/incubator-gluten/issues/10021 - [VL] Iceberg metric NumDeletes