### PR TITLE
fix: Coercion cost for UNKNOWN -> UNKNOWN

### DIFF
--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -77,6 +77,9 @@ std::optional<int32_t> TypeCoercer::coercible(
     const TypePtr& fromType,
     const TypePtr& toType) {
   if (fromType->isUnKnown()) {
+    if (toType->isUnKnown()) {
+      return 0;
+    }
     return 1;
   }
 

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -64,6 +64,35 @@ TEST(TypeCoercerTest, unknown) {
   ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), ARRAY(INTEGER())));
 }
 
+TEST(TypeCoercerTest, noCost) {
+  auto assertNoCost = [](const TypePtr& type) {
+    SCOPED_TRACE(type->toString());
+    auto cost = TypeCoercer::coercible(type, type);
+    ASSERT_TRUE(cost.has_value());
+    EXPECT_EQ(cost.value(), 0);
+  };
+
+  assertNoCost(UNKNOWN());
+  assertNoCost(BOOLEAN());
+  assertNoCost(TINYINT());
+  assertNoCost(SMALLINT());
+  assertNoCost(INTEGER());
+  assertNoCost(BIGINT());
+  assertNoCost(REAL());
+  assertNoCost(DOUBLE());
+  assertNoCost(VARCHAR());
+  assertNoCost(VARBINARY());
+  assertNoCost(TIMESTAMP());
+  assertNoCost(DATE());
+
+  assertNoCost(ARRAY(INTEGER()));
+  assertNoCost(ARRAY(UNKNOWN()));
+  assertNoCost(MAP(INTEGER(), REAL()));
+  assertNoCost(MAP(UNKNOWN(), UNKNOWN()));
+  assertNoCost(ROW({INTEGER(), REAL()}));
+  assertNoCost(ROW({UNKNOWN(), UNKNOWN()}));
+}
+
 TEST(TypeCoercerTest, array) {
   ASSERT_TRUE(TypeCoercer::coercible(ARRAY(UNKNOWN()), ARRAY(INTEGER())));
   ASSERT_TRUE(


### PR DESCRIPTION
Summary: Coercion from UNKNOWN to UNKNOWN is a no-op, hence, should have a cost of 0, not 1.

Differential Revision: D91779507


