### PR TITLE
misc: Improve AsyncSource with atomic State enum state machine and fix TSAN race conditions

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -16,11 +16,14 @@
 
 #pragma once
 
+#include <fmt/core.h>
 #include <folly/Unit.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
 #include <folly/futures/Future.h>
+#include <atomic>
 #include <functional>
 #include <memory>
+#include <vector>
 #include "velox/common/time/CpuWallTimer.h"
 
 #include "velox/common/base/Exceptions.h"
@@ -31,22 +34,23 @@
 
 namespace facebook::velox {
 
-// A future-like object that prefabricates Items on an executor and
-// allows consumer threads to pick items as they are ready. If the
-// consumer needs the item before the executor started making it, the
-// consumer will make it instead. If multiple consumers request the
-// same item, exactly one gets it. Propagates exceptions to the
-// consumer.
+/// A future-like object that prefabricates Items on an executor and
+/// allows consumer threads to pick items as they are ready. If the
+/// consumer needs the item before the executor started making it, the
+/// consumer will make it instead. If multiple consumers request the
+/// same item, exactly one gets it. Propagates exceptions to the
+/// consumer.
 template <typename Item>
 class AsyncSource {
  public:
-  explicit AsyncSource(std::function<std::unique_ptr<Item>()> make)
-      : make_(std::move(make)) {
+  explicit AsyncSource(std::function<std::unique_ptr<Item>()> itemMaker)
+      : itemMaker_(std::move(itemMaker)) {
+    VELOX_CHECK_NOT_NULL(itemMaker_);
     if (process::GetThreadDebugInfo() != nullptr) {
       auto* currentThreadDebugInfo = process::GetThreadDebugInfo();
       // We explicitly leave out the callback when copying the ThreadDebugInfo
       // as that may have captured state that goes out of scope by the time
-      // _make is called.
+      // itemMaker_ is called.
       threadDebugInfo_ = std::make_optional<process::ThreadDebugInfo>(
           {currentThreadDebugInfo->queryId_,
            currentThreadDebugInfo->taskId_,
@@ -55,180 +59,349 @@ class AsyncSource {
   }
 
   ~AsyncSource() {
+    const auto currentState = state();
     VELOX_CHECK(
-        moved_ || closed_ || (cancelled_ && !making_),
-        "AsyncSource should be properly consumed, closed, or cancelled.");
+        currentState == State::kFinished || currentState == State::kCancelled ||
+            currentState == State::kFailed,
+        "AsyncSource should be properly finished, cancelled, or failed, unexpected state: {}",
+        stateName(currentState));
   }
 
-  // Makes an item if it is not already made. To be called on a background
-  // executor.
+  /// Makes an item if it is not already made. To be called on a background
+  /// executor.
   void prepare() {
     common::testutil::TestValue::adjust(
         "facebook::velox::AsyncSource::prepare", this);
-    std::function<std::unique_ptr<Item>()> make = nullptr;
+    std::function<std::unique_ptr<Item>()> itemMaker{nullptr};
     {
       std::lock_guard<std::mutex> l(mutex_);
-      if (!make_) {
+      if (state() != State::kInit) {
+        VELOX_CHECK_NULL(itemMaker_);
         return;
       }
-      making_ = true;
-      std::swap(make, make_);
+      setState(State::kMaking);
+      std::swap(itemMaker, itemMaker_);
     }
-    std::unique_ptr<Item> item;
-    try {
-      CpuWallTimer timer(timing_);
-      item = runMake(make);
-    } catch (std::exception&) {
-      std::lock_guard<std::mutex> l(mutex_);
-      exception_ = std::current_exception();
-    }
-    std::unique_ptr<ContinuePromise> promise;
-    {
-      std::lock_guard<std::mutex> l(mutex_);
-      VELOX_CHECK_NULL(item_);
-      if (FOLLY_LIKELY(exception_ == nullptr)) {
-        item_ = std::move(item);
-      }
-      making_ = false;
-      promise.swap(promise_);
-    }
-    if (promise != nullptr) {
-      promise->setValue();
-    }
+    makeItem(std::move(itemMaker));
   }
 
-  // Returns the item to the first caller and nullptr to subsequent callers.
-  // If the item is preparing on the executor, waits for the item and
-  // otherwise makes it on the caller thread.
+  /// Returns the item to the first caller and nullptr to subsequent callers.
+  /// If the item is preparing on the executor, waits for the item and
+  /// otherwise makes it on the caller thread.
   std::unique_ptr<Item> move() {
     common::testutil::TestValue::adjust(
         "facebook::velox::AsyncSource::move", this);
-    std::function<std::unique_ptr<Item>()> make = nullptr;
+    auto currentState = state();
+    std::function<std::unique_ptr<Item>()> itemMaker{nullptr};
     ContinueFuture wait;
     {
       std::lock_guard<std::mutex> l(mutex_);
-      moved_ = true;
-      // 'making_' can be read atomically, 'exception' maybe not. So test
-      // 'making' so as not to read half-assigned 'exception_'.
-      if (!making_ && exception_) {
-        std::rethrow_exception(exception_);
-      }
-      if (item_) {
-        return std::move(item_);
-      }
-      if (promise_) {
-        // Somebody else is now waiting for the item to be made.
-        return nullptr;
-      }
-      if (making_) {
-        promise_ = std::make_unique<ContinuePromise>("AsyncSource::move");
-        wait = promise_->getSemiFuture();
-      } else {
-        if (!make_) {
+      const auto currentState = state();
+      switch (currentState) {
+        case State::kFinished:
+        case State::kCancelled:
           return nullptr;
-        }
-        std::swap(make, make_);
+        case State::kFailed:
+          VELOX_CHECK_NOT_NULL(exception_);
+          std::rethrow_exception(exception_);
+        case State::kPrepared:
+          VELOX_CHECK(promises_.empty());
+          setState(State::kFinished);
+          return std::move(item_);
+        case State::kMaking:
+          VELOX_CHECK_NULL(itemMaker_);
+          VELOX_CHECK_NULL(item_);
+          if (!promises_.empty()) {
+            // Somebody else is already waiting for the item to be made.
+            return nullptr;
+          }
+          promises_.emplace_back("AsyncSource::move");
+          wait = promises_.back().getSemiFuture();
+          break;
+        case State::kInit:
+          VELOX_CHECK_NOT_NULL(itemMaker_);
+          VELOX_CHECK_NULL(item_);
+          setState(State::kMaking);
+          std::swap(itemMaker, itemMaker_);
+          break;
       }
     }
     // Outside of mutex_.
-    if (make) {
-      try {
-        return runMake(make);
-      } catch (const std::exception&) {
-        std::lock_guard<std::mutex> l(mutex_);
-        exception_ = std::current_exception();
-        throw;
-      }
+    if (itemMaker != nullptr) {
+      makeItem(std::move(itemMaker));
     }
-    auto& exec = folly::QueuedImmediateExecutor::instance();
-    std::move(wait).via(&exec).wait();
+
+    makeWait(std::move(wait));
+
     std::lock_guard<std::mutex> l(mutex_);
-    if (exception_) {
+    currentState = state();
+    if (exception_ != nullptr) {
+      checkState(currentState, State::kFailed);
       std::rethrow_exception(exception_);
     }
+    if (currentState == State::kFinished) {
+      // Another move() or close() might have grabbed the item first.
+      return nullptr;
+    }
+    checkState(currentState, State::kPrepared);
+    setState(State::kFinished);
     return std::move(item_);
   }
 
-  // If true, move() will not block. But there is no guarantee that somebody
-  // else will not get the item first.
+  /// If true, move() will not block. But there is no guarantee that somebody
+  /// else will not get the item first.
   bool hasValue() const {
     tsan_lock_guard<std::mutex> l(mutex_);
     return item_ != nullptr || exception_ != nullptr;
   }
 
-  /// Returns the timing of prepare(). If the item was made on the calling
-  /// thread, the timing is 0 since only off-thread activity needs to be added
-  /// to the caller's timing.
-  const CpuWallTiming& prepareTiming() {
-    return timing_;
+  /// Returns the timing of making the item. If the item was made on the
+  /// calling thread, the timing is 0 since only off-thread activity needs to
+  /// be added to the caller's timing.
+  const CpuWallTiming& prepareTiming() const {
+    return makeTiming_;
   }
 
-  /// Cancels the task if it hasn't started yet.
-  /// If the task has already started, the task will continue but AsyncSource
+  /// Cancels the task if it hasn't started yet or if item is already prepared.
+  /// If the task is making, the task will continue but AsyncSource
   /// is marked as cancelled to allow proper cleanup in destructor.
   void cancel() {
     std::lock_guard<std::mutex> l(mutex_);
-    cancelled_ = true;
-    if (make_ == nullptr) {
-      return;
+    const auto currentState = state();
+    switch (currentState) {
+      case State::kInit:
+        VELOX_CHECK_NOT_NULL(itemMaker_);
+        VELOX_CHECK_NULL(item_);
+        itemMaker_ = nullptr;
+        setState(State::kCancelled);
+        return;
+      case State::kPrepared:
+        VELOX_CHECK_NULL(itemMaker_);
+        item_ = nullptr;
+        setState(State::kCancelled);
+        return;
+      default:
+        return;
     }
-    make_ = nullptr;
   }
 
   /// This function assists the caller in ensuring that resources allocated in
   /// AsyncSource are promptly released:
-  /// 1. Waits for the completion of the 'make_' function if it is executing
-  /// in the thread pool.
-  /// 2. Resets the 'make_' function if it has not started yet.
-  /// 3. Cleans up the 'item_' if 'make_' has completed, but the result
+  /// 1. Waits for the completion of the 'itemMaker_' function if it is
+  /// executing in the thread pool.
+  /// 2. Resets the 'itemMaker_' function if it has not started yet.
+  /// 3. Cleans up the 'item_' if 'itemMaker_' has completed, but the result
   /// 'item_' has not been returned to the caller.
   void close() {
-    if (closed_ || moved_) {
+    auto currentState = state();
+    if (currentState == State::kFinished || currentState == State::kFailed ||
+        currentState == State::kCancelled) {
       return;
     }
     ContinueFuture wait;
     {
       std::lock_guard<std::mutex> l(mutex_);
-      if (making_) {
-        promise_ = std::make_unique<ContinuePromise>("AsyncSource::close");
-        wait = promise_->getSemiFuture();
-      } else if (make_) {
-        make_ = nullptr;
+      if (tryCloseLocked()) {
+        return;
       }
+      checkState(state(), State::kMaking);
+      promises_.emplace_back("AsyncSource::close");
+      wait = promises_.back().getSemiFuture();
     }
 
-    auto& exec = folly::QueuedImmediateExecutor::instance();
-    std::move(wait).via(&exec).wait();
+    makeWait(std::move(wait));
+
     {
       std::lock_guard<std::mutex> l(mutex_);
-      if (item_) {
-        item_ = nullptr;
-      }
-      closed_ = true;
+      const auto closed = tryCloseLocked();
+      VELOX_CHECK(closed, "Unexpected close failure");
     }
   }
 
  private:
-  std::unique_ptr<Item> runMake(std::function<std::unique_ptr<Item>()>& make) {
-    process::ScopedThreadDebugInfo threadDebugInfo(
-        threadDebugInfo_.has_value() ? &threadDebugInfo_.value() : nullptr);
-    return make();
+  // State transition diagram:
+  //
+  //     ┌───────┐   prepare()   ┌─────────┐   success   ┌──────────┐
+  //     │ kInit │ ────────────► │ kMaking │ ──────────► │kPrepared │
+  //     └───────┘    move()     └─────────┘             └──────────┘
+  //       │   │                      │                     │    │
+  //       │   │ close()              │ exception           │    │ cancel()
+  //       │   │                      ▼                     │    │
+  //       │   │                ┌──────────┐   move()       │    │
+  //       │   │                │ kFailed  │   close()      │    │
+  //       │   │                └──────────┘                │    │
+  //       │   │                                            │    │
+  //       │   └──────────────────────┬─────────────────────┘    │
+  //       │                          ▼                          │
+  //       │ cancel()           ┌───────────┐                    │
+  //       │                    │ kFinished │                    │
+  //       │                    └───────────┘                    │
+  //       │                                                     │
+  //       └──────────────────────────┬──────────────────────────┘
+  //                                  ▼
+  //                            ┌───────────┐
+  //                            │kCancelled │
+  //                            └───────────┘
+  //
+  enum class State : uint8_t {
+    // Initial state before prepare() or move() is called.
+    kInit = 0,
+    // prepare() is executing.
+    kMaking = 1,
+    // prepare() has completed and item is ready.
+    kPrepared = 2,
+    // prepare() has failed with an exception.
+    kFailed = 3,
+    // move() or close() has been called and the AsyncSource is finished.
+    kFinished = 4,
+    // cancel() has been called.
+    kCancelled = 5,
+  };
+
+  State state() const {
+    return state_.load(std::memory_order_acquire);
   }
 
-  // Stored context (if present upon construction) so they can be restored when
-  // make_ is invoked.
+  static std::string stateName(State state) {
+    switch (state) {
+      case State::kInit:
+        return "INIT";
+      case State::kMaking:
+        return "MAKING";
+      case State::kPrepared:
+        return "PREPARED";
+      case State::kFailed:
+        return "FAILED";
+      case State::kFinished:
+        return "FINISHED";
+      case State::kCancelled:
+        return "CANCELLED";
+      default:
+        VELOX_UNREACHABLE("Unknown state: {}", static_cast<int>(state));
+    }
+  }
+
+  inline void checkState(State actualState, State expectedState) const {
+    VELOX_CHECK(
+        actualState == expectedState,
+        "Unexpected state: {}, expected: {}",
+        stateName(actualState),
+        stateName(expectedState));
+  }
+
+  inline void setState(State newState) {
+    const auto oldState = state();
+    VELOX_CHECK(
+        isValidStateTransition(oldState, newState),
+        "Invalid state transition from {} to {}",
+        stateName(oldState),
+        stateName(newState));
+    state_.store(newState, std::memory_order_release);
+  }
+
+  static bool isValidStateTransition(State oldState, State newState) {
+    switch (oldState) {
+      case State::kInit:
+        return newState == State::kMaking || newState == State::kFinished ||
+            newState == State::kCancelled;
+      case State::kMaking:
+        return newState == State::kPrepared || newState == State::kFailed;
+      case State::kPrepared:
+        return newState == State::kFinished || newState == State::kCancelled;
+      case State::kFailed:
+      case State::kFinished:
+      case State::kCancelled:
+        return false;
+      default:
+        VELOX_UNREACHABLE("Unknown state: {}", stateName(oldState));
+    }
+  }
+
+  // Makes item with timing, handles exceptions, state transitions, and promise
+  // signaling.
+  void makeItem(std::function<std::unique_ptr<Item>()>&& itemMaker) {
+    VELOX_CHECK_NOT_NULL(itemMaker);
+    std::unique_ptr<Item> item;
+    std::exception_ptr exceptionPtr;
+    try {
+      CpuWallTimer timer(makeTiming_);
+      process::ScopedThreadDebugInfo threadDebugInfo(
+          threadDebugInfo_.has_value() ? &threadDebugInfo_.value() : nullptr);
+      item = itemMaker();
+    } catch (std::exception&) {
+      exceptionPtr = std::current_exception();
+    }
+
+    std::vector<ContinuePromise> promises;
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      VELOX_CHECK_NULL(item_);
+      VELOX_CHECK_NULL(itemMaker_);
+      checkState(state(), State::kMaking);
+      if (FOLLY_LIKELY(exceptionPtr == nullptr)) {
+        item_ = std::move(item);
+        setState(State::kPrepared);
+      } else {
+        setExceptionLocked(std::move(exceptionPtr));
+      }
+      promises.swap(promises_);
+    }
+    for (auto& promise : promises) {
+      promise.setValue();
+    }
+  }
+
+  inline void setExceptionLocked(std::exception_ptr exception) {
+    VELOX_CHECK_NULL(exception_);
+    exception_ = std::move(exception);
+    setState(State::kFailed);
+  }
+
+  // Waits for the promise to be fulfilled and injects a TestValue for testing
+  // race conditions.
+  inline void makeWait(ContinueFuture&& wait) {
+    common::testutil::TestValue::adjust(
+        "facebook::velox::AsyncSource::makeWait", this);
+    auto& exec = folly::QueuedImmediateExecutor::instance();
+    std::move(wait).via(&exec).wait();
+  }
+
+  // Attempts to close immediately while holding the lock. Returns true if
+  // close completed, false if caller needs to wait for making to complete.
+  inline bool tryCloseLocked() {
+    const auto currentState = state();
+    switch (currentState) {
+      case State::kInit:
+        VELOX_CHECK_NOT_NULL(itemMaker_);
+        VELOX_CHECK_NULL(item_);
+        itemMaker_ = nullptr;
+        setState(State::kFinished);
+        return true;
+      case State::kPrepared:
+        VELOX_CHECK_NULL(itemMaker_);
+        item_ = nullptr;
+        setState(State::kFinished);
+        return true;
+      case State::kMaking:
+        return false;
+      default:
+        VELOX_CHECK_NULL(itemMaker_);
+        VELOX_CHECK_NULL(item_);
+        return true;
+    }
+  }
+
+  // Stored context (if present upon construction) so they can be restored
+  // when itemMaker_ is invoked.
   std::optional<process::ThreadDebugInfo> threadDebugInfo_;
 
+  std::atomic<State> state_{State::kInit};
+  CpuWallTiming makeTiming_;
   mutable std::mutex mutex_;
-  // True if 'prepare() is making the item.
-  bool making_{false};
-  std::unique_ptr<ContinuePromise> promise_;
+  std::vector<ContinuePromise> promises_;
   std::unique_ptr<Item> item_;
-  std::function<std::unique_ptr<Item>()> make_;
+  std::function<std::unique_ptr<Item>()> itemMaker_;
   std::exception_ptr exception_;
-  CpuWallTiming timing_;
-  bool closed_{false};
-  bool moved_{false};
-  bool cancelled_{false};
 };
+
 } // namespace facebook::velox

--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -22,140 +22,18 @@
 #include <gtest/gtest.h>
 #include <thread>
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/testutil/TestValue.h"
 
 using namespace facebook::velox;
 using namespace std::chrono_literals;
 
-// A sample class to be constructed via AsyncSource.
+namespace {
 struct Gizmo {
   explicit Gizmo(int32_t _id) : id(_id) {}
 
   const int32_t id;
 };
-
-TEST(AsyncSourceTest, basic) {
-  AsyncSource<Gizmo> gizmo([]() { return std::make_unique<Gizmo>(11); });
-  EXPECT_FALSE(gizmo.hasValue());
-  gizmo.prepare();
-  EXPECT_TRUE(gizmo.hasValue());
-  auto value = gizmo.move();
-  EXPECT_FALSE(gizmo.hasValue());
-  EXPECT_EQ(11, value->id);
-  EXPECT_EQ(1, gizmo.prepareTiming().count);
-
-  AsyncSource<Gizmo> error(
-      []() -> std::unique_ptr<Gizmo> { VELOX_USER_FAIL("Testing error"); });
-  EXPECT_THROW(error.move(), VeloxException);
-  EXPECT_TRUE(error.hasValue());
-}
-
-TEST(AsyncSourceTest, threads) {
-  constexpr int32_t kNumThreads = 10;
-  constexpr int32_t kNumGizmos = 2000;
-  folly::Synchronized<std::unordered_set<int32_t>> results;
-  std::vector<std::shared_ptr<AsyncSource<Gizmo>>> gizmos;
-  for (auto i = 0; i < kNumGizmos; ++i) {
-    gizmos.push_back(std::make_shared<AsyncSource<Gizmo>>([i]() {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1)); // NOLINT
-      return std::make_unique<Gizmo>(i);
-    }));
-  }
-
-  std::vector<std::thread> threads;
-  threads.reserve(kNumThreads);
-  for (int32_t threadIndex = 0; threadIndex < kNumThreads; ++threadIndex) {
-    threads.push_back(std::thread([threadIndex, &gizmos, &results]() {
-      if (threadIndex < kNumThreads / 2) {
-        // The first half of the threads prepare Gizmos in the background.
-        for (auto i = 0; i < kNumGizmos; ++i) {
-          gizmos[i]->prepare();
-        }
-      } else {
-        // The rest of the threads first get random Gizmos and then do a pass
-        // over all the Gizmos to make sure all get collected. We assert that
-        // each Gizmo is obtained once.
-        folly::Random::DefaultGenerator rng;
-        for (auto i = 0; i < kNumGizmos / 3; ++i) {
-          auto gizmo =
-              gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
-          if (gizmo) {
-            results.withWLock([&](auto& set) {
-              EXPECT_TRUE(set.find(gizmo->id) == set.end());
-              set.insert(gizmo->id);
-            });
-          }
-        }
-        for (auto i = 0; i < gizmos.size(); ++i) {
-          auto gizmo = gizmos[i]->move();
-          if (gizmo) {
-            results.withWLock([&](auto& set) {
-              EXPECT_TRUE(set.find(gizmo->id) == set.end());
-              set.insert(gizmo->id);
-            });
-          }
-        }
-      }
-    }));
-  }
-  for (auto& thread : threads) {
-    thread.join();
-  }
-  results.withRLock([&](auto& set) {
-    for (auto i = 0; i < kNumGizmos; ++i) {
-      EXPECT_TRUE(set.find(i) != set.end());
-    }
-  });
-}
-
-TEST(AsyncSourceTest, errorsWithThreads) {
-  constexpr int32_t kNumGizmos = 50;
-  constexpr int32_t kNumThreads = 10;
-  std::vector<std::shared_ptr<AsyncSource<Gizmo>>> gizmos;
-  std::atomic<int32_t> numErrors{0};
-  for (auto i = 0; i < kNumGizmos; ++i) {
-    gizmos.push_back(
-        std::make_shared<AsyncSource<Gizmo>>([]() -> std::unique_ptr<Gizmo> {
-          std::this_thread::sleep_for(std::chrono::milliseconds(1)); // NOLINT
-          VELOX_USER_FAIL("Testing error");
-        }));
-  }
-
-  std::vector<std::thread> threads;
-  threads.reserve(kNumThreads);
-  for (int32_t threadIndex = 0; threadIndex < kNumThreads; ++threadIndex) {
-    threads.push_back(std::thread([threadIndex, &gizmos, &numErrors]() {
-      if (threadIndex < kNumThreads / 2) {
-        // The first half of the threads prepare Gizmos in the background.
-        for (auto i = 0; i < kNumGizmos; ++i) {
-          gizmos[i]->prepare();
-        }
-      } else {
-        // The rest of the threads get random gizmos. They are
-        // expected to produce an error or nullptr in the event
-        // another thread is already waiting for the same gizmo.
-        folly::Random::DefaultGenerator rng;
-        for (auto i = 0; i < kNumGizmos / 3; ++i) {
-          try {
-            auto gizmo =
-                gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
-            EXPECT_EQ(nullptr, gizmo);
-          } catch (std::exception&) {
-            ++numErrors;
-          }
-        }
-      }
-    }));
-  }
-  for (auto& thread : threads) {
-    thread.join();
-  }
-  // There will always be errors since the first to wait for any given
-  // gizmo is sure to get an error.
-  EXPECT_LT(0, numErrors);
-  for (auto& source : gizmos) {
-    source->close();
-  }
-}
 
 class DataCounter {
  public:
@@ -185,79 +63,107 @@ class DataCounter {
   }
 
  private:
-  static std::atomic<uint64_t> numCreatedDataCounters_;
-  static std::atomic<uint64_t> numDeletedDataCounters_;
+  inline static std::atomic<uint64_t> numCreatedDataCounters_{0};
+  inline static std::atomic<uint64_t> numDeletedDataCounters_{0};
 
   uint64_t objectNumber_{0};
 };
-
-std::atomic<uint64_t> DataCounter::numCreatedDataCounters_ = 0;
-
-std::atomic<uint64_t> DataCounter::numDeletedDataCounters_ = 0;
-
-TEST(AsyncSourceTest, close) {
-  // If 'prepare()' is not executed within the thread pool, invoking 'close()'
-  // will set 'make_' to nullptr. The deletion of 'dateCounter' is used as a
-  // verification for this behavior.
-  auto dateCounter = std::make_shared<DataCounter>();
-  AsyncSource<uint64_t> countAsyncSource([dateCounter]() {
-    return std::make_unique<uint64_t>(dateCounter->objectNumber());
-  });
-  dateCounter.reset();
-  EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
-  EXPECT_EQ(DataCounter::numDeletedDataCounters(), 0);
-
-  countAsyncSource.close();
-  EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
-  EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
-  DataCounter::reset();
-
-  // If 'prepare()' is executed within the thread pool but 'move()' is not
-  // invoked, invoking 'close()' will set 'item_' to nullptr. The deletion of
-  // 'dateCounter' is used as a verification for this behavior.
-  auto asyncSource = std::make_shared<AsyncSource<DataCounter>>(
-      []() { return std::make_unique<DataCounter>(); });
-  asyncSource->prepare();
-  EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
-  EXPECT_EQ(DataCounter::numDeletedDataCounters(), 0);
-
-  asyncSource->close();
-  EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
-  EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
-  DataCounter::reset();
-
-  // If 'prepare()' is currently being executed within the thread pool,
-  // 'close()' should wait for the completion of 'prepare()' and set 'item_' to
-  // nullptr.
-  folly::Baton<> baton;
-  auto sleepAsyncSource =
-      std::make_shared<AsyncSource<DataCounter>>([&baton]() {
-        baton.post();
-        return std::make_unique<DataCounter>();
-      });
-  auto thread1 =
-      std::thread([&sleepAsyncSource] { sleepAsyncSource->prepare(); });
-  EXPECT_TRUE(baton.try_wait_for(1s));
-  sleepAsyncSource->close();
-  EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
-  EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
-  thread1.join();
-}
 
 void verifyContexts(
     const std::string& expectedPoolName,
     const std::string& expectedTaskId) {
   EXPECT_EQ(process::GetThreadDebugInfo()->taskId_, expectedTaskId);
 }
+} // namespace
 
-TEST(AsyncSourceTest, emptyContexts) {
+class AsyncSourceTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    common::testutil::TestValue::enable();
+  }
+
+  void SetUp() override {
+    DataCounter::reset();
+  }
+
+  void TearDown() override {
+    DataCounter::reset();
+  }
+};
+
+TEST_F(AsyncSourceTest, basic) {
+  AsyncSource<Gizmo> gizmo([]() { return std::make_unique<Gizmo>(11); });
+  EXPECT_FALSE(gizmo.hasValue());
+  gizmo.prepare();
+  EXPECT_TRUE(gizmo.hasValue());
+  auto value = gizmo.move();
+  EXPECT_FALSE(gizmo.hasValue());
+  EXPECT_EQ(11, value->id);
+  EXPECT_EQ(1, gizmo.prepareTiming().count);
+
+  AsyncSource<Gizmo> error(
+      []() -> std::unique_ptr<Gizmo> { VELOX_USER_FAIL("Testing error"); });
+  VELOX_ASSERT_USER_THROW(error.move(), "Testing error");
+  EXPECT_TRUE(error.hasValue());
+}
+
+TEST_F(AsyncSourceTest, close) {
+  {
+    auto dateCounter = std::make_shared<DataCounter>();
+    AsyncSource<uint64_t> countAsyncSource([dateCounter]() {
+      return std::make_unique<uint64_t>(dateCounter->objectNumber());
+    });
+    dateCounter.reset();
+    EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 0);
+    EXPECT_EQ(0, countAsyncSource.prepareTiming().count);
+
+    countAsyncSource.close();
+
+    EXPECT_EQ(0, countAsyncSource.prepareTiming().count);
+    EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
+  }
+  DataCounter::reset();
+
+  {
+    auto asyncSource = std::make_shared<AsyncSource<DataCounter>>(
+        []() { return std::make_unique<DataCounter>(); });
+    asyncSource->prepare();
+    EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 0);
+    EXPECT_EQ(1, asyncSource->prepareTiming().count);
+
+    asyncSource->close();
+    EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
+    EXPECT_EQ(1, asyncSource->prepareTiming().count);
+  }
+  DataCounter::reset();
+
+  {
+    folly::Baton<> baton;
+    auto sleepAsyncSource =
+        std::make_shared<AsyncSource<DataCounter>>([&baton]() {
+          baton.post();
+          return std::make_unique<DataCounter>();
+        });
+    auto thread =
+        std::thread([&sleepAsyncSource] { sleepAsyncSource->prepare(); });
+    EXPECT_TRUE(baton.try_wait_for(1s));
+    sleepAsyncSource->close();
+    EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
+    EXPECT_EQ(1, sleepAsyncSource->prepareTiming().count);
+    thread.join();
+  }
+}
+
+TEST_F(AsyncSourceTest, emptyContexts) {
   EXPECT_EQ(process::GetThreadDebugInfo(), nullptr);
 
   AsyncSource<bool> src([]() {
-    // The Contexts at the time this was created were null so we should inherit
-    // them from the caller.
     verifyContexts("test", "task_id");
-
     return std::make_unique<bool>(true);
   });
 
@@ -271,7 +177,7 @@ TEST(AsyncSourceTest, emptyContexts) {
   verifyContexts("test", "task_id");
 }
 
-TEST(AsyncSourceTest, setContexts) {
+TEST_F(AsyncSourceTest, setContexts) {
   process::ThreadDebugInfo debugInfo1{"query_id1", "task_id1", nullptr};
 
   std::unique_ptr<AsyncSource<bool>> src;
@@ -280,10 +186,7 @@ TEST(AsyncSourceTest, setContexts) {
   verifyContexts("test1", "task_id1");
 
   src = std::make_unique<AsyncSource<bool>>(([]() {
-    // The Contexts at the time this was created were set so we should have
-    // the same contexts when this is executed.
     verifyContexts("test1", "task_id1");
-
     return std::make_unique<bool>(true);
   }));
 
@@ -297,10 +200,7 @@ TEST(AsyncSourceTest, setContexts) {
   verifyContexts("test2", "task_id2");
 }
 
-TEST(AsyncSourceTest, cancel) {
-  DataCounter::reset();
-
-  // Cancel before prepare() - task should not run and resources cleaned up
+TEST_F(AsyncSourceTest, cancel) {
   {
     auto dataCounter = std::make_shared<DataCounter>();
     auto asyncSource = std::make_shared<AsyncSource<uint64_t>>([dataCounter]() {
@@ -313,8 +213,6 @@ TEST(AsyncSourceTest, cancel) {
   }
   DataCounter::reset();
 
-  // Cancel while task is running in prepare() - should not affect the
-  // prepare() result
   {
     folly::Baton<> startBaton;
     folly::Baton<> finishBaton;
@@ -326,35 +224,35 @@ TEST(AsyncSourceTest, cancel) {
         });
 
     auto thread = std::thread([&asyncSource] { asyncSource->prepare(); });
-    EXPECT_TRUE(
-        startBaton.try_wait_for(1s)); // Make sure prepare() gets lock first
+    EXPECT_TRUE(startBaton.try_wait_for(1s));
 
-    asyncSource->cancel(); // Should be no-op
+    asyncSource->cancel();
 
     finishBaton.post();
     thread.join();
 
     EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
     EXPECT_TRUE(asyncSource->hasValue());
+    asyncSource->close();
+    EXPECT_EQ(1, asyncSource->prepareTiming().count);
   }
   DataCounter::reset();
 
-  // Cancel after prepare() completes - should not destroy the result
   {
     auto asyncSource = std::make_shared<AsyncSource<DataCounter>>(
         []() { return std::make_unique<DataCounter>(); });
     asyncSource->prepare();
 
-    asyncSource->cancel(); // Should be no-op since make_ was taken
+    asyncSource->cancel();
 
-    EXPECT_TRUE(asyncSource->hasValue());
-    EXPECT_NE(asyncSource->move(), nullptr);
+    EXPECT_FALSE(asyncSource->hasValue());
+    EXPECT_EQ(asyncSource->move(), nullptr);
+    EXPECT_EQ(1, asyncSource->prepareTiming().count);
   }
   DataCounter::reset();
 
-  // prepare() and move() are no-ops after cancel()
   {
-    std::atomic<bool> taskExecuted{false};
+    std::atomic_bool taskExecuted{false};
     auto asyncSource =
         std::make_shared<AsyncSource<DataCounter>>([&taskExecuted]() {
           taskExecuted = true;
@@ -362,15 +260,14 @@ TEST(AsyncSourceTest, cancel) {
         });
 
     asyncSource->cancel();
-    asyncSource->prepare(); // No-op
+    asyncSource->prepare();
     EXPECT_FALSE(taskExecuted);
     EXPECT_FALSE(asyncSource->hasValue());
 
-    EXPECT_EQ(asyncSource->move(), nullptr); // No-op
+    EXPECT_EQ(asyncSource->move(), nullptr);
     EXPECT_FALSE(taskExecuted);
   }
 
-  // Multiple cancel calls are idempotent
   {
     auto dataCounter = std::make_shared<DataCounter>();
     auto asyncSource = std::make_shared<AsyncSource<uint64_t>>([dataCounter]() {
@@ -379,12 +276,12 @@ TEST(AsyncSourceTest, cancel) {
     dataCounter.reset();
 
     asyncSource->cancel();
-    asyncSource->cancel(); // Should be safe
+    asyncSource->cancel();
     EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
+    EXPECT_EQ(0, asyncSource->prepareTiming().count);
   }
   DataCounter::reset();
 
-  // Cancel called during move() execution - should be no-op
   {
     folly::Baton<> moveStarted;
     folly::Baton<> continueMove;
@@ -395,15 +292,14 @@ TEST(AsyncSourceTest, cancel) {
           return std::make_unique<DataCounter>();
         });
 
-    // move() will execute the lambda inline since prepare() wasn't called
     auto moveThread = std::thread([&asyncSource] {
       auto result = asyncSource->move();
       EXPECT_NE(result, nullptr);
     });
 
-    EXPECT_TRUE(moveStarted.try_wait_for(1s)); // Wait for move to start
+    EXPECT_TRUE(moveStarted.try_wait_for(1s));
 
-    asyncSource->cancel(); // Should be no-op - make_ already taken
+    asyncSource->cancel();
 
     continueMove.post();
     moveThread.join();
@@ -411,19 +307,373 @@ TEST(AsyncSourceTest, cancel) {
   }
   DataCounter::reset();
 
-  // Cancel called after move() completes - should be no-op
   {
     auto asyncSource = std::make_shared<AsyncSource<DataCounter>>(
         []() { return std::make_unique<DataCounter>(); });
 
-    auto result = asyncSource->move(); // Complete move
+    auto result = asyncSource->move();
     EXPECT_NE(result, nullptr);
     EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
 
-    asyncSource->cancel(); // Should be no-op - moved_ is true, make_ is null
+    asyncSource->cancel();
 
-    // Item was already consumed
+    EXPECT_EQ(1, asyncSource->prepareTiming().count);
     EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
   }
   DataCounter::reset();
+
+  // Cancel called after close() - should be no-op.
+  {
+    auto asyncSource = std::make_shared<AsyncSource<DataCounter>>(
+        []() { return std::make_unique<DataCounter>(); });
+    asyncSource->prepare();
+    EXPECT_EQ(DataCounter::numCreatedDataCounters(), 1);
+
+    asyncSource->close();
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
+
+    asyncSource->cancel();
+    EXPECT_EQ(DataCounter::numDeletedDataCounters(), 1);
+    EXPECT_EQ(1, asyncSource->prepareTiming().count);
+  }
+}
+
+TEST_F(AsyncSourceTest, multithreadedPrepareAndMove) {
+  constexpr int32_t kNumThreads = 10;
+  constexpr int32_t kNumGizmos = 2000;
+  folly::Synchronized<std::unordered_set<int32_t>> results;
+  std::vector<std::shared_ptr<AsyncSource<Gizmo>>> gizmos;
+  gizmos.reserve(kNumGizmos);
+  for (auto i = 0; i < kNumGizmos; ++i) {
+    gizmos.push_back(std::make_shared<AsyncSource<Gizmo>>([i]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1)); // NOLINT
+      return std::make_unique<Gizmo>(i);
+    }));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int32_t threadIndex = 0; threadIndex < kNumThreads; ++threadIndex) {
+    threads.emplace_back([threadIndex, &gizmos, &results]() {
+      if (threadIndex < kNumThreads / 2) {
+        for (auto i = 0; i < kNumGizmos; ++i) {
+          gizmos[i]->prepare();
+        }
+      } else {
+        folly::Random::DefaultGenerator rng;
+        for (auto i = 0; i < kNumGizmos / 3; ++i) {
+          auto gizmo =
+              gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
+          if (gizmo) {
+            results.withWLock([&](auto& set) {
+              EXPECT_TRUE(set.find(gizmo->id) == set.end());
+              set.insert(gizmo->id);
+            });
+          }
+        }
+        for (auto i = 0; i < gizmos.size(); ++i) {
+          auto gizmo = gizmos[i]->move();
+          if (gizmo) {
+            results.withWLock([&](auto& set) {
+              EXPECT_TRUE(set.find(gizmo->id) == set.end());
+              set.insert(gizmo->id);
+            });
+          }
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  results.withRLock([&](auto& set) {
+    for (auto i = 0; i < kNumGizmos; ++i) {
+      EXPECT_TRUE(set.find(i) != set.end());
+    }
+  });
+}
+
+TEST_F(AsyncSourceTest, multithreadedErrorHandling) {
+  constexpr int32_t kNumGizmos = 50;
+  constexpr int32_t kNumThreads = 10;
+  std::vector<std::shared_ptr<AsyncSource<Gizmo>>> gizmos;
+  std::atomic<int32_t> numErrors{0};
+  gizmos.reserve(kNumGizmos);
+  for (auto i = 0; i < kNumGizmos; ++i) {
+    gizmos.push_back(
+        std::make_shared<AsyncSource<Gizmo>>([]() -> std::unique_ptr<Gizmo> {
+          std::this_thread::sleep_for(std::chrono::milliseconds(1)); // NOLINT
+          VELOX_USER_FAIL("Testing error");
+        }));
+  }
+
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  for (int32_t threadIndex = 0; threadIndex < kNumThreads; ++threadIndex) {
+    threads.emplace_back([threadIndex, &gizmos, &numErrors]() {
+      if (threadIndex < kNumThreads / 2) {
+        for (auto i = 0; i < kNumGizmos; ++i) {
+          gizmos[i]->prepare();
+        }
+      } else {
+        folly::Random::DefaultGenerator rng;
+        for (auto i = 0; i < kNumGizmos / 3; ++i) {
+          try {
+            auto gizmo =
+                gizmos[folly::Random::rand32(rng) % gizmos.size()]->move();
+            EXPECT_EQ(nullptr, gizmo);
+          } catch (std::exception&) {
+            ++numErrors;
+          }
+        }
+      }
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  EXPECT_LT(0, numErrors);
+  for (auto& source : gizmos) {
+    source->close();
+  }
+}
+
+DEBUG_ONLY_TEST_F(AsyncSourceTest, concurrentMoveSteal) {
+  // Test scenario: first move() waits for making
+  // it gets signaled through promises, but a second move() comes in
+  // between the wait completion and lock re-acquisition and steals the item.
+  // The first move() should get nothing.
+  folly::Baton<> makingStarted;
+  folly::Baton<> makingContinue;
+  folly::Baton<> firstMoveWaiting;
+  folly::Baton<> secondMoveComplete;
+
+  auto asyncSource =
+      std::make_shared<AsyncSource<Gizmo>>([&makingStarted, &makingContinue]() {
+        makingStarted.post();
+        makingContinue.wait();
+        return std::make_unique<Gizmo>(42);
+      });
+
+  std::atomic<Gizmo*> firstMoveResult{nullptr};
+  std::atomic<Gizmo*> secondMoveResult{nullptr};
+  std::unique_ptr<Gizmo> firstMoveHolder;
+  std::unique_ptr<Gizmo> secondMoveHolder;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::AsyncSource::makeWait",
+      std::function<void(AsyncSource<Gizmo>*)>([&](AsyncSource<Gizmo>* source) {
+        // Signal that first move is about to re-acquire lock.
+        firstMoveWaiting.post();
+        // Wait for second move to complete and steal the item.
+        secondMoveComplete.wait();
+      }));
+
+  // Thread 1: First move() - will wait for making and then get blocked by
+  // TestValue.
+  auto firstMoveThread = std::thread([&]() {
+    firstMoveHolder = asyncSource->move();
+    firstMoveResult = firstMoveHolder.get();
+  });
+
+  // Thread 2: prepare() - starts making the item.
+  auto prepareThread = std::thread([&]() { asyncSource->prepare(); });
+
+  // Wait for making to start.
+  ASSERT_TRUE(makingStarted.try_wait_for(1s));
+
+  // Let making complete - this will signal the first move's promise.
+  makingContinue.post();
+
+  // Wait for first move to be signaled and about to re-acquire lock.
+  ASSERT_TRUE(firstMoveWaiting.try_wait_for(1s));
+
+  // Thread 3: Second move() - steals the item while first move is blocked.
+  auto secondMoveThread = std::thread([&]() {
+    secondMoveHolder = asyncSource->move();
+    secondMoveResult = secondMoveHolder.get();
+    secondMoveComplete.post();
+  });
+
+  firstMoveThread.join();
+  secondMoveThread.join();
+  prepareThread.join();
+
+  // Second move should have stolen the item.
+  EXPECT_NE(secondMoveResult.load(), nullptr);
+  EXPECT_EQ(secondMoveResult.load()->id, 42);
+
+  // First move should get nothing because second move stole the item.
+  EXPECT_EQ(firstMoveResult.load(), nullptr);
+}
+
+DEBUG_ONLY_TEST_F(AsyncSourceTest, concurrentMoveCloseRace) {
+  // Test scenario: Tests the race condition where move()
+  // preparation and close() sneaks in to grab the item first.
+  //
+  // Timeline:
+  //   1. prepare() starts making the item in a background thread
+  //   2. move() enters and waits for preparation to complete (blocked on
+  //   promise)
+  //   3. prepare() completes and signals the promise
+  //   4. move() wakes up but TestValue blocks it before re-acquiring the lock
+  //   5. close() runs and transitions state to kFinished, clearing the item
+  //   6. move() finally re-acquires lock but finds state is kFinished
+  //   7. move() returns nullptr
+  //
+  // Expected: move() gets nullptr because close() grabbed the item first.
+  folly::Baton<> makingStarted;
+  folly::Baton<> makingContinue;
+  folly::Baton<> moveWaiting;
+  folly::Baton<> closeComplete;
+
+  auto asyncSource =
+      std::make_shared<AsyncSource<Gizmo>>([&makingStarted, &makingContinue]() {
+        makingStarted.post();
+        makingContinue.wait();
+        return std::make_unique<Gizmo>(42);
+      });
+
+  std::atomic<Gizmo*> moveResult{nullptr};
+  std::unique_ptr<Gizmo> moveHolder;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::AsyncSource::makeWait",
+      std::function<void(AsyncSource<Gizmo>*)>([&](AsyncSource<Gizmo>* source) {
+        // Signal that move is about to re-acquire lock.
+        moveWaiting.post();
+        // Wait for close to complete.
+        closeComplete.wait();
+      }));
+
+  // Thread 1: move() - will wait for making and then get blocked by TestValue.
+  auto moveThread = std::thread([&]() {
+    moveHolder = asyncSource->move();
+    moveResult = moveHolder.get();
+  });
+
+  // Thread 2: prepare() - starts making the item.
+  auto prepareThread = std::thread([&]() { asyncSource->prepare(); });
+
+  // Wait for making to start.
+  ASSERT_TRUE(makingStarted.try_wait_for(1s));
+
+  // Let making complete - this will signal move's promise.
+  makingContinue.post();
+
+  // Wait for move to be signaled and about to re-acquire lock.
+  ASSERT_TRUE(moveWaiting.try_wait_for(1s));
+
+  // close() comes in and closes the item while move is blocked.
+  asyncSource->close();
+  closeComplete.post();
+
+  moveThread.join();
+  prepareThread.join();
+
+  // move() should get nothing because close() grabbed the item first.
+  EXPECT_EQ(moveResult.load(), nullptr);
+}
+
+DEBUG_ONLY_TEST_F(AsyncSourceTest, concurrentCloseMoveRace) {
+  // Test scenario: Tests the race condition where close()
+  // preparation and move() sneaks in to grab the item first.
+  //
+  // Timeline:
+  //   1. prepare() starts making the item in a background thread
+  //   2. close() enters and waits for preparation to complete (blocked on
+  //   promise)
+  //   3. prepare() completes and signals the promise
+  //   4. close() wakes up but TestValue blocks it before re-acquiring the lock
+  //   5. move() runs and transitions state to kFinished, taking the item
+  //   6. close() finally re-acquires lock and finds state is kFinished
+  //   7. close() completes successfully (nothing to close)
+  //
+  // Expected: move() gets the item, close() finds nothing to close.
+  folly::Baton<> makingStarted;
+  folly::Baton<> makingContinue;
+  folly::Baton<> closeWaiting;
+  folly::Baton<> moveComplete;
+
+  auto asyncSource =
+      std::make_shared<AsyncSource<Gizmo>>([&makingStarted, &makingContinue]() {
+        makingStarted.post();
+        makingContinue.wait();
+        return std::make_unique<Gizmo>(42);
+      });
+
+  std::atomic<Gizmo*> moveResult{nullptr};
+  std::unique_ptr<Gizmo> moveHolder;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::AsyncSource::makeWait",
+      std::function<void(AsyncSource<Gizmo>*)>([&](AsyncSource<Gizmo>* source) {
+        // Signal that close is about to re-acquire lock.
+        closeWaiting.post();
+        // Wait for move to complete and take the item.
+        moveComplete.wait();
+      }));
+
+  // Thread 1: prepare() - starts making the item.
+  auto prepareThread = std::thread([&]() { asyncSource->prepare(); });
+
+  // Wait for making to start.
+  ASSERT_TRUE(makingStarted.try_wait_for(1s));
+
+  // Thread 2: close() - will wait for making and then get blocked by TestValue.
+  auto closeThread = std::thread([&]() { asyncSource->close(); });
+
+  // Wait for close to be signaled and about to re-acquire lock.
+  ASSERT_TRUE(closeWaiting.try_wait_for(1s));
+
+  // Let making complete - this will signal close's promise.
+  makingContinue.post();
+
+  std::this_thread::sleep_for(std::chrono::seconds(1)); // NOLINT
+
+  // move() comes in and takes the item while close is blocked.
+  moveHolder = asyncSource->move();
+  moveResult = moveHolder.get();
+  moveComplete.post();
+
+  closeThread.join();
+  prepareThread.join();
+
+  // move() should have taken the item.
+  EXPECT_NE(moveResult.load(), nullptr);
+  EXPECT_EQ(moveResult.load()->id, 42);
+}
+
+TEST_F(AsyncSourceTest, prepareTiming) {
+  auto asyncSource = std::make_shared<AsyncSource<Gizmo>>([]() {
+    std::this_thread::sleep_for(1s);
+    return std::make_unique<Gizmo>(42);
+  });
+
+  asyncSource->prepare();
+
+  const auto& timing = asyncSource->prepareTiming();
+  EXPECT_EQ(timing.count, 1);
+  EXPECT_GE(timing.wallNanos, 1'000'000'000);
+  asyncSource->close();
+}
+
+TEST_F(AsyncSourceTest, itemMakerReturnsNull) {
+  // Test when itemMaker returns nullptr via prepare().
+  {
+    auto asyncSource = std::make_shared<AsyncSource<Gizmo>>(
+        []() -> std::unique_ptr<Gizmo> { return nullptr; });
+    asyncSource->prepare();
+    EXPECT_FALSE(asyncSource->hasValue());
+    auto result = asyncSource->move();
+    EXPECT_EQ(result, nullptr);
+  }
+
+  // Test when itemMaker returns nullptr via move() (inline making).
+  {
+    auto asyncSource = std::make_shared<AsyncSource<Gizmo>>(
+        []() -> std::unique_ptr<Gizmo> { return nullptr; });
+    auto result = asyncSource->move();
+    EXPECT_EQ(result, nullptr);
+  }
 }


### PR DESCRIPTION
Summary:
Replace four boolean flags (making_, closed_, moved_, cancelled_) with a single atomic State enum
Benefits: cleaner state representation, thread-safe transitions, validated state changes, better debugging
Renamed variables for clarity (make_ → itemMaker_, timing_ → makeTiming_)
Changed from single promise pointer to vector to support multiple waiters like concurrent move and close
Added helper methods: makeItem(), tryCloseLocked(), makeWait()
Added concurrent race condition tests

Differential Revision: D91415890


