### PR TITLE
fix: Update setup in KHyperLogLog Test

### DIFF
--- a/velox/functions/lib/tests/KHyperLogLogTest.cpp
+++ b/velox/functions/lib/tests/KHyperLogLogTest.cpp
@@ -35,8 +35,11 @@ const double kDefaultStandardError = 1.04 / std::sqrt(kDefaultNumBuckets);
 
 class KHyperLogLogTest : public ::testing::Test {
  public:
+  static void SetUpTestSuite() {
+    facebook::velox::memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    facebook::velox::memory::MemoryManager::initialize({});
     pool_ = facebook::velox::memory::memoryManager()->addLeafPool();
     hsa_ = std::make_unique<HashStringAllocator>(pool_.get());
     allocator_ = hsa_.get();


### PR DESCRIPTION
Pull Request resolved: https://github.com/facebookincubator/velox/pull/16076

MemoryManager::initialize() should only be called once per test suite not per individual test. Calling it in SetUp() can cause issues when the MemoryManager is already initialized from a previous test.

This change moves the MemoryManager initialization from per-test SetUp() to suite-level SetUpTestSuite() using testingSetInstance({}), matching the pattern used in HllAccumulatorTest.