### PR TITLE
refactor(simple-function): Make materialization of string-types explicit

### DIFF
--- a/velox/examples/SimpleFunctions.cpp
+++ b/velox/examples/SimpleFunctions.cpp
@@ -341,7 +341,7 @@ struct MyRegexpMatchFunction {
     // quite expensive to compile it on a per-row basis. In this example we
     // support both modes (const and non-const).
     if (pattern != nullptr) {
-      re_.emplace(*pattern);
+      re_.emplace(std::string_view(*pattern));
     }
 
     // Optionally, one could also inspect the session configs in `QueryConfig`.
@@ -359,7 +359,8 @@ struct MyRegexpMatchFunction {
     // > `my_regexp_match(col1, col2)`
     result = re_.has_value()
         ? RE2::PartialMatch(toStringPiece(input), *re_)
-        : RE2::PartialMatch(toStringPiece(input), ::re2::RE2(pattern));
+        : RE2::PartialMatch(
+              toStringPiece(input), ::re2::RE2(std::string_view(pattern)));
     return true;
   }
 

--- a/velox/expression/tests/RowViewTest.cpp
+++ b/velox/expression/tests/RowViewTest.cpp
@@ -23,11 +23,10 @@
 #include "velox/functions/prestosql/Comparisons.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
+namespace facebook::velox::functions::test {
 namespace {
 
-using namespace facebook::velox;
-using namespace facebook::velox::functions;
-using namespace facebook::velox::test;
+using velox::test::assertEqualVectors;
 
 DecodedVector* decode(DecodedVector& decoder, const BaseVector& vector) {
   SelectivityVector rows(vector.size());
@@ -517,4 +516,6 @@ TEST_F(DynamicRowViewTest, castToDynamicRowInFunction) {
     assertEqualVectors(makeFlatVector<int64_t>({2, 2}), result);
   }
 }
+
 } // namespace
+} // namespace facebook::velox::functions::test

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -373,7 +373,8 @@ TEST_F(TableWriterReplayerTest, basic) {
   // Second column contains details about written files.
   const auto details = results->childAt(TableWriteTraits::kFragmentChannel)
                            ->as<FlatVector<StringView>>();
-  const folly::dynamic obj = folly::parseJson(details->valueAt(1));
+  const folly::dynamic obj =
+      folly::parseJson(std::string_view(details->valueAt(1)));
   const auto fileWriteInfos = obj["fileWriteInfos"];
   ASSERT_EQ(1, fileWriteInfos.size());
 

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -468,14 +468,14 @@ template <>
 struct MaterializeType<Varchar> {
   using nullable_t = std::string;
   using null_free_t = std::string;
-  static constexpr bool requiresMaterialization = false;
+  static constexpr bool requiresMaterialization = true;
 };
 
 template <>
 struct MaterializeType<Varbinary> {
   using nullable_t = std::string;
   using null_free_t = std::string;
-  static constexpr bool requiresMaterialization = false;
+  static constexpr bool requiresMaterialization = true;
 };
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Changing the internal trait API used for View wrappers in simple
functions. The API contains an internal `requiresMaterialization` flag for
types like Row, Maps, and Array, which need to be materialized (copied) into a
container. Strings were silently copied into std::string, which also naturally
qualifies as a materialization.

Changing the flag for string types to make it explicit that the StringView gets
materialized into a std::string. The code will now explicitly call
StringView::materialize() which will do the exact same an the implicit std::string
conversion.

Differential Revision: D89897907


