### PR TITLE
feat: Support mixed index join conditions and filters in HiveIndexReader

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -256,9 +256,8 @@ bool isSpecialColumn(
 
 const std::string& getColumnName(const common::Subfield& subfield) {
   VELOX_CHECK_GT(subfield.path().size(), 0);
-  auto* field = dynamic_cast<const common::Subfield::NestedField*>(
+  auto* field = checkedPointerCast<const common::Subfield::NestedField>(
       subfield.path()[0].get());
-  VELOX_CHECK_NOT_NULL(field);
   return field->name();
 }
 

--- a/velox/connectors/hive/HiveIndexReader.h
+++ b/velox/connectors/hive/HiveIndexReader.h
@@ -100,7 +100,7 @@ class HiveIndexReader {
   // declared before rowReader_.
   std::unique_ptr<dwio::common::RowReader> createRowReader();
 
-  // Initializes indexColumnSpecs_ and requestColumnIndices_ from join
+  // Initializes joinIndexColumnSpecs_ and requestColumnIndices_ from join
   // conditions.
   void initJoinConditions();
 
@@ -139,7 +139,7 @@ class HiveIndexReader {
   const std::vector<core::IndexLookupConditionPtr> joinConditions_;
 
   // Cached ScanSpec children for index columns used in join conditions.
-  std::vector<common::ScanSpec*> indexColumnSpecs_;
+  std::vector<common::ScanSpec*> joinIndexColumnSpecs_;
   // Request column indices for each join condition (for probe side columns).
   // For EqualIndexLookupCondition, stores {valueIndex}.
   // For BetweenIndexLookupCondition, stores {lowerIndex, upperIndex}.
@@ -154,7 +154,7 @@ class HiveIndexReader {
   // Indexed by join condition index and then by column index within that
   // condition (0 for equal condition value, 0/1 for between condition
   // lower/upper).
-  std::vector<std::vector<DecodedVector>> decodedVectors_;
+  std::vector<std::vector<DecodedVector>> decodedRequestVectors_;
 };
 
 } // namespace facebook::velox::connector::hive


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/461

This diff enhances HiveIndexReader to support mixed index join conditions and filters on index columns. The main changes include:

**Lazy index bounds initialization in SelectiveNimbleReader**: Changed `setIndexBounds()` to `maybeSetIndexBounds()` which is called lazily from `nextRowNumber()` instead of during construction. This allows the scan spec to be fully configured before index bounds are computed. Added `hasSetIndexBounds_` flag to track whether bounds have been set for the current scan, which is reset on each `reset()` call.

**Point lookup filter detection in HiveIndexReader**: Added `isPointLookupFilter()` helper function to determine if a filter on an index column is a point lookup (single value equality) or a range filter. This is important because:
   - Point lookup filters on index columns allow subsequent join conditions to be processed
   - Range filters cause the join condition processing to break, as range scans cannot be followed by additional index column conditions

**Join condition validation**: Added validation in `initJoinConditions()` to ensure all join conditions are processed. If a range filter on an index column causes early termination, the check ensures proper error reporting.

Differential Revision: D91662372


