### PR TITLE
fix: Use folly:hasher instead of std::hash

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/core/Expressions.h"
+#include <folly/hash/Hash.h>
 #include "velox/common/Casts.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/vector/ComplexVector.h"
@@ -424,7 +425,8 @@ uint64_t hashImpl(const TypePtr& type, const Variant& value) {
 } // namespace
 
 size_t ConstantTypedExpr::localHash() const {
-  static const size_t kBaseHash = std::hash<const char*>()("ConstantTypedExpr");
+  static const size_t kBaseHash =
+      folly::hasher<std::string_view>()("ConstantTypedExpr");
 
   uint64_t h;
 

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/hash/Hash.h>
+
 #include "velox/common/Casts.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/ITypedExpr.h"
@@ -36,7 +38,8 @@ class InputTypedExpr : public ITypedExpr {
   }
 
   size_t localHash() const override {
-    static const size_t kBaseHash = std::hash<const char*>()("InputTypedExpr");
+    static const size_t kBaseHash =
+        folly::hasher<std::string_view>()("InputTypedExpr");
     return kBaseHash;
   }
 
@@ -226,8 +229,9 @@ class CallTypedExpr : public ITypedExpr {
   std::string toString() const override;
 
   size_t localHash() const override {
-    static const size_t kBaseHash = std::hash<const char*>()("CallTypedExpr");
-    return bits::hashMix(kBaseHash, std::hash<std::string>()(name_));
+    static const size_t kBaseHash =
+        folly::hasher<std::string_view>()("CallTypedExpr");
+    return bits::hashMix(kBaseHash, folly::hasher<std::string>()(name_));
   }
 
   void accept(
@@ -295,8 +299,8 @@ class FieldAccessTypedExpr : public ITypedExpr {
 
   size_t localHash() const override {
     static const size_t kBaseHash =
-        std::hash<const char*>()("FieldAccessTypedExpr");
-    return bits::hashMix(kBaseHash, std::hash<std::string>()(name_));
+        folly::hasher<std::string_view>()("FieldAccessTypedExpr");
+    return bits::hashMix(kBaseHash, folly::hasher<std::string>()(name_));
   }
 
   void accept(
@@ -378,7 +382,7 @@ class DereferenceTypedExpr : public ITypedExpr {
 
   size_t localHash() const override {
     static const size_t kBaseHash =
-        std::hash<const char*>()("DereferenceTypedExpr");
+        folly::hasher<std::string_view>()("DereferenceTypedExpr");
     return bits::hashMix(kBaseHash, index_);
   }
 
@@ -433,7 +437,8 @@ class ConcatTypedExpr : public ITypedExpr {
   std::string toString() const override;
 
   size_t localHash() const override {
-    static const size_t kBaseHash = std::hash<const char*>()("ConcatTypedExpr");
+    static const size_t kBaseHash =
+        folly::hasher<std::string_view>()("ConcatTypedExpr");
     return kBaseHash;
   }
 
@@ -497,7 +502,8 @@ class LambdaTypedExpr : public ITypedExpr {
   }
 
   size_t localHash() const override {
-    static const size_t kBaseHash = std::hash<const char*>()("LambdaTypedExpr");
+    static const size_t kBaseHash =
+        folly::hasher<std::string_view>()("LambdaTypedExpr");
     return bits::hashMix(kBaseHash, body_->hash());
   }
 
@@ -561,8 +567,9 @@ class CastTypedExpr : public ITypedExpr {
   std::string toString() const override;
 
   size_t localHash() const override {
-    static const size_t kBaseHash = std::hash<const char*>()("CastTypedExpr");
-    return bits::hashMix(kBaseHash, std::hash<bool>()(isTryCast_));
+    static const size_t kBaseHash =
+        folly::hasher<std::string_view>()("CastTypedExpr");
+    return bits::hashMix(kBaseHash, folly::hasher<bool>()(isTryCast_));
   }
 
   void accept(

--- a/velox/core/tests/TypedExprHashConsistencyTest.cpp
+++ b/velox/core/tests/TypedExprHashConsistencyTest.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/Expressions.h"
+#include "velox/type/Variant.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::core::test {
+
+/// This test verifies that hash() functions of ITypedExpr classes are
+/// deterministic across different processes and machines.
+///
+/// For cross-process/cross-machine consistency, the hash function must:
+/// 1. Be deterministic (same input -> same output)
+/// 2. Not depend on memory addresses or pointers
+/// 3. Not depend on process-specific state (PIDs, random seeds, etc.)
+///
+/// These tests use hardcoded expected hash values to verify that the hash
+/// values remain stable across different processes and machines. If these
+/// tests fail, it indicates that the hash values have changed, which may
+/// break systems that rely on hash consistency (e.g., distributed caching,
+/// query plan comparison across nodes).
+class TypedExprHashConsistencyTest : public ::testing::Test,
+                                     public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool();
+  }
+
+  // Helper to create a ConstantTypedExpr from a variant
+  std::shared_ptr<ConstantTypedExpr> makeConstantExpr(
+      const TypePtr& type,
+      const Variant& value) {
+    return std::make_shared<ConstantTypedExpr>(type, value);
+  }
+
+  // Helper to create a null ConstantTypedExpr
+  std::shared_ptr<ConstantTypedExpr> makeNullConstantExpr(const TypePtr& type) {
+    return std::make_shared<ConstantTypedExpr>(
+        type, variant::null(type->kind()));
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(TypedExprHashConsistencyTest, inputTypedExpr) {
+  auto expr = std::make_shared<InputTypedExpr>(INTEGER());
+  EXPECT_EQ(expr->hash(), 4049903845529765328ULL)
+      << "InputTypedExpr hash changed. Actual: " << expr->hash();
+
+  auto expr2 = std::make_shared<InputTypedExpr>(VARCHAR());
+  EXPECT_EQ(expr2->hash(), 4643169249201813153ULL)
+      << "InputTypedExpr(VARCHAR) hash changed. Actual: " << expr2->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, constantTypedExpr) {
+  // Boolean
+  auto boolExpr = makeConstantExpr(BOOLEAN(), variant(true));
+  EXPECT_EQ(boolExpr->hash(), 8856849273132034487ULL)
+      << "BOOLEAN(true) hash changed. Actual: " << boolExpr->hash();
+
+  // Integer
+  auto intExpr = makeConstantExpr(INTEGER(), variant(int32_t(42)));
+  EXPECT_EQ(intExpr->hash(), 18252912680933339002ULL)
+      << "INTEGER(42) hash changed. Actual: " << intExpr->hash();
+
+  // Null BIGINT
+  auto nullExpr = makeNullConstantExpr(BIGINT());
+  EXPECT_EQ(nullExpr->hash(), 13436946328467595667ULL)
+      << "BIGINT(null) hash changed. Actual: " << nullExpr->hash();
+
+  // String
+  auto strExpr = makeConstantExpr(VARCHAR(), variant("hello"));
+  EXPECT_EQ(strExpr->hash(), 14416578975068601291ULL)
+      << "VARCHAR(hello) hash changed. Actual: " << strExpr->hash();
+
+  // Double
+  auto doubleExpr = makeConstantExpr(DOUBLE(), variant(3.14159));
+  EXPECT_EQ(doubleExpr->hash(), 12939170893996246636ULL)
+      << "DOUBLE hash changed. Actual: " << doubleExpr->hash();
+
+  // Array
+  auto arrayExpr =
+      makeConstantExpr(ARRAY(INTEGER()), Variant::array({1, 2, 3}));
+  EXPECT_EQ(arrayExpr->hash(), 9490324506690155522ULL)
+      << "ARRAY hash changed. Actual: " << arrayExpr->hash();
+
+  // Row
+  auto rowType = ROW({{"a", INTEGER()}, {"b", VARCHAR()}});
+  auto rowExpr = makeConstantExpr(rowType, Variant::row({42, "hello"}));
+  EXPECT_EQ(rowExpr->hash(), 3198785565592166050ULL)
+      << "ROW hash changed. Actual: " << rowExpr->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, callTypedExpr) {
+  auto expr = std::make_shared<CallTypedExpr>(
+      BIGINT(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a")},
+      "plus");
+  EXPECT_EQ(expr->hash(), 9673001606852849486ULL)
+      << "CallTypedExpr hash changed. Actual: " << expr->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, fieldAccessTypedExpr) {
+  auto expr = std::make_shared<FieldAccessTypedExpr>(BIGINT(), "column_a");
+  EXPECT_EQ(expr->hash(), 11777945155662407419ULL)
+      << "FieldAccessTypedExpr hash changed. Actual: " << expr->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, dereferenceTypedExpr) {
+  auto expr = std::make_shared<DereferenceTypedExpr>(
+      VARCHAR(),
+      std::make_shared<FieldAccessTypedExpr>(
+          ROW({"a", "b"}, {VARCHAR(), BOOLEAN()}), "ab"),
+      0);
+  EXPECT_EQ(expr->hash(), 13224256824664123067ULL)
+      << "DereferenceTypedExpr hash changed. Actual: " << expr->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, castTypedExpr) {
+  // CAST
+  auto expr = std::make_shared<CastTypedExpr>(
+      VARCHAR(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(INTEGER(), "x")},
+      false);
+  EXPECT_EQ(expr->hash(), 10329268476666944746ULL)
+      << "CastTypedExpr hash changed. Actual: " << expr->hash();
+
+  // TRY_CAST
+  auto tryCastExpr = std::make_shared<CastTypedExpr>(
+      VARCHAR(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(INTEGER(), "x")},
+      true);
+  EXPECT_EQ(tryCastExpr->hash(), 3445540181233255608ULL)
+      << "CastTypedExpr(try) hash changed. Actual: " << tryCastExpr->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, concatTypedExpr) {
+  auto expr = std::make_shared<ConcatTypedExpr>(
+      std::vector<std::string>{"a", "b"},
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(INTEGER(), "x"),
+          std::make_shared<FieldAccessTypedExpr>(VARCHAR(), "y")});
+  EXPECT_EQ(expr->hash(), 17944415127129017832ULL)
+      << "ConcatTypedExpr hash changed. Actual: " << expr->hash();
+}
+
+TEST_F(TypedExprHashConsistencyTest, lambdaTypedExpr) {
+  auto signature = ROW({"x"}, {INTEGER()});
+  auto body = std::make_shared<FieldAccessTypedExpr>(INTEGER(), "x");
+  auto expr = std::make_shared<LambdaTypedExpr>(signature, body);
+  EXPECT_EQ(expr->hash(), 9214329465187572972ULL)
+      << "LambdaTypedExpr hash changed. Actual: " << expr->hash();
+}
+
+} // namespace facebook::velox::core::test


### PR DESCRIPTION
Summary: std::hash is not guaranteed to be consistent across runs, this improves the hashing functions to use folly:hasher which is consistent across runs and processes

Differential Revision: D92096899


