### PR TITLE
fix: Add FuzzerTestUtils.h to reduce code duplication in map function tests

### DIFF
--- a/velox/functions/prestosql/tests/MapAppendTest.cpp
+++ b/velox/functions/prestosql/tests/MapAppendTest.cpp
@@ -15,7 +15,7 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
-#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/functions/prestosql/tests/utils/FuzzerTestUtils.h"
 
 using namespace facebook::velox::test;
 
@@ -428,104 +428,49 @@ class MapAppendFuzzerTest : public test::FunctionBaseTest {
           << "Result map should be at least as large as input map at row " << i;
     }
   }
+
+  void runFuzzTest(const TypePtr& type, const test::FuzzerTestOptions& opts) {
+    test::FuzzerTestHelper helper(pool());
+    helper.runMapArrayArrayTestSameType(
+        type,
+        [this](
+            const VectorPtr& inputMap,
+            const VectorPtr& keys,
+            const VectorPtr& values) {
+          auto data = makeRowVector({inputMap, keys, values});
+          testMapAppendProperties(data);
+        },
+        opts);
+  }
 };
 
 TEST_F(MapAppendFuzzerTest, fuzzInteger) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 50;
-  opts.nullRatio = 0.1;
-  opts.containerLength = 5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-  auto keys = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto values = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(INTEGER(), {.vectorSize = 50, .containerLength = 5});
 }
 
 TEST_F(MapAppendFuzzerTest, fuzzBigint) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 50;
-  opts.nullRatio = 0.1;
-  opts.containerLength = 5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(BIGINT(), BIGINT()));
-  auto keys = fuzzer.fuzz(ARRAY(BIGINT()));
-  auto values = fuzzer.fuzz(ARRAY(BIGINT()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(BIGINT(), {.vectorSize = 50, .containerLength = 5});
 }
 
 TEST_F(MapAppendFuzzerTest, fuzzVarchar) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 50;
-  opts.nullRatio = 0.1;
-  opts.containerLength = 5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(VARCHAR(), VARCHAR()));
-  auto keys = fuzzer.fuzz(ARRAY(VARCHAR()));
-  auto values = fuzzer.fuzz(ARRAY(VARCHAR()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(VARCHAR(), {.vectorSize = 50, .containerLength = 5});
 }
 
 TEST_F(MapAppendFuzzerTest, fuzzDouble) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 50;
-  opts.nullRatio = 0.1;
-  opts.containerLength = 5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(DOUBLE(), DOUBLE()));
-  auto keys = fuzzer.fuzz(ARRAY(DOUBLE()));
-  auto values = fuzzer.fuzz(ARRAY(DOUBLE()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(DOUBLE(), {.vectorSize = 50, .containerLength = 5});
 }
 
 TEST_F(MapAppendFuzzerTest, fuzzHighNullRatio) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 50;
-  opts.nullRatio = 0.5;
-  opts.containerLength = 5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-  auto keys = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto values = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(
+      INTEGER(), {.vectorSize = 50, .nullRatio = 0.5, .containerLength = 5});
 }
 
 TEST_F(MapAppendFuzzerTest, fuzzSmallint) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 50;
-  opts.nullRatio = 0.1;
-  opts.containerLength = 5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(SMALLINT(), SMALLINT()));
-  auto keys = fuzzer.fuzz(ARRAY(SMALLINT()));
-  auto values = fuzzer.fuzz(ARRAY(SMALLINT()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(SMALLINT(), {.vectorSize = 50, .containerLength = 5});
 }
 
 TEST_F(MapAppendFuzzerTest, fuzzLargeVectors) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 200;
-  opts.nullRatio = 0.1;
-  opts.containerLength = 3;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-  auto keys = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto values = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto data = makeRowVector({inputMap, keys, values});
-  testMapAppendProperties(data);
+  runFuzzTest(INTEGER(), {.vectorSize = 200, .containerLength = 3});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/MapExceptTest.cpp
+++ b/velox/functions/prestosql/tests/MapExceptTest.cpp
@@ -15,8 +15,8 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/prestosql/tests/utils/FuzzerTestUtils.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
-#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox::test;
 
@@ -406,222 +406,152 @@ class MapExceptFuzzerTest : public test::FunctionBaseTest {
       }
     }
   }
