### PR TITLE
feat(spark): Added to Int ANSI support

### DIFF
--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -42,7 +42,16 @@ class CastHooks {
 
   virtual Expected<Timestamp> castIntToTimestamp(int64_t seconds) const = 0;
 
-  virtual Expected<int64_t> castTimestampToInt(Timestamp timestamp) const = 0;
+  virtual Expected<std::optional<int8_t>> castTimestampToInt8(
+      Timestamp timestamp) const = 0;
+
+  virtual Expected<std::optional<int16_t>> castTimestampToInt16(
+      Timestamp timestamp) const = 0;
+
+  virtual Expected<std::optional<int32_t>> castTimestampToInt32(
+      Timestamp timestamp) const = 0;
+
+  virtual Expected<int64_t> castTimestampToInt64(Timestamp timestamp) const = 0;
 
   virtual Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const = 0;

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -59,7 +59,24 @@ Expected<Timestamp> PrestoCastHooks::castIntToTimestamp(
       Status::UserError("Conversion to Timestamp is not supported"));
 }
 
-Expected<int64_t> PrestoCastHooks::castTimestampToInt(
+Expected<std::optional<int8_t>> PrestoCastHooks::castTimestampToInt8(
+    Timestamp /*timestamp*/) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion from Timestamp to Int is not supported"));
+}
+
+Expected<std::optional<int16_t>> PrestoCastHooks::castTimestampToInt16(
+    Timestamp /*timestamp*/) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion from Timestamp to Int is not supported"));
+}
+Expected<std::optional<int32_t>> PrestoCastHooks::castTimestampToInt32(
+    Timestamp /*timestamp*/) const {
+  return folly::makeUnexpected(
+      Status::UserError("Conversion from Timestamp to Int is not supported"));
+}
+
+Expected<int64_t> PrestoCastHooks::castTimestampToInt64(
     Timestamp /*timestamp*/) const {
   return folly::makeUnexpected(
       Status::UserError("Conversion from Timestamp to Int is not supported"));
@@ -115,8 +132,8 @@ Expected<T> doCastToFloatingPoint(const StringView& data) {
         begin, length, &processedCharactersCount);
   }
   // Since we already removed leading space, if processedCharactersCount == 0,
-  // it means the remaining string is either empty or a junk string. So return a
-  // user error in this case.
+  // it means the remaining string is either empty or a junk string. So return
+  // a user error in this case.
   if UNLIKELY (processedCharactersCount == 0) {
     return folly::makeUnexpected(Status::UserError());
   }

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -34,7 +34,16 @@ class PrestoCastHooks : public CastHooks {
 
   Expected<Timestamp> castBooleanToTimestamp(bool seconds) const override;
 
-  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const override;
+  Expected<std::optional<int8_t>> castTimestampToInt8(
+      Timestamp timestamp) const override;
+
+  Expected<std::optional<int16_t>> castTimestampToInt16(
+      Timestamp timestamp) const override;
+
+  Expected<std::optional<int32_t>> castTimestampToInt32(
+      Timestamp timestamp) const override;
+
+  Expected<int64_t> castTimestampToInt64(Timestamp timestamp) const override;
 
   Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const override;

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -36,7 +36,16 @@ class SparkCastHooks : public exec::CastHooks {
   /// number of seconds since the epoch (1970-01-01 00:00:00 UTC).
   Expected<Timestamp> castIntToTimestamp(int64_t seconds) const override;
 
-  Expected<int64_t> castTimestampToInt(Timestamp timestamp) const override;
+  Expected<std::optional<int8_t>> castTimestampToInt8(
+      Timestamp timestamp) const override;
+
+  Expected<std::optional<int16_t>> castTimestampToInt16(
+      Timestamp timestamp) const override;
+
+  Expected<std::optional<int32_t>> castTimestampToInt32(
+      Timestamp timestamp) const override;
+
+  Expected<int64_t> castTimestampToInt64(Timestamp timestamp) const override;
 
   /// When casting double as timestamp, the input is treated as
   /// the number of seconds since the epoch (1970-01-01 00:00:00 UTC).

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -284,6 +284,11 @@ TEST_F(SparkCastExprTest, stringToTimestamp) {
 }
 
 TEST_F(SparkCastExprTest, intToTimestamp) {
+  testCast<Timestamp, int8_t>("timestamp", {Timestamp(-1, 0)}, {std::nullopt});
+  testCast<Timestamp, int16_t>("timestamp", {Timestamp(-1, 0)}, {std::nullopt});
+  testCast<Timestamp, int32_t>("timestamp", {Timestamp(-1, 0)}, {std::nullopt});
+  testCast<Timestamp, int64_t>("timestamp", {Timestamp(-1, 0)}, {-1L});
+
   // Cast bigint as timestamp.
   testCast(
       makeNullableFlatVector<int64_t>({


### PR DESCRIPTION
Added ANSI support for casting timestamps to INT.

Part of:
https://github.com/apache/incubator-gluten/issues/10134