### PR TITLE
fix: Add explicit timezone adjustment for LocalRunnerService

### DIFF
--- a/velox/exec/fuzzer/LocalRunnerService.cpp
+++ b/velox/exec/fuzzer/LocalRunnerService.cpp
@@ -71,6 +71,7 @@ std::pair<RowVectorPtr, std::string> execute(
 
   try {
     exec::test::AssertQueryBuilder queryBuilder(plan);
+    queryBuilder.config("session_timezone", "America/Los_Angeles");
 
     std::shared_ptr<exec::Task> task;
     auto results = queryBuilder.copyResults(pool.get(), task);


### PR DESCRIPTION
Summary:
Title.

Executing LocalRunnerService in continuous serverless exposed an issue with the query config that wasn't adjust timezone, we should add explicit adjustment congruent with the fuzzer.

Differential Revision: D90194198


