### PR TITLE
Extract NameToIndex from RowType into standalone header

### DIFF
--- a/velox/type/NameToIndex.h
+++ b/velox/type/NameToIndex.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include <folly/Hash.h>
+#include <folly/container/F14Set.h>
+
+namespace facebook::velox {
+
+/// A lookup structure that maps string names to uint32_t indices.
+/// This is written to decrease memory footprint.
+/// In general it can be replaced with Map<string_view, size_t>.
+// TODO: Consider using absl::flat_hash_set instead.
+class NameToIndex {
+ public:
+  NameToIndex() = default;
+
+  /// Reserves space for the specified number of elements.
+  void reserve(size_t size) {
+    set_.reserve(size);
+  }
+
+  /// Inserts a name with its corresponding index.
+  /// @param name The string to insert.
+  /// @param index The index to associate with the name.
+  void insert(std::string_view name, uint32_t index) {
+    set_.emplace(
+        NameIndex{name.data(), static_cast<uint32_t>(name.size()), index});
+  }
+
+  /// Checks if a name exists in the lookup.
+  /// @param name The name to check.
+  /// @return true if the name exists, false otherwise.
+  bool contains(std::string_view name) const {
+    return set_.contains(
+        NameIndex{name.data(), static_cast<uint32_t>(name.size()), 0});
+  }
+
+  /// Finds the index associated with a name.
+  /// @param name The name to find.
+  /// @return The index if found, std::nullopt otherwise.
+  std::optional<uint32_t> find(std::string_view name) const {
+    auto it = set_.find(
+        NameIndex{name.data(), static_cast<uint32_t>(name.size()), 0});
+    if (it != set_.end()) {
+      return it->index;
+    }
+    return std::nullopt;
+  }
+
+  /// Returns the number of elements in the lookup.
+  /// @return The number of name-index pairs stored.
+  size_t size() const {
+    return set_.size();
+  }
+
+ private:
+  struct NameIndex {
+    const char* data = nullptr;
+    uint32_t size = 0;
+    uint32_t index = 0;
+
+    bool operator==(const NameIndex& other) const {
+      return size == other.size && std::memcmp(data, other.data, size) == 0;
+    }
+  };
+
+  struct NameIndexHasher {
+    size_t operator()(const NameIndex& nameIndex) const {
+      folly::f14::DefaultHasher<std::string_view> hasher;
+      return hasher(std::string_view{nameIndex.data, nameIndex.size});
+    }
+  };
+
+  folly::F14ValueSet<NameIndex, NameIndexHasher> set_;
+};
+
+} // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -436,7 +436,7 @@ const std::vector<TypeParameter>* RowType::ensureParameters() const {
   return newParameters.release();
 }
 
