### PR TITLE
feat: Limit maximum number of distinct values when merging VectorHasher's

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -778,6 +778,11 @@ class QueryConfig {
   /// estimates.
   static constexpr const char* kRowSizeTrackingMode = "row_size_tracking_mode";
 
+  /// Maximum number of distinct values to keep when merging vector hashers in
+  /// join HashBuild.
+  static constexpr const char* kJoinBuildVectorHasherMaxNumDistinct =
+      "join_build_vector_hasher_max_num_distinct";
+
   enum class RowSizeTrackingMode {
     DISABLED = 0,
     EXCLUDE_DELTA_SPLITS = 1,
@@ -1395,6 +1400,10 @@ class QueryConfig {
 
   std::string clientTags() const {
     return get<std::string>(kClientTags, "");
+  }
+
+  uint32_t joinBuildVectorHasherMaxNumDistinct() const {
+    return get<uint32_t>(kJoinBuildVectorHasherMaxNumDistinct, 1'000'000);
   }
 
   template <typename T>

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -64,6 +64,8 @@ HashBuild::HashBuild(
       nullAware_{joinNode_->isNullAware()},
       needProbedFlagSpill_{needRightSideJoin(joinType_)},
       dropDuplicates_(joinNode_->canDropDuplicates()),
+      vectorHasherMaxNumDistinct_(
+          driverCtx->queryConfig().joinBuildVectorHasherMaxNumDistinct()),
       abandonHashBuildDedupMinRows_(
           driverCtx->queryConfig().abandonHashBuildDedupMinRows()),
       abandonHashBuildDedupMinPct_(
@@ -782,6 +784,7 @@ bool HashBuild::finishHashBuild() {
         std::move(otherTables),
         isInputFromSpill() ? spillConfig()->startPartitionBit
                            : BaseHashTable::kNoSpillInputStartPartitionBit,
+        vectorHasherMaxNumDistinct_,
         dropDuplicates_,
         allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
                                : nullptr);

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -229,6 +229,9 @@ class HashBuild final : public Operator {
   // can be removed for left semi and anti join.
   const bool dropDuplicates_;
 
+  // Maximum number of distinct values to keep when merging vector hashers
+  const size_t vectorHasherMaxNumDistinct_;
+
   // Minimum number of rows to see before deciding to give up build no
   // duplicates hash table.
   const int32_t abandonHashBuildDedupMinRows_;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1925,6 +1925,7 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::prepareJoinTable(
     std::vector<std::unique_ptr<BaseHashTable>> tables,
     int8_t spillInputStartPartitionBit,
+    size_t vectorHasherMaxNumDistinct,
     bool dropDuplicates,
     folly::Executor* executor) {
   buildExecutor_ = executor;
@@ -1975,7 +1976,7 @@ void HashTable<ignoreNullKeys>::prepareJoinTable(
           other->analyze();
         }
         for (auto i = 0; i < hashers_.size(); ++i) {
-          hashers_[i]->merge(*other->hashers_[i]);
+          hashers_[i]->merge(*other->hashers_[i], vectorHasherMaxNumDistinct);
           if (!hashers_[i]->mayUseValueIds()) {
             useValueIds = false;
             break;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -320,6 +320,7 @@ class BaseHashTable {
   virtual void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
       int8_t spillInputStartPartitionBit,
+      size_t vectorHasherMaxNumDistinct,
       bool dropDuplicates = false,
       folly::Executor* executor = nullptr) = 0;
 
@@ -640,6 +641,7 @@ class HashTable : public BaseHashTable {
   void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
       int8_t spillInputStartPartitionBit,
+      size_t vectorHasherMaxNumDistinct,
       bool dropDuplicates = false,
       folly::Executor* executor = nullptr) override;
 

--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -337,7 +337,7 @@ class VectorHasher {
 
   // Merges the value ids information of 'other' into 'this'. Ranges
   // and distinct values are unioned.
-  void merge(const VectorHasher& other);
+  void merge(const VectorHasher& other, size_t maxNumDistinct);
 
   // true if no values have been added.
   bool empty() const {

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -394,6 +394,7 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
       topTable_->prepareJoinTable(
           std::move(otherTables),
           BaseHashTable::kNoSpillInputStartPartitionBit,
+          1'000'000,
           false,
           executor_.get());
     }

--- a/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
@@ -129,6 +129,7 @@ class HashJoinPrepareJoinTableBenchmark : public VectorTestBase {
     topTable_->prepareJoinTable(
         std::move(otherTables_),
         BaseHashTable::kNoSpillInputStartPartitionBit,
+        1'000'000,
         false,
         executor_.get());
     VELOX_CHECK_EQ(topTable_->hashMode(), params_.mode);

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -199,6 +199,7 @@ class HashTableBenchmark : public VectorTestBase {
     topTable_->prepareJoinTable(
         std::move(otherTables),
         BaseHashTable::kNoSpillInputStartPartitionBit,
+        1'000'000,
         false,
         executor_.get());
     LOG(INFO) << "Made table " << topTable_->toString();

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -159,6 +159,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
     topTable_->prepareJoinTable(
         std::move(otherTables),
         BaseHashTable::kNoSpillInputStartPartitionBit,
+        1'000'000,
         false,
         executor_.get());
     ASSERT_GE(
@@ -547,6 +548,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
     table->prepareJoinTable(
         {},
         BaseHashTable::kNoSpillInputStartPartitionBit,
+        1'000'000,
         false,
         executor_.get());
     ASSERT_EQ(table->hashMode(), mode);
@@ -848,6 +850,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
     table->prepareJoinTable(
         {},
         BaseHashTable::kNoSpillInputStartPartitionBit,
+        1'000'000,
         false,
         executor_.get());
     ASSERT_EQ(table->hashMode(), mode);
@@ -1155,6 +1158,7 @@ DEBUG_ONLY_TEST_P(HashTableTest, failureInCreateRowPartitions) {
   topTable->prepareJoinTable(
       std::move(otherTables),
       BaseHashTable::kNoSpillInputStartPartitionBit,
+      1'000'000,
       false,
       executor_.get());
   auto topTabletestHelper = HashTableTestHelper<false>::create(topTable.get());
@@ -1244,7 +1248,8 @@ TEST_P(HashTableTest, toStringSingleKey) {
 
   store(*table->rows(), data);
 
-  table->prepareJoinTable({}, BaseHashTable::kNoSpillInputStartPartitionBit);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
 
   ASSERT_NO_THROW(table->toString());
   ASSERT_NO_THROW(table->toString(0));
@@ -1275,7 +1280,8 @@ TEST_P(HashTableTest, toStringMultipleKeys) {
 
   store(*table->rows(), data);
 
-  table->prepareJoinTable({}, BaseHashTable::kNoSpillInputStartPartitionBit);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
 
   ASSERT_NO_THROW(table->toString());
 }

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -96,7 +96,8 @@ std::shared_ptr<TestIndexTable> TestIndexTable::create(
   }
 
   // Build the table index.
-  table->prepareJoinTable({}, BaseHashTable::kNoSpillInputStartPartitionBit);
+  table->prepareJoinTable(
+      {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
   return std::make_shared<TestIndexTable>(
       std::move(keyType), std::move(valueType), std::move(table));
 }

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -139,7 +139,8 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
     }
 
     // Build the table index.
-    table->prepareJoinTable({}, BaseHashTable::kNoSpillInputStartPartitionBit);
+    table->prepareJoinTable(
+        {}, BaseHashTable::kNoSpillInputStartPartitionBit, 1'000'000);
     return std::make_shared<TestIndexTable>(
         keyType, std::move(valueType), std::move(table));
   }


### PR DESCRIPTION
Summary:
When running with high concurrency (for example 150 threads) the total number
of distinct values can grow to very high number (15M). When the number of
distinct values is that high it is more efficient to rely on bloom filters
instead.

Differential Revision: D89670508


