### PR TITLE
perf(functions): Remove unecessary string copies in parse_presto_data_size()

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.cpp
+++ b/velox/functions/remote/client/RemoteVectorFunction.cpp
@@ -129,7 +129,7 @@ void RemoteVectorFunction::applyRemote(
         return;
       }
       try {
-        throw std::runtime_error(errorsVector->valueAt(i));
+        throw std::runtime_error(std::string(errorsVector->valueAt(i)));
       } catch (const std::exception&) {
         context.setError(i, std::current_exception());
       }


### PR DESCRIPTION
Summary:
Remove unecessary string copies in parse_presto_data_size(). Also
moving a string->double conversion to folly::to, since std::stod() only works
with std::string's, for some historical reason.

Reviewed By: amitkdutta

Differential Revision: D89582197


