### PR TITLE
fix: Fix OSS Asan error in FlatMapVectorTest

### DIFF
--- a/velox/vector/tests/FlatMapVectorTest.cpp
+++ b/velox/vector/tests/FlatMapVectorTest.cpp
@@ -153,9 +153,9 @@ TEST_F(FlatMapVectorTest, encodedKeys) {
     EXPECT_EQ(mapValues->valueAt(0), 7);
     EXPECT_EQ(mapValues->valueAt(1), 8);
     EXPECT_EQ(mapValues->valueAt(2), 9);
-    EXPECT_EQ(flatMap->projectKey(1)->as<FlatVector<int32_t>>(), nullptr);
-    EXPECT_EQ(flatMap->projectKey(3)->as<FlatVector<int32_t>>(), nullptr);
-    EXPECT_EQ(flatMap->projectKey(5)->as<FlatVector<int32_t>>(), nullptr);
+    EXPECT_EQ(flatMap->projectKey(1), nullptr);
+    EXPECT_EQ(flatMap->projectKey(3), nullptr);
+    EXPECT_EQ(flatMap->projectKey(5), nullptr);
 
     // Repeated keys
     flatMap = constructFlatMap(
@@ -165,8 +165,7 @@ TEST_F(FlatMapVectorTest, encodedKeys) {
             3,
             makeFlatVector<int32_t>({1, 2, 3})));
 
-    mapValues = flatMap->projectKey(1)->as<FlatVector<int32_t>>();
-    EXPECT_EQ(mapValues, nullptr);
+    EXPECT_EQ(flatMap->projectKey(1), nullptr);
     mapValues = flatMap->projectKey(2)->as<FlatVector<int32_t>>();
     EXPECT_EQ(mapValues->size(), 3);
     EXPECT_EQ(mapValues->valueAt(0), 7); // Becomes last set vector
@@ -188,10 +187,8 @@ TEST_F(FlatMapVectorTest, encodedKeys) {
     EXPECT_EQ(mapValues->valueAt(0), 7); // Becomes last set vector
     EXPECT_EQ(mapValues->valueAt(1), 8);
     EXPECT_EQ(mapValues->valueAt(2), 9);
-    mapValues = flatMap->projectKey(2)->as<FlatVector<int32_t>>();
-    EXPECT_EQ(mapValues, nullptr);
-    mapValues = flatMap->projectKey(3)->as<FlatVector<int32_t>>();
-    EXPECT_EQ(mapValues, nullptr);
+    EXPECT_EQ(flatMap->projectKey(2), nullptr);
+    EXPECT_EQ(flatMap->projectKey(3), nullptr);
   }
 }
 


### PR DESCRIPTION
Differential Revision: D91275269

```
=================================================================
==4058438==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000a563a4 bp 0x7ffd54ee5bc0 sp 0x7ffd54ee5aa0 T0)
==4058438==The signal is caused by a READ memory access.
==4058438==Hint: address points to the zero page.
    #0 0x000000a563a4 in facebook::velox::FlatVector<int>* facebook::velox::BaseVector::as<facebook::velox::FlatVector<int>>() /velox/./velox/vector/BaseVector.h:116:12
    #1 0x000000a563a4 in facebook::velox::test::(anonymous namespace)::FlatMapVectorTest_encodedKeys_Test::TestBody() /velox/velox/vector/tests/FlatMapVectorTest.cpp:156:5
    #2 0x70874f90ce0b  (/lib64/libgtest.so.1.11.0+0x4fe0b) (BuildId: 506b2df0fc901091ff83631fd797a325cae6b679)
    #3 0x70874f8ed825 in testing::Test::Run() (/lib64/libgtest.so.1.11.0+0x30825) (BuildId: 506b2df0fc901091ff83631fd797a325cae6b679)
    #4 0x70874f8ed9ef in testing::TestInfo::Run() (/lib64/libgtest.so.1.11.0+0x309ef) (BuildId: 506b2df0fc901091ff83631fd797a325cae6b679)
    #5 0x70874f8edaf8 in testing::TestSuite::Run() (/lib64/libgtest.so.1.11.0+0x30af8) (BuildId: 506b2df0fc901091ff83631fd797a325cae6b679)
    #6 0x70874f8fcfc4 in testing::internal::UnitTestImpl::RunAllTests() (/lib64/libgtest.so.1.11.0+0x3ffc4) (BuildId: 506b2df0fc901091ff83631fd797a325cae6b679)
    #7 0x70874f8fa7c7 in testing::UnitTest::Run() (/lib64/libgtest.so.1.11.0+0x3d7c7) (BuildId: 506b2df0fc901091ff83631fd797a325cae6b679)
    #8 0x70877c073153 in main (/lib64/libgtest_main.so.1.11.0+0x1153) (BuildId: c3a576d37d6cfc6875afdc98684c143107a226a0)
    #9 0x70874f48460f in __libc_start_call_main (/lib64/libc.so.6+0x2a60f) (BuildId: 4dbf824d0f6afd9b2faee4787d89a39921c0a65e)
    #10 0x70874f4846bf in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x2a6bf) (BuildId: 4dbf824d0f6afd9b2faee4787d89a39921c0a65e)
    #11 0x00000044c1b4 in _start (/velox/_build/debug/velox/vector/tests/velox_vector_test+0x44c1b4) (BuildId: 6da0b0d1074134be8f4d4534e5dbac9eeb9d482b)
```


