### PR TITLE
feat: Add Python code generation for RemoteFunction.thrift

### DIFF
--- a/velox/functions/remote/if/RemoteFunction.thrift
+++ b/velox/functions/remote/if/RemoteFunction.thrift
@@ -18,6 +18,7 @@ package "facebook.com/velox/functions"
 
 namespace cpp2 facebook.velox.functions.remote
 namespace java.swift com.facebook.spark.remotefunctionserver.api
+namespace py3 facebook.velox.functions.remote
 
 cpp_include "folly/io/IOBuf.h"
 


### PR DESCRIPTION
Summary:
This enables Python thrift types for RemoteFunctionPage and related structs.
Required for Python sink support in XStream pipelines, since CustomSink.thrift
depends on RemoteFunction.thrift for the RemoteFunctionPage type used in
SinkWriteRequest.

Differential Revision: D91050192


