### PR TITLE
refactor: Modify aggregates under prestosql to take the name as part of registration

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -138,6 +138,7 @@ std::vector<AggregateRegistrationResult> registerAggregateFunction(
     bool registerCompanionFunctions,
     bool overwrite) {
   auto size = names.size();
+  VELOX_CHECK_NE(size, 0, "Aggregate function registered without a name.");
   std::vector<AggregateRegistrationResult> registrationResults{size};
   for (int i = 0; i < size; ++i) {
     registrationResults[i] = registerAggregateFunction(

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -70,8 +70,8 @@ class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
 };
 
 template <template <typename U> class T>
-exec::AggregateRegistrationResult registerBitwise(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerBitwise(
+    const std::vector<std::string>& names,
     bool ignoreDuplicates,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
@@ -91,13 +91,14 @@ exec::AggregateRegistrationResult registerBitwise(
   }
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step /*step*/,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(argTypes.size(), 1, "{} takes only one argument", name);
         auto inputType = argTypes[0];
         switch (inputType->kind()) {

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h"
 #include "velox/functions/prestosql/aggregates/HyperLogLogAggregate.h"
 #include "velox/functions/prestosql/types/HyperLogLogRegistration.h"
@@ -23,8 +22,8 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-exec::AggregateRegistrationResult registerApproxDistinct(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerApproxDistinct(
+    const std::vector<std::string>& names,
     bool hllAsFinalResult,
     bool withCompanionFunctions,
     bool overwrite,
@@ -91,9 +90,9 @@ exec::AggregateRegistrationResult registerApproxDistinct(
           .argumentType("double")
           .build());
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name, hllAsFinalResult, hllAsRawInput, defaultError](
+      [hllAsFinalResult, hllAsRawInput, defaultError](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
@@ -128,12 +127,13 @@ exec::AggregateRegistrationResult registerApproxDistinct(
 } // namespace
 
 void registerApproxDistinctAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& approxDistinctNames,
+    const std::vector<std::string>& approxSetNames,
     bool withCompanionFunctions,
     bool overwrite) {
   registerHyperLogLogType();
   registerApproxDistinct(
-      prefix + kApproxDistinct,
+      approxDistinctNames,
       false,
       withCompanionFunctions,
       overwrite,
@@ -141,7 +141,7 @@ void registerApproxDistinctAggregates(
   // approx_set is companion function for approx_distinct. Don't register
   // companion functions for it.
   registerApproxDistinct(
-      prefix + kApproxSet,
+      approxSetNames,
       true,
       false,
       overwrite,

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h
@@ -17,11 +17,13 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerApproxDistinctAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& approxDistinctNames,
+    const std::vector<std::string>& approxSetNames,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -21,7 +21,6 @@
 #include "velox/exec/Strings.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/ApproxMostFrequentStreamSummary.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -587,7 +586,7 @@ std::unique_ptr<exec::Aggregate> makeApproxMostFrequentAggregate(
 } // namespace
 
 void registerApproxMostFrequentAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -610,11 +609,10 @@ void registerApproxMostFrequentAggregate(
             .argumentType("bigint")
             .build());
   }
-  auto name = prefix + kApproxMostFrequent;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
@@ -625,7 +623,7 @@ void registerApproxMostFrequentAggregate(
         return VELOX_DYNAMIC_TYPE_DISPATCH(
             makeApproxMostFrequentAggregate,
             valueType->kind(),
-            name,
+            names.front(),
             step,
             argTypes,
             resultType,

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerApproxMostFrequentAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
@@ -33,7 +34,7 @@ enum ApproxPercentileIntermediateTypeChildIndex {
 };
 
 void registerApproxPercentileAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -19,7 +19,6 @@
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -412,7 +411,7 @@ class NonNumericArbitrary : public exec::Aggregate {
 } // namespace
 
 void registerArbitraryAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -423,16 +422,16 @@ void registerArbitraryAggregate(
           .argumentType("T")
           .build()};
 
-  std::vector<std::string> names = {prefix + kArbitrary, prefix + kAnyValue};
   exec::registerAggregateFunction(
       names,
       std::move(signatures),
-      [name = names.front()](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(argTypes.size(), 1, "{} takes only one argument", name);
         auto inputType = argTypes[0];
         switch (inputType->kind()) {

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.h
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.h
@@ -17,17 +17,18 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 /// Register arbitrary aggregate function.
-/// @param prefix Prefix for the aggregate functions.
+/// @param names Names to use for the aggregate function.
 /// @param withCompanionFunctions Also register companion functions, defaults
 /// to true.
 /// @param overwrite Whether to overwrite existing entry in the function
 /// registry, defaults to true.
 void registerArbitraryAggregate(
-    const std::string& prefix = "",
+    const std::vector<std::string>& names,
     bool withCompanionFunctions = true,
     bool overwrite = true);
 

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -18,7 +18,6 @@
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 namespace facebook::velox::aggregate::prestosql {
 namespace {
@@ -428,7 +427,7 @@ class ArrayAggAggregate : public exec::Aggregate {
 } // namespace
 
 void registerArrayAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -439,17 +438,16 @@ void registerArrayAggAggregate(
           .argumentType("E")
           .build()};
 
-  auto name = prefix + kArrayAgg;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(
-            argTypes.size(), 1, "{} takes at most one argument", name);
+            argTypes.size(), 1, "{} takes at most one argument", names.front());
         return std::make_unique<ArrayAggAggregate>(
             resultType, config.prestoArrayAggIgnoreNulls());
       },
@@ -458,7 +456,7 @@ void registerArrayAggAggregate(
 }
 
 void registerInternalArrayAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -469,18 +467,17 @@ void registerInternalArrayAggAggregate(
           .argumentType("E")
           .build()};
 
-  auto name = prefix + "$internal$array_agg";
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step /*step*/,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(
-            argTypes.size(), 1, "{} takes at most one argument", name);
+            argTypes.size(), 1, "{} takes at most one argument", names.front());
         return std::make_unique<ArrayAggAggregate>(
             resultType, /*ignoreNulls*/ false);
       },

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.h
@@ -17,22 +17,23 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 /// Register array_agg aggregate function.
-/// @param prefix Prefix for the aggregate function.
+/// @param names Names to use for the aggregate function.
 /// @param withCompanionFunctions Also register companion functions, defaults
 /// to true.
 /// @param overwrite Whether to overwrite existing entry in the function
 /// registry, defaults to true.
 void registerArrayAggAggregate(
-    const std::string& prefix = "",
+    const std::vector<std::string>& names,
     bool withCompanionFunctions = true,
     bool overwrite = true);
 
 void registerInternalArrayAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/functions/prestosql/aggregates/AverageAggregate.h"
 #include "velox/functions/lib/aggregates/AverageAggregateBase.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -31,7 +30,7 @@ namespace facebook::velox::aggregate::prestosql {
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
 void registerAverageAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -71,16 +70,16 @@ void registerAverageAggregate(
           .returnType("DECIMAL(a_precision, a_scale)")
           .build());
 
-  auto name = prefix + kAvg;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         auto inputType = argTypes[0];

--- a/velox/functions/prestosql/aggregates/AverageAggregate.h
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerAverageAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/functions/prestosql/aggregates/BitwiseAggregates.h"
 #include "velox/functions/lib/aggregates/BitwiseAggregateBase.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -102,23 +101,22 @@ class BitwiseAndAggregate : public BitwiseAggregateBase<T> {
 
 } // namespace
 
-void registerBitwiseAggregates(
-    const std::string& prefix,
+void registerBitwiseAndAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool onlyPrestoSignatures,
+    bool overwrite) {
+  registerBitwise<BitwiseAndAggregate>(
+      names, true, withCompanionFunctions, onlyPrestoSignatures, overwrite);
+}
+
+void registerBitwiseOrAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite) {
   registerBitwise<BitwiseOrAggregate>(
-      prefix + kBitwiseOr,
-      true,
-      withCompanionFunctions,
-      onlyPrestoSignatures,
-      overwrite);
-  registerBitwise<BitwiseAndAggregate>(
-      prefix + kBitwiseAnd,
-      true,
-      withCompanionFunctions,
-      onlyPrestoSignatures,
-      overwrite);
+      names, true, withCompanionFunctions, onlyPrestoSignatures, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.h
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.h
@@ -17,11 +17,18 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerBitwiseAggregates(
-    const std::string& prefix,
+void registerBitwiseAndAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool onlyPrestoSignatures,
+    bool overwrite);
+
+void registerBitwiseOrAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite);

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/functions/prestosql/aggregates/BitwiseXorAggregate.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::exec;
 
@@ -70,12 +69,10 @@ class BitwiseXorAggregate {
 } // namespace
 
 void registerBitwiseXorAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite) {
-  const std::string name = prefix + kBitwiseXor;
-
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> typeList{"tinyint", "smallint", "integer", "bigint"};
   if (onlyPrestoSignatures) {
@@ -91,14 +88,15 @@ void registerBitwiseXorAggregate(
   }
 
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_USER_CHECK_EQ(argTypes.size(), 1, "{} takes one argument", name);
         auto inputType = argTypes[0];
         switch (inputType->kind()) {

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.h
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerBitwiseXorAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite);

--- a/velox/functions/prestosql/aggregates/BoolAggregates.h
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.h
@@ -17,11 +17,17 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerBoolAggregates(
-    const std::string& prefix,
+void registerBoolAndAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerBoolOrAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CentralMomentsAggregates.h
+++ b/velox/functions/prestosql/aggregates/CentralMomentsAggregates.h
@@ -17,11 +17,17 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerCentralMomentsAggregates(
-    const std::string& prefix,
+void registerKurtosisAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerSkewnessAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -19,7 +19,6 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/ChecksumAggregate.h"
 #include "velox/functions/prestosql/aggregates/PrestoHasher.h"
 #include "velox/vector/FlatVector.h"
@@ -255,7 +254,7 @@ class ChecksumAggregate : public exec::Aggregate {
 } // namespace
 
 void registerChecksumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -267,16 +266,16 @@ void registerChecksumAggregate(
           .build(),
   };
 
-  auto name = prefix + kChecksum;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [&name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes one argument", name);
 
         if (exec::isPartialOutput(step)) {

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.h
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerChecksumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
+++ b/velox/functions/prestosql/aggregates/ClassificationAggregation.cpp
@@ -17,11 +17,27 @@
 #include "velox/functions/prestosql/aggregates/ClassificationAggregation.h"
 #include "velox/common/base/IOUtils.h"
 #include "velox/exec/Aggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {
 namespace {
+const auto kSignatures =
+    std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>{
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType("array(double)")
+            .intermediateType("varbinary")
+            .argumentType("bigint")
+            .argumentType("boolean")
+            .argumentType("double")
+            .build(),
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType("array(double)")
+            .intermediateType("varbinary")
+            .argumentType("bigint")
+            .argumentType("boolean")
+            .argumentType("double")
+            .argumentType("double")
+            .build()};
 
 enum class ClassificationType {
   kFallout = 0,
@@ -612,13 +628,13 @@ class ClassificationAggregation : public exec::Aggregate {
 
 template <ClassificationType T>
 void registerAggregateFunctionImpl(
-    const std::string& name,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite,
     const std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>&
         signatures) {
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
       [](core::AggregationNode::Step,
          const std::vector<TypePtr>& args,
@@ -637,52 +653,44 @@ void registerAggregateFunctionImpl(
 }
 } // namespace
 
-void registerClassificationFunctions(
-    const std::string& prefix,
+void registerFalloutAggregation(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  const auto signatures =
-      std::vector<std::shared_ptr<exec::AggregateFunctionSignature>>{
-          exec::AggregateFunctionSignatureBuilder()
-              .returnType("array(double)")
-              .intermediateType("varbinary")
-              .argumentType("bigint")
-              .argumentType("boolean")
-              .argumentType("double")
-              .build(),
-          exec::AggregateFunctionSignatureBuilder()
-              .returnType("array(double)")
-              .intermediateType("varbinary")
-              .argumentType("bigint")
-              .argumentType("boolean")
-              .argumentType("double")
-              .argumentType("double")
-              .build()};
   registerAggregateFunctionImpl<ClassificationType::kFallout>(
-      prefix + kClassificationFallout,
-      withCompanionFunctions,
-      overwrite,
-      signatures);
+      names, withCompanionFunctions, overwrite, kSignatures);
+}
+
+void registerPrecisionAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerAggregateFunctionImpl<ClassificationType::kPrecision>(
-      prefix + kClassificationPrecision,
-      withCompanionFunctions,
-      overwrite,
-      signatures);
+      names, withCompanionFunctions, overwrite, kSignatures);
+}
+
+void registerRecallAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerAggregateFunctionImpl<ClassificationType::kRecall>(
-      prefix + kClassificationRecall,
-      withCompanionFunctions,
-      overwrite,
-      signatures);
+      names, withCompanionFunctions, overwrite, kSignatures);
+}
+
+void registerMissRateAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerAggregateFunctionImpl<ClassificationType::kMissRate>(
-      prefix + kClassificationMissRate,
-      withCompanionFunctions,
-      overwrite,
-      signatures);
+      names, withCompanionFunctions, overwrite, kSignatures);
+}
+
+void registerThresholdAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerAggregateFunctionImpl<ClassificationType::kThresholds>(
-      prefix + kClassificationThreshold,
-      withCompanionFunctions,
-      overwrite,
-      signatures);
+      names, withCompanionFunctions, overwrite, kSignatures);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ClassificationAggregation.h
+++ b/velox/functions/prestosql/aggregates/ClassificationAggregation.h
@@ -17,11 +17,32 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerClassificationFunctions(
-    const std::string& prefix,
+void registerFalloutAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerPrecisionAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRecallAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerMissRateAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerThresholdAggregation(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -17,7 +17,6 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SumAggregateBase.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -153,7 +152,7 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
 } // namespace
 
 void registerCountAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -169,18 +168,17 @@ void registerCountAggregate(
           .build(),
   };
 
-  auto name = prefix + kCount;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_LE(
-            argTypes.size(), 1, "{} takes at most one argument", name);
+            argTypes.size(), 1, "{} takes at most one argument", names.front());
         return std::make_unique<CountAggregate>();
       },
       {.orderSensitive = false},

--- a/velox/functions/prestosql/aggregates/CountAggregate.h
+++ b/velox/functions/prestosql/aggregates/CountAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerCountAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -17,7 +17,6 @@
 #include "velox/functions/prestosql/aggregates/CountIfAggregate.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/SimpleVector.h"
@@ -173,7 +172,7 @@ class CountIfAggregate : public exec::Aggregate {
 } // namespace
 
 void registerCountIfAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -184,16 +183,16 @@ void registerCountIfAggregate(
           .build(),
   };
 
-  auto name = prefix + kCountIf;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           std::vector<TypePtr> argTypes,
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes one argument", name);
 
         auto isPartial = exec::isRawInput(step);

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.h
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerCountIfAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -17,7 +17,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/CovarianceAggregatesBase.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -243,8 +242,8 @@ template <
     typename TIntermediateInput,
     typename TIntermediateResult,
     typename TResultAccessor>
-exec::AggregateRegistrationResult registerCovariance(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerCovariance(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
@@ -265,7 +264,7 @@ exec::AggregateRegistrationResult registerCovariance(
   };
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
       [](core::AggregationNode::Step step,
          const std::vector<TypePtr>& argTypes,
@@ -302,81 +301,136 @@ exec::AggregateRegistrationResult registerCovariance(
 
 } // namespace
 
-void registerCovarianceAggregates(
-    const std::string& prefix,
+void registerCovarPopAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarPopResultAccessor>(
-      prefix + kCovarPop, withCompanionFunctions, overwrite);
+      CovarPopResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerCovarSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarSampResultAccessor>(
-      prefix + kCovarSamp, withCompanionFunctions, overwrite);
+      CovarSampResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerCorrAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       CorrAccumulator,
       CorrIntermediateInput,
       CorrIntermediateResult,
-      CorrResultAccessor>(prefix + kCorr, withCompanionFunctions, overwrite);
+      CorrResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrInterceptAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       RegrAccumulator,
       RegrIntermediateInput,
       RegrIntermediateResult,
-      RegrInterceptResultAccessor>(
-      prefix + kRegrIntercept, withCompanionFunctions, overwrite);
+      RegrInterceptResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrSlopeAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       RegrAccumulator,
       RegrIntermediateInput,
       RegrIntermediateResult,
-      RegrSlopeResultAccessor>(
-      prefix + kRegrSlop, withCompanionFunctions, overwrite);
+      RegrSlopeResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrCountAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrCountResultAccessor>(
-      prefix + kRegrCount, withCompanionFunctions, overwrite);
+      RegrCountResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrAvgyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrAvgyResultAccessor>(
-      prefix + kRegrAvgy, withCompanionFunctions, overwrite);
+      RegrAvgyResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrAvgxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrAvgxResultAccessor>(
-      prefix + kRegrAvgx, withCompanionFunctions, overwrite);
+      RegrAvgxResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrSxyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrSxyResultAccessor>(
-      prefix + kRegrSxy, withCompanionFunctions, overwrite);
+      RegrSxyResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrSxxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrSxxResultAccessor>(
-      prefix + kRegrSxx, withCompanionFunctions, overwrite);
+      RegrSxxResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrSyyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrSyyResultAccessor>(
-      prefix + kRegrSyy, withCompanionFunctions, overwrite);
+      RegrSyyResultAccessor>(names, withCompanionFunctions, overwrite);
+}
+
+void registerRegrR2Aggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       ExtendedRegrAccumulator,
       ExtendedRegrIntermediateInput,
       ExtendedRegrIntermediateResult,
-      RegrR2ResultAccessor>(
-      prefix + kRegrR2, withCompanionFunctions, overwrite);
+      RegrR2ResultAccessor>(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.h
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.h
@@ -17,11 +17,67 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerCovarianceAggregates(
-    const std::string& prefix,
+void registerCovarPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerCovarSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerCorrAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrInterceptAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrSlopeAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrCountAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrAvgyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrAvgxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrSxyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrSxxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrSyyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerRegrR2Aggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -16,7 +16,6 @@
 #include "velox/functions/prestosql/aggregates/EntropyAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
@@ -342,7 +341,7 @@ void checkRowType(const TypePtr& type, const std::string& errorMessage) {
 } // namespace
 
 void registerEntropyAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -356,16 +355,16 @@ void registerEntropyAggregate(
             .build());
   }
 
-  auto name = prefix + kEntropy;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         const auto& inputType = argTypes[0];

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.h
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerEntropyAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -17,7 +17,6 @@
 #include "velox/functions/prestosql/aggregates/GeometricMeanAggregate.h"
 #include <cmath>
 #include "velox/exec/SimpleAggregateAdapter.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::exec;
 
@@ -85,11 +84,9 @@ class GeometricMeanAggregate {
 } // namespace
 
 void registerGeometricMeanAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  const std::string name = prefix + kGeometricMean;
-
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType : {"bigint", "double"}) {
@@ -110,14 +107,15 @@ void registerGeometricMeanAggregate(
           .build());
 
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_USER_CHECK_EQ(argTypes.size(), 1, "{} takes one argument", name);
         auto inputType = argTypes[0];
 

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.h
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerGeometricMeanAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometryAggregate.cpp
@@ -24,7 +24,6 @@
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/exec/Strings.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/types/GeometryRegistration.h"
 #include "velox/functions/prestosql/types/GeometryType.h"
 
@@ -158,7 +157,9 @@ class ConvexHullAggregate {
   };
 };
 
-void registerConvexHullAggregate(const std::string& prefix, bool overwrite) {
+void registerConvexHullAggregate(
+    const std::vector<std::string>& names,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(
@@ -168,16 +169,16 @@ void registerConvexHullAggregate(const std::string& prefix, bool overwrite) {
           .argumentType("geometry")
           .build());
 
-  std::string name = prefix + kConvexHull;
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         const auto& inputType = argTypes[0];
@@ -296,7 +297,9 @@ class GeometryUnionAggregate {
   };
 };
 
-void registerGeometryUnionAggregate(const std::string& prefix, bool overwrite) {
+void registerGeometryUnionAggregate(
+    const std::vector<std::string>& names,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(
@@ -306,16 +309,16 @@ void registerGeometryUnionAggregate(const std::string& prefix, bool overwrite) {
           .argumentType("geometry")
           .build());
 
-  std::string name = prefix + kGeometryUnion;
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         const auto& inputType = argTypes[0];
@@ -335,10 +338,13 @@ void registerGeometryUnionAggregate(const std::string& prefix, bool overwrite) {
 
 } // namespace
 
-void registerGeometryAggregate(const std::string& prefix, bool overwrite) {
+void registerGeometryAggregate(
+    const std::vector<std::string>& convexHullNames,
+    const std::vector<std::string>& geometryUnionNames,
+    bool overwrite) {
   registerGeometryType();
-  registerConvexHullAggregate(prefix, overwrite);
-  registerGeometryUnionAggregate(prefix, overwrite);
+  registerConvexHullAggregate(convexHullNames, overwrite);
+  registerGeometryUnionAggregate(geometryUnionNames, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometryAggregate.h
+++ b/velox/functions/prestosql/aggregates/GeometryAggregate.h
@@ -17,9 +17,13 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerGeometryAggregate(const std::string& prefix, bool overwrite);
+void registerGeometryAggregate(
+    const std::vector<std::string>& convexHullNames,
+    const std::vector<std::string>& geometryUnionNames,
+    bool overwrite);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -20,7 +20,6 @@
 #include "velox/exec/AddressableNonNullValueList.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Strings.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/HistogramAggregate.h"
 #include "velox/vector/FlatVector.h"
 
@@ -564,7 +563,7 @@ std::unique_ptr<exec::Aggregate> createHistogramAggregateWithCustomCompare(
 } // namespace
 
 void registerHistogramAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
@@ -576,16 +575,16 @@ void registerHistogramAggregate(
           .build(),
   };
 
-  auto name = prefix + kHistogram;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_EQ(
             argTypes.size(), 1, "{}: unexpected number of arguments", name);
 

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.h
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerHistogramAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/KHyperLogLogAggregate.cpp
@@ -16,7 +16,6 @@
 
 #include "velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h"
 #include "velox/exec/Aggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::aggregate;
 
@@ -40,8 +39,8 @@ std::unique_ptr<exec::Aggregate> dispatchOnUiiType(
 }
 
 /// Registration for khyperloglog_agg aggregate function.
-exec::AggregateRegistrationResult registerKHyperLogLogAgg(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerKHyperLogLogAgg(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -74,16 +73,19 @@ exec::AggregateRegistrationResult registerKHyperLogLogAgg(
   }
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step /*step*/,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(
-            argTypes.size(), 2, "{}: unexpected number of arguments", name);
+            argTypes.size(),
+            2,
+            "{}: unexpected number of arguments",
+            names.front());
 
         auto joinKeyKind = argTypes[0]->kind();
         auto uiiKind = argTypes[1]->kind();
@@ -98,11 +100,10 @@ exec::AggregateRegistrationResult registerKHyperLogLogAgg(
 } // namespace
 
 void registerKHyperLogLogAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerKHyperLogLogAgg(
-      prefix + kKHyperLogLogAgg, withCompanionFunctions, overwrite);
+  registerKHyperLogLogAgg(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<exec::Aggregate> createMapAggAggregateWithCustomCompare(
 } // namespace
 
 void registerMapAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -169,16 +169,16 @@ void registerMapAggAggregate(
           .argumentType("V")
           .build()};
 
-  auto name = prefix + kMapAgg;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         auto rawInput = exec::isRawInput(step);
         VELOX_CHECK_EQ(
             argTypes.size(),

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMapAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -85,7 +85,7 @@ std::unique_ptr<exec::Aggregate> createMapUnionAggregateWithCustomCompare(
 } // namespace
 
 void registerMapUnionAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -97,16 +97,16 @@ void registerMapUnionAggregate(
           .argumentType("map(K,V)")
           .build()};
 
-  auto name = prefix + kMapUnion;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step /*step*/,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_EQ(
             argTypes.size(), 1, "{}: unexpected number of arguments", name);
 

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.h
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMapUnionAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -18,7 +18,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Strings.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -488,7 +487,7 @@ std::unique_ptr<exec::Aggregate> createMapUnionSumAggregate(
 } // namespace
 
 void registerMapUnionSumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   const std::vector<std::string> valueTypes = {
@@ -506,15 +505,13 @@ void registerMapUnionSumAggregate(
             .build());
   }
 
-  auto name = prefix + kMapUnionSum;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
-          core::AggregationNode::Step /*step*/,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step /*step*/,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(argTypes.size(), 1);
         VELOX_CHECK(argTypes[0]->isMap());

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.h
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMapUnionSumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxByAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxByAggregate.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/functions/prestosql/aggregates/MaxByAggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -42,13 +41,13 @@ class MaxByNAggregate<ComplexType, C>
 };
 
 void registerMaxByAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   registerMinMaxBy<
       functions::aggregate::MinMaxByAggregateBase,
       true,
-      MaxByNAggregate>(prefix + kMaxBy, withCompanionFunctions, overwrite);
+      MaxByNAggregate>(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxByAggregate.h
+++ b/velox/functions/prestosql/aggregates/MaxByAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMaxByAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -18,7 +18,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox::functions::aggregate;
@@ -206,7 +205,7 @@ class MaxSizeForStatsAggregate
 } // namespace
 
 void registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -219,17 +218,17 @@ void registerMaxDataSizeForStatsAggregate(
           .argumentType("T")
           .build());
 
-  auto name = prefix + kMaxSizeForStats;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes only one argument", name);
+        VELOX_CHECK_EQ(
+            argTypes.size(), 1, "{} takes only one argument", names.front());
         auto inputType = argTypes[0];
 
         return std::make_unique<MaxSizeForStatsAggregate>(resultType);

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.h
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MergeAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MergeAggregate.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/functions/prestosql/aggregates/MergeAggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/HyperLogLogAggregate.h"
 #include "velox/functions/prestosql/aggregates/MergeKHyperLogLogAggregate.h"
 #include "velox/functions/prestosql/aggregates/MergeQDigestAggregate.h"
@@ -34,8 +33,8 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-exec::AggregateRegistrationResult registerMerge(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerMerge(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite,
     double defaultError) {
@@ -60,9 +59,9 @@ exec::AggregateRegistrationResult registerMerge(
   bool hllAsRawInput = true;
   bool hllAsFinalResult = true;
   return exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name, hllAsFinalResult, hllAsRawInput, defaultError](
+      [hllAsFinalResult, hllAsRawInput, defaultError](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
@@ -111,7 +110,7 @@ exec::AggregateRegistrationResult registerMerge(
 } // namespace
 
 void registerMergeAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool /* withCompanionFunctions */,
     bool overwrite) {
   registerSfmSketchType();
@@ -122,10 +121,7 @@ void registerMergeAggregate(
   // merge is companion function for approx_distinct. Don't register companion
   // functions for it.
   registerMerge(
-      prefix + kMerge,
-      false,
-      overwrite,
-      common::hll::kDefaultApproxSetStandardError);
+      names, false, overwrite, common::hll::kDefaultApproxSetStandardError);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MergeAggregate.h
+++ b/velox/functions/prestosql/aggregates/MergeAggregate.h
@@ -16,11 +16,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMergeAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/MinByAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MinByAggregate.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "velox/functions/prestosql/aggregates/MinByAggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -42,13 +41,13 @@ class MinByNAggregate<ComplexType, C>
 };
 
 void registerMinByAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   registerMinMaxBy<
       functions::aggregate::MinMaxByAggregateBase,
       false,
-      MinByNAggregate>(prefix + kMinBy, withCompanionFunctions, overwrite);
+      MinByNAggregate>(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinByAggregate.h
+++ b/velox/functions/prestosql/aggregates/MinByAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMinByAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -20,7 +20,6 @@
 #include "velox/functions/lib/aggregates/MinMaxAggregateBase.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/lib/aggregates/ValueSet.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/type/FloatingPointUtil.h"
 #include "velox/vector/AggregationHook.h"
 
@@ -491,8 +490,8 @@ class MaxNAggregate : public MinMaxNAggregateBase<T, GreaterThanComparator<T>> {
 };
 
 template <template <typename T> typename AggregateN>
-exec::AggregateRegistrationResult registerMinMax(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerMinMax(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite,
     bool registerMin) {
@@ -535,13 +534,14 @@ exec::AggregateRegistrationResult registerMinMax(
           .build());
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name, registerMin](
+      [names, registerMin](
           core::AggregationNode::Step step,
           std::vector<TypePtr> argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         const bool nAgg = !resultType->equivalent(*argTypes[0]);
         if (nAgg) {
           // We have either 2 arguments: T, bigint (partial aggregation)
@@ -602,14 +602,19 @@ exec::AggregateRegistrationResult registerMinMax(
 
 } // namespace
 
-void registerMinMaxAggregates(
-    const std::string& prefix,
+void registerMinAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerMinMax<MinNAggregate>(
-      prefix + kMin, withCompanionFunctions, overwrite, true);
+  registerMinMax<MinNAggregate>(names, withCompanionFunctions, overwrite, true);
+}
+
+void registerMaxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerMinMax<MaxNAggregate>(
-      prefix + kMax, withCompanionFunctions, overwrite, false);
+      names, withCompanionFunctions, overwrite, false);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.h
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.h
@@ -17,11 +17,17 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerMinMaxAggregates(
-    const std::string& prefix,
+void registerMinAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerMaxAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregateBase.h
@@ -1130,8 +1130,8 @@ template <
         bool compareTypeUsesCustomComparison> class Aggregate,
     bool isMaxFunc,
     template <typename U, typename V> class NAggregate>
-exec::AggregateRegistrationResult registerMinMaxBy(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerMinMaxBy(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -1186,9 +1186,9 @@ exec::AggregateRegistrationResult registerMinMaxBy(
           .argumentType("bigint")
           .build());
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
@@ -1196,7 +1196,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(
           -> std::unique_ptr<exec::Aggregate> {
         const std::string errorMessage = fmt::format(
             "Unknown input types for {} ({}) aggregation: {}",
-            name,
+            names.front(),
             mapAggregationStepToName(step),
             toString(argTypes));
 

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -18,7 +18,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Strings.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/type/FloatingPointUtil.h"
 #include "velox/vector/FlatVector.h"
 
@@ -599,7 +598,7 @@ std::unique_ptr<exec::Aggregate> createMultiMapAggAggregateWithCustomCompare(
 } // namespace
 
 void registerMultiMapAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -612,15 +611,13 @@ void registerMultiMapAggAggregate(
           .argumentType("V")
           .build()};
 
-  auto name = prefix + kMultiMapAgg;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         const auto keyType = resultType->childAt(0);
         const auto typeKind = keyType->kind();

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMultiMapAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.cpp
@@ -16,14 +16,15 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/SfmSketchAggregate.h"
 #include "velox/functions/prestosql/types/SfmSketchRegistration.h"
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNoisyApproxSfmAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& noisyApproxSetSfmNames,
+    const std::vector<std::string>& noisyApproxDistinctSfmNames,
+    const std::vector<std::string>& noisyApproxSetSfmFromIndexAndZerosNames,
     bool withCompanionFunctions,
     bool overwrite) {
   // Register the SfmSketch type.
@@ -105,13 +106,12 @@ void registerNoisyApproxSfmAggregate(
           .build());
 
   exec::registerAggregateFunction(
-      prefix + kNoisyApproxSetSfm,
+      noisyApproxSetSfmNames,
       setSignatures,
-      [prefix](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& /*argTypes*/,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& /*argTypes*/,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         if (exec::isPartialOutput(step)) {
           return std::make_unique<SfmSketchAggregate<true, false, false>>(
@@ -124,13 +124,12 @@ void registerNoisyApproxSfmAggregate(
       overwrite);
 
   exec::registerAggregateFunction(
-      prefix + kNoisyApproxDistinctSfm,
+      noisyApproxDistinctSfmNames,
       countSignatures,
-      [prefix](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& /*argTypes*/,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& /*argTypes*/,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         if (exec::isPartialOutput(step)) {
           return std::make_unique<SfmSketchAggregate<false, false, false>>(
@@ -143,13 +142,12 @@ void registerNoisyApproxSfmAggregate(
       overwrite);
 
   exec::registerAggregateFunction(
-      prefix + kNoisyApproxSetSfmFromIndexAndZeros,
+      noisyApproxSetSfmFromIndexAndZerosNames,
       setFromIndexAndZerosSignatures,
-      [prefix](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& /*argTypes*/,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& /*argTypes*/,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         if (exec::isPartialOutput(step)) {
           return std::make_unique<SfmSketchAggregate<true, true, false>>(

--- a/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyApproxSfmAggregate.h
@@ -17,11 +17,14 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNoisyApproxSfmAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& noisyApproxSetSfmNames,
+    const std::vector<std::string>& noisyApproxDistinctSfmNames,
+    const std::vector<std::string>& noisyApproxSetSfmFromIndexAndZerosNames,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.cpp
@@ -18,7 +18,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/noisy_aggregation/NoisyCountSumAvgAccumulator.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/NoisyHelperFunctionFactory.h"
 #include "velox/vector/FlatVector.h"
 
@@ -220,7 +219,7 @@ class NoisyAvgGaussianAggregate : public exec::Aggregate {
 } // namespace
 
 void registerNoisyAvgGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   // Helper function to create a signature builder with return and
@@ -336,18 +335,17 @@ void registerNoisyAvgGaussianAggregate(
     }
   }
 
-  auto name = prefix + kNoisyAvgGaussian;
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_GE(
-            argTypes.size(), 2, "{} takes at least 2 arguments", name);
+            argTypes.size(), 2, "{} takes at least 2 arguments", names.front());
 
         if (exec::isPartialOutput(step)) {
           return std::make_unique<NoisyAvgGaussianAggregate>(VARBINARY());

--- a/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyAvgGaussianAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNoisyAvgGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.cpp
@@ -19,7 +19,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/noisy_aggregation/NoisyCountSumAvgAccumulator.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/NoisyHelperFunctionFactory.h"
 #include "velox/vector/FlatVector.h"
 
@@ -215,7 +214,7 @@ class NoisyCountGaussianAggregate : public exec::Aggregate {
 } // namespace
 
 void registerNoisyCountGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -251,17 +250,16 @@ void registerNoisyCountGaussianAggregate(
           .build(),
   };
 
-  auto name = prefix + kNoisyCountGaussian;
-
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           [[maybe_unused]] const TypePtr& resultType,
           [[maybe_unused]] const core::QueryConfig& config)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(
             argTypes.size(), 3, "{} takes at most 3 arguments", name);
         VELOX_CHECK_GE(

--- a/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyCountGaussianAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNoisyCountGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.cpp
@@ -19,7 +19,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/noisy_aggregation/NoisyCountSumAvgAccumulator.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/NoisyHelperFunctionFactory.h"
 #include "velox/vector/FlatVector.h"
 
@@ -225,7 +224,7 @@ class NoisyCountIfGaussianAggregate : public exec::Aggregate {
 } // namespace
 
 void registerNoisyCountIfGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -257,16 +256,16 @@ void registerNoisyCountIfGaussianAggregate(
           .build(),
   };
 
-  auto name = prefix + kNoisyCountIfGaussian;
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step step,
           std::vector<TypePtr> argTypes,
           const TypePtr& /*resultType*/,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(argTypes.size(), 3, "{} takes 2 or 3 arguments", name);
         VELOX_CHECK_GE(argTypes.size(), 2, "{} takes 2 or 3 arguments", name);
 

--- a/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisyCountIfGaussianAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNoisyCountIfGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.cpp
@@ -17,7 +17,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/noisy_aggregation/NoisyCountSumAvgAccumulator.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/NoisyHelperFunctionFactory.h"
 #include "velox/vector/FlatVector.h"
 
@@ -211,7 +210,7 @@ class NoisySumGaussianAggregate : public exec::Aggregate {
 } // namespace
 
 void registerNoisySumGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   // Helper function to create a signature builder with return and
@@ -327,16 +326,16 @@ void registerNoisySumGaussianAggregate(
     }
   }
 
-  auto name = prefix + kNoisySumGaussian;
   exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           [[maybe_unused]] const TypePtr& resultType,
           [[maybe_unused]] const core::QueryConfig&)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_GE(
             argTypes.size(), 2, "{} takes at least 2 arguments", name);
         VELOX_CHECK_LE(

--- a/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h
+++ b/velox/functions/prestosql/aggregates/NoisySumGaussianAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNoisySumGaussianAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/NumericHistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NumericHistogramAggregate.cpp
@@ -16,7 +16,6 @@
 #include "velox/common/base/IOUtils.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 #include <algorithm>
 #include <limits>
@@ -475,7 +474,7 @@ class NumericHistogramAggregate<TValue, TWeight, 3> {
 } // namespace
 
 void registerNumericHistogramAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -503,17 +502,17 @@ void registerNumericHistogramAggregate(
               .build());
     }
   }
-  auto name = prefix + kNumericHistogram;
 
   exec::registerAggregateFunction(
-      name,
-      signatures,
-      [name](
+      names,
+      std::move(signatures),
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_USER_CHECK_GE(
             argTypes.size(), 2, "{} takes at least two arguments", name);
         VELOX_USER_CHECK_LE(

--- a/velox/functions/prestosql/aggregates/NumericHistogramAggregate.h
+++ b/velox/functions/prestosql/aggregates/NumericHistogramAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerNumericHistogramAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/QDigestAggAggregate.h
+++ b/velox/functions/prestosql/aggregates/QDigestAggAggregate.h
@@ -17,9 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerQDigestAggAggregate(const std::string& prefix, bool overwrite);
+void registerQDigestAggAggregate(
+    const std::vector<std::string>& names,
+    bool overwrite);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -19,7 +19,6 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 namespace facebook::velox::aggregate::prestosql {
 namespace {
@@ -791,7 +790,7 @@ class ReduceAgg : public exec::Aggregate {
 } // namespace
 
 void registerReduceAgg(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -806,16 +805,13 @@ void registerReduceAgg(
           .argumentType("function(S,S,S)")
           .build()};
 
-  const std::string name = prefix + kReduceAgg;
-
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<ReduceAgg>(resultType);
       },
       {.orderSensitive = false},

--- a/velox/functions/prestosql/aggregates/ReduceAgg.h
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerReduceAgg(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/ApproxDistinctAggregates.h"
 #include "velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.h"
 #include "velox/functions/prestosql/aggregates/ApproxPercentileAggregate.h"
@@ -67,158 +68,249 @@
 namespace facebook::velox::aggregate::prestosql {
 
 extern void registerApproxMostFrequentAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerApproxPercentileAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerArbitraryAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerArrayAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerAverageAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerBitwiseXorAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite);
 extern void registerChecksumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerClassificationFunctions(
-    const std::string& prefix,
+extern void registerFalloutAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerPrecisionAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRecallAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerMissRateAggregation(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerThresholdAggregation(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerCountAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerCountIfAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerEntropyAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerGeometricMeanAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 #ifdef VELOX_ENABLE_GEO
 extern void registerGeometryAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& convexHullNames,
+    const std::vector<std::string>& geometryUnionNames,
     bool overwrite);
 #endif
 extern void registerHistogramAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMapAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMapUnionAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMapUnionSumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMakeSetDigestAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMergeSetDigestAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMaxDataSizeForStatsAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMultiMapAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerSumDataSizeForStatsAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerReduceAgg(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerSetAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerSetUnionAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 
 extern void registerApproxDistinctAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& approxDistinctNames,
+    const std::vector<std::string>& approxSetNames,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerBitwiseAggregates(
-    const std::string& prefix,
+extern void registerBitwiseAndAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool onlyPrestoSignatures,
     bool overwrite);
-extern void registerBoolAggregates(
-    const std::string& prefix,
+extern void registerBitwiseOrAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool onlyPrestoSignatures,
+    bool overwrite);
+extern void registerBoolAndAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerCentralMomentsAggregates(
-    const std::string& prefix,
+extern void registerBoolOrAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerCovarianceAggregates(
-    const std::string& prefix,
+extern void registerKurtosisAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerMinMaxAggregates(
-    const std::string& prefix,
+extern void registerSkewnessAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerCovarPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerCovarSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerCorrAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrInterceptAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrSlopeAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrCountAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrAvgyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrAvgxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrSxyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrSxxAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrSyyAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerRegrR2Aggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerMinAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerMaxAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMaxByAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerMinByAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 extern void registerSumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerVarianceAggregates(
-    const std::string& prefix,
+extern void registerStdDevSampAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerTDigestAggregate(const std::string& prefix, bool overwrite);
+extern void registerStdDevPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerVarSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerVarPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+extern void registerTDigestAggregate(
+    const std::vector<std::string>& names,
+    bool overwrite);
 extern void registerKHyperLogLogAggregates(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
-extern void registerTDigestAggregate(const std::string& prefix, bool overwrite);
-extern void registerKHyperLogLogAggregates(
-    const std::string& prefix,
-    bool withCompanionFunctions,
+extern void registerQDigestAggAggregate(
+    const std::vector<std::string>& names,
     bool overwrite);
 
 void registerAllAggregateFunctions(
@@ -230,68 +322,163 @@ void registerAllAggregateFunctions(
   registerSetDigestType();
   registerTDigestType();
   registerKHyperLogLogType();
-  registerApproxDistinctAggregates(prefix, withCompanionFunctions, overwrite);
+  registerApproxDistinctAggregates(
+      {prefix + kApproxDistinct},
+      {prefix + kApproxSet},
+      withCompanionFunctions,
+      overwrite);
   registerApproxMostFrequentAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerApproxPercentileAggregate(prefix, withCompanionFunctions, overwrite);
-  registerQDigestAggAggregate(prefix, overwrite);
-  registerArbitraryAggregate(prefix, withCompanionFunctions, overwrite);
-  registerArrayAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerAverageAggregate(prefix, withCompanionFunctions, overwrite);
-  registerBitwiseAggregates(
-      prefix, withCompanionFunctions, onlyPrestoSignatures, overwrite);
+      {prefix + kApproxMostFrequent}, withCompanionFunctions, overwrite);
+  registerApproxPercentileAggregate(
+      {prefix + kApproxPercentile}, withCompanionFunctions, overwrite);
+  registerQDigestAggAggregate({prefix + kQDigestAgg}, overwrite);
+  registerArbitraryAggregate(
+      {prefix + kArbitrary, prefix + kAnyValue},
+      withCompanionFunctions,
+      overwrite);
+  registerArrayAggAggregate(
+      {prefix + kArrayAgg}, withCompanionFunctions, overwrite);
+  registerAverageAggregate({prefix + kAvg}, withCompanionFunctions, overwrite);
+  registerBitwiseAndAggregate(
+      {prefix + kBitwiseAnd},
+      withCompanionFunctions,
+      onlyPrestoSignatures,
+      overwrite);
+  registerBitwiseOrAggregate(
+      {prefix + kBitwiseOr},
+      withCompanionFunctions,
+      onlyPrestoSignatures,
+      overwrite);
   registerBitwiseXorAggregate(
-      prefix, withCompanionFunctions, onlyPrestoSignatures, overwrite);
-  registerBoolAggregates(prefix, withCompanionFunctions, overwrite);
-  registerCentralMomentsAggregates(prefix, withCompanionFunctions, overwrite);
-  registerChecksumAggregate(prefix, withCompanionFunctions, overwrite);
-  registerClassificationFunctions(prefix, withCompanionFunctions, overwrite);
-  registerCountAggregate(prefix, withCompanionFunctions, overwrite);
-  registerCountIfAggregate(prefix, withCompanionFunctions, overwrite);
-  registerCovarianceAggregates(prefix, withCompanionFunctions, overwrite);
-  registerEntropyAggregate(prefix, withCompanionFunctions, overwrite);
-  registerGeometricMeanAggregate(prefix, withCompanionFunctions, overwrite);
+      {prefix + kBitwiseXor},
+      withCompanionFunctions,
+      onlyPrestoSignatures,
+      overwrite);
+  registerBoolAndAggregate(
+      {prefix + kEvery, prefix + kBoolAnd}, withCompanionFunctions, overwrite);
+  registerBoolOrAggregate(
+      {prefix + kBoolOr}, withCompanionFunctions, overwrite);
+  registerKurtosisAggregate(
+      {prefix + kKurtosis}, withCompanionFunctions, overwrite);
+  registerSkewnessAggregate(
+      {prefix + kSkewness}, withCompanionFunctions, overwrite);
+  registerChecksumAggregate(
+      {prefix + kChecksum}, withCompanionFunctions, overwrite);
+  registerFalloutAggregation(
+      {prefix + kClassificationFallout}, withCompanionFunctions, overwrite);
+  registerPrecisionAggregation(
+      {prefix + kClassificationPrecision}, withCompanionFunctions, overwrite);
+  registerRecallAggregation(
+      {prefix + kClassificationRecall}, withCompanionFunctions, overwrite);
+  registerMissRateAggregation(
+      {prefix + kClassificationMissRate}, withCompanionFunctions, overwrite);
+  registerThresholdAggregation(
+      {prefix + kClassificationThreshold}, withCompanionFunctions, overwrite);
+  registerCountAggregate({prefix + kCount}, withCompanionFunctions, overwrite);
+  registerCountIfAggregate(
+      {prefix + kCountIf}, withCompanionFunctions, overwrite);
+  registerCovarPopAggregate(
+      {prefix + kCovarPop}, withCompanionFunctions, overwrite);
+  registerCovarSampAggregate(
+      {prefix + kCovarSamp}, withCompanionFunctions, overwrite);
+  registerCorrAggregate({prefix + kCorr}, withCompanionFunctions, overwrite);
+  registerRegrInterceptAggregate(
+      {prefix + kRegrIntercept}, withCompanionFunctions, overwrite);
+  registerRegrSlopeAggregate(
+      {prefix + kRegrSlop}, withCompanionFunctions, overwrite);
+  registerRegrCountAggregate(
+      {prefix + kRegrCount}, withCompanionFunctions, overwrite);
+  registerRegrAvgyAggregate(
+      {prefix + kRegrAvgy}, withCompanionFunctions, overwrite);
+  registerRegrAvgxAggregate(
+      {prefix + kRegrAvgx}, withCompanionFunctions, overwrite);
+  registerRegrSxyAggregate(
+      {prefix + kRegrSxy}, withCompanionFunctions, overwrite);
+  registerRegrSxxAggregate(
+      {prefix + kRegrSxx}, withCompanionFunctions, overwrite);
+  registerRegrSyyAggregate(
+      {prefix + kRegrSyy}, withCompanionFunctions, overwrite);
+  registerRegrR2Aggregate(
+      {prefix + kRegrR2}, withCompanionFunctions, overwrite);
+  registerEntropyAggregate(
+      {prefix + kEntropy}, withCompanionFunctions, overwrite);
+  registerGeometricMeanAggregate(
+      {prefix + kGeometricMean}, withCompanionFunctions, overwrite);
 #ifdef VELOX_ENABLE_GEO
-  registerGeometryAggregate(prefix, overwrite);
+  registerGeometryAggregate(
+      {prefix + kConvexHull}, {prefix + kGeometryUnion}, overwrite);
 #endif
-  registerHistogramAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMapAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMapUnionAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMapUnionSumAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMakeSetDigestAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMergeSetDigestAggregate(prefix, withCompanionFunctions, overwrite);
+  registerHistogramAggregate(
+      {prefix + kHistogram}, withCompanionFunctions, overwrite);
+  registerMapAggAggregate(
+      {prefix + kMapAgg}, withCompanionFunctions, overwrite);
+  registerMapUnionAggregate(
+      {prefix + kMapUnion}, withCompanionFunctions, overwrite);
+  registerMapUnionSumAggregate(
+      {prefix + kMapUnionSum}, withCompanionFunctions, overwrite);
+  registerMakeSetDigestAggregate(
+      {prefix + kMakeSetDigest}, withCompanionFunctions, overwrite);
+  registerMergeSetDigestAggregate(
+      {prefix + kMergeSetDigest}, withCompanionFunctions, overwrite);
   registerMaxDataSizeForStatsAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerMultiMapAggAggregate(prefix, withCompanionFunctions, overwrite);
+      {prefix + kMaxSizeForStats}, withCompanionFunctions, overwrite);
+  registerMultiMapAggAggregate(
+      {prefix + kMultiMapAgg}, withCompanionFunctions, overwrite);
   registerSumDataSizeForStatsAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerMergeAggregate(prefix, withCompanionFunctions, overwrite);
-  registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
-  registerMaxByAggregates(prefix, withCompanionFunctions, overwrite);
-  registerMinByAggregates(prefix, withCompanionFunctions, overwrite);
-  registerNoisyAvgGaussianAggregate(prefix, withCompanionFunctions, overwrite);
+      {prefix + kSumDataSizeForStats}, withCompanionFunctions, overwrite);
+  registerMergeAggregate({prefix + kMerge}, withCompanionFunctions, overwrite);
+  registerMinAggregate({prefix + kMin}, withCompanionFunctions, overwrite);
+  registerMaxAggregate({prefix + kMax}, withCompanionFunctions, overwrite);
+  registerMaxByAggregates({prefix + kMaxBy}, withCompanionFunctions, overwrite);
+  registerMinByAggregates({prefix + kMinBy}, withCompanionFunctions, overwrite);
+  registerNoisyAvgGaussianAggregate(
+      {prefix + kNoisyAvgGaussian}, withCompanionFunctions, overwrite);
   registerNoisyCountIfGaussianAggregate(
-      prefix, withCompanionFunctions, overwrite);
+      {prefix + kNoisyCountIfGaussian}, withCompanionFunctions, overwrite);
   registerNoisyCountGaussianAggregate(
-      prefix, withCompanionFunctions, overwrite);
-  registerNoisySumGaussianAggregate(prefix, withCompanionFunctions, overwrite);
-  registerReduceAgg(prefix, withCompanionFunctions, overwrite);
-  registerReservoirSampleAggregate(prefix, withCompanionFunctions, overwrite);
-  registerSetAggAggregate(prefix, withCompanionFunctions, overwrite);
-  registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);
-  registerSumAggregate(prefix, withCompanionFunctions, overwrite);
-  registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
-  registerTDigestAggregate(prefix, overwrite);
-  registerNoisyApproxSfmAggregate(prefix, withCompanionFunctions, overwrite);
-  registerNumericHistogramAggregate(prefix, withCompanionFunctions, overwrite);
-  registerKHyperLogLogAggregates(prefix, withCompanionFunctions, overwrite);
+      {prefix + kNoisyCountGaussian}, withCompanionFunctions, overwrite);
+  registerNoisySumGaussianAggregate(
+      {prefix + kNoisySumGaussian}, withCompanionFunctions, overwrite);
+  registerReduceAgg({prefix + kReduceAgg}, withCompanionFunctions, overwrite);
+  registerReservoirSampleAggregate(
+      {prefix + kReservoirSample}, withCompanionFunctions, overwrite);
+  registerSetAggAggregate(
+      {prefix + kSetAgg}, withCompanionFunctions, overwrite);
+  registerSetUnionAggregate(
+      {prefix + kSetUnion}, withCompanionFunctions, overwrite);
+  registerSumAggregate({prefix + kSum}, withCompanionFunctions, overwrite);
+  registerStdDevSampAggregate(
+      {prefix + kStdDevSamp, prefix + kStdDev},
+      withCompanionFunctions,
+      overwrite);
+  registerStdDevPopAggregate(
+      {prefix + kStdDevPop}, withCompanionFunctions, overwrite);
+  registerVarSampAggregate(
+      {prefix + kVarSamp, prefix + kVariance},
+      withCompanionFunctions,
+      overwrite);
+  registerVarPopAggregate(
+      {prefix + kVarPop}, withCompanionFunctions, overwrite);
+  registerTDigestAggregate({prefix + kTDigestAgg}, overwrite);
+  registerNoisyApproxSfmAggregate(
+      {prefix + kNoisyApproxSetSfm},
+      {prefix + kNoisyApproxDistinctSfm},
+      {prefix + kNoisyApproxSetSfmFromIndexAndZeros},
+      withCompanionFunctions,
+      overwrite);
+  registerNumericHistogramAggregate(
+      {prefix + kNumericHistogram}, withCompanionFunctions, overwrite);
+  registerKHyperLogLogAggregates(
+      {prefix + kKHyperLogLogAgg}, withCompanionFunctions, overwrite);
 }
 
 void registerInternalAggregateFunctions(const std::string& prefix) {
   bool withCompanionFunctions = false;
   bool overwrite = false;
-  registerCountDistinctAggregate(prefix, withCompanionFunctions, overwrite);
-  registerInternalArrayAggAggregate(prefix, withCompanionFunctions, overwrite);
+  registerCountDistinctAggregate(
+      {prefix + "$internal$count_distinct"}, withCompanionFunctions, overwrite);
+  registerInternalArrayAggAggregate(
+      {prefix + "$internal$array_agg"}, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ReservoirSampleAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ReservoirSampleAggregate.cpp
@@ -20,7 +20,6 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/exec/Aggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
@@ -834,7 +833,7 @@ ReservoirSampleAggregate::computeTotalSamples(char** groups, int32_t numGroups)
 } // namespace
 
 void registerReservoirSampleAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -870,18 +869,17 @@ void registerReservoirSampleAggregate(
             .build());
   }
 
-  auto name = prefix + kReservoirSample;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step /* step */,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /* config */)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(
-            argTypes.size(), 4, "reservoir_sample requires 4 arguments");
+            argTypes.size(), 4, "{} requires 4 arguments", names.front());
 
         return std::make_unique<ReservoirSampleAggregate>(resultType);
       },

--- a/velox/functions/prestosql/aggregates/ReservoirSampleAggregate.h
+++ b/velox/functions/prestosql/aggregates/ReservoirSampleAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerReservoirSampleAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/functions/prestosql/aggregates/SetAggregates.h"
 #include "velox/functions/lib/aggregates/SetBaseAggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -240,7 +239,7 @@ std::unique_ptr<exec::Aggregate> createCountDistinctAggregate(
 } // namespace
 
 void registerSetAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
@@ -251,15 +250,13 @@ void registerSetAggAggregate(
           .argumentType("T")
           .build()};
 
-  auto name = prefix + kSetAgg;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(argTypes.size(), 1);
 
@@ -318,7 +315,7 @@ void registerSetAggAggregate(
 }
 
 void registerSetUnionAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
@@ -329,15 +326,13 @@ void registerSetUnionAggregate(
           .argumentType("array(T)")
           .build()};
 
-  auto name = prefix + kSetUnion;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
-          core::AggregationNode::Step /*step*/,
-          const std::vector<TypePtr>& argTypes,
-          const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
+      [](core::AggregationNode::Step /*step*/,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(argTypes.size(), 1);
 
@@ -349,7 +344,7 @@ void registerSetUnionAggregate(
 }
 
 void registerCountDistinctAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
@@ -360,9 +355,8 @@ void registerCountDistinctAggregate(
           .argumentType("T")
           .build()};
 
-  auto name = prefix + "$internal$count_distinct";
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
       [](core::AggregationNode::Step step,
          const std::vector<TypePtr>& argTypes,

--- a/velox/functions/prestosql/aggregates/SetAggregates.h
+++ b/velox/functions/prestosql/aggregates/SetAggregates.h
@@ -17,21 +17,22 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerSetAggAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 
 void registerSetUnionAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 
 void registerCountDistinctAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SetDigestAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SetDigestAggregate.cpp
@@ -17,7 +17,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/SetDigest.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -281,8 +280,8 @@ std::unique_ptr<exec::Aggregate> createSetDigestAggregate(
   return std::make_unique<SetDigestAggregate<T>>(resultType);
 }
 
-exec::AggregateRegistrationResult registerMakeSetDigest(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerMakeSetDigest(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -312,7 +311,7 @@ exec::AggregateRegistrationResult registerMakeSetDigest(
   }
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
       [](core::AggregationNode::Step /*step*/,
          const std::vector<TypePtr>& argTypes,
@@ -350,11 +349,10 @@ exec::AggregateRegistrationResult registerMakeSetDigest(
 }
 
 void registerMakeSetDigestAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerMakeSetDigest(
-      prefix + kMakeSetDigest, withCompanionFunctions, overwrite);
+  registerMakeSetDigest(names, withCompanionFunctions, overwrite);
 }
 
 class MergeSetDigestAggregate : public exec::Aggregate {
@@ -556,8 +554,8 @@ class MergeSetDigestAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-exec::AggregateRegistrationResult registerMergeSetDigest(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerMergeSetDigest(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -570,7 +568,7 @@ exec::AggregateRegistrationResult registerMergeSetDigest(
           .build());
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       signatures,
       [](core::AggregationNode::Step /*step*/,
          const std::vector<TypePtr>& /*argTypes*/,
@@ -584,11 +582,10 @@ exec::AggregateRegistrationResult registerMergeSetDigest(
 }
 
 void registerMergeSetDigestAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerMergeSetDigest(
-      prefix + kMergeSetDigest, withCompanionFunctions, overwrite);
+  registerMergeSetDigest(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SetDigestAggregate.h
+++ b/velox/functions/prestosql/aggregates/SetDigestAggregate.h
@@ -17,16 +17,17 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerMakeSetDigestAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions = true,
     bool overwrite = true);
 
 void registerMergeSetDigestAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions = true,
     bool overwrite = true);
 

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/functions/prestosql/aggregates/SumAggregate.h"
 #include "velox/functions/lib/aggregates/SumAggregateBase.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -25,8 +24,8 @@ template <typename TInput, typename TAccumulator, typename ResultType>
 using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, false>;
 
 template <template <typename U, typename V, typename W> class T>
-exec::AggregateRegistrationResult registerSum(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerSum(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -64,14 +63,15 @@ exec::AggregateRegistrationResult registerSum(
   }
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes only one argument", name);
         auto inputType = argTypes[0];
         switch (inputType->kind()) {
@@ -123,10 +123,10 @@ exec::AggregateRegistrationResult registerSum(
 } // namespace
 
 void registerSumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
-  registerSum<SumAggregate>(prefix + kSum, withCompanionFunctions, overwrite);
+  registerSum<SumAggregate>(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerSumAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -18,7 +18,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/serializers/PrestoSerializer.h"
 
 using namespace facebook::velox::functions::aggregate;
@@ -186,7 +185,7 @@ class SumDataSizeForStatsAggregate
 } // namespace
 
 void registerSumDataSizeForStatsAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -199,17 +198,17 @@ void registerSumDataSizeForStatsAggregate(
           .argumentType("T")
           .build());
 
-  auto name = prefix + kSumDataSizeForStats;
   exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(argTypes.size(), 1, "{} takes only one argument", name);
+        VELOX_CHECK_EQ(
+            argTypes.size(), 1, "{} takes only one argument", names.front());
         auto inputType = argTypes[0];
 
         return std::make_unique<SumDataSizeForStatsAggregate>(resultType);

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h
@@ -17,11 +17,12 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
 void registerSumDataSizeForStatsAggregate(
-    const std::string& prefix,
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -16,7 +16,6 @@
 #include "velox/functions/prestosql/aggregates/VarianceAggregates.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/functions/lib/aggregates/VarianceAggregatesBase.h"
-#include "velox/functions/prestosql/aggregates/AggregateNames.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -107,8 +106,8 @@ class VarSampAggregate : public VarianceAggregate<T, VarSampResultAccessor> {
 };
 
 template <template <typename TInput> class TClass>
-exec::AggregateRegistrationResult registerVariance(
-    const std::string& name,
+std::vector<exec::AggregateRegistrationResult> registerVariance(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -124,14 +123,15 @@ exec::AggregateRegistrationResult registerVariance(
   }
 
   return exec::registerAggregateFunction(
-      name,
+      names,
       std::move(signatures),
-      [name](
+      [names](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
+        const std::string& name = names.front();
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
         auto inputType = argTypes[0];
@@ -167,22 +167,34 @@ exec::AggregateRegistrationResult registerVariance(
 
 } // namespace
 
-void registerVarianceAggregates(
-    const std::string& prefix,
+void registerStdDevSampAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite) {
   registerVariance<StdDevSampAggregate>(
-      prefix + kStdDev, withCompanionFunctions, overwrite);
+      names, withCompanionFunctions, overwrite);
+}
+
+void registerStdDevPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerVariance<StdDevPopAggregate>(
-      prefix + kStdDevPop, withCompanionFunctions, overwrite);
-  registerVariance<StdDevSampAggregate>(
-      prefix + kStdDevSamp, withCompanionFunctions, overwrite);
-  registerVariance<VarSampAggregate>(
-      prefix + kVariance, withCompanionFunctions, overwrite);
-  registerVariance<VarPopAggregate>(
-      prefix + kVarPop, withCompanionFunctions, overwrite);
-  registerVariance<VarSampAggregate>(
-      prefix + kVarSamp, withCompanionFunctions, overwrite);
+      names, withCompanionFunctions, overwrite);
+}
+
+void registerVarSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerVariance<VarSampAggregate>(names, withCompanionFunctions, overwrite);
+}
+
+void registerVarPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerVariance<VarPopAggregate>(names, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.h
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.h
@@ -17,11 +17,27 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerVarianceAggregates(
-    const std::string& prefix,
+void registerStdDevSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerStdDevPopAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerVarSampAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+void registerVarPopAggregate(
+    const std::vector<std::string>& names,
     bool withCompanionFunctions,
     bool overwrite);
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
@@ -65,12 +65,12 @@ class BitwiseXorAggregate : public BitwiseAggregateBase<T> {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerBitwiseXorAggregate(
+std::vector<exec::AggregateRegistrationResult> registerBitwiseXorAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
     bool overwrite) {
   return functions::aggregate::registerBitwise<BitwiseXorAggregate>(
-      prefix + "bit_xor", false, withCompanionFunctions, false, overwrite);
+      {prefix + "bit_xor"}, false, withCompanionFunctions, false, overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
@@ -17,12 +17,13 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "velox/exec/AggregateUtil.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-exec::AggregateRegistrationResult registerBitwiseXorAggregate(
+std::vector<exec::AggregateRegistrationResult> registerBitwiseXorAggregate(
     const std::string& name,
     bool withCompanionFunctions,
     bool overwrite);


### PR DESCRIPTION
Summary:
Currently the aggregates under prestosql hard code the names the aggregates are registered
with. This makes it hard to reuse these functions in other engines where they may have
different names.

This change modifies the registration functions to take a collection of names rather than just
the prefix, so the caller has the flexibility to use different names.

Differential Revision: D90706025
