### PR TITLE
feat: Support iceberg compatible min max stats

### DIFF
--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -1849,5 +1849,362 @@ TEST(TestEncodedStatistics, CopySafe) {
 }
 */
 
+namespace {
+
+constexpr int32_t kTruncLen = 16;
+
+template <typename ParquetType, typename T>
+std::shared_ptr<TypedStatistics<ParquetType>> makeStats(
+    const ColumnDescriptor* descr,
+    std::initializer_list<T> values) {
+  auto stats = MakeStatistics<ParquetType>(descr);
+  std::vector<T> v(values);
+  stats->Update(v.data(), v.size(), 0);
+  return stats;
+}
+
+std::shared_ptr<TypedStatistics<ByteArrayType>> makeStats(
+    const ColumnDescriptor* descr,
+    std::initializer_list<std::string> values) {
+  auto stats = MakeStatistics<ByteArrayType>(descr);
+  std::vector<std::string> strings(values);
+  std::vector<ByteArray> byteArrays;
+  byteArrays.reserve(strings.size());
+  for (const auto& s : strings) {
+    byteArrays.push_back(ByteArrayFromString(s));
+  }
+  stats->Update(byteArrays.data(), byteArrays.size(), 0);
+  return stats;
+}
+
+} // namespace
+
+TEST(IcebergStatistics, decimalMinMaxValue) {
+  const NodePtr node = PrimitiveNode::Make(
+      "decimal_col",
+      Repetition::REQUIRED,
+      LogicalType::Decimal(10, 2),
+      Type::INT64);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats =
+      makeStats<Int64Type, int64_t>(&descr, {12345, -67890, 100, 50000});
+
+  ASSERT_TRUE(stats->HasMinMax());
+  EXPECT_EQ(stats->min(), -67890);
+  EXPECT_EQ(stats->max(), 50000);
+
+  const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+
+  ASSERT_TRUE(upperBound.has_value());
+
+  // Verify the encoding is big-endian.
+  int64_t decodedMin = ::arrow::bit_util::FromBigEndian(
+      *reinterpret_cast<const int64_t*>(lowerBound.data()));
+  int64_t decodedMax = ::arrow::bit_util::FromBigEndian(
+      *reinterpret_cast<const int64_t*>(upperBound->data()));
+
+  EXPECT_EQ(decodedMin, -67890);
+  EXPECT_EQ(decodedMax, 50000);
+}
+
+TEST(IcebergStatistics, nonDecimalBounds) {
+  const NodePtr node =
+      PrimitiveNode::Make("int_col", Repetition::REQUIRED, Type::INT64);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats = makeStats<Int64Type, int64_t>(&descr, {100, -200, 300, 50});
+
+  ASSERT_TRUE(stats->HasMinMax());
+
+  // For non-decimal INT64, IcebergLowerBound should equal EncodeMin (plain
+  // encoding).
+  EXPECT_EQ(stats->IcebergLowerBoundInclusive(kTruncLen), stats->EncodeMin());
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+  ASSERT_TRUE(upperBound.has_value());
+  EXPECT_EQ(*upperBound, stats->EncodeMax());
+}
+
+TEST(IcebergStatistics, byteArrayBounds) {
+  NodePtr node = PrimitiveNode::Make(
+      "string_col",
+      Repetition::REQUIRED,
+      Type::BYTE_ARRAY,
+      ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats = makeStats(
+      &descr,
+      {"AAAAAAAAAAAAAAAAAAAAAAAAA", "ZZZZZZZZZZZZZZZZZZZZZZZZZ", "Hello"});
+
+  ASSERT_TRUE(stats->HasMinMax());
+
+  // IcebergLowerBound should be truncated to 16 characters.
+  const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+  EXPECT_EQ(lowerBound, "AAAAAAAAAAAAAAAA");
+
+  // IcebergUpperBound should be truncated and incremented.
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+  ASSERT_TRUE(upperBound.has_value());
+  // 'Z' (0x5A) incremented becomes '[' (0x5B).
+  EXPECT_EQ(*upperBound, "ZZZZZZZZZZZZZZZ[");
+}
+
+TEST(IcebergStatistics, byteArrayBoundsNoTruncation) {
+  NodePtr node = PrimitiveNode::Make(
+      "string_col",
+      Repetition::REQUIRED,
+      Type::BYTE_ARRAY,
+      ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+
+  // Create strings shorter than 16 characters.
+  auto stats = makeStats(&descr, {"apple", "zebra", "banana"});
+
+  ASSERT_TRUE(stats->HasMinMax());
+
+  // For short strings, IcebergLowerBound/IcebergUpperBound should be the same
+  // as EncodeMin/EncodeMax.
+  EXPECT_EQ(stats->IcebergLowerBoundInclusive(kTruncLen), stats->EncodeMin());
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+  ASSERT_TRUE(upperBound.has_value());
+  EXPECT_EQ(*upperBound, stats->EncodeMax());
+}
+
+TEST(IcebergStatistics, byteArrayBoundsUnicode) {
+  NodePtr node = PrimitiveNode::Make(
+      "string_col",
+      Repetition::REQUIRED,
+      Type::BYTE_ARRAY,
+      ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+
+  // Create Unicode strings longer than 16 characters to trigger truncation.
+  // Truncation is based on character count (16 chars), not byte count.
+  // "世" is U+4E16 (3 bytes in UTF-8: E4 B8 96)
+  // "界" is U+754C (3 bytes in UTF-8: E7 95 8C)
+  // "你" is U+4F60 (3 bytes in UTF-8: E4 BD A0)
+  // "好" is U+597D (3 bytes in UTF-8: E5 A5 BD)
+  auto stats = makeStats(
+      &descr,
+      {"AAAA世界世界世界世界世界世界世",
+       "ZZZZ你好你好你好你好你好你好你",
+       "Hello, 世界!"});
+
+  ASSERT_TRUE(stats->HasMinMax());
+
+  const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+
+  ASSERT_TRUE(upperBound.has_value());
+
+  // str1 has 18 characters (4 ASCII + 14 Chinese).
+  // Truncated to 16 chars: "AAAA" (4) + "世界世界世界世界世界世界 (12)".
+  const std::string expectedLower = "AAAA世界世界世界世界世界世界";
+  EXPECT_EQ(lowerBound, expectedLower);
+
+  // str2 has 18 characters (4 ASCII + 14 Chinese).
+  // For upperBound, the last character is incremented after truncation.
+  // "好" (U+597D) incremented becomes U+597E "奾".
+  const std::string expectedUpper = "ZZZZ你好你好你好你好你好你奾";
+  EXPECT_EQ(*upperBound, expectedUpper);
+}
+
+TEST(IcebergStatistics, floatBounds) {
+  NodePtr node =
+      PrimitiveNode::Make("float_col", Repetition::REQUIRED, Type::FLOAT);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats = makeStats<FloatType, float>(&descr, {1.5f, -2.5f, 3.5f, 0.5f});
+
+  ASSERT_TRUE(stats->HasMinMax());
+  EXPECT_EQ(stats->IcebergLowerBoundInclusive(kTruncLen), stats->EncodeMin());
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+  ASSERT_TRUE(upperBound.has_value());
+  EXPECT_EQ(*upperBound, stats->EncodeMax());
+}
+
+TEST(IcebergStatistics, doubleBounds) {
+  NodePtr node =
+      PrimitiveNode::Make("double_col", Repetition::REQUIRED, Type::DOUBLE);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats = makeStats<DoubleType, double>(&descr, {1.5, -2.5, 3.5, 0.5});
+
+  ASSERT_TRUE(stats->HasMinMax());
+  EXPECT_EQ(stats->IcebergLowerBoundInclusive(kTruncLen), stats->EncodeMin());
+  const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+  ASSERT_TRUE(upperBound.has_value());
+  EXPECT_EQ(*upperBound, stats->EncodeMax());
+}
+
+TEST(IcebergStatistics, emptyStringBounds) {
+  NodePtr node = PrimitiveNode::Make(
+      "string_col",
+      Repetition::REQUIRED,
+      Type::BYTE_ARRAY,
+      ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+
+  {
+    auto stats = makeStats(&descr, {"", "hello", ""});
+
+    ASSERT_TRUE(stats->HasMinMax());
+    EXPECT_EQ(stats->IcebergLowerBoundInclusive(kTruncLen), "");
+
+    const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+    ASSERT_TRUE(upperBound.has_value());
+    EXPECT_EQ(*upperBound, "hello");
+  }
+
+  {
+    auto stats = makeStats(&descr, {"", ""});
+
+    ASSERT_TRUE(stats->HasMinMax());
+    EXPECT_EQ(stats->min(), ByteArray(""));
+    EXPECT_EQ(stats->max(), ByteArray(""));
+
+    EXPECT_EQ(stats->IcebergLowerBoundInclusive(kTruncLen), "");
+
+    const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+    ASSERT_TRUE(upperBound.has_value());
+    EXPECT_EQ(*upperBound, "");
+  }
+}
+
+TEST(IcebergStatistics, unboundedUpperBound) {
+  NodePtr node = PrimitiveNode::Make(
+      "string_col",
+      Repetition::REQUIRED,
+      Type::BYTE_ARRAY,
+      ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+
+  {
+    std::string allMaxAscii(20, '\x7F');
+    auto stats = makeStats(&descr, {"hello", allMaxAscii});
+
+    ASSERT_TRUE(stats->HasMinMax());
+
+    const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+    const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+
+    EXPECT_EQ(lowerBound, stats->EncodeMin());
+    EXPECT_FALSE(upperBound.has_value());
+  }
+
+  {
+    std::string allMaxUnicode;
+    allMaxUnicode.reserve(17 * 4);
+    for (int i = 0; i < 17; ++i) {
+      allMaxUnicode += "\U0010FFFF";
+    }
+    auto stats = makeStats(&descr, {"hello", allMaxUnicode});
+
+    ASSERT_TRUE(stats->HasMinMax());
+
+    const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+    const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+    EXPECT_EQ(lowerBound, stats->EncodeMin());
+    EXPECT_FALSE(upperBound.has_value());
+  }
+
+  {
+    std::string allMaxAscii(20, '\x7F');
+    auto stats = makeStats(&descr, {allMaxAscii, allMaxAscii});
+
+    ASSERT_TRUE(stats->HasMinMax());
+    EXPECT_EQ(stats->min(), ByteArray(allMaxAscii));
+    EXPECT_EQ(stats->max(), ByteArray(allMaxAscii));
+
+    const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+    const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+    EXPECT_TRUE(stats->EncodeMin().starts_with(lowerBound));
+    EXPECT_FALSE(upperBound.has_value());
+  }
+
+  {
+    std::string allMaxUnicode;
+    allMaxUnicode.reserve(17 * 4);
+    for (int i = 0; i < 17; ++i) {
+      allMaxUnicode += "\U0010FFFF";
+    }
+    auto stats = makeStats(&descr, {allMaxUnicode, allMaxUnicode});
+
+    ASSERT_TRUE(stats->HasMinMax());
+    EXPECT_EQ(stats->min(), ByteArray(allMaxUnicode));
+    EXPECT_EQ(stats->max(), ByteArray(allMaxUnicode));
+
+    const auto lowerBound = stats->IcebergLowerBoundInclusive(kTruncLen);
+    const auto upperBound = stats->IcebergUpperBoundExclusive(kTruncLen);
+    EXPECT_TRUE(stats->EncodeMin().starts_with(lowerBound));
+    EXPECT_FALSE(upperBound.has_value());
+  }
+}
+
+TEST(StatisticsComparison, withInt64) {
+  NodePtr node =
+      PrimitiveNode::Make("int_col", Repetition::REQUIRED, Type::INT64);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats1 = makeStats<Int64Type, int64_t>(&descr, {10, 20, 30});
+  auto stats2 = makeStats<Int64Type, int64_t>(&descr, {5, 15, 25});
+  auto stats3 = makeStats<Int64Type, int64_t>(&descr, {10, 20, 30});
+
+  ASSERT_TRUE(stats1->HasMinMax());
+  ASSERT_TRUE(stats2->HasMinMax());
+  ASSERT_TRUE(stats3->HasMinMax());
+
+  EXPECT_TRUE(stats1->MaxGreaterThan(*stats2));
+  EXPECT_FALSE(stats2->MaxGreaterThan(*stats1));
+  EXPECT_TRUE(stats1->MaxGreaterThan(*stats3));
+  EXPECT_TRUE(stats3->MaxGreaterThan(*stats1));
+
+  EXPECT_FALSE(stats1->MinLessThan(*stats2));
+  EXPECT_TRUE(stats2->MinLessThan(*stats1));
+  EXPECT_FALSE(stats1->MinLessThan(*stats3));
+  EXPECT_FALSE(stats3->MinLessThan(*stats1));
+}
+
+TEST(StatisticsComparison, withDouble) {
+  NodePtr node =
+      PrimitiveNode::Make("double_col", Repetition::REQUIRED, Type::DOUBLE);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats1 = makeStats<DoubleType, double>(&descr, {1.0, 2.0, 3.0});
+  auto stats2 = makeStats<DoubleType, double>(&descr, {0.5, 1.5, 2.5});
+
+  ASSERT_TRUE(stats1->HasMinMax());
+  ASSERT_TRUE(stats2->HasMinMax());
+
+  EXPECT_TRUE(stats1->MaxGreaterThan(*stats2));
+  EXPECT_FALSE(stats2->MaxGreaterThan(*stats1));
+
+  EXPECT_FALSE(stats1->MinLessThan(*stats2));
+  EXPECT_TRUE(stats2->MinLessThan(*stats1));
+}
+
+TEST(StatisticsComparison, withByteArray) {
+  NodePtr node = PrimitiveNode::Make(
+      "string_col",
+      Repetition::REQUIRED,
+      Type::BYTE_ARRAY,
+      ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto stats1 = makeStats(&descr, {"apple", "zebra"});
+  auto stats2 = makeStats(&descr, {"banana", "mangomango"});
+
+  ASSERT_TRUE(stats1->HasMinMax());
+  ASSERT_TRUE(stats2->HasMinMax());
+
+  EXPECT_TRUE(stats1->MaxGreaterThan(*stats2));
+  EXPECT_FALSE(stats2->MaxGreaterThan(*stats1));
+
+  EXPECT_TRUE(stats1->MinLessThan(*stats2));
+  EXPECT_FALSE(stats2->MinLessThan(*stats1));
+}
+
 } // namespace test
 } // namespace facebook::velox::parquet::arrow

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -213,6 +213,20 @@ class StringImplTest : public testing::Test {
         {"CAPS_LOCK@DOMAIN.COM", "Caps_lock@domain.com"},
         {"__init__.py@example.dev", "__init__.py@example.dev"}};
   }
+
+  static void testTruncate(
+      const std::string& input,
+      int32_t numCodePoints,
+      const std::string& expected) {
+    EXPECT_EQ(truncateUtf8(input, numCodePoints), expected);
+  }
+
+  static void testRoundUp(
+      const std::string& input,
+      int32_t numCodePoints,
+      const std::optional<std::string>& expected) {
+    EXPECT_EQ(roundUpUtf8(input, numCodePoints), expected);
+  }
 };
 
 TEST_F(StringImplTest, upperAscii) {
@@ -1033,4 +1047,98 @@ TEST_F(StringImplTest, initcapAsciiSpark) {
         /*greekFinalSigma=*/true>(output, input);
     ASSERT_EQ(output, expected);
   }
+}
+
+TEST_F(StringImplTest, truncate) {
+  // ASCII string.
+  std::string ascii = "Hello, world!";
+  testTruncate(ascii, 0, "");
+  testTruncate(ascii, 1, "H");
+  testTruncate(ascii, 5, "Hello");
+  testTruncate(ascii, 13, ascii);
+  testTruncate(ascii, 20, ascii);
+
+  // String with multi-bytes characters.
+  std::string unicode = "Hello, 世界!";
+  testTruncate(unicode, 7, "Hello, ");
+  testTruncate(unicode, 8, "Hello, 世");
+  testTruncate(unicode, 9, "Hello, 世界");
+  testTruncate(unicode, 10, unicode);
+  testTruncate(unicode, 20, unicode);
+
+  // String with emoji (surrogate pairs).
+  std::string emoji = "Hello 🌍!";
+  testTruncate(emoji, 6, "Hello ");
+  testTruncate(emoji, 7, "Hello 🌍");
+  testTruncate(emoji, 8, emoji);
+  testTruncate(emoji, 10, emoji);
+
+  std::string empty = "";
+  testTruncate(empty, 0, "");
+  testTruncate(empty, 5, "");
+
+  std::string mixed = "café世界🌍";
+  testTruncate(mixed, 3, "caf");
+  testTruncate(mixed, 4, "café");
+  testTruncate(mixed, 5, "café世");
+  testTruncate(mixed, 6, "café世界");
+  testTruncate(mixed, 7, mixed);
+}
+
+TEST_F(StringImplTest, roundUp) {
+  std::string ascii = "Hello, world!";
+  // Empty truncation returns nullopt.
+  testRoundUp(ascii, 0, std::nullopt);
+  // 'o' -> 'p'.
+  testRoundUp(ascii, 5, "Hellp");
+  testRoundUp(ascii, ascii.length(), ascii);
+
+  ascii = "Customer#000001500";
+  // '5' -> '6'.
+  testRoundUp(ascii, 16, "Customer#0000016");
+
+  std::string unicode = "Hello, 世界!";
+  testRoundUp(unicode, 8, "Hello, 丗");
+
+  // No truncation needed.
+  std::string shortString = "Hi";
+  testRoundUp(shortString, 2, shortString);
+  testRoundUp(shortString, 20, shortString);
+
+  // Last character is already at maximum value, returns nullopt.
+  std::string maxChar = "Hello\U0010FFFF";
+  testRoundUp(maxChar, 6, maxChar);
+
+  std::string empty = "";
+  testRoundUp(empty, 0, "");
+  testRoundUp(empty, 5, "");
+
+  std::string single = "a";
+  // No truncation needed.
+  testRoundUp(single, 1, "a");
+
+  std::string zChar = "zz";
+  // 'z' -> '{'.
+  testRoundUp(zChar, 1, "{");
+
+  std::string emojiTest = "🌍!!";
+  // U1F30D (🌍) -> U1F30E.
+  testRoundUp(emojiTest, 1, "\U0001F30E");
+
+  std::string multiByteTest = "café+";
+  // 'f' -> 'g'.
+  testRoundUp(multiByteTest, 3, "cag");
+  // 'é' -> 'ê'.
+  testRoundUp(multiByteTest, 4, "cafê");
+
+  // Test surrogate boundary: U+D7FF should increment to U+E000 (skipping
+  // surrogate range U+D800-U+DFFF).
+  // U+D7FF followed by "!!"
+  std::string surrogateTest = "\xED\x9F\xBF!!";
+  // U+E000
+  testRoundUp(surrogateTest, 1, "\xEE\x80\x80");
+
+  // Test all max code points - should return nullopt.
+  std::string allMax = "\U0010FFFF\U0010FFFF";
+  testRoundUp(allMax, 1, std::nullopt);
 }


### PR DESCRIPTION
Add support for computing Iceberg-compatible min/max statistics in Parquet writer.
Iceberg requires specific encoding formats for column statistics that differ from the standard Parquet encoding.

**Decimal types:** Encoded in big-endian format instead of little-endian, as required by Iceberg's binary comparison semantics.
See [binary-single-value-serialization](https://iceberg.apache.org/spec/#binary-single-value-serialization).

**String Types (BYTE_ARRAY with UTF8):**
**Lower Bound:** Truncates to the specified number of Unicode code points (default 16)
Simple truncation ensures the result is ≤ the original string.
**Upper Bound:** Truncates and increments to create an exclusive upper bound
If the string has ≤ truncateTo code points, returns the exact value;
If longer, truncates to truncateTo code points and increments the last code point.
Increments from the last code point backwards until a valid increment is found.
Returns std::nullopt if no valid upper bound exists (e.g., all code points are at max value U+10FFFF)
Properly handles Unicode surrogate ranges (U+D800-U+DFFF) by skipping them during increment.
**Other Types (INT64 non-decimal, FLOAT, DOUBLE, etc.):**
Use standard Parquet plain encoding (no special handling needed)

Added two new methods to the Statistics interface:
IcebergLowerBoundInclusive(int32_t truncateTo): Returns an encoded value guaranteed to be ≤ the actual minimum value
IcebergUpperBoundExclusive(int32_t truncateTo): Returns an encoded value guaranteed to be ≥ the actual maximum value, or std::nullopt if no valid upper bound can be computed

Added comparison methods to enable merging statistics across row groups:
MaxGreaterThan(const Statistics& other): Compares maximum values between two statistics objects
MinLessThan(const Statistics& other): Compares minimum values between two statistics objects

Added new utility functions in velox/functions/lib/Utf8Utils.h:
truncate(std::string_view input, int32_t numCodePoints): Truncates a UTF-8 string to at most N code points.
roundUp(std::string_view input, int32_t numCodePoints): Rounds up a UTF-8 string to produce an exclusive upper bound.

