### PR TITLE
misc: Add root pool name and state to HiveDataSink non-reclaimable warning

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -1349,9 +1349,10 @@ uint64_t HiveDataSink::WriterReclaimer::reclaim(
   if (*writerInfo_->nonReclaimableSectionHolder.get()) {
     RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING) << "Can't reclaim from hive writer pool " << pool->name()
-                 << " which is under non-reclaimable section, "
-                 << " reserved memory: "
-                 << succinctBytes(pool->reservedBytes());
+                 << " which is under non-reclaimable section, root pool: "
+                 << pool->root()->name()
+                 << ", state: " << stateString(dataSink_->state_)
+                 << ", reservation: " << succinctBytes(pool->reservedBytes());
     ++stats.numNonReclaimableAttempts;
     return 0;
   }


### PR DESCRIPTION
Summary:
Currently, the warning message appears as follows:

```
W0113 16:13:36.849711 115699 [Driver31097] HiveDataSink.cpp:1351] Can't reclaim from hive writer pool op.8.1.3.TableWrite.prism_batch.part[130] which is under non-reclaimable section, reserved memory: 74.00MB
```

However, we lack context regarding the root pool and its states. The hive writer pool can enter a non-reclaimable status in multiple scenarios. To aid in diagnosis, we should expose additional information about these cases.

Differential Revision: D90782787


