### PR TITLE
perf(utf8): Remove unnecessary string allocations

### DIFF
--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -137,23 +137,21 @@ cappedByteLength(const TString& input, size_t maxCharacters) {
   }
 }
 
-/// Write the Unicode codePoint as string to the output string. The function
+/// Write the Unicode codePoint as string to an output StringView. The function
 /// behavior is undefined when code point it invalid. Implements the logic of
 /// presto chr function.
-template <typename TOutString>
-FOLLY_ALWAYS_INLINE void codePointToString(
-    TOutString& output,
-    const int64_t codePoint) {
+///
+/// Returns an StringView with an inlined buffer (since the maximum string size
+/// is only 4 bytes).
+FOLLY_ALWAYS_INLINE StringView codePointToString(const int64_t codePoint) {
   auto validCodePoint =
       codePoint <= INT32_MAX && utf8proc_codepoint_valid(codePoint);
   VELOX_USER_CHECK(
       validCodePoint, "Not a valid Unicode code point: {}", codePoint);
 
-  output.reserve(4);
-  auto size = utf8proc_encode_char(
-      codePoint, reinterpret_cast<unsigned char*>(output.data()));
-
-  output.resize(size);
+  unsigned char output[4];
+  auto size = utf8proc_encode_char(codePoint, output);
+  return StringView((const char*)output, size);
 }
 
 /// Returns the Unicode code point of the first char in a single char input

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -466,15 +466,11 @@ TEST_F(StringImplTest, badUnicodeLength) {
 TEST_F(StringImplTest, codePointToString) {
   auto testValidInput = [](const int64_t codePoint,
                            const std::string& expectedString) {
-    core::StringWriter output;
-    codePointToString(output, codePoint);
-    ASSERT_EQ(
-        StringView(expectedString), StringView(output.data(), output.size()));
+    ASSERT_EQ(StringView(expectedString), codePointToString(codePoint));
   };
 
   auto testInvalidCodePoint = [](const int64_t codePoint) {
-    core::StringWriter output;
-    EXPECT_THROW(codePointToString(output, codePoint), VeloxUserError)
+    EXPECT_THROW(codePointToString(codePoint), VeloxUserError)
         << "codePoint " << codePoint;
   };
 
@@ -494,9 +490,8 @@ TEST_F(StringImplTest, charToCodePoint) {
   };
 
   auto testValidInputRoundTrip = [](const int64_t codePoint) {
-    core::StringWriter string;
-    codePointToString(string, codePoint);
-    ASSERT_EQ(charToCodePoint(string), codePoint) << "codePoint " << codePoint;
+    ASSERT_EQ(charToCodePoint(codePointToString(codePoint)), codePoint)
+        << "codePoint " << codePoint;
   };
 
   auto testExpectDeath = [](const std::string& charString) {

--- a/velox/functions/prestosql/FromUtf8.cpp
+++ b/velox/functions/prestosql/FromUtf8.cpp
@@ -43,7 +43,7 @@ class FromUtf8Function : public exec::VectorFunction {
     // Read the constant replacement if it exisits and verify that it is valid.
     bool constantReplacement =
         args.size() == 1 || decodedArgs.at(1)->isConstantMapping();
-    std::string constantReplacementValue = kReplacementChar;
+    StringView constantReplacementValue = kReplacementChar;
 
     if (constantReplacement) {
       if (args.size() > 1) {
@@ -146,24 +146,17 @@ class FromUtf8Function : public exec::VectorFunction {
   }
 
  private:
-  static const std::string kReplacementChar;
+  static const StringView kReplacementChar;
 
-  static std::string codePointToString(int64_t codePoint) {
-    std::string result;
-    result.resize(4);
-    stringImpl::codePointToString(result, codePoint);
-    return result;
-  }
-
-  std::string getReplacementCharacter(
+  StringView getReplacementCharacter(
       const TypePtr& type,
       DecodedVector& decoded,
       vector_size_t row) const {
     if (type->isBigint()) {
-      return codePointToString(decoded.valueAt<int64_t>(row));
+      return stringImpl::codePointToString(decoded.valueAt<int64_t>(row));
     }
 
-    auto replacement = decoded.valueAt<StringView>(row);
+    StringView replacement = decoded.valueAt<StringView>(row);
     if (!replacement.empty()) {
       int32_t codePoint;
       auto charLength = tryGetUtf8CharLength(
@@ -260,7 +253,7 @@ class FromUtf8Function : public exec::VectorFunction {
 
   void fixInvalidUtf8(
       StringView input,
-      const std::string& replacement,
+      const StringView& replacement,
       exec::StringWriter& fixedWriter) const {
     if (input.empty()) {
       fixedWriter.setEmpty();
@@ -290,8 +283,9 @@ class FromUtf8Function : public exec::VectorFunction {
 };
 
 // static
-const std::string FromUtf8Function::kReplacementChar =
-    codePointToString(0xFFFD);
+const StringView FromUtf8Function::kReplacementChar =
+    stringImpl::codePointToString(0xFFFD);
+
 } // namespace
 
 VELOX_DECLARE_VECTOR_FUNCTION(

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -33,7 +33,7 @@ struct ChrFunction {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const int64_t& codePoint) {
-    stringImpl::codePointToString(result, codePoint);
+    result = stringImpl::codePointToString(codePoint);
   }
 };
 


### PR DESCRIPTION
Summary:
Removing unnecessary string allocations in codepoint conversions and
from_utf8() Presto function.

Differential Revision: D89566485


