### PR TITLE
feat(operator): Velox MixedUnion support

### DIFF
--- a/velox/core/PlanConsistencyChecker.cpp
+++ b/velox/core/PlanConsistencyChecker.cpp
@@ -139,6 +139,11 @@ class Checker : public PlanNodeVisitor {
     visitSources(&node, ctx);
   }
 
+  void visit(const MixedUnionNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitSources(&node, ctx);
+  }
+
   void visit(const MarkDistinctNode& node, PlanNodeVisitorContext& ctx)
       const override {
     visitSources(&node, ctx);

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3598,6 +3598,7 @@ void PlanNode::registerSerDe() {
   registry.Register("ValuesNode", ValuesNode::create);
   registry.Register("WindowNode", WindowNode::create);
   registry.Register("MarkDistinctNode", MarkDistinctNode::create);
+  registry.Register("MixedUnionNode", MixedUnionNode::create);
   registry.Register(
       "GatherPartitionFunctionSpec", GatherPartitionFunctionSpec::deserialize);
 }
@@ -3845,4 +3846,24 @@ void EqualIndexLookupCondition::validate() const {
       key->type()->toString(),
       value->type()->toString());
 }
+
+void MixedUnionNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+folly::dynamic MixedUnionNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  return obj;
+}
+
+// static
+PlanNodePtr MixedUnionNode::create(const folly::dynamic& obj, void* context) {
+  auto sources = deserializeSources(obj, context);
+
+  return std::make_shared<MixedUnionNode>(
+      deserializePlanNodeId(obj), std::move(sources));
+}
+
 } // namespace facebook::velox::core

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -56,6 +56,7 @@ velox_add_library(
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp
+  MixedUnion.cpp
   NestedLoopJoinBuild.cpp
   NestedLoopJoinProbe.cpp
   SpatialIndex.cpp

--- a/velox/exec/MixedUnion.cpp
+++ b/velox/exec/MixedUnion.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MixedUnion.h"
+#include "velox/exec/OperatorUtils.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+
+MixedUnion::MixedUnion(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::MixedUnionNode>& unionNode)
+    : SourceOperator(
+          driverCtx,
+          unionNode->outputType(),
+          operatorId,
+          unionNode->id(),
+          "MixedUnion"),
+      unionNode_(unionNode),
+      maxOutputBatchRows_(outputBatchRows()),
+      maxOutputBatchBytes_(
+          driverCtx->queryConfig().preferredOutputBatchBytes()) {}
+
+BlockingReason MixedUnion::addMergeSources(ContinueFuture* /* future */) {
+  if (sources_.empty()) {
+    // Get merge sources from the task
+    sources_ = operatorCtx_->task()->getLocalMergeSources(
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+
+    // Initialize tracking vectors
+    const auto numSources = sources_.size();
+    pendingData_.resize(numSources);
+    sourcesFinished_.resize(numSources, false);
+  }
+  return BlockingReason::kNotBlocked;
+}
+
+void MixedUnion::startSources() {
+  if (sourcesStarted_) {
+    return;
+  }
+
+  // Start all sources
+  for (auto& source : sources_) {
+    source->start();
+  }
+  sourcesStarted_ = true;
+}
+
+BlockingReason MixedUnion::isBlocked(ContinueFuture* future) {
+  // Get sources from the task if not already acquired
+  const auto reason = addMergeSources(future);
+  if (reason != BlockingReason::kNotBlocked) {
+    return reason;
+  }
+
+  // If task terminated early with no sources, mark as finished
+  if (sources_.empty()) {
+    finished_ = true;
+    return BlockingReason::kNotBlocked;
+  }
+
+  // Start sources if not already started
+  startSources();
+
+  // Try to fetch data from each source that doesn't have pending data
+  sourceBlockingFutures_.clear();
+  for (size_t i = 0; i < sources_.size(); ++i) {
+    if (sourcesFinished_[i] || pendingData_[i]) {
+      // Source is finished or already has data
+      continue;
+    }
+
+    ContinueFuture sourceFuture;
+    RowVectorPtr data;
+    const auto blockingReason = sources_[i]->next(data, &sourceFuture);
+
+    if (blockingReason != BlockingReason::kNotBlocked) {
+      // Source is blocked, add future to the list
+      sourceBlockingFutures_.push_back(std::move(sourceFuture));
+    } else if (data) {
+      // Got data from this source
+      pendingData_[i] = std::move(data);
+    } else {
+      // Source is finished
+      sourcesFinished_[i] = true;
+    }
+  }
+
+  // If any source is blocked, return a blocking future
+  if (!sourceBlockingFutures_.empty()) {
+    *future = std::move(sourceBlockingFutures_.back());
+    sourceBlockingFutures_.pop_back();
+    return BlockingReason::kWaitForProducer;
+  }
+
+  return BlockingReason::kNotBlocked;
+}
+
+bool MixedUnion::isFinished() {
+  return finished_;
+}
+
+RowVectorPtr MixedUnion::getOutput() {
+  if (finished_) {
+    return nullptr;
+  }
+
+  return getOutputMixed();
+}
+
+RowVectorPtr MixedUnion::getOutputMixed() {
+  // Collect all available data from sources
+  std::vector<RowVectorPtr> validInputs;
+  for (size_t i = 0; i < pendingData_.size(); ++i) {
+    if (pendingData_[i]) {
+      validInputs.push_back(std::move(pendingData_[i]));
+      pendingData_[i] = nullptr;
+    }
+  }
+
+  // If we have no data, check if all sources are finished
+  if (validInputs.empty()) {
+    bool allFinished = true;
+    for (bool isFinished : sourcesFinished_) {
+      if (!isFinished) {
+        allFinished = false;
+        break;
+      }
+    }
+    if (allFinished) {
+      finished_ = true;
+    }
+    return nullptr;
+  }
+
+  // Combine results from all sources
+  return combineResults(validInputs);
+}
+
+RowVectorPtr MixedUnion::combineResults(std::vector<RowVectorPtr>& results) {
+  if (results.empty()) {
+    return nullptr;
+  }
+
+  if (results.size() == 1) {
+    auto result = std::move(results[0]);
+    // Record output statistics
+    {
+      auto lockedStats = stats_.wlock();
+      lockedStats->addOutputVector(result->estimateFlatSize(), result->size());
+    }
+    return result;
+  }
+
+  // Calculate total number of rows
+  vector_size_t totalRows = 0;
+  for (const auto& result : results) {
+    totalRows += result->size();
+  }
+
+  if (totalRows == 0) {
+    return nullptr;
+  }
+
+  // Create combined output vector
+  auto combinedResult =
+      BaseVector::create<RowVector>(outputType_, totalRows, pool());
+
+  // Copy data from all input vectors
+  vector_size_t currentOffset = 0;
+  for (const auto& result : results) {
+    if (result->size() > 0) {
+      for (auto i = 0; i < outputType_->size(); ++i) {
+        // Copy column data
+        std::vector<BaseVector::CopyRange> ranges;
+        ranges.push_back({0, currentOffset, result->size()});
+
+        combinedResult->childAt(i)->copyRanges(
+            result->childAt(i).get(), ranges);
+      }
+      currentOffset += result->size();
+    }
+  }
+
+  // Record output statistics
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addOutputVector(
+        combinedResult->estimateFlatSize(), combinedResult->size());
+  }
+
+  return combinedResult;
+}
+
+bool MixedUnion::hasDataFromAllSources() const {
+  for (size_t i = 0; i < pendingData_.size(); ++i) {
+    // If source is not finished and has no data, we don't have all sources
+    if (!sourcesFinished_[i] && !pendingData_[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void MixedUnion::close() {
+  // Close all sources
+  for (auto& source : sources_) {
+    source->close();
+  }
+  pendingData_.clear();
+  Operator::close();
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MixedUnion.h
+++ b/velox/exec/MixedUnion.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/MergeSource.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+/// Union operator that processes splits from all inputs simultaneously as a
+/// SourceOperator. Unlike traditional operators that receive input via
+/// addInput(), MixedUnion manages multiple MergeSource objects internally,
+/// pulling data from each source and combining results in a round-robin or
+/// interleaved fashion.
+class MixedUnion : public SourceOperator {
+ public:
+  MixedUnion(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::MixedUnionNode>& unionNode);
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
+
+  void close() override;
+
+ private:
+  /// Get merge sources from the task
+  BlockingReason addMergeSources(ContinueFuture* future);
+
+  /// Start reading from sources
+  void startSources();
+
+  /// Process inputs in mixed mode (all at once)
+  RowVectorPtr getOutputMixed();
+
+  /// Combine multiple row vectors into a single output vector
+  RowVectorPtr combineResults(std::vector<RowVectorPtr>& results);
+
+  /// Check if we have data from all active sources for mixed mode
+  bool hasDataFromAllSources() const;
+
+  const std::shared_ptr<const core::MixedUnionNode> unionNode_;
+
+  /// MergeSource objects representing each input pipeline
+  std::vector<std::shared_ptr<MergeSource>> sources_;
+
+  /// Track which sources have been started
+  bool sourcesStarted_{false};
+
+  /// Store pending data from each source
+  std::vector<RowVectorPtr> pendingData_;
+
+  /// Track which sources have finished
+  std::vector<bool> sourcesFinished_;
+
+  /// List of blocking futures for sources
+  std::vector<ContinueFuture> sourceBlockingFutures_;
+
+  /// True when all sources are exhausted
+  bool finished_{false};
+
+  /// Maximum output batch size
+  const vector_size_t maxOutputBatchRows_;
+  const uint64_t maxOutputBatchBytes_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
@@ -177,6 +177,11 @@ class DuckQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
     VELOX_NYI();
   }
 
+  void visit(const core::MixedUnionNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
  private:
   std::unordered_set<std::string> aggregateFunctionNames_;
 };

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
@@ -179,6 +179,11 @@ class PrestoQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
   void visit(const core::WindowNode& node, core::PlanNodeVisitorContext& ctx)
       const override;
 
+  void visit(const core::MixedUnionNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   /// Used to visit custom PlanNodes that extend the set provided by Velox.
   void visit(const core::PlanNode&, core::PlanNodeVisitorContext&)
       const override {

--- a/velox/exec/tests/MixedUnionTest.cpp
+++ b/velox/exec/tests/MixedUnionTest.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class MixedUnionTest : public OperatorTestBase {
+ protected:
+  std::shared_ptr<core::MixedUnionNode> makeUnionNode(
+      std::vector<core::PlanNodePtr> sources,
+      std::shared_ptr<core::PlanNodeIdGenerator> planNodeIdGenerator) {
+    return std::make_shared<core::MixedUnionNode>(
+        planNodeIdGenerator->next(), std::move(sources));
+  }
+};
+
+TEST_F(MixedUnionTest, basicUnion) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<std::string>({"a", "b", "c"}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int32_t>({4, 5, 6}),
+      makeFlatVector<std::string>({"d", "e", "f"}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  assertQuery(
+      CursorParameters{
+          .planNode = unionNode,
+          .maxDrivers = 1,
+      },
+      "VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e'), (6, 'f')");
+}
+
+TEST_F(MixedUnionTest, singleSource) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<std::string>({"a", "b", "c"}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data}).planNode()},
+      planNodeIdGenerator);
+
+  assertQuery(
+      CursorParameters{
+          .planNode = unionNode,
+          .maxDrivers = 1,
+      },
+      "VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+}
+
+TEST_F(MixedUnionTest, emptyFirstSource) {
+  auto emptyData = makeRowVector(
+      {makeFlatVector<int32_t>({}), makeFlatVector<std::string>({})});
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeFlatVector<std::string>({"a", "b"}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({emptyData}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data}).planNode()},
+      planNodeIdGenerator);
+
+  assertQuery(
+      CursorParameters{
+          .planNode = unionNode,
+          .maxDrivers = 1,
+      },
+      "VALUES (1, 'a'), (2, 'b')");
+}
+
+TEST_F(MixedUnionTest, emptyLastSource) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeFlatVector<std::string>({"a", "b"}),
+  });
+  auto emptyData = makeRowVector(
+      {makeFlatVector<int32_t>({}), makeFlatVector<std::string>({})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({emptyData}).planNode()},
+      planNodeIdGenerator);
+
+  assertQuery(
+      CursorParameters{
+          .planNode = unionNode,
+          .maxDrivers = 1,
+      },
+      "VALUES (1, 'a'), (2, 'b')");
+}
+
+TEST_F(MixedUnionTest, allEmptySources) {
+  auto emptyData = makeRowVector(
+      {makeFlatVector<int32_t>({}), makeFlatVector<std::string>({})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({emptyData}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({emptyData}).planNode()},
+      planNodeIdGenerator);
+
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), 0);
+}
+
+TEST_F(MixedUnionTest, multipleInputs) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int32_t>({1}),
+      makeFlatVector<std::string>({"a"}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int32_t>({2}),
+      makeFlatVector<std::string>({"b"}),
+  });
+  auto data3 = makeRowVector({
+      makeFlatVector<int32_t>({3}),
+      makeFlatVector<std::string>({"c"}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data3}).planNode()},
+      planNodeIdGenerator);
+
+  assertQuery(
+      CursorParameters{
+          .planNode = unionNode,
+          .maxDrivers = 1,
+      },
+      "VALUES (1, 'a'), (2, 'b'), (3, 'c')");
+}
+
+TEST_F(MixedUnionTest, manySources) {
+  constexpr int kNumSources = 10;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  std::vector<core::PlanNodePtr> sources;
+  sources.reserve(kNumSources);
+  for (int i = 0; i < kNumSources; ++i) {
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({i}),
+    });
+    sources.push_back(
+        PlanBuilder(planNodeIdGenerator).values({data}).planNode());
+  }
+
+  auto unionNode = makeUnionNode(std::move(sources), planNodeIdGenerator);
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), kNumSources);
+}
+
+TEST_F(MixedUnionTest, unequalSourceSizes) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({6, 7}),
+  });
+  auto data3 = makeRowVector({
+      makeFlatVector<int64_t>({8, 9, 10, 11, 12, 13, 14}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data3}).planNode()},
+      planNodeIdGenerator);
+
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), 14);
+}
+
+TEST_F(MixedUnionTest, multipleBatchesPerSource) {
+  // Test that union correctly handles the case where sources provide data
+  // in a single batch each
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({7, 8, 9, 10, 11, 12}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), 12);
+}
+
+TEST_F(MixedUnionTest, withNulls) {
+  auto data1 = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+      makeNullableFlatVector<std::string>({"a", "b", std::nullopt}),
+  });
+  auto data2 = makeRowVector({
+      makeNullableFlatVector<int64_t>({std::nullopt, 5, 6}),
+      makeNullableFlatVector<std::string>({std::nullopt, "e", "f"}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), 6);
+
+  auto* col0 = result->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_TRUE(col0->isNullAt(1));
+  EXPECT_TRUE(col0->isNullAt(3));
+
+  auto* col1 = result->childAt(1)->asFlatVector<StringView>();
+  EXPECT_TRUE(col1->isNullAt(2));
+  EXPECT_TRUE(col1->isNullAt(3));
+}
+
+TEST_F(MixedUnionTest, variousTypes) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeFlatVector<double>({1.1, 2.2}),
+      makeFlatVector<bool>({true, false}),
+      makeFlatVector<StringView>({"hello", "world"}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({3, 4}),
+      makeFlatVector<double>({3.3, 4.4}),
+      makeFlatVector<bool>({false, true}),
+      makeFlatVector<StringView>({"foo", "bar"}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), 4);
+
+  auto* int64Col = result->childAt(0)->asFlatVector<int64_t>();
+  EXPECT_EQ(int64Col->valueAt(0), 1);
+  EXPECT_EQ(int64Col->valueAt(3), 4);
+
+  auto* doubleCol = result->childAt(1)->asFlatVector<double>();
+  EXPECT_DOUBLE_EQ(doubleCol->valueAt(0), 1.1);
+  EXPECT_DOUBLE_EQ(doubleCol->valueAt(3), 4.4);
+}
+
+TEST_F(MixedUnionTest, largeDataVolume) {
+  constexpr int kRowsPerSource = 1000;
+  constexpr int kNumSources = 3;
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  std::vector<core::PlanNodePtr> sources;
+  sources.reserve(kNumSources);
+
+  for (int s = 0; s < kNumSources; ++s) {
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>(
+            kRowsPerSource, [s](auto row) { return s * 10000 + row; }),
+        makeFlatVector<double>(
+            kRowsPerSource, [](auto row) { return row * 0.1; }),
+    });
+    sources.push_back(
+        PlanBuilder(planNodeIdGenerator).values({data}).planNode());
+  }
+
+  auto unionNode = makeUnionNode(std::move(sources), planNodeIdGenerator);
+  auto result = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(result->size(), kRowsPerSource * kNumSources);
+}
+
+TEST_F(MixedUnionTest, stats) {
+  constexpr int kRowsPerSource = 100;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRowsPerSource, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(
+          kRowsPerSource, [](auto row) { return row + 100; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId unionNodeId;
+  auto unionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+  unionNodeId = unionNode->id();
+
+  auto task = AssertQueryBuilder(unionNode).copyResults(pool());
+  ASSERT_EQ(task->size(), kRowsPerSource * 2);
+}
+
+TEST_F(MixedUnionTest, withFilter) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({6, 7, 8, 9, 10}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .addNode([&](auto, auto) { return unionNode; })
+                  .filter("c0 > 5")
+                  .planNode();
+
+  assertQuery(plan, "VALUES (6), (7), (8), (9), (10)");
+}
+
+TEST_F(MixedUnionTest, withProject) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeFlatVector<int64_t>({10, 20}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({3, 4}),
+      makeFlatVector<int64_t>({30, 40}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .addNode([&](auto, auto) { return unionNode; })
+                  .project({"c0 + c1 as sum"})
+                  .planNode();
+
+  assertQuery(plan, "VALUES (11), (22), (33), (44)");
+}
+
+TEST_F(MixedUnionTest, withAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2}),
+      makeFlatVector<int64_t>({10, 20, 30}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 2}),
+      makeFlatVector<int64_t>({40, 50, 60}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto unionNode = makeUnionNode(
+      {PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+       PlanBuilder(planNodeIdGenerator).values({data2}).planNode()},
+      planNodeIdGenerator);
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .addNode([&](auto, auto) { return unionNode; })
+                  .singleAggregation({"c0"}, {"sum(c1)"})
+                  .planNode();
+
+  assertQuery(plan, "VALUES (1, 70), (2, 140)");
+}

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
@@ -186,6 +186,11 @@ class SparkQueryRunnerToSqlPlanNodeVisitor
       const override {
     VELOX_NYI();
   }
+
+  void visit(const core::MixedUnionNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
 };
 
 } // namespace facebook::velox::functions::sparksql::fuzzer


### PR DESCRIPTION
Summary:
Add a velox mixedUnion operator using MergeSource, and tests for this.

For now this behavior does not support fixed ratios; it's one split at most per each side of the union, and they are merged according to their underlying batch sizes. The mixing behavior and multi-split-per-tag is added later in the stack.

Resolves #16183
Differential Revision: D86714583


