### PR TITLE
perf: Using Batch serialization in RemoteFunction when preserveEncoding is true

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.h
+++ b/velox/functions/remote/client/RemoteVectorFunction.h
@@ -26,6 +26,10 @@ struct RemoteVectorFunctionMetadata : public exec::VectorFunctionMetadata {
   /// The serialization format to be used to send batches of data to the remote
   /// process.
   remote::PageFormat serdeFormat{remote::PageFormat::PRESTO_PAGE};
+
+  /// Whether to preserve the input vector encoding in the request sent to
+  /// remote service.
+  bool preserveEncoding{false};
 };
 
 /// Main vector function logic. Needs to be extended with the transport-specific
@@ -65,6 +69,8 @@ class RemoteVectorFunction : public exec::VectorFunction {
 
   remote::PageFormat serdeFormat_;
   std::unique_ptr<VectorSerde> serde_;
+  std::unique_ptr<VectorSerde::Options> serdeOptions_;
+  bool preserveEncoding_;
 
   // Structures we construct once to cache:
   RowTypePtr remoteInputType_;

--- a/velox/functions/remote/if/GetSerde.cpp
+++ b/velox/functions/remote/if/GetSerde.cpp
@@ -30,4 +30,21 @@ std::unique_ptr<VectorSerde> getSerde(const remote::PageFormat& format) {
   }
   VELOX_UNREACHABLE();
 }
+
+std::unique_ptr<VectorSerde::Options> getSerdeOptions(
+    const remote::PageFormat& format,
+    bool preserveEncoding) {
+  switch (format) {
+    case remote::PageFormat::PRESTO_PAGE: {
+      auto options = std::make_unique<
+          serializer::presto::PrestoVectorSerde::PrestoOptions>();
+      options->preserveEncodings = preserveEncoding;
+      return options;
+    }
+    case remote::PageFormat::SPARK_UNSAFE_ROW:
+      return std::make_unique<VectorSerde::Options>();
+  }
+  VELOX_UNREACHABLE();
+}
+
 } // namespace facebook::velox::functions

--- a/velox/functions/remote/if/GetSerde.h
+++ b/velox/functions/remote/if/GetSerde.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/functions/remote/if/gen-cpp2/RemoteFunction_types.h"
+#include "velox/vector/VectorStream.h"
 
 namespace facebook::velox {
 class VectorSerde;
@@ -25,5 +26,10 @@ class VectorSerde;
 namespace facebook::velox::functions {
 
 std::unique_ptr<VectorSerde> getSerde(const remote::PageFormat& format);
+
+/// Creates appropriate serde options based on format and configuration.
+std::unique_ptr<VectorSerde::Options> getSerdeOptions(
+    const remote::PageFormat& format,
+    bool preserveEncoding);
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Right now constant encoding is not preserved during serialization of Row vectors in RemoteFunction client when creating the thrift request. We use a lot of constant parameters in our remote funciton udf and if we don't preserve the constant encoding, it will more than double/triple the payload size.

After debugging the issue, the fix is to use batch serializer (instead of iterative serializer) which preserves the encoding correctly. I noticed >70% reduced in payload size after testing this change locally for our remote function udf. This is just a simple case, in other cases we will have even more savings (more than 3x reduction in payload size).

Reviewed By: Sullivan-Patrick

Differential Revision: D91602429


