### PR TITLE
build: Shorten flat map encoded fuzzer test iterations

### DIFF
--- a/velox/vector/tests/EncodedVectorCopyTest.cpp
+++ b/velox/vector/tests/EncodedVectorCopyTest.cpp
@@ -794,11 +794,7 @@ TEST_P(EncodedVectorCopyTest, fuzzerNewCopy) {
   auto seed = common::testutil::getRandomSeed(42);
   VectorFuzzer fuzzer(fuzzerOptions, pool(), seed);
   fuzzer::FuzzerGenerator rng(seed);
-#ifndef NDEBUG
-  constexpr int kNumIterations = 20;
-#else
-  constexpr int kNumIterations = 1000;
-#endif
+  constexpr int kNumIterations = 10;
   for (int i = 0; i < kNumIterations; ++i) {
     auto type = fuzzer.randType();
     SCOPED_TRACE(fmt::format("i={} type={}", i, type->toString()));


### PR DESCRIPTION
Summary: OSS builds fail with timeout for fuzzerFlatMap in the EncodedVectorTest suite. Fuzzing copies can be time consuming, especially with a high number of iterations. Let's temporarily shorten these iterations. Increased test coverage will return in D91278343

Differential Revision: D91708188


