### PR TITLE
refactor(geo): Reduce memcpy in GeometryCollection serialization

### DIFF
--- a/velox/common/geospatial/GeometrySerde.h
+++ b/velox/common/geospatial/GeometrySerde.h
@@ -357,15 +357,14 @@ class GeometrySerializer {
     for (size_t geometryIndex = 0;
          geometryIndex < collection.getNumGeometries();
          ++geometryIndex) {
-      auto* geometry = collection.getGeometryN(geometryIndex);
-      // Use a temporary buffer to serialize the geometry and calculate its
-      // length
-      std::string tempBuffer;
-      writeGeometry(*geometry, tempBuffer);
-
-      int32_t length = static_cast<int32_t>(tempBuffer.size());
-      appendBytes(writer, length);
-      writer.append(std::string_view(tempBuffer.data(), tempBuffer.size()));
+      const auto* geometry = collection.getGeometryN(geometryIndex);
+      size_t lengthOffset = writer.size();
+      // Placeholder for the length of the child geometry
+      appendBytes(writer, int32_t{0});
+      writeGeometry(*geometry, writer);
+      int32_t length =
+          static_cast<int32_t>(writer.size() - lengthOffset - sizeof(int32_t));
+      writer.writeAt(length, lengthOffset);
     }
   }
 };

