### PR TITLE
refactor: Fold registerSerialization into registerType for OpaqueType

### DIFF
--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -140,9 +140,7 @@ class RemoteFunctionTest
     registerFunction<OpaqueTypeFunction, int64_t, std::shared_ptr<Foo>>(
         {params.functionPrefix + ".remote_opaque"});
 
-    registerOpaqueType<Foo>("Foo");
-    OpaqueType::registerSerialization<Foo>(
-        "Foo", Foo::serialize, Foo::deserialize);
+    registerOpaqueType<Foo>("Foo", Foo::serialize, Foo::deserialize);
   }
 };
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -937,6 +937,14 @@ void OpaqueType::registerSerializationTypeErased(
   registry.reverse[persistentName] = type;
 }
 
+void OpaqueType::unregisterSerializationTypeErased(
+    const std::shared_ptr<const OpaqueType>& type,
+    const std::string& persistentName) {
+  auto& registry = OpaqueSerdeRegistry::get();
+  registry.mapping.erase(type->typeIndex_);
+  registry.reverse.erase(persistentName);
+}
+
 ArrayTypePtr ARRAY(TypePtr elementType) {
   return TypeFactory<TypeKind::ARRAY>::create(std::move(elementType));
 }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1353,6 +1353,12 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
 
   static void clearSerializationRegistry();
 
+  template <typename T>
+  FOLLY_NOINLINE static void unregisterSerialization(
+      const std::string& persistentName) {
+    unregisterSerializationTypeErased(OpaqueType::create<T>(), persistentName);
+  }
+
  protected:
   bool equals(const Type& other) const override;
 
@@ -1364,6 +1370,10 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
       const std::string& persistentName,
       SerializeFunc<void> serialize = nullptr,
       DeserializeFunc<void> deserialize = nullptr);
+
+  static void unregisterSerializationTypeErased(
+      const std::shared_ptr<const OpaqueType>& type,
+      const std::string& persistentName);
 };
 
 using IntegerType = ScalarType<TypeKind::INTEGER>;
@@ -2342,11 +2352,22 @@ std::string getOpaqueAliasForTypeId(std::type_index typeIndex);
 /// might not be able to deserialize it in another process. To solve this
 /// problem, we require that both the serializing and deserializing processes
 /// register the opaque type using registerOpaqueType() with the same alias.
+///
+/// This function also registers the serialization for the opaque type. If
+/// custom serialize/deserialize functions are provided, they will be used;
+/// otherwise, default (nullptr) will be registered.
 template <typename Class>
-bool registerOpaqueType(const std::string& alias) {
+bool registerOpaqueType(
+    const std::string& alias,
+    OpaqueType::SerializeFunc<Class> serialize = nullptr,
+    OpaqueType::DeserializeFunc<Class> deserialize = nullptr) {
   auto typeIndex = std::type_index(typeid(Class));
-  return getTypeIndexByOpaqueAlias().emplace(alias, typeIndex).second &&
+  bool success = getTypeIndexByOpaqueAlias().emplace(alias, typeIndex).second &&
       getOpaqueAliasByTypeIndex().emplace(typeIndex, alias).second;
+  if (success) {
+    OpaqueType::registerSerialization<Class>(alias, serialize, deserialize);
+  }
+  return success;
 }
 
 /// Unregisters an opaque type. Returns true if the type was unregistered.
@@ -2355,6 +2376,7 @@ bool registerOpaqueType(const std::string& alias) {
 template <typename Class>
 bool unregisterOpaqueType(const std::string& alias) {
   auto typeIndex = std::type_index(typeid(Class));
+  OpaqueType::unregisterSerialization<Class>(alias);
   return getTypeIndexByOpaqueAlias().erase(alias) == 1 &&
       getOpaqueAliasByTypeIndex().erase(typeIndex) == 1;
 }


### PR DESCRIPTION
Summary:
This refactoring unifies the OpaqueType registration API by folding the `registerSerialization()` call into `registerType()`/`registerOpaqueType()`.

Previously, registering an opaque type with serialization support required two separate calls:
1. `registerType()` or `registerOpaqueType<T>(name)`
2. `OpaqueType::registerSerialization<T>(name, serialize, deserialize)`

Now, the unified API accepts optional serialize/deserialize parameters and internally handles serialization registration when type registration succeeds. This:
- Reduces boilerplate at call sites by consolidating two calls into one
- Ensures serialization is only registered when type registration succeeds (avoiding duplicate registration errors)
- Maintains backward compatibility through default nullptr parameters

Changes:
- Extended `registerType()`/`registerOpaqueType()` to accept optional serialize/deserialize functions
- Added `unregisterSerialization()` to properly clean up during `unregisterType()`
- Updated all call sites that previously made two separate calls to use the unified API

Differential Revision: D89686258


