### PR TITLE
Enable conversion to complex nested C++ types (#16159)

### DIFF
--- a/velox/type/CppToType.h
+++ b/velox/type/CppToType.h
@@ -15,6 +15,10 @@
  */
 #pragma once
 
+#include <map>
+#include <unordered_map>
+#include <vector>
+
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -107,6 +111,28 @@ struct CppToType<std::shared_ptr<T>> : public CppToTypeBase<TypeKind::OPAQUE> {
 
 template <>
 struct CppToType<UnknownValue> : public CppToTypeBase<TypeKind::UNKNOWN> {};
+
+template <typename T>
+struct CppToType<std::vector<T>> : public CppToTypeBase<TypeKind::ARRAY> {
+  static auto create() {
+    return ARRAY(CppToType<T>::create());
+  }
+};
+
+template <typename K, typename V>
+struct CppToType<std::map<K, V>> : public CppToTypeBase<TypeKind::MAP> {
+  static auto create() {
+    return MAP(CppToType<K>::create(), CppToType<V>::create());
+  }
+};
+
+template <typename K, typename V>
+struct CppToType<std::unordered_map<K, V>>
+    : public CppToTypeBase<TypeKind::MAP> {
+  static auto create() {
+    return MAP(CppToType<K>::create(), CppToType<V>::create());
+  }
+};
 
 // todo: remaining cpp2type
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -25,12 +25,14 @@
 #include <ctime>
 #include <iomanip>
 #include <limits>
+#include <map>
 #include <memory>
 #include <optional>
 #include <span>
 #include <string>
 #include <type_traits>
 #include <typeindex>
+#include <unordered_map>
 #include <vector>
 
 #include <velox/common/Enums.h>
@@ -372,6 +374,38 @@ constexpr bool is_nested_kind(TypeKind kind) {
   return kind == TypeKind::ARRAY || kind == TypeKind::MAP ||
       kind == TypeKind::ROW;
 }
+
+// Type traits for detecting C++ container types.
+template <typename T>
+struct is_std_map : std::false_type {};
+
+template <typename K, typename V>
+struct is_std_map<std::map<K, V>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_std_map_v = is_std_map<T>::value;
+
+template <typename T>
+struct is_std_unordered_map : std::false_type {};
+
+template <typename K, typename V>
+struct is_std_unordered_map<std::unordered_map<K, V>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_std_unordered_map_v = is_std_unordered_map<T>::value;
+
+template <typename T>
+struct is_std_vector : std::false_type {};
+
+template <typename E>
+struct is_std_vector<std::vector<E>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_std_vector_v = is_std_vector<T>::value;
+
+template <typename T>
+inline constexpr bool is_std_container_v =
+    is_std_map_v<T> || is_std_unordered_map_v<T> || is_std_vector_v<T>;
 
 template <TypeKind KIND>
 struct TypeFactory;

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -203,6 +203,15 @@ struct VariantTypeTraits<TypeKind::OPAQUE, usesCustomComparison> {
       TypeStorage<OpaqueCapsule, TypeKind::OPAQUE, usesCustomComparison>;
   using value_type = OpaqueCapsule;
 };
+
+// Forward declaration for ToVariantValue, defined after Variant class.
+template <typename T, typename Enable = void>
+struct ToVariantValue;
+
+// Forward declaration for FromVariantValue, defined after Variant class.
+template <typename T, typename Enable = void>
+struct FromVariantValue;
+
 } // namespace detail
 
 class Variant {
@@ -390,6 +399,40 @@ class Variant {
       const typename detail::VariantTypeTraits<CppToType<T>::typeKind, false>::
           value_type& v) {
     return create<CppToType<T>::typeKind>(v);
+  }
+
+  /// Creates a non-null Variant from a C++ container type (std::map or
+  /// std::vector) by recursively converting all elements to Variants.
+  ///
+  /// This overload handles container types that need recursive conversion:
+  /// - std::vector<T> becomes an ARRAY Variant with each element converted
+  /// - std::map<K, V> becomes a MAP Variant with keys and values converted
+  ///
+  /// The conversion is recursive, so nested containers like
+  /// std::map<std::string, std::vector<int>> are fully supported.
+  ///
+  /// @tparam T A container type (std::map<K,V> or std::vector<E>)
+  /// @param v The container value to convert
+  ///
+  /// @return A new non-null Variant containing the converted container
+  ///
+  /// Example usage:
+  ///   // Create a map variant from std::map<std::string, int>
+  ///   std::map<std::string, int> m = {{"one", 1}, {"two", 2}};
+  ///   auto mapVar = Variant::create<std::map<std::string, int>>(m);
+  ///
+  ///   // Create an array variant from std::vector<double>
+  ///   std::vector<double> v = {1.1, 2.2, 3.3};
+  ///   auto arrVar = Variant::create<std::vector<double>>(v);
+  ///
+  ///   // Nested containers work too
+  ///   std::map<std::string, std::vector<int>> nested = {{"evens", {2, 4, 6}}};
+  ///   auto nestedVar = Variant::create<std::map<std::string,
+  ///   std::vector<int>>>(nested);
+  template <typename T, std::enable_if_t<is_std_container_v<T>, int> = 0>
+  static Variant create(T v) {
+    return create<CppToType<T>::typeKind>(
+        detail::ToVariantValue<T>::convert(std::move(v)));
   }
 
   /// Deserializes a Variant from a folly::dynamic object.
@@ -734,9 +777,16 @@ class Variant {
     }
   }
 
-  template <typename T>
+  template <typename T, std::enable_if_t<!is_std_container_v<T>, int> = 0>
   const auto& value() const {
     return value<CppToType<T>::typeKind>();
+  }
+
+  /// Returns a container (std::map or std::vector) with recursively converted
+  /// elements. For primitive types, use the non-container overload above.
+  template <typename T, std::enable_if_t<is_std_container_v<T>, int> = 0>
+  T value() const {
+    return detail::FromVariantValue<T>::convert(*this);
   }
 
   bool isNull() const {
@@ -1038,6 +1088,119 @@ struct VariantConverter {
     return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(convert, toKind, value);
   }
 };
+
+namespace detail {
+
+template <typename T, typename Enable>
+struct ToVariantValue {
+  static T convert(T value) {
+    return value;
+  }
+};
+
+// Helper to create a Variant from a converted value.
+// For primitives, use constructor; for containers, use create<TypeKind>.
+template <typename T, typename = void>
+struct MakeVariant {
+  static Variant make(T value) {
+    return Variant{value};
+  }
+};
+
+template <typename T>
+struct MakeVariant<
+    T,
+    std::enable_if_t<is_std_map_v<T> || is_std_unordered_map_v<T>>> {
+  static Variant make(std::map<Variant, Variant> value) {
+    return Variant::create<TypeKind::MAP>(std::move(value));
+  }
+};
+
+template <typename T>
+struct MakeVariant<T, std::enable_if_t<is_std_vector_v<T>>> {
+  static Variant make(std::vector<Variant> value) {
+    return Variant::create<TypeKind::ARRAY>(std::move(value));
+  }
+};
+
+template <typename T>
+struct ToVariantValue<
+    T,
+    std::enable_if_t<is_std_map_v<T> || is_std_unordered_map_v<T>>> {
+  static std::map<Variant, Variant> convert(T mapValue) {
+    using K = typename T::key_type;
+    using V = typename T::mapped_type;
+
+    std::map<Variant, Variant> variantMap;
+    for (auto& [key, value] : mapValue) {
+      variantMap.emplace(
+          detail::MakeVariant<K>::make(
+              ToVariantValue<K>::convert(std::move(key))),
+          detail::MakeVariant<V>::make(
+              ToVariantValue<V>::convert(std::move(value))));
+    }
+    return variantMap;
+  }
+};
+
+template <typename T>
+struct ToVariantValue<T, std::enable_if_t<is_std_vector_v<T>>> {
+  static std::vector<Variant> convert(T vecValue) {
+    using E = typename T::value_type;
+
+    std::vector<Variant> variantVec;
+    variantVec.reserve(vecValue.size());
+    for (auto elem : vecValue) {
+      variantVec.push_back(
+          detail::MakeVariant<E>::make(
+              ToVariantValue<E>::convert(std::move(elem))));
+    }
+    return variantVec;
+  }
+};
+
+template <typename T, typename Enable>
+struct FromVariantValue {
+  static T convert(const Variant& v) {
+    return v.value<T>();
+  }
+};
+
+template <typename T>
+struct FromVariantValue<
+    T,
+    std::enable_if_t<is_std_map_v<T> || is_std_unordered_map_v<T>>> {
+  static T convert(const Variant& v) {
+    using K = typename T::key_type;
+    using V = typename T::mapped_type;
+
+    const auto& variantMap = v.map();
+    T result;
+    for (const auto& [key, value] : variantMap) {
+      result.emplace(
+          FromVariantValue<K>::convert(key),
+          FromVariantValue<V>::convert(value));
+    }
+    return result;
+  }
+};
+
+template <typename T>
+struct FromVariantValue<T, std::enable_if_t<is_std_vector_v<T>>> {
+  static T convert(const Variant& v) {
+    using E = typename T::value_type;
+
+    const auto& variantVec = v.array();
+    T result;
+    result.reserve(variantVec.size());
+    for (const auto& elem : variantVec) {
+      result.push_back(FromVariantValue<E>::convert(elem));
+    }
+    return result;
+  }
+};
+
+} // namespace detail
 
 // For backward compatibility.
 using variant = Variant;

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -1995,5 +1995,498 @@ TEST(VariantTest, accessWrongTypeVariantValue) {
       intVar.value<TypeKind::VARCHAR>(), "wrong kind! INTEGER != VARCHAR");
 }
 
