### PR TITLE
feat(python): Hook support in LocalDebuggerRunner

### DIFF
--- a/python/test/test_debugger_runner.py
+++ b/python/test/test_debugger_runner.py
@@ -169,3 +169,88 @@ class TestPyVeloxDebuggerRunner(unittest.TestCase):
 
         it.step()
         self.assertEqual(it.at(), self._node_ids[3])
+
+    def test_hook_always_stop(self):
+        """Hook that always returns True should behave like set_breakpoint."""
+        runner = LocalDebuggerRunner(self._plan_node)
+        runner.set_hook(self._node_ids[3], lambda v: True)
+        runner.set_hook(self._node_ids[5], lambda v: True)
+        runner.set_hook(self._node_ids[8], lambda v: True)
+        self.assertEqual(
+            self._count_step(runner), self._batch_size * self._num_batches * 4
+        )
+
+    def test_hook_never_stop(self):
+        """Hook that always returns False should skip the breakpoint."""
+        runner = LocalDebuggerRunner(self._plan_node)
+        runner.set_hook(self._node_ids[3], lambda v: False)
+        runner.set_hook(self._node_ids[5], lambda v: False)
+        runner.set_hook(self._node_ids[8], lambda v: False)
+        # Since all hooks return False, step() should behave like next()
+        self.assertEqual(self._count_step(runner), self._batch_size * self._num_batches)
+
+    def test_hook_conditional(self):
+        """Hook that conditionally stops based on vector content."""
+        runner = LocalDebuggerRunner(self._plan_node)
+
+        # Track how many times the hook is called.
+        call_count = 0
+
+        def conditional_hook(vector):
+            nonlocal call_count
+            call_count += 1
+            # Stop only on odd calls.
+            return call_count % 2 == 1
+
+        runner.set_hook(self._node_ids[5], conditional_hook)
+
+        # The hook is called for each batch (10 batches).
+        # It stops on odd calls (1, 3, 5, 7, 9) = 5 stops.
+        # Plus 10 task outputs = 15 total vectors.
+        self.assertEqual(self._count_step(runner), self._batch_size * 15)
+        self.assertEqual(call_count, self._num_batches)
+
+    def test_hook_mixed_with_breakpoint(self):
+        """Mix set_breakpoint and set_hook."""
+        runner = LocalDebuggerRunner(self._plan_node)
+
+        # set_breakpoint always stops.
+        runner.set_breakpoint(self._node_ids[3])
+
+        # set_hook that never stops.
+        runner.set_hook(self._node_ids[5], lambda v: False)
+
+        # set_hook that always stops.
+        runner.set_hook(self._node_ids[8], lambda v: True)
+
+        # node_ids[3] stops (10 batches), node_ids[8] stops (10 batches),
+        # plus 10 task outputs = 30 total vectors.
+        self.assertEqual(
+            self._count_step(runner), self._batch_size * self._num_batches * 3
+        )
+
+    def test_hook_inspects_vector(self):
+        """Verify the hook receives a valid vector."""
+        runner = LocalDebuggerRunner(self._plan_node)
+
+        received_sizes = []
+
+        def inspect_hook(vector):
+            received_sizes.append(vector.size())
+            return True
+
+        runner.set_hook(self._node_ids[5], inspect_hook)
+
+        it = runner.execute()
+
+        # Consume all output.
+        while True:
+            try:
+                it.step()
+            except StopIteration:
+                break
+
+        # Hook should have been called for each batch.
+        self.assertEqual(len(received_sizes), self._num_batches)
+        # Each vector should have batch_size rows.
+        self.assertTrue(all(s == self._batch_size for s in received_sizes))

