### PR TITLE
refactor(cursor): Remove hasNext() method

### DIFF
--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -159,8 +159,6 @@ class TaskCursor {
   /// Starts the task if not started yet.
   virtual bool moveNext() = 0;
 
-  virtual bool hasNext() = 0;
-
   virtual RowVectorPtr& current() = 0;
 
   virtual void setError(std::exception_ptr error) = 0;
@@ -190,8 +188,6 @@ class RowCursor {
   }
 
   bool next();
-
-  bool hasNext();
 
   std::shared_ptr<Task> task() const {
     return cursor_->task();

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -189,10 +189,11 @@ class DriverTest : public OperatorTestBase {
     bool paused = false;
     for (;;) {
       if (operation == ResultOperation::kPause && paused) {
-        if (!cursor->hasNext()) {
-          paused = false;
-          Task::resume(cursor->task());
-        }
+        // Resume the task so that next() can retrieve more data.
+        // If there's already buffered data, next() returns it immediately;
+        // otherwise it will wait for the resumed task to produce output.
+        paused = false;
+        Task::resume(cursor->task());
       }
       if (!cursor->next()) {
         break;

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -1617,8 +1617,7 @@ DEBUG_ONLY_TEST_F(TaskTest, inconsistentExecutionMode) {
     VELOX_ASSERT_THROW(task->next(), "Inconsistent task execution mode.");
     getOutputWaitFlag = true;
     getOutputWait.notify();
-    while (cursor->hasNext()) {
-      cursor->moveNext();
+    while (cursor->moveNext()) {
     }
     waitForTaskCompletion(task);
   }


### PR DESCRIPTION
Summary:
hasNext() method in cursors is non-standard, and it forces the cursor
to "peek" on the next result of the task, and materialize two vectors at the
same time (which can turn out to be problematic in some cases). Removing this
function to clean up the code; the expected behavior is for the use to simply
getNext() on the cursor until it returns false/null.

Differential Revision: D91788155


