### PR TITLE
docs: Update Presto functions coverage map

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -2,7 +2,7 @@
 Array Functions
 =============================
 
-.. function:: all_match(array(T), function(T, boolean)) → boolean
+.. function:: all_match(array(T), function(T, boolean)) -> boolean
 
     Returns whether all elements of an array match the given predicate.
 
@@ -11,12 +11,21 @@ Array Functions
         Returns NULL if the predicate function returns NULL for one or more elements and true for all other elements.
         Throws an exception if the predicate fails for one or more elements and returns true or NULL for the rest.
 
-.. function:: any_match(array(T), function(T, boolean)) → boolean
+.. function:: any_match(array(T), function(T, boolean)) -> boolean
 
     Returns whether at least one element of an array matches the given predicate.
 
         Returns true if one or more elements match the predicate;
         Returns false if none of the elements matches (a special case is when the array is empty);
+        Returns NULL if the predicate function returns NULL for one or more elements and false for all other elements.
+        Throws an exception if the predicate fails for one or more elements and returns false or NULL for the rest.
+
+.. function:: none_match(array(T), function(T, boolean)) -> boolean
+
+    Returns whether no elements of an array match the given predicate.
+
+        Returns true if none of the elements matches the predicate (a special case is when the array is empty);
+        Returns false if one or more elements match;
         Returns NULL if the predicate function returns NULL for one or more elements and false for all other elements.
         Throws an exception if the predicate fails for one or more elements and returns false or NULL for the rest.
 
