### PR TITLE
fix: Rename Type::isUnKnown() to isUnknown()

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.cpp
@@ -91,7 +91,7 @@ int32_t AggregationFuzzerBase::randInt(int32_t min, int32_t max) {
 
 bool AggregationFuzzerBase::isSupportedType(const TypePtr& type) const {
   // Date / IntervalDayTime/ Unknown are not currently supported by DWRF.
-  if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown()) {
+  if (type->isDate() || type->isIntervalDayTime() || type->isUnknown()) {
     return false;
   }
 

--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -210,7 +210,7 @@ const std::vector<TypePtr>& PrestoQueryRunner::supportedScalarTypes() const {
 
 // static
 bool PrestoQueryRunner::isSupportedDwrfType(const TypePtr& type) {
-  if (type->isDate() || type->isIntervalDayTime() || type->isUnKnown() ||
+  if (type->isDate() || type->isIntervalDayTime() || type->isUnknown() ||
       isGeometryType(type)) {
     return false;
   }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -226,7 +226,7 @@ bool SignatureVariable::isEligibleType(const Type& type) const {
     return false;
   }
 
-  if (knownTypesOnly_ && type.isUnKnown()) {
+  if (knownTypesOnly_ && type.isUnknown()) {
     return false;
   }
 

--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -145,7 +145,7 @@ namespace {
 
 // Same as Type::kindEquals, but matches UNKNOWN in 'physicalType' to any type.
 bool physicalTypeMatches(const TypePtr& type, const TypePtr& physicalType) {
-  if (physicalType->isUnKnown()) {
+  if (physicalType->isUnknown()) {
     return true;
   }
 

--- a/velox/functions/lib/ArraySort.cpp
+++ b/velox/functions/lib/ArraySort.cpp
@@ -513,7 +513,7 @@ std::shared_ptr<exec::VectorFunction> makeArraySort(
     bool nullsFirst,
     bool throwOnNestedNull) {
   const auto elementType = inputArgs.front().type->childAt(0);
-  if (elementType->isUnKnown()) {
+  if (elementType->isUnknown()) {
     return createTyped<TypeKind::UNKNOWN>(
         inputArgs, ascending, nullsFirst, throwOnNestedNull);
   }

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -291,7 +291,7 @@ std::shared_ptr<exec::VectorFunction> create(
     const core::QueryConfig& /*config*/) {
   validateType(inputArgs);
   auto elementType = inputArgs.front().type->childAt(0);
-  if (elementType->isUnKnown()) {
+  if (elementType->isUnknown()) {
     return std::make_shared<ArrayDistinctFunction<UnknownType>>();
   }
 

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -98,7 +98,7 @@ std::vector<exec::AggregateRegistrationResult> registerApproxDistinct(
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        if (argTypes[0]->isUnKnown()) {
+        if (argTypes[0]->isUnknown()) {
           if (hllAsFinalResult) {
             return std::make_unique<HyperLogLogAggregate<UnknownValue, true>>(
                 resultType, hllAsRawInput, defaultError);

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -77,12 +77,12 @@ class ChecksumAggregate : public exec::Aggregate {
   }
 
   bool isNullOrNullArray(const TypePtr& type) {
-    if (type->isUnKnown()) {
+    if (type->isUnknown()) {
       return true;
     }
     // Only supports null array type for now.
     if (type->kind() == TypeKind::ARRAY) {
-      return type->asArray().elementType()->isUnKnown();
+      return type->asArray().elementType()->isUnknown();
     }
     return false;
   }

--- a/velox/functions/prestosql/aggregates/MergeAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MergeAggregate.cpp
@@ -86,7 +86,7 @@ std::vector<exec::AggregateRegistrationResult> registerMerge(
         if (argTypes[0] == KHYPERLOGLOG()) {
           return std::make_unique<MergeKHyperLogLogAggregate>(resultType);
         }
-        if (argTypes[0]->isUnKnown()) {
+        if (argTypes[0]->isUnknown()) {
           return std::make_unique<HyperLogLogAggregate<UnknownValue, true>>(
               resultType, hllAsRawInput, defaultError);
         }

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -1193,8 +1193,8 @@ bool JsonCastOperator::isSupportedFromType(const TypePtr& other) const {
       }
       return true;
     case TypeKind::MAP:
-      if (other->childAt(1)->isUnKnown()) {
-        if (other->childAt(0)->isUnKnown()) {
+      if (other->childAt(1)->isUnknown()) {
+        if (other->childAt(0)->isUnknown()) {
           return true;
         }
         return isSupportedBasicType(other->childAt(0)) &&

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -1051,7 +1051,7 @@ ArrayVectorPtr deserializeArrays(
 
   VectorPtr elements;
   const auto& elementType = type->childAt(0);
-  if (elementType->isUnKnown()) {
+  if (elementType->isUnknown()) {
     elements =
         deserializeUnknownArrays(elementType, data, arraySizes, offsets, pool);
   } else if (elementType->isFixedWidth()) {

--- a/velox/row/UnsafeRow.h
+++ b/velox/row/UnsafeRow.h
@@ -421,7 +421,7 @@ FOLLY_ALWAYS_INLINE size_t serializedSizeInBytes<TypeKind::VARBINARY>() {
 /// Returns the number of bytes needed to serialized fixed-width type. Throws if
 /// 'type' is not fixed-width.
 FOLLY_ALWAYS_INLINE size_t serializedSizeInBytes(const TypePtr& type) {
-  if (type->isUnKnown()) {
+  if (type->isUnknown()) {
     return 0;
   }
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -912,7 +912,7 @@ ArrayVectorPtr deserializeArrays(
 
   VectorPtr elements;
   const auto& elementType = type->childAt(0);
-  if (elementType->isUnKnown()) {
+  if (elementType->isUnknown()) {
     elements = deserializeUnknownArrays(elementType, data, arraySizes, pool);
   } else if (isFixedWidth(elementType)) {
     elements = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -639,7 +639,7 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
   VELOX_FLUENT_CAST(Map, MAP)
   VELOX_FLUENT_CAST(Row, ROW)
   VELOX_FLUENT_CAST(Opaque, OPAQUE)
-  VELOX_FLUENT_CAST(UnKnown, UNKNOWN)
+  VELOX_FLUENT_CAST(Unknown, UNKNOWN)
   VELOX_FLUENT_CAST(Function, FUNCTION)
 
   const ShortDecimalType& asShortDecimal() const;

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -86,8 +86,8 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
 std::optional<int32_t> TypeCoercer::coercible(
     const TypePtr& fromType,
     const TypePtr& toType) {
-  if (fromType->isUnKnown()) {
-    if (toType->isUnKnown()) {
+  if (fromType->isUnknown()) {
+    if (toType->isUnknown()) {
       return 0;
     }
     return 1;
@@ -152,11 +152,11 @@ TypePtr leastCommonSuperRowType(const RowType& a, const RowType& b) {
 
 // static
 TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
-  if (a->isUnKnown()) {
+  if (a->isUnknown()) {
     return b;
   }
 
-  if (b->isUnKnown()) {
+  if (b->isUnknown()) {
     return a;
   }
 

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -439,7 +439,7 @@ VectorPtr VectorFuzzer::fuzzConstant(
     if (coinToss(opts_.nullRatio)) {
       return BaseVector::createNullConstant(type, size, pool_);
     }
-    if (type->isUnKnown()) {
+    if (type->isUnknown()) {
       return BaseVector::createNullConstant(type, size, pool_);
     } else {
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
@@ -578,7 +578,7 @@ VectorPtr VectorFuzzer::fuzzFlatPrimitive(
   VELOX_CHECK(type->isPrimitiveType());
   auto vector = BaseVector::create(type, size, pool_);
 
-  if (type->isUnKnown()) {
+  if (type->isUnknown()) {
     auto* rawNulls = vector->mutableRawNulls();
     bits::fillBits(rawNulls, 0, size, bits::kNull);
   } else {


### PR DESCRIPTION
Summary: Rename the `isUnKnown()` method to `isUnknown()` to fix the typo (capital 'K' should be lowercase 'k'). This brings the method naming in line with other similar methods like `isUnscaledLongDecimal()`, `isOpaque()`, etc.

Differential Revision: D92610008


