### PR TITLE
misc: Make `requests_` and `coalescedLoads_` protected

### DIFF
--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -209,6 +209,13 @@ class DirectBufferedInput : public BufferedInput {
     VELOX_NYI();
   }
 
+ protected:
+  // Regions that are candidates for loading.
+  std::vector<LoadRequest> requests_;
+
+  // Distinct coalesced loads in 'coalescedLoads_'.
+  std::vector<std::shared_ptr<cache::CoalescedLoad>> coalescedLoads_;
+
  private:
   /// Constructor used by clone().
   DirectBufferedInput(
@@ -274,17 +281,11 @@ class DirectBufferedInput : public BufferedInput {
   folly::Executor* const executor_;
   const uint64_t fileSize_;
 
-  // Regions that are candidates for loading.
-  std::vector<LoadRequest> requests_;
-
   // Coalesced loads spanning multiple streams in one IO.
   folly::Synchronized<folly::F14FastMap<
       const SeekableInputStream*,
       std::shared_ptr<DirectCoalescedLoad>>>
       streamToCoalescedLoad_;
-
-  // Distinct coalesced loads in 'coalescedLoads_'.
-  std::vector<std::shared_ptr<cache::CoalescedLoad>> coalescedLoads_;
 
   io::ReaderOptions options_;
 };


### PR DESCRIPTION
Make `requests_` and `coalescedLoads_` protected so that registered custom 
DirectBufferedInput implementations can access them.

Follow-up for: https://github.com/facebookincubator/velox/commit/6ced2785a14845440a2e160bd23de01ea66d98ac