### PR TITLE
fix: Fix the memory pool hierarchy of writer node

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -606,9 +606,7 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
     options->schema = getNonPartitionTypes(dataChannels_, inputType_);
   }
 
-  if (options->memoryPool == nullptr) {
-    options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
-  }
+  options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
 
   if (!options->compressionKind) {
     options->compressionKind = insertTableHandle_->compressionKind();

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -606,8 +606,6 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
     options->schema = getNonPartitionTypes(dataChannels_, inputType_);
   }
 
-  options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
-
   if (!options->compressionKind) {
     options->compressionKind = insertTableHandle_->compressionKind();
   }
@@ -616,9 +614,10 @@ std::shared_ptr<dwio::common::WriterOptions> HiveDataSink::createWriterOptions(
     options->spillConfig = spillConfig_;
   }
 
-  // Always set nonReclaimableSection to the current writer's holder.
-  // Since insertTableHandle_->writerOptions() returns a shared_ptr, we need
-  // to ensure each writer has its own nonReclaimableSection pointer.
+  // Always set per-writer options to the current writer's values.
+  // Since insertTableHandle_->writerOptions() returns a shared_ptr, each writer
+  // needs its own memory pool and nonReclaimableSection pointer.
+  options->memoryPool = writerInfo_[writerIndex]->writerPool.get();
   options->nonReclaimableSection =
       writerInfo_[writerIndex]->nonReclaimableSectionHolder.get();
 

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -160,13 +160,8 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gtest_main
   )
 
-  add_executable(
-    velox_hive_writer_options_adapter_test WriterOptionsAdapterTest.cpp
-  )
-  add_test(
-    velox_hive_writer_options_adapter_test
-    velox_hive_writer_options_adapter_test
-  )
+  add_executable(velox_hive_writer_options_adapter_test WriterOptionsAdapterTest.cpp)
+  add_test(velox_hive_writer_options_adapter_test velox_hive_writer_options_adapter_test)
 
   target_link_libraries(
     velox_hive_writer_options_adapter_test

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1951,6 +1951,44 @@ TEST_F(HiveDataSinkTest, sharedWriterOptionsWithMultipleWriters) {
       outputDirectory->getPath(), static_cast<uint32_t>(partitions.size()));
 }
 
+DEBUG_ONLY_TEST_F(HiveDataSinkTest, sharedWriterOptionsUsePerWriterMemoryPool) {
+  const auto outputDirectory = TempDirectoryPath::create();
+  auto sharedWriterOptions = std::make_shared<dwrf::WriterOptions>();
+
+  const auto rowType = ROW({"c0", "p0"}, {BIGINT(), VARCHAR()});
+  auto dataSink = createDataSink(
+      rowType,
+      outputDirectory->getPath(),
+      dwio::common::FileFormat::DWRF,
+      {"p0"},
+      nullptr,
+      sharedWriterOptions);
+
+  std::set<std::string> writerPoolNames;
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::dwrf::Writer::write",
+      std::function<void(dwrf::Writer*)>([&](dwrf::Writer* writer) {
+        // Memory pool hierarchy:
+        // Hive writer pool -> DWRF writer pool -> DWRF category leaf pools.
+        auto* dwrfPool = writer->getContext()
+                             .getMemoryPool(dwrf::MemoryUsageCategory::GENERAL)
+                             .parent();
+        ASSERT_NE(dwrfPool, nullptr);
+        auto* writerPool = dwrfPool->parent();
+        ASSERT_NE(writerPool, nullptr);
+        writerPoolNames.insert(writerPool->name());
+      }));
+
+  auto c0 = makeFlatVector<int64_t>(200, [](auto row) { return row; });
+  auto p0 = makeFlatVector<StringView>(
+      200, [](auto row) { return row % 2 == 0 ? "part_0" : "part_1"; });
+  dataSink->appendData(makeRowVector({c0, p0}));
+
+  ASSERT_EQ(writerPoolNames.size(), 2);
+  ASSERT_TRUE(dataSink->finish());
+  ASSERT_EQ(dataSink->close().size(), 2);
+}
+
 TEST_F(HiveDataSinkTest, sanitizeFileName) {
   auto sanitizeFileName = [](std::string fileName) {
     HiveInsertFileNameGenerator::sanitizeFileName(fileName);

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1951,9 +1951,9 @@ TEST_F(HiveDataSinkTest, sharedWriterOptionsWithMultipleWriters) {
       outputDirectory->getPath(), static_cast<uint32_t>(partitions.size()));
 }
 
-DEBUG_ONLY_TEST_F(HiveDataSinkTest, sharedWriterOptionsUsePerWriterMemoryPool) {
+DEBUG_ONLY_TEST_F(HiveDataSinkTest, perWriterMemoryPool) {
   const auto outputDirectory = TempDirectoryPath::create();
-  auto sharedWriterOptions = std::make_shared<dwrf::WriterOptions>();
+  auto writerOptions = std::make_shared<dwrf::WriterOptions>();
 
   const auto rowType = ROW({"c0", "p0"}, {BIGINT(), VARCHAR()});
   auto dataSink = createDataSink(
@@ -1962,7 +1962,7 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, sharedWriterOptionsUsePerWriterMemoryPool) {
       dwio::common::FileFormat::DWRF,
       {"p0"},
       nullptr,
-      sharedWriterOptions);
+      writerOptions);
 
   std::set<std::string> writerPoolNames;
   SCOPED_TESTVALUE_SET(
@@ -1970,19 +1970,20 @@ DEBUG_ONLY_TEST_F(HiveDataSinkTest, sharedWriterOptionsUsePerWriterMemoryPool) {
       std::function<void(dwrf::Writer*)>([&](dwrf::Writer* writer) {
         // Memory pool hierarchy:
         // Hive writer pool -> DWRF writer pool -> DWRF category leaf pools.
-        auto* dwrfPool = writer->getContext()
-                             .getMemoryPool(dwrf::MemoryUsageCategory::GENERAL)
-                             .parent();
-        ASSERT_NE(dwrfPool, nullptr);
-        auto* writerPool = dwrfPool->parent();
+        auto* innerPool = writer->getContext()
+                              .getMemoryPool(dwrf::MemoryUsageCategory::GENERAL)
+                              .parent();
+        ASSERT_NE(innerPool, nullptr);
+        auto* writerPool = innerPool->parent();
         ASSERT_NE(writerPool, nullptr);
         writerPoolNames.insert(writerPool->name());
       }));
 
-  auto c0 = makeFlatVector<int64_t>(200, [](auto row) { return row; });
-  auto p0 = makeFlatVector<StringView>(
-      200, [](auto row) { return row % 2 == 0 ? "part_0" : "part_1"; });
-  dataSink->appendData(makeRowVector({c0, p0}));
+  dataSink->appendData(makeRowVector({
+      makeFlatVector<int64_t>(200, folly::identity),
+      makeFlatVector<StringView>(
+          200, [](auto row) { return row % 2 == 0 ? "part_0" : "part_1"; }),
+  }));
 
   ASSERT_EQ(writerPoolNames.size(), 2);
   ASSERT_TRUE(dataSink->finish());


### PR DESCRIPTION
`insertTableHandle_->writerOptions()` returns a shared `WriterOptions` object. Previously, `memoryPool` was only set when null, so after writer 0 initialized it, later writers reused writer 0's pool. As a result, all writers' memory gets attributed to writer 0's pool while other writers' pools show no usage, making it impossible to identify which writer is consuming memory.

Fix: set `memoryPool` unconditionally, matching the existing pattern for `nonReclaimableSection`.