### PR TITLE
fix: Remove generic overloads from map_except

### DIFF
--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -96,12 +96,6 @@ void registerMapIntersect(const std::string& prefix) {
       Map<Varchar, Generic<T1>>,
       Map<Varchar, Generic<T1>>,
       Array<Varchar>>({prefix + "map_intersect"});
-
-  registerFunction<
-      MapIntersectFunction,
-      Map<Generic<T1>, Generic<T2>>,
-      Map<Generic<T1>, Generic<T2>>,
-      Array<Generic<T1>>>({prefix + "map_intersect"});
 }
 
 template <typename T>
@@ -129,12 +123,6 @@ void registerMapExcept(const std::string& prefix) {
       Map<Varchar, Generic<T1>>,
       Map<Varchar, Generic<T1>>,
       Array<Varchar>>({prefix + "map_except"});
-
-  registerFunction<
-      MapExceptFunction,
-      Map<Generic<T1>, Generic<T2>>,
-      Map<Generic<T1>, Generic<T2>>,
-      Array<Generic<T1>>>({prefix + "map_except"});
 }
 
 template <typename T>

--- a/velox/functions/prestosql/tests/MapExceptTest.cpp
+++ b/velox/functions/prestosql/tests/MapExceptTest.cpp
@@ -13,10 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/tests/utils/FuzzerTestUtils.h"
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox::test;
 
@@ -56,29 +54,6 @@ class MapExceptTest : public test::FunctionBaseTest {
         "{3:null, 4:40, 6:60}",
         "{}",
     });
-    result = evaluate("map_except(c0, c1)", data);
-    assertEqualVectors(expected, result);
-
-    // Case 3: Map with Complex type as key.
-    // Map: { [{1, NaN,3}: 1, {4, 5}: 2], [{NaN, 3}: 3, {1, 2}: 4] }
-    data = makeRowVector({
-        makeMapVector(
-            {0, 2},
-            makeArrayVector<T>({{1, kNaN, 3}, {4, 5}, {kSNaN, 3}, {1, 2}}),
-            makeFlatVector<int32_t>({1, 2, 3, 4})),
-        makeNestedArrayVectorFromJson<T>({
-            "[[1, NaN, 3], [4, 5]]",
-            "[[1, 2, 3], [NaN, 3]]",
-        }),
-    });
-    // Row 0: Exclude [{1, NaN, 3}, {4, 5}] from [{1, NaN, 3}: 1, {4, 5}: 2] →
-    // empty Row 1: Exclude [[1, 2, 3], [NaN, 3]] from [{kSNaN, 3}: 3, {1, 2}:
-    // 4]
-    //        [NaN, 3] matches {kSNaN, 3} (NaN equality), so exclude it
-    //        [1, 2, 3] does NOT match {1, 2}, so keep {1, 2}: 4
-    expected = makeMapVector(
-        {0, 0}, makeArrayVector<T>({{1, 2}}), makeFlatVector<int32_t>({4}));
-
     result = evaluate("map_except(c0, c1)", data);
     assertEqualVectors(expected, result);
   }
@@ -172,179 +147,12 @@ TEST_F(MapExceptTest, varcharKey) {
   assertEqualVectors(expected, result);
 }
 
