### PR TITLE
fix(cudf): Slow S3 IO performance

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSourceHelpers.hpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSourceHelpers.hpp
@@ -58,6 +58,12 @@ class BufferedInputDataSource : public cudf::io::datasource {
 
   [[nodiscard]] bool supports_device_read() const override;
 
+  std::future<size_t> device_read_async(
+      size_t offset,
+      size_t size,
+      uint8_t* dst,
+      rmm::cuda_stream_view stream) override;
+
  private:
   void readContiguous(size_t offset, size_t size, uint8_t* dst);
 


### PR DESCRIPTION
Use IO executor to schedule the chunk reads async.
Set `connector.num-io-threads-hw-multiplier` to 2 or 4 from Presto.