### PR TITLE
fix: Reduce flakiness in window fuzzer

### DIFF
--- a/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
+++ b/velox/functions/prestosql/fuzzer/ApproxDistinctResultVerifier.h
@@ -255,7 +255,7 @@ class ApproxDistinctResultVerifier : public ResultVerifier {
 
     // We expect large deviations (>2 stddev) in < 5% of values.
     if (numGroups >= 50) {
-      return largeGaps.size() <= 0.05 * numGroups;
+      return largeGaps.size() <= std::ceil(0.05 * numGroups);
     }
 
     return numGroups == 1 || largeGaps.empty();


### PR DESCRIPTION
Summary:
When WindowFuzzer validates approx_distinct it uses a heuristic which it expects the results
to follow. Specifically if the number of groups is large we expect to be within 2 standard
deviations in at least 95% of groups.

We see some flakiness in this in our internal runs (which run more frequently than in OS) due
to cases exceeding this threshold.

Looking through these, they don't seem to be indicative of anything incorrect in the 
implementation of approx_distinct, but rather an off by one error in the validation. We
currently take the floor of 5% of the number of groups and use that as the threshold. This
seems to be just a bit too strict and looking at the past week or so of failures we can eliminate
all but 1 by taking the ceiling instead (giving us the full 5% we expect).

Differential Revision: D90044699


