### PR TITLE
feat: Add IPAddress support to PrestoQueryRunner for Velox fuzzers

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -204,7 +204,8 @@ const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
       VARBINARY(),
       TIMESTAMP(),
       TIMESTAMP_WITH_TIME_ZONE(),
-  };
+      IPADDRESS(),
+      TIME_WITH_TIME_ZONE()};
   return kScalarTypes;
 }
 
@@ -362,7 +363,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "hugeint") ||
       usesTypeName(signature, "geometry") || usesTypeName(signature, "time") ||
       usesTypeName(signature, "p4hyperloglog") ||
-      usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
       usesInputTypeName(signature, "uuid"));
 }

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -21,6 +21,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/KHyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
@@ -85,6 +86,9 @@ intermediateTypeTransforms() {
            std::make_shared<IntermediateTypeTransformUsingCast>(
                BINGTILE(), BIGINT())},
           {INTERVAL_DAY_TIME(), std::make_shared<IntervalDayTimeTransform>()},
+          {IPADDRESS(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               IPADDRESS(), VARCHAR())},
       };
   return intermediateTypeTransforms;
 }


### PR DESCRIPTION
Summary:
Enable IPAddress type testing across all Velox fuzzers that use PrestoQueryRunner, including JoinFuzzer, AggregationFuzzer, and ExpressionFuzzer etc.

Previously, IPAddress was excluded from fuzzer testing because PrestoQueryRunner didn't register it as a supported scalar type and explicitly blocked it in signature validation. This change adds IPAddress to the scalar types list and provides a VARCHAR-based intermediate type transform for result comparison against Presto.

Differential Revision: D89539377


