### PR TITLE
fix(cudf): Fix cudf validate expression memory pool

### DIFF
--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -106,7 +106,7 @@ bool canBeEvaluatedByCudf(
   }
 
   auto precompilePool = memory::memoryManager()->addLeafPool(
-      "cudf-expr-precompile", /*threadSafe*/ false);
+      "cudf-expr-precompile" + queryCtx->queryId(), /*threadSafe*/ false);
   core::ExecCtx precompileCtx(precompilePool.get(), queryCtx);
 
   bool lazyDereference = false;


### PR DESCRIPTION
Current logic works well in single thread, but Gluten validate the cudf execution with multiple threads, and execute in single thread, fix this exception
```
W20260119 02:35:19.517676   480 ExceptionTracer.cpp:189] Invalid trace stack for exception of type: std::runtime_error
terminate called after throwing an instance of 'std::runtime_error'
26/01/19 02:35:19 ERROR TaskResources: Task 12126 failed by error: 
org.apache.gluten.exception.GlutenException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (1 vs. 0) Leaf child memory pool cudf-expr-precompile already exists in __sys_root__
Retriable: False
Expression: children_.count(name) == 0
Function: addLeafChild
File: /opt/gluten/ep/build-velox/build/velox_ep/velox/common/memory/MemoryPool.cpp
Line: 331
Stack trace:
# 0  _ZN8facebook5velox7process10StackTraceC1Ei
```