### PR TITLE
fix(ci): Clang-tidy parse issue with deleted files

### DIFF
--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -47,12 +47,17 @@ def git_changed_lines(commit):
             file = match.group(1)
 
         match = re.match(r"^@@", line)
-        if match and file != "":
+        if match and file != "" and len(fields) >= 3:
             lspan = fields[2].split(",")
             if len(lspan) <= 1:
-                lspan.append(0)
+                lspan.append("0")
 
-            changed_lines[file] = [int(lspan[0]), int(lspan[0]) + int(lspan[1])]
+            start_line = int(lspan[0])
+            line_count = int(lspan[1])
+
+            # Skip invalid line ranges (e.g., +0,0 from deleted files)
+            if start_line > 0 or line_count > 0:
+                changed_lines[file] = [start_line, start_line + line_count]
 
     return changed_lines
 


### PR DESCRIPTION
Parsing issue with input of:
+++ /dev/null
@@ -1,25 +0,0 @@

For deleted files it matches the pattern +++ and doesn’t reset the file name. But it doesn’t change the name because /dev/null and does not match the pattern *.h,*.ccp. As a result it parses out the +0,0 from the following line and adds it to the previous file line list.
And adding [0, 0] to the list causes the invalid line range error (YAML:1:3004: error: Invalid line range) by clang-tidy.