### PR TITLE
fix(macos): Install gflags and glog from source instead of Homebrew

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -74,6 +74,8 @@ jobs:
           source scripts/setup-macos.sh
           install_build_prerequisites
           install_velox_deps_from_brew
+          install_gflags
+          install_glog
           # Needed for faiss to find BLAS
           install_faiss_deps
           install_double_conversion

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -41,8 +41,9 @@ export OS_CXXFLAGS
 export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_VELOX_DEPS="bison flex gflags glog googletest icu4c libevent libsodium lz4 openssl protobuf@21 simdjson snappy xz xxhash zstd"
-
+# gflags and glog are installed from source to ensure version compatibility.
+# Homebrew's glog 0.7.x has breaking API changes that are incompatible with folly.
+MACOS_VELOX_DEPS="bison flex googletest icu4c libevent libsodium lz4 openssl protobuf@21 simdjson snappy xz xxhash zstd"
 MACOS_BUILD_DEPS="ninja cmake"
 
 SUDO="${SUDO:-""}"
@@ -103,6 +104,11 @@ function install_velox_deps_from_brew {
   done
 }
 
+function install_gflags {
+  wget_and_untar https://github.com/gflags/gflags/archive/"${GFLAGS_VERSION}".tar.gz gflags
+  cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON
+}
+
 function install_s3 {
   install_aws_deps
 
@@ -151,7 +157,6 @@ function install_faiss {
     install_faiss_deps
 
     wget_and_untar "https://github.com/facebookresearch/faiss/archive/refs/tags/v${FAISS_VERSION}.tar.gz" faiss
-
     local cmake_args
     cmake_args=(
       -DFAISS_ENABLE_GPU=OFF
@@ -177,6 +182,8 @@ function install_velox_deps {
   run_and_time install_ranges_v3
   run_and_time install_double_conversion
   run_and_time install_re2
+  run_and_time install_gflags
+  run_and_time install_glog
   run_and_time install_boost
   run_and_time install_fmt
   run_and_time install_fast_float


### PR DESCRIPTION
## Summary

This PR fixes the macOS build failure caused by Homebrew's glog 0.7.x breaking API changes.

## Problem

Homebrew recently upgraded glog to version 0.7.1 which has breaking API changes - the `GLOG_EXPORT` macro requires CMake target linking which breaks direct header includes. This causes folly compilation to fail with the error:

```
<glog/logging.h> was not included correctly. See the document in the comment of logging.h for detail.
```

The root cause is that Velox pins glog to `v0.6.0` in `setup-versions.sh`, but the macOS setup script uses Homebrew which installs the latest incompatible version.

## Solution

This change:
- Removes `gflags` and `glog` from `MACOS_VELOX_DEPS` (Homebrew packages)
- Adds `install_gflags` function for macOS (similar to other setup scripts)
- Installs both gflags (v2.2.2) and glog (v0.6.0) from source using the pinned versions from `setup-versions.sh`
- Updates the CI workflow to call `install_gflags` and `install_glog`

This approach is consistent with how other Linux setup scripts handle these dependencies.

## Testing

This fix has been validated based on feedback from issue #16135 where contributors confirmed that:
- Uninstalling Homebrew's glog and building from source fixes the issue
- The pinned v0.6.0 version works correctly

Fixes #16135