### PR TITLE
fix(ci): Trigger to run clang-tidy

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -198,7 +198,7 @@ jobs:
       # need to run clang-tidy for that.
       # Let's also run this as last step so that if skipped it doesn't affect subsequent steps.
       - name: Install and run clang-tidy
-        if: ${{ ! inputs.use-clang }}
+        if: ${{ ! inputs.use-clang && needs.get-changes.outputs.run-clang-tidy == 'true' }}
         env:
           FILES: ${{ needs.get-changes.outputs.changed-files }}
           RANGE: ${{ needs.get-changes.outputs.diff-range }}


### PR DESCRIPTION
When the clang-tidy step was moved to the adapters build, the check to whether or not run clang-tidy determined the get-changes job was not ported. This resulted in running the clang-tidy job on the push trigger which has no commit range resulting in failure.

Addresses: https://github.com/facebookincubator/velox/issues/16094