-TEST_F(MapExceptTest, arrayKey) {
-  auto data = makeRowVector({
-      makeMapVector(
-          {0, 2},
-          makeArrayVectorFromJson<int32_t>({
-              "[1, 2, 3]",
-              "[4, 5]",
-              "[]",
-              "[1, 2]",
-          }),
-          makeFlatVector<std::string>(
-              {"apple", "orange", "Cucurbitaceae", "date"})),
-      makeNestedArrayVectorFromJson<int32_t>({
-          "[[1, 2, 3], [4, 5, 6]]",
-          "[[1, 2, 3], []]",
-      }),
-  });
-
-  auto result = evaluate("map_except(c0, c1)", data);
-
-  auto expected = makeMapVector(
-      {0, 1},
-      makeArrayVectorFromJson<int32_t>({
-          "[4, 5]",
-          "[1, 2]",
-      }),
-      makeFlatVector<std::string>({"orange", "date"}));
-
-  assertEqualVectors(expected, result);
-}
-
-// Verify that complex keys with null descendants are handled gracefully.
-// When comparing two keys that both contain nulls, the comparison returns
-// "indeterminate" which we treat as not equal (consistent with SQL semantics
-// where NULL != NULL).
-TEST_F(MapExceptTest, complexKeyWithNullElements) {
-  // Map with key [1, 2] and exclusion keys [[1, null], [1, null]].
-  // The key [1, 2] does not match [1, null], so it should be kept in the
-  // result.
-  auto data = makeRowVector({
-      makeMapVector(
-          {0},
-          makeArrayVectorFromJson<int32_t>({
-              "[1, 2]",
-          }),
-          makeFlatVector<int32_t>({10})),
-      makeNestedArrayVectorFromJson<int32_t>({
-          "[[1, null], [1, null]]",
-      }),
-  });
-
-  auto result = evaluate("map_except(c0, c1)", data);
-
-  // The key [1, 2] doesn't match [1, null] (null != 2), so it should remain.
-  auto expected = makeMapVector(
-      {0},
-      makeArrayVectorFromJson<int32_t>({
-          "[1, 2]",
-      }),
-      makeFlatVector<int32_t>({10}));
-
-  assertEqualVectors(expected, result);
-
-  // Test case from the bug: the hash set compares two null-containing keys
-  // during collision resolution. Previously this threw an exception due to
-  // inconsistent behavior depending on hash bucket count from previous rows.
-  // Now it should succeed by treating null comparisons as not equal.
-  data = makeRowVector({
-      makeMapVector(
-          {0, 2},
-          makeArrayVectorFromJson<int32_t>({
-              "[1, 2]",
-              "[3, 4]",
-              "[5, 6]",
-              "[7, 8]",
-          }),
-          makeFlatVector<int32_t>({10, 20, 30, 40})),
-      makeNestedArrayVectorFromJson<int32_t>({
-          "[[1, null], [1, null]]",
-          "[[null, 2], [null, 3]]",
-      }),
-  });
-
-  result = evaluate("map_except(c0, c1)", data);
-
-  // Row 0: [1, 2] and [3, 4] don't match [1, null] (different keys).
-  // Row 1: [5, 6] and [7, 8] don't match [null, 2] or [null, 3].
-  expected = makeMapVector(
-      {0, 2},
-      makeArrayVectorFromJson<int32_t>({
-          "[1, 2]",
-          "[3, 4]",
-          "[5, 6]",
-          "[7, 8]",
-      }),
-      makeFlatVector<int32_t>({10, 20, 30, 40}));
-
-  assertEqualVectors(expected, result);
-}
-
 TEST_F(MapExceptTest, floatNaNs) {
   testFloatNaNs<float>();
   testFloatNaNs<double>();
 }
 
-TEST_F(MapExceptTest, timestampWithTimeZone) {
-  const auto keys = makeFlatVector<int64_t>(
-      {pack(1, 1),
-       pack(2, 2),
-       pack(3, 3),
-       pack(4, 4),
-       pack(5, 5),
-       pack(6, 6),
-       pack(1, 7),
-       pack(2, 8),
-       pack(4, 9),
-       pack(5, 10)},
-      TIMESTAMP_WITH_TIME_ZONE());
-  const auto values = makeNullableFlatVector<int32_t>(
-      {10, 20, std::nullopt, 40, 50, 60, 70, 80, 90, 100});
-  const auto maps = makeMapVector({0, 6, 10}, keys, values);
-
-  // For map_except, we want the inverse of map_subset.
-  // Test map with TimestampWithTimeZone keys and constant second arg.
-  // The lookup is [pack(1, 1), pack(3, 2), pack(5, 3)].
-  // These match pack(1, 1), pack(3, 3), pack(5, 5) from the maps.
-  const auto constLookup = BaseVector::wrapInConstant(
-      2,
-      0,
-      makeArrayVector(
-          {0},
-          makeFlatVector<int64_t>(
-              {pack(1, 1), pack(3, 2), pack(5, 3)},
-              TIMESTAMP_WITH_TIME_ZONE())));
-  const auto exceptKeys = makeFlatVector<int64_t>(
-      {pack(2, 2), pack(4, 4), pack(6, 6), pack(2, 8), pack(4, 9)},
-      TIMESTAMP_WITH_TIME_ZONE());
-  const auto exceptValues =
-      makeNullableFlatVector<int32_t>({20, 40, 60, 80, 90});
-  const auto expected = makeMapVector({0, 3, 5}, exceptKeys, exceptValues);
-  auto result =
-      evaluate("map_except(c0, c1)", makeRowVector({maps, constLookup}));
-
-  assertEqualVectors(expected, result);
-
-  // Test map with TimestampWithTimeZone keys and non-constant second arg.
-  const auto lookupKeys = makeFlatVector<int64_t>(
-      {pack(1, 1),
-       pack(3, 3),
-       pack(5, 5),
-       pack(1, 10),
-       pack(3, 12),
-       pack(5, 13),
-       pack(7, 14)},
-      TIMESTAMP_WITH_TIME_ZONE());
-  const auto lookup = makeArrayVector({0, 3, 7}, lookupKeys);
-
-  result = evaluate("map_except(c0, c1)", makeRowVector({maps, lookup}));
-  assertEqualVectors(expected, result);
-
-  // Test map with TimestampWithTimeZone wrapped in a complex type as keys.
-  const auto mapsWithRowKeys =
-      makeMapVector({0, 6, 10}, makeRowVector({keys}), values);
-  const auto lookupWithRowKeys =
-      makeArrayVector({0, 3, 7}, makeRowVector({lookupKeys}));
-  const auto expectedWithRowKeys =
-      makeMapVector({0, 3, 5}, makeRowVector({exceptKeys}), exceptValues);
-
-  result = evaluate(
-      "map_except(c0, c1)",
-      makeRowVector({mapsWithRowKeys, lookupWithRowKeys}));
-  assertEqualVectors(expectedWithRowKeys, result);
-}
+// Custom fuzzer tests
 
 // Custom fuzzer tests to compare map_except with equivalent expression
 // using existing UDFs. The equivalent expression is:

