### PR TITLE
 test case velox_exec_test spillPartitionBitsOverlap to debug seed-dependent behaviour

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1198,6 +1198,8 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
           folly::Range(mapping.data(), outputBatchSize),
           folly::Range(outputTableRows, outputBatchSize),
           operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes());
+      LOG(INFO) << "ManuHP.listJoinResults inputSize=" << inputSize
+                << " batchOutputRowsBeforeFilter=" << numOut;
     }
 
     // We are done processing the input batch if there are no more joined rows
@@ -1210,6 +1212,7 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
     VELOX_CHECK_LE(numOut, outputBatchSize);
 
     numOut = evalFilter(numOut);
+    LOG(INFO) << "ManuHP.afterFilter batchOutputRowsAfterFilter=" << numOut;
 
     if (numOut == 0) {
       // The hash probe might get stuck in the output loop if the filter is

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -190,6 +190,13 @@ std::shared_ptr<Task> AssertQueryBuilder::assertResults(
   VELOX_CHECK_NOT_NULL(duckDbQueryRunner_);
 
   auto [cursor, results] = readCursor();
+  uint64_t totalRows{0};
+  for (const auto& batch : results) {
+    totalRows += batch->size();
+  }
+  LOG(INFO) << "ManuAQB resultRowCount rows=" << totalRows
+            << " batches=" << results.size();
+
   if (results.empty()) {
     test::assertResults(results, ROW({}, {}), duckDbSql, *duckDbQueryRunner_);
   } else if (sortingKeys.has_value()) {

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -73,7 +73,6 @@ const std::vector<TypePtr>& defaultScalarTypes();
 ///      fuzzer.fuzzArray(
 ///          fuzzer.fuzzConstant(DOUBLE(), 40), 100),
 ///      10);
-///
 class VectorFuzzer {
  public:
   struct Options {
@@ -183,7 +182,13 @@ class VectorFuzzer {
       const VectorFuzzer::Options& options,
       memory::MemoryPool* pool,
       size_t seed = 123456)
-      : opts_(options), pool_(pool), rng_(seed) {}
+      : opts_(options), pool_(pool), rng_(seed) {
+        const char* name = "INJECT_BASE_SEED";
+        const char* env_p = getenv(name);
+        if (env_p) {
+          rng_.seed(atoi(env_p));
+        }
+      }
 #if defined(__GNUC__) && \
     ((__GNUC__ > 12) || (__GNUC__ == 12 && __GNUC_MINOR__ >= 4))
   VELOX_UNSUPPRESS_STRINGOP_OVERFLOW_WARNING


### PR DESCRIPTION
  - Add INJECT_BASE_SEED seeding in VectorFuzzer (VectorFuzzer.h:170–179) so we can reproduce the same fuzzer output per seed on a given platform.
  - Log fuzzer encoding decisions in VectorFuzzer::fuzz (ManuVF.fuzzBranch type=... tookConstant=0/1) to see when BIGINT keys take the constant path.
  - Log per-batch join output in HashProbe::getOutputInternal (ManuHP.listJoinResults / ManuHP.afterFilter) to track how many rows each batch contributes.
  - Log final result rows and batch count in AssertQueryBuilder (ManuAQB resultRowCount rows=... batches=...) to correlate seeds with total join cardinality (3–6K vs 3.3M–4.4M rows).

  This commit only adds Velox-side, test-only instrumentation; it does not change hash join or spill semantics. In a separate Folly change we switched to a consistent RNG so behaviour is now aligned across ARM/AMD; this patch
  helps analyse the remaining seed-dependent behaviour of this benchmark.