+
+  void runFuzzTest(
+      const TypePtr& keyType,
+      const TypePtr& valueType,
+      const test::FuzzerTestOptions& opts) {
+    test::FuzzerTestHelper helper(pool());
+    helper.runMapArrayTest(
+        keyType,
+        valueType,
+        [this](const VectorPtr& inputMap, const VectorPtr& keysArray) {
+          auto data = makeRowVector({inputMap, keysArray});
+          testEquivalence(data);
+        },
+        opts);
+  }
 };
 
 // Fuzz test with flat vectors, no nulls, fixed-size maps
 TEST_F(MapExceptFuzzerTest, fuzzFlatNoNulls) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.0;
-  options.containerHasNulls = false;
-  options.containerLength = 10;
-  options.containerVariableLength = false;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 10; ++i) {
-    // Generate random map with integer keys and values
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-
-    // Generate exclusion keys array
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      INTEGER(),
+      INTEGER(),
+      {.vectorSize = 100,
+       .nullRatio = 0.0,
+       .containerLength = 10,
+       .iterations = 10});
 }
 
 // Fuzz test with nulls in maps and keys array
 TEST_F(MapExceptFuzzerTest, fuzzWithNulls) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  options.containerLength = 10;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 10; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      INTEGER(),
+      INTEGER(),
+      {.vectorSize = 100,
+       .containerLength = 10,
+       .containerHasNulls = true,
+       .containerVariableLength = true,
+       .iterations = 10});
 }
 
 // Fuzz test with dictionary-encoded vectors
 TEST_F(MapExceptFuzzerTest, fuzzDictionaryEncoded) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  options.containerLength = 10;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
+  test::FuzzerTestHelper helper(pool());
+  test::FuzzerTestOptions opts{
+      .vectorSize = 100,
+      .containerLength = 10,
+      .containerHasNulls = true,
+      .containerVariableLength = true};
+  auto fuzzer = helper.createFuzzer(opts);
 
   for (auto i = 0; i < 10; ++i) {
-    // Generate base vectors
     auto baseInputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
     auto baseKeysArray = fuzzer.fuzz(ARRAY(INTEGER()));
 
-    // Wrap in dictionary encoding
-    auto inputMap = fuzzer.fuzzDictionary(baseInputMap, options.vectorSize);
-    auto keysArray = fuzzer.fuzzDictionary(baseKeysArray, options.vectorSize);
+    auto inputMap = fuzzer.fuzzDictionary(baseInputMap, opts.vectorSize);
+    auto keysArray = fuzzer.fuzzDictionary(baseKeysArray, opts.vectorSize);
 
     auto data = makeRowVector({inputMap, keysArray});
-
-    // Flatten for comparison
     auto flatData = makeRowVector({flatten(inputMap), flatten(keysArray)});
 
-    // Verify results match between dictionary and flat encodings
     auto result = evaluate("map_except(c0, c1)", data);
     auto expectedResult = evaluate("map_except(c0, c1)", flatData);
     assertEqualVectors(expectedResult, result);
 
-    // Also verify against the equivalent expression
     testEquivalence(flatData);
   }
 }
 
 // Fuzz test with variable-length maps and high null ratio
 TEST_F(MapExceptFuzzerTest, fuzzVariableLengthWithHighNullRatio) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.3;
-  options.containerHasNulls = true;
-  options.containerLength = 20;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 10; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      INTEGER(),
+      INTEGER(),
+      {.vectorSize = 100,
+       .nullRatio = 0.3,
+       .containerLength = 20,
+       .containerHasNulls = true,
+       .containerVariableLength = true,
+       .iterations = 10});
 }
 
 // Fuzz test with string keys
 TEST_F(MapExceptFuzzerTest, fuzzStringKeys) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  options.containerLength = 10;
-  options.containerVariableLength = true;
-  options.stringLength = 20;
-  options.stringVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 10; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(VARCHAR(), INTEGER()));
-    auto keysArray = fuzzer.fuzz(ARRAY(VARCHAR()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      VARCHAR(),
+      INTEGER(),
+      {.vectorSize = 100,
+       .containerLength = 10,
+       .containerHasNulls = true,
+       .containerVariableLength = true,
+       .iterations = 10});
 }
 
 // Fuzz test with bigint keys
 TEST_F(MapExceptFuzzerTest, fuzzBigintKeys) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  options.containerLength = 10;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 10; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(BIGINT(), VARCHAR()));
