### PR TITLE
fix(build): Remove velox_dwio_parquet_field_id from Iceberg link library

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -29,10 +29,13 @@ velox_add_library(
 velox_link_libraries(
   velox_hive_iceberg_splitreader
   velox_connector
-  velox_dwio_parquet_field_id
   velox_functions_iceberg
   Folly::folly
 )
+
+if(VELOX_ENABLE_PARQUET)
+  velox_link_libraries(velox_hive_iceberg_splitreader velox_dwio_parquet_field_id)
+endif()
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -20,7 +20,7 @@
 
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
-#include "velox/dwio/parquet/writer/ParquetFieldId.h"
+#include "velox/dwio/parquet/ParquetFieldId.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 

--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.h
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.h
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/dwio/parquet/writer/ParquetFieldId.h"
+#include "velox/dwio/parquet/ParquetFieldId.h"
 #include "velox/type/Subfield.h"
 #include "velox/type/Type.h"
 

--- a/velox/dwio/parquet/CMakeLists.txt
+++ b/velox/dwio/parquet/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 velox_add_library(velox_dwio_parquet_reader RegisterParquetReader.cpp)
 velox_add_library(velox_dwio_parquet_writer RegisterParquetWriter.cpp)
+velox_add_library(velox_dwio_parquet_field_id INTERFACE ParquetFieldId.h)
 
 if(VELOX_ENABLE_PARQUET)
   velox_link_libraries(velox_dwio_parquet_reader velox_dwio_native_parquet_reader xsimd)

--- a/velox/dwio/parquet/ParquetFieldId.h
+++ b/velox/dwio/parquet/ParquetFieldId.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <vector>
+
 namespace facebook::velox::parquet {
 /// Parquet field IDs during write operations. Each ID must be unique positive
 /// number, do not need to be sequential.

--- a/velox/dwio/parquet/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/CMakeLists.txt
@@ -14,8 +14,6 @@
 
 add_subdirectory(arrow)
 
-velox_add_library(velox_dwio_parquet_field_id INTERFACE ParquetFieldId.h)
-
 velox_add_library(velox_dwio_arrow_parquet_writer Writer.cpp)
 
 velox_link_libraries(
@@ -23,7 +21,6 @@ velox_link_libraries(
   velox_dwio_arrow_parquet_writer_lib
   velox_dwio_arrow_parquet_writer_util_lib
   velox_dwio_common
-  velox_dwio_parquet_field_id
   velox_arrow_bridge
   arrow
   fmt::fmt

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -25,7 +25,7 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Writer.h"
 #include "velox/dwio/common/WriterFactory.h"
-#include "velox/dwio/parquet/writer/ParquetFieldId.h"
+#include "velox/dwio/parquet/ParquetFieldId.h"
 #include "velox/dwio/parquet/writer/arrow/Types.h"
 #include "velox/dwio/parquet/writer/arrow/util/Compression.h"
 #include "velox/vector/ComplexVector.h"


### PR DESCRIPTION
Resolve prestissimo building error. When parquet is disabled, `velox_dwio_parquet_field_id` can not be found.

See https://github.com/prestodb/presto/actions/runs/21270527640/job/61219536504?pr=26982. 