### PR TITLE
fix(test): Fix race condition in SkewedPartitionRebalancerTest.serializedRebalanceExecution

### DIFF
--- a/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
+++ b/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
@@ -76,6 +76,10 @@ class SkewedPartitionRebalancerTestHelper {
 
 class SkewedPartitionRebalancerTest : public testing::Test {
  protected:
+  static void SetUpTestSuite() {
+    TestValue::enable();
+  }
+
   std::unique_ptr<SkewedPartitionRebalancer> createBalancer(
       uint32_t numPartitions = 128,
       uint32_t numTasks = 8,
@@ -356,7 +360,7 @@ DEBUG_ONLY_TEST_F(SkewedPartitionRebalancerTest, serializedRebalanceExecution) {
   // there. This ensures that when we call rebalance() from the main thread,
   // rebalancing_ is already true and our rebalance() call will return early.
   mainThreadRebalancerWait.await(
-      [&] { return mainThreadRebalancerWaitFlag.load(); });
+      [&] { return !mainThreadRebalancerWaitFlag.load(); });
 
   balancer->rebalance();
 


### PR DESCRIPTION
## Summary

This PR fixes the remaining race condition in `SkewedPartitionRebalancerTest.serializedRebalanceExecution` that still causes intermittent CI timeouts after #16300.

## Root Cause

Two bugs remain after #16300:

1. **`TestValue::enable()` is never called**: `SetUpTestCase()` is defined on `SkewedPartitionRebalancerTestHelper` (a helper class), not on the `SkewedPartitionRebalancerTest` fixture. GTest only calls `SetUpTestSuite()`/`SetUpTestCase()` on the actual test fixture, so TestValue callbacks are never registered.


## Fix

1. Added `SetUpTestSuite()` to the `SkewedPartitionRebalancerTest` fixture to enable TestValue.

Fixes #16158