### PR TITLE
feat(cursor): Support custom callbacks on breakpoints

### DIFF
--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -64,13 +64,13 @@ struct CursorParameters {
 
   /// Spilling directory, if not empty, then the task's spilling directory
   /// would be built from it.
-  std::string spillDirectory;
+  std::string spillDirectory = "";
 
   /// Callback function to dynamically create or determine the spill directory
   /// path at runtime. If provided, this callback is invoked when spilling is
   /// needed and must return a valid directory path. This allows for dynamic
   /// spill directory creation or path resolution based on runtime conditions.
-  std::function<std::string()> spillDirectoryCallback;
+  std::function<std::string()> spillDirectoryCallback = nullptr;
 
   bool copyResult = true;
 
@@ -82,13 +82,34 @@ struct CursorParameters {
 
   /// If both 'queryConfigs' and 'queryCtx' are specified, the configurations
   /// in 'queryCtx' will be overridden by 'queryConfig'.
-  std::unordered_map<std::string, std::string> queryConfigs;
+  std::unordered_map<std::string, std::string> queryConfigs = {};
+
+  // Debugging related structures:
+
+  /// Callback type for breakpoints.
+  ///
+  /// Called with the current vector when the breakpoint is hit. The return
+  /// value semantics is "should block?"; returns true if the driver should stop
+  /// and produce the vector, false to continue without stopping.
+  ///
+  /// If callback is not specified (nullptr), assume the partial vector should
+  /// always be produced, which is the same as callback returning true (always
+  /// stop).
+  using BreakpointCallback = std::function<bool(const RowVectorPtr&)>;
+
+  /// Map type for breakpoints: plan node ID to optional callback.
+  using TBreakpointMap =
+      std::unordered_map<core::PlanNodeId, BreakpointCallback>;
 
   /// Breakpoints enable step-by-step execution of a query plan, allowing users
   /// to inspect intermediate results at operator boundaries containing
   /// breakpoints. This is useful for debugging query execution and
   /// understanding data flow through operators.
-  std::vector<core::PlanNodeId> breakpoints;
+  ///
+  /// Maps plan node IDs to optional callbacks. When a breakpoint is hit, the
+  /// callback (if non-null) is invoked with the current vector before the
+  /// cursor pauses.
+  TBreakpointMap breakpoints = {};
 };
 
 /// Abstract interface for iterating over query results. TaskCursor manages

--- a/velox/exec/tests/CustomTraceTest.cpp
+++ b/velox/exec/tests/CustomTraceTest.cpp
@@ -137,6 +137,17 @@ TEST_F(CustomTraceTest, customTrace) {
   tracedVectors.clear();
 }
 
+// Helper to convert a vector of plan node IDs to a breakpoints map with null
+// callbacks.
+CursorParameters::TBreakpointMap toBreakpointsMap(
+    const std::vector<core::PlanNodeId>& ids) {
+  CursorParameters::TBreakpointMap result;
+  for (const auto& id : ids) {
+    result[id] = nullptr;
+  }
+  return result;
+}
+
 void assertCursorOutput(
     const core::PlanNodePtr& plan,
     const std::vector<core::PlanNodeId>& breakpoints,
@@ -144,7 +155,7 @@ void assertCursorOutput(
   auto cursor = TaskCursor::create({
       .planNode = plan,
       .serialExecution = true,
-      .breakpoints = breakpoints,
+      .breakpoints = toBreakpointsMap(breakpoints),
   });
   size_t i = 0;
 
@@ -262,7 +273,7 @@ TEST_F(CustomTraceTest, cursorAt) {
   auto cursor = TaskCursor::create({
       .planNode = plan,
       .serialExecution = true,
-      .breakpoints = {project1, project3},
+      .breakpoints = toBreakpointsMap({project1, project3}),
   });
 
   // Before any step, at() should return empty string.
@@ -299,7 +310,7 @@ TEST_F(CustomTraceTest, cursorAt) {
   auto cursor2 = TaskCursor::create({
       .planNode = plan,
       .serialExecution = true,
-      .breakpoints = {project1, project3},
+      .breakpoints = toBreakpointsMap({project1, project3}),
   });
 
   EXPECT_EQ(cursor2->at(), "");
@@ -312,6 +323,172 @@ TEST_F(CustomTraceTest, cursorAt) {
   EXPECT_EQ(cursor2->at(), "");
 
   EXPECT_FALSE(cursor2->moveNext());
+}
+
+TEST_F(CustomTraceTest, breakpointCallbackAlwaysStop) {
+  const size_t size = 10;
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(size, [](auto row) { return row; })});
+
+  core::PlanNodeId project1;
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(project1)
+                  .planNode();
+
+  // Callback that always returns true (always stop).
+  int callbackCount = 0;
+  CursorParameters::TBreakpointMap breakpoints;
+  breakpoints[project1] = [&](const RowVectorPtr& vector) {
+    ++callbackCount;
+    EXPECT_EQ(vector->size(), size);
+    return true;
+  };
+
+  auto cursor = TaskCursor::create({
+      .planNode = plan,
+      .serialExecution = true,
+      .breakpoints = std::move(breakpoints),
+  });
+
+  // First step should stop at breakpoint.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), project1);
+  EXPECT_EQ(callbackCount, 1);
+
+  // Second step should produce final output.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), "");
+
+  EXPECT_FALSE(cursor->moveStep());
+}
+
+TEST_F(CustomTraceTest, breakpointCallbackNeverStop) {
+  const size_t size = 10;
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(size, [](auto row) { return row; })});
+
+  core::PlanNodeId project1;
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(project1)
+                  .planNode();
+
+  // Callback that always returns false (never stop).
+  int callbackCount = 0;
+  CursorParameters::TBreakpointMap breakpoints;
+  breakpoints[project1] = [&](const RowVectorPtr& vector) {
+    ++callbackCount;
+    EXPECT_EQ(vector->size(), size);
+    return false;
+  };
+
+  auto cursor = TaskCursor::create({
+      .planNode = plan,
+      .serialExecution = true,
+      .breakpoints = std::move(breakpoints),
+  });
+
+  // Step should skip the breakpoint and go directly to final output.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), "");
+  EXPECT_EQ(callbackCount, 1); // Callback was still invoked.
+
+  EXPECT_FALSE(cursor->moveStep());
+}
+
+TEST_F(CustomTraceTest, breakpointCallbackConditional) {
+  const size_t size = 10;
+  auto input1 = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(size, [](auto row) { return row; })});
+  auto input2 = makeRowVector(
+      {"a"},
+      {makeFlatVector<int64_t>(size, [](auto row) { return row + 100; })});
+
+  core::PlanNodeId project1;
+  auto plan = PlanBuilder()
+                  .values({input1, input2})
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(project1)
+                  .planNode();
+
+  // Callback that stops only when first element is >= 100.
+  int callbackCount = 0;
+  CursorParameters::TBreakpointMap breakpoints;
+  breakpoints[project1] = [&](const RowVectorPtr& vector) {
+    ++callbackCount;
+    auto values = vector->childAt(0)->asFlatVector<int64_t>();
+    return values->valueAt(0) >= 100;
+  };
+
+  auto cursor = TaskCursor::create({
+      .planNode = plan,
+      .serialExecution = true,
+      .breakpoints = std::move(breakpoints),
+  });
+
+  // First batch: callback returns false (first element is 0), skips breakpoint.
+  // Goes to final output for first batch.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), "");
+  EXPECT_EQ(callbackCount, 1);
+
+  // Second batch: callback returns true (first element is 100), stops at
+  // breakpoint.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), project1);
+  EXPECT_EQ(callbackCount, 2);
+
+  // Final output for second batch.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), "");
+
+  EXPECT_FALSE(cursor->moveStep());
+}
+
+TEST_F(CustomTraceTest, breakpointMixedCallbacks) {
+  const size_t size = 10;
+  auto input = makeRowVector(
+      {"a"}, {makeFlatVector<int64_t>(size, [](auto row) { return row; })});
+
+  core::PlanNodeId project1, project2;
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(project1)
+                  .project({"a * 10 as a"})
+                  .capturePlanNodeId(project2)
+                  .planNode();
+
+  // project1 has callback returning false (don't stop).
+  // project2 has null callback (always stop).
+  int callbackCount = 0;
+  CursorParameters::TBreakpointMap breakpoints;
+  breakpoints[project1] = [&](const RowVectorPtr&) {
+    ++callbackCount;
+    return false;
+  };
+  breakpoints[project2] = nullptr; // null callback = always stop.
+
+  auto cursor = TaskCursor::create({
+      .planNode = plan,
+      .serialExecution = true,
+      .breakpoints = std::move(breakpoints),
+  });
+
+  // project1 callback returns false, so it's skipped.
+  // project2 has null callback, so it stops.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), project2);
+  EXPECT_EQ(callbackCount, 1);
+
+  // Final output.
+  EXPECT_TRUE(cursor->moveStep());
+  EXPECT_EQ(cursor->at(), "");
+
+  EXPECT_FALSE(cursor->moveStep());
 }
 
 } // namespace

