### PR TITLE
perf(exchange): Reduce awakened consumer count

### DIFF
--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -74,14 +74,7 @@ void ExchangeQueue::enqueueLocked(
 
   queue_.push_back(std::move(page));
   const auto minBatchSize = minOutputBatchBytesLocked();
-  while (!promises_.empty()) {
-    VELOX_CHECK_LE(promises_.size(), numberOfConsumers_);
-    const int32_t unblockedConsumers = numberOfConsumers_ - promises_.size();
-    const int64_t unasignedBytes =
-        totalBytes_ - unblockedConsumers * minBatchSize;
-    if (unasignedBytes < minBatchSize) {
-      break;
-    }
+  if (!promises_.empty() && totalBytes_ >= minBatchSize) {
     // Resume one of the waiting drivers.
     auto it = promises_.begin();
     promises.push_back(std::move(it->second));

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -890,7 +890,7 @@ TEST_P(ExchangeClientTest, minOutputBatchBytesMultipleConsumers) {
           consumers.begin(),
           consumers.end(),
           [](auto& consumer) { return consumer.isReady(); }),
-      numConsumers);
+      1);
 
   auto pages = client->next(1, 1, &atEnd, &consumers[1]);
   ASSERT_EQ(1, pages.size());
@@ -922,10 +922,10 @@ TEST_P(ExchangeClientTest, minOutputBatchBytesMultipleConsumers) {
           consumers.begin(),
           consumers.end(),
           [](auto& consumer) { return consumer.isReady(); }),
-      2);
+      3);
 
   for (int consumerId = 0; consumerId < numConsumers; consumerId++) {
-    if (consumers[consumerId].isReady()) {
+    if (consumers[consumerId].isReady() && consumerId != 2) {
       pages = client->next(consumerId, 1, &atEnd, &consumers[consumerId]);
       ASSERT_EQ(1, pages.size());
     }


### PR DESCRIPTION
Replace the 'while' loop with a simple 'if' condition in 
'ExchangeQueue::enqueueLocked()' to avoid unnecessary iterations when 
checking for waiting consumers. Because after all, only one page is 
added here, so at most **only one consumer** should be awakened. 
Otherwise, excess awakened consumers will block again immediately 
due to no available pages, which wastes resources. 

After this patch, we only wake up one waiting consumer at a time when 
accumulated data meets the minimum batch size requirement(see 
'minOutputBatchBytesLocked()'). This reduces the number of awakened 
consumers and improves performance.  

See [1] for discussion.

[1] https://github.com/facebookincubator/velox/pull/12010#discussion_r1954908872