### PR TITLE
refactor(serde): Initialize CompactRow member variables with default values

### DIFF
--- a/velox/row/CompactRow.h
+++ b/velox/row/CompactRow.h
@@ -153,9 +153,9 @@ class CompactRow {
   bool supportsBulkCopy_{false};
 
   // ROW type only. Number of bytes used by null flags.
-  size_t rowNullBytes_;
+  size_t rowNullBytes_{0};
 
   // Fixed-width types only. Number of bytes used for a single value.
-  size_t valueBytes_;
+  size_t valueBytes_{0};
 };
 } // namespace facebook::velox::row


### PR DESCRIPTION
Summary:
Prevents potential undefined behavior from uninitialized member variables by adding value-initialization to rowNullBytes_ and valueBytes_.

Also without this, sanitizer keep triggering alerts. Let's silence them with this.

Differential Revision: D90397061


