### PR TITLE
feat: Consolidate equi-join keys into EqualIndexLookupCondition

### DIFF
--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -116,6 +116,29 @@ core::TypedExprPtr toJoinConditionExpr(
   std::vector<core::TypedExprPtr> conditionExprs;
   conditionExprs.reserve(joinConditions.size());
   for (const auto& condition : joinConditions) {
+    // Check for EqualIndexLookupCondition first to skip equi-join conditions
+    // before creating indexColumnExpr, since equi-join key names may not exist
+    // in keyType (they are handled by hash table lookup, not filter
+    // evaluation).
+    if (auto equalCondition =
+            std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
+                condition)) {
+      // Skip equi-join conditions (non-constant values) as they are handled
+      // by the hash table lookup, not by filter evaluation.
+      if (!equalCondition->isFilter()) {
+        continue;
+      }
+      // Filter conditions (constant values) need to be evaluated.
+      auto indexColumnExpr = std::make_shared<core::FieldAccessTypedExpr>(
+          keyType->findChild(condition->key->name()), condition->key->name());
+      conditionExprs.push_back(
+          std::make_shared<const core::CallTypedExpr>(
+              BOOLEAN(),
+              "eq",
+              std::move(indexColumnExpr),
+              equalCondition->value));
+      continue;
+    }
     auto indexColumnExpr = std::make_shared<core::FieldAccessTypedExpr>(
         keyType->findChild(condition->key->name()), condition->key->name());
     if (auto inCondition =
@@ -141,21 +164,34 @@ core::TypedExprPtr toJoinConditionExpr(
               betweenCondition->upper));
       continue;
     }
-    if (auto equalCondition =
-            std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
-                condition)) {
-      conditionExprs.push_back(
-          std::make_shared<const core::CallTypedExpr>(
-              BOOLEAN(),
-              "eq",
-              std::move(indexColumnExpr),
-              equalCondition->value));
-      continue;
-    }
     VELOX_FAIL("Invalid index join condition: {}", condition->toString());
+  }
+  if (conditionExprs.empty()) {
+    return nullptr;
+  }
+  if (conditionExprs.size() == 1) {
+    return conditionExprs[0];
   }
   return std::make_shared<core::CallTypedExpr>(
       BOOLEAN(), conditionExprs, "and");
+}
+
+// Counts the number of equi-join keys in the given join conditions.
+// An equi-join key is an EqualIndexLookupCondition where isFilter()
+// returns false (i.e., the value references a probe column, not a constant).
+size_t countEqualJoinKeys(
+    const std::vector<core::IndexLookupConditionPtr>& joinConditions) {
+  size_t count = 0;
+  for (const auto& condition : joinConditions) {
+    if (auto equalCondition =
+            std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
+                condition)) {
+      if (!equalCondition->isFilter()) {
+        ++count;
+      }
+    }
+  }
+  return count;
 }
 
 // Copy values from 'rows' of 'table' according to 'projections' in
@@ -564,13 +600,14 @@ TestIndexConnector::TestIndexConnector(
 
 std::shared_ptr<connector::IndexSource> TestIndexConnector::createIndexSource(
     const RowTypePtr& inputType,
-    size_t numJoinKeys,
     const std::vector<core::IndexLookupConditionPtr>& joinConditions,
     const RowTypePtr& outputType,
     const connector::ConnectorTableHandlePtr& tableHandle,
     const connector::ColumnHandleMap& columnHandles,
     connector::ConnectorQueryCtx* connectorQueryCtx) {
-  VELOX_CHECK_GE(inputType->size(), numJoinKeys + joinConditions.size());
+  const size_t numEqualJoinKeys = countEqualJoinKeys(joinConditions);
+  VELOX_CHECK_GE(inputType->size(), numEqualJoinKeys);
+
   auto testIndexTableHandle =
       std::dynamic_pointer_cast<const TestIndexTableHandle>(tableHandle);
   VELOX_CHECK_NOT_NULL(testIndexTableHandle);
@@ -590,7 +627,7 @@ std::shared_ptr<connector::IndexSource> TestIndexConnector::createIndexSource(
   return std::make_shared<TestIndexSource>(
       inputType,
       outputType,
-      numJoinKeys,
+      numEqualJoinKeys,
       joinConditionExpr,
       testIndexTableHandle,
       testColumnHandles,

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -374,7 +374,6 @@ class TestIndexConnector : public connector::Connector {
 
   std::shared_ptr<connector::IndexSource> createIndexSource(
       const RowTypePtr& inputType,
-      size_t numJoinKeys,
       const std::vector<core::IndexLookupConditionPtr>& joinConditions,
       const RowTypePtr& outputType,
       const connector::ConnectorTableHandlePtr& tableHandle,


### PR DESCRIPTION
Summary: This change consolidates the contract for equality-based joins in IndexLookupJoin by normalizing equi-join keys (leftKeys/rightKeys) into EqualIndexLookupCondition objects.

Differential Revision: D91618297


