### PR TITLE
fix(test): Flakiness in KHLL uniqueDistribution test

### DIFF
--- a/velox/functions/lib/tests/KHyperLogLogTest.cpp
+++ b/velox/functions/lib/tests/KHyperLogLogTest.cpp
@@ -293,7 +293,9 @@ TEST_F(KHyperLogLogTest, uniquenessDistribution) {
 
     // Use 10% tolerance since the values of uniqueness distribution are a sum
     // of 1 / size of minHash, and not the cardinality estimates.
-    EXPECT_NEAR(khllEstimated, expected, expected * 0.1)
+    // Allow larger tolerance for buckets with very few values.
+    double tolerance = std::max(2.0 / size, 0.1 * expected);
+    EXPECT_NEAR(khllEstimated, expected, tolerance)
         << "Histogram mismatch at bucket " << i;
   }
 }


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/16110

Summary: There was some flakiness in the uniqueness distribution test when the expected was 0, because it would allow 0 tolerance. Fix: use a larger tolerance (2/size which allows for error up to 2 values in that bucket) while comparing buckets with too few expected values

Differential Revision: D92242037