+// Tests for C++ container type conversions (std::map, std::unordered_map,
+// std::vector).
+
+TEST(VariantTest, createFromStdVector) {
+  // Simple vector of integers.
+  std::vector<int32_t> intVec = {1, 2, 3, 4, 5};
+  auto variant = Variant::create<std::vector<int32_t>>(intVec);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<int32_t>>();
+  EXPECT_EQ(result, intVec);
+}
+
+TEST(VariantTest, createFromStdVectorDouble) {
+  std::vector<double> doubleVec = {1.1, 2.2, 3.3, 4.4};
+  auto variant = Variant::create<std::vector<double>>(doubleVec);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<double>>();
+  EXPECT_EQ(result.size(), doubleVec.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    EXPECT_DOUBLE_EQ(result[i], doubleVec[i]);
+  }
+}
+
+TEST(VariantTest, createFromStdVectorString) {
+  std::vector<std::string> strVec = {"apple", "banana", "cherry"};
+  auto variant = Variant::create<std::vector<std::string>>(strVec);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<std::string>>();
+  EXPECT_EQ(result, strVec);
+}
+
+TEST(VariantTest, createFromEmptyStdVector) {
+  std::vector<int32_t> emptyVec;
+  auto variant = Variant::create<std::vector<int32_t>>(emptyVec);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<int32_t>>();
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(VariantTest, createFromStdMap) {
+  std::map<int32_t, double> intDoubleMap = {{1, 1.1}, {2, 2.2}, {3, 3.3}};
+  auto variant = Variant::create<std::map<int32_t, double>>(intDoubleMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::map<int32_t, double>>();
+  EXPECT_EQ(result, intDoubleMap);
+}
+
+TEST(VariantTest, createFromStdMapStringKey) {
+  std::map<std::string, int64_t> strIntMap = {
+      {"one", 1}, {"two", 2}, {"three", 3}};
+  auto variant = Variant::create<std::map<std::string, int64_t>>(strIntMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::map<std::string, int64_t>>();
+  EXPECT_EQ(result, strIntMap);
+}
+
+TEST(VariantTest, createFromEmptyStdMap) {
+  std::map<int32_t, std::string> emptyMap;
+  auto variant = Variant::create<std::map<int32_t, std::string>>(emptyMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::map<int32_t, std::string>>();
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(VariantTest, createFromStdUnorderedMap) {
+  std::unordered_map<int32_t, double> intDoubleMap = {
+      {1, 1.1}, {2, 2.2}, {3, 3.3}};
+  auto variant =
+      Variant::create<std::unordered_map<int32_t, double>>(intDoubleMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::unordered_map<int32_t, double>>();
+  EXPECT_EQ(result, intDoubleMap);
+}
+
+TEST(VariantTest, createFromStdUnorderedMapStringKey) {
+  std::unordered_map<std::string, int64_t> strIntMap = {
+      {"one", 1}, {"two", 2}, {"three", 3}};
+  auto variant =
+      Variant::create<std::unordered_map<std::string, int64_t>>(strIntMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::unordered_map<std::string, int64_t>>();
+  EXPECT_EQ(result, strIntMap);
+}
+
+TEST(VariantTest, createFromEmptyStdUnorderedMap) {
+  std::unordered_map<int32_t, std::string> emptyMap;
+  auto variant =
+      Variant::create<std::unordered_map<int32_t, std::string>>(emptyMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::unordered_map<int32_t, std::string>>();
+  EXPECT_TRUE(result.empty());
+}
+
+// Nested container tests.
+
+TEST(VariantTest, nestedVectorOfVectors) {
+  std::vector<std::vector<int32_t>> nestedVec = {
+      {1, 2, 3}, {4, 5}, {6, 7, 8, 9}};
+  auto variant = Variant::create<std::vector<std::vector<int32_t>>>(nestedVec);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<std::vector<int32_t>>>();
+  EXPECT_EQ(result, nestedVec);
+}
+
+TEST(VariantTest, nestedMapOfMaps) {
+  std::map<int32_t, std::map<int32_t, double>> nestedMap = {
+      {1, {{10, 1.1}, {20, 2.2}}},
+      {2, {{30, 3.3}, {40, 4.4}}},
+  };
+  auto variant =
+      Variant::create<std::map<int32_t, std::map<int32_t, double>>>(nestedMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::map<int32_t, std::map<int32_t, double>>>();
+  EXPECT_EQ(result, nestedMap);
+}
+
+TEST(VariantTest, nestedUnorderedMapOfUnorderedMaps) {
+  std::unordered_map<int32_t, std::unordered_map<int32_t, double>> nestedMap = {
+      {1, {{10, 1.1}, {20, 2.2}}},
+      {2, {{30, 3.3}, {40, 4.4}}},
+  };
+  auto variant = Variant::create<
+      std::unordered_map<int32_t, std::unordered_map<int32_t, double>>>(
+      nestedMap);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<
+      std::unordered_map<int32_t, std::unordered_map<int32_t, double>>>();
+  EXPECT_EQ(result, nestedMap);
+}
+
+TEST(VariantTest, mapOfVectors) {
+  std::map<std::string, std::vector<int32_t>> mapOfVecs = {
+      {"odds", {1, 3, 5, 7}},
+      {"evens", {2, 4, 6, 8}},
+  };
+  auto variant =
+      Variant::create<std::map<std::string, std::vector<int32_t>>>(mapOfVecs);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::map<std::string, std::vector<int32_t>>>();
+  EXPECT_EQ(result, mapOfVecs);
+}
+
+TEST(VariantTest, unorderedMapOfVectors) {
+  std::unordered_map<std::string, std::vector<double>> mapOfVecs = {
+      {"temps", {98.6, 99.1, 97.8}},
+      {"pressures", {14.7, 15.0, 14.5}},
+  };
+  auto variant =
+      Variant::create<std::unordered_map<std::string, std::vector<double>>>(
+          mapOfVecs);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result =
+      variant.value<std::unordered_map<std::string, std::vector<double>>>();
+  EXPECT_EQ(result, mapOfVecs);
+}
+
+TEST(VariantTest, vectorOfMaps) {
+  std::vector<std::map<std::string, int32_t>> vecOfMaps = {
+      {{"a", 1}, {"b", 2}},
+      {{"c", 3}, {"d", 4}, {"e", 5}},
+  };
+  auto variant =
+      Variant::create<std::vector<std::map<std::string, int32_t>>>(vecOfMaps);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<std::map<std::string, int32_t>>>();
+  EXPECT_EQ(result, vecOfMaps);
+}
+
+TEST(VariantTest, vectorOfUnorderedMaps) {
+  std::vector<std::unordered_map<int32_t, std::string>> vecOfMaps = {
+      {{1, "one"}, {2, "two"}},
+      {{3, "three"}, {4, "four"}, {5, "five"}},
+  };
+  auto variant =
+      Variant::create<std::vector<std::unordered_map<int32_t, std::string>>>(
+          vecOfMaps);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result =
+      variant.value<std::vector<std::unordered_map<int32_t, std::string>>>();
+  EXPECT_EQ(result, vecOfMaps);
+}
+
+// Deeply nested container tests.
+
+TEST(VariantTest, deeplyNestedMapOfMapOfVectors) {
+  std::map<int32_t, std::map<int32_t, std::vector<double>>> deepNested = {
+      {1, {{10, {1.1, 1.2}}, {20, {2.1, 2.2, 2.3}}}},
+      {2, {{30, {3.1}}, {40, {4.1, 4.2}}}},
+  };
+  auto variant = Variant::create<
+      std::map<int32_t, std::map<int32_t, std::vector<double>>>>(deepNested);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result =
+      variant
+          .value<std::map<int32_t, std::map<int32_t, std::vector<double>>>>();
+  EXPECT_EQ(result, deepNested);
+}
+
+TEST(VariantTest, deeplyNestedUnorderedMapOfUnorderedMapOfVectors) {
+  std::unordered_map<int32_t, std::unordered_map<int32_t, std::vector<double>>>
+      deepNested = {
+          {1, {{10, {1.1, 1.2}}, {20, {2.1, 2.2, 2.3}}}},
+          {2, {{30, {3.1}}, {40, {4.1, 4.2}}}},
+      };
+  auto variant = Variant::create<std::unordered_map<
+      int32_t,
+      std::unordered_map<int32_t, std::vector<double>>>>(deepNested);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result = variant.value<std::unordered_map<
+      int32_t,
+      std::unordered_map<int32_t, std::vector<double>>>>();
+  EXPECT_EQ(result, deepNested);
+}
+
+TEST(VariantTest, vectorOfVectorOfVectors) {
+  std::vector<std::vector<std::vector<int32_t>>> tripleNested;
+  tripleNested.push_back(
+      {std::vector<int32_t>{1, 2}, std::vector<int32_t>{3, 4}});
+  tripleNested.push_back({std::vector<int32_t>{5, 6}});
+  tripleNested.push_back(
+      {std::vector<int32_t>{7}, std::vector<int32_t>{8, 9, 10}});
+
+  auto variant =
+      Variant::create<std::vector<std::vector<std::vector<int32_t>>>>(
+          tripleNested);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::ARRAY);
+
+  auto result = variant.value<std::vector<std::vector<std::vector<int32_t>>>>();
+  EXPECT_EQ(result, tripleNested);
+}
+
+// Mixed container types tests.
+
+TEST(VariantTest, mapWithUnorderedMapValues) {
+  std::map<std::string, std::unordered_map<int32_t, double>> mixed = {
+      {"group1", {{1, 1.1}, {2, 2.2}}},
+      {"group2", {{3, 3.3}, {4, 4.4}}},
+  };
+  auto variant = Variant::create<
+      std::map<std::string, std::unordered_map<int32_t, double>>>(mixed);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result =
+      variant
+          .value<std::map<std::string, std::unordered_map<int32_t, double>>>();
+  EXPECT_EQ(result, mixed);
+}
+
+TEST(VariantTest, unorderedMapWithMapValues) {
+  std::unordered_map<int32_t, std::map<std::string, int64_t>> mixed = {
+      {1, {{"a", 10}, {"b", 20}}},
+      {2, {{"c", 30}, {"d", 40}}},
+  };
+  auto variant = Variant::create<
+      std::unordered_map<int32_t, std::map<std::string, int64_t>>>(mixed);
+
+  EXPECT_FALSE(variant.isNull());
+  EXPECT_EQ(variant.kind(), TypeKind::MAP);
+
+  auto result =
+      variant
+          .value<std::unordered_map<int32_t, std::map<std::string, int64_t>>>();
+  EXPECT_EQ(result, mixed);
+}
+
+// Type trait tests.
+
+TEST(VariantTest, isStdMapTrait) {
+  EXPECT_TRUE((is_std_map_v<std::map<int, int>>));
+  EXPECT_TRUE((is_std_map_v<std::map<std::string, double>>));
+  EXPECT_FALSE((is_std_map_v<std::unordered_map<int, int>>));
+  EXPECT_FALSE(is_std_map_v<std::vector<int>>);
+  EXPECT_FALSE(is_std_map_v<int>);
+  EXPECT_FALSE(is_std_map_v<std::string>);
+}
+
+TEST(VariantTest, isStdUnorderedMapTrait) {
+  EXPECT_TRUE((is_std_unordered_map_v<std::unordered_map<int, int>>));
+  EXPECT_TRUE(
+      (is_std_unordered_map_v<std::unordered_map<std::string, double>>));
+  EXPECT_FALSE((is_std_unordered_map_v<std::map<int, int>>));
+  EXPECT_FALSE(is_std_unordered_map_v<std::vector<int>>);
+  EXPECT_FALSE(is_std_unordered_map_v<int>);
+  EXPECT_FALSE(is_std_unordered_map_v<std::string>);
+}
+
+TEST(VariantTest, isStdVectorTrait) {
+  EXPECT_TRUE(is_std_vector_v<std::vector<int>>);
+  EXPECT_TRUE(is_std_vector_v<std::vector<std::string>>);
+  EXPECT_TRUE((is_std_vector_v<std::vector<std::vector<int>>>));
+  EXPECT_FALSE((is_std_vector_v<std::map<int, int>>));
+  EXPECT_FALSE((is_std_vector_v<std::unordered_map<int, int>>));
+  EXPECT_FALSE(is_std_vector_v<int>);
+  EXPECT_FALSE(is_std_vector_v<std::string>);
+}
+
+TEST(VariantTest, isStdContainerTrait) {
+  EXPECT_TRUE(is_std_container_v<std::vector<int>>);
+  EXPECT_TRUE((is_std_container_v<std::map<int, int>>));
+  EXPECT_TRUE((is_std_container_v<std::unordered_map<int, int>>));
+  EXPECT_TRUE((is_std_container_v<std::vector<std::map<int, int>>>));
+  EXPECT_FALSE(is_std_container_v<int>);
+  EXPECT_FALSE(is_std_container_v<double>);
+  EXPECT_FALSE(is_std_container_v<std::string>);
+}
+
+// CppToType tests for containers.
+
+TEST(VariantTest, cppToTypeVector) {
+  EXPECT_EQ(CppToType<std::vector<int32_t>>::typeKind, TypeKind::ARRAY);
+  EXPECT_EQ(CppToType<std::vector<std::string>>::typeKind, TypeKind::ARRAY);
+  EXPECT_EQ(
+      CppToType<std::vector<std::vector<double>>>::typeKind, TypeKind::ARRAY);
+}
+
+TEST(VariantTest, cppToTypeMap) {
+  EXPECT_EQ((CppToType<std::map<int32_t, double>>::typeKind), TypeKind::MAP);
+  EXPECT_EQ(
+      (CppToType<std::map<std::string, int64_t>>::typeKind), TypeKind::MAP);
+  EXPECT_EQ(
+      (CppToType<std::map<int32_t, std::map<int32_t, double>>>::typeKind),
+      TypeKind::MAP);
+}
+
+TEST(VariantTest, cppToTypeUnorderedMap) {
+  EXPECT_EQ(
+      (CppToType<std::unordered_map<int32_t, double>>::typeKind),
+      TypeKind::MAP);
+  EXPECT_EQ(
+      (CppToType<std::unordered_map<std::string, int64_t>>::typeKind),
+      TypeKind::MAP);
+  EXPECT_EQ(
+      (CppToType<
+          std::unordered_map<int32_t, std::unordered_map<int32_t, double>>>::
+           typeKind),
+      TypeKind::MAP);
+}
+
+// Round-trip tests to ensure conversion preserves data.
+
+TEST(VariantTest, roundTripLargeVector) {
+  std::vector<int64_t> largeVec(1000);
+  for (size_t i = 0; i < largeVec.size(); ++i) {
+    largeVec[i] = static_cast<int64_t>(i * i);
+  }
+
+  auto variant = Variant::create<std::vector<int64_t>>(largeVec);
+  auto result = variant.value<std::vector<int64_t>>();
+
+  EXPECT_EQ(result, largeVec);
+}
+
+TEST(VariantTest, roundTripLargeMap) {
+  std::map<int32_t, std::string> largeMap;
+  for (int i = 0; i < 100; ++i) {
+    largeMap[i] = "value_" + std::to_string(i);
+  }
+
+  auto variant = Variant::create<std::map<int32_t, std::string>>(largeMap);
+  auto result = variant.value<std::map<int32_t, std::string>>();
+
+  EXPECT_EQ(result, largeMap);
+}
+
+TEST(VariantTest, roundTripLargeUnorderedMap) {
+  std::unordered_map<std::string, double> largeMap;
+  for (int i = 0; i < 100; ++i) {
+    largeMap["key_" + std::to_string(i)] = i * 0.1;
+  }
+
+  auto variant =
+      Variant::create<std::unordered_map<std::string, double>>(largeMap);
+  auto result = variant.value<std::unordered_map<std::string, double>>();
+
+  EXPECT_EQ(result, largeMap);
+}
+
+// Edge case tests.
+
+TEST(VariantTest, vectorWithSingleElement) {
+  std::vector<int32_t> singleVec = {42};
+  auto variant = Variant::create<std::vector<int32_t>>(singleVec);
+  auto result = variant.value<std::vector<int32_t>>();
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_EQ(result[0], 42);
+}
+
+TEST(VariantTest, mapWithSingleEntry) {
+  std::map<std::string, int32_t> singleMap = {{"only", 1}};
+  auto variant = Variant::create<std::map<std::string, int32_t>>(singleMap);
+  auto result = variant.value<std::map<std::string, int32_t>>();
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_EQ(result["only"], 1);
+}
+
+TEST(VariantTest, unorderedMapWithSingleEntry) {
+  std::unordered_map<int32_t, std::string> singleMap = {{99, "ninety-nine"}};
+  auto variant =
+      Variant::create<std::unordered_map<int32_t, std::string>>(singleMap);
+  auto result = variant.value<std::unordered_map<int32_t, std::string>>();
+
+  EXPECT_EQ(result.size(), 1);
+  EXPECT_EQ(result[99], "ninety-nine");
+}
+
+TEST(VariantTest, vectorOfEmptyVectors) {
+  std::vector<std::vector<int32_t>> vecOfEmpty = {{}, {}, {}};
+  auto variant = Variant::create<std::vector<std::vector<int32_t>>>(vecOfEmpty);
+  auto result = variant.value<std::vector<std::vector<int32_t>>>();
+
+  EXPECT_EQ(result.size(), 3);
+  for (const auto& inner : result) {
+    EXPECT_TRUE(inner.empty());
+  }
+}
+
+TEST(VariantTest, mapOfEmptyMaps) {
+  std::map<int32_t, std::map<int32_t, int32_t>> mapOfEmpty = {
+      {1, {}},
+      {2, {}},
+  };
+  auto variant = Variant::create<std::map<int32_t, std::map<int32_t, int32_t>>>(
+      mapOfEmpty);
+  auto result = variant.value<std::map<int32_t, std::map<int32_t, int32_t>>>();
+
+  EXPECT_EQ(result.size(), 2);
+  EXPECT_TRUE(result[1].empty());
+  EXPECT_TRUE(result[2].empty());
+}
+
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:

Extends Velox's Variant class to support seamless conversion between C++ standard containers (std::map, std::unordered_map, std::vector) and Variant types, including support for arbitrarily nested containers.

This enables APIs like `Variant::create<std::map<int, std::vector<double>>>()` and `variant.value<std::map<int, std::vector<double>>>()` to work correctly with recursive type conversion.

Key additions:
- Type traits (is_std_map_v, is_std_unordered_map_v, is_std_vector_v) in Type.h
- CppToType specializations for container types in CppToType.h
- ToVariantValue/FromVariantValue converters for recursive container conversion in Variant.h
- Container-aware value<T>() overload in Variant class

Differential Revision: D91715808
