### PR TITLE
refactor: Extract SqlExpressionsParser interface

### DIFF
--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -259,15 +259,7 @@ class PreprocBenchmark : public functions::test::FunctionBenchmarkBase {
   }
 
   exec::ExprSet compile(const std::vector<std::string>& texts) {
-    std::vector<core::TypedExprPtr> typedExprs;
-    parse::ParseOptions options;
-    for (const auto& text : texts) {
-      auto untyped = parse::parseExpr(text, options);
-      auto typed = core::Expressions::inferTypes(
-          untyped, ROW({"c0"}, {REAL()}), execCtx_.pool());
-      typedExprs.push_back(typed);
-    }
-    return exec::ExprSet(typedExprs, &execCtx_);
+    return compileExpressions(texts, ROW({{"c0", REAL()}}));
   }
 
   std::string makeExpression(int n, RunConfig config, bool withNulls) {

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -485,6 +485,12 @@ void E2EFilterTestBase::testRunLengthDictionaryScenario(
   }
 }
 
+namespace {
+core::ExprPtr parseExpr(const std::string& text) {
+  return parse::DuckSqlExpressionsParser().parseExpr(text);
+}
+} // namespace
+
 void E2EFilterTestBase::testMetadataFilterImpl(
     const std::vector<RowVectorPtr>& batches,
     common::Subfield filterField,
@@ -493,7 +499,7 @@ void E2EFilterTestBase::testMetadataFilterImpl(
     const std::string& remainingFilter,
     std::function<bool(int64_t, int64_t)> validationFilter) {
   SCOPED_TRACE(fmt::format("remainingFilter='{}'", remainingFilter));
-  auto untypedExpr = parse::parseExpr(remainingFilter, {});
+  auto untypedExpr = parseExpr(remainingFilter);
   auto typedExpr = core::Expressions::inferTypes(
       untypedExpr, batches[0]->type(), leafPool_.get());
   testMetadataFilterImpl(
@@ -642,11 +648,11 @@ void E2EFilterTestBase::testMetadataFilter() {
   {
     SCOPED_TRACE("remainingFilter='a == 1 or a == 3 or a == 8'");
     auto typedExpr1 = core::Expressions::inferTypes(
-        parse::parseExpr("a == 1", {}), batches[0]->type(), leafPool_.get());
+        parseExpr("a == 1"), batches[0]->type(), leafPool_.get());
     auto typedExpr2 = core::Expressions::inferTypes(
-        parse::parseExpr("a == 3", {}), batches[0]->type(), leafPool_.get());
+        parseExpr("a == 3"), batches[0]->type(), leafPool_.get());
     auto typedExpr3 = core::Expressions::inferTypes(
-        parse::parseExpr("a == 8", {}), batches[0]->type(), leafPool_.get());
+        parseExpr("a == 8"), batches[0]->type(), leafPool_.get());
 
     auto typedExpr = std::make_shared<core::CallTypedExpr>(
         velox::BOOLEAN(),
@@ -667,11 +673,11 @@ void E2EFilterTestBase::testMetadataFilter() {
   {
     SCOPED_TRACE("remainingFilter='a >= 1 and a <= 100 and a == 8'");
     auto typedExpr1 = core::Expressions::inferTypes(
-        parse::parseExpr("a >= 1", {}), batches[0]->type(), leafPool_.get());
+        parseExpr("a >= 1"), batches[0]->type(), leafPool_.get());
     auto typedExpr2 = core::Expressions::inferTypes(
-        parse::parseExpr("a <= 100", {}), batches[0]->type(), leafPool_.get());
+        parseExpr("a <= 100"), batches[0]->type(), leafPool_.get());
     auto typedExpr3 = core::Expressions::inferTypes(
-        parse::parseExpr("b.c != 8", {}), batches[0]->type(), leafPool_.get());
+        parseExpr("b.c != 8"), batches[0]->type(), leafPool_.get());
 
     auto typedExpr = std::make_shared<core::CallTypedExpr>(
         velox::BOOLEAN(),
@@ -713,7 +719,7 @@ void E2EFilterTestBase::testMetadataFilter() {
     writeToMemory(batches[0]->type(), batches, false);
     auto spec = std::make_shared<common::ScanSpec>("<root>");
     spec->addAllChildFields(*batches[0]->type());
-    auto untypedExpr = parse::parseExpr("a = 1 or b + c = 2", {});
+    auto untypedExpr = parseExpr("a = 1 or b + c = 2");
     auto typedExpr = core::Expressions::inferTypes(
         untypedExpr, batches[0]->type(), leafPool_.get());
     auto metadataFilter =

--- a/velox/exec/tests/ExpressionBuilderTest.cpp
+++ b/velox/exec/tests/ExpressionBuilderTest.cpp
@@ -36,7 +36,7 @@ bool is(detail::ExprWrapper in) {
 
 // Parses a SQL expression using DuckDB.
 core::ExprPtr parseSql(const std::string& sql) {
-  return parse::parseExpr(sql, {});
+  return parse::DuckSqlExpressionsParser().parseExpr(sql);
 }
 
 TEST(ExpressionBuilderTest, columnReference) {

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -64,8 +64,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    parse::ParseOptions options;
-    auto untyped = parse::parseExpr(text, options);
+    auto untyped = parse::DuckSqlExpressionsParser().parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -244,7 +244,7 @@ core::TypedExprPtr OperatorTestBase::parseExpr(
     const std::string& text,
     RowTypePtr rowType,
     const parse::ParseOptions& options) {
-  auto untyped = parse::parseExpr(text, options);
+  auto untyped = parse::DuckSqlExpressionsParser(options).parseExpr(text);
   return core::Expressions::inferTypes(untyped, rowType, pool_.get());
 }
 

--- a/velox/experimental/cudf/tests/utils/ExpressionTestUtil.h
+++ b/velox/experimental/cudf/tests/utils/ExpressionTestUtil.h
@@ -32,7 +32,7 @@ inline core::TypedExprPtr parseAndInferTypedExpr(
     const RowTypePtr& rowType,
     core::ExecCtx* execCtx,
     const parse::ParseOptions& options = {}) {
-  auto untyped = parse::parseExpr(sql, options);
+  auto untyped = parse::DuckSqlExpressionsParser(options).parseExpr(sql);
   return core::Expressions::inferTypes(untyped, rowType, execCtx->pool());
 }
 

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -42,7 +42,7 @@ class ExprCompilerTest : public testing::Test,
   core::TypedExprPtr makeTypedExpr(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text, {});
+    auto untyped = parse::DuckSqlExpressionsParser().parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -177,7 +177,7 @@ class ExprEncodingsTest
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text, options_);
+    auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -52,7 +52,7 @@ class ExprToSubfieldFilterTest : public testing::Test {
       const std::string& expr,
       const RowTypePtr& type) {
     return core::Expressions::inferTypes(
-        parse::parseExpr(expr, {}), type, pool_.get());
+        parse::DuckSqlExpressionsParser().parseExpr(expr), type, pool_.get());
   }
 
   core::CallTypedExprPtr parseCallExpr(

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -111,7 +111,7 @@ std::vector<core::TypedExprPtr> ExpressionRunner::parseSql(
     const TypePtr& inputType,
     memory::MemoryPool* pool,
     const VectorPtr& complexConstants) {
-  auto exprs = parse::parseMultipleExpressions(sql, {});
+  auto exprs = parse::DuckSqlExpressionsParser().parseExprs(sql);
 
   std::vector<core::TypedExprPtr> typedExprs;
   typedExprs.reserve(exprs.size());

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -84,8 +84,7 @@ class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
-    parse::ParseOptions options;
-    auto untyped = parse::parseExpr(text, options);
+    auto untyped = parse::DuckSqlExpressionsParser().parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, pool_.get());
   }
 

--- a/velox/functions/lib/tests/MakeRowFromMapTest.cpp
+++ b/velox/functions/lib/tests/MakeRowFromMapTest.cpp
@@ -173,7 +173,8 @@ class MakeRowFroMapTest : public testing::Test, public test::VectorTestBase {
     // eg: cast(row_constructor(c0[1], c0[2]) as row(key1 bigint, key2 bigint))
     // Extract keys and wrap it in a struct
     auto typedExpr = core::Expressions::inferTypes(
-        parse::parseExpr("row_constructor(c0[1], c0[2])", {}),
+        parse::DuckSqlExpressionsParser().parseExpr(
+            "row_constructor(c0[1], c0[2])"),
         inputRow->type(),
         execCtx_->pool());
     // Wrap the struct in a cast to get the correct field names

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -18,7 +18,6 @@
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/SimpleComparisonMatcher.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
-#include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -43,7 +42,7 @@ class SimpleComparisonMatcherTest : public testing::Test,
       const RowTypePtr& rowType) {
     parse::ParseOptions options;
     options.functionPrefix = prefix_;
-    auto untyped = parse::parseExpr(text, options);
+    auto untyped = parse::DuckSqlExpressionsParser(options).parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -94,7 +94,7 @@ class FunctionBaseTest : public testing::Test,
   core::TypedExprPtr makeTypedExpr(
       const std::string& text,
       const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text, options_);
+    auto untyped = parse::DuckSqlExpressionsParser(options_).parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_.pool());
   }
 
@@ -310,18 +310,11 @@ class FunctionBaseTest : public testing::Test,
                                : TReturn(result->valueAt(0));
   }
 
-  core::TypedExprPtr parseExpression(
-      const std::string& text,
-      const RowTypePtr& rowType) {
-    auto untyped = parse::parseExpr(text, options_);
-    return core::Expressions::inferTypes(untyped, rowType, pool());
-  }
-
   std::unique_ptr<exec::ExprSet> compileExpression(
       const std::string& expr,
       const RowTypePtr& rowType) {
     std::vector<core::TypedExprPtr> expressions = {
-        parseExpression(expr, rowType)};
+        makeTypedExpr(expr, rowType)};
     return std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
   }
 
@@ -331,7 +324,7 @@ class FunctionBaseTest : public testing::Test,
     std::vector<core::TypedExprPtr> expressions;
     expressions.reserve(exprs.size());
     for (const auto& expr : exprs) {
-      expressions.emplace_back(parseExpression(expr, rowType));
+      expressions.emplace_back(makeTypedExpr(expr, rowType));
     }
     return std::make_unique<exec::ExprSet>(std::move(expressions), &execCtx_);
   }

