### PR TITLE
refactor: Add is_string_kind/is_nested_kind() metaprogramming helpers

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -388,11 +388,8 @@ std::optional<int32_t> compareSwitch(
 template <
     bool typeProvidesCustomComparison,
     TypeKind Kind,
-    std::enable_if_t<
-        Kind != TypeKind::VARCHAR && Kind != TypeKind::VARBINARY &&
-            Kind != TypeKind::ARRAY && Kind != TypeKind::MAP &&
-            Kind != TypeKind::ROW,
-        int32_t> = 0>
+    std::enable_if_t<!is_string_kind(Kind) && !is_nested_kind(Kind), int32_t> =
+        0>
 std::optional<int32_t> compare(
     ByteInputStream& left,
     const BaseVector& right,
@@ -693,11 +690,8 @@ std::optional<int32_t> compareSwitch(
 template <
     bool typeProvidesCustomComparison,
     TypeKind Kind,
-    std::enable_if_t<
-        Kind != TypeKind::VARCHAR && Kind != TypeKind::VARBINARY &&
-            Kind != TypeKind::ARRAY && Kind != TypeKind::MAP &&
-            Kind != TypeKind::ROW,
-        int32_t> = 0>
+    std::enable_if_t<!is_string_kind(Kind) && !is_nested_kind(Kind), int32_t> =
+        0>
 std::optional<int32_t> compare(
     ByteInputStream& left,
     ByteInputStream& right,
@@ -898,11 +892,8 @@ uint64_t hashSwitch(ByteInputStream& stream, const Type* type);
 template <
     bool typeProvidesCustomComparison,
     TypeKind Kind,
-    std::enable_if_t<
-        Kind != TypeKind::VARBINARY && Kind != TypeKind::VARCHAR &&
-            Kind != TypeKind::ARRAY && Kind != TypeKind::MAP &&
-            Kind != TypeKind::ROW,
-        int32_t> = 0>
+    std::enable_if_t<!is_string_kind(Kind) && !is_nested_kind(Kind), int32_t> =
+        0>
 uint64_t hashOne(ByteInputStream& stream, const Type* type) {
   using T = typename TypeTraits<Kind>::NativeType;
 

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -593,7 +593,7 @@ int32_t RowContainer::variableSizeAt(const char* row, column_index_t column)
   }
 
   const auto typeKind = typeKinds_[column];
-  if (typeKind == TypeKind::VARCHAR || typeKind == TypeKind::VARBINARY) {
+  if (is_string_kind(typeKind)) {
     return reinterpret_cast<const StringView*>(row + rowColumn.offset())
         ->size();
   } else {
@@ -619,7 +619,7 @@ int32_t RowContainer::extractVariableSizeAt(
   }
 
   const auto typeKind = typeKinds_[column];
-  if (typeKind == TypeKind::VARCHAR || typeKind == TypeKind::VARBINARY) {
+  if (is_string_kind(typeKind)) {
     const auto value = valueAt<StringView>(row, rowColumn.offset());
     const auto size = value.size();
     ::memcpy(output, &size, 4);
@@ -657,7 +657,7 @@ int32_t RowContainer::storeVariableSizeAt(
   // First 4 bytes is the size of the data.
   const auto size = *reinterpret_cast<const int32_t*>(data);
 
-  if (typeKind == TypeKind::VARCHAR || typeKind == TypeKind::VARBINARY) {
+  if (is_string_kind(typeKind)) {
     if (size > 0) {
       stringAllocator_->copyMultipart(
           StringView(data + 4, size), row, rowColumn.offset());
@@ -895,13 +895,11 @@ void RowContainer::hashTyped(
                       : BaseVector::kNullHash;
     } else {
       uint64_t hash;
-      if constexpr (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+      if constexpr (is_string_kind(Kind)) {
         hash =
             folly::hasher<StringView>()(HashStringAllocator::contiguousString(
                 valueAt<StringView>(row, offset), storage));
-      } else if constexpr (
-          Kind == TypeKind::ROW || Kind == TypeKind::ARRAY ||
-          Kind == TypeKind::MAP) {
+      } else if constexpr (is_nested_kind(Kind)) {
         auto in = prepareRead(row, offset);
         hash = ContainerRowSerde::hash(in, type);
       } else if constexpr (typeProvidesCustomComparison) {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1248,8 +1248,7 @@ class RowContainer {
         Kind == TypeKind::ROW || Kind == TypeKind::ARRAY ||
         Kind == TypeKind::MAP) {
       return compareComplexType(row, column.offset(), decoded, index, flags);
-    } else if constexpr (
-        Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+    } else if constexpr (is_string_kind(Kind)) {
       auto result = compareStringAsc(
           valueAt<StringView>(row, column.offset()), decoded, index);
       return flags.ascending ? result : result * -1;
@@ -1329,8 +1328,7 @@ class RowContainer {
         Kind == TypeKind::MAP) {
       return compareComplexType(
           left, right, type, leftOffset, rightOffset, flags);
-    } else if constexpr (
-        Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+    } else if constexpr (is_string_kind(Kind)) {
       auto leftValue = valueAt<StringView>(left, leftOffset);
       auto rightValue = valueAt<StringView>(right, rightOffset);
       auto result = compareStringAsc(leftValue, rightValue);

--- a/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixEncoderTest.cpp
@@ -270,8 +270,7 @@ class PrefixEncoderTest : public testing::Test,
         const auto rightValue = rightVector->isNullAt(i)
             ? std::nullopt
             : std::optional<ValueDataType>(rightVector->valueAt(i));
-        if constexpr (
-            Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
+        if constexpr (is_string_kind(Kind)) {
           encoder.encode(leftValue, leftEncoded, 17, true);
           encoder.encode(rightValue, rightEncoded, 17, true);
         } else {

--- a/velox/experimental/wave/vector/WaveVector.cpp
+++ b/velox/experimental/wave/vector/WaveVector.cpp
@@ -29,7 +29,7 @@ static int32_t kindSize() {
 
 int32_t waveTypeKindSize(WaveTypeKind waveKind) {
   TypeKind kind = static_cast<TypeKind>(waveKind);
-  if (kind == TypeKind::VARCHAR || kind == TypeKind::VARBINARY) {
+  if (is_string_kind(kind)) {
     // Wave StringView is 8, not 16 bytes.
     return sizeof(StringView);
   }

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -175,8 +175,7 @@ void CastExpr::applyCastKernel(
     }
 
     // Optimize empty input strings casting by avoiding throwing exceptions.
-    if constexpr (
-        FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
+    if constexpr (is_string_kind(FromKind)) {
       if constexpr (
           TypeTraits<ToKind>::isPrimitiveType &&
           TypeTraits<ToKind>::isFixedWidth) {
@@ -225,8 +224,7 @@ void CastExpr::applyCastKernel(
 
     const auto& output = castResult.value();
 
-    if constexpr (
-        ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
+    if constexpr (is_string_kind(ToKind)) {
       // Write the result output to the output vector
       auto writer = exec::StringWriter(result, row);
       writer.copy_from(output);

--- a/velox/python/legacy/pyvelox.cpp
+++ b/velox/python/legacy/pyvelox.cpp
@@ -88,8 +88,7 @@ static VectorPtr variantsToFlatVector(
     const std::vector<velox::variant>& variants,
     facebook::velox::memory::MemoryPool* pool) {
   using NativeType = typename TypeTraits<T>::NativeType;
-  constexpr bool kNeedsHolder =
-      (T == TypeKind::VARCHAR || T == TypeKind::VARBINARY);
+  constexpr bool kNeedsHolder = is_string_kind(T);
 
   TypePtr type = createScalarType(T);
   auto result =

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -363,6 +363,17 @@ struct TypeTraits<TypeKind::OPAQUE> {
   static constexpr const char* name = "OPAQUE";
 };
 
+// Convenience constexpr function to check for string-like and nested type
+// kinds.
+constexpr bool is_string_kind(TypeKind kind) {
+  return kind == TypeKind::VARCHAR || kind == TypeKind::VARBINARY;
+}
+
+constexpr bool is_nested_kind(TypeKind kind) {
+  return kind == TypeKind::ARRAY || kind == TypeKind::MAP ||
+      kind == TypeKind::ROW;
+}
+
 template <TypeKind KIND>
 struct TypeFactory;
 


### PR DESCRIPTION
Summary:
Adding two common constexpr methods commonly used in metaprogramming
templates throughout the codebase. Adding a helper function for convenience
since they are quite common.

Differential Revision: D89706562


