### PR TITLE
feat: Add adaptive batch sizing with row size estimate fallback in TableScan

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -558,10 +558,14 @@ void HiveDataSource::setFromDataSource(
 }
 
 int64_t HiveDataSource::estimatedRowSize() {
-  if (!splitReader_) {
+  if (splitReader_ == nullptr) {
     return kUnknownRowSize;
   }
-  return splitReader_->estimatedRowSize();
+  auto rowSize = splitReader_->estimatedRowSize();
+  TestValue::adjust(
+      "facebook::velox::connector::hive::HiveDataSource::estimatedRowSize",
+      &rowSize);
+  return rowSize;
 }
 
 vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -68,6 +68,11 @@ class TableScan : public SourceOperator {
     return scaledController_;
   }
 
+  /// Returns the current read batch size. Used for testing.
+  vector_size_t testingReadBatchSize() const {
+    return readBatchSize_;
+  }
+
  private:
   // Checks if this table scan operator needs to yield before processing the
   // next split.
@@ -98,6 +103,10 @@ class TableScan : public SourceOperator {
   // the scan driver memory usage and check to see if we need to scale up scan
   // processing or not.
   void tryScaleUp();
+
+  // Calculates the batch size to read based on available row size information.
+  // Returns the number of rows to read in the next batch.
+  int32_t calculateBatchSize(int64_t currentEstimatedRowSize);
 
   const connector::ConnectorTableHandlePtr tableHandle_;
   const connector::ColumnHandleMap columnHandles_;
@@ -140,6 +149,10 @@ class TableScan : public SourceOperator {
   int32_t numReadyPreloadedSplits_{0};
 
   double maxFilteringRatio_{0};
+
+  // Row size estimate from the file reader. It is set to the last known
+  // estimated row size from the current split reader or the previous ones.
+  int64_t fileEstimatedRowSize_{connector::DataSource::kUnknownRowSize};
 
   // String shown in ExceptionContext inside DataSource and LazyVector loading.
   std::string debugString_;

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1358,6 +1358,80 @@ TEST_F(TableScanTest, batchSize) {
   }
 }
 
+DEBUG_ONLY_TEST_F(TableScanTest, batchSizeFileEstimateFallback) {
+  const auto rowSize = 1024;
+  const auto columnSize = sizeof(int64_t);
+  const auto numColumns = 2 * rowSize / columnSize;
+  const auto numRowsSplit1 = 100;
+  const auto numRowsSplit2 = 2000;
+  const auto kDefaultBatchRows = 1024;
+
+  std::vector<std::string> names;
+  names.reserve(numColumns);
+  for (size_t i = 0; i < numColumns; i++) {
+    names.push_back(fmt::format("c{}", i));
+  }
+  auto rowType =
+      ROW(std::move(names), std::vector<TypePtr>(numColumns, BIGINT()));
+
+  auto vector1 = makeVectors(1, numRowsSplit1, rowType);
+  auto vector2 = makeVectors(1, numRowsSplit2, rowType);
+
+  auto filePath1 = TempFilePath::create();
+  auto filePath2 = TempFilePath::create();
+  writeToFile(filePath1->getPath(), vector1);
+  writeToFile(filePath2->getPath(), vector2);
+
+  std::vector<RowVectorPtr> allVectors;
+  allVectors.reserve(2);
+  allVectors.push_back(vector1[0]);
+  allVectors.push_back(vector2[0]);
+  createDuckDbTable(allVectors);
+
+  auto plan = PlanBuilder().tableScan(rowType).planNode();
+
+  std::atomic_int splitCount{0};
+  std::vector<int32_t> batchSizesUsed;
+  std::mutex mutex;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::TableScan::getOutput::gotSplit",
+      std::function<void(const TableScan*)>([&](const TableScan* tableScan) {
+        ++splitCount;
+        std::lock_guard<std::mutex> lock(mutex);
+        batchSizesUsed.push_back(tableScan->testingReadBatchSize());
+      }));
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::connector::hive::HiveDataSource::estimatedRowSize",
+      std::function<void(int64_t*)>([&](int64_t* estimatedRowSize) {
+        if (splitCount.load() >= 2) {
+          *estimatedRowSize = connector::DataSource::kUnknownRowSize;
+        }
+      }));
+
+  auto task = AssertQueryBuilder(duckDbQueryRunner_)
+                  .plan(plan)
+                  .splits(makeHiveConnectorSplits({filePath1, filePath2}))
+                  .config(
+                      QueryConfig::kPreferredOutputBatchBytes,
+                      folly::to<std::string>(rowSize * 100))
+                  .config(
+                      QueryConfig::kPreferredOutputBatchRows,
+                      folly::to<std::string>(kDefaultBatchRows))
+                  .assertResults("SELECT * FROM tmp");
+
+  const auto opStats = task->taskStats().pipelineStats[0].operatorStats[0];
+
+  EXPECT_EQ(opStats.outputPositions, numRowsSplit1 + numRowsSplit2);
+  EXPECT_GE(splitCount.load(), 2);
+  ASSERT_GE(batchSizesUsed.size(), 2);
+
+  EXPECT_LT(batchSizesUsed[1], kDefaultBatchRows)
+      << "Second split should use the last known estimated row size, not default";
+  EXPECT_GT(opStats.outputVectors, 3);
+}
+
 // Test that adding the same split with the same sequence id does not cause
 // double read and the 2nd split is ignored.
 TEST_F(TableScanTest, sequentialSplitNoDoubleRead) {


### PR DESCRIPTION
Summary:
adds adaptive batch sizing that uses row size estimates to calculate appropriate batch sizes.

The implementation adds two new member variables to track row size estimates:

footerRowSizeEstimate_: Row size estimate from file footer statistics
batchRowSizeEstimate_: Row size estimate computed from loaded batch data (estimateFlatSize() / rowCount)
The calculateBatchSize() helper function determines the effective row size with the following priority:

1. Current footer estimate 
2. Previous batch estimate 
3. Previous footer estimate 
4. No estimate: use default preferredOutputBatchRows()

Differential Revision: D90088277