--- a/velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/LambdaParameterizedBaseTest.h
@@ -34,7 +34,7 @@ class LambdaParameterizedBaseTest
       const std::string& expression,
       const RowVectorPtr& data) {
     std::vector<core::TypedExprPtr> parseExpr = {
-        parseExpression(expression, asRowType(data->type()))};
+        makeTypedExpr(expression, asRowType(data->type()))};
     auto exprSet = std::make_unique<exec::ExprSet>(
         std::move(parseExpr), &execCtxParametrized_);
 

--- a/velox/functions/tests/DynamicTypeFuncDemo.cpp
+++ b/velox/functions/tests/DynamicTypeFuncDemo.cpp
@@ -137,7 +137,8 @@ void runDynamicTypeTest(
   std::shared_ptr<core::QueryCtx> queryCtx{core::QueryCtx::create()};
   core::ExecCtx execCtx{pool, queryCtx.get()};
   SelectivityVector rows(elementSize);
-  auto untypedExpr = parse::parseExpr("dynamic_row_udf(c0)", {});
+  auto untypedExpr =
+      parse::DuckSqlExpressionsParser().parseExpr("dynamic_row_udf(c0)");
   auto parsedExpr =
       core::Expressions::inferTypes(untypedExpr, inputVector->type(), pool);
   exec::ExprSet exprSet({parsedExpr}, &execCtx);

--- a/velox/parse/SqlExpressionsParser.h
+++ b/velox/parse/SqlExpressionsParser.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/parse/IExpr.h"
+
+namespace facebook::velox::parse {
+
+struct OrderByClause {
+  core::ExprPtr expr;
+  bool ascending;
+  bool nullsFirst;
+};
+
+class SqlExpressionsParser {
+ public:
+  virtual ~SqlExpressionsParser() = default;
+
+  /// Parses a single expression. Throws on error.
+  virtual core::ExprPtr parseExpr(const std::string& expr) = 0;
+
+  /// Parses a comma-separated list of expressions. Throws on error.
+  virtual std::vector<core::ExprPtr> parseExprs(const std::string& expr) = 0;
+
+  /// Parses an expression that represents an ORDER BY clause. Throws on error.
+  virtual OrderByClause parseOrderByExpr(const std::string& expr) = 0;
+};
+
+} // namespace facebook::velox::parse

--- a/velox/python/legacy/pyvelox.cpp
+++ b/velox/python/legacy/pyvelox.cpp
@@ -290,8 +290,7 @@ static void addExpressionBindings(
           },
           "Evaluates the expression, taking in a map from names to input vectors")
       .def_static("from_string", [](std::string& str) {
-        parse::ParseOptions opts;
-        return IExprWrapper{parse::parseExpr(str, opts)};
+        return IExprWrapper{parse::DuckSqlExpressionsParser().parseExpr(str)};
       });
 }
 


### PR DESCRIPTION
Summary: Refactor the SQL expression parsing functionality in Velox by extracting a SqlExpressionsParser interface and implementing it with DuckSqlExpressionsParser. The refactoring decouples SQL expression parsing from DuckDB and enables adding support for parsing PrestoSQL using the Axiom parser.

Differential Revision: D90397037


