### PR TITLE
refactor(type): Fix type conversion warnings and improve code efficiency

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2214,11 +2214,11 @@ template <>
 struct SimpleTypeTrait<UnknownValue> : public TypeTraits<TypeKind::UNKNOWN> {};
 
 template <TypeKind KIND>
-static inline int32_t sizeOfTypeKindHelper() {
+inline int32_t sizeOfTypeKindHelper() {
   return sizeof(typename TypeTraits<KIND>::NativeType);
 }
 
-static inline int32_t sizeOfTypeKind(TypeKind kind) {
+inline int32_t sizeOfTypeKind(TypeKind kind) {
   if (kind == TypeKind::BOOLEAN) {
     throw std::invalid_argument("sizeOfTypeKind dos not apply to boolean");
   }
@@ -2226,7 +2226,7 @@ static inline int32_t sizeOfTypeKind(TypeKind kind) {
 }
 
 template <typename T, typename U>
-static inline T to(const U& value) {
+inline T to(const U& value) {
   return folly::to<T>(value);
 }
 


### PR DESCRIPTION
Summary:
This is fixing some of Clangtidy warnings, not all.
I applied fixes that looked clearly reasonable.

Thanks
---
Address implicit type conversion warnings by adding explicit casts for `int32_t` conversions and changing loop counters from `size_t` to `uint32_t` to avoid narrowing conversions. Also apply minor optimizations: use `emplace_back` instead of `push_back` with temporary construction, use `std::move` for serialize/deserialize callbacks to avoid copies, initialize `tmValue` struct to avoid uninitialized memory, and remove redundant `static` keyword from inline helper functions.

Differential Revision: D90708811


