### PR TITLE
perf(function): Avoid unnecessary string copies

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -36,7 +36,7 @@ re2::StringPiece toStringPiece(const T& s) {
 namespace detail {
 
 Expected<RE2*> ReCache::tryFindOrCompile(const StringView& pattern) {
-  const std::string key = pattern;
+  const auto key = std::string(pattern);
 
   auto reIt = cache_.find(key);
   if (reIt != cache_.end()) {

--- a/velox/functions/prestosql/EnumFunctions.h
+++ b/velox/functions/prestosql/EnumFunctions.h
@@ -61,8 +61,8 @@ struct EnumKeyFunction {
     return Status::OK();
   }
 
-  Status call(out_type<Varchar>& result, const std::string& input) {
-    auto keyAt = enumPtr_->keyAt(input);
+  Status call(out_type<Varchar>& result, const arg_type<Varchar>& input) {
+    auto keyAt = enumPtr_->keyAt(std::string(input));
     if (!keyAt.has_value()) {
       return Status::UserError(
           "Value '{}' not in VarcharEnum: {}", input, enumPtr_->toString());

--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -54,7 +54,7 @@ struct StGeometryFromTextFunction {
     GEOS_TRY(
         {
           geos::io::WKTReader reader;
-          geosGeometry = reader.read(wkt);
+          geosGeometry = reader.read(std::string(wkt));
         },
         "Failed to parse WKT");
     common::geospatial::GeometrySerializer::serialize(*geosGeometry, result);
@@ -184,7 +184,7 @@ struct StPolygonFunction {
     GEOS_TRY(
         {
           geos::io::WKTReader reader;
-          geosGeometry = reader.read(wkt);
+          geosGeometry = reader.read(std::string(wkt));
         },
         "Failed to parse WKT");
     auto validate = geospatial::validateType(
@@ -214,7 +214,8 @@ struct StRelateFunction {
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
     GEOS_TRY(
-        result = leftGeosGeometry->relate(*rightGeosGeometry, relation);
+        result =
+            leftGeosGeometry->relate(*rightGeosGeometry, std::string(relation));
         , "Failed to check geometry relation");
 
     return Status::OK();
@@ -1788,7 +1789,7 @@ struct GeometryFromGeoJsonFunction {
       out_type<Geometry>& result,
       const arg_type<Varchar>& geometry) {
     auto reader = geos::io::GeoJSONReader();
-    auto geosGeometry = reader.read(geometry);
+    auto geosGeometry = reader.read(std::string(geometry));
     common::geospatial::GeometrySerializer::serialize(*geosGeometry, result);
   }
 };
@@ -1951,7 +1952,7 @@ struct StLineFromTextFunction {
     GEOS_TRY(
         {
           geos::io::WKTReader reader;
-          geosGeometry = reader.read(wkt);
+          geosGeometry = reader.read(std::string(wkt));
         },
         "Failed to parse WKT");
     auto validate = geospatial::validateType(

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -69,7 +69,8 @@ struct IPPrefixFunction {
       out_type<IPPrefix>& result,
       const arg_type<Varchar>& ipString,
       const arg_type<int64_t>& prefixBits) {
-    auto tryIp = folly::IPAddress::tryFromString(ipString);
+    // TODO: Remove explicit std::string_view cast.
+    auto tryIp = folly::IPAddress::tryFromString(std::string_view(ipString));
     if (tryIp.hasError()) {
       VELOX_USER_FAIL("Cannot cast value to IPADDRESS: {}", ipString);
     }

--- a/velox/functions/prestosql/JsonFunctions.cpp
+++ b/velox/functions/prestosql/JsonFunctions.cpp
@@ -805,7 +805,9 @@ struct JsonExtractImpl {
       return simdjson::SUCCESS;
     };
 
-    auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
+    // TODO: Remove explicit std::string_view cast.
+    auto& extractor =
+        SIMDJsonExtractor::getInstance(std::string_view(jsonPath));
     bool isDefinitePath = true;
     simdjson::padded_string paddedJson(json.data(), json.size());
 

--- a/velox/functions/prestosql/JsonFunctions.h
+++ b/velox/functions/prestosql/JsonFunctions.h
@@ -241,7 +241,9 @@ struct JsonExtractScalarFunction {
       return simdjson::SUCCESS;
     };
 
-    auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
+    // TODO: Remove explicit std::string_view cast.
+    auto& extractor =
+        SIMDJsonExtractor::getInstance(std::string_view(jsonPath));
 
     // Check for valid json
     simdjson::padded_string paddedJson(json.data(), json.size());
@@ -311,7 +313,9 @@ struct JsonSizeFunction {
       return simdjson::SUCCESS;
     };
 
-    auto& extractor = SIMDJsonExtractor::getInstance(jsonPath);
+    // TODO: Remove explicit std::string_view cast.
+    auto& extractor =
+        SIMDJsonExtractor::getInstance(std::string_view(jsonPath));
     bool isDefinitePath = true;
     simdjson::padded_string paddedJson(json.data(), json.size());
     SIMDJSON_TRY(extractor.extract(paddedJson, consumer, isDefinitePath));

--- a/velox/functions/prestosql/WordStem.h
+++ b/velox/functions/prestosql/WordStem.h
@@ -97,8 +97,8 @@ struct WordStemFunction {
   FOLLY_ALWAYS_INLINE void doCall(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
-      const std::string& lang = "en") {
-    auto* stemmer = getStemmer(lang);
+      const arg_type<Varchar>& lang = "en") {
+    auto* stemmer = getStemmer(std::string(lang));
     VELOX_USER_CHECK_NOT_NULL(
         stemmer, "Unsupported stemmer language: {}", lang);
 

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -42,7 +42,7 @@ struct FollyIsJsonScalarFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE void call(bool& result, const arg_type<Json>& json) {
-    auto parsedJson = folly::parseJson(json);
+    auto parsedJson = folly::parseJson(std::string_view(json));
     result = parsedJson.isNumber() || parsedJson.isString() ||
         parsedJson.isBool() || parsedJson.isNull();
   }
@@ -103,7 +103,7 @@ struct FollyJsonArrayLengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Json>& json) {
-    auto parsedJson = folly::parseJson(json);
+    auto parsedJson = folly::parseJson(std::string_view(json));
     if (!parsedJson.isArray()) {
       return false;
     }
@@ -120,7 +120,7 @@ struct FollyJsonArrayContainsFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool
   call(bool& result, const arg_type<Json>& json, const TInput& value) {
-    auto parsedJson = folly::parseJson(json);
+    auto parsedJson = folly::parseJson(std::string_view(json));
     if (!parsedJson.isArray()) {
       return false;
     }

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -32,7 +32,7 @@ template <typename Fn, typename TOutString, typename TInputString>
 FOLLY_ALWAYS_INLINE bool
 runURIFn(Fn func, TOutString& result, TInputString& url) {
   try {
-    auto parsedUrl = folly::Uri(url);
+    auto parsedUrl = folly::Uri(std::string_view(url));
     auto datum = (parsedUrl.*func)();
     result.resize(datum.size());
     if (datum.size() != 0) {
@@ -123,7 +123,7 @@ struct FollyUrlExtractPortFunction {
 
   FOLLY_ALWAYS_INLINE bool call(int64_t& result, const arg_type<Varchar>& url) {
     try {
-      auto parsedUrl = folly::Uri(url);
+      auto parsedUrl = folly::Uri(std::string_view(url));
       result = parsedUrl.port();
     } catch (const folly::ConversionError&) {
       return false;
@@ -145,7 +145,7 @@ struct FollyUrlExtractParameterFunction {
       const arg_type<Varchar>& url,
       const arg_type<Varchar>& param) {
     try {
-      auto parsedUrl = folly::Uri(url);
+      auto parsedUrl = folly::Uri(std::string_view(url));
       auto params = parsedUrl.getQueryParams();
 
       for (const auto& pair : params) {

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox::functions {
 
 /* static */ SIMDJsonExtractor& SIMDJsonExtractor::getInstance(
-    folly::StringPiece path) {
+    std::string_view path) {
   // Cache tokenize operations in JsonExtractor across invocations in the same
   // thread for the same JsonPath.
   thread_local static std::

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -82,7 +82,7 @@ class SIMDJsonExtractor {
   /// Use this method to get an instance of SIMDJsonExtractor given a JSON path.
   /// Uses a thread local cache, therefore the caller must ensure the returned
   /// instance is not passed between threads.
-  static SIMDJsonExtractor& getInstance(folly::StringPiece path);
+  static SIMDJsonExtractor& getInstance(std::string_view path);
 
  private:
   // Shouldn't instantiate directly - use getInstance().

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -612,7 +612,7 @@ TEST_F(ArraySortTest, unsupporteLambda) {
 
 TEST_F(ArraySortTest, failOnMapTypeSort) {
   static const std::string kErrorMessage =
-      "Scalar function signature is not supported"_sv;
+      "Scalar function signature is not supported";
   auto data = makeRowVector({BaseVector::createNullConstant(
       ARRAY(MAP(BIGINT(), VARCHAR())), 8, pool())});
   auto testFail = [&](const std::string& name) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4249,29 +4249,19 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   for (int i = 0; i < 31; i++) {
     std::string date("2022-08-" + std::to_string(i + 1));
     EXPECT_EQ(
-        std::to_string(i % 7 + 1),
-        formatDatetime(parseTimestamp(StringView{date}), "e"));
+        std::to_string(i % 7 + 1), formatDatetime(parseTimestamp(date), "e"));
   }
   EXPECT_EQ("000001", formatDatetime(parseTimestamp("2022-08-01"), "eeeeee"));
 
   // Day of week text - 'E'
   for (int i = 0; i < 31; i++) {
     std::string date("2022-08-" + std::to_string(i + 1));
+    EXPECT_EQ(daysShort[i % 7], formatDatetime(parseTimestamp(date), "E"));
+    EXPECT_EQ(daysShort[i % 7], formatDatetime(parseTimestamp(date), "EE"));
+    EXPECT_EQ(daysShort[i % 7], formatDatetime(parseTimestamp(date), "EEE"));
+    EXPECT_EQ(daysLong[i % 7], formatDatetime(parseTimestamp(date), "EEEE"));
     EXPECT_EQ(
-        daysShort[i % 7],
-        formatDatetime(parseTimestamp(StringView{date}), "E"));
-    EXPECT_EQ(
-        daysShort[i % 7],
-        formatDatetime(parseTimestamp(StringView{date}), "EE"));
-    EXPECT_EQ(
-        daysShort[i % 7],
-        formatDatetime(parseTimestamp(StringView{date}), "EEE"));
-    EXPECT_EQ(
-        daysLong[i % 7],
-        formatDatetime(parseTimestamp(StringView{date}), "EEEE"));
-    EXPECT_EQ(
-        daysLong[i % 7],
-        formatDatetime(parseTimestamp(StringView{date}), "EEEEEEEE"));
+        daysLong[i % 7], formatDatetime(parseTimestamp(date), "EEEEEEEE"));
   }
 
   // Year test cases - 'y'
@@ -4309,21 +4299,11 @@ TEST_F(DateTimeFunctionsTest, formatDateTime) {
   for (int i = 0; i < 12; i++) {
     auto month = i + 1;
     std::string date("2022-" + std::to_string(month) + "-01");
-    EXPECT_EQ(
-        std::to_string(month),
-        formatDatetime(parseTimestamp(StringView{date}), "M"));
-    EXPECT_EQ(
-        padNumber(month),
-        formatDatetime(parseTimestamp(StringView{date}), "MM"));
-    EXPECT_EQ(
-        monthsShort[i],
-        formatDatetime(parseTimestamp(StringView{date}), "MMM"));
-    EXPECT_EQ(
-        monthsLong[i],
-        formatDatetime(parseTimestamp(StringView{date}), "MMMM"));
-    EXPECT_EQ(
-        monthsLong[i],
-        formatDatetime(parseTimestamp(StringView{date}), "MMMMMMMM"));
+    EXPECT_EQ(std::to_string(month), formatDatetime(parseTimestamp(date), "M"));
+    EXPECT_EQ(padNumber(month), formatDatetime(parseTimestamp(date), "MM"));
+    EXPECT_EQ(monthsShort[i], formatDatetime(parseTimestamp(date), "MMM"));
+    EXPECT_EQ(monthsLong[i], formatDatetime(parseTimestamp(date), "MMMM"));
+    EXPECT_EQ(monthsLong[i], formatDatetime(parseTimestamp(date), "MMMMMMMM"));
   }
 
   // Day of month test cases - 'd'
@@ -4756,11 +4736,9 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   for (int i = 0; i < 8; i++) {
     std::string date("1996-01-0" + std::to_string(i + 1));
     // Full length name.
-    EXPECT_EQ(
-        daysLong[i % 7], dateFormat(parseTimestamp(StringView{date}), "%W"));
+    EXPECT_EQ(daysLong[i % 7], dateFormat(parseTimestamp(date), "%W"));
     // Abbreviated name.
-    EXPECT_EQ(
-        daysShort[i % 7], dateFormat(parseTimestamp(StringView{date}), "%a"));
+    EXPECT_EQ(daysShort[i % 7], dateFormat(parseTimestamp(date), "%a"));
   }
 
   // Month cases.
@@ -4769,23 +4747,19 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
     std::string monthNum = std::to_string(i + 1);
 
     // Full length name.
-    EXPECT_EQ(
-        monthsLong[i % 12], dateFormat(parseTimestamp(StringView{date}), "%M"));
+    EXPECT_EQ(monthsLong[i % 12], dateFormat(parseTimestamp(date), "%M"));
 
     // Abbreviated name.
-    EXPECT_EQ(
-        monthsShort[i % 12],
-        dateFormat(parseTimestamp(StringView{date}), "%b"));
+    EXPECT_EQ(monthsShort[i % 12], dateFormat(parseTimestamp(date), "%b"));
 
     // Numeric.
-    EXPECT_EQ(monthNum, dateFormat(parseTimestamp(StringView{date}), "%c"));
+    EXPECT_EQ(monthNum, dateFormat(parseTimestamp(date), "%c"));
 
     // Numeric 0-padded.
     if (i + 1 < 10) {
-      EXPECT_EQ(
-          "0" + monthNum, dateFormat(parseTimestamp(StringView{date}), "%m"));
+      EXPECT_EQ("0" + monthNum, dateFormat(parseTimestamp(date), "%m"));
     } else {
-      EXPECT_EQ(monthNum, dateFormat(parseTimestamp(StringView{date}), "%m"));
+      EXPECT_EQ(monthNum, dateFormat(parseTimestamp(date), "%m"));
     }
   }
 
@@ -4793,12 +4767,11 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
   for (int i = 1; i <= 31; i++) {
     std::string dayOfMonth = std::to_string(i);
     std::string date("1970-01-" + dayOfMonth);
-    EXPECT_EQ(dayOfMonth, dateFormat(parseTimestamp(StringView{date}), "%e"));
+    EXPECT_EQ(dayOfMonth, dateFormat(parseTimestamp(date), "%e"));
     if (i < 10) {
-      EXPECT_EQ(
-          "0" + dayOfMonth, dateFormat(parseTimestamp(StringView{date}), "%d"));
+      EXPECT_EQ("0" + dayOfMonth, dateFormat(parseTimestamp(date), "%d"));
     } else {
-      EXPECT_EQ(dayOfMonth, dateFormat(parseTimestamp(StringView{date}), "%d"));
+      EXPECT_EQ(dayOfMonth, dateFormat(parseTimestamp(date), "%d"));
     }
   }
 

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -751,7 +751,7 @@ TEST_F(JsonFunctionsTest, jsonArrayGet) {
     std::optional<StringView> s = json.has_value()
         ? std::make_optional(StringView(json.value()))
         : std::nullopt;
-    auto jsonInput = makeNullableFlatVector<std::string>({s}, jsontype);
+    auto jsonInput = makeNullableFlatVector<StringView>({s}, jsontype);
     auto indexInput = makeFlatVector<int64_t>(std::vector<int64_t>{index});
     return JsonFunctionsTest::jsonArrayGet(jsonInput, indexInput);
   };
@@ -1207,7 +1207,7 @@ TEST_F(JsonFunctionsTest, jsonExtractVarcharInput) {
     std::optional<StringView> s = json.has_value()
         ? std::make_optional(StringView(json.value()))
         : std::nullopt;
-    auto varcharInput = makeNullableFlatVector<std::string>({s}, VARCHAR());
+    auto varcharInput = makeNullableFlatVector<StringView>({s}, VARCHAR());
     auto pathInput = makeFlatVector<std::string>({path});
     return JsonFunctionsTest::jsonExtract(varcharInput, pathInput, wrapInTry);
   };
@@ -1241,11 +1241,12 @@ TEST_F(JsonFunctionsTest, jsonExtractVarcharInput) {
 
 TEST_F(JsonFunctionsTest, jsonStringToArrayCast) {
   // Array of strings.
-  auto data = makeRowVector({makeNullableFlatVector<std::string>(
-      {R"(["red","blue"])"_sv,
-       R"([null,null,"purple"])"_sv,
-       "[]"_sv,
-       "null"_sv})});
+  auto data = makeRowVector({makeNullableFlatVector<StringView>({
+      R"(["red","blue"])"_sv,
+      R"([null,null,"purple"])"_sv,
+      "[]"_sv,
+      "null"_sv,
+  })});
   auto expected = makeNullableArrayVector<StringView>(
       {{{"red"_sv, "blue"_sv}},
        {{std::nullopt, std::nullopt, "purple"_sv}},
@@ -1256,8 +1257,10 @@ TEST_F(JsonFunctionsTest, jsonStringToArrayCast) {
       "$internal$json_string_to_array_cast", ARRAY(VARCHAR()), data, expected);
 
   // Array of integers.
-  data = makeRowVector({makeNullableFlatVector<std::string>(
-      {R"(["10212","1015353"])"_sv, R"(["10322","285000"])"})});
+  data = makeRowVector({makeNullableFlatVector<StringView>({
+      R"(["10212","1015353"])"_sv,
+      R"(["10322","285000"])",
+  })});
   expected =
       makeNullableArrayVector<int64_t>({{10212, 1015353}, {10322, 285000}});
 
@@ -1267,19 +1270,21 @@ TEST_F(JsonFunctionsTest, jsonStringToArrayCast) {
 
 TEST_F(JsonFunctionsTest, jsonStringToMapCast) {
   // Map of strings.
-  auto data = makeRowVector({makeFlatVector<std::string>(
-      {R"({"red":1,"blue":2})"_sv,
-       R"({"green":3,"magenta":4})"_sv,
-       R"({"violet":1,"blue":2})"_sv,
-       R"({"yellow":1,"blue":2})"_sv,
-       R"({"purple":10,"cyan":5})"_sv})});
+  auto data = makeRowVector({makeFlatVector<StringView>({
+      R"({"red":1,"blue":2})"_sv,
+      R"({"green":3,"magenta":4})"_sv,
+      R"({"violet":1,"blue":2})"_sv,
+      R"({"yellow":1,"blue":2})"_sv,
+      R"({"purple":10,"cyan":5})"_sv,
+  })});
 
-  auto expected = makeMapVector<StringView, int64_t>(
-      {{{"red"_sv, 1}, {"blue"_sv, 2}},
-       {{"green"_sv, 3}, {"magenta"_sv, 4}},
-       {{"violet"_sv, 1}, {"blue"_sv, 2}},
-       {{"yellow"_sv, 1}, {"blue"_sv, 2}},
-       {{"purple"_sv, 10}, {"cyan"_sv, 5}}});
+  auto expected = makeMapVector<StringView, int64_t>({
+      {{"red"_sv, 1}, {"blue"_sv, 2}},
+      {{"green"_sv, 3}, {"magenta"_sv, 4}},
+      {{"violet"_sv, 1}, {"blue"_sv, 2}},
+      {{"yellow"_sv, 1}, {"blue"_sv, 2}},
+      {{"purple"_sv, 10}, {"cyan"_sv, 5}},
+  });
 
   checkInternalFn(
       "$internal$json_string_to_map_cast",
@@ -1290,12 +1295,13 @@ TEST_F(JsonFunctionsTest, jsonStringToMapCast) {
 
 TEST_F(JsonFunctionsTest, jsonStringToRowCast) {
   // Row of strings.
-  auto data = makeRowVector({makeFlatVector<std::string>(
-      {R"({"red":1,"blue":2})"_sv,
-       R"({"red":3,"blue":4})"_sv,
-       R"({"red":1,"blue":2})"_sv,
-       R"({"red":1,"blue":2})"_sv,
-       R"({"red":10,"blue":5})"_sv})});
+  auto data = makeRowVector({makeFlatVector<StringView>({
+      R"({"red":1,"blue":2})"_sv,
+      R"({"red":3,"blue":4})"_sv,
+      R"({"red":1,"blue":2})"_sv,
+      R"({"red":1,"blue":2})"_sv,
+      R"({"red":10,"blue":5})"_sv,
+  })});
 
   auto expected = makeRowVector(
       {makeFlatVector<int64_t>({1, 3, 1, 1, 10}),

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -69,7 +69,7 @@ TEST_F(ZipTest, combineInt) {
 
   auto firstResult = makeNullableFlatVector<int64_t>(
       {1, 1, 1, 1, 2, 2, 2, std::nullopt, std::nullopt});
-  auto secondResult = makeNullableFlatVector<std::string>(
+  auto secondResult = makeNullableFlatVector<StringView>(
       {S("a"),
        S("a"),
        S("a"),

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -354,7 +354,7 @@ class FunctionBaseTest : public testing::Test,
 
   /// Parses a timestamp string into Timestamp.
   /// Accepts strings formatted as 'YYYY-MM-DD HH:mm:ss[.nnn]'.
-  static Timestamp parseTimestamp(const std::string& text) {
+  static Timestamp parseTimestamp(std::string_view text) {
     return util::fromTimestampString(
                text.data(), text.size(), util::TimestampParseMode::kPrestoCast)
         .thenOrThrow(folly::identity, [&](const Status& status) {
@@ -362,10 +362,26 @@ class FunctionBaseTest : public testing::Test,
         });
   }
 
+  // TODO: Remove explicit std::string_view cast.
+  static Timestamp parseTimestamp(StringView text) {
+    return parseTimestamp(std::string_view(text));
+  }
+  static Timestamp parseTimestamp(const char* text) {
+    return parseTimestamp(std::string_view(text));
+  }
+
   /// Parses a date string into days since epoch.
   /// Accepts strings formatted as 'YYYY-MM-DD'.
-  static int32_t parseDate(const std::string& text) {
+  static int32_t parseDate(std::string_view text) {
     return DATE()->toDays(text);
+  }
+
+  // TODO: Remove explicit std::string_view cast.
+  static int32_t parseDate(StringView text) {
+    return parseDate(std::string_view(text));
+  }
+  static int32_t parseDate(const char* text) {
+    return parseDate(std::string_view(text));
   }
 
   /// Returns a vector of signatures for the given function name and return

--- a/velox/functions/sparksql/ToJson.h
+++ b/velox/functions/sparksql/ToJson.h
@@ -192,13 +192,13 @@ inline void toJson<TypeKind::VARCHAR>(
     bool isMapKey) {
   auto value = input.castTo<Varchar>();
   if (!isMapKey) {
-    folly::json::escapeString(value, result, {});
+    folly::json::escapeString(std::string_view(value), result, {});
   } else {
     // toJson<TypeKind::MAP> wraps the key with double quotes.
     // To avoid duplicate quotes, we strip the surrounding quotes after
     // escaping.
     std::string quotedString;
-    folly::json::escapeString(value, quotedString, {});
+    folly::json::escapeString(std::string_view(value), quotedString, {});
     result.append(quotedString.substr(1, quotedString.size() - 2));
   }
 }

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -127,7 +127,7 @@ TEST_F(ArraySortTest, array) {
 TEST_F(ArraySortTest, failOnMapTypeSort) {
   auto input = makeArrayOfMapVector(mapInput());
   const std::string kErrorMessage =
-      "Scalar function signature is not supported"_sv;
+      "Scalar function signature is not supported";
 
   VELOX_ASSERT_THROW(
       evaluate("array_sort(c0)", makeRowVector({input})), kErrorMessage);

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -158,7 +158,7 @@ TEST_F(SortArrayTest, array) {
 TEST_F(SortArrayTest, failOnMapTypeSort) {
   auto input = makeArrayOfMapVector(mapInput());
   const std::string kErrorMessage =
-      "Scalar function signature is not supported"_sv;
+      "Scalar function signature is not supported";
 
   VELOX_ASSERT_THROW(
       evaluate("sort_array(c0)", makeRowVector({input})), kErrorMessage);


### PR DESCRIPTION
Summary:
Two items:
* Removing unnecessary copied from StringView into std::string in many places
  across Presto function implementations.
* In places where copies are needed, making them explicit since we will soon
  remove the unwanted implicit conversion.

Differential Revision: D89820646


