### PR TITLE
feat(connector): Add TPCH connector serdes

### DIFF
--- a/velox/common/serialization/DeserializationRegistry.h
+++ b/velox/common/serialization/DeserializationRegistry.h
@@ -53,6 +53,16 @@ struct is_templated_create<
     T,
     std::void_t<decltype(T::template create<T>(
         std::declval<folly::dynamic>()))>> : std::true_type {};
+
+template <class, class = void>
+struct is_templated_create_with_context : std::false_type {};
+
+template <class T>
+struct is_templated_create_with_context<
+    T,
+    std::void_t<decltype(T::template create<T>(
+        std::declval<folly::dynamic>(),
+        std::declval<void*>()))>> : std::true_type {};
 } // namespace detail
 
 template <class T>
@@ -62,6 +72,17 @@ void registerDeserializer() {
         T::getClassName(), T::template create<T>);
   } else {
     DeserializationRegistryForSharedPtr().Register(
+        T::getClassName(), T::create);
+  }
+}
+
+template <class T>
+void registerDeserializerWithContext() {
+  if constexpr (detail::is_templated_create_with_context<T>::value) {
+    DeserializationWithContextRegistryForSharedPtr().Register(
+        T::getClassName(), T::template create<T>);
+  } else {
+    DeserializationWithContextRegistryForSharedPtr().Register(
         T::getClassName(), T::create);
   }
 }

--- a/velox/connectors/tpch/TpchConnectorSplit.h
+++ b/velox/connectors/tpch/TpchConnectorSplit.h
@@ -39,12 +39,38 @@ struct TpchConnectorSplit : public connector::ConnectorSplit {
     VELOX_CHECK_GT(totalParts, partNumber, "totalParts must be > partNumber");
   }
 
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = TpchConnectorSplit::getClassName();
+    obj["connectorId"] = connectorId;
+    obj["splitWeight"] = splitWeight;
+    obj["cacheable"] = cacheable;
+    obj["totalParts"] = totalParts;
+    obj["partNumber"] = partNumber;
+    return obj;
+  }
+
+  static std::shared_ptr<TpchConnectorSplit> create(const folly::dynamic& obj) {
+    auto connectorId = obj["connectorId"].asString();
+    auto cacheable = obj["cacheable"].asBool();
+    auto totalParts = static_cast<size_t>(obj["totalParts"].asInt());
+    auto partNumber = static_cast<size_t>(obj["partNumber"].asInt());
+    return std::make_shared<TpchConnectorSplit>(
+        connectorId, cacheable, totalParts, partNumber);
+  }
+
+  static void registerSerDe() {
+    registerDeserializer<TpchConnectorSplit>();
+  }
+
   // In how many parts the generated TPC-H table will be segmented, roughly
   // `rowCount / totalParts`
   size_t totalParts{1};
 
   // Which of these parts will be read by this split.
   size_t partNumber{0};
+
+  VELOX_DEFINE_CLASS_NAME(TpchConnectorSplit)
 };
 
 } // namespace facebook::velox::connector::tpch

--- a/velox/connectors/tpch/tests/CMakeLists.txt
+++ b/velox/connectors/tpch/tests/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_tpch_connector_test TpchConnectorTest.cpp)
+add_executable(velox_tpch_connector_test TpchConnectorTest.cpp TpchConnectorSerDeTest.cpp)
 
 add_test(velox_tpch_connector_test velox_tpch_connector_test)
 

