### PR TITLE
misc: Add cursor_copy_result flag to trace replayer

### DIFF
--- a/velox/tool/trace/OperatorReplayerBase.cpp
+++ b/velox/tool/trace/OperatorReplayerBase.cpp
@@ -83,7 +83,9 @@ OperatorReplayerBase::OperatorReplayerBase(
   queryConfigs_[core::QueryConfig::kQueryTraceEnabled] = "false";
 }
 
-RowVectorPtr OperatorReplayerBase::run(bool copyResults) {
+RowVectorPtr OperatorReplayerBase::run(
+    bool copyResults,
+    bool cursorCopyResult) {
   auto queryCtx = createQueryCtx();
   std::shared_ptr<exec::test::TempDirectoryPath> localSpillDirectory;
   if (queryCtx->queryConfig().spillEnabled() && spillBaseDir_.empty()) {
@@ -96,6 +98,7 @@ RowVectorPtr OperatorReplayerBase::run(bool copyResults) {
           .spillDirectory(
               localSpillDirectory != nullptr ? localSpillDirectory->getPath()
                                              : spillBaseDir_)
+          .cursorCopyResult(cursorCopyResult)
           .run(copyResults);
   printStats(task);
   return result;

--- a/velox/tool/trace/OperatorReplayerBase.h
+++ b/velox/tool/trace/OperatorReplayerBase.h
@@ -46,7 +46,23 @@ class OperatorReplayerBase {
   OperatorReplayerBase& operator=(OperatorReplayerBase&& other) noexcept =
       delete;
 
-  virtual RowVectorPtr run(bool copyResults = true);
+  /// @deprecated Use the two-parameter version instead. This overload exists
+  ///        for backward compatibility and will be removed once all subclasses
+  ///        migrate to the new interface.
+  virtual RowVectorPtr run(bool copyResults) {
+    return run(copyResults, /*cursorCopyResult=*/false);
+  }
+
+  /// Runs the replayer with control over both result copying and cursor
+  /// per-batch copying.
+  /// @param copyResults If true, copies and returns all results as a single
+  ///        RowVector. If false, returns nullptr.
+  /// @param cursorCopyResult If true, each output batch is deep copied as it's
+  ///        consumed by the cursor. This can be expensive for complex nested
+  ///        types. Default is false.
+  virtual RowVectorPtr run(
+      bool copyResults = true,
+      bool cursorCopyResult = false);
 
  protected:
   virtual core::PlanNodePtr createPlanNode(

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -136,7 +136,9 @@ PartitionedOutputReplayer::PartitionedOutputReplayer(
       std::make_shared<folly::NamedThreadFactory>("Consumer"));
 }
 
-RowVectorPtr PartitionedOutputReplayer::run(bool /*unused*/) {
+RowVectorPtr PartitionedOutputReplayer::run(
+    bool /*copyResults*/,
+    bool /*cursorCopyResult*/) {
   const auto task = Task::create(
       "local://partitioned-output-replayer",
       core::PlanFragment{createPlan()},

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -53,7 +53,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       folly::Executor* executor,
       const ConsumerCallBack& consumerCb = [](auto partition, auto page) {});
 
-  RowVectorPtr run(bool /*unused*/) override;
+  RowVectorPtr run(bool /*copyResults*/, bool /*cursorCopyResult*/) override;
 
  private:
   core::PlanNodePtr createPlanNode(

--- a/velox/tool/trace/TableScanReplayer.cpp
+++ b/velox/tool/trace/TableScanReplayer.cpp
@@ -29,10 +29,11 @@ using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::tool::trace {
 
-RowVectorPtr TableScanReplayer::run(bool copyResults) {
+RowVectorPtr TableScanReplayer::run(bool copyResults, bool cursorCopyResult) {
   TraceReplayTaskRunner traceTaskRunner(createPlan(), createQueryCtx());
   auto [task, result] = traceTaskRunner.maxDrivers(driverIds_.size())
                             .splits(replayPlanNodeId_, getSplits())
+                            .cursorCopyResult(cursorCopyResult)
                             .run(copyResults);
   printStats(task);
   return result;

--- a/velox/tool/trace/TableScanReplayer.h
+++ b/velox/tool/trace/TableScanReplayer.h
@@ -47,7 +47,8 @@ class TableScanReplayer final : public OperatorReplayerBase {
             queryCapacity,
             executor) {}
 
-  RowVectorPtr run(bool copyResults = true) override;
+  RowVectorPtr run(bool copyResults = true, bool cursorCopyResult = false)
+      override;
 
  private:
   core::PlanNodePtr createPlanNode(

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -105,6 +105,12 @@ DEFINE_uint64(
     0,
     "Specify the query memory capacity limit in GB. If it is zero, then there is no limit.");
 DEFINE_bool(copy_results, false, "Copy the replaying results.");
+DEFINE_bool(
+    cursor_copy_result,
+    false,
+    "Enable per-batch copying in TaskCursor. When false (default), avoids "
+    "expensive deep copies of complex nested types during output consumption. "
+    "Only enable for debugging or when output vectors need to be retained.");
 DEFINE_string(
     function_prefix,
     "",
@@ -471,6 +477,6 @@ void TraceReplayRunner::run() {
     return;
   }
   VELOX_USER_CHECK(!FLAGS_task_id.empty(), "--task_id must be provided");
-  createReplayer()->run(FLAGS_copy_results);
+  createReplayer()->run(FLAGS_copy_results, FLAGS_cursor_copy_result);
 }
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/TraceReplayTaskRunner.cpp
+++ b/velox/tool/trace/TraceReplayTaskRunner.cpp
@@ -74,6 +74,12 @@ TraceReplayTaskRunner& TraceReplayTaskRunner::splits(
   return *this;
 }
 
+TraceReplayTaskRunner& TraceReplayTaskRunner::cursorCopyResult(
+    bool copyResult) {
+  cursorParams_.copyResult = copyResult;
+  return *this;
+}
+
 void TraceReplayTaskRunner::addSplits(exec::Task* task) {
   for (auto& [nodeId, nodeSplits] : splits_) {
     for (auto& split : nodeSplits) {

--- a/velox/tool/trace/TraceReplayTaskRunner.h
+++ b/velox/tool/trace/TraceReplayTaskRunner.h
@@ -28,6 +28,10 @@ class TraceReplayTaskRunner {
       std::shared_ptr<core::QueryCtx> queryCtx) {
     cursorParams_.planNode = std::move(plan);
     cursorParams_.queryCtx = std::move(queryCtx);
+    // Disable per-batch copying in MultiThreadedTaskCursor by default to avoid
+    // expensive deep copies of complex nested types. The final result copy is
+    // handled in run() if needed.
+    cursorParams_.copyResult = false;
     VELOX_CHECK_NOT_NULL(cursorParams_.planNode);
     VELOX_CHECK_NOT_NULL(cursorParams_.queryCtx);
   }
@@ -48,6 +52,11 @@ class TraceReplayTaskRunner {
   TraceReplayTaskRunner& splits(
       const core::PlanNodeId& planNodeId,
       std::vector<exec::Split> splits);
+
+  /// Enable or disable per-batch copying in TaskCursor. When true, each output
+  /// batch is copied as it's consumed, which can be expensive for complex
+  /// nested types. Default is false.
+  TraceReplayTaskRunner& cursorCopyResult(bool copyResult);
 
  private:
   void addSplits(exec::Task* task);

--- a/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
+++ b/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
@@ -163,7 +163,7 @@ TEST_P(PartitionedOutputReplayerTest, defaultConsumer) {
                       "",
                       0,
                       executor_.get())
-                      .run(false));
+                      .run(false, false));
 }
 
 TEST_P(PartitionedOutputReplayerTest, basic) {
@@ -260,7 +260,7 @@ TEST_P(PartitionedOutputReplayerTest, basic) {
           [&](auto partition, auto page) {
             replayedPartitionedResults[partition].push_back(std::move(page));
           })
-          .run(false);
+          .run(false, false);
 
       ASSERT_EQ(replayedPartitionedResults.size(), testParam.numPartitions);
       for (uint32_t partition = 0; partition < testParam.numPartitions;


### PR DESCRIPTION
Summary:
Add a command-line flag `--cursor_copy_result` to control per-batch copying in `TaskCursor` during trace replay. When false (default), avoids expensive deep copies of complex nested types during output consumption.

Note: This is different from the existing `--copy_results` flag:
- `cursor_copy_result`: Controls per-batch copying in TaskCursor (N copies, one per batch)
- `copy_results`: Controls final result merging after replay completes (1 copy at the end)

Differential Revision: D92184007


