### PR TITLE
refactor(query-ctx): Add builder pattern and documentation

### DIFF
--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -2815,8 +2815,10 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromTableWriter) {
       const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
       const int numPrevNonReclaimableAttempts =
           arbitrator->stats().numNonReclaimableAttempts;
-      auto queryCtx = core::QueryCtx::create(
-          executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+      auto queryCtx = core::QueryCtx::Builder()
+                          .executor(executor_.get())
+                          .pool(std::move(queryPool))
+                          .build();
       ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
       std::atomic_int numInputs{0};
@@ -2934,8 +2936,10 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, reclaimFromSortTableWriter) {
       const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
       const int numPrevNonReclaimableAttempts =
           arbitrator->stats().numNonReclaimableAttempts;
-      auto queryCtx = core::QueryCtx::create(
-          executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+      auto queryCtx = core::QueryCtx::Builder()
+                          .executor(executor_.get())
+                          .pool(std::move(queryPool))
+                          .build();
       ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
       const auto spillStats = common::globalSpillStats();
@@ -3049,8 +3053,11 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, writerFlushThreshold) {
     const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
     const int numPrevNonReclaimableAttempts =
         arbitrator->stats().numNonReclaimableAttempts;
-    auto queryCtx = core::QueryCtx::create(
-        executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+    auto queryCtx = core::QueryCtx::Builder()
+                        .executor(executor_.get())
+                        .pool(std::move(queryPool))
+                        .build();
+
     ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
     memory::MemoryPool* compressionPool{nullptr};
@@ -3157,8 +3164,11 @@ DEBUG_ONLY_TEST_F(
   const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
   const int numPrevNonReclaimableAttempts =
       arbitrator->stats().numNonReclaimableAttempts;
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
+
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   std::atomic<bool> injectFakeAllocationOnce{true};
@@ -3240,8 +3250,10 @@ DEBUG_ONLY_TEST_F(
   const int numPrevNonReclaimableAttempts =
       arbitrator->stats().numNonReclaimableAttempts;
   const int numPrevReclaimedBytes = arbitrator->stats().reclaimedUsedBytes;
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   std::atomic<bool> writerNoMoreInput{false};
@@ -3340,8 +3352,10 @@ DEBUG_ONLY_TEST_F(
   const int numPrevArbitrationFailures = arbitrator->stats().numFailures;
   const int numPrevNonReclaimableAttempts =
       arbitrator->stats().numNonReclaimableAttempts;
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   std::atomic<bool> injectFakeAllocationOnce{true};
@@ -3432,8 +3446,11 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableFileWriteError) {
 
   auto queryPool = memory::memoryManager()->addRootPool(
       "tableFileWriteError", kQueryMemoryCapacity);
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
+
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   std::atomic_bool injectWriterErrorOnce{true};
@@ -3500,8 +3517,10 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteSpillUseMoreMemory) {
 
   auto queryPool = memory::memoryManager()->addRootPool(
       "tableWriteSpillUseMoreMemory", kQueryMemoryCapacity / 4);
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity / 4);
 
   auto fakeLeafPool = queryCtx->pool()->addLeafChild(
@@ -3587,14 +3606,18 @@ DEBUG_ONLY_TEST_F(TableWriterArbitrationTest, tableWriteReclaimOnClose) {
 
   auto queryPool = memory::memoryManager()->addRootPool(
       "tableWriteSpillUseMoreMemory", kQueryMemoryCapacity);
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   auto fakeQueryPool =
       memory::memoryManager()->addRootPool("fake", kQueryMemoryCapacity);
-  auto fakeQueryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(fakeQueryPool));
+  auto fakeQueryCtx = core::QueryCtx::Builder()
+                          .executor(executor_.get())
+                          .pool(std::move(fakeQueryPool))
+                          .build();
   ASSERT_EQ(fakeQueryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   auto fakeLeafPool = fakeQueryCtx->pool()->addLeafChild(
@@ -3680,8 +3703,10 @@ DEBUG_ONLY_TEST_F(
           .data;
   auto queryPool = memory::memoryManager()->addRootPool(
       "tableWriteSpillUseMoreMemory", kQueryMemoryCapacity);
-  auto queryCtx = core::QueryCtx::create(
-      executor_.get(), QueryConfig{{}}, {}, nullptr, std::move(queryPool));
+  auto queryCtx = core::QueryCtx::Builder()
+                      .executor(executor_.get())
+                      .pool(std::move(queryPool))
+                      .build();
   ASSERT_EQ(queryCtx->pool()->capacity(), kQueryMemoryCapacity);
 
   std::atomic_bool writerCloseWaitFlag{true};

--- a/velox/exec/tests/utils/ArbitratorTestUtil.cpp
+++ b/velox/exec/tests/utils/ArbitratorTestUtil.cpp
@@ -19,9 +19,6 @@
 #include "velox/dwio/dwrf/common/Config.h"
 #include "velox/exec/TableWriter.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::exec;
-using namespace facebook::velox::exec::test;
 using namespace facebook::velox::memory;
 
 namespace facebook::velox::exec::test {
@@ -31,18 +28,11 @@ std::shared_ptr<core::QueryCtx> newQueryCtx(
     folly::Executor* executor,
     int64_t memoryCapacity,
     const std::string& queryId) {
-  std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>> configs;
-  std::shared_ptr<MemoryPool> pool =
-      memoryManager->addRootPool("", memoryCapacity);
-  auto queryCtx = core::QueryCtx::create(
-      executor,
-      core::QueryConfig({}),
-      configs,
-      cache::AsyncDataCache::getInstance(),
-      std::move(pool),
-      nullptr,
-      queryId);
-  return queryCtx;
+  return core::QueryCtx::Builder()
+      .executor(executor)
+      .pool(memoryManager->addRootPool("", memoryCapacity))
+      .queryId(queryId)
+      .build();
 }
 
 std::unique_ptr<memory::MemoryManager> createMemoryManager(

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -311,17 +311,14 @@ AssertQueryBuilder::readCursor() {
       static std::atomic<uint64_t> cursorQueryId{0};
       const std::string queryId =
           fmt::format("TaskCursorQuery_{}", cursorQueryId++);
-      auto queryPool = memory::memoryManager()->addRootPool(
-          queryId, params_.maxQueryCapacity);
-      params_.queryCtx = core::QueryCtx::create(
-          executor_.get(),
-          core::QueryConfig({}),
-          std::
-              unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
-          cache::AsyncDataCache::getInstance(),
-          std::move(queryPool),
-          nullptr,
-          queryId);
+
+      params_.queryCtx = core::QueryCtx::Builder()
+                             .executor(executor_.get())
+                             .pool(
+                                 memory::memoryManager()->addRootPool(
+                                     queryId, params_.maxQueryCapacity))
+                             .queryId(queryId)
+                             .build();
     }
   }
   if (!configs_.empty()) {

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -616,15 +616,14 @@ class HashJoinBuilder {
         builder.splits(splitEntry.first, splitEntry.second);
       }
     }
-    auto queryCtx = core::QueryCtx::create(
-        executor_,
-        core::QueryConfig{{}},
-        std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
-        cache::AsyncDataCache::getInstance(),
-        memory::MemoryManager::getInstance()->addRootPool(
-            "query_pool",
-            memory::kMaxMemory,
-            memory::MemoryReclaimer::create()));
+    auto queryCtx = core::QueryCtx::Builder()
+                        .executor(executor_)
+                        .pool(
+                            memory::MemoryManager::getInstance()->addRootPool(
+                                "query_pool",
+                                memory::kMaxMemory,
+                                memory::MemoryReclaimer::create()))
+                        .build();
     std::shared_ptr<TempDirectoryPath> spillDirectory;
     int32_t spillPct{0};
     if (injectSpill) {


### PR DESCRIPTION
Summary:
Adding a builder pattern for constructing QueryCtx objects. QueryCtx
is part of the external API, and adding members to it over time has cluttered
the create() and constructor methods. It was pretty inconvenient to add and
pass new members to it.

Also adding more documentation and removing unnecessary includes and forward
declarations. No logic changes.

Differential Revision: D89744645


