### PR TITLE
misc: Rename QueryConfig::kParallelJoinBuildRowsEnabled to kParallelOutputJoinBuildRowsEnabled to avoid confusion

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -278,8 +278,8 @@ class QueryConfig {
       "adaptive_filter_reordering_enabled";
 
   /// If true, allow hash probe drivers to generate build-side rows in parallel.
-  static constexpr const char* kParallelJoinBuildRowsEnabled =
-      "parallel_join_build_rows_enabled";
+  static constexpr const char* kParallelOutputJoinBuildRowsEnabled =
+      "parallel_output_join_build_rows_enabled";
 
   /// Global enable spilling flag.
   static constexpr const char* kSpillEnabled = "spill_enabled";
@@ -1030,8 +1030,8 @@ class QueryConfig {
     return get<bool>(kExprEvalSimplified, false);
   }
 
-  bool parallelJoinBuildRowsEnabled() const {
-    return get<bool>(kParallelJoinBuildRowsEnabled, false);
+  bool parallelOutputJoinBuildRowsEnabled() const {
+    return get<bool>(kParallelOutputJoinBuildRowsEnabled, false);
   }
 
   bool spillEnabled() const {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -133,7 +133,7 @@ HashProbe::HashProbe(
       filterResult_(1),
       outputTableRowsCapacity_(outputBatchSize_),
       parallelJoinBuildRowsEnabled_(
-          driverCtx->queryConfig().parallelJoinBuildRowsEnabled()) {
+          driverCtx->queryConfig().parallelOutputJoinBuildRowsEnabled()) {
   VELOX_CHECK_NOT_NULL(joinBridge_);
 }
 

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -649,7 +649,7 @@ class HashJoinBuilder {
         core::QueryConfig::kHashProbeFinishEarlyOnEmptyBuild,
         hashProbeFinishEarlyOnEmptyBuild_ ? "true" : "false");
     config(
-        core::QueryConfig::kParallelJoinBuildRowsEnabled,
+        core::QueryConfig::kParallelOutputJoinBuildRowsEnabled,
         parallelJoinBuildRowsEnabled_ ? "true" : "false");
     if (maxDriverYieldTimeMs != 0) {
       config(


### PR DESCRIPTION
Summary: Rename the query config to avoid confusion with parallel join build.

Differential Revision: D89736171