--- a/velox/connectors/tpch/tests/TpchConnectorSerDeTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorSerDeTest.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/connectors/tpch/TpchConnector.h"
+#include "velox/connectors/tpch/TpchConnectorSplit.h"
+#include "velox/core/ITypedExpr.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::connector::tpch::test {
+namespace {
+
+class TpchConnectorSerDeTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  TpchConnectorSerDeTest() {
+    Type::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+    TpchConnector::registerSerDe();
+  }
+
+  template <typename T>
+  static void testSerde(const T& handle) {
+    auto str = handle.toString();
+    auto obj = handle.serialize();
+    auto clone = ISerializable::deserialize<T>(obj);
+    ASSERT_EQ(clone->toString(), str);
+  }
+
+  static void testSerde(const TpchColumnHandle& handle) {
+    auto obj = handle.serialize();
+    auto clone = ISerializable::deserialize<TpchColumnHandle>(obj);
+    ASSERT_EQ(handle.name(), clone->name());
+  }
+
+  static void testSerde(const TpchTableHandle& handle) {
+    auto str = handle.toString();
+    auto obj = handle.serialize();
+    auto pool = memory::memoryManager()->addLeafPool();
+    auto clone = ISerializable::deserialize<TpchTableHandle>(obj, pool.get());
+    ASSERT_EQ(clone->toString(), str);
+    ASSERT_EQ(handle.connectorId(), clone->connectorId());
+    ASSERT_EQ(handle.getTable(), clone->getTable());
+    ASSERT_EQ(handle.getScaleFactor(), clone->getScaleFactor());
+    if (handle.filterExpression()) {
+      ASSERT_NE(clone->filterExpression(), nullptr);
+      ASSERT_EQ(
+          handle.filterExpression()->toString(),
+          clone->filterExpression()->toString());
+    } else {
+      ASSERT_EQ(clone->filterExpression(), nullptr);
+    }
+  }
+
+  static void testSerde(const TpchConnectorSplit& split) {
+    auto str = split.toString();
+    auto obj = split.serialize();
+    auto clone = ISerializable::deserialize<TpchConnectorSplit>(obj);
+    ASSERT_EQ(clone->toString(), str);
+    ASSERT_EQ(split.connectorId, clone->connectorId);
+    ASSERT_EQ(split.splitWeight, clone->splitWeight);
+    ASSERT_EQ(split.cacheable, clone->cacheable);
+    ASSERT_EQ(split.totalParts, clone->totalParts);
+    ASSERT_EQ(split.partNumber, clone->partNumber);
+  }
+};
+
+TEST_F(TpchConnectorSerDeTest, tpchColumnHandle) {
+  auto handle1 = TpchColumnHandle("n_nationkey");
+  testSerde(handle1);
+
+  auto handle2 = TpchColumnHandle("l_orderkey");
+  testSerde(handle2);
+
+  auto handle3 = TpchColumnHandle("c_name");
+  testSerde(handle3);
+}
+
+TEST_F(TpchConnectorSerDeTest, tpchTableHandle) {
+  const std::string connectorId = "test-tpch";
+
+  auto handle1 = TpchTableHandle(connectorId, velox::tpch::Table::TBL_NATION);
+  testSerde(handle1);
+
+  auto handle2 =
+      TpchTableHandle(connectorId, velox::tpch::Table::TBL_LINEITEM, 10.0);
+  testSerde(handle2);
+
+  auto handle3 =
+      TpchTableHandle(connectorId, velox::tpch::Table::TBL_ORDERS, 0.01);
+  testSerde(handle3);
+
+  // Test with filterExpression
+  auto filterExpr =
+      std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "n_nationkey");
+  auto handle4 = TpchTableHandle(
+      connectorId, velox::tpch::Table::TBL_NATION, 1.0, filterExpr);
+  testSerde(handle4);
+
+  std::vector<velox::tpch::Table> tables = {
+      velox::tpch::Table::TBL_NATION,
+      velox::tpch::Table::TBL_REGION,
+      velox::tpch::Table::TBL_PART,
+      velox::tpch::Table::TBL_SUPPLIER,
+      velox::tpch::Table::TBL_PARTSUPP,
+      velox::tpch::Table::TBL_CUSTOMER,
+      velox::tpch::Table::TBL_ORDERS,
+      velox::tpch::Table::TBL_LINEITEM,
+  };
+
+  for (auto table : tables) {
+    testSerde(TpchTableHandle(connectorId, table, 1.0));
+  }
+
+  std::vector<double> scaleFactors = {0.01, 0.1, 1.0, 5.0, 10.0, 100.0, 1000.0};
+  for (auto sf : scaleFactors) {
+    testSerde(
+        TpchTableHandle(connectorId, velox::tpch::Table::TBL_CUSTOMER, sf));
+  }
+}
+
+TEST_F(TpchConnectorSerDeTest, tpchConnectorSplit) {
+  const std::string connectorId = "test-tpch";
+
+  auto split1 = TpchConnectorSplit(connectorId, false, 10, 5);
+  testSerde(split1);
+
+  auto split2 = TpchConnectorSplit(connectorId, true, 100, 99);
+  testSerde(split2);
+
+  auto split3 = TpchConnectorSplit(connectorId, 1, 0);
+  testSerde(split3);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::tpch::test


### PR DESCRIPTION
Summary:
TPCH does not currently have serialization/deserialization APIs for TableHandle, ColumnHandle, or ConnectorSplit. I used the Hive connector serdes as a guide to add equivalent serdes for the TPCH connector. These serdes are relatively trivial given the simplicity of the TPCH connector structures.

Also adding test coverage for each serde type in `TpchConnectorSerDeTest.cpp`

Differential Revision: D90791949


