### PR TITLE
feat: Add BaseVector::createFromVariants convenience API

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -182,14 +182,14 @@ std::string stringifyFloatingPointerValue(T val) {
 }
 
 void Variant::throwCheckIsKindError(TypeKind kind) const {
-  throw std::invalid_argument{fmt::format(
+  VELOX_USER_FAIL(
       "wrong kind! {} != {}",
       TypeKindName::toName(kind_),
-      TypeKindName::toName(kind))};
+      TypeKindName::toName(kind));
 }
 
 void Variant::throwCheckPtrError() const {
-  throw std::invalid_argument{"missing Variant value"};
+  VELOX_USER_FAIL("missing Variant value");
 }
 
 std::string Variant::toString(const TypePtr& type) const {

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -839,7 +839,9 @@ TEST(VariantOpaqueTest, opaque) {
     EXPECT_TRUE(v.hasValue());
     EXPECT_EQ(TypeKind::OPAQUE, v.kind());
     EXPECT_EQ(foo, v.opaque<Foo>());
-    EXPECT_THROW(v.opaque<Bar>(), std::exception);
+    VELOX_ASSERT_THROW(
+        v.opaque<Bar>(),
+        "Requested OPAQUE<facebook::velox::test::(anonymous namespace)::Bar> but contains OPAQUE<facebook::velox::test::(anonymous namespace)::Foo>");
     EXPECT_EQ(*v.inferType(), *OPAQUE<Foo>());
   }
 
@@ -901,7 +903,7 @@ TEST(VariantOpaqueTest, opaque) {
     EXPECT_EQ(castFoo1, foo);
     EXPECT_EQ(castBar1, nullptr);
     EXPECT_EQ(castBar2, bar);
-    EXPECT_THROW(int1.tryOpaque<Foo>(), std::invalid_argument);
+    VELOX_ASSERT_THROW(int1.tryOpaque<Foo>(), "wrong kind! BIGINT != OPAQUE");
   }
 }
 
@@ -1833,6 +1835,18 @@ TEST(VariantTest, nullableMapOfArraysGetter) {
       {{"a", std::vector<std::optional<int64_t>>{1, std::nullopt}},
        {"b", std::nullopt},
        {"c", std::vector<std::optional<int64_t>>{3}}});
+}
+
+TEST(VariantTest, accessNullVariantValue) {
+  Variant nullVar = Variant::null(TypeKind::INTEGER);
+  VELOX_ASSERT_THROW(
+      nullVar.value<TypeKind::INTEGER>(), "missing Variant value");
+}
+
+TEST(VariantTest, accessWrongTypeVariantValue) {
+  Variant intVar = Variant::create<int32_t>(1);
+  VELOX_ASSERT_THROW(
+      intVar.value<TypeKind::VARCHAR>(), "wrong kind! INTEGER != VARCHAR");
 }
 
 } // namespace

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -142,6 +142,15 @@ Variant BaseVector::variantAt(vector_size_t index) const {
   return variantAtImpl(this, index);
 }
 