--- a/velox/python/runner/PyLocalDebuggerRunner.cpp
+++ b/velox/python/runner/PyLocalDebuggerRunner.cpp
@@ -18,8 +18,32 @@
 
 namespace facebook::velox::py {
 
+namespace py = pybind11;
+
 void PyLocalDebuggerRunner::setBreakpoint(const std::string& planNodeId) {
   breakpoints_[planNodeId] = nullptr;
+}
+
+void PyLocalDebuggerRunner::setHook(
+    const std::string& planNodeId,
+    pybind11::function callback) {
+  // Capture the Python callback and outputPool in a C++ lambda.
+  // The lambda will be called when the breakpoint is hit.
+  auto pool = outputPool_;
+  breakpoints_[planNodeId] = [callback = std::move(callback),
+                              pool](const RowVectorPtr& vector) -> bool {
+    // Acquire the GIL before calling Python code.
+    py::gil_scoped_acquire acquire;
+
+    // Create a PyVector from the RowVectorPtr.
+    PyVector pyVector(vector, pool);
+
+    // Call the Python function and get the result.
+    py::object result = callback(pyVector);
+
+    // Convert the result to bool.
+    return result.cast<bool>();
+  };
 }
 
 exec::CursorParameters PyLocalDebuggerRunner::createCursorParameters(

--- a/velox/python/runner/PyLocalDebuggerRunner.h
+++ b/velox/python/runner/PyLocalDebuggerRunner.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <pybind11/pybind11.h>
 #include <string>
 
 #include "velox/python/runner/PyLocalRunner.h"
@@ -33,10 +34,21 @@ class PyLocalDebuggerRunner : public PyLocalRunner {
       const std::shared_ptr<folly::CPUThreadPoolExecutor>& executor)
       : PyLocalRunner(pyPlanNode, pool, executor) {}
 
-  /// Sets a breakpoint at the specified plan node.
+  /// Sets a breakpoint at the specified plan node with no callback.
+  /// The breakpoint will always stop execution.
   ///
   /// @param planNodeId The ID of the plan node where execution should pause.
   void setBreakpoint(const std::string& planNodeId);
+
+  /// Sets a breakpoint at the specified plan node with a Python callback.
+  ///
+  /// The callback is invoked with a PyVector when the breakpoint is hit.
+  /// If the callback returns True, execution stops and the vector is produced.
+  /// If the callback returns False, execution continues without stopping.
+  ///
+  /// @param planNodeId The ID of the plan node where the hook is installed.
+  /// @param callback Python function that takes a PyVector and returns bool.
+  void setHook(const std::string& planNodeId, pybind11::function callback);
 
  protected:
   exec::CursorParameters createCursorParameters(int32_t maxDrivers) override;

--- a/velox/python/runner/runner.cpp
+++ b/velox/python/runner/runner.cpp
@@ -135,10 +135,28 @@ PYBIND11_MODULE(runner, m) {
           &velox::py::PyLocalDebuggerRunner::setBreakpoint,
           py::arg("plan_node_id"),
           py::doc(R"(
-        Sets a breakpoint at the specified plan node.
+        Sets a breakpoint at the specified plan node. The breakpoint will
+        always stop execution.
 
         Args:
           plan_node_id: The ID of the plan node where execution should pause.
+          )"))
+      .def(
+          "set_hook",
+          &velox::py::PyLocalDebuggerRunner::setHook,
+          py::arg("plan_node_id"),
+          py::arg("callback"),
+          py::doc(R"(
+        Sets a breakpoint with a callback at the specified plan node.
+
+        The callback is invoked with a Vector when the breakpoint is hit.
+        If the callback returns True, execution stops and the vector is
+        produced. If the callback returns False, execution continues
+        without stopping.
+
+        Args:
+          plan_node_id: The ID of the plan node where the hook is installed.
+          callback: Python function that takes a Vector and returns bool.
           )"));
 
   m.def(


### PR DESCRIPTION
Summary:
Adding `set_hook(plan_node_id, hook_func)` support in
LocalDebuggerRunner to enable users debugging data issues in the DAG to add a
callback that inspects the vector, then decides whether the control loop should
stop and produce the vector as output, or keep going. Example:

```
def hook(vector):
    # inspect vector
    return True # or False, to ignore and keep advancing.


runner = LocalDebuggerRunner(plan_node)
runner.set_hook(some_node_id, hook)
runner.execute()
...
```

Reviewed By: xiaoxmeng

Differential Revision: D92328798