@@ -140,6 +149,17 @@ Array Functions
 .. function:: array_normalize(array(E), E) -> array(E)
 
     Normalizes array ``x`` by dividing each element by the p-norm of the array. It is equivalent to ``TRANSFORM(array, v -> v / REDUCE(array, 0, (a, v) -> a + POW(ABS(v), p), a -> POW(a, 1 / p))``, but the reduce part is only executed once. Returns null if the array is null or there are null array elements. If ``p`` is 0, then the input array is returned. Only REAL and DOUBLE types are supported.
+
+.. function:: arrays_overlap(x, y) -> boolean
+
+    Tests if arrays ``x`` and ``y`` have any non-null elements in common.
+    Returns null if there are no non-null elements in common but either array contains null.
+    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
+
+.. function:: array_union(x, y) -> array
+
+    Returns an array of the elements in the union of x and y, without duplicates.
+    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
 
 .. function:: array_position(x, element) -> bigint
 

--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -35,7 +35,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(4) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(4) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(9) {background-color: #6BA81E;}
@@ -56,13 +55,13 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(7) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(7) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(8) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(9) {background-color: #6BA81E;}
@@ -83,13 +82,13 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(11) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(11) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(11) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(12) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(1) {background-color: #6BA81E;}
@@ -106,31 +105,33 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(14) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(15) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(16) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(5) {background-color: #6BA81E;}
@@ -162,7 +163,9 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(25) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(26) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(4) {background-color: #6BA81E;}
@@ -171,35 +174,40 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(29) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(3) {background-color: #6BA81E;}
@@ -212,7 +220,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(36) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(36) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
@@ -223,7 +230,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(38) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(38) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(1) {background-color: #6BA81E;}
@@ -258,7 +264,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(43) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(44) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(7) {background-color: #6BA81E;}
@@ -276,6 +281,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(46) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(47) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(7) {background-color: #6BA81E;}
@@ -316,11 +322,13 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(53) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(54) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(5) {background-color: #6BA81E;}
@@ -333,13 +341,11 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(56) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(57) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(7) {background-color: #6BA81E;}
@@ -351,11 +357,13 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(59) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(60) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(61) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(7) {background-color: #6BA81E;}
@@ -410,7 +418,6 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(70) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(71) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(71) td:nth-child(7) {background-color: #6BA81E;}
@@ -428,6 +435,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(73) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(74) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(74) td:nth-child(7) {background-color: #6BA81E;}
@@ -453,11 +461,13 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(78) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(78) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(78) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(79) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(79) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(80) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(80) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(80) td:nth-child(3) {background-color: #6BA81E;}
@@ -466,6 +476,10 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(81) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(81) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(81) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(82) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(82) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(82) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(82) td:nth-child(4) {background-color: #6BA81E;}
     </style>
 
 .. table::
@@ -475,85 +489,86 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions                           Window Functions
     ================================================================================================================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`abs`                               :func:`date_format`                       :func:`ip_subnet_range`                   :func:`random`                            :func:`st_numpoints`                          :func:`approx_distinct`                       :func:`cume_dist`
-    :func:`acos`                              :func:`date_parse`                        :func:`is_finite`                         :func:`reduce`                            :func:`st_overlaps`                           :func:`approx_most_frequent`                  :func:`dense_rank`
-    :func:`all_match`                         :func:`date_trunc`                        :func:`is_infinite`                       :func:`regexp_extract`                    :func:`st_point`                              :func:`approx_percentile`                     :func:`first_value`
-    :func:`any_keys_match`                    :func:`day`                               :func:`is_json_scalar`                    :func:`regexp_extract_all`                :func:`st_pointn`                             :func:`approx_set`                            :func:`lag`
-    :func:`any_match`                         :func:`day_of_month`                      :func:`is_nan`                            :func:`regexp_like`                       :func:`st_points`                             :func:`arbitrary`                             :func:`last_value`
-    :func:`any_values_match`                  :func:`day_of_week`                       :func:`is_private_ip`                     :func:`regexp_replace`                    :func:`st_polygon`                            :func:`array_agg`                             :func:`lead`
-    :func:`array_average`                     :func:`day_of_year`                       :func:`is_subnet_of`                      :func:`regexp_split`                      :func:`st_relate`                             :func:`avg`                                   :func:`nth_value`
-    :func:`array_cum_sum`                     :func:`degrees`                           :func:`jaccard_index`                     regress                                   :func:`st_startpoint`                         :func:`bitwise_and_agg`                       :func:`ntile`
-    :func:`array_distinct`                    :func:`dot_product`                       :func:`json_array_contains`               :func:`reidentification_potential`        :func:`st_symdifference`                      :func:`bitwise_or_agg`                        :func:`percent_rank`
-    :func:`array_duplicates`                  :func:`dow`                               :func:`json_array_get`                    :func:`remove_nulls`                      :func:`st_touches`                            :func:`bool_and`                              :func:`rank`
-    :func:`array_except`                      :func:`doy`                               :func:`json_array_length`                 render                                    :func:`st_union`                              :func:`bool_or`                               :func:`row_number`
-    :func:`array_frequency`                   :func:`e`                                 :func:`json_extract`                      :func:`repeat`                            :func:`st_within`                             :func:`checksum`
-    :func:`array_has_duplicates`              :func:`element_at`                        :func:`json_extract_scalar`               :func:`replace`                           :func:`st_x`                                  :func:`classification_fall_out`
-    :func:`array_intersect`                   :func:`empty_approx_set`                  :func:`json_format`                       :func:`replace_first`                     :func:`st_xmax`                               :func:`classification_miss_rate`
-    :func:`array_join`                        :func:`ends_with`                         :func:`json_parse`                        :func:`reverse`                           :func:`st_xmin`                               :func:`classification_precision`
-    array_least_frequent                      :func:`enum_key`                          :func:`json_size`                         rgb                                       :func:`st_y`                                  :func:`classification_recall`
-    :func:`array_max`                         :func:`exp`                               key_sampling_percent                      :func:`round`                             :func:`st_ymax`                               :func:`classification_thresholds`
-    :func:`array_max_by`                      :func:`expand_envelope`                   l2_squared                                :func:`rpad`                              :func:`st_ymin`                               :func:`convex_hull_agg`
-    :func:`array_min`                         :func:`f_cdf`                             :func:`laplace_cdf`                       :func:`rtrim`                             :func:`starts_with`                           :func:`corr`
-    :func:`array_min_by`                      features                                  :func:`last_day_of_month`                 :func:`scale_qdigest`                     :func:`strpos`                                :func:`count`
-    :func:`array_normalize`                   :func:`filter`                            :func:`least`                             :func:`second`                            :func:`strrpos`                               :func:`count_if`
-    :func:`array_position`                    :func:`filter`                            :func:`length`                            :func:`secure_rand`                       :func:`substr`                                :func:`covar_pop`
-    :func:`array_remove`                      :func:`find_first`                        :func:`levenshtein_distance`              :func:`secure_random`                     :func:`tan`                                   :func:`covar_samp`
-    :func:`array_sort`                        :func:`find_first_index`                  :func:`line_interpolate_point`            :func:`sequence`                          :func:`tanh`                                  differential_entropy
-    :func:`array_sort_desc`                   :func:`flatten`                           :func:`line_locate_point`                 :func:`sha1`                              tdigest_agg                                   :func:`entropy`
-    array_split_into_chunks                   :func:`flatten_geometry_collections`      :func:`ln`                                :func:`sha256`                            :func:`timezone_hour`                         evaluate_classifier_predictions
-    :func:`array_sum`                         :func:`floor`                             :func:`localtime`                         :func:`sha512`                            :func:`timezone_minute`                       :func:`every`
-    :func:`array_top_n`                       :func:`fnv1_32`                           :func:`localtimestamp`                    :func:`shuffle`                           :func:`to_base`                               :func:`geometric_mean`
-    :func:`array_union`                       :func:`fnv1_64`                           :func:`log10`                             :func:`sign`                              to_base32                                     geometry_union_agg
-    :func:`arrays_overlap`                    :func:`fnv1a_32`                          :func:`log2`                              :func:`simplify_geometry`                 :func:`to_base64`                             :func:`histogram`
-    :func:`asin`                              :func:`fnv1a_64`                          :func:`longest_common_prefix`             :func:`sin`                               :func:`to_base64url`                          khyperloglog_agg
-    :func:`atan`                              :func:`format_datetime`                   :func:`lower`                             sketch_kll_quantile                       :func:`to_big_endian_32`                      :func:`kurtosis`
-    :func:`atan2`                             :func:`from_base`                         :func:`lpad`                              sketch_kll_rank                           :func:`to_big_endian_64`                      learn_classifier
-    bar                                       :func:`from_base32`                       :func:`ltrim`                             :func:`slice`                             :func:`to_geometry`                           learn_libsvm_classifier
-    :func:`beta_cdf`                          :func:`from_base64`                       :func:`map`                               spatial_partitions                        :func:`to_hex`                                learn_libsvm_regressor
-    :func:`bing_tile`                         :func:`from_base64url`                    :func:`map_concat`                        :func:`split`                             :func:`to_ieee754_32`                         learn_regressor
-    :func:`bing_tile_at`                      :func:`from_big_endian_32`                :func:`map_entries`                       :func:`split_part`                        :func:`to_ieee754_64`                         :func:`make_set_digest`
-    :func:`bing_tile_children`                :func:`from_big_endian_64`                :func:`map_filter`                        :func:`split_to_map`                      :func:`to_iso8601`                            :func:`map_agg`
-    :func:`bing_tile_coordinates`             :func:`from_hex`                          :func:`map_from_entries`                  :func:`split_to_multimap`                 :func:`to_milliseconds`                       :func:`map_union`
-    :func:`bing_tile_parent`                  :func:`from_ieee754_32`                   :func:`map_keys`                          :func:`spooky_hash_v2_32`                 :func:`to_spherical_geography`                :func:`map_union_sum`
-    :func:`bing_tile_polygon`                 :func:`from_ieee754_64`                   :func:`map_keys_by_top_n_values`          :func:`spooky_hash_v2_64`                 :func:`to_unixtime`                           :func:`max`
-    :func:`bing_tile_quadkey`                 :func:`from_iso8601_date`                 :func:`map_normalize`                     :func:`sqrt`                              :func:`to_utf8`                               :func:`max_by`
-    :func:`bing_tile_zoom_level`              :func:`from_iso8601_timestamp`            :func:`map_remove_null_values`            :func:`st_area`                           :func:`trail`                                 :func:`merge`
-    :func:`bing_tiles_around`                 :func:`from_unixtime`                     :func:`map_subset`                        :func:`st_asbinary`                       :func:`transform`                             :func:`merge_set_digest`
-    :func:`binomial_cdf`                      :func:`from_utf8`                         :func:`map_top_n`                         :func:`st_astext`                         :func:`transform_keys`                        :func:`min`
-    :func:`bit_count`                         :func:`gamma_cdf`                         :func:`map_top_n_keys`                    :func:`st_boundary`                       :func:`transform_values`                      :func:`min_by`
-    :func:`bit_length`                        :func:`geometry_as_geojson`               map_top_n_keys_by_value                   :func:`st_buffer`                         :func:`trim`                                  :func:`multimap_agg`
-    :func:`bitwise_and`                       :func:`geometry_from_geojson`             :func:`map_top_n_values`                  :func:`st_centroid`                       :func:`trim_array`                            :func:`noisy_avg_gaussian`
-    :func:`bitwise_arithmetic_shift_right`    :func:`geometry_invalid_reason`           :func:`map_values`                        :func:`st_contains`                       :func:`truncate`                              :func:`noisy_count_gaussian`
-    :func:`bitwise_left_shift`                :func:`geometry_nearest_points`           :func:`map_zip_with`                      :func:`st_convexhull`                     :func:`typeof`                                :func:`noisy_count_if_gaussian`
-    :func:`bitwise_logical_shift_right`       :func:`geometry_to_bing_tiles`            :func:`md5`                               :func:`st_coorddim`                       :func:`uniqueness_distribution`               :func:`noisy_sum_gaussian`
-    :func:`bitwise_not`                       :func:`geometry_to_dissolved_bing_tiles`  :func:`merge_hll`                         :func:`st_crosses`                        :func:`upper`                                 :func:`numeric_histogram`
-    :func:`bitwise_or`                        :func:`geometry_union`                    :func:`merge_khll`                        :func:`st_difference`                     :func:`url_decode`                            :func:`qdigest_agg`
-    :func:`bitwise_right_shift`               google_polyline_decode                    :func:`millisecond`                       :func:`st_dimension`                      :func:`url_encode`                            :func:`reduce_agg`
-    :func:`bitwise_right_shift_arithmetic`    google_polyline_encode                    :func:`minute`                            :func:`st_disjoint`                       :func:`url_extract_fragment`                  :func:`regr_avgx`
-    :func:`bitwise_shift_left`                :func:`great_circle_distance`             :func:`mod`                               :func:`st_distance`                       :func:`url_extract_host`                      :func:`regr_avgy`
-    :func:`bitwise_xor`                       :func:`greatest`                          :func:`month`                             :func:`st_endpoint`                       :func:`url_extract_parameter`                 :func:`regr_count`
-    :func:`cardinality`                       :func:`hamming_distance`                  :func:`multimap_from_entries`             :func:`st_envelope`                       :func:`url_extract_path`                      :func:`regr_intercept`
-    :func:`cauchy_cdf`                        :func:`hash_counts`                       :func:`murmur3_x64_128`                   :func:`st_envelopeaspts`                  :func:`url_extract_port`                      :func:`regr_r2`
-    :func:`cbrt`                              :func:`hmac_md5`                          myanmar_font_encoding                     :func:`st_equals`                         :func:`url_extract_protocol`                  :func:`regr_slope`
-    :func:`ceil`                              :func:`hmac_sha1`                         myanmar_normalize_unicode                 :func:`st_exteriorring`                   :func:`url_extract_query`                     :func:`regr_sxx`
-    :func:`ceiling`                           :func:`hmac_sha256`                       :func:`nan`                               :func:`st_geometries`                     :func:`uuid`                                  :func:`regr_sxy`
-    :func:`chi_squared_cdf`                   :func:`hmac_sha512`                       :func:`ngrams`                            :func:`st_geometryfromtext`               :func:`value_at_quantile`                     :func:`regr_syy`
-    :func:`chr`                               :func:`hour`                              :func:`no_keys_match`                     :func:`st_geometryn`                      :func:`values_at_quantiles`                   :func:`reservoir_sample`
-    classify                                  :func:`infinity`                          :func:`no_values_match`                   :func:`st_geometrytype`                   :func:`week`                                  :func:`set_agg`
-    :func:`codepoint`                         :func:`intersection_cardinality`          :func:`none_match`                        :func:`st_geomfrombinary`                 :func:`week_of_year`                          :func:`set_union`
-    color                                     :func:`inverse_beta_cdf`                  :func:`normal_cdf`                        :func:`st_interiorringn`                  :func:`weibull_cdf`                           sketch_kll
-    :func:`combinations`                      :func:`inverse_binomial_cdf`              :func:`normalize`                         :func:`st_interiorrings`                  :func:`width_bucket`                          sketch_kll_with_k
-    :func:`concat`                            :func:`inverse_cauchy_cdf`                :func:`now`                               :func:`st_intersection`                   :func:`wilson_interval_lower`                 :func:`skewness`
-    :func:`contains`                          :func:`inverse_chi_squared_cdf`           :func:`parse_datetime`                    :func:`st_intersects`                     :func:`wilson_interval_upper`                 spatial_partitioning
-    :func:`cos`                               :func:`inverse_f_cdf`                     :func:`parse_duration`                    :func:`st_isclosed`                       :func:`word_stem`                             :func:`stddev`
-    :func:`cosh`                              :func:`inverse_gamma_cdf`                 :func:`parse_presto_data_size`            :func:`st_isempty`                        :func:`xxhash64`                              :func:`stddev_pop`
-    :func:`cosine_similarity`                 :func:`inverse_laplace_cdf`               :func:`pi`                                :func:`st_isring`                         :func:`year`                                  :func:`stddev_samp`
-    :func:`crc32`                             :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            :func:`st_issimple`                       :func:`year_of_week`                          :func:`sum`
-    :func:`current_date`                      :func:`inverse_poisson_cdf`               :func:`poisson_cdf`                       :func:`st_isvalid`                        :func:`yow`                                   :func:`tdigest_agg`
-    :func:`current_time`                      :func:`inverse_weibull_cdf`               :func:`pow`                               :func:`st_length`                         :func:`zip`                                   :func:`var_pop`
-    :func:`current_timestamp`                 :func:`ip_prefix`                         :func:`power`                             :func:`st_linefromtext`                   :func:`zip_with`                              :func:`var_samp`
-    :func:`current_timezone`                  :func:`ip_prefix_collapse`                :func:`quantile_at_value`                 :func:`st_linestring`                                                                   :func:`variance`
-    :func:`date`                              :func:`ip_prefix_subnets`                 :func:`quarter`                           :func:`st_multipoint`
-    :func:`date_add`                          :func:`ip_subnet_max`                     :func:`radians`                           :func:`st_numgeometries`
-    :func:`date_diff`                         :func:`ip_subnet_min`                     :func:`rand`                              :func:`st_numinteriorring`
+    :func:`abs`                               :func:`date_parse`                        :func:`is_json_scalar`                    :func:`regexp_like`                       :func:`st_numgeometries`                      :func:`approx_distinct`                       :func:`cume_dist`
+    :func:`acos`                              :func:`date_trunc`                        :func:`is_nan`                            :func:`regexp_replace`                    :func:`st_numinteriorring`                    :func:`approx_most_frequent`                  :func:`dense_rank`
+    :func:`all_match`                         :func:`day`                               :func:`is_private_ip`                     :func:`regexp_split`                      :func:`st_numpoints`                          :func:`approx_percentile`                     :func:`first_value`
+    :func:`any_keys_match`                    :func:`day_of_month`                      :func:`is_subnet_of`                      regress                                   :func:`st_overlaps`                           :func:`approx_set`                            :func:`lag`
+    :func:`any_match`                         :func:`day_of_week`                       :func:`jaccard_index`                     :func:`reidentification_potential`        :func:`st_point`                              :func:`arbitrary`                             :func:`last_value`
+    :func:`any_values_match`                  :func:`day_of_year`                       :func:`json_array_contains`               :func:`remove_nulls`                      :func:`st_pointn`                             :func:`array_agg`                             :func:`lead`
+    :func:`array_average`                     :func:`degrees`                           :func:`json_array_get`                    render                                    :func:`st_points`                             :func:`avg`                                   :func:`nth_value`
+    :func:`array_cum_sum`                     :func:`dot_product`                       :func:`json_array_length`                 :func:`repeat`                            :func:`st_polygon`                            :func:`bitwise_and_agg`                       :func:`ntile`
+    :func:`array_distinct`                    :func:`dow`                               :func:`json_extract`                      :func:`replace`                           :func:`st_relate`                             :func:`bitwise_or_agg`                        :func:`percent_rank`
+    :func:`array_duplicates`                  :func:`doy`                               :func:`json_extract_scalar`               :func:`replace_first`                     :func:`st_startpoint`                         :func:`bool_and`                              :func:`rank`
+    :func:`array_except`                      :func:`e`                                 :func:`json_format`                       :func:`reverse`                           :func:`st_symdifference`                      :func:`bool_or`                               :func:`row_number`
+    :func:`array_frequency`                   :func:`element_at`                        :func:`json_parse`                        rgb                                       :func:`st_touches`                            :func:`checksum`
+    :func:`array_has_duplicates`              :func:`empty_approx_set`                  :func:`json_size`                         :func:`round`                             :func:`st_union`                              :func:`classification_fall_out`
+    :func:`array_intersect`                   :func:`ends_with`                         :func:`key_sampling_percent`              :func:`rpad`                              :func:`st_within`                             :func:`classification_miss_rate`
+    :func:`array_join`                        :func:`enum_key`                          l2_squared                                :func:`rtrim`                             :func:`st_x`                                  :func:`classification_precision`
+    array_least_frequent                      :func:`exp`                               :func:`laplace_cdf`                       :func:`s2_cell_area_sq_km`                :func:`st_xmax`                               :func:`classification_recall`
+    :func:`array_max`                         :func:`expand_envelope`                   :func:`last_day_of_month`                 :func:`s2_cell_contains`                  :func:`st_xmin`                               :func:`classification_thresholds`
+    :func:`array_max_by`                      :func:`f_cdf`                             :func:`least`                             :func:`s2_cell_from_token`                :func:`st_y`                                  :func:`convex_hull_agg`
+    :func:`array_min`                         features                                  :func:`length`                            :func:`s2_cell_level`                     :func:`st_ymax`                               :func:`corr`
+    :func:`array_min_by`                      :func:`filter`                            :func:`levenshtein_distance`              :func:`s2_cell_parent`                    :func:`st_ymin`                               :func:`count`
+    :func:`array_normalize`                   :func:`find_first`                        :func:`line_interpolate_point`            :func:`s2_cell_to_token`                  :func:`starts_with`                           :func:`count_if`
+    :func:`array_position`                    :func:`find_first_index`                  :func:`line_locate_point`                 :func:`s2_cells`                          :func:`strpos`                                :func:`covar_pop`
+    :func:`array_remove`                      :func:`flatten`                           :func:`ln`                                :func:`scale_qdigest`                     :func:`strrpos`                               :func:`covar_samp`
+    :func:`array_sort`                        :func:`flatten_geometry_collections`      :func:`localtime`                         :func:`second`                            :func:`substr`                                differential_entropy
+    :func:`array_sort_desc`                   :func:`floor`                             :func:`localtimestamp`                    :func:`secure_rand`                       :func:`tan`                                   :func:`entropy`
+    :func:`array_split_into_chunks`           :func:`fnv1_32`                           :func:`log10`                             :func:`secure_random`                     :func:`tanh`                                  evaluate_classifier_predictions
+    :func:`array_sum`                         :func:`fnv1_64`                           :func:`log2`                              :func:`sequence`                          tdigest_agg                                   :func:`every`
+    :func:`array_top_n`                       :func:`fnv1a_32`                          :func:`longest_common_prefix`             :func:`sha1`                              :func:`timezone_hour`                         :func:`geometric_mean`
+    :func:`array_union`                       :func:`fnv1a_64`                          :func:`lower`                             :func:`sha256`                            :func:`timezone_minute`                       :func:`geometry_union_agg`
+    :func:`arrays_overlap`                    :func:`format_datetime`                   :func:`lpad`                              :func:`sha512`                            :func:`to_base`                               :func:`histogram`
+    :func:`asin`                              :func:`from_base`                         :func:`ltrim`                             :func:`shuffle`                           to_base32                                     :func:`khyperloglog_agg`
+    :func:`atan`                              :func:`from_base32`                       :func:`map`                               :func:`sign`                              :func:`to_base64`                             :func:`kurtosis`
+    :func:`atan2`                             :func:`from_base64`                       :func:`map_concat`                        :func:`simplify_geometry`                 :func:`to_base64url`                          learn_classifier
+    bar                                       :func:`from_base64url`                    :func:`map_entries`                       :func:`sin`                               :func:`to_big_endian_32`                      learn_libsvm_classifier
+    :func:`beta_cdf`                          :func:`from_big_endian_32`                :func:`map_filter`                        sketch_kll_quantile                       :func:`to_big_endian_64`                      learn_libsvm_regressor
+    :func:`bing_tile`                         :func:`from_big_endian_64`                :func:`map_from_entries`                  sketch_kll_rank                           :func:`to_geometry`                           learn_regressor
+    :func:`bing_tile_at`                      :func:`from_hex`                          :func:`map_keys`                          :func:`slice`                             :func:`to_hex`                                :func:`make_set_digest`
+    :func:`bing_tile_children`                :func:`from_ieee754_32`                   :func:`map_keys_by_top_n_values`          spatial_partitions                        :func:`to_ieee754_32`                         :func:`map_agg`
+    :func:`bing_tile_coordinates`             :func:`from_ieee754_64`                   :func:`map_normalize`                     :func:`split`                             :func:`to_ieee754_64`                         :func:`map_union`
+    :func:`bing_tile_parent`                  :func:`from_iso8601_date`                 :func:`map_remove_null_values`            :func:`split_part`                        :func:`to_iso8601`                            :func:`map_union_sum`
+    :func:`bing_tile_polygon`                 :func:`from_iso8601_timestamp`            :func:`map_subset`                        :func:`split_to_map`                      :func:`to_milliseconds`                       :func:`max`
+    :func:`bing_tile_quadkey`                 :func:`from_unixtime`                     :func:`map_top_n`                         :func:`split_to_multimap`                 :func:`to_spherical_geography`                :func:`max_by`
+    :func:`bing_tile_zoom_level`              :func:`from_utf8`                         :func:`map_top_n_keys`                    :func:`spooky_hash_v2_32`                 :func:`to_unixtime`                           :func:`merge`
+    :func:`bing_tiles_around`                 :func:`gamma_cdf`                         map_top_n_keys_by_value                   :func:`spooky_hash_v2_64`                 :func:`to_utf8`                               :func:`merge_set_digest`
+    :func:`binomial_cdf`                      :func:`geometry_as_geojson`               :func:`map_top_n_values`                  :func:`sqrt`                              :func:`trail`                                 :func:`min`
+    :func:`bit_count`                         :func:`geometry_from_geojson`             :func:`map_values`                        :func:`st_area`                           :func:`transform`                             :func:`min_by`
+    :func:`bit_length`                        :func:`geometry_invalid_reason`           :func:`map_zip_with`                      :func:`st_asbinary`                       :func:`transform_keys`                        :func:`multimap_agg`
+    :func:`bitwise_and`                       :func:`geometry_nearest_points`           :func:`md5`                               :func:`st_astext`                         :func:`transform_values`                      :func:`noisy_avg_gaussian`
+    :func:`bitwise_arithmetic_shift_right`    :func:`geometry_to_bing_tiles`            :func:`merge_hll`                         :func:`st_boundary`                       :func:`trim`                                  :func:`noisy_count_gaussian`
+    :func:`bitwise_left_shift`                :func:`geometry_to_dissolved_bing_tiles`  :func:`merge_khll`                        :func:`st_buffer`                         :func:`trim_array`                            :func:`noisy_count_if_gaussian`
+    :func:`bitwise_logical_shift_right`       :func:`geometry_union`                    :func:`millisecond`                       :func:`st_centroid`                       :func:`truncate`                              :func:`noisy_sum_gaussian`
+    :func:`bitwise_not`                       :func:`google_polyline_decode`            :func:`minute`                            :func:`st_contains`                       :func:`typeof`                                :func:`numeric_histogram`
+    :func:`bitwise_or`                        :func:`google_polyline_encode`            :func:`mod`                               :func:`st_convexhull`                     :func:`uniqueness_distribution`               :func:`qdigest_agg`
+    :func:`bitwise_right_shift`               :func:`great_circle_distance`             :func:`month`                             :func:`st_coorddim`                       :func:`upper`                                 :func:`reduce_agg`
+    :func:`bitwise_right_shift_arithmetic`    :func:`greatest`                          :func:`multimap_from_entries`             :func:`st_crosses`                        :func:`url_decode`                            :func:`regr_avgx`
+    :func:`bitwise_shift_left`                :func:`hamming_distance`                  :func:`murmur3_x64_128`                   :func:`st_difference`                     :func:`url_encode`                            :func:`regr_avgy`
+    :func:`bitwise_xor`                       :func:`hash_counts`                       myanmar_font_encoding                     :func:`st_dimension`                      :func:`url_extract_fragment`                  :func:`regr_count`
+    :func:`cardinality`                       :func:`hmac_md5`                          myanmar_normalize_unicode                 :func:`st_disjoint`                       :func:`url_extract_host`                      :func:`regr_intercept`
+    :func:`cauchy_cdf`                        :func:`hmac_sha1`                         :func:`nan`                               :func:`st_distance`                       :func:`url_extract_parameter`                 :func:`regr_r2`
+    :func:`cbrt`                              :func:`hmac_sha256`                       :func:`ngrams`                            :func:`st_endpoint`                       :func:`url_extract_path`                      :func:`regr_slope`
+    :func:`ceil`                              :func:`hmac_sha512`                       :func:`no_keys_match`                     :func:`st_envelope`                       :func:`url_extract_port`                      :func:`regr_sxx`
+    :func:`ceiling`                           :func:`hour`                              :func:`no_values_match`                   :func:`st_envelopeaspts`                  :func:`url_extract_protocol`                  :func:`regr_sxy`
+    :func:`chi_squared_cdf`                   :func:`infinity`                          :func:`none_match`                        :func:`st_equals`                         :func:`url_extract_query`                     :func:`regr_syy`
+    :func:`chr`                               :func:`intersection_cardinality`          :func:`normal_cdf`                        :func:`st_exteriorring`                   :func:`uuid`                                  :func:`reservoir_sample`
+    classify                                  :func:`inverse_beta_cdf`                  :func:`normalize`                         :func:`st_geometries`                     :func:`value_at_quantile`                     :func:`set_agg`
+    :func:`codepoint`                         :func:`inverse_binomial_cdf`              :func:`now`                               :func:`st_geometryfromtext`               :func:`values_at_quantiles`                   :func:`set_union`
+    color                                     :func:`inverse_cauchy_cdf`                :func:`parse_datetime`                    :func:`st_geometryn`                      :func:`week`                                  sketch_kll
+    :func:`combinations`                      :func:`inverse_chi_squared_cdf`           :func:`parse_duration`                    :func:`st_geometrytype`                   :func:`week_of_year`                          sketch_kll_with_k
+    :func:`concat`                            :func:`inverse_f_cdf`                     :func:`parse_presto_data_size`            :func:`st_geomfrombinary`                 :func:`weibull_cdf`                           :func:`skewness`
+    :func:`contains`                          :func:`inverse_gamma_cdf`                 :func:`pi`                                :func:`st_interiorringn`                  :func:`width_bucket`                          spatial_partitioning
+    :func:`cos`                               :func:`inverse_laplace_cdf`               pinot_binary_decimal_to_double            :func:`st_interiorrings`                  :func:`wilson_interval_lower`                 :func:`stddev`
+    :func:`cosh`                              :func:`inverse_normal_cdf`                :func:`poisson_cdf`                       :func:`st_intersection`                   :func:`wilson_interval_upper`                 :func:`stddev_pop`
+    :func:`cosine_similarity`                 :func:`inverse_poisson_cdf`               :func:`pow`                               :func:`st_intersects`                     :func:`word_stem`                             :func:`stddev_samp`
+    :func:`crc32`                             :func:`inverse_weibull_cdf`               :func:`power`                             :func:`st_isclosed`                       :func:`xxhash64`                              :func:`sum`
+    :func:`current_date`                      :func:`ip_prefix`                         :func:`quantile_at_value`                 :func:`st_isempty`                        :func:`year`                                  :func:`tdigest_agg`
+    :func:`current_time`                      :func:`ip_prefix_collapse`                :func:`quarter`                           :func:`st_isring`                         :func:`year_of_week`                          :func:`var_pop`
+    :func:`current_timestamp`                 :func:`ip_prefix_subnets`                 :func:`radians`                           :func:`st_issimple`                       :func:`yow`                                   :func:`var_samp`
+    :func:`current_timezone`                  :func:`ip_subnet_max`                     :func:`rand`                              :func:`st_isvalid`                        :func:`zip`                                   :func:`variance`
+    :func:`date`                              :func:`ip_subnet_min`                     :func:`random`                            :func:`st_length`                         :func:`zip_with`
+    :func:`date_add`                          :func:`ip_subnet_range`                   :func:`reduce`                            :func:`st_linefromtext`
+    :func:`date_diff`                         :func:`is_finite`                         :func:`regexp_extract`                    :func:`st_linestring`
+    :func:`date_format`                       :func:`is_infinite`                       :func:`regexp_extract_all`                :func:`st_multipoint`
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -46,40 +46,40 @@ the coordinate order is (x, y). The details of both WKT and WKB can be found
 Geometry Constructors
 ---------------------
 
-.. function:: ST_GeometryFromText(wkt: varchar) -> geometry: Geometry
+.. function:: st_geometryfromtext(wkt: varchar) -> geometry: Geometry
 
     Creates a Geometry object from the Well-Known Text (WKT) formatted string.
     Ill-formed strings will return a User Error.
 
-.. function:: ST_GeomFromBinary(wkb: varbinary) -> geometry: Geometry
+.. function:: st_geomfrombinary(wkb: varbinary) -> geometry: Geometry
 
     Creates a Geometry object from the Well-Known Binary (WKB) formatted binary.
     Ill-formed binary will return a User Error.
 
-.. function:: ST_AsText(geometry: Geometry) -> wkt: varchar
+.. function:: st_astext(geometry: Geometry) -> wkt: varchar
 
     Returns the Well-Known Text (WKT) formatted string of the Geometry object.
 
-.. function:: ST_AsBinary(geometry: Geometry) -> wkb: varbinary
+.. function:: st_asbinary(geometry: Geometry) -> wkb: varbinary
 
     Returns the Well-Known Binary (WKB) formatted binary of the Geometry object.
 
-.. function:: ST_Point(x: double, y: double) -> geometry: Geometry
+.. function:: st_point(x: double, y: double) -> geometry: Geometry
 
     Returns the Point geometry at the given coordinates.  This will raise an
     error if ``x`` or ``y`` is ``NaN`` or ``infinity``.
 
-.. function:: ST_Polygon(wkt: varchar) -> polygon: Geometry
+.. function:: st_polygon(wkt: varchar) -> polygon: Geometry
 
     Returns a geometry type polygon object from WKT representation.
 
-.. function:: ST_LineFromText(wkt: varchar) -> linestring: Geometry
+.. function:: st_linefromtext(wkt: varchar) -> linestring: Geometry
 
     Returns a geometry type linestring object from WKT representation.
     An error is returned if the input WKT represents a valid non-LineString
     geometry. Null input returns null output.
 
-.. function:: ST_LineString(points: array(Geometry)) -> linestring: Geometry
+.. function:: st_linestring(points: array(Geometry)) -> linestring: Geometry
 
     Returns a LineString formed from an array of points. If there are fewer
     than two non-empty points in the input array, an empty LineString will
@@ -88,7 +88,7 @@ Geometry Constructors
     e.g. may self-intersect or may contain duplicate vertexes depending on the
     input.
 
-.. function:: ST_MultiPoint(points: array(Geometry)) -> multipoint: Geometry
+.. function:: st_multipoint(points: array(Geometry)) -> multipoint: Geometry
 
     Returns a MultiPoint geometry object formed from the specified points.
     Return null if input array is empty. Throws an exception if any element
@@ -117,51 +117,51 @@ as "overlaps" or "touches." The exact conditions can be surprising (especially
 for empty geometries), so be sure to read the documentation for the specific
 function you are using.
 
-.. function:: ST_Contains(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_contains(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if and only if no points of the second geometry lie in the
     exterior of the first geometry, and at least one point of the interior of
     the first geometry lies in the interior of the second geometry.
 
-.. function:: ST_Crosses(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_crosses(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if the supplied geometries have some, but not all, interior
     points in common.
 
-.. function:: ST_Disjoint(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_disjoint(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if the give geometries do not spatially intersect -- if
     they do not share any space together.
 
-.. function:: ST_Equals(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_equals(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if the given geometries represent the same geometry
     according to ISO SQL/MM semantics. Also returns ``true`` if both geometries are empty,
     regardless of their geometry types.
 
-.. function:: ST_Intersects(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_intersects(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if the given geometries spatially intersect in two
     dimensions (share any portion of space) and ``false``0 if they do not (they
     are disjoint).
 
-.. function:: ST_Overlaps(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_overlaps(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if the given geometries share space, are of the same
     dimension, but are not completely contained by each other.
 
-.. function:: ST_Relate(geometry1: Geometry, geometry2: Geometry, relation: varchar) -> boolean
+.. function:: st_relate(geometry1: Geometry, geometry2: Geometry, relation: varchar) -> boolean
 
     Returns true if first geometry is spatially related to second geometry as
     described by the relation.  The relation is a string like ``'"1*T***T**'``:
     please see the description of DM-9IM for more details.
 
-.. function:: ST_Touches(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_touches(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns ``true`` if the given geometries have at least one point in common,
     but their interiors do not intersect.
 
-.. function:: ST_Within(geometry1: Geometry, geometry2: Geometry) -> boolean
+.. function:: st_within(geometry1: Geometry, geometry2: Geometry) -> boolean
 
     Returns true if first geometry is completely inside second geometry.
 
@@ -171,38 +171,38 @@ function you are using.
 Spatial Operations
 ------------------
 
-.. function:: ST_Boundary(geometry: Geometry) -> boundary: Geometry
+.. function:: st_boundary(geometry: Geometry) -> boundary: Geometry
 
     Returns the closure of the combinatorial boundary of ``geometry``.
      Empty geometry inputs result in empty output.
 
-.. function:: ST_Difference(geometry1: Geometry, geometry2: Geometry) -> difference: Geometry
+.. function:: st_difference(geometry1: Geometry, geometry2: Geometry) -> difference: Geometry
 
     Returns the geometry that represents the portion of ``geometry1`` that is
     not contained in ``geometry2``.
 
-.. function:: ST_Intersection(geometry1: Geometry, geometry2: Geometry) -> intersection: Geometry
+.. function:: st_intersection(geometry1: Geometry, geometry2: Geometry) -> intersection: Geometry
 
     Returns the geometry that represents the portion of ``geometry1`` that is
     also contained in ``geometry2``.
 
-.. function:: ST_SymDifference(geometry1: Geometry, geometry2: Geometry) -> symdifference: Geometry
+.. function:: st_symdifference(geometry1: Geometry, geometry2: Geometry) -> symdifference: Geometry
 
     Returns the geometry that represents the portion of ``geometry1`` that is
     not contained in ``geometry2`` as well as the portion of ``geometry1`` that
     is not congtained in ``geometry1``.
 
-.. function:: ST_Union(geometry1: Geometry, geometry2: Geometry) -> intersection: Geometry
+.. function:: st_union(geometry1: Geometry, geometry2: Geometry) -> intersection: Geometry
 
     Returns the geometry that represents the all points in either ``geometry1``
     or ``geometry2``.
 
-.. function:: ST_Envelope(geometry: Geometry) -> envelope: Geometry
+.. function:: st_envelope(geometry: Geometry) -> envelope: Geometry
 
     Returns the bounding rectangular polygon of a ``geometry``. Empty input will
     result in empty output.
 
-.. function:: ST_ExteriorRing(geometry: Geometry) -> output: Geometry
+.. function:: st_exteriorring(geometry: Geometry) -> output: Geometry
 
     Returns a LineString representing the exterior ring of the input polygon.
     Empty or null inputs result in null output. Non-polygon types will return
@@ -268,57 +268,57 @@ Spatial Operations
 
 Accessors
 ---------
-.. function:: ST_IsValid(geometry: Geometry) -> valid: bool
+.. function:: st_isvalid(geometry: Geometry) -> valid: bool
 
     Returns if ``geometry`` is valid, according to `SQL/MM Part 3: Spatial`_.
     Examples of non-valid geometries include Polygons with self-intersecting shells.
 
-.. function:: ST_IsSimple(geometry: Geometry) -> simple: bool
+.. function:: st_issimple(geometry: Geometry) -> simple: bool
 
     Returns if ``geometry`` is simple, according to `SQL/MM Part 3: Spatial`_.
     Examples of non-simple geometries include LineStrings with self-intersections,
     Polygons with empty rings for holes, and more.
 
-.. function:: ST_IsClosed(geometry: Geometry) -> closed: bool
+.. function:: st_isclosed(geometry: Geometry) -> closed: bool
 
     Returns true if the LineString’s start and end points are coincident. Will
     return an error if the input geometry is not a LineString or MultiLineString.
 
-.. function:: ST_IsRing(geometry: Geometry) -> ring: bool
+.. function:: st_isring(geometry: Geometry) -> ring: bool
 
    Returns true if and only if the line is closed and simple. Will return an error
    if input geometry is not a LineString.
 
-.. function:: ST_IsEmpty(geometry: Geometry) -> empty: bool
+.. function:: st_isempty(geometry: Geometry) -> empty: bool
 
    Returns true if and only if this Geometry is an empty GeometryCollection, Polygon,
    Point etc.
 
-.. function:: ST_Length(geometry: Geometry) -> length: double
+.. function:: st_length(geometry: Geometry) -> length: double
 
    Returns the length of a LineString or MultiLineString using Euclidean measurement
    on a two dimensional plane (based on spatial ref) in projected units. Will
    return an error if the input geometry is not a LineString or MultiLineString.
 
-.. function:: ST_Length(sphericalgeography: SphericalGeography) -> length: double
+.. function:: st_length(sphericalgeography: SphericalGeography) -> length: double
    :noindex:
 
     Returns the length of a ``LineString`` or ``MultiLineString`` on a spherical model of the
     Earth. This is equivalent to the sum of great-circle distances between adjacent points
     on the ``LineString``.
 
-.. function:: ST_PointN(linestring: Geometry, index: integer) -> point: geometry
+.. function:: st_pointn(linestring: Geometry, index: integer) -> point: geometry
 
    Returns the vertex of a LineString at a given index (indices start at 1).
    If the given index is less than 1 or greater than the total number of elements
    in the collection, returns NULL.
 
-.. function:: ST_Points(geometry: Geometry) -> points: array(geometry)
+.. function:: st_points(geometry: Geometry) -> points: array(geometry)
 
    Returns an array of points in a geometry. Empty or null inputs
    return null.
 
-.. function:: ST_NumPoints(geometry: Geometry) -> points: bigint
+.. function:: st_numpoints(geometry: Geometry) -> points: bigint
 
    Returns the number of points in a geometry. This is an extension
    to the SQL/MM ``ST_NumPoints`` function which only applies to
@@ -333,7 +333,7 @@ Accessors
    argument. If there are multiple pairs with the minimum distance, one pair
    is chosen arbitrarily.
 
-.. function:: ST_EnvelopeAsPts(geometry: Geometry) -> points: array(geometry)
+.. function:: st_envelopeaspts(geometry: Geometry) -> points: array(geometry)
 
    Returns an array of two points: the lower left and upper right corners
    of the bounding rectangular polygon of a geometry. Empty or null inputs
@@ -349,24 +349,24 @@ Accessors
 
     Returns the great-circle distance between two points on Earth's surface in kilometers.
 
-.. function:: ST_Area(geometry: Geometry) -> area: double
+.. function:: st_area(geometry: Geometry) -> area: double
 
     Returns the 2D Euclidean area of ``geometry``.
     For Point and LineString types, returns 0.0. For GeometryCollection types,
     returns the sum of the areas of the individual geometries. Empty geometries
     return 0.
 
-.. function:: ST_Area(sphericalgeography: SphericalGeography) -> area: double
+.. function:: st_area(sphericalgeography: SphericalGeography) -> area: double
    :noindex:
 
     Returns the area of a polygon or multi-polygon in square meters using a spherical model for Earth.
 
-.. function:: ST_Centroid(geometry: Geometry) -> geometry: Geometry
+.. function:: st_centroid(geometry: Geometry) -> geometry: Geometry
 
     Returns the point value that is the mathematical centroid of ``geometry``.
     Empty geometry inputs result in null output.
 
-.. function:: ST_Centroid(SphericalGeography) -> Point
+.. function:: st_centroid(SphericalGeography) -> Point
    :noindex:
 
     Returns the point value that is the mathematical centroid of a spherical geometry.
@@ -379,65 +379,65 @@ Accessors
     (e.g. MULTIPOINT (0 0, -180 0)), the spherical centroid is undefined and an
     arbitrary point will be returned.
 
-.. function:: ST_Distance(geometry1: Geometry, geometry2: Geometry) -> distance: double
+.. function:: st_distance(geometry1: Geometry, geometry2: Geometry) -> distance: double
 
     Returns the 2-dimensional cartesian minimum distance (based on spatial ref)
     between two geometries in projected units. Empty geometries result in null output.
 
-.. function:: ST_Distance(sphericalgeography1: SphericalGeography, sphericalgeography2: SphericalGeography) -> distance: double
+.. function:: st_distance(sphericalgeography1: SphericalGeography, sphericalgeography2: SphericalGeography) -> distance: double
    :noindex:
 
     Returns the great-circle distance in meters between two SphericalGeography points.
 
-.. function:: ST_GeometryType(geometry: Geometry) -> type: varchar
+.. function:: st_geometrytype(geometry: Geometry) -> type: varchar
 
     Returns the type of the geometry.
 
-.. function:: ST_X(geometry: Geometry) -> x: double
+.. function:: st_x(geometry: Geometry) -> x: double
 
     Returns the ``x`` coordinate of the geometry if it is a Point.  Returns
     ``null`` if the geometry is empty.  Raises an error if the geometry is
     not a Point and not empty.
 
-.. function:: ST_Y(geometry: Geometry) -> x: double
+.. function:: st_y(geometry: Geometry) -> x: double
 
     Returns the ``y`` coordinate of the geometry if it is a Point.  Returns
     ``null`` if the geometry is empty.  Raises an error if the geometry is
     not a Point and not empty.
 
-.. function:: ST_XMin(geometry: Geometry) -> x: double
+.. function:: st_xmin(geometry: Geometry) -> x: double
 
     Returns the minimum ``x`` coordinate of the geometries bounding box.
     Returns ``null`` if the geometry is empty.
 
-.. function:: ST_YMin(geometry: Geometry) -> y: double
+.. function:: st_ymin(geometry: Geometry) -> y: double
 
     Returns the minimum ``y`` coordinate of the geometries bounding box.
     Returns ``null`` if the geometry is empty.
 
-.. function:: ST_XMax(geometry: Geometry) -> x: double
+.. function:: st_xmax(geometry: Geometry) -> x: double
 
     Returns the maximum ``x`` coordinate of the geometries bounding box.
     Returns ``null`` if the geometry is empty.
 
-.. function:: ST_YMax(geometry: Geometry) -> y: double
+.. function:: st_ymax(geometry: Geometry) -> y: double
 
     Returns the maximum ``y`` coordinate of the geometries bounding box.
     Returns ``null`` if the geometry is empty.
 
-.. function:: ST_StartPoint(geometry: Geometry) -> point: Geometry
+.. function:: st_startpoint(geometry: Geometry) -> point: Geometry
 
     Returns the first point of a LineString geometry as a Point.
     This is a shortcut for ``ST_PointN(geometry, 1)``. Empty
     input will return ``null``.
 
-.. function:: ST_EndPoint(geometry: Geometry) -> point: Geometry
+.. function:: st_endpoint(geometry: Geometry) -> point: Geometry
 
     Returns the last point of a LineString geometry as a Point.
     This is a shortcut for ``ST_PointN(geometry, ST_NumPoints(geometry))``.
     Empty input will return ``null``.
 
-.. function:: ST_GeometryN(geometry: Geometry, index: integer) -> geometry: Geometry
+.. function:: st_geometryn(geometry: Geometry, index: integer) -> geometry: Geometry
 
     Returns the ``geometry`` element at a given index (indices start at 1).
     If the ``geometry`` is a collection of geometries (e.g., GeometryCollection or
@@ -447,7 +447,7 @@ Accessors
     Singular geometries (e.g., Point, LineString, Polygon), are treated as
     collections of one element. Empty geometries are treated as empty collections.
 
-.. function:: ST_InteriorRingN(geometry: Geometry, index: integer) -> geometry: Geometry
+.. function:: st_interiorringn(geometry: Geometry, index: integer) -> geometry: Geometry
 
     Returns the interior ring element at the specified index (indices start at 1).
     If the given index is less than 1 or greater than the total number of interior
@@ -455,7 +455,7 @@ Accessors
     is not a polygon. Use ``:func:ST_NumInteriorRing`` to find out the total number of
     elements.
 
-.. function:: ST_NumGeometries(geometry: Geometry) -> output: integer
+.. function:: st_numgeometries(geometry: Geometry) -> output: integer
 
     Returns the number of geometries in the collection. If the geometry is a
     collection of geometries (e.g., GeometryCollection or Multi*),
@@ -468,14 +468,14 @@ Accessors
     ``ST_NumGeometries(ST_GeometryFromText('GEOMETRYCOLLECTION(POINT EMPTY, POINT (1 2))'))``
     will evaluate to 1.
 
-.. function:: ST_InteriorRings(geometry: Geometry) -> output: array(geometry)
+.. function:: st_interiorrings(geometry: Geometry) -> output: array(geometry)
 
     Returns an array of all interior rings found in the input geometry,
     or an empty array if the polygon has no interior rings. Returns
     null if the input geometry is empty.
     Throws an error if the input geometry is not a polygon.
 
-.. function:: ST_Geometries(geometry: Geometry) -> output: array(geometry)
+.. function:: st_geometries(geometry: Geometry) -> output: array(geometry)
 
     Returns an array of geometries in the specified collection. Returns
     a one-element array if the input geometry is not a multi-geometry.
@@ -497,29 +497,29 @@ Accessors
     GEOMETRYCOLLECTION (POINT (0 0), GEOMETRYCOLLECTION (POINT (1 1))) ->
     [POINT (0 0), POINT (1 1)], GEOMETRYCOLLECTION EMPTY -> [].
 
-.. function:: ST_NumInteriorRing(geometry: Geometry) -> output: bigint
+.. function:: st_numinteriorring(geometry: Geometry) -> output: bigint
 
     Returns the cardinality of the collection of interior rings of a polygon.
 
-.. function:: ST_ConvexHull(geometry: Geometry) -> output: Geometry
+.. function:: st_convexhull(geometry: Geometry) -> output: Geometry
 
     Returns the minimum convex geometry that encloses all input geometries.
 
-.. function:: ST_CoordDim(geometry: Geometry) -> output: tinyint
+.. function:: st_coorddim(geometry: Geometry) -> output: tinyint
 
     Return the coordinate dimension of the geometry.
 
-.. function:: ST_Dimension(geometry: Geometry) -> output: tinyint
+.. function:: st_dimension(geometry: Geometry) -> output: tinyint
 
     Returns the inherent dimension of this geometry object, which
     must be less than or equal to the coordinate dimension.
 
-.. function:: ST_ExteriorRing(geometry: Geometry) -> output: Geometry
+.. function:: st_exteriorring(geometry: Geometry) -> output: Geometry
    :noindex:
 
     Returns a line string representing the exterior ring of the input polygon.
 
-.. function:: ST_Buffer(geometry: Geometry, distance: double) -> output: Geometry
+.. function:: st_buffer(geometry: Geometry, distance: double) -> output: Geometry
 
     Returns the geometry that represents all points whose distance from the
     specified ``geometry`` is less than or equal to the specified ``distance``.

--- a/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
@@ -102,7 +102,6 @@ features
 filter
 find_first
 find_first_index
-filter
 flatten
 flatten_geometry_collections
 floor


### PR DESCRIPTION
Closes #15917 
Removed duplicate function filter() being shown in the coverage map.
Also updated functions that appeared green on the coverage map but were missing links, even though the documentation with links already existed.