### PR TITLE
fix: Use probe side column name for input column type and update SS check usage

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -310,7 +310,7 @@ void IndexLookupJoin::initLookupInput() {
           indexKeyType->toString(),
           probeKeyType->toString());
       addLookupInputColumn(
-          indexKeyName,
+          probeKeyName,
           probeKeyType,
           probeKeyChannel,
           lookupInputNames,


### PR DESCRIPTION
Summary:
Fix a bug in `IndexLookupJoin.cpp` where the lookup input column was incorrectly using `indexKeyName` instead of `probeKeyName`

Replaces all `VELOX_CHECK*` macros with their `SS_CHECK*` equivalents in `SequenceStorageIndexSource.cpp` to use the Sequence Storage-specific exception handling macros for better error categorization and consistency.

Differential Revision: D92024520


