### PR TITLE
fix: Free the memory held by this in move assignment operator of `Allocation`

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -30,6 +30,16 @@ Allocation::~Allocation() {
   }
 }
 
+void Allocation::operator=(Allocation&& other) {
+  if (pool_ != nullptr) {
+    pool_->freeNonContiguous(*this);
+  }
+  pool_ = other.pool_;
+  runs_ = std::move(other.runs_);
+  numPages_ = other.numPages_;
+  other.clear();
+}
+
 void Allocation::append(uint8_t* address, MachinePageCount numPages) {
   VELOX_CHECK(
       runs_.empty() || address != runs_.back().data(),

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -113,12 +113,7 @@ class Allocation {
 
   void operator=(const Allocation& other) = delete;
 
-  void operator=(Allocation&& other) {
-    pool_ = other.pool_;
-    runs_ = std::move(other.runs_);
-    numPages_ = other.numPages_;
-    other.clear();
-  }
+  void operator=(Allocation&& other);
 
   MachinePageCount numPages() const {
     return numPages_;


### PR DESCRIPTION
In the move assignment operator of `Allocation`, we should free the memory held by `this`. Otherwise, we will have a memory leak.