### PR TITLE
build: Split iceberg target

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -36,7 +36,7 @@ velox_add_library(
 
 velox_link_libraries(
   velox_hive_connector
-  PUBLIC velox_hive_iceberg_splitreader
+  PUBLIC velox_hive_iceberg_reader
   PRIVATE velox_common_io velox_connector velox_dwio_catalog_fbhive velox_hive_partition_function
 )
 

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -13,28 +13,33 @@
 # limitations under the License.
 
 velox_add_library(
-  velox_hive_iceberg_splitreader
-  IcebergColumnHandle.cpp
-  IcebergConnector.cpp
-  IcebergDataSink.cpp
-  IcebergPartitionName.cpp
+  velox_hive_iceberg_reader
   IcebergSplit.cpp
   IcebergSplitReader.cpp
-  PartitionSpec.cpp
   PositionalDeleteFileReader.cpp
-  TransformEvaluator.cpp
-  TransformExprBuilder.cpp
 )
 
-velox_link_libraries(
-  velox_hive_iceberg_splitreader
-  velox_connector
-  velox_functions_iceberg
-  Folly::folly
-)
+velox_link_libraries(velox_hive_iceberg_reader velox_connector velox_functions_iceberg Folly::folly)
 
 if(VELOX_ENABLE_PARQUET)
-  velox_link_libraries(velox_hive_iceberg_splitreader velox_dwio_parquet_field_id)
+  velox_add_library(
+    velox_hive_iceberg_writer
+    IcebergColumnHandle.cpp
+    IcebergConnector.cpp
+    IcebergDataSink.cpp
+    IcebergPartitionName.cpp
+    IcebergSplit.cpp
+    PartitionSpec.cpp
+    TransformEvaluator.cpp
+    TransformExprBuilder.cpp
+  )
+  velox_link_libraries(
+    velox_hive_iceberg_writer
+    velox_connector
+    velox_functions_iceberg
+    Folly::folly
+    velox_dwio_parquet_field_id
+  )
 endif()
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -36,29 +36,31 @@ if(VELOX_ENABLE_BENCHMARKS)
   )
 endif()
 
-if(NOT VELOX_DISABLE_GOOGLETEST)
-  add_executable(velox_hive_iceberg_test IcebergReadTest.cpp IcebergSplitReaderBenchmarkTest.cpp)
-  add_test(velox_hive_iceberg_test velox_hive_iceberg_test)
+add_executable(velox_hive_iceberg_test IcebergReadTest.cpp IcebergSplitReaderBenchmarkTest.cpp)
+add_test(velox_hive_iceberg_test velox_hive_iceberg_test)
 
-  target_link_libraries(
-    velox_hive_iceberg_test
-    velox_dwio_iceberg_reader_benchmark_lib
-    velox_hive_connector
-    velox_hive_iceberg_splitreader
-    velox_hive_partition_function
-    velox_dwio_common_exception
-    velox_dwio_common_test_utils
-    velox_vector_test_lib
-    velox_exec
-    velox_exec_test_lib
-    Folly::folly
-    Folly::follybenchmark
-    GTest::gtest
-    GTest::gtest_main
-  )
+target_link_libraries(
+  velox_hive_iceberg_test
+  velox_dwio_iceberg_reader_benchmark_lib
+  velox_hive_connector
+  velox_hive_iceberg_reader
+  velox_hive_partition_function
+  velox_dwio_common_exception
+  velox_dwio_common_test_utils
+  velox_vector_test_lib
+  velox_exec
+  velox_exec_test_lib
+  Folly::folly
+  Folly::follybenchmark
+  GTest::gtest
+  GTest::gtest_main
+)
+
+if(VELOX_ENABLE_PARQUET)
+  target_link_libraries(velox_hive_iceberg_test velox_dwio_parquet_reader)
 
   add_executable(
-    velox_hive_iceberg_insert_test
+    velox_hive_iceberg_writer_test
     IcebergConnectorTest.cpp
     IcebergInsertTest.cpp
     IcebergTestBase.cpp
@@ -70,27 +72,19 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     TransformTest.cpp
   )
 
-  add_test(velox_hive_iceberg_insert_test velox_hive_iceberg_insert_test)
+  add_test(velox_hive_iceberg_writer_test velox_hive_iceberg_writer_test)
 
   target_link_libraries(
-    velox_hive_iceberg_insert_test
+    velox_hive_iceberg_writer_test
+    velox_dwio_parquet_reader
+    velox_dwio_parquet_writer
     velox_exec_test_lib
     velox_hive_connector
-    velox_hive_iceberg_splitreader
+    velox_hive_iceberg_writer
     velox_vector_fuzzer
     GTest::gtest
     GTest::gtest_main
   )
-
-  if(VELOX_ENABLE_PARQUET)
-    target_link_libraries(velox_hive_iceberg_test velox_dwio_parquet_reader)
-
-    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-
-    target_link_libraries(
-      velox_hive_iceberg_insert_test
-      velox_dwio_parquet_reader
-      velox_dwio_parquet_writer
-    )
-  endif()
 endif()
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
The Iceberg connector is tightly coupled with Parquet. However, there is a known issue when referencing Parquet symbols from the connector layer, which can result in duplicate symbols from Thrift. Several workarounds have been adopted to mitigate this problem.

One way to address this cleanly is to conditionally compile the Iceberg connector only when VELOX_ENABLE_PARQUET is enabled.

This makes sense to some extent. The Iceberg specification supports three file formats: Avro, Parquet, and ORC. Velox currently supports ORC and Parquet, and Parquet is the de facto standard in most Iceberg deployments. Therefore, enabling Iceberg only when VELOX_ENABLE_PARQUET is set should be acceptable.

Gluten and Prestissimo all enable parquet by default. 

Let’s see how the discussion evolves.


@mbasmanova @yingsu00 @zhouyuan 
