### PR TITLE
feat(expr): Add error code filtering to TryExpr

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -843,6 +843,12 @@ class QueryConfig {
   static constexpr const char* kJoinBuildVectorHasherMaxNumDistinct =
       "join_build_vector_hasher_max_num_distinct";
 
+  /// Comma-separated list of additional error codes that TRY() should catch.
+  /// TRY() always catches user errors. When specified, also catches errors
+  /// with these codes. Example: "ARITHMETIC_ERROR,INVALID_ARGUMENT"
+  static constexpr const char* kTryCatchableErrorCodes =
+      "try_catchable_error_codes";
+
   enum class RowSizeTrackingMode {
     DISABLED = 0,
     EXCLUDE_DELTA_SPLITS = 1,
@@ -1502,6 +1508,10 @@ class QueryConfig {
 
   uint32_t joinBuildVectorHasherMaxNumDistinct() const {
     return get<uint32_t>(kJoinBuildVectorHasherMaxNumDistinct, 1'000'000);
+  }
+
+  std::string tryCatchableErrorCodes() const {
+    return get<std::string>(kTryCatchableErrorCodes, "");
   }
 
   template <typename T>


### PR DESCRIPTION
Summary:
Add support for filtering catchable error codes in TryExpr. This allows
TRY() to catch only specific error codes and rethrow others.

**Changes:**
- Add `kTryCatchableErrorCodes` config in Velox QueryConfig
- Modify TryExpr to filter errors based on configured catchable codes:
  - Empty config = catch all user errors (backward compatible)
  - Specific codes = only catch matching errors, rethrow others
- Enable captureErrorDetails only when filtering is needed (performance)

**Design decisions:**
- Error codes matched by exact string (e.g., "ARITHMETIC_ERROR")
- Non-user errors are never caught regardless of configuration
- Non-Velox exceptions are treated as catchable

Related change in Presto Java https://github.com/prestodb/presto/pull/26976/

Differential Revision: D92117739


