### PR TITLE
feat: Add IPADDRESS support to Arbitrary aggregate function

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -19,6 +19,7 @@
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
+#include "velox/functions/prestosql/types/IPAddressType.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -453,7 +454,7 @@ void registerArbitraryAggregate(
           case TypeKind::BIGINT:
             return std::make_unique<ArbitraryAggregate<int64_t>>(inputType);
           case TypeKind::HUGEINT:
-            if (inputType->isLongDecimal()) {
+            if (inputType->isLongDecimal() || isIPAddressType(inputType)) {
               return std::make_unique<ArbitraryAggregate<int128_t>>(inputType);
             }
             VELOX_NYI();


### PR DESCRIPTION
Summary:
The arbitrary() aggregate function was throwing NOT_IMPLEMENTED when used
with IPADDRESS type. This was caught by the aggregation fuzzer.

This change adds a check for isIPAddressType() for HUGEINT type in
ArbitraryAggregate, allowing IPADDRESS values to be properly handled.

Differential Revision: D92026533


