### PR TITLE
build(cuda): Add CUDA_VERSION build arg to adapters dockerfile

### DIFF
--- a/scripts/docker/centos-multi.dockerfile
+++ b/scripts/docker/centos-multi.dockerfile
@@ -133,7 +133,7 @@ COPY scripts/setup-centos-adapters.sh /
 ARG CUDA_VERSION
 ENV CUDA_VERSION=${CUDA_VERSION:-12.9}
 
-RUN bash /setup-centos-adapters.sh install_cuda ${CUDA_VERSION} && \
+RUN bash /setup-centos-adapters.sh install_cuda && \
       dnf clean all
 
 RUN bash /setup-centos-adapters.sh install_adapters_deps_from_dnf && \


### PR DESCRIPTION
## Summary
We would like to make it easier to configure the CUDA version used in building Velox containers.

This PR adds a `CUDA_VERSION` build arg to the adapters stage in `centos-multi.dockerfile` which allows overriding the CUDA version at build time. As before, it defaults to 12.9.

This mirrors the approach in https://github.com/prestodb/presto/pull/27074.