### PR TITLE
fix(build): S3MultipleEndpointsTest folly::parseJson issue

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -102,7 +102,8 @@ class S3MultipleEndpoints : public S3Test, public ::test::VectorTestBase {
     // Second column contains details about written files.
     auto details = results->childAt(exec::TableWriteTraits::kFragmentChannel)
                        ->as<FlatVector<StringView>>();
-    folly::dynamic obj = folly::parseJson(details->valueAt(1));
+    folly::dynamic obj =
+        folly::parseJson(std::string_view(details->valueAt(1)));
     return obj["fileWriteInfos"];
   }
 


### PR DESCRIPTION
FAILED: velox/connectors/hive/storage_adapters/s3fs/tests/CMakeFiles/velox_s3multiendpoints_test.dir/S3MultipleEndpointsTest.cpp.o 
/usr/bin/ccache /opt/rh/gcc-toolset-14/root/usr/bin/g++ -DAWS_ENABLE_EPOLL -DAWS_SDK_VERSION_MAJOR=1 -DAWS_SDK_VERSION_MINOR=11 -DAWS_SDK_VERSION_PATCH=654 -DAZ_RTTI -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DGEOS_INLINE -DGFLAGS_IS_A_DLL=0 -DGTEST_LINKED_AS_SHARED_LIBRARY=1 -DNDEBUG -DSIMDJSON_THREADS_ENABLED=1 -DUSE_UNSTABLE_GEOS_CPP_API -DVELOX_ENABLE_ABFS -DVELOX_ENABLE_GCS -DVELOX_ENABLE_HDFS -DVELOX_ENABLE_PARQUET -DVELOX_ENABLE_S3 -I/__w/velox/velox/. -I/__w/velox/velox/velox/external/xxhash -I/__w/velox/velox/_build/release -I/__w/velox/velox/velox/tpcds/gen/dsdgen/include -I/__w/velox/velox/_build/release/_deps/curl-src/include -isystem /__w/velox/velox/velox -isystem /__w/velox/velox/velox/external -isystem /usr/include/libdwarf-0 -isystem /usr/local/include/geos -isystem /__w/velox/velox/_build/release/_deps/faiss-src -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -DFOLLY_CFG_NO_COROUTINES -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-implicit-fallthrough          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -Wno-error=template-id-cdtor -Wno-overloaded-virtual -Wno-error=tautological-compare -Werror -O3 -DNDEBUG -std=gnu++20 -fPIE -fdiagnostics-color=always -ffp-contract=off -fsized-deallocation -MD -MT velox/connectors/hive/storage_adapters/s3fs/tests/CMakeFiles/velox_s3multiendpoints_test.dir/S3MultipleEndpointsTest.cpp.o -MF velox/connectors/hive/storage_adapters/s3fs/tests/CMakeFiles/velox_s3multiendpoints_test.dir/S3MultipleEndpointsTest.cpp.o.d -o velox/connectors/hive/storage_adapters/s3fs/tests/CMakeFiles/velox_s3multiendpoints_test.dir/S3MultipleEndpointsTest.cpp.o -c /__w/velox/velox/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
/__w/velox/velox/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp: In member function 'folly::dynamic facebook::velox::{anonymous}::S3MultipleEndpoints::writeData(facebook::velox::RowVectorPtr, const std::string&, const std::string&)':
/__w/velox/velox/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp:105:42: error: no matching function for call to 'parseJson(const facebook::velox::StringView)'
  105 |     folly::dynamic obj = folly::parseJson(details->valueAt(1));
      |                          ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
In file included from /usr/local/include/folly/json.h:17,
                 from /__w/velox/velox/./velox/common/serialization/Serializable.h:21,
                 from /__w/velox/velox/./velox/type/Type.h:42,
                 from /__w/velox/velox/./velox/vector/ComplexVector.h:23,
                 from /__w/velox/velox/./velox/core/ExpressionEvaluator.h:18,
                 from /__w/velox/velox/./velox/connectors/Connector.h:29,
                 from /__w/velox/velox/./velox/connectors/hive/HiveConnector.h:18,
                 from /__w/velox/velox/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp:20:
/usr/local/include/folly/json/json.h:210:9: note: candidate: 'folly::dynamic folly::parseJson(StringPiece, const json::serialization_opts&)'
  210 | dynamic parseJson(StringPiece, json::serialization_opts const&);
      |         ^~~~~~~~~
/usr/local/include/folly/json/json.h:210:9: note:   candidate expects 2 arguments, 1 provided
/usr/local/include/folly/json/json.h:211:9: note: candidate: 'folly::dynamic folly::parseJson(StringPiece)'
  211 | dynamic parseJson(StringPiece);
      |         ^~~~~~~~~
/usr/local/include/folly/json/json.h:211:19: note:   no known conversion for argument 1 from 'const facebook::velox::StringView' to 'folly::StringPiece' {aka 'folly::Range<const char*>'}
  211 | dynamic parseJson(StringPiece);