### PR TITLE
perf(function): Avoid string copy in normalize() Presto function

### DIFF
--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -602,13 +602,14 @@ template <typename T>
 struct NormalizeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  // Map for holding normalization form options
-  const static inline std::unordered_map<std::string, utf8proc_int16_t>
+  // Map for holding normalization form options.
+  const static inline std::unordered_map<std::string_view, utf8proc_int16_t>
       normalizationOptions{
           {"NFC", (UTF8PROC_STABLE | UTF8PROC_COMPOSE)},
           {"NFD", (UTF8PROC_STABLE | UTF8PROC_DECOMPOSE)},
           {"NFKC", (UTF8PROC_STABLE | UTF8PROC_COMPOSE | UTF8PROC_COMPAT)},
-          {"NFKD", (UTF8PROC_STABLE | UTF8PROC_DECOMPOSE | UTF8PROC_COMPAT)}};
+          {"NFKD", (UTF8PROC_STABLE | UTF8PROC_DECOMPOSE | UTF8PROC_COMPAT)},
+      };
 
   FOLLY_ALWAYS_INLINE void initialize(
       const std::vector<TypePtr>& /*inputTypes*/,
@@ -616,8 +617,10 @@ struct NormalizeFunction {
       const arg_type<Varchar>* /*string*/,
       const arg_type<Varchar>* form) {
     VELOX_USER_CHECK_NOT_NULL(form);
+
+    // TODO: Remove explicit std::string_view cast.
     VELOX_USER_CHECK_NE(
-        normalizationOptions.count(*form),
+        normalizationOptions.count(std::string_view(*form)),
         0,
         "Normalization form must be one of [NFD, NFC, NFKD, NFKC]");
   }
@@ -646,7 +649,8 @@ struct NormalizeFunction {
         (utf8proc_uint8_t*)string.data(),
         string.size(),
         &output,
-        normalizationOptions.at(form));
+        // TODO: Remove explicit std::string_view cast.
+        normalizationOptions.at(std::string_view(form)));
     if (outputLength < 0) {
       result = string;
     } else {
@@ -666,7 +670,9 @@ template <typename T>
 struct BitLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE void call(int64_t& result, const StringView& input) {
+  FOLLY_ALWAYS_INLINE void call(
+      int64_t& result,
+      const arg_type<Varchar>& input) {
     result = static_cast<int64_t>(input.size()) * 8;
   }
 };


### PR DESCRIPTION
Summary:
Avoid string allocation and copy to std::string in normalize()
Presto function.

Differential Revision: D89731021


