### PR TITLE
feat(function): Add varbinary variants for strpos and contains (#15809)

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -6,6 +6,10 @@ Binary Functions
 
     Computes the crc32 checksum of ``binary``.
 
+.. function:: contains(x, element) -> boolean
+
+     Returns true if the binary ``x`` contains the ``element``.
+
 .. function:: fnv1_32(binary) -> integer
 
     Computes the FNV-1 32-bit hash of ``binary``.
@@ -140,6 +144,30 @@ Binary Functions
 
     Computes the 64-bit SpookyHashV2 hash of ``binary``.
 
+.. function:: strpos(binary, pattern) -> bigint
+
+     Returns the starting byte position of the first instance of ``pattern`` in
+     ``binary``. Positions start with ``1``. If not found, ``0`` is returned.
+
+.. function:: strpos(binary, pattern, instance) -> bigint
+     :noindex:
+
+     Returns the byte position of the N-th ``instance`` of ``pattern`` in ``binary``.
+     ``instance`` must be a positive number.
+     Positions start with ``1``. If not found, ``0`` is returned.
+
+.. function:: strrpos(binary, pattern) -> bigint
+
+     Returns the starting byte position of the last instance of ``pattern`` in
+     ``binary``. Positions start with ``1``. If not found, ``0`` is returned.
+
+.. function:: strrpos(binary, pattern, instance) -> bigint
+     :noindex:
+
+     Returns the byte position of the N-th ``instance`` of ``pattern`` in ``binary`` starting from the end of the binary.
+     ``instance`` must be a positive number.
+     Positions start with ``1``. If not found, ``0`` is returned.
+
 .. function:: to_base64(binary) -> varchar
 
     Encodes ``binary`` into a base64 string representation.
@@ -166,12 +194,12 @@ Binary Functions
 
 .. function:: to_ieee754_64(double) -> varbinary
 
-    Encodes ``double`` in a 64-bit big-endian binary according to IEEE 754 double-precision floating-point format.
+     Encodes ``double`` in a 64-bit big-endian binary according to IEEE 754 double-precision floating-point format.
 
 .. function:: xxhash64(binary) -> varbinary
 
-    Computes the xxhash64 hash of ``binary``.
+     Computes the xxhash64 hash of ``binary``.
 
 .. function:: xxhash64(binary, bigint) -> varbinary
 
-    Computes the xxhash64 hash of ``binary`` with ``bigint`` seed.
+     Computes the xxhash64 hash of ``binary`` with ``bigint`` seed.

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -207,6 +207,14 @@ std::unordered_set<std::string> skipFunctions = {
     // https://github.com/facebookincubator/velox/issues/13047
     "inverse_poisson_cdf",
     "map_subset", // https://github.com/facebookincubator/velox/issues/12654
+    // Presto doesn't support varbinary variants of strpos, strrpos and
+    // contains. Presto only has contains(array(T), T), not contains(varbinary,
+    // varbinary).
+    "strpos(varbinary,varbinary) -> bigint",
+    "strpos(varbinary,varbinary,bigint) -> bigint",
+    "strrpos(varbinary,varbinary) -> bigint",
+    "strrpos(varbinary,varbinary,bigint) -> bigint",
+    "contains(varbinary,varbinary) -> boolean",
     // JSON not supported, Real doesn't match exactly, etc.
     "array_join(array(json),varchar) -> varchar",
     "array_join(array(json),varchar,varchar) -> varchar",

--- a/velox/functions/prestosql/VarbinaryFunctions.h
+++ b/velox/functions/prestosql/VarbinaryFunctions.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/string/StringCore.h"
+
+namespace facebook::velox::functions {
+
+/// strpos and strrpos functions for varbinary
+/// strpos(varbinary, varbinary) → bigint
+///     Returns the starting byte position of the first instance of the pattern
+///     in the binary data. Positions start with 1. If not found, 0 is returned.
+/// strpos(varbinary, varbinary, instance) → bigint
+///     Returns the byte position of the N-th instance of the pattern.
+///     instance must be a positive number. Positions start with 1. If not
+///     found, 0 is returned.
+/// strrpos(varbinary, varbinary) → bigint
+///     Returns the starting byte position of the first instance of the pattern
+///     in the binary data counting from the end. Positions start with 1. If not
+///     found, 0 is returned.
+/// strrpos(varbinary, varbinary, instance) → bigint
+///     Returns the byte position of the N-th instance of the pattern
+///     counting from the end. Instance must be a positive number. Positions
+///     start with 1. If not found, 0 is returned.
+template <typename T, bool lpos>
+struct StrPosVarbinaryFunctionBase {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<Varbinary>& haystack,
+      const arg_type<Varbinary>& needle,
+      const arg_type<int64_t>& instance = 1) {
+    VELOX_USER_CHECK_GT(instance, 0, "'instance' must be a positive number");
+    if (needle.size() == 0) {
+      result = 1;
+      return;
+    }
+
+    int64_t byteIndex = -1;
+    if constexpr (lpos) {
+      byteIndex = stringCore::findNthInstanceByteIndexFromStart(
+          std::string_view(haystack.data(), haystack.size()),
+          std::string_view(needle.data(), needle.size()),
+          instance);
+    } else {
+      byteIndex = stringCore::findNthInstanceByteIndexFromEnd(
+          std::string_view(haystack.data(), haystack.size()),
+          std::string_view(needle.data(), needle.size()),
+          instance);
+    }
+
+    // Return 1-based byte position, or 0 if not found.
+    result = byteIndex == -1 ? 0 : byteIndex + 1;
+  }
+};
+
+template <typename T>
+struct StrLPosVarbinaryFunction : public StrPosVarbinaryFunctionBase<T, true> {
+};
+
+template <typename T>
+struct StrRPosVarbinaryFunction : public StrPosVarbinaryFunctionBase<T, false> {
+};
+
+/// contains for varbinary - returns true if the pattern exists in the binary
+/// data contains(varbinary, varbinary) → boolean
+template <typename T>
+struct ContainsVarbinaryFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<bool>& result,
+      const arg_type<Varbinary>& haystack,
+      const arg_type<Varbinary>& needle) {
+    if (needle.size() == 0) {
+      result = true;
+      return;
+    }
+    auto pos = std::string_view(haystack.data(), haystack.size())
+                   .find(std::string_view(needle.data(), needle.size()));
+    result = pos != std::string_view::npos;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -42,6 +42,7 @@ velox_add_library(
   TDigestFunctionsRegistration.cpp
   QDigestFunctionsRegistration.cpp
   URLFunctionsRegistration.cpp
+  VarbinaryFunctionsRegistration.cpp
 )
 
 if(VELOX_ENABLE_GEO)

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -41,6 +41,7 @@ extern void registerFloatingPointFunctions(const std::string& prefix);
 extern void registerJsonFunctions(const std::string& prefix);
 extern void registerMapFunctions(const std::string& prefix);
 extern void registerStringFunctions(const std::string& prefix);
+extern void registerVarbinaryFunctions(const std::string& prefix);
 extern void registerBinaryFunctions(const std::string& prefix);
 extern void registerURLFunctions(const std::string& prefix);
 extern void registerDataSizeFunctions(const std::string& prefix);
@@ -139,6 +140,10 @@ void registerStringFunctions(const std::string& prefix) {
   functions::registerStringFunctions(prefix);
 }
 
+void registerVarbinaryFunctions(const std::string& prefix) {
+  functions::registerVarbinaryFunctions(prefix);
+}
+
 void registerBinaryFunctions(const std::string& prefix) {
   functions::registerBinaryFunctions(prefix);
 }
@@ -173,6 +178,7 @@ void registerAllScalarFunctions(const std::string& prefix) {
   registerDateTimeFunctions(prefix);
   registerURLFunctions(prefix);
   registerStringFunctions(prefix);
+  registerVarbinaryFunctions(prefix);
   registerBinaryFunctions(prefix);
   registerBitwiseFunctions(prefix);
   registerUuidFunctions(prefix);

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -53,6 +53,8 @@ void registerURLFunctions(const std::string& prefix = "");
 
 void registerStringFunctions(const std::string& prefix = "");
 
+void registerVarbinaryFunctions(const std::string& prefix = "");
+
 void registerBinaryFunctions(const std::string& prefix = "");
 
 void registerBitwiseFunctions(const std::string& prefix = "");

--- a/velox/functions/prestosql/registration/VarbinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/VarbinaryFunctionsRegistration.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/VarbinaryFunctions.h"
+
+namespace facebook::velox::functions {
+
+void registerVarbinaryFunctions(const std::string& prefix) {
+  // strpos/strrpos for varbinary
+  registerFunction<StrLPosVarbinaryFunction, int64_t, Varbinary, Varbinary>(
+      {prefix + "strpos"});
+  registerFunction<
+      StrLPosVarbinaryFunction,
+      int64_t,
+      Varbinary,
+      Varbinary,
+      int64_t>({prefix + "strpos"});
+  registerFunction<StrRPosVarbinaryFunction, int64_t, Varbinary, Varbinary>(
+      {prefix + "strrpos"});
+  registerFunction<
+      StrRPosVarbinaryFunction,
+      int64_t,
+      Varbinary,
+      Varbinary,
+      int64_t>({prefix + "strrpos"});
+
+  // contains for varbinary
+  registerFunction<ContainsVarbinaryFunction, bool, Varbinary, Varbinary>(
+      {prefix + "contains"});
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -134,6 +134,7 @@ add_executable(
   QDigestFunctionsTest.cpp
   URLFunctionsTest.cpp
   UuidFunctionsTest.cpp
+  VarbinaryFunctionsTest.cpp
   WidthBucketArrayTest.cpp
   WordStemTest.cpp
   ZipTest.cpp

--- a/velox/functions/prestosql/tests/VarbinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/VarbinaryFunctionsTest.cpp
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace {
+
+class VarbinaryFunctionsTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(VarbinaryFunctionsTest, strpos) {
+  auto strpos = [&](const std::string& haystack,
+                    const std::string& needle,
+                    std::optional<int64_t> instance = std::nullopt) {
+    if (instance.has_value()) {
+      return evaluateOnce<int64_t>(
+          "strpos(c0, c1, c2)",
+          {VARBINARY(), VARBINARY(), BIGINT()},
+          std::optional(haystack),
+          std::optional(needle),
+          instance);
+    } else {
+      return evaluateOnce<int64_t>(
+          "strpos(c0, c1)",
+          {VARBINARY(), VARBINARY()},
+          std::optional(haystack),
+          std::optional(needle));
+    }
+  };
+
+  // Basic tests
+  EXPECT_EQ(strpos("hello", "l"), 3);
+  EXPECT_EQ(strpos("hello", "o"), 5);
+  EXPECT_EQ(strpos("hello", "x"), 0);
+  EXPECT_EQ(strpos("hello", ""), 1);
+  EXPECT_EQ(strpos("", ""), 1);
+  EXPECT_EQ(strpos("", "a"), 0);
+
+  // Find nth instance
+  EXPECT_EQ(strpos("hello", "l", 1), 3);
+  EXPECT_EQ(strpos("hello", "l", 2), 4);
+  EXPECT_EQ(strpos("hello", "l", 3), 0);
+
+  // Binary data with embedded nulls
+  std::string binaryWithNull = std::string(
+      "ab\x00"
+      "cd",
+      5);
+  std::string nullPattern = std::string("\x00", 1);
+  EXPECT_EQ(strpos(binaryWithNull, nullPattern), 3);
+  EXPECT_EQ(strpos(binaryWithNull, "cd"), 4);
+  EXPECT_EQ(strpos(binaryWithNull, "ab"), 1);
+
+  // Binary patterns (non-ASCII bytes)
+  std::string binaryData = std::string("\xDE\xAD\xBE\xEF\xCA\xFE", 6);
+  std::string pattern1 = std::string("\xBE\xEF", 2);
+  std::string pattern2 = std::string("\xCA\xFE", 2);
+  EXPECT_EQ(strpos(binaryData, pattern1), 3);
+  EXPECT_EQ(strpos(binaryData, pattern2), 5);
+  EXPECT_EQ(strpos(binaryData, std::string("\xFF", 1)), 0);
+
+  // Multi-byte UTF-8 characters (treated as bytes)
+  std::string utf8String = "\u4FE1\u5FF5"; // Two 3-byte Chinese characters
+  EXPECT_EQ(strpos(utf8String, "\xE5"), 4); // Byte position, not char position
+}
+
+TEST_F(VarbinaryFunctionsTest, strposInvalidInstance) {
+  VELOX_ASSERT_THROW(
+      evaluateOnce<int64_t>(
+          "strpos(c0, c1, c2)",
+          {VARBINARY(), VARBINARY(), BIGINT()},
+          std::optional<std::string>("hello"),
+          std::optional<std::string>("l"),
+          std::optional<int64_t>(0)),
+      "'instance' must be a positive number");
+
+  VELOX_ASSERT_THROW(
+      evaluateOnce<int64_t>(
+          "strpos(c0, c1, c2)",
+          {VARBINARY(), VARBINARY(), BIGINT()},
+          std::optional<std::string>("hello"),
+          std::optional<std::string>("l"),
+          std::optional<int64_t>(-1)),
+      "'instance' must be a positive number");
+}
+
+TEST_F(VarbinaryFunctionsTest, strposFlatVector) {
+  // Test with flat vectors for better coverage
+  auto haystack = makeFlatVector<std::string>(
+      {"hello world", "abcabc", "test", ""}, VARBINARY());
+  auto needle =
+      makeFlatVector<std::string>({"world", "bc", "x", ""}, VARBINARY());
+
+  auto result = evaluate("strpos(c0, c1)", makeRowVector({haystack, needle}));
+  auto expected = makeFlatVector<int64_t>({7, 2, 0, 1});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(VarbinaryFunctionsTest, strrpos) {
+  auto strrpos = [&](const std::string& haystack,
+                     const std::string& needle,
+                     std::optional<int64_t> instance = std::nullopt) {
+    if (instance.has_value()) {
+      return evaluateOnce<int64_t>(
+          "strrpos(c0, c1, c2)",
+          {VARBINARY(), VARBINARY(), BIGINT()},
+          std::optional(haystack),
+          std::optional(needle),
+          instance);
+    } else {
+      return evaluateOnce<int64_t>(
+          "strrpos(c0, c1)",
+          {VARBINARY(), VARBINARY()},
+          std::optional(haystack),
+          std::optional(needle));
+    }
+  };
+
+  // Basic tests - strrpos finds from the end
+  EXPECT_EQ(strrpos("hello", "l"), 4);
+  EXPECT_EQ(strrpos("hello", "o"), 5);
+  EXPECT_EQ(strrpos("hello", "x"), 0);
+  EXPECT_EQ(strrpos("hello", ""), 1);
+  EXPECT_EQ(strrpos("", ""), 1);
+  EXPECT_EQ(strrpos("", "a"), 0);
+
+  // Find nth instance from end
+  EXPECT_EQ(strrpos("hello", "l", 1), 4);
+  EXPECT_EQ(strrpos("hello", "l", 2), 3);
+  EXPECT_EQ(strrpos("hello", "l", 3), 0);
+
+  // Binary data
+  std::string binaryData = std::string("\xAB\xCD\xAB\xEF", 4);
+  std::string pattern = std::string("\xAB", 1);
+  EXPECT_EQ(strrpos(binaryData, pattern), 3);
+  EXPECT_EQ(strrpos(binaryData, pattern, 2), 1);
+}
+
+TEST_F(VarbinaryFunctionsTest, contains) {
+  auto contains = [&](const std::string& haystack, const std::string& needle) {
+    return evaluateOnce<bool>(
+        "contains(c0, c1)",
+        {VARBINARY(), VARBINARY()},
+        std::optional(haystack),
+        std::optional(needle));
+  };
+
+  // Basic tests
+  EXPECT_EQ(contains("hello", "ell"), true);
+  EXPECT_EQ(contains("hello", "x"), false);
+  EXPECT_EQ(contains("hello", ""), true);
+  EXPECT_EQ(contains("", ""), true);
+  EXPECT_EQ(contains("", "a"), false);
+
+  // Binary data with embedded nulls
+  std::string binaryWithNull = std::string(
+      "ab\x00"
+      "cd",
+      5);
+  std::string nullPattern = std::string("\x00", 1);
+  EXPECT_EQ(contains(binaryWithNull, nullPattern), true);
+  EXPECT_EQ(contains(binaryWithNull, "cd"), true);
+  EXPECT_EQ(contains(binaryWithNull, "xyz"), false);
+
+  // Binary patterns (non-ASCII bytes)
+  std::string binaryData = std::string("\xDE\xAD\xBE\xEF", 4);
+  std::string pattern1 = std::string("\xAD\xBE", 2);
+  std::string pattern2 = std::string("\xFF\xFF", 2);
+  EXPECT_EQ(contains(binaryData, pattern1), true);
+  EXPECT_EQ(contains(binaryData, pattern2), false);
+}
+
+TEST_F(VarbinaryFunctionsTest, containsFlatVector) {
+  auto haystack = makeFlatVector<std::string>(
+      {"hello world", "abcabc", "test", ""}, VARBINARY());
+  auto needle =
+      makeFlatVector<std::string>({"world", "xyz", "est", ""}, VARBINARY());
+
+  auto result = evaluate("contains(c0, c1)", makeRowVector({haystack, needle}));
+  auto expected = makeFlatVector<bool>({true, false, true, true});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(VarbinaryFunctionsTest, nullHandling) {
+  // Test strpos with null values
+  {
+    auto haystack = makeNullableFlatVector<std::string>(
+        {std::nullopt, std::string("test"), std::nullopt}, VARBINARY());
+    auto needle = makeNullableFlatVector<std::string>(
+        {std::string("test"), std::nullopt, std::nullopt}, VARBINARY());
+    auto result = evaluate("strpos(c0, c1)", makeRowVector({haystack, needle}));
+    auto expected = makeNullableFlatVector<int64_t>(
+        {std::nullopt, std::nullopt, std::nullopt});
+    assertEqualVectors(expected, result);
+  }
+
+  // Test strpos with null instance parameter
+  {
+    auto haystack = makeFlatVector<std::string>({"hello"}, VARBINARY());
+    auto needle = makeFlatVector<std::string>({"l"}, VARBINARY());
+    auto instance = makeNullableFlatVector<int64_t>({std::nullopt}, BIGINT());
+    auto result = evaluate(
+        "strpos(c0, c1, c2)", makeRowVector({haystack, needle, instance}));
+    auto expected = makeNullableFlatVector<int64_t>({std::nullopt});
+    assertEqualVectors(expected, result);
+  }
+
+  // Test strrpos with null values
+  {
+    auto haystack = makeNullableFlatVector<std::string>(
+        {std::nullopt, std::string("test")}, VARBINARY());
+    auto needle = makeNullableFlatVector<std::string>(
+        {std::string("test"), std::nullopt}, VARBINARY());
+    auto result =
+        evaluate("strrpos(c0, c1)", makeRowVector({haystack, needle}));
+    auto expected =
+        makeNullableFlatVector<int64_t>({std::nullopt, std::nullopt});
+    assertEqualVectors(expected, result);
+  }
+
+  // Test contains with null values
+  {
+    auto haystack = makeNullableFlatVector<std::string>(
+        {std::nullopt, std::string("test"), std::nullopt}, VARBINARY());
+    auto needle = makeNullableFlatVector<std::string>(
+        {std::string("test"), std::nullopt, std::nullopt}, VARBINARY());
+    auto result =
+        evaluate("contains(c0, c1)", makeRowVector({haystack, needle}));
+    auto expected = makeNullableFlatVector<bool>(
+        {std::nullopt, std::nullopt, std::nullopt});
+    assertEqualVectors(expected, result);
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Summary:

Adds `strpos`, `strrpos` and `contains` for varbinary columns which will allow for efficient string searching in encoded text data where we don't want to pay the charset decoding price (i.e. we don't have to convert the column to utf-8 and just do byte matches as an approximation).

Reviewed By: kaikalur

Differential Revision: D89479354
