### PR TITLE
perf: Optimize stats collection in ExchangeClient::collectStatsLocked()

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -120,23 +120,26 @@ ExchangeClient::collectStatsLocked() const {
   for (const auto& source : sources_) {
     if (source->supportsMetrics()) {
       for (const auto& [name, value] : source->metrics()) {
-        if (UNLIKELY(stats.count(name) == 0)) {
-          stats.insert(std::pair(name, RuntimeMetric(value.unit)));
-        }
-        stats[name].merge(value);
+        auto [iter, inserted] = stats.try_emplace(name, value.unit);
+        iter->second.merge(value);
       }
     } else {
       for (const auto& [name, value] : source->stats()) {
-        stats[name].addValue(value);
+        auto [iter, inserted] = stats.try_emplace(name);
+        iter->second.addValue(value);
       }
     }
   }
 
-  stats["peakBytes"] =
-      RuntimeMetric(queue_->peakBytes(), RuntimeCounter::Unit::kBytes);
-  stats["numReceivedPages"] = RuntimeMetric(queue_->receivedPages());
-  stats["averageReceivedPageBytes"] = RuntimeMetric(
-      queue_->averageReceivedPageBytes(), RuntimeCounter::Unit::kBytes);
+  stats.insert_or_assign(
+      "peakBytes",
+      RuntimeMetric(queue_->peakBytes(), RuntimeCounter::Unit::kBytes));
+  stats.insert_or_assign(
+      "numReceivedPages", RuntimeMetric(queue_->receivedPages()));
+  stats.insert_or_assign(
+      "averageReceivedPageBytes",
+      RuntimeMetric(
+          queue_->averageReceivedPageBytes(), RuntimeCounter::Unit::kBytes));
 
   return stats;
 }
@@ -292,10 +295,10 @@ ExchangeClient::pickSourcesToRequestLocked() {
     // 1. We have full capacity but still cannot initiate one single data
     //    transfer. Let the transfer happen in this case to avoid getting stuck.
     //
-    // 2. We have some data in the queue that is not big enough for
-    //    consumers and it is big enough to not allow ExchangeClient to
-    //    initiate request for more data. Let transfer happen in this case
-    //    to avoid this deadlock situation.
+    // 2. We have some data in the queue that is not big enough for consumers,
+    //    and it is big enough to not allow ExchangeClient to initiate request
+    //    for more data. Let transfer happen in this case to avoid this deadlock
+    //    situation.
     auto& source = producingSources_.front().source;
     auto requestBytes = producingSources_.front().remainingBytes.at(0);
     LOG(INFO) << "Requesting large single page " << requestBytes


### PR DESCRIPTION
Optimize `ExchangeClient::collectStatsLocked()` to reduce hash table
lookups when collecting metrics from ExchangeSources. Instead of using
'stats.count() + stats.insert() + stats[name]' (3 lookups per entry),
use `try_emplace()` which provides both insertion and access in a single
operation (1 lookup per entry).

Alose use `insert_or_assign()` for the "set or overwrite" pattern.
This is more efficient than operator[] as it avoids a potentially
wasteful default-construction followed by an assignment.