### PR TITLE
feat(trace): Support custom trace provider

### DIFF
--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -53,7 +53,8 @@ std::shared_ptr<QueryCtx> QueryCtx::Builder::build() {
       std::move(pool_),
       spillExecutor_,
       std::move(queryId_),
-      std::move(tokenProvider_)));
+      std::move(tokenProvider_),
+      std::move(traceCtxProvider_)));
   queryCtx->maybeSetReclaimer();
   for (auto& cb : releaseCallbacks_) {
     queryCtx->addReleaseCallback(std::move(cb));
@@ -70,7 +71,8 @@ QueryCtx::QueryCtx(
     std::shared_ptr<memory::MemoryPool> pool,
     folly::Executor* spillExecutor,
     const std::string& queryId,
-    std::shared_ptr<filesystems::TokenProvider> tokenProvider)
+    std::shared_ptr<filesystems::TokenProvider> tokenProvider,
+    TraceCtxProvider traceCtxProvider)
     : queryId_(queryId),
       executor_(executor),
       spillExecutor_(spillExecutor),
@@ -78,7 +80,8 @@ QueryCtx::QueryCtx(
       connectorSessionProperties_(connectorSessionProperties),
       pool_(std::move(pool)),
       queryConfig_{std::move(queryConfig)},
-      fsTokenProvider_(std::move(tokenProvider)) {
+      fsTokenProvider_(std::move(tokenProvider)),
+      traceCtxProvider_(std::move(traceCtxProvider)) {
   initPool(queryId);
 }
 

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -26,7 +26,13 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/VectorPool.h"
 
+namespace facebook::velox::exec::trace {
+class TraceCtx;
+}
+
 namespace facebook::velox::core {
+
+struct PlanFragment;
 
 /// Query execution context that manages resources and configuration for a
 /// query.
@@ -72,6 +78,9 @@ namespace facebook::velox::core {
 class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
  public:
   using ReleaseCallback = std::function<void()>;
+  using TraceCtxProvider = std::function<std::unique_ptr<exec::trace::TraceCtx>(
+      core::QueryCtx&,
+      const core::PlanFragment&)>;
 
   ~QueryCtx();
 
@@ -173,6 +182,11 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
       return *this;
     }
 
+    Builder& traceCtxProvider(TraceCtxProvider provider) {
+      traceCtxProvider_ = std::move(provider);
+      return *this;
+    }
+
     /// Constructs and returns a QueryCtx with the configured parameters.
     ///
     /// @return Shared pointer to the newly created QueryCtx instance
@@ -189,6 +203,7 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
     std::string queryId_;
     std::shared_ptr<filesystems::TokenProvider> tokenProvider_;
     std::deque<ReleaseCallback> releaseCallbacks_;
+    TraceCtxProvider traceCtxProvider_;
   };
 
   /// Generates a unique memory pool name for a query.
@@ -294,6 +309,10 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   /// the max query trace bytes limit.
   void updateTracedBytesAndCheckLimit(uint64_t bytes);
 
+  TraceCtxProvider traceCtxProvider() {
+    return traceCtxProvider_;
+  }
+
   void testingOverrideMemoryPool(std::shared_ptr<memory::MemoryPool> pool) {
     pool_ = std::move(pool);
   }
@@ -322,7 +341,8 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       folly::Executor* spillExecutor = nullptr,
       const std::string& queryId = "",
-      std::shared_ptr<filesystems::TokenProvider> tokenProvider = {});
+      std::shared_ptr<filesystems::TokenProvider> tokenProvider = {},
+      TraceCtxProvider traceCtxProvider = nullptr);
 
   class MemoryReclaimer : public memory::MemoryReclaimer {
    public:
@@ -401,6 +421,9 @@ class QueryCtx : public std::enable_shared_from_this<QueryCtx> {
   std::shared_ptr<filesystems::TokenProvider> fsTokenProvider_;
   // Callbacks invoked before destruction to clean up external resources.
   std::deque<ReleaseCallback> releaseCallbacks_;
+
+  // A function that constructs a custom trace ctx object.
+  TraceCtxProvider traceCtxProvider_;
 };
 
 // Represents the state of one thread of query execution.

--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include <vector>
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/trace/TraceCtx.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::trace::test {
+namespace {
+
+using exec::test::AssertQueryBuilder;
+using exec::test::PlanBuilder;
+using velox::test::assertEqualVectors;
+
+using TCapturedVectors = std::unordered_map<core::PlanNodeId, VectorPtr>;
+
+// A custom test trace implementation that only captures pointers to internal
+// vectors. It only traces operators from `traceIds`, and assumes
+// single-threaded execution. Vectors are captured in TCapturedVectors.
+class TestTraceCtx : public TraceCtx {
+ public:
+  TestTraceCtx(
+      const std::vector<core::PlanNodeId>& tracedIds,
+      TCapturedVectors& tracedVectors)
+      : TraceCtx(false),
+        tracedIds_(tracedIds.begin(), tracedIds.end()),
+        tracedVectors_(tracedVectors) {}
+
+  bool shouldTrace(const Operator& op) const override {
+    return tracedIds_.contains(op.planNodeId());
+  }
+
+  class TestTraceInputWriter : public TraceInputWriter {
+   public:
+    TestTraceInputWriter(
+        const core::PlanNodeId& planId,
+        TCapturedVectors& tracedVectors)
+        : planId_(planId), tracedVectors_(tracedVectors) {}
+
+    void write(const RowVectorPtr& rows) override {
+      tracedVectors_[planId_] = rows;
+    }
+
+    void finish() override {}
+
+   private:
+    const core::PlanNodeId planId_;
+    TCapturedVectors& tracedVectors_;
+  };
+
+  std::unique_ptr<TraceInputWriter> createInputTracer(
+      Operator& op) const override {
+    return std::make_unique<TestTraceInputWriter>(
+        op.planNodeId(), tracedVectors_);
+  }
+
+ private:
+  std::unordered_set<core::PlanNodeId> tracedIds_;
+
+  TCapturedVectors& tracedVectors_;
+};
+
+class CustomTraceTest : public exec::test::HiveConnectorTestBase {};
+
+TEST_F(CustomTraceTest, customTrace) {
+  auto vector = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+
+  core::PlanNodeId traceNodeId1;
+  core::PlanNodeId traceNodeId2;
+
+  // Trace the inputs from two operators.
+  auto plan = PlanBuilder()
+                  .values({vector})
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(traceNodeId1)
+                  .project({"a * 10 as a"})
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(traceNodeId2)
+                  .planNode();
+
+  TCapturedVectors tracedVectors;
+  auto queryCtx =
+      core::QueryCtx::Builder()
+          .executor(executor_.get())
+          .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+            return std::make_unique<TestTraceCtx>(
+                std::vector<core::PlanNodeId>{traceNodeId1, traceNodeId2},
+                tracedVectors);
+          })
+          .build();
+
+  std::shared_ptr<Task> task;
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kQueryTraceEnabled, true)
+      .queryCtx(queryCtx)
+      .countResults(task);
+
+  auto it1 = tracedVectors.find(traceNodeId1);
+  auto it2 = tracedVectors.find(traceNodeId2);
+
+  ASSERT_TRUE(it1 != tracedVectors.end());
+  ASSERT_TRUE(it2 != tracedVectors.end());
+
+  auto expected1 = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(10, [](auto row) { return row; })});
+  auto expected2 = makeRowVector(
+      {"a"},
+      {makeFlatVector<int64_t>(10, [](auto row) { return row * 10 * 10; })});
+
+  assertEqualVectors(it1->second, expected1);
+  assertEqualVectors(it2->second, expected2);
+
+  // Vectors need to be destructed before the pool in the task dies.
+  tracedVectors.clear();
+}
+
+} // namespace
+} // namespace facebook::velox::exec::trace::test

