### PR TITLE
feat: Expose 'runningIsBlockedWallNanos' operator runtime metric

### DIFF
--- a/velox/exec/OperatorStats.h
+++ b/velox/exec/OperatorStats.h
@@ -103,6 +103,8 @@ struct OperatorStats {
       "runningGetOutputWallNanos";
   static constexpr std::string_view kRunningFinishWallNanos =
       "runningFinishWallNanos";
+  static constexpr std::string_view kRunningIsBlockedWallNanos =
+      "runningIsBlockedWallNanos";
 
   /// Initial ordinal position in the operator's pipeline.
   int32_t operatorId = 0;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -138,6 +138,8 @@ void addRunningTimeOperatorMetrics(exec::OperatorStats& op) {
       RuntimeMetric(op.getOutputTiming.wallNanos, RuntimeCounter::Unit::kNanos);
   op.runtimeStats[std::string(OperatorStats::kRunningFinishWallNanos)] =
       RuntimeMetric(op.finishTiming.wallNanos, RuntimeCounter::Unit::kNanos);
+  op.runtimeStats[std::string(OperatorStats::kRunningIsBlockedWallNanos)] =
+      RuntimeMetric(op.isBlockedTiming.wallNanos, RuntimeCounter::Unit::kNanos);
 }
 
 void buildSplitStates(

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -175,6 +175,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"      runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"      runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"      runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"  -- HashJoin\\[3\\]\\[INNER c0=u_c0\\] -> c0:INTEGER, c1:BIGINT, u_c1:BIGINT"},
        {"     Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
        {"     HashBuild: Input: 100 rows \\(.+\\), Output: 0 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
@@ -190,6 +191,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"     HashProbe: Input: 2000 rows \\(.+\\), Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
        // These lines may or may not appear depending on whether the operator
        // gets blocked during a run.
@@ -208,6 +210,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"        runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"    -- TableScan\\[2\\]\\[table: hive_table\\] -> c0:INTEGER, c1:BIGINT"},
        {"       Input: 2000 rows \\(.+\\), Raw Input: 20480 rows \\(.+\\), Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 20, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
        {"          cacheWaitWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
@@ -239,6 +242,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"          runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"          runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"          runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"          runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"          ssdCacheReadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
         true},
        {"          storageReadBytes    [ ]* sum: .+, count: .+, min: .+, max: .+"},
@@ -255,12 +259,14 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"          runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"          runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"          runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"          runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"      -- Values\\[0\\]\\[100 rows in 1 vectors\\] -> c0:INTEGER, c1:BIGINT"},
        {"         Input: 0 rows \\(.+\\), Output: 100 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: 0B, Memory allocations: .+, Threads: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
        {"            driverCpuTimeNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"            runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"            runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
-       {"            runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"}});
+       {"            runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+       {"            runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"}});
 }
 
 TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
@@ -316,7 +322,8 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
         {"      loadedToValueHook\\s+sum: 50000, count: 5, min: 10000, max: 10000, avg: 10000"},
         {"      runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"      runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
-        {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"}};
+        {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+        {"      runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"}};
 
     std::vector<ExpectedLine> scanDisablePrefetchMetrics = {
         {"  -- TableScan\\[0\\]\\[table: hive_table\\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR"},
@@ -351,6 +358,7 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
         {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+        {"        runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"        ssdCacheReadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
          true},
         {"        storageReadBytes [ ]* sum: .+, count: .+, min: .+, max: .+"},
@@ -394,6 +402,7 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
         {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+        {"        runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
         {"        storageReadBytes [ ]* sum: .+, count: .+, min: .+, max: .+"},
         {"        storageReadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
          true},
@@ -458,6 +467,7 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
           {"      runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"      runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"      runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+          {"      runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"      runningWallNanos\\s+sum: .+, count: 1, min: .+, max: .+, avg: .+"},
           {"      stripeSize\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"      writeIOWallNanos\\s+sum: .+, count: 1, min: .+, max: .+, avg: .+"},
@@ -493,6 +503,7 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
           {"        runningAddInputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"        runningFinishWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"        runningGetOutputWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
+          {"        runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
           {"        storageReadBytes [ ]* sum: .+, count: .+, min: .+, max: .+"},
           {"        storageReadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
            true},


### PR DESCRIPTION
The 'isBlockedTiming' field was present in 'OperatorStats' but not
exposed in the stats output, making it difficult to debug performance
issues related to 'Operator::isBlocked()' method calls. This change
exposes the field to help identify when operators are spending
significant time evaluating the 'isBlocked()'.

This enhancement will aid in troubleshooting performance issues by
providing visibility into the timing of 'isBlocked()' method calls,
which were previously hidden.