### PR TITLE
refactor: CastKernel [1/11] Introduce CastKernel

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -52,6 +52,7 @@ velox_add_library(
   LambdaExpr.cpp
   PeeledEncoding.cpp
   PrestoCastHooks.cpp
+  PrestoCastKernel.cpp
   RegisterSpecialForm.cpp
   RowConstructor.cpp
   SimpleFunctionRegistry.cpp

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -23,6 +23,7 @@
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/PeeledEncoding.h"
 #include "velox/expression/PrestoCastHooks.h"
+#include "velox/expression/PrestoCastKernel.h"
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
@@ -1166,7 +1167,8 @@ ExprPtr CastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       false,
-      std::make_shared<PrestoCastHooks>(config));
+      std::make_shared<PrestoCastHooks>(config),
+      std::make_shared<PrestoCastKernel>(config));
 }
 
 TypePtr TryCastCallToSpecialForm::resolveType(
@@ -1189,6 +1191,7 @@ ExprPtr TryCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       true,
-      std::make_shared<PrestoCastHooks>(config));
+      std::make_shared<PrestoCastHooks>(config),
+      std::make_shared<PrestoCastKernel>(config));
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/expression/CastHooks.h"
+#include "velox/expression/CastKernel.h"
 #include "velox/expression/ExprConstants.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
@@ -86,7 +87,8 @@ class CastExpr : public SpecialForm {
       ExprPtr&& expr,
       bool trackCpuUsage,
       bool isTryCast,
-      std::shared_ptr<CastHooks> hooks)
+      std::shared_ptr<CastHooks> hooks,
+      std::shared_ptr<CastKernel> kernel)
       : SpecialForm(
             SpecialFormKind::kCast,
             type,
@@ -95,7 +97,8 @@ class CastExpr : public SpecialForm {
             false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
         isTryCast_(isTryCast),
-        hooks_(std::move(hooks)) {}
+        hooks_(std::move(hooks)),
+        kernel_(std::move(kernel)) {}
 
   void evalSpecialForm(
       const SelectivityVector& rows,
@@ -329,6 +332,7 @@ class CastExpr : public SpecialForm {
 
   bool isTryCast_;
   std::shared_ptr<CastHooks> hooks_;
+  std::shared_ptr<CastKernel> kernel_;
 
   bool inTopLevel = false;
 };

--- a/velox/expression/CastKernel.h
+++ b/velox/expression/CastKernel.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+
+/// Implementations of this class should provide the logic to handle casting
+/// between the core primitive types provided by Velox. This is inteded to be
+/// used by CastExpr and custom CastOperators.
+///
+/// For logical Types (Date, Time, Decimal, etc.) the functions castFromType
+/// and castToType are provided. These should handle any supported conversions
+/// between core primitive Types in Velox and Type.
+///
+/// For physical Types (Boolean, Integer, Varchar, etc.) only the function
+/// castToType is provided. These only need to handle converting from core
+/// physical primitive Types in Velox to Type.
+class CastKernel {
+ public:
+  virtual ~CastKernel() = default;
+
+ protected:
+  /// Initializes a result vector with the specified type and clears nulls
+  /// for the selected rows.
+  static FOLLY_ALWAYS_INLINE void initializeResultVector(
+      const SelectivityVector& rows,
+      const TypePtr& toType,
+      exec::EvalCtx& context,
+      VectorPtr& result) {
+    context.ensureWritable(rows, toType, result);
+    result->clearNulls(rows);
+  }
+
+  /// Constructs a helpful error message containing the Types involved in the
+  /// cast, the value being casted, and any additional details the caller
+  /// provides.
+  static FOLLY_ALWAYS_INLINE std::string makeErrorMessage(
+      const BaseVector& input,
+      vector_size_t row,
+      const TypePtr& toType,
+      const std::string& details = "") {
+    return fmt::format(
+        "Cannot cast {} '{}' to {}. {}",
+        input.type()->toString(),
+        input.toString(row),
+        toType->toString(),
+        details);
+  }
+
+  /// Inokes `func` passing each `row` in `rows`. For each `row` handles any
+  /// exceptions by either setting the value in `result` to NULL if
+  /// `setNullInResultAtError` is true, or setting the status in `context` if
+  /// `setNullInResultAtError` is false.
+  ///
+  /// If the exception is a VeloxException but not a UserError, the exception
+  /// will not be handled.
+  template <typename Func>
+  static FOLLY_ALWAYS_INLINE void applyToSelectedNoThrowLocal(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const VectorPtr& result,
+      bool setNullInResultAtError,
+      Func&& func) {
+    if (setNullInResultAtError) {
+      rows.applyToSelected([&](auto row) INLINE_LAMBDA {
+        try {
+          func(row);
+        } catch (const VeloxException& e) {
+          if (!e.isUserError()) {
+            throw;
+          }
+          result->setNull(row, true);
+        } catch (const std::exception&) {
+          result->setNull(row, true);
+        }
+      });
+    } else {
+      rows.applyToSelected([&](auto row) INLINE_LAMBDA {
+        try {
+          func(row);
+        } catch (const VeloxException& e) {
+          if (!e.isUserError()) {
+            throw;
+          }
+
+          context.setStatus(row, Status::UserError("{}", e.message()));
+        } catch (const std::exception& e) {
+          context.setStatus(row, Status::UserError("{}", e.what()));
+        }
+      });
+    }
+  }
+
+  static FOLLY_ALWAYS_INLINE void setError(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      BaseVector& result,
+      vector_size_t row,
+      const std::string& details,
+      bool setNullInResultAtError) {
+    if (setNullInResultAtError) {
+      result.setNull(row, true);
+    } else if (context.captureErrorDetails()) {
+      const auto errorDetails =
+          makeErrorMessage(input, row, result.type(), details);
+      context.setStatus(row, Status::UserError("{}", errorDetails));
+    } else {
+      context.setStatus(row, Status::UserError());
+    }
+  }
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastKernel.cpp
+++ b/velox/expression/PrestoCastKernel.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/PrestoCastKernel.h"
+
+namespace facebook::velox::exec {
+
+PrestoCastKernel::PrestoCastKernel(const core::QueryConfig& config)
+    : legacyCast_(config.isLegacyCast()) {}
+} // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastKernel.h
+++ b/velox/expression/PrestoCastKernel.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/CastKernel.h"
+
+namespace facebook::velox::exec {
+
+class PrestoCastKernel : public CastKernel {
+ public:
+  explicit PrestoCastKernel(const core::QueryConfig& config);
+
+ private:
+  const bool legacyCast_;
+};
+} // namespace facebook::velox::exec

--- a/velox/functions/sparksql/specialforms/CMakeLists.txt
+++ b/velox/functions/sparksql/specialforms/CMakeLists.txt
@@ -22,6 +22,7 @@ velox_add_library(
   MakeDecimal.cpp
   SparkCastExpr.cpp
   SparkCastHooks.cpp
+  SparkCastKernel.cpp
 )
 
 velox_link_libraries(

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -60,7 +60,8 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       isTryCast,
-      std::make_shared<SparkCastHooks>(config, true));
+      std::make_shared<SparkCastHooks>(config, true),
+      std::make_shared<SparkCastKernel>(config, true));
 }
 
 exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
@@ -78,6 +79,7 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       true,
-      std::make_shared<SparkCastHooks>(config, false));
+      std::make_shared<SparkCastHooks>(config, false),
+      std::make_shared<SparkCastKernel>(config, false));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -18,6 +18,7 @@
 
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
+#include "velox/functions/sparksql/specialforms/SparkCastKernel.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -31,9 +32,15 @@ class SparkCastExpr : public exec::CastExpr {
       exec::ExprPtr&& expr,
       bool trackCpuUsage,
       bool isTryCast,
