### PR TITLE
feat: Add DistinctFromArgTypesGenerator to block array(IPADDRESS)

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -204,7 +204,7 @@ const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
       VARBINARY(),
       TIMESTAMP(),
       TIMESTAMP_WITH_TIME_ZONE(),
-  };
+      IPADDRESS()};
   return kScalarTypes;
 }
 
@@ -362,7 +362,6 @@ bool PrestoQueryRunner::isSupported(const exec::FunctionSignature& signature) {
       usesTypeName(signature, "hugeint") ||
       usesTypeName(signature, "geometry") || usesTypeName(signature, "time") ||
       usesTypeName(signature, "p4hyperloglog") ||
-      usesInputTypeName(signature, "ipaddress") ||
       usesInputTypeName(signature, "ipprefix") ||
       usesInputTypeName(signature, "uuid"));
 }

--- a/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunnerIntermediateTypeTransforms.cpp
@@ -21,6 +21,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/functions/prestosql/types/KHyperLogLogType.h"
 #include "velox/functions/prestosql/types/QDigestType.h"
@@ -85,6 +86,9 @@ intermediateTypeTransforms() {
            std::make_shared<IntermediateTypeTransformUsingCast>(
                BINGTILE(), BIGINT())},
           {INTERVAL_DAY_TIME(), std::make_shared<IntervalDayTimeTransform>()},
+          {IPADDRESS(),
+           std::make_shared<IntermediateTypeTransformUsingCast>(
+               IPADDRESS(), VARCHAR())},
       };
   return intermediateTypeTransforms;
 }

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
 #include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
+#include "velox/functions/prestosql/fuzzer/DistinctFromArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/DivideArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/FloorAndRoundArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/ModulusArgTypesGenerator.h"
@@ -78,7 +79,8 @@ std::unordered_map<std::string, std::shared_ptr<ArgTypesGenerator>>
         {"floor", std::make_shared<FloorAndRoundArgTypesGenerator>()},
         {"round", std::make_shared<FloorAndRoundArgTypesGenerator>()},
         {"mod", std::make_shared<ModulusArgTypesGenerator>()},
-        {"truncate", std::make_shared<TruncateArgTypesGenerator>()}};
+        {"truncate", std::make_shared<TruncateArgTypesGenerator>()},
+        {"distinct_from", std::make_shared<DistinctFromArgTypesGenerator>()}};
 
 std::unordered_map<std::string, std::shared_ptr<ExprTransformer>>
     exprTransformers = {

--- a/velox/functions/prestosql/fuzzer/DistinctFromArgTypesGenerator.h
+++ b/velox/functions/prestosql/fuzzer/DistinctFromArgTypesGenerator.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/fuzzer/ArgTypesGenerator.h"
+#include "velox/expression/fuzzer/ArgumentTypeFuzzer.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
+
+namespace facebook::velox::exec::test {
+
+/// Custom argument type generator for distinct_from function that blocks
+/// array(IPADDRESS) combinations which fail in Presto due to missing
+/// compareTo() implementation in Int128ArrayBlock.
+/// See: https://github.com/prestodb/presto/issues/26836
+class DistinctFromArgTypesGenerator : public fuzzer::ArgTypesGenerator {
+ public:
+  std::vector<TypePtr> generateArgs(
+      const exec::FunctionSignature& signature,
+      const TypePtr& returnType,
+      fuzzer::FuzzerGenerator& rng) override {
+    // Use default ArgumentTypeFuzzer to generate types.
+    fuzzer::ArgumentTypeFuzzer fuzzer(signature, returnType, rng);
+
+    if (!fuzzer.fuzzArgumentTypes(0 /* maxVariadicArgs */)) {
+      // Cannot generate valid argument types.
+      return {};
+    }
+
+    auto argTypes = fuzzer.argumentTypes();
+
+    // Block array(IPADDRESS) combinations as they fail in Presto.
+    // Presto throws: UnsupportedOperationException in
+    // Int128ArrayBlock.compareTo()
+    for (const auto& argType : argTypes) {
+      if (argType->isArray() &&
+          isIPAddressType(argType->asArray().elementType())) {
+        // Return empty vector to indicate this type combination is not
+        // supported.
+        return {};
+      }
+    }
+
+    return argTypes;
+  }
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/fuzzer/TruncateArgTypesGenerator.h
+++ b/velox/functions/prestosql/fuzzer/TruncateArgTypesGenerator.h
@@ -29,7 +29,9 @@ class TruncateArgTypesGenerator : public fuzzer::ArgTypesGenerator {
     // Only the single-arg truncate function is supported because
     // ArgumentTypeFuzzer can generate argument types for the two-arg truncate
     // function.
-    VELOX_CHECK_EQ(1, signature.argumentTypes().size());
+    if (signature.argumentTypes().size() != 1) {
+      return {};
+    }
     // Generates a decimal type following below formulas:
     // p = max(p1 - s1, 1)
     // s = 0


### PR DESCRIPTION
Summary:
Enable IPAddress type testing across all Velox fuzzers that use PrestoQueryRunner, including JoinFuzzer, AggregationFuzzer, and ExpressionFuzzer etc.

Add a custom argument type generator for the `distinct_from` function that blocks array(IPADDRESS) combinations. These combinations fail in Presto verification due to missing compareTo() implementation in Int128ArrayBlock.

Also updates ExpressionFuzzer to check custom argument type generators first before falling back to the default ArgumentTypeFuzzer. This ensures custom generators take precedence for functions with known type constraints.

See: https://github.com/prestodb/presto/issues/26836

Differential Revision: D90640359


