### PR TITLE
fbcode/velox/vector/BaseVector.cpp

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -422,6 +422,7 @@ VectorPtr BaseVector::createInternal(
     case TypeKind::ROW: {
       std::vector<VectorPtr> children;
       auto& rowType = type->as<TypeKind::ROW>();
+      children.reserve(rowType.size());
       // Children are reserved the parent size and accessible for those rows.
       for (int32_t i = 0; i < rowType.size(); ++i) {
         children.push_back(create(rowType.childAt(i), size, pool));


### PR DESCRIPTION
This diff pre-allocates capacity of rowType.size() for the vector children via folly::grow_capacity_by(children, rowType.size()). The size rowType.size() is calculated based on the following reasoning: the loop iterates exactly rowType.size() times (from i=0 to i < rowType.size()), adding one child vector per iteration via children.push_back(), so the exact number of elements to be added is known upfront from the row type's child count. This optimization avoids expensive vector reallocations during the loop execution in the facebook::velox::BaseVector::createInternal function when creating ROW type vectors.

Differential Revision: D90290664


