### PR TITLE
fix(build): Missing typename in Clang 15

### DIFF
--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -98,7 +98,8 @@ std::unique_ptr<SimpleVector<uint64_t>> BiasVector<T>::hashAll() const {
 }
 
 template <typename T>
-SimpleVector<T>::TValueAt BiasVector<T>::valueAtFast(vector_size_t idx) const {
+typename SimpleVector<T>::TValueAt BiasVector<T>::valueAtFast(
+    vector_size_t idx) const {
   switch (valueType_) {
     case TypeKind::INTEGER:
       return bias_ + reinterpret_cast<const int32_t*>(rawValues_)[idx];

--- a/velox/vector/BiasVector.h
+++ b/velox/vector/BiasVector.h
@@ -118,9 +118,9 @@ class BiasVector : public SimpleVector<T> {
     return BaseVector::isNullAt(idx);
   }
 
-  SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
+  typename SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
 
-  SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
+  typename SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
     SimpleVector<T>::checkElementSize();
     return valueAtFast(idx);
   }

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -161,16 +161,17 @@ class ConstantVector final : public SimpleVector<T> {
     VELOX_FAIL("setNull not supported on ConstantVector");
   }
 
-  SimpleVector<T>::TValueAt value() const {
+  typename SimpleVector<T>::TValueAt value() const {
     VELOX_DCHECK(initialized_);
     return value_;
   }
 
-  SimpleVector<T>::TValueAt valueAtFast(vector_size_t /*idx*/) const {
+  typename SimpleVector<T>::TValueAt valueAtFast(vector_size_t /*idx*/) const {
     return value();
   }
 
-  SimpleVector<T>::TValueAt valueAt(vector_size_t /*idx*/) const override {
+  typename SimpleVector<T>::TValueAt valueAt(
+      vector_size_t /*idx*/) const override {
     VELOX_DCHECK(initialized_);
     SimpleVector<T>::checkElementSize();
     return value();

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -103,7 +103,7 @@ bool DictionaryVector<T>::isNullAt(vector_size_t idx) const {
 }
 
 template <typename T>
-SimpleVector<T>::TValueAt DictionaryVector<T>::valueAtFast(
+typename SimpleVector<T>::TValueAt DictionaryVector<T>::valueAtFast(
     vector_size_t idx) const {
   VELOX_DCHECK(initialized_);
   if (rawDictionaryValues_) {

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -95,13 +95,13 @@ class DictionaryVector : public SimpleVector<T> {
     }
   }
 
-  SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
+  typename SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
 
   /**
    * @return the value at the given index value for a dictionary entry, i.e.
    * gets the dictionary value by its indexed value.
    */
-  SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
+  typename SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
     VELOX_DCHECK(initialized_);
     VELOX_DCHECK(!isNullAt(idx), "found null value at: {}", idx);
     auto innerIndex = getDictionaryIndex(idx);

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -60,7 +60,8 @@ const T* FlatVector<T>::rawValues() const {
 }
 
 template <typename T>
-SimpleVector<T>::TValueAt FlatVector<T>::valueAtFast(vector_size_t idx) const {
+typename SimpleVector<T>::TValueAt FlatVector<T>::valueAtFast(
+    vector_size_t idx) const {
   VELOX_DCHECK_LT(idx, BaseVector::length_, "Index out of range");
   return rawValues_[idx];
 }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -109,9 +109,9 @@ class FlatVector final : public SimpleVector<T> {
 
   virtual ~FlatVector() override = default;
 
-  SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
+  typename SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
 
-  SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
+  typename SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
     return valueAtFast(idx);
   }
 

--- a/velox/vector/SequenceVector-inl.h
+++ b/velox/vector/SequenceVector-inl.h
@@ -71,7 +71,7 @@ bool SequenceVector<T>::isNullAtFast(vector_size_t idx) const {
 }
 
 template <typename T>
-SimpleVector<T>::TValueAt SequenceVector<T>::valueAtFast(
+typename SimpleVector<T>::TValueAt SequenceVector<T>::valueAtFast(
     vector_size_t idx) const {
   size_t offset = offsetOfIndex(idx);
   return scalarSequenceValues_->valueAt(offset);

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -83,9 +83,9 @@ class SequenceVector : public SimpleVector<T> {
     }
   }
 
-  SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
+  typename SimpleVector<T>::TValueAt valueAtFast(vector_size_t idx) const;
 
-  SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
+  typename SimpleVector<T>::TValueAt valueAt(vector_size_t idx) const override {
     return valueAtFast(idx);
   }
 


### PR DESCRIPTION
Clang 15 doesn’t support the "down with typename" C++20 feature where typename still needs to be explicit for a dependent type in a return type declaration.
This broke the scheduled CI run for Clang 15 and Prestissimo.

PR introducing the dependent type as return type: https://github.com/facebookincubator/velox/pull/16132