### PR TITLE
perf(dwio): Avoid redundant outputBuffer clearing

### DIFF
--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -28,12 +28,16 @@ namespace facebook::velox::dwio::common {
 template <typename T, typename = std::enable_if_t<std::is_trivial_v<T>>>
 class DataBuffer {
  public:
-  explicit DataBuffer(velox::memory::MemoryPool& pool, uint64_t size = 0)
+  explicit DataBuffer(
+      velox::memory::MemoryPool& pool,
+      uint64_t size = 0,
+      bool zeroFilled = true)
       : pool_(&pool),
-        // Initial allocation uses calloc, to avoid memset.
+        // Initial allocation uses calloc if zeroFilled, to avoid memset.
         buf_(
             reinterpret_cast<T*>(
-                pool_->allocateZeroFilled(1, sizeInBytes(size)))),
+                zeroFilled ? pool_->allocateZeroFilled(1, sizeInBytes(size))
+                           : pool_->allocate(sizeInBytes(size)))),
         size_(size),
         capacity_(size) {
     VELOX_CHECK(buf_ != nullptr || size_ == 0);

--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -22,8 +22,9 @@ namespace facebook::velox::dwio::common::compression {
 
 void PagedInputStream::prepareOutputBuffer(uint64_t uncompressedLength) {
   if (!outputBuffer_ || uncompressedLength > outputBuffer_->capacity()) {
+    // OutputBuffer is intended for writing before reading, not need zeroFilled.
     outputBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
-        pool_, uncompressedLength);
+        pool_, uncompressedLength, false);
   }
 }
 


### PR DESCRIPTION
OutputBuffer is intended for writing before using it, clearing buffer with calloc is redundant.

Furthermore, memory allocator like jemalloc may send madvise syscall with MADV_DONTNEED to kernel for clearing memory, later memory access will trigger page fault. The page fault and madvise syscall in Linux kernel involves some global locks which may cause performance issue in large systems with many CPU cores.

The patch can reduce total latency of TPCDS (SF6T) by ~3% when running Spark with Gluten in 2-socket Xeon 6960P system.