--- a/velox/common/geospatial/tests/CMakeLists.txt
+++ b/velox/common/geospatial/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ if(VELOX_ENABLE_GEO)
   target_link_libraries(
     velox_common_geospatial_serde_test
     velox_common_geospatial_serde
+    velox_vector_test_lib
     GTest::gtest
     GTest::gtest_main
     GTest::gmock

--- a/velox/common/geospatial/tests/GeometrySerdeTest.cpp
+++ b/velox/common/geospatial/tests/GeometrySerdeTest.cpp
@@ -19,31 +19,48 @@
 #include <geos/io/WKTReader.h>
 #include <geos/io/WKTWriter.h>
 #include <gtest/gtest.h>
+#include "velox/common/memory/Memory.h"
+#include "velox/expression/StringWriter.h"
 #include "velox/type/StringView.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace ::testing;
 
+using namespace facebook::velox;
 using namespace facebook::velox::common::geospatial;
 
-void assertRoundtrip(const std::string& wkt) {
-  geos::io::WKTReader reader;
-  geos::io::WKTWriter writer;
-  std::unique_ptr<geos::geom::Geometry> geometry = reader.read(wkt);
+namespace {
+class GeometrySerdeTest : public ::testing::Test,
+                          public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
 
-  std::string buffer;
-  GeometrySerializer::serialize(*geometry, buffer);
-  facebook::velox::StringView readBuffer(buffer);
-  auto deserialized = GeometryDeserializer::deserialize(readBuffer);
+  void assertRoundtrip(const std::string& wkt) {
+    geos::io::WKTReader reader;
+    geos::io::WKTWriter writer;
+    std::unique_ptr<geos::geom::Geometry> geometry = reader.read(wkt);
 
-  EXPECT_TRUE(geometry->equals(deserialized.get()))
-      << std::endl
-      << "Input:" << std::endl
-      << wkt << std::endl
-      << "Output:" << std::endl
-      << writer.write(deserialized.get());
-}
+    auto vector = makeFlatVector<StringView>(1);
+    exec::StringWriter stringWriter(vector.get(), 0);
+    GeometrySerializer::serialize(*geometry, stringWriter);
+    stringWriter.finalize();
 
-TEST(GeometrySerdeTest, testBasicSerde) {
+    StringView readBuffer = vector->valueAt(0);
+    auto deserialized = GeometryDeserializer::deserialize(readBuffer);
+
+    EXPECT_TRUE(geometry->equals(deserialized.get()))
+        << std::endl
+        << "Input:" << std::endl
+        << wkt << std::endl
+        << "Output:" << std::endl
+        << writer.write(deserialized.get());
+  }
+};
+} // namespace
+
+TEST_F(GeometrySerdeTest, testBasicSerde) {
   assertRoundtrip("POINT EMPTY");
   assertRoundtrip("POINT (1 2)");
   assertRoundtrip("MULTIPOINT EMPTY");
@@ -67,7 +84,7 @@ TEST(GeometrySerdeTest, testBasicSerde) {
       "MULTIPOLYGON ( ((10 0, 20 0, 20 10, 10 10, 10 0)),  ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)) )");
 }
 
-TEST(GeometrySerdeTest, testGeometryCollectionSerde) {
+TEST_F(GeometrySerdeTest, testGeometryCollectionSerde) {
   assertRoundtrip("GEOMETRYCOLLECTION EMPTY");
   assertRoundtrip("GEOMETRYCOLLECTION (POINT EMPTY)");
   assertRoundtrip("GEOMETRYCOLLECTION (POINT (0 0))");
@@ -92,7 +109,7 @@ TEST(GeometrySerdeTest, testGeometryCollectionSerde) {
       "GEOMETRYCOLLECTION (GEOMETRYCOLLECTION ( MULTIPOINT (1 2) ))");
 }
 
-TEST(GeometrySerdeTest, testComplexSerde) {
+TEST_F(GeometrySerdeTest, testComplexSerde) {
   assertRoundtrip("GEOMETRYCOLLECTION ( MULTIPOINT EMPTY, MULTIPOINT (1 1) )");
   assertRoundtrip("GEOMETRYCOLLECTION (POLYGON EMPTY, POINT (1 2))");
   assertRoundtrip(
@@ -101,7 +118,7 @@ TEST(GeometrySerdeTest, testComplexSerde) {
       "GEOMETRYCOLLECTION (POLYGON EMPTY, GEOMETRYCOLLECTION ( POINT (1 2), POLYGON ((0 0, 4 0, 4 4, 0 4, 0 0), (1 1, 2 1, 2 2, 1 2, 1 1)), GEOMETRYCOLLECTION EMPTY, MULTIPOLYGON ( ((10 10, 14 10, 14 14, 10 14, 10 10), (11 11, 12 11, 12 12, 11 12, 11 11)), ((-1 -1, -2 -2, -1 -2, -1 -1)) ) ))");
 }
 
-TEST(GeometrySerdeTest, testSmallAreaRing) {
+TEST_F(GeometrySerdeTest, testSmallAreaRing) {
   assertRoundtrip(
       "MULTIPOLYGON (((18.6317421 49.9605785, 18.6318832 49.9607979, 18.6324683 49.9607312, 18.6332842 49.9605658, 18.6332003 49.9603557, 18.6339711 49.9602283, 18.6341994 49.9601905, 18.6343455 49.96016, 18.6344167 49.9601452, 18.6346696 49.9600919, 18.6349643 49.9600567, 18.6352271 49.9601455, 18.6354493 49.9600501, 18.6358024 49.9601071, 18.6358911 49.9600263, 18.6336542 49.9592453, 18.6334794 49.9591838, 18.6337483 49.9581339, 18.6335303 49.9580562, 18.6331284 49.9579122, 18.6324931 49.9576885, 18.6322503 49.9575998, 18.6321381 49.9581593, 18.6321172 49.9582692, 18.6324683 49.9583852, 18.6325255 49.9584004, 18.6327588 49.958489, 18.6324792 49.9588351, 18.6323941 49.9588049, 18.6323261 49.9587807, 18.6320354 49.9586789, 18.6319443 49.9592903, 18.6326731 49.9595648, 18.6331388 49.9594836, 18.6335981 49.959673, 18.6333065 49.9597934, 18.6328096 49.9600844, 18.6330209 49.9601348, 18.633424 49.9602597, 18.6332263 49.960317, 18.6315633 49.9597642, 18.6309331 49.9600741, 18.6317421 49.9605785)), ((18.6298591 49.9606201, 18.6298592 49.96062, 18.6298589 49.9606193, 18.6298591 49.9606201)))");
 }

--- a/velox/expression/StringWriter.h
+++ b/velox/expression/StringWriter.h
@@ -135,6 +135,20 @@ class StringWriter : public UDFOutputString {
     append(std::string_view(input));
   }
 
+  template <typename T>
+  void writeAt(const T& value, size_t pos) {
+    static_assert(
+        std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+    const char* dataToCopy = reinterpret_cast<const char*>(&value);
+    writeAt(dataToCopy, pos, sizeof(T));
+  }
+
+  void writeAt(const char* value, size_t pos, size_t length) {
+    VELOX_DCHECK(!finalized_);
+    VELOX_CHECK_GE(size(), pos + length);
+    std::memcpy(data() + pos, value, length);
+  }
+
  private:
   StringWriter() = default;
 


### PR DESCRIPTION
Summary:
Writing a GeometryCollection requires writing the length of the child geometry
before writing the child geometry. Previously we did this by writing to a
temporary std::string, then writing the length of that string to the output and
then copying the std::string to the output. Recursive GeometryCollections made
this worse because the "output" was actually just the parent std::string.

This commit writes a placeholder size (0), recording the offset. It then writes
the geometry, then writes the resulting length at the offset. This prevents all
the memcpys.

Removing this greatly simplifies our code an allows us to remove
VarbinaryWriter and almost all templating, which futher allows us to move most
implementations into the cpp file.

Differential Revision: D89928986
