### PR TITLE
perf(join): Allow parallelizing last probe in spilling mode

### DIFF
--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -740,6 +740,11 @@ class HashProbe : public Operator {
   // The index of the row container in the current hash table that this hash
   // probe oprator is processing to output build-side rows.
   int buildSideOutputRowContainerId_{-1};
+
+  // Flag to indicate whether this hash probe operator has more build-side rows
+  // to output for the current hash table. This flag is only used when
+  // `outputBuildRowsInParallel_` is true.
+  bool hasMoreBuildSideOutput_{true};
 };
 
 inline std::ostream& operator<<(std::ostream& os, ProbeOperatorState state) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2227,7 +2227,8 @@ bool Task::allPeersFinished(
     Driver* caller,
     ContinueFuture* future,
     std::vector<ContinuePromise>& promises,
-    std::vector<std::shared_ptr<Driver>>& peers) {
+    std::vector<std::shared_ptr<Driver>>& peers,
+    uint32_t barrierId) {
   std::lock_guard<std::timed_mutex> l(mutex_);
   if (exception_) {
     VELOX_FAIL(
@@ -2235,14 +2236,17 @@ bool Task::allPeersFinished(
         errorMessageImpl(exception_));
   }
   const auto splitGroupId = caller->driverCtx()->splitGroupId;
-  auto& barriers = splitGroupStates_[splitGroupId].barriers;
-  auto& state = barriers[planNodeId];
+  auto& barriers = splitGroupStates_[splitGroupId].barriers[planNodeId];
+  while (barriers.size() <= barrierId) {
+    barriers.emplace_back();
+  }
+  auto& state = barriers[barrierId];
 
   const auto numPeers = numDrivers(caller->driverCtx()->pipelineId);
   if (++state.numRequested == numPeers) {
     peers = std::move(state.drivers);
     promises = std::move(state.allPeersFinishedPromises);
-    barriers.erase(planNodeId);
+    state = {};
     return true;
   }
   std::shared_ptr<Driver> callerShared;

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -191,8 +191,9 @@ struct SplitGroupState {
   /// This map will contain all other custom bridges.
   std::unordered_map<core::PlanNodeId, std::shared_ptr<JoinBridge>>
       customBridges;
-  /// Holds states for Task::allPeersFinished.
-  std::unordered_map<core::PlanNodeId, BarrierState> barriers;
+  /// Holds states for Task::allPeersFinished. Each PlanNode can have multiple
+  /// barriers if needed.
+  std::unordered_map<core::PlanNodeId, std::vector<BarrierState>> barriers;
 
   /// Map of merge sources keyed on LocalMergeNode plan node ID.
   std::


### PR DESCRIPTION
Summary: A recent change in https://github.com/facebookincubator/velox/pull/15808 allows parallelizing the last probe for full and right joins when spilling is disabled. This diff extends it be allowing parallelized last probe when spilling is enabled too.

Differential Revision: D90908805


