### PR TITLE
fix: TypeCoercer::leastCommonSuperType for named structs

### DIFF
--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -104,6 +104,38 @@ std::optional<int32_t> TypeCoercer::coercible(
   return totalCost;
 }
 
+namespace {
+
+TypePtr leastCommonSuperRowType(const RowType& a, const RowType& b) {
+  std::vector<std::string> childNames;
+  childNames.reserve(a.size());
+
+  const auto& aNames = a.names();
+  const auto& bNames = b.names();
+
+  for (auto i = 0; i < a.size(); i++) {
+    if (aNames[i] == bNames[i]) {
+      childNames.push_back(aNames[i]);
+    } else {
+      childNames.push_back("");
+    }
+  }
+
+  std::vector<TypePtr> childTypes;
+  childTypes.reserve(a.size());
+  for (auto i = 0; i < a.size(); i++) {
+    if (auto childType =
+            TypeCoercer::leastCommonSuperType(a.childAt(i), b.childAt(i))) {
+      childTypes.push_back(childType);
+    } else {
+      return nullptr;
+    }
+  }
+
+  return ROW(std::move(childNames), std::move(childTypes));
+}
+} // namespace
+
 // static
 TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
   if (a->isUnKnown()) {
@@ -132,6 +164,10 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
 
   if (a->name() != b->name()) {
     return nullptr;
+  }
+
+  if (a->name() == TypeKindName::toName(TypeKind::ROW)) {
+    return leastCommonSuperRowType(a->asRow(), b->asRow());
   }
 
   std::vector<TypeParameter> childTypes;

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -83,13 +83,17 @@ class TypeCoercer {
 
   /// Checks if 'fromType' can be implicitly converted to 'toType'.
   ///
-  /// @return Cost of conversion is possible. std::nullopt otherwise.
+  /// @return Cost of conversion if possible. std::nullopt otherwise.
   static std::optional<int32_t> coercible(
       const TypePtr& fromType,
       const TypePtr& toType);
 
   /// Returns least common type for 'a' and 'b', i.e. a type that both 'a' and
   /// 'b' are coercible to. Returns nullptr if no such type exists.
+  ///
+  /// When `a` and `b` are ROW types with different field names, the resulting
+  /// ROW has empty field names for any positions where the corresponding field
+  /// names do not match.
   static TypePtr leastCommonSuperType(const TypePtr& a, const TypePtr& b);
 };
 

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -134,6 +134,21 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
           ROW({"", "", ""}, INTEGER()), ROW({"", "", ""}, SMALLINT())),
       ROW({"", "", ""}, INTEGER()));
 
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(
+          ROW({"a", "b", "c"}, INTEGER()), ROW({"a", "b", "c"}, SMALLINT())),
+      ROW({"a", "b", "c"}, INTEGER()));
+
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(
+          ROW({"", "", ""}, INTEGER()), ROW({"a", "b", "c"}, SMALLINT())),
+      ROW({"", "", ""}, INTEGER()));
+
+  VELOX_ASSERT_EQ_TYPES(
+      TypeCoercer::leastCommonSuperType(
+          ROW({"a", "bb", ""}, INTEGER()), ROW({"a", "b", "c"}, SMALLINT())),
+      ROW({"a", "", ""}, INTEGER()));
+
   ASSERT_TRUE(
       TypeCoercer::leastCommonSuperType(VARCHAR(), TINYINT()) == nullptr);
 


### PR DESCRIPTION
Summary:
Before the fix, TypeCoercer::leastCommonSuperType always returned an anonymous ROW when applied to ROW types. For example, leastCommonSuperType(ROW(a, b), ROW(a, b)) incorrectly produced ROW("", "") instead of preserving field names as ROW(a, b).

After the fix, field names are preserved when they match across inputs. If the input field names mismatch, the corresponding result field name is set to an empty string.

For example,
- leastCommonSuperType(ROW(a, b), ROW("", "")) -> ROW("", "")
- leastCommonSuperType(ROW(a, b), ROW("a", "")) -> ROW("a", "")
- leastCommonSuperType(ROW(a, b), ROW("aa", "bb")) -> ROW("", "")

Differential Revision: D90860790


