### PR TITLE
fix: RowConstructorCallToSpecialForm::resolveType

### DIFF
--- a/velox/expression/RowConstructor.cpp
+++ b/velox/expression/RowConstructor.cpp
@@ -22,14 +22,8 @@ namespace facebook::velox::exec {
 
 TypePtr RowConstructorCallToSpecialForm::resolveType(
     const std::vector<TypePtr>& argTypes) {
-  auto numInput = argTypes.size();
-  std::vector<std::string> names(numInput);
-  std::vector<TypePtr> types(numInput);
-  for (auto i = 0; i < numInput; i++) {
-    types[i] = argTypes[i];
-    names[i] = fmt::format("c{}", i + 1);
-  }
-  return ROW(std::move(names), std::move(types));
+  std::vector<std::string> names(argTypes.size(), "");
+  return ROW(std::move(names), folly::copy(argTypes));
 }
 
 ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -949,8 +949,7 @@ TEST_F(FunctionRegistryTest, resolveCoalesceWithCoercions) {
 TEST_F(FunctionRegistryTest, resolveRowConstructor) {
   auto result = resolveFunctionOrCallableSpecialForm(
       "row_constructor", {INTEGER(), BOOLEAN(), DOUBLE()});
-  ASSERT_EQ(
-      *result, *ROW({"c1", "c2", "c3"}, {INTEGER(), BOOLEAN(), DOUBLE()}));
+  ASSERT_EQ(*result, *ROW({"", "", ""}, {INTEGER(), BOOLEAN(), DOUBLE()}));
 }
 
 TEST_F(FunctionRegistryTest, resolveFunctionNotSpecialForm) {

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -64,6 +64,15 @@ TypePtr resolveType(
     inputTypes.emplace_back(input->type());
   }
 
+  if (expr->name() == "row_constructor") {
+    const auto numInput = inputTypes.size();
+    std::vector<std::string> names(numInput);
+    for (auto i = 0; i < numInput; i++) {
+      names[i] = fmt::format("c{}", i + 1);
+    }
+    return ROW(std::move(names), std::move(inputTypes));
+  }
+
   if (auto resolvedType =
           exec::resolveTypeForSpecialForm(expr->name(), inputTypes)) {
     return resolvedType;


### PR DESCRIPTION
Summary: Fixes row_constructor(a, b, c, ...) type resolution. Previously it incorrectly produced ROW(c1, c2, ... cN) (an auto-named struct) to simplify testing. Now it correctly returns an anonymous struct ROW("", "", ...), and the test-only TypeResolver is updated to preserve the legacy behavior in tests.

Differential Revision: D90865781


