### PR TITLE
feat: Allow EncodedVectorCopy to generate FlatMapVector in non-NULL vectors (#16161)

### DIFF
--- a/velox/vector/EncodedVectorCopy.cpp
+++ b/velox/vector/EncodedVectorCopy.cpp
@@ -622,13 +622,15 @@ void copyIntoConstant(
   VectorPtr alphabet;
   if (decodedSource.isConstantMapping()) {
     fillIndices(1, ranges, rawIndices);
-    alphabet = BaseVector::create(target->type(), 2, options.pool);
+    alphabet =
+        BaseVector::createEmptyLike(decodedTarget.base(), 2, options.pool);
     alphabet->copy(decodedTarget.base(), 0, decodedTarget.index(0), 1);
     alphabet->copy(decodedSource.base(), 1, decodedSource.index(0), 1);
   } else {
     nulls = newNulls(size, options.pool, decodedSource.nulls(), ranges);
     auto baseRanges = toBaseRanges(decodedSource, ranges, 1, rawIndices);
-    alphabet = BaseVector::create(target->type(), 1, options.pool);
+    alphabet =
+        BaseVector::createEmptyLike(decodedTarget.base(), 1, options.pool);
     alphabet->copy(decodedTarget.base(), 0, decodedTarget.index(0), 1);
     copyImpl(options, sourceBase, baseRanges, alphabet, true);
   }
@@ -904,6 +906,140 @@ void copyIntoArray(
   }
 }
 
+void copyIntoFlatMapMutable(
+    const EncodedVectorCopyOptions& options,
+    const FlatMapVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target) {
+  const auto size = targetSize(target->size(), ranges);
+  target->resize(size);
+  target->resetDataDependentFlags(nullptr);
+  setSourceNulls(source.rawNulls(), *target, ranges);
+
+  auto* targetFlatMap = target->asUnchecked<FlatMapVector>();
+  auto startingNumDistinctKeys = targetFlatMap->numDistinctKeys();
+
+  for (column_index_t i = 0; i < source.numDistinctKeys(); ++i) {
+    const auto channel = targetFlatMap->getKeyChannel(source.distinctKeys(), i)
+                             .value_or(targetFlatMap->numDistinctKeys());
+
+    if (channel == targetFlatMap->numDistinctKeys()) {
+      targetFlatMap->appendDistinctKey(source.distinctKeys(), i);
+      targetFlatMap->inMapsAt(channel, true) =
+          AlignedBuffer::allocate<bool>(size, options.pool, false);
+      targetFlatMap->mapValuesAt(channel) = BaseVector::createEmptyLike(
+          source.mapValuesAt(i).get(), size, options.pool);
+    }
+
+    auto& mapValue = targetFlatMap->mapValuesAt(channel);
+    bool childMutable = mapValue.use_count() == 1;
+    copyImpl(options, source.mapValuesAt(i), ranges, mapValue, childMutable);
+    targetFlatMap->copyInMapRanges(channel, source.rawInMapsAt(i), ranges);
+  }
+
+  for (column_index_t i = 0; i < startingNumDistinctKeys; ++i) {
+    if (source.getKeyChannel(targetFlatMap->distinctKeys(), i) ==
+        std::nullopt) {
+      auto& targetInMapsBuffer = targetFlatMap->inMapsAt(i, true);
+      if (targetInMapsBuffer == nullptr) {
+        targetInMapsBuffer =
+            AlignedBuffer::allocate<bool>(size, options.pool, false);
+      }
+      auto* targetInMaps = targetInMapsBuffer->asMutable<uint64_t>();
+
+      applyToEachRange(
+          ranges, [targetInMaps](auto targetIndex, auto, auto count) {
+            bits::fillBits(
+                targetInMaps, targetIndex, targetIndex + count, false);
+          });
+    }
+  }
+}
+
+void copyIntoFlatMapImmutable(
+    const EncodedVectorCopyOptions& options,
+    const FlatMapVector& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    VectorPtr& target) {
+  const auto size = targetSize(target->size(), ranges);
+  auto* targetFlatMap = target->asUnchecked<FlatMapVector>();
+
+  auto mapValues = targetFlatMap->mapValues();
+  std::vector<BufferPtr> inMaps(targetFlatMap->inMaps().size());
+  for (size_t i = 0; i < targetFlatMap->inMaps().size(); ++i) {
+    if (targetFlatMap->inMaps()[i]) {
+      inMaps[i] = AlignedBuffer::copy(options.pool, targetFlatMap->inMaps()[i]);
+      if (bits::nbytes(size) > inMaps[i]->size()) {
+        AlignedBuffer::reallocate<bool>(&inMaps[i], size, false);
+      }
+    }
+  }
+  auto distinctKeys =
+      BaseVector::copy(*targetFlatMap->distinctKeys(), options.pool);
+
+  BufferPtr nulls;
+  if (target->rawNulls() || source.rawNulls()) {
+    nulls = combineNulls(
+        size,
+        options.pool,
+        target->rawNulls(),
+        target->size(),
+        source.rawNulls(),
+        ranges);
+  }
+
+  target = std::make_shared<FlatMapVector>(
+      options.pool,
+      target->type(),
+      std::move(nulls),
+      size,
+      std::move(distinctKeys),
+      std::move(mapValues),
+      std::move(inMaps));
+  target->resetDataDependentFlags(nullptr);
+  copyIntoFlatMapMutable(options, source, ranges, target);
+}
+
+void copyIntoFlatMap(
+    const EncodedVectorCopyOptions& options,
+    const VectorPtr& source,
+    const folly::Range<const BaseVector::CopyRange*>& ranges,
+    DecodedVector& decodedSource,
+    const VectorPtr& sourceBase,
+    VectorPtr& target,
+    bool targetMutable) {
+  if (decodedSource.isIdentityMapping()) {
+    auto& flatMapSource = *source->asUnchecked<FlatMapVector>();
+    if (targetMutable) {
+      copyIntoFlatMapMutable(options, flatMapSource, ranges, target);
+    } else {
+      copyIntoFlatMapImmutable(options, flatMapSource, ranges, target);
+    }
+    return;
+  }
+  const auto size = targetSize(target->size(), ranges);
+  BufferPtr nulls;
+  auto indices = allocateIndices(size, options.pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  std::iota(rawIndices, rawIndices + target->size(), 0);
+  BaseVector::CopyRange baseRange;
+  baseRange.targetIndex = target->size();
+  if (decodedSource.isConstantMapping()) {
+    fillIndices(target->size(), ranges, rawIndices);
+    baseRange.sourceIndex = decodedSource.index(0);
+    baseRange.count = 1;
+  } else {
+    nulls = newNulls(size, options.pool, decodedSource.nulls(), ranges);
+    copyIndices(decodedSource.indices(), ranges, target->size(), rawIndices);
+    baseRange.sourceIndex = 0;
+    baseRange.count = sourceBase->size();
+  }
+  copyImpl(
+      options, sourceBase, folly::Range(&baseRange, 1), target, targetMutable);
+  target = BaseVector::wrapInDictionary(
+      std::move(nulls), std::move(indices), size, target);
+}
+
 void copyIntoComplex(
     const EncodedVectorCopyOptions& options,
     DecodedVector& decodedSource,
@@ -1043,8 +1179,15 @@ void copyIntoExisting(
           options, decodedSource, sourceBase, ranges, target, targetMutable);
       break;
     case VectorEncoding::Simple::FLAT_MAP:
-      VELOX_UNSUPPORTED(
-          "EncodedVectorCopy copyInto does not support FlatMapVector.");
+      copyIntoFlatMap(
+          options,
+          source,
+          ranges,
+          decodedSource,
+          sourceBase,
+          target,
+          targetMutable);
+      break;
     case VectorEncoding::Simple::LAZY:
       copyIntoLazy(options, source, ranges, target, targetMutable);
       break;
@@ -1062,7 +1205,7 @@ void copyImpl(
     bool targetMutable) {
   if (ranges.empty()) {
     if (!target) {
-      target = BaseVector::create(source->type(), 0, options.pool);
+      target = BaseVector::createEmptyLike(source.get(), 0, options.pool);
     }
     return;
   }

--- a/velox/vector/FlatMapVector.cpp
+++ b/velox/vector/FlatMapVector.cpp
@@ -101,7 +101,7 @@ vector_size_t FlatMapVector::sizeAt(vector_size_t index) const {
 
   for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
     if (i < inMaps_.size() && inMaps_[i] != nullptr) {
-      size += bits::isBitSet(inMaps_[i]->asMutable<uint64_t>(), index);
+      size += bits::isBitSet(inMaps_[i]->as<uint64_t>(), index);
     } else {
       // By default assume the key exists.
       ++size;

--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -349,22 +349,7 @@ class FlatMapVector : public BaseVector {
     VELOX_NYI("{} unsupported", __FUNCTION__);
   }
 
- private:
-  void setDistinctKeysImpl(VectorPtr distinctKeys) {
-    VELOX_CHECK(distinctKeys != nullptr);
-    VELOX_CHECK(
-        *distinctKeys->type() == *keyType(),
-        "Unexpected key type: {}",
-        distinctKeys->type()->toString());
-
-    distinctKeys_ = std::move(distinctKeys);
-    keyToChannel_.clear();
-
-    for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
-      keyToChannel_.insert({distinctKeys_->hashValueAt(i), i});
-    }
-  }
-
+ public:
   /// Appends a new distinct key to the flat map specified by `sourceChannel` on
   /// `sourceDistinctKeys`.
   void appendDistinctKey(
@@ -393,6 +378,22 @@ class FlatMapVector : public BaseVector {
       column_index_t targetChannel,
       const uint64_t* sourceInMaps,
       const folly::Range<const BaseVector::CopyRange*>& ranges);
+
+ private:
+  void setDistinctKeysImpl(VectorPtr distinctKeys) {
+    VELOX_CHECK(distinctKeys != nullptr);
+    VELOX_CHECK(
+        *distinctKeys->type() == *keyType(),
+        "Unexpected key type: {}",
+        distinctKeys->type()->toString());
+
+    distinctKeys_ = std::move(distinctKeys);
+    keyToChannel_.clear();
+
+    for (vector_size_t i = 0; i < numDistinctKeys(); i++) {
+      keyToChannel_.insert({distinctKeys_->hashValueAt(i), i});
+    }
+  }
 
   /// Compares a map in this Vector with a map in a MapVector.
   std::optional<int32_t> compareToMap(

--- a/velox/vector/tests/EncodedVectorCopyTest.cpp
+++ b/velox/vector/tests/EncodedVectorCopyTest.cpp
@@ -579,6 +579,7 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange range = {0, 0, source->size()};
     VectorPtr actual;
     copy(source, folly::Range(&range, 1), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(source, actual);
   }
   {
@@ -586,6 +587,7 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange range = {1, 0, 2};
     VectorPtr actual;
     copy(source, folly::Range(&range, 1), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(
         source->slice(range.sourceIndex, range.count), actual);
   }
@@ -602,6 +604,7 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange range = {0, 0, source->size()};
     VectorPtr actual;
     copy(source, folly::Range(&range, 1), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(source, actual);
   }
   {
@@ -609,6 +612,7 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange range = {1, 0, 2};
     VectorPtr actual;
     copy(source, folly::Range(&range, 1), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(
         source->slice(range.sourceIndex, range.count), actual);
   }
@@ -625,6 +629,7 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange range = {0, 0, source->size()};
     VectorPtr actual;
     copy(source, folly::Range(&range, 1), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(source, actual);
   }
 
@@ -640,6 +645,7 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange ranges[] = {{0, 0, 1}, {2, 1, 2}};
     VectorPtr actual;
     copy(source, folly::Range(ranges, 2), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(
         vectorMaker_.flatMapVector<int64_t, int64_t>({
             {{1, 10}},
@@ -670,7 +676,296 @@ TEST_P(EncodedVectorCopyTest, flatMapVector) {
     BaseVector::CopyRange range = {0, 0, source->size()};
     VectorPtr actual;
     copy(source, folly::Range(&range, 1), actual);
+    ASSERT_EQ(actual->encoding(), VectorEncoding::Simple::FLAT_MAP);
     test::assertEqualVectors(source, actual);
+  }
+}
+
+/// Tests copying into an existing FlatMapVector target.
+TEST_P(EncodedVectorCopyTest, flatMapVectorCopyInto) {
+  {
+    SCOPED_TRACE("Copy into same keys");
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 100}, {2, 200}},
+        {{1, 300}, {2, 400}},
+    });
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}, {2, 40}},
+        {{1, 50}, {2, 60}},
+    });
+
+    // Copy source rows 0-1 to target rows 1-2.
+    BaseVector::CopyRange range = {0, 1, 2};
+    copy(source, folly::Range(&range, 1), target);
+    ASSERT_EQ(target->encoding(), VectorEncoding::Simple::FLAT_MAP);
+
+    // Row 0 should be unchanged: {1: 10, 2: 20}
+    // Row 1 should be from source row 0: {1: 100, 2: 200}
+    // Row 2 should be from source row 1: {1: 300, 2: 400}
+    auto expected = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 300}, {2, 400}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+
+  {
+    SCOPED_TRACE("Copy into same keys with non-mutable target");
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 100}, {2, 200}},
+        {{1, 300}, {2, 400}},
+    });
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 300}, {2, 400}},
+    });
+    auto immutableTarget = target;
+
+    // Copy source rows 0-1 to target rows 1-2.
+    BaseVector::CopyRange range = {0, 1, 2};
+    copy(source, folly::Range(&range, 1), immutableTarget);
+    ASSERT_EQ(immutableTarget->encoding(), VectorEncoding::Simple::FLAT_MAP);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 300}, {2, 400}},
+    });
+    test::assertEqualVectors(expected, immutableTarget);
+  }
+
+  {
+    SCOPED_TRACE("Copy into different keys");
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{3, 300}, {4, 400}},
+        {{3, 500}},
+    });
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}},
+    });
+
+    // Copy source to target rows 2-3.
+    BaseVector::CopyRange range = {0, 2, 2};
+    copy(source, folly::Range(&range, 1), target);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}},
+        {{3, 300}, {4, 400}},
+        {{3, 500}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+
+  {
+    SCOPED_TRACE("Copy into different keys with non-mutable target");
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{3, 300}, {4, 400}},
+        {{3, 500}},
+    });
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}},
+    });
+    auto immutableTarget = target;
+
+    BaseVector::CopyRange range = {0, 2, 2};
+    copy(source, folly::Range(&range, 1), immutableTarget);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}},
+        {{3, 300}, {4, 400}},
+        {{3, 500}},
+    });
+    test::assertEqualVectors(expected, immutableTarget);
+  }
+
+  {
+    SCOPED_TRACE("Overlapping keys");
+
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{2, 200}, {3, 300}},
+    });
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}, {2, 40}},
+    });
+
+    // Copy source to target row 1.
+    BaseVector::CopyRange range = {0, 1, 1};
+    copy(source, folly::Range(&range, 1), target);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{2, 200}, {3, 300}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+
+  {
+    SCOPED_TRACE("Overlapping keys with non-mutable target");
+
+    auto source = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{2, 200}, {3, 300}},
+    });
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{1, 30}, {2, 40}},
+    });
+    auto immutableTarget = target;
+
+    BaseVector::CopyRange range = {0, 1, 1};
+    copy(source, folly::Range(&range, 1), target);
+
+    EXPECT_EQ(target->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    ASSERT_EQ(target->size(), 2);
+    ASSERT_NE(target.get(), immutableTarget.get());
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 10}, {2, 20}},
+        {{2, 200}, {3, 300}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+}
+
+TEST_P(EncodedVectorCopyTest, flatMapVectorEncoded) {
+  auto source = BaseVector::wrapInConstant(
+      3,
+      1,
+      vectorMaker_.flatMapVector<int64_t, int64_t>(
+          {{{1, 10}, {2, 20}}, {{1, 100}, {2, 200}}}));
+  BaseVector::CopyRange range = {0, 0, 3};
+  auto expected = makeMapVector<int64_t, int64_t>(
+      {{{1, 100}, {2, 200}}, {{1, 100}, {2, 200}}, {{1, 100}, {2, 200}}});
+  {
+    SCOPED_TRACE("Constant wrapped FlatMapVector copy - NULL case");
+
+    VectorPtr target;
+    copy(source, folly::Range(&range, 1), target);
+    ASSERT_EQ(
+        target->wrappedVector()->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    ASSERT_EQ(target->encoding(), VectorEncoding::Simple::CONSTANT);
+    test::assertEqualVectors(expected, target);
+  }
+  {
+    SCOPED_TRACE(
+        "Constant wrapped FlatMapVector copy - non-NULL mutable encoded source case");
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>(
+        {{{0, 0}, {1, 10}}, {{2, 200}, {3, 300}}});
+    copy(source, folly::Range(&range, 1), target);
+    ASSERT_EQ(
+        target->wrappedVector()->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    ASSERT_EQ(target->encoding(), VectorEncoding::Simple::DICTIONARY);
+    test::assertEqualVectors(expected, target);
+  }
+  {
+    SCOPED_TRACE(
+        "Constant wrapped FlatMapVector copy - non-NULL mutable encoded target case");
+
+    VectorPtr target = BaseVector::wrapInConstant(
+        3,
+        1,
+        vectorMaker_.flatMapVector<int64_t, int64_t>(
+            {{{0, 0}, {1, 10}}, {{2, 200}, {3, 300}}}));
+    copy(source, folly::Range(&range, 1), target);
+    ASSERT_EQ(
+        target->wrappedVector()->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    ASSERT_EQ(target->encoding(), VectorEncoding::Simple::DICTIONARY);
+    test::assertEqualVectors(expected, target);
+  }
+  {
+    SCOPED_TRACE(
+        "Constant wrapped FlatMapVector copy - non-NULL immutable case");
+
+    VectorPtr target = vectorMaker_.flatMapVector<int64_t, int64_t>(
+        {{{0, 0}, {1, 10}}, {{2, 200}, {3, 300}}});
+    auto immutableTarget = target;
+    copy(source, folly::Range(&range, 1), immutableTarget);
+    test::assertEqualVectors(expected, immutableTarget);
+  }
+
+  source = wrapInDictionary(
+      makeIndices({1, 0, 1, 0}),
+      vectorMaker_.flatMapVector<int64_t, int64_t>({
+          {{1, 10}, {2, 20}},
+          {{1, 100}, {2, 200}},
+      }));
+  {
+    SCOPED_TRACE("Dictionary wrapped FlatMapVector copy - NULL case");
+
+    VectorPtr target;
+    BaseVector::CopyRange range = {0, 0, 4};
+    copy(source, folly::Range(&range, 1), target);
+    ASSERT_EQ(
+        target->wrappedVector()->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    ASSERT_EQ(target->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 100}, {2, 200}},
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 10}, {2, 20}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+  {
+    SCOPED_TRACE(
+        "Dictionary wrapped FlatMapVector copy - non-NULL mutable case");
+
+    VectorPtr target = wrapInDictionary(
+        makeIndices({1, 0, 1, 0}),
+        vectorMaker_.flatMapVector<int64_t, int64_t>({
+            {{0, 0}, {1, 10}},
+            {{2, 200}, {3, 300}},
+        }));
+    BaseVector::CopyRange range = {0, 0, 4};
+    copy(source, folly::Range(&range, 1), target);
+    ASSERT_EQ(
+        target->wrappedVector()->encoding(), VectorEncoding::Simple::FLAT_MAP);
+    ASSERT_EQ(target->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 100}, {2, 200}},
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 10}, {2, 20}},
+    });
+    test::assertEqualVectors(expected, target);
+  }
+  {
+    SCOPED_TRACE(
+        "Dictionary wrapped FlatMapVector copy - non-NULL mutable case");
+
+    VectorPtr target = wrapInDictionary(
+        makeIndices({1, 0, 1, 0}),
+        vectorMaker_.flatMapVector<int64_t, int64_t>({
+            {{0, 0}, {1, 10}},
+            {{2, 200}, {3, 300}},
+        }));
+    BaseVector::CopyRange range = {0, 0, 4};
+    auto immutableTarget = target;
+    copy(source, folly::Range(&range, 1), immutableTarget);
+
+    auto expected = makeMapVector<int64_t, int64_t>({
+        {{1, 100}, {2, 200}},
+        {{1, 10}, {2, 20}},
+        {{1, 100}, {2, 200}},
+        {{1, 10}, {2, 20}},
+    });
+    test::assertEqualVectors(expected, immutableTarget);
   }
 }
 
