### PR TITLE
fix(type): Use precompiled RE2 for column name escaping check

### DIFF
--- a/velox/exec/fuzzer/FuzzerUtil.cpp
+++ b/velox/exec/fuzzer/FuzzerUtil.cpp
@@ -43,7 +43,8 @@ std::pair<std::string, std::string> extractPartition(
 }
 
 std::optional<int32_t> getBucketNum(const std::string& fileName) {
-  if (RE2::FullMatch(fileName, "0[0-9]+_0_TaskCursorQuery_[0-9]+")) {
+  static const RE2 kPattern("0[0-9]+_0_TaskCursorQuery_[0-9]+");
+  if (RE2::FullMatch(fileName, kPattern)) {
     return std::optional(stoi(fileName.substr(0, fileName.find("+"))));
   }
   return std::nullopt;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -41,8 +41,8 @@ struct hash<facebook::velox::TypeKind> {
 namespace facebook::velox {
 namespace {
 bool isColumnNameRequiringEscaping(const std::string& name) {
-  static const std::string re("^[a-zA-Z_][a-zA-Z0-9_]*$");
-  return !RE2::FullMatch(name, re);
+  static const re2::RE2 kPattern("^[a-zA-Z_][a-zA-Z0-9_]*$");
+  return !RE2::FullMatch(name, kPattern);
 }
 
 const auto& typeKindNames() {


### PR DESCRIPTION
Summary: Avoid repeated regex compilation by using a static RE2 object instead of a string pattern. The RE2::FullMatch function was already being called with the pattern, but passing a string caused RE2 to recompile the pattern on each invocation.

Differential Revision: D90685920
