### PR TITLE
perf: Parallelize output of build-side rows for right and full joins

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -277,6 +277,10 @@ class QueryConfig {
   static constexpr const char* kAdaptiveFilterReorderingEnabled =
       "adaptive_filter_reordering_enabled";
 
+  /// If true, allow hash probe drivers to generate build-side rows in parallel.
+  static constexpr const char* kParallelJoinBuildRowsEnabled =
+      "parallel_join_build_rows_enabled";
+
   /// Global enable spilling flag.
   static constexpr const char* kSpillEnabled = "spill_enabled";
 
@@ -1024,6 +1028,10 @@ class QueryConfig {
 
   bool exprEvalSimplified() const {
     return get<bool>(kExprEvalSimplified, false);
+  }
+
+  bool parallelJoinBuildRowsEnabled() const {
+    return get<bool>(kParallelJoinBuildRowsEnabled, false);
   }
 
   bool spillEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -83,6 +83,11 @@ Generic Configuration
      - bool
      - true
      - If true, the conjunction expression can reorder inputs based on the time taken to calculate them.
+   * - parallel_join_build_rows_enabled
+     - bool
+     - false
+     - If true, the hash probe drivers can output build-side rows in parallel for full and right joins (only when spilling is not
+     - enabled by hash probe). If false, only the last prober is allowed to output build-side rows.
    * - max_local_exchange_buffer_size
      - integer
      - 32MB

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -630,7 +630,7 @@ class HashProbe : public Operator {
     std::optional<bool> currentRowPassed;
   };
 
-  BaseHashTable::RowsIterator lastProbeIterator_;
+  RowContainerIterator lastProbeIterator_;
 
   // For left and anti join with filter, tracks the probe side rows which had
   // matches on the build side but didn't pass the filter.
@@ -728,6 +728,23 @@ class HashProbe : public Operator {
 
   // Input vector used for listing rows with null keys.
   VectorPtr nullKeyProbeInput_;
+
+  // Flag to indicate whether the query config allows hash probe drivers to
+  // output build-side rows in parallel.
+  const bool parallelJoinBuildRowsEnabled_;
+
+  // Flag to indicate whether this hash probe operator is outputing build-side
+  // rows in parallel with the peer operators for the current hash table.
+  // Outputing build-side rows in parallel is not enabled in either of the
+  // following cases:
+  // 1. parallelJoinBuildRowsEnabled_ is false.
+  // 2. This join type does not need build-side rows.
+  // 3. There are more spilled data to restore.
+  bool outputBuildRowsInParallel_{false};
+
+  // The index of the row container in the current hash table that this hash
+  // probe oprator is processing to output build-side rows.
+  int buildSideOutputRowContainerId_{-1};
 };
 
 inline std::ostream& operator<<(std::ostream& os, ProbeOperatorState state) {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -2203,6 +2203,58 @@ int32_t HashTable<ignoreNullKeys>::listAllRows(
   return listRows<RowContainer::ProbeType::kAll>(iter, maxRows, maxBytes, rows);
 }
 
+template <bool ignoreNullKeys>
+template <RowContainer::ProbeType probeType>
+int32_t HashTable<ignoreNullKeys>::listRows(
+    RowContainerIterator& rowContainerIterator,
+    int rowContainerId,
+    int32_t maxRows,
+    uint64_t maxBytes,
+    char** rows) {
+  const auto& rowContainer = rowContainerId == 0
+      ? rows_.get()
+      : otherTables_[rowContainerId - 1]->rows();
+  const auto numRows = rowContainer->template listRows<probeType>(
+      &rowContainerIterator, maxRows, maxBytes, rows);
+  if (numRows > 0) {
+    return numRows;
+  }
+  return 0;
+}
+
+template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listNotProbedRows(
+    RowContainerIterator& rowContainerIterator,
+    int rowContainerId,
+    int32_t maxRows,
+    uint64_t maxBytes,
+    char** rows) {
+  return listRows<RowContainer::ProbeType::kNotProbed>(
+      rowContainerIterator, rowContainerId, maxRows, maxBytes, rows);
+}
+
+template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listProbedRows(
+    RowContainerIterator& rowContainerIterator,
+    int rowContainerId,
+    int32_t maxRows,
+    uint64_t maxBytes,
+    char** rows) {
+  return listRows<RowContainer::ProbeType::kProbed>(
+      rowContainerIterator, rowContainerId, maxRows, maxBytes, rows);
+}
+
+template <bool ignoreNullKeys>
+int32_t HashTable<ignoreNullKeys>::listAllRows(
+    RowContainerIterator& rowContainerIterator,
+    int rowContainerId,
+    int32_t maxRows,
+    uint64_t maxBytes,
+    char** rows) {
+  return listRows<RowContainer::ProbeType::kAll>(
+      rowContainerIterator, rowContainerId, maxRows, maxBytes, rows);
+}
+
 template <>
 int32_t HashTable<false>::listNullKeyRows(
     NullKeyRowsIterator* iter,

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -44,6 +44,7 @@ class HashJoinBridgeTestHelper {
   HashJoinBridge* const bridge_;
 };
 
+namespace {
 struct TestParam {
   int32_t numProbers{1};
   int32_t numBuilders{1};
@@ -728,4 +729,5 @@ TEST(HashJoinBridgeTest, hashJoinTableSpillType) {
     ASSERT_EQ(spillType->names(), testData.expectedTableSpillType->names());
   }
 }
+} // namespace
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -45,27 +45,35 @@ using facebook::velox::test::BatchMaker;
 namespace facebook::velox::exec {
 namespace {
 
-class HashJoinTest : public HashJoinTestBase {
+class HashJoinTest : public HashJoinTestBase,
+                     public testing::WithParamInterface<TestParam> {
  public:
-  HashJoinTest() : HashJoinTestBase(TestParam(1)) {}
+  HashJoinTest() : HashJoinTestBase(GetParam()) {}
 
   explicit HashJoinTest(const TestParam& param) : HashJoinTestBase(param) {}
+
+  static std::vector<TestParam> getTestParams() {
+    return std::vector<TestParam>({TestParam{1, false}, TestParam{1, true}});
+  }
 };
 
-class MultiThreadedHashJoinTest
-    : public HashJoinTest,
-      public testing::WithParamInterface<TestParam> {
+class MultiThreadedHashJoinTest : public HashJoinTest {
  public:
   MultiThreadedHashJoinTest() : HashJoinTest(GetParam()) {}
 
   static std::vector<TestParam> getTestParams() {
-    return std::vector<TestParam>({TestParam{1}, TestParam{3}});
+    return std::vector<TestParam>(
+        {TestParam{1, false},
+         TestParam{1, true},
+         TestParam{3, false},
+         TestParam{3, true}});
   }
 };
 
 TEST_P(MultiThreadedHashJoinTest, bigintArray) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -77,6 +85,7 @@ TEST_P(MultiThreadedHashJoinTest, bigintArray) {
 TEST_P(MultiThreadedHashJoinTest, outOfJoinKeyColumnOrder) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeType(probeType_)
       .probeKeys({"t_k2"})
       .probeVectors(5, 10)
@@ -92,6 +101,7 @@ TEST_P(MultiThreadedHashJoinTest, outOfJoinKeyColumnOrder) {
 TEST_P(MultiThreadedHashJoinTest, joinWithCancellation) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -109,6 +119,7 @@ TEST_P(MultiThreadedHashJoinTest, testJoinWithSpillenabledCancellation) {
   auto spillDirectory = exec::test::TempDirectoryPath::create();
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -129,6 +140,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .keyTypes({BIGINT()})
         .probeVectors(1600, 5)
         .buildVectors(0, 5)
@@ -160,6 +172,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
 TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT()})
       .probeVectors(0, 5)
       .buildVectors(1500, 5)
@@ -196,6 +209,7 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
 TEST_P(MultiThreadedHashJoinTest, normalizedKey) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT(), VARCHAR()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -221,6 +235,7 @@ DEBUG_ONLY_TEST_P(MultiThreadedHashJoinTest, parallelJoinBuildCheck) {
       std::function<void(void*)>([&](void*) { isParallelBuild = true; }));
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT(), VARCHAR()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -251,6 +266,7 @@ DEBUG_ONLY_TEST_P(
   VELOX_ASSERT_THROW(
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .numDrivers(numDrivers_)
+          .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
           .keyTypes({BIGINT(), VARCHAR()})
           .probeVectors(1600, 5)
           .buildVectors(1500, 5)
@@ -281,6 +297,7 @@ TEST_P(MultiThreadedHashJoinTest, allTypes) {
 TEST_P(MultiThreadedHashJoinTest, filter) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -313,6 +330,7 @@ DEBUG_ONLY_TEST_P(MultiThreadedHashJoinTest, filterSpillOnFirstProbeInput) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({BIGINT()})
       .numDrivers(1)
       .probeVectors(1600, 5)
@@ -363,6 +381,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithNull) {
 
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeType(probeType_)
         .probeKeys({"t_k2"})
         .probeVectors(std::move(probeVectors))
@@ -402,6 +421,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithLargeOutput) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u0"})
@@ -453,6 +473,7 @@ TEST_P(MultiThreadedHashJoinTest, arrayBasedLookup) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"c0"})
@@ -519,6 +540,7 @@ TEST_P(MultiThreadedHashJoinTest, joinSidesDifferentSchema) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"t_c0"})
       .probeVectors(std::move(probeVectors))
       .probeProjections({"c0 AS t_c0", "c1 AS t_c1", "c2 AS t_c2"})
@@ -558,6 +580,7 @@ TEST_P(MultiThreadedHashJoinTest, innerJoinWithEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"c0"})
@@ -592,6 +615,7 @@ TEST_P(MultiThreadedHashJoinTest, innerJoinWithEmptyBuild) {
 TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilter) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeType(probeType_)
       .probeVectors(174, 5)
       .probeKeys({"t_k1"})
@@ -628,6 +652,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"c0"})
@@ -669,6 +694,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithExtraFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -685,6 +711,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithExtraFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -701,6 +728,7 @@ TEST_P(MultiThreadedHashJoinTest, leftSemiJoinFilterWithExtraFilter) {
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilter) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeType(probeType_)
       .probeVectors(133, 3)
       .probeKeys({"t_k1"})
@@ -742,6 +770,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"u0"})
@@ -799,6 +828,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithAllMatches) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u0"})
@@ -834,6 +864,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -856,6 +887,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -877,6 +909,7 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithExtraFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -1020,6 +1053,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"c0"})
@@ -1040,6 +1074,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"c0"})
@@ -1060,6 +1095,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoin) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"c0"})
@@ -1097,6 +1133,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilter) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"t0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u0"})
@@ -1151,6 +1188,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::vector<RowVectorPtr>(probeVectors))
         .buildKeys({"u0"})
