### PR TITLE
fix: Check type constraints when binding homogeneous row

### DIFF
--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -221,6 +221,26 @@ SignatureVariable::SignatureVariable(
       "Type variables cannot have constraints");
 }
 
+bool SignatureVariable::isEligibleType(const Type& type) const {
+  if (!isTypeParameter()) {
+    return false;
+  }
+
+  if (knownTypesOnly_ && type.isUnKnown()) {
+    return false;
+  }
+
+  if (orderableTypesOnly_ && !type.isOrderable()) {
+    return false;
+  }
+
+  if (comparableTypesOnly_ && !type.isComparable()) {
+    return false;
+  }
+
+  return true;
+}
+
 FunctionSignature::FunctionSignature(
     std::unordered_map<std::string, SignatureVariable> variables,
     TypeSignature returnType,

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -53,7 +53,7 @@ enum class FunctionCanonicalName {
 /// a_precision + b_precision" in decimals).
 class SignatureVariable {
  public:
-  explicit SignatureVariable(
+  SignatureVariable(
       std::string name,
       std::optional<std::string> constraint,
       ParameterType type,
@@ -83,6 +83,10 @@ class SignatureVariable {
     VELOX_USER_CHECK(isTypeParameter());
     return comparableTypesOnly_;
   }
+
+  /// Return true if this variable describes a type and the specified type
+  /// satisfies the constraints.
+  bool isEligibleType(const Type& type) const;
 
   bool isTypeParameter() const {
     return type_ == ParameterType::kTypeParameter;

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -80,6 +80,10 @@ class SignatureBinderBase {
       const std::string& parameterName,
       const VarcharEnumParameter& params);
 
+  std::optional<bool> checkSetTypeVariable(
+      const exec::TypeSignature& typeSignature,
+      const TypePtr& actualType);
+
   /// Try to bind the integer parameter from the actualType.
   bool tryBindIntegerParameters(
       const std::vector<exec::TypeSignature>& parameters,

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -1328,6 +1328,11 @@ TEST(SignatureBinderTest, homogeneousRow) {
 
     testSignatureBinder(signature, {ROW({VARCHAR(), VARCHAR()})}, BOOLEAN());
 
+    testSignatureBinder(
+        signature,
+        {ROW({MAP(INTEGER(), REAL()), MAP(INTEGER(), REAL())})},
+        BOOLEAN());
+
     // Named row fields should also bind when types are homogeneous.
     testSignatureBinder(
         signature,
@@ -1343,6 +1348,20 @@ TEST(SignatureBinderTest, homogeneousRow) {
 
     assertCannotBind(signature, {BIGINT()});
     assertCannotBind(signature, {ARRAY(BIGINT())});
+  }
+
+  // row(T:orderable, ...) -> boolean
+  {
+    auto signature = exec::FunctionSignatureBuilder()
+                         .orderableTypeVariable("T")
+                         .returnType("boolean")
+                         .argumentType("row(T, ...)")
+                         .build();
+
+    testSignatureBinder(signature, {ROW({BIGINT()})}, BOOLEAN());
+
+    // MAP type is not orderable.
+    assertCannotBind(signature, {ROW({MAP(INTEGER(), REAL())})});
   }
 
   // (row(T, ...), row(T, ...)) -> T


### PR DESCRIPTION
Summary: Make sure to check type constraints (orderable, comparable, known only) when binding to homogeneous generic row type.

Differential Revision: D89539215


