### PR TITLE
fix: Use EvictingCacheMap for compiled regular expressions

### DIFF
--- a/velox/common/caching/SimpleLRUCache.h
+++ b/velox/common/caching/SimpleLRUCache.h
@@ -109,8 +109,8 @@ struct SimpleLRUCacheStats {
 /// A simple LRU cache that allows each element to occupy an arbitrary amount of
 /// space in the cache. Useful when the size of the cached elements can vary a
 /// lot; if they are all roughly the same size something that only tracks the
-/// number of elements in the cache like common/datastruct/LRUCacheMap.h may be
-/// better.
+/// number of elements in the cache like folly/container/EvictingCacheMap.h may
+/// be better.
 ///
 /// NOTE:
 /// 1. NOT Thread-Safe: All the public calls modify internal structures and

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -113,8 +113,8 @@ class QueryConfig {
   static constexpr const char* kExprMaxArraySizeInReduce =
       "expression.max_array_size_in_reduce";
 
-  /// Controls maximum number of compiled regular expression patterns per
-  /// function instance per thread of execution.
+  /// Controls the capacity of the LRU cache for compiled regular expression
+  /// patterns per function instance per thread of execution.
   static constexpr const char* kExprMaxCompiledRegexes =
       "expression.max_compiled_regexes";
 

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -281,7 +281,7 @@ Expression Evaluation Configuration
    * - expression.max_compiled_regexes
      - integer
      - 100
-     - Controls maximum number of compiled regular expression patterns per batch.
+     - Controls the capacity of the LRU cache for compiled regular expression patterns per batch.
    * - debug_disable_expression_with_peeling
      - bool
      - false

--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -26,11 +26,11 @@ See https://github.com/google/re2/wiki/Syntax for more information.
     Note: The wildcard '%' represents 0, 1 or multiple characters and the
     wildcard '_' represents exactly one character.
 
-    Note: Each function instance allow for a maximum of ``expression.max_compiled_regexes``
-    (default 100) regular expressions to be compiled per thread of execution. Not all patterns
-    require compilation of regular expressions. Patterns 'hello', 'hello%', '_hello__%',
-    '%hello', '%__hello_', '%hello%', where 'hello', 'velox'
-    contains only regular characters and '_' wildcards are evaluated without
+    Note: Each function instance maintains an LRU cache with a maximum capacity of
+    ``expression.max_compiled_regexes`` (default 100) for compiled regular expressions
+    per thread of execution. Not all patterns require compilation of regular expressions.
+    Patterns 'hello', 'hello%', '_hello__%', '%hello', '%__hello_', '%hello%', where
+    'hello', 'velox' contains only regular characters and '_' wildcards are evaluated without
     using regular expressions. Only those patterns that require the compilation of
     regular expressions are counted towards the limit. ::
 

--- a/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/RegexFunctionsTest.cpp
@@ -546,6 +546,7 @@ TEST_F(RegexFunctionsTest, regexpReplaceMassiveVectors) {
   assertEqualVectors(result, output);
 }
 
+// LRUCache supports compile more than "expression.max_compiled_regexes".
 TEST_F(RegexFunctionsTest, regexpReplaceCacheLimitTest) {
   std::vector<std::string> patterns;
   std::vector<std::string> strings;
@@ -561,9 +562,9 @@ TEST_F(RegexFunctionsTest, regexpReplaceCacheLimitTest) {
         "X" + std::to_string(i) + "-Y" + std::to_string(i));
   }
 
-  VELOX_ASSERT_THROW(
-      testingRegexpReplaceRows(strings, patterns, replaces),
-      "Max number of regex reached");
+  auto result = testingRegexpReplaceRows(strings, patterns, replaces);
+  auto output = convertOutput(expectedOutputs, 1);
+  assertEqualVectors(result, output);
 }
 
 TEST_F(RegexFunctionsTest, regexpReplaceCacheMissLimit) {


### PR DESCRIPTION
Velox throw exception when cached compiled regex number hit the `expression.max_compiled_regexes`, but the regex number varies if it's from the input table column. For example, in the following query there are many distinct `location_path` as regex, it's very easy to hit the limit.
```sql
select split(dir_path, location_path)[1] as partition_name from test_tbl
```

In this patch we want to use the `folly::EvictingCacheMap` to store the cached regex with 2 advantages:
1. the cached regex number is still in control by `expression.max_compiled_regexes`.
2. task will not fail when where are many regex.