### PR TITLE
feat(build): Enable coroutines

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -54,8 +54,6 @@ set(BUILD_SHARED_LIBS ${VELOX_BUILD_SHARED})
 
 # Enable INT128 support
 set(FOLLY_HAVE_INT128_T ON)
-set(PREVIOUS_CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DFOLLY_CFG_NO_COROUTINES")
 
 FetchContent_MakeAvailable(folly)
 
@@ -66,4 +64,3 @@ add_library(Folly::follybenchmark ALIAS follybenchmark)
 if(gflags_SOURCE STREQUAL "BUNDLED")
   add_dependencies(folly glog::glog gflags::gflags fmt::fmt)
 endif()
-set(CMAKE_CXX_FLAGS ${PREVIOUS_CMAKE_CXX_FLAGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,13 +406,6 @@ if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "aarch64")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char")
 endif()
 
-# Ensure that we don't bring in headers that might have coroutines enabled. The
-# dependencies turn off coroutines in folly and the other FBOS dependencies. If
-# not explicitly turned off differences in the build using GCC cause libray
-# incompatibilities of the thrift server and the remote functions library
-# causing SEGVs in the tests.
-string(APPEND CMAKE_CXX_FLAGS " -DFOLLY_CFG_NO_COROUTINES")
-
 # Under Ninja, we are able to designate certain targets large enough to require
 # restricted parallelism.
 if("${MAX_HIGH_MEM_JOBS}")
@@ -659,9 +652,12 @@ if(VELOX_ENABLE_GCS)
 endif()
 
 # GCC needs to link a library to enable std::filesystem.
+# GCC needs to enable co-routines. We only support compiler that
+# support coroutines.
 if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   # Find Threads library
   find_package(Threads REQUIRED)
+  add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-fcoroutines>)
 endif()
 
 if(VELOX_BUILD_TESTING AND NOT VELOX_ENABLE_DUCKDB)

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -45,19 +45,11 @@ function install_fmt {
 }
 
 function install_folly {
-  # Folly Portability.h being used to decide whether or not support coroutines
-  # causes issues (build, link) if the selection is not consistent across users of folly.
-  # shellcheck disable=SC2034
-  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/folly/archive/refs/tags/"${FB_OS_VERSION}".tar.gz folly
   cmake_install_dir folly -DBUILD_SHARED_LIBS="$VELOX_BUILD_SHARED" -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_fizz {
-  # Folly Portability.h being used to decide whether or not support coroutines
-  # causes issues (build, link) if the selection is not consistent across users of folly.
-  # shellcheck disable=SC2034
-  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/"${FB_OS_VERSION}".tar.gz fizz
   cmake_install_dir fizz/fizz -DBUILD_TESTS=OFF
 }
@@ -68,28 +60,16 @@ function install_fast_float {
 }
 
 function install_wangle {
-  # Folly Portability.h being used to decide whether or not support coroutines
-  # causes issues (build, link) if the selection is not consistent across users of folly.
-  # shellcheck disable=SC2034
-  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/wangle/archive/refs/tags/"${FB_OS_VERSION}".tar.gz wangle
   cmake_install_dir wangle/wangle -DBUILD_TESTS=OFF
 }
 
 function install_mvfst {
-  # Folly Portability.h being used to decide whether or not support coroutines
-  # causes issues (build, link) if the selection is not consistent across users of folly.
-  # shellcheck disable=SC2034
-  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/mvfst/archive/refs/tags/"${FB_OS_VERSION}".tar.gz mvfst
   cmake_install_dir mvfst -DBUILD_TESTS=OFF
 }
 
 function install_fbthrift {
-  # Folly Portability.h being used to decide whether or not support coroutines
-  # causes issues (build, link) if the selection is not consistent across users of folly.
-  # shellcheck disable=SC2034
-  EXTRA_PKG_CXXFLAGS=" -DFOLLY_CFG_NO_COROUTINES"
   wget_and_untar https://github.com/facebook/fbthrift/archive/refs/tags/"${FB_OS_VERSION}".tar.gz fbthrift
   cmake_install_dir fbthrift -Denable_tests=OFF -DBUILD_TESTS=OFF -DBUILD_SHARED_LIBS=OFF
 }


### PR DESCRIPTION
Note, we need changes when Velox is updated in PrestoC++ to align and create a new dependency image.
This breaks PrestoC++ on update otherwise (CI, remote functions).