### PR TITLE
fix(build): Add velox_hive_connector dependency to velox_dwio_common_test

### DIFF
--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_test(velox_dwio_common_test velox_dwio_common_test)
 target_link_libraries(
   velox_dwio_common_test
   velox_dwio_common_test_utils
+  velox_hive_connector
   velox_temp_path
   velox_vector_test_lib
   velox_link_libs


### PR DESCRIPTION
Add the dependent lib to fix the build error, which is
```C++
ndefined symbols for architecture arm64:
  "facebook::velox::connector::hive::BufferedInputBuilder::builder_", referenced from:
      facebook::velox::connector::hive::BufferedInputBuilder::getInstance() in TestBufferedInput.cpp.o
      facebook::velox::connector::hive::BufferedInputBuilder::getInstance() in TestBufferedInput.cpp.o
      facebook::velox::connector::hive::BufferedInputBuilder::registerBuilder(std::__1::shared_ptr<facebook::velox::connector::hive::BufferedInputBuilder>) in TestBufferedInput.cpp.o
ld: symbol(s) not found for architecture arm64
```