### PR TITLE
feat(cursor): Add at() API to return cursor location

### DIFF
--- a/python/test/test_debugger_runner.py
+++ b/python/test/test_debugger_runner.py
@@ -101,10 +101,10 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         [runner.set_breakpoint(i) for i in self._node_ids]
         self.assertEqual(
             self._count_step(runner),
-            self._batch_size * self._num_batches * (self._num_projections + 1)
+            self._batch_size * self._num_batches * (self._num_projections + 1),
         )
 
-    def test_breakpoint_wit_aggregate(self):
+    def test_breakpoint_with_aggregate(self):
         """Set a breakpoint before aggregation to see pre-aggregated data."""
         batch_size = 100
 
@@ -140,3 +140,32 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
         # Should be done now.
         with self.assertRaises(StopIteration):
             it.next()
+
+    def test_iterator_at(self):
+        runner = LocalDebuggerRunner(self._plan_node)
+        runner.set_breakpoint(self._node_ids[3])
+        runner.set_breakpoint(self._node_ids[8])
+
+        it = runner.execute()
+        self.assertEqual(it.at(), "")
+
+        it.step()
+        self.assertEqual(it.at(), self._node_ids[3])
+
+        it.step()
+        self.assertEqual(it.at(), self._node_ids[8])
+
+        it.step()
+        self.assertEqual(it.at(), "")
+
+        it.step()
+        self.assertEqual(it.at(), self._node_ids[3])
+
+        it.next()
+        self.assertEqual(it.at(), "")
+
+        it.next()
+        self.assertEqual(it.at(), "")
+
+        it.step()
+        self.assertEqual(it.at(), self._node_ids[3])

--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -135,7 +135,13 @@ class TaskCursor {
   /// @return Returns false is the task is done producing output.
   virtual bool moveStep() = 0;
 
+  /// Returns the vector the cursor is currently on.
   virtual RowVectorPtr& current() = 0;
+
+  /// If breakpoints are set, returns the plan node that generated the trace. If
+  /// the cursor is at the task output or if there are no breakpoints,
+  /// returns empty string.
+  virtual core::PlanNodeId at() const = 0;
 
   virtual void setError(std::exception_ptr error) = 0;
 

--- a/velox/python/CMakeLists.txt
+++ b/velox/python/CMakeLists.txt
@@ -99,7 +99,12 @@ pyvelox_add_module(plan_builder MODULE plan_builder/plan_builder.cpp)
 target_link_libraries(plan_builder PRIVATE velox_py_plan_builder_lib)
 
 # pyvelox.runner library:
-add_library(velox_py_local_runner_lib runner/PyLocalRunner.cpp runner/PyConnectors.cpp)
+add_library(
+  velox_py_local_runner_lib
+  runner/PyLocalRunner.cpp
+  runner/PyLocalDebuggerRunner.cpp
+  runner/PyConnectors.cpp
+)
 target_include_directories(
   velox_py_local_runner_lib
   PUBLIC ${PROJECT_SOURCE_DIR}/velox/external/xxhash
@@ -118,6 +123,7 @@ target_link_libraries(
   velox_dwio_dwrf_common
   velox_dwio_dwrf_writer
   pybind11::module
+  pybind11::embed
 )
 
 pyvelox_add_module(runner MODULE runner/runner.cpp)

--- a/velox/python/plan_builder/PyPlanBuilder.h
+++ b/velox/python/plan_builder/PyPlanBuilder.h
@@ -175,8 +175,8 @@ class PyPlanBuilder {
   ///  )
   PyPlanBuilder& tableScan(
       const PyType& outputSchema,
-      const pybind11::dict& aliases,
-      const pybind11::dict& subfields,
+      const std::unordered_map<std::string, std::string>& aliases,
+      const std::unordered_map<std::string, std::vector<int64_t>>& subfields,
       const std::vector<std::string>& filters,
       const std::string& remainingFilter,
       const std::string& rowIndexColumnName,

--- a/velox/python/plan_builder/plan_builder.cpp
+++ b/velox/python/plan_builder/plan_builder.cpp
@@ -95,8 +95,9 @@ PYBIND11_MODULE(plan_builder, m) {
           "table_scan",
           &velox::py::PyPlanBuilder::tableScan,
           py::arg("output_schema") = velox::py::PyType{},
-          py::arg("aliases") = py::dict{},
-          py::arg("subfields") = py::dict{},
+          py::arg("aliases") = std::unordered_map<std::string, std::string>{},
+          py::arg("subfields") =
+              std::unordered_map<std::string, std::vector<int64_t>>{},
           py::arg("filters") = std::vector<std::string>{},
           py::arg("remaining_filter") = "",
           py::arg("row_index") = "",

--- a/velox/python/runner/PyConnectors.h
+++ b/velox/python/runner/PyConnectors.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include <pybind11/embed.h>
+#include <string>
+#include <unordered_map>
 
 namespace facebook::velox::py {
 

--- a/velox/python/runner/PyLocalRunner.cpp
+++ b/velox/python/runner/PyLocalRunner.cpp
@@ -86,6 +86,10 @@ PyVector PyTaskIterator::step() {
   return PyVector{vector_, outputPool_};
 }
 
+std::string PyTaskIterator::at() const {
+  return cursor_->at();
+}
+
 PyLocalRunner::PyLocalRunner(
     const PyPlanNode& pyPlanNode,
     const std::shared_ptr<memory::MemoryPool>& pool,

--- a/velox/python/runner/PyLocalRunner.h
+++ b/velox/python/runner/PyLocalRunner.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include <pybind11/embed.h>
-
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -52,6 +50,10 @@ class PyTaskIterator {
     }
     return PyVector{vector_, outputPool_};
   }
+
+  /// Returns the plan node ID where the cursor is currently stopped. This is
+  /// useful for debugging to know where in the plan the execution has paused.
+  std::string at() const;
 
  private:
   std::shared_ptr<memory::MemoryPool> outputPool_;

--- a/velox/python/runner/runner.cpp
+++ b/velox/python/runner/runner.cpp
@@ -57,6 +57,11 @@ PYBIND11_MODULE(runner, m) {
           "current",
           &velox::py::PyTaskIterator::current,
           py::keep_alive<0, 1>())
+      .def("at", &velox::py::PyTaskIterator::at, py::doc(R"(
+        Returns the plan node ID where the cursor is currently stopped.
+        This is useful for debugging to know where in the plan the
+        execution has paused.
+          )"))
       .def(
           "__iter__",
           &velox::py::PyTaskIterator::iter,

--- a/velox/python/type/PyType.h
+++ b/velox/python/type/PyType.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <pybind11/embed.h>
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/type/Type.h"
 

--- a/velox/python/vector/PyVector.h
+++ b/velox/python/vector/PyVector.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <pybind11/embed.h>
 #include "velox/python/type/PyType.h"
 #include "velox/vector/BaseVector.h"
 


### PR DESCRIPTION
Summary:
Adding at() method to the cursor API to return where the cursor is
currently located. at() returns empty string if it's at a task output, or the
plan node id of the current operator if it's at a breakpoint.

Reviewed By: xiaoxmeng

Differential Revision: D92220367


