### PR TITLE
fix: Fix preload data source timing stat for cancellation case

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -362,16 +362,16 @@ bool TableScan::getSplit() {
     stats_.wlock()->addRuntimeStat(
         "waitForPreloadSplitNanos",
         RuntimeCounter(endTimeNs - startTimeNs, RuntimeCounter::Unit::kNanos));
+    if (preparedDataSource == nullptr) {
+      // There must be a cancellation.
+      VELOX_CHECK(operatorCtx_->task()->isCancelled());
+      return false;
+    }
     stats_.wlock()->addRuntimeStat(
         "preloadSplitPrepareTimeNanos",
         RuntimeCounter(
             connectorSplit->dataSource->prepareTiming().wallNanos,
             RuntimeCounter::Unit::kNanos));
-    if (!preparedDataSource) {
-      // There must be a cancellation.
-      VELOX_CHECK(operatorCtx_->task()->isCancelled());
-      return false;
-    }
     dataSource_->setFromDataSource(std::move(preparedDataSource));
   } else {
     uint64_t addSplitTimeUs{0};


### PR DESCRIPTION
Summary:
Move the cancellation check before recording `preloadSplitPrepareTimeNanos` to avoid accessing `prepareTiming()` on a cancelled/null data source.

Previously, the code would attempt to record the prepare timing stat even when `preparedDataSource` was null (due to task cancellation), which could lead to accessing `prepareTiming()` on an invalid state. Now we check for cancellation first and return early before attempting to access the timing.

Differential Revision: D91441694


