### PR TITLE
refactor(connector): Delete unused options from HiveConfig

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -244,14 +244,6 @@ bool HiveConfig::readStatsBasedFilterReorderDisabled(
       config_->get<bool>(kReadStatsBasedFilterReorderDisabled, false));
 }
 
-std::string HiveConfig::hiveLocalDataPath() const {
-  return config_->get<std::string>(kLocalDataPath, "");
-}
-
-std::string HiveConfig::hiveLocalFileFormat() const {
-  return config_->get<std::string>(kLocalFileFormat, "");
-}
-
 bool HiveConfig::preserveFlatMapsInMemory(
     const config::ConfigBase* session) const {
   return session->get<bool>(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -194,9 +194,6 @@ class HiveConfig {
   static constexpr const char* kReadStatsBasedFilterReorderDisabledSession =
       "stats_based_filter_reorder_disabled";
 
-  static constexpr const char* kLocalDataPath = "hive_local_data_path";
-  static constexpr const char* kLocalFileFormat = "hive_local_file_format";
-
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.
   static constexpr const char* kPreserveFlatMapsInMemory =
@@ -282,15 +279,6 @@ class HiveConfig {
   /// Returns true if the stats based filter reorder for read is disabled.
   bool readStatsBasedFilterReorderDisabled(
       const config::ConfigBase* session) const;
-
-  /// Returns the file system path containing local data. If non-empty,
-  /// initializes LocalHiveConnectorMetadata to provide metadata for the tables
-  /// in the directory.
-  std::string hiveLocalDataPath() const;
-
-  /// Returns the name of the file format to use in interpreting the contents of
-  /// hiveLocalDataPath().
-  std::string hiveLocalFileFormat() const;
 
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.


### PR DESCRIPTION
Summary: These options were so that HiveConfig could store config for the Axiom repository, and not actually used within Velox. That external dependency is being moved to a separate Hive configuration object, so these options can be removed (see https://github.com/facebookincubator/axiom/pull/785 for the external PR)

Differential Revision: D91282774


