### PR TITLE
feat: Support DATE to TIMESTAMP coercion

### DIFF
--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -49,6 +49,7 @@ allowedCoercions() {
   add(INTEGER(), {BIGINT(), REAL(), DOUBLE()});
   add(BIGINT(), {DOUBLE()});
   add(REAL(), {DOUBLE()});
+  add(DATE(), {TIMESTAMP()});
 
   return coercions;
 }

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -42,6 +42,7 @@ TEST(TypeCoercerTest, basic) {
   testCoercion(TINYINT(), TINYINT());
   testCoercion(TINYINT(), BIGINT());
   testCoercion(TINYINT(), REAL());
+  testCoercion(DATE(), TIMESTAMP());
 
   testNoCoercion(TINYINT(), VARCHAR());
   testNoCoercion(TINYINT(), DATE());


### PR DESCRIPTION
Summary: Support DATE to TIMESTAMP coercion in Axiom

Support DATE to TIMESTAMP coercion in Axiom
Use name not kindname
For DATE() the name is DATE and the kindName is INTEGER
For TIMESTAMP() the name is TIMESTAMP and the kindName is BIGINT

Differential Revision: D90896054

- [x] Add case in TypeCoercerTest, rest of TypeCoercerTest passes


