### PR TITLE
fix: Add $SUDO to uv installation commands for proper permissions

### DIFF
--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -427,13 +427,13 @@ function install_uv {
     export UV_TOOL_BIN_DIR="${UV_TOOL_BIN_DIR:-$INSTALL_PREFIX/bin}"
     export UV_INSTALL_DIR=${UV_INSTALL_DIR:-"$UV_TOOL_BIN_DIR"}
 
-    curl -LsSf https://astral.sh/uv/install.sh | sh
+    curl -LsSf https://astral.sh/uv/install.sh | $SUDO sh
     uv tool update-shell
   fi
 }
 
 function uv_install {
-  uv tool install "$@" || {
+  $SUDO uv tool install "$@" || {
     ret=$?
     # exit code 2 means the binary already exists, so we can ignore that
     [ "$ret" -eq 2 ] || exit "$ret"


### PR DESCRIPTION
The `install_uv` and `uv_install` functions install binaries to \$INSTALL_PREFIX/bin (defaults to /usr/local/bin), which requires elevated permissions on non-root systems.

This change adds \$SUDO to both functions, consistent with how apt commands are already handled in the setup scripts. 
 These lines were initially introduced for Docker-based development, where containers run as root and no permission issues occur. This fix addresses the case when running `setup-ubuntu.sh` directly on a Ubuntu host machine as a non-root user.

  The change is consistent with the existing pattern used for apt commands throughout the setup scripts.

  ## Test plan
  - [x] Tested `./scripts/setup-ubuntu.sh install_build_prerequisites` on Ubuntu 22.04 as non-root user
  - [x] Verified uv and cmake installations complete successfully with the fix