### PR TITLE
feat: Add sortOrders() getter to KeyEncoder

### DIFF
--- a/velox/serializers/KeyEncoder.h
+++ b/velox/serializers/KeyEncoder.h
@@ -162,6 +162,11 @@ class KeyEncoder {
   std::optional<EncodedKeyBounds> encodeIndexBounds(
       const IndexBounds& indexBounds);
 
+  /// Returns the sort orders for each index column.
+  const std::vector<core::SortOrder>& sortOrders() const {
+    return sortOrders_;
+  }
+
  private:
   KeyEncoder(
       std::vector<std::string> keyColumns,


### PR DESCRIPTION
Summary:
This change adds a `sortOrders()` getter method to `KeyEncoder` that returns the sort orders for each index column. This enables downstream consumers (like Nimble index writer) to retrieve the sort orders configured for the key encoder.

The sort orders are essential metadata that needs to be persisted in the index root for proper index reading and key comparisons.

Differential Revision: D90955333


