### PR TITLE
fix: Add fail-fast validation for synthesized column filters in HiveConnector

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -468,14 +468,6 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
 
   for (auto& pair : subfieldFilters) {
     const auto name = pair.first.toString();
-    // SelectiveColumnReader doesn't support constant columns with filters,
-    // hence, we can't have a filter for a $path or $bucket column.
-    //
-    // Unfortunately, Presto happens to specify a filter for $path, $file_size,
-    // $file_modified_time or $bucket column. This filter is redundant and needs
-    // to be removed.
-    // TODO Remove this check when Presto is fixed to not specify a filter
-    // on $path and $bucket column.
     if (isSynthesizedColumn(name, infoColumns)) {
       continue;
     }

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -213,7 +213,8 @@ std::unique_ptr<SplitReader> HiveDataSource::createSplitReader() {
       fsStats_,
       fileHandleFactory_,
       ioExecutor_,
-      scanSpec_);
+      scanSpec_,
+      /*subfieldFiltersForValidation=*/&filters_);
 }
 
 std::vector<column_index_t> HiveDataSource::setupBucketConversion() {
@@ -313,6 +314,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   }
 
   splitReader_ = createSplitReader();
+  splitReader_->setInfoColumns(&infoColumns_);
   if (!bucketChannels.empty()) {
     splitReader_->setBucketConversion(std::move(bucketChannels));
   }

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -99,7 +99,8 @@ std::unique_ptr<SplitReader> SplitReader::create(
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* ioExecutor,
-    const std::shared_ptr<common::ScanSpec>& scanSpec) {
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    const common::SubfieldFilters* subfieldFiltersForValidation) {
   //  Create the SplitReader based on hiveSplit->customSplitInfo["table_format"]
   if (hiveSplit->customSplitInfo.count("table_format") > 0 &&
       hiveSplit->customSplitInfo["table_format"] == "hive-iceberg") {
@@ -127,7 +128,8 @@ std::unique_ptr<SplitReader> SplitReader::create(
         fsStats,
         fileHandleFactory,
         ioExecutor,
-        scanSpec));
+        scanSpec,
+        subfieldFiltersForValidation));
   }
 }
 
@@ -142,10 +144,12 @@ SplitReader::SplitReader(
     const std::shared_ptr<filesystems::File::IoStats>& fsStats,
     FileHandleFactory* fileHandleFactory,
     folly::Executor* ioExecutor,
-    const std::shared_ptr<common::ScanSpec>& scanSpec)
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    const common::SubfieldFilters* subfieldFiltersForValidation)
     : hiveSplit_(hiveSplit),
       hiveTableHandle_(hiveTableHandle),
       partitionKeys_(partitionKeys),
+      infoColumns_(nullptr),
       connectorQueryCtx_(connectorQueryCtx),
       hiveConfig_(hiveConfig),
       readerOutputType_(readerOutputType),
