### PR TITLE
fix: Reduce dependencies on Parquet in Iceberg connector

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -29,6 +29,7 @@ velox_add_library(
 velox_link_libraries(
   velox_hive_iceberg_splitreader
   velox_connector
+  velox_dwio_parquet_field_id
   velox_functions_iceberg
   Folly::folly
 )

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -20,7 +20,7 @@
 
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
-#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/dwio/parquet/writer/ParquetFieldId.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/dwio/parquet/writer/ParquetFieldId.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 

--- a/velox/dwio/parquet/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 add_subdirectory(arrow)
 
+velox_add_library(velox_dwio_parquet_field_id INTERFACE ParquetFieldId.h)
+
 velox_add_library(velox_dwio_arrow_parquet_writer Writer.cpp)
 
 velox_link_libraries(
@@ -21,6 +23,7 @@ velox_link_libraries(
   velox_dwio_arrow_parquet_writer_lib
   velox_dwio_arrow_parquet_writer_util_lib
   velox_dwio_common
+  velox_dwio_parquet_field_id
   velox_arrow_bridge
   arrow
   fmt::fmt

--- a/velox/dwio/parquet/writer/ParquetFieldId.h
+++ b/velox/dwio/parquet/writer/ParquetFieldId.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::parquet {
+/// Parquet field IDs during write operations. Each ID must be unique positive
+/// number, do not need to be sequential.
+/// Used to explicitly control field ID assignment in the Parquet schema.
+struct ParquetFieldId {
+  int32_t fieldId;
+  std::vector<ParquetFieldId> children;
+};
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -25,6 +25,7 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Writer.h"
 #include "velox/dwio/common/WriterFactory.h"
+#include "velox/dwio/parquet/writer/ParquetFieldId.h"
 #include "velox/dwio/parquet/writer/arrow/Types.h"
 #include "velox/dwio/parquet/writer/arrow/util/Compression.h"
 #include "velox/vector/ComplexVector.h"
@@ -86,14 +87,6 @@ class LambdaFlushPolicy : public DefaultFlushPolicy {
 
  private:
   std::function<bool()> lambda_;
-};
-
-/// Parquet field IDs during write operations. Each ID must be unique positive
-/// number, do not need to be sequential.
-/// Used to explicitly control field ID assignment in the Parquet schema.
-struct ParquetFieldId {
-  int32_t fieldId;
-  std::vector<ParquetFieldId> children;
 };
 
 struct WriterOptions : public dwio::common::WriterOptions {


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/velox/pull/15607 introduced a dependency on the 
Parquet writer in Velox's Iceberg connector. This is breaking the build of projects that depend 
on the Iceberg connector and the Facebook Thrift library due to the duplicate symbols found
in the Apache Thrift library Parquet's writer depends on.

Fortunately, the Iceberg connector just depends on the ParquetFieldId class used by the
Parquet writer, which is itself very simple and does not have additional depedendencies.

In order to preserve the changes to the Iceberg connector and resolve the build issues, I've
split out the ParquetFieldId class into its own header file so the Iceberg connector can simply
include this header file, rather than the whole header file for the Parquet writer. This gives us
the flexibility to avoid introducing a transitive dependency on Apache Thrift.

Differential Revision: D90874048


