### PR TITLE
feat: Implement array_top_n with transform lambda argument

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -512,6 +512,11 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "s2_cell_to_token",
     "ip_version", // New function, pending Presto Java implementation
     "ip_prefix_masklen", // New function, pending Presto Java implementation
+    // Skip only the lambda and null-lambda signatures: Velox uses a transform
+    // lambda function(T,U) while Presto uses a comparator lambda
+    // function(T,T,integer).
+    "array_top_n(array(T),integer,function(T,U)) -> array(T)",
+    "array_top_n(array(T),integer,unknown) -> array(T)",
 };
 
 int main(int argc, char** argv) {

--- a/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
+++ b/velox/expression/fuzzer/PrestoSkippedFunctions.cpp
@@ -382,6 +382,11 @@ const std::unordered_set<std::string>& prestoSkippedFunctionsSOT() {
       "s2_cell_to_token",
       "ip_version", // New function, pending Presto Java implementation
       "ip_prefix_masklen", // New function, pending Presto Java implementation
+      // Skip only the lambda and null-lambda signatures: Velox uses a transform
+      // lambda function(T,U) while Presto uses a comparator lambda
+      // function(T,T,integer).
+      "array_top_n(array(T),integer,function(T,U)) -> array(T)",
+      "array_top_n(array(T),integer,unknown) -> array(T)",
   };
   return kSkippedFunctionsSOT;
 }

