### PR TITLE
docs: Document convex_hull_agg and geometry_union_agg behavior with nulls and empty geometries

### DIFF
--- a/velox/docs/functions/presto/geospatial.rst
+++ b/velox/docs/functions/presto/geospatial.rst
@@ -223,13 +223,35 @@ Spatial Operations
 .. function:: geometry_union_agg(geometry: Geometry) -> union: Geometry
 
     Returns a geometry that represents the point set union of the aggregated
-    input geometries. Null geometries are ignored. Empty input returns null.
+    input geometries.
+
+    **Behavior with nulls and empty geometries:**
+    * Null geometries (SQL NULL values) are ignored and do not contribute to
+      the result.
+    * Empty geometries (e.g., ``POINT EMPTY``, ``LINESTRING EMPTY``) are
+      included in the aggregation. If all input geometries are empty, the
+      result is ``GEOMETRYCOLLECTION EMPTY``. If there is at least one
+      non-empty geometry, empty geometries are ignored and only non-empty
+      geometries contribute to the union.
+    * If there are no input rows (empty input), the function returns null.
 
 .. function:: convex_hull_agg(geometry: Geometry) -> union: Geometry
 
     Returns a geometry that represents the convex hull of the points in the
-    aggregated input geometries.  Null geometries are ignored. Empty input
-    returns null.
+    aggregated input geometries.
+
+    **Behavior with nulls and empty geometries:**
+    * Null geometries (SQL NULL values) are ignored and do not contribute to
+      the result.
+    * Empty geometries (e.g., ``POINT EMPTY``, ``LINESTRING EMPTY``) are
+      included in the aggregation. If all input geometries are empty, the
+      result is ``GEOMETRYCOLLECTION EMPTY``. If some inputs are empty and
+      some are non-empty, empty geometries are ignored and only non-empty
+      geometries contribute to the convex hull calculation.
+    * If there are no input rows (empty input), the function returns null.
+    * The convex hull is computed from all points in the non-empty input
+      geometries. If all input geometries are collinear points, the result
+      is a LINESTRING. If all points are the same, the result is a POINT.
 
 Accessors
 ---------


### PR DESCRIPTION
Closes #16055

## Summary
This PR enhances the documentation for `convex_hull_agg` and `geometry_union_agg` aggregate functions by explicitly describing their behavior with nulls, empty geometries, and edge cases.

## Changes
Added comprehensive documentation explaining:
- **Null geometries**: SQL NULL values are ignored and do not contribute to the result
- **Empty geometries**: Behavior when inputs are empty geometries (e.g., `POINT EMPTY`, `LINESTRING EMPTY`)
  - If all inputs are empty → returns `GEOMETRYCOLLECTION EMPTY`
  - If mixed with non-empty geometries → empty geometries are ignored
- **Empty input**: When there are no rows to aggregate, the function returns null
- **Additional details for `convex_hull_agg`**: Documented output types (LINESTRING for collinear points, POINT when all points are the same)

## Testing
The documented behavior is verified by existing tests in `GeometryAggregateTest.cpp`, which cover all the edge cases mentioned.

This documentation improvement addresses the requirement in issue #16055 to explicitly describe behavior with nulls, empty geometries, etc.