### PR TITLE
fix: Use aggregate initialization to fix cmake error

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -192,7 +192,7 @@ bool SignatureBinder::tryBind(
             if (auto cost =
                     TypeCoercer::coercible(actualTypes_[i], firstType)) {
               if (cost.value() > 0) {
-                coercions[i] = Coercion(firstType, cost.value());
+                coercions[i] = Coercion{firstType, cost.value()};
               }
             } else {
               return false;


### PR DESCRIPTION
Summary:
This fixes the build error:
   /__w/presto/presto/presto-native-execution/velox/velox/expression/SignatureBinder.cpp:195:32: error: no matching constructor for initialization of 'facebook::velox::Coercion'
                coercions[i] = Coercion(firstType, cost.value());
                               ^        ~~~~~~~~~~~~~~~~~~~~~~~
  /__w/presto/presto/presto-native-execution/velox/velox/type/TypeCoercer.h:23:8: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 2 were provided
  struct Coercion {
       ^
  /__w/presto/presto/presto-native-execution/velox/velox/type/TypeCoercer.h:23:8: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 2 were provided
  /__w/presto/presto/presto-native-execution/velox/velox/type/TypeCoercer.h:23:8: note: candidate constructor (the implicit default constructor) not viable: requires 0 arguments, but 2 were provided

from https://github.com/prestodb/presto/actions/runs/20438741770/job/58726921849?pr=26841

Differential Revision: D89688157


