### PR TITLE
fix(build): Add c-ares installation to Mac setup

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -43,7 +43,7 @@ export CMAKE_POLICY_VERSION_MINIMUM="3.5"
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 # gflags and glog are installed from source to ensure version compatibility.
 # Homebrew's glog 0.7.x has breaking API changes that are incompatible with folly.
-MACOS_VELOX_DEPS="bison flex googletest icu4c libevent libsodium lz4 openssl protobuf@21 simdjson snappy xz xxhash zstd"
+MACOS_VELOX_DEPS="bison c-ares flex googletest icu4c libevent libsodium lz4 openssl protobuf@21 simdjson snappy xz xxhash zstd"
 MACOS_BUILD_DEPS="ninja cmake"
 
 SUDO="${SUDO:-""}"


### PR DESCRIPTION
c-ares is required by proxygen most probably due to the recent FB_OS_VERSION upgrade. Was missing from Mac setup script.