-    auto keysArray = fuzzer.fuzz(ARRAY(BIGINT()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      BIGINT(),
+      VARCHAR(),
+      {.vectorSize = 100,
+       .containerLength = 10,
+       .containerHasNulls = true,
+       .containerVariableLength = true,
+       .iterations = 10});
 }
 
 // Fuzz test with empty maps and arrays
 TEST_F(MapExceptFuzzerTest, fuzzWithEmptyContainers) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  // Use very small container length to increase likelihood of empty containers
-  options.containerLength = 2;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 10; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      INTEGER(),
+      INTEGER(),
+      {.vectorSize = 100,
+       .containerLength = 2,
+       .containerHasNulls = true,
+       .containerVariableLength = true,
+       .iterations = 10});
 }
 
 // Fuzz test with various value types
 TEST_F(MapExceptFuzzerTest, fuzzVariousValueTypes) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  options.containerLength = 10;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
+  test::FuzzerTestOptions opts{
+      .vectorSize = 100,
+      .containerLength = 10,
+      .containerHasNulls = true,
+      .containerVariableLength = true,
+      .iterations = 5};
 
   // Test with DOUBLE values
-  for (auto i = 0; i < 5; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), DOUBLE()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(INTEGER(), DOUBLE(), opts);
 
   // Test with BOOLEAN values
-  for (auto i = 0; i < 5; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), BOOLEAN()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(INTEGER(), BOOLEAN(), opts);
 
   // Test with VARCHAR values
-  for (auto i = 0; i < 5; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), VARCHAR()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(INTEGER(), VARCHAR(), opts);
 }
 
 // Fuzz test with constant vectors
 TEST_F(MapExceptFuzzerTest, fuzzConstantVectors) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 100;
-  options.nullRatio = 0.0;
-  options.containerHasNulls = false;
-  options.containerLength = 5;
-  options.containerVariableLength = false;
-
-  VectorFuzzer fuzzer(options, pool());
+  test::FuzzerTestHelper helper(pool());
+  test::FuzzerTestOptions opts{
+      .vectorSize = 100, .nullRatio = 0.0, .containerLength = 5};
+  auto fuzzer = helper.createFuzzer(opts);
 
   for (auto i = 0; i < 10; ++i) {
-    // Create varying input map
     auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-
-    // Create a constant keys array
-    auto keysArray = fuzzer.fuzzConstant(ARRAY(INTEGER()), options.vectorSize);
+    auto keysArray = fuzzer.fuzzConstant(ARRAY(INTEGER()), opts.vectorSize);
 
     auto data = makeRowVector({inputMap, keysArray});
     testEquivalence(data);
@@ -630,22 +560,14 @@ TEST_F(MapExceptFuzzerTest, fuzzConstantVectors) {
 
 // Stress test with large vectors
 TEST_F(MapExceptFuzzerTest, fuzzLargeVectors) {
-  VectorFuzzer::Options options;
-  options.vectorSize = 1000;
-  options.nullRatio = 0.1;
-  options.containerHasNulls = true;
-  options.containerLength = 50;
-  options.containerVariableLength = true;
-
-  VectorFuzzer fuzzer(options, pool());
-
-  for (auto i = 0; i < 5; ++i) {
-    auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-    auto keysArray = fuzzer.fuzz(ARRAY(INTEGER()));
-
-    auto data = makeRowVector({inputMap, keysArray});
-    testEquivalence(data);
-  }
+  runFuzzTest(
+      INTEGER(),
+      INTEGER(),
+      {.vectorSize = 1000,
+       .containerLength = 50,
+       .containerHasNulls = true,
+       .containerVariableLength = true,
+       .iterations = 5});
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/MapIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/MapIntersectTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
-#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/functions/prestosql/tests/utils/FuzzerTestUtils.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
@@ -385,90 +385,46 @@ class MapIntersectFuzzerTest : public test::FunctionBaseTest {
       }
     }
   }
+
+  void runFuzzTest(const TypePtr& type, const test::FuzzerTestOptions& opts) {
+    test::FuzzerTestHelper helper(pool());
+    helper.runMapArrayTest(
+        type,
+        type,
+        [this](const VectorPtr& inputMap, const VectorPtr& keys) {
+          auto data = makeRowVector({inputMap, keys});
+          testEquivalence(data);
+        },
+        opts);
+  }
 };
 
 TEST_F(MapIntersectFuzzerTest, fuzzInteger) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.1;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-  auto keys = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(INTEGER(), {.vectorSize = 100});
 }
 
 TEST_F(MapIntersectFuzzerTest, fuzzBigint) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.1;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(BIGINT(), BIGINT()));
