### PR TITLE
feat: Add constant bound support for between conditions in HiveIndexReader

### DIFF
--- a/velox/connectors/hive/HiveIndexReader.h
+++ b/velox/connectors/hive/HiveIndexReader.h
@@ -155,6 +155,13 @@ class HiveIndexReader {
   // condition (0 for equal condition value, 0/1 for between condition
   // lower/upper).
   std::vector<std::vector<DecodedVector>> decodedRequestVectors_;
+
+  // For BetweenIndexLookupCondition with constant bounds, stores the constant
+  // values directly. The outer vector is indexed by join condition index. The
+  // inner vector has size 2 for between conditions (lower, upper). If a bound
+  // is a constant, the corresponding optional contains the value; otherwise
+  // it's std::nullopt and the value should be decoded from request.
+  std::vector<std::vector<std::optional<variant>>> constantBoundValues_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -271,8 +271,11 @@ std::vector<std::string> HiveIndexSource::initJoinConditions(
         filters_.find(subfield) == filters_.end(),
         "Unexpected filter found on index column {}",
         columnName);
-    VELOX_CHECK(!condition->isFilter());
-    // Non-filter conditions are kept as join conditions.
+    VELOX_CHECK(
+        !condition->isFilter(),
+        "Join condition on index column '{}' cannot be a filter condition",
+        columnName);
+
     joinConditions_.push_back(condition);
     joinColumns.push_back(columnName);
   }


### PR DESCRIPTION
Summary:
This diff adds support for constant bounds in between conditions for index lookups. When a between condition has one constant bound (either lower or upper), the constant value is extracted at initialization time and used directly instead of decoding from the request at runtime.

- Added `constantBoundValues_` member to store constant values for between condition bounds
- Modified `initJoinConditions` to detect `ConstantTypedExpr` bounds and extract their values at init time
- Modified `setRequest` to skip decoding for constant bounds (indicated by `kConstantChannel`)
- Modified `applyFiltersFromRequest` to use stored constants via a lambda function for bound value extraction
- Added validation to ensure at least one bound is not constant (both constant bounds should be a pushdown filter instead)
- Added validation in HiveIndexSource to fail early at construction time for between conditions with both constant bounds

Differential Revision: D92125957