--- a/velox/functions/prestosql/tests/MapIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/MapIntersectTest.cpp
@@ -236,45 +236,6 @@ TEST_F(MapIntersectTest, booleanMap) {
   testMapIntersect("map_intersect(c0, c1)", {inputMap, keys}, expected);
 }
 
-TEST_F(MapIntersectTest, complexValueMap) {
-  // Create value arrays that will be used in the maps
-  auto valueArrays = makeArrayVector<int32_t>({
-      {1, 2}, // value for key [1, 2] in map 0
-      {3, 4, 5}, // value for key [3, 4] in map 0
-      {6}, // value for key [5, 6] in map 1
-      {7, 8, 9, 10}, // value for key [7, 8] in map 1
-  });
-
-  // Create input map with 2 maps:
-  // Map 0: {[1,2] => [1,2], [3,4] => [3,4,5]}
-  // Map 1: {[5,6] => [6], [7,8] => [7,8,9,10]}
-  auto inputMap = makeMapVector(
-      {0, 2, 4},
-      makeArrayVector<int32_t>({{1, 2}, {3, 4}, {5, 6}, {7, 8}}),
-      valueArrays);
-
-  // Keys to filter (array of arrays):
-  // Map 0: keep entries with key [1,2]
-  // Map 1: keep entries with key [5,6]
-  auto keys =
-      makeArrayVector({0, 1, 2}, makeArrayVector<int32_t>({{1, 2}, {5, 6}}));
-
-  // Expected output:
-  // Map 0: {[1,2] => [1,2]}
-  // Map 1: {[5,6] => [6]}
-  auto expectedValueArrays = makeArrayVector<int32_t>({
-      {1, 2}, // value for key [1, 2] in map 0
-      {6}, // value for key [5, 6] in map 1
-  });
-
-  auto expected = makeMapVector(
-      {0, 1, 2},
-      makeArrayVector<int32_t>({{1, 2}, {5, 6}}),
-      expectedValueArrays);
-
-  testMapIntersect("map_intersect(c0, c1)", {inputMap, keys}, expected);
-}
-
 TEST_F(MapIntersectTest, nullArguments) {
   auto inputMap =
       makeMapVector<int32_t, int32_t>({{{1, 10}, {2, 20}, {3, 30}}});


### PR DESCRIPTION
Summary:
The generic overloads `Map<Generic<T1>, Generic<T2>>` for `map_except` and `map_intersect` were causing false positive UPM118 linter errors due to overload ambiguity with the primitive-specific overloads.

When the binder resolves a call like `MAP_EXCEPT(id_list_features, ARRAY[436, 61137788])` where the map has `int32` keys, it finds two matching overloads:
1. `map_except(Mapping[int32?, TypeVar[T0]]?, List[int32?]?)` - primitive overload
2. `map_except(Mapping[TypeVar[T0], TypeVar[T1]]?, List[TypeVar[T0]]?)` - generic overload

This causes "More than one instance of overloaded function matches" errors even though the code works fine at runtime (Velox only registers one overload per primitive type).

Removing the generic overloads eliminates the ambiguity. The primitive overloads (bool, int8-64, float, double, Timestamp, Date) and varchar overload cover all practical use cases. Complex types as map keys are rare and have tricky equality semantics anyway.

Differential Revision: D91916623