--- a/velox/functions/prestosql/ArrayTopNTransform.cpp
+++ b/velox/functions/prestosql/ArrayTopNTransform.cpp
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <queue>
+
+#include "velox/common/base/CheckedArithmetic.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// Implements array_top_n(array(T), integer, function(T, U)) -> array(T).
+// Returns the top n elements of the array in descending order by the
+// transform lambda's output. Elements whose transform result is null are
+// placed at the end.
+class ArrayTopNTransformFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 3);
+
+    exec::LocalDecodedVector arrayDecoder(context, *args[0], rows);
+    auto& decodedArray = *arrayDecoder.get();
+    auto flatArray = flattenArray(rows, args[0], decodedArray);
+    VELOX_CHECK_NOT_NULL(flatArray);
+
+    auto arrayElements = flatArray->elements();
+    auto numElements = arrayElements->size();
+
+    exec::LocalDecodedVector nDecoder(context, *args[1], rows);
+    auto& decodedN = *nDecoder.get();
+
+    exec::LocalSelectivityVector remainingRows(context, rows);
+    context.applyToSelectedNoThrow(*remainingRows, [&](vector_size_t row) {
+      if (decodedArray.isNullAt(row) || decodedN.isNullAt(row)) {
+        return;
+      }
+      int64_t n = decodedN.valueAt<int32_t>(row);
+      VELOX_USER_CHECK_GE(n, 0, "n must be greater than or equal to 0");
+    });
+    context.deselectErrors(*remainingRows);
+
+    // All rows errored; emit an all-null result via moveOrCopyResult so a
+    // sibling IF/CASE branch's already-populated rows are not overwritten.
+    if (!remainingRows->hasSelections()) {
+      auto nullArray = std::make_shared<ArrayVector>(
+          context.pool(),
+          outputType,
+          nullptr,
+          rows.end(),
+          allocateOffsets(rows.end(), context.pool()),
+          allocateSizes(rows.end(), context.pool()),
+          BaseVector::create(
+              outputType->asArray().elementType(), 0, context.pool()));
+      rows.applyToSelected(
+          [&](vector_size_t row) { nullArray->setNull(row, true); });
+      context.moveOrCopyResult(nullArray, rows, result);
+      return;
+    }
+
+    std::vector<VectorPtr> lambdaArgs = {arrayElements};
+    SelectivityVector validRowsInReusedResult = toElementRows<ArrayVector>(
+        numElements, *remainingRows, flatArray.get());
+
+    VectorPtr transformedElements;
+
+    // Check if the lambda argument is NULL.
+    bool isLambdaNull = args[2]->type()->kind() == TypeKind::UNKNOWN;
+
+    if (isLambdaNull) {
+      // Fall back to natural sort order, matching the 2-arg simple-function
+      // behavior.
+      transformedElements = arrayElements;
+    } else {
+      applyLambdaToElements<ArrayVector>(
+          args[2],
+          *remainingRows,
+          numElements,
+          flatArray,
+          lambdaArgs,
+          validRowsInReusedResult,
+          context,
+          transformedElements);
+    }
+
+    // Deselect rows where the lambda raised errors so the heap loop below does
+    // not read their unset transform-output slots.
+    context.deselectErrors(*remainingRows);
+
+    // Decode the lambda transform output used for comparisons.
+    exec::LocalDecodedVector decodedTransformed(
+        context, *transformedElements, validRowsInReusedResult);
+    auto* baseTransformed = decodedTransformed->base();
+
+    BufferPtr indices = allocateIndices(numElements, context.pool());
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+    for (vector_size_t i = 0; i < numElements; ++i) {
+      rawIndices[i] = i;
+    }
+
+    CompareFlags flags{
+        .nullsFirst = true,
+        .ascending = true,
+        .nullHandlingMode =
+            CompareFlags::NullHandlingMode::kNullAsIndeterminate,
+    };
+
+    // Min-heap comparator: returns true if left > right by the transform value.
+    // The heap keeps the smallest seen value at the top so we can evict it when
+    // a larger value arrives, maintaining the top-n by value in descending
+    // order. Top-level nulls are handled here so that compare() only fires on
+    // nested nulls inside non-null values (where kNullAsIndeterminate throws).
+    struct GreaterThanComparator {
+      const DecodedVector* decodedTransformed;
+      const BaseVector* baseTransformed;
+      CompareFlags flags;
+
+      bool operator()(vector_size_t leftIdx, vector_size_t rightIdx) const {
+        if (leftIdx == rightIdx) {
+          return false;
+        }
+
+        bool leftNull = decodedTransformed->isNullAt(leftIdx);
+        bool rightNull = decodedTransformed->isNullAt(rightIdx);
+
+        // Nulls sort last in descending top-n, so a null is never "greater"
+        // than a non-null. Among two nulls, the later input index wins, to
+        // match the reverse-stable order documented at the tie-break below.
+        if (leftNull && rightNull) {
+          return leftIdx > rightIdx;
+        }
+        if (leftNull) {
+          return false;
+        }
+        if (rightNull) {
+          return true;
+        }
+
+        auto leftTransformedIdx = decodedTransformed->index(leftIdx);
+        auto rightTransformedIdx = decodedTransformed->index(rightIdx);
+
+        // Under kNullAsIndeterminate ordering, compare() throws on any null it
+        // encounters (nested nulls inside non-null values), so it always
+        // returns a value here.
+        auto result = baseTransformed->compare(
+            baseTransformed, leftTransformedIdx, rightTransformedIdx, flags);
+
+        // Reverse-stable tie-break to match Presto's array_top_n, which is
+        // SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n): among equal values the
+        // later input index is treated as "larger", so it is kept by the
+        // min-heap and emitted before earlier ties.
+        if (result.value() == 0) {
+          return leftIdx > rightIdx;
+        }
+
+        return result.value() > 0;
+      }
+    };
+
+    GreaterThanComparator comparator{
+        decodedTransformed.get(), baseTransformed, flags};
+
+    // Use applyToSelectedNoThrow so that compare()-thrown errors are captured
+    // per row (letting try() convert them to nulls) instead of escaping.
+    context.applyToSelectedNoThrow(*remainingRows, [&](vector_size_t row) {
+      if (decodedArray.isNullAt(row) || decodedN.isNullAt(row)) {
+        return;
+      }
+
+      auto arrayOffset = flatArray->offsetAt(row);
+      auto arraySize = flatArray->sizeAt(row);
+
+      int64_t n = decodedN.valueAt<int32_t>(row);
+      auto resultSize = static_cast<vector_size_t>(
+          std::min(n, static_cast<int64_t>(arraySize)));
+
+      if (arraySize <= 1 || resultSize == 0) {
+        return;
+      }
+
+      std::priority_queue<
+          vector_size_t,
+          std::vector<vector_size_t>,
+          GreaterThanComparator>
+          minHeap(comparator);
+
+      // Build heap with top N elements.
+      for (vector_size_t i = 0; i < arraySize; ++i) {
+        auto idx = arrayOffset + i;
+        if (minHeap.size() < static_cast<size_t>(resultSize)) {
+          minHeap.push(idx);
+        } else if (comparator(idx, minHeap.top())) {
+          minHeap.push(idx);
+          minHeap.pop();
+        }
+      }
+
+      // Pop in reverse so the final order is descending by transform value.
+      std::vector<vector_size_t> topIndices(minHeap.size());
+      auto heapSize = minHeap.size();
+      for (int i = heapSize - 1; i >= 0; --i) {
+        topIndices[i] = minHeap.top();
+        minHeap.pop();
+      }
+
+      // Copy back to rawIndices.
+      for (size_t i = 0; i < topIndices.size(); ++i) {
+        rawIndices[arrayOffset + i] = topIndices[i];
+      }
+    });
+
+    // Drop rows whose heap loop threw, so they don't contribute to
+    // totalElements or get copied below.
+    context.deselectErrors(*remainingRows);
+
+    vector_size_t totalElements = 0;
+    remainingRows->applyToSelected([&](vector_size_t row) {
+      if (decodedArray.isNullAt(row) || decodedN.isNullAt(row)) {
+        return;
+      }
+      auto arraySize = flatArray->sizeAt(row);
+      int64_t n = decodedN.valueAt<int32_t>(row);
+      totalElements = checkedPlus<vector_size_t>(
+          totalElements,
+          static_cast<vector_size_t>(
+              std::min(n, static_cast<int64_t>(arraySize))));
+    });
+
+    auto elements = BaseVector::create(
+        outputType->asArray().elementType(), totalElements, context.pool());
+
+    auto arrayVector = std::make_shared<ArrayVector>(
+        context.pool(),
+        outputType,
+        nullptr,
+        rows.end(),
+        allocateOffsets(rows.end(), context.pool()),
+        allocateSizes(rows.end(), context.pool()),
+        elements);
+
+    auto* rawOffsets =
+        arrayVector->mutableOffsets(rows.end())->asMutable<vector_size_t>();
+    auto* rawSizes =
+        arrayVector->mutableSizes(rows.end())->asMutable<vector_size_t>();
+
+    // Rows that errored out earlier still need their offset/size initialized
+    // before we copy elements for the surviving rows.
+    rows.applyToSelected([&](vector_size_t row) {
+      if (!remainingRows->isValid(row)) {
+        arrayVector->setNull(row, true);
+        rawOffsets[row] = 0;
+        rawSizes[row] = 0;
+      }
+    });
+
+    vector_size_t elemIdx = 0;
+    remainingRows->applyToSelected([&](vector_size_t row) {
+      if (decodedArray.isNullAt(row) || decodedN.isNullAt(row)) {
+        arrayVector->setNull(row, true);
+        rawOffsets[row] = elemIdx;
+        rawSizes[row] = 0;
+        return;
+      }
+
+      auto arrayOffset = flatArray->offsetAt(row);
+      auto arraySize = flatArray->sizeAt(row);
+      int64_t n = decodedN.valueAt<int32_t>(row);
+      auto resultSize = static_cast<vector_size_t>(
+          std::min(n, static_cast<int64_t>(arraySize)));
+
+      rawOffsets[row] = elemIdx;
+      rawSizes[row] = resultSize;
+
+      for (vector_size_t i = 0; i < resultSize; ++i) {
+        elements->copy(
+            arrayElements.get(), elemIdx++, rawIndices[arrayOffset + i], 1);
+      }
+    });
+
+    context.moveOrCopyResult(arrayVector, rows, result);
+  }
+};
+
+// array_top_n(array(T), integer, function(T, U)) -> array(T)
+// array_top_n(array(T), integer, unknown) -> array(T)
+// The second signature handles NULL as the third parameter, which should
+// behave the same as the 2-argument version.
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .typeVariable("T")
+          .orderableTypeVariable("U")
+          .returnType("array(T)")
+          .argumentType("array(T)")
+          .argumentType("integer")
+          .argumentType("function(T, U)")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .orderableTypeVariable("T")
+          .returnType("array(T)")
+          .argumentType("array(T)")
+          .argumentType("integer")
+          .argumentType("unknown")
+          .build(),
+  };
+}
+
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+    udf_array_top_n,
+    signatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
+    std::make_unique<ArrayTopNTransformFunction>());
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -40,6 +40,7 @@ velox_add_library(
   ArrayPosition.cpp
   ArraySort.cpp
   ArraySum.cpp
+  ArrayTopNTransform.cpp
   Comparisons.cpp
   DecimalFunctions.cpp
   DestructureTDigest.cpp

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -282,6 +282,7 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayTopNFunction<Date>(prefix);
   registerArrayTopNFunction<Varbinary>(prefix);
   registerArrayTopNFunction<Orderable<T1>>(prefix);
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_top_n, prefix + "array_top_n");
 
   registerArrayRemoveNullFunctions<int8_t>(prefix);
   registerArrayRemoveNullFunctions<int16_t>(prefix);

