### PR TITLE
fix(build): Issues in tests found by macOS15 intel compiler

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -65,10 +65,10 @@ class MockStreamInformation : public StreamInformation {
     return streamIdentifier_.encodingKey().sequence();
   }
 
-  MOCK_CONST_METHOD0(getOffset, uint64_t());
-  MOCK_CONST_METHOD0(getLength, uint64_t());
-  MOCK_CONST_METHOD0(getUseVInts, bool());
-  MOCK_CONST_METHOD0(valid, bool());
+  MOCK_METHOD(uint64_t, getOffset, (), (const, override));
+  MOCK_METHOD(uint64_t, getLength, (), (const, override));
+  MOCK_METHOD(bool, getUseVInts, (), (const, override));
+  MOCK_METHOD(bool, valid, (), (const, override));
 
  private:
   const DwrfStreamIdentifier& streamIdentifier_;

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -98,16 +98,20 @@ class MockStripeStreams : public StripeStreams {
   MOCK_METHOD2(
       genMockDictDataSetter,
       std::function<void(BufferPtr&, MemoryPool*)>(uint32_t, uint32_t));
-  MOCK_METHOD0(
+  MOCK_METHOD(
+      std::shared_ptr<StripeDictionaryCache>,
       getStripeDictionaryCache,
-      std::shared_ptr<StripeDictionaryCache>());
+      (),
+      (override));
   MOCK_CONST_METHOD1(getEncodingProxy, proto::ColumnEncoding*(uint64_t));
   MOCK_CONST_METHOD1(
       getEncodingOrcProxy,
       proto::orc::ColumnEncoding*(uint64_t));
-  MOCK_CONST_METHOD2(
+  MOCK_METHOD(
+      uint32_t,
       visitStreamsOfNode,
-      uint32_t(uint32_t, std::function<void(const StreamInformation&)>));
+      (uint32_t, std::function<void(const StreamInformation&)>),
+      (const, override));
   MOCK_CONST_METHOD3(
       getStreamProxy,
       dwio::common::SeekableInputStream*(uint32_t, proto::Stream_Kind, bool));

--- a/velox/dwio/dwrf/test/StripeStreamTest.cpp
+++ b/velox/dwio/dwrf/test/StripeStreamTest.cpp
@@ -864,9 +864,11 @@ class TestStripeStreams : public StripeStreamsBase {
   MOCK_CONST_METHOD2(
       getEncodingOrcProxy,
       proto::orc::ColumnEncoding*(uint32_t, uint32_t));
-  MOCK_CONST_METHOD2(
+  MOCK_METHOD(
+      uint32_t,
       visitStreamsOfNode,
-      uint32_t(uint32_t, std::function<void(const StreamInformation&)>));
+      (uint32_t, std::function<void(const StreamInformation&)>),
+      (const, override));
   MOCK_CONST_METHOD4(
       getStreamProxy,
       SeekableInputStream*(uint32_t, uint32_t, proto::Stream_Kind, bool));

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -181,11 +181,11 @@ class MockMemoryPool : public velox::memory::MemoryPool {
         name, kind, parent, parent->capacity());
   }
 
-  MOCK_CONST_METHOD0(peakBytes, int64_t());
+  MOCK_METHOD(int64_t, peakBytes, (), (const, override));
 
   MOCK_METHOD1(updateSubtreeMemoryUsage, int64_t(int64_t));
 
-  MOCK_CONST_METHOD0(alignment, uint16_t());
+  MOCK_METHOD(uint16_t, alignment, (), (const, override));
 
   uint64_t freeBytes() const override {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -339,11 +339,24 @@ void checkDataPageHeader(
 
   const DataPageV1* dataPage = static_cast<const DataPageV1*>(page);
   ASSERT_EQ(expected.num_values, dataPage->numValues());
-  ASSERT_EQ(expected.encoding, dataPage->encoding());
+  // The encoding enum for thrift::DataPageHeader isn't the same as in
+  // DataPageV1::parquet::thrift::Encoding::type vs
+  // parquet::arrow::Encoding::type.
   ASSERT_EQ(
-      expected.definition_level_encoding, dataPage->definitionLevelEncoding());
+      static_cast<std::underlying_type_t<thrift::Encoding::type>>(
+          expected.encoding),
+      static_cast<std::underlying_type_t<Encoding::type>>(
+          dataPage->encoding()));
   ASSERT_EQ(
-      expected.repetition_level_encoding, dataPage->repetitionLevelEncoding());
+      static_cast<std::underlying_type_t<thrift::Encoding::type>>(
+          expected.definition_level_encoding),
+      static_cast<std::underlying_type_t<Encoding::type>>(
+          dataPage->definitionLevelEncoding()));
+  ASSERT_EQ(
+      static_cast<std::underlying_type_t<thrift::Encoding::type>>(
+          expected.repetition_level_encoding),
+      static_cast<std::underlying_type_t<Encoding::type>>(
+          dataPage->repetitionLevelEncoding()));
   checkStatistics(expected, dataPage->statistics());
 }
 
@@ -357,7 +370,14 @@ void checkDataPageHeader(
   ASSERT_EQ(expected.num_values, dataPage->numValues());
   ASSERT_EQ(expected.num_nulls, dataPage->numNulls());
   ASSERT_EQ(expected.num_rows, dataPage->numRows());
-  ASSERT_EQ(expected.encoding, dataPage->encoding());
+  // The encoding enum for thrift::DataPageHeader isn't the same as in
+  // DataPageV2::parquet::thrift::Encoding::type vs
+  // parquet::arrow::Encoding::type.
+  ASSERT_EQ(
+      static_cast<std::underlying_type_t<thrift::Encoding::type>>(
+          expected.encoding),
+      static_cast<std::underlying_type_t<Encoding::type>>(
+          dataPage->encoding()));
   ASSERT_EQ(
       expected.definition_levels_byte_length,
       dataPage->definitionLevelsByteLength());

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -839,10 +839,16 @@ class OpaqueWithMetadataType : public OpaqueType {
       : OpaqueType(std::type_index(typeid(OpaqueWithMetadata))),
         metadata(metadata) {}
 
+  bool operator==(const OpaqueWithMetadataType& other) const {
+    return OpaqueType::operator==(other) && other.metadata == metadata;
+  }
+
   bool operator==(const Type& other) const override {
-    return OpaqueType::operator==(other) &&
-        reinterpret_cast<const OpaqueWithMetadataType*>(&other)->metadata ==
-        metadata;
+    if (const auto* otherType =
+            reinterpret_cast<const OpaqueWithMetadataType*>(&other)) {
+      return (*this == *otherType);
+    }
+    return false;
   }
 
   folly::dynamic serialize() const override {


### PR DESCRIPTION
Several issues were found in test programs:
- Not directly comparable enums
- Ambiguous function calls involving derived function overridden implementation
- Incorrectly implemented derived function that don’t use const or override correctly I expect newer compiler to pick up on these eventually so let’s fix them now. These are test fixes and don’t affect engine code.