### PR TITLE
feat: Add BaseVector::createLike to support empty vector creating matching source vector

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -23,6 +23,7 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/DictionaryVector.h"
+#include "velox/vector/FlatMapVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/LazyVector.h"
 #include "velox/vector/SequenceVector.h"
@@ -473,6 +474,76 @@ VectorPtr BaseVector::createInternal(
     default:
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
           createEmpty, kind, size, pool, type);
+  }
+}
+
+// static
+VectorPtr BaseVector::createEmptyLike(
+    const BaseVector* source,
+    vector_size_t size,
+    memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(source);
+  auto* wrapped = source->wrappedVector();
+  const auto& type = source->type();
+
+  switch (type->kind()) {
+    case TypeKind::ROW: {
+      auto& rowType = type->as<TypeKind::ROW>();
+      auto* sourceRow = wrapped->as<RowVector>();
+      std::vector<VectorPtr> children;
+      children.reserve(rowType.size());
+      for (size_t i = 0; i < rowType.size(); ++i) {
+        children.push_back(
+            createEmptyLike(sourceRow->childAt(i).get(), size, pool));
+      }
+      return std::make_shared<RowVector>(
+          pool, type, nullptr, size, std::move(children));
+    }
+    case TypeKind::ARRAY: {
+      auto offsets = allocateOffsets(size, pool);
+      auto sizes = allocateSizes(size, pool);
+      auto* sourceArray = wrapped->as<ArrayVector>();
+      auto elements = createEmptyLike(sourceArray->elements().get(), 0, pool);
+      return std::make_shared<ArrayVector>(
+          pool,
+          type,
+          nullptr,
+          size,
+          std::move(offsets),
+          std::move(sizes),
+          std::move(elements));
+    }
+    case TypeKind::MAP: {
+      // If source is FLAT_MAP, directly create FlatMapVector.
+      if (wrapped->encoding() == VectorEncoding::Simple::FLAT_MAP) {
+        return std::make_shared<FlatMapVector>(
+            pool,
+            type,
+            nullptr, // nulls
+            size,
+            nullptr, // distinctKeys
+            std::vector<VectorPtr>{}, // mapValues
+            std::vector<BufferPtr>{}); // inMaps
+      }
+
+      // Otherwise create standard MapVector.
+      auto offsets = allocateOffsets(size, pool);
+      auto sizes = allocateSizes(size, pool);
+      auto* sourceMap = wrapped->as<MapVector>();
+      auto keys = createEmptyLike(sourceMap->mapKeys().get(), 0, pool);
+      auto values = createEmptyLike(sourceMap->mapValues().get(), 0, pool);
+      return std::make_shared<MapVector>(
+          pool,
+          type,
+          nullptr,
+          size,
+          std::move(offsets),
+          std::move(sizes),
+          std::move(keys),
+          std::move(values));
+    }
+    default:
+      return BaseVector::create(type, size, pool);
   }
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -746,6 +746,17 @@ class BaseVector {
     return vector ? vector : create(type, 0, pool);
   }
 
+  /// Creates a vector matching the structure of a source vector, preserving
+  /// FLAT_MAP encoding where the source uses it. For nested types (ROW, ARRAY,
+  /// MAP), it recursively handles children to preserve encoding at each level.
+  /// BaseVector::create builds from type, without reference to encodings. This
+  /// will still flatten other encodings (e.g. dictionary, constant and lazy),
+  /// only preserving flat map as FlatMapVector.
+  static VectorPtr createEmptyLike(
+      const BaseVector* source,
+      vector_size_t size,
+      memory::MemoryPool* pool);
+
   /// Set 'nulls' to be the nulls buffer of this vector. This API should not be
   /// used on ConstantVector.
   void setNulls(const BufferPtr& nulls);


### PR DESCRIPTION
Summary: Adds function `BaseVector::createLike` to BaseVector's vector creation suite to allow empty vector creation matching a source vector. This will help in creating template vectors preserving flat map encoding and will adds capability for other encoding preserve template vectors.

Differential Revision: D92333447


