### PR TITLE
fix: Ignore mismatches due to SWITCH and IF rewrites

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -442,7 +442,6 @@ jobs:
                 --velox_fuzzer_enable_expression_reuse \
                 --max_expression_trees_per_step 2 \
                 --retry_with_try \
-                --special_forms="and,or,cast,coalesce" \
                 --enable_dereference \
                 --duration_sec $DURATION \
                 --minloglevel=0 \
@@ -706,7 +705,6 @@ jobs:
                 --retry_with_try \
                 --enable_dereference \
                 --velox_fuzzer_enable_decimal_type \
-                --special_forms="and,or,cast,coalesce" \
                 --duration_sec $DURATION \
                 --minloglevel=0 \
                 --stderrthreshold=2 \

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -485,6 +485,8 @@ void ExpressionFuzzerVerifier::go() {
   }
   logStats();
 
+  LOG(ERROR) << "==============================> Results";
+
   LOG(ERROR) << "Total test cases: " << totalTestCases;
   LOG(ERROR) << "Total test cases verified in the reference DB: "
              << numVerified;
@@ -492,6 +494,8 @@ void ExpressionFuzzerVerifier::go() {
              << numFailed;
   LOG(ERROR) << "Total test cases unsupported in the reference DB: "
              << numReferenceUnsupported;
+  LOG(ERROR) << "Total test cases skipped due to SWITCH/IF rewrites: "
+             << verifier_.numSkippedIfSwitchMismatches();
 }
 
 } // namespace facebook::velox::fuzzer

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -90,6 +90,10 @@ class ExpressionVerifier {
       bool canThrow,
       const InputRowMetadata& inputRowMetadata = {});
 
+  int numSkippedIfSwitchMismatches() const {
+    return numSkippedIfSwitchMismatches_;
+  }
+
  private:
   // Utility method used to serialize the relevant data required to repro a
   // crash.
@@ -115,6 +119,7 @@ class ExpressionVerifier {
   const ExpressionVerifierOptions options_;
 
   std::shared_ptr<ReferenceQueryRunner> referenceQueryRunner_;
+  int numSkippedIfSwitchMismatches_{0};
 };
 
 // Finds the minimum common subexpression which fails for a plan should it


### PR DESCRIPTION
A recent change to SWITCH and IF special forms introduced branch pruning for NULL conditions. As a result of these rewritten expressions, null propagation may behave differently and introduce exceptions or non-NULL output. This diff introduces special behavior for these rewritten special forms to ignore potential behavior mismatches caused by SWITCH and IF, rather than simply removing them from fuzzer test coverage.
More information on this behavior change can be found here: https://github.com/facebookincubator/velox/issues/15486#issuecomment-3555149199

Differential Revision: D90129914


