### PR TITLE
feat: Support reset() for BufferedInput and derived classes for hive index source

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -268,6 +268,7 @@ class InMemoryReadFile : public ReadFile {
   void setShouldCoalesce(bool shouldCoalesce) {
     shouldCoalesce_ = shouldCoalesce;
   }
+
   bool shouldCoalesce() const final {
     return shouldCoalesce_;
   }

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -44,6 +44,14 @@ uint64_t BufferedInput::nextFetchSize() const {
       });
 }
 
+void BufferedInput::reset() {
+  regions_.clear();
+  offsets_.clear();
+  buffers_.clear();
+  enqueuedToBufferOffset_.clear();
+  allocPool_->clear();
+}
+
 void BufferedInput::load(const LogType logType) {
   // no regions to load
   if (regions_.size() == 0) {

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -153,6 +153,12 @@ class BufferedInput {
 
   virtual uint64_t nextFetchSize() const;
 
+  /// Resets the buffered input for reuse. This is used by index lookup which
+  /// reuses the same BufferedInput across different index lookups. For
+  /// instance, Nimble file format with cluster index supports index lookup and
+  /// needs to reset the buffered input state between lookups.
+  virtual void reset();
+
  protected:
   static int adjustedReadPct(const cache::TrackingData& trackingData) {
     // When this method is called, there is one more reference that is already

--- a/velox/dwio/common/DirectBufferedInput.cpp
+++ b/velox/dwio/common/DirectBufferedInput.cpp
@@ -244,6 +244,16 @@ std::shared_ptr<DirectCoalescedLoad> DirectBufferedInput::coalescedLoad(
       });
 }
 
+void DirectBufferedInput::reset() {
+  BufferedInput::reset();
+  for (auto& load : coalescedLoads_) {
+    load->cancel();
+  }
+  coalescedLoads_.clear();
+  streamToCoalescedLoad_.wlock()->clear();
+  requests_.clear();
+}
+
 std::unique_ptr<SeekableInputStream> DirectBufferedInput::read(
     uint64_t offset,
     uint64_t length,

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -50,7 +50,9 @@ add_executable(
   RetryTests.cpp
   ScanSpecTest.cpp
   SortingWriterTest.cpp
-  TestBufferedInput.cpp
+  BufferedInputTest.cpp
+  CachedBufferedInputTest.cpp
+  DirectBufferedInputTest.cpp
   ThrottlerTest.cpp
   TypeTests.cpp
   UnitLoaderToolsTests.cpp

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -1,0 +1,481 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/CachedBufferedInput.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/io/Options.h"
+#include "velox/common/memory/MallocAllocator.h"
+#include "velox/common/testutil/TestValue.h"
+
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/synchronization/Baton.h>
+
+#include <thread>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::cache;
+using namespace facebook::velox::memory;
+using facebook::velox::common::testutil::TestValue;
+
+namespace {
+
+std::optional<std::string> getNext(SeekableInputStream& input) {
+  const void* buf = nullptr;
+  int32_t size;
+  if (input.Next(&buf, &size)) {
+    return std::string(
+        static_cast<const char*>(buf), static_cast<size_t>(size));
+  } else {
+    return std::nullopt;
+  }
+}
+
+class CachedBufferedInputTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    TestValue::enable();
+    MemoryManager::testingSetInstance(MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
+    allocator_ = std::make_shared<MallocAllocator>(
+        512 << 20 /*capacity=*/, 0 /*reservationByteLimit=*/);
+    cache_ = AsyncDataCache::create(allocator_.get());
+    ioStats_ = std::make_shared<IoStatistics>();
+    tracker_ = std::make_shared<ScanTracker>(
+        "testTracker", nullptr, 256 << 10 /* 256KB */);
+    pool_ = memoryManager()->addLeafPool();
+  }
+
+  void TearDown() override {
+    executor_.reset();
+    cache_->shutdown();
+    cache_.reset();
+    allocator_.reset();
+  }
+
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::shared_ptr<MemoryPool> pool_;
+  std::shared_ptr<MallocAllocator> allocator_;
+  std::shared_ptr<AsyncDataCache> cache_;
+  std::shared_ptr<IoStatistics> ioStats_;
+  std::shared_ptr<ScanTracker> tracker_;
+};
+
+TEST_F(CachedBufferedInputTest, reset) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  // First round: enqueue and load streams.
+  constexpr int32_t kRegionSize = 8 << 10; // 8KB
+  auto stream1 = input.enqueue({0, kRegionSize}, nullptr);
+  auto stream2 = input.enqueue({kRegionSize, kRegionSize}, nullptr);
+  ASSERT_NE(stream1, nullptr);
+  ASSERT_NE(stream2, nullptr);
+
+  // Verify cache is empty before load.
+  auto stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 0);
+
+  input.load(LogType::TEST);
+
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Wait until cache has two entries after load.
+  while (cache_->refreshStats().numEntries != 2) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Consume streams.
+  auto next1 = getNext(*stream1);
+  ASSERT_TRUE(next1.has_value());
+  EXPECT_EQ(next1.value(), content.substr(0, kRegionSize));
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+
+  auto next2 = getNext(*stream2);
+  ASSERT_TRUE(next2.has_value());
+  EXPECT_EQ(next2.value(), content.substr(kRegionSize, kRegionSize));
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  stream1.reset();
+  stream2.reset();
+
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.sharedPinnedBytes, 0);
+  EXPECT_EQ(stats.exclusivePinnedBytes, 0);
+  EXPECT_EQ(stats.numEntries, 2);
+
+  // Reset the input.
+  input.reset();
+
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.sharedPinnedBytes, 0);
+  EXPECT_EQ(stats.exclusivePinnedBytes, 0);
+  EXPECT_EQ(stats.numEntries, 2);
+
+  // Second round: enqueue different regions after reset.
+  auto stream3 = input.enqueue({2 * kRegionSize, kRegionSize}, nullptr);
+  auto stream4 = input.enqueue({3 * kRegionSize, kRegionSize}, nullptr);
+  ASSERT_NE(stream3, nullptr);
+  ASSERT_NE(stream4, nullptr);
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.sharedPinnedBytes, 0);
+  EXPECT_EQ(stats.exclusivePinnedBytes, 0);
+  EXPECT_EQ(stats.numEntries, 2);
+
+  input.load(LogType::TEST);
+
+  // Wait until cache has two entries after load.
+  while (cache_->refreshStats().numEntries != 4) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 4);
+
+  auto next3 = getNext(*stream3);
+  ASSERT_TRUE(next3.has_value());
+  EXPECT_EQ(next3.value(), content.substr(2 * kRegionSize, kRegionSize));
+
+  auto next4 = getNext(*stream4);
+  ASSERT_TRUE(next4.has_value());
+  EXPECT_EQ(next4.value(), content.substr(3 * kRegionSize, kRegionSize));
+
+  // Reset the input.
+  input.reset();
+
+  stats = cache_->refreshStats();
+  EXPECT_GT(stats.sharedPinnedBytes, 0);
+  EXPECT_EQ(stats.exclusivePinnedBytes, 0);
+  EXPECT_EQ(stats.numEntries, 4);
+
+  stream3.reset();
+  stream4.reset();
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.sharedPinnedBytes, 0);
+  EXPECT_EQ(stats.exclusivePinnedBytes, 0);
+  EXPECT_EQ(stats.numEntries, 4);
+}
+
+TEST_F(CachedBufferedInputTest, readAfterReset) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr int32_t kRegionSize = 8 << 10; // 8KB
+
+  // Enqueue and load streams.
+  auto stream1 = input.enqueue({0, kRegionSize}, nullptr);
+  auto stream2 = input.enqueue({kRegionSize, kRegionSize}, nullptr);
+  ASSERT_NE(stream1, nullptr);
+  ASSERT_NE(stream2, nullptr);
+
+  input.load(LogType::TEST);
+
+  // Wait until cache has two entries after load.
+  while (cache_->refreshStats().numEntries != 2) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  auto stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+
+  // Reset the input before reading from streams.
+  input.reset();
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+
+  // Read from streams after reset - data should still be available from cache.
+  auto next1 = getNext(*stream1);
+  ASSERT_TRUE(next1.has_value());
+  EXPECT_EQ(next1.value(), content.substr(0, kRegionSize));
+
+  auto next2 = getNext(*stream2);
+  ASSERT_TRUE(next2.has_value());
+  EXPECT_EQ(next2.value(), content.substr(kRegionSize, kRegionSize));
+
+  EXPECT_EQ(stats.sharedPinnedBytes, 0);
+  EXPECT_EQ(stats.exclusivePinnedBytes, 0);
+  EXPECT_EQ(stats.numEntries, 2);
+}
+
+TEST_F(CachedBufferedInputTest, resetInputWithBeforeLoading) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr int32_t kRegionSize = 8 << 10; // 8KB
+
+  // Block the coalesced load to verify cache references are held.
+  folly::Baton<> loadStarted;
+  folly::Baton<> loadAllowed;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::cache::CoalescedLoad::loadOrFuture",
+      std::function<void(const CoalescedLoad*)>(
+          [&](const CoalescedLoad* /*load*/) {
+            loadStarted.post();
+            loadAllowed.wait();
+          }));
+
+  // Enqueue and load streams.
+  auto stream1 = input.enqueue({0, kRegionSize}, nullptr);
+  auto stream2 = input.enqueue({kRegionSize, kRegionSize}, nullptr);
+  ASSERT_NE(stream1, nullptr);
+  ASSERT_NE(stream2, nullptr);
+
+  input.load(LogType::TEST);
+
+  // Wait for the load to start (but it's blocked).
+  loadStarted.wait();
+
+  // Verify cache is still empty (load is pending).
+  auto stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 0);
+  EXPECT_EQ(stats.numExclusive, 0);
+
+  // Verify coalesced load references are held.
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Reset the input while load is pending.
+  input.reset();
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 0);
+  EXPECT_EQ(stats.numExclusive, 0);
+
+  // After reset, internal tracking should be cleared.
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+  // Allow the load to proceed but cancelled.
+  loadAllowed.post();
+
+  std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 0);
+  EXPECT_EQ(stats.numExclusive, 0);
+
+  // Read from streams - data should be available from cache.
+  auto next1 = getNext(*stream1);
+  ASSERT_TRUE(next1.has_value());
+  EXPECT_EQ(next1.value(), content.substr(0, kRegionSize));
+
+  auto next2 = getNext(*stream2);
+  ASSERT_TRUE(next2.has_value());
+  EXPECT_EQ(next2.value(), content.substr(kRegionSize, kRegionSize));
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+  EXPECT_EQ(stats.numExclusive, 0);
+}
+
+TEST_F(CachedBufferedInputTest, resetInputWithAfterLoading) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStats_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr int32_t kRegionSize = 8 << 10; // 8KB
+
+  // Block the coalesced load to verify cache references are held.
+  folly::Baton<> loadStarted;
+  folly::Baton<> loadAllowed;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::cache::CoalescedLoad::loadOrFuture::loading",
+      std::function<void(const CoalescedLoad*)>(
+          [&](const CoalescedLoad* /*load*/) {
+            loadStarted.post();
+            loadAllowed.wait();
+          }));
+
+  // Enqueue and load streams.
+  auto stream1 = input.enqueue({0, kRegionSize}, nullptr);
+  auto stream2 = input.enqueue({kRegionSize, kRegionSize}, nullptr);
+  ASSERT_NE(stream1, nullptr);
+  ASSERT_NE(stream2, nullptr);
+
+  input.load(LogType::TEST);
+
+  // Wait for the load to start (but it's blocked).
+  loadStarted.wait();
+
+  // Verify cache is still empty (load is pending).
+  auto stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 0);
+  EXPECT_EQ(stats.numExclusive, 0);
+
+  // Verify coalesced load references are held.
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+  // Reset the input while load is pending.
+  input.reset();
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 0);
+  EXPECT_EQ(stats.numExclusive, 0);
+
+  // After reset, internal tracking should be cleared.
+  EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+  EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+  // Allow the load to proceed without cancelling.
+  loadAllowed.post();
+
+  // Wait until cache has two entries after load.
+  while (cache_->refreshStats().numEntries != 2) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+  EXPECT_EQ(stats.numExclusive, 0);
+
+  // Read from streams - data should be available from cache.
+  auto next1 = getNext(*stream1);
+  ASSERT_TRUE(next1.has_value());
+  EXPECT_EQ(next1.value(), content.substr(0, kRegionSize));
+
+  auto next2 = getNext(*stream2);
+  ASSERT_TRUE(next2.has_value());
+  EXPECT_EQ(next2.value(), content.substr(kRegionSize, kRegionSize));
+
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+  EXPECT_EQ(stats.numExclusive, 0);
+}
+} // namespace

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/DirectBufferedInput.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/io/Options.h"
+#include "velox/common/testutil/TestValue.h"
+
+#include <fmt/core.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/synchronization/Baton.h>
+
+#include <thread>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::cache;
+using namespace facebook::velox::memory;
+using facebook::velox::common::testutil::TestValue;
+
+namespace {
+
+std::optional<std::string> getNext(SeekableInputStream& input) {
+  const void* buf = nullptr;
+  int32_t size;
+  if (input.Next(&buf, &size)) {
+    return std::string(
+        static_cast<const char*>(buf), static_cast<size_t>(size));
+  } else {
+    return std::nullopt;
+  }
+}
+
+class DirectBufferedInputTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    TestValue::enable();
+    MemoryManager::testingSetInstance(MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
+    ioStats_ = std::make_shared<IoStatistics>();
+    tracker_ = std::make_shared<ScanTracker>(
+        "testTracker", nullptr, 256 << 10 /* 256KB */);
+    rootPool_ = memoryManager()->addRootPool();
+    pool_ = rootPool_->addLeafChild("DirectBufferedInputTest");
+  }
+
+  void TearDown() override {
+    executor_.reset();
+  }
+
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::shared_ptr<MemoryPool> rootPool_;
+  std::shared_ptr<MemoryPool> pool_;
+  std::shared_ptr<IoStatistics> ioStats_;
+  std::shared_ptr<ScanTracker> tracker_;
+};
+
+TEST_F(DirectBufferedInputTest, reset) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+
+  // Test both tiny and non-tiny region sizes.
+  for (const bool tinyRegion : {false, true}) {
+    SCOPED_TRACE(fmt::format("tinyRegion: {}", tinyRegion));
+
+    const uint64_t regionSize = tinyRegion
+        ? DirectBufferedInput::kTinySize - 100
+        : DirectBufferedInput::kTinySize + 1000;
+
+    auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, "testFile");
+    StringIdLease groupId(ids, "testGroup");
+
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        ioStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    // First round: enqueue and load streams.
+    auto stream1 = input.enqueue(common::Region{0, regionSize}, nullptr);
+    auto stream2 =
+        input.enqueue(common::Region{regionSize, regionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+    // Consume streams.
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(0, regionSize));
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 1);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(regionSize, regionSize));
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    stream1.reset();
+    stream2.reset();
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Reset the input.
+    input.reset();
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Second round: enqueue different regions after reset.
+    auto stream3 =
+        input.enqueue(common::Region{2 * regionSize, regionSize}, nullptr);
+    auto stream4 =
+        input.enqueue(common::Region{3 * regionSize, regionSize}, nullptr);
+    ASSERT_NE(stream3, nullptr);
+    ASSERT_NE(stream4, nullptr);
+
+    input.load(LogType::TEST);
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+    auto next3 = getNext(*stream3);
+    ASSERT_TRUE(next3.has_value());
+    EXPECT_EQ(next3.value(), content.substr(2 * regionSize, regionSize));
+
+    auto next4 = getNext(*stream4);
+    ASSERT_TRUE(next4.has_value());
+    EXPECT_EQ(next4.value(), content.substr(3 * regionSize, regionSize));
+
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    // Reset the input.
+    input.reset();
+
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+    stream3.reset();
+    stream4.reset();
+    ASSERT_EQ(pool_->usedBytes(), 0);
+  }
+}
+
+TEST_F(DirectBufferedInputTest, readAfterReset) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+
+  // Test both tiny and non-tiny region sizes.
+  for (const bool tinyRegion : {false, true}) {
+    SCOPED_TRACE(fmt::format("tinyRegion: {}", tinyRegion));
+
+    const uint64_t regionSize = tinyRegion
+        ? DirectBufferedInput::kTinySize - 100
+        : DirectBufferedInput::kTinySize + 1000;
+
+    auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, "testFile");
+    StringIdLease groupId(ids, "testGroup");
+
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        ioStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    // Enqueue and load streams.
+    auto stream1 = input.enqueue(common::Region{0, regionSize}, nullptr);
+    auto stream2 =
+        input.enqueue(common::Region{regionSize, regionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    input.load(LogType::TEST);
+
+    // Reset the input before reading from streams.
+    input.reset();
+
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+    // Read from streams after reset - data should still be available.
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(0, regionSize));
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(regionSize, regionSize));
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    stream1.reset();
+    stream2.reset();
+    while (pool_->usedBytes() > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+}
+
+TEST_F(DirectBufferedInputTest, resetInputWithBeforeLoading) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+
+  // Test both tiny and non-tiny region sizes.
+  for (const bool tinyRegion : {false, true}) {
+    SCOPED_TRACE(fmt::format("tinyRegion: {}", tinyRegion));
+
+    const uint64_t regionSize = tinyRegion
+        ? DirectBufferedInput::kTinySize - 100
+        : DirectBufferedInput::kTinySize + 1000;
+
+    auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, "testFile");
+    StringIdLease groupId(ids, "testGroup");
+
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        ioStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    // Block the coalesced load to verify references are held.
+    folly::Baton<> loadStarted;
+    folly::Baton<> loadAllowed;
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::cache::CoalescedLoad::loadOrFuture",
+        std::function<void(const CoalescedLoad*)>(
+            [&](const CoalescedLoad* /*load*/) {
+              loadStarted.post();
+              loadAllowed.wait();
+            }));
+
+    // Enqueue and load streams.
+    auto stream1 = input.enqueue(common::Region{0, regionSize}, nullptr);
+    auto stream2 =
+        input.enqueue(common::Region{regionSize, regionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    ASSERT_EQ(pool_->usedBytes(), 0);
+    input.load(LogType::TEST);
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Wait for the load to start (but it's blocked).
+    loadStarted.wait();
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Verify coalesced load references are held.
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+    // Reset the input while load is pending.
+    input.reset();
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // After reset, internal tracking should be cleared.
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+    // Allow the load to proceed but cancelled.
+    loadAllowed.post();
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Read from streams - data should be available after load completes.
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(0, regionSize));
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(regionSize, regionSize));
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+    stream1.reset();
+    stream2.reset();
+    ASSERT_EQ(pool_->usedBytes(), 0);
+  }
+}
+
+TEST_F(DirectBufferedInputTest, resetInputWithAfterLoading) {
+  constexpr int32_t kContentSize = 4 << 20; // 4MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+
+  // Test both tiny and non-tiny region sizes.
+  for (const bool tinyRegion : {false, true}) {
+    SCOPED_TRACE(fmt::format("tinyRegion: {}", tinyRegion));
+
+    const uint64_t regionSize = tinyRegion
+        ? DirectBufferedInput::kTinySize - 100
+        : DirectBufferedInput::kTinySize + 1000;
+
+    auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+    io::ReaderOptions readerOptions(pool_.get());
+    readerOptions.setLoadQuantum(1 << 20);
+
+    auto& ids = fileIds();
+    StringIdLease fileId(ids, "testFile");
+    StringIdLease groupId(ids, "testGroup");
+
+    DirectBufferedInput input(
+        readFile,
+        MetricsLog::voidLog(),
+        std::move(fileId),
+        tracker_,
+        std::move(groupId),
+        ioStats_,
+        nullptr,
+        executor_.get(),
+        readerOptions);
+
+    // Block the coalesced load to verify references are held.
+    folly::Baton<> loadStarted;
+    folly::Baton<> loadAllowed;
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::cache::CoalescedLoad::loadOrFuture::loading",
+        std::function<void(const CoalescedLoad*)>(
+            [&](const CoalescedLoad* /*load*/) {
+              loadStarted.post();
+              loadAllowed.wait();
+            }));
+
+    // Enqueue and load streams.
+    auto stream1 = input.enqueue(common::Region{0, regionSize}, nullptr);
+    auto stream2 =
+        input.enqueue(common::Region{regionSize, regionSize}, nullptr);
+    ASSERT_NE(stream1, nullptr);
+    ASSERT_NE(stream2, nullptr);
+
+    ASSERT_EQ(pool_->usedBytes(), 0);
+    input.load(LogType::TEST);
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Wait for the load to start (but it's blocked).
+    loadStarted.wait();
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // Verify coalesced load references are held.
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 2);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 1);
+
+    // Reset the input while load is pending.
+    input.reset();
+    ASSERT_EQ(pool_->usedBytes(), 0);
+
+    // After reset, internal tracking should be cleared.
+    EXPECT_EQ(input.testingStreamToCoalescedLoadSize(), 0);
+    EXPECT_EQ(input.testingCoalescedLoads().size(), 0);
+
+    // Allow the load to proceed without cancelling.
+    loadAllowed.post();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // Read from streams - data should be available after load completes.
+    auto next1 = getNext(*stream1);
+    ASSERT_TRUE(next1.has_value());
+    EXPECT_EQ(next1.value(), content.substr(0, regionSize));
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+
+    auto next2 = getNext(*stream2);
+    ASSERT_TRUE(next2.has_value());
+    EXPECT_EQ(next2.value(), content.substr(regionSize, regionSize));
+    if (tinyRegion) {
+      ASSERT_EQ(pool_->usedBytes(), 0);
+    } else {
+      ASSERT_GT(pool_->usedBytes(), 0);
+    }
+    stream1.reset();
+    stream2.reset();
+    while (pool_->usedBytes() > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Summary:
Implement the `reset()` method for `BufferedInput` and all its derived classes (`DirectBufferedInput` and `CachedBufferedInput`) to support reusing the same buffered input instance across different operations.

This is needed for index lookup workflows that reuse the same `BufferedInput` across different index lookups. For instance, Nimble file format with cluster index supports index lookup and needs to reset the buffered input state between lookups.

The reset implementation:
- **BufferedInput**: Clears all transient state (`regions_`, `offsets_`, `buffers_`, `enqueuedToBufferOffset_`) and the allocation pool
- **DirectBufferedInput**: Calls parent's reset, cancels pending coalesced loads, and clears `requests_` and stream-to-load mappings
- **CachedBufferedInput**: Calls parent's reset, cancels pending coalesced loads, and clears `requests_` and load mappings

The cancellation logic follows the same pattern as the destructors to ensure proper cleanup of async operations.

Differential Revision: D91388633
