### PR TITLE
test: Enhance parsing of IF expressions in DuckParser

### DIFF
--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -462,6 +462,8 @@ TEST(DuckParserTest, ifCase) {
       "if(\"a\",plus(\"b\",\"c\"),g(\"d\"))",
       parseExpr("if(a, b + c, g(d))")->toString());
 
+  EXPECT_EQ("if(gt(\"a\",0),10)", parseExpr("if(a > 0, 10, null)")->toString());
+
   // CASE statements.
   EXPECT_EQ(
       "if(1,null,0)",

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -330,10 +330,9 @@ ExprPtr SwitchCallToSpecialForm::constructSpecialForm(
 }
 
 TypePtr IfCallToSpecialForm::resolveType(const std::vector<TypePtr>& argTypes) {
-  VELOX_CHECK_EQ(
-      argTypes.size(),
-      3,
-      "An IF statement must have 3 clauses: 'if', 'then', and 'else'.");
+  VELOX_CHECK(
+      argTypes.size() == 2 || argTypes.size() == 3,
+      "An IF statement must have 2 or 3 clauses: 'if', 'then', and optional 'else'.");
 
   return resolveTypeInt(argTypes);
 }

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -207,13 +207,6 @@ TEST_F(ArraySortTest, lambda) {
       true,
       data,
       sortedDesc);
-
-  // Lambda function return NULL.
-  VELOX_ASSERT_THROW(
-      evaluate(
-          "array_sort(c0, (x, y) -> IF(lessthan(x, y), 1, IF(equalto(x, y), 0, null)))",
-          makeRowVector({data})),
-      "Else clause of a SWITCH statement must have the same type as 'then' clauses. Expected BIGINT, but got UNKNOWN.");
 }
 
 TEST_F(ArraySortTest, unsupporteLambda) {


### PR DESCRIPTION
Summary:
DuckDB parser requires IF to have 3 arguments: condition, then-clause, and else-clause. For example, `IF(a > b, 10)` doesn't parse correctly and must be written as `IF(a > b, 10, null)`.

This change removes the redundant null else-clause when parsing IF expressions. When the else-clause is a constant of UNKNOWN type (i.e., null), it is removed from the parsed expression. This makes the parsed representation cleaner and consistent with how Velox handles IF expressions with only 2 arguments.

Differential Revision: D92610056


