### PR TITLE
feat: Add resolveVectorFunctionWithMetadataWithCoercions

### DIFF
--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -198,6 +198,19 @@ resolveVectorFunctionWithMetadata(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Like 'resolveVectorFunctionWithMetadata', but with support for applying type
+/// coercions if no signature matches 'argTypes' exactly.
+///
+/// @param coercions A list of optional type coercions that were applied to
+/// resolve the function successfully. Contains one entry per argument. The
+/// entry is null if no coercion is required for that argument. The entry is not
+/// null if coercion is necessary.
+std::optional<std::pair<TypePtr, VectorFunctionMetadata>>
+resolveVectorFunctionWithMetadataWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions);
+
 /// Returns an instance of VectorFunction for the given name, input types and
 /// optionally constant input values.
 /// constantInputs should be empty if there are no constant inputs.

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -250,6 +250,15 @@ resolveVectorFunctionWithMetadata(
   return exec::resolveVectorFunctionWithMetadata(functionName, argTypes);
 }
 
+std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
+resolveVectorFunctionWithMetadataWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions) {
+  return exec::resolveVectorFunctionWithMetadataWithCoercions(
+      functionName, argTypes, coercions);
+}
+
 void removeFunction(const std::string& functionName) {
   exec::mutableSimpleFunctions().removeFunction(functionName);
   exec::vectorFunctionFactories().withWLock(

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -150,6 +150,19 @@ resolveVectorFunctionWithMetadata(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes);
 
+/// Like 'resolveVectorFunctionWithMetadata', but with support for applying type
+/// coercions if no signature matches 'argTypes' exactly.
+///
+/// @param coercions A list of optional type coercions that were applied to
+/// resolve the function successfully. Contains one entry per argument. The
+/// entry is null if no coercion is required for that argument. The entry is not
+/// null if coercion is necessary.
+std::optional<std::pair<TypePtr, exec::VectorFunctionMetadata>>
+resolveVectorFunctionWithMetadataWithCoercions(
+    const std::string& functionName,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions);
+
 /// Given name of a function, removes it from both the simple and vector
 /// function registries (including all signatures).
 void removeFunction(const std::string& functionName);


### PR DESCRIPTION
Summary:
Add a new function `resolveVectorFunctionWithMetadataWithCoercions` that combines the functionality of `resolveVectorFunctionWithMetadata` and `resolveVectorFunctionWithCoercions`. This function returns both the return type and metadata for a vector function while also supporting type coercions when no signature matches the argument types exactly.

This is useful for callers that need function metadata (e.g., deterministic flag) in addition to the resolved return type when working with implicit type coercions.

Additionally, refactored `resolveVectorFunctionWithCoercions` to reuse `resolveVectorFunctionWithMetadataWithCoercions` internally, reducing code duplication.

Differential Revision: D91273969


