### PR TITLE
feat: Add runtime stats in RowReader for the filter to index conversion

### DIFF
--- a/velox/common/file/Region.h
+++ b/velox/common/file/Region.h
@@ -17,7 +17,12 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 #include <string_view>
+
+#include <fmt/format.h>
+
+#include "velox/common/base/SuccinctPrinter.h"
 
 namespace facebook::velox::common {
 
@@ -34,6 +39,14 @@ struct Region {
   bool operator<(const Region& other) const {
     return offset < other.offset ||
         (offset == other.offset && length < other.length);
+  }
+
+  std::string toString() const {
+    return fmt::format(
+        "Region{{offset: {}, length: {}, label: {}}}",
+        offset,
+        succinctBytes(length),
+        label);
   }
 };
 

--- a/velox/common/file/tests/UtilsTest.cpp
+++ b/velox/common/file/tests/UtilsTest.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/file/Region.h"
 #include "velox/common/file/Utils.h"
 #include "velox/common/file/tests/TestUtils.h"
 
@@ -290,3 +291,19 @@ INSTANTIATE_TEST_SUITE_P(
     ReadToIOBufsTest,
     ValuesIn(
         std::vector<bool /* Should generated chained IOBuf */>({false, true})));
+
+TEST(RegionTest, toString) {
+  EXPECT_EQ(Region(0, 0).toString(), "Region{offset: 0, length: 0B, label: }");
+  EXPECT_EQ(
+      Region(100, 256).toString(),
+      "Region{offset: 100, length: 256B, label: }");
+  EXPECT_EQ(
+      Region(1024, 1024, "test").toString(),
+      "Region{offset: 1024, length: 1.00KB, label: test}");
+  EXPECT_EQ(
+      Region(0, 1'048'576, "stream").toString(),
+      "Region{offset: 0, length: 1.00MB, label: stream}");
+  EXPECT_EQ(
+      Region(12345, 1'073'741'824).toString(),
+      "Region{offset: 12345, length: 1.00GB, label: }");
+}

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -345,3 +345,9 @@ These stats are reported only by connector data or index sources.
    * - totalRemainingFilterWallNanos
      - nanos
      - The total walltime in nanoseconds that the data or index connector do the remaining filtering.
+   * - numIndexFilterConversions
+     -
+     - The number of index columns that were converted from ScanSpec filters to
+       index bounds for index-based filtering (e.g., cluster index pruning in
+       Nimble). A value greater than zero indicates filters were successfully
+       converted to leverage file index structures for row pruning.

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -114,8 +114,9 @@ std::unique_ptr<SeekableInputStream> BufferedInput::enqueue(
       // help faster lookup using enqueuedToBufferOffset_ later.
       [region, this, i = regions_.size() - 1]() {
         auto result = readInternal(region.offset, region.length, i);
-        VELOX_CHECK(
-            std::get<1>(result) != MAX_UINT64,
+        VELOX_CHECK_NE(
+            std::get<1>(result),
+            MAX_UINT64,
             "Fail to read region offset={} length={}",
             region.offset,
             region.length);

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -44,6 +44,13 @@ class RowReader {
  public:
   static constexpr int64_t kAtEnd = -1;
 
+  /// Runtime stat names.
+  /// Tracks the number of index columns that were converted from ScanSpec
+  /// filters to index bounds for index-based filtering (e.g., cluster index
+  /// pruning in Nimble).
+  static inline const std::string kNumIndexFilterConversions =
+      "numIndexFilterConversions";
+
   virtual ~RowReader() = default;
 
   /**

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -2515,3 +2515,13 @@ std::unique_ptr<Filter> createNegatedBigintValues(
     bool nullAllowed);
 
 } // namespace facebook::velox::common
+
+template <>
+struct fmt::formatter<facebook::velox::common::FilterKind>
+    : formatter<std::string> {
+  auto format(facebook::velox::common::FilterKind s, format_context& ctx)
+      const {
+    return formatter<std::string>::format(
+        std::string(facebook::velox::common::FilterKindName::toName(s)), ctx);
+  }
+};


### PR DESCRIPTION
Summary:
Add a runtime statistic `numIndexFilterConversions` to track when ScanSpec filters are successfully converted to index bounds for index-based filtering. This metric helps monitor the effectiveness of cluster index pruning by reporting the number of index columns that were converted from filters.

The stat is:
- Defined as a static constant `kNumIndexFilterConversions` in `RowReader` base class
- Updated via `addThreadLocalRuntimeStat` when filters are converted to index bounds
- Documented in the metrics.rst reference guide under a new "Row Reader" section

This enables observability into how often and how many columns are leveraging index-based filtering for row/stripe pruning.

Differential Revision: D90031012


