### PR TITLE
fix: Fix replayer crash at cleanup

### DIFF
--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -35,7 +35,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
   void TearDown() override;
 
   void resetHiveConnector(
-      const std::shared_ptr<const config::ConfigBase>& config);
+      const std::shared_ptr<const config::ConfigBase>& config =
+          std::make_shared<config::ConfigBase>(
+              std::unordered_map<std::string, std::string>()));
 
   void writeToFiles(
       const std::vector<std::string>& filePaths,

--- a/velox/tool/trace/TraceReplayRunner.h
+++ b/velox/tool/trace/TraceReplayRunner.h
@@ -47,7 +47,7 @@ namespace facebook::velox::tool::trace {
 class TraceReplayRunner {
  public:
   TraceReplayRunner();
-  virtual ~TraceReplayRunner() = default;
+  virtual ~TraceReplayRunner();
 
   /// Initializes the trace replay runner by setting the velox runtime
   /// environment for the trace replay. It is invoked before run().

--- a/velox/tool/trace/tests/AggregationReplayerTest.cpp
+++ b/velox/tool/trace/tests/AggregationReplayerTest.cpp
@@ -287,6 +287,7 @@ TEST_F(AggregationReplayerTest, hashAggregationTest) {
         runner.init();
         runner.run();
       }
+      resetHiveConnector();
 
       FLAGS_task_id = task->taskId();
       FLAGS_driver_ids = "";
@@ -296,6 +297,7 @@ TEST_F(AggregationReplayerTest, hashAggregationTest) {
         runner.init();
         runner.run();
       }
+      resetHiveConnector();
     }
   }
 }
@@ -354,6 +356,7 @@ TEST_F(AggregationReplayerTest, streamingAggregateTest) {
         runner.init();
         runner.run();
       }
+      resetHiveConnector();
 
       FLAGS_task_id = task->taskId();
       FLAGS_driver_ids = "";
@@ -363,6 +366,7 @@ TEST_F(AggregationReplayerTest, streamingAggregateTest) {
         runner.init();
         runner.run();
       }
+      resetHiveConnector();
     }
   }
 }

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -315,6 +315,7 @@ TEST_F(TableWriterReplayerTest, runner) {
     runner.init();
     runner.run();
   }
+  resetHiveConnector();
 
   const auto traceOutputDir = TempDirectoryPath::create();
   FLAGS_task_id = task->taskId();
@@ -326,6 +327,7 @@ TEST_F(TableWriterReplayerTest, runner) {
     runner.init();
     runner.run();
   }
+  resetHiveConnector();
 }
 
 TEST_F(TableWriterReplayerTest, basic) {


### PR DESCRIPTION
Summary:
### Summary

#### Fixed replayer crash at cleanup

The replayer would crash at cleanup due to connectors not being properly unregistered. This diff fixes the issue by adding an explicit connector unregistration in the `TraceReplayRunner` destructor.

Differential Revision: D91977848


