### PR TITLE
fix(build): Fix broken build with StringView change

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp
@@ -102,7 +102,8 @@ class S3MultipleEndpoints : public S3Test, public ::test::VectorTestBase {
     // Second column contains details about written files.
     auto details = results->childAt(exec::TableWriteTraits::kFragmentChannel)
                        ->as<FlatVector<StringView>>();
-    folly::dynamic obj = folly::parseJson(details->valueAt(1));
+    folly::dynamic obj =
+        folly::parseJson(std::string_view(details->valueAt(1)));
     return obj["fileWriteInfos"];
   }
 


### PR DESCRIPTION
Summary:
I think this is a left-over from Pedro's StringView change, which currently broke the build. I hope this is the only place broken, I couldn't verify this locally.
```
/__w/velox/velox/velox/connectors/hive/storage_adapters/s3fs/tests/S3MultipleEndpointsTest.cpp:105:42: error: no matching function for call to 'parseJson(const facebook::velox::StringView)'
  105 |     folly::dynamic obj = folly::parseJson(details->valueAt(1));
      |                          ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
```

Differential Revision: D90528368


