### PR TITLE
fix(cudf): Fix precompile pool name in CudfFilterProject.cpp

### DIFF
--- a/velox/experimental/cudf/exec/CudfFilterProject.cpp
+++ b/velox/experimental/cudf/exec/CudfFilterProject.cpp
@@ -105,8 +105,8 @@ bool canBeEvaluatedByCudf(
     return true;
   }
 
-  auto precompilePool = memory::memoryManager()->addLeafPool(
-      "", /*threadSafe*/ false);
+  auto precompilePool =
+      memory::memoryManager()->addLeafPool("", /*threadSafe*/ false);
   core::ExecCtx precompileCtx(precompilePool.get(), queryCtx);
 
   bool lazyDereference = false;


### PR DESCRIPTION
A single query can have multiple tasks from Presto GPU. so the name has to be unique. So, here we are letting addLeafPool generate unique names for each call.

Related: https://github.com/facebookincubator/velox/pull/16056