### PR TITLE
refactor: Update HashBitRangeTest with proper naming

### DIFF
--- a/velox/exec/HashBitRange.h
+++ b/velox/exec/HashBitRange.h
@@ -19,8 +19,8 @@
 
 namespace facebook::velox::exec {
 
-// Describes a bit range inside a 64 bit hash number for use in
-// partitioning data.
+/// Describes a bit range inside a 64-bit hash number for use in partitioning
+/// data.
 class HashBitRange {
  public:
   HashBitRange(uint8_t begin, uint8_t end)

--- a/velox/exec/tests/HashBitRangeTest.cpp
+++ b/velox/exec/tests/HashBitRangeTest.cpp
@@ -15,21 +15,22 @@
  */
 
 #include "velox/exec/HashBitRange.h"
-#include "velox/vector/tests/utils/VectorTestBase.h"
 
-using namespace facebook;
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-class HashRangeBitTest : public velox::test::VectorTestBase,
-                         public testing::Test {
+class HashBitRangeTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 };
 
-TEST_F(HashRangeBitTest, hashBitRange) {
+TEST_F(HashBitRangeTest, hashBitRange) {
   HashBitRange bitRange(29, 31);
   ASSERT_EQ(29, bitRange.begin());
   ASSERT_EQ(4, bitRange.numPartitions());


### PR DESCRIPTION
- Change class name from `HashRangeBitTest` to `HashBitRangeTest` to 
  match the actual class being tested (`HashBitRange`). 
- Remove unused VectorTestBase inheritance from test class. 
- Clean up includes by removing unused VectorTestBase header and 
  adding proper gtest/mem headers. 