### PR TITLE
feat: Add dynamic output batch sizing for MergeJoin

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -284,6 +284,14 @@ class QueryConfig {
   /// output rows.
   static constexpr const char* kMaxOutputBatchRows = "max_output_batch_rows";
 
+  /// Initial output batch size in rows for MergeJoin operator. When non-zero,
+  /// the batch size starts at this value and is dynamically adjusted based on
+  /// the average row size of previous output batches. When zero (default),
+  /// dynamic adjustment is disabled and the batch size is fixed at
+  /// preferredOutputBatchRows.
+  static constexpr const char* kMergeJoinOutputBatchStartSize =
+      "merge_join_output_batch_start_size";
+
   /// TableScan operator will exit getOutput() method after this many
   /// milliseconds even if it has no data to return yet. Zero means 'no time
   /// limit'.
@@ -1014,6 +1022,12 @@ class QueryConfig {
     VELOX_USER_CHECK_LE(
         maxBatchRows, std::numeric_limits<vector_size_t>::max());
     return maxBatchRows;
+  }
+
+  vector_size_t mergeJoinOutputBatchStartSize() const {
+    const uint32_t batchRows = get<uint32_t>(kMergeJoinOutputBatchStartSize, 0);
+    VELOX_USER_CHECK_LE(batchRows, std::numeric_limits<vector_size_t>::max());
+    return batchRows;
   }
 
   uint32_t tableScanGetOutputTimeLimitMs() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -27,6 +27,12 @@ Generic Configuration
      - 10000
      - Max number of rows that could be return by operators from Operator::getOutput. It is used when an estimate of
        average row size is known and preferred_output_batch_bytes is used to compute the number of output rows.
+   * - merge_join_output_batch_start_size
+     - integer
+     - 0
+     - Initial output batch size in rows for MergeJoin operator. When non-zero, the batch size starts at this value
+       and is dynamically adjusted based on the average row size of previous output batches. When zero (default),
+       dynamic adjustment is disabled and the batch size is fixed at preferred_output_batch_rows.
    * - max_elements_size_in_repeat_and_sequence
      - integer
      - 10000

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -2235,3 +2235,268 @@ TEST_F(MergeJoinTest, testJoinWithTwoKeysAndSecondColumnHasNulls) {
 
   testJoinTwoKeysWithNulls(left, right);
 }
+
+// Test that the dynamic output batch sizing follows the expected growth pattern
+// Verifies that when dynamic batch sizing is enabled
+// (mergeJoinOutputBatchStartSize > 0), MergeJoin adjusts output batch size
+// based on average row size and preferred bytes.
+TEST_F(MergeJoinTest, dynamicOutputBatchSizing) {
+  // Create simple two-column BIGINT data for both left and right sides.
+  // Each row is approximately 16 bytes (2 x 8 bytes for BIGINT).
+  // We create enough rows to see multiple output batches.
+  const vector_size_t numRows = 1000;
+
+  auto left = makeRowVector(
+      {"t_c0", "t_c1"},
+      {
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row * 10; }),
+      });
+
+  auto right = makeRowVector(
+      {"u_c0", "u_c1"},
+      {
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row * 100; }),
+      });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId mergeJoinNodeId;
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"t_c0"},
+              {"u_c0"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "",
+              {"t_c0", "t_c1", "u_c1"},
+              core::JoinType::kInner)
+          .capturePlanNodeId(mergeJoinNodeId)
+          .planNode();
+
+  // Set a very high preferred row count (10000) but a relatively small byte
+  // limit. The dynamic sizing should compute batch size based on
+  // preferredBytes / avgRowSize, rather than immediately producing 10000 rows.
+  const uint32_t highPreferredRows = 10000;
+  // Set preferred bytes to allow roughly 64 rows per batch (each output row is
+  // ~24 bytes: 3 x 8 bytes for 3 BIGINT columns).
+  const uint64_t preferredBytes = 24 * 64;
+
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kPreferredOutputBatchRows,
+       std::to_string(highPreferredRows)},
+      {core::QueryConfig::kPreferredOutputBatchBytes,
+       std::to_string(preferredBytes)},
+      // Enable dynamic batch sizing by setting a non-zero start size.
+      {core::QueryConfig::kMergeJoinOutputBatchStartSize, "1"},
+  });
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = queryCtx;
+
+  auto cursor = TaskCursor::create(params);
+  cursor->start();
+
+  std::vector<vector_size_t> outputBatchSizes;
+  while (cursor->moveNext()) {
+    auto result = cursor->current();
+    if (result && result->size() > 0) {
+      outputBatchSizes.push_back(result->size());
+    }
+  }
+
+  // Verify that we got multiple output batches.
+  ASSERT_GT(outputBatchSizes.size(), 1);
+
+  // Verify the first batch starts small (should be 1 row due to initial
+  // outputBatchSize_ = 1).
+  EXPECT_EQ(outputBatchSizes[0], 1);
+
+  // After the first batch, the batch size should immediately jump to the
+  // computed size based on preferredBytes / avgRowSize (roughly 64 rows).
+  // All subsequent batches (except the last which may have fewer remaining
+  // rows) should be approximately this computed size.
+  for (size_t i = 1; i < outputBatchSizes.size() - 1; ++i) {
+    EXPECT_GT(outputBatchSizes[i], 8)
+        << "Batch " << i
+        << " should be computed based on preferredBytes / avgRowSize";
+  }
+
+  // Verify we never exceed the preferred row count.
+  for (size_t i = 0; i < outputBatchSizes.size(); ++i) {
+    EXPECT_LE(outputBatchSizes[i], highPreferredRows);
+  }
+}
+
+// Test that filterInput_ properly handles the case where outputBatchSize_
+// increases after initial creation.
+//
+// This test uses variable-length string data where:
+// - First batch of rows have LARGE strings (causing small batch size when
+//   filterInput_ is created)
+// - Later batches have SMALL strings (causing batch size to increase)
+//
+// CRITICAL: The filter expression references columns that are NOT in the
+// output projection. This creates non-shared child vectors in filterInput_
+// that are allocated with the initial outputBatchSize_. When outputBatchSize_
+// increases, copyRow() would write beyond the buffer capacity if not handled
+// correctly.
+TEST_F(MergeJoinTest, dynamicOutputBatchSizingWithFilter) {
+  const vector_size_t numRows = 1000;
+
+  // Left side has 4 columns: t_c0 (join key), t_c1 (in output), t_c2 (in
+  // output), t_c3 (ONLY in filter, NOT in output).
+  auto left = makeRowVector(
+      {"t_c0", "t_c1", "t_c2", "t_c3"},
+      {
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row * 10; }),
+          makeFlatVector<std::string>(
+              numRows,
+              [](auto row) {
+                if (row < 100) {
+                  return std::string(1000, 'A' + (row % 26));
+                } else {
+                  return std::to_string(row);
+                }
+              }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row % 10; }),
+      });
+
+  auto right = makeRowVector(
+      {"u_c0", "u_c1", "u_c2", "u_c3"},
+      {
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row * 100; }),
+          makeFlatVector<std::string>(
+              numRows,
+              [](auto row) {
+                if (row < 100) {
+                  return std::string(1000, 'X' + (row % 3));
+                } else {
+                  return std::to_string(row * 2);
+                }
+              }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row % 5; }),
+      });
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId mergeJoinNodeId;
+
+  // The filter references t_c3 and u_c3 which are NOT in the output projection.
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"t_c0"},
+              {"u_c0"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "(t_c3 + u_c3) % 3 = 0",
+              {"t_c0", "t_c1", "t_c2", "u_c1", "u_c2"},
+              core::JoinType::kInner)
+          .capturePlanNodeId(mergeJoinNodeId)
+          .planNode();
+
+  const uint32_t highPreferredRows = 10000;
+  const uint64_t preferredBytes = 10000;
+
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kPreferredOutputBatchRows,
+       std::to_string(highPreferredRows)},
+      {core::QueryConfig::kPreferredOutputBatchBytes,
+       std::to_string(preferredBytes)},
+      {core::QueryConfig::kMergeJoinOutputBatchStartSize, "1"},
+  });
+
+  // If filterInput_ buffer overflow occurs, ASAN will catch it.
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .queryCtx(queryCtx)
+      .assertResults(
+          "SELECT t_c0, t_c1, t_c2, u_c1, u_c2 FROM t, u "
+          "WHERE t_c0 = u_c0 AND (t.t_c3 + u.u_c3) % 3 = 0");
+}
+
+// Verifies that when mergeJoinOutputBatchStartSize is 0 (default), dynamic
+// batch sizing is disabled and the batch size is fixed at
+// preferredOutputBatchRows.
+TEST_F(MergeJoinTest, dynamicOutputBatchSizingDisabledByDefault) {
+  const vector_size_t numRows = 1000;
+
+  auto left = makeRowVector(
+      {"t_c0", "t_c1"},
+      {
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row * 10; }),
+      });
+
+  auto right = makeRowVector(
+      {"u_c0", "u_c1"},
+      {
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(numRows, [](auto row) { return row * 100; }),
+      });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId mergeJoinNodeId;
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({left})
+          .mergeJoin(
+              {"t_c0"},
+              {"u_c0"},
+              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
+              "",
+              {"t_c0", "t_c1", "u_c1"},
+              core::JoinType::kInner)
+          .capturePlanNodeId(mergeJoinNodeId)
+          .planNode();
+
+  // Use the default config (mergeJoinOutputBatchStartSize = 0), which disables
+  // dynamic batch sizing. The batch size should be fixed at
+  // preferredOutputBatchRows.
+  const uint32_t preferredRows = 100;
+
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  queryCtx->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kPreferredOutputBatchRows,
+       std::to_string(preferredRows)},
+  });
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = queryCtx;
+
+  auto cursor = TaskCursor::create(params);
+  cursor->start();
+
+  std::vector<vector_size_t> outputBatchSizes;
+  while (cursor->moveNext()) {
+    auto result = cursor->current();
+    if (result && result->size() > 0) {
+      outputBatchSizes.push_back(result->size());
+    }
+  }
+
+  // Verify that we got multiple output batches.
+  ASSERT_GT(outputBatchSizes.size(), 1);
+
+  // Since dynamic batch sizing is disabled, all batches (except possibly the
+  // last one) should be exactly preferredRows in size.
+  for (size_t i = 0; i < outputBatchSizes.size() - 1; ++i) {
+    EXPECT_EQ(outputBatchSizes[i], preferredRows)
+        << "Batch " << i << " should be exactly " << preferredRows
+        << " rows when dynamic batch sizing is disabled";
+  }
+
+  // The last batch should be <= preferredRows (may have fewer remaining rows).
+  EXPECT_LE(outputBatchSizes.back(), preferredRows);
+}


### PR DESCRIPTION
Summary:
## Overview

This diff resolves a memory management issue in the operator, specifically targeting the risk of memory explosion. The underlying problem stems from a cross product effect: when the left and right sides are combined and the resulting vector is flattened, memory usage can increase dramatically because the flattened vector makes copies for every single row, potentially allocating a significant amount of memory. This happens because each element on the left is paired with every element on the right, producing a large number of intermediate results.

## Improvements in Memory Control

- **Prevents Memory Explosion:** The diff introduces safeguards and optimizations to ensure the operator does not create an excessive number of intermediate results during the flattening process.
- **Efficient Resource Management:** These changes cap or limit the memory footprint, making the operator more robust and less susceptible to out-of-memory errors.
- **Improved Stability:** With enhanced memory control, the operator can process larger join explosions without compromising system stability.

In summary, this diff implements memory control strategies to prevent memory explosion caused by cross product operations during joining when vector flattening.

Differential Revision: D90914193


