### PR TITLE
misc: Add microsecond option for timestamps in presto serializer

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -88,6 +88,10 @@ PrestoVectorSerde::PrestoOptions toPrestoOptions(
       dynamic_cast<const PrestoVectorSerde::PrestoOptions*>(options);
   VELOX_CHECK_NOT_NULL(
       prestoOptions, "Serde options are not Presto-compatible");
+  VELOX_CHECK(
+      !(prestoOptions->useLosslessTimestamp &&
+        prestoOptions->useMicrosecondPrecision),
+      "useLosslessTimestamp and useMicrosecondPrecision are mutually exclusive");
   return *prestoOptions;
 }
 } // namespace

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -69,6 +69,12 @@ class PrestoVectorSerde : public VectorSerde {
     /// currently used for spilling. Is false by default.
     bool useLosslessTimestamp{false};
 
+    /// When true, interprets serialized timestamp values as microseconds
+    /// instead of milliseconds. Used when the source data contains timestamps
+    /// in microsecond precision (e.g., TIMESTAMP_MICROSECONDS Presto type).
+    /// Mutually exclusive with useLosslessTimestamp.
+    bool useMicrosecondPrecision{false};
+
     /// Serializes nulls of structs before the columns. Used to allow
     /// single pass reading of in spilling.
     ///

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -596,6 +596,38 @@ void readLosslessTimestampValues(
   }
 }
 
+Timestamp readMicrosecondTimestamp(ByteInputStream* source) {
+  int64_t micros = source->read<int64_t>();
+  return Timestamp::fromMicros(micros);
+}
+
+void readMicrosecondTimestampValues(
+    ByteInputStream* source,
+    vector_size_t size,
+    vector_size_t offset,
+    const BufferPtr& nulls,
+    vector_size_t nullCount,
+    const BufferPtr& values) {
+  auto rawValues = values->asMutable<Timestamp>();
+  checkValuesSize<Timestamp>(values, nulls, size, offset);
+  if (nullCount > 0) {
+    int32_t toClear = offset;
+    bits::forEachSetBit(
+        nulls->as<uint64_t>(), offset, offset + size, [&](int32_t row) {
+          // Set the values between the last non-null and this to type default.
+          for (; toClear < row; ++toClear) {
+            rawValues[toClear] = Timestamp();
+          }
+          rawValues[row] = readMicrosecondTimestamp(source);
+          toClear = row + 1;
+        });
+  } else {
+    for (int32_t row = offset; row < offset + size; ++row) {
+      rawValues[row] = readMicrosecondTimestamp(source);
+    }
+  }
+}
+
 template <typename T>
 void readValues(
     ByteInputStream* source,
@@ -710,6 +742,16 @@ void read(
   if constexpr (std::is_same_v<T, Timestamp>) {
     if (opts.useLosslessTimestamp) {
       readLosslessTimestampValues(
+          source,
+          numNewValues,
+          resultOffset,
+          flatResult->nulls(),
+          nullCount,
+          values);
+      return;
+    }
+    if (opts.useMicrosecondPrecision) {
+      readMicrosecondTimestampValues(
           source,
           numNewValues,
           resultOffset,

--- a/velox/serializers/VectorStream.cpp
+++ b/velox/serializers/VectorStream.cpp
@@ -342,6 +342,10 @@ void VectorStream::append(folly::Range<const Timestamp*> values) {
       appendOne(value.getSeconds());
       appendOne(value.getNanos());
     }
+  } else if (opts_.useMicrosecondPrecision) {
+    for (auto& value : values) {
+      appendOne(value.toMicros());
+    }
   } else {
     for (auto& value : values) {
       appendOne(value.toMillis());


### PR DESCRIPTION
Summary:
Currently, timestamp deserialization through Velox's Presto serialization assumes timestamps are serialized as 8 bytes representing millisecond values. This change introduces a new option which specifies that the 8 bytes represents a microsecond value.

This allows for microsecond precision in 8 bytes rather than 16 bytes utilizing useLosslessTimestamp.

Differential Revision: D90148801


