### PR TITLE
fix: Iceberg date partition filter cannot be parsed

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
+++ b/velox/connectors/hive/iceberg/IcebergColumnHandle.cpp
@@ -37,7 +37,9 @@ IcebergColumnHandle::IcebergColumnHandle(
           columnType,
           dataType,
           dataType,
-          std::move(requiredSubfields)),
+          std::move(requiredSubfields),
+          ColumnParseParameters{ColumnParseParameters::
+                                    PartitionDateValueFormat::kDaysSinceEpoch}),
       field_(std::move(icebergField)) {}
 
 const parquet::ParquetFieldId& IcebergColumnHandle::field() const {


### PR DESCRIPTION
Fix query error "Unable to parse date value: "20147". Valid date string pattern is (YYYY-MM-DD)"

presto:iceberg> select * from day_t1 where c_date > date '2024-04-03';

Query 20260123_133652_00011_ttym8, FAILED, 1 node
Splits: 2 total, 0 done (0.00%)
[Latency: client-side: 61ms, server-side: 54ms] [0 rows, 0B] [0 rows/s, 0B/s]

Query 20260123_133652_00011_ttym8 failed:  Unable to parse date value: "20147". Valid date string pattern is (YYYY-MM-DD), and can be prefixed with [+-] Split Hive: file:/data/iceberg_data/HIVE/iceberg/day_t1/data/c_date=2025-02-28/20260123_133649_00010_ttym8.1.0.0.0_0_5_9df219d0-2ba7-4032-82df-f92295d95a6c.parquet 0 - 1299 Task 20260123_133652_00011_ttym8.1.0.0.0

Prestissimo CI error: https://github.com/prestodb/presto/actions/runs/21283121235/job/61264726185
