### PR TITLE
feat: Add hive index reader for Nimble file format

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -28,6 +28,7 @@ velox_add_library(
   HiveConnectorSplit.cpp
   HiveDataSink.cpp
   HiveDataSource.cpp
+  HiveIndexReader.cpp
   HivePartitionName.cpp
   PartitionIdGenerator.cpp
   SplitReader.cpp

--- a/velox/connectors/hive/HiveIndexReader.cpp
+++ b/velox/connectors/hive/HiveIndexReader.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/HiveIndexReader.h"
+
+#include <folly/container/F14Set.h>
+
+#include "velox/common/Casts.h"
+#include "velox/connectors/hive/BufferedInputBuilder.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/ReaderFactory.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::connector::hive {
+namespace {
+// Returns the single split from the vector. Checks that the vector is not empty
+// and has exactly one element.
+// TODO: Support multiple splits.
+std::shared_ptr<const HiveConnectorSplit> getSingleSplit(
+    const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits) {
+  VELOX_CHECK_EQ(
+      hiveSplits.size(),
+      1,
+      "HiveIndexReader currently only supports a single split");
+  return hiveSplits[0];
+}
+
+template <TypeKind kind>
+variant extractValue(const DecodedVector& decoded, vector_size_t row) {
+  using T = typename TypeTraits<kind>::NativeType;
+  return variant(decoded.valueAt<T>(row));
+}
+} // namespace
+
+HiveIndexReader::HiveIndexReader(
+    const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits,
+    const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    const std::shared_ptr<common::ScanSpec>& scanSpec,
+    const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+    const RowTypePtr& requestType,
+    const RowTypePtr& outputType,
+    const std::shared_ptr<io::IoStatistics>& ioStats,
+    const std::shared_ptr<filesystems::File::IoStats>& fsStats,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* ioExecutor)
+    : hiveSplit_{getSingleSplit(hiveSplits)},
+      tableHandle_{hiveTableHandle},
+      connectorQueryCtx_{connectorQueryCtx},
+      hiveConfig_{hiveConfig},
+      fileHandleFactory_{fileHandleFactory},
+      requestType_{requestType},
+      outputType_{outputType},
+      ioStats_{ioStats},
+      fsStats_{fsStats},
+      ioExecutor_{ioExecutor},
+      pool_{connectorQueryCtx->memoryPool()},
+      scanSpec_{scanSpec},
+      fileReader_{createFileReader()},
+      rowReader_{createRowReader()},
+      joinConditions_{joinConditions} {
+  initJoinConditions();
+}
+
+void HiveIndexReader::initJoinConditions() {
+  VELOX_CHECK(!joinConditions_.empty(), "Join conditions cannot be empty");
+  VELOX_CHECK(
+      !tableHandle_->indexColumns().empty(),
+      "Index columns not set in hive table handle");
+  VELOX_CHECK(indexColumnSpecs_.empty());
+  VELOX_CHECK(requestColumnIndices_.empty());
+
+  indexColumnSpecs_.reserve(joinConditions_.size());
+  requestColumnIndices_.reserve(joinConditions_.size());
+  decodedVectors_.resize(joinConditions_.size());
+
+  auto getRequestColumnIndex = [&](const std::string& name) {
+    const auto idxOpt = requestType_->getChildIdxIfExists(name);
+    VELOX_CHECK(
+        idxOpt.has_value(),
+        "Request column {} not found in request type",
+        name);
+    return idxOpt.value();
+  };
+
+  // Validate join conditions:
+  // 1. Index columns must follow the order of table index columns (prefix).
+  // 2. Equal conditions must come before between conditions.
+  const auto& tableIndexColumns = tableHandle_->indexColumns();
+  bool seenBetweenCondition = false;
+  for (size_t i = 0; i < joinConditions_.size(); ++i) {
+    const auto& condition = joinConditions_[i];
+    VELOX_CHECK(!condition->isFilter());
+
+    const auto& keyName = condition->key->name();
+    VELOX_CHECK_LT(
+        i,
+        tableIndexColumns.size(),
+        "Join condition index column '{}' exceeds the number of table index columns {}",
+        keyName,
+        tableIndexColumns.size());
+    VELOX_CHECK_EQ(
+        keyName,
+        tableIndexColumns[i],
+        "Join condition index column '{}' at position {} does not match table index column '{}'. "
+        "Join conditions must use index columns in order as a prefix.",
+        keyName,
+        i,
+        tableIndexColumns[i]);
+
+    const bool isBetweenCondition =
+        std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
+            condition) != nullptr;
+    if (isBetweenCondition) {
+      seenBetweenCondition = true;
+    } else {
+      VELOX_CHECK(
+          !seenBetweenCondition,
+          "Equal join condition on index column '{}' cannot come after a between condition. "
+          "Equal conditions must precede between conditions.",
+          keyName);
+    }
+    auto* spec = scanSpec_->childByName(keyName);
+    VELOX_CHECK_NOT_NULL(
+        spec, "Index column {} not found in scan spec", keyName);
+    VELOX_CHECK(
+        !spec->hasFilter(),
+        "Index column '{}' used in join condition cannot have a pushdown filter",
+        keyName);
+    indexColumnSpecs_.push_back(spec);
+
+    // Determine the request column index for the condition value.
+    if (auto equalCondition =
+            std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
+                condition)) {
+      const auto requestFieldAccess =
+          checkedPointerCast<const core::FieldAccessTypedExpr>(
+              equalCondition->value);
+      requestColumnIndices_.push_back(
+          {getRequestColumnIndex(requestFieldAccess->name())});
+      decodedVectors_[i].resize(1);
+      continue;
+    }
+
+    if (auto betweenCondition =
+            std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
+                condition)) {
+      auto lowerFieldAccess =
+          checkedPointerCast<const core::FieldAccessTypedExpr>(
+              betweenCondition->lower);
+      auto upperFieldAccess =
+          checkedPointerCast<const core::FieldAccessTypedExpr>(
+              betweenCondition->upper);
+      requestColumnIndices_.push_back(
+          {getRequestColumnIndex(lowerFieldAccess->name()),
+           getRequestColumnIndex(upperFieldAccess->name())});
+      decodedVectors_[i].resize(2);
+      continue;
+    }
+
+    VELOX_FAIL("Unsupported join condition type: {}", condition->toString());
+  }
+}
+
+std::unique_ptr<dwio::common::Reader> HiveIndexReader::createFileReader() {
+  VELOX_CHECK_NOT_NULL(hiveSplit_);
+
+  dwio::common::ReaderOptions readerOpts(connectorQueryCtx_->memoryPool());
+  hive::configureReaderOptions(
+      hiveConfig_, connectorQueryCtx_, tableHandle_, hiveSplit_, readerOpts);
+  readerOpts.setScanSpec(scanSpec_);
+  readerOpts.setFileFormat(hiveSplit_->fileFormat);
+  VELOX_CHECK_NULL(readerOpts.randomSkip());
+
+  FileHandleKey fileHandleKey{
+      .filename = hiveSplit_->filePath,
+      .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
+
+  auto fileProperties = hiveSplit_->properties.value_or(FileProperties{});
+  auto fileHandleCachePtr = fileHandleFactory_->generate(
+      fileHandleKey, &fileProperties, fsStats_ ? fsStats_.get() : nullptr);
+  VELOX_CHECK_NOT_NULL(fileHandleCachePtr.get());
+
+  auto baseFileInput = BufferedInputBuilder::getInstance()->create(
+      *fileHandleCachePtr,
+      readerOpts,
+      connectorQueryCtx_,
+      ioStats_,
+      fsStats_,
+      ioExecutor_,
+      /*fileReadOps=*/{});
+
+  auto reader = dwio::common::getReaderFactory(readerOpts.fileFormat())
+                    ->createReader(std::move(baseFileInput), readerOpts);
+  VELOX_CHECK_NOT_NULL(reader);
+  return reader;
+}
+
+std::unique_ptr<dwio::common::RowReader> HiveIndexReader::createRowReader() {
+  VELOX_CHECK_NOT_NULL(fileReader_);
+  VELOX_CHECK_EQ(
+      hiveSplit_->fileFormat,
+      dwio::common::FileFormat::NIMBLE,
+      "HiveIndexReader only supports Nimble file format");
+
+  dwio::common::RowReaderOptions rowReaderOpts;
+  configureRowReaderOptions(
+      tableHandle_->tableParameters(),
+      scanSpec_,
+      /*metadataFilter=*/nullptr,
+      fileReader_->rowType(),
+      hiveSplit_,
+      hiveConfig_,
+      connectorQueryCtx_->sessionProperties(),
+      ioExecutor_,
+      rowReaderOpts);
+  rowReaderOpts.setIndexEnabled(true);
+  // Disable eager first stripe load since HiveIndexReader loads stripes
+  // on-demand based on index lookup results.
+  rowReaderOpts.setEagerFirstStripeLoad(false);
+  return fileReader_->createRowReader(rowReaderOpts);
+}
+
+std::unique_ptr<HiveIndexReader::Result> HiveIndexReader::next(
+    vector_size_t maxOutputRows) {
+  VELOX_CHECK_NOT_NULL(request_, "No request set. Call setRequest first.");
+  VELOX_CHECK(hasNext(), "No more rows to process.");
+
+  SCOPE_EXIT {
+    if (requestRow_ == request_->size()) {
+      reset();
+    }
+  };
+
+  std::vector<RowVectorPtr> outputChunks;
+  std::vector<vector_size_t> inputIndices;
+  vector_size_t numOutputRows{0};
+  const vector_size_t numRequestRows = request_->size();
+  // Check the limit before starting a new input row, but once we start
+  // processing an input row, produce all its output rows.
+  for (; requestRow_ < numRequestRows && numOutputRows < maxOutputRows;
+       ++requestRow_) {
+    applyFiltersFromRequest(requestRow_);
+
+    // Read all matching rows for this input row regardless of the limit.
+    // We need a loop here because rowReader_->next() may return partial results
+    // when crossing stripe boundaries.
+    while (true) {
+      VectorPtr output;
+      const uint64_t numRows = readNext(output);
+      if (numRows == 0) {
+        break;
+      }
+      if (output->size() == 0) {
+        continue;
+      }
+
+      numOutputRows += output->size();
+      // Record the input row index for each output row.
+      for (uint64_t i = 0; i < output->size(); ++i) {
+        inputIndices.push_back(requestRow_);
+      }
+      // Load all lazy vectors because lazy loading doesn't work across batches.
+      output->loadedVector();
+      outputChunks.push_back(
+          std::dynamic_pointer_cast<RowVector>(std::move(output)));
+    }
+
+    clearKeyFilters();
+  }
+
+  if (numOutputRows == 0) {
+    return nullptr;
+  }
+
+  // Populate inputHits buffer.
+  auto inputHits = AlignedBuffer::allocate<vector_size_t>(numOutputRows, pool_);
+  auto* rawInputHits = inputHits->asMutable<vector_size_t>();
+  std::copy(inputIndices.begin(), inputIndices.end(), rawInputHits);
+
+  RowVectorPtr output;
+  if (outputChunks.size() == 1) {
+    output = std::move(outputChunks[0]);
+  } else {
+    output = BaseVector::create<RowVector>(outputType_, numOutputRows, pool_);
+    vector_size_t offset = 0;
+    for (const auto& chunk : outputChunks) {
+      output->copy(chunk.get(), offset, 0, chunk->size());
+      offset += chunk->size();
+    }
+  }
+  return std::make_unique<Result>(std::move(inputHits), std::move(output));
+}
+
+void HiveIndexReader::setRequest(const Request& request) {
+  VELOX_CHECK_NULL(request_, "Request already set. Call reset first.");
+  VELOX_CHECK_EQ(requestRow_, 0, "Request already set. Call reset first.");
+  request_ = request.input;
+  VELOX_CHECK_NOT_NULL(request_);
+  VELOX_CHECK(requestType_->equivalent(*request_->type()));
+  requestRow_ = 0;
+
+  // Decode all input vectors used in join conditions.
+  SelectivityVector allRows(request_->size());
+  for (size_t i = 0; i < joinConditions_.size(); ++i) {
+    const auto& indices = requestColumnIndices_[i];
+    for (size_t j = 0; j < indices.size(); ++j) {
+      decodedVectors_[i][j].decode(*request_->childAt(indices[j]), allRows);
+    }
+  }
+}
+
+bool HiveIndexReader::hasNext() const {
+  return request_ != nullptr && requestRow_ < request_->size();
+}
+
+void HiveIndexReader::reset() {
+  request_.reset();
+  requestRow_ = 0;
+}
+
+void HiveIndexReader::applyFiltersFromRequest(vector_size_t row) {
+  VELOX_CHECK_NOT_NULL(request_);
+  VELOX_CHECK_EQ(decodedVectors_.size(), joinConditions_.size());
+  VELOX_CHECK_LT(row, request_->size());
+
+  for (size_t i = 0; i < joinConditions_.size(); ++i) {
+    auto* spec = indexColumnSpecs_[i];
+    const auto& condition = joinConditions_[i];
+
+    if (auto equalCondition =
+            std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
+                condition)) {
+      VELOX_CHECK_EQ(decodedVectors_[i].size(), 1);
+      const auto& decoded = decodedVectors_[i][0];
+      VELOX_CHECK(
+          !decoded.isNullAt(row), "Null value not allowed for equal condition");
+      const auto& type = requestType_->childAt(requestColumnIndices_[i][0]);
+      const auto value = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          extractValue, type->kind(), decoded, row);
+      spec->setFilter(createPointFilter(type, value));
+    } else if (
+        auto betweenCondition =
+            std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
+                condition)) {
+      const auto& lowerDecoded = decodedVectors_[i][0];
+      VELOX_CHECK(
+          !lowerDecoded.isNullAt(row),
+          "Null value not allowed for lower bound");
+      const auto& upperDecoded = decodedVectors_[i][1];
+      VELOX_CHECK(
+          !upperDecoded.isNullAt(row),
+          "Null value not allowed for upper bound");
+      const auto& type = requestType_->childAt(requestColumnIndices_[i][0]);
+      const auto lower = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          extractValue, type->kind(), lowerDecoded, row);
+      const auto upper = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          extractValue, type->kind(), upperDecoded, row);
+      spec->setFilter(createRangeFilter(type, lower, upper));
+    } else {
+      VELOX_FAIL("Unsupported join condition type: {}", condition->toString());
+    }
+  }
+  scanSpec_->resetCachedValues(/*doReorder=*/false);
+  // Resets the row reader for the new index lookup. This resets internal state
+  // and re-applies index bounds based on the updated filters set above.
+  rowReader_->reset();
+}
+
+void HiveIndexReader::clearKeyFilters() {
+  for (auto* spec : indexColumnSpecs_) {
+    spec->setFilter(nullptr);
+  }
+}
+
+uint64_t HiveIndexReader::readNext(VectorPtr& output) {
+  VELOX_CHECK_NOT_NULL(rowReader_);
+  // Pre-allocate output vector with correct schema to ensure the reader returns
+  // results with expected schema even when no rows match.
+  if (output == nullptr) {
+    output = BaseVector::create(outputType_, 0, pool_);
+  }
+  return rowReader_->next(1024, output);
+}
+
+void HiveIndexReader::resetFilterCaches() {
+  VELOX_CHECK_NOT_NULL(rowReader_);
+  rowReader_->resetFilterCaches();
+}
+
+std::string HiveIndexReader::toString() const {
+  return fmt::format(
+      "HiveIndexReader: hiveSplit_{} scanSpec_{} requestType_{} outputType_{}",
+      hiveSplit_->toString(),
+      scanSpec_->toString(),
+      requestType_->toString(),
+      outputType_->toString());
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexReader.h
+++ b/velox/connectors/hive/HiveIndexReader.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/core/PlanNode.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Reader.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::connector {
+class ConnectorQueryCtx;
+} // namespace facebook::velox::connector
+
+namespace facebook::velox::connector::hive {
+
+struct HiveConnectorSplit;
+class HiveTableHandle;
+class HiveColumnHandle;
+class HiveConfig;
+
+/// HiveIndexReader is similar to SplitReader but supports index lookup API.
+/// It takes a request row vector, converts each row into filters inserted into
+/// the scan spec, and reads matching data from the underlying reader. The
+/// result includes matched rows and a buffer containing the count of matches
+/// for each input request row.
+///
+/// The HiveIndexReader is designed to be reusable across multiple lookup
+/// requests on the same split.
+class HiveIndexReader {
+ public:
+  HiveIndexReader(
+      const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits,
+      const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
+      const std::shared_ptr<common::ScanSpec>& scanSpec,
+      const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+      const RowTypePtr& requestType,
+      const RowTypePtr& outputType,
+      const std::shared_ptr<io::IoStatistics>& ioStats,
+      const std::shared_ptr<filesystems::File::IoStats>& fsStats,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* ioExecutor);
+
+  virtual ~HiveIndexReader() = default;
+
+  using Request = IndexSource::Request;
+  using Result = IndexSource::Result;
+
+  /// Sets the input for index lookup. Each row in 'input' will be converted
+  /// to filters on key columns and used to query matching rows from the
+  /// underlying data.
+  ///
+  /// @param request The lookup request containing input row vector with lookup
+  /// keys.
+  void setRequest(const Request& request);
+
+  /// Returns true if there are more input rows to process.
+  bool hasNext() const;
+
+  /// Reads the next batch of matching rows for the current input rows.
+  /// The result from a single request row is never split across multiple
+  /// calls to next().
+  ///
+  /// @param maxOutputRows Maximum number of output rows to return.
+  /// @return Result containing matched rows and input hit indices, or nullptr
+  /// if no more results.
+  std::unique_ptr<Result> next(vector_size_t maxOutputRows);
+
+  std::string toString() const;
+
+ private:
+  // Resets filter caches for reuse.
+  void resetFilterCaches();
+
+  // Creates the file reader for reading file metadata and schema.
+  // NOTE: Called from constructor initializer list, so only accesses members
+  // declared before fileReader_.
+  std::unique_ptr<dwio::common::Reader> createFileReader();
+
+  // Creates the row reader.
+  // NOTE: Called from constructor initializer list, so only accesses members
+  // declared before rowReader_.
+  std::unique_ptr<dwio::common::RowReader> createRowReader();
+
+  // Initializes indexColumnSpecs_ and requestColumnIndices_ from join
+  // conditions.
+  void initJoinConditions();
+
+  // Converts the input row at the given index to filters on key columns
+  // and applies them to the scan spec.
+  void applyFiltersFromRequest(vector_size_t row);
+
+  // Clears filters applied to key columns in the scan spec.
+  void clearKeyFilters();
+
+  // Reads the next batch of rows based on the current filters.
+  // Returns the number of rows read. The output vector is passed by reference
+  // and will be populated with the matching rows.
+  uint64_t readNext(VectorPtr& output);
+
+  // Resets request_ and requestRow_.
+  void reset();
+
+  std::shared_ptr<const HiveConnectorSplit> hiveSplit_;
+  const std::shared_ptr<const HiveTableHandle> tableHandle_;
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  const std::shared_ptr<const HiveConfig> hiveConfig_;
+  FileHandleFactory* const fileHandleFactory_;
+  const RowTypePtr requestType_;
+  const RowTypePtr outputType_;
+
+  const std::shared_ptr<io::IoStatistics> ioStats_;
+  const std::shared_ptr<filesystems::File::IoStats> fsStats_;
+  folly::Executor* const ioExecutor_;
+  memory::MemoryPool* const pool_;
+
+  const std::shared_ptr<common::ScanSpec> scanSpec_;
+  const std::unique_ptr<dwio::common::Reader> fileReader_;
+  const std::unique_ptr<dwio::common::RowReader> rowReader_;
+  // Join conditions (including equal conditions converted from join keys).
+  const std::vector<core::IndexLookupConditionPtr> joinConditions_;
+
+  // Cached ScanSpec children for index columns used in join conditions.
+  std::vector<common::ScanSpec*> indexColumnSpecs_;
+  // Request column indices for each join condition (for probe side columns).
+  // For EqualIndexLookupCondition, stores {valueIndex}.
+  // For BetweenIndexLookupCondition, stores {lowerIndex, upperIndex}.
+  std::vector<std::vector<column_index_t>> requestColumnIndices_;
+
+  // Current request for lookup.
+  RowVectorPtr request_;
+  // Current row index in the request being processed.
+  vector_size_t requestRow_{0};
+
+  // Decoded vectors for input columns used in join conditions.
+  // Indexed by join condition index and then by column index within that
+  // condition (0 for equal condition value, 0/1 for between condition
+  // lower/upper).
+  std::vector<std::vector<DecodedVector>> decodedVectors_;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -169,8 +169,22 @@ class HiveTableHandle : public ConnectorTableHandle {
       common::SubfieldFilters subfieldFilters,
       const core::TypedExprPtr& remainingFilter,
       const RowTypePtr& dataColumns = nullptr,
+      std::vector<std::string> indexColumns = {},
       const std::unordered_map<std::string, std::string>& tableParameters = {},
       std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
+      double sampleRate = 1.0);
+
+  /// Legacy constructor without indexColumns parameter for backward
+  /// compatibility.
+  HiveTableHandle(
+      std::string connectorId,
+      const std::string& tableName,
+      bool filterPushdownEnabled,
+      common::SubfieldFilters subfieldFilters,
+      const core::TypedExprPtr& remainingFilter,
+      const RowTypePtr& dataColumns,
+      const std::unordered_map<std::string, std::string>& tableParameters,
+      std::vector<HiveColumnHandlePtr> filterColumnHandles,
       double sampleRate = 1.0);
 
   const std::string& tableName() const {
@@ -179,6 +193,14 @@ class HiveTableHandle : public ConnectorTableHandle {
 
   const std::string& name() const override {
     return tableName();
+  }
+
+  bool supportsIndexLookup() const override {
+    return !indexColumns_.empty();
+  }
+
+  bool needsIndexSplit() const override {
+    return true;
   }
 
   [[deprecated]] bool isFilterPushdownEnabled() const {
@@ -214,6 +236,11 @@ class HiveTableHandle : public ConnectorTableHandle {
     return dataColumns_;
   }
 
+  /// Returns the names of the index columns for the table.
+  const std::vector<std::string>& indexColumns() const {
+    return indexColumns_;
+  }
+
   /// Extra parameters to pass down to file format reader layer.  Keys should be
   /// in dwio::common::TableParameter.
   const std::unordered_map<std::string, std::string>& tableParameters() const {
@@ -245,6 +272,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const core::TypedExprPtr remainingFilter_;
   const double sampleRate_;
   const RowTypePtr dataColumns_;
+  const std::vector<std::string> indexColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
   const std::vector<HiveColumnHandlePtr> filterColumnHandles_;
 };

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -115,26 +115,45 @@ TEST_F(HiveConnectorSerDeTest, hiveTableHandle) {
   auto rowType =
       ROW({"c0c0", "c1", "c2", "c3", "c4", "c5"},
           {INTEGER(), BIGINT(), DOUBLE(), BOOLEAN(), BIGINT(), VARCHAR()});
-  auto tableHandle = makeTableHandle(
-      common::test::SubfieldFiltersBuilder()
-          .add("c0.c0", isNotNull())
-          .add(
-              "c1",
-              lessThanOrEqualHugeint(std::numeric_limits<int128_t>::max()))
-          .add("c2", greaterThanOrEqualDouble(3.1415))
-          .add("c3", boolEqual(true))
-          .add("c4", in({0xdeadbeaf, 0xcafecafe}))
-          .add("c2", notIn({0xdeadbeaf, 0xcafecafe}))
-          .add(
-              "c5",
-              orFilter(between("abc", "efg"), greaterThanOrEqual("dragon")))
-          .build(),
-      parseExpr("c1 > c4 and c3 = true", rowType),
-      "hive_table",
-      ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
-      true,
-      {{dwio::common::TableParameter::kSkipHeaderLineCount, "1"}});
-  testSerde(*tableHandle);
+
+  for (bool withIndexColumns : {false, true}) {
+    SCOPED_TRACE(fmt::format("withIndexColumns: {}", withIndexColumns));
+
+    std::vector<std::string> indexColumns = withIndexColumns
+        ? std::vector<std::string>{"c0c0", "c1"}
+        : std::vector<std::string>{};
+
+    auto tableHandle = makeTableHandle(
+        common::test::SubfieldFiltersBuilder()
+            .add("c0.c0", isNotNull())
+            .add(
+                "c1",
+                lessThanOrEqualHugeint(std::numeric_limits<int128_t>::max()))
+            .add("c2", greaterThanOrEqualDouble(3.1415))
+            .add("c3", boolEqual(true))
+            .add("c4", in({0xdeadbeaf, 0xcafecafe}))
+            .add("c2", notIn({0xdeadbeaf, 0xcafecafe}))
+            .add(
+                "c5",
+                orFilter(between("abc", "efg"), greaterThanOrEqual("dragon")))
+            .build(),
+        parseExpr("c1 > c4 and c3 = true", rowType),
+        "hive_table",
+        ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
+        indexColumns,
+        /*filterPushdownEnabled=*/true,
+        {{dwio::common::TableParameter::kSkipHeaderLineCount, "1"}});
+
+    EXPECT_EQ(tableHandle->supportsIndexLookup(), withIndexColumns);
+    EXPECT_TRUE(tableHandle->needsIndexSplit());
+    EXPECT_EQ(tableHandle->indexColumns().empty(), !withIndexColumns);
+    if (withIndexColumns) {
+      EXPECT_EQ(tableHandle->indexColumns().size(), 2);
+      EXPECT_EQ(tableHandle->indexColumns()[0], "c0c0");
+      EXPECT_EQ(tableHandle->indexColumns()[1], "c1");
+    }
+    testSerde(*tableHandle);
+  }
 }
 
 TEST_F(HiveConnectorSerDeTest, hiveColumnHandle) {

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -107,6 +107,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
         common::SubfieldFilters{},
         nullptr,
         nullptr,
+        /*indexColumns=*/std::vector<std::string>{},
         tableParameters);
   };
 
@@ -333,6 +334,7 @@ TEST_F(HiveConnectorUtilTest, cacheRetention) {
         common::SubfieldFilters{},
         nullptr,
         nullptr,
+        /*indexColumns=*/std::vector<std::string>{},
         std::unordered_map<std::string, std::string>{});
 
     auto hiveSplit = std::make_shared<hive::HiveConnectorSplit>(

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -351,3 +351,8 @@ These stats are reported only by connector data or index sources.
        index bounds for index-based filtering (e.g., cluster index pruning in
        Nimble). A value greater than zero indicates filters were successfully
        converted to leverage file index structures for row pruning.
+   * - numStripeLoads
+     -
+     - The number of times a stripe has been loaded during index lookup. This
+       metric helps track the I/O efficiency of index-based reads, where lower
+       values indicate better stripe reuse across lookups.

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -63,8 +63,8 @@ class ScanSpec {
     return filterDisabled_ ? nullptr : filter_.get();
   }
 
-  // Sets 'filter_'. May be used at initialization or when adding a
-  // pushed down filter, e.g. top k cutoff.
+  /// Sets 'filter_'. May be used at initialization or when adding a
+  /// pushed down filter, e.g. top k cutoff.
   void setFilter(std::shared_ptr<Filter> filter) {
     filter_ = std::move(filter);
   }
@@ -95,8 +95,8 @@ class ScanSpec {
     return metadataFilters_[i].second;
   }
 
-  // Returns a constant vector if 'this' corresponds to a partitioning
-  // column or to a missing column. These change from split to split.
+  /// Returns a constant vector if 'this' corresponds to a partitioning
+  /// column or to a missing column. These change from split to split.
   VectorPtr constantValue() const {
     return constantValue_;
   }
@@ -127,22 +127,22 @@ class ScanSpec {
     return columnType_ == ColumnType::kRegular && !isConstant();
   }
 
-  // Name of the value in its container, i.e. field name in struct or
-  // string key in map. Not all fields of 'this' apply in list/map
-  // value cases but the overhead is manageable, the space taken is
-  // less than the Subfield path that will in any case exist for each
-  // separately named list/map element.
+  /// Name of the value in its container, i.e. field name in struct or
+  /// string key in map. Not all fields of 'this' apply in list/map
+  /// value cases but the overhead is manageable, the space taken is
+  /// less than the Subfield path that will in any case exist for each
+  /// separately named list/map element.
   const std::string& fieldName() const {
     return fieldName_;
   }
 
-  // Subscript if this refers to a member of a list or an
-  // integer-keyed map value. If this is a member in a row, this is
-  // the ordinal position in the row type.  Subscript is mutable, for
-  // example the position of the reader in a struct's readers may vary
-  // between splits. Set to correspond to the position of 'fieldName'
-  // when first reading a struct. Not mutable if this refers to a
-  // list/map subscript.
+  /// Subscript if this refers to a member of a list or an
+  /// integer-keyed map value. If this is a member in a row, this is
+  /// the ordinal position in the row type.  Subscript is mutable, for
+  /// example the position of the reader in a struct's readers may vary
+  /// between splits. Set to correspond to the position of 'fieldName'
+  /// when first reading a struct. Not mutable if this refers to a
+  /// list/map subscript.
   int64_t subscript() const {
     return subscript_;
   }
@@ -153,8 +153,8 @@ class ScanSpec {
     }
   }
 
-  // True if the value is returned from scan.  A runtime pushdown of a filter
-  // function may cause this to become false at run time.
+  /// True if the value is returned from scan.  A runtime pushdown of a filter
+  /// function may cause this to become false at run time.
   bool projectOut() const {
     return projectOut_;
   }
@@ -181,31 +181,31 @@ class ScanSpec {
     return children_;
   }
 
-  // Returns 'children in a stable order. May be used for parallel
-  // construction and read-ahead of reader trees while the main user
-  // of 'this' is running. 'children_' may be reordered while running
-  // but the tree being constructed must see a single, unchanging
-  // order.
+  /// Returns 'children in a stable order. May be used for parallel
+  /// construction and read-ahead of reader trees while the main user
+  /// of 'this' is running. 'children_' may be reordered while running
+  /// but the tree being constructed must see a single, unchanging
+  /// order.
   const std::vector<ScanSpec*>& stableChildren();
 
-  // Returns a read sequence number. This can b used for tagging
-  // lazy vectors with a generation number so that we can check that
-  // the reader that made them has not advanced between the making and
-  // the loading of the lazy vector. This must be called if 'this'
-  // corresponds to a struct or flat map reader with pushdown. This
-  // may periodically do adaptation such as filter reordering. This
-  // will initialize the read order on first call and calling this at
-  // each level of struct is mandatory.
+  /// Returns a read sequence number. This can b used for tagging
+  /// lazy vectors with a generation number so that we can check that
+  /// the reader that made them has not advanced between the making and
+  /// the loading of the lazy vector. This must be called if 'this'
+  /// corresponds to a struct or flat map reader with pushdown. This
+  /// may periodically do adaptation such as filter reordering. This
+  /// will initialize the read order on first call and calling this at
+  /// each level of struct is mandatory.
   uint64_t newRead();
 
   /// Returns the ScanSpec corresponding to 'name'. Creates it if needed without
   /// any intermediate level.
   ScanSpec* getOrCreateChild(const std::string& name);
 
-  // Returns the ScanSpec corresponding to 'subfield'. Creates it if
-  // needed, including any intermediate levels. This is used at
-  // TableScan initialization to create the ScanSpec tree that
-  // corresponds to the ColumnReader tree.
+  /// Returns the ScanSpec corresponding to 'subfield'. Creates it if
+  /// needed, including any intermediate levels. This is used at
+  /// TableScan initialization to create the ScanSpec tree that
+  /// corresponds to the ColumnReader tree.
   ScanSpec* getOrCreateChild(const Subfield& subfield);
 
   ScanSpec* childByName(const std::string& name) const {
@@ -228,11 +228,11 @@ class ScanSpec {
     valueHook_ = valueHook;
   }
 
-  // Returns true if the corresponding reader only needs to reference the nulls
-  // stream.  True if filter is is-null with or without value extraction or if
-  // filter is is-not-null and no value is extracted.  Note that this does not
-  // apply to Nimble format leaf nodes, because nulls are mixed in the encoding
-  // with actual values.
+  /// Returns true if the corresponding reader only needs to reference the nulls
+  /// stream.  True if filter is is-null with or without value extraction or if
+  /// filter is is-not-null and no value is extracted.  Note that this does not
+  /// apply to Nimble format leaf nodes, because nulls are mixed in the encoding
+  /// with actual values.
   bool readsNullsOnly() const {
     if (auto* filter = this->filter()) {
       if (filter->kind() == FilterKind::kIsNull) {
@@ -253,11 +253,11 @@ class ScanSpec {
     makeFlat_ = makeFlat;
   }
 
-  // True if this or a descendant has a filter that will affect the number of
-  // output rows.  Note that filter on map keys and array indices is not
-  // counted, as they do not change the number of container output rows.
-  //
-  // This may change as a result of runtime adaptation.
+  /// True if this or a descendant has a filter that will affect the number of
+  /// output rows.  Note that filter on map keys and array indices is not
+  /// counted, as they do not change the number of container output rows.
+  ///
+  /// This may change as a result of runtime adaptation.
   bool hasFilter() const;
 
   /// Similar as hasFilter() but also return true even there is a filter on
@@ -272,8 +272,8 @@ class ScanSpec {
   /// filtered out.
   bool testNull() const;
 
-  // Resets cached values after this or children were updated, e.g. a new filter
-  // was added or existing filter was modified.
+  /// Resets cached values after this or children were updated, e.g. a new
+  /// filter was added or existing filter was modified.
   void resetCachedValues(bool doReorder) {
     hasFilter_.reset();
     for (auto& child : children_) {
@@ -284,49 +284,50 @@ class ScanSpec {
     }
   }
 
-  // Returns the child which produces values for 'channel'. Throws if not found.
+  /// Returns the child which produces values for 'channel'. Throws if not
+  /// found.
   ScanSpec& getChildByChannel(column_index_t channel);
 
-  // sets filter order and filters of 'this' from 'other'. Used when
-  // initializing a ScanSpec for a new split or stripe. This transfers
-  // dynamically acquired filters and adaptive filter order. 'other'
-  // should not be used after this. Different splits or stripes may
-  // have their own ScanSpec trees, so we only move the content, not
-  // the ScanSpec tree itself.
+  /// Sets filter order and filters of 'this' from 'other'. Used when
+  /// initializing a ScanSpec for a new split or stripe. This transfers
+  /// dynamically acquired filters and adaptive filter order. 'other'
+  /// should not be used after this. Different splits or stripes may
+  /// have their own ScanSpec trees, so we only move the content, not
+  /// the ScanSpec tree itself.
   void moveAdaptationFrom(ScanSpec& other);
 
   std::string toString() const;
 
-  // Add a field to this ScanSpec, with content projected out.
+  /// Add a field to this ScanSpec, with content projected out.
   ScanSpec* addField(const std::string& name, column_index_t channel);
 
-  // Add a field and its children recursively to this ScanSpec, all projected
-  // out.
+  /// Add a field and its children recursively to this ScanSpec, all projected
+  /// out.
   ScanSpec* addFieldRecursively(
       const std::string& name,
       const Type&,
       column_index_t channel);
 
-  // Add a field for map key.
+  /// Add a field for map key.
   ScanSpec* addMapKeyField();
 
-  // Add a field for map key, along with its child recursively.
+  /// Add a field for map key, along with its child recursively.
   ScanSpec* addMapKeyFieldRecursively(const Type&);
 
-  // Add a field for map value.
+  /// Add a field for map value.
   ScanSpec* addMapValueField();
 
-  // Add a field for map value, along with its child recursively.
+  /// Add a field for map value, along with its child recursively.
   ScanSpec* addMapValueFieldRecursively(const Type&);
 
-  // Add a field for array element.
+  /// Add a field for array element.
   ScanSpec* addArrayElementField();
 
-  // Add a field for array element, along with its child recursively.
+  /// Add a field for array element, along with its child recursively.
   ScanSpec* addArrayElementFieldRecursively(const Type&);
 
-  // Add all child fields on the type recursively to this ScanSpec, all
-  // projected out.
+  /// Add all child fields on the type recursively to this ScanSpec, all
+  /// projected out.
   void addAllChildFields(const Type&);
 
   const std::vector<std::string>& flatMapFeatureSelection() const {
@@ -502,8 +503,8 @@ void ScanSpec::visit(const Type& type, F&& f) {
   }
 }
 
-// Returns false if no value from a range defined by stats can pass the
-// filter. True, otherwise.
+/// Returns false if no value from a range defined by stats can pass the
+/// filter. True, otherwise.
 bool testFilter(
     const common::Filter* filter,
     dwio::common::ColumnStatistics* stats,

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -697,7 +697,7 @@ void IndexLookupJoin::mergeLookupResults(InputBatchState& batch) {
     outputOffset += static_cast<vector_size_t>(result->size());
   }
 
-  batch.lookupResult = std::make_unique<connector::IndexSource::LookupResult>(
+  batch.lookupResult = std::make_unique<connector::IndexSource::Result>(
       std::move(mergedInputHits), std::move(mergedOutput));
   batch.partialOutputs.clear();
 }
@@ -795,8 +795,8 @@ void IndexLookupJoin::startLookup(InputBatchState& batch) {
   }
 
   // Create the lookup result iterator.
-  batch.lookupResultIter = indexSource_->lookup(
-      connector::IndexSource::LookupRequest{batch.lookupInput});
+  batch.lookupResultIter =
+      indexSource_->lookup(connector::IndexSource::Request{batch.lookupInput});
 
   getLookupResults(batch);
 }

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -83,8 +83,8 @@ class IndexLookupJoin : public Operator {
       "clientNumErrorResults"};
 
  private:
-  using LookupResultIter = connector::IndexSource::LookupResultIterator;
-  using LookupResult = connector::IndexSource::LookupResult;
+  using ResultIterator = connector::IndexSource::ResultIterator;
+  using Result = connector::IndexSource::Result;
 
   // Contains the state of an input batch processing.
   struct InputBatchState {
@@ -103,14 +103,14 @@ class IndexLookupJoin : public Operator {
     // The reusable vector projected from 'input' as index lookup input.
     RowVectorPtr lookupInput;
     // Used to fetch lookup results for an input batch.
-    std::shared_ptr<LookupResultIter> lookupResultIter;
+    std::shared_ptr<ResultIterator> lookupResultIter;
     // Used for synchronization with the async fetch result from index source
     // through 'lookupResultIter'.
     ContinueFuture lookupFuture;
     // Used to store the lookup result fetched from 'lookupResultIter' for
     // output processing. We might split the output result into multiple output
     // batches based on the operator's output batch size limit.
-    std::unique_ptr<LookupResult> lookupResult;
+    std::unique_ptr<Result> lookupResult;
     // Specifies the indices of input row in 'input' that have matches in
     // 'output' from 'lookupResult'. This is only used in case
     // 'lookupInputHasNullKeys' is true in which 'inputHits' in 'lookupResult'
@@ -123,7 +123,7 @@ class IndexLookupJoin : public Operator {
     // When splitOutput_ is false, this tracks partially accumulated results
     // that are waiting for async operations to complete before continuing
     // accumulation.
-    std::vector<std::unique_ptr<LookupResult>> partialOutputs;
+    std::vector<std::unique_ptr<Result>> partialOutputs;
 
     InputBatchState() : lookupFuture(ContinueFuture::makeEmpty()) {}
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -130,6 +130,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const core::TypedExprPtr& remainingFilter = nullptr,
       const std::string& tableName = "hive_table",
       const RowTypePtr& dataColumns = nullptr,
+      const std::vector<std::string>& indexColumns = {},
       bool filterPushdownEnabled = true,
       const std::unordered_map<std::string, std::string>& tableParameters =
           {}) {
@@ -140,6 +141,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
         std::move(subfieldFilters),
         remainingFilter,
         dataColumns,
+        indexColumns,
         tableParameters);
   }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -390,6 +390,7 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
         std::move(subfieldFiltersMap_),
         remainingFilterExpr,
         dataColumns_,
+        indexColumns_,
         /*tableParameters=*/std::unordered_map<std::string, std::string>{},
         filterColumnHandles_);
   }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -340,6 +340,13 @@ class PlanBuilder {
       return *this;
     }
 
+    /// @param indexColumns Names of columns that form the index key for the
+    /// table. When set, enables index-based lookups.
+    TableScanBuilder& indexColumns(std::vector<std::string> indexColumns) {
+      indexColumns_ = std::move(indexColumns);
+      return *this;
+    }
+
     /// Stop the TableScanBuilder.
     PlanBuilder& endTableScan() {
       planBuilder_.planNode_ = build(planBuilder_.nextPlanNodeId());
@@ -357,6 +364,7 @@ class PlanBuilder {
     core::ExprPtr remainingFilter_;
     double sampleRate_{1.0};
     RowTypePtr dataColumns_;
+    std::vector<std::string> indexColumns_;
     std::vector<connector::hive::HiveColumnHandlePtr> filterColumnHandles_;
     std::unordered_map<std::string, std::string> columnAliases_;
     connector::ConnectorTableHandlePtr tableHandle_;

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -198,8 +198,7 @@ class TestIndexSource : public connector::IndexSource,
     splits_ = std::move(splits);
   }
 
-  std::shared_ptr<LookupResultIterator> lookup(
-      const LookupRequest& request) override;
+  std::shared_ptr<ResultIterator> lookup(const Request& request) override;
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats() override;
 
@@ -219,17 +218,17 @@ class TestIndexSource : public connector::IndexSource,
     return lookupOutputProjections_;
   }
 
-  class ResultIterator : public LookupResultIterator {
+  class ResultIterator : public connector::IndexSource::ResultIterator {
    public:
     ResultIterator(
         std::shared_ptr<TestIndexSource> source,
-        const LookupRequest& request,
+        const Request& request,
         std::unique_ptr<HashLookup> lookupResult,
         folly::Executor* executor);
 
     bool hasNext() override;
 
-    std::optional<std::unique_ptr<LookupResult>> next(
+    std::optional<std::unique_ptr<connector::IndexSource::Result>> next(
         vector_size_t size,
         ContinueFuture& future) override;
 
@@ -271,16 +270,17 @@ class TestIndexSource : public connector::IndexSource,
 
     // Synchronously lookup the index table and return up to 'size' number of
     // output rows in result.
-    std::unique_ptr<LookupResult> syncLookup(vector_size_t size);
+    std::unique_ptr<connector::IndexSource::Result> syncLookup(
+        vector_size_t size);
 
     const std::shared_ptr<TestIndexSource> source_;
-    const LookupRequest request_;
+    const Request request_;
     const std::unique_ptr<HashLookup> lookupResult_;
     folly::Executor* const executor_{nullptr};
 
     std::atomic_bool hasPendingRequest_{false};
     std::unique_ptr<BaseHashTable::JoinResultIterator> lookupResultIter_;
-    std::optional<std::unique_ptr<LookupResult>> asyncResult_;
+    std::optional<std::unique_ptr<connector::IndexSource::Result>> asyncResult_;
 
     // The reusable buffers for lookup result processing.
     // The input row number in lookup request for each matched result which is


### PR DESCRIPTION
Summary:
This diff introduces HiveIndexReader, a new component that enables index-based lookup functionality for Hive tables stored in Nimble file format. The reader provides efficient point lookups by leveraging Nimble's cluster indexing capabilities.

HiveIndexReader: New class that wraps Nimble's SelectiveNimbleReader for index-based reads. Supports:
Setting probe data via setRequest() for index lookups
Iterating through matching rows with hasNext() and next()
Integration with AsyncDataCache for caching
IoStatistics tracking for monitoring cache hits

HiveTableHandle extension: Added indexColumns parameter to specify indexed columns, along with new APIs:
supportsIndexLookup() - Returns true if table has index columns configured
needsIndexSplit() - Returns true (index lookups require split info)
indexColumns() - Returns the list of indexed column names

SelectiveNimbleReader improvements:
Added reset() method to reuse the reader for multiple index lookups
Separated initIndex() (one-time setup) from setIndexBounds() (per-query setup)
Added split stripe boundary tracking for proper reset behavior

Test utilities: Renamed and enhanced TabletIndexTestUtils to IndexTestUtils with additional helpers for generating test data and writing indexed Nimble files.

The followup is to support skip list to handle batch lookup request in one pass of selective reader scan

Differential Revision: D91415139
