### PR TITLE
perf(string-view)!: Remove implicit conversion to std::string

### DIFF
--- a/velox/connectors/hive/storage_adapters/gcs/tests/GcsMultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GcsMultipleEndpointsTest.cpp
@@ -100,7 +100,8 @@ class GcsMultipleEndpointsTest : public testing::Test,
     // Second column contains details about written files.
     auto details = results->childAt(exec::TableWriteTraits::kFragmentChannel)
                        ->as<FlatVector<StringView>>();
-    folly::dynamic obj = folly::parseJson(details->valueAt(1));
+    folly::dynamic obj =
+        folly::parseJson(std::string_view(details->valueAt(1)));
     return obj["fileWriteInfos"];
   }
 

--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -87,7 +87,8 @@ class InsertTest : public velox::test::VectorTestBase {
                        ->as<FlatVector<StringView>>();
     ASSERT_TRUE(details->isNullAt(0));
     ASSERT_FALSE(details->isNullAt(1));
-    folly::dynamic obj = folly::parseJson(details->valueAt(1));
+    folly::dynamic obj =
+        folly::parseJson(std::string_view(details->valueAt(1)));
 
     ASSERT_EQ(numRows, obj["rowCount"].asInt());
     auto fileWriteInfos = obj["fileWriteInfos"];

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -32,17 +32,40 @@
 
 namespace facebook::velox {
 
-/// Variable length string or binary type for use in vectors. This has
-/// semantics similar to std::string_view or folly::StringPiece and
-/// exposes a subset of the interface. If the string is 12 characters
-/// or less, it is inlined and no reference is held. If it is longer, a
-/// reference to the string is held and the 4 first characters are
-/// cached in the StringView. This allows failing comparisons early and
-/// reduces the CPU cache working set when dealing with short strings.
+/// C++ container to store a variable length string (or binary type) optimized
+/// for use in Vectors.
 ///
-/// Adapted from TU Munich Umbra and CWI DuckDB.
+/// StringView provides a lightweight, non-owning view of string data with
+/// semantics similar to std::string or std::string_view. It implements the
+/// following space optimization:
 ///
-/// TODO: Extend the interface to parity with folly::StringPiece as needed.
+/// - Strings <= 12 bytes: Fully inlined, no heap allocation or pointer
+///     indirection.
+/// - Strings > 12 bytes: Stores pointer + caches first 4 bytes as prefix.
+///
+/// The prefix caching enables early comparison failures and reduces CPU cache
+/// pressure when working with large sets of strings.
+///
+/// Memory Layout (16 bytes total):
+/// - 4 bytes: size.
+/// - 4 bytes: prefix (first 4 chars, or part of inline data).
+/// - 8 bytes: either inline data continuation OR pointer to external data.
+///
+/// Key Characteristics:
+/// - Non-owning: Does not manage lifetime of referenced data.
+/// - Immutable: Provides const access to underlying data.
+/// - Efficient comparisons: Uses prefix and size for fast inequality checks.
+/// - Zero-overhead for small strings: Fully inlined with no allocations.
+///
+/// Conversions:
+/// - Implicit: from char*, std::string_view (const& only).
+/// - Explicit: from std::string, folly::StringPiece.
+///
+/// Safety Notes:
+/// - StringView does NOT own the data it references.
+/// - Callers must ensure referenced data outlives the StringView.
+/// - Conversion to views from temporaries is explicitly deleted to prevent
+///   dangling references to inlined data.
 struct StringView {
  public:
   using value_type = char;
@@ -77,13 +100,13 @@ struct StringView {
     }
   }
 
-  // Making StringView implicitly constructible/convertible from char* and
-  // string literals, in order to allow for a more flexible API and optional
-  // interoperability. E.g:
-  //
-  //   StringView sv = "literal";
-  //   std::optional<StringView> osv = "literal";
-  //
+  /// Enabling StringView to be implicitly constructed from char* and
+  /// string literals, in order to allow for a more flexible API and optional
+  /// interoperability. E.g:
+  ///
+  /// >  StringView sv = "literal";
+  /// >  std::optional<StringView> osv = "literal";
+  ///
   /* implicit */ StringView(const char* data)
       : StringView(data, strlen(data)) {}
 
@@ -156,9 +179,9 @@ struct StringView {
                size_ - kPrefixSize) == 0;
   }
 
-  // Returns 0, if this == other
-  //       < 0, if this < other
-  //       > 0, if this > other
+  /// Returns 0, if this == other
+  ///       < 0, if this < other
+  ///       > 0, if this > other
   int32_t compare(const StringView& other) const {
     if (prefixAsInt() != other.prefixAsInt()) {
       // The result is decided on prefix. The shorter will be less because the
@@ -186,35 +209,52 @@ struct StringView {
                    : std::strong_ordering::equal;
   }
 
-  operator folly::StringPiece() && = delete;
-  operator folly::StringPiece() const& {
+  /// Conversion to folly::StringPiece can only be done explicitly. For example,
+  /// this is ok:
+  ///
+  /// > StringView sv();
+  /// > folly::StringPiece sp(sv);
+  ///
+  /// but no:
+  ///
+  /// > StringView sv();
+  /// > folly::StringPiece sp = sv;
+  ///
+  /// Note that we also explicitly disable conversion from a temporary (rvalue)
+  /// because this could have resulted in a folly::StringPiece wrapping around a
+  /// temporary buffer, if the StringView was inlined:
+  ///
+  /// > folly::StringPiece sp(StringView()); // unsafe, won't compile.
+  ///
+  explicit operator folly::StringPiece() && = delete;
+  explicit operator folly::StringPiece() const& {
     return folly::StringPiece(data(), size());
   }
 
-  operator std::string() const {
+  /// Similarly, conversion to std::string can only be done explicitly, since
+  /// this may result in an allocation and string copy.
+  ///
+  /// Note that in this case it is ok to enable conversion from a temporary
+  /// (rvalue) StringView since its contents will be copied into the
+  /// std::string.
+  ///
+  /// > std::string str(StringView()); // ok
+  explicit operator std::string() const {
     return std::string(data(), size());
   }
 
-  std::string str() const {
-    return *this;
-  }
-
-  std::string getString() const {
-    return *this;
-  }
-
-  std::string materialize() const {
-    return *this;
-  }
-
-  operator folly::dynamic() && = delete;
-  operator folly::dynamic() const& {
-    return folly::dynamic(folly::StringPiece(data(), size()));
-  }
-
-  operator std::string_view() && = delete;
-  explicit operator std::string_view() const& {
+  /// Conversion to std::string_view are allowed to be implicit, as long as they
+  /// are not from a temporary (rvalue) StringView, for the same reasons
+  /// described above.
+  /* implicit */ operator std::string_view() && = delete;
+  /* implicit */ operator std::string_view() const& {
     return std::string_view(data(), size());
+  }
+
+  // TODO: Should make this explicit-only.
+  /* implicit */ operator folly::dynamic() && = delete;
+  /* implicit */ operator folly::dynamic() const& {
+    return folly::dynamic(folly::StringPiece(data(), size()));
   }
 
   const char* begin() && = delete;
@@ -231,13 +271,28 @@ struct StringView {
     return size() == 0;
   }
 
-  /// Searches for 'key == strings[i]'for i >= 0 < numStrings. If
-  /// 'indices' is given. searches for 'key ==
-  /// strings[indices[i]]. Returns the first i for which the strings
-  /// match or -1 if no match is found. Uses SIMD to accelerate the
-  /// search. Accesses StringView bodies in 32 byte vectors, thus
-  /// expects up to 31 bytes of addressable padding after out of
-  /// line strings. This is the case for velox Buffers.
+  /// Convenience common std::string conversion aliases.
+  std::string str() const {
+    return std::string(*this);
+  }
+
+  std::string getString() const {
+    return std::string(*this);
+  }
+
+  std::string materialize() const {
+    return std::string(*this);
+  }
+
+  /// Searches for 'key == strings[i]' for i >= 0 < numStrings.
+  ///
+  /// If 'indices' is given, searches for 'key == strings[indices[i]]'. Returns
+  /// the first i for which the strings match or -1 if no match is found. Uses
+  /// SIMD to accelerate the search.
+  ///
+  /// Accesses StringView bodies in 32 byte vectors, thus expects up to 31 bytes
+  /// of addressable padding after out of line strings. This is the case for
+  /// velox Buffers.
   static int32_t linearSearch(
       StringView key,
       const StringView* strings,


### PR DESCRIPTION
Summary:
Remove implicit conversions from velox::StringView to
std::string, to avoid silent unintended copies and allocations. You can still
to do the conversion, but now it needs to explicitly stated:

> StringView sv;
> auto str = std::string(sv);

Also removing implicit conversions to folly::StringPiece, and some conversions
would have been made ambiguous with the implicit conversion to
std::string_view.

The codebase has been cleaned up from relying on these conversion in
previous PRs. 

Reviewed By: Magoja

Differential Revision: D89950455


