### PR TITLE
feat: Add async data cache lock contention stats

### DIFF
--- a/velox/common/base/Counters.cpp
+++ b/velox/common/base/Counters.cpp
@@ -196,6 +196,16 @@ void registerVeloxMetrics() {
   DEFINE_METRIC(
       kMetricMemoryCacheNumAllocClocks, facebook::velox::StatType::SUM);
 
+  // Clocks spent waiting to acquire shard mutexes, since last counter retrieval
+  DEFINE_METRIC(
+      kMetricMemoryCacheNumShardMutexWaitClocks,
+      facebook::velox::StatType::SUM);
+
+  // Time in milliseconds spent waiting to acquire shard mutexes, since last
+  // counter retrieval. Converted from raw clocks assuming ~3GHz CPU frequency.
+  DEFINE_METRIC(
+      kMetricMemoryCacheShardMutexWaitTimeMs, facebook::velox::StatType::SUM);
+
   // Number of AsyncDataCache entries that are aged out and evicted
   // given configured TTL.
   DEFINE_METRIC(

--- a/velox/common/base/Counters.h
+++ b/velox/common/base/Counters.h
@@ -244,6 +244,14 @@ constexpr std::string_view kMetricMemoryCacheNumWaitExclusive{
 constexpr std::string_view kMetricMemoryCacheNumAllocClocks{
     "velox.memory_cache_num_alloc_clocks"};
 
+constexpr std::string_view kMetricMemoryCacheNumShardMutexWaitClocks{
+    "velox.memory_cache_num_shard_mutex_wait_clocks"};
+
+/// Cumulative time in milliseconds spent waiting to acquire shard mutexes.
+/// Converted from raw clocks assuming ~3GHz CPU frequency.
+constexpr std::string_view kMetricMemoryCacheShardMutexWaitTimeMs{
+    "velox.memory_cache_shard_mutex_wait_time_ms"};
+
 constexpr std::string_view kMetricMemoryCacheNumAgedOutEntries{
     "velox.memory_cache_num_aged_out_entries"};
 

--- a/velox/common/base/PeriodicStatsReporter.cpp
+++ b/velox/common/base/PeriodicStatsReporter.cpp
@@ -175,6 +175,14 @@ void PeriodicStatsReporter::reportCacheStats() {
   REPORT_IF_NOT_ZERO(
       kMetricMemoryCacheNumAllocClocks, deltaCacheStats.allocClocks);
   REPORT_IF_NOT_ZERO(
+      kMetricMemoryCacheNumShardMutexWaitClocks,
+      deltaCacheStats.shardMutexWaitClocks);
+  // Convert clocks to milliseconds assuming ~3GHz CPU frequency.
+  // 3GHz = 3,000,000 clocks per millisecond.
+  REPORT_IF_NOT_ZERO(
+      kMetricMemoryCacheShardMutexWaitTimeMs,
+      deltaCacheStats.shardMutexWaitClocks / 3000000);
+  REPORT_IF_NOT_ZERO(
       kMetricMemoryCacheNumAgedOutEntries, deltaCacheStats.numAgedOut);
   REPORT_IF_NOT_ZERO(
       kMetricMemoryCacheSumEvictScore, deltaCacheStats.sumEvictScore);

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -475,6 +475,13 @@ TEST_F(PeriodicStatsReporterTest, basic) {
     ASSERT_EQ(
         counterMap.count(std::string(kMetricMemoryCacheNumAllocClocks)), 0);
     ASSERT_EQ(
+        counterMap.count(
+            std::string(kMetricMemoryCacheNumShardMutexWaitClocks)),
+        0);
+    ASSERT_EQ(
+        counterMap.count(std::string(kMetricMemoryCacheShardMutexWaitTimeMs)),
+        0);
+    ASSERT_EQ(
         counterMap.count(std::string(kMetricMemoryCacheNumAgedOutEntries)), 0);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricMemoryCacheSumEvictScore)), 0);
@@ -552,6 +559,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
        .numAgedOut = 10,
        .allocClocks = 10,
        .sumEvictScore = 10,
+       .shardMutexWaitClocks = 10,
        .ssdStats = newSsdStats});
   arbitrator.updateStats(
       memory::MemoryArbitrator::Stats(
@@ -577,6 +585,10 @@ TEST_F(PeriodicStatsReporterTest, basic) {
         counterMap.count(std::string(kMetricMemoryCacheNumWaitExclusive)), 1);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricMemoryCacheNumAllocClocks)), 1);
