### PR TITLE
fix: Task cleanup in ExchangeClientTest to prevent CI timeout

### DIFF
--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -1057,11 +1057,16 @@ TEST_P(ExchangeClientTest, skipRequestDataSizeNotTriggeredWithMultipleSources) {
   auto pages = fetchPages(1, *client, 6);
   ASSERT_EQ(pages.size(), 6);
 
-  // Cleanup
+  // Cleanup: Signal no more data first to allow faster task termination,
+  // then cancel and remove tasks.
+  for (auto& task : tasks) {
+    bufferManager_->noMoreData(task->taskId());
+  }
   for (auto& task : tasks) {
     task->requestCancel();
     bufferManager_->removeTask(task->taskId());
   }
+  tasks.clear();
 
   client->close();
 }
@@ -1105,6 +1110,7 @@ TEST_P(ExchangeClientTest, lazyFetching) {
 
     task->requestCancel();
     bufferManager_->removeTask(taskId);
+    task.reset();
     client->close();
   }
 
@@ -1139,6 +1145,7 @@ TEST_P(ExchangeClientTest, lazyFetching) {
 
     task->requestCancel();
     bufferManager_->removeTask(taskId);
+    task.reset();
     client->close();
   }
 }


### PR DESCRIPTION
Differential Revision: D91793550

Problem:

The CI logs showed that tests like skipRequestDataSizeNotTriggeredWithMultipleSources and lazyFetching were taking exactly 1001 ms each, even though the actual test logic should complete in milliseconds. This contributed to velox_exec_test timing out.

Solution:

tasks.clear() / task.reset() releases the shared_ptr<Task> references immediately
Calling noMoreData() signals to the OutputBuffer that no more data will be produced, allowing the Task to transition to a terminal state more quickly. Without this signal, the Task termination process takes longer as it waits for potential data that will never arrive.

This mirrors the cleanup pattern already used in the acknowledge test, which doesn't exhibit the delay issue.
This allows the Task destructor to run before TearDown() is called.
When TearDown() calls waitForAllTasksToBeDeleted(), Task::numRunningTasks() is already 0.
