### PR TITLE
feat: Add support for TZDIR environment variable

### DIFF
--- a/velox/docs/develop/timestamp.rst
+++ b/velox/docs/develop/timestamp.rst
@@ -139,6 +139,16 @@ generally more efficient, but std::chrono does not handle time zone offsets
 such as ``+09:00``.  Timezone offsets are only supported in the API version
 that takes a timezone ID.
 
+Timezone Database Lookup
+------------------------
+
+Velox uses the IANA Time Zone Database to handle timezone conversions. It looks for the database in the following order:
+
+1. The directory specified by the ``TZDIR`` environment variable.
+2. ``/usr/share/zoneinfo/uclibc`` (on Linux).
+3. ``/usr/share/zoneinfo`` (on Linux).
+4. The path pointed to by ``/etc/localtime`` (on macOS).
+
 Casts
 -----
 

--- a/velox/external/tzdb/patches/0004-support-tzdir-pr-15871.patch
+++ b/velox/external/tzdb/patches/0004-support-tzdir-pr-15871.patch
@@ -1,0 +1,18 @@
+diff --git a/velox/external/tzdb/tzdb.cpp b/velox/external/tzdb/tzdb.cpp
+index c4e16b139..63a6d3458 100644
+--- a/velox/external/tzdb/tzdb.cpp
++++ b/velox/external/tzdb/tzdb.cpp
+@@ -57,6 +57,13 @@ using namespace std::chrono_literals;
+ std::string __libcpp_tzdb_directory() {
+   struct stat sb;
+   using namespace std;
++  // First, check for the TZDIR environment variable.
++  // If set, it takes precedence over standard system paths.
++  if (auto tzdir = getenv("TZDIR")) {
++    if (stat(tzdir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
++        return tzdir;
++    }
++  }
+ #if !defined(__APPLE__)
+   CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
+   CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";

--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -57,6 +57,8 @@ using namespace std::chrono_literals;
 std::string __libcpp_tzdb_directory() {
   struct stat sb;
   using namespace std;
+  // First, check for the TZDIR environment variable.
+  // If set, it takes precedence over standard system paths.
   if (auto tzdir = getenv("TZDIR")) {
     if (stat(tzdir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
         return tzdir;

--- a/velox/external/tzdb/tzdb.cpp
+++ b/velox/external/tzdb/tzdb.cpp
@@ -57,6 +57,11 @@ using namespace std::chrono_literals;
 std::string __libcpp_tzdb_directory() {
   struct stat sb;
   using namespace std;
+  if (auto tzdir = getenv("TZDIR")) {
+    if (stat(tzdir, &sb) == 0 && S_ISDIR(sb.st_mode)) {
+        return tzdir;
+    }
+  }
 #if !defined(__APPLE__)
   CONSTDATA auto tz_dir_default = "/usr/share/zoneinfo";
   CONSTDATA auto tz_dir_buildroot = "/usr/share/zoneinfo/uclibc";


### PR DESCRIPTION
This PR adds support for the `TZDIR` environment variable in the `tzdb` implementation.

Previously, the timezone database discovery logic was limited to standard system paths (e.g., `/usr/share/zoneinfo`, `/usr/share/zoneinfo/uclibc`). This limitation caused issues in large scale data center since if we want to upgrade tzdata dependency for velox, we have to upgrade the system's.

With this change, `__libcpp_tzdb_directory` now checks for `TZDIR` first. This aligns Velox's behavior with other standard C++ libraries (like abseil-cpp) and provides users with greater flexibility to configure the timezone database location.