### PR TITLE
fix: Fix incorrect comments

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -706,7 +706,7 @@ StopReason Driver::runInternal(
     }
   } catch (velox::VeloxException&) {
     task()->setError(std::current_exception());
-    // The CancelPoolGuard will close 'self' and remove from Task.
+    // The CancelGuard will close 'self' and remove from Task.
     return StopReason::kAlreadyTerminated;
   } catch (std::exception&) {
     task()->setError(std::current_exception());

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -86,7 +86,7 @@ std::ostream& operator<<(std::ostream& out, const StopReason& reason);
 ///  Terminated - 'isTerminated' is set. The Driver cannot run after this and
 /// the state is final.
 ///
-/// CancelPool  allows terminating or pausing a set of Drivers. The Task API
+/// Task allows terminating or pausing a set of Drivers. The Task API
 /// allows starting or resuming Drivers. When terminate is requested the request
 /// is successful when all Drivers are off thread, blocked or suspended. When
 /// pause is requested, we have success when all Drivers are either enqueued,

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -513,7 +513,7 @@ class Task : public std::enable_shared_from_this<Task> {
   void setError(const std::string& message);
 
   /// Returns all the peer operators of the 'caller' operator from a given
-  /// 'pipelindId' in this task.
+  /// 'pipelineId' in this task.
   std::vector<Operator*> findPeerOperators(int pipelineId, Operator* caller);
 
   /// Synchronizes completion of an Operator across Drivers of 'this'.
@@ -619,7 +619,7 @@ class Task : public std::enable_shared_from_this<Task> {
   StopReason enterForTerminateLocked(ThreadState& state);
 
   /// Marks that the Driver is not on thread. If no more Drivers in the
-  /// CancelPool are on thread, this realizes threadFinishFutures_. These allow
+  /// Task are on thread, this realizes threadFinishFutures_.
   /// syncing with pause or termination. The Driver may go off thread because of
   /// hasBlockingFuture or pause requested or terminate requested. The
   /// return value indicates the reason. If kTerminate is returned, the
@@ -859,7 +859,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // message.
   bool allNodesReceivedNoMoreSplitsMessageLocked() const;
 
-  // Recursive helper for 'allSpilitsConsumed()' method.
+  // Recursive helper for 'allSplitsConsumed()' method.
   bool allSplitsConsumedHelper(const core::PlanNode* planNode) const;
 
   // Remove the spill directory, if the Task was creating it for potential
@@ -944,7 +944,7 @@ class Task : public std::enable_shared_from_this<Task> {
       VELOX_CHECK_NOT_NULL(task);
     }
 
-    // Gets the shared pointer to the driver to ensure its liveness during the
+    // Gets the shared pointer to the task to ensure its liveness during the
     // memory reclaim operation.
     //
     // NOTE: a task's memory pool might outlive the task itself.
@@ -1176,7 +1176,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // to pool_ must be defined after pool_, childPools_.
   std::shared_ptr<memory::MemoryPool> pool_;
 
-  // Keep driver and operator memory pools alive for the duration of the task
+  // Keep plan node and operator memory pools alive for the duration of the task
   // to allow for sharing vectors across drivers without copy.
   std::vector<std::shared_ptr<memory::MemoryPool>> childPools_;
 
@@ -1215,7 +1215,7 @@ class Task : public std::enable_shared_from_this<Task> {
   ConsumerSupplier consumerSupplier_;
 
   // The function that is executed when the task encounters its first error,
-  // that is, serError() is called for the first time.
+  // that is, setError() is called for the first time.
   std::function<void(std::exception_ptr)> onError_;
 
   std::vector<std::unique_ptr<DriverFactory>> driverFactories_;


### PR DESCRIPTION
Summary:
Some comments in the driver and task files are incorrect or misleading
1. CancelPool was deprecated
2. There is no driver memory pool, is should be plan node memory pool instead
3. fix some typos

Differential Revision: D89669101