@@ -155,6 +159,7 @@ SplitReader::SplitReader(
       ioExecutor_(ioExecutor),
       pool_(connectorQueryCtx->memoryPool()),
       scanSpec_(scanSpec),
+      subfieldFiltersForValidation_(subfieldFiltersForValidation),
       baseReaderOpts_(connectorQueryCtx->memoryPool()),
       emptySplit_(false) {}
 
@@ -175,6 +180,10 @@ void SplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,
     const folly::F14FastMap<std::string, std::string>& fileReadOps) {
+  // Validate synthesized column filters early, before creating the reader.
+  // This handles filter-only synthesized columns that are not in the scanSpec.
+  validateSynthesizedColumnFilters();
+
   createReader(fileReadOps);
   if (emptySplit_) {
     return;
@@ -187,6 +196,50 @@ void SplitReader::prepareSplit(
   }
 
   createRowReader(std::move(metadataFilter), std::move(rowType), std::nullopt);
+}
+
+void SplitReader::validateSynthesizedColumnFilters() const {
+  if (!subfieldFiltersForValidation_ || !infoColumns_) {
+    return;
+  }
+  for (const auto& [subfield, filter] : *subfieldFiltersForValidation_) {
+    const auto& fieldName = subfield.toString();
+    // Check if this is a synthesized column filter.
+    auto infoColIter = hiveSplit_->infoColumns.find(fieldName);
+    if (infoColIter == hiveSplit_->infoColumns.end()) {
+      // Not a synthesized column, skip.
+      continue;
+    }
+    // Validate the filter against the split's value.
+    bool passed = false;
+    const auto& value = infoColIter->second;
+    // Look up the type from the column handles in infoColumns_.
+    auto handleIter = infoColumns_->find(fieldName);
+    VELOX_CHECK(
+        handleIter != infoColumns_->end(),
+        "Column handle for synthesized column '{}' not found in infoColumns",
+        fieldName);
+    TypeKind typeKind = handleIter->second->dataType()->kind();
+    switch (typeKind) {
+      case TypeKind::BIGINT:
+      case TypeKind::INTEGER:
+        passed = common::applyFilter(*filter, folly::to<int64_t>(value));
+        break;
+      case TypeKind::VARCHAR:
+        passed = common::applyFilter(*filter, value);
+        break;
+      default:
+        VELOX_FAIL("Unexpected type for synthesized column '{}'.", fieldName);
+    }
+    VELOX_CHECK(
+        passed,
+        "Synthesized column '{}' failed filter validation. "
+        "Filter: {}, Value: '{}'. Split: {}",
+        fieldName,
+        filter->toString(),
+        value,
+        hiveSplit_->toString());
+  }
 }
 
 void SplitReader::setBucketConversion(
@@ -425,6 +478,9 @@ std::vector<TypePtr> SplitReader::adaptColumns(
       setPartitionValue(childSpec, fieldName, it->second);
     } else if (auto iter = hiveSplit_->infoColumns.find(fieldName);
                iter != hiveSplit_->infoColumns.end()) {
+      // Synthesized column filter validation is done in prepareSplit() for
+      // fail-fast behavior before any file I/O. Here we only need to set the
+      // constant value for the column.
       auto infoColumnType =
           readerOutputType_->childAt(readerOutputType_->getChildIdx(fieldName));
       auto constant = newConstantFromString(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3067,6 +3067,81 @@ TEST_F(TableScanTest, fileSizeAndModifiedTime) {
   filterTest(fmt::format("\"{}\" = {}", kModifiedTime, fileTimeValue));
 }
 
+// Test that synthesized column filter validation throws an error when the
+// filter doesn't match the split's value.
+TEST_F(TableScanTest, synthesizedColumnFilterValidation) {
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto filePath = makeFilePaths(1)[0];
+  auto vector = makeVectors(1, 10, rowType)[0];
+  writeToFile(filePath->getPath(), vector);
+
+  static const char* kPath = "$path";
+  auto assignments = allRegularColumns(rowType);
+  assignments[kPath] = synthesizedColumn(kPath, VARCHAR());
+
+  auto typeWithPath = ROW({kPath, "a"}, {VARCHAR(), BIGINT()});
+
+  // Create a filter that doesn't match the actual $path value.
+  auto tableHandle = makeTableHandle(
+      common::SubfieldFilters{},
+      parseExpr(
+          fmt::format("\"{}\" = '/nonexistent/path'", kPath), typeWithPath));
+
+  auto op = PlanBuilder()
+                .startTableScan()
+                .outputType(typeWithPath)
+                .tableHandle(tableHandle)
+                .assignments(assignments)
+                .endTableScan()
+                .planNode();
+
+  auto split =
+      exec::test::HiveConnectorSplitBuilder(filePath->getPath()).build();
+
+  // The query should throw an exception because the filter doesn't match.
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(op).splits({split}).copyResults(pool()),
+      "Synthesized column '$path' failed filter validation");
+}
+
+// Test that synthesized column filter validation throws an error for
+// $file_modified_time when the filter doesn't match the split's value.
+TEST_F(TableScanTest, synthesizedColumnFilterValidationModifiedTime) {
+  auto rowType = ROW({"a"}, {BIGINT()});
+  auto filePath = makeFilePaths(1)[0];
+  auto vector = makeVectors(1, 10, rowType)[0];
+  writeToFile(filePath->getPath(), vector);
+
+  static const char* kModifiedTime = "$file_modified_time";
+  auto assignments = allRegularColumns(rowType);
+  assignments[kModifiedTime] = synthesizedColumn(kModifiedTime, BIGINT());
+
+  auto typeWithModifiedTime = ROW({kModifiedTime, "a"}, {BIGINT(), BIGINT()});
+
+  // Create a filter that doesn't match the actual $file_modified_time value.
+  // Use 0 which won't match any real file's modification time.
+  auto tableHandle = makeTableHandle(
+      common::SubfieldFilters{},
+      parseExpr(
+          fmt::format("\"{}\" = 0", kModifiedTime), typeWithModifiedTime));
+
+  auto op = PlanBuilder()
+                .startTableScan()
+                .outputType(typeWithModifiedTime)
+                .tableHandle(tableHandle)
+                .assignments(assignments)
+                .endTableScan()
+                .planNode();
+
+  // Use makeHiveConnectorSplits to ensure infoColumns are set properly.
+  auto splits = makeHiveConnectorSplits({filePath});
+
+  // The query should throw an exception because the filter doesn't match.
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(op).splits(splits).copyResults(pool()),
+      "Synthesized column '$file_modified_time' failed filter validation");
+}
+
 TEST_F(TableScanTest, bucket) {
   vector_size_t size = 1'000;
   int numBatches = 5;


### PR DESCRIPTION
Summary:
Previously, filters on synthesized columns ($path, $bucket, $file_size, $file_modified_time) were silently skipped in makeScanSpec, allowing splits with non-matching values to proceed through the reader, potentially causing unexpected behavior.

This change adds early validation of synthesized column filters in SplitReader::prepareSplit(), before any file I/O occurs. Filters are passed from HiveDataSource via subfieldFiltersForValidation_ and validated against the split's infoColumns values. If a filter doesn't match, an exception is thrown immediately.

fix https://github.com/facebookincubator/velox/issues/15915

Differential Revision: D91151498


