### PR TITLE
refactor: Rename member variable to follow coding style

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -183,7 +183,7 @@ void ExchangeClient::request(std::vector<RequestSpec>&& requestSpecs) {
   for (auto& spec : requestSpecs) {
     auto future = folly::SemiFuture<ExchangeSource::Response>::makeEmpty();
     if (spec.maxBytes == 0) {
-      future = spec.source->requestDataSizes(kRequestDataSizesMaxWaitSec_);
+      future = spec.source->requestDataSizes(requestDataSizesMaxWaitSec_);
     } else {
       future = spec.source->request(spec.maxBytes, kRequestDataMaxWait);
     }

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -41,7 +41,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
       : taskId_{std::move(taskId)},
         destination_(destination),
         maxQueuedBytes_{maxQueuedBytes},
-        kRequestDataSizesMaxWaitSec_{requestDataSizesMaxWaitSec},
+        requestDataSizesMaxWaitSec_{requestDataSizesMaxWaitSec},
         pool_(pool),
         executor_(executor),
         queue_(
@@ -115,7 +115,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   folly::dynamic toJson() const;
 
   std::chrono::seconds requestDataSizesMaxWaitSec() const {
-    return kRequestDataSizesMaxWaitSec_;
+    return requestDataSizesMaxWaitSec_;
   }
 
   const std::unordered_set<std::string>& getRemoteTaskIdList() const {
@@ -171,7 +171,7 @@ class ExchangeClient : public std::enable_shared_from_this<ExchangeClient> {
   const std::string taskId_;
   const int destination_;
   const int64_t maxQueuedBytes_;
-  const std::chrono::seconds kRequestDataSizesMaxWaitSec_;
+  const std::chrono::seconds requestDataSizesMaxWaitSec_;
 
   memory::MemoryPool* const pool_;
   folly::Executor* const executor_;


### PR DESCRIPTION
According to Velox naming conventions, variables prefixed with 'k' should  
be static constants, not member variables. The member variable  
'ExchangeClient::kRequestDataSizesMaxWaitSec_' violates this convention.  

This change renames it to 'requestDataSizesMaxWaitSec_'.

No functional changes. 