### PR TITLE
fix(parquet): Crash when writing all-null batches

### DIFF
--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -2206,8 +2206,10 @@ Status WriteArrowSerialize(
       ctx->GetScratchData<ParquetCType>(array.length(), &buffer));
 
   SerializeFunctor<ParquetType, ArrowType> functor;
-  RETURN_NOT_OK(
-      functor.Serialize(checked_cast<const ArrayType&>(array), ctx, buffer));
+  if (array.null_count() != array.length()) {
+    RETURN_NOT_OK(
+        functor.Serialize(checked_cast<const ArrayType&>(array), ctx, buffer));
+  }
   bool no_nulls = writer->descr()->schema_node()->is_required() ||
       (array.null_count() == 0);
   if (!maybe_parent_nulls && no_nulls) {

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -748,12 +748,15 @@ void exportValues(
   const auto& type = vec.type();
   out.n_buffers = 2;
 
-  if (!rows.changed() && isFlatScalarZeroCopy(type)) {
+  if (!rows.changed() && !vec.values()) {
     // Arrow does not allow a nullptr for the values buffer. If the input vector
     // has no values buffer (all-null case), allocate an empty buffer of size 0.
-    auto values =
-        vec.values() ? vec.values() : AlignedBuffer::allocate<uint8_t>(0, pool);
-    holder.setBuffer(1, values);
+    holder.setBuffer(1, AlignedBuffer::allocate<uint8_t>(0, pool));
+    return;
+  }
+
+  if (!rows.changed() && isFlatScalarZeroCopy(type)) {
+    holder.setBuffer(1, vec.values());
     return;
   }
 


### PR DESCRIPTION
Fix a segmentation fault and buffer overflow when writing all-null Velox vectors to Parquet via the Arrow bridge by allocating a correctly sized dummy values buffer for all-null vectors.

PR #14755 partially fixed all-null buffers for certain types. However, `Bridge.cpp::exportValues` could still crash for types such as timestamp when `rows.changed()` was true and the all-null vector had no values buffer.