### PR TITLE
fix(ci): Clang-tidy coroutines flag unused

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -213,6 +213,7 @@ jobs:
           sed -i 's/-Wno-error=template-id-cdtor//g' $BUILD_PATH/compile_commands.json
           sed -i 's/-Wno-class-memaccess//g' $BUILD_PATH/compile_commands.json
           sed -i 's/-Wno-maybe-uninitialized//g' $BUILD_PATH/compile_commands.json
+          sed -i 's/-fcoroutines//g' $BUILD_PATH/compile_commands.json
           python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE $FILES
 
   ubuntu-debug:

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -109,6 +109,8 @@ def tidy(args):
                 )
 
     ok = check_output(stdout)
+    if not ok:
+        print(stdout)
 
     return 0 if ok else 1
 


### PR DESCRIPTION
When the coroutines were enabled a new flag was added for gcc to ensure the correct compilation.
But this is also an unknown compile flag to clang-tidy/clang and needs to be removed.

Let's also add the stdout output if a failure occurs for easier diagnostic.