### PR TITLE
feat: Add IcebergDataSource

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -36,7 +36,6 @@ velox_add_library(
 
 velox_link_libraries(
   velox_hive_connector
-  PUBLIC velox_hive_iceberg_splitreader
   PRIVATE velox_common_io velox_connector velox_dwio_catalog_fbhive velox_hive_partition_function
 )
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -56,7 +56,7 @@ HiveConnector::HiveConnector(
 std::unique_ptr<DataSource> HiveConnector::createDataSource(
     const RowTypePtr& outputType,
     const ConnectorTableHandlePtr& tableHandle,
-    const std::unordered_map<std::string, ColumnHandlePtr>& columnHandles,
+    const ColumnHandleMap& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
   return std::make_unique<HiveDataSource>(
       outputType,

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -22,7 +22,6 @@
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
-#include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 #include "velox/dwio/common/ReaderFactory.h"
 
 namespace facebook::velox::connector::hive {
@@ -101,36 +100,19 @@ std::unique_ptr<SplitReader> SplitReader::create(
     folly::Executor* ioExecutor,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
     const common::SubfieldFilters* subfieldFiltersForValidation) {
-  //  Create the SplitReader based on hiveSplit->customSplitInfo["table_format"]
-  if (hiveSplit->customSplitInfo.count("table_format") > 0 &&
-      hiveSplit->customSplitInfo["table_format"] == "hive-iceberg") {
-    return std::make_unique<iceberg::IcebergSplitReader>(
-        hiveSplit,
-        hiveTableHandle,
-        partitionKeys,
-        connectorQueryCtx,
-        hiveConfig,
-        readerOutputType,
-        ioStats,
-        fsStats,
-        fileHandleFactory,
-        ioExecutor,
-        scanSpec);
-  } else {
-    return std::unique_ptr<SplitReader>(new SplitReader(
-        hiveSplit,
-        hiveTableHandle,
-        partitionKeys,
-        connectorQueryCtx,
-        hiveConfig,
-        readerOutputType,
-        ioStats,
-        fsStats,
-        fileHandleFactory,
-        ioExecutor,
-        scanSpec,
-        subfieldFiltersForValidation));
-  }
+  return std::unique_ptr<SplitReader>(new SplitReader(
+      hiveSplit,
+      hiveTableHandle,
+      partitionKeys,
+      connectorQueryCtx,
+      hiveConfig,
+      readerOutputType,
+      ioStats,
+      fsStats,
+      fileHandleFactory,
+      ioExecutor,
+      scanSpec,
+      subfieldFiltersForValidation));
 }
 
 SplitReader::SplitReader(

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   IcebergColumnHandle.cpp
   IcebergConnector.cpp
   IcebergDataSink.cpp
+  IcebergDataSource.cpp
   IcebergPartitionName.cpp
   IcebergSplit.cpp
   IcebergSplitReader.cpp

--- a/velox/connectors/hive/iceberg/IcebergConnector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergConnector.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergDataSink.h"
+#include "velox/connectors/hive/iceberg/IcebergDataSource.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -49,6 +50,21 @@ IcebergConnector::IcebergConnector(
           std::string(kIcebergFunctionPrefixConfig),
           std::string(kDefaultIcebergFunctionPrefix))) {
   registerIcebergInternalFunctions(functionPrefix_);
+}
+
+std::unique_ptr<DataSource> IcebergConnector::createDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& columnHandles,
+    ConnectorQueryCtx* connectorQueryCtx) {
+  return std::make_unique<IcebergDataSource>(
+      outputType,
+      tableHandle,
+      columnHandles,
+      &fileHandleFactory_,
+      ioExecutor_,
+      connectorQueryCtx,
+      hiveConfig_);
 }
 
 std::unique_ptr<DataSink> IcebergConnector::createDataSink(

--- a/velox/connectors/hive/iceberg/IcebergConnector.h
+++ b/velox/connectors/hive/iceberg/IcebergConnector.h
@@ -25,8 +25,8 @@ extern const std::string_view kIcebergFunctionPrefixConfig;
 extern const std::string_view kDefaultIcebergFunctionPrefix;
 
 /// Provides Iceberg table format support.
-/// - Creates HiveDataSource instances that use IcebergSplitReader for reading
-///   Iceberg tables with support for delete files and schema evolution.
+/// - Creates IcebergDataSource instances for reading Iceberg tables with
+///   support for delete files and schema evolution.
 /// - Creates IcebergDataSink instances for writing data with Iceberg-specific
 ///   partition transforms and commit metadata.
 class IcebergConnector final : public HiveConnector {
@@ -35,6 +35,19 @@ class IcebergConnector final : public HiveConnector {
       const std::string& id,
       std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* ioExecutor);
+
+  /// Creates IcebergDataSource for reading from Iceberg tables.
+  ///
+  /// @param outputType The schema of the output data to read.
+  /// @param tableHandle The table handle containing table metadata.
+  /// @param columnHandles Map of column names to column handles.
+  /// @param connectorQueryCtx Query context for the read operation.
+  /// @return IcebergDataSource instance configured for the read operation.
+  std::unique_ptr<DataSource> createDataSource(
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& columnHandles,
+      ConnectorQueryCtx* connectorQueryCtx) override;
 
   /// Creates IcebergDataSink for writing to Iceberg tables.
   ///

--- a/velox/connectors/hive/iceberg/IcebergDataSource.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDataSource.h"
+
+#include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+IcebergDataSource::IcebergDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& assignments,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* ioExecutor,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<HiveConfig>& hiveConfig)
+    : HiveDataSource(
+          outputType,
+          tableHandle,
+          assignments,
+          fileHandleFactory,
+          ioExecutor,
+          connectorQueryCtx,
+          hiveConfig) {}
+
+std::unique_ptr<SplitReader> IcebergDataSource::createSplitReader() {
+  return std::make_unique<IcebergSplitReader>(
+      split_,
+      hiveTableHandle_,
+      &partitionKeys_,
+      connectorQueryCtx_,
+      hiveConfig_,
+      readerOutputType_,
+      ioStats_,
+      fsStats_,
+      fileHandleFactory_,
+      ioExecutor_,
+      scanSpec_);
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSource.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveDataSource.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Iceberg-specific data source that extends HiveDataSource.
+///
+/// Provides Iceberg table format support by creating
+/// IcebergSplitReader instances that handle:
+/// - Positional delete files for row-level deletes.
+/// - Schema evolution with column adaptation.
+/// - Iceberg-specific metadata columns.
+class IcebergDataSource : public HiveDataSource {
+ public:
+  IcebergDataSource(
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& assignments,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* ioExecutor,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<HiveConfig>& hiveConfig);
+
+ protected:
+  /// Creates an IcebergSplitReader for reading Iceberg data files.
+  ///
+  /// Unlike the base HiveDataSource which creates a generic SplitReader,
+  /// this method creates an IcebergSplitReader that handles Iceberg-specific
+  /// features like positional delete files and schema evolution.
+  std::unique_ptr<SplitReader> createSplitReader() override;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -27,7 +27,7 @@ namespace facebook::velox::connector::hive::iceberg {
 IcebergSplitReader::IcebergSplitReader(
     const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
     const HiveTableHandlePtr& hiveTableHandle,
-    const std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
+    const HiveColumnHandleMap* partitionKeys,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const RowTypePtr& readerOutputType,
@@ -69,8 +69,7 @@ void IcebergSplitReader::prepareSplit(
 
   createRowReader(std::move(metadataFilter), std::move(rowType), std::nullopt);
 
-  std::shared_ptr<const HiveIcebergSplit> icebergSplit =
-      std::dynamic_pointer_cast<const HiveIcebergSplit>(hiveSplit_);
+  auto icebergSplit = checkedPointerCast<const HiveIcebergSplit>(hiveSplit_);
   baseReadOffset_ = 0;
   splitOffset_ = baseRowReader_->nextRowNumber();
   positionalDeleteFileReaders_.clear();

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -29,7 +29,7 @@ class IcebergSplitReader : public SplitReader {
   IcebergSplitReader(
       const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
       const HiveTableHandlePtr& hiveTableHandle,
-      const std::unordered_map<std::string, HiveColumnHandlePtr>* partitionKeys,
+      const HiveColumnHandleMap* partitionKeys,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
       const RowTypePtr& readerOutputType,

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
@@ -38,6 +39,8 @@ using namespace facebook::velox::test;
 
 namespace facebook::velox::connector::hive::iceberg {
 
+static const char* kIcebergConnectorId = "test-iceberg";
+
 class HiveIcebergTest : public HiveConnectorTestBase {
  public:
   void SetUp() override {
@@ -45,6 +48,19 @@ class HiveIcebergTest : public HiveConnectorTestBase {
 #ifdef VELOX_ENABLE_PARQUET
     parquet::registerParquetReaderFactory();
 #endif
+    // Register IcebergConnector.
+    IcebergConnectorFactory icebergFactory;
+    auto icebergConnector = icebergFactory.newConnector(
+        kIcebergConnectorId,
+        std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()),
+        ioExecutor_.get());
+    connector::registerConnector(icebergConnector);
+  }
+
+  void TearDown() override {
+    connector::unregisterConnector(kIcebergConnectorId);
+    HiveConnectorTestBase::TearDown();
   }
 
   HiveIcebergTest()
@@ -235,9 +251,13 @@ class HiveIcebergTest : public HiveConnectorTestBase {
 
     std::string duckdbSql =
         getDuckDBQuery(rowGroupSizesForFiles, deleteFilesForBaseDatafiles);
-    auto plan = PlanBuilder().tableScan(ROW({"c0"}, {BIGINT()})).planNode();
-    auto task = HiveConnectorTestBase::assertQuery(
-        plan, splits, duckdbSql, numPrefetchSplits);
+    auto plan = PlanBuilder()
+                    .startTableScan()
+                    .connectorId(kIcebergConnectorId)
+                    .outputType(ROW({"c0"}, {BIGINT()}))
+                    .endTableScan()
+                    .planNode();
+    auto task = assertQuery(plan, splits, duckdbSql, numPrefetchSplits);
 
     auto planStats = toPlanStats(task->taskStats());
 
@@ -258,9 +278,6 @@ class HiveIcebergTest : public HiveConnectorTestBase {
       const std::unordered_map<std::string, std::optional<std::string>>&
           partitionKeys = {},
       const uint32_t splitCount = 1) {
-    std::unordered_map<std::string, std::string> customSplitInfo;
-    customSplitInfo["table_format"] = "hive-iceberg";
-
     auto file = filesystems::getFileSystem(dataFilePath, nullptr)
                     ->openFileForRead(dataFilePath);
     const int64_t fileSize = file->size();
@@ -272,14 +289,14 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     for (int i = 0; i < splitCount; ++i) {
       splits.emplace_back(
           std::make_shared<HiveIcebergSplit>(
-              kHiveConnectorId,
+              kIcebergConnectorId,
               dataFilePath,
               fileFomat_,
               i * splitSize,
               splitSize,
               partitionKeys,
               std::nullopt,
-              customSplitInfo,
+              std::unordered_map<std::string, std::string>{},
               nullptr,
               /*cacheable=*/true,
               deleteFiles));
@@ -340,18 +357,16 @@ class HiveIcebergTest : public HiveConnectorTestBase {
                         ->openFileForRead(path)
                         ->size();
 
-    std::unordered_map<std::string, std::string> customSplitInfo{
-        {"table_format", "hive-iceberg"}};
     std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
     return {std::make_shared<HiveIcebergSplit>(
-        kHiveConnectorId,
+        kIcebergConnectorId,
         path,
         dwio::common::FileFormat::PARQUET,
         0,
         fileSize,
         partitionKeys,
         std::nullopt,
-        customSplitInfo,
+        std::unordered_map<std::string, std::string>{},
         nullptr,
         /*cacheable=*/true,
         std::vector<IcebergDeleteFile>{icebergDeleteFile})};
@@ -786,7 +801,12 @@ TEST_F(HiveIcebergTest, schemaEvolutionRemoveColumn) {
       }));
 
   // Read with new schema (c0 and c2 only, c1 removed).
-  auto plan = PlanBuilder().tableScan(newRowType).planNode();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(newRowType)
+                  .endTableScan()
+                  .planNode();
   AssertQueryBuilder(plan).splits(icebergSplits).assertResults(expectedVectors);
 }
 
@@ -812,8 +832,13 @@ TEST_F(HiveIcebergTest, schemaEvolutionAddColumns) {
   }));
 
   // Read with new schema (c0, c1, and c2).
-  auto plan =
-      PlanBuilder().tableScan(newRowType, {}, "", newRowType).planNode();
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(newRowType)
+                  .dataColumns(newRowType)
+                  .endTableScan()
+                  .planNode();
   AssertQueryBuilder(plan).splits(icebergSplits).assertResults(expectedVectors);
 }
 
@@ -859,7 +884,12 @@ TEST_F(HiveIcebergTest, partitionColumnsFromHive) {
 
   // Read with table schema including partition columns.
   auto plan = PlanBuilder()
-                  .tableScan(tableRowType, {}, "", tableRowType, assignments)
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(tableRowType)
+                  .dataColumns(tableRowType)
+                  .assignments(assignments)
+                  .endTableScan()
                   .planNode();
   AssertQueryBuilder(plan).splits(icebergSplits).assertResults(expectedVectors);
 }
@@ -880,10 +910,15 @@ TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
       deletedPositionSize); // allocate 100 elements, [100, 199].
   std::iota(deletePositionsVec.begin(), deletePositionsVec.end(), 100);
   auto deleteFilePath = TempFilePath::create();
-  HiveConnectorTestBase::assertQuery(
+  assertQuery(
       PlanBuilder()
-          .tableScan(ROW({"id"}, {BIGINT()}), {"id >= 100"})
+          .startTableScan()
+          .connectorId(kIcebergConnectorId)
+          .outputType(ROW({"id"}, {BIGINT()}))
+          .remainingFilter("id >= 100")
+          .endTableScan()
           .planNode(),
+
       createParquetDeleteFileAndSplits(
           path, deletePositionsVec, deletedPositionSize, deleteFilePath),
       "SELECT i AS id FROM range(100, 300) AS t(i)",

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -99,8 +99,6 @@ IcebergSplitReaderBenchmark::makeIcebergSplit(
     const std::string& dataFilePath,
     const std::vector<IcebergDeleteFile>& deleteFiles) {
   std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-  std::unordered_map<std::string, std::string> customSplitInfo;
-  customSplitInfo["table_format"] = "hive-iceberg";
 
   auto readFile = std::make_shared<LocalReadFile>(dataFilePath);
   const int64_t fileSize = readFile->size();
@@ -113,7 +111,7 @@ IcebergSplitReaderBenchmark::makeIcebergSplit(
       fileSize,
       partitionKeys,
       std::nullopt,
-      customSplitInfo,
+      std::unordered_map<std::string, std::string>{},
       nullptr,
       /*cacheable=*/true,
       deleteFiles);

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -277,8 +277,6 @@ IcebergTestBase::extractPartitionKeys(const std::string& filePath) {
 std::vector<std::shared_ptr<ConnectorSplit>>
 IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
   std::vector<std::shared_ptr<ConnectorSplit>> splits;
-  std::unordered_map<std::string, std::string> customSplitInfo;
-  customSplitInfo["table_format"] = "hive-iceberg";
 
   auto files = listFiles(directory);
   for (const auto& filePath : files) {
@@ -295,7 +293,7 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
             file->size(),
             partitionKeys,
             std::nullopt,
-            customSplitInfo,
+            std::unordered_map<std::string, std::string>{},
             nullptr,
             /*cacheable=*/true,
             std::vector<IcebergDeleteFile>()));

--- a/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
@@ -734,8 +734,6 @@ TEST_F(TransformE2ETest, dateIdentityPartitionWithFilter) {
 
   auto partitionDirs = verifyPartitionCount(outputDirectory->getPath(), 2);
 
-  std::unordered_map<std::string, std::string> customSplitInfo{
-      {"table_format", "hive-iceberg"}};
   std::vector<std::shared_ptr<ConnectorSplit>> splits;
 
   for (const auto& dir : partitionDirs) {
@@ -755,7 +753,7 @@ TEST_F(TransformE2ETest, dateIdentityPartitionWithFilter) {
               std::unordered_map<std::string, std::optional<std::string>>{
                   {"c_date", daysSinceEpoch}},
               std::nullopt,
-              customSplitInfo,
+              std::unordered_map<std::string, std::string>{},
               nullptr,
               /*cacheable=*/true,
               std::vector<IcebergDeleteFile>()));


### PR DESCRIPTION
Add IcebergDataSource to support creating IcebergSplitReader instances, and remove the IcebergSplitReader creation logic from the Hive split reader.

IcebergSplitReader is the last remaining Iceberg-specific symbol that Hive depends on. By moving this logic out of Hive, Hive no longer has a dependency on Iceberg. As a result, the Hive CMake configuration can be simplified and cleaned up.