--- a/velox/python/CMakeLists.txt
+++ b/velox/python/CMakeLists.txt
@@ -123,8 +123,8 @@ target_link_libraries(
   velox_dwio_dwrf_common
   velox_dwio_dwrf_writer
   pybind11::module
-  pybind11::embed
 )
+target_compile_options(velox_py_local_runner_lib PRIVATE -Wno-missing-field-initializers)
 
 pyvelox_add_module(runner MODULE runner/runner.cpp)
 target_link_libraries(runner PRIVATE velox_py_local_runner_lib)

--- a/velox/python/runner/PyLocalDebuggerRunner.cpp
+++ b/velox/python/runner/PyLocalDebuggerRunner.cpp
@@ -19,7 +19,7 @@
 namespace facebook::velox::py {
 
 void PyLocalDebuggerRunner::setBreakpoint(const std::string& planNodeId) {
-  breakpoints_.push_back(planNodeId);
+  breakpoints_[planNodeId] = nullptr;
 }
 
 exec::CursorParameters PyLocalDebuggerRunner::createCursorParameters(

--- a/velox/python/runner/PyLocalDebuggerRunner.h
+++ b/velox/python/runner/PyLocalDebuggerRunner.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include "velox/python/runner/PyLocalRunner.h"
 
@@ -43,7 +42,7 @@ class PyLocalDebuggerRunner : public PyLocalRunner {
   exec::CursorParameters createCursorParameters(int32_t maxDrivers) override;
 
  private:
-  std::vector<std::string> breakpoints_;
+  exec::CursorParameters::TBreakpointMap breakpoints_;
 };
 
 } // namespace facebook::velox::py


### PR DESCRIPTION
Summary:
Enabling cursor users to add callbacks to specific breakpoints.
If provided, callbacks take the current vector being traced, and return whether
the driver should stop and produce the partial vector in the cursor output, or
move on.

Reviewed By: xiaoxmeng

Differential Revision: D92323821


