### PR TITLE
misc: Use selective Nimble reader by default for Hive connector

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -819,7 +819,7 @@ class QueryConfig {
   };
 
   bool selectiveNimbleReaderEnabled() const {
-    return get<bool>(kSelectiveNimbleReaderEnabled, false);
+    return get<bool>(kSelectiveNimbleReaderEnabled, true);
   }
 
   RowSizeTrackingMode rowSizeTrackingMode() const {


### PR DESCRIPTION
Differential Revision: D91337841


