### PR TITLE
feat: Implement one step registration for OpaqueCustomType

### DIFF
--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/type/SimpleFunctionApi.h"
 #include "velox/type/Type.h"
 
@@ -34,14 +35,19 @@ class CastOperator;
 template <typename T, const char* customTypeName>
 class OpaqueCustomTypeRegister {
  public:
-  static bool registerType() {
-    return facebook::velox::registerCustomType(
-        customTypeName, std::make_unique<const TypeFactory>());
-  }
+  using SerializeValueFunc = OpaqueType::SerializeFunc<T>;
+  using DeserializeValueFunc = OpaqueType::DeserializeFunc<T>;
 
-  static bool unregisterType() {
-    return facebook::velox::unregisterCustomType(customTypeName);
-  }
+  // @param serializeValueFunc Optional serialization function for values of
+  // type T.
+  // @param deserializeValueFunc Optional deserialization function for values of
+  // type T. Both serializeValueFunc and deserializeValueFunc must be specified
+  // or not together.
+  static bool registerType(
+      SerializeValueFunc serializeValueFunc = nullptr,
+      DeserializeValueFunc deserializeValueFunc = nullptr);
+
+  static bool unregisterType();
 
   // Type used in the simple function interface as CustomType<TypeT>.
   struct TypeT {
@@ -51,13 +57,16 @@ class OpaqueCustomTypeRegister {
 
   using SimpleType = CustomType<TypeT>;
 
+  class VeloxType;
+  using VeloxTypePtr = std::shared_ptr<const VeloxType>;
+
   class VeloxType : public OpaqueType {
    public:
     VeloxType() : OpaqueType(std::type_index(typeid(T))) {}
 
-    static const TypePtr& get() {
+    static const VeloxTypePtr& get() {
       static const VeloxType kInstance;
-      static const TypePtr kInstancePtr{TypePtr{}, &kInstance};
+      static const VeloxTypePtr kInstancePtr{TypePtr{}, &kInstance};
       return kInstancePtr;
     }
 
@@ -77,13 +86,20 @@ class OpaqueCustomTypeRegister {
     std::string toString() const override {
       return customTypeName;
     }
+
+    folly::dynamic serialize() const override {
+      folly::dynamic obj = folly::dynamic::object;
+      obj["name"] = "Type";
+      obj["type"] = customTypeName;
+      return obj;
+    }
   };
 
-  static const TypePtr& singletonTypePtr() {
+  static const VeloxTypePtr& singletonTypePtr() {
     return VeloxType::get();
   }
 
-  static const TypePtr& get() {
+  static const VeloxTypePtr& get() {
     return VeloxType::get();
   }
 
@@ -108,4 +124,34 @@ class OpaqueCustomTypeRegister {
     }
   };
 };
+
+template <typename T, const char* customTypeName>
+bool OpaqueCustomTypeRegister<T, customTypeName>::registerType(
+    SerializeValueFunc serializeValueFunc,
+    DeserializeValueFunc deserializeValueFunc) {
+  VELOX_USER_CHECK(
+      ((serializeValueFunc && deserializeValueFunc) ||
+       (!serializeValueFunc && !deserializeValueFunc)),
+      "Both serialization and deserialization functions need to be registered for custom type {}",
+      customTypeName);
+  if (registerCustomType(
+          customTypeName, std::make_unique<const TypeFactory>())) {
+    if (serializeValueFunc && deserializeValueFunc) {
+      OpaqueType::registerSerialization<T>(
+          customTypeName, serializeValueFunc, deserializeValueFunc);
+    }
+    return true;
+  }
+  return false;
+}
+
+template <typename T, const char* customTypeName>
+bool OpaqueCustomTypeRegister<T, customTypeName>::unregisterType() {
+  if (unregisterCustomType(customTypeName)) {
+    OpaqueType::unregisterSerialization(singletonTypePtr(), customTypeName);
+    return true;
+  }
+  return false;
+}
+
 } // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -907,6 +907,15 @@ std::shared_ptr<const OpaqueType> OpaqueType::deserializeExtra(
   return nullptr;
 }
 
+bool OpaqueType::unregisterSerialization(
+    const OpaqueTypePtr& opaqueType,
+    const std::string& persistentName) {
+  VELOX_CHECK_NOT_NULL(opaqueType);
+  auto& registry = OpaqueSerdeRegistry::get();
+  registry.reverse.erase(persistentName);
+  return registry.mapping.erase(opaqueType->typeIndex_);
+}
+
 void OpaqueType::clearSerializationRegistry() {
   auto& registry = OpaqueSerdeRegistry::get();
   registry.mapping.clear();

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1362,6 +1362,15 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
         deserializeTypeErased);
   }
 
+  // This function is used to remove the serialization/deserialization functions
+  // for a type. It reverses the state changes made by registerSerialization
+  // function.
+  // @return true if the functions are found and removed
+  // successfully. False otherwise.
+  static bool unregisterSerialization(
+      const std::shared_ptr<const OpaqueType>& opaqueType,
+      const std::string& persistentName);
+
   static void clearSerializationRegistry();
 
  protected:
@@ -1376,6 +1385,8 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
       SerializeFunc<void> serialize = nullptr,
       DeserializeFunc<void> deserialize = nullptr);
 };
