### PR TITLE
test: QueryAssertions: fix BLOCK_SIZE macro collision

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -22,6 +22,9 @@
 #include "velox/exec/Operator.h"
 #include "velox/vector/ComplexVector.h"
 
+#ifdef BLOCK_SIZE
+#undef BLOCK_SIZE
+#endif
 #include <duckdb.hpp> // @manual
 
 namespace facebook::velox::exec::test {


### PR DESCRIPTION
Summary: With BLOCK_SIZE in linux/fs.h

Differential Revision: D91241763