--- a/velox/exec/trace/TraceCtx.h
+++ b/velox/exec/trace/TraceCtx.h
@@ -33,16 +33,28 @@ class TraceCtx {
 
   virtual ~TraceCtx() = default;
 
+  /// Overwrite the methods below to provide a concrete trace writer
+  /// implementation for input, split, and task metadata.
   virtual std::unique_ptr<trace::TraceInputWriter> createInputTracer(
-      Operator& op) const = 0;
+      Operator&) const {
+    return nullptr;
+  }
 
   virtual std::unique_ptr<trace::TraceSplitWriter> createSplitTracer(
-      Operator& op) const = 0;
+      Operator&) const {
+    return nullptr;
+  }
 
   virtual std::unique_ptr<trace::TraceMetadataWriter> createMetadataTracer()
-      const = 0;
+      const {
+    return nullptr;
+  }
 
-  virtual bool shouldTrace(const Operator& op) const = 0;
+  /// Whether a particular operator should be traced. Called before the task
+  /// starts execution, when operators are instantiated.
+  virtual bool shouldTrace(const Operator&) const {
+    return false;
+  }
 
   bool dryRun() const {
     return dryRun_;


### PR DESCRIPTION
Summary:
Add a provider callback to QueryCtx to enable users to provide a
custom TraceCtx specialization. Adding a unit test to exercise this behavior.

Differential Revision: D91253979


