### PR TITLE
fix: Pre-commit regex error on python14

### DIFF
--- a/scripts/checks/license-header.py
+++ b/scripts/checks/license-header.py
@@ -120,7 +120,12 @@ file_types = OrderedDict(
 )
 
 file_pattern = regex.compile(
-    "|".join(["^" + fnmatch.translate(type) + "$" for type in file_types.keys()])
+    "|".join(
+        [
+            "^" + fnmatch.translate(type).replace(r"\z", r"\Z") + "$"
+            for type in file_types.keys()
+        ]
+    )
 )
 
 


### PR DESCRIPTION
With python@14, the pre-commit failed with following error message:
```
license-header...........................................................Failed
- hook id: license-header
- exit code: 1

Traceback (most recent call last):
  File "velox/./scripts/checks/license-header.py", line 122, in <module>
    file_pattern = regex.compile(
        "|".join(["^" + fnmatch.translate(type) + "$" for type in file_types.keys()])
    )
  File "py_env-python3.14/lib/python3.14/site-packages/regex/_main.py", line 353, in compile
    return _compile(pattern, flags, ignore_unused, kwargs, cache_pattern)
  File "py_env-python3.14/lib/python3.14/site-packages/regex/_main.py", line 542, in _compile
    raise error(caught_exception.msg, caught_exception.pattern,
      caught_exception.pos)
regex._regex_core.error: bad escape \z at position 23
```
