### PR TITLE
fix: Add cursor param to modulate encoded vector copy

### DIFF
--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -89,6 +89,10 @@ struct CursorParameters {
   /// breakpoints. This is useful for debugging query execution and
   /// understanding data flow through operators.
   std::vector<core::PlanNodeId> breakpoints;
+
+  /// Preserves encoded vector copy.
+  /// TODO remove.
+  bool preserveEncodedCopy = false;
 };
 
 /// Abstract interface for iterating over query results. TaskCursor manages

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -967,6 +967,7 @@ TEST_F(MergeTest, preserveVectorEncoding) {
   params.planNode = plan;
   params.queryCtx = core::QueryCtx::create(executor_.get());
   params.maxDrivers = 2;
+  params.preserveEncodedCopy = true;
 
   auto result = readCursor(params);
   ASSERT_EQ(result.second.size(), 1);


### PR DESCRIPTION
Summary:
Add cursor parameter to modulate preservation of encoded vector copy in cursor.

Axiom may lack the full e2e support to support encoded vectors. Although Presto serializer can handle encoded vectors, somewhere PrestoClient is getting hung when result vectors are wrapped. Velox will need encoded copies to support flat map encodings, but we can add a temporary fix to achieve both Axiom's and Velox's needs. Long-term (rather medium to short term) we should investigate why PrestoClient hangs with encoded vectors.

Differential Revision: D92443953


