### PR TITLE
misc: Add utilities for hive index source to use and hive data source refactor

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -23,6 +23,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprConstants.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/expression/FieldReference.h"
 
 namespace facebook::velox::connector::hive {
 namespace {
@@ -119,7 +120,7 @@ void addSubfields(
             element->toString());
         required[nestedField->name()].push_back(subfield);
       }
-      auto& rowType = type.asRow();
+      const auto& rowType = type.asRow();
       for (int i = 0; i < rowType.size(); ++i) {
         auto& childName = rowType.nameOf(i);
         auto& childType = rowType.childAt(i);
@@ -335,9 +336,10 @@ void processFieldSpec(
     }
   });
   if (dataColumns) {
-    auto i = dataColumns->getChildIdxIfExists(fieldSpec.fieldName());
-    if (i.has_value()) {
-      if (dataColumns->childAt(*i)->isMap() && outputType->isRow()) {
+    const auto childIdxOpt =
+        dataColumns->getChildIdxIfExists(fieldSpec.fieldName());
+    if (childIdxOpt.has_value()) {
+      if (dataColumns->childAt(*childIdxOpt)->isMap() && outputType->isRow()) {
         fieldSpec.setFlatMapAsStruct(true);
       }
     }
@@ -346,11 +348,36 @@ void processFieldSpec(
 
 } // namespace
 
+void checkColumnHandleConsistent(
+    const HiveColumnHandle& x,
+    const HiveColumnHandle& y) {
+  VELOX_CHECK_EQ(
+      x.columnType(),
+      y.columnType(),
+      "Inconsistent column handle type: {}, expected {}, got {}",
+      x.name(),
+      HiveColumnHandle::columnTypeName(x.columnType()),
+      HiveColumnHandle::columnTypeName(y.columnType()));
+  VELOX_CHECK(
+      x.dataType()->equivalent(*y.dataType()),
+      "Inconsistent column handle data type: {}, expected {}, got {}",
+      x.name(),
+      x.dataType()->toString(),
+      y.dataType()->toString());
+  VELOX_CHECK(
+      x.hiveType()->equivalent(*y.hiveType()),
+      "Inconsistent column handle hive type: {}, expected {}, got {}",
+      x.name(),
+      x.hiveType()->toString(),
+      y.hiveType()->toString());
+}
+
 std::shared_ptr<common::ScanSpec> makeScanSpec(
     const RowTypePtr& rowType,
     const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
         outputSubfields,
-    const common::SubfieldFilters& filters,
+    const common::SubfieldFilters& subfieldFilters,
+    const std::vector<std::string>& indexColumns,
     const RowTypePtr& dataColumns,
     const std::unordered_map<std::string, HiveColumnHandlePtr>& partitionKeys,
     const std::unordered_map<std::string, HiveColumnHandlePtr>& infoColumns,
@@ -361,7 +388,7 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       filterSubfields;
   std::vector<SubfieldSpec> subfieldSpecs;
-  for (auto& [subfield, _] : filters) {
+  for (const auto& [subfield, _] : subfieldFilters) {
     if (auto name = subfield.toString();
         !isSynthesizedColumn(name, infoColumns) &&
         partitionKeys.count(name) == 0) {
@@ -428,7 +455,18 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
     }
   }
 
-  for (auto& pair : filters) {
+  // Process index columns from join conditions to ensure they are read.
+  // These columns are not projected out, only used for index lookup.
+  for (const auto& keyName : indexColumns) {
+    VELOX_CHECK_NOT_NULL(dataColumns);
+    if (spec->childByName(keyName) == nullptr) {
+      // This is required so that we can set filter on the index column in the
+      // selective reader later.
+      spec->getOrCreateChild(keyName);
+    }
+  }
+
+  for (auto& pair : subfieldFilters) {
     const auto name = pair.first.toString();
     // SelectiveColumnReader doesn't support constant columns with filters,
     // hence, we can't have a filter for a $path or $bucket column.
@@ -996,6 +1034,106 @@ core::TypedExprPtr extractFiltersFromRemainingFilter(
     double& sampleRate) {
   return extractFiltersFromRemainingFilter(
       expr, evaluator, /*negated=*/false, filters, sampleRate);
+}
+
+bool shouldEagerlyMaterialize(
+    const exec::Expr& remainingFilter,
+    const exec::FieldReference& field) {
+  const auto isMember = [](const std::vector<exec::FieldReference*>& fields,
+                           const exec::FieldReference& field) {
+    return std::find(fields.begin(), fields.end(), &field) != fields.end();
+  };
+
+  if (!remainingFilter.evaluatesArgumentsOnNonIncreasingSelection()) {
+    return true;
+  }
+  for (auto& input : remainingFilter.inputs()) {
+    if (isMember(input->distinctFields(), field) && input->hasConditionals()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+namespace {
+template <TypeKind kind>
+std::unique_ptr<common::Filter> createRangeFilterInternal(
+    const variant& lower,
+    const variant& upper) {
+  using T = typename TypeTraits<kind>::NativeType;
+  const bool lowerUnbounded = lower.isNull();
+  const bool upperUnbounded = upper.isNull();
+
+  if constexpr (
+      kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT) {
+    return std::make_unique<common::BigintRange>(
+        lowerUnbounded ? std::numeric_limits<int64_t>::min() : lower.value<T>(),
+        upperUnbounded ? std::numeric_limits<int64_t>::max() : upper.value<T>(),
+        /*nullAllowed=*/false);
+  } else if constexpr (kind == TypeKind::REAL) {
+    return std::make_unique<common::FloatRange>(
+        lowerUnbounded ? std::numeric_limits<float>::lowest()
+                       : lower.value<T>(),
+        lowerUnbounded,
+        /*lowerExclusive=*/false,
+        upperUnbounded ? std::numeric_limits<float>::max() : upper.value<T>(),
+        upperUnbounded,
+        /*upperExclusive=*/false,
+        /*nullAllowed=*/false);
+  } else if constexpr (kind == TypeKind::DOUBLE) {
+    return std::make_unique<common::DoubleRange>(
+        lowerUnbounded ? std::numeric_limits<double>::lowest()
+                       : lower.value<T>(),
+        lowerUnbounded,
+        /*lowerExclusive=*/false,
+        upperUnbounded ? std::numeric_limits<double>::max() : upper.value<T>(),
+        upperUnbounded,
+        /*upperExclusive=*/false,
+        /*nullAllowed=*/false);
+  } else if constexpr (
+      kind == TypeKind::VARCHAR || kind == TypeKind::VARBINARY) {
+    return std::make_unique<common::BytesRange>(
+        lowerUnbounded ? "" : std::string(lower.value<StringView>()),
+        lowerUnbounded,
+        /*lowerExclusive=*/false,
+        upperUnbounded ? "" : std::string(upper.value<StringView>()),
+        upperUnbounded,
+        /*upperExclusive=*/false,
+        /*nullAllowed=*/false);
+  } else if constexpr (kind == TypeKind::BOOLEAN) {
+    VELOX_CHECK(
+        !lowerUnbounded && !upperUnbounded,
+        "Boolean range filter requires both bounds");
+    return std::make_unique<common::BoolValue>(
+        lower.value<T>(), /*nullAllowed=*/false);
+  } else {
+    VELOX_UNSUPPORTED(
+        "Unsupported type kind for filter creation: {}",
+        TypeKindName::toName(kind));
+  }
+}
+} // namespace
+
+std::unique_ptr<common::Filter> createPointFilter(
+    const TypePtr& type,
+    const variant& value) {
+  VELOX_CHECK(!value.isNull(), "Value cannot be null");
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      createRangeFilterInternal, type->kind(), value, value);
+}
+
+std::unique_ptr<common::Filter> createRangeFilter(
+    const TypePtr& type,
+    const variant& lower,
+    const variant& upper) {
+  VELOX_CHECK(
+      !lower.isNull() || !upper.isNull(),
+      "At least one of lower or upper bound must be set");
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      createRangeFilterInternal, type->kind(), lower, upper);
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -23,6 +23,11 @@
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Reader.h"
 
+namespace facebook::velox::exec {
+class Expr;
+class FieldReference;
+} // namespace facebook::velox::exec
+
 namespace facebook::velox::connector::hive {
 
 class HiveColumnHandle;
@@ -47,11 +52,47 @@ struct SpecialColumnNames {
   std::optional<std::string> rowId;
 };
 
+/// Checks that two HiveColumnHandle instances are consistent in terms of
+/// column type, data type, and hive type. Throws if inconsistent.
+void checkColumnHandleConsistent(
+    const HiveColumnHandle& x,
+    const HiveColumnHandle& y);
+
+/// Creates a ScanSpec for reading data from a Hive table.
+///
+/// The ScanSpec describes which columns to read and what filters to apply.
+/// It handles several types of columns:
+/// - Regular data columns from the file
+/// - Partition key columns (values from file path)
+/// - Synthesized columns (e.g., $path, $bucket)
+/// - Special columns (e.g., row index, row ID)
+/// - Index columns for index lookup joins
+///
+/// @param rowType Schema of columns to be projected in the output.
+/// @param outputSubfields Map of column names to subfields that need to be
+///     read. Used for pruning nested structures.
+/// @param subfieldFilters Map of subfields to filters to apply during scan.
+/// @param indexColumns Column names used for index lookup joins. These columns
+///     are added to the scan spec even if they are not in the output
+///     projection, ensuring they are read from the file for join key matching.
+/// @param dataColumns Full schema of all columns in the data file. Used to
+///     look up column types when a column is referenced in filters or index
+///     columns but not in the output projection.
+/// @param partitionKeys Map of partition column names to their handles.
+///     Partition columns are not read from the file.
+/// @param infoColumns Map of synthesized column names (e.g., $path) to their
+///     handles.
+/// @param specialColumns Names of special columns like row index and row ID.
+/// @param disableStatsBasedFilterReorder If true, disables reordering of
+///     filters based on statistics.
+/// @param pool Memory pool for allocations during scan spec construction.
+/// @return A ScanSpec that can be used to configure a reader.
 std::shared_ptr<common::ScanSpec> makeScanSpec(
     const RowTypePtr& rowType,
     const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
         outputSubfields,
-    const common::SubfieldFilters& filters,
+    const common::SubfieldFilters& subfieldFilters,
+    const std::vector<std::string>& indexColumns,
     const RowTypePtr& dataColumns,
     const std::unordered_map<
         std::string,
@@ -62,6 +103,35 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
     const SpecialColumnNames& specialColumns,
     bool disableStatsBasedFilterReorder,
     memory::MemoryPool* pool);
+
+/// Overload without indexColumns for backward compatibility.
+inline std::shared_ptr<common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType,
+    const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
+        outputSubfields,
+    const common::SubfieldFilters& subfieldFilters,
+    const RowTypePtr& dataColumns,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& partitionKeys,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& infoColumns,
+    const SpecialColumnNames& specialColumns,
+    bool disableStatsBasedFilterReorder,
+    memory::MemoryPool* pool) {
+  return makeScanSpec(
+      rowType,
+      outputSubfields,
+      subfieldFilters,
+      /*indexColumns=*/{},
+      dataColumns,
+      partitionKeys,
+      infoColumns,
+      specialColumns,
+      disableStatsBasedFilterReorder,
+      pool);
+}
 
 void configureReaderOptions(
     const std::shared_ptr<const HiveConfig>& config,
@@ -151,5 +221,49 @@ core::TypedExprPtr extractFiltersFromRemainingFilter(
     core::ExpressionEvaluator* evaluator,
     common::SubfieldFilters& filters,
     double& sampleRate);
+
+/// Determines whether a field referenced in the remaining filter should be
+/// eagerly materialized (loaded upfront) or can be lazily loaded.
+///
+/// Returns true (eager materialization needed) when:
+/// 1. The remaining filter is NOT an AND expression (e.g., OR), because row
+///    access patterns are unpredictable.
+/// 2. The field is used within a conditional sub-expression (IF, CASE, nested
+///    AND/OR) of an AND expression, because the conditional may access rows
+///    unpredictably.
+///
+/// Returns false (lazy loading OK) when the remaining filter is an AND
+/// expression and the field is only used in simple, non-conditional conjuncts.
+///
+/// @param remainingFilter The compiled remaining filter expression.
+/// @param field The field reference to check.
+/// @return true if the field should be eagerly materialized.
+bool shouldEagerlyMaterialize(
+    const exec::Expr& remainingFilter,
+    const exec::FieldReference& field);
+
+/// Creates a point lookup filter from a variant value.
+/// Null values are not allowed.
+/// Supports TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN,
+/// VARCHAR, and VARBINARY types.
+/// @param type The type of the value.
+/// @param value The filter value (must not be null).
+/// @return A filter for point lookup, or nullptr if type is not supported.
+std::unique_ptr<common::Filter> createPointFilter(
+    const TypePtr& type,
+    const variant& value);
+
+/// Creates a range filter from two variant values.
+/// Both lower and upper bounds are inclusive. Null values are not allowed.
+/// Supports TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, VARCHAR,
+/// and VARBINARY types.
+/// @param type The type of the values.
+/// @param lower The lower bound value.
+/// @param upper The upper bound value.
+/// @return A filter for range lookup, or nullptr if type is not supported.
+std::unique_ptr<common::Filter> createRangeFilter(
+    const TypePtr& type,
+    const variant& lower,
+    const variant& upper);
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -20,50 +20,15 @@
 #include <string>
 #include <unordered_map>
 
+#include "velox/common/Casts.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
+
 #include "velox/expression/FieldReference.h"
 
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::connector::hive {
-
-namespace {
-
-bool isMember(
-    const std::vector<exec::FieldReference*>& fields,
-    const exec::FieldReference& field) {
-  return std::find(fields.begin(), fields.end(), &field) != fields.end();
-}
-
-bool shouldEagerlyMaterialize(
-    const exec::Expr& remainingFilter,
-    const exec::FieldReference& field) {
-  if (!remainingFilter.evaluatesArgumentsOnNonIncreasingSelection()) {
-    return true;
-  }
-  for (auto& input : remainingFilter.inputs()) {
-    if (isMember(input->distinctFields(), field) && input->hasConditionals()) {
-      return true;
-    }
-  }
-  return false;
-}
-
-void checkColumnHandleConsistent(
-    const HiveColumnHandle& x,
-    const HiveColumnHandle& y) {
-  VELOX_CHECK(
-      x.columnType() == y.columnType(),
-      "Inconsistent column handle: {}",
-      x.name());
-  VELOX_CHECK_EQ(
-      *x.dataType(), *y.dataType(), "Inconsistent column handle: {}", x.name());
-  VELOX_CHECK_EQ(
-      *x.hiveType(), *y.hiveType(), "Inconsistent column handle: {}", x.name());
-}
-
-} // namespace
 
 void HiveDataSource::processColumnHandle(const HiveColumnHandlePtr& handle) {
   switch (handle->columnType()) {
@@ -99,20 +64,12 @@ HiveDataSource::HiveDataSource(
       pool_(connectorQueryCtx->memoryPool()),
       outputType_(outputType),
       expressionEvaluator_(connectorQueryCtx->expressionEvaluator()) {
-  hiveTableHandle_ =
-      std::dynamic_pointer_cast<const HiveTableHandle>(tableHandle);
-  VELOX_CHECK_NOT_NULL(
-      hiveTableHandle_, "TableHandle must be an instance of HiveTableHandle");
+  hiveTableHandle_ = checkedPointerCast<const HiveTableHandle>(tableHandle);
 
   folly::F14FastMap<std::string_view, const HiveColumnHandle*> columnHandles;
   // Column handled keyed on the column alias, the name used in the query.
-  for (const auto& [canonicalizedName, columnHandle] : assignments) {
-    auto handle =
-        std::dynamic_pointer_cast<const HiveColumnHandle>(columnHandle);
-    VELOX_CHECK_NOT_NULL(
-        handle,
-        "ColumnHandle must be an instance of HiveColumnHandle for {}",
-        canonicalizedName);
+  for (const auto& [_, columnHandle] : assignments) {
+    auto handle = checkedPointerCast<const HiveColumnHandle>(columnHandle);
     const auto [it, unique] =
         columnHandles.emplace(handle->name(), handle.get());
     if (!unique) {
@@ -120,8 +77,9 @@ HiveDataSource::HiveDataSource(
       // queries that sometimes we do get duplicate assignments for partitioning
       // columns.
       checkColumnHandleConsistent(*handle, *it->second);
-      VELOX_CHECK(
-          handle->columnType() == HiveColumnHandle::ColumnType::kPartitionKey,
+      VELOX_CHECK_EQ(
+          handle->columnType(),
+          HiveColumnHandle::ColumnType::kPartitionKey,
           "Cannot map from same table column to different outputs in table scan; a project node should be used instead: {}",
           handle->name());
       continue;
@@ -336,8 +294,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   VELOX_CHECK_NULL(
       split_,
       "Previous split has not been processed yet. Call next to process the split.");
-  split_ = std::dynamic_pointer_cast<HiveConnectorSplit>(split);
-  VELOX_CHECK_NOT_NULL(split_, "Wrong type of split");
+  split_ = checkedPointerCast<HiveConnectorSplit>(split);
 
   VLOG(1) << "Adding split " << split_->toString();
 

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -161,6 +161,9 @@ class HiveDataSource : public DataSource {
   std::vector<common::Subfield> remainingFilterSubfields_;
   folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
       subfields_;
+  // Optional post-processors for each output column, collected from
+  // HiveColumnHandle::postProcessor(). Applied after reading and filtering to
+  // transform column values. Indexed by output column position.
   std::vector<std::function<void(VectorPtr&)>> columnPostProcessors_;
   common::SubfieldFilters filters_;
   std::shared_ptr<common::MetadataFilter> metadataFilter_;

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -252,3 +252,17 @@ class HiveTableHandle : public ConnectorTableHandle {
 using HiveTableHandlePtr = std::shared_ptr<const HiveTableHandle>;
 
 } // namespace facebook::velox::connector::hive
+
+template <>
+struct fmt::formatter<
+    facebook::velox::connector::hive::HiveColumnHandle::ColumnType>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::HiveColumnHandle::ColumnType type,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::HiveColumnHandle::columnTypeName(
+            type),
+        ctx);
+  }
+};

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -16,10 +16,17 @@
 
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/TableHandle.h"
+#include "velox/core/Expressions.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/expression/FieldReference.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
 
 #include "velox/dwio/dwrf/writer/Writer.h"
 
@@ -30,6 +37,24 @@
 namespace facebook::velox::connector {
 
 using namespace dwio::common;
+
+namespace {
+// Unsupported types for createPointFilter and createRangeFilter with test
+// values.
+struct UnsupportedFilterType {
+  TypePtr type;
+  variant value;
+};
+
+const std::vector<UnsupportedFilterType> kUnsupportedFilterTypes = {
+    {TIMESTAMP(), variant(Timestamp(0, 0))},
+    {ARRAY(BIGINT()), variant::array({variant::create<TypeKind::BIGINT>(1)})},
+    {MAP(VARCHAR(), BIGINT()),
+     variant::map({{variant("key"), variant::create<TypeKind::BIGINT>(1)}})},
+    {ROW({{"a", BIGINT()}}),
+     variant::row({variant::create<TypeKind::BIGINT>(1)})},
+};
+} // namespace
 
 class HiveConnectorUtilTest : public exec::test::HiveConnectorTestBase {
  protected:
@@ -463,6 +488,457 @@ TEST_F(HiveConnectorUtilTest, configureRowReaderOptionsFromConfig) {
         /*rowReaderOptions=*/rowReaderOpts);
 
     EXPECT_TRUE(rowReaderOpts.preserveFlatMapsInMemory());
+  }
+}
+
+TEST_F(HiveConnectorUtilTest, checkColumnHandleConsistent) {
+  // Create two consistent column handles
+  auto handle1 = std::make_shared<hive::HiveColumnHandle>(
+      "col1", hive::HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+  auto handle2 = std::make_shared<hive::HiveColumnHandle>(
+      "col1", hive::HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+
+  // Should not throw for consistent handles
+  EXPECT_NO_THROW(hive::checkColumnHandleConsistent(*handle1, *handle2));
+
+  // Test inconsistent column type
+  auto handlePartition = std::make_shared<hive::HiveColumnHandle>(
+      "col1",
+      hive::HiveColumnHandle::ColumnType::kPartitionKey,
+      BIGINT(),
+      BIGINT());
+  VELOX_ASSERT_THROW(
+      hive::checkColumnHandleConsistent(*handle1, *handlePartition),
+      "Inconsistent column handle type: col1, expected Regular, got PartitionKey");
+
+  // Test inconsistent data type
+  auto handleVarchar = std::make_shared<hive::HiveColumnHandle>(
+      "col1",
+      hive::HiveColumnHandle::ColumnType::kRegular,
+      VARCHAR(),
+      VARCHAR());
+  VELOX_ASSERT_THROW(
+      hive::checkColumnHandleConsistent(*handle1, *handleVarchar),
+      "Inconsistent column handle data type: col1, expected BIGINT, got VARCHAR");
+}
+
+TEST_F(HiveConnectorUtilTest, makeScanSpecWithIndexColumns) {
+  // Data columns schema - all columns available in the file.
+  const auto dataColumns = ROW(
+      {{"a", BIGINT()},
+       {"b", VARCHAR()},
+       {"c", INTEGER()},
+       {"d", DOUBLE()},
+       {"e", ROW({{"x", INTEGER()}, {"y", VARCHAR()}})}});
+
+  struct TestCase {
+    std::string name;
+    RowTypePtr rowType;
+    folly::F14FastMap<std::string, std::vector<const common::Subfield*>>
+        outputSubfields;
+    std::function<common::SubfieldFilters()> makeSubfieldFilters;
+    std::vector<std::string> indexColumns;
+    std::vector<std::string> expectedColumns;
+    std::vector<std::string> unexpectedColumns;
+
+    std::string debugString() const {
+      return fmt::format(
+          "name: {}, indexColumns: [{}], expectedColumns: [{}], unexpectedColumns: [{}]",
+          name,
+          folly::join(", ", indexColumns),
+          folly::join(", ", expectedColumns),
+          folly::join(", ", unexpectedColumns));
+    }
+  };
+
+  // Subfields for nested column 'e'.
+  const common::Subfield subfieldEx("e.x");
+  const common::Subfield subfieldEy("e.y");
+
+  const std::vector<TestCase> testCases = {
+      {
+          "Index columns not in output projection",
+          ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+          /*outputSubfields=*/{},
+          /*makeSubfieldFilters=*/nullptr,
+          /*indexColumns=*/{"c", "d"},
+          /*expectedColumns=*/{"a", "b", "c", "d"},
+          /*unexpectedColumns=*/{"e"},
+      },
+      {
+          "Index column already in output projection",
+          ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+          /*outputSubfields=*/{},
+          /*makeSubfieldFilters=*/nullptr,
+          /*indexColumns=*/{"a", "c"},
+          /*expectedColumns=*/{"a", "b", "c"},
+          /*unexpectedColumns=*/{"d", "e"},
+      },
+      {
+          "Empty index columns",
+          ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+          /*outputSubfields=*/{},
+          /*makeSubfieldFilters=*/nullptr,
+          /*indexColumns=*/{},
+          /*expectedColumns=*/{"a", "b"},
+          /*unexpectedColumns=*/{"c", "d", "e"},
+      },
+      {
+          "Output subfield without index columns",
+          ROW({"e"}, {ROW({{"x", INTEGER()}, {"y", VARCHAR()}})}),
+          /*outputSubfields=*/{{"e", {&subfieldEx}}},
+          /*makeSubfieldFilters=*/nullptr,
+          /*indexColumns=*/{},
+          /*expectedColumns=*/{"e"},
+          /*unexpectedColumns=*/{"a", "b", "c", "d"},
+      },
+      {
+          "Output subfield with different index column",
+          ROW({"e"}, {ROW({{"x", INTEGER()}, {"y", VARCHAR()}})}),
+          /*outputSubfields=*/{{"e", {&subfieldEx}}},
+          /*makeSubfieldFilters=*/nullptr,
+          /*indexColumns=*/{"c"},
+          /*expectedColumns=*/{"e", "c"},
+          /*unexpectedColumns=*/{"a", "b", "d"},
+      },
+      {
+          "Output subfield with same parent as index column",
+          ROW({"a", "e"},
+              {BIGINT(), ROW({{"x", INTEGER()}, {"y", VARCHAR()}})}),
+          /*outputSubfields=*/{{"e", {&subfieldEx}}},
+          /*makeSubfieldFilters=*/nullptr,
+          /*indexColumns=*/{"a", "e"},
+          /*expectedColumns=*/{"a", "e"},
+          /*unexpectedColumns=*/{"b", "c", "d"},
+      },
+      {
+          "Subfield filter without index column",
+          ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+          /*outputSubfields=*/{},
+          /*makeSubfieldFilters=*/
+          []() {
+            common::SubfieldFilters filters;
+            filters.emplace(
+                common::Subfield("c"), exec::greaterThanOrEqual(10));
+            return filters;
+          },
+          /*indexColumns=*/{"d"},
+          /*expectedColumns=*/{"a", "b", "c", "d"},
+          /*unexpectedColumns=*/{"e"},
+      },
+      {
+          "Subfield filter without index column",
+          ROW({"a", "b"}, {BIGINT(), VARCHAR()}),
+          /*outputSubfields=*/{},
+          /*makeSubfieldFilters=*/
+          []() {
+            common::SubfieldFilters filters;
+            filters.emplace(
+                common::Subfield("c"), exec::greaterThanOrEqual(10));
+            return filters;
+          },
+          /*indexColumns=*/{"c"},
+          /*expectedColumns=*/{"a", "b", "c"},
+          /*unexpectedColumns=*/{"e"},
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+
+    common::SubfieldFilters subfieldFilters;
+    if (testCase.makeSubfieldFilters) {
+      subfieldFilters = testCase.makeSubfieldFilters();
+    }
+
+    auto scanSpec = hive::makeScanSpec(
+        testCase.rowType,
+        testCase.outputSubfields,
+        subfieldFilters,
+        testCase.indexColumns,
+        dataColumns,
+        /*partitionKeys=*/{},
+        /*infoColumns=*/{},
+        /*specialColumns=*/{},
+        /*disableStatsBasedFilterReorder=*/false,
+        pool_.get());
+
+    for (const auto& col : testCase.expectedColumns) {
+      EXPECT_NE(scanSpec->childByName(col), nullptr)
+          << "Expected column " << col << " to be in scan spec";
+    }
+    for (const auto& col : testCase.unexpectedColumns) {
+      EXPECT_EQ(scanSpec->childByName(col), nullptr)
+          << "Unexpected column " << col << " should not be in scan spec";
+    }
+  }
+}
+
+TEST_F(HiveConnectorUtilTest, makeScanSpecWithIndexColumnsError) {
+  // Test that makeScanSpec throws when index columns are set but dataColumns
+  // is null.
+  const auto rowType = ROW({"a", "b"}, {BIGINT(), VARCHAR()});
+
+  VELOX_ASSERT_THROW(
+      hive::makeScanSpec(
+          rowType,
+          /*outputSubfields=*/{},
+          /*subfieldFilters=*/{},
+          /*indexColumns=*/{"c"},
+          /*dataColumns=*/nullptr,
+          /*partitionKeys=*/{},
+          /*infoColumns=*/{},
+          /*specialColumns=*/{},
+          /*disableStatsBasedFilterReorder=*/false,
+          pool_.get()),
+      "");
+}
+
+TEST_F(HiveConnectorUtilTest, shouldEagerlyMaterialize) {
+  auto queryCtx = core::QueryCtx::create();
+  auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+
+  auto compileExpression = [&](const std::string& expr,
+                               const RowTypePtr& rowType) {
+    auto untyped = parse::DuckSqlExpressionsParser().parseExpr(expr);
+    auto typedExpr =
+        core::Expressions::inferTypes(untyped, rowType, pool_.get());
+    std::vector<core::TypedExprPtr> expressions = {typedExpr};
+    return std::make_unique<exec::ExprSet>(
+        std::move(expressions), execCtx.get());
+  };
+
+  const auto rowType = ROW({"a", "b", "c"}, {BIGINT(), BIGINT(), BIGINT()});
+
+  // Test 1: OR expression doesn't evaluate arguments on non-increasing
+  // selection, so should return true (eager materialization needed).
+  {
+    auto exprSet = compileExpression("a > 10 OR b > 20", rowType);
+    auto& expr = *exprSet->exprs().front();
+    for (const auto& field : expr.distinctFields()) {
+      EXPECT_TRUE(hive::shouldEagerlyMaterialize(expr, *field));
+    }
+  }
+
+  // Test 2: AND expression evaluates arguments on non-increasing selection.
+  // Field used in simple conjunct (no conditionals) should not be eagerly
+  // materialized.
+  {
+    auto exprSet = compileExpression("a > 10 AND b > 20", rowType);
+    auto& expr = *exprSet->exprs().front();
+    for (const auto& field : expr.distinctFields()) {
+      EXPECT_FALSE(hive::shouldEagerlyMaterialize(expr, *field));
+    }
+  }
+
+  // Test 3: AND expression with field used in IF conditional.
+  // Field used in input with conditionals should be eagerly materialized.
+  {
+    auto exprSet =
+        compileExpression("a > 10 AND if(b > 20, c < 30, c > 5)", rowType);
+    auto& expr = *exprSet->exprs().front();
+    for (const auto& field : expr.distinctFields()) {
+      if (field->field() == "c" || field->field() == "b") {
+        EXPECT_TRUE(hive::shouldEagerlyMaterialize(expr, *field));
+      } else {
+        EXPECT_FALSE(hive::shouldEagerlyMaterialize(expr, *field));
+      }
+    }
+  }
+
+  // Test 4: AND expression where field is used in simple conjunct,
+  // not in conditional.
+  {
+    auto exprSet =
+        compileExpression("a > 10 OR if(b > 20, c < 30, c < 5)", rowType);
+    auto& expr = *exprSet->exprs().front();
+    // Find field 'a' which is used in simple comparison, not in conditional.
+    for (const auto& field : expr.distinctFields()) {
+      EXPECT_TRUE(hive::shouldEagerlyMaterialize(expr, *field));
+    }
+  }
+}
+
+TEST_F(HiveConnectorUtilTest, createPointFilter) {
+  // Test BIGINT point filter.
+  {
+    auto filter = hive::createPointFilter(
+        BIGINT(), variant::create<TypeKind::BIGINT>(42));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testInt64(42));
+    EXPECT_FALSE(filter->testInt64(41));
+    EXPECT_FALSE(filter->testInt64(43));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test INTEGER point filter.
+  {
+    auto filter = hive::createPointFilter(INTEGER(), variant(100));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testInt64(100));
+    EXPECT_FALSE(filter->testInt64(99));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test DOUBLE point filter.
+  {
+    auto filter = hive::createPointFilter(DOUBLE(), variant(3.14));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testDouble(3.14));
+    EXPECT_FALSE(filter->testDouble(3.15));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test VARCHAR point filter.
+  {
+    auto filter = hive::createPointFilter(VARCHAR(), variant("hello"));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testBytes("hello", 5));
+    EXPECT_FALSE(filter->testBytes("world", 5));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test BOOLEAN point filter.
+  {
+    auto filter = hive::createPointFilter(BOOLEAN(), variant(true));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testBool(true));
+    EXPECT_FALSE(filter->testBool(false));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test null value throws.
+  {
+    VELOX_ASSERT_THROW(
+        hive::createPointFilter(BIGINT(), variant::null(TypeKind::BIGINT)),
+        "Value cannot be null");
+  }
+
+  // Test unsupported types throw.
+  for (const auto& unsupported : kUnsupportedFilterTypes) {
+    SCOPED_TRACE(
+        fmt::format("Unsupported type: {}", unsupported.type->toString()));
+    VELOX_ASSERT_THROW(
+        hive::createPointFilter(unsupported.type, unsupported.value), "");
+  }
+}
+
+TEST_F(HiveConnectorUtilTest, createRangeFilter) {
+  // Test BIGINT range filter.
+  {
+    auto filter = hive::createRangeFilter(
+        BIGINT(),
+        variant::create<TypeKind::BIGINT>(10),
+        variant::create<TypeKind::BIGINT>(20));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testInt64(10));
+    EXPECT_TRUE(filter->testInt64(15));
+    EXPECT_TRUE(filter->testInt64(20));
+    EXPECT_FALSE(filter->testInt64(9));
+    EXPECT_FALSE(filter->testInt64(21));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test INTEGER range filter.
+  {
+    auto filter = hive::createRangeFilter(INTEGER(), variant(0), variant(100));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testInt64(0));
+    EXPECT_TRUE(filter->testInt64(50));
+    EXPECT_TRUE(filter->testInt64(100));
+    EXPECT_FALSE(filter->testInt64(-1));
+    EXPECT_FALSE(filter->testInt64(101));
+  }
+
+  // Test DOUBLE range filter.
+  {
+    auto filter = hive::createRangeFilter(DOUBLE(), variant(1.0), variant(2.0));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testDouble(1.0));
+    EXPECT_TRUE(filter->testDouble(1.5));
+    EXPECT_TRUE(filter->testDouble(2.0));
+    EXPECT_FALSE(filter->testDouble(0.9));
+    EXPECT_FALSE(filter->testDouble(2.1));
+  }
+
+  // Test VARCHAR range filter.
+  {
+    auto filter =
+        hive::createRangeFilter(VARCHAR(), variant("apple"), variant("banana"));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testBytes("apple", 5));
+    EXPECT_TRUE(filter->testBytes("ball", 4));
+    EXPECT_TRUE(filter->testBytes("banana", 6));
+    EXPECT_FALSE(filter->testBytes("aaa", 3));
+    EXPECT_FALSE(filter->testBytes("cherry", 6));
+  }
+
+  // Test lower bound only (upper unbounded) - BIGINT.
+  {
+    auto filter = hive::createRangeFilter(
+        BIGINT(),
+        variant::create<TypeKind::BIGINT>(10),
+        variant::null(TypeKind::BIGINT));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testInt64(10));
+    EXPECT_TRUE(filter->testInt64(100));
+    EXPECT_TRUE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+    EXPECT_FALSE(filter->testInt64(9));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test upper bound only (lower unbounded) - BIGINT.
+  {
+    auto filter = hive::createRangeFilter(
+        BIGINT(),
+        variant::null(TypeKind::BIGINT),
+        variant::create<TypeKind::BIGINT>(20));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testInt64(20));
+    EXPECT_TRUE(filter->testInt64(0));
+    EXPECT_TRUE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+    EXPECT_FALSE(filter->testInt64(21));
+    EXPECT_FALSE(filter->testNull());
+  }
+
+  // Test lower bound only - DOUBLE.
+  {
+    auto filter = hive::createRangeFilter(
+        DOUBLE(), variant(1.5), variant::null(TypeKind::DOUBLE));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testDouble(1.5));
+    EXPECT_TRUE(filter->testDouble(100.0));
+    EXPECT_FALSE(filter->testDouble(1.0));
+  }
+
+  // Test upper bound only - VARCHAR.
+  {
+    auto filter = hive::createRangeFilter(
+        VARCHAR(), variant::null(TypeKind::VARCHAR), variant("banana"));
+    ASSERT_NE(filter, nullptr);
+    EXPECT_TRUE(filter->testBytes("banana", 6));
+    EXPECT_TRUE(filter->testBytes("aaa", 3));
+    EXPECT_FALSE(filter->testBytes("cherry", 6));
+  }
+
+  // Test both bounds null throws.
+  {
+    VELOX_ASSERT_THROW(
+        hive::createRangeFilter(
+            BIGINT(),
+            variant::null(TypeKind::BIGINT),
+            variant::null(TypeKind::BIGINT)),
+        "At least one of lower or upper bound must be set");
+  }
+
+  // Test unsupported types throw.
+  for (const auto& unsupported : kUnsupportedFilterTypes) {
+    SCOPED_TRACE(
+        fmt::format("Unsupported type: {}", unsupported.type->toString()));
+    VELOX_ASSERT_THROW(
+        hive::createRangeFilter(
+            unsupported.type, unsupported.value, unsupported.value),
+        "");
   }
 }
 

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -53,7 +53,7 @@ MarkDistinct::MarkDistinct(
 }
 
 void MarkDistinct::addInput(RowVectorPtr input) {
-  groupingSet_->addInput(input, false /*mayPushdown*/);
+  groupingSet_->addInput(input, /*mayPushdown=*/false);
 
   input_ = std::move(input);
 }


### PR DESCRIPTION
Summary:
Move some of utilities from hive data source to hive connector utility for share with hive index source. We might consider to have a common hive source as base class later:

1. **HiveConnector**: Added `createIndexSource()` method to create index data sources for index lookup join operations.

2. **HiveConnectorUtil**: Added new utility functions:
   - `createPointFilter()`: Creates point lookup filters for index key columns based on lookup keys
   - `createRangeFilter()`: Creates range filters for index key columns based on lookup key ranges
   - `shouldEagerlyMaterialize()`: Determines if a column should be eagerly materialized during index lookup
   - `checkColumnHandleConsistent()`: Validates consistency between column handles and output types

3. **makeScanSpec extension**: Extended to support index columns, allowing scan specs to be created with both regular and index column specifications.

4. **HiveDataSource**: Updated to use the new utility functions for filter creation and column materialization decisions.

Differential Revision: D91297962


