### PR TITLE
build: Add build flag for LocalRunnerService (#15909)

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -222,6 +222,7 @@ jobs:
             -DVELOX_MONO_LIBRARY=ON
             -DVELOX_BUILD_PYTHON_PACKAGE=ON
             -DVELOX_PYTHON_LEGACY_ONLY=ON
+            -DVELOX_ENABLE_LOCAL_RUNNER_SERVICE=ON
             ${{ inputs.extraCMakeFlags }}
         run: |
           make python-venv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,11 @@ option(VELOX_ENABLE_PARQUET "Enable Parquet support" ON)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_GEO "Enable Geospatial support" ON)
 option(VELOX_ENABLE_REMOTE_FUNCTIONS "Enable remote function support" OFF)
+option(
+  VELOX_ENABLE_LOCAL_RUNNER_SERVICE
+  "Enable LocalRunnerService and VeloxQueryRunner for expression fuzzer regression testing"
+  OFF
+)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 option(VELOX_ENABLE_COMPRESSION_LZ4 "Enable Lz4 compression support." OFF)
 
@@ -644,9 +649,11 @@ if(${VELOX_BUILD_TESTING})
   velox_resolve_dependency(gRPC)
 endif()
 
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
-  # TODO: Move this to use resolve_dependency(). For some reason, FBThrift
-  # requires clients to explicitly install fizz and wangle.
+# FBThrift is required by remote functions and LocalRunnerService.
+# TODO: Move this to use resolve_dependency(). For some reason, FBThrift
+# requires clients to explicitly install fizz and wangle.
+if(VELOX_ENABLE_REMOTE_FUNCTIONS OR VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  add_definitions(-DVELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   find_package(fizz CONFIG REQUIRED)
   find_package(wangle CONFIG REQUIRED)
   find_package(FBThrift CONFIG REQUIRED)

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# LocalRunnerService thrift library (requires FBThrift support)
+# Generate this first as it's needed by velox_fuzzer_util below.
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
+  include(FBThriftCppLibrary)
+  add_fbthrift_cpp_library(
+    local_runner_service_thrift
+    if/LocalRunnerService.thrift
+    SERVICES
+    LocalRunnerService
+  )
+
+  target_compile_options(local_runner_service_thrift PRIVATE -Wno-error=deprecated-declarations)
+endif()
+
 add_library(
   velox_fuzzer_util
   ReferenceQueryRunner.cpp
@@ -27,12 +41,10 @@ add_library(
   PrestoSql.cpp
 )
 
-# TODO Add VeloxQueryRunner to velox_fuzzer_util to support in
-# ExpressionFuzzerTest. More information can be found here:
-# https://github.com/facebookincubator/velox/issues/15414
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+# VeloxQueryRunner requires LocalRunnerService thrift library
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   target_sources(velox_fuzzer_util PRIVATE VeloxQueryRunner.cpp)
-  target_link_libraries(velox_fuzzer_util FBThrift::thriftcpp2)
+  target_link_libraries(velox_fuzzer_util local_runner_service_thrift FBThrift::thriftcpp2)
 endif()
 
 target_link_libraries(
@@ -219,18 +231,7 @@ target_link_libraries(
 )
 
 # LocalRunnerService (requires FBThrift support)
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
-  # Generate Thrift library for LocalRunnerService
-  include(FBThriftCppLibrary)
-  add_fbthrift_cpp_library(
-    local_runner_service_thrift
-    if/LocalRunnerService.thrift
-    SERVICES
-    LocalRunnerService
-  )
-
-  target_compile_options(local_runner_service_thrift PRIVATE -Wno-error=deprecated-declarations)
-
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   # LocalRunnerService Library
   add_library(velox_local_runner_service_lib LocalRunnerService.cpp)
 

--- a/velox/exec/fuzzer/tests/CMakeLists.txt
+++ b/velox/exec/fuzzer/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_test(presto_sql_test presto_sql_test)
 target_link_libraries(presto_sql_test velox_fuzzer_util velox_presto_types)
 
 # LocalRunnerService Test (requires FBThrift support)
-if(VELOX_ENABLE_REMOTE_FUNCTIONS)
+if(VELOX_ENABLE_LOCAL_RUNNER_SERVICE)
   add_executable(local_runner_service_test LocalRunnerServiceTest.cpp)
   add_test(local_runner_service_test local_runner_service_test)
 


### PR DESCRIPTION
Summary:

Gate LocalRunnerService and VeloxQueryRunner behind a dedicated VELOX_ENABLE_LOCAL_RUNNER_SERVICE option rather than VELOX_ENABLE_REMOTE_FUNCTIONS. Building the expression fuzzer's reference service previously required turning on remote function support, which pulls in machinery the fuzzer never uses. The new option also defines a preprocessor macro of the same name so C++ callers can compile the VeloxQueryRunner path conditionally.

Differential Revision: D90206765


