### PR TITLE
refactor: CastKernel [2/11] Port cast to/from Date to CastKernel

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -52,6 +52,7 @@ velox_add_library(
   LambdaExpr.cpp
   PeeledEncoding.cpp
   PrestoCastHooks.cpp
+  PrestoCastKernel.cpp
   RegisterSpecialForm.cpp
   RowConstructor.cpp
   SimpleFunctionRegistry.cpp

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -23,6 +23,7 @@
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/PeeledEncoding.h"
 #include "velox/expression/PrestoCastHooks.h"
+#include "velox/expression/PrestoCastKernel.h"
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
@@ -1166,7 +1167,8 @@ ExprPtr CastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       false,
-      std::make_shared<PrestoCastHooks>(config));
+      std::make_shared<PrestoCastHooks>(config),
+      std::make_shared<PrestoCastKernel>(config));
 }
 
 TypePtr TryCastCallToSpecialForm::resolveType(
@@ -1189,6 +1191,7 @@ ExprPtr TryCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       true,
-      std::make_shared<PrestoCastHooks>(config));
+      std::make_shared<PrestoCastHooks>(config),
+      std::make_shared<PrestoCastKernel>(config));
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -17,15 +17,12 @@
 #include "velox/expression/CastExpr.h"
 
 #include <fmt/format.h>
-#include <stdexcept>
 
 #include "velox/common/base/Exceptions.h"
-#include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/PeeledEncoding.h"
 #include "velox/expression/PrestoCastHooks.h"
 #include "velox/expression/PrestoCastKernel.h"
 #include "velox/expression/ScopedVarSetter.h"
-#include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -49,128 +46,6 @@ const tz::TimeZone* getTimeZoneFromConfig(const core::QueryConfig& config) {
 }
 
 } // namespace