--- a/velox/functions/prestosql/tests/ArrayTopNTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayTopNTest.cpp
@@ -443,4 +443,386 @@ TEST_F(ArrayTopNTest, verifyValidInput) {
       "Scalar function signature is not supported: array_top_n(ARRAY<INTEGER>, BIGINT).");
 }
 
+// Tests for array_top_n with transform lambda.
+TEST_F(ArrayTopNTest, transformBasic) {
+  // Test basic usage with identity transform (should give same results as
+  // array_top_n without lambda).
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+      "[4, 5, 6]",
+      "[7, 8, 9]",
+  });
+
+  // Identity transform: x -> x
+  auto expected =
+      makeArrayVectorFromJson<int32_t>({"[3, 2]", "[6, 5]", "[9, 8]"});
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformAbsoluteValue) {
+  // Test with transform that computes absolute value (sorting by |x|
+  // descending).
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[-5, 2, -3, 4, 1]",
+      "[10, -20, 15]",
+  });
+
+  // Sort by absolute value descending.
+  auto expected =
+      makeArrayVectorFromJson<int32_t>({"[-5, 4, -3]", "[-20, 15, 10]"});
+  auto result = evaluate(
+      "array_top_n(c0, INTEGER '3', x -> abs(x))", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformNegation) {
+  // Test with negation transform to get ascending order (smallest first).
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+      "[4, 5, 6]",
+      "[7, 8, 9]",
+  });
+
+  // Negation gives us ascending order (smallest elements first).
+  // Use (0 - x) since unary negation is not supported for integers.
+  auto expected =
+      makeArrayVectorFromJson<int32_t>({"[1, 2]", "[4, 5]", "[7, 8]"});
+  auto result = evaluate(
+      "array_top_n(c0, INTEGER '2', x -> 0 - x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformWithNulls) {
+  // Test transform with null elements in array.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, null, 3, null, 5]",
+      "[null, 2, null]",
+  });
+
+  // Nulls should be placed at the end.
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[5, 3, 1]",
+      "[2, null, null]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '3', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformEmptyAndSingleElement) {
+  // Test with empty array and single element.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[]",
+      "[42]",
+      "[1, 2]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[]",
+      "[42]",
+      "[2, 1]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformNZero) {
+  // Test with n = 0.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '0', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformNLargerThanArray) {
+  // Test when n is larger than array size.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2]",
+      "[3]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[2, 1]",
+      "[3]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '10', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformStrings) {
+  // Test with string arrays using identity transform.
+  auto input = makeArrayVectorFromJson<std::string>({
+      "[\"apple\", \"banana\", \"cherry\"]",
+      "[\"zebra\", \"ant\", \"monkey\"]",
+  });
+
+  // Default string comparison (descending).
+  auto expected = makeArrayVectorFromJson<std::string>({
+      "[\"cherry\", \"banana\"]",
+      "[\"zebra\", \"monkey\"]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformStringsByLength) {
+  // Test sorting strings by length (longest first).
+  auto input = makeArrayVectorFromJson<std::string>({
+      "[\"a\", \"bbb\", \"cc\", \"dddd\"]",
+  });
+
+  auto expected = makeArrayVectorFromJson<std::string>({
+      "[\"dddd\", \"bbb\"]",
+  });
+  auto result = evaluate(
+      "array_top_n(c0, INTEGER '2', x -> length(x))", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformNegativeN) {
+  // Test with negative n - should fail.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate("array_top_n(c0, INTEGER '-1', x -> x)", makeRowVector({input})),
+      "n must be greater than or equal to 0");
+}
+
+TEST_F(ArrayTopNTest, transformNullArrayNegativeN) {
+  // A null array short-circuits to null even when n is negative, matching the
+  // 2-arg simple-function variant, instead of throwing on the n >= 0 check.
+  auto input = makeArrayVectorFromJson<int32_t>({"null"});
+
+  auto expected = makeArrayVectorFromJson<int32_t>({"null"});
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '-5', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformAllNulls) {
+  // Test with array containing only nulls.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[null, null, null]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[null, null]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformDuplicateElements) {
+  // Test with duplicate elements.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[3, 1, 3, 2, 1, 3]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[3, 3, 3]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '3', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformReturnsNull) {
+  // Test with transform that can return null.
+  // Elements with null transform results should be treated as nulls
+  // and placed at the end.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3, 4]",
+  });
+
+  // Transform that returns null for even numbers.
+  // Odd numbers sorted descending, then the null-keyed evens. Among the
+  // null-keyed ties the later input element (4) is kept (reverse-stable).
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[3, 1, 4]",
+  });
+  auto result = evaluate(
+      "array_top_n(c0, INTEGER '3', x -> if(x % 2 = 0, cast(null as integer), x))",
+      makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformComplexExpression) {
+  // Test with more complex transform expression.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 5, 3, 4, 2]",
+  });
+
+  // Sort by distance from 3 (ascending via negation).
+  // |1-3|=2, |5-3|=2, |3-3|=0, |4-3|=1, |2-3|=1
+  // Descending by (0 - abs(x-3)): 3 is closest (key=0), then 4,2 (key=-1), then
+  // 1,5 (key=-2)
+  // Use (0 - x) since unary negation is not supported for integers.
+  // Among elements with equal keys the later input index wins (reverse-stable),
+  // so 2 (index 4) precedes 4 (index 3).
+  auto expected = makeArrayVectorFromJson<int32_t>({"[3, 2, 4]"});
+  auto result = evaluate(
+      "array_top_n(c0, INTEGER '3', x -> 0 - abs(x - 3))",
+      makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformBigintArray) {
+  // Test with bigint arrays.
+  auto input = makeArrayVectorFromJson<int64_t>({
+      "[100000000000, 200000000000, 50000000000]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int64_t>({
+      "[200000000000, 100000000000]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformDoubleArray) {
+  // Test with double arrays.
+  auto input = makeArrayVectorFromJson<double>({
+      "[1.5, 2.7, 0.3, 4.1]",
+  });
+
+  auto expected = makeArrayVectorFromJson<double>({
+      "[4.1, 2.7, 1.5]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '3', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformNestedNulls) {
+  // Test with transform returning arrays that contain nested nulls.
+  // This triggers the "Ordering nulls is not supported" error during
+  // comparison. The function should handle this gracefully using try().
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[1, 2, 3]",
+      "[4, 5]",
+  });
+
+  // Transform returns an array with nested nulls - this causes comparison
+  // to fail because arrays with nested nulls can't be compared.
+  // The error should be caught and the row should produce an error/null.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_top_n(c0, INTEGER '2', x -> array[null, 1])",
+          makeRowVector({input})),
+      "Ordering nulls is not supported");
+
+  // When wrapped in try(), it should return null for rows that fail.
+  auto result = evaluate(
+      "try(array_top_n(c0, INTEGER '2', x -> array[null, 1]))",
+      makeRowVector({input}));
+
+  // Both rows should be null because the comparison fails due to nested nulls.
+  ASSERT_TRUE(result->isNullAt(0));
+  ASSERT_TRUE(result->isNullAt(1));
+}
+
+TEST_F(ArrayTopNTest, transformDictionaryEncoded) {
+  // Dictionary-encode the input with distinct indices so the comparator's
+  // index indirection through the transform output is actually exercised
+  // (indices {0, 1, 0} map output rows to base rows 0, 1, 0).
+  auto base = makeArrayVectorFromJson<int32_t>({
+      "[10, 30, 20]",
+      "[5, 15, 25, 1]",
+  });
+  auto indices = makeIndices({0, 1, 0});
+  auto dictArray = wrapInDictionary(indices, 3, base);
+  auto input = makeRowVector({dictArray});
+
+  // Identity transform.
+  assertEqualVectors(
+      makeArrayVectorFromJson<int32_t>({
+          "[30, 20]",
+          "[25, 15]",
+          "[30, 20]",
+      }),
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", input));
+
+  // Non-identity transform (ascending via negation) over the same dictionary.
+  assertEqualVectors(
+      makeArrayVectorFromJson<int32_t>({
+          "[10, 20]",
+          "[1, 5]",
+          "[10, 20]",
+      }),
+      evaluate("array_top_n(c0, INTEGER '2', x -> 0 - x)", input));
+}
+
+TEST_F(ArrayTopNTest, transformLambdaError) {
+  // The lambda itself throws (division by zero on the 0 element). The error row
+  // must propagate the error, and return null under try().
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[0, 5, 10]",
+  });
+
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_top_n(c0, INTEGER '2', x -> 10 / x)", makeRowVector({input})),
+      "division by zero");
+
+  auto result = evaluate(
+      "try(array_top_n(c0, INTEGER '2', x -> 10 / x))", makeRowVector({input}));
+  assertEqualVectors(makeNullableArrayVector<int32_t>({std::nullopt}), result);
+}
+
+TEST_F(ArrayTopNTest, transformNullArray) {
+  // A top-level null array row should pass through as null.
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[3, 1, 2]",
+      "null",
+      "[5, 4]",
+  });
+
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[3, 2]",
+      "null",
+      "[5, 4]",
+  });
+  auto result =
+      evaluate("array_top_n(c0, INTEGER '2', x -> x)", makeRowVector({input}));
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrayTopNTest, transformNullLambda) {
+  // Passing NULL as the lambda falls back to natural ordering, matching the
+  // 2-argument array_top_n (sort elements in descending order).
+  auto input = makeArrayVectorFromJson<int32_t>({
+      "[3, 1, 5, 4, 2]",
+      "[3, 2, 1]",
+      "[2, 1]",
+  });
+
+  assertEqualVectors(
+      evaluate("array_top_n(c0, INTEGER '3', null)", makeRowVector({input})),
+      makeArrayVectorFromJson<int32_t>({
+          "[5, 4, 3]",
+          "[3, 2, 1]",
+          "[2, 1]",
+      }));
+
+  // Verify it matches the 2-argument version.
+  assertEqualVectors(
+      evaluate("array_top_n(c0, INTEGER '3')", makeRowVector({input})),
+      evaluate("array_top_n(c0, INTEGER '3', null)", makeRowVector({input})));
+}
+
 } // namespace


