### PR TITLE
fix(build): Arrow bundle might fail with missing boost

### DIFF
--- a/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/arrow/CMakeLists.txt
@@ -20,6 +20,19 @@ if(VELOX_ENABLE_ARROW)
     set(THRIFT_SOURCE "BUNDLED")
   endif()
 
+  # Avoid issues in finding the boost headers and libraries
+  # by setting the BOOST_ROOT to the install prefix.
+  # The same logic is used in the setup script-common.sh to install boost.
+  if(NOT DEFINED ENV{BOOST_ROOT} OR "$ENV{BOOST_ROOT}" STREQUAL "")
+    if(DEFINED ENV{INSTALL_PREFIX} AND NOT "$ENV{INSTALL_PREFIX}" STREQUAL "")
+      set(BOOST_ROOT "$ENV{INSTALL_PREFIX}")
+    else()
+      set(BOOST_ROOT "/usr/local")
+    endif()
+  else()
+    set(BOOST_ROOT "$ENV{BOOST_ROOT}")
+  endif()
+  message(STATUS "Using BOOST_ROOT: ${BOOST_ROOT}")
   set(ARROW_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/arrow_ep")
   set(
     ARROW_CMAKE_ARGS
@@ -41,6 +54,7 @@ if(VELOX_ENABLE_ARROW)
     -DARROW_BUILD_STATIC=ON
     -DThrift_SOURCE=${THRIFT_SOURCE}
     -DCMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH}
+    -DBOOST_ROOT=${BOOST_ROOT}
     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     # Remove with Arrow upgrade to Arrow 20.
     -DARROW_CXXFLAGS=-Wno-documentation


### PR DESCRIPTION
The error shows as CMake error:

```
Call Stack (most recent call first):
  lib/cpp/CMakeLists.txt:22 (REQUIRE_BOOST_HEADERS)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at /opt/homebrew/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find Boost (missing: Boost_INCLUDE_DIR) (Required is at least
  version "1.56")
Call Stack (most recent call first):
  /opt/homebrew/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:654 (_FPHSA_FAILURE_MESSAGE)
  /opt/homebrew/share/cmake/Modules/FindBoost.cmake:2438 (find_package_handle_standard_args)
  build/cmake/BoostMacros.cmake:23 (find_package)
  lib/cpp/CMakeLists.txt:22 (REQUIRE_BOOST_HEADERS)
```

On macOS thrift is not installed into the system and this triggers an arrow bundling which can run into the missing boost headers/libraries.