### PR TITLE
fix: Revert Check for overlapping ranges when validating Array/MapVectors

### DIFF
--- a/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayDistinctTest.cpp
@@ -432,3 +432,43 @@ TEST_F(ArrayDistinctTest, timestampWithTimezone) {
        std::nullopt},
       {pack(1, 0), pack(2, 1), pack(3, 2), std::nullopt, pack(4, 3)});
 }
+
+TEST_F(ArrayDistinctTest, overlappingRanges) {
+  auto size = 4;
+  auto elements = makeFlatVector<int64_t>({0, 1, 2, 1, 2, 1, 2, 3});
+
+  // Allocate some overlapping arrays.
+  BufferPtr offsetsBuffer = allocateOffsets(size, pool());
+  BufferPtr sizesBuffer = allocateSizes(size, pool());
+  auto rawOffsets = offsetsBuffer->asMutable<vector_size_t>();
+  auto rawSizes = sizesBuffer->asMutable<vector_size_t>();
+
+  // [0, 1, 2, 1, 2]
+  rawOffsets[0] = 0;
+  rawSizes[0] = 5;
+
+  // [1, 2, 1, 2]
+  rawOffsets[1] = 1;
+  rawSizes[1] = 4;
+
+  // [2, 1, 2]
+  rawOffsets[2] = 4;
+  rawSizes[2] = 3;
+
+  // [1, 2, 3]
+  rawOffsets[3] = 5;
+  rawSizes[3] = 3;
+
+  auto array = std::make_shared<ArrayVector>(
+      pool(),
+      ARRAY(BIGINT()),
+      nullptr,
+      size,
+      offsetsBuffer,
+      sizesBuffer,
+      elements);
+
+  assertEqualVectors(
+      makeArrayVector<int64_t>({{0, 1, 2}, {1, 2}, {2, 1}, {1, 2, 3}}),
+      evaluate("array_distinct(c0)", makeRowVector({array})));
+}

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -985,10 +985,6 @@ void ArrayVectorBase::validateArrayVectorBase(
         "vector's size. Index: {}.",
         i);
   }
-
-  VELOX_CHECK(
-      !hasOverlappingRanges(),
-      "ArrayVectorBase must not have overlapping ranges of elements.");
 }
 
 namespace {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -4295,11 +4295,7 @@ TEST_F(VectorTest, hasOverlappingRanges) {
     if (!overlap) {
       ASSERT_FALSE(makeArray()->hasOverlappingRanges());
     } else {
-      const auto array = makeArray();
-      ASSERT_TRUE(array->hasOverlappingRanges());
-      VELOX_ASSERT_THROW(
-          array->validate({}),
-          "ArrayVectorBase must not have overlapping ranges of elements.");
+      ASSERT_TRUE(makeArray()->hasOverlappingRanges());
     }
   };
   test(3, {false, false, false}, {0, 1, 2}, {1, 1, 1}, false);


### PR DESCRIPTION
Summary:
We see at least some use cases still producing Array/MapVectors with overlapping range.

Reverting the checks until we get these fixed.

Differential Revision: D90354290