@@ -786,10 +1081,16 @@ TEST_P(EncodedVectorCopyTest, fuzzer) {
   }
 }
 
-TEST_P(EncodedVectorCopyTest, fuzzerNewCopy) {
+TEST_P(EncodedVectorCopyTest, fuzzerFlatMapEncoded) {
   VectorFuzzer::Options fuzzerOptions;
-  fuzzerOptions.allowFlatMapVector = true;
   fuzzerOptions.allowLazyVector = reuseSource();
+  // Requires FlatMapVector to support encoded sources in copyRanges.
+  fuzzerOptions.allowConstantVector = false;
+  fuzzerOptions.allowDictionaryVector = false;
+  fuzzerOptions.allowFlatMapVector = true;
+  fuzzerOptions.allowLazyVector = false;
+  fuzzerOptions.flatMapRatio = 1.0;
+  fuzzerOptions.normalizeMapKeys = false;
   fuzzerOptions.nullRatio = 0.05;
   auto seed = common::testutil::getRandomSeed(42);
   VectorFuzzer fuzzer(fuzzerOptions, pool(), seed);
@@ -812,8 +1113,37 @@ TEST_P(EncodedVectorCopyTest, fuzzerNewCopy) {
           source->slice(range.sourceIndex, range.count), target);
     }
 
-    // Copy does not support copyInto non-null for FlatMapVector. Let's avoid
-    // throwing for these particular cases until there is support.
+    {
+      SCOPED_TRACE("Immutable target");
+      auto source = fuzzer.fuzz(type);
+      auto target = fuzzer.fuzz(type);
+      auto actual = target;
+      BaseVector::CopyRange range;
+      range.sourceIndex = folly::Random::rand32(source->size() - 1, rng);
+      range.count =
+          folly::Random::rand32(1, source->size() - range.sourceIndex, rng);
+      range.targetIndex = folly::Random::rand32(0, target->size() - 1, rng);
+      copy(source, folly::Range(&range, 1), actual);
+      test::assertEqualVectors(
+          source->slice(range.sourceIndex, range.count),
+          actual->slice(range.targetIndex, range.count));
+    }
+
+    {
+      SCOPED_TRACE("Mutable target");
+      auto source = fuzzer.fuzz(type);
+      auto target = fuzzer.fuzz(type);
+      BaseVector::CopyRange mutableRange;
+      mutableRange.sourceIndex = folly::Random::rand32(source->size() - 1, rng);
+      mutableRange.count = folly::Random::rand32(
+          1, source->size() - mutableRange.sourceIndex, rng);
+      mutableRange.targetIndex =
+          folly::Random::rand32(0, target->size() - 1, rng);
+      copy(source, folly::Range(&mutableRange, 1), target);
+      test::assertEqualVectors(
+          source->slice(mutableRange.sourceIndex, mutableRange.count),
+          target->slice(mutableRange.targetIndex, mutableRange.count));
+    }
   }
 }
 


### PR DESCRIPTION
Summary:

Adds support to EncodedVectorCopy to copy FlatMapVector into non-NULL vectors. Will work in conjunction with D91092336 to support the full FlatMapVector copy capability. Currently has lack of support for wrapped FlatMapVectors due to limitations caused by `BaseVector::create` noted in `createTemplateVector` below. A pervasive solution to solve this will need to be investigated.

Reviewed By: Yuhta

Differential Revision: D91278343


