### PR TITLE
fix(cudf): Fix errors setFromDataSource UNSUPPORTED

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnector.h
@@ -47,6 +47,10 @@ class CudfHiveConnector final
     return false;
   }
 
+  bool supportsSplitPreload() const override {
+    return false;
+  }
+
   // TODO (dm): Re-add data sink
 
  protected:


### PR DESCRIPTION
This errors shows up due to preload feature in HiveConnector.
CudfHiveConnector does not support it yet. So, this PR disables it.
Fixes test failures of velox/experimental/cudf/tests/velox_cudf_s3_read_test and  velox/experimental/cudf/tests/velox_cudf_table_scan_test 