### PR TITLE
fix(build): Add missing constructor in TestCustomType

### DIFF
--- a/velox/type/tests/OpaqueCustomTypesTest.cpp
+++ b/velox/type/tests/OpaqueCustomTypesTest.cpp
@@ -33,6 +33,8 @@ class OpaqueCustomTypeTest : public testing::Test {
   struct TestCustomType {
     std::string name;
 
+    explicit TestCustomType(const std::string& typeName) : name(typeName) {}
+
     bool operator==(const TestCustomType& other) const {
       return name == other.name;
     }


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/16008

Fix build error:
```
In file included from /velox/velox/type/tests/OpaqueCustomTypesTest.cpp:17:
In file included from /velox/_build/release/_deps/folly-src/folly/dynamic.h:17:
In file included from /velox/_build/release/_deps/folly-src/folly/json/dynamic.h:63:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/memory:66:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_uninitialized.h:64:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/ext/alloc_traits.h:34:
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/alloc_traits.h:518:4: error: no matching function for call to 'construct_at'
          std::construct_at(__p, std::forward<_Args>(__args)...);
          ^~~~~~~~~~~~~~~~~
...
                  ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/bits/stl_construct.h:94:5: note: candidate template ignored: substitution failure [with _Tp = facebook::velox::(anonymous namespace)::OpaqueCustomTypeTest::TestCustomType, _Args = <std::basic_string<char>>]: no matching constructor for initialization of 'facebook::velox::(anonymous namespace)::OpaqueCustomTypeTest::TestCustomType'
    construct_at(_Tp* __location, _Args&&... __args)
    ^

```