### PR TITLE
fix: Reduce scope of PARQUET-251 stats fix

### DIFF
--- a/velox/dwio/parquet/reader/ParquetStatsContext.h
+++ b/velox/dwio/parquet/reader/ParquetStatsContext.h
@@ -30,6 +30,14 @@ struct ParquetStatsContext : dwio::common::StatsContext {
       : parquetVersion(version) {}
 
   bool shouldIgnoreStatistics(thrift::Type::type type) const {
+    // Follow parquet-java community's approach: check type first, then
+    // version.
+    // https://github.com/apache/parquet-java/blob/312a15f53a011d1dc4863df196c0169bdf6db629/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java#L57
+    if (type != thrift::Type::BYTE_ARRAY &&
+        type != thrift::Type::FIXED_LEN_BYTE_ARRAY) {
+      return false;
+    }
+
     if (!parquetVersion.has_value()) {
       return true;
     }

--- a/velox/dwio/parquet/reader/SemanticVersion.cpp
+++ b/velox/dwio/parquet/reader/SemanticVersion.cpp
@@ -60,10 +60,6 @@ std::optional<SemanticVersion> SemanticVersion::parse(
 }
 
 bool SemanticVersion::shouldIgnoreStatistics(thrift::Type::type type) const {
-  if (type != thrift::Type::BYTE_ARRAY &&
-      type != thrift::Type::FIXED_LEN_BYTE_ARRAY) {
-    return false;
-  }
   if (this->application_ != "parquet-mr") {
     return false;
   }


### PR DESCRIPTION
The current fix([#10823](https://github.com/facebookincubator/velox/pull/10823/files)) for PARQUET-251 disables all row group filtering if a Parquet file's version is not set. This is overly aggressive, as the issue only affects binary columns. In real-world cases with version-less files, this causes a major performance regression for non-binary columns.

This commit aligns our logic with parquet-java(https://github.com/apache/parquet-java/blob/312a15f53a011d1dc4863df196c0169bdf6db629/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java#L57) by checking the column type first. The version check is now only applied to BYTE_ARRAY and FIXED_LEN_BYTE_ARRAY columns. This ensures that filter pushdown on non-binary columns remains effective even when the file version is missing.