### PR TITLE
fix: TSAN data race in LocalMergeSource by deferring data reset

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -120,10 +120,10 @@ class LocalMergeSource : public MergeSource {
         ContinueFuture* future,
         ScopedPromiseNotification& notification) {
       VELOX_CHECK(started_);
-      data.reset();
 
       if (data_.empty()) {
         if (atEnd_) {
+          data.reset();
           return BlockingReason::kNotBlocked;
         }
         consumerPromises_.emplace_back("LocalMergeSourceQueue::next");


### PR DESCRIPTION
Summary: The MergeTest.localMergeSpill test was failing with TSAN data race errors. The race occurred between the Merge operator reading from a vector via SourceStream::copyToOutput() and the upstream operator modifying the same vector. It doesn't seem to be a real race but the TSAN might detect this as failure because the timing is so close. LocalMergeSourceQueue::next() which was calling data.reset() unconditionally at the start of the function. This reset the caller's reference to the previous batch allow the upstream operator sort buffer to reuse the output vector. The TSAN fix is to move the data.reset() call to only execute when the queue is empty and has reached the end (atEnd_ is true), ensuring the reference is only cleared when there's no more data to process. The TSAN test passed 5'000 iterations.

Differential Revision: D91402349