-
-VectorPtr CastExpr::castFromDate(
-    const SelectivityVector& rows,
-    const BaseVector& input,
-    exec::EvalCtx& context,
-    const TypePtr& toType) {
-  VectorPtr castResult;
-  context.ensureWritable(rows, toType, castResult);
-  (*castResult).clearNulls(rows);
-
-  auto* inputFlatVector = input.as<SimpleVector<int32_t>>();
-  switch (toType->kind()) {
-    case TypeKind::VARCHAR: {
-      auto* resultFlatVector = castResult->as<FlatVector<StringView>>();
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        try {
-          // TODO Optimize to avoid creating an intermediate string.
-          auto output = DATE()->toString(inputFlatVector->valueAt(row));
-          auto writer = exec::StringWriter(resultFlatVector, row);
-          writer.resize(output.size());
-          ::memcpy(writer.data(), output.data(), output.size());
-          writer.finalize();
-        } catch (const VeloxException& ue) {
-          if (!ue.isUserError()) {
-            throw;
-          }
-          VELOX_USER_FAIL(
-              makeErrorMessage(input, row, toType) + " " + ue.message());
-        } catch (const std::exception& e) {
-          VELOX_USER_FAIL(
-              makeErrorMessage(input, row, toType) + " " + e.what());
-        }
-      });
-      return castResult;
-    }
-    case TypeKind::TIMESTAMP: {
-      static const int64_t kMillisPerDay{86'400'000};
-      const auto* timeZone =
-          getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
-      auto* resultFlatVector = castResult->as<FlatVector<Timestamp>>();
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        auto timestamp = Timestamp::fromMillis(
-            inputFlatVector->valueAt(row) * kMillisPerDay);
-        if (timeZone) {
-          timestamp.toGMT(*timeZone);
-        }
-        resultFlatVector->set(row, timestamp);
-      });
-
-      return castResult;
-    }
-    default:
-      VELOX_UNSUPPORTED(
-          "Cast from DATE to {} is not supported", toType->toString());
-  }
-}
-
-VectorPtr CastExpr::castToDate(
-    const SelectivityVector& rows,
-    const BaseVector& input,
-    exec::EvalCtx& context,
-    const TypePtr& fromType) {
-  VectorPtr castResult;
-  context.ensureWritable(rows, DATE(), castResult);
-  (*castResult).clearNulls(rows);
-  auto* resultFlatVector = castResult->as<FlatVector<int32_t>>();
-  switch (fromType->kind()) {
-    case TypeKind::VARCHAR: {
-      auto* inputVector = input.as<SimpleVector<StringView>>();
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        bool wrapException = true;
-        try {
-          const auto result =
-              hooks_->castStringToDate(inputVector->valueAt(row));
-          if (result.hasError()) {
-            wrapException = false;
-            if (setNullInResultAtError()) {
-              resultFlatVector->setNull(row, true);
-            } else {
-              if (context.captureErrorDetails()) {
-                context.setStatus(
-                    row,
-                    Status::UserError(
-                        "{} {}",
-                        makeErrorMessage(input, row, DATE()),
-                        result.error().message()));
-              } else {
-                context.setStatus(row, Status::UserError());
-              }
-            }
-          } else {
-            resultFlatVector->set(row, result.value());
-          }
-        } catch (const VeloxUserError& ue) {
-          if (!wrapException) {
-            throw;
-          }
-          VELOX_USER_FAIL(
-              makeErrorMessage(input, row, DATE()) + " " + ue.message());
-        } catch (const std::exception& e) {
-          VELOX_USER_FAIL(
-              makeErrorMessage(input, row, DATE()) + " " + e.what());
-        }
-      });
-
-      return castResult;
-    }
-    case TypeKind::TIMESTAMP: {
-      auto* inputVector = input.as<SimpleVector<Timestamp>>();
-      const auto* timeZone =
-          getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
-      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
-        const auto days = util::toDate(inputVector->valueAt(row), timeZone);
-        resultFlatVector->set(row, days);
-      });
-      return castResult;
-    }
-    default:
-      VELOX_UNSUPPORTED(
-          "Cast from {} to DATE is not supported", fromType->toString());
-  }
-}
 
 VectorPtr CastExpr::castFromIntervalDayTime(
     const SelectivityVector& rows,
@@ -834,9 +709,11 @@ void CastExpr::applyPeeled(
       applyCustomCast();
     }
   } else if (fromType->isDate()) {
-    result = castFromDate(rows, input, context, toType);
+    result = kernel_->castFromDate(
+        rows, input, context, toType, setNullInResultAtError());
   } else if (toType->isDate()) {
-    result = castToDate(rows, input, context, fromType);
+    result =
+        kernel_->castToDate(rows, input, context, setNullInResultAtError());
   } else if (fromType->isIntervalDayTime()) {
     result = castFromIntervalDayTime(rows, input, context, toType);
   } else if (toType->isIntervalDayTime()) {

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/expression/CastHooks.h"
+#include "velox/expression/CastKernel.h"
 #include "velox/expression/ExprConstants.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
 #include "velox/expression/SpecialForm.h"
@@ -86,7 +87,8 @@ class CastExpr : public SpecialForm {
       ExprPtr&& expr,
       bool trackCpuUsage,
       bool isTryCast,
-      std::shared_ptr<CastHooks> hooks)
+      std::shared_ptr<CastHooks> hooks,
+      std::shared_ptr<CastKernel> kernel)
       : SpecialForm(
             SpecialFormKind::kCast,
             type,
@@ -95,7 +97,8 @@ class CastExpr : public SpecialForm {
             false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage),
         isTryCast_(isTryCast),
-        hooks_(std::move(hooks)) {}
+        hooks_(std::move(hooks)),
+        kernel_(std::move(kernel)) {}
 
   void evalSpecialForm(
       const SelectivityVector& rows,
@@ -329,6 +332,7 @@ class CastExpr : public SpecialForm {
 
   bool isTryCast_;
   std::shared_ptr<CastHooks> hooks_;
+  std::shared_ptr<CastKernel> kernel_;
 
   bool inTopLevel = false;
 };

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -189,18 +189,6 @@ class CastExpr : public SpecialForm {
       const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
       FlatVector<typename TypeTraits<ToKind>::NativeType>* result);
 
-  VectorPtr castFromDate(
-      const SelectivityVector& rows,
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const TypePtr& toType);
-
-  VectorPtr castToDate(
-      const SelectivityVector& rows,
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const TypePtr& fromType);
-
   VectorPtr castFromIntervalDayTime(
       const SelectivityVector& rows,
       const BaseVector& input,

--- a/velox/expression/CastHooks.h
+++ b/velox/expression/CastHooks.h
@@ -47,9 +47,6 @@ class CastHooks {
   virtual Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const = 0;
 
-  virtual Expected<int32_t> castStringToDate(
-      const StringView& dateString) const = 0;
-
   /// 'data' is guaranteed to be non-empty and has been processed by
   /// removeWhiteSpaces.
   virtual Expected<float> castStringToReal(const StringView& data) const = 0;

--- a/velox/expression/CastKernel.h
+++ b/velox/expression/CastKernel.h
@@ -36,6 +36,19 @@ class CastKernel {
  public:
   virtual ~CastKernel() = default;
 
+  virtual VectorPtr castFromDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType,
+      bool setNullInResultAtError) const = 0;
+
+  virtual VectorPtr castToDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      bool setNullInResultAtError) const = 0;
+
  protected:
   /// Initializes a result vector with the specified type and clears nulls
   /// for the selected rows.

--- a/velox/expression/CastKernel.h
+++ b/velox/expression/CastKernel.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec {
+
+/// Implementations of this class should provide the logic to handle casting
+/// between the core primitive types provided by Velox. This is inteded to be
+/// used by CastExpr and custom CastOperators.
+///
+/// For logical Types (Date, Time, Decimal, etc.) the functions castFromType
+/// and castToType are provided. These should handle any supported conversions
+/// between core primitive Types in Velox and Type.
+///
+/// For physical Types (Boolean, Integer, Varchar, etc.) only the function
+/// castToType is provided. These only need to handle converting from core
+/// physical primitive Types in Velox to Type.
+class CastKernel {
+ public:
+  virtual ~CastKernel() = default;
+
+ protected:
+  /// Initializes a result vector with the specified type and clears nulls
+  /// for the selected rows.
+  static FOLLY_ALWAYS_INLINE void initializeResultVector(
+      const SelectivityVector& rows,
+      const TypePtr& toType,
+      exec::EvalCtx& context,
+      VectorPtr& result) {
+    context.ensureWritable(rows, toType, result);
+    result->clearNulls(rows);
+  }
+
+  /// Constructs a helpful error message containing the Types involved in the
+  /// cast, the value being casted, and any additional details the caller
+  /// provides.
+  static FOLLY_ALWAYS_INLINE std::string makeErrorMessage(
+      const BaseVector& input,
+      vector_size_t row,
+      const TypePtr& toType,
+      const std::string& details = "") {
+    return fmt::format(
+        "Cannot cast {} '{}' to {}. {}",
+        input.type()->toString(),
+        input.toString(row),
+        toType->toString(),
+        details);
+  }
+
+  /// Inokes `func` passing each `row` in `rows`. For each `row` handles any
+  /// exceptions by either setting the value in `result` to NULL if
+  /// `setNullInResultAtError` is true, or setting the status in `context` if
+  /// `setNullInResultAtError` is false.
+  ///
+  /// If the exception is a VeloxException but not a UserError, the exception
+  /// will not be handled.
+  template <typename Func>
+  static FOLLY_ALWAYS_INLINE void applyToSelectedNoThrowLocal(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const VectorPtr& result,
+      bool setNullInResultAtError,
+      Func&& func) {
+    if (setNullInResultAtError) {
+      rows.applyToSelected([&](auto row) INLINE_LAMBDA {
+        try {
+          func(row);
+        } catch (const VeloxException& e) {
+          if (!e.isUserError()) {
+            throw;
+          }
+          result->setNull(row, true);
+        } catch (const std::exception&) {
+          result->setNull(row, true);
+        }
+      });
+    } else {
+      rows.applyToSelected([&](auto row) INLINE_LAMBDA {
+        try {
+          func(row);
+        } catch (const VeloxException& e) {
+          if (!e.isUserError()) {
+            throw;
+          }
+
+          context.setStatus(row, Status::UserError("{}", e.message()));
+        } catch (const std::exception& e) {
+          context.setStatus(row, Status::UserError("{}", e.what()));
+        }
+      });
+    }
+  }
+
+  static FOLLY_ALWAYS_INLINE void setError(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      BaseVector& result,
+      vector_size_t row,
+      const std::string& details,
+      bool setNullInResultAtError) {
+    if (setNullInResultAtError) {
+      result.setNull(row, true);
+    } else if (context.captureErrorDetails()) {
+      const auto errorDetails =
+          makeErrorMessage(input, row, result.type(), details);
+      context.setStatus(row, Status::UserError("{}", errorDetails));
+    } else {
+      context.setStatus(row, Status::UserError());
+    }
+  }
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastHooks.cpp
+++ b/velox/expression/PrestoCastHooks.cpp
@@ -71,13 +71,6 @@ Expected<std::optional<Timestamp>> PrestoCastHooks::castDoubleToTimestamp(
       Status::UserError("Conversion to Timestamp is not supported"));
 }
 
-Expected<int32_t> PrestoCastHooks::castStringToDate(
-    const StringView& dateString) const {
-  // Cast from string to date allows only complete ISO 8601 formatted strings:
-  // [+-](YYYY-MM-DD).
-  return util::fromDateString(dateString, util::ParseMode::kPrestoCast);
-}
-
 Expected<Timestamp> PrestoCastHooks::castBooleanToTimestamp(
     bool /*seconds*/) const {
   return folly::makeUnexpected(

--- a/velox/expression/PrestoCastHooks.h
+++ b/velox/expression/PrestoCastHooks.h
@@ -39,10 +39,6 @@ class PrestoCastHooks : public CastHooks {
   Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double seconds) const override;
 
-  // Uses standard cast mode to cast from string to date.
-  Expected<int32_t> castStringToDate(
-      const StringView& dateString) const override;
-
   // Allows casting 'NaN', 'Infinity', and '-Infinity' to real, but not 'Inf' or
   // these strings with different letter cases.
   Expected<float> castStringToReal(const StringView& data) const override;

--- a/velox/expression/PrestoCastKernel.cpp
+++ b/velox/expression/PrestoCastKernel.cpp
@@ -16,8 +16,115 @@
 
 #include "velox/expression/PrestoCastKernel.h"
 
+#include "velox/expression/StringWriter.h"
+
 namespace facebook::velox::exec {
 
 PrestoCastKernel::PrestoCastKernel(const core::QueryConfig& config)
     : legacyCast_(config.isLegacyCast()) {}
+
+VectorPtr PrestoCastKernel::castFromDate(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& toType,
+    bool setNullInResultAtError) const {
+  const auto* inputFlatVector = input.as<SimpleVector<int32_t>>();
+
+  VectorPtr result;
+  initializeResultVector(rows, toType, context, result);
+
+  switch (toType->kind()) {
+    case TypeKind::VARCHAR: {
+      auto* resultFlatVector = result->as<FlatVector<StringView>>();
+      applyToSelectedNoThrowLocal(
+          rows, context, result, setNullInResultAtError, [&](int row) {
+            // TODO Optimize to avoid creating an intermediate string.
+            auto output = DATE()->toString(inputFlatVector->valueAt(row));
+            auto writer = exec::StringWriter(resultFlatVector, row);
+            writer.resize(output.size());
+            ::memcpy(writer.data(), output.data(), output.size());
+            writer.finalize();
+          });
+
+      return result;
+    }
+    case TypeKind::TIMESTAMP: {
+      static const int64_t kMillisPerDay{86'400'000};
+      const auto* timeZone =
+          getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
+      auto* resultFlatVector = result->as<FlatVector<Timestamp>>();
+      applyToSelectedNoThrowLocal(
+          rows, context, result, setNullInResultAtError, [&](int row) {
+            auto timestamp = Timestamp::fromMillis(
+                inputFlatVector->valueAt(row) * kMillisPerDay);
+            if (timeZone) {
+              timestamp.toGMT(*timeZone);
+            }
+            resultFlatVector->set(row, timestamp);
+          });
+
+      return result;
+    }
+    default:
+      VELOX_UNSUPPORTED(
+          "Cast from DATE to {} is not supported", toType->toString());
+  }
+}
+
+VectorPtr PrestoCastKernel::castToDate(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    bool setNullInResultAtError) const {
+  const auto& fromType = input.type();
+
+  VectorPtr result;
+  initializeResultVector(rows, DATE(), context, result);
+  auto* resultFlatVector = result->as<FlatVector<int32_t>>();
+
+  switch (fromType->kind()) {
+    case TypeKind::VARCHAR: {
+      auto* inputVector = input.as<SimpleVector<StringView>>();
+      applyToSelectedNoThrowLocal(
+          rows, context, result, setNullInResultAtError, [&](int row) {
+            // Cast from string to date allows only complete ISO 8601
+            // formatted strings :
+            // [+-](YYYY-MM-DD).
+            const auto resultValue = util::fromDateString(
+                inputVector->valueAt(row), util::ParseMode::kPrestoCast);
+
+            if (resultValue.hasValue()) {
+              resultFlatVector->set(row, resultValue.value());
+            } else {
+              setError(
+                  input,
+                  context,
+                  *result,
+                  row,
+                  resultValue.error().message(),
+                  setNullInResultAtError);
+            }
+          });
+
+      return result;
+    }
+    case TypeKind::TIMESTAMP: {
+      auto* inputVector = input.as<SimpleVector<Timestamp>>();
+      const auto* timeZone =
+          getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
+      applyToSelectedNoThrowLocal(
+          rows, context, result, setNullInResultAtError, [&](int row) {
+            const auto days = util::toDate(inputVector->valueAt(row), timeZone);
+            resultFlatVector->set(row, days);
+          });
+
+      return result;
+    }
+    default:
+      VELOX_UNSUPPORTED(
+          "Cast from {} to DATE is not supported", fromType->toString());
+  }
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastKernel.cpp
+++ b/velox/expression/PrestoCastKernel.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/PrestoCastKernel.h"
+
+namespace facebook::velox::exec {
+
+PrestoCastKernel::PrestoCastKernel(const core::QueryConfig& config)
+    : legacyCast_(config.isLegacyCast()) {}
+} // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastKernel.h
+++ b/velox/expression/PrestoCastKernel.h
@@ -24,7 +24,31 @@ class PrestoCastKernel : public CastKernel {
  public:
   explicit PrestoCastKernel(const core::QueryConfig& config);
 
+  VectorPtr castFromDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType,
+      bool setNullInResultAtError) const override;
+
+  VectorPtr castToDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      bool setNullInResultAtError) const override;
+
  private:
+  static inline const tz::TimeZone* FOLLY_NULLABLE
+  getTimeZoneFromConfig(const core::QueryConfig& config) {
+    if (config.adjustTimestampToTimezone()) {
+      const auto sessionTzName = config.sessionTimezone();
+      if (!sessionTzName.empty()) {
+        return tz::locateZone(sessionTzName);
+      }
+    }
+    return nullptr;
+  }
+
   const bool legacyCast_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/PrestoCastKernel.h
+++ b/velox/expression/PrestoCastKernel.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/CastKernel.h"
+
+namespace facebook::velox::exec {
+
+class PrestoCastKernel : public CastKernel {
+ public:
+  explicit PrestoCastKernel(const core::QueryConfig& config);
+
+ private:
+  const bool legacyCast_;
+};
+} // namespace facebook::velox::exec

--- a/velox/functions/sparksql/specialforms/CMakeLists.txt
+++ b/velox/functions/sparksql/specialforms/CMakeLists.txt
@@ -22,6 +22,7 @@ velox_add_library(
   MakeDecimal.cpp
   SparkCastExpr.cpp
   SparkCastHooks.cpp
+  SparkCastKernel.cpp
 )
 
 velox_link_libraries(

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -60,7 +60,8 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       isTryCast,
-      std::make_shared<SparkCastHooks>(config, true));
+      std::make_shared<SparkCastHooks>(config, true),
+      std::make_shared<SparkCastKernel>(config, true));
 }
 
 exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
@@ -78,6 +79,7 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       std::move(compiledChildren[0]),
       trackCpuUsage,
       true,
-      std::make_shared<SparkCastHooks>(config, false));
+      std::make_shared<SparkCastHooks>(config, false),
+      std::make_shared<SparkCastKernel>(config, false));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.h
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.h
@@ -18,6 +18,7 @@
 
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/sparksql/specialforms/SparkCastHooks.h"
+#include "velox/functions/sparksql/specialforms/SparkCastKernel.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -31,9 +32,15 @@ class SparkCastExpr : public exec::CastExpr {
       exec::ExprPtr&& expr,
       bool trackCpuUsage,
       bool isTryCast,
-      std::shared_ptr<SparkCastHooks> hooks)
-      : exec::CastExpr(type, std::move(expr), trackCpuUsage, isTryCast, hooks) {
-  }
+      std::shared_ptr<SparkCastHooks> hooks,
+      std::shared_ptr<SparkCastKernel> kernel)
+      : exec::CastExpr(
+            type,
+            std::move(expr),
+            trackCpuUsage,
+            isTryCast,
+            hooks,
+            std::move(kernel)) {}
 };
 
 class SparkCastCallToSpecialForm : public exec::CastCallToSpecialForm {

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.cpp
@@ -93,23 +93,6 @@ Expected<Timestamp> SparkCastHooks::castBooleanToTimestamp(bool val) const {
   return Timestamp::fromMicrosNoError(val ? 1 : 0);
 }
 
-Expected<int32_t> SparkCastHooks::castStringToDate(
-    const StringView& dateString) const {
-  // Allows all patterns supported by Spark:
-  // `[+-]yyyy*`
-  // `[+-]yyyy*-[m]m`
-  // `[+-]yyyy*-[m]m-[d]d`
-  // `[+-]yyyy*-[m]m-[d]d *`
-  // `[+-]yyyy*-[m]m-[d]dT*`
-  // The asterisk `*` in `yyyy*` stands for any numbers.
-  // For the last two patterns, the trailing `*` can represent none or any
-  // sequence of characters, e.g:
-  //   "1970-01-01 123"
-  //   "1970-01-01 (BC)"
-  return util::fromDateString(
-      removeWhiteSpaces(dateString), util::ParseMode::kSparkCast);
-}
-
 Expected<float> SparkCastHooks::castStringToReal(const StringView& data) const {
   return util::Converter<TypeKind::REAL>::tryCast(data);
 }

--- a/velox/functions/sparksql/specialforms/SparkCastHooks.h
+++ b/velox/functions/sparksql/specialforms/SparkCastHooks.h
@@ -43,11 +43,6 @@ class SparkCastHooks : public exec::CastHooks {
   Expected<std::optional<Timestamp>> castDoubleToTimestamp(
       double value) const override;
 
-  /// 1) Removes all leading and trailing UTF8 white-spaces before cast. 2) Uses
-  /// non-standard cast mode to cast from string to date.
-  Expected<int32_t> castStringToDate(
-      const StringView& dateString) const override;
-
   // Allows casting 'NaN', 'Infinity', '-Infinity', 'Inf', '-Inf', and these
   // strings with different letter cases to real.
   Expected<float> castStringToReal(const StringView& data) const override;

--- a/velox/functions/sparksql/specialforms/SparkCastKernel.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastKernel.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/functions/sparksql/specialforms/SparkCastKernel.h"
 
+#include "velox/functions/lib/string/StringImpl.h"
+
 namespace facebook::velox::functions::sparksql {
 SparkCastKernel::SparkCastKernel(
     const velox::core::QueryConfig& config,
@@ -23,4 +25,62 @@ SparkCastKernel::SparkCastKernel(
     : exec::PrestoCastKernel(config),
       config_(config),
       allowOverflow_(allowOverflow) {}
+
+VectorPtr SparkCastKernel::castToDate(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    bool setNullInResultAtError) const {
+  const auto& fromType = input.type();
+  switch (fromType->kind()) {
+    case TypeKind::VARCHAR: {
+      auto* inputVector = input.as<SimpleVector<StringView>>();
+      VectorPtr result;
+      initializeResultVector(rows, DATE(), context, result);
+      auto* resultFlatVector = result->as<FlatVector<int32_t>>();
+      applyToSelectedNoThrowLocal(
+          rows, context, result, setNullInResultAtError, [&](int row) {
+            // Allows all patterns supported by Spark:
+            // `[+-]yyyy*`
+            // `[+-]yyyy*-[m]m`
+            // `[+-]yyyy*-[m]m-[d]d`
+            // `[+-]yyyy*-[m]m-[d]d *`
+            // `[+-]yyyy*-[m]m-[d]dT*`
+            // The asterisk `*` in `yyyy*` stands for any numbers.
+            // For the last two patterns, the trailing `*` can represent none
+            // or any sequence of characters, e.g:
+            //   "1970-01-01 123"
+            //   "1970-01-01 (BC)"
+            const auto resultValue = util::fromDateString(
+                removeWhiteSpaces(inputVector->valueAt(row)),
+                util::ParseMode::kSparkCast);
+
+            if (resultValue.hasValue()) {
+              resultFlatVector->set(row, resultValue.value());
+            } else {
+              setError(
+                  input,
+                  context,
+                  *result,
+                  row,
+                  resultValue.error().message(),
+                  setNullInResultAtError);
+            }
+          });
+
+      return result;
+    }
+    default:
+      // Otherwise default back to Presto's behavior.
+      return exec::PrestoCastKernel::castToDate(
+          rows, input, context, setNullInResultAtError);
+  }
+}
+
+StringView SparkCastKernel::removeWhiteSpaces(const StringView& view) const {
+  StringView output;
+  stringImpl::trimUnicodeWhiteSpace<true, true, StringView, StringView>(
+      output, view);
+  return output;
+}
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastKernel.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastKernel.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/specialforms/SparkCastKernel.h"
+
+namespace facebook::velox::functions::sparksql {
+SparkCastKernel::SparkCastKernel(
+    const velox::core::QueryConfig& config,
+    bool allowOverflow)
+    : exec::PrestoCastKernel(config),
+      config_(config),
+      allowOverflow_(allowOverflow) {}
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/specialforms/SparkCastKernel.h
+++ b/velox/functions/sparksql/specialforms/SparkCastKernel.h
@@ -27,7 +27,15 @@ class SparkCastKernel : public exec::PrestoCastKernel {
       const velox::core::QueryConfig& config,
       bool allowOverflow);
 
+  VectorPtr castToDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      bool setNullInResultAtError) const override;
+
  private:
+  StringView removeWhiteSpaces(const StringView& view) const;
+
   const core::QueryConfig& config_;
 
   // If true, the cast will truncate the overflow value to fit the target type.

--- a/velox/functions/sparksql/specialforms/SparkCastKernel.h
+++ b/velox/functions/sparksql/specialforms/SparkCastKernel.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/expression/PrestoCastKernel.h"
+
+namespace facebook::velox::functions::sparksql {
+
+// This class provides cast hooks following Spark semantics.
+class SparkCastKernel : public exec::PrestoCastKernel {
+ public:
+  explicit SparkCastKernel(
+      const velox::core::QueryConfig& config,
+      bool allowOverflow);
+
+ private:
+  const core::QueryConfig& config_;
+
+  // If true, the cast will truncate the overflow value to fit the target type.
+  const bool allowOverflow_;
+};
+} // namespace facebook::velox::functions::sparksql


### PR DESCRIPTION
Summary:
This change is part of a stack to address the performance and usability issues 
with CastExpr/CastHooks/CastPolicy and different engine semantics. Please 
see https://github.com/facebookincubator/velox/issues/16087 for a fuller 
description of the motivation. The stack will be landed as a unit, I've broken it 
up to try to make it easier to review.

This change introduces the castToDate and castFromDate functions to 
CastKernel and implements them in PrestoCastKernel and SparkCastKernel.

I have removed what I can of the relevant code in CastExpr and the CastHooks 
to help with seeing mapping to where the new code came from, it was just 
moved and slightly refactored. Note that I couldn't remove the 
removeWhiteSpaces functions from the Hooks, but it is copied from there. 
They will deleted from the Hooks once it's possible later in the stack.

Differential Revision: D91834120


