### PR TITLE
fix: Increase base machine for ubuntu resolve dependencies

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -222,7 +222,7 @@ jobs:
           python ./scripts/checks/run-clang-tidy.py -p $BUILD_PATH --commit $RANGE $FILES
 
   ubuntu-debug:
-    runs-on: 8-core-ubuntu-22.04
+    runs-on: 16-core-ubuntu
     # prevent errors when forks ff their main branch
     if: ${{ github.repository == 'facebookincubator/velox' }}
     name: Ubuntu debug with resolve_dependency
@@ -263,7 +263,7 @@ jobs:
         env:
           VELOX_DEPENDENCY_SOURCE: BUNDLED
           ICU_SOURCE: SYSTEM
-          MAKEFLAGS: NUM_THREADS=8 MAX_HIGH_MEM_JOBS=2 MAX_LINK_JOBS=2
+          MAKEFLAGS: NUM_THREADS=16 MAX_HIGH_MEM_JOBS=4 MAX_LINK_JOBS=2
         run: |
           EXTRA_CMAKE_FLAGS=(
             "-DCMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY"


### PR DESCRIPTION
Summary:
We are currently seeing OOM's when building presto_sql_test (See issue : 16202) .
There are several ways to fix this,
* Get beefier machines (More costly on our CI Budget)
* Refactor presto_sql_tests (Based on some cmake commands I ran it ends up pulling 70+ libraries (velox and others) to build)

Giving this build a beefier machine now to unblock while we investigate refactoring the tests to reduce memory consumption.

Differential Revision: D92075908