-      std::shared_ptr<SparkCastHooks> hooks)
-      : exec::CastExpr(type, std::move(expr), trackCpuUsage, isTryCast, hooks) {
-  }
+      std::shared_ptr<SparkCastHooks> hooks,
+      std::shared_ptr<SparkCastKernel> kernel)
+      : exec::CastExpr(
+            type,
+            std::move(expr),
+            trackCpuUsage,
+            isTryCast,
+            hooks,
+            std::move(kernel)) {}
 };
 
 class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {

--- a/velox/functions/sparksql/specialforms/SparkCastKernel.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastKernel.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/SparkCastKernel.h"
+
+namespace facebook::velox::functions::sparksql {
+SparkCastKernel::SparkCastKernel(
+    const velox::core::QueryConfig& config,
+    bool allowOverflow)
+    : exec::PrestoCastKernel(config),
+      config_(config),
+      allowOverflow_(allowOverflow) {}
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastKernel.h
+++ b/velox/functions/sparksql/specialforms/SparkCastKernel.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/PrestoCastKernel.h"
+
+namespace facebook::velox::functions::sparksql {
+
+// This class provides cast hooks following Spark semantics.
+class SparkCastKernel : public exec::PrestoCastKernel {
+ public:
+  explicit SparkCastKernel(
+      const velox::core::QueryConfig& config,
+      bool allowOverflow);
+
+ private:
+  const core::QueryConfig& config_;
+
+  // If true, the cast will truncate the overflow value to fit the target type.
+  const bool allowOverflow_;
+};
+} // namespace facebook::velox::functions::sparksql


### PR DESCRIPTION
Summary:
This change is part of a stack to address the performance and usability issues 
with CastExpr/CastHooks/CastPolicy and different engine semantics. Please 
see https://github.com/facebookincubator/velox/issues/16087 for a fuller 
description of the motivation. The stack will be landed as a unit, I've broken it 
up to try to make it easier to review.

This change introduces the CastKernel and the two implementations provided 
by Velox: PrestoCastKernel and SparkCastKernel. They are introduced with a 
few helper functions and variables that will be used throughout the stack.

Note that for now, we're passing both CastHooks and CastKernel to CastExpr, 
by the end of the stack we will delete CastHooks entirely and only CastKernel 
will be passed.

Differential Revision: D91833387


