### PR TITLE
feat: Add isDefaultNullBehavior API

### DIFF
--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -109,6 +109,25 @@ std::optional<bool> isDeterministic(const std::string& functionName) {
   return true;
 }
 
+std::optional<bool> isDefaultNullBehavior(const std::string& functionName) {
+  const auto simpleFunctions =
+      exec::simpleFunctions().getFunctionSignaturesAndMetadata(functionName);
+  const auto metadata = exec::getVectorFunctionMetadata(functionName);
+  if (simpleFunctions.empty() && !metadata.has_value()) {
+    return std::nullopt;
+  }
+
+  for (const auto& [funcMetadata, _] : simpleFunctions) {
+    if (!funcMetadata.defaultNullBehavior) {
+      return false;
+    }
+  }
+  if (metadata.has_value() && !metadata.value().defaultNullBehavior) {
+    return false;
+  }
+  return true;
+}
+
 TypePtr resolveFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {

--- a/velox/functions/FunctionRegistry.h
+++ b/velox/functions/FunctionRegistry.h
@@ -46,6 +46,13 @@ FunctionSignatureMap getVectorFunctionSignatures();
 /// the entries are not deterministic.
 std::optional<bool> isDeterministic(const std::string& functionName);
 
+/// Returns if a function has default null behavior (null in any input produces
+/// null output) by fetching all registry entries for the given function name
+/// and checking if all of them have default null behavior.
+/// Returns std::nullopt if the function is not found. Returns false if any of
+/// the entries do not have default null behavior.
+std::optional<bool> isDefaultNullBehavior(const std::string& functionName);
+
 /// Given a function name and argument types, returns
 /// the return type if function exists otherwise returns nullptr
 TypePtr resolveFunction(

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -601,6 +601,23 @@ TEST_F(FunctionRegistryTest, isDeterministic) {
   ASSERT_FALSE(isDeterministic("not_found_function").has_value());
 }
 
+TEST_F(FunctionRegistryTest, isDefaultNullBehavior) {
+  functions::prestosql::registerAllScalarFunctions();
+
+  // Functions with default null behavior.
+  ASSERT_TRUE(isDefaultNullBehavior("eq").value());
+  ASSERT_TRUE(isDefaultNullBehavior("plus").value());
+  ASSERT_TRUE(isDefaultNullBehavior("substr").value());
+
+  // Functions with non-default null behavior.
+  ASSERT_FALSE(isDefaultNullBehavior("distinct_from").value());
+  ASSERT_FALSE(isDefaultNullBehavior("in").value());
+
+  // Not found functions.
+  ASSERT_FALSE(isDefaultNullBehavior("cast").has_value());
+  ASSERT_FALSE(isDefaultNullBehavior("not_found_function").has_value());
+}
+
 TEST_F(FunctionRegistryTest, companionFunction) {
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();


### PR DESCRIPTION
Summary:
Add `isDefaultNullBehavior` function to the Velox function registry API. This function allows callers to check if a registered function has default null behavior (null in any input produces null output).

This API is needed by the Axiom optimizer to determine whether filter predicates can be pushed through outer joins.

Differential Revision: D92271292


