### PR TITLE
refactor(trace): Rename TraceConfig to TraceCtx

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -62,7 +62,7 @@ velox_add_library(
   SpatialJoinBuild.cpp
   SpatialJoinProbe.cpp
   Operator.cpp
-  OperatorTraceConfig.cpp
+  OperatorTraceCtx.cpp
   OperatorTraceReader.cpp
   OperatorTraceScan.cpp
   OperatorTraceWriter.cpp

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -96,8 +96,8 @@ const core::QueryConfig& DriverCtx::queryConfig() const {
   return task->queryCtx()->queryConfig();
 }
 
-const trace::TraceConfig* DriverCtx::traceConfig() const {
-  return task->traceConfig();
+const trace::TraceCtx* DriverCtx::traceCtx() const {
+  return task->traceCtx();
 }
 
 velox::memory::MemoryPool* DriverCtx::addOperatorPool(

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -27,7 +27,7 @@
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/core/PlanFragment.h"
 #include "velox/exec/BlockingReason.h"
-#include "velox/exec/trace/TraceConfig.h"
+#include "velox/exec/trace/TraceCtx.h"
 
 namespace facebook::velox::exec {
 
@@ -248,7 +248,7 @@ struct DriverCtx {
 
   const core::QueryConfig& queryConfig() const;
 
-  const trace::TraceConfig* traceConfig() const;
+  const trace::TraceCtx* traceCtx() const;
 
   velox::memory::MemoryPool* addOperatorPool(
       const core::PlanNodeId& planNodeId,

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -94,8 +94,8 @@ Operator::Operator(
       outputType_(std::move(outputType)),
       spillConfig_(std::move(spillConfig)),
       dryRun_(
-          operatorCtx_->driverCtx()->traceConfig() &&
-          operatorCtx_->driverCtx()->traceConfig()->dryRun()),
+          operatorCtx_->driverCtx()->traceCtx() &&
+          operatorCtx_->driverCtx()->traceCtx()->dryRun()),
       stats_(
           OperatorStats{
               operatorId,
@@ -114,13 +114,13 @@ void Operator::maybeSetReclaimer() {
 }
 
 void Operator::maybeSetTracer() {
-  const auto* traceConfig = operatorCtx_->driverCtx()->traceConfig();
+  const auto* traceCtx = operatorCtx_->driverCtx()->traceCtx();
 
-  if (traceConfig && traceConfig->shouldTrace(*this)) {
+  if (traceCtx && traceCtx->shouldTrace(*this)) {
     if (dynamic_cast<SourceOperator*>(this) != nullptr) {
-      splitTracer_ = traceConfig->createSplitTracer(*this);
+      splitTracer_ = traceCtx->createSplitTracer(*this);
     } else {
-      inputTracer_ = traceConfig->createInputTracer(*this);
+      inputTracer_ = traceCtx->createInputTracer(*this);
     }
   }
 }

--- a/velox/exec/OperatorTraceCtx.h
+++ b/velox/exec/OperatorTraceCtx.h
@@ -18,7 +18,7 @@
 
 #include "velox/core/PlanFragment.h"
 #include "velox/core/QueryCtx.h"
-#include "velox/exec/trace/TraceConfig.h"
+#include "velox/exec/trace/TraceCtx.h"
 
 namespace facebook::velox::exec::trace {
 
@@ -30,16 +30,16 @@ class TraceSplitWriter;
 /// bytes exceed the set limit otherwise return false.
 using UpdateAndCheckTraceLimitCB = std::function<void(uint64_t)>;
 
-class OperatorTraceConfig : public TraceConfig {
+class OperatorTraceCtx : public TraceCtx {
  public:
-  OperatorTraceConfig(
+  OperatorTraceCtx(
       std::string queryNodeId,
       std::string queryTraceDir,
       UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB,
       std::string taskRegExp,
       bool dryRun);
 
-  static std::unique_ptr<OperatorTraceConfig> maybeCreate(
+  static std::unique_ptr<OperatorTraceCtx> maybeCreate(
       core::QueryCtx& queryCtx,
       const core::PlanFragment& planFragment,
       const std::string& taskId);

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -18,9 +18,9 @@
 
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
-#include "velox/exec/OperatorTraceConfig.h"
+#include "velox/exec/OperatorTraceCtx.h"
 #include "velox/exec/Split.h"
-#include "velox/exec/trace/TraceConfig.h"
+#include "velox/exec/trace/TraceCtx.h"
 #include "velox/exec/trace/TraceWriter.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/vector/VectorStream.h"

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -27,7 +27,7 @@
 #include "velox/exec/ScaledScanController.h"
 #include "velox/exec/TaskStats.h"
 #include "velox/exec/TaskStructs.h"
-#include "velox/exec/trace/TraceConfig.h"
+#include "velox/exec/trace/TraceCtx.h"
 #include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::exec {
@@ -153,8 +153,8 @@ class Task : public std::enable_shared_from_this<Task> {
   }
 
   /// Returns query trace config if specified.
-  const trace::TraceConfig* traceConfig() const {
-    return traceConfig_.get();
+  const trace::TraceCtx* traceCtx() const {
+    return traceCtx_.get();
   }
 
   /// Returns ConsumerSupplier passed in the constructor.
@@ -1118,7 +1118,7 @@ class Task : public std::enable_shared_from_this<Task> {
       int32_t pipelineId) const;
 
   // Builds the query trace config.
-  std::unique_ptr<trace::TraceConfig> maybeMakeTraceConfig() const;
+  std::unique_ptr<trace::TraceCtx> maybeMakeTraceCtx() const;
 
   // Create a 'QueryMetadtaWriter' to trace the query metadata if the query
   // trace enabled.
@@ -1165,7 +1165,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // and all its plan nodes support barrier processing.
   const core::PlanNode* firstNodeNotSupportingBarrier_{};
 
-  const std::unique_ptr<trace::TraceConfig> traceConfig_;
+  const std::unique_ptr<trace::TraceCtx> traceCtx_;
 
   inline static std::atomic_uint64_t numCreatedTasks_;
 

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -27,11 +27,11 @@ class Operator;
 
 namespace facebook::velox::exec::trace {
 
-class TraceConfig {
+class TraceCtx {
  public:
-  TraceConfig(bool dryRun) : dryRun_(dryRun) {}
+  TraceCtx(bool dryRun) : dryRun_(dryRun) {}
 
-  virtual ~TraceConfig() = default;
+  virtual ~TraceCtx() = default;
 
   virtual std::unique_ptr<trace::TraceInputWriter> createInputTracer(
       Operator& op) const = 0;


### PR DESCRIPTION
Summary:
As a follow up from https://github.com/facebookincubator/velox/pull/16074
renaming TraceConfig to TraceCtx reflect its new purpose. No logic changes,
just renaming.

Differential Revision: D91148323
