### PR TITLE
feat: Add dot_product UDF for Map<Varchar, double>

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -74,6 +74,21 @@ Mathematical Functions
     Returns the squared `Euclidean distance <https://en.wikipedia.org/wiki/Euclidean_distance>`_ between the vectors represented as array(double).
     If any input array is empty, the function returns NaN. If the input arrays have different sizes, the function throws VeloxUserError.
 
+.. function:: dot_product(map(varchar, double), map(varchar, double)) -> double
+
+    Returns the `Dot Product <https://en.wikipedia.org/wiki/Dot_product>`_ between the sparse vectors represented as map(varchar, double).
+    The dot product is computed as the sum of products of values for matching keys.
+    Keys that exist in only one map contribute 0 to the result.
+    If any input map is empty, the function returns NaN.
+
+        SELECT dot_product(MAP(ARRAY['a'], ARRAY[1.0]), MAP(ARRAY['a'], ARRAY[2.0])); -- 2.0
+
+        SELECT dot_product(MAP(ARRAY['a', 'b'], ARRAY[1.0, 2.0]), MAP(ARRAY['b', 'c'], ARRAY[3.0, 4.0])); -- 6.0
+
+        SELECT dot_product(MAP(ARRAY['a'], ARRAY[1.0]), MAP(ARRAY['b'], ARRAY[2.0])); -- 0.0
+
+        SELECT dot_product(MAP(ARRAY[], ARRAY[]), MAP(ARRAY['a'], ARRAY[1.0])); -- NaN
+
 .. function:: dot_product(array(real), array(real)) -> real
 
     Returns the `Dot Product <https://en.wikipedia.org/wiki/Dot_product>`_ between the vectors represented as array(real).

--- a/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp
@@ -124,6 +124,11 @@ void registerMathFunctions(const std::string& prefix) {
       double,
       Array<double>,
       Array<double>>({prefix + "cosine_similarity"});
+  registerFunction<
+      DotProductMap,
+      double,
+      Map<Varchar, double>,
+      Map<Varchar, double>>({prefix + "dot_product"});
   registerFunction<DotProductArray, double, Array<double>, Array<double>>(
       {prefix + "dot_product"});
 #ifdef VELOX_ENABLE_FAISS

--- a/velox/functions/prestosql/tests/DistanceFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DistanceFunctionsTest.cpp
@@ -119,6 +119,42 @@ TEST_F(DistanceFunctionsTest, cosineSimilarityArray) {
   EXPECT_TRUE(std::isnan(cosineSimilarity({1, 3}, {kInf, 1})));
 }
 
+TEST_F(DistanceFunctionsTest, dotProductMap) {
+  const auto dotProduct =
+      [&](const std::vector<std::pair<std::string, std::optional<double>>>&
+              left,
+          const std::vector<std::pair<std::string, std::optional<double>>>&
+              right) {
+        auto leftMap = makeMapVector<std::string, double>({left});
+        auto rightMap = makeMapVector<std::string, double>({right});
+        return evaluateOnce<double>(
+                   "dot_product(c0,c1)", makeRowVector({leftMap, rightMap}))
+            .value();
+      };
+
+  EXPECT_NEAR(
+      2.0 * 3.0, dotProduct({{"a", 1}, {"b", 2}}, {{"c", 1}, {"b", 3}}), 1e-6);
+
+  EXPECT_NEAR(
+      1 * 1 + 2 * 3,
+      dotProduct({{"a", 1}, {"b", 2}}, {{"a", 1}, {"b", 3}}),
+      1e-6);
+
+  EXPECT_DOUBLE_EQ(0.0, dotProduct({{"a", 1}, {"b", 2}}, {{"c", 1}, {"d", 3}}));
+
+  EXPECT_TRUE(std::isnan(dotProduct({}, {})));
+  EXPECT_TRUE(std::isnan(dotProduct({{"a", 1}}, {})));
+
+  auto nullableLeftMap = makeNullableMapVector<StringView, double>(
+      {{{{"a"_sv, 1}, {"b"_sv, std::nullopt}}}});
+  auto rightMap =
+      makeMapVector<StringView, double>({{{{"a"_sv, 2}, {"b"_sv, 3}}}});
+  EXPECT_FALSE(
+      evaluateOnce<double>(
+          "dot_product(c0,c1)", makeRowVector({nullableLeftMap, rightMap}))
+          .has_value());
+}
+
 TEST_F(DistanceFunctionsTest, dotProductArray) {
   const auto dotProduct = [&](const std::vector<double>& left,
                               const std::vector<double>& right) {


### PR DESCRIPTION
Summary:
Implemented DOT_PRODUCT function for sparse vectors represented as map(varchar, double), enabling efficient vector operations for ML and analytics workloads.

**Implementation Details:**

Added `DotProductMap` struct in `DistanceFunctions.h` with two implementations:
- FAISS version: Uses `faiss::fvec_inner_product` for optimized computation
- Non-FAISS version: Simple loop computing sum of products for matching keys

**Function Behavior:**
- Computes dot product as sum of products of values for matching keys
- Keys existing in only one map contribute 0 to the result
- Returns NaN if either input map is empty
- Returns NULL if any map contains null values

**Files Modified:**
1. `fbcode/velox/functions/prestosql/DistanceFunctions.h` - Added DotProductMap implementation for both FAISS and non-FAISS builds
2. `fbcode/velox/functions/prestosql/registration/MathematicalFunctionsRegistration.cpp` - Registered the function
3. `fbcode/velox/functions/prestosql/tests/DistanceFunctionsTest.cpp` - Added comprehensive tests
4. `fbcode/velox/docs/functions/presto/math.rst` - Added documentation with examples

**Test Coverage:**
- Basic dot product with common keys
- Multiple common keys
- No common keys (returns 0)
- Empty maps (returns NaN)
- Null values in map (returns NULL)

This follows the same pattern as the existing `cosine_similarity` function for maps but without normalization.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=T248293705-0688a7dc-b80a-42be-b458-e965b2a65470)

Differential Revision: D90123688