-const RowType::NameToIndex* RowType::ensureNameToIndex() const {
+const NameToIndex* RowType::ensureNameToIndex() const {
   auto newNameToIndex = std::make_unique<NameToIndex>();
   newNameToIndex->reserve(names_.size());
   for (uint32_t i = 0; const auto& name : names_) {
@@ -444,7 +444,7 @@ const RowType::NameToIndex* RowType::ensureNameToIndex() const {
         [[unlikely]] {
       return oldNameToIndex;
     }
-    newNameToIndex->emplace(NameIndex{name, i++});
+    newNameToIndex->insert(name, i++);
   }
 
   NameToIndex* oldNameToIndex = nullptr;
@@ -508,7 +508,7 @@ bool RowType::isComparable() const {
 }
 
 bool RowType::containsChild(std::string_view name) const {
-  return nameToIndex().contains(NameIndex{name, 0});
+  return nameToIndex().contains(name);
 }
 
 uint32_t RowType::getChildIdx(std::string_view name) const {
@@ -521,12 +521,7 @@ uint32_t RowType::getChildIdx(std::string_view name) const {
 
 std::optional<uint32_t> RowType::getChildIdxIfExists(
     std::string_view name) const {
-  const auto& nameToIndex = this->nameToIndex();
-  auto it = nameToIndex.find(NameIndex{name, 0});
-  if (it != nameToIndex.end()) {
-    return it->index;
-  }
-  return std::nullopt;
+  return nameToIndex().find(name);
 }
 
 bool RowType::equivalent(const Type& other) const {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -41,6 +41,7 @@
 #include "velox/common/base/Macros.h"
 #include "velox/common/serialization/Serializable.h"
 #include "velox/type/HugeInt.h"
+#include "velox/type/NameToIndex.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/Tree.h"
@@ -1093,34 +1094,6 @@ class MapType : public TypeBase<TypeKind::MAP> {
 using MapTypePtr = std::shared_ptr<const MapType>;
 
 class RowType : public TypeBase<TypeKind::ROW> {
-  // This Set<NameIndex> written only to decrease memory footprint.
-  // In general it can be replaced with Map<string_view, size_t>
-  struct NameIndex {
-    explicit NameIndex(std::string_view name, uint32_t index)
-        : data{name.data()},
-          size{static_cast<uint32_t>(name.size())},
-          index{index} {}
-
-    const char* data = nullptr;
-    uint32_t size = 0;
-
-    bool operator==(const NameIndex& other) const {
-      return size == other.size && std::memcmp(data, other.data, size) == 0;
-    }
-
-    uint32_t index = 0;
-  };
-
-  struct NameIndexHasher {
-    size_t operator()(const NameIndex& nameIndex) const {
-      folly::f14::DefaultHasher<std::string_view> hasher;
-      return hasher(std::string_view{nameIndex.data, nameIndex.size});
-    }
-  };
-
-  // TODO: Consider using absl::flat_hash_set instead.
-  using NameToIndex = folly::F14ValueSet<NameIndex, NameIndexHasher>;
-
  public:
   /// @param names Child names. Case sensitive. Can be empty. May contain
   /// duplicates.

--- a/velox/type/tests/NameToIndexTest.cpp
+++ b/velox/type/tests/NameToIndexTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/type/NameToIndex.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+class NameToIndexTest : public testing::Test {
+ protected:
+  NameToIndex nameToIndex_;
+};
+
+TEST_F(NameToIndexTest, emptyLookup) {
+  EXPECT_FALSE(nameToIndex_.contains("foo"));
+  EXPECT_FALSE(nameToIndex_.find("foo").has_value());
+}
+
+TEST_F(NameToIndexTest, insertAndContains) {
+  nameToIndex_.insert("foo", 0);
+  nameToIndex_.insert("bar", 1);
+  nameToIndex_.insert("baz", 2);
+
+  EXPECT_TRUE(nameToIndex_.contains("foo"));
+  EXPECT_TRUE(nameToIndex_.contains("bar"));
+  EXPECT_TRUE(nameToIndex_.contains("baz"));
+  EXPECT_FALSE(nameToIndex_.contains("qux"));
+}
+
+TEST_F(NameToIndexTest, insertAndFind) {
+  nameToIndex_.insert("foo", 0);
+  nameToIndex_.insert("bar", 1);
+  nameToIndex_.insert("baz", 2);
+
+  EXPECT_EQ(nameToIndex_.find("foo"), 0);
+  EXPECT_EQ(nameToIndex_.find("bar"), 1);
+  EXPECT_EQ(nameToIndex_.find("baz"), 2);
+  EXPECT_FALSE(nameToIndex_.find("qux").has_value());
+}
+
+TEST_F(NameToIndexTest, caseSensitivity) {
+  nameToIndex_.insert("Foo", 0);
+
+  EXPECT_TRUE(nameToIndex_.contains("Foo"));
+  EXPECT_FALSE(nameToIndex_.contains("foo"));
+  EXPECT_FALSE(nameToIndex_.contains("FOO"));
+}
+
+TEST_F(NameToIndexTest, emptyString) {
+  nameToIndex_.insert("", 0);
+
+  EXPECT_TRUE(nameToIndex_.contains(""));
+  EXPECT_EQ(nameToIndex_.find(""), 0);
+}
+
+TEST_F(NameToIndexTest, reserve) {
+  nameToIndex_.reserve(100);
+
+  nameToIndex_.insert("foo", 0);
+  EXPECT_TRUE(nameToIndex_.contains("foo"));
+  EXPECT_EQ(nameToIndex_.find("foo"), 0);
+}
+
+TEST_F(NameToIndexTest, duplicateInsert) {
+  nameToIndex_.insert("foo", 0);
+  nameToIndex_.insert("foo", 1);
+
+  // The first insert should win since we use emplace.
+  EXPECT_EQ(nameToIndex_.find("foo"), 0);
+}
+
+TEST_F(NameToIndexTest, size) {
+  EXPECT_EQ(nameToIndex_.size(), 0);
+
+  nameToIndex_.insert("foo", 0);
+  EXPECT_EQ(nameToIndex_.size(), 1);
+
+  nameToIndex_.insert("bar", 1);
+  EXPECT_EQ(nameToIndex_.size(), 2);
+
+  nameToIndex_.insert("baz", 2);
+  EXPECT_EQ(nameToIndex_.size(), 3);
+
+  // Duplicate insert should not increase size.
+  nameToIndex_.insert("foo", 3);
+  EXPECT_EQ(nameToIndex_.size(), 3);
+}


### PR DESCRIPTION
Summary:
## TL/DR
We seemed to have introduced O(1) name lookup for `RowType`. However, we are exposing the implementation detail `F14FastSet` directly in the interface.
This creates unnecessary API dependencies that Velox shouldn't be responsible for.

Here is my suggestion:
- Create a wrapper, and provide the minimal interfaces.
- Put it in a separate header, so that we can easily unittest.
- In future, we can evolve it with the minimal interfaces

This is exactly what this diff tries to achieve.

I hope this is reasonable

Following is AI generated summary
---
Refactors the NameToIndex lookup structure from RowType into a separate header file to improve code organization and reusability. The NameToIndex class provides a memory-efficient mapping from string names to uint32_t indices, which was previously embedded as an implementation detail within RowType.

Differential Revision: D90140810


