### PR TITLE
perf: Improve streamingAggregation noGroupsSpanBatches on corner case

### DIFF
--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -365,11 +365,13 @@ RowVectorPtr StreamingAggregation::getOutput() {
 
   RowVectorPtr output;
 
+  // we do not respect minOutputBatchRows or outputDueToBatchBytes
+  // when noGroupsSpanBatches is set
   const bool outputDueToBatchSize = numGroups_ > minOutputBatchSize_;
   const bool outputDueToBatchBytes =
       numGroups_ > 1 && estimatedBatchBytes > maxOutputBatchBytes_;
-  if ((noGroupsSpanBatches_ || numPrevGroups > 0) &&
-      (outputDueToBatchSize || outputDueToBatchBytes)) {
+  if (noGroupsSpanBatches_ ||
+      (numPrevGroups > 0 && (outputDueToBatchSize || outputDueToBatchBytes))) {
     size_t numOutputGroups{0};
     if (noGroupsSpanBatches_) {
       numOutputGroups = numGroups_;

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -218,6 +218,12 @@ class ArrayAggAggregate : public exec::Aggregate {
         } else {
           elements->copyRanges(currentSource->get(), ranges);
         }
+      } else {
+        // Nothing to aggregate, mandatory behavior is to return nulls instead
+        // of empty array
+        for (int32_t i = 0; i < numGroups; ++i) {
+          vector->setNull(i, true);
+        }
       }
     } else {
       for (int32_t i = 0; i < numGroups; ++i) {


### PR DESCRIPTION
Summary:
right now when noGroupsSpanBatches is set, a corner case appears when numGroups_ is 1. The input would not be processed and stored to prevInput_, which causes reference to previous batch and unwanted memory usage.
We should be able to safely create output if there is just one input group

Differential Revision: D91519395


