### PR TITLE
feat: Add deserialization support for subfield pushdown in MAP functions

### DIFF
--- a/velox/type/Tokenizer.h
+++ b/velox/type/Tokenizer.h
@@ -87,5 +87,11 @@ class Tokenizer {
   char peekCharacter();
 
   std::unique_ptr<Subfield::PathElement> matchWildcardSubscript();
+
+  std::unique_ptr<Subfield::PathElement> matchCardinalityOnlySubscript();
+
+  std::unique_ptr<Subfield::PathElement> matchMapSubscript(bool includeKeys);
+
+  std::unique_ptr<Subfield::PathElement> matchSingleQuotedSubscript();
 };
 } // namespace facebook::velox::common

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/type/Subfield.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/Tokenizer.h"
 
 using namespace facebook::velox::common;
@@ -156,4 +157,437 @@ TEST(SubfieldTest, longSubscript) {
       dynamic_cast<const Subfield::LongSubscript*>(subfield.path()[1].get());
   ASSERT_TRUE(longSubscript);
   ASSERT_EQ(longSubscript->index(), 3309189884973035076);
+}
+
+TEST(SubfieldTest, cardinalityOnlySubscript) {
+  // Test basic parsing of x[$]
+  Subfield subfield("x[$]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  // Verify toString round-trip
+  EXPECT_EQ(subfield.toString(), "x[$]");
+
+  // Test with nested field
+  Subfield nestedSubfield("a.b[$]");
+  ASSERT_EQ(nestedSubfield.path().size(), 3);
+  EXPECT_EQ(nestedSubfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(nestedSubfield.path()[1]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(
+      nestedSubfield.path()[2]->kind(), SubfieldKind::kArrayOrMapSubscript);
+  EXPECT_EQ(nestedSubfield.toString(), "a.b[$]");
+}
+
+TEST(SubfieldTest, cardinalityOnlyEquality) {
+  // Test equality of cardinality-only subscripts
+  Subfield s1("x[$]");
+  Subfield s2("x[$]");
+  Subfield s3("y[$]");
+
+  EXPECT_EQ(s1, s2);
+  EXPECT_NE(s1, s3);
+
+  // Test path element equality
+  auto cardinalityOnly1 =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  auto cardinalityOnly2 =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  EXPECT_EQ(*cardinalityOnly1, *cardinalityOnly2);
+}
+
+TEST(SubfieldTest, cardinalityOnlyHash) {
+  // Test hashing works correctly
+  std::unordered_set<Subfield> subfields;
+  subfields.emplace("x[$]");
+  subfields.emplace("y[$]");
+  subfields.emplace("x[$]"); // Duplicate, should not increase size
+
+  EXPECT_EQ(subfields.size(), 2);
+  EXPECT_TRUE(subfields.find(Subfield("x[$]")) != subfields.end());
+  EXPECT_TRUE(subfields.find(Subfield("y[$]")) != subfields.end());
+}
+
+TEST(SubfieldTest, nestedCardinalityOnly) {
+  // Test arr[*][$] for array of maps
+  Subfield subfield("arr[*][$]");
+  ASSERT_EQ(subfield.path().size(), 3);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kAllSubscripts);
+  EXPECT_EQ(subfield.path()[2]->kind(), SubfieldKind::kArrayOrMapSubscript);
+  EXPECT_EQ(subfield.toString(), "arr[*][$]");
+
+  // Test map_col[*][*][$] for nested structures
+  Subfield complexSubfield("data[*][\"key\"][$]");
+  ASSERT_EQ(complexSubfield.path().size(), 4);
+  EXPECT_EQ(complexSubfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(complexSubfield.path()[1]->kind(), SubfieldKind::kAllSubscripts);
+  EXPECT_EQ(complexSubfield.path()[2]->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(
+      complexSubfield.path()[3]->kind(), SubfieldKind::kArrayOrMapSubscript);
+}
+
+TEST(SubfieldTest, cardinalityOnlyRoundTrip) {
+  // Test round-trip through tokenization
+  std::vector<std::string> testPaths = {
+      "x[$]",
+      "a.b[$]",
+      "arr[*][$]",
+      "map_col[\"key\"][$]",
+      "data[123][$]",
+      "nested[*][\"field\"][$]"};
+
+  for (const auto& path : testPaths) {
+    Subfield original(path);
+    ASSERT_TRUE(original.valid());
+
+    // Convert to string and parse back
+    auto roundTrip = Subfield(original.toString());
+    ASSERT_TRUE(roundTrip.valid());
+    EXPECT_EQ(original, roundTrip) << "Failed round-trip for: " << path;
+    EXPECT_EQ(original.toString(), roundTrip.toString());
+  }
+}
+
+TEST(SubfieldTest, cardinalityOnlyInCreateElements) {
+  // Add ArrayOrMapSubscript to the mix of all subscript types
+  auto elements = createElements();
+  elements.push_back(
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr));
+
+  // Test with base field
+  std::vector<std::unique_ptr<Subfield::PathElement>> newElements;
+  newElements.push_back(std::make_unique<Subfield::NestedField>("a"));
+  newElements.push_back(
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr));
+  testRoundTrip(Subfield(std::move(newElements)));
+}
+
+TEST(SubfieldTest, arrayOrMapSubscriptCardinalityOnly) {
+  // Test basic ArrayOrMapSubscript in cardinality-only mode (equivalent to [$])
+  auto arrayOrMap =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  EXPECT_TRUE(arrayOrMap->isCardinalityOnly());
+  EXPECT_FALSE(arrayOrMap->includeKeys());
+  EXPECT_FALSE(arrayOrMap->includeValues());
+  EXPECT_EQ(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->toString(), "[$]");
+
+  // Test in a full subfield path
+  std::vector<std::unique_ptr<Subfield::PathElement>> elements;
+  elements.push_back(std::make_unique<Subfield::NestedField>("x"));
+  elements.push_back(
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr));
+  Subfield subfield(std::move(elements));
+  EXPECT_EQ(subfield.toString(), "x[$]");
+}
+
+TEST(SubfieldTest, arrayOrMapSubscriptEquality) {
+  // Test equality of cardinality-only subscripts
+  auto sub1 =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  auto sub2 =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  EXPECT_EQ(*sub1, *sub2);
+
+  // Test clone
+  auto cloned = sub1->clone();
+  EXPECT_EQ(*sub1, *cloned);
+}
+
+TEST(SubfieldTest, arrayOrMapSubscriptDesignPatterns) {
+  // Pattern 1: cardinality-only mode [$]
+  auto cardinalityOnly =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  EXPECT_TRUE(cardinalityOnly->isCardinalityOnly());
+  EXPECT_EQ(cardinalityOnly->toString(), "[$]");
+
+  // Future patterns (not yet implemented in parser, but data structure
+  // supports): Pattern 2: All keys only [K*, *]
+  auto allKeys = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      true /* includeKeys */,
+      false /* includeValues */,
+      std::make_unique<Subfield::AllSubscripts>());
+  EXPECT_TRUE(allKeys->includeKeys());
+  EXPECT_FALSE(allKeys->includeValues());
+  EXPECT_NE(allKeys->subscript(), nullptr);
+  EXPECT_EQ(allKeys->subscript()->kind(), SubfieldKind::kAllSubscripts);
+
+  // Pattern 3: Only keys with LongSubscript 42 [K*, 42]
+  auto keysWithLong = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      true /* includeKeys */,
+      false /* includeValues */,
+      std::make_unique<Subfield::LongSubscript>(42));
+  EXPECT_TRUE(keysWithLong->includeKeys());
+  EXPECT_FALSE(keysWithLong->includeValues());
+  EXPECT_EQ(keysWithLong->subscript()->kind(), SubfieldKind::kLongSubscript);
+  EXPECT_EQ(keysWithLong->toString(), "[K*, 42]");
+
+  // Pattern 4: Only keys with StringSubscript 'foo' [K*, 'foo']
+  auto keysWithString = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      true /* includeKeys */,
+      false /* includeValues */,
+      std::make_unique<Subfield::StringSubscript>("foo"));
+  EXPECT_TRUE(keysWithString->includeKeys());
+  EXPECT_FALSE(keysWithString->includeValues());
+  EXPECT_EQ(
+      keysWithString->subscript()->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(keysWithString->toString(), "[K*, 'foo']");
+
+  // Pattern 5: All values only [V*, *]
+  auto allValues = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      false /* includeKeys */,
+      true /* includeValues */,
+      std::make_unique<Subfield::AllSubscripts>());
+  EXPECT_FALSE(allValues->includeKeys());
+  EXPECT_TRUE(allValues->includeValues());
+  EXPECT_EQ(allValues->subscript()->kind(), SubfieldKind::kAllSubscripts);
+
+  // Pattern 6: Only values with key equals to LongSubscript 42 [V*, 42]
+  auto valuesWithLong = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      false /* includeKeys */,
+      true /* includeValues */,
+      std::make_unique<Subfield::LongSubscript>(42));
+  EXPECT_FALSE(valuesWithLong->includeKeys());
+  EXPECT_TRUE(valuesWithLong->includeValues());
+  EXPECT_EQ(valuesWithLong->subscript()->kind(), SubfieldKind::kLongSubscript);
+  EXPECT_EQ(valuesWithLong->toString(), "[V*, 42]");
+
+  // Pattern 7: Only values with key equals to StringSubscript 'foo' [V*, 'foo']
+  auto valuesWithString = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      false /* includeKeys */,
+      true /* includeValues */,
+      std::make_unique<Subfield::StringSubscript>("foo"));
+  EXPECT_FALSE(valuesWithString->includeKeys());
+  EXPECT_TRUE(valuesWithString->includeValues());
+  EXPECT_EQ(
+      valuesWithString->subscript()->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(valuesWithString->toString(), "[V*, 'foo']");
+
+  // Pattern 8: All keys and values with no [*, *]
+  auto allKeysAndValues = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      true /* includeKeys */,
+      true /* includeValues */,
+      std::make_unique<Subfield::AllSubscripts>());
+  VELOX_ASSERT_THROW(
+      allKeysAndValues->toString(),
+      "Invalid subfield pushdown, should use kAllSubscripts, LongSubscript or StringSubscript directly");
+
+  // Pattern 9: All keys and values with StringSubscript
+  auto keysAndValuesWithString =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(
+          true /* includeKeys */,
+          true /* includeValues */,
+          std::make_unique<Subfield::StringSubscript>("foo"));
+  VELOX_ASSERT_THROW(
+      keysAndValuesWithString->toString(),
+      "Invalid subfield pushdown, should use kAllSubscripts, LongSubscript or StringSubscript directly");
+
+  // Pattern 10: All keys and values with LongSubscript
+  auto keysAndValuesWithLong = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      true /* includeKeys */,
+      true /* includeValues */,
+      std::make_unique<Subfield::LongSubscript>(42));
+  VELOX_ASSERT_THROW(
+      keysAndValuesWithLong->toString(),
+      "Invalid subfield pushdown, should use kAllSubscripts, LongSubscript or StringSubscript directly");
+}
+
+TEST(SubfieldTest, arrayOrMapSubscriptHash) {
+  // Test hashing for cardinality-only mode
+  auto sub1 =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  auto sub2 =
+      std::make_unique<Subfield::ArrayOrMapSubscript>(false, false, nullptr);
+  EXPECT_EQ(sub1->hash(), sub2->hash());
+
+  // Test hashing for different configurations
+  auto allKeys = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      true, false, std::make_unique<Subfield::AllSubscripts>());
+  auto allValues = std::make_unique<Subfield::ArrayOrMapSubscript>(
+      false, true, std::make_unique<Subfield::AllSubscripts>());
+  // Different configurations should have different hashes (usually)
+  EXPECT_NE(allKeys->hash(), allValues->hash());
+}
+
+TEST(SubfieldTest, mapKeysOnlyAllSubscripts) {
+  // Test [K*, *] pattern - read all keys, skip values
+  Subfield subfield("x[K*, *]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_TRUE(arrayOrMap->includeKeys());
+  EXPECT_FALSE(arrayOrMap->includeValues());
+  EXPECT_EQ(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->toString(), "[K*, *]");
+}
+
+TEST(SubfieldTest, mapKeysOnlyWithLongSubscript) {
+  // Test [K*, 42] pattern - read only keys matching index 42
+  Subfield subfield("x[K*, 42]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_TRUE(arrayOrMap->includeKeys());
+  EXPECT_FALSE(arrayOrMap->includeValues());
+  ASSERT_NE(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->subscript()->kind(), SubfieldKind::kLongSubscript);
+  EXPECT_EQ(
+      arrayOrMap->subscript()->as<Subfield::LongSubscript>()->index(), 42);
+  EXPECT_EQ(arrayOrMap->toString(), "[K*, 42]");
+}
+
+TEST(SubfieldTest, mapKeysOnlyWithStringSubscript) {
+  // Test [K*, 'foo'] pattern - read only keys matching 'foo'
+  Subfield subfield("x[K*, 'foo']");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_TRUE(arrayOrMap->includeKeys());
+  EXPECT_FALSE(arrayOrMap->includeValues());
+  ASSERT_NE(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->subscript()->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(
+      arrayOrMap->subscript()->as<Subfield::StringSubscript>()->index(), "foo");
+  EXPECT_EQ(arrayOrMap->toString(), "[K*, 'foo']");
+}
+
+TEST(SubfieldTest, mapKeysOnlyWithDoubleQuotedStringSubscript) {
+  // Test [K*, "foo"] pattern - read only keys matching "foo"
+  Subfield subfield("x[K*, \"foo\"]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_TRUE(arrayOrMap->includeKeys());
+  EXPECT_FALSE(arrayOrMap->includeValues());
+  ASSERT_NE(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->subscript()->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(
+      arrayOrMap->subscript()->as<Subfield::StringSubscript>()->index(), "foo");
+}
+
+TEST(SubfieldTest, mapValuesOnlyAllSubscripts) {
+  // Test [V*, *] pattern - read all values, skip keys
+  Subfield subfield("x[V*, *]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_FALSE(arrayOrMap->includeKeys());
+  EXPECT_TRUE(arrayOrMap->includeValues());
+  EXPECT_EQ(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->toString(), "[V*, *]");
+}
+
+TEST(SubfieldTest, mapValuesOnlyWithLongSubscript) {
+  // Test [V*, 42] pattern - read only values where key matches index 42
+  Subfield subfield("x[V*, 42]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_FALSE(arrayOrMap->includeKeys());
+  EXPECT_TRUE(arrayOrMap->includeValues());
+  ASSERT_NE(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->subscript()->kind(), SubfieldKind::kLongSubscript);
+  EXPECT_EQ(
+      arrayOrMap->subscript()->as<Subfield::LongSubscript>()->index(), 42);
+  EXPECT_EQ(arrayOrMap->toString(), "[V*, 42]");
+}
+
+TEST(SubfieldTest, mapValuesOnlyWithStringSubscript) {
+  // Test [V*, 'foo'] pattern - read only values where key matches 'foo'
+  Subfield subfield("x[V*, 'foo']");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_FALSE(arrayOrMap->includeKeys());
+  EXPECT_TRUE(arrayOrMap->includeValues());
+  ASSERT_NE(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->subscript()->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(
+      arrayOrMap->subscript()->as<Subfield::StringSubscript>()->index(), "foo");
+  EXPECT_EQ(arrayOrMap->toString(), "[V*, 'foo']");
+}
+
+TEST(SubfieldTest, mapValuesOnlyWithDoubleQuotedStringSubscript) {
+  // Test [V*, "foo"] pattern - read only values where key matches "foo"
+  Subfield subfield("x[V*, \"foo\"]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      subfield.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_FALSE(arrayOrMap->includeKeys());
+  EXPECT_TRUE(arrayOrMap->includeValues());
+  ASSERT_NE(arrayOrMap->subscript(), nullptr);
+  EXPECT_EQ(arrayOrMap->subscript()->kind(), SubfieldKind::kStringSubscript);
+  EXPECT_EQ(
+      arrayOrMap->subscript()->as<Subfield::StringSubscript>()->index(), "foo");
+}
+
+TEST(SubfieldTest, mapSubscriptWithWhitespace) {
+  // Test patterns with whitespace after comma
+  Subfield s1("x[K*,    *]"); // Multiple spaces
+  ASSERT_EQ(s1.path().size(), 2);
+  const auto* a1 = s1.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(a1, nullptr);
+  EXPECT_TRUE(a1->includeKeys());
+
+  Subfield s2("x[V*,42]"); // No space
+  ASSERT_EQ(s2.path().size(), 2);
+  const auto* a2 = s2.path()[1]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(a2, nullptr);
+  EXPECT_TRUE(a2->includeValues());
+}
+
+TEST(SubfieldTest, nestedMapSubscript) {
+  // Test nested paths with MAP subscripts
+  Subfield subfield("a.b[K*, *]");
+  ASSERT_EQ(subfield.path().size(), 3);
+  EXPECT_EQ(subfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[1]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(subfield.path()[2]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  // Test with existing subscripts
+  Subfield complexSubfield("arr[*][K*, 'key']");
+  ASSERT_EQ(complexSubfield.path().size(), 3);
+  EXPECT_EQ(complexSubfield.path()[0]->kind(), SubfieldKind::kNestedField);
+  EXPECT_EQ(complexSubfield.path()[1]->kind(), SubfieldKind::kAllSubscripts);
+  EXPECT_EQ(
+      complexSubfield.path()[2]->kind(), SubfieldKind::kArrayOrMapSubscript);
+
+  const auto* arrayOrMap =
+      complexSubfield.path()[2]->as<Subfield::ArrayOrMapSubscript>();
+  ASSERT_NE(arrayOrMap, nullptr);
+  EXPECT_TRUE(arrayOrMap->includeKeys());
+  EXPECT_FALSE(arrayOrMap->includeValues());
 }


### PR DESCRIPTION
Summary: Functions like MAP_KEYS, MAP_VALUES or CARDINALITY doesn't requires us to read all keys or all values or neither(in case of cardinality). This PR is part of prototype we are working to optimize CARDINALITY case, where we don't require neither keys not values. This PR contains design interface for deserializing/parsing message from coordinator. We completed the implementation for cardinality usecase and left out the parsing logic for other cases as future work (H1 2026).

Reviewed By: Yuhta

Differential Revision: D88739397


