### PR TITLE
feat: Add coercions for variable arity arguments

### DIFF
--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1157,41 +1157,82 @@ void testNoCoercions(
 }
 
 TEST(SignatureBinderTest, coercions) {
-  auto signature = exec::FunctionSignatureBuilder()
-                       .returnType("boolean")
-                       .argumentType("smallint")
-                       .argumentType("integer")
-                       .argumentType("bigint")
-                       .argumentType("real")
-                       .argumentType("double")
-                       .build();
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("boolean")
+                         .argumentType("smallint")
+                         .argumentType("integer")
+                         .argumentType("bigint")
+                         .argumentType("real")
+                         .argumentType("double")
+                         .build();
 
-  testCoercions(
-      signature,
-      {TINYINT(), TINYINT(), TINYINT(), TINYINT(), TINYINT()},
-      {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()},
-      BOOLEAN());
+    testCoercions(
+        signature,
+        {TINYINT(), TINYINT(), TINYINT(), TINYINT(), TINYINT()},
+        {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()},
+        BOOLEAN());
 
-  testCoercions(
-      signature,
-      {SMALLINT(), SMALLINT(), SMALLINT(), REAL(), REAL()},
-      {nullptr, INTEGER(), BIGINT(), nullptr, DOUBLE()},
-      BOOLEAN());
+    testCoercions(
+        signature,
+        {SMALLINT(), SMALLINT(), SMALLINT(), REAL(), REAL()},
+        {nullptr, INTEGER(), BIGINT(), nullptr, DOUBLE()},
+        BOOLEAN());
 
-  testNoCoercions(
-      signature,
-      {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()},
-      BOOLEAN());
+    testNoCoercions(
+        signature,
+        {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()},
+        BOOLEAN());
 
-  assertCannotBind(
-      signature,
-      {INTEGER(), INTEGER(), INTEGER(), INTEGER(), INTEGER()},
-      /*allowCoercion*/ true);
+    assertCannotBind(
+        signature,
+        {INTEGER(), INTEGER(), INTEGER(), INTEGER(), INTEGER()},
+        /*allowCoercion*/ true);
 
-  assertCannotBind(
-      signature,
-      {SMALLINT(), INTEGER(), VARCHAR(), INTEGER(), INTEGER()},
-      /*allowCoercion*/ true);
+    assertCannotBind(
+        signature,
+        {SMALLINT(), INTEGER(), VARCHAR(), INTEGER(), INTEGER()},
+        /*allowCoercion*/ true);
+  }
+
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .returnType("boolean")
+                         .argumentType("smallint")
+                         .variableArity("integer")
+                         .build();
+
+    testCoercions(
+        signature,
+        {TINYINT(), TINYINT(), TINYINT()},
+        {SMALLINT(), INTEGER(), INTEGER()},
+        BOOLEAN());
+
+    testCoercions(
+        signature,
+        {TINYINT(), INTEGER(), TINYINT()},
+        {SMALLINT(), nullptr, INTEGER()},
+        BOOLEAN());
+
+    testCoercions(
+        signature,
+        {SMALLINT(), TINYINT(), INTEGER()},
+        {nullptr, INTEGER(), nullptr},
+        BOOLEAN());
+
+    testNoCoercions(signature, {SMALLINT(), INTEGER()}, BOOLEAN());
+    testNoCoercions(signature, {SMALLINT(), INTEGER(), INTEGER()}, BOOLEAN());
+
+    assertCannotBind(
+        signature,
+        {SMALLINT(), INTEGER(), VARCHAR(), INTEGER(), INTEGER()},
+        /*allowCoercion*/ true);
+
+    assertCannotBind(
+        signature,
+        {SMALLINT(), INTEGER(), BIGINT(), INTEGER(), INTEGER()},
+        /*allowCoercion*/ true);
+  }
 }
 
 TEST(SignatureBinderTest, homogeneousRow) {

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -786,18 +786,24 @@ TEST_F(FunctionRegistryTest, resolveFunctionWithCoercions) {
         {velox::exec::FunctionSignatureBuilder()
              .returnType("bigint")
              .argumentType("bigint")
-             .argumentType("bigint")
-             .variableArity()
+             .variableArity("bigint")
              .build(),
          velox::exec::FunctionSignatureBuilder()
              .returnType("double")
              .argumentType("double")
-             .argumentType("double")
-             .variableArity()
+             .variableArity("double")
              .build()},
         std::make_unique<DummyVectorFunction>());
 
-    testCannotResolve("foo", {TINYINT(), SMALLINT(), INTEGER()});
+    testCoercions(
+        "foo",
+        {TINYINT(), SMALLINT(), INTEGER()},
+        BIGINT(),
+        {BIGINT(), BIGINT(), BIGINT()});
+
+    testNoCoercions("foo", {BIGINT(), BIGINT(), BIGINT()}, BIGINT());
+
+    testCannotResolve("foo", {TINYINT(), SMALLINT(), VARCHAR()});
   }
 
   // Coercions with generic types are not supported yet.

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -83,8 +83,10 @@ class TypeCoercer {
 
   /// Checks if 'fromType' can be implicitly converted to 'toType'.
   ///
-  /// @return true if conversion is possible.
-  static bool coercible(const TypePtr& fromType, const TypePtr& toType);
+  /// @return Cost of conversion is possible. std::nullopt otherwise.
+  static std::optional<int32_t> coercible(
+      const TypePtr& fromType,
+      const TypePtr& toType);
 };
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Add support for coercions to functions with variable arity arguments.

Support for coercions for complex and generic types is still a TODO.

Differential Revision: D89510204


