### PR TITLE
fix: Disable SSD cache write when SSD is full

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -257,6 +257,10 @@ void registerVeloxMetrics() {
   // Total number of error while writing to SSD cache files.
   DEFINE_METRIC(kMetricSsdCacheWriteSsdErrors, facebook::velox::StatType::SUM);
 
+  // Total number of errors due to SSD no space for writes.
+  DEFINE_METRIC(
+      kMetricSsdCacheWriteNoSpaceErrors, facebook::velox::StatType::SUM);
+
   // Total number of errors while writing SSD checkpoint file.
   DEFINE_METRIC(
       kMetricSsdCacheWriteCheckpointErrors, facebook::velox::StatType::SUM);

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -295,6 +295,9 @@ constexpr std::string_view kMetricSsdCacheGrowFileErrors{
 constexpr std::string_view kMetricSsdCacheWriteSsdErrors{
     "velox.ssd_cache_write_ssd_errors"};
 
+constexpr std::string_view kMetricSsdCacheWriteNoSpaceErrors{
+    "velox.ssd_cache_write_no_space_errors"};
+
 constexpr std::string_view kMetricSsdCacheWriteSsdDropped{
     "velox.ssd_cache_write_ssd_dropped"};
 

--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -212,6 +212,8 @@ void PeriodicStatsReporter::reportCacheStats() {
     REPORT_IF_NOT_ZERO(
         kMetricSsdCacheWriteSsdErrors, deltaSsdStats.writeSsdErrors);
     REPORT_IF_NOT_ZERO(
+        kMetricSsdCacheWriteNoSpaceErrors, deltaSsdStats.writeSsdNoSpaceErrors);
+    REPORT_IF_NOT_ZERO(
         kMetricSsdCacheWriteSsdDropped, deltaSsdStats.writeSsdDropped);
     REPORT_IF_NOT_ZERO(
         kMetricSsdCacheWriteExceedEntryLimit,

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -490,6 +490,8 @@ TEST_F(PeriodicStatsReporterTest, basic) {
         counterMap.count(std::string(kMetricSsdCacheMetaFileDeleteErrors)), 0);
     ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheGrowFileErrors)), 0);
     ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdErrors)), 0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheWriteNoSpaceErrors)), 0);
     ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdDropped)), 0);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricSsdCacheWriteExceedEntryLimit)), 0);
@@ -530,6 +532,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
   newSsdStats->deleteMetaFileErrors = 10;
   newSsdStats->growFileErrors = 10;
   newSsdStats->writeSsdErrors = 10;
+  newSsdStats->writeSsdNoSpaceErrors = 1;
   newSsdStats->writeSsdDropped = 10;
   newSsdStats->writeSsdExceedEntryLimit = 10;
   newSsdStats->writeCheckpointErrors = 10;
@@ -590,6 +593,8 @@ TEST_F(PeriodicStatsReporterTest, basic) {
         counterMap.count(std::string(kMetricSsdCacheMetaFileDeleteErrors)), 1);
     ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheGrowFileErrors)), 1);
     ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdErrors)), 1);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricSsdCacheWriteNoSpaceErrors)), 1);
     ASSERT_EQ(counterMap.count(std::string(kMetricSsdCacheWriteSsdDropped)), 1);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricSsdCacheWriteExceedEntryLimit)), 1);
@@ -609,7 +614,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
         counterMap.count(std::string(kMetricSsdCacheRecoveredEntries)), 1);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricSsdCacheReadWithoutChecksum)), 1);
-    ASSERT_EQ(counterMap.size(), 57);
+    ASSERT_EQ(counterMap.size(), 58);
   }
 }
 

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -23,6 +23,8 @@ namespace facebook::velox::cache {
 #define VELOX_SSD_CACHE_LOG_PREFIX "[SSDCA] "
 #define VELOX_SSD_CACHE_LOG(severity) \
   LOG(severity) << VELOX_SSD_CACHE_LOG_PREFIX
+#define VELOX_SSD_CACHE_LOG_EVERY_MS(severity, ms) \
+  FB_LOG_EVERY_MS(severity, ms) << VELOX_SSD_CACHE_LOG_PREFIX
 
 namespace test {
 class SsdCacheTestHelper;

--- a/velox/common/caching/tests/CacheTestUtil.h
+++ b/velox/common/caching/tests/CacheTestUtil.h
@@ -59,6 +59,18 @@ class SsdFileTestHelper {
     return ssdFile_->checksumReadVerificationEnabled_;
   }
 
+  SsdFile::State state() const {
+    return ssdFile_->state_.load();
+  }
+
+  void setState(SsdFile::State state) {
+    ssdFile_->state_ = state;
+  }
+
+  int32_t maxRegions() const {
+    return ssdFile_->maxRegions_;
+  }
+
   /// Deletes the backing file.
   void deleteFile() {
     process::TraceContext trace("SsdFile::testingDeleteFile");

--- a/velox/docs/monitoring/metrics.rst
+++ b/velox/docs/monitoring/metrics.rst
@@ -419,6 +419,9 @@ Cache
    * - ssd_cache_write_ssd_errors
      - Sum
      - Total number of error while writing to SSD cache files.
+   * - ssd_cache_write_no_space_errors
+     - Sum
+     - Total number of errors due to SSD no space for writes.
    * - ssd_cache_write_ssd_dropped
      - Sum
      - Total number of writes dropped due to no cache space.


### PR DESCRIPTION
When SSD has no space, SSD file writes take longer time while finally fail or succeed.
This makes SsdCache holds writesInProgress_ positive for longer time and blocks other
tasks to proceed, ex., time-sensitive cache ttl task. SSD no space state is not
recoverable given the SSD cache write pattern today.

This change detects SSD no space error early, put the SsdFile into kNoSpace state
and stops SSD file writes. It also stops future checkpointing, eviction and eviction logging.