### PR TITLE
feat(parquet): Support read TIME_MILLIS parquet type

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -141,6 +141,18 @@ VectorPtr BatchMaker::createVector<TypeKind::BIGINT>(
     MemoryPool& pool,
     std::mt19937& gen,
     std::function<bool(vector_size_t /*index*/)> isNullAt) {
+  if (type->isTime()) {
+    return createScalar<int64_t>(
+        size,
+        gen,
+        [&gen]() {
+          // TIME is milliseconds since midnight.
+          return Random::rand64(0, 86400000, gen);
+        },
+        pool,
+        isNullAt,
+        type);
+  }
   return createScalar<int64_t>(
       size,
       gen,

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -393,7 +393,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
           ? sizeof(float)
           : sizeof(double);
       auto numBytes = dictionary_.numValues * typeSize;
-      if ((type_->type()->isShortDecimal() || type_->type()->isTime()) &&
+      if (type_->type()->isShortDecimal() &&
           parquetType == thrift::Type::INT32) {
         auto veloxTypeLength = type_->type()->cppSizeInBytes();
         auto numVeloxBytes = dictionary_.numValues * veloxTypeLength;
@@ -421,7 +421,7 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
         }
         stats_.pageLoadTimeNs.increment(readUs * 1'000);
       }
-      if ((type_->type()->isShortDecimal() || type_->type()->isTime()) &&
+      if (type_->type()->isShortDecimal() &&
           parquetType == thrift::Type::INT32) {
         auto values = dictionary_.values->asMutable<int64_t>();
         auto parquetValues = dictionary_.values->asMutable<int32_t>();

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -27,6 +27,7 @@
 #include "velox/dwio/parquet/reader/RepeatedColumnReader.h"
 #include "velox/dwio/parquet/reader/StringColumnReader.h"
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
+#include "velox/dwio/parquet/reader/TimeColumnReader.h"
 #include "velox/dwio/parquet/reader/TimestampColumnReader.h"
 #include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
@@ -40,6 +41,12 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     ParquetParams& params,
     common::ScanSpec& scanSpec) {
   auto colName = scanSpec.fieldName();
+
+  if (fileType->type()->isTime()) {
+    VELOX_CHECK(fileType->type()->equivalent(*TIME()));
+    return std::make_unique<TimeColumnReader>(
+        requestedType, fileType, params, scanSpec);
+  }
 
   switch (fileType->type()->kind()) {
     case TypeKind::INTEGER:

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -996,10 +996,27 @@ TypePtr ReaderBase::convertType(
             requestedType->toString());
         return VARCHAR();
       }
+      case thrift::ConvertedType::TIME_MILLIS:
+        VELOX_CHECK_EQ(
+            schemaElement.type,
+            thrift::Type::INT32,
+            "TIME_MILLIS converted type can only be set for value of thrift::Type::INT32");
+        VELOX_CHECK(
+            !requestedType ||
+                isCompatible(
+                    requestedType,
+                    isRepeated,
+                    [](const TypePtr& type) {
+                      return type->equivalent(*TIME());
+                    }),
+            kTypeMappingErrorFmtStr,
+            "TIME",
+            requestedType->toString());
+        return TIME();
+
       case thrift::ConvertedType::MAP:
       case thrift::ConvertedType::MAP_KEY_VALUE:
       case thrift::ConvertedType::LIST:
-      case thrift::ConvertedType::TIME_MILLIS:
       case thrift::ConvertedType::TIME_MICROS:
       case thrift::ConvertedType::JSON:
       case thrift::ConvertedType::BSON:

--- a/velox/dwio/parquet/reader/TimeColumnReader.h
+++ b/velox/dwio/parquet/reader/TimeColumnReader.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/parquet/reader/IntegerColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetColumnReader.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
+
+namespace facebook::velox::parquet {
+
+/// Column reader for Parquet TIME type.
+/// Handles conversion from Parquet TIME_MILLIS (INT32, milliseconds) to
+/// Velox TIME type (BIGINT, milliseconds).
+class TimeColumnReader : public IntegerColumnReader {
+ public:
+  TimeColumnReader(
+      const TypePtr& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+      ParquetParams& params,
+      common::ScanSpec& scanSpec)
+      : IntegerColumnReader(requestedType, fileType, params, scanSpec) {
+    const auto typeWithId =
+        std::static_pointer_cast<const ParquetTypeWithId>(fileType_);
+    if (auto logicalType = typeWithId->logicalType_) {
+      VELOX_CHECK(logicalType->__isset.TIME);
+      const auto unit = logicalType->TIME.unit;
+      VELOX_CHECK(
+          unit.__isset.MILLIS,
+          "TIME precision other than milliseconds is not supported");
+    } else if (auto convertedType = typeWithId->convertedType_) {
+      VELOX_CHECK(
+          convertedType == thrift::ConvertedType::type::TIME_MILLIS,
+          "TIME converted type other than TIME_MILLIS is not supported");
+    } else {
+      VELOX_NYI("Logical type and converted type are not provided for TIME.");
+    }
+  }
+
+  void read(
+      int64_t offset,
+      const RowSet& rows,
+      const uint64_t* /*incomingNulls*/) override {
+    // Parquet stores TIME as INT32 (TIME_MILLIS).
+    // Velox represents TIME as BIGINT (8-byte).
+    // Use the physical width: TIME_MILLIS is INT32 (4 bytes).
+    VELOX_WIDTH_DISPATCH(4, prepareRead, offset, rows, nullptr);
+    readCommon<IntegerColumnReader, true>(rows);
+    readOffset_ += rows.back() + 1;
+  }
+};
+
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -692,6 +692,52 @@ TEST_F(E2EFilterTest, date) {
       20);
 }
 
+TEST_F(E2EFilterTest, time) {
+  struct {
+    parquet::arrow::Encoding::type encoding;
+    bool enableDictionary;
+    bool keepNulls;
+  } testCases[] = {
+      {parquet::arrow::Encoding::kPlain, false, true},
+      {parquet::arrow::Encoding::kPlain, true, true},
+      {parquet::arrow::Encoding::kDeltaBinaryPacked, false, false},
+      {parquet::arrow::Encoding::kDeltaBinaryPacked, false, true},
+  };
+
+  for (const auto& testCase : testCases) {
+    options_.encoding = testCase.encoding;
+    bool enableDictionary = testCase.enableDictionary;
+    bool keepNulls = testCase.keepNulls;
+    SCOPED_TRACE(
+        fmt::format(
+            "Encoding: {}, Dictionary: {}, KeepNulls: {}",
+            static_cast<int>(options_.encoding),
+            enableDictionary,
+            keepNulls));
+
+    options_.enableDictionary = enableDictionary;
+    options_.dataPageSize = 4 * 1024;
+    const int valMax = enableDictionary ? 1000 : 86399999;
+
+    testWithTypes(
+        "time_val:time",
+        [&]() {
+          makeIntDistribution<int64_t>(
+              "time_val",
+              0, // min
+              valMax, // max
+              22, // repeats
+              19, // rareFrequency
+              0, // rareMin
+              valMax, // rareMax
+              keepNulls); // keepNulls
+        },
+        false,
+        {"time_val"},
+        20);
+  }
+}
+
 TEST_F(E2EFilterTest, combineRowGroup) {
   rowsInRowGroup_ = 5;
   rowType_ = ROW({"c0"}, {INTEGER()});

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1913,6 +1913,69 @@ TEST_F(ParquetReaderTest, columnStatisticsMultipleRowGroups) {
   EXPECT_EQ(intStats->getMaximum(), 50);
 }
 
+TEST_F(ParquetReaderTest, readTimeMillis) {
+  // Write TIME data using the parquet writer.
+  // The writer exports Velox TIME as Arrow time32 with milliseconds unit,
+  // which maps to Parquet TIME_MILLIS (INT32).
+  const auto rowType = ROW({"time_col"}, {TIME()});
+
+  auto data = makeRowVector(
+      rowType->names(),
+      {makeNullableFlatVector<int64_t>(
+          {1, 1'000, 3'600'000, std::nullopt, 43'200'000, 86'399'999},
+          TIME())});
+  auto sink = write(data);
+
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  auto reader = createReaderInMemory(*sink, readerOpts);
+
+  EXPECT_EQ(reader->numberOfRows(), 6ULL);
+
+  auto type = reader->typeWithId();
+  EXPECT_EQ(type->size(), 1ULL);
+  auto col0 = type->childAt(0);
+  EXPECT_TRUE(col0->type()->isTime());
+
+  auto rowReaderOpts = getReaderOpts(rowType);
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
+}
+
+TEST_F(ParquetReaderTest, readTimeWithMultipleColumns) {
+  const auto rowType =
+      ROW({"id", "time_col", "name"}, {INTEGER(), TIME(), VARCHAR()});
+
+  auto data = makeRowVector(
+      rowType->names(),
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>(
+              {0, 1'000, 3'600'000, 43'200'000, 86'399'999}, TIME()),
+          makeFlatVector<StringView>({"a", "b", "c", "d", "e"}),
+      });
+
+  auto sink = write(data);
+
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  auto reader = createReaderInMemory(*sink, readerOpts);
+
+  EXPECT_EQ(reader->numberOfRows(), 5ULL);
+
+  auto type = reader->typeWithId();
+  EXPECT_EQ(type->size(), 3ULL);
+  EXPECT_EQ(type->childAt(0)->type()->kind(), TypeKind::INTEGER);
+  EXPECT_TRUE(type->childAt(1)->type()->isTime());
+  EXPECT_EQ(type->childAt(2)->type()->kind(), TypeKind::VARCHAR);
+
+  auto rowReaderOpts = getReaderOpts(rowType);
+  rowReaderOpts.setScanSpec(makeScanSpec(rowType));
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
+}
+
 // Comprehensive test matrix covering all combinations:
 // - Nulls: No nulls, With nulls
 // - Dictionary: Enabled, Disabled

--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -58,6 +58,7 @@ HiveTypeParser::HiveTypeParser() {
   setupMetadata<TokenType::Integer, TypeKind::INTEGER>({"integer", "int"});
   setupMetadata<TokenType::Long, TypeKind::BIGINT>("bigint");
   setupMetadata<TokenType::Date, TypeKind::INTEGER>("date");
+  setupMetadata<TokenType::Time, TypeKind::BIGINT>("time");
   setupMetadata<TokenType::Float, TypeKind::REAL>({"float", "real"});
   setupMetadata<TokenType::Double, TypeKind::DOUBLE>("double");
   setupMetadata<TokenType::Decimal, TypeKind::BIGINT>("decimal");
@@ -121,6 +122,8 @@ Result HiveTypeParser::parseType() {
           std::atoi(precision.value.data()), std::atoi(scale.value.data()))};
     } else if (nt.metadata->tokenString[0] == "date") {
       return Result{DATE()};
+    } else if (nt.metadata->tokenString[0] == "time") {
+      return Result{TIME()};
     }
     auto scalarType = createScalarType(nt.typeKind());
     VELOX_CHECK_NOT_NULL(

--- a/velox/type/fbhive/HiveTypeParser.h
+++ b/velox/type/fbhive/HiveTypeParser.h
@@ -52,6 +52,7 @@ enum class TokenType {
   Identifier,
   EndOfStream,
   Decimal,
+  Time,
   LeftRoundBracket,
   RightRoundBracket,
   MaxTokenType


### PR DESCRIPTION
Support read TIME type from parquet data file.

Added TimeColumnReader class to handle TIME_MILLIS (INT32, milliseconds) parquet type.
Modified ParquetColumnReader.cpp to instantiate the appropriate TimeColumnReader based on the underlying Parquet physical type.