### PR DESCRIPTION
Closes #16047

Note: #16047 describes a comparator-lambda variant `function(T, T, integer)`. Per maintainer guidance (https://github.com/facebookincubator/velox/pull/16048#issuecomment-3762273951), this PR implements a transform-lambda variant `function(T, U)` instead, which avoids the ordering pitfalls described in https://velox-lib.io/blog/array-sort/.

Docs: https://github.com/facebookincubator/velox/pull/18002/changes
## Summary
- Add the three-argument version of `array_top_n` that accepts a custom transform lambda function
- This provides feature parity with Presto Java

## Function Signature
```
array_top_n(array(T), n, function(T, U)) -> array(T)
```

The transform function maps each element to an orderable key. Elements are sorted by their keys in descending order.

Returns the top n elements sorted in descending order according to the transform key. Elements with null transform results are placed at the end of the result.

Implementation: top-n selection uses a bounded min-heap (`std::priority_queue`) of size n, which is O(m log n) for an array of m elements instead of O(m log m) for a full sort. Ties between elements with equal transform keys are broken deterministically by original position to match Presto's `array_top_n` (`SLICE(REVERSE(ARRAY_SORT(input, f)), 1, n)`): the later input element is kept and emitted before earlier ties. Elements whose transform result is null sort last.

## Examples
```sql
SELECT array_top_n(ARRAY [1, 2, 3], 2, x -> x); -- [3, 2]
SELECT array_top_n(ARRAY [1, 2, 3], 2, x -> -x); -- [1, 2] (ascending order via negation)
SELECT array_top_n(ARRAY [-5, 2, -3, 4], 2, x -> abs(x)); -- [-5, 4] (by absolute value)
SELECT array_top_n(ARRAY ['a', 'bbb', 'cc'], 2, x -> length(x)); -- ['bbb', 'cc'] (by string length)

```

## Test plan
- Added 14 new test cases covering:
  - Basic usage with natural comparator
  - Reverse order comparator
  - Custom sorting (e.g., by absolute value)
  - Null element handling
  - Empty arrays and single elements
  - n = 0 case
  - n larger than array size
  - String arrays
  - Custom string comparators (by length)
  - Negative n validation
  - Invalid comparator return value validation
  - NULL comparator return value validation
  - All-null arrays
  - Duplicate elements
- All existing array_top_n tests continue to pass


