### PR TITLE
feat: Support unknown in coerceTypeBase

### DIFF
--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -50,6 +50,16 @@ allowedCoercions() {
   add(BIGINT(), {DOUBLE()});
   add(REAL(), {DOUBLE()});
   add(DATE(), {TIMESTAMP()});
+  add(UNKNOWN(),
+      {TINYINT(),
+       BOOLEAN(),
+       SMALLINT(),
+       INTEGER(),
+       BIGINT(),
+       REAL(),
+       DOUBLE(),
+       VARCHAR(),
+       VARBINARY()});
 
   return coercions;
 }

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -64,6 +64,19 @@ TEST(TypeCoercerTest, unknown) {
   ASSERT_TRUE(TypeCoercer::coercible(UNKNOWN(), ARRAY(INTEGER())));
 }
 
+TEST(TypeCoercerTest, coerceTypeBaseFromUnknown) {
+  // Test coercion from UNKNOWN to various types.
+  testCoercion(UNKNOWN(), TINYINT());
+  testCoercion(UNKNOWN(), BOOLEAN());
+  testCoercion(UNKNOWN(), SMALLINT());
+  testCoercion(UNKNOWN(), INTEGER());
+  testCoercion(UNKNOWN(), BIGINT());
+  testCoercion(UNKNOWN(), REAL());
+  testCoercion(UNKNOWN(), DOUBLE());
+  testCoercion(UNKNOWN(), VARCHAR());
+  testCoercion(UNKNOWN(), VARBINARY());
+}
+
 TEST(TypeCoercerTest, noCost) {
   auto assertNoCost = [](const TypePtr& type) {
     SCOPED_TRACE(type->toString());


### PR DESCRIPTION
Summary: Add support for UNKNOWN type coercion in coerceTypeBase. When the source type is UNKNOWN, it can be coerced to following types TINYINT(), BOOLEAN(), SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE(), VARCHAR(), VARBINARY(). Cost of the coercion is higher according to the list order.

Differential Revision: D92099013