+    ASSERT_EQ(
+        counterMap.count(
+            std::string(kMetricMemoryCacheNumShardMutexWaitClocks)),
+        1);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricMemoryCacheNumAgedOutEntries)), 1);
     ASSERT_EQ(
@@ -614,7 +626,7 @@ TEST_F(PeriodicStatsReporterTest, basic) {
         counterMap.count(std::string(kMetricSsdCacheRecoveredEntries)), 1);
     ASSERT_EQ(
         counterMap.count(std::string(kMetricSsdCacheReadWithoutChecksum)), 1);
-    ASSERT_EQ(counterMap.size(), 58);
+    ASSERT_EQ(counterMap.size(), 59);
   }
 }
 

--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -35,6 +35,21 @@
 
 namespace facebook::velox::cache {
 
+namespace {
+// Helper that uses ClockTimer to measure the lock acquisition time.
+class TimedLockGuard {
+ public:
+  TimedLockGuard(std::mutex& mutex, std::atomic<uint64_t>& waitClocks)
+      : lock_(mutex, std::defer_lock) {
+    ClockTimer timer(waitClocks);
+    lock_.lock();
+  }
+
+ private:
+  std::unique_lock<std::mutex> lock_;
+};
+} // namespace
+
 using memory::MachinePageCount;
 using memory::MemoryAllocator;
 
@@ -168,7 +183,7 @@ CachePin CacheShard::findOrCreate(
     folly::SemiFuture<bool>* wait) {
   AsyncDataCacheEntry* entryToInit = nullptr;
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    TimedLockGuard l(mutex_, shardMutexWaitClocks_);
     ++eventCounter_;
     auto it = entryMap_.find(key);
     if (it != entryMap_.end()) {
@@ -235,7 +250,7 @@ CachePin CacheShard::findOrCreate(
 }
 
 void CacheShard::makeEvictable(RawFileCacheKey key) {
-  std::lock_guard<std::mutex> l(mutex_);
+  TimedLockGuard l(mutex_, shardMutexWaitClocks_);
   auto it = entryMap_.find(key);
   if (it == entryMap_.end()) {
     return;
@@ -244,7 +259,7 @@ void CacheShard::makeEvictable(RawFileCacheKey key) {
 }
 
 bool CacheShard::exists(RawFileCacheKey key) const {
-  std::lock_guard<std::mutex> l(mutex_);
+  TimedLockGuard l(mutex_, shardMutexWaitClocks_);
   auto it = entryMap_.find(key);
   if (it != entryMap_.end()) {
     it->second->touch();
@@ -336,7 +351,7 @@ void CoalescedLoad::setEndState(State endState) {
 
 std::unique_ptr<folly::SharedPromise<bool>> CacheShard::removeEntry(
     AsyncDataCacheEntry* entry) {
-  std::lock_guard<std::mutex> l(mutex_);
+  TimedLockGuard l(mutex_, shardMutexWaitClocks_);
   removeEntryLocked(entry);
   // After the entry is removed from the hash table, a promise can no longer
   // be made. It is safe to move the promise and realize it.
@@ -384,7 +399,7 @@ uint64_t CacheShard::evict(
   int64_t largeEvicted = 0;
   int32_t evictSaveableSkipped = 0;
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    TimedLockGuard l(mutex_, shardMutexWaitClocks_);
     const size_t size = entries_.size();
     if (size == 0) {
       return 0;
@@ -518,7 +533,7 @@ void CacheShard::calibrateThresholdLocked() {
 }
 
 void CacheShard::updateStats(CacheStats& stats) {
-  std::lock_guard<std::mutex> l(mutex_);
+  TimedLockGuard l(mutex_, shardMutexWaitClocks_);
   for (auto& entry : entries_) {
     if (!entry) {
       ++stats.numEmptyEntries;
@@ -573,10 +588,11 @@ void CacheShard::updateStats(CacheStats& stats) {
   stats.numStales += numStales_;
   stats.sumEvictScore += sumEvictScore_;
   stats.allocClocks += allocClocks_;
+  stats.shardMutexWaitClocks += shardMutexWaitClocks_;
 }
 
 void CacheShard::appendSsdSaveable(bool saveAll, std::vector<CachePin>& pins) {
-  std::lock_guard<std::mutex> l(mutex_);
+  TimedLockGuard l(mutex_, shardMutexWaitClocks_);
   // Do not add entries to a write batch more than maxWriteRatio_. If SSD save
   // is slower than storage read, we must not have a situation where SSD save
   // pins everything and stops reading.
@@ -612,7 +628,7 @@ bool CacheShard::removeFileEntries(
   int64_t pagesRemoved = 0;
   std::vector<memory::Allocation> toFree;
   {
-    std::lock_guard<std::mutex> l(mutex_);
+    TimedLockGuard l(mutex_, shardMutexWaitClocks_);
 
     auto entryIndex = -1;
     for (auto& cacheEntry : entries_) {
@@ -662,6 +678,8 @@ CacheStats CacheStats::operator-(const CacheStats& other) const {
   result.numStales = numStales - other.numStales;
   result.allocClocks = allocClocks - other.allocClocks;
   result.sumEvictScore = sumEvictScore - other.sumEvictScore;
+  result.shardMutexWaitClocks =
+      shardMutexWaitClocks - other.shardMutexWaitClocks;
   if (ssdStats != nullptr) {
     if (other.ssdStats != nullptr) {
       result.ssdStats =
@@ -1042,7 +1060,8 @@ std::string CacheStats::toString() const {
       << " bytes: " << succinctBytes(prefetchBytes)
       << "\n"
       // Cache timing stats.
-      << "Alloc Megaclocks " << (allocClocks >> 20);
+      << "Alloc Megaclocks " << (allocClocks >> 20)
+      << " Shard mutex wait Megaclocks: " << (shardMutexWaitClocks >> 20);
   return out.str();
 }
 

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -34,6 +34,7 @@
 #include "velox/common/file/File.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryAllocator.h"
+#include "velox/common/time/Timer.h"
 
 namespace facebook::velox::cache {
 
@@ -544,6 +545,8 @@ struct CacheStats {
   /// Sum of scores of evicted entries. This serves to infer an average
   /// lifetime for entries in cache.
   int64_t sumEvictScore{0};
+  /// Cumulative clocks spent waiting to acquire shard mutexes.
+  uint64_t shardMutexWaitClocks{0};
 
   /// Ssd cache stats that include both snapshot and cumulative stats.
   std::shared_ptr<SsdCacheStats> ssdStats = nullptr;
@@ -697,6 +700,9 @@ class CacheShard {
   // Tracker of cumulative time spent in allocating/freeing MemoryAllocator
   // space for backing cached data.
   std::atomic<uint64_t> allocClocks_{0};
+  // Tracker of cumulative clocks spent waiting to acquire shard mutex.
+  // Mutable to allow updating from const methods like exists().
+  mutable std::atomic<uint64_t> shardMutexWaitClocks_{0};
 
   friend class test::CacheShardTestHelper;
 };

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -943,6 +943,7 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
   stats.allocClocks = 1320;
   stats.sumEvictScore = 123;
   stats.numStales = 100;
+  stats.shardMutexWaitClocks = 1320;
   ASSERT_EQ(
       stats.toString(),
       "Cache size: 2.56KB tinySize: 257B large size: 2.31KB\n"
@@ -950,7 +951,7 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
       " num write wait: 244 empty entries: 20\n"
       "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 savable eviction: 0 eviction checks: 348 aged out: 10 stales: 100\n"
       "Prefetch entries: 30 bytes: 100B\n"
-      "Alloc Megaclocks 0");
+      "Alloc Megaclocks 0 Shard mutex wait Megaclocks: 0");
 
   CacheStats statsDelta = stats - stats;
   ASSERT_EQ(statsDelta.tinySize, 0);
@@ -975,6 +976,7 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
   ASSERT_EQ(statsDelta.allocClocks, 0);
   ASSERT_EQ(statsDelta.sumEvictScore, 0);
   ASSERT_EQ(statsDelta.numStales, 0);
+  ASSERT_EQ(statsDelta.shardMutexWaitClocks, 0);
 
   constexpr uint64_t kRamBytes = 32 << 20;
   constexpr uint64_t kSsdBytes = 512UL << 20;
@@ -986,7 +988,7 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
       " num write wait: 0 empty entries: 0\n"
       "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 savable eviction: 0 eviction checks: 0 aged out: 0 stales: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
-      "Alloc Megaclocks 0\n"
+      "Alloc Megaclocks 0 Shard mutex wait Megaclocks: 0\n"
       "Allocated pages: 0 cached pages: 0\n"
       "Backing: Memory Allocator[MMAP total capacity 64.00MB free capacity 64.00MB allocated pages 0 mapped pages 0 external mapped pages 0\n"
       "[size 1: 0(0MB) allocated 0 mapped]\n"
@@ -1010,7 +1012,7 @@ TEST_P(AsyncDataCacheTest, cacheStats) {
       " num write wait: 0 empty entries: 0\n"
       "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 savable eviction: 0 eviction checks: 0 aged out: 0 stales: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
-      "Alloc Megaclocks 0\n"
+      "Alloc Megaclocks 0 Shard mutex wait Megaclocks: 0\n"
       "Allocated pages: 0 cached pages: 0\n";
   ASSERT_EQ(cache_->toString(false), expectedShortCacheOutput);
 }
@@ -1031,7 +1033,7 @@ TEST_P(AsyncDataCacheTest, cacheStatsWithSsd) {
   ASSERT_EQ(deltaStats.ssdStats->bytesWritten, 1);
   ASSERT_EQ(deltaStats.ssdStats->bytesRead, 1);
   const std::string expectedDeltaCacheStats =
-      "Cache size: 0B tinySize: 0B large size: 0B\nCache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n num write wait: 0 empty entries: 0\nCache access miss: 0 hit: 234 hit bytes: 0B eviction: 1024 savable eviction: 0 eviction checks: 0 aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0";
+      "Cache size: 0B tinySize: 0B large size: 0B\nCache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n num write wait: 0 empty entries: 0\nCache access miss: 0 hit: 234 hit bytes: 0B eviction: 1024 savable eviction: 0 eviction checks: 0 aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0 Shard mutex wait Megaclocks: 0";
   ASSERT_EQ(deltaStats.toString(), expectedDeltaCacheStats);
 }
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -770,7 +770,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n "
                     "num write wait: 0 empty entries: 0\nCache access miss: 0 "
                     "hit: 0 hit bytes: 0B eviction: 0 savable eviction: 0 eviction checks: 0 "
-                    "aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\n"
+                    "aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0 Shard mutex wait Megaclocks: 0\n"
                     "Allocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
@@ -805,7 +805,7 @@ TEST_P(MemoryPoolTest, memoryCapExceptions) {
                     "exclusive: 0B\n num write wait: 0 empty entries: 0\nCache "
                     "access miss: 0 hit: 0 hit bytes: 0B eviction: 0 savable eviction: 0 eviction "
                     "checks: 0 aged out: 0 stales: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
-                    " 0\nAllocated pages: 0 cached pages: 0\n",
+                    " 0 Shard mutex wait Megaclocks: 0\nAllocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
           } else {


### PR DESCRIPTION
Summary:
New metrics added to monitor time spent waiting for shard mutexes:

- `kMetricMemoryCacheNumShardMutexWaitClocks`: Total clocks waiting for shard mutexes.
- `kMetricMemoryCacheShardMutexWaitTimeMs`: Milliseconds waited, based on ~3GHz CPU.

Differential Revision: D92068037