+std::vector<Variant> BaseVector::toVariants() const {
+  std::vector<Variant> result;
+  result.reserve(size());
+  for (auto i = 0; i < size(); ++i) {
+    result.push_back(variantAt(i));
+  }
+  return result;
+}
+
 BaseVector::BaseVector(
     velox::memory::MemoryPool* pool,
     std::shared_ptr<const Type> type,
@@ -1020,6 +1029,14 @@ VectorPtr BaseVector::createConstant(
 
   auto variantVector = callMakeVector(type, {value}, pool);
   return BaseVector::wrapInConstant(size, 0, std::move(variantVector));
+}
+
+// static
+VectorPtr BaseVector::createFromVariants(
+    const TypePtr& type,
+    const std::vector<Variant>& values,
+    velox::memory::MemoryPool* pool) {
+  return callMakeVector(type, values, pool);
 }
 
 // static

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -862,6 +862,16 @@ class BaseVector {
   /// Returns the value at specified index as a Variant.
   Variant variantAt(vector_size_t index) const;
 
+  /// Returns values for all rows as Variants.
+  std::vector<Variant> toVariants() const;
+
+  /// Creates a vector from a list of Variant values. The result is a flat
+  /// vector with one element per value.
+  static VectorPtr createFromVariants(
+      const TypePtr& type,
+      const std::vector<Variant>& values,
+      velox::memory::MemoryPool* pool);
+
   /// Returns string representation of the value in the specified row.
   virtual std::string toString(vector_size_t index) const;
 

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -36,7 +36,7 @@ class VariantToVectorTest : public testing::Test, public test::VectorTestBase {
         type, Variant::null(type->kind()), 1, pool());
 
     EXPECT_TRUE(vector->isConstantEncoding());
-    EXPECT_EQ(vector->type()->toString(), type->toString());
+    VELOX_EXPECT_EQ_TYPES(vector->type(), type);
     EXPECT_TRUE(vector->isNullAt(0));
 
     auto copy = vector->variantAt(0);
@@ -51,7 +51,7 @@ class VariantToVectorTest : public testing::Test, public test::VectorTestBase {
     auto vector = BaseVector::createConstant(type, value, 1, pool());
 
     EXPECT_TRUE(vector->isConstantEncoding());
-    EXPECT_EQ(vector->type()->toString(), type->toString());
+    VELOX_EXPECT_EQ_TYPES(vector->type(), type);
     EXPECT_TRUE(expected->equalValueAt(vector.get(), 0, 0))
         << "Expected: " << expected->toString(0)
         << ", but got: " << vector->toString(0);
@@ -60,6 +60,21 @@ class VariantToVectorTest : public testing::Test, public test::VectorTestBase {
     EXPECT_FALSE(copy.isNull());
     EXPECT_TRUE(copy.isTypeCompatible(type));
     EXPECT_EQ(copy, value);
+  }
+
+  void testFromVariants(
+      const TypePtr& type,
+      const std::vector<Variant>& values) {
+    auto vector = BaseVector::createFromVariants(type, values, pool());
+
+    EXPECT_FALSE(vector->isConstantEncoding());
+    VELOX_EXPECT_EQ_TYPES(vector->type(), type);
+    EXPECT_EQ(vector->size(), values.size());
+
+    for (auto i = 0; i < values.size(); ++i) {
+      EXPECT_EQ(values[i], vector->variantAt(i));
+      EXPECT_TRUE(vector->variantAt(i).isTypeCompatible(type));
+    }
   }
 };
 
@@ -215,6 +230,72 @@ TEST_F(VariantToVectorTest, opaque) {
   auto expected = makeFlatVector<std::shared_ptr<void>>({data});
 
   testValue(type, Variant::opaque(data), expected);
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsInteger) {
+  testFromVariants(
+      INTEGER(),
+      {
+          Variant::create<int32_t>(1),
+          Variant::create<int32_t>(2),
+          Variant::create<int32_t>(3),
+      });
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsWithNulls) {
+  testFromVariants(
+      INTEGER(),
+      {
+          Variant::create<int32_t>(1),
+          Variant::null(TypeKind::INTEGER),
+          Variant::create<int32_t>(3),
+      });
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsVarchar) {
+  testFromVariants(
+      VARCHAR(), {Variant("hello"), Variant("world"), Variant("test")});
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsArray) {
+  testFromVariants(
+      ARRAY(INTEGER()),
+      {Variant::array({1, 2, 3}), Variant::array({4, 5}), Variant::array({})});
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsMap) {
+  testFromVariants(
+      MAP(INTEGER(), DOUBLE()),
+      {Variant::map({{1, 1.0}, {2, 2.0}}), Variant::map({{3, 3.0}})});
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsRow) {
+  testFromVariants(
+      ROW({"a", "b"}, {INTEGER(), DOUBLE()}),
+      {Variant::row({1, 1.0}), Variant::row({2, 2.0})});
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsEmpty) {
+  auto vector = BaseVector::createFromVariants(INTEGER(), {}, pool());
+  EXPECT_EQ(vector->size(), 0);
+}
+
+TEST_F(VariantToVectorTest, createFromVariantsMismatchedType) {
+  {
+    std::vector<Variant> values = {
+        Variant::create<int32_t>(1),
+        Variant::create<int32_t>(2),
+    };
+    VELOX_ASSERT_THROW(
+        BaseVector::createFromVariants(VARCHAR(), values, pool()),
+        "wrong kind! INTEGER != VARCHAR");
+  }
+  {
+    std::vector<Variant> values = {Variant::create<int32_t>(1), Variant("one")};
+    VELOX_ASSERT_THROW(
+        BaseVector::createFromVariants(INTEGER(), values, pool()),
+        "wrong kind! VARCHAR != INTEGER");
+  }
 }
 
 } // namespace


### PR DESCRIPTION
Add a new helper function to create a vector from a list of Variant values.
Supports all primitive types and complex types (ARRAY, MAP, ROW).