### PR TITLE
fix: Fix TopNRowNumber crash by handling add new groups failure properly

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -338,6 +338,8 @@ char* HashTable<ignoreNullKeys>::insertEntry(
     HashLookup& lookup,
     uint64_t index,
     vector_size_t row) {
+  TestValue::adjust(
+      "facebook::velox::exec::HashTable::insertEntry", rows_->pool());
   char* group = rows_->newRow();
   lookup.hits[row] = group; // NOLINT
   storeKeys(lookup, row);

--- a/velox/exec/TopNRowNumber.h
+++ b/velox/exec/TopNRowNumber.h
@@ -166,6 +166,11 @@ class TopNRowNumber : public Operator {
 
   void initializeNewPartitions();
 
+  // Cleans up any newly inserted but uninitialized partitions from the hash
+  // table. This is called when groupProbe throws (e.g., due to OOM) to ensure
+  // close() doesn't crash trying to destroy uninitialized TopRows structures.
+  void cleanupNewPartitions();
+
   TopRows& partitionAt(char* group) {
     return *reinterpret_cast<TopRows*>(group + partitionOffset_);
   }


### PR DESCRIPTION
Summary:
This change adds error handling in `TopNRowNumber::addInput` to properly clean up newly inserted groups if `groupProbe` throws an exception (e.g., due to OOM).

Problem:
When `groupProbe` throws an exception after inserting some new rows into the row container but before `initializeNewPartitions()` is called, the newly inserted rows contain uninitialized `TopRows` structures. When the operator's `close()` method is later invoked, it calls `std::destroy_at` on these uninitialized structures, which can cause crashes.

Fix:
- Added a try-catch block around `table_->groupProbe()` in `TopNRowNumber::addInput`
- In the catch block, erase all newly inserted rows from the row container before re-throwing
- This prevents `close()` from attempting to destroy uninitialized `TopRows` structures

Test:
Added a new test `oomInGroupProbe` that uses TestValue injection in `HashTable::insertEntry` to simulate OOM after inserting 100 rows. The test verifies that the query fails gracefully without crashing.

Differential Revision: D89699263


