### PR TITLE
feat: Add string compaction for approx_most_frequent global aggregation

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -205,6 +205,24 @@ class QueryConfig {
   static constexpr const char* kAbandonPartialAggregationMinPct =
       "abandon_partial_aggregation_min_pct";
 
+  /// Memory threshold in bytes for triggering string compaction during
+  /// global aggregation. When total string storage exceeds this limit with
+  /// high unused memory ratio, compaction is triggered to reclaim dead strings.
+  /// Disabled by default (0).
+  ///
+  /// NOTE: currently only applies to approx_most_frequent aggregate with
+  /// StringView type during global aggregation. May extend to other types.
+  static constexpr const char* kAggregationCompactionBytesThreshold =
+      "aggregation_compaction_bytes_threshold";
+
+  /// Ratio of unused (evicted) bytes to total bytes that triggers compaction.
+  /// Value is between 0.0 and 1.0. Default is 0.25.
+  ///
+  /// NOTE: currently only applies to approx_most_frequent aggregate with
+  /// StringView type during global aggregation. May extend to other types.
+  static constexpr const char* kAggregationCompactionUnusedMemoryRatio =
+      "aggregation_compaction_unused_memory_ratio";
+
   static constexpr const char* kAbandonPartialTopNRowNumberMinRows =
       "abandon_partial_topn_row_number_min_rows";
 
@@ -870,6 +888,14 @@ class QueryConfig {
 
   int32_t abandonPartialAggregationMinPct() const {
     return get<int32_t>(kAbandonPartialAggregationMinPct, 80);
+  }
+
+  uint64_t aggregationCompactionBytesThreshold() const {
+    return get<uint64_t>(kAggregationCompactionBytesThreshold, 0);
+  }
+
+  double aggregationCompactionUnusedMemoryRatio() const {
+    return get<double>(kAggregationCompactionUnusedMemoryRatio, 0.25);
   }
 
   int32_t abandonPartialTopNRowNumberMinRows() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -521,6 +521,21 @@ Aggregation
      - integer
      - 80
      - Abandons partial aggregation if number of groups equals or exceeds this percentage of the number of input rows.
+   * - aggregation_compaction_bytes_threshold
+     - integer
+     - 0
+     - Memory threshold in bytes for triggering string compaction during global
+       aggregation. When total string storage exceeds this limit with high unused
+       memory ratio, compaction is triggered to reclaim dead strings. Disabled by
+       default (0). Currently only applies to approx_most_frequent aggregate with
+       StringView type during global aggregation.
+   * - aggregation_compaction_unused_memory_ratio
+     - double
+     - 0.25
+     - Ratio of unused (evicted) bytes to total bytes that triggers compaction.
+       The value is in the range of [0, 1). Currently only applies to approx_most_frequent
+       aggregate with StringView type during global aggregation. May be extended
+       to other aggregation types on-demand.
    * - streaming_aggregation_min_output_batch_rows
      - integer
      - 0

--- a/velox/functions/lib/ApproxMostFrequentStreamSummary.h
+++ b/velox/functions/lib/ApproxMostFrequentStreamSummary.h
@@ -44,8 +44,9 @@ struct ApproxMostFrequentStreamSummary {
 
   void setCapacity(int);
 
-  /// Add one or multiple new values to the summary.
-  void insert(T value, int64_t count = 1);
+  /// Add a value with the given count to the summary.
+  /// Returns the evicted value if at capacity, std::nullopt otherwise.
+  std::optional<T> insert(T value, int64_t count = 1);
 
   /// Get the top `k` frequent elements with their estimated counts, sorted from
   /// most hits to least hits.
@@ -131,17 +132,25 @@ int ApproxMostFrequentStreamSummary<T, A>::capacity() const {
 }
 
 template <typename T, typename A>
-void ApproxMostFrequentStreamSummary<T, A>::insert(T value, int64_t count) {
+std::optional<T> ApproxMostFrequentStreamSummary<T, A>::insert(
+    T value,
+    int64_t count) {
   auto index = queue_.getValueIndex(value);
   if (index.has_value()) {
-    auto oldCount = queue_.priorities()[*index];
+    const auto oldCount = queue_.priorities()[*index];
     queue_.updatePriority(*index, oldCount + count);
-  } else if (size() < capacity_) {
-    queue_.addNewValue(value, count);
-  } else {
-    auto oldCount = queue_.topPriority();
-    queue_.replaceTop(value, oldCount + count);
+    return std::nullopt;
   }
+  if (size() < capacity_) {
+    queue_.addNewValue(value, count);
+    return std::nullopt;
+  }
+
+  // At capacity - need to evict the minimum entry.
+  std::optional<T> evictedValue{queue_.top()};
+  auto evictedCount = queue_.topPriority();
+  queue_.replaceTop(value, evictedCount + count);
+  return evictedValue;
 }
 
 template <typename T, typename A>
@@ -180,7 +189,7 @@ void ApproxMostFrequentStreamSummary<T, A>::topK(
 template <typename T, typename A>
 std::vector<std::pair<T, int64_t>> ApproxMostFrequentStreamSummary<T, A>::topK(
     int k) const {
-  VELOX_CHECK(k >= 0);
+  VELOX_CHECK_GE(k, 0);
   k = std::min(k, size());
   std::vector<T> values(k);
   std::vector<int64_t> counts(k);


### PR DESCRIPTION
**Summary:**
This diff adds memory compaction for the approx_most_frequent aggregate function during global aggregation (addSingleGroupRawInput).

**Problem**
During global aggregation with high string churn, dead (evicted) strings accumulate in the HashStringAllocator, causing unbounded memory growth that can lead to OOM.

**Solution**
Implement periodic compaction that copies active strings to new storage and frees the old storage when:
Total string storage exceeds the compaction threshold (default 512MB)
Evicted bytes exceed a percentage of the threshold (default 25%)

**Changes**
1: Added new query configs 
    - aggregation_string_compaction_bytes
    - aggregation_string_compaction_pct 
for configuring compaction behavior

2: Implemented compact() method in Accumulator<StringView> to reclaim memory from dead strings
Only enabled for StringView type during global aggregation (addSingleGroupRawInput)

Differential Revision: D89728171