-  auto keys = fuzzer.fuzz(ARRAY(BIGINT()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(BIGINT(), {.vectorSize = 100});
 }
 
 TEST_F(MapIntersectFuzzerTest, fuzzVarchar) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.1;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(VARCHAR(), VARCHAR()));
-  auto keys = fuzzer.fuzz(ARRAY(VARCHAR()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(VARCHAR(), {.vectorSize = 100});
 }
 
 TEST_F(MapIntersectFuzzerTest, fuzzDouble) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.1;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(DOUBLE(), DOUBLE()));
-  auto keys = fuzzer.fuzz(ARRAY(DOUBLE()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(DOUBLE(), {.vectorSize = 100});
 }
 
 TEST_F(MapIntersectFuzzerTest, fuzzHighNullRatio) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.5;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-  auto keys = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(INTEGER(), {.vectorSize = 100, .nullRatio = 0.5});
 }
 
 TEST_F(MapIntersectFuzzerTest, fuzzSmallint) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.1;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(SMALLINT(), SMALLINT()));
-  auto keys = fuzzer.fuzz(ARRAY(SMALLINT()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(SMALLINT(), {.vectorSize = 100});
 }
 
 TEST_F(MapIntersectFuzzerTest, fuzzLargeVectors) {
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 500;
-  opts.nullRatio = 0.1;
-  VectorFuzzer fuzzer(opts, pool());
-
-  auto inputMap = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
-  auto keys = fuzzer.fuzz(ARRAY(INTEGER()));
-  auto data = makeRowVector({inputMap, keys});
-  testEquivalence(data);
+  runFuzzTest(INTEGER(), {.vectorSize = 500});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/utils/FuzzerTestUtils.h
+++ b/velox/functions/prestosql/tests/utils/FuzzerTestUtils.h
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <functional>
+#include "velox/type/Type.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::functions::test {
+
+/// Configuration options for fuzzer tests.
+struct FuzzerTestOptions {
+  vector_size_t vectorSize = 100;
+  double nullRatio = 0.1;
+  size_t containerLength = 5;
+  bool containerHasNulls = false;
+  bool containerVariableLength = false;
+  size_t stringLength = 20;
+  bool stringVariableLength = true;
+  int iterations = 1;
+};
+
+/// Helper class for running fuzzer tests on map functions.
+/// Eliminates boilerplate code for VectorFuzzer setup across test files.
+class FuzzerTestHelper {
+ public:
+  explicit FuzzerTestHelper(memory::MemoryPool* pool) : pool_(pool) {}
+
+  /// Creates a VectorFuzzer with the given options.
+  VectorFuzzer createFuzzer(const FuzzerTestOptions& opts) {
+    VectorFuzzer::Options fuzzerOpts;
+    fuzzerOpts.vectorSize = opts.vectorSize;
+    fuzzerOpts.nullRatio = opts.nullRatio;
+    fuzzerOpts.containerLength = opts.containerLength;
+    fuzzerOpts.containerHasNulls = opts.containerHasNulls;
+    fuzzerOpts.containerVariableLength = opts.containerVariableLength;
+    fuzzerOpts.stringLength = opts.stringLength;
+    fuzzerOpts.stringVariableLength = opts.stringVariableLength;
+    return VectorFuzzer(fuzzerOpts, pool_);
+  }
+
+  /// Runs a fuzzer test for map functions that take (map, array) as input.
+  /// Used by: map_intersect, map_except
+  /// @param keyType The type for map keys and array elements
+  /// @param valueType The type for map values
+  /// @param testFn The test function to call with the generated vectors
+  ///               (inputMap, keysArray)
+  /// @param opts Optional configuration for the fuzzer
+  void runMapArrayTest(
+      const TypePtr& keyType,
+      const TypePtr& valueType,
+      std::function<void(const VectorPtr&, const VectorPtr&)> testFn,
+      const FuzzerTestOptions& opts = {}) {
+    auto fuzzer = createFuzzer(opts);
+    auto mapType = MAP(keyType, valueType);
+    auto arrayType = ARRAY(keyType);
+    for (int i = 0; i < opts.iterations; ++i) {
+      auto inputMap = fuzzer.fuzz(mapType);
+      auto keys = fuzzer.fuzz(arrayType);
+      testFn(inputMap, keys);
+    }
+  }
+
+  /// Runs a fuzzer test for map functions that take (map, array, array) as
+  /// input. Used by: map_append
+  /// @param keyType The type for map keys and key array elements
+  /// @param valueType The type for map values and value array elements
+  /// @param testFn The test function to call with the generated vectors
+  ///               (inputMap, keysArray, valuesArray)
+  /// @param opts Optional configuration for the fuzzer
+  void runMapArrayArrayTest(
+      const TypePtr& keyType,
+      const TypePtr& valueType,
+      std::function<void(const VectorPtr&, const VectorPtr&, const VectorPtr&)>
+          testFn,
+      const FuzzerTestOptions& opts = {}) {
+    auto fuzzer = createFuzzer(opts);
+    auto mapType = MAP(keyType, valueType);
+    auto keyArrayType = ARRAY(keyType);
+    auto valueArrayType = ARRAY(valueType);
+    for (int i = 0; i < opts.iterations; ++i) {
+      auto inputMap = fuzzer.fuzz(mapType);
+      auto keys = fuzzer.fuzz(keyArrayType);
+      auto values = fuzzer.fuzz(valueArrayType);
+      testFn(inputMap, keys, values);
+    }
+  }
+
+  /// Runs a fuzzer test for map functions with same key and value types.
+  /// Convenience overload for functions like map_append where key == value
+  /// type.
+  /// @param type The type for both keys and values
+  /// @param testFn The test function to call with the generated vectors
+  /// @param opts Optional configuration for the fuzzer
+  void runMapArrayArrayTestSameType(
+      const TypePtr& type,
+      std::function<void(const VectorPtr&, const VectorPtr&, const VectorPtr&)>
+          testFn,
+      const FuzzerTestOptions& opts = {}) {
+    runMapArrayArrayTest(type, type, testFn, opts);
+  }
+
+  /// Runs a fuzzer test for map functions that take (map, map) as input.
+  /// @param keyType The type for map keys
+  /// @param valueType The type for map values
+  /// @param testFn The test function to call with the generated vectors
+  /// @param opts Optional configuration for the fuzzer
+  void runMapMapTest(
+      const TypePtr& keyType,
+      const TypePtr& valueType,
+      std::function<void(const VectorPtr&, const VectorPtr&)> testFn,
+      const FuzzerTestOptions& opts = {}) {
+    auto fuzzer = createFuzzer(opts);
+    auto mapType = MAP(keyType, valueType);
+    for (int i = 0; i < opts.iterations; ++i) {
+      auto inputMap1 = fuzzer.fuzz(mapType);
+      auto inputMap2 = fuzzer.fuzz(mapType);
+      testFn(inputMap1, inputMap2);
+    }
+  }
+
+ private:
+  memory::MemoryPool* pool_;
+};
+
+} // namespace facebook::velox::functions::test


### PR DESCRIPTION
Summary:
Created a shared FuzzerTestUtils.h helper to eliminate code duplication across MapAppendTest, MapIntersectTest, and MapExceptTest.

The fuzzer tests in these files had significant code duplication - each test repeated the same VectorFuzzer setup boilerplate with only the type differing. This addresses reviewer feedback from D90790110, D90788851, and D90791159 suggesting refactoring to use a templated function or parameterized test.

Changes:
- Added FuzzerTestUtils.h with FuzzerTestOptions struct and FuzzerTestHelper class
- FuzzerTestHelper provides runMapArrayTest(), runMapArrayArrayTest(), and runMapMapTest() methods
- Refactored MapAppendTest.cpp: 7 duplicate test functions (~85 lines) reduced to one-liners
- Refactored MapIntersectTest.cpp: 7 duplicate test functions (~85 lines) reduced to one-liners
- Refactored MapExceptTest.cpp: 10 duplicate test functions (~240 lines) simplified
- Updated BUCK files to include the new header and dependencies

Differential Revision: D91493163