+
+using OpaqueTypePtr = std::shared_ptr<const OpaqueType>;
 
 using IntegerType = ScalarType<TypeKind::INTEGER>;
 using BooleanType = ScalarType<TypeKind::BOOLEAN>;
@@ -2371,6 +2382,7 @@ bool registerOpaqueType(const std::string& alias) {
 template <typename Class>
 bool unregisterOpaqueType(const std::string& alias) {
   auto typeIndex = std::type_index(typeid(Class));
+  OpaqueType::unregisterSerialization(OpaqueType::create<Class>(), alias);
   return getTypeIndexByOpaqueAlias().erase(alias) == 1 &&
       getOpaqueAliasByTypeIndex().erase(typeIndex) == 1;
 }

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   FilterSerDeTest.cpp
   FloatingPointUtilTest.cpp
   HugeIntTest.cpp
+  OpaqueCustomTypesTest.cpp
   StringViewTest.cpp
   SubfieldTest.cpp
   TimestampConversionTest.cpp

--- a/velox/type/tests/OpaqueCustomTypesTest.cpp
+++ b/velox/type/tests/OpaqueCustomTypesTest.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/dynamic.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/OpaqueCustomTypes.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::velox {
+namespace {
+
+class OpaqueCustomTypeTest : public testing::Test {
+ public:
+  OpaqueCustomTypeTest()
+      : testCustomType_(TestCustomTypeRegister::VeloxType::get()) {}
+
+ protected:
+  struct TestCustomType {
+    std::string name;
+
+    bool operator==(const TestCustomType& other) const {
+      return name == other.name;
+    }
+
+    folly::dynamic serialize() const {
+      folly::dynamic obj = folly::dynamic::object();
+      obj["name"] = name;
+      return obj;
+    }
+
+    static std::shared_ptr<TestCustomType> create(const folly::dynamic& obj) {
+      return std::make_shared<TestCustomType>(obj["name"].asString());
+    }
+  };
+
+  static constexpr char testCustomTypeName[] = "my_test_custom_type";
+  using TestCustomTypeRegister =
+      OpaqueCustomTypeRegister<TestCustomType, testCustomTypeName>;
+
+  TestCustomTypeRegister::VeloxTypePtr testCustomType_;
+
+  void testUnregisterType() {
+    TestCustomTypeRegister::unregisterType();
+    ASSERT_EQ(getCustomType(testCustomTypeName, {}), nullptr);
+    VELOX_ASSERT_THROW(
+        testCustomType_->getSerializeFunc(),
+        "No serialization function registered for my_test_custom_type");
+    VELOX_ASSERT_THROW(
+        testCustomType_->getDeserializeFunc(),
+        "No deserialization function registered for my_test_custom_type");
+  }
+
+  void testTypeSerde() {
+    auto serializedCustomType = testCustomType_->serialize();
+    EXPECT_EQ(testCustomType_->name(), serializedCustomType["type"]);
+    auto deserializedType = Type::create(serializedCustomType);
+    EXPECT_EQ(testCustomType_, deserializedType);
+  }
+};
+
+TEST_F(OpaqueCustomTypeTest, registerWithoutSerde) {
+  // Register type without serialization/deserialization and build a TypePtr.
+  TestCustomTypeRegister::registerType();
+  testTypeSerde();
+  testUnregisterType();
+}
+
+TEST_F(OpaqueCustomTypeTest, registerWithSerde) {
+  // Register type with serialization/deserialization and build a TypePtr.
+  TestCustomTypeRegister::registerType(
+      /*serializeValueFunc=*/
+      [](const auto& obj) { return folly::toJson(obj->serialize()); },
+      /*deserializeValueFunc=*/
+      [](const auto& str) {
+        return TestCustomType::create(folly::parseJson(str));
+      });
+
+  // Test value serialization/deserialization, with serde functions provided in
+  // TestCustomTypeRegister::registerType() method.
+  auto original = std::make_shared<TestCustomType>("test");
+  auto opaque = Variant::create(Variant::opaque(original).serialize())
+                    .value<TypeKind::OPAQUE>()
+                    .obj;
+  auto copy = std::static_pointer_cast<TestCustomType>(opaque);
+  EXPECT_EQ(*original, *copy);
+
+  testTypeSerde();
+  testUnregisterType();
+}
+
+TEST_F(OpaqueCustomTypeTest, registerWithIncompleteSerde) {
+  VELOX_ASSERT_THROW(
+      TestCustomTypeRegister::registerType(
+          /*serializeValueFunc=*/nullptr,
+          /*deserializeValueFunc=*/
+          [](const auto& str) {
+            return TestCustomType::create(folly::parseJson(str));
+          }),
+      "Both serialization and deserialization functions need to be registered for custom type my_test_custom_type");
+
+  VELOX_ASSERT_THROW(
+      TestCustomTypeRegister::registerType(
+          /*serializeValueFunc=*/
+          [](const auto& obj) { return folly::toJson(obj->serialize()); },
+          /*deserializeValueFunc=*/nullptr),
+      "Both serialization and deserialization functions need to be registered for custom type my_test_custom_type");
+
+  testUnregisterType();
+}
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -661,12 +661,24 @@ TEST(TypeTest, opaque) {
   auto foo3 = Type::create(foo->serialize());
   ASSERT_EQ(*foo, *foo3);
 
+  // Clearing the serialization registry when no serialization/deserialization
+  // functions have been provided, should return true, since the registry
+  // contained nullptr as serialization/deserialization functions.
+  EXPECT_TRUE(OpaqueType::unregisterSerialization(foo2, "id_of_foo"));
+  // Clearing the serialization registry a second time should return false.
+  EXPECT_FALSE(OpaqueType::unregisterSerialization(foo2, "id_of_foo"));
+
   OpaqueType::registerSerialization<Bar>(
       "id_of_bar",
       [](const std::shared_ptr<Bar>&) -> std::string { return ""; },
       [](const std::string&) -> std::shared_ptr<Bar> { return nullptr; });
   bar->getSerializeFunc();
   bar->getDeserializeFunc();
+
+  // Clearing the serialization registry should return true.
+  EXPECT_TRUE(
+      OpaqueType::unregisterSerialization(
+          OpaqueType::create<Bar>(), "id_of_bar"));
 }
 
 // Example of an opaque type that keeps some additional type-level metadata.


### PR DESCRIPTION
Summary:
## Background.
- Today, a CustomType (inner type) may be wrapped by an OpaqueType (outer type), forming a OpaqueCustomType.
- When an OpaqueCustomType is defined, it needs to be registered in two place.
   - Custom Type Registry - a mapping from type name to an instance of CustomTypeFactory   that provides an instance of the type
   - OpaqueSerdeRegistry - a mapping from type name to functions that serialize and deserialize opaque type values
- Today, this requires two separate calls to the API. These separate calls are inconvenient and error prone.

## Implementation
- OpaqueCustomTypes.h
   - This PR changes the OpaqueCustomTypeRegister::registerType() function to accept optional serialization/deserialization functions, thus eliminating the need for a separate API call.
   - By keep the function arguments optional, it provides backward compatibility with existing code.

## Testing Changes
- OpaqueCustomTypesTest.cpp
   - Implements unit-tests that ensure that serialization/deserialization functions can be provided in the registerType function optionally.
   - Unit-tests ensure that serialization/deserialization functions can be provided utmost once.

Differential Revision: D89686612


