### PR TITLE
refactor(LocalMerge): Preserve encoding copy during template output vector creation

### DIFF
--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -386,10 +386,7 @@ RowVectorPtr SourceMerger::getOutput(
   VELOX_CHECK_GT(outputBatchRows_, 0);
 
   if (!output_) {
-    output_ = BaseVector::create<RowVector>(type_, outputBatchRows_, pool_);
-    for (auto& child : output_->children()) {
-      child->resize(outputBatchRows_);
-    }
+    output_ = createOutputVector();
   }
 
   for (;;) {
@@ -433,6 +430,23 @@ RowVectorPtr SourceMerger::getOutput(
       return nullptr;
     }
   }
+}
+
+RowVectorPtr SourceMerger::createOutputVector() {
+  // Attempt to generate output vector using stream data to preserve encodings.
+  // First, find the first stream with non-null data to determine column
+  // encodings.
+  const RowVector* source = nullptr;
+  for (const auto* stream : streams_) {
+    if (stream->hasData() && (source = stream->data())) {
+      return std::static_pointer_cast<RowVector>(
+          BaseVector::createEmptyLike(source, outputBatchRows_, pool_));
+    }
+  }
+
+  // If a non-null stream cannot be found, default to generating row vector by
+  // type.
+  return BaseVector::create<RowVector>(type_, outputBatchRows_, pool_);
 }
 
 bool SourceStream::operator<(const MergeStream& other) const {

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -167,6 +167,10 @@ class SourceMerger {
  private:
   void setOutputBatchSize();
 
+  /// Creates the output vector. If a template is available from input data,
+  /// creates output children with matching encodings to support FlatMapVector.
+  RowVectorPtr createOutputVector();
+
   const RowTypePtr type_;
   const vector_size_t maxOutputBatchRows_;
   const uint64_t maxOutputBatchBytes_;
@@ -209,6 +213,12 @@ class SourceStream final : public MergeStream {
 
   bool hasData() const override {
     return !atEnd_;
+  }
+
+  /// Returns the current data batch from the source. Used for encoding
+  /// detection to create output vectors with matching encodings.
+  const RowVector* data() const {
+    return data_.get();
   }
 
   // Returns the estimated row size based on the vector received from the

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -986,3 +986,236 @@ TEST_F(MergeTest, preserveVectorEncoding) {
   });
   facebook::velox::test::assertEqualVectors(mapColumn, verifier);
 }
+
+/// Tests that LocalMerge correctly preserves FlatMapVector encoding
+/// when merging data with FlatMapVector columns.
+TEST_F(MergeTest, flatMapVectorEncoding) {
+  // Create input data with FlatMapVector columns.
+  // Data is already sorted by c0.
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({0, 2, 4}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{1, 10}, {2, 20}},
+          {{1, 30}, {3, 40}},
+          {{2, 50}},
+      }),
+  });
+
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 5}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{1, 100}, {2, 200}},
+          {{3, 300}},
+          {{1, 400}, {2, 500}, {3, 600}},
+      }),
+  });
+
+  auto verifyResult = [this](const std::vector<RowVectorPtr>& results) {
+    ASSERT_EQ(results.size(), 1);
+
+    auto output = results[0];
+    ASSERT_EQ(output->size(), 6);
+
+    auto sortKey = output->childAt(0)->asFlatVector<int64_t>();
+    for (int i = 0; i < 6; ++i) {
+      EXPECT_EQ(sortKey->valueAt(i), i);
+    }
+
+    auto mapColumn = output->childAt(1);
+    EXPECT_EQ(mapColumn->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    auto flatMapVector = mapColumn->as<FlatMapVector>();
+    EXPECT_EQ(flatMapVector->distinctKeys()->size(), 3);
+    auto verifier = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 30}, {3, 40}},
+        {{3, 300}},
+        {{2, 50}},
+        {{1, 400}, {2, 500}, {3, 600}},
+    });
+    // Merge does not resize child vectors.
+    verifier->resize(mapColumn->size());
+    facebook::velox::test::assertEqualVectors(mapColumn, verifier);
+  };
+
+  // Test multi-threaded execution.
+  {
+    SCOPED_TRACE("Multi-threaded execution");
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .localMerge(
+                {"c0"},
+                {
+                    PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+                    PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+                })
+            .planNode();
+
+    CursorParameters params;
+    params.planNode = plan;
+    params.queryCtx = core::QueryCtx::create(executor_.get());
+    params.maxDrivers = 2;
+
+    auto result = readCursor(params);
+    verifyResult(result.second);
+  }
+
+  // Test serial execution.
+  {
+    SCOPED_TRACE("Serial execution");
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .localMerge(
+                {"c0"},
+                {
+                    PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+                    PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+                })
+            .planNode();
+
+    CursorParameters params;
+    params.planNode = plan;
+    params.queryCtx = core::QueryCtx::create();
+    params.serialExecution = true;
+
+    auto result = readCursor(params);
+    verifyResult(result.second);
+  }
+}
+
+/// Tests that LocalMerge correctly handles FlatMapVector encoding
+/// when the first source is empty but subsequent sources have data.
+TEST_F(MergeTest, flatMapVectorEncodingWithEmptyFirstSource) {
+  // Create an empty first source.
+  auto emptyData = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({}),
+          vectorMaker_.flatMapVector<int64_t, int64_t>({}),
+      });
+
+  // Create second source with FlatMapVector data.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{1, 10}, {2, 20}},
+          {{1, 30}},
+          {{2, 40}, {3, 50}},
+      }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {
+                  PlanBuilder(planNodeIdGenerator)
+                      .values({emptyData})
+                      .planNode(),
+                  PlanBuilder(planNodeIdGenerator).values({data}).planNode(),
+              })
+          .planNode();
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = core::QueryCtx::create(executor_.get());
+  params.maxDrivers = 2;
+
+  auto result = readCursor(params);
+  ASSERT_EQ(result.second.size(), 1);
+
+  auto output = result.second[0];
+  ASSERT_EQ(output->size(), 3);
+
+  // Verify the FlatMapVector encoding is preserved even when first source is
+  // empty.
+  auto mapColumn = output->childAt(1);
+  EXPECT_EQ(mapColumn->encoding(), VectorEncoding::Simple::FLAT_MAP);
+  auto flatMapVector = mapColumn->as<FlatMapVector>();
+  EXPECT_EQ(flatMapVector->distinctKeys()->size(), 3);
+  auto verifier = vectorMaker_.flatMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{1, 30}},
+      {{2, 40}, {3, 50}},
+  });
+  verifier->resize(mapColumn->size());
+  facebook::velox::test::assertEqualVectors(mapColumn, verifier);
+}
+
+/// Tests that LocalMerge correctly merges multiple sources with FlatMapVector
+/// columns and different key sets.
+TEST_F(MergeTest, flatMapVectorEncodingMultipleSources) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({0, 3}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{1, 10}},
+          {{1, 40}, {2, 50}},
+      }),
+  });
+
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 4}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{2, 20}},
+          {{3, 60}},
+      }),
+  });
+
+  auto data3 = makeRowVector({
+      makeFlatVector<int64_t>({2, 5}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{1, 30}, {3, 35}},
+          {{1, 70}, {2, 80}, {3, 90}},
+      }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {
+                  PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+                  PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+                  PlanBuilder(planNodeIdGenerator).values({data3}).planNode(),
+              })
+          .planNode();
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = core::QueryCtx::create(executor_.get());
+  params.maxDrivers = 3;
+
+  auto result = readCursor(params);
+  ASSERT_EQ(result.second.size(), 1);
+
+  auto output = result.second[0];
+  ASSERT_EQ(output->size(), 6);
+
+  // Verify the output is sorted correctly.
+  auto sortKey = output->childAt(0)->asFlatVector<int64_t>();
+  for (int i = 0; i < 6; ++i) {
+    EXPECT_EQ(sortKey->valueAt(i), i);
+  }
+
+  // Verify the FlatMapVector encoding is preserved.
+  auto mapColumn = output->childAt(1);
+  EXPECT_EQ(mapColumn->encoding(), VectorEncoding::Simple::FLAT_MAP);
+  auto flatMapVector = mapColumn->as<FlatMapVector>();
+  EXPECT_EQ(flatMapVector->distinctKeys()->size(), 3);
+  auto verifier = vectorMaker_.flatMapVector<int64_t, int64_t>({
+      {{1, 10}},
+      {{2, 20}},
+      {{1, 30}, {3, 35}},
+      {{1, 40}, {2, 50}},
+      {{3, 60}},
+      {{1, 70}, {2, 80}, {3, 90}},
+  });
+  verifier->resize(mapColumn->size());
+  facebook::velox::test::assertEqualVectors(mapColumn, verifier);
+}


### PR DESCRIPTION
Summary: Support k-way merging of flat map encodeded columns. This will require some minimal support from BaseVector::create to support generating template FlatMapVectors. This will prevent errors like we see in [https://github.com/facebookincubator/velox/issues/15485](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebookincubator%2Fvelox%2Fissues%2F15485&h=AT2DhTcKC08_uO_B6kqHDP7jLEI7UlrAxB7mlopQzjOYDW7Hk6HetnBRUdwburF_1o8Hq8W-r5-E1gyYP-A-kIqa3YJMJ1CyFdxZ3vm3yKbrvSLztcm3FcsoLFVcSi8kqEa4l1Rbpct9jo13ZqCA3J5kIMZm) where copies fail due to mismatched vector encodings.

Differential Revision: D90622855


