### PR TITLE
feat(trace): Add TaskDebuggerCursor

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -498,14 +498,27 @@ StopReason Driver::runInternal(
   try {
     // Invoked to initialize the operators once before driver starts execution.
     initializeOperators();
+    int32_t startingOperator = getStartingOperator();
 
     TestValue::adjust("facebook::velox::exec::Driver::runInternal", this);
 
-    const int32_t numOperators = operators_.size();
+    // If the driver is coming back from a trace interruption, feed the
+    // intermediate result into the next operator, then resume execution at the
+    // exact operator where the trace was interrupted.
+    if (traceInput_ != nullptr) {
+      Operator* tracedOp = operators_[startingOperator].get();
+      CALL_OPERATOR(
+          addInput(tracedOp, traceInput_),
+          tracedOp,
+          startingOperator,
+          kOpMethodAddInput);
+      traceInput_ = nullptr;
+    }
+
     ContinueFuture future = ContinueFuture::makeEmpty();
 
     for (;;) {
-      for (int32_t i = numOperators - 1; i >= 0; --i) {
+      for (int32_t i = startingOperator; i >= 0; --i) {
         stop = task()->shouldStop();
         if (stop != StopReason::kNone) {
           guard.notThrown();
@@ -550,7 +563,7 @@ StopReason Driver::runInternal(
           return blockDriver(self, i, std::move(future), blockingState, guard);
         }
 
-        if (i < numOperators - 1) {
+        if (i < operators_.size() - 1) {
           Operator* nextOp = operators_[i + 1].get();
 
           withDeltaCpuWallTimer(nextOp, &OperatorStats::isBlockedTiming, [&]() {
@@ -595,6 +608,16 @@ StopReason Driver::runInternal(
               }
             });
             if (intermediateResult) {
+              const bool block =
+                  nextOp->traceInput(intermediateResult, &future);
+
+              if (block) {
+                blockingReason_ = BlockingReason::kWaitForConsumer;
+                traceInput_ = intermediateResult;
+                return blockDriver(
+                    self, i + 1, std::move(future), blockingState, guard);
+              }
+
               withDeltaCpuWallTimer(
                   nextOp, &OperatorStats::addInputTiming, [&]() {
                     {
@@ -603,7 +626,6 @@ StopReason Driver::runInternal(
                           resultBytes, intermediateResult->size());
                     }
 
-                    nextOp->traceInput(intermediateResult);
                     TestValue::adjust(
                         "facebook::velox::exec::Driver::runInternal::addInput",
                         nextOp);
@@ -1244,6 +1266,14 @@ StopReason Driver::blockDriver(
       self, std::move(future), op, blockingReason_);
   guard.notThrown();
   return StopReason::kBlock;
+}
+
+int32_t Driver::getStartingOperator() const {
+  if (traceInput_ != nullptr) {
+    return blockedOperatorId_;
+  }
+  // By default, start at the last (the consumer).
+  return operators_.size() - 1;
 }
 
 std::string Driver::label() const {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -224,9 +224,11 @@ constexpr uint32_t kUngroupedGroupId{std::numeric_limits<uint32_t>::max()};
 struct DriverCtx {
   const int driverId;
   const int pipelineId;
+
   /// Id of the split group this driver should process in case of grouped
   /// execution, kUngroupedGroupId otherwise.
   const uint32_t splitGroupId;
+
   /// Id of the partition to use by this driver. For local exchange, for
   /// instance.
   const uint32_t partitionId;
@@ -234,6 +236,7 @@ struct DriverCtx {
   std::shared_ptr<Task> task;
   Driver* driver{nullptr};
   facebook::velox::process::ThreadDebugInfo threadDebugInfo;
+
   /// Tracks the traced operator ids. It is also used to avoid tracing the
   /// auxiliary operator such as the aggregation operator used by the table
   /// writer to generate the columns stats.
@@ -627,6 +630,15 @@ class Driver : public std::enable_shared_from_this<Driver> {
       std::shared_ptr<BlockingState>& blockingState,
       CancelGuard& guard);
 
+  // Returns the operator to start from. The Driver always start the driver
+  // pipeline from the consumer (leaf), then walk backwards to the root based on
+  // whether they are ready to consume data, and the previous is ready to
+  // produce data.
+  //
+  // The only exception is when resuming from a trace, in which case the Driver
+  // must resume at the operator where it was blocked.
+  int32_t getStartingOperator() const;
+
   std::unique_ptr<DriverCtx> ctx_;
 
   // If set, the operator output batch size stats will be collected during
@@ -650,6 +662,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
 
   // Timer used to track down the time we are sitting in the driver queue.
   size_t queueTimeStartUs_{0};
+
   // Id (index in the vector) of the current operator to run (or the 1st one if
   // we haven't started yet). Used to determine which operator's queueTime we
   // should update.
@@ -658,7 +671,16 @@ class Driver : public std::enable_shared_from_this<Driver> {
   std::vector<std::unique_ptr<Operator>> operators_;
 
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+
+  // Stores the operator where the driver was last blocked. Note that the driver
+  // always resumes at the leaf (consumer) to prioritize getting data out of the
+  // task. The only exception is when resuming from a trace.
   size_t blockedOperatorId_{0};
+
+  // If this driver is being traced, store a pointer to the current data. Once
+  // the trace client unblocks the driver, we will feed this vector to the next
+  // operator in the pipeline.
+  RowVectorPtr traceInput_;
 
   bool trackOperatorCpuUsage_;
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -125,10 +125,11 @@ void Operator::maybeSetTracer() {
   }
 }
 
-void Operator::traceInput(const RowVectorPtr& input) {
+bool Operator::traceInput(const RowVectorPtr& input, ContinueFuture* future) {
   if (FOLLY_UNLIKELY(inputTracer_ != nullptr)) {
-    inputTracer_->write(input);
+    return inputTracer_->write(input, future);
   }
+  return false;
 }
 
 void Operator::finishTrace() {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -295,7 +295,7 @@ class Operator : public BaseRuntimeStatWriter {
   }
 
   /// Traces input batch of the operator.
-  virtual void traceInput(const RowVectorPtr&);
+  virtual bool traceInput(const RowVectorPtr& input, ContinueFuture* future);
 
   /// Finishes tracing of the operator.
   virtual void finishTrace();

--- a/velox/exec/OperatorTraceWriter.cpp
+++ b/velox/exec/OperatorTraceWriter.cpp
@@ -60,9 +60,11 @@ OperatorTraceInputWriter::OperatorTraceInputWriter(
   VELOX_CHECK_NOT_NULL(traceFile_);
 }
 
-void OperatorTraceInputWriter::write(const RowVectorPtr& rows) {
+bool OperatorTraceInputWriter::write(
+    const RowVectorPtr& rows,
+    ContinueFuture*) {
   if (FOLLY_UNLIKELY(finished_)) {
-    return;
+    return false;
   }
 
   if (batch_ == nullptr) {
@@ -82,6 +84,7 @@ void OperatorTraceInputWriter::write(const RowVectorPtr& rows) {
   auto iobuf = out.getIOBuf();
   updateAndCheckTraceLimitCB_(iobuf->computeChainDataLength());
   traceFile_->append(std::move(iobuf));
+  return false;
 }
 
 void OperatorTraceInputWriter::finish() {

--- a/velox/exec/OperatorTraceWriter.h
+++ b/velox/exec/OperatorTraceWriter.h
@@ -45,7 +45,7 @@ class OperatorTraceInputWriter : public TraceInputWriter {
       UpdateAndCheckTraceLimitCB updateAndCheckTraceLimitCB);
 
   /// Serializes rows and writes out each batch.
-  void write(const RowVectorPtr& rows) override;
+  bool write(const RowVectorPtr& rows, ContinueFuture* future) override;
 
   /// Closes the data file and writes out the data summary.
   void finish() override;

--- a/velox/exec/TaskDebuggerCursor.h
+++ b/velox/exec/TaskDebuggerCursor.h
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <unordered_set>
+
+#include "velox/core/PlanFragment.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/exec/Cursor.h"
+#include "velox/exec/Task.h"
+#include "velox/exec/trace/TraceCtx.h"
+
+namespace facebook::velox::exec {
+
+/// A debugging cursor for interactive task execution.
+///
+/// TaskDebuggerCursor enables step-by-step execution of a query plan, allowing
+/// users to inspect intermediate results at traced operator boundaries. This is
+/// useful for debugging query execution and understanding data flow through
+/// operators.
+///
+/// The cursor uses a custom tracing context that pauses execution at traced
+/// operators, allowing inspection of input vectors before they are processed.
+///
+/// Example usage:
+/// @code
+///
+///   TaskDebuggerCursor cursor(planFragment, {"planNodeId1", "plaNodeId10"});
+///
+///   auto vector = cursor.step(); // advances until the next "breakpoint";
+///                                // either input of a traced operator or task
+///                                // output.
+///
+///   auto vector = cursor.next(); // advances until the next task output.
+///
+///   // Get every result, from traced operators and output:
+///   while (auto vector = cursor.step()) {
+///   }
+/// @endcode
+///
+/// @note This class assumes serial (single-threaded) execution mode.
+/// @note The cursor maintains ownership of the underlying task and ensures
+///       proper cleanup in the destructor.
+class TaskDebuggerCursor {
+ public:
+  /// Constructs a TaskDebuggerCursor for the given plan fragment.
+  ///
+  /// @param planFragment The plan fragment to execute. This contains the
+  ///        query plan and associated metadata.
+  /// @param tracedPlanNodeIds A list of plan node IDs where execution should
+  ///        pause to allow inspection of intermediate results. Only operators
+  ///        corresponding to these node IDs will be traced.
+  TaskDebuggerCursor(
+      core::PlanFragment planFragment,
+      const std::vector<core::PlanNodeId>& tracedPlanNodeIds) {
+    static std::atomic_int32_t cursorId{0};
+    taskId_ = fmt::format("debug_cursor_{}", ++cursorId);
+
+    auto queryCtx =
+        core::QueryCtx::Builder()
+            .queryConfig(
+                core::QueryConfig({
+                    {core::QueryConfig::kQueryTraceEnabled, "true"},
+                }))
+            .traceCtxProvider([&](core::QueryCtx&, const core::PlanFragment&) {
+              return std::make_unique<TaskDebuggerTraceCtx>(
+                  tracedPlanNodeIds, traceState_);
+            })
+            .build();
+
+    task_ = Task::create(
+        taskId_,
+        std::move(planFragment),
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kSerial);
+  }
+
+  /// Ensures the task completes before cleanup.
+  ~TaskDebuggerCursor() {
+    if (task_) {
+      waitForTaskDriversToFinish(task_.get());
+    }
+  }
+
+  TaskDebuggerCursor(TaskDebuggerCursor&&) noexcept = default;
+  TaskDebuggerCursor& operator=(TaskDebuggerCursor&&) noexcept = default;
+
+  /// Retrieves the next complete result vector from the task.
+  ///
+  /// This method advances execution until a final output vector is produced,
+  /// skipping over any intermediate traced results. Use this when you want
+  /// to get the final query results without pausing at traced operators.
+  ///
+  /// @return The next result vector, or nullptr if execution is complete.
+  RowVectorPtr next() {
+    return advance(false);
+  }
+
+  /// Steps through execution, returning either a traced intermediate result
+  /// or a final output vector.
+  ///
+  /// This method advances execution until either:
+  /// - A traced operator produces an input vector (returns the traced input)
+  /// - A final output vector is produced (returns the output)
+  /// - Execution completes (returns nullptr)
+  ///
+  /// When a traced result is returned, execution is paused at that point.
+  /// Call step() again to continue execution from where it left off.
+  ///
+  /// @return The next intermediate or final result vector, or nullptr if
+  ///         execution is complete.
+  RowVectorPtr step() {
+    return advance(true);
+  }
+
+ private:
+  // Advance to the next vector to produce. If `isStep` is true, move to the
+  // next trace point or task output. If false, moves to the next task output.
+  RowVectorPtr advance(bool isStep) {
+    if (traceState_.traceData) {
+      traceState_.traceData = nullptr;
+      traceState_.tracePromise.setValue();
+    }
+
+    while (true) {
+      ContinueFuture future = ContinueFuture::makeEmpty();
+
+      if (auto vector = task_->next(&future)) {
+        return vector;
+      }
+
+      // When we hit a tracing point, the driver will return nullptr, set a
+      // future, and the trace implementation will capture state in traceState_.
+      if (traceState_.traceData) {
+        if (isStep) {
+          return traceState_.traceData;
+        }
+
+        // Signal the task driver to unblock.
+        traceState_.traceData = nullptr;
+        traceState_.tracePromise.setValue();
+      }
+
+      // Wait until the task future is unblocked.
+      if (future.valid()) {
+        future.wait();
+      } else {
+        // When no vector was produced and the future is not valid, it's the
+        // task signal that it has finished producing output.
+        break;
+      }
+    }
+    return nullptr;
+  }
+
+  /// Internal state for coordinating between the tracer and cursor.
+  ///
+  /// This struct manages the synchronization between the trace writer
+  /// (which produces intermediate results) and the cursor (which consumes
+  /// them).
+  struct TraceState {
+    /// Promise used to signal the tracer to continue after a partial result
+    /// has been consumed.
+    ContinuePromise tracePromise{ContinuePromise::makeEmpty()};
+
+    /// The most recent intermediate result from a traced operator.
+    RowVectorPtr traceData;
+  } traceState_;
+
+  // Custom trace context implementation for the debugger.
+  //
+  // This trace context pauses execution at traced operators by blocking
+  // the trace writer until the cursor consumes the intermediate result.
+  class TaskDebuggerTraceCtx : public trace::TraceCtx {
+   public:
+    // Constructs a trace context for the specified plan nodes.
+    //
+    // @param tracedIds The plan node IDs to trace.
+    // @param traceState Reference to the shared trace state for coordination.
+    TaskDebuggerTraceCtx(
+        const std::vector<core::PlanNodeId>& tracedIds,
+        TraceState& traceState)
+        : TraceCtx(false),
+          tracedIds_(tracedIds.begin(), tracedIds.end()),
+          traceState_(traceState) {}
+
+    // Determines whether a given operator should be traced.
+    //
+    // @param op The operator to check.
+    // @return true if the operator's plan node ID is in the traced set.
+    bool shouldTrace(const Operator& op) const override {
+      return tracedIds_.contains(op.planNodeId());
+    }
+
+    // Creates an input trace writer for the given operator.
+    //
+    // @param op The operator to create a tracer for.
+    // @return A unique pointer to the trace input writer.
+    std::unique_ptr<trace::TraceInputWriter> createInputTracer(
+        Operator& op) const override {
+      return std::make_unique<TaskDebuggerTraceInputWriter>(
+          op.planNodeId(), traceState_);
+    }
+
+   private:
+    // Trace writer that captures input vectors and pauses execution.
+    //
+    // When an input vector is written, this writer stores it in the shared
+    // trace state and blocks until the cursor signals to continue.
+    class TaskDebuggerTraceInputWriter : public trace::TraceInputWriter {
+     public:
+      TaskDebuggerTraceInputWriter(
+          const core::PlanNodeId& planId,
+          TraceState& traceState)
+          : planId_(planId), traceState_(traceState) {}
+
+      // Writes an input vector and pauses execution.
+      //
+      // Stores the vector in the trace state and creates a future that
+      // blocks until the cursor consumes the result and signals continuation.
+      //
+      // @param vector The input vector to trace.
+      // @param future Output parameter set to a future that blocks until
+      //        the cursor is ready to continue.
+      // @return true to indicate the writer is blocked waiting for the future.
+      bool write(const RowVectorPtr& vector, ContinueFuture* future) override {
+        VELOX_CHECK(traceState_.tracePromise.isFulfilled());
+
+        traceState_.traceData = vector;
+        traceState_.tracePromise = ContinuePromise("TaskQueue::dequeue");
+        *future = traceState_.tracePromise.getFuture();
+        return true;
+      }
+
+      // Called when tracing is complete for this operator.
+      void finish() override {}
+
+     private:
+      const core::PlanNodeId planId_;
+      TraceState& traceState_;
+    };
+
+    std::unordered_set<core::PlanNodeId> tracedIds_;
+    TraceState& traceState_;
+  };
+
+  std::shared_ptr<exec::Task> task_;
+  std::string taskId_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/trace/TraceWriter.h
+++ b/velox/exec/trace/TraceWriter.h
@@ -36,8 +36,10 @@ class TraceInputWriter {
  public:
   virtual ~TraceInputWriter() = default;
 
-  /// Serializes rows and writes out each batch.
-  virtual void write(const RowVectorPtr& rows) = 0;
+  /// Serializes rows and writes out each batch. Return whether the driver
+  /// should block the pipeline. If it returns true, a future needs to be set
+  /// (returned) to signal the driver when it can resume execution.
+  virtual bool write(const RowVectorPtr& rows, ContinueFuture* future) = 0;
 
   /// Closes the data file and writes out the data summary.
   virtual void finish() = 0;


### PR DESCRIPTION
Summary:
Add a task debugger cursor, enabling users to specify plan nodes to
trace/debug. This is inspired in the behavior of a debugger like gdb with
breakpoints set.

The cursor provides a step() function to return the vector produced by next
traced operator, and a next() function that ignores traced operators and moves
to the next regular output.

Extending the trace writer API to enable it to signal the driver it needs to
block and release the thread. The debugger will later on signal the driver it
is done with the partial state and that the driver is free to move to the next
point.

Only supports serial execution for now.

Differential Revision: D91386453


