### PR TITLE
fix(cudf): Fix some join type does not need AST tree

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -401,16 +401,19 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     std::vector<PrecomputeInstruction> leftPrecomputeInstructions;
     static constexpr bool kAllowPureAstOnly = true;
     if (joinNode_->isRightJoin() || joinNode_->isRightSemiFilterJoin()) {
-      createAstTree(
-          exprs.exprs()[0],
-          tree_,
-          scalars_,
-          buildType,
-          probeType,
-          rightPrecomputeInstructions,
-          leftPrecomputeInstructions,
-          kAllowPureAstOnly);
-    } else {
+      if (joinNode_->isRightSemiFilterJoin()) {
+        createAstTree(
+            exprs.exprs()[0],
+            tree_,
+            scalars_,
+            buildType,
+            probeType,
+            rightPrecomputeInstructions,
+            leftPrecomputeInstructions,
+            kAllowPureAstOnly);
+      }
+
+    } else if (joinNode_->isAntiJoin() || joinNode_->isLeftSemiFilterJoin()) {
       createAstTree(
           exprs.exprs()[0],
           tree_,
@@ -423,7 +426,7 @@ CudfHashJoinProbe::CudfHashJoinProbe(
     }
     if (leftPrecomputeInstructions.size() > 0 ||
         rightPrecomputeInstructions.size() > 0) {
-      VELOX_NYI("Filters that require precomputation are not yet supported");
+      VELOX_NYI("Filters that require precomputation are not yet supported, join type is {}", core::JoinTypeName::toName(joinNode_->joinType()));
     }
   }
 }


### PR DESCRIPTION
After PR https://github.com/facebookincubator/velox/pull/15337, some join types does not require the AST tree, it uses cudf ExpressionEvaluator which supports more expressions to evaluate the expression.

After this PR, TPCDS Q4 can run successfully.