### PR TITLE
feat: Implement file rollover at configurable size limit

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -211,6 +211,14 @@ uint64_t HiveConfig::sortWriterFinishTimeSliceLimitMs(
       kSortWriterFinishTimeSliceLimitMsSession,
       config_->get<uint64_t>(kSortWriterFinishTimeSliceLimitMs, 5'000));
 }
+uint64_t HiveConfig::maxTargetFileSizeBytes(
+    const config::ConfigBase* session) const {
+  return config::toCapacity(
+      session->get<std::string>(
+          kMaxTargetFileSizeSession,
+          config_->get<std::string>(kMaxTargetFileSize, "0B")),
+      config::CapacityUnit::BYTE);
+}
 
 uint64_t HiveConfig::footerEstimatedSize() const {
   return config_->get<uint64_t>(kFooterEstimatedSize, 256UL << 10);

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -178,6 +178,13 @@ class HiveConfig {
   static constexpr const char* kSortWriterFinishTimeSliceLimitMsSession =
       "sort_writer_finish_time_slice_limit_ms";
 
+  /// Maximum target file size. When a file exceeds this size during writing,
+  /// the writer will close the current file and start writing to a new file.
+  /// Accepts human-readable values like "1GB". Zero means no limit (default).
+  static constexpr const char* kMaxTargetFileSize = "max-target-file-size";
+  static constexpr const char* kMaxTargetFileSizeSession =
+      "max_target_file_size";
+
   // The unit for reading timestamps from files.
   static constexpr const char* kReadTimestampUnit =
       "hive.reader.timestamp-unit";
@@ -263,6 +270,8 @@ class HiveConfig {
 
   uint64_t sortWriterFinishTimeSliceLimitMs(
       const config::ConfigBase* session) const;
+
+  uint64_t maxTargetFileSizeBytes(const config::ConfigBase* session) const;
 
   uint64_t footerEstimatedSize() const;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -41,6 +41,48 @@ namespace {
   memory::NonReclaimableSectionGuard nonReclaimableGuard( \
       writerInfo_[(index)]->nonReclaimableSectionHolder.get())
 
+// Appends a sequence number to a filename for file rotation.
+// Returns the original filename if sequenceNumber is 0 (no rotation yet).
+// Example: "file.orc" with seq 0 remains "file.orc"
+// Example: "file.orc" with seq 2 becomes "file_2.orc"
+std::string makeSequencedFileName(
+    const std::string& filename,
+    uint32_t sequenceNumber) {
+  if (sequenceNumber == 0) {
+    return filename;
+  }
+  const auto dotPos = filename.rfind('.');
+  if (dotPos == std::string::npos) {
+    // No extension, just append the sequence number
+    return fmt::format("{}_{}", filename, sequenceNumber);
+  }
+  // Insert sequence number before the extension
+  return fmt::format(
+      "{}_{}{}",
+      filename.substr(0, dotPos),
+      sequenceNumber,
+      filename.substr(dotPos));
+}
+
+std::unique_ptr<dwio::common::FileSink> createHiveFileSink(
+    const std::string& path,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    memory::MemoryPool* sinkPool,
+    io::IoStatistics* ioStats,
+    filesystems::File::IoStats* fileSystemStats) {
+  return dwio::common::FileSink::create(
+      path,
+      {
+          .bufferWrite = false,
+          .connectorProperties = hiveConfig->config(),
+          .fileCreateConfig = hiveConfig->writeFileCreateConfig(),
+          .pool = sinkPool,
+          .metricLogger = dwio::common::MetricsLog::voidLog(),
+          .stats = ioStats,
+          .fileSystemStats = fileSystemStats,
+      });
+}
+
 // Returns the type of non-partition data columns.
 RowTypePtr getNonPartitionTypes(
     const std::vector<column_index_t>& dataCols,
@@ -477,10 +519,13 @@ HiveDataSink::HiveDataSink(
       sortWriterFinishTimeSliceLimitMs_(getFinishTimeSliceLimitMsFromHiveConfig(
           hiveConfig_,
           connectorQueryCtx->sessionProperties())),
+      maxTargetFileBytes_(hiveConfig_->maxTargetFileSizeBytes(
+          connectorQueryCtx->sessionProperties())),
       partitionKeyAsLowerCase_(hiveConfig_->isPartitionPathAsLowerCase(
           connectorQueryCtx_->sessionProperties())),
       fileNameGenerator_(insertTableHandle_->fileNameGenerator()) {
   fileSystemStats_ = std::make_unique<filesystems::File::IoStats>();
+
   if (isBucketed()) {
     VELOX_USER_CHECK_LT(
         bucketCount_,
@@ -576,6 +621,98 @@ void HiveDataSink::write(size_t index, RowVectorPtr input) {
   writers_[index]->write(dataInput);
   writerInfo_[index]->inputSizeInBytes += dataInput->estimateFlatSize();
   writerInfo_[index]->numWrittenRows += dataInput->size();
+
+  // File rotation is not supported for bucketed tables (require one file per
+  // bucket with predictable name) or sorted writes (SortingWriter not
+  // recreated).
+  if (maxTargetFileBytes_ == 0 || isBucketed() || sortWrite()) {
+    return;
+  }
+
+  const auto currentFileBytes = getCurrentFileBytes(index);
+  if (currentFileBytes >= maxTargetFileBytes_) {
+    rotateWriter(index);
+  }
+}
+
+uint64_t HiveDataSink::getCurrentFileBytes(size_t writerIndex) const {
+  VELOX_CHECK_LT(writerIndex, ioStats_.size());
+  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
+  const auto totalBytes = ioStats_[writerIndex]->rawBytesWritten();
+  const auto baselineBytes = writerInfo_[writerIndex]->cumulativeWrittenBytes;
+  // Sanity check: total should always be >= baseline since ioStats is
+  // never reset and cumulative is a snapshot of rawBytesWritten at rotation.
+  VELOX_DCHECK_GE(
+      totalBytes,
+      baselineBytes,
+      "rawBytesWritten ({}) < cumulativeWrittenBytes ({})",
+      totalBytes,
+      baselineBytes);
+  return totalBytes - baselineBytes;
+}
+
+void HiveDataSink::finalizeWriterFile(size_t index) {
+  VELOX_CHECK_LT(index, writerInfo_.size());
+  VELOX_CHECK_LT(index, ioStats_.size());
+
+  auto& info = writerInfo_[index];
+
+  // Capture current file stats AFTER close to include footer bytes.
+  const auto currentFileBytes = getCurrentFileBytes(index);
+
+  // Finalize the current file into writtenFiles using the stored names.
+  HiveFileInfo fileInfo;
+  fileInfo.writeFileName = info->currentWriteFileName;
+  fileInfo.targetFileName = info->currentTargetFileName;
+  fileInfo.fileSize = currentFileBytes;
+  info->writtenFiles.push_back(std::move(fileInfo));
+
+  // Update cumulative stats as a snapshot of total stats so far.
+  // This becomes the baseline for the next file.
+  info->cumulativeWrittenBytes = ioStats_[index]->rawBytesWritten();
+}
+
+// Rotates the current writer to a new file when the file size exceeds the
+// threshold. This enables writing multiple smaller files instead of one large
+// file, which improves downstream read performance and parallel processing.
+void HiveDataSink::rotateWriter(size_t index) {
+  VELOX_CHECK_LT(index, writers_.size());
+  VELOX_CHECK_LT(index, writerInfo_.size());
+
+  auto& info = writerInfo_[index];
+  const auto& originalParams = info->writerParameters;
+
+  // Close the writer first to flush all data including footer.
+  writers_[index]->close();
+
+  // Finalize the current file state.
+  finalizeWriterFile(index);
+
+  // Release old writer's memory pools before creating new writer.
+  writers_[index].reset();
+
+  ++info->fileSequenceNumber;
+
+  // Compute and store the new file names.
+  info->currentWriteFileName = makeSequencedFileName(
+      originalParams.writeFileName(), info->fileSequenceNumber);
+  info->currentTargetFileName = makeSequencedFileName(
+      originalParams.targetFileName(), info->fileSequenceNumber);
+
+  const auto writePath =
+      (fs::path(originalParams.writeDirectory()) / info->currentWriteFileName)
+          .string();
+
+  auto options = createWriterOptions(index);
+
+  writers_[index] = writerFactory_->createWriter(
+      createHiveFileSink(
+          writePath,
+          hiveConfig_,
+          info->sinkPool.get(),
+          ioStats_[index].get(),
+          fileSystemStats_.get()),
+      options);
 }
 
 std::string HiveDataSink::stateString(State state) {
@@ -625,23 +762,21 @@ DataSink::Stats HiveDataSink::stats() const {
     return stats;
   }
 
-  int64_t numWrittenBytes{0};
-  int64_t writeIOTimeUs{0};
   for (const auto& ioStats : ioStats_) {
-    numWrittenBytes += ioStats->rawBytesWritten();
-    writeIOTimeUs += ioStats->writeIOTimeUs();
+    stats.numWrittenBytes += ioStats->rawBytesWritten();
+    stats.writeIOTimeUs += ioStats->writeIOTimeUs();
   }
-  stats.numWrittenBytes = numWrittenBytes;
-  stats.writeIOTimeUs = writeIOTimeUs;
 
   if (state_ != State::kClosed) {
     return stats;
   }
 
-  stats.numWrittenFiles = writers_.size();
-  for (int i = 0; i < writerInfo_.size(); ++i) {
+  // Count total files written, including rotated files.
+  stats.numWrittenFiles = 0;
+  for (size_t i = 0; i < writerInfo_.size(); ++i) {
     const auto& info = writerInfo_.at(i);
     VELOX_CHECK_NOT_NULL(info);
+    stats.numWrittenFiles += info->writtenFiles.size();
     const auto spillStats = info->spillStats->rlock();
     if (!spillStats->empty()) {
       stats.spillStats += *spillStats;
@@ -749,6 +884,16 @@ std::vector<std::string> HiveDataSink::commitMessage() const {
   for (int i = 0; i < writerInfo_.size(); ++i) {
     const auto& info = writerInfo_.at(i);
     VELOX_CHECK_NOT_NULL(info);
+
+    // Build the fileWriteInfos array from all written files.
+    folly::dynamic fileWriteInfosArray = folly::dynamic::array;
+    for (const auto& fileInfo : info->writtenFiles) {
+      fileWriteInfosArray.push_back(
+          folly::dynamic::object("writeFileName", fileInfo.writeFileName)(
+              "targetFileName", fileInfo.targetFileName)(
+              "fileSize", fileInfo.fileSize));
+    }
+
     // clang-format off
       auto partitionUpdateJson = folly::toJson(
        folly::dynamic::object
@@ -758,11 +903,7 @@ std::vector<std::string> HiveDataSink::commitMessage() const {
               info->writerParameters.updateMode()))
           ("writePath", info->writerParameters.writeDirectory())
           ("targetPath", info->writerParameters.targetDirectory())
-          ("fileWriteInfos", folly::dynamic::array(
-            folly::dynamic::object
-              ("writeFileName", info->writerParameters.writeFileName())
-              ("targetFileName", info->writerParameters.targetFileName())
-              ("fileSize", ioStats_.at(i)->rawBytesWritten())))
+          ("fileWriteInfos", std::move(fileWriteInfosArray))
           ("rowCount", info->numWrittenRows)
           ("inMemoryDataSizeInBytes", info->inputSizeInBytes)
           ("onDiskDataSizeInBytes", ioStats_.at(i)->rawBytesWritten())
@@ -785,13 +926,24 @@ void HiveDataSink::closeInternal() {
   TestValue::adjust(
       "facebook::velox::connector::hive::HiveDataSink::closeInternal", this);
 
+  // NOTE: writers_[i] can be nullptr during file rotation. In rotateWriter(),
+  // we call writers_[index].reset() to release the old writer before creating
+  // a new one. If an error occurs during new writer creation, or if abort is
+  // called during this window, the writer slot may be empty.
   if (state_ == State::kClosed) {
     for (int i = 0; i < writers_.size(); ++i) {
+      if (writers_[i] == nullptr) {
+        continue;
+      }
       WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
       writers_[i]->close();
+      finalizeWriterFile(i);
     }
   } else {
     for (int i = 0; i < writers_.size(); ++i) {
+      if (writers_[i] == nullptr) {
+        continue;
+      }
       WRITER_NON_RECLAIMABLE_SECTION_GUARD(i);
       writers_[i]->abort();
     }
@@ -808,6 +960,14 @@ uint32_t HiveDataSink::ensureWriter(const HiveWriterId& id) {
 
 std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions()
     const {
+  // Default: use the last writer's info (for appendWriter which just added it)
+  return createWriterOptions(writerInfo_.size() - 1);
+}
+
+std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
+    size_t writerIndex) const {
+  VELOX_CHECK_LT(writerIndex, writerInfo_.size());
+
   // Take the writer options provided by the user as a starting point, or
   // allocate a new one.
   auto options = insertTableHandle_->writerOptions();
@@ -824,7 +984,7 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions()
   }
 
   if (options->memoryPool == nullptr) {
-    options->memoryPool = writerInfo_.back()->writerPool.get();
+    options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
   }
 
   if (!options->compressionKind) {
@@ -839,7 +999,7 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions()
   // Since insertTableHandle_->writerOptions() returns a shared_ptr, we need
   // to ensure each writer has its own nonReclaimableSection pointer.
   options->nonReclaimableSection =
-      writerInfo_.back()->nonReclaimableSectionHolder.get();
+      writerInfo_[writerIndex]->nonReclaimableSectionHolder.get();
 
   if (options->memoryReclaimerFactory == nullptr ||
       options->memoryReclaimerFactory() == nullptr) {
@@ -890,6 +1050,10 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
           std::move(writerPool),
           std::move(sinkPool),
           std::move(sortPool)));
+  // Set current file names for the initial file (sequence 0).
+  auto& newInfo = writerInfo_.back();
+  newInfo->currentWriteFileName = newInfo->writerParameters.writeFileName();
+  newInfo->currentTargetFileName = newInfo->writerParameters.targetFileName();
   ioStats_.emplace_back(std::make_unique<io::IoStatistics>());
 
   setMemoryReclaimers(writerInfo_.back().get(), ioStats_.back().get());
@@ -899,17 +1063,12 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   // Prevents the memory allocation during the writer creation.
   WRITER_NON_RECLAIMABLE_SECTION_GUARD(writerInfo_.size() - 1);
   auto writer = writerFactory_->createWriter(
-      dwio::common::FileSink::create(
+      createHiveFileSink(
           writePath,
-          {
-              .bufferWrite = false,
-              .connectorProperties = hiveConfig_->config(),
-              .fileCreateConfig = hiveConfig_->writeFileCreateConfig(),
-              .pool = writerInfo_.back()->sinkPool.get(),
-              .metricLogger = dwio::common::MetricsLog::voidLog(),
-              .stats = ioStats_.back().get(),
-              .fileSystemStats = fileSystemStats_.get(),
-          }),
+          hiveConfig_,
+          writerInfo_.back()->sinkPool.get(),
+          ioStats_.back().get(),
+          fileSystemStats_.get()),
       options);
   writer = maybeCreateBucketSortWriter(std::move(writer));
   writers_.emplace_back(std::move(writer));
@@ -953,6 +1112,7 @@ HiveDataSink::maybeCreateBucketSortWriter(
       connectorQueryCtx_->prefixSortConfig(),
       spillConfig_,
       writerInfo_.back()->spillStats.get());
+
   return std::make_unique<dwio::common::SortingWriter>(
       std::move(writer),
       std::move(sortBuffer),

--- a/velox/exec/fuzzer/WriterFuzzer.cpp
+++ b/velox/exec/fuzzer/WriterFuzzer.cpp
@@ -59,6 +59,13 @@ DEFINE_int32(
 
 DEFINE_int32(num_batches, 10, "The number of generated vectors.");
 
+DEFINE_string(
+    max_target_file_size,
+    "",
+    "Maximum target file size for testing file rotation. "
+    "If empty, randomly selects from various sizes (10KB-5MB) to test edge cases. "
+    "Set to a specific value like '1MB' to use a fixed size.");
+
 DEFINE_double(
     null_ratio,
     0.1,
@@ -149,6 +156,17 @@ class WriterFuzzer {
       const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortBy,
       const std::shared_ptr<TempDirectoryPath>& outputDirectoryPath);
 
+  // Verifies file rotation by writing with a small max target file size.
+  // This specifically tests the file split logic for non-bucketed,
+  // non-sorted tables.
+  void verifyFileRotation(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& names,
+      const std::vector<TypePtr>& types,
+      int32_t partitionOffset,
+      const std::vector<std::string>& partitionKeys,
+      const std::shared_ptr<TempDirectoryPath>& outputDirectoryPath);
+
   // Generates table column handles based on table column properties
   connector::ColumnHandleMap getTableColumnHandles(
       const std::vector<std::string>& names,
@@ -160,7 +178,8 @@ class WriterFuzzer {
   RowVectorPtr execute(
       const core::PlanNodePtr& plan,
       const int32_t maxDrivers = 2,
-      const std::vector<exec::Split>& splits = {});
+      const std::vector<exec::Split>& splits = {},
+      const std::string& maxTargetFileSizeBytes = "0B");
 
   RowVectorPtr veloxToPrestoResult(const RowVectorPtr& result);
 
@@ -265,6 +284,10 @@ class WriterFuzzer {
   const std::string injectedErrorMsg_{"Injected Faulty File Error"};
   std::atomic<uint64_t> injectedErrorCount_{0};
 
+  // Current max target file size for file rotation testing.
+  // Randomized per iteration to test various file split scenarios.
+  std::string currentMaxTargetFileSize_;
+
   FuzzerGenerator rng_;
   size_t currentSeed_{0};
   std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner_;
@@ -333,8 +356,20 @@ void WriterFuzzer::go() {
   }
 
   while (!isDone(iteration, startTime)) {
+    // Randomize max target file size for file rotation testing.
+    // Use small sizes to trigger file splits. Include very small sizes
+    // (10KB, 50KB) to force many splits and test edge cases.
+    const std::vector<std::string> fileSizes = {
+        "10KB", "50KB", "100KB", "500KB", "1MB", "2MB", "5MB"};
+    auto fileSizeIdx = boost::random::uniform_int_distribution<size_t>(
+        0, fileSizes.size() - 1)(rng_);
+    currentMaxTargetFileSize_ = FLAGS_max_target_file_size.empty()
+        ? fileSizes[fileSizeIdx]
+        : FLAGS_max_target_file_size;
+
     LOG(INFO) << "==============================> Started iteration "
-              << iteration << " (seed: " << currentSeed_ << ")";
+              << iteration << " (seed: " << currentSeed_
+              << ", maxTargetFileSize: " << currentMaxTargetFileSize_ << ")";
 
     std::vector<std::string> names;
     std::vector<TypePtr> types;
@@ -395,6 +430,21 @@ void WriterFuzzer::go() {
         sortColumnOffset,
         sortBy,
         outputDirPath);
+
+    // Test file rotation for non-bucketed, non-sorted tables.
+    // File rotation only works when bucketCount == 0 and sortBy is empty.
+    if (bucketCount == 0 && sortBy.empty()) {
+      const auto fileRotationOutputDirPath =
+          exec::test::TempDirectoryPath::create(
+              FLAGS_file_system_error_injection);
+      verifyFileRotation(
+          input,
+          names,
+          types,
+          partitionOffset,
+          partitionKeys,
+          fileRotationOutputDirPath);
+    }
 
     LOG(INFO) << "==============================> Done with iteration "
               << iteration++;
@@ -638,6 +688,132 @@ void WriterFuzzer::verifyWriter(
   LOG(INFO) << "Verified results against reference DB";
 }
 
+void WriterFuzzer::verifyFileRotation(
+    const std::vector<RowVectorPtr>& input,
+    const std::vector<std::string>& names,
+    const std::vector<TypePtr>& types,
+    const int32_t partitionOffset,
+    const std::vector<std::string>& partitionKeys,
+    const std::shared_ptr<TempDirectoryPath>& outputDirectoryPath) {
+  // Create a non-bucketed, non-sorted table write plan.
+  // File rotation only works for non-bucketed, non-sorted tables.
+  const auto plan = PlanBuilder()
+                        .values(input)
+                        .tableWrite(
+                            outputDirectoryPath->getPath(),
+                            partitionKeys,
+                            dwio::common::FileFormat::DWRF)
+                        .planNode();
+
+  const auto maxDrivers =
+      boost::random::uniform_int_distribution<int32_t>(1, 16)(rng_);
+  RowVectorPtr result;
+  const uint64_t prevInjectedErrorCount = injectedErrorCount_;
+  try {
+    result = veloxToPrestoResult(
+        execute(plan, maxDrivers, {}, currentMaxTargetFileSize_));
+  } catch (VeloxRuntimeError& error) {
+    if (injectedErrorCount_ == prevInjectedErrorCount) {
+      throw error;
+    }
+    VELOX_CHECK_GT(
+        injectedErrorCount_,
+        prevInjectedErrorCount,
+        "Unexpected writer fuzzer failure: {}",
+        error.message());
+    VELOX_CHECK_EQ(
+        error.message(), injectedErrorMsg_, "Unexpected writer fuzzer failure");
+    return;
+  }
+
+  const auto outputPath = outputDirectoryPath->getDelegatePath();
+
+  // 1. Count the number of files created to verify file rotation occurred.
+  const auto partitionNameAndFileCount =
+      getPartitionNameAndFilecount(outputPath);
+  int32_t totalFileCount = 0;
+  for (const auto& [partitionName, fileCount] : partitionNameAndFileCount) {
+    totalFileCount += fileCount;
+  }
+  LOG(INFO) << "File rotation: " << totalFileCount
+            << " files created with max target file size "
+            << currentMaxTargetFileSize_;
+
+  // 2. Verify the written data by reading it back.
+  auto splits = makeSplits(outputPath);
+  auto columnHandles =
+      getTableColumnHandles(names, types, partitionOffset, /*bucketCount=*/0);
+  const auto rowType = generateOutputType(names, types, /*bucketCount=*/0);
+
+  auto readPlan = PlanBuilder()
+                      .tableScan(rowType, {}, "", rowType, columnHandles)
+                      .planNode();
+  auto actual = execute(readPlan, maxDrivers, splits);
+
+  // 3. Compare row count with input.
+  int64_t expectedRowCount = 0;
+  for (const auto& batch : input) {
+    expectedRowCount += batch->size();
+  }
+  VELOX_CHECK_EQ(
+      actual->size(),
+      expectedRowCount,
+      "File rotation: Row count mismatch. Expected {}, got {}",
+      expectedRowCount,
+      actual->size());
+
+  // 4. Verify the actual data content matches the input.
+  std::vector<RowVectorPtr> expectedBatches;
+  expectedBatches.reserve(input.size());
+  for (const auto& batch : input) {
+    std::vector<VectorPtr> children;
+    children.reserve(batch->childrenSize());
+    for (int32_t i = 0; i < partitionOffset; ++i) {
+      children.push_back(batch->childAt(i));
+    }
+    for (int32_t i = partitionOffset; i < batch->childrenSize(); ++i) {
+      children.push_back(batch->childAt(i));
+    }
+    expectedBatches.push_back(
+        std::make_shared<RowVector>(
+            pool_.get(), rowType, nullptr, batch->size(), std::move(children)));
+  }
+
+  VELOX_CHECK(
+      assertEqualResults(expectedBatches, {actual}),
+      "File rotation: Data content mismatch between written and read-back data");
+
+  // 5. Compare with Presto as the source of truth.
+  try {
+    referenceQueryRunner_->execute("DROP TABLE IF EXISTS tmp_write");
+  } catch (...) {
+    LOG(WARNING) << "Drop table query failed in the reference DB";
+    return;
+  }
+
+  auto prestoResult = referenceQueryRunner_->execute(plan);
+  if (!prestoResult.first.has_value()) {
+    LOG(WARNING) << "Presto write query failed, skipping comparison";
+    return;
+  }
+
+  VELOX_CHECK(
+      assertEqualResults(*prestoResult.first, plan->outputType(), {result}),
+      "File rotation: Velox and Presto row counts don't match");
+
+  try {
+    auto prestoData = referenceQueryRunner_->execute("SELECT * FROM tmp_write");
+    VELOX_CHECK(
+        assertEqualResults(prestoData, {actual}),
+        "File rotation: Velox and Presto data don't match");
+  } catch (...) {
+    LOG(WARNING) << "Query failed in the reference DB";
+    return;
+  }
+
+  LOG(INFO) << "File rotation verification succeeded";
+}
+
 connector::ColumnHandleMap WriterFuzzer::getTableColumnHandles(
     const std::vector<std::string>& names,
     const std::vector<TypePtr>& types,
@@ -672,7 +848,8 @@ connector::ColumnHandleMap WriterFuzzer::getTableColumnHandles(
 RowVectorPtr WriterFuzzer::execute(
     const core::PlanNodePtr& plan,
     const int32_t maxDrivers,
-    const std::vector<exec::Split>& splits) {
+    const std::vector<exec::Split>& splits,
+    const std::string& maxTargetFileSizeBytes) {
   LOG(INFO) << "Executing query plan: " << std::endl
             << plan->toString(true, true);
   fuzzer::ResultOrError resultOrError;
@@ -685,6 +862,10 @@ RowVectorPtr WriterFuzzer::execute(
           kHiveConnectorId,
           connector::hive::HiveConfig::kMaxPartitionsPerWritersSession,
           "400")
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          connector::hive::HiveConfig::kMaxTargetFileSizeSession,
+          maxTargetFileSizeBytes)
       .copyResults(pool_.get());
 }
 


### PR DESCRIPTION
Summary:
**Context**:

Large file causes warm storage local throttling issues due to hot blocks (It triggers FFRs). In such cases, the footer block is accessed by lot of workers, given most of them are assigned split from the same file and have to read footer to do further processing. More analysis / details in this [doc](https://docs.google.com/document/d/1JMeStVrE1Kqx2JA-mQwmwgr8rt9I3ZfR4f8IPC8CGMI/edit?tab=t.0#bookmark=kix.mdel4wv8eoh5). Also few relevant tasks: T249501068 and T241325745

**Fix:**
In this proposal I am introducing a default config / session property which can be used to rotate writer and write smaller files when they exceed the limit. From our [earlier analysis](https://docs.google.com/document/d/1JMeStVrE1Kqx2JA-mQwmwgr8rt9I3ZfR4f8IPC8CGMI/edit?tab=t.0#bookmark=id.vhojfp8w1lto) p99.5 <= 1GB and in these cases we haven't see throttling issues.

Differential Revision: D89820483


