### PR TITLE
feat: Extend PlanConsistencyChecker to check for duplicate names in the output of NLJ

### DIFF
--- a/velox/core/PlanConsistencyChecker.cpp
+++ b/velox/core/PlanConsistencyChecker.cpp
@@ -163,6 +163,8 @@ class Checker : public PlanNodeVisitor {
       checkInputs(node.joinCondition(), rowType);
     }
 
+    verifyOutputNames(node);
+
     visitSources(&node, ctx);
   }
 


### PR DESCRIPTION
Summary: Extended PlanConsistencyChecker to verify that NestedLoopJoinNode doesn't have duplicate output column names, similar to checks that exist for other plan nodes.

Differential Revision: D92046090