@@ -1210,6 +1248,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -1270,6 +1309,7 @@ TEST_P(
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u0"})
@@ -1308,6 +1348,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
     });
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"u0"})
@@ -1358,6 +1399,7 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
     });
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"u0"})
@@ -1406,6 +1448,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
   });
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"t0"})
       .probeVectors(std::vector<RowVectorPtr>(probeVectors))
       .buildKeys({"u0"})
@@ -1434,6 +1477,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
   for (const std::string& filter : filters) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::vector<RowVectorPtr>(probeVectors))
         .buildKeys({"u0"})
@@ -1474,6 +1518,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"t0"})
         .probeVectors(std::vector<RowVectorPtr>(probeVectors))
         .buildKeys({"u0"})
@@ -1548,6 +1593,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoin) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -1603,6 +1649,7 @@ TEST_P(MultiThreadedHashJoinTest, nullStatsWithEmptyBuild) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -1686,6 +1733,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"u_c0"})
@@ -1747,6 +1795,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithNoJoin) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -1805,6 +1854,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithAllMatch) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .probeFilter("c0 < 5")
@@ -1868,6 +1918,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u_c0"})
@@ -1887,6 +1938,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u_c0"})
@@ -1939,6 +1991,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithNullableFilter) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -1990,6 +2043,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoin) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -2045,6 +2099,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"u_c0"})
@@ -2097,6 +2152,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithAllMatch) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -2152,6 +2208,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u_c0"})
@@ -2171,6 +2228,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u_c0"})
@@ -2224,6 +2282,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoin) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -2279,6 +2338,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithEmptyBuild) {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .hashProbeFinishEarlyOnEmptyBuild(finishOnEmpty)
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(probeVectors))
         .buildKeys({"u_c0"})
