### PR TITLE
refactor: Make std::string conversions explicit

### DIFF
--- a/velox/core/TableWriteTraits.cpp
+++ b/velox/core/TableWriteTraits.cpp
@@ -111,7 +111,8 @@ folly::dynamic TableWriteTraits::getTableCommitContext(
   VELOX_CHECK_GT(input->size(), 0);
   auto* contextVector =
       input->childAt(kContextChannel)->as<SimpleVector<StringView>>();
-  return folly::parseJson(contextVector->valueAt(input->size() - 1));
+  return folly::parseJson(
+      std::string_view(contextVector->valueAt(input->size() - 1)));
 }
 
 int64_t TableWriteTraits::getRowCount(const RowVectorPtr& output) {

--- a/velox/dwio/common/tests/utils/DataSetBuilder.cpp
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.cpp
@@ -208,7 +208,7 @@ DataSetBuilder& DataSetBuilder::withUniqueStringsForField(
       if (strings->isNullAt(row)) {
         continue;
       }
-      std::string value = strings->valueAt(row);
+      auto value = std::string(strings->valueAt(row));
       value += fmt::format("{}", row);
       strings->set(row, StringView(value));
     }
@@ -283,7 +283,7 @@ DataSetBuilder& DataSetBuilder::makeMapStringValues(
             continue;
           }
           if (!keys->isNullAt(i) && i % 3 == 0) {
-            std::string str = keys->valueAt(i);
+            auto str = std::string(keys->valueAt(i));
             str += "----123456789";
             keys->set(i, StringView(str));
           }
@@ -305,7 +305,7 @@ DataSetBuilder& DataSetBuilder::makeMapStringValues(
             continue;
           }
           if (!values->isNullAt(i) && i % 3 == 0) {
-            std::string str = values->valueAt(i);
+            auto str = std::string(values->valueAt(i));
             str += "----123456789";
             values->set(i, StringView(str));
           }

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -663,7 +663,7 @@ void pruneRandomSubfield(
                 break;
               case TypeKind::VARCHAR:
               case TypeKind::VARBINARY:
-                stringKeys.push_back(
+                stringKeys.emplace_back(
                     keys->asUnchecked<SimpleVector<StringView>>()->valueAt(jj));
                 break;
               default:

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -23,7 +23,6 @@
 #include "velox/vector/FlatMapVector.h"
 
 namespace facebook::velox::dwrf {
-
 namespace {
 
 template <typename T>
@@ -41,7 +40,7 @@ inline dwio::common::flatmap::KeyValue<StringView> extractKey<StringView>(
 template <typename T>
 std::string toString(const T& x) {
   if constexpr (std::is_same_v<T, StringView>) {
-    return x;
+    return std::string(x);
   } else {
     return std::to_string(x);
   }

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -404,9 +404,10 @@ std::string PrestoQueryRunner::createTable(
 
   // Query Presto to find out table's location on disk.
   auto results = execute(fmt::format("SELECT \"$path\" FROM {}", name));
-
   auto filePath = extractSingleValue<StringView>(results);
-  auto tableDirectoryPath = fs::path(filePath).parent_path();
+
+  // TODO: Remove explicit std::string_view cast.
+  auto tableDirectoryPath = fs::path(std::string_view(filePath)).parent_path();
 
   // Delete the all-null row.
   execute(fmt::format("DELETE FROM {}", name));

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -707,8 +707,9 @@ RowVectorPtr WriterFuzzer::veloxToPrestoResult(const RowVectorPtr& result) {
 std::string WriterFuzzer::getReferenceOutputDirectoryPath(int32_t layers) {
   auto filePath =
       referenceQueryRunner_->execute("SELECT \"$path\" FROM tmp_write");
+  auto stringView = extractSingleValue<StringView>(filePath);
   auto tableDirectoryPath =
-      fs::path(extractSingleValue<StringView>(filePath)).parent_path();
+      fs::path(std::string_view(stringView)).parent_path();
   while (layers-- > 0) {
     tableDirectoryPath = tableDirectoryPath.parent_path();
   }

--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -296,7 +296,7 @@ void buildScanSplitFromTableWriteResult(
   auto* fragments =
       writeResult[0]->childAt(1)->asChecked<SimpleVector<StringView>>();
   for (int i = 1; i < writeResult[0]->size(); ++i) {
-    auto fragment = folly::parseJson(fragments->valueAt(i));
+    auto fragment = folly::parseJson(std::string_view(fragments->valueAt(i)));
     auto fileName = fragment["fileWriteInfos"][0]["writeFileName"].asString();
     auto hiveSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
         TableEvolutionFuzzer::connectorId(),

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -82,7 +82,7 @@ TEST_F(BasicTableWriterTestBase, roundTrip) {
                      ->as<FlatVector<StringView>>();
   ASSERT_TRUE(details->isNullAt(0));
   ASSERT_FALSE(details->isNullAt(1));
-  folly::dynamic obj = folly::parseJson(details->valueAt(1));
+  folly::dynamic obj = folly::parseJson(std::string_view(details->valueAt(1)));
 
   ASSERT_EQ(size, obj["rowCount"].asInt());
   auto fileWriteInfos = obj["fileWriteInfos"];
@@ -180,7 +180,7 @@ TEST_F(BasicTableWriterTestBase, targetFileName) {
   auto results = AssertQueryBuilder(plan).copyResults(pool());
   auto* details = results->childAt(TableWriteTraits::kFragmentChannel)
                       ->asUnchecked<SimpleVector<StringView>>();
-  auto detail = folly::parseJson(details->valueAt(1));
+  auto detail = folly::parseJson(std::string_view(details->valueAt(1)));
   auto fileWriteInfos = detail["fileWriteInfos"];
   ASSERT_EQ(1, fileWriteInfos.size());
   ASSERT_EQ(fileWriteInfos[0]["writeFileName"].asString(), kFileName);
@@ -1817,7 +1817,8 @@ TEST_P(AllTableWriterTest, tableWriteOutputCheck) {
     }
     if (!fragmentVector->isNullAt(i)) {
       ASSERT_FALSE(fragmentVector->isNullAt(i));
-      folly::dynamic obj = folly::parseJson(fragmentVector->valueAt(i));
+      folly::dynamic obj =
+          folly::parseJson(std::string_view(fragmentVector->valueAt(i)));
       if (testMode_ == TestMode::kUnpartitioned) {
         ASSERT_EQ(obj["targetPath"], outputDirectory->getPath());
         ASSERT_EQ(obj["writePath"], outputDirectory->getPath());

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -278,7 +278,8 @@ variant variantAt<TypeKind::VARBINARY>(
     int32_t row,
     int32_t column) {
   return variant::binary(
-      StringView(::duckdb::StringValue::Get(dataChunk->GetValue(column, row))));
+      std::string(
+          ::duckdb::StringValue::Get(dataChunk->GetValue(column, row))));
 }
 
 template <>
@@ -323,7 +324,7 @@ variant variantAt<TypeKind::VARCHAR>(const ::duckdb::Value& value) {
 
 template <>
 variant variantAt<TypeKind::VARBINARY>(const ::duckdb::Value& value) {
-  return variant::binary(StringView(::duckdb::StringValue::Get(value)));
+  return variant::binary(std::string(::duckdb::StringValue::Get(value)));
 }
 
 variant nullVariant(const TypePtr& type) {

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1770,8 +1770,8 @@ common::Subfield extractSubfield(
         break;
       case TypeKind::VARCHAR:
         path.push_back(
-            std::make_unique<common::Subfield::StringSubscript>(
-                index->value()->as<ConstantVector<StringView>>()->value()));
+            std::make_unique<common::Subfield::StringSubscript>(std::string(
+                index->value()->as<ConstantVector<StringView>>()->value())));
         break;
       default:
         return {};

--- a/velox/expression/tests/RowViewTest.cpp
+++ b/velox/expression/tests/RowViewTest.cpp
@@ -406,7 +406,7 @@ TEST_F(NullableRowViewTest, materialize) {
 
   std::tuple<
       std::optional<int64_t>,
-      std::optional<std::string>,
+      std::optional<StringView>,
       std::optional<std::vector<std::optional<int64_t>>>>
       expected{1, "hi", {{1, 2, std::nullopt}}};
   ASSERT_EQ(reader[0].materialize(), expected);

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -866,7 +866,7 @@ void read<OpaqueType>(
   for (int32_t i = 0; i < numNewValues; ++i) {
     int32_t offset = offsets[i];
     auto sv = StringView(rawString + previousOffset, offset - previousOffset);
-    auto opaqueValue = deserialization(sv);
+    auto opaqueValue = deserialization(std::string(sv));
     rawValues[resultOffset + i] = opaqueValue;
     previousOffset = offset;
   }

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -25,6 +25,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Status.h"
 #include "velox/type/CppToType.h"
+#include "velox/type/StringView.h"
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2234,6 +2234,11 @@ inline std::string to(const int128_t& value) {
   return std::to_string(value);
 }
 
+template <typename T>
+inline T to(const velox::StringView& value) {
+  return to<T>(std::string_view(value.data(), value.size()));
+}
+
 template <>
 inline std::string to(const velox::StringView& value) {
   return std::string(value.data(), value.size());

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -32,7 +32,6 @@
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox {
-
 namespace {
 
 Variant nullVariant(const TypePtr& type) {
@@ -56,7 +55,8 @@ template <>
 Variant variantAtTyped<TypeKind::VARBINARY>(
     const BaseVector* vector,
     vector_size_t row) {
-  return Variant::binary(vector->as<SimpleVector<StringView>>()->valueAt(row));
+  return Variant::binary(
+      std::string(vector->as<SimpleVector<StringView>>()->valueAt(row)));
 }
 
 Variant variantAtImpl(const BaseVector* vector, vector_size_t row);

--- a/velox/vector/VariantToVector.cpp
+++ b/velox/vector/VariantToVector.cpp
@@ -50,7 +50,8 @@ Variant variantAt(const VectorPtr& vector, int32_t row) {
 
 template <>
 Variant variantAt<TypeKind::VARBINARY>(const VectorPtr& vector, int32_t row) {
-  return Variant::binary(vector->as<SimpleVector<StringView>>()->valueAt(row));
+  return Variant::binary(
+      std::string(vector->as<SimpleVector<StringView>>()->valueAt(row)));
 }
 
 Variant variantAt(const VectorPtr& vector, vector_size_t row);

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -1036,9 +1036,9 @@ TEST_F(VectorFuzzerTest, customTypeGenerator) {
       if (decoded.isNullAt(j)) {
         continue;
       }
-      std::string value = decoded.valueAt<StringView>(j);
       try {
-        json = folly::parseJson(value, opts);
+        auto stringView = decoded.valueAt<StringView>(j);
+        json = folly::parseJson(std::string_view(stringView), opts);
       } catch (...) {
         EXPECT_TRUE(false);
       }
@@ -1078,9 +1078,10 @@ TEST_F(VectorFuzzerTest, jsonConstrained) {
       if (decoded.isNullAt(j)) {
         continue;
       }
-      std::string value = decoded.valueAt<StringView>(j);
       folly::dynamic json;
-      EXPECT_NO_THROW(json = folly::parseJson(value, jsonOpts));
+      auto stringView = decoded.valueAt<StringView>(j);
+      EXPECT_NO_THROW(
+          json = folly::parseJson(std::string_view(stringView), jsonOpts));
       EXPECT_TRUE(json.isNull() || json.isArray());
     }
   }
@@ -1098,7 +1099,7 @@ TEST_F(VectorFuzzerTest, setConstrained) {
 
   DecodedVector decoded(*vector, SelectivityVector(kSize));
   for (auto i = 0; i < kSize; ++i) {
-    std::string value = decoded.valueAt<StringView>(i);
+    auto value = decoded.valueAt<StringView>(i);
     EXPECT_TRUE(value == "a" || value == "b");
   }
 }


### PR DESCRIPTION
Summary:
To be able to remove unsafe implicit conversions from StringView into
std::string, we first need to ensure all conversion being done implicitly are
not either avoided, or made explicit. Fixing a bunch of place throughout the
codebase.

Since we will also remove implicit conversion from StringView into
folly::StringPiece, making explicit conversion to std::string_view into
libraries that expect folly::StringPiece, since the former can be implicitly
converted to the latter.

Differential Revision: D89818861


