### PR TITLE
feat: Add to_base32 Presto function

### DIFF
--- a/velox/docs/functions/presto/binary.rst
+++ b/velox/docs/functions/presto/binary.rst
@@ -140,6 +140,10 @@ Binary Functions
 
     Computes the 64-bit SpookyHashV2 hash of ``binary``.
 
+.. function:: to_base32(binary) -> varchar
+
+    Encodes ``binary`` into a base32 string representation using the `RFC 4648 <https://www.rfc-editor.org/rfc/rfc4648#section-6>`_ alphabet (A-Z, 2-7).
+
 .. function:: to_base64(binary) -> varchar
 
     Encodes ``binary`` into a base64 string representation.

--- a/velox/functions/prestosql/BinaryFunctions.h
+++ b/velox/functions/prestosql/BinaryFunctions.h
@@ -337,6 +337,18 @@ struct FromBase32Function {
 };
 
 template <typename T>
+struct ToBase32Function {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varbinary>& input) {
+    result.append(
+        encoding::Base32::encode(std::string_view(input.data(), input.size())));
+  }
+};
+
+template <typename T>
 struct FromBase64UrlFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BinaryFunctionsRegistration.cpp
@@ -66,6 +66,9 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<FromBase32Function, Varbinary, Varbinary>(
       {prefix + "from_base32"});
 
+  registerFunction<ToBase32Function, Varchar, Varbinary>(
+      {prefix + "to_base32"});
+
   registerFunction<ToBase64UrlFunction, Varchar, Varbinary>(
       {prefix + "to_base64url"});
   registerFunction<FromBase64UrlFunction, Varbinary, Varchar>(

--- a/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/BinaryFunctionsTest.cpp
@@ -1013,4 +1013,39 @@ TEST_F(BinaryFunctionsTest, fromBase32) {
       fromBase32("NBSWY3DPEB3W64"), "Invalid input length 14");
 }
 
+TEST_F(BinaryFunctionsTest, toBase32) {
+  const auto toBase32 = [&](std::optional<std::string> value) {
+    return evaluateOnce<std::string>("to_base32(cast(c0 as varbinary))", value);
+  };
+
+  // Null handling.
+  EXPECT_EQ(std::nullopt, toBase32(std::nullopt));
+
+  // Empty input.
+  EXPECT_EQ("", toBase32(""));
+
+  // Basic encoding tests covering all trailing-byte counts (1-5 bytes).
+  EXPECT_EQ("ME======", toBase32("a"));
+  EXPECT_EQ("MFRA====", toBase32("ab"));
+  EXPECT_EQ("MFRGG===", toBase32("abc"));
+  EXPECT_EQ("MFRGGZA=", toBase32("abcd"));
+  EXPECT_EQ("MFRGGZDF", toBase32("abcde"));
+
+  // Longer strings.
+  EXPECT_EQ("NBSWY3DPEB3W64TMMQ======", toBase32("hello world"));
+
+  // Special characters and binary data.
+  const auto fromHex = [&](std::optional<std::string> value) {
+    return evaluateOnce<std::string>("from_hex(c0)", value);
+  };
+  EXPECT_EQ("75H36UA=", toBase32(fromHex("FF4FBF50")));
+
+  // Round-trip test: decode(encode(x)) == x.
+  const auto fromBase32 = [&](const std::optional<std::string>& value) {
+    return evaluateOnce<std::string>("from_base32(c0)", VARCHAR(), value);
+  };
+  auto encoded = toBase32("hello world");
+  EXPECT_EQ("hello world", fromBase32(encoded));
+}
+
 } // namespace


### PR DESCRIPTION
Adds the `to_base32` Presto scalar function (`varbinary -> varchar`), complementing the existing `from_base32`. Encodes using `Base32::encode()` with the RFC 4648 alphabet (A-Z, 2-7).