### PR TITLE
fix: Let spiller report file io stats

### DIFF
--- a/velox/exec/ColumnStatsCollector.cpp
+++ b/velox/exec/ColumnStatsCollector.cpp
@@ -148,7 +148,8 @@ void ColumnStatsCollector::createGroupingSet() {
       nonReclaimableSection_,
       queryConfig_,
       pool_,
-      /*spillStats=*/nullptr);
+      /*spillStats=*/nullptr,
+      /*spillFsStats=*/nullptr);
 }
 
 void ColumnStatsCollector::addInput(RowVectorPtr input) {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -56,26 +56,28 @@ GroupingSet::GroupingSet(
     tsan_atomic<bool>* nonReclaimableSection,
     const core::QueryConfig* queryConfig,
     memory::MemoryPool* pool,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* spillFsStats)
     : preGroupedKeyChannels_(std::move(preGroupedKeys)),
-      groupingKeyOutputProjections_(std::move(groupingKeyOutputProjections)),
-      hashers_(std::move(hashers)),
-      isGlobal_(hashers_.empty()),
+      isGlobal_(hashers.empty()),
       isPartial_(isPartial),
       isRawInput_(isRawInput),
+      ignoreNullKeys_(ignoreNullKeys),
+      isAdaptive_(queryConfig->hashAdaptivityEnabled()),
+      globalGroupingSets_(globalGroupingSets),
+      nonReclaimableSection_(nonReclaimableSection),
+      spillConfig_(spillConfig),
       queryConfig_(queryConfig),
       pool_(pool),
+      spillStats_(spillStats),
+      spillFsStats_(spillFsStats),
+      groupingKeyOutputProjections_(std::move(groupingKeyOutputProjections)),
+      hashers_(std::move(hashers)),
       aggregates_(std::move(aggregates)),
       masks_(extractMaskChannels(aggregates_)),
-      ignoreNullKeys_(ignoreNullKeys),
-      globalGroupingSets_(globalGroupingSets),
       groupIdChannel_(groupIdChannel),
-      spillConfig_(spillConfig),
-      nonReclaimableSection_(nonReclaimableSection),
       stringAllocator_(pool_),
-      rows_(pool_),
-      isAdaptive_(queryConfig_->hashAdaptivityEnabled()),
-      spillStats_(spillStats) {
+      rows_(pool_) {
   VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
   VELOX_CHECK(pool_->trackUsage());
 
@@ -152,7 +154,8 @@ std::unique_ptr<GroupingSet> GroupingSet::createForMarkDistinct(
       nonReclaimableSection,
       &operatorCtx->driverCtx()->queryConfig(),
       operatorCtx->pool(),
-      /*spillStats=*/nullptr);
+      /*spillStats=*/nullptr,
+      /*spillFsStats=*/nullptr);
 };
 
 namespace {
@@ -1031,7 +1034,8 @@ void GroupingSet::spill() {
                 spillConfig_->numPartitionBits)),
         sortingKeys,
         spillConfig_,
-        spillStats_);
+        spillStats_,
+        spillFsStats_);
   }
   // Spilling may execute on multiple partitions in parallel, and
   // HashStringAllocator is not thread safe. If any aggregations
@@ -1067,7 +1071,7 @@ void GroupingSet::spill(const RowContainerIterator& rowIterator) {
   auto* rows = table_->rows();
   VELOX_CHECK(pool_->trackUsage());
   outputSpiller_ = std::make_unique<AggregationOutputSpiller>(
-      rows, makeSpillType(), spillConfig_, spillStats_);
+      rows, makeSpillType(), spillConfig_, spillStats_, spillFsStats_);
 
   // Spilling may execute on multiple partitions in parallel, and
   // HashStringAllocator is not thread safe. If any aggregations
@@ -1139,7 +1143,8 @@ bool GroupingSet::prepareNextSpillPartitionOutput() {
   auto it = spillPartitionSet_.begin();
   VELOX_CHECK_NE(outputSpillPartition_, it->first.partitionNumber());
   outputSpillPartition_ = it->first.partitionNumber();
-  merge_ = it->second->createOrderedReader(*spillConfig_, pool_, spillStats_);
+  merge_ = it->second->createOrderedReader(
+      *spillConfig_, pool_, spillStats_, spillFsStats_);
   spillPartitionSet_.erase(it);
   return true;
 }
@@ -1576,7 +1581,8 @@ AggregationInputSpiller::AggregationInputSpiller(
     const HashBitRange& hashBitRange,
     const std::vector<SpillSortKey>& sortingKeys,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* fileSystemStats)
     : SpillerBase(
           container,
           std::move(rowType),
@@ -1586,13 +1592,15 @@ AggregationInputSpiller::AggregationInputSpiller(
           spillConfig->maxSpillRunRows,
           std::nullopt,
           spillConfig,
-          spillStats) {}
+          spillStats,
+          fileSystemStats) {}
 
 AggregationOutputSpiller::AggregationOutputSpiller(
     RowContainer* container,
     RowTypePtr rowType,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* fileSystemStats)
     : SpillerBase(
           container,
           std::move(rowType),
@@ -1602,7 +1610,8 @@ AggregationOutputSpiller::AggregationOutputSpiller(
           spillConfig->maxSpillRunRows,
           std::nullopt,
           spillConfig,
-          spillStats) {}
+          spillStats,
+          fileSystemStats) {}
 
 void AggregationInputSpiller::spill() {
   SpillerBase::spill(nullptr);

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/common/base/TreeOfLosers.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/exec/AggregateInfo.h"
 #include "velox/exec/AggregationMasks.h"
 #include "velox/exec/DistinctAggregations.h"
@@ -45,7 +46,8 @@ class GroupingSet {
       tsan_atomic<bool>* nonReclaimableSection,
       const core::QueryConfig* queryConfig,
       memory::MemoryPool* pool,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   ~GroupingSet();
 
@@ -289,42 +291,42 @@ class GroupingSet {
   // 'toIntermediate'.
   std::vector<Accumulator> accumulators(bool excludeToIntermediate);
 
-  std::vector<column_index_t> keyChannels_;
-
   // A subset of grouping keys on which the input is clustered.
   const std::vector<column_index_t> preGroupedKeyChannels_;
 
+  const bool isGlobal_;
+  const bool isPartial_;
+  const bool isRawInput_;
+  const bool ignoreNullKeys_;
+  const bool isAdaptive_;
+  // List of global grouping set numbers, if being used with a GROUPING SET.
+  const std::vector<vector_size_t> globalGroupingSets_;
+  // Indicates if this grouping set and the associated hash aggregation operator
+  // is under non-reclaimable execution section or not.
+  tsan_atomic<bool>* const nonReclaimableSection_;
+
+  const common::SpillConfig* const spillConfig_;
+  const core::QueryConfig* const queryConfig_;
+  memory::MemoryPool* const pool_;
+  folly::Synchronized<common::SpillStats>* const spillStats_;
+  filesystems::File::IoStats* const spillFsStats_{nullptr};
+
+  std::vector<column_index_t> keyChannels_;
   // Provides the column projections for extracting the grouping keys from
   // 'table_' for output. The vector index is the output channel and the value
   // is the corresponding column index stored in 'table_'.
   std::vector<column_index_t> groupingKeyOutputProjections_;
-
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
-  const bool isGlobal_;
-  const bool isPartial_;
-  const bool isRawInput_;
-  const core::QueryConfig* const queryConfig_;
-  memory::MemoryPool* const pool_;
 
   std::vector<AggregateInfo> aggregates_;
   AggregationMasks masks_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;
   std::vector<std::unique_ptr<DistinctAggregations>> distinctAggregations_;
 
-  const bool ignoreNullKeys_;
-
   uint64_t numInputRows_ = 0;
 
-  // List of global grouping set numbers, if being used with a GROUPING SET.
-  const std::vector<vector_size_t> globalGroupingSets_;
   // Column for groupId for a GROUPING SET.
   std::optional<column_index_t> groupIdChannel_;
-
-  const common::SpillConfig* const spillConfig_;
-
-  // Indicates if this grouping set and the associated hash aggregation operator
-  // is under non-reclaimable execution section or not.
-  tsan_atomic<bool>* const nonReclaimableSection_;
 
   // Boolean indicating whether accumulators for a global aggregation (i.e.
   // aggregation with no grouping keys) have been initialized.
@@ -342,7 +344,6 @@ class GroupingSet {
   // aggregation
   HashStringAllocator stringAllocator_;
   memory::AllocationPool rows_;
-  const bool isAdaptive_;
 
   bool noMoreInput_{false};
 
@@ -413,8 +414,6 @@ class GroupingSet {
   // Temporary for case where an aggregate in toIntermediate() outputs post-init
   // state of aggregate for all rows.
   std::vector<char*> firstGroup_;
-
-  folly::Synchronized<common::SpillStats>* const spillStats_;
 };
 
 class AggregationInputSpiller : public SpillerBase {
@@ -427,7 +426,8 @@ class AggregationInputSpiller : public SpillerBase {
       const HashBitRange& hashBitRange,
       const std::vector<SpillSortKey>& sortingKeys,
       const common::SpillConfig* spillConfig,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   void spill();
 
@@ -449,7 +449,8 @@ class AggregationOutputSpiller : public SpillerBase {
       RowContainer* container,
       RowTypePtr rowType,
       const common::SpillConfig* spillConfig,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   void spill(const RowContainerIterator& startRowIter);
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -114,7 +114,8 @@ void HashAggregation::initialize() {
       &nonReclaimableSection_,
       &operatorCtx_->driverCtx()->queryConfig(),
       operatorCtx_->pool(),
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 
   aggregationNode_.reset();
 }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -333,7 +333,8 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       HashBitRange(
           startPartitionBit, startPartitionBit + config->numPartitionBits),
       config,
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 
   const int32_t numPartitions = spiller_->hashBits().numPartitions();
   spillInputIndicesBuffers_.resize(numPartitions);
@@ -1379,7 +1380,8 @@ HashBuildSpiller::HashBuildSpiller(
     RowTypePtr rowType,
     HashBitRange bits,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* spillFsStats)
     : SpillerBase(
           container,
           std::move(rowType),
@@ -1389,7 +1391,8 @@ HashBuildSpiller::HashBuildSpiller(
           spillConfig->maxSpillRunRows,
           parentId,
           spillConfig,
-          spillStats),
+          spillStats,
+          spillFsStats),
       spillProbeFlag_(needRightSideJoin(joinType)) {
   VELOX_CHECK(container_->accumulators().empty());
 }

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -413,7 +413,8 @@ class HashBuildSpiller : public SpillerBase {
       RowTypePtr rowType,
       HashBitRange bits,
       const common::SpillConfig* spillConfig,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   /// Invoked to spill all the rows stored in the row container of the hash
   /// build.

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -103,7 +103,8 @@ std::unique_ptr<HashBuildSpiller> createSpiller(
     const RowTypePtr& tableType,
     const HashBitRange& hashBitRange,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* stats) {
+    folly::Synchronized<common::SpillStats>* stats,
+    filesystems::File::IoStats* fileSystemStats = nullptr) {
   return std::make_unique<HashBuildSpiller>(
       joinType,
       parentId,
@@ -111,7 +112,8 @@ std::unique_ptr<HashBuildSpiller> createSpiller(
       hashJoinTableSpillType(tableType, joinType),
       hashBitRange,
       spillConfig,
-      stats);
+      stats,
+      fileSystemStats);
 }
 } // namespace
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -253,7 +253,8 @@ void HashProbe::maybeSetupInputSpiller(
       restoringPartitionId_,
       HashBitRange(bitOffset, bitOffset + spillConfig()->numPartitionBits),
       spillConfig(),
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 
   // Set the spill partitions to the corresponding ones at the build side. We
   // only spill the seen partitions from the build side. For the ones not seen
@@ -2037,7 +2038,8 @@ void HashProbe::spillOutput() {
       std::nullopt,
       HashBitRange{},
       spillConfig(),
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
   outputSpiller->setPartitionsSpilled({SpillPartitionId(0)});
 
   RowVectorPtr output{nullptr};

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -118,7 +118,8 @@ void Merge::maybeSetupOutputSpiller() {
       HashBitRange{},
       sortingKeys_,
       &spillConfig_.value(),
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 }
 
 void Merge::spill() {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -453,6 +453,15 @@ void Operator::recordSpillStats() {
             RuntimeCounter::Unit::kNanos});
   }
   lockedSpillStats->reset();
+
+  // Collect filesystem I/O stats for spilling.
+  if (spillFsStats_) {
+    const auto fsStatsMap = spillFsStats_->stats();
+    for (const auto& [statName, statValue] : fsStatsMap) {
+      lockedStats->addRuntimeStat(
+          statName, RuntimeCounter(statValue.sum, statValue.unit));
+    }
+  }
 }
 
 std::string Operator::toString() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <folly/Synchronized.h>
+#include "velox/common/file/FileSystems.h"
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Driver.h"
@@ -622,6 +623,11 @@ class Operator : public BaseRuntimeStatWriter {
   /// Invoked to record spill stats in operator stats.
   virtual void recordSpillStats();
 
+  /// Returns the filesystem I/O stats for spill operations.
+  filesystems::File::IoStats* spillFsStats() {
+    return spillFsStats_.get();
+  }
+
   const std::unique_ptr<OperatorCtx> operatorCtx_;
   const RowTypePtr outputType_;
   /// Contains the disk spilling related configs if spilling is enabled (e.g.
@@ -635,6 +641,8 @@ class Operator : public BaseRuntimeStatWriter {
   folly::Synchronized<OperatorStats> stats_;
   std::shared_ptr<folly::Synchronized<common::SpillStats>> spillStats_ =
       std::make_shared<folly::Synchronized<common::SpillStats>>();
+  std::unique_ptr<filesystems::File::IoStats> spillFsStats_ =
+      std::make_unique<filesystems::File::IoStats>();
 
   /// NOTE: only one of the two could be set for an operator for tracing .
   /// 'splitTracer_' is only set for table scan to record the processed split

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -408,7 +408,8 @@ SpillPartitionIdSet RowNumber::spillHashTable() {
       tableType,
       spillPartitionBits_,
       &spillConfig,
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 
   hashTableSpiller->spill();
   hashTableSpiller->finishSpill(spillHashTablePartitionSet_);
@@ -429,7 +430,8 @@ void RowNumber::setupInputSpiller(
       restoringPartitionId_,
       spillPartitionBits_,
       &spillConfig,
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 
   const auto& hashers = table_->hashers();
 
@@ -544,7 +546,8 @@ RowNumberHashTableSpiller::RowNumberHashTableSpiller(
     RowTypePtr rowType,
     HashBitRange bits,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* spillFsStats)
     : SpillerBase(
           container,
           std::move(rowType),
@@ -554,7 +557,8 @@ RowNumberHashTableSpiller::RowNumberHashTableSpiller(
           spillConfig->maxSpillRunRows,
           parentId,
           spillConfig,
-          spillStats) {}
+          spillStats,
+          spillFsStats) {}
 
 void RowNumberHashTableSpiller::spill() {
   SpillerBase::spill(nullptr);

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -161,7 +161,8 @@ class RowNumberHashTableSpiller : public SpillerBase {
       RowTypePtr rowType,
       HashBitRange bits,
       const common::SpillConfig* spillConfig,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   void spill();
 

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -28,7 +28,8 @@ SortBuffer::SortBuffer(
     tsan_atomic<bool>* nonReclaimableSection,
     common::PrefixSortConfig prefixSortConfig,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<velox::common::SpillStats>* spillStats)
+    folly::Synchronized<velox::common::SpillStats>* spillStats,
+    filesystems::File::IoStats* spillFsStats)
     : input_(input),
       sortCompareFlags_(sortCompareFlags),
       pool_(pool),
@@ -36,6 +37,7 @@ SortBuffer::SortBuffer(
       prefixSortConfig_(prefixSortConfig),
       spillConfig_(spillConfig),
       spillStats_(spillStats),
+      spillFsStats_(spillFsStats),
       sortedRows_(0, memory::StlAllocator<char*>(*pool)) {
   VELOX_CHECK_GE(input_->children().size(), sortCompareFlags_.size());
   VELOX_CHECK_GT(sortCompareFlags_.size(), 0);
@@ -349,7 +351,12 @@ void SortBuffer::spillInput() {
     VELOX_CHECK(!noMoreInput_);
     const auto sortingKeys = SpillState::makeSortingKeys(sortCompareFlags_);
     inputSpiller_ = std::make_unique<SortInputSpiller>(
-        data_.get(), spillerStoreType_, sortingKeys, spillConfig_, spillStats_);
+        data_.get(),
+        spillerStoreType_,
+        sortingKeys,
+        spillConfig_,
+        spillStats_,
+        spillFsStats_);
   }
   inputSpiller_->spill();
   data_->clear();
@@ -366,7 +373,7 @@ void SortBuffer::spillOutput() {
   }
 
   outputSpiller_ = std::make_unique<SortOutputSpiller>(
-      data_.get(), spillerStoreType_, spillConfig_, spillStats_);
+      data_.get(), spillerStoreType_, spillConfig_, spillStats_, spillFsStats_);
   auto spillRows = SpillerBase::SpillRows(
       sortedRows_.begin() + numOutputRows_,
       sortedRows_.end(),
@@ -485,7 +492,7 @@ void SortBuffer::prepareOutputWithSpill() {
 
   VELOX_CHECK_EQ(spillPartitionSet_.size(), 1);
   spillMerger_ = spillPartitionSet_.begin()->second->createOrderedReader(
-      *spillConfig_, pool(), spillStats_);
+      *spillConfig_, pool(), spillStats_, spillFsStats_);
   spillPartitionSet_.clear();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/SortBuffer.h
+++ b/velox/exec/SortBuffer.h
@@ -40,7 +40,8 @@ class SortBuffer {
       tsan_atomic<bool>* nonReclaimableSection,
       common::PrefixSortConfig prefixSortConfig,
       const common::SpillConfig* spillConfig = nullptr,
-      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr);
+      folly::Synchronized<velox::common::SpillStats>* spillStats = nullptr,
+      filesystems::File::IoStats* spillFsStats = nullptr);
 
   ~SortBuffer();
 
@@ -126,6 +127,8 @@ class SortBuffer {
   const common::SpillConfig* const spillConfig_;
 
   folly::Synchronized<common::SpillStats>* const spillStats_;
+
+  filesystems::File::IoStats* const spillFsStats_;
 
   // The column projection map between 'input_' and 'spillerStoreType_' as sort
   // buffer stores the sort columns first in 'data_'.

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/common/file/FileSystems.h"
 #include "velox/exec/PrefixSort.h"
 #include "velox/exec/Spiller.h"
 #include "velox/exec/WindowBuild.h"
@@ -33,7 +34,8 @@ class SortWindowBuild : public WindowBuild {
       const common::SpillConfig* spillConfig,
       tsan_atomic<bool>* nonReclaimableSection,
       folly::Synchronized<OperatorStats>* opStats,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   ~SortWindowBuild() override {
     pool_->release();
@@ -102,6 +104,8 @@ class SortWindowBuild : public WindowBuild {
   folly::Synchronized<OperatorStats>* const opStats_;
 
   folly::Synchronized<common::SpillStats>* const spillStats_;
+
+  filesystems::File::IoStats* const spillFsStats_{nullptr};
 
   // allKeyInfo_ is a combination of (partitionKeyInfo_ and sortKeyInfo_).
   // It is used to perform a full sorting of the input rows to be able to

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -514,7 +514,8 @@ class SpillPartition {
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> createOrderedReader(
       const common::SpillConfig& spillConfig,
       memory::MemoryPool* pool,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* fsStats);
 
   std::string toString() const;
 
@@ -586,7 +587,7 @@ class SpillState {
   /// 'numSortKeys' is the number of leading columns on which the data is
   /// sorted, 0 if only hash partitioning is used. 'targetFileSize' is the
   /// target size of a single file.  'pool' owns the memory for state and
-  /// results.
+  /// results. 'fsStats' is used to collect filesystem I/O stats.
   SpillState(
       const common::GetSpillDirectoryPathCB& getSpillDirectoryPath,
       const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
@@ -598,7 +599,8 @@ class SpillState {
       const std::optional<common::PrefixSortConfig>& prefixSortConfig,
       memory::MemoryPool* pool,
       folly::Synchronized<common::SpillStats>* stats,
-      const std::string& fileCreateConfig = {});
+      const std::string& fileCreateConfig = {},
+      filesystems::File::IoStats* fsStats = nullptr);
 
   static std::vector<SpillSortKey> makeSortingKeys(
       const std::vector<CompareFlags>& compareFlags = {});
@@ -703,6 +705,7 @@ class SpillState {
   const std::string fileCreateConfig_;
   memory::MemoryPool* const pool_;
   folly::Synchronized<common::SpillStats>* const stats_;
+  filesystems::File::IoStats* const fsStats_{nullptr};
 
   // A set of spilled partition ids.
   SpillPartitionIdSet spilledPartitionIdSet_;

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -38,7 +38,8 @@ SpillWriter::SpillWriter(
     const std::string& fileCreateConfig,
     const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
     memory::MemoryPool* pool,
-    folly::Synchronized<common::SpillStats>* stats)
+    folly::Synchronized<common::SpillStats>* stats,
+    filesystems::File::IoStats* fsStats)
     : serializer::SerializedPageFileWriter(
           pathPrefix,
           targetFileSize,
@@ -51,7 +52,8 @@ SpillWriter::SpillWriter(
               0.8,
               /*_nullsFirst=*/true),
           getNamedVectorSerde(VectorSerde::Kind::kPresto),
-          pool),
+          pool,
+          fsStats),
       type_(type),
       sortingKeys_(sortingKeys),
       stats_(stats),
@@ -138,7 +140,8 @@ std::unique_ptr<SpillReadFile> SpillReadFile::create(
     const SpillFileInfo& fileInfo,
     uint64_t bufferSize,
     memory::MemoryPool* pool,
-    folly::Synchronized<common::SpillStats>* stats) {
+    folly::Synchronized<common::SpillStats>* stats,
+    filesystems::File::IoStats* fsStats) {
   return std::unique_ptr<SpillReadFile>(new SpillReadFile(
       fileInfo.id,
       fileInfo.path,
@@ -148,7 +151,8 @@ std::unique_ptr<SpillReadFile> SpillReadFile::create(
       fileInfo.sortingKeys,
       fileInfo.compressionKind,
       pool,
-      stats));
+      stats,
+      fsStats));
 }
 
 SpillReadFile::SpillReadFile(
@@ -160,7 +164,8 @@ SpillReadFile::SpillReadFile(
     const std::vector<SpillSortKey>& sortingKeys,
     common::CompressionKind compressionKind,
     memory::MemoryPool* pool,
-    folly::Synchronized<common::SpillStats>* stats)
+    folly::Synchronized<common::SpillStats>* stats,
+    filesystems::File::IoStats* fsStats)
     : serializer::SerializedPageFileReader(
           path,
           bufferSize,
@@ -172,7 +177,8 @@ SpillReadFile::SpillReadFile(
               compressionKind,
               0.8,
               /*_nullsFirst=*/true),
-          pool),
+          pool,
+          fsStats),
       id_(id),
       path_(path),
       size_(size),

--- a/velox/exec/SpillFile.h
+++ b/velox/exec/SpillFile.h
@@ -59,7 +59,8 @@ class SpillWriter : public serializer::SerializedPageFileWriter {
   /// write to file. 'fileOptions' specifies the file layout on remote storage
   /// which is storage system specific. 'pool' is used for buffering and
   /// constructing the result data read from 'this'. 'stats' is used to collect
-  /// the spill write stats.
+  /// the spill write stats. 'fsStats' is used to collect filesystem
+  /// internal stats.
   ///
   /// When writing sorted spill runs, the caller is responsible for buffering
   /// and sorting the data. write is called multiple times, followed by flush().
@@ -73,7 +74,8 @@ class SpillWriter : public serializer::SerializedPageFileWriter {
       const std::string& fileCreateConfig,
       const common::UpdateAndCheckSpillLimitCB& updateAndCheckSpillLimitCb,
       memory::MemoryPool* pool,
-      folly::Synchronized<common::SpillStats>* stats);
+      folly::Synchronized<common::SpillStats>* stats,
+      filesystems::File::IoStats* fsStats);
 
   /// Finishes this file writer and returns the written spill files info.
   ///
@@ -123,7 +125,8 @@ class SpillReadFile : public serializer::SerializedPageFileReader {
       const SpillFileInfo& fileInfo,
       uint64_t bufferSize,
       memory::MemoryPool* pool,
-      folly::Synchronized<common::SpillStats>* stats);
+      folly::Synchronized<common::SpillStats>* stats,
+      filesystems::File::IoStats* fsStats = nullptr);
 
   uint32_t id() const {
     return id_;
@@ -152,7 +155,8 @@ class SpillReadFile : public serializer::SerializedPageFileReader {
       const std::vector<SpillSortKey>& sortingKeys,
       common::CompressionKind compressionKind,
       memory::MemoryPool* pool,
-      folly::Synchronized<common::SpillStats>* stats);
+      folly::Synchronized<common::SpillStats>* stats,
+      filesystems::File::IoStats* fsStats);
 
   // Records spill read stats at the end of read input.
   void updateFinalStats() override;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -37,7 +37,8 @@ SpillerBase::SpillerBase(
     uint64_t maxSpillRunRows,
     std::optional<SpillPartitionId> parentId,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* fileSystemStats)
     : container_(container),
       executor_(spillConfig->executor),
       bits_(bits),
@@ -64,7 +65,8 @@ SpillerBase::SpillerBase(
           spillConfig->prefixSortConfig,
           memory::spillMemoryPool(),
           spillStats,
-          spillConfig->fileCreateConfig) {
+          spillConfig->fileCreateConfig,
+          fileSystemStats) {
   TestValue::adjust("facebook::velox::exec::SpillerBase", this);
 }
 
@@ -389,14 +391,16 @@ NoRowContainerSpiller::NoRowContainerSpiller(
     std::optional<SpillPartitionId> parentId,
     HashBitRange bits,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* fileSystemStats)
     : NoRowContainerSpiller(
           std::move(rowType),
           parentId,
           bits,
           {},
           spillConfig,
-          spillStats) {}
+          spillStats,
+          fileSystemStats) {}
 
 NoRowContainerSpiller::NoRowContainerSpiller(
     RowTypePtr rowType,
@@ -404,7 +408,8 @@ NoRowContainerSpiller::NoRowContainerSpiller(
     HashBitRange bits,
     const std::vector<SpillSortKey>& sortingKeys,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* fileSystemStats)
     : SpillerBase(
           nullptr,
           std::move(rowType),
@@ -414,7 +419,8 @@ NoRowContainerSpiller::NoRowContainerSpiller(
           0,
           parentId,
           spillConfig,
-          spillStats) {}
+          spillStats,
+          fileSystemStats) {}
 
 void NoRowContainerSpiller::spill(
     const SpillPartitionId& partitionId,
@@ -437,7 +443,8 @@ SortOutputSpiller::SortOutputSpiller(
     RowContainer* container,
     RowTypePtr rowType,
     const common::SpillConfig* spillConfig,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* fileSystemStats)
     : SpillerBase(
           container,
           std::move(rowType),
@@ -447,7 +454,8 @@ SortOutputSpiller::SortOutputSpiller(
           spillConfig->maxSpillRunRows,
           std::nullopt,
           spillConfig,
-          spillStats) {}
+          spillStats,
+          fileSystemStats) {}
 
 void SortOutputSpiller::spill(SpillRows& rows) {
   VELOX_CHECK(!finalized_);

--- a/velox/exec/SubPartitionedSortWindowBuild.cpp
+++ b/velox/exec/SubPartitionedSortWindowBuild.cpp
@@ -27,12 +27,14 @@ SubPartitionedSortWindowBuild::SubPartitionedSortWindowBuild(
     const common::SpillConfig* spillConfig,
     tsan_atomic<bool>* nonReclaimableSection,
     folly::Synchronized<OperatorStats>* opStats,
-    folly::Synchronized<common::SpillStats>* spillStats)
+    folly::Synchronized<common::SpillStats>* spillStats,
+    filesystems::File::IoStats* spillFsStats)
     : WindowBuild(node, pool, spillConfig, nonReclaimableSection),
       numSubPartitions_(numSubPartitions),
       numPartitionKeys_{node->partitionKeys().size()},
       pool_(pool),
-      spillStats_(spillStats) {
+      spillStats_(spillStats),
+      spillFsStats_(spillFsStats) {
   VELOX_CHECK_NOT_NULL(pool_);
   data_.reset();
 
@@ -51,7 +53,8 @@ SubPartitionedSortWindowBuild::SubPartitionedSortWindowBuild(
         spillConfig,
         nonReclaimableSection,
         opStats,
-        spillStats);
+        spillStats,
+        spillFsStats);
   }
 }
 

--- a/velox/exec/SubPartitionedSortWindowBuild.h
+++ b/velox/exec/SubPartitionedSortWindowBuild.h
@@ -38,7 +38,8 @@ class SubPartitionedSortWindowBuild : public WindowBuild {
       const common::SpillConfig* spillConfig,
       tsan_atomic<bool>* nonReclaimableSection,
       folly::Synchronized<OperatorStats>* opStats,
-      folly::Synchronized<common::SpillStats>* spillStats);
+      folly::Synchronized<common::SpillStats>* spillStats,
+      filesystems::File::IoStats* spillFsStats);
 
   ~SubPartitionedSortWindowBuild() override {
     pool_->release();
@@ -78,6 +79,8 @@ class SubPartitionedSortWindowBuild : public WindowBuild {
   memory::MemoryPool* const pool_;
 
   folly::Synchronized<common::SpillStats>* const spillStats_;
+
+  filesystems::File::IoStats* const spillFsStats_{nullptr};
 
   // Divide input rows to the corresponding sub partitions.
   std::unique_ptr<HashPartitionFunction> subPartitioningFunction_;

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -482,7 +482,7 @@ void TopNRowNumber::noMoreInput() {
     spiller_->finishSpill(spillPartitionSet);
     VELOX_CHECK_EQ(spillPartitionSet.size(), 1);
     merge_ = spillPartitionSet.begin()->second->createOrderedReader(
-        *spillConfig_, pool(), spillStats_.get());
+        *spillConfig_, pool(), spillStats_.get(), spillFsStats());
   } else {
     outputRows_.resize(outputBatchSize_);
   }
@@ -1073,7 +1073,8 @@ void TopNRowNumber::setupSpiller() {
       inputType_,
       sortingKeys,
       &spillConfig_.value(),
-      spillStats_.get());
+      spillStats_.get(),
+      spillFsStats());
 }
 
 // Using the underlying vector of the priority queue for the algorithms to

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -78,7 +78,8 @@ Window::Window(
           spillConfig,
           &nonReclaimableSection_,
           &stats_,
-          spillStats_.get());
+          spillStats_.get(),
+          spillFsStats());
     } else {
       windowBuild_ = std::make_unique<SortWindowBuild>(
           windowNode,
@@ -87,7 +88,8 @@ Window::Window(
           spillConfig,
           &nonReclaimableSection_,
           &stats_,
-          spillStats_.get());
+          spillStats_.get(),
+          spillFsStats());
     }
   }
 }

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -160,12 +160,17 @@ std::unique_ptr<SpillerBase> AggregateSpillBenchmarkBase::makeSpiller() {
                 spillConfig.startPartitionBit + spillConfig.numPartitionBits)},
         sortingKeys,
         &spillConfig,
-        &spillStats_);
+        &spillStats_,
+        /*fsStats=*/nullptr);
   } else {
     VELOX_CHECK_EQ(spillerType_, AggregationOutputSpiller::kType);
     // TODO: Add config flag to control the max spill rows.
     return std::make_unique<AggregationOutputSpiller>(
-        rowContainer_.get(), rowType_, &spillConfig, &spillStats_);
+        rowContainer_.get(),
+        rowType_,
+        &spillConfig,
+        &spillStats_,
+        /*fsStats=*/nullptr);
   }
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -73,7 +73,8 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
         HashBitRange{},
         sortingKeys_,
         &spillConfig_,
-        &spillStats_);
+        &spillStats_,
+        /*fsStats=*/nullptr);
     for (const auto& vector : sortedVectors) {
       spiller->spill(SpillPartitionId(0), vector);
     }

--- a/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
+++ b/velox/exec/tests/JoinSpillInputBenchmarkBase.cpp
@@ -46,7 +46,12 @@ void JoinSpillInputBenchmarkBase::setUp() {
   spillConfig.fileCreateConfig = {};
 
   spiller_ = std::make_unique<NoRowContainerSpiller>(
-      rowType_, std::nullopt, HashBitRange{29, 29}, &spillConfig, &spillStats_);
+      rowType_,
+      std::nullopt,
+      HashBitRange{29, 29},
+      &spillConfig,
+      &spillStats_,
+      /*fsStats=*/nullptr);
   dynamic_cast<NoRowContainerSpiller*>(spiller_.get())
       ->setPartitionsSpilled({SpillPartitionId(0)});
 }

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -77,7 +77,8 @@ class MergerTest : public OperatorTestBase {
         HashBitRange{},
         sortingKeys_,
         &spillConfig_,
-        spillStats_.get());
+        spillStats_.get(),
+        /*fsStats=*/nullptr);
     for (const auto& vector : sortedVectors) {
       spiller->spill(SpillPartitionId(0), vector);
     }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -529,7 +529,8 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
       spillConfig.updateAndCheckSpillLimitCb = [](int64_t) {};
       spillConfig.fileCreateConfig = "";
       std::unique_ptr<TreeOfLosers<SpillMergeStream>> merge =
-          spillPartition.createOrderedReader(spillConfig, pool(), &spillStats_);
+          spillPartition.createOrderedReader(
+              spillConfig, pool(), &spillStats_, /*fsStats=*/nullptr);
       int numReadBatches = 0;
       // We expect all the rows in dense increasing order.
       for (auto i = 0; i < numBatches * numRowsPerBatch; ++i) {
@@ -749,12 +750,12 @@ TEST_P(SpillTest, spillTimestamp) {
   spillConfig.writeBufferSize = 1 << 20;
   spillConfig.updateAndCheckSpillLimitCb = [](int64_t) {};
   spillConfig.fileCreateConfig = "";
-  auto merge =
-      spillPartition.createOrderedReader(spillConfig, pool(), &spillStats_);
+  auto merge = spillPartition.createOrderedReader(
+      spillConfig, pool(), &spillStats_, /*fsStats=*/nullptr);
   ASSERT_TRUE(merge != nullptr);
   ASSERT_TRUE(
-      spillPartition.createOrderedReader(spillConfig, pool(), &spillStats_) ==
-      nullptr);
+      spillPartition.createOrderedReader(
+          spillConfig, pool(), &spillStats_, /*fsStats=*/nullptr) == nullptr);
   for (auto i = 0; i < timeValues.size(); ++i) {
     auto* stream = merge->next();
     ASSERT_NE(stream, nullptr);

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -893,7 +893,8 @@ DEBUG_ONLY_TEST_F(WindowTest, reserveMemorySort) {
         spillEnabled ? &spillConfig : nullptr,
         &nonReclaimableSection_,
         &opStats,
-        &spillStats);
+        &spillStats,
+        nullptr);
 
     TestScopedSpillInjection scopedSpillInjection(0);
     const auto data = usePrefixSort ? prefixSortData : nonPrefixSortData;

--- a/velox/serializers/tests/SerializedPageFileTest.cpp
+++ b/velox/serializers/tests/SerializedPageFileTest.cpp
@@ -130,7 +130,8 @@ TEST_P(SerializedPageFileTest, serializedPageFileBasic) {
   const std::string pathPrefix = getTestFilePath();
   const uint32_t kFileId = 123;
 
-  auto pageFile = SerializedPageFile::create(kFileId, pathPrefix, "");
+  auto pageFile =
+      SerializedPageFile::create(kFileId, pathPrefix, "", /*fsStats=*/nullptr);
 
   EXPECT_EQ(pageFile->id(), kFileId);
   EXPECT_TRUE(pageFile->path().find(pathPrefix) == 0);
@@ -159,7 +160,8 @@ TEST_P(SerializedPageFileTest, serializedPageFileMultipleWrites) {
   const uint32_t kNumWrites = 10;
 
   const std::string pathPrefix = getTestFilePath();
-  auto pageFile = SerializedPageFile::create(kFileId, pathPrefix, "");
+  auto pageFile =
+      SerializedPageFile::create(kFileId, pathPrefix, "", /*fsStats=*/nullptr);
 
   uint64_t totalSize = 0;
   for (int i = 0; i < kNumWrites; ++i) {
@@ -315,7 +317,8 @@ TEST_P(SerializedPageFileTest, serializedPageRoundTripBasic) {
       asRowType(originalVector->type()),
       serde_,
       createSerdeOptions(),
-      pool());
+      pool(),
+      /*fsStats=*/nullptr);
 
   RowVectorPtr readVector;
   bool hasData = reader.nextBatch(readVector);
@@ -368,7 +371,8 @@ TEST_P(SerializedPageFileTest, serializedPageRoundTripMultipleBatches) {
         asRowType(originalVectors[0]->type()),
         serde_,
         createSerdeOptions(),
-        pool());
+        pool(),
+        /*fsStats=*/nullptr);
 
     RowVectorPtr readVector;
     while (reader.nextBatch(readVector)) {
@@ -436,7 +440,8 @@ TEST_P(SerializedPageFileTest, roundTripWithComplexTypes) {
         asRowType(originalVectors[0]->type()),
         serde_,
         createSerdeOptions(),
-        pool());
+        pool(),
+        /*fsStats=*/nullptr);
 
     RowVectorPtr readVector;
     while (reader.nextBatch(readVector)) {


### PR DESCRIPTION
Summary: file io stats are not currently reported from spilling. report such stats for more accuratlely tracking query level IO cost.

Reviewed By: xiaoxmeng

Differential Revision: D91977949
