### PR TITLE
fix(dwio): Decode string dictionary values before invoking hooks

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -1228,7 +1228,14 @@ class StringDictionaryColumnVisitor
     vector_size_t previous =
         isDense && TFilter::deterministic ? 0 : super::currentRow();
     if constexpr (!DictSuper::hasFilter()) {
-      super::filterPassed(index);
+      // Hooks are LazyVector-level and have no access to the dictionary.
+      // They must receive decoded StringView values, not dictionary indices.
+      if constexpr (super::kHasHook) {
+        super::values_.addValue(
+            super::rowIndex_ + super::numValuesBias_, valueInDictionary(index));
+      } else {
+        super::filterPassed(index);
+      }
     } else {
       // check the dictionary cache
       if (TFilter::deterministic &&


### PR DESCRIPTION
 Root cause: On the scalar (non-AVX2) path, StringDictionaryColumnVisitor::process() was
 calling filterPassed(index) in the "no dictionary filter" case. That passed raw dictionary
 indices (int32/64) into ValueHook, which for TestingHook<StringView> in E2EFilterTestBase
 triggers an INVALID_STATE because it expects string values, not integers. This path is only
 exercised on non-AVX2 architectures (e.g. ARM), so x86 with AVX2 was masked by the SIMD fast path.

 Fix: In StringDictionaryColumnVisitor::process(), when !DictSuper::hasFilter() and kHasHook is true,
 call values_.addValue(rowIndex + numValuesBias_, valueInDictionary(index)) so the hook receives
 decoded StringView values. For the no-hook case we keep the original behavior (filterPassed(index)),
 and the dictionary-filtering branch is left unchanged.

 Rationale: This aligns the scalar path with the existing SIMD bulk path (processRun),
 which already decodes indices and feeds StringView values to ValueHook. As a result,
 both DWRF and Parquet string/varbinary dictionary readers now deliver decoded values to hooks on
 ARM, fixing the failures in velox_dwrf_e2e_filter_test (stringDictionary) and velox_parquet_e2e_filter_test
 (stringDictionary, dedictionarize, varbinaryDictionary) without changing behavior for non-hooked scans or
 x86 fast-path behavior.

fix https://github.com/facebookincubator/velox/issues/12954