### PR TITLE
fix: Add new utility file BaseEncoderUtils.h 

### DIFF
--- a/velox/common/encode/Base32.cpp
+++ b/velox/common/encode/Base32.cpp
@@ -21,6 +21,7 @@
 
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/encode/BaseEncoderUtils.h"
 
 namespace facebook::velox::encoding {
 
@@ -63,12 +64,37 @@ constexpr const Base32::ReverseIndex kBase32ReverseIndexTable = {
     255, 255, 255, 255, 255, 255, 255 // 240-255
 };
 
+// Character set for Base32 encoding (RFC 4648).
+// Uses uppercase letters A-Z (values 0-25) and digits 2-7 (values 26-31).
+constexpr const Base32::Charset kBase32Charset = {
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
+    'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
+    'W', 'X', 'Y', 'Z', '2', '3', '4', '5', '6', '7'};
+
+// Verify that for every entry in kBase32Charset, the corresponding entry
+// in kBase32ReverseIndexTable is correct.
+static_assert(
+    utils::checkForwardIndex(
+        sizeof(kBase32Charset) - 1,
+        kBase32Charset,
+        kBase32ReverseIndexTable),
+    "kBase32Charset has incorrect entries");
+
+// Verify that for every entry in kBase32ReverseIndexTable, the corresponding
+// entry in kBase32Charset is correct.
+static_assert(
+    utils::checkReverseIndex(
+        sizeof(kBase32ReverseIndexTable) - 1,
+        kBase32Charset,
+        kBase32ReverseIndexTable),
+    "kBase32ReverseIndexTable has incorrect entries.");
+
 // static
 folly::Expected<uint8_t, Status> Base32::base32ReverseLookup(
     char encodedChar,
     const ReverseIndex& reverseIndex) {
   auto index = reverseIndex[static_cast<uint8_t>(encodedChar)];
-  if (index >= 32) {
+  if (index >= kCharsetSize) {
     return folly::makeUnexpected(
         Status::UserError("Unrecognized character: {}", encodedChar));
   }
@@ -87,13 +113,13 @@ folly::Expected<size_t, Status> Base32::calculateDecodedSize(
   size_t validCharCount = 0;
   for (size_t i = 0; i < inputSize; ++i) {
     char c = input[i];
-    if (c == Base32::kPadding || std::isspace(static_cast<unsigned char>(c))) {
+    if (c == utils::kPadding || std::isspace(static_cast<unsigned char>(c))) {
       continue;
     }
 
     // Validate character first
     auto index = kBase32ReverseIndexTable[static_cast<uint8_t>(c)];
-    if (index >= 32) {
+    if (index >= kCharsetSize) {
       return folly::makeUnexpected(
           Status::UserError("Unrecognized character: {}", c));
     }
@@ -159,7 +185,7 @@ folly::Expected<size_t, Status> Base32::decodeImpl(
     char c = input[i];
 
     // Skip padding and whitespace (RFC 4648 allows whitespace in encoded data)
-    if (c == Base32::kPadding || std::isspace(static_cast<unsigned char>(c))) {
+    if (c == utils::kPadding || std::isspace(static_cast<unsigned char>(c))) {
       continue;
     }
 

--- a/velox/common/encode/Base32.h
+++ b/velox/common/encode/Base32.h
@@ -52,13 +52,10 @@ class Base32 {
       const char* input,
       const size_t inputSize);
 
-  // Padding character used in encoding.
-  static const char kPadding = '=';
-
   // Constants defining the size in bytes of binary and encoded blocks for
-  // Base32 encoding. Size of a binary block in bytes (5 bytes = 40 bits)
+  // Base32 encoding. Size of a binary block in bytes (5 bytes = 40 bits).
   static const int kBinaryBlockByteSize = 5;
-  // Size of an encoded block in bytes (8 bytes = 40 bits)
+  // Size of an encoded block in bytes (8 bytes = 40 bits).
   static const int kEncodedBlockByteSize = 8;
 
  private:

--- a/velox/common/encode/Base64.cpp
+++ b/velox/common/encode/Base64.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/encode/BaseEncoderUtils.h"
 
 namespace facebook::velox::encoding {
 
@@ -87,19 +88,10 @@ constexpr const Base64::ReverseIndex kBase64UrlReverseIndexTable = {
     255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
     255};
 
-// Validate the character in charset with ReverseIndex table
-constexpr bool checkForwardIndex(
-    uint8_t index,
-    const Base64::Charset& charset,
-    const Base64::ReverseIndex& reverseIndex) {
-  return (reverseIndex[static_cast<uint8_t>(charset[index])] == index) &&
-      (index > 0 ? checkForwardIndex(index - 1, charset, reverseIndex) : true);
-}
-
 // Verify that for every entry in kBase64Charset, the corresponding entry
 // in kBase64ReverseIndexTable is correct.
 static_assert(
-    checkForwardIndex(
+    utils::checkForwardIndex(
         sizeof(kBase64Charset) - 1,
         kBase64Charset,
         kBase64ReverseIndexTable),
@@ -108,38 +100,16 @@ static_assert(
 // Verify that for every entry in kBase64UrlCharset, the corresponding entry
 // in kBase64UrlReverseIndexTable is correct.
 static_assert(
-    checkForwardIndex(
+    utils::checkForwardIndex(
         sizeof(kBase64UrlCharset) - 1,
         kBase64UrlCharset,
         kBase64UrlReverseIndexTable),
     "kBase64UrlCharset has incorrect entries");
 
-// Searches for a character within a charset up to a certain index.
-constexpr bool findCharacterInCharset(
-    const Base64::Charset& charset,
-    uint8_t index,
-    const char targetChar) {
-  return index < charset.size() &&
-      ((charset[index] == targetChar) ||
-       findCharacterInCharset(charset, index + 1, targetChar));
-}
-
-// Checks the consistency of a reverse index mapping for a given character
-// set.
-constexpr bool checkReverseIndex(
-    uint8_t index,
-    const Base64::Charset& charset,
-    const Base64::ReverseIndex& reverseIndex) {
-  return (reverseIndex[index] == 255
-              ? !findCharacterInCharset(charset, 0, static_cast<char>(index))
-              : (charset[reverseIndex[index]] == index)) &&
-      (index > 0 ? checkReverseIndex(index - 1, charset, reverseIndex) : true);
-}
-
 // Verify that for every entry in kBase64ReverseIndexTable, the corresponding
 // entry in kBase64Charset is correct.
 static_assert(
-    checkReverseIndex(
+    utils::checkReverseIndex(
         sizeof(kBase64ReverseIndexTable) - 1,
         kBase64Charset,
         kBase64ReverseIndexTable),
@@ -148,9 +118,9 @@ static_assert(
 // Verify that for every entry in kBase64ReverseIndexTable, the corresponding
 // entry in kBase64Charset is correct.
 // We can't run this check as the URL version has two duplicate entries so
-// that the url decoder can handle url encodings and default encodings
+// that the url decoder can handle url encodings and default encodings.
 // static_assert(
-//     checkReverseIndex(
+//     utils::checkReverseIndex(
 //         sizeof(kBase64UrlReverseIndexTable) - 1,
 //         kBase64UrlCharset,
 //         kBase64UrlReverseIndexTable),
@@ -172,17 +142,7 @@ std::string Base64::encodeImpl(
 
 // static
 size_t Base64::calculateEncodedSize(size_t inputSize, bool withPadding) {
-  if (inputSize == 0) {
-    return 0;
-  }
-
-  // Calculate the output size assuming that we are including padding.
-  size_t encodedSize = ((inputSize + 2) / 3) * 4;
-  if (!withPadding) {
-    // If the padding was not requested, subtract the padding bytes.
-    encodedSize -= (3 - (inputSize % 3)) % 3;
-  }
-  return encodedSize;
+  return utils::calculateEncodedSize(inputSize, withPadding, kBase64BlockSizes);
 }
 
 // static
@@ -235,13 +195,13 @@ void Base64::encodeImpl(
       *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
       *outputPointer++ = charset[(inputBlock >> 6) & 0x3f];
       if (includePadding) {
-        *outputPointer = kPadding;
+        *outputPointer = utils::kPadding;
       }
     } else {
       *outputPointer++ = charset[(inputBlock >> 12) & 0x3f];
       if (includePadding) {
-        *outputPointer++ = kPadding;
-        *outputPointer = kPadding;
+        *outputPointer++ = utils::kPadding;
+        *outputPointer = utils::kPadding;
       }
     }
   }
@@ -343,14 +303,7 @@ void Base64::decode(const char* input, size_t inputSize, char* outputBuffer) {
 Expected<uint8_t> Base64::base64ReverseLookup(
     char encodedChar,
     const ReverseIndex& reverseIndex) {
-  auto reverseLookupValue = reverseIndex[static_cast<uint8_t>(encodedChar)];
-  if (reverseLookupValue >= 0x40) {
-    return folly::makeUnexpected(
-        Status::UserError(
-            "decode() - invalid input string: invalid character '{}'",
-            encodedChar));
-  }
-  return reverseLookupValue;
+  return utils::reverseLookup(encodedChar, reverseIndex, kCharsetSize);
 }
 
 // static
@@ -371,48 +324,7 @@ Status Base64::decode(
 Expected<size_t> Base64::calculateDecodedSize(
     const char* input,
     size_t& inputSize) {
-  if (inputSize == 0) {
-    return 0;
-  }
-
-  // Check if the input string is padded
-  if (isPadded(input, inputSize)) {
-    // If padded, ensure that the string length is a multiple of the encoded
-    // block size
-    if (inputSize % kEncodedBlockByteSize != 0) {
-      return folly::makeUnexpected(
-          Status::UserError(
-              "Base64::decode() - invalid input string: "
-              "string length is not a multiple of 4."));
-    }
-
-    auto decodedSize =
-        (inputSize * kBinaryBlockByteSize) / kEncodedBlockByteSize;
-    auto paddingCount = numPadding(input, inputSize);
-    inputSize -= paddingCount;
-
-    // Adjust the needed size by deducting the bytes corresponding to the
-    // padding from the calculated size.
-    return decodedSize -
-        ((paddingCount * kBinaryBlockByteSize) + (kEncodedBlockByteSize - 1)) /
-        kEncodedBlockByteSize;
-  }
-  // If not padded, Calculate extra bytes, if any
-  auto extraBytes = inputSize % kEncodedBlockByteSize;
-  auto decodedSize = (inputSize / kEncodedBlockByteSize) * kBinaryBlockByteSize;
-
-  // Adjust the needed size for extra bytes, if present
-  if (extraBytes) {
-    if (extraBytes == 1) {
-      return folly::makeUnexpected(
-          Status::UserError(
-              "Base64::decode() - invalid input string: "
-              "string length cannot be 1 more than a multiple of 4."));
-    }
-    decodedSize += (extraBytes * kBinaryBlockByteSize) / kEncodedBlockByteSize;
-  }
-
-  return decodedSize;
+  return utils::calculateDecodedSize(input, inputSize, kBase64BlockSizes);
 }
 
 // static
@@ -567,10 +479,11 @@ Status Base64::decodeMime(const char* input, size_t inputSize, char* output) {
     int val = kBase64ReverseIndexTable[c];
 
     // Padding character.
-    if (c == kPadding) {
+    if (c == utils::kPadding) {
       // If we see '=' too early or only one '=' when two are needed → error.
       if (bitsNeeded == 18 ||
-          (bitsNeeded == 6 && (idx == inputSize || input[idx++] != kPadding))) {
+          (bitsNeeded == 6 &&
+           (idx == inputSize || input[idx++] != utils::kPadding))) {
         return Status::UserError(
             "Input byte array has wrong 4-byte ending unit.");
       }
@@ -639,7 +552,7 @@ Expected<size_t> Base64::calculateMimeDecodedSize(
   // Compute how many true Base64 chars.
   for (size_t i = 0; i < inputSize; ++i) {
     auto c = input[i];
-    if (c == kPadding) {
+    if (c == utils::kPadding) {
       decodedSize -= inputSize - i;
       break;
     }
@@ -710,14 +623,14 @@ void Base64::encodeMime(const char* input, size_t inputSize, char* output) {
     if (remaining == 1) {
       // Only one byte remains: produce two chars + two '=' paddings.
       *writePtr++ = kBase64Charset[(b0 & 0x03) << 4];
-      *writePtr++ = kPadding;
-      *writePtr = kPadding;
+      *writePtr++ = utils::kPadding;
+      *writePtr = utils::kPadding;
     } else {
       // Two bytes remain: produce three chars + one '=' padding.
       uint8_t b1 = static_cast<uint8_t>(*readPtr);
       *writePtr++ = kBase64Charset[((b0 & 0x03) << 4) | (b1 >> 4)];
       *writePtr++ = kBase64Charset[(b1 & 0x0F) << 2];
-      *writePtr = kPadding;
+      *writePtr = utils::kPadding;
     }
   }
 }

--- a/velox/common/encode/Base64.h
+++ b/velox/common/encode/Base64.h
@@ -21,7 +21,6 @@
 #include <array>
 #include <string>
 
-#include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/Status.h"
 
 namespace facebook::velox::encoding {
@@ -139,28 +138,10 @@ class Base64 {
   static size_t calculateMimeEncodedSize(size_t inputSize);
 
  private:
-  // Padding character used in encoding.
-  static const char kPadding = '=';
-
   // Soft Line breaks used in mime encoding as defined in RFC 2045, section 6.8:
   // https://www.rfc-editor.org/rfc/rfc2045#section-6.8
   inline static const std::string kNewline{"\r\n"};
   static const size_t kMaxLineLength = 76;
-
-  // Checks if the input Base64 string is padded.
-  static inline bool isPadded(const char* input, size_t inputSize) {
-    return (inputSize > 0 && input[inputSize - 1] == kPadding);
-  }
-
-  // Counts the number of padding characters in encoded input.
-  static inline size_t numPadding(const char* input, size_t inputSize) {
-    size_t numPadding{0};
-    while (inputSize > 0 && input[inputSize - 1] == kPadding) {
-      numPadding++;
-      inputSize--;
-    }
-    return numPadding;
-  }
 
   // Reverse lookup helper function to get the original index of a Base64
   // character.
@@ -188,9 +169,6 @@ class Base64 {
       char* outputBuffer,
       size_t outputSize,
       const ReverseIndex& reverseIndex);
-
-  VELOX_FRIEND_TEST(Base64Test, checksPadding);
-  VELOX_FRIEND_TEST(Base64Test, countsPaddingCorrectly);
 };
 
 } // namespace facebook::velox::encoding

--- a/velox/common/encode/BaseEncoderUtils.cpp
+++ b/velox/common/encode/BaseEncoderUtils.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/encode/BaseEncoderUtils.h"
+
+#include <folly/Expected.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::encoding::utils {
+
+Expected<size_t> calculateDecodedSize(
+    const char* input,
+    size_t& inputSize,
+    const CodecBlockSizes& blockSizes) {
+  VELOX_CHECK_NOT_NULL(input);
+  VELOX_CHECK_GT(blockSizes.binaryBlockByteSize, 0);
+  VELOX_CHECK_GT(blockSizes.encodedBlockByteSize, 0);
+
+  if (inputSize == 0) {
+    return 0;
+  }
+
+  auto binaryBlockByteSize = blockSizes.binaryBlockByteSize;
+  auto encodedBlockByteSize = blockSizes.encodedBlockByteSize;
+
+  // Check if the input string is padded.
+  if (isPadded(input, inputSize)) {
+    // If padded, ensure that the string length is a multiple of the encoded
+    // block size.
+    if (inputSize % encodedBlockByteSize != 0) {
+      return folly::makeUnexpected(Status::UserError(kInvalidInputLengthError));
+    }
+
+    auto decodedSize = (inputSize * binaryBlockByteSize) / encodedBlockByteSize;
+    auto paddingCount = numPadding(input, inputSize);
+    inputSize -= paddingCount;
+
+    // Adjust the needed size by deducting the bytes corresponding to the
+    // padding from the calculated size.
+    return decodedSize -
+        ((paddingCount * binaryBlockByteSize) + (encodedBlockByteSize - 1)) /
+        encodedBlockByteSize;
+  }
+
+  // If not padded, calculate extra bytes, if any.
+  auto extraBytes = inputSize % encodedBlockByteSize;
+  auto decodedSize = (inputSize / encodedBlockByteSize) * binaryBlockByteSize;
+
+  // Adjust the needed size for extra bytes, if present.
+  if (extraBytes) {
+    if (extraBytes == 1) {
+      return folly::makeUnexpected(Status::UserError(kInvalidInputLengthError));
+    }
+    decodedSize += (extraBytes * binaryBlockByteSize) / encodedBlockByteSize;
+  }
+
+  return decodedSize;
+}
+
+size_t calculateEncodedSize(
+    size_t inputSize,
+    bool includePadding,
+    const CodecBlockSizes& blockSizes) {
+  VELOX_CHECK_GT(blockSizes.binaryBlockByteSize, 0);
+  VELOX_CHECK_GT(blockSizes.encodedBlockByteSize, 0);
+
+  if (inputSize == 0) {
+    return 0;
+  }
+
+  auto binaryBlockByteSize = blockSizes.binaryBlockByteSize;
+  auto encodedBlockByteSize = blockSizes.encodedBlockByteSize;
+
+  // Calculate the output size assuming that we are including padding.
+  size_t encodedSize =
+      ((inputSize + binaryBlockByteSize - 1) / binaryBlockByteSize) *
+      encodedBlockByteSize;
+
+  if (!includePadding) {
+    // If padding was not requested, compute the exact number of encoded
+    // characters needed: ceil(inputSize * encodedBlockByteSize /
+    // binaryBlockByteSize).
+    return (inputSize * encodedBlockByteSize + binaryBlockByteSize - 1) /
+        binaryBlockByteSize;
+  }
+  return encodedSize;
+}
+
+} // namespace facebook::velox::encoding::utils

--- a/velox/common/encode/BaseEncoderUtils.h
+++ b/velox/common/encode/BaseEncoderUtils.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string_view>
+
+#include "velox/common/base/Status.h"
+
+namespace facebook::velox::encoding {
+
+/// Describes the binary and encoded block sizes for a base encoding codec.
+struct CodecBlockSizes {
+  int binaryBlockByteSize;
+  int encodedBlockByteSize;
+};
+
+static constexpr CodecBlockSizes kBase64BlockSizes{3, 4};
+static constexpr CodecBlockSizes kBase32BlockSizes{5, 8};
+
+/// Shared utility functions for base encoding schemes (e.g. Base64, Base32).
+/// Provides common operations for padding detection, charset validation,
+/// reverse lookup, and encoded size calculation.
+namespace utils {
+
+/// Padding character used in base encoding schemes.
+inline constexpr char kPadding = '=';
+
+/// Sentinel value in reverse index tables indicating an invalid character.
+inline constexpr uint8_t kInvalidBase = 255;
+
+/// Error message for invalid encoded input string length.
+inline constexpr std::string_view kInvalidInputLengthError =
+    "decode() - invalid input string length.";
+
+/// Checks if the encoded input ends with padding character(s).
+inline bool isPadded(const char* input, size_t inputSize) {
+  return inputSize > 0 && input[inputSize - 1] == kPadding;
+}
+
+/// Counts the number of trailing padding characters in encoded input.
+inline size_t numPadding(const char* input, size_t inputSize) {
+  size_t count{0};
+  while (count < inputSize && input[inputSize - 1 - count] == kPadding) {
+    ++count;
+  }
+  return count;
+}
+
+/// Validates that each character in the charset maps correctly through the
+/// reverse index table back to its original index.
+/// @param index The current index to validate (iterates down to 0).
+/// @param charset The character set used for encoding.
+/// @param reverseIndex The reverse lookup table mapping characters to
+/// indices.
+template <typename Charset, typename ReverseIndex>
+constexpr bool checkForwardIndex(
+    uint8_t index,
+    const Charset& charset,
+    const ReverseIndex& reverseIndex) {
+  return (reverseIndex[static_cast<uint8_t>(charset[index])] == index) &&
+      (index > 0 ? checkForwardIndex(index - 1, charset, reverseIndex) : true);
+}
+
+/// Searches for a target character within a charset starting from the given
+/// index.
+/// @param charset The character set to search.
+/// @param index The starting index for the search.
+/// @param targetChar The character to find.
+template <typename Charset>
+constexpr bool findCharacterInCharset(
+    const Charset& charset,
+    uint8_t index,
+    const char targetChar) {
+  return index < charset.size() &&
+      ((charset[index] == targetChar) ||
+       findCharacterInCharset(charset, index + 1, targetChar));
+}
+
+/// Checks the consistency of a reverse index mapping for a given character
+/// set. For each byte value, verifies that either:
+/// - The reverse index is kInvalidBase and the character is not in the
+///   charset, or
+/// - The charset at the reverse index position equals the byte value.
+/// @param index The current byte value to validate (iterates down to 0).
+/// @param charset The character set used for encoding.
+/// @param reverseIndex The reverse lookup table to validate.
+template <typename Charset, typename ReverseIndex>
+constexpr bool checkReverseIndex(
+    uint8_t index,
+    const Charset& charset,
+    const ReverseIndex& reverseIndex) {
+  return (reverseIndex[index] == kInvalidBase
+              ? !findCharacterInCharset(charset, 0, static_cast<char>(index))
+              : (charset[reverseIndex[index]] == index)) &&
+      (index > 0 ? checkReverseIndex(index - 1, charset, reverseIndex) : true);
+}
+
+/// Performs reverse lookup of an encoded character to its numeric value.
+/// @param encodedChar The encoded character to look up.
+/// @param reverseIndex The reverse index table for the encoding scheme.
+/// @param charsetSize The size of the character set (e.g. 64 for Base64, 32
+///   for Base32). Characters mapping to values >= charsetSize are considered
+///   invalid.
+template <typename ReverseIndex>
+Expected<uint8_t> reverseLookup(
+    char encodedChar,
+    const ReverseIndex& reverseIndex,
+    uint8_t charsetSize) {
+  auto value = reverseIndex[static_cast<uint8_t>(encodedChar)];
+  if (value >= charsetSize) {
+    return folly::makeUnexpected(
+        Status::UserError(
+            "decode() - invalid input string: invalid character '{}'",
+            encodedChar));
+  }
+  return value;
+}
+
+/// Calculates the decoded output size from encoded input, accounting for
+/// padding. Also strips padding from 'inputSize' so that the caller can
+/// iterate over only the non-padding characters.
+/// @param input The encoded input string (used to detect trailing padding).
+/// @param inputSize The length of the encoded input. Modified on return to
+///   exclude padding characters.
+/// @param blockSizes The binary and encoded block sizes for the codec.
+Expected<size_t> calculateDecodedSize(
+    const char* input,
+    size_t& inputSize,
+    const CodecBlockSizes& blockSizes);
+
+/// Calculates the encoded output size based on input size and block sizes.
+/// @param inputSize Size of the input data in bytes.
+/// @param includePadding Whether to include padding in the output.
+/// @param blockSizes The binary and encoded block sizes for the codec.
+size_t calculateEncodedSize(
+    size_t inputSize,
+    bool includePadding,
+    const CodecBlockSizes& blockSizes);
+
+} // namespace utils
+
+} // namespace facebook::velox::encoding

--- a/velox/common/encode/CMakeLists.txt
+++ b/velox/common/encode/CMakeLists.txt
@@ -20,9 +20,11 @@ velox_add_library(
   velox_encode
   Base64.cpp
   Base32.cpp
+  BaseEncoderUtils.cpp
   HEADERS
   Base32.h
   Base64.h
+  BaseEncoderUtils.h
 )
 velox_link_libraries(velox_encode PUBLIC velox_status Folly::folly)
 

--- a/velox/common/encode/tests/Base64Test.cpp
+++ b/velox/common/encode/tests/Base64Test.cpp
@@ -57,8 +57,7 @@ TEST_F(Base64Test, calculateDecodedSizeProperSize) {
 
   encodedSize = 21;
   EXPECT_EQ(
-      Status::UserError(
-          "Base64::decode() - invalid input string: string length is not a multiple of 4."),
+      Status::UserError("decode() - invalid input string length."),
       Base64::calculateDecodedSize("SGVsbG8sIFdvcmxkIQ===", encodedSize)
           .error());
 
@@ -88,17 +87,6 @@ TEST_F(Base64Test, calculateDecodedSizeProperSize) {
   EXPECT_EQ(
       10, Base64::calculateDecodedSize("MTIzNDU2Nzg5MA", encodedSize).value());
   EXPECT_EQ(14, encodedSize);
-}
-
-TEST_F(Base64Test, checksPadding) {
-  EXPECT_TRUE(Base64::isPadded("ABC=", 4));
-  EXPECT_FALSE(Base64::isPadded("ABC", 3));
-}
-
-TEST_F(Base64Test, countsPaddingCorrectly) {
-  EXPECT_EQ(0, Base64::numPadding("ABC", 3));
-  EXPECT_EQ(1, Base64::numPadding("ABC=", 4));
-  EXPECT_EQ(2, Base64::numPadding("AB==", 4));
 }
 
 TEST_F(Base64Test, calculateMimeDecodedSize) {

--- a/velox/common/encode/tests/BaseEncoderUtilsTest.cpp
+++ b/velox/common/encode/tests/BaseEncoderUtilsTest.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/encode/BaseEncoderUtils.h"
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::encoding {
+namespace {
+
+void testCalculateDecodedSize(
+    const std::string& input,
+    size_t initialInputSize,
+    const CodecBlockSizes& blockSizes,
+    size_t expectedDecodedSize,
+    size_t expectedInputSize) {
+  size_t inputSize = initialInputSize;
+  EXPECT_EQ(
+      expectedDecodedSize,
+      utils::calculateDecodedSize(input.data(), inputSize, blockSizes).value());
+  EXPECT_EQ(expectedInputSize, inputSize);
+}
+
+void testCalculateDecodedSizeError(
+    const std::string& input,
+    size_t initialInputSize,
+    const CodecBlockSizes& blockSizes) {
+  size_t inputSize = initialInputSize;
+  EXPECT_EQ(
+      Status::UserError("decode() - invalid input string length."),
+      utils::calculateDecodedSize(input.data(), inputSize, blockSizes).error());
+}
+
+TEST(BaseEncoderUtilsTest, isPadded) {
+  EXPECT_TRUE(utils::isPadded("ABC=", 4));
+  EXPECT_TRUE(utils::isPadded("AB==", 4));
+  EXPECT_FALSE(utils::isPadded("ABC", 3));
+  EXPECT_FALSE(utils::isPadded("", 0));
+}
+
+TEST(BaseEncoderUtilsTest, numPadding) {
+  EXPECT_EQ(0, utils::numPadding("ABC", 3));
+  EXPECT_EQ(1, utils::numPadding("ABC=", 4));
+  EXPECT_EQ(2, utils::numPadding("AB==", 4));
+  EXPECT_EQ(0, utils::numPadding("", 0));
+}
+
+TEST(BaseEncoderUtilsTest, reverseLookup) {
+  // Build a simple reverse index for testing.
+  std::array<uint8_t, 256> reverseIndex{};
+  reverseIndex.fill(255);
+  reverseIndex['A'] = 0;
+  reverseIndex['B'] = 1;
+  reverseIndex['C'] = 2;
+
+  EXPECT_EQ(0, utils::reverseLookup('A', reverseIndex, 64).value());
+  EXPECT_EQ(1, utils::reverseLookup('B', reverseIndex, 64).value());
+  EXPECT_EQ(2, utils::reverseLookup('C', reverseIndex, 64).value());
+
+  // Invalid character should return an error.
+  EXPECT_EQ(
+      utils::reverseLookup('Z', reverseIndex, 64).error(),
+      Status::UserError(
+          "decode() - invalid input string: invalid character 'Z'"));
+}
+
+TEST(BaseEncoderUtilsTest, calculateEncodedSizeBase64) {
+  EXPECT_EQ(0, utils::calculateEncodedSize(0, true, kBase64BlockSizes));
+  EXPECT_EQ(4, utils::calculateEncodedSize(1, true, kBase64BlockSizes));
+  EXPECT_EQ(4, utils::calculateEncodedSize(2, true, kBase64BlockSizes));
+  EXPECT_EQ(4, utils::calculateEncodedSize(3, true, kBase64BlockSizes));
+  EXPECT_EQ(8, utils::calculateEncodedSize(4, true, kBase64BlockSizes));
+  EXPECT_EQ(8, utils::calculateEncodedSize(6, true, kBase64BlockSizes));
+
+  // Without padding.
+  EXPECT_EQ(2, utils::calculateEncodedSize(1, false, kBase64BlockSizes));
+  EXPECT_EQ(3, utils::calculateEncodedSize(2, false, kBase64BlockSizes));
+  EXPECT_EQ(4, utils::calculateEncodedSize(3, false, kBase64BlockSizes));
+  EXPECT_EQ(6, utils::calculateEncodedSize(4, false, kBase64BlockSizes));
+}
+
+TEST(BaseEncoderUtilsTest, calculateEncodedSizeBase32) {
+  EXPECT_EQ(0, utils::calculateEncodedSize(0, true, kBase32BlockSizes));
+  EXPECT_EQ(8, utils::calculateEncodedSize(1, true, kBase32BlockSizes));
+  EXPECT_EQ(8, utils::calculateEncodedSize(5, true, kBase32BlockSizes));
+  EXPECT_EQ(16, utils::calculateEncodedSize(6, true, kBase32BlockSizes));
+  EXPECT_EQ(16, utils::calculateEncodedSize(10, true, kBase32BlockSizes));
+
+  // Without padding.
+  EXPECT_EQ(2, utils::calculateEncodedSize(1, false, kBase32BlockSizes));
+  EXPECT_EQ(4, utils::calculateEncodedSize(2, false, kBase32BlockSizes));
+  EXPECT_EQ(5, utils::calculateEncodedSize(3, false, kBase32BlockSizes));
+  EXPECT_EQ(7, utils::calculateEncodedSize(4, false, kBase32BlockSizes));
+  EXPECT_EQ(8, utils::calculateEncodedSize(5, false, kBase32BlockSizes));
+}
+
+TEST(BaseEncoderUtilsTest, calculateDecodedSizeBase64) {
+  // Empty input.
+  testCalculateDecodedSize("", 0, kBase64BlockSizes, 0, 0);
+
+  // Padded input: "SGVsbG8sIFdvcmxkIQ==" (20 chars, 2 padding).
+  testCalculateDecodedSize(
+      "SGVsbG8sIFdvcmxkIQ==", 20, kBase64BlockSizes, 13, 18);
+
+  // Unpadded input: "SGVsbG8sIFdvcmxkIQ" (18 chars).
+  testCalculateDecodedSize("SGVsbG8sIFdvcmxkIQ", 18, kBase64BlockSizes, 13, 18);
+
+  // Invalid padded input: length not a multiple of encodedBlockByteSize.
+  testCalculateDecodedSizeError("SGVsbG8sIFdvcmxkIQ===", 21, kBase64BlockSizes);
+
+  // Single extra byte (invalid for Base64 unpadded).
+  testCalculateDecodedSizeError("A", 1, kBase64BlockSizes);
+}
+
+TEST(BaseEncoderUtilsTest, calculateDecodedSizeBase32) {
+  // Empty input.
+  testCalculateDecodedSize("", 0, kBase32BlockSizes, 0, 0);
+
+  // Padded input: 8 chars with 6 padding (single byte encoded).
+  testCalculateDecodedSize("ME======", 8, kBase32BlockSizes, 1, 2);
+
+  // Padded input: 8 chars with 1 padding (4 bytes encoded).
+  testCalculateDecodedSize("MFRGIZL=", 8, kBase32BlockSizes, 4, 7);
+
+  // Unpadded input: 2 chars (single byte).
+  testCalculateDecodedSize("ME", 2, kBase32BlockSizes, 1, 2);
+
+  // Invalid padded input: length not a multiple of 8.
+  testCalculateDecodedSizeError("ME======X", 9, kBase32BlockSizes);
+
+  // Single extra byte (invalid for Base32 unpadded).
+  testCalculateDecodedSizeError("M", 1, kBase32BlockSizes);
+}
+
+} // namespace
+} // namespace facebook::velox::encoding

--- a/velox/common/encode/tests/CMakeLists.txt
+++ b/velox/common/encode/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_common_encode_test Base64Test.cpp ZigZagTest.cpp)
+add_executable(velox_common_encode_test Base64Test.cpp BaseEncoderUtilsTest.cpp ZigZagTest.cpp)
 add_test(velox_common_encode_test velox_common_encode_test)
 target_link_libraries(
   velox_common_encode_test

--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -40,7 +40,7 @@ Binary Functions
 
     Query with partial-padded Base64 string:
     ::
-    SELECT from_base64('SGVsbG8gV29ybGQgZm9yIHZlbG94IQ='); -- UserError: Base64::decode() - invalid input string: string length is not a multiple of 4.
+    SELECT from_base64('SGVsbG8gV29ybGQgZm9yIHZlbG94IQ='); -- UserError: decode() - invalid input string length.
 
     In the above examples, both the fully padded and non-padded Base64 strings ('SGVsbG8gV29ybGQ=' and 'SGVsbG8gV29ybGQ') decode to the binary representation of the text 'Hello World'.
     A partial-padded Base64 string 'SGVsbG8gV29ybGQgZm9yIHZlbG94IQ=' will result in a "UserError" status indicating the Base64 string is invalid.

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -515,11 +515,9 @@ TEST_F(BinaryFunctionsTest, fromBase64) {
       fromBase64("SGVsbG8gV29ybGQgZnJvbSBWZWxveCE="));
 
   VELOX_ASSERT_USER_THROW(
-      fromBase64("YQ="),
-      "Base64::decode() - invalid input string: string length is not a multiple of 4.");
+      fromBase64("YQ="), "decode() - invalid input string length.");
   VELOX_ASSERT_USER_THROW(
-      fromBase64("YQ==="),
-      "Base64::decode() - invalid input string: string length is not a multiple of 4.");
+      fromBase64("YQ==="), "decode() - invalid input string length.");
   VELOX_ASSERT_USER_THROW(
       fromBase64("aG;"),
       "decode() - invalid input string: invalid character ';'");


### PR DESCRIPTION
### Summary
Extracts common encoding/decoding utilities shared between Base64 and Base32 into a new BaseEncoderUtils class, as proposed in #8650 and addressing reviewer feedback from that PR. Credit to @Joe-Abraham 

This PR refactors shared Base64/Base32 encoding utilities into BaseEncoderUtils. It should be reviewed and merged before #16235, which builds on top of it. The two PRs share the same commit history — this PR contains only the refactor commit, while #16235 adds the Base32 encoding feature on top.

## Changes

**`BaseEncoderUtils.h` (new)** — Shared utility class with:
- `isPadded`, `numPadding` — padding detection
- `checkForwardIndex`, `checkReverseIndex` — compile-time charset/reverse-index validation
- `reverseLookup` — character-to-value mapping with error handling
- `calculateEncodedSize`, `calculateDecodedSize` — generic size computation

**`Base64.h/.cpp`** — Refactored to delegate to `BaseEncoderUtils` for shared logic (no behavioral change).
