### PR TITLE
feat(geo): Make ST_Centroid consistent with ISO spec

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -323,7 +323,7 @@ Accessors
 .. function:: ST_Centroid(geometry: Geometry) -> geometry: Geometry
 
     Returns the point value that is the mathematical centroid of ``geometry``.
-    Empty geometry inputs result in empty output.
+    Empty geometry inputs result in null output.
 
 .. function:: ST_Centroid(SphericalGeography) -> Point
 

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -1467,15 +1467,14 @@ TEST_F(GeometryFunctionsTest, testStCentroid) {
             "ST_AsText(ST_Centroid(ST_GeometryFromText(c0)))", wkt);
 
         if (wkt.has_value()) {
-          ASSERT_TRUE(result.has_value());
-          ASSERT_TRUE(expected.has_value());
-          ASSERT_EQ(result.value(), expected.value());
+          ASSERT_EQ(result, expected);
         } else {
+          ASSERT_FALSE(expected.has_value());
           ASSERT_FALSE(result.has_value());
         }
       };
 
-  testStCentroidFunc("LINESTRING EMPTY", "POINT EMPTY");
+  testStCentroidFunc("LINESTRING EMPTY", std::nullopt);
   testStCentroidFunc("POINT (3 5)", "POINT (3 5)");
   testStCentroidFunc("MULTIPOINT (1 2, 2 4, 3 6, 4 8)", "POINT (2.5 5)");
   testStCentroidFunc("LINESTRING (1 1, 2 2, 3 3)", "POINT (2 2)");


### PR DESCRIPTION
Summary:
The ISO specification has ST_Centroid returning NULL on
empty geometries.  ST_Centroid(Geometry) currently returns an empty
geometry for empty geometries.  This is the same as Java, but
inconsistent with the spec and also with ST_Centroid(SphericalGeography).

This change makes Velox compatible with the ISO spec but incompatible
with Presto Java.

Differential Revision: D90506624


