### PR TITLE
refactor(geo): Replace VarbinaryWriter with exec::StringWriter

### DIFF
--- a/velox/common/geospatial/tests/CMakeLists.txt
+++ b/velox/common/geospatial/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ if(VELOX_ENABLE_GEO)
   target_link_libraries(
     velox_common_geospatial_serde_test
     velox_common_geospatial_serde
+    velox_vector_test_lib
     GTest::gtest
     GTest::gtest_main
     GTest::gmock


### PR DESCRIPTION
Summary:
Replace the custom VarbinaryWriter template class with the standard
velox::exec::StringWriter. The private write methods remain templated
to support both exec::StringWriter (for the main API) and std::string
(for temporary buffers in writeGeometryCollection).

This change simplifies the serialization interface by using Velox's
standard StringWriter instead of a custom abstraction.

Differential Revision: D90505499


