### PR TITLE
fix: TypeCoercer::leastCommonSuperType(MAP, ROW) should be null

### DIFF
--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -130,6 +130,10 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
     return nullptr;
   }
 
+  if (a->name() != b->name()) {
+    return nullptr;
+  }
+
   std::vector<TypeParameter> childTypes;
   childTypes.reserve(a->size());
   for (auto i = 0; i < a->size(); i++) {

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -148,6 +148,10 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
   ASSERT_TRUE(
       TypeCoercer::leastCommonSuperType(
           ROW({""}, TINYINT()), ROW({"", ""}, TINYINT())) == nullptr);
+
+  ASSERT_TRUE(
+      TypeCoercer::leastCommonSuperType(
+          MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
 }
 
 } // namespace


### PR DESCRIPTION
Differential Revision: D89661371