@@ -2332,6 +2392,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithNoMatch) {
 
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .probeKeys({"c0"})
       .probeVectors(std::move(probeVectors))
       .buildKeys({"u_c0"})
@@ -2387,6 +2448,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u_c0"})
@@ -2406,6 +2468,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
     auto testBuildVectors = buildVectors;
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .probeKeys({"c0"})
         .probeVectors(std::move(testProbeVectors))
         .buildKeys({"u_c0"})
@@ -2423,6 +2486,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoinWithFilters) {
 TEST_P(MultiThreadedHashJoinTest, noSpillLevelLimit) {
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .keyTypes({INTEGER()})
       .probeVectors(1600, 5)
       .buildVectors(1500, 5)
@@ -2443,7 +2507,7 @@ TEST_P(MultiThreadedHashJoinTest, noSpillLevelLimit) {
 
 // Verify that dynamic filter pushed down is turned off for null-aware right
 // semi project join.
-TEST_F(HashJoinTest, nullAwareRightSemiProjectOverScan) {
+TEST_P(HashJoinTest, nullAwareRightSemiProjectOverScan) {
   std::vector<RowVectorPtr> probes;
   std::vector<RowVectorPtr> builds;
   // Matches present:
@@ -2517,7 +2581,7 @@ TEST_F(HashJoinTest, nullAwareRightSemiProjectOverScan) {
   }
 }
 
-TEST_F(HashJoinTest, duplicateJoinKeys) {
+TEST_P(HashJoinTest, duplicateJoinKeys) {
   auto leftVectors = makeBatches(3, [&](int32_t /*unused*/) {
     return makeRowVector({
         makeNullableFlatVector<int64_t>(
@@ -2599,7 +2663,7 @@ TEST_F(HashJoinTest, duplicateJoinKeys) {
   }
 }
 
-TEST_F(HashJoinTest, semiProject) {
+TEST_P(HashJoinTest, semiProject) {
   // Some keys have multiple rows: 2, 3, 5.
   auto probeVectors = makeBatches(3, [&](int32_t /*unused*/) {
     return makeRowVector({
@@ -2715,7 +2779,7 @@ TEST_F(HashJoinTest, semiProject) {
       .run();
 }
 
-TEST_F(HashJoinTest, semiProjectWithNullKeys) {
+TEST_P(HashJoinTest, semiProjectWithNullKeys) {
   // Some keys have multiple rows: 2, 3, 5.
   auto probeVectors = makeBatches(3, [&](int32_t /*unused*/) {
     return makeRowVector(
@@ -2918,7 +2982,7 @@ TEST_F(HashJoinTest, semiProjectWithNullKeys) {
       .run();
 }
 
-TEST_F(HashJoinTest, semiProjectWithFilter) {
+TEST_P(HashJoinTest, semiProjectWithFilter) {
   auto probeVectors = makeBatches(3, [&](auto /*unused*/) {
     return makeRowVector(
         {"t0", "t1"},
@@ -2989,7 +3053,7 @@ TEST_F(HashJoinTest, semiProjectWithFilter) {
   }
 }
 
-TEST_F(HashJoinTest, nullAwareRightSemiProjectWithFilterNotAllowed) {
+TEST_P(HashJoinTest, nullAwareRightSemiProjectWithFilterNotAllowed) {
   auto probe = makeRowVector(ROW({"t0", "t1"}, {INTEGER(), BIGINT()}), 10);
   auto build = makeRowVector(ROW({"u0", "u1"}, {INTEGER(), BIGINT()}), 10);
 
@@ -3008,7 +3072,7 @@ TEST_F(HashJoinTest, nullAwareRightSemiProjectWithFilterNotAllowed) {
       "Null-aware right semi project join doesn't support extra filter");
 }
 
-TEST_F(HashJoinTest, leftSemiJoinWithExtraOutputCapacity) {
+TEST_P(HashJoinTest, leftSemiJoinWithExtraOutputCapacity) {
   std::vector<RowVectorPtr> probeVectors;
   std::vector<RowVectorPtr> buildVectors;
   probeVectors.push_back(makeRowVector(
@@ -3083,7 +3147,7 @@ TEST_F(HashJoinTest, leftSemiJoinWithExtraOutputCapacity) {
   }
 }
 
-TEST_F(HashJoinTest, nullAwareMultiKeyNotAllowed) {
+TEST_P(HashJoinTest, nullAwareMultiKeyNotAllowed) {
   auto probe = makeRowVector(
       ROW({"t0", "t1", "t2"}, {INTEGER(), BIGINT(), VARCHAR()}), 10);
   auto build = makeRowVector(
@@ -3133,7 +3197,7 @@ TEST_F(HashJoinTest, nullAwareMultiKeyNotAllowed) {
       "Null-aware joins allow only one join key");
 }
 
-TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
+TEST_P(HashJoinTest, semiProjectOverLazyVectors) {
   auto probeVectors = makeBatches(1, [&](auto /*unused*/) {
     return makeRowVector(
         {"t0", "t1"},
@@ -3237,12 +3301,15 @@ TEST_F(HashJoinTest, semiProjectOverLazyVectors) {
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(
-    HashJoinTest,
     MultiThreadedHashJoinTest,
-    testing::ValuesIn(MultiThreadedHashJoinTest::getTestParams()));
+    MultiThreadedHashJoinTest,
+    testing::ValuesIn(MultiThreadedHashJoinTest::getTestParams()),
+    [](const testing::TestParamInfo<TestParam>& info) {
+      return TestParamToName(info.param);
+    });
 
 // TODO: try to parallelize the following test cases if possible.
-TEST_F(HashJoinTest, memory) {
+TEST_P(HashJoinTest, memory) {
   // Measures memory allocation in a 1:n hash join followed by
   // projection and aggregation. We expect vectors to be mostly
   // reused, except for t_k0 + 1, which is a dictionary after the
@@ -3281,7 +3348,7 @@ TEST_F(HashJoinTest, memory) {
   EXPECT_GT(40'000'000, params.queryCtx->pool()->stats().cumulativeBytes);
 }
 
-TEST_F(HashJoinTest, lazyVectors) {
+TEST_P(HashJoinTest, lazyVectors) {
   // a dataset of multiple row groups with multiple columns. We create
   // different dictionary wrappings for different columns and load the
   // rows in scope at different times.
@@ -3396,7 +3463,7 @@ TEST_F(HashJoinTest, lazyVectors) {
   }
 }
 
-TEST_F(HashJoinTest, lazyVectorNotLoadedInFilter) {
+TEST_P(HashJoinTest, lazyVectorNotLoadedInFilter) {
   // Ensure that if lazy vectors are temporarily wrapped during a filter's
   // execution and remain unloaded, the temporary wrap is promptly
   // discarded. This precaution prevents the generation of the probe's output
@@ -3414,7 +3481,7 @@ TEST_F(HashJoinTest, lazyVectorNotLoadedInFilter) {
       "SELECT t.c1, t.c2 FROM t, u WHERE t.c0 = u.c0");
 }
 
-TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftJoin) {
+TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftJoin) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
 
@@ -3425,7 +3492,7 @@ TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftJoin) {
       "SELECT t.c1, t.c2 FROM t LEFT JOIN u ON t.c0 = u.c0 AND (c1 > 0 AND c2 > 0)");
 }
 
-TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterFullJoin) {
+TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterFullJoin) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
 
@@ -3436,7 +3503,7 @@ TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterFullJoin) {
       "SELECT t.c1, t.c2 FROM t FULL OUTER JOIN u ON t.c0 = u.c0 AND (c1 > 0 AND c2 > 0)");
 }
 
-TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiProject) {
+TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiProject) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
 
@@ -3447,7 +3514,7 @@ TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiProject) {
       "SELECT t.c1, t.c2, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND (t.c1 > 0 AND t.c2 > 0)) FROM t");
 }
 
-TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterAntiJoin) {
+TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterAntiJoin) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
 
@@ -3458,7 +3525,7 @@ TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterAntiJoin) {
       "SELECT t.c1, t.c2 FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE t.c0 = u.c0 AND (t.c1 > 0 AND t.c2 > 0))");
 }
 
-TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterInnerJoin) {
+TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterInnerJoin) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
 
@@ -3469,7 +3536,7 @@ TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterInnerJoin) {
       "SELECT t.c1, t.c2 FROM t, u WHERE t.c0 = u.c0 AND NOT (c1 < 15 AND c2 >= 0)");
 }
 
-TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiFilter) {
+TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiFilter) {
   // Test the case where a filter loads a subset of the rows that will be output
   // from a column on the probe side.
 
@@ -3480,7 +3547,7 @@ TEST_F(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiFilter) {
       "SELECT t.c1, t.c2 FROM t WHERE c0 IN (SELECT u.c0 FROM u WHERE t.c0 = u.c0 AND NOT (t.c1 < 15 AND t.c2 >= 0))");
 }
 
-TEST_F(HashJoinTest, dynamicFilters) {
+TEST_P(HashJoinTest, dynamicFilters) {
   const int32_t numSplits = 10;
   const int32_t numRowsProbe = 333;
   const int32_t numRowsBuild = 100;
@@ -4171,7 +4238,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   }
 }
 
-TEST_F(HashJoinTest, dynamicFiltersStatsWithChainedJoins) {
+TEST_P(HashJoinTest, dynamicFiltersStatsWithChainedJoins) {
   const int32_t numSplits = 10;
   const int32_t numProbeRows = 333;
   const int32_t numBuildRows = 100;
@@ -4268,7 +4335,7 @@ TEST_F(HashJoinTest, dynamicFiltersStatsWithChainedJoins) {
       .run();
 }
 
-TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
+TEST_P(HashJoinTest, dynamicFiltersWithSkippedSplits) {
   const int32_t numSplits = 20;
   const int32_t numNonSkippedSplits = 10;
   const int32_t numRowsProbe = 333;
@@ -4490,7 +4557,7 @@ TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
   }
 }
 
-TEST_F(HashJoinTest, dynamicFiltersAppliedToPreloadedSplits) {
+TEST_P(HashJoinTest, dynamicFiltersAppliedToPreloadedSplits) {
   vector_size_t size = 1000;
   const int32_t numSplits = 5;
 
@@ -4574,7 +4641,7 @@ TEST_F(HashJoinTest, dynamicFiltersAppliedToPreloadedSplits) {
       .run();
 }
 
-TEST_F(HashJoinTest, dynamicFiltersPushDownThroughAgg) {
+TEST_P(HashJoinTest, dynamicFiltersPushDownThroughAgg) {
   const int32_t numRowsProbe = 300;
   const int32_t numRowsBuild = 100;
 
@@ -4643,7 +4710,7 @@ TEST_F(HashJoinTest, dynamicFiltersPushDownThroughAgg) {
       .run();
 }
 
-TEST_F(HashJoinTest, noDynamicFiltersPushDownThroughRightJoin) {
+TEST_P(HashJoinTest, noDynamicFiltersPushDownThroughRightJoin) {
   std::vector<RowVectorPtr> innerBuild = {makeRowVector(
       {"a"},
       {
@@ -4690,7 +4757,7 @@ TEST_F(HashJoinTest, noDynamicFiltersPushDownThroughRightJoin) {
 
 // Verify the size of the join output vectors when projecting build-side
 // variable-width column.
-TEST_F(HashJoinTest, memoryUsage) {
+TEST_P(HashJoinTest, memoryUsage) {
   std::vector<RowVectorPtr> probeVectors =
       makeBatches(10, [&](int32_t /*unused*/) {
         return makeRowVector(
@@ -4745,7 +4812,7 @@ TEST_F(HashJoinTest, memoryUsage) {
 /// Test an edge case in producing small output batches where the logic to
 /// calculate the set of probe-side rows to load lazy vectors for was
 /// triggering a crash.
-TEST_F(HashJoinTest, smallOutputBatchSize) {
+TEST_P(HashJoinTest, smallOutputBatchSize) {
   // Setup probe data with 50 non-null matching keys followed by 50 null
   // keys: 1, 2, 1, 2,...null, null.
   auto probeVectors = makeRowVector({
@@ -4791,12 +4858,13 @@ TEST_F(HashJoinTest, smallOutputBatchSize) {
       .run();
 }
 
-TEST_F(HashJoinTest, spillFileSize) {
+TEST_P(HashJoinTest, spillFileSize) {
   const std::vector<uint64_t> maxSpillFileSizes({0, 1, 1'000'000'000});
   for (const auto spillFileSize : maxSpillFileSizes) {
     SCOPED_TRACE(fmt::format("spillFileSize: {}", spillFileSize));
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .keyTypes({BIGINT()})
         .probeVectors(100, 3)
         .buildVectors(100, 3)
@@ -4827,10 +4895,11 @@ TEST_F(HashJoinTest, spillFileSize) {
   }
 }
 
-TEST_F(HashJoinTest, spillPartitionBitsOverlap) {
+TEST_P(HashJoinTest, spillPartitionBitsOverlap) {
   auto builder =
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .numDrivers(numDrivers_)
+          .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
           .keyTypes({BIGINT(), BIGINT()})
           .probeVectors(2'000, 3)
           .buildVectors(2'000, 3)
@@ -4845,7 +4914,7 @@ TEST_F(HashJoinTest, spillPartitionBitsOverlap) {
 
 // The test is to verify if the hash build reservation has been released on
 // task error.
-DEBUG_ONLY_TEST_F(HashJoinTest, buildReservationReleaseCheck) {
+DEBUG_ONLY_TEST_P(HashJoinTest, buildReservationReleaseCheck) {
   std::vector<RowVectorPtr> probeVectors =
       makeBatches(1, [&](int32_t /*unused*/) {
         return std::dynamic_pointer_cast<RowVector>(
@@ -4897,7 +4966,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, buildReservationReleaseCheck) {
   ASSERT_TRUE(waitForTaskAborted(task, 5'000'000));
 }
 
-TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
+TEST_P(HashJoinTest, dynamicFilterOnPartitionKey) {
   vector_size_t size = 10;
   auto filePaths = makeFilePaths(1);
   auto rowVector = makeRowVector(
@@ -4944,7 +5013,7 @@ TEST_F(HashJoinTest, dynamicFilterOnPartitionKey) {
       .run();
 }
 
-TEST_F(HashJoinTest, probeMemoryLimitOnBuildProjection) {
+TEST_P(HashJoinTest, probeMemoryLimitOnBuildProjection) {
   const uint64_t numBuildRows = 20;
   std::vector<RowVectorPtr> probeVectors =
       makeBatches(10, [&](int32_t /*unused*/) {
@@ -5049,7 +5118,7 @@ TEST_F(HashJoinTest, probeMemoryLimitOnBuildProjection) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringInputProcessing) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 10;
@@ -5144,6 +5213,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
     std::thread taskThread([&]() {
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .numDrivers(numDrivers_)
+          .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
           .planNode(plan)
           .queryPool(std::move(queryPool))
           .injectSpill(false)
@@ -5215,7 +5285,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
   ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{});
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
+DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringReserve) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   const int32_t numBuildVectors = 3;
   std::vector<RowVectorPtr> buildVectors;
@@ -5299,6 +5369,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   std::thread taskThread([&]() {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .planNode(plan)
         .queryPool(std::move(queryPool))
         .injectSpill(false)
@@ -5348,7 +5419,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   taskThread.join();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
+DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringAllocation) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 10;
@@ -5432,6 +5503,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
     std::thread taskThread([&]() {
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .numDrivers(numDrivers_)
+          .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
           .planNode(plan)
           .queryPool(std::move(queryPool))
           .injectSpill(false)
@@ -5479,7 +5551,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
   ASSERT_EQ(reclaimerStats_, memory::MemoryReclaimer::Stats{0});
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringOutputProcessing) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 10;
@@ -5551,6 +5623,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
     std::thread taskThread([&]() {
       HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
           .numDrivers(numDrivers_)
+          .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
           .planNode(plan)
           .queryPool(std::move(queryPool))
           .injectSpill(false)
@@ -5612,7 +5685,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
   ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 1);
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
+DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringWaitForProbe) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 10;
@@ -5698,6 +5771,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   std::thread taskThread([&]() {
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .planNode(plan)
         .queryPool(std::move(queryPool))
         .injectSpill(false)
@@ -5750,7 +5824,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   ASSERT_EQ(reclaimerStats_.numNonReclaimableAttempts, 1);
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
   const auto buildVectors = makeVectors(buildType_, 10, 128);
   const auto probeVectors = makeVectors(probeType_, 5, 128);
 
@@ -5816,6 +5890,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
     VELOX_ASSERT_THROW(
         HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
             .numDrivers(numDrivers_)
+            .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
             .planNode(plan)
             .injectSpill(false)
             .referenceQuery(
@@ -5826,7 +5901,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashBuildAbortDuringInputProcessing) {
   const auto buildVectors = makeVectors(buildType_, 10, 128);
   const auto probeVectors = makeVectors(probeType_, 5, 128);
 
@@ -5892,6 +5967,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputProcessing) {
     VELOX_ASSERT_THROW(
         HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
             .numDrivers(numDrivers_)
+            .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
             .planNode(plan)
             .injectSpill(false)
             .referenceQuery(
@@ -5903,7 +5979,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputProcessing) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringAllocation) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashBuildAbortDuringAllocation) {
   const auto buildVectors = makeVectors(buildType_, 10, 128);
   const auto probeVectors = makeVectors(probeType_, 5, 128);
 
@@ -5970,6 +6046,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringAllocation) {
     VELOX_ASSERT_THROW(
         HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
             .numDrivers(numDrivers_)
+            .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
             .planNode(plan)
             .injectSpill(false)
             .referenceQuery(
@@ -5981,7 +6058,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringAllocation) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeAbortDuringInputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeAbortDuringInputProcessing) {
   const auto buildVectors = makeVectors(buildType_, 10, 128);
   const auto probeVectors = makeVectors(probeType_, 5, 128);
 
@@ -6043,6 +6120,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeAbortDuringInputProcessing) {
     VELOX_ASSERT_THROW(
         HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
             .numDrivers(numDrivers_)
+            .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
             .planNode(plan)
             .injectSpill(false)
             .referenceQuery(
@@ -6053,7 +6131,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeAbortDuringInputProcessing) {
   }
 }
 
-TEST_F(HashJoinTest, leftJoinWithMissAtEndOfBatch) {
+TEST_P(HashJoinTest, leftJoinWithMissAtEndOfBatch) {
   // Tests some cases where the row at the end of an output batch fails the
   // filter.
   auto probeVectors = std::vector<RowVectorPtr>{makeRowVector(
@@ -6105,7 +6183,7 @@ TEST_F(HashJoinTest, leftJoinWithMissAtEndOfBatch) {
   test("t_k2 > 9");
 }
 
-TEST_F(HashJoinTest, leftJoinWithMissAtEndOfBatchMultipleBuildMatches) {
+TEST_P(HashJoinTest, leftJoinWithMissAtEndOfBatchMultipleBuildMatches) {
   // Tests some cases where the row at the end of an output batch fails the
   // filter and there are multiple matches with the build side..
   auto probeVectors = std::vector<RowVectorPtr>{makeRowVector(
@@ -6155,7 +6233,7 @@ TEST_F(HashJoinTest, leftJoinWithMissAtEndOfBatchMultipleBuildMatches) {
   test("t_k2 != 4 and t_k2 != 8");
 }
 
-TEST_F(HashJoinTest, leftJoinPreserveProbeOrder) {
+TEST_P(HashJoinTest, leftJoinPreserveProbeOrder) {
   const std::vector<RowVectorPtr> probeVectors = {
       makeRowVector(
           {"k1", "v1"},
@@ -6197,7 +6275,7 @@ TEST_F(HashJoinTest, leftJoinPreserveProbeOrder) {
   ASSERT_EQ(v1->valueAt(2), 0);
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, minSpillableMemoryReservation) {
+DEBUG_ONLY_TEST_P(HashJoinTest, minSpillableMemoryReservation) {
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 10;
   std::vector<RowVectorPtr> buildVectors;
@@ -6247,6 +6325,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, minSpillableMemoryReservation) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
         .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
         .planNode(plan)
         .injectSpill(false)
         .spillDirectory(tempDirectory->getPath())
@@ -6256,7 +6335,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, minSpillableMemoryReservation) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, exceededMaxSpillLevel) {
+DEBUG_ONLY_TEST_P(HashJoinTest, exceededMaxSpillLevel) {
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 10;
   std::vector<RowVectorPtr> buildVectors;
@@ -6346,7 +6425,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, exceededMaxSpillLevel) {
       exceededMaxSpillLevelCount + 16);
 }
 
-TEST_F(HashJoinTest, maxSpillBytes) {
+TEST_P(HashJoinTest, maxSpillBytes) {
   const auto rowType =
       ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});
   const auto probeVectors = createVectors(rowType, 1024, 10 << 20);
@@ -6403,7 +6482,7 @@ TEST_F(HashJoinTest, maxSpillBytes) {
   }
 }
 
-TEST_F(HashJoinTest, onlyHashBuildMaxSpillBytes) {
+TEST_P(HashJoinTest, onlyHashBuildMaxSpillBytes) {
   const auto rowType =
       ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});
   const auto probeVectors = createVectors(rowType, 32, 128);
@@ -6459,7 +6538,7 @@ TEST_F(HashJoinTest, onlyHashBuildMaxSpillBytes) {
   }
 }
 
-TEST_F(HashJoinTest, reclaimFromJoinBuilderWithMultiDrivers) {
+TEST_P(HashJoinTest, reclaimFromJoinBuilderWithMultiDrivers) {
   auto rowType = ROW({
       {"c0", INTEGER()},
       {"c1", INTEGER()},
@@ -6508,7 +6587,7 @@ TEST_F(HashJoinTest, reclaimFromJoinBuilderWithMultiDrivers) {
   ASSERT_GT(arbitrator->stats().reclaimedUsedBytes, 0);
 }
 
-TEST_F(HashJoinTest, semiJoinAbandonBuildNoDupHashEarly) {
+TEST_P(HashJoinTest, semiJoinAbandonBuildNoDupHashEarly) {
   auto probeVectors = makeBatches(3, [&](int32_t /*unused*/) {
     return makeRowVector({
         makeFlatVector<int64_t>({1, 2, 2, 3, 3, 3, 4, 5, 5, 6, 7}),
@@ -6551,7 +6630,7 @@ TEST_F(HashJoinTest, semiJoinAbandonBuildNoDupHashEarly) {
       .run();
 }
 
-TEST_F(HashJoinTest, antiJoinAbandonBuildNoDupHashEarly) {
+TEST_P(HashJoinTest, antiJoinAbandonBuildNoDupHashEarly) {
   auto probeVectors = makeBatches(64, [&](int32_t /*unused*/) {
     return makeRowVector(
         {"t0", "t1"},
@@ -6583,7 +6662,7 @@ TEST_F(HashJoinTest, antiJoinAbandonBuildNoDupHashEarly) {
       .run();
 }
 
-TEST_F(HashJoinTest, semiJoinDeduplicateResetCapacity) {
+TEST_P(HashJoinTest, semiJoinDeduplicateResetCapacity) {
   const int32_t vectorSize = 10;
   const int32_t batches = 210;
   auto probeVectors = makeBatches(batches, [&](int32_t /*unused*/) {
@@ -6636,7 +6715,7 @@ TEST_F(HashJoinTest, semiJoinDeduplicateResetCapacity) {
       .run();
 }
 
-DEBUG_ONLY_TEST_F(
+DEBUG_ONLY_TEST_P(
     HashJoinTest,
     failedToReclaimFromHashJoinBuildersInNonReclaimableSection) {
   auto rowType = ROW({
@@ -6729,7 +6808,7 @@ DEBUG_ONLY_TEST_F(
       2);
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringTableBuild) {
+DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringTableBuild) {
   VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
   const int32_t numBuildVectors = 5;
   std::vector<RowVectorPtr> buildVectors;
@@ -6789,7 +6868,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringTableBuild) {
       .run();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, exceptionDuringFinishJoinBuild) {
+DEBUG_ONLY_TEST_P(HashJoinTest, exceptionDuringFinishJoinBuild) {
   // This test is to make sure there is no memory leak when exceptions are
   // thrown while parallelly preparing join table.
   auto memoryManager = memory::memoryManager();
@@ -6873,7 +6952,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, exceptionDuringFinishJoinBuild) {
   ASSERT_EQ(arbitrator->stats().freeCapacityBytes, expectedFreeCapacityBytes);
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, arbitrationTriggeredDuringParallelJoinBuild) {
+DEBUG_ONLY_TEST_P(HashJoinTest, arbitrationTriggeredDuringParallelJoinBuild) {
   std::unique_ptr<memory::MemoryManager> memoryManager = createMemoryManager();
   const uint64_t numDrivers = 2;
 
@@ -6988,7 +7067,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, arbitrationTriggeredDuringParallelJoinBuild) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, arbitrationTriggeredByEnsureJoinTableFit) {
+DEBUG_ONLY_TEST_P(HashJoinTest, arbitrationTriggeredByEnsureJoinTableFit) {
   // Use manual spill injection other than spill injection framework. This is
   // because spill injection framework does not allow fine grain spill within a
   // single operator (We do not want to spill during addInput() but only during
@@ -7002,6 +7081,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, arbitrationTriggeredByEnsureJoinTableFit) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .numDrivers(numDrivers_)
+      .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
       .injectSpill(false)
       .spillDirectory(tempDirectory->getPath())
       .keyTypes({BIGINT()})
@@ -7016,7 +7096,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, arbitrationTriggeredByEnsureJoinTableFit) {
       .run();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, joinBuildSpillError) {
+DEBUG_ONLY_TEST_P(HashJoinTest, joinBuildSpillError) {
   const int kMemoryCapacity = 27 << 20;
   // Set a small memory capacity to trigger spill.
   std::unique_ptr<memory::MemoryManager> memoryManager =
@@ -7079,7 +7159,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, joinBuildSpillError) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, probeSpillOnWaitForPeers) {
+DEBUG_ONLY_TEST_P(HashJoinTest, probeSpillOnWaitForPeers) {
   // This test creates a scenario when tester probe thread finishes processing
   // input, entering kWaitForPeers state, and the other thread is still
   // processing, spill is triggered properly performed.
@@ -7186,7 +7266,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, probeSpillOnWaitForPeers) {
   waitForAllTasksToBeDeleted();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, taskWaitTimeout) {
+DEBUG_ONLY_TEST_P(HashJoinTest, taskWaitTimeout) {
   const int queryMemoryCapacity = 128 << 20;
   // Creates a large number of vectors based on the query capacity to trigger
   // memory arbitration.
@@ -7276,7 +7356,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, taskWaitTimeout) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpill) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpill) {
   struct {
     bool triggerBuildSpill;
     // Triggers after no more input or not.
@@ -7366,7 +7446,9 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpill) {
         .injectSpill(false)
         .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
           auto opStats = toOperatorStats(task->taskStats());
-          ASSERT_GT(opStats.at("HashProbe").spilledBytes, 0);
+          if (!parallelBuildSideRowsEnabled_) {
+            ASSERT_GT(opStats.at("HashProbe").spilledBytes, 0);
+          }
           if (testData.triggerBuildSpill) {
             ASSERT_GT(opStats.at("HashBuild").spilledBytes, 0);
           } else {
@@ -7381,7 +7463,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpill) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillInMiddeOfLastOutputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpillInMiddleOfLastOutputProcessing) {
   std::atomic_int outputCountAfterNoMoreInout{0};
   std::atomic_bool injectOnce{true};
   ::facebook::velox::common::testutil::ScopedTestValue abc(
@@ -7434,7 +7516,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillInMiddeOfLastOutputProcessing) {
 // Inject probe-side spilling in the middle of output processing. If
 // 'recursiveSpill' is true, we trigger probe-spilling when probe the hash table
 // built from spilled data.
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillInMiddeOfOutputProcessing) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpillInMiddleOfOutputProcessing) {
   for (bool recursiveSpill : {false, true}) {
     std::atomic_int buildInputCount{0};
     SCOPED_TESTVALUE_SET(
@@ -7504,7 +7586,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillInMiddeOfOutputProcessing) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillWhenOneOfProbeFinish) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpillWhenOneOfProbeFinish) {
   const int numDrivers{3};
 
   std::atomic_bool probeWaitFlag{true};
@@ -7561,7 +7643,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillWhenOneOfProbeFinish) {
   queryThread.join();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillExceedLimit) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpillExceedLimit) {
   // If 'buildTriggerSpill' is true, then spilling is triggered by hash build.
   for (const bool buildTriggerSpill : {false, true}) {
     SCOPED_TRACE(fmt::format("buildTriggerSpill {}", buildTriggerSpill));
@@ -7633,7 +7715,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillExceedLimit) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillUnderNonReclaimableSection) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpillUnderNonReclaimableSection) {
   std::atomic_bool injectOnce{true};
   SCOPED_TESTVALUE_SET(
       "facebook::velox::common::memory::MemoryPoolImpl::allocateNonContiguous",
@@ -7677,7 +7759,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillUnderNonReclaimableSection) {
 // This test case is to cover the case that hash probe trigger spill for right
 // semi join types and the pending input needs to be processed in multiple
 // steps.
-DEBUG_ONLY_TEST_F(HashJoinTest, spillOutputWithRightSemiJoins) {
+DEBUG_ONLY_TEST_P(HashJoinTest, spillOutputWithRightSemiJoins) {
   for (const auto joinType :
        {core::JoinType::kRightSemiFilter, core::JoinType::kRightSemiProject}) {
     std::atomic_bool injectOnce{true};
@@ -7733,7 +7815,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, spillOutputWithRightSemiJoins) {
   }
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, spillCheckOnLeftSemiFilterWithDynamicFilters) {
+DEBUG_ONLY_TEST_P(HashJoinTest, spillCheckOnLeftSemiFilterWithDynamicFilters) {
   const int32_t numSplits = 10;
   const int32_t numRowsProbe = 333;
   const int32_t numRowsBuild = 100;
@@ -7849,7 +7931,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, spillCheckOnLeftSemiFilterWithDynamicFilters) {
 // start processing. This can cause unnecessary spill and query OOM under some
 // real workload with many stages as each hash probe might reserve non-trivial
 // amount of memory.
-DEBUG_ONLY_TEST_F(
+DEBUG_ONLY_TEST_P(
     HashJoinTest,
     hashProbeMemoryReservationCheckBeforeProbeStartWithSpillEnabled) {
   fuzzerOpts_.vectorSize = 128;
@@ -7895,7 +7977,7 @@ DEBUG_ONLY_TEST_F(
       .run();
 }
 
-TEST_F(HashJoinTest, nanKeys) {
+TEST_P(HashJoinTest, nanKeys) {
   // Verify the NaN values with different binary representations are considered
   // equal.
   static const double kNan = std::numeric_limits<double>::quiet_NaN();
@@ -7929,7 +8011,7 @@ TEST_F(HashJoinTest, nanKeys) {
   facebook::velox::test::assertEqualVectors(expected, result);
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, spillOnBlockedProbe) {
+DEBUG_ONLY_TEST_P(HashJoinTest, spillOnBlockedProbe) {
   auto blockedOperatorFactoryUniquePtr =
       std::make_unique<BlockedOperatorFactory>();
   auto blockedOperatorFactory = blockedOperatorFactoryUniquePtr.get();
@@ -8003,9 +8085,10 @@ DEBUG_ONLY_TEST_F(HashJoinTest, spillOnBlockedProbe) {
   }
   arbitrationThread.join();
   waitForAllTasksToBeDeleted(30'000'000);
+  Operator::unregisterAllOperators();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, buildReclaimedMemoryReport) {
+DEBUG_ONLY_TEST_P(HashJoinTest, buildReclaimedMemoryReport) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   const int32_t numBuildVectors = 3;
   std::vector<RowVectorPtr> buildVectors;
@@ -8132,7 +8215,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, buildReclaimedMemoryReport) {
   taskThread.join();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, probeReclaimedMemoryReport) {
+DEBUG_ONLY_TEST_P(HashJoinTest, probeReclaimedMemoryReport) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   const int32_t numBuildVectors = 3;
   std::vector<RowVectorPtr> buildVectors;
@@ -8237,7 +8320,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, probeReclaimedMemoryReport) {
   taskThread.join();
 }
 
-DEBUG_ONLY_TEST_F(HashJoinTest, hashTableCleanupAfterProbeFinish) {
+DEBUG_ONLY_TEST_P(HashJoinTest, hashTableCleanupAfterProbeFinish) {
   auto buildVectors = makeVectors(buildType_, 5, 100);
   auto probeVectors = makeVectors(probeType_, 5, 100);
 
@@ -8289,7 +8372,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashTableCleanupAfterProbeFinish) {
   ASSERT_TRUE(tableEmpty);
 }
 
-TEST_F(HashJoinTest, innerJoinForTypeWithCustomComparisonAndSmallVector) {
+TEST_P(HashJoinTest, innerJoinForTypeWithCustomComparisonAndSmallVector) {
   // This test corresponds to the SQL query:
   // SELECT
   //   LEFT_TABLE.ip_addr as ip_left_string,
@@ -8392,7 +8475,7 @@ TEST_F(HashJoinTest, innerJoinForTypeWithCustomComparisonAndSmallVector) {
 /// Test hash join where build-side keys have a type that supports custom
 /// comparison and come from a small range which would allow for array-based
 /// lookup instead of a hash table for other types.
-TEST_F(HashJoinTest, arrayBasedLookupCustomComparisonType) {
+TEST_P(HashJoinTest, arrayBasedLookupCustomComparisonType) {
   std::vector<RowVectorPtr> probeVectors = {
       makeRowVector({makeFlatVector<int64_t>(
           1'024,
@@ -8435,7 +8518,7 @@ TEST_F(HashJoinTest, arrayBasedLookupCustomComparisonType) {
   EXPECT_EQ(result->size(), 1'024);
 }
 
-DEBUG_ONLY_TEST_F(
+DEBUG_ONLY_TEST_P(
     HashJoinTest,
     hashProbeShouldYieldWhenFilterConsistentlyRejectAll) {
   const uint32_t kProbeSize = 100;
@@ -8532,7 +8615,7 @@ DEBUG_ONLY_TEST_F(
 // This test validates that when spillOutput() is running (toSpillOutput=true),
 // the operator should NOT yield even when shouldYield() returns true. This is
 // critical because yielding during spillOutput would break the spilling loop.
-DEBUG_ONLY_TEST_F(
+DEBUG_ONLY_TEST_P(
     HashJoinTest,
     spillOutputShouldNotYieldWhenFilterConsistentlyRejectAll) {
   const uint32_t kProbeSize = 100;
@@ -8621,5 +8704,14 @@ DEBUG_ONLY_TEST_F(
 
   ASSERT_TRUE(spillTriggered.load());
 }
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    HashJoinTest,
+    HashJoinTest,
+    testing::ValuesIn(HashJoinTest::getTestParams()),
+    [](const testing::TestParamInfo<TestParam>& info) {
+      return TestParamToName(info.param);
+    });
+
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
This diff makes HashProbe drivers generate build-side outputs for right and full joins in parallel, with each driver 
claiming and processing one row container of the current hash table from the HashJoinBridge. If there are more 
row containers than the number of HashProbe drivers, the drivers continue picking up unclaimed row containers 
after processing the previous one, until all row containers of the current hash table have been claimed and 
processed.

Outputting build-side rows in parallel is only allowed when all the following three conditions are met:
1. This join type requires build-side output.
2. The query config "parallel_join_build_rows_enabled" is set to true (default is false).
3. HashProbe::canSpill() is false.

A subsequent diff will add support for parallelizing the output of build-side rows when spilling is enabled in 
HashProbe.

This diff addresses https://github.com/facebookincubator/velox/issues/15484.

Below is the TPC-H sf1000 benchmark before and after this change. Specifically, Q13 has 41% and Q21 has 8.1% 
improvement of execution time.
<img width="1328" height="677" alt="Screenshot 2025-12-17 at 11 10 55 AM" src="https://github.com/user-attachments/assets/ded508ef-5a41-43ff-afb0-ec4cdec018f8" />


Differential Revision: D88913782


