### PR TITLE
feat: Add optional allow null key feature in index writer

### DIFF
--- a/velox/serializers/KeyEncoder.cpp
+++ b/velox/serializers/KeyEncoder.cpp
@@ -1083,8 +1083,11 @@ std::unique_ptr<KeyEncoder> KeyEncoder::create(
     RowTypePtr inputType,
     std::vector<core::SortOrder> sortOrders,
     memory::MemoryPool* pool) {
-  return std::unique_ptr<KeyEncoder>(
-      new KeyEncoder(keyColumns, inputType, sortOrders, pool));
+  return std::unique_ptr<KeyEncoder>(new KeyEncoder(
+      std::move(keyColumns),
+      std::move(inputType),
+      std::move(sortOrders),
+      pool));
 }
 
 KeyEncoder::KeyEncoder(


### PR DESCRIPTION
Summary: Optional Null Key Feature: Adds an `allowNullKeys` option to the index writer, letting users permit or reject null keys in index columns. If enabled, nulls are allowed; if not, an exception is thrown.

Differential Revision: D92303291


