### PR TITLE
feat: Add 'partitioned_output_eager_flush' to QueryConfig

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -244,6 +244,11 @@ class QueryConfig {
   static constexpr const char* kMaxElementsSizeInRepeatAndSequence =
       "max_elements_size_in_repeat_and_sequence";
 
+  /// If true, the PartitionedOutput operator will flush rows eagerly, without
+  /// waiting until buffers reach certain size. Default is false.
+  static constexpr const char* kPartitionedOutputEagerFlush =
+      "partitioned_output_eager_flush";
+
   /// The maximum number of bytes to buffer in PartitionedOutput operator to
   /// avoid creating tiny SerializedPages.
   ///
@@ -926,6 +931,10 @@ class QueryConfig {
   uint64_t maxSpillBytes() const {
     static constexpr uint64_t kDefault = 100UL << 30;
     return get<uint64_t>(kMaxSpillBytes, kDefault);
+  }
+
+  bool partitionedOutputEagerFlush() const {
+    return get<bool>(kPartitionedOutputEagerFlush, false);
   }
 
   uint64_t maxPartitionedOutputBufferSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -137,6 +137,10 @@ Generic Configuration
      - The maximum size in bytes for the task's buffered output when output is partitioned using hash of partitioning keys. See PartitionedOutputNode::Kind::kPartitioned.
        The producer Drivers are blocked when the buffered size exceeds this.
        The Drivers are resumed when the buffered size goes below OutputBufferManager::kContinuePct (90)% of this.
+   * - partitioned_output_eager_flush
+     - bool
+     - false
+     - If true, the PartitionedOutput operator will flush rows eagerly, without waiting until buffers reach certain size. Default is false.
    * - max_output_buffer_size
      - integer
      - 32MB

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -187,7 +187,9 @@ PartitionedOutput::PartitionedOutput(
       maxBufferedBytes_(ctx->task->queryCtx()
                             ->queryConfig()
                             .maxPartitionedOutputBufferSize()),
-      eagerFlush_(eagerFlush),
+      eagerFlush_(
+          eagerFlush ||
+          ctx->task->queryCtx()->queryConfig().partitionedOutputEagerFlush()),
       serde_(getNamedVectorSerde(planNode->serdeKind())),
       serdeOptions_(getVectorSerdeOptions(
           common::stringToCompressionKind(operatorCtx_->driverCtx()


### PR DESCRIPTION
Summary:
Adding 'partitioned_output_eager_flush' to QueryConfig, which would correspond to the 'native_partitioned_output_eager_flush' session property in Presto.
It can be used to match Presto's behavior where it unconditionally eagerly returns results from PartitionedOutput operators.
This is needed for so called 'needle in the haystack' queries (think DaiQuery or custom UIs), when a small number of rows is found really quickly but the query continues scanning a very large volume of data and won't return any results for very long time and even times out.

Another change would add the session property to Presto code.

Differential Revision: D91796412


