### PR TITLE
feat: Add array_union_sum aggregation function

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -307,6 +307,22 @@ Map Aggregate Functions
     Returns the union of all the input maps summing the values of matching keys in all
     the maps. All null values in the original maps are coalesced to 0.
 
+Array Aggregate Functions
+-------------------------
+
+.. function:: array_union_sum(array(T)) -> array(T)
+
+    Returns the element-wise sum of all input arrays.
+    Arrays of different lengths are extended to the longest with zeros.
+    Null elements are treated as 0. Supported types for T are:
+    TINYINT, SMALLINT, INTEGER, BIGINT, REAL and DOUBLE.
+    Overflow is checked for integer types.
+
+    A variadic form ``array_union_sum(c1, c2, ..., cN)`` is also supported,
+    where each argument is a scalar at a fixed array position. This avoids
+    per-row array construction overhead when the number of positions is known
+    at query time.
+
 Approximate Aggregate Functions
 -------------------------------
 

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -294,6 +294,7 @@ std::unordered_set<std::string> skipFunctions = {
 
 std::unordered_set<std::string> skipFunctionsSOT = {
     "l2_norm", // Velox-only function, not available in Presto
+    "array_union_sum", // Velox-only function, not available in Presto
     "t_cdf", // New function, not yet widely deployed in Presto instances
     "inverse_t_cdf", // New function, not yet widely deployed in Presto
                      // instances

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -22,6 +22,7 @@ const char* const kApproxDistinct = "approx_distinct";
 const char* const kApproxMostFrequent = "approx_most_frequent";
 const char* const kApproxPercentile = "approx_percentile";
 const char* const kApproxSet = "approx_set";
+const char* const kArrayUnionSum = "array_union_sum";
 const char* const kQDigestAgg = "qdigest_agg";
 const char* const kArbitrary = "arbitrary";
 const char* const kAnyValue = "any_value";

--- a/velox/functions/prestosql/aggregates/ArrayUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayUnionSumAggregate.cpp
@@ -1,0 +1,616 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/ArrayUnionSumAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+
+template <typename S>
+struct Accumulator {
+  using SumsVector = std::vector<S, AlignedStlAllocator<S, 16>>;
+  SumsVector sums;
+  bool initialized{false};
+
+  explicit Accumulator(const TypePtr& /*type*/, HashStringAllocator* allocator)
+      : sums{AlignedStlAllocator<S, 16>(allocator)} {}
+
+  size_t size() const {
+    return sums.size();
+  }
+
+  void addValues(
+      const ArrayVector* arrayVector,
+      const VectorPtr& arrayElements,
+      vector_size_t row) {
+    auto elements = arrayElements->template as<SimpleVector<S>>();
+    auto offset = arrayVector->offsetAt(row);
+    auto arraySize = arrayVector->sizeAt(row);
+
+    if (!initialized) {
+      // First array: just hold onto the values directly, no aggregation needed.
+      sums.resize(arraySize, S{0});
+      for (auto i = 0; i < arraySize; ++i) {
+        if (!elements->isNullAt(offset + i)) {
+          sums[i] = elements->valueAt(offset + i);
+        }
+      }
+      initialized = true;
+      return;
+    }
+
+    if (static_cast<size_t>(arraySize) > sums.size()) {
+      sums.resize(arraySize, S{0});
+    }
+
+    for (auto i = 0; i < arraySize; ++i) {
+      if (!elements->isNullAt(offset + i)) {
+        auto value = elements->valueAt(offset + i);
+        if (value != S{0}) {
+          addToSum(i, value);
+        }
+      }
+    }
+  }
+
+  void combineValues(
+      const ArrayVector* arrayVector,
+      const VectorPtr& arrayElements,
+      vector_size_t row) {
+    auto elements = arrayElements->template as<SimpleVector<S>>();
+    auto offset = arrayVector->offsetAt(row);
+    auto arraySize = arrayVector->sizeAt(row);
+
+    if (!initialized) {
+      // First intermediate result: copy directly, no null checks needed
+      // as intermediates have nulls zeroed out.
+      sums.resize(arraySize);
+      for (auto i = 0; i < arraySize; ++i) {
+        sums[i] = elements->valueAt(offset + i);
+      }
+      initialized = true;
+      return;
+    }
+
+    if (static_cast<size_t>(arraySize) > sums.size()) {
+      sums.resize(arraySize, S{0});
+    }
+
+    for (auto i = 0; i < arraySize; ++i) {
+      auto value = elements->valueAt(offset + i);
+      if (value != S{0}) {
+        addToSum(i, value);
+      }
+    }
+  }
+
+  vector_size_t extractValues(VectorPtr& arrayElements, vector_size_t offset) {
+    auto elements = arrayElements->asFlatVector<S>();
+
+    for (size_t i = 0; i < sums.size(); ++i) {
+      elements->set(offset + static_cast<vector_size_t>(i), sums[i]);
+    }
+
+    return static_cast<vector_size_t>(sums.size());
+  }
+
+  void addToSum(vector_size_t i, S value) {
+    if constexpr (std::is_same_v<S, double> || std::is_same_v<S, float>) {
+      sums[i] += value;
+    } else {
+      S checkedSum;
+      auto overflow = __builtin_add_overflow(sums[i], value, &checkedSum);
+
+      if (UNLIKELY(overflow)) {
+        auto errorValue = (int128_t(sums[i]) + int128_t(value));
+
+        if (errorValue < 0) {
+          VELOX_ARITHMETIC_ERROR(
+              "Value {} is less than {}",
+              errorValue,
+              std::numeric_limits<S>::min());
+        } else {
+          VELOX_ARITHMETIC_ERROR(
+              "Value {} exceeds {}", errorValue, std::numeric_limits<S>::max());
+        }
+      }
+      sums[i] = checkedSum;
+    }
+  }
+};
+
+template <typename S>
+class ArrayUnionSumAggregate : public exec::Aggregate {
+ public:
+  explicit ArrayUnionSumAggregate(TypePtr resultType)
+      : Aggregate(std::move(resultType)) {}
+
+  using AccumulatorType = Accumulator<S>;
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(AccumulatorType);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto arrayVector = (*result)->as<ArrayVector>();
+    VELOX_CHECK(arrayVector);
+    arrayVector->resize(numGroups);
+
+    auto arrayElementsPtr = arrayVector->elements();
+
+    auto numElements = countElements(groups, numGroups);
+    arrayVector->elements()->as<FlatVector<S>>()->resize(numElements);
+
+    auto rawNulls = arrayVector->mutableRawNulls();
+    vector_size_t offset = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        bits::setNull(rawNulls, i, true);
+        arrayVector->setOffsetAndSize(i, 0, 0);
+      } else {
+        clearNull(rawNulls, i);
+
+        auto arraySize = value<AccumulatorType>(group)->extractValues(
+            arrayElementsPtr, offset);
+        arrayVector->setOffsetAndSize(i, offset, arraySize);
+        offset += arraySize;
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedArrays_.decode(*args[0], rows);
+    auto arrayVector = decodedArrays_.base()->template as<ArrayVector>();
+    auto arrayElements = arrayVector->elements();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedArrays_.isNullAt(row)) {
+        auto* group = groups[row];
+        clearNull(group);
+
+        auto tracker = trackRowSize(group);
+        auto groupAccumulator = value<AccumulatorType>(group);
+        addArray(*groupAccumulator, arrayVector, arrayElements, row);
+      }
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedArrays_.decode(*args[0], rows);
+    auto arrayVector = decodedArrays_.base()->template as<ArrayVector>();
+    auto arrayElements = arrayVector->elements();
+
+    auto groupAccumulator = value<AccumulatorType>(group);
+
+    auto tracker = trackRowSize(group);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedArrays_.isNullAt(row)) {
+        clearNull(group);
+        addArray(*groupAccumulator, arrayVector, arrayElements, row);
+      }
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodedArrays_.decode(*args[0], rows);
+    auto arrayVector = decodedArrays_.base()->template as<ArrayVector>();
+    auto arrayElements = arrayVector->elements();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedArrays_.isNullAt(row)) {
+        auto* group = groups[row];
+        clearNull(group);
+
+        auto tracker = trackRowSize(group);
+        auto groupAccumulator = value<AccumulatorType>(group);
+        combineArray(*groupAccumulator, arrayVector, arrayElements, row);
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedArrays_.decode(*args[0], rows);
+    auto arrayVector = decodedArrays_.base()->template as<ArrayVector>();
+    auto arrayElements = arrayVector->elements();
+
+    auto groupAccumulator = value<AccumulatorType>(group);
+
+    auto tracker = trackRowSize(group);
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedArrays_.isNullAt(row)) {
+        clearNull(group);
+        combineArray(*groupAccumulator, arrayVector, arrayElements, row);
+      }
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto index : indices) {
+      new (groups[index] + offset_) AccumulatorType{resultType_, allocator_};
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<AccumulatorType>(groups);
+  }
+
+ private:
+  void addArray(
+      AccumulatorType& groupAccumulator,
+      const ArrayVector* arrayVector,
+      const VectorPtr& arrayElements,
+      vector_size_t row) const {
+    auto decodedRow = decodedArrays_.index(row);
+    groupAccumulator.addValues(arrayVector, arrayElements, decodedRow);
+  }
+
+  void combineArray(
+      AccumulatorType& groupAccumulator,
+      const ArrayVector* arrayVector,
+      const VectorPtr& arrayElements,
+      vector_size_t row) const {
+    auto decodedRow = decodedArrays_.index(row);
+    groupAccumulator.combineValues(arrayVector, arrayElements, decodedRow);
+  }
+
+  vector_size_t countElements(char** groups, int32_t numGroups) const {
+    vector_size_t size = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        size += value<AccumulatorType>(groups[i])->size();
+      }
+    }
+    return size;
+  }
+
+  DecodedVector decodedArrays_;
+};
+
+/// Variadic version: array_union_sum(c1, c2, ..., cN) where each ci is a
+/// scalar. Each row's arguments are treated as positions in a virtual array,
+/// and sums are accumulated across rows. This avoids per-row array construction
+/// overhead.
+template <typename S>
+class VariadicArrayUnionSumAggregate : public exec::Aggregate {
+ public:
+  explicit VariadicArrayUnionSumAggregate(TypePtr resultType, size_t numArgs)
+      : Aggregate(std::move(resultType)), numArgs_(numArgs) {}
+
+  using AccumulatorType = Accumulator<S>;
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(AccumulatorType);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto arrayVector = (*result)->as<ArrayVector>();
+    VELOX_CHECK(arrayVector);
+    arrayVector->resize(numGroups);
+
+    auto arrayElementsPtr = arrayVector->elements();
+
+    auto numElements = countElements(groups, numGroups);
+    arrayVector->elements()->as<FlatVector<S>>()->resize(numElements);
+
+    auto rawNulls = arrayVector->mutableRawNulls();
+    vector_size_t offset = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        bits::setNull(rawNulls, i, true);
+        arrayVector->setOffsetAndSize(i, 0, 0);
+      } else {
+        clearNull(rawNulls, i);
+
+        auto arraySize = value<AccumulatorType>(group)->extractValues(
+            arrayElementsPtr, offset);
+        arrayVector->setOffsetAndSize(i, offset, arraySize);
+        offset += arraySize;
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodeArgs(args, rows);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      auto* group = groups[row];
+      clearNull(group);
+      auto tracker = trackRowSize(group);
+      auto* acc = value<AccumulatorType>(group);
+
+      for (size_t argIdx = 0; argIdx < args.size(); ++argIdx) {
+        if (!decodedArgs_[argIdx].isNullAt(row)) {
+          auto val = decodedArgs_[argIdx].template valueAt<S>(row);
+          if (val != S{0}) {
+            acc->addToSum(static_cast<vector_size_t>(argIdx), val);
+          }
+        }
+      }
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodeArgs(args, rows);
+
+    auto* acc = value<AccumulatorType>(group);
+    auto tracker = trackRowSize(group);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      clearNull(group);
+
+      for (size_t argIdx = 0; argIdx < args.size(); ++argIdx) {
+        if (!decodedArgs_[argIdx].isNullAt(row)) {
+          auto val = decodedArgs_[argIdx].template valueAt<S>(row);
+          if (val != S{0}) {
+            acc->addToSum(static_cast<vector_size_t>(argIdx), val);
+          }
+        }
+      }
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    // Intermediate results are array(T), same as the array version.
+    decodedIntermediate_.decode(*args[0], rows);
+    auto arrayVector = decodedIntermediate_.base()->template as<ArrayVector>();
+    auto arrayElements = arrayVector->elements();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedIntermediate_.isNullAt(row)) {
+        auto* group = groups[row];
+        clearNull(group);
+
+        auto tracker = trackRowSize(group);
+        auto* acc = value<AccumulatorType>(group);
+        auto decodedRow = decodedIntermediate_.index(row);
+        acc->combineValues(arrayVector, arrayElements, decodedRow);
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedIntermediate_.decode(*args[0], rows);
+    auto arrayVector = decodedIntermediate_.base()->template as<ArrayVector>();
+    auto arrayElements = arrayVector->elements();
+
+    auto* acc = value<AccumulatorType>(group);
+    auto tracker = trackRowSize(group);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!decodedIntermediate_.isNullAt(row)) {
+        clearNull(group);
+        auto decodedRow = decodedIntermediate_.index(row);
+        acc->combineValues(arrayVector, arrayElements, decodedRow);
+      }
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto index : indices) {
+      auto* acc = new (groups[index] + offset_)
+          AccumulatorType{resultType_, allocator_};
+      acc->sums.resize(numArgs_, S{0});
+      acc->initialized = true;
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    destroyAccumulators<AccumulatorType>(groups);
+  }
+
+ private:
+  void decodeArgs(
+      const std::vector<VectorPtr>& args,
+      const SelectivityVector& rows) {
+    decodedArgs_.resize(args.size());
+    for (size_t i = 0; i < args.size(); ++i) {
+      decodedArgs_[i].decode(*args[i], rows);
+    }
+  }
+
+  vector_size_t countElements(char** groups, int32_t numGroups) const {
+    vector_size_t size = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      if (!isNull(groups[i])) {
+        size += value<AccumulatorType>(groups[i])->size();
+      }
+    }
+    return size;
+  }
+
+  const size_t numArgs_;
+  std::vector<DecodedVector> decodedArgs_;
+  DecodedVector decodedIntermediate_;
+};
+
+std::unique_ptr<exec::Aggregate> createArrayUnionSumAggregate(
+    TypeKind elementKind,
+    const TypePtr& resultType) {
+  switch (elementKind) {
+    case TypeKind::TINYINT:
+      return std::make_unique<ArrayUnionSumAggregate<int8_t>>(resultType);
+    case TypeKind::SMALLINT:
+      return std::make_unique<ArrayUnionSumAggregate<int16_t>>(resultType);
+    case TypeKind::INTEGER:
+      return std::make_unique<ArrayUnionSumAggregate<int32_t>>(resultType);
+    case TypeKind::BIGINT:
+      return std::make_unique<ArrayUnionSumAggregate<int64_t>>(resultType);
+    case TypeKind::REAL:
+      return std::make_unique<ArrayUnionSumAggregate<float>>(resultType);
+    case TypeKind::DOUBLE:
+      return std::make_unique<ArrayUnionSumAggregate<double>>(resultType);
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected element type {}", TypeKindName::toName(elementKind));
+  }
+}
+
+std::unique_ptr<exec::Aggregate> createVariadicArrayUnionSumAggregate(
+    TypeKind elementKind,
+    const TypePtr& resultType,
+    size_t numArgs) {
+  switch (elementKind) {
+    case TypeKind::TINYINT:
+      return std::make_unique<VariadicArrayUnionSumAggregate<int8_t>>(
+          resultType, numArgs);
+    case TypeKind::SMALLINT:
+      return std::make_unique<VariadicArrayUnionSumAggregate<int16_t>>(
+          resultType, numArgs);
+    case TypeKind::INTEGER:
+      return std::make_unique<VariadicArrayUnionSumAggregate<int32_t>>(
+          resultType, numArgs);
+    case TypeKind::BIGINT:
+      return std::make_unique<VariadicArrayUnionSumAggregate<int64_t>>(
+          resultType, numArgs);
+    case TypeKind::REAL:
+      return std::make_unique<VariadicArrayUnionSumAggregate<float>>(
+          resultType, numArgs);
+    case TypeKind::DOUBLE:
+      return std::make_unique<VariadicArrayUnionSumAggregate<double>>(
+          resultType, numArgs);
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected element type {}", TypeKindName::toName(elementKind));
+  }
+}
+
+} // namespace
+
+void registerArrayUnionSumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  const std::vector<std::string> elementTypes = {
+      "tinyint", "smallint", "integer", "bigint", "double", "real"};
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  signatures.reserve(elementTypes.size() * 2);
+  for (const auto& elementType : elementTypes) {
+    // array(T) -> array(T) signature (original aggregate over rows of arrays).
+    signatures.push_back(
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType(fmt::format("array({})", elementType))
+            .intermediateType(fmt::format("array({})", elementType))
+            .argumentType(fmt::format("array({})", elementType))
+            .build());
+
+    // T, T... -> array(T) variadic signature (scalars, avoids array
+    // construction overhead).
+    signatures.push_back(
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType(fmt::format("array({})", elementType))
+            .intermediateType(fmt::format("array({})", elementType))
+            .argumentType(elementType)
+            .variableArity(elementType)
+            .build());
+  }
+
+  auto name = prefix + kArrayUnionSum;
+  exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_GE(argTypes.size(), 1);
+
+        if (argTypes[0]->isArray()) {
+          // Original array(T) path.
+          VELOX_CHECK_EQ(argTypes.size(), 1);
+          auto& arrayType = argTypes[0]->asArray();
+          auto elementTypeKind = arrayType.elementType()->kind();
+          return createArrayUnionSumAggregate(elementTypeKind, resultType);
+        }
+
+        // Variadic scalar path: (T, T, ..., T) -> array(T).
+        auto elementTypeKind = argTypes[0]->kind();
+        return createVariadicArrayUnionSumAggregate(
+            elementTypeKind, resultType, argTypes.size());
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayUnionSumAggregate.h
+++ b/velox/functions/prestosql/aggregates/ArrayUnionSumAggregate.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::aggregate::prestosql {
+
+void registerArrayUnionSumAggregate(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite);
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -19,6 +19,7 @@ velox_add_library(
   ApproxPercentileAggregate.cpp
   ArbitraryAggregate.cpp
   ArrayAggAggregate.cpp
+  ArrayUnionSumAggregate.cpp
   AverageAggregate.cpp
   BitwiseAggregates.cpp
   BitwiseXorAggregate.cpp

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h"
 #include "velox/functions/prestosql/aggregates/ArbitraryAggregate.h"
 #include "velox/functions/prestosql/aggregates/ArrayAggAggregate.h"
+#include "velox/functions/prestosql/aggregates/ArrayUnionSumAggregate.h"
 #include "velox/functions/prestosql/aggregates/AverageAggregate.h"
 #include "velox/functions/prestosql/aggregates/BitwiseAggregates.h"
 #include "velox/functions/prestosql/aggregates/BitwiseXorAggregate.h"
@@ -338,6 +339,10 @@ void registerAllAggregateFunctions(
       overwrite);
   registerArrayAggAggregate(
       {prefix + kArrayAgg}, withCompanionFunctions, overwrite);
+  // array_union_sum is a Velox-only function, not available in Presto.
+  if (!onlyPrestoSignatures) {
+    registerArrayUnionSumAggregate(prefix, withCompanionFunctions, overwrite);
+  }
   registerAverageAggregate({prefix + kAvg}, withCompanionFunctions, overwrite);
   registerBitwiseAndAggregate(
       {prefix + kBitwiseAnd},

--- a/velox/functions/prestosql/aggregates/tests/ArrayUnionSumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayUnionSumTest.cpp
@@ -1,0 +1,843 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+class ArrayUnionSumTest : public AggregationTestBase {};
+
+TEST_F(ArrayUnionSumTest, global) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{1, 2, 3}},
+      {{10, 5, 4, 1}},
+      {{9, std::nullopt, 5, 4}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {20, 7, 12, 5},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, globalWithNulls) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{1, std::nullopt, 3}},
+      {{10, 5, std::nullopt}},
+      {{std::nullopt, std::nullopt, 5}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {11, 5, 8},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, globalDifferentLengths) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{1, 2}},
+      {{10, 5, 4, 1}},
+      {{9}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {20, 7, 4, 1},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, emptyArrays) {
+  auto allEmptyArrays = makeRowVector({
+      makeArrayVector<int64_t>({
+          {},
+          {},
+          {},
+      }),
+  });
+
+  auto expectedEmpty = makeRowVector({
+      makeArrayVector<int64_t>({
+          {},
+      }),
+  });
+
+  testAggregations(
+      {allEmptyArrays}, {}, {"array_union_sum(c0)"}, {expectedEmpty});
+}
+
+TEST_F(ArrayUnionSumTest, nullArrays) {
+  auto allNullArrays = makeRowVector(
+      {BaseVector::createNullConstant(ARRAY(BIGINT()), 3, pool())});
+
+  auto expectedNull = makeRowVector(
+      {BaseVector::createNullConstant(ARRAY(BIGINT()), 1, pool())});
+
+  testAggregations(
+      {allNullArrays}, {}, {"array_union_sum(c0)"}, {expectedNull});
+}
+
+TEST_F(ArrayUnionSumTest, tinyintOverflow) {
+  const std::vector<std::vector<std::optional<int8_t>>> inputData = {
+      {{10, 20}},
+      {{100, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"array_union_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()), "Value 140 exceeds 127");
+
+  const std::vector<std::vector<std::optional<int8_t>>> negInputData = {
+      {{-10, -20}},
+      {{-100, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"array_union_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value -140 is less than -128");
+}
+
+TEST_F(ArrayUnionSumTest, smallintOverflow) {
+  const int16_t largeValue = std::numeric_limits<int16_t>::max() - 20;
+  const int16_t smallValue = std::numeric_limits<int16_t>::min() + 20;
+
+  const std::vector<std::vector<std::optional<int16_t>>> inputData = {
+      {{10, 20}},
+      {{largeValue, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"array_union_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value 32787 exceeds 32767");
+
+  const std::vector<std::vector<std::optional<int16_t>>> negInputData = {
+      {{-10, -20}},
+      {{smallValue, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"array_union_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value -32788 is less than -32768");
+}
+
+TEST_F(ArrayUnionSumTest, integerOverflow) {
+  const int32_t largeValue = std::numeric_limits<int32_t>::max() - 20;
+  const int32_t smallValue = std::numeric_limits<int32_t>::min() + 20;
+
+  const std::vector<std::vector<std::optional<int32_t>>> inputData = {
+      {{10, 20}},
+      {{largeValue, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"array_union_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value 2147483667 exceeds 2147483647");
+
+  const std::vector<std::vector<std::optional<int32_t>>> negInputData = {
+      {{-10, -20}},
+      {{smallValue, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"array_union_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value -2147483668 is less than -2147483648");
+}
+
+TEST_F(ArrayUnionSumTest, bigintOverflow) {
+  const int64_t largeValue = std::numeric_limits<int64_t>::max() - 20;
+  const int64_t smallValue = std::numeric_limits<int64_t>::min() + 20;
+
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{10, 20}},
+      {{largeValue, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"array_union_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value 9223372036854775827 exceeds 9223372036854775807");
+
+  const std::vector<std::vector<std::optional<int64_t>>> negInputData = {
+      {{-10, -20}},
+      {{smallValue, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"array_union_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value -9223372036854775828 is less than -9223372036854775808");
+}
+
+TEST_F(ArrayUnionSumTest, floatNan) {
+  constexpr float kInf = std::numeric_limits<float>::infinity();
+  constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+
+  const std::vector<std::vector<std::optional<float>>> inputData = {
+      {{10.0F, 20.0F}},
+      {{kNan, 30.0F}},
+      {{30.0F, kInf}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({
+          {kNan, kInf},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, doubleNan) {
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
+
+  const std::vector<std::vector<std::optional<double>>> inputData = {
+      {{10.0, 20.0}},
+      {{kNan, 30.0}},
+      {{30.0, kInf}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({
+          {kNan, kInf},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, groupBy) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData1 = {
+      {{1, 2, 3}},
+  };
+  const std::vector<std::vector<std::optional<int64_t>>> inputData2 = {
+      {{10, 5, 4}},
+  };
+  const std::vector<std::vector<std::optional<int64_t>>> inputData3 = {
+      {{1, 2}},
+  };
+  const std::vector<std::vector<std::optional<int64_t>>> inputData4 = {
+      {{9, 0, 5}},
+  };
+
+  // Create multiple batches for group by
+  auto batch1 = makeRowVector({
+      makeFlatVector<int64_t>({1}),
+      makeNullableArrayVector(inputData1),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int64_t>({1}),
+      makeNullableArrayVector(inputData2),
+  });
+  auto batch3 = makeRowVector({
+      makeFlatVector<int64_t>({2}),
+      makeNullableArrayVector(inputData3),
+  });
+  auto batch4 = makeRowVector({
+      makeFlatVector<int64_t>({1}),
+      makeNullableArrayVector(inputData4),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int64_t>({
+          {20, 7, 12},
+          {1, 2},
+      }),
+  });
+
+  testAggregations(
+      {batch1, batch2, batch3, batch4},
+      {"c0"},
+      {"array_union_sum(c1)"},
+      {expected});
+}
+
+TEST_F(ArrayUnionSumTest, zerosSkipped) {
+  // Zeros should be skipped (treated like nulls) for performance.
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{0, 0, 0}},
+      {{0, 0, 0, 0}},
+      {{0, 0, 0, 0}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {0, 0, 0, 0},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, mixedZerosNullsAndValues) {
+  // Verify zeros, nulls, and real values all interact correctly.
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{0, std::nullopt, 5, 0}},
+      {{std::nullopt, 0, 0, 3}},
+      {{7, 0, std::nullopt, 0}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {7, 0, 5, 3},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, allZerosAndNulls) {
+  // Every element is either 0 or null => result is all zeros.
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{0, std::nullopt}},
+      {{std::nullopt, 0}},
+      {{0, 0}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {0, 0},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, zerosWithFloats) {
+  // Verify zero-skipping works for float types too.
+  const std::vector<std::vector<std::optional<float>>> inputData = {
+      {{0.0F, 1.5F, 0.0F}},
+      {{3.5F, 0.0F, 0.0F}},
+      {{0.0F, 0.0F, 2.5F}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({
+          {3.5F, 1.5F, 2.5F},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, zerosWithDoubles) {
+  const std::vector<std::vector<std::optional<double>>> inputData = {
+      {{0.0, 1.5, 0.0}},
+      {{3.5, 0.0, 0.0}},
+      {{0.0, 0.0, 2.5}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({
+          {3.5, 1.5, 2.5},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, singleElement) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{100}},
+      {{200}},
+      {{300}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {600},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, allNullElements) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {0, 0},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, realType) {
+  const std::vector<std::vector<std::optional<float>>> inputData = {
+      {{1.5F, 2.5F}},
+      {{10.5F, 5.5F, 4.0F}},
+      {{9.0F, std::nullopt, 5.5F}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({
+          {21.0F, 8.0F, 9.5F},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumTest, doubleType) {
+  const std::vector<std::vector<std::optional<double>>> inputData = {
+      {{1.5, 2.5}},
+      {{10.5, 5.5, 4.0}},
+      {{9.0, std::nullopt, 5.5}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({
+          {21.0, 8.0, 9.5},
+      }),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+} // namespace
+
+// ============================================================================
+// VARIADIC SCALAR TESTS
+// These tests verify the variadic signature: array_union_sum(c1, c2, ..., cN)
+// where each ci is a scalar, not an array.
+// ============================================================================
+
+namespace {
+
+class ArrayUnionSumVariadicTest : public AggregationTestBase {};
+
+TEST_F(ArrayUnionSumVariadicTest, globalTwoColumns) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 10, 9}),
+      makeNullableFlatVector<int64_t>({2, 5, std::nullopt}),
+  });
+
+  // Positional sums: pos0 = 1+10+9 = 20, pos1 = 2+5+0 = 7
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{20, 7}}),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0, c1)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, globalThreeColumns) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 10, 9}),
+      makeNullableFlatVector<int64_t>({2, 5, std::nullopt}),
+      makeNullableFlatVector<int64_t>({3, 4, 5}),
+  });
+
+  // pos0 = 1+10+9 = 20, pos1 = 2+5+0 = 7, pos2 = 3+4+5 = 12
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{20, 7, 12}}),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0, c1, c2)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, globalWithNulls) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 9}),
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+      makeNullableFlatVector<int64_t>({3, 4, std::nullopt}),
+  });
+
+  // pos0 = 1+0+9 = 10, pos1 = 0+0+0 = 0, pos2 = 3+4+0 = 7
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{10, 0, 7}}),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0, c1, c2)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, globalWithZeros) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({0, 0, 5}),
+      makeNullableFlatVector<int64_t>({0, 3, 0}),
+  });
+
+  // pos0 = 0+0+5 = 5, pos1 = 0+3+0 = 3
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{5, 3}}),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0, c1)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, groupBy) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2}),
+      makeNullableFlatVector<int64_t>({1, 10, 100}),
+      makeNullableFlatVector<int64_t>({2, 5, 200}),
+  });
+
+  // group 1: pos0 = 1+10 = 11, pos1 = 2+5 = 7
+  // group 2: pos0 = 100, pos1 = 200
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int64_t>({{11, 7}, {100, 200}}),
+  });
+
+  testAggregations({batch1}, {"c0"}, {"array_union_sum(c1, c2)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, singleColumn) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 10, 9}),
+  });
+
+  // Single position: pos0 = 1+10+9 = 20
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{20}}),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, doubleType) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<double>({1.5, 10.5}),
+      makeNullableFlatVector<double>({2.5, 5.5}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({{12.0, 8.0}}),
+  });
+
+  testAggregations({data}, {}, {"array_union_sum(c0, c1)"}, {expected});
+}
+
+TEST_F(ArrayUnionSumVariadicTest, manyColumns) {
+  // Test with 10 columns to verify variadic works with more args.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1}),
+      makeFlatVector<int64_t>({2, 2}),
+      makeFlatVector<int64_t>({3, 3}),
+      makeFlatVector<int64_t>({4, 4}),
+      makeFlatVector<int64_t>({5, 5}),
+      makeFlatVector<int64_t>({6, 6}),
+      makeFlatVector<int64_t>({7, 7}),
+      makeFlatVector<int64_t>({8, 8}),
+      makeFlatVector<int64_t>({9, 9}),
+      makeFlatVector<int64_t>({10, 10}),
+  });
+
+  // Each position sums over 2 rows, so pos_i = i*2 + 2 for i=0..9
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{2, 4, 6, 8, 10, 12, 14, 16, 18, 20}}),
+  });
+
+  testAggregations(
+      {data},
+      {},
+      {"array_union_sum(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)"},
+      {expected});
+}
+
+} // namespace
+
+// ============================================================================
+// CUSTOM FUZZER TESTS
+// These tests use VectorFuzzer to generate random inputs and verify
+// properties of the array_union_sum aggregation function.
+// ============================================================================
+
+class ArrayUnionSumFuzzerTest
+    : public functions::aggregate::test::AggregationTestBase {
+ protected:
+  template <typename T>
+  void runFuzzerTest(
+      const TypePtr& elementType,
+      int vectorSize,
+      double nullRatio,
+      int iterations) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = vectorSize;
+    opts.nullRatio = nullRatio;
+    opts.containerLength = 10;
+    opts.containerVariableLength = true;
+    opts.containerHasNulls = true;
+    VectorFuzzer fuzzer(opts, pool());
+
+    for (int iter = 0; iter < iterations; ++iter) {
+      auto inputArrays = fuzzer.fuzz(ARRAY(elementType));
+      auto data = makeRowVector({inputArrays});
+
+      auto plan = exec::test::PlanBuilder()
+                      .values({data})
+                      .singleAggregation({}, {"array_union_sum(c0)"})
+                      .planNode();
+
+      VectorPtr result;
+      try {
+        result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
+      } catch (const VeloxUserError&) {
+        // Overflow errors are expected for integer types with random data
+        continue;
+      }
+
+      if (!result) {
+        continue;
+      }
+
+      auto resultRow = result->as<RowVector>();
+      if (!resultRow || resultRow->size() == 0) {
+        continue;
+      }
+
+      auto resultArray = resultRow->childAt(0);
+      if (resultArray->isNullAt(0)) {
+        // Result is null when all input arrays are null
+        bool allInputsNull = true;
+        for (vector_size_t i = 0; i < inputArrays->size(); ++i) {
+          if (!inputArrays->isNullAt(i)) {
+            allInputsNull = false;
+            break;
+          }
+        }
+        ASSERT_TRUE(allInputsNull)
+            << "Result should only be null when all inputs are null";
+        continue;
+      }
+
+      auto resultArrayVec = resultArray->as<ArrayVector>();
+      ASSERT_NE(resultArrayVec, nullptr);
+
+      // Verify: result array length should be max of all input array lengths.
+      // We need to decode the input arrays since VectorFuzzer may generate
+      // wrapped vectors (Dictionary, Constant, etc.)
+      SelectivityVector allRows(inputArrays->size());
+      DecodedVector decodedInputArrays(*inputArrays, allRows);
+      auto baseArrayVector =
+          decodedInputArrays.base()->template as<ArrayVector>();
+
+      vector_size_t maxInputLength = 0;
+      if (baseArrayVector) {
+        for (vector_size_t i = 0; i < inputArrays->size(); ++i) {
+          if (!decodedInputArrays.isNullAt(i)) {
+            auto decodedIndex = decodedInputArrays.index(i);
+            maxInputLength =
+                std::max(maxInputLength, baseArrayVector->sizeAt(decodedIndex));
+          }
+        }
+
+        ASSERT_EQ(resultArrayVec->sizeAt(0), maxInputLength)
+            << "Result array length should equal max input array length";
+      }
+
+      // Verify: result array elements are not null (nulls are treated as 0)
+      auto resultElements = resultArrayVec->elements();
+      auto resultOffset = resultArrayVec->offsetAt(0);
+      auto resultSize = resultArrayVec->sizeAt(0);
+      for (vector_size_t i = 0; i < resultSize; ++i) {
+        ASSERT_FALSE(resultElements->isNullAt(resultOffset + i))
+            << "Result elements should never be null";
+      }
+    }
+  }
+};
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzBigint) {
+  runFuzzerTest<int64_t>(BIGINT(), 100, 0.1, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzInteger) {
+  runFuzzerTest<int32_t>(INTEGER(), 100, 0.1, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzSmallint) {
+  runFuzzerTest<int16_t>(SMALLINT(), 100, 0.1, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzTinyint) {
+  runFuzzerTest<int8_t>(TINYINT(), 100, 0.1, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzDouble) {
+  runFuzzerTest<double>(DOUBLE(), 100, 0.1, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzReal) {
+  runFuzzerTest<float>(REAL(), 100, 0.1, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzHighNullRatio) {
+  runFuzzerTest<int64_t>(BIGINT(), 100, 0.5, 50);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzLargeVectors) {
+  runFuzzerTest<int64_t>(BIGINT(), 500, 0.1, 20);
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzGroupBy) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 100;
+  opts.nullRatio = 0.1;
+  opts.containerLength = 10;
+  opts.containerVariableLength = true;
+  opts.containerHasNulls = true;
+  VectorFuzzer fuzzer(opts, pool());
+
+  for (int iter = 0; iter < 20; ++iter) {
+    auto groupKeys = fuzzer.fuzz(INTEGER());
+    auto inputArrays = fuzzer.fuzz(ARRAY(BIGINT()));
+    auto data = makeRowVector({groupKeys, inputArrays});
+
+    auto plan = exec::test::PlanBuilder()
+                    .values({data})
+                    .singleAggregation({"c0"}, {"array_union_sum(c1)"})
+                    .planNode();
+
+    VectorPtr result;
+    try {
+      result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
+    } catch (const VeloxUserError&) {
+      // Overflow errors are expected
+      continue;
+    }
+
+    // Verify result is not empty and has expected structure
+    ASSERT_NE(result, nullptr);
+    auto resultRow = result->as<RowVector>();
+    ASSERT_NE(resultRow, nullptr);
+    ASSERT_EQ(resultRow->childrenSize(), 2);
+  }
+}
+
+TEST_F(ArrayUnionSumFuzzerTest, fuzzEmptyArrays) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 50;
+  opts.nullRatio = 0.1;
+  opts.containerLength = 0; // Empty arrays
+  opts.containerVariableLength = true;
+  VectorFuzzer fuzzer(opts, pool());
+
+  for (int iter = 0; iter < 20; ++iter) {
+    auto inputArrays = fuzzer.fuzz(ARRAY(BIGINT()));
+    auto data = makeRowVector({inputArrays});
+
+    auto plan = exec::test::PlanBuilder()
+                    .values({data})
+                    .singleAggregation({}, {"array_union_sum(c0)"})
+                    .planNode();
+
+    VectorPtr result;
+    try {
+      result = exec::test::AssertQueryBuilder(plan).copyResults(pool());
+    } catch (const VeloxUserError&) {
+      continue;
+    }
+
+    // Verify result doesn't crash and has valid structure
+    ASSERT_NE(result, nullptr);
+    auto resultRow = result->as<RowVector>();
+    ASSERT_NE(resultRow, nullptr);
+  }
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   ApproxPercentileTest.cpp
   ArbitraryTest.cpp
   ArrayAggTest.cpp
+  ArrayUnionSumTest.cpp
   AverageAggregationTest.cpp
   BitwiseAggregationTest.cpp
   BoolAndOrTest.cpp

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -136,7 +136,7 @@ int main(int argc, char** argv) {
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 
   // List of functions that have known bugs that cause crashes or failures.
-  static const std::unordered_set<std::string> skipFunctions = {
+  std::unordered_set<std::string> skipFunctions = {
       // https://github.com/prestodb/presto/issues/24936
       "classification_fall_out",
       "classification_precision",
@@ -174,8 +174,17 @@ int main(int argc, char** argv) {
       "convex_hull_agg_merge",
       "convex_hull_agg_extract",
       "convex_hull_agg_merge_extract",
-
   };
+  if (!FLAGS_presto_url.empty()) {
+    skipFunctions.insert({
+        // Velox-only function, not available in Presto.
+        "array_union_sum",
+        "array_union_sum_partial",
+        "array_union_sum_merge",
+        "array_union_sum_extract",
+        "array_union_sum_merge_extract",
+    });
+  }
 
   static const std::unordered_set<std::string> functionsRequireSortedInput = {
       "tdigest_agg",

--- a/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/WindowFuzzerTest.cpp
@@ -113,6 +113,12 @@ int main(int argc, char** argv) {
 
   // List of functions that have known bugs that cause crashes or failures.
   std::unordered_set<std::string> skipFunctions = {
+      // Velox-only function, not available in Presto.
+      "array_union_sum",
+      "array_union_sum_partial",
+      "array_union_sum_merge",
+      "array_union_sum_extract",
+      "array_union_sum_merge_extract",
       // https://github.com/prestodb/presto/issues/24936
       "classification_fall_out",
       "classification_precision",


### PR DESCRIPTION
Summary:
This adds a new `array_union_sum` aggregation function that performs element-wise sum of arrays, similar to the existing `map_union_sum` function.

The function:
- Unions arrays of different lengths (extending to max length)
- Sums corresponding elements at each position
- Treats null elements as 0
- Supports numeric types: tinyint, smallint, integer, bigint, real, double
- Includes overflow checking for integer types

A variadic signature array_union_sum(c1, c2, ..., cN) is also supported, where each argument is a scalar at a fixed array position. This avoids per-row array construction overhead when the number of positions is known at query time.

Array form:

SELECT array_union_sum(x) FROM (
    VALUES
        (ARRAY[1, 2, 3]),
        (ARRAY[10, 5, 4, 1]),
        (ARRAY[9, NULL, 5, 4])
) AS t(x);
-- ARRAY[20, 7, 12, 5]

Variadic form:

SELECT array_union_sum(c0, c1, c2) FROM (
    VALUES
        (1, 2, 3),
        (10, 5, 4),
        (9, NULL, 5)
) AS t(c0, c1, c2);
-- ARRAY[20, 7, 12]

This is a Velox-only function (not available in Presto), so it has been added to the fuzzer SOT exclusion list.

Differential Revision: D90476644


