### PR TITLE
refactor: Replace begin/end with cbegin/cend in calls to erase

### DIFF
--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -276,7 +276,7 @@ class SsdFileTest : public testing::Test {
     EXPECT_FALSE(
         ssdFile_->find(RawFileCacheKey{fileName_.id(), ssdSize}).empty());
 
-    pins.erase(pins.begin(), pins.begin() + numWritten);
+    pins.erase(pins.cbegin(), pins.cbegin() + numWritten);
     ssdFile_->write(pins);
     for (auto& pin : pins) {
       if (pin.entry()->ssdFile()) {

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -748,7 +748,7 @@ std::vector<std::unique_ptr<Operator>> DriverFactory::replaceOperators(
   }
 
   driver.operators_.erase(
-      driver.operators_.begin() + begin, driver.operators_.begin() + end);
+      driver.operators_.cbegin() + begin, driver.operators_.cbegin() + end);
 
   // Insert the replacement at the place of the erase. Do manually because
   // insert() is not good with unique pointers.

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -278,7 +278,7 @@ std::vector<std::shared_ptr<SerializedPageBase>> DestinationBuffer::acknowledge(
     stats_.recordAcknowledge(*data_[i]);
     freed.push_back(std::move(data_[i]));
   }
-  data_.erase(data_.begin(), data_.begin() + numDeleted);
+  data_.erase(data_.cbegin(), data_.cbegin() + numDeleted);
   sequence_ += numDeleted;
   return freed;
 }

--- a/velox/exec/PartitionStreamingWindowBuild.cpp
+++ b/velox/exec/PartitionStreamingWindowBuild.cpp
@@ -78,7 +78,7 @@ PartitionStreamingWindowBuild::nextPartition() {
     data_->eraseRows(
         folly::Range<char**>(sortedRows_.data(), numPreviousPartitionRows));
     sortedRows_.erase(
-        sortedRows_.begin(), sortedRows_.begin() + numPreviousPartitionRows);
+        sortedRows_.cbegin(), sortedRows_.cbegin() + numPreviousPartitionRows);
     sortedRows_.shrink_to_fit();
     for (int i = currentPartition_; i < partitionStartRows_.size(); ++i) {
       partitionStartRows_[i] =

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -299,7 +299,7 @@ bool registerSplitListenerFactory(
 bool unregisterSplitListenerFactory(
     const std::shared_ptr<SplitListenerFactory>& factory) {
   return splitListenerFactories().withWLock([&](auto& factories) {
-    for (auto it = factories.begin(); it != factories.end(); ++it) {
+    for (auto it = factories.cbegin(); it != factories.cend(); ++it) {
       if ((*it) == factory) {
         factories.erase(it);
         return true;
@@ -1891,8 +1891,8 @@ void Task::dropInputLocked(
     VELOX_CHECK(!drivers.empty());
     const auto dropNodeId = *dropNodeIds.begin();
     bool foundDriver{false};
-    auto it = drivers.begin();
-    while (it != drivers.end()) {
+    auto it = drivers.cbegin();
+    while (it != drivers.cend()) {
       Driver* driver = *it;
       VELOX_CHECK_NOT_NULL(driver);
       if (auto* dropOp = driver->findOperator(dropNodeId)) {

--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -74,7 +74,7 @@ void WindowPartition::removeProcessedRows(vector_size_t numRows) {
     previousRow_ = rows_[numRows - 1];
   }
 
-  rows_.erase(rows_.begin(), rows_.begin() + numRows);
+  rows_.erase(rows_.cbegin(), rows_.cbegin() + numRows);
   partition_ = folly::Range(rows_.data(), rows_.size());
   startRow_ += numRows;
 }

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -835,8 +835,8 @@ class RowContainerTest : public exec::test::RowContainerTestBase,
         kNumRows, rawValues, rawExpected);
     // Remove nulls in data because keys cannot be null.
     auto numNulls = countLeadingNulls(rawValues);
-    rawValues.erase(rawValues.begin(), rawValues.begin() + numNulls);
-    rawExpected.erase(rawExpected.begin(), rawExpected.begin() + numNulls);
+    rawValues.erase(rawValues.cbegin(), rawValues.cbegin() + numNulls);
+    rawExpected.erase(rawExpected.cbegin(), rawExpected.cbegin() + numNulls);
     std::optional<int32_t> second = 0;
     for (auto value : rawValues) {
       std::vector<std::pair<T, std::optional<int32_t>>> temp{

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -3008,7 +3008,7 @@ class TestBarrierOperator : public exec::Operator {
       return nullptr;
     }
     auto output = inputs_.front();
-    inputs_.erase(inputs_.begin());
+    inputs_.erase(inputs_.cbegin());
     return output;
   }
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -352,7 +352,7 @@ AssertQueryBuilder::readCursor() {
         } else {
           task->addSplit(nodeId, std::move(nodeSplits[0]));
         }
-        nodeSplits.erase(nodeSplits.begin());
+        nodeSplits.erase(nodeSplits.cbegin());
       }
       if (numSplits > 0) {
         VELOX_CHECK_EQ(

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -84,7 +84,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
                 << requestedSequence;
         int64_t nExtra = requestedSequence - sequence;
         VELOX_CHECK(nExtra < data.size());
-        data.erase(data.begin(), data.begin() + nExtra);
+        data.erase(data.cbegin(), data.cbegin() + nExtra);
         sequence = requestedSequence;
       }
       if (data.empty()) {


### PR DESCRIPTION
This PR proposes to replace `begin`/`end` with `cbegin`/`cend` as the parameters of `erase`.
C++11 and later:
`iterator erase(const_iterator position);`