### PR TITLE
feat: Add EnforceDistinct operator

### DIFF
--- a/velox/core/PlanConsistencyChecker.cpp
+++ b/velox/core/PlanConsistencyChecker.cpp
@@ -149,6 +149,11 @@ class Checker : public PlanNodeVisitor {
     visitSources(&node, ctx);
   }
 
+  void visit(const EnforceDistinctNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitSources(&node, ctx);
+  }
+
   void visit(const MergeExchangeNode& node, PlanNodeVisitorContext& ctx)
       const override {
     visitSources(&node, ctx);

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -56,6 +56,7 @@ ValuesNode                  Values                                           Y
 LocalMergeNode              LocalMerge
 LocalPartitionNode          LocalPartition and LocalExchange
 EnforceSingleRowNode        EnforceSingleRow
+EnforceDistinctNode         EnforceDistinct or StreamingEnforceDistinct
 AssignUniqueIdNode          AssignUniqueId
 WindowNode                  Window
 RowNumberNode               RowNumber
@@ -851,6 +852,35 @@ returns that row unmodified. If input is empty, returns a single row with all
 values set to null. If input contains more than one row raises an exception.
 
 Used for queries with non-correlated sub-queries.
+
+EnforceDistinctNode
+~~~~~~~~~~~~~~~~~~~
+
+The EnforceDistinct operator ensures that input rows have unique values for
+specified key columns. It passes through all input rows unchanged, but throws
+an exception with a custom error message if any duplicate key values are
+detected. This is useful for validating uniqueness constraints at runtime,
+such as ensuring a correlated scalar subquery returns at most one row per group.
+
+When preGroupedKeys equals distinctKeys (i.e., input is clustered on the
+distinct keys), the streaming implementation is used which requires only O(1)
+memory. Otherwise, the hash-based implementation is used which requires O(n)
+memory to track all unique key combinations seen so far.
+
+.. list-table::
+   :widths: 10 30
+   :align: left
+   :header-rows: 1
+
+   * - Property
+     - Description
+   * - distinctKeys
+     - List of columns that must have unique values.
+   * - preGroupedKeys
+     - Optional subset of distinctKeys that input is already clustered on. When
+       equal to distinctKeys, uses streaming enforcement with O(1) memory.
+   * - errorMessage
+     - Error message to include in the exception when duplicates are found.
 
 AssignUniqueIdNode
 ~~~~~~~~~~~~~~~~~~

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -52,6 +52,7 @@ velox_add_library(
   LocalPartition.cpp
   LocalPlanner.cpp
   MarkDistinct.cpp
+  EnforceDistinct.cpp
   MemoryReclaimer.cpp
   Merge.cpp
   MergeJoin.cpp
@@ -93,6 +94,7 @@ velox_add_library(
   SpillFile.cpp
   Spiller.cpp
   StreamingAggregation.cpp
+  StreamingEnforceDistinct.cpp
   Strings.cpp
   TableScan.cpp
   TableWriteMerge.cpp

--- a/velox/exec/EnforceDistinct.cpp
+++ b/velox/exec/EnforceDistinct.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/EnforceDistinct.h"
+
+namespace facebook::velox::exec {
+
+EnforceDistinct::EnforceDistinct(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::EnforceDistinctNode>& planNode)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "EnforceDistinct"),
+      errorMessage_{planNode->errorMessage()} {
+  const auto& inputType = planNode->sources()[0]->outputType();
+
+  for (auto i = 0; i < inputType->size(); ++i) {
+    identityProjections_.emplace_back(i, i);
+  }
+
+  groupingSet_ = GroupingSet::createForDistinct(
+      inputType,
+      createVectorHashers(inputType, planNode->distinctKeys()),
+      toChannels(
+          inputType,
+          std::vector<core::TypedExprPtr>{
+              planNode->preGroupedKeys().begin(),
+              planNode->preGroupedKeys().end()}),
+      operatorCtx_.get(),
+      &nonReclaimableSection_);
+}
+
+void EnforceDistinct::addInput(RowVectorPtr input) {
+  groupingSet_->addInput(input, /*mayPushdown=*/false);
+
+  const auto& newGroups = groupingSet_->hashLookup().newGroups;
+  if (newGroups.size() != input->size()) {
+    VELOX_USER_FAIL("{}", errorMessage_);
+  }
+
+  input_ = std::move(input);
+}
+
+RowVectorPtr EnforceDistinct::getOutput() {
+  if (isFinished() || !input_) {
+    return nullptr;
+  }
+
+  auto output = fillOutput(input_->size(), nullptr);
+
+  input_ = nullptr;
+
+  return output;
+}
+
+bool EnforceDistinct::isFinished() {
+  return noMoreInput_ && !input_;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/EnforceDistinct.h
+++ b/velox/exec/EnforceDistinct.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/GroupingSet.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+/// Enforces uniqueness of rows based on specified key columns. Passes through
+/// all input rows unchanged. Throws an exception if any duplicate key values
+/// are detected.
+class EnforceDistinct : public Operator {
+ public:
+  EnforceDistinct(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::EnforceDistinctNode>& planNode);
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ private:
+  const std::string errorMessage_;
+  std::unique_ptr<GroupingSet> groupingSet_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -134,15 +134,16 @@ GroupingSet::~GroupingSet() {
   }
 }
 
-std::unique_ptr<GroupingSet> GroupingSet::createForMarkDistinct(
+std::unique_ptr<GroupingSet> GroupingSet::createForDistinct(
     const RowTypePtr& inputType,
     std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+    std::vector<column_index_t>&& preGroupedKeys,
     OperatorCtx* operatorCtx,
     tsan_atomic<bool>* nonReclaimableSection) {
   return std::make_unique<GroupingSet>(
       inputType,
       std::move(hashers),
-      /*preGroupedKeys=*/std::vector<column_index_t>{},
+      std::move(preGroupedKeys),
       /*groupingKeyOutputProjections=*/std::vector<column_index_t>{},
       /*aggregates=*/std::vector<AggregateInfo>{},
       /*ignoreNullKeys=*/false,

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -51,10 +51,14 @@ class GroupingSet {
 
   ~GroupingSet();
 
-  /// Used by MarkDistinct operator to identify rows with unique values.
-  static std::unique_ptr<GroupingSet> createForMarkDistinct(
+  /// Used by MarkDistinct and EnforceDistinct operators to identify rows with
+  /// unique values for a set of keys.
+  /// @param preGroupedKeys Subset of grouping keys that input is already
+  /// clustered on.
+  static std::unique_ptr<GroupingSet> createForDistinct(
       const RowTypePtr& inputType,
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+      std::vector<column_index_t>&& preGroupedKeys,
       OperatorCtx* operatorCtx,
       tsan_atomic<bool>* nonReclaimableSection);
 

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -43,9 +43,10 @@ MarkDistinct::MarkDistinct(
   // We will use result[0] for distinct mask output.
   resultProjections_.emplace_back(0, inputType->size());
 
-  groupingSet_ = GroupingSet::createForMarkDistinct(
+  groupingSet_ = GroupingSet::createForDistinct(
       inputType,
       createVectorHashers(inputType, planNode->distinctKeys()),
+      /*preGroupedKeys=*/{},
       operatorCtx_.get(),
       &nonReclaimableSection_);
 

--- a/velox/exec/StreamingEnforceDistinct.cpp
+++ b/velox/exec/StreamingEnforceDistinct.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/StreamingEnforceDistinct.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+// Compares two rows in the same or different vectors and returns true if they
+// match in all key columns.
+bool equalKeys(
+    const std::vector<column_index_t>& keyChannels,
+    const RowVectorPtr& batch,
+    vector_size_t index,
+    const RowVectorPtr& otherBatch,
+    vector_size_t otherIndex) {
+  for (auto channel : keyChannels) {
+    if (!batch->childAt(channel)->equalValueAt(
+            otherBatch->childAt(channel).get(), index, otherIndex)) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
+
+StreamingEnforceDistinct::StreamingEnforceDistinct(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::EnforceDistinctNode>& planNode)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "StreamingEnforceDistinct"),
+      inputType_{planNode->sources()[0]->outputType()},
+      keyChannels_{toChannels(
+          inputType_,
+          std::vector<core::TypedExprPtr>{
+              planNode->distinctKeys().begin(),
+              planNode->distinctKeys().end()})},
+      errorMessage_{planNode->errorMessage()} {
+  for (auto i = 0; i < inputType_->size(); ++i) {
+    identityProjections_.emplace_back(i, i);
+  }
+}
+
+void StreamingEnforceDistinct::addInput(RowVectorPtr input) {
+  if (input->size() == 0) {
+    return;
+  }
+
+  // Check first row against previous batch's last row.
+  if (prevKeyValues_ != nullptr &&
+      equalKeys(keyChannels_, input, 0, prevKeyValues_, 0)) {
+    VELOX_USER_FAIL("{}", errorMessage_);
+  }
+
+  // Check consecutive rows within this batch.
+  for (vector_size_t i = 1; i < input->size(); ++i) {
+    if (equalKeys(keyChannels_, input, i, input, i - 1)) {
+      VELOX_USER_FAIL("{}", errorMessage_);
+    }
+  }
+
+  // Save key values from the last row for comparison with next batch.
+
+  if (prevKeyValues_ == nullptr) {
+    std::vector<VectorPtr> keyVectors(inputType_->size());
+    for (auto channel : keyChannels_) {
+      keyVectors[channel] =
+          BaseVector::create(inputType_->childAt(channel), 1, pool());
+    }
+    prevKeyValues_ = std::make_shared<RowVector>(
+        pool(), inputType_, nullptr, 1, std::move(keyVectors));
+  }
+
+  const auto lastRow = input->size() - 1;
+  for (auto channel : keyChannels_) {
+    prevKeyValues_->childAt(channel)->copy(
+        input->childAt(channel).get(), 0, lastRow, 1);
+  }
+
+  input_ = std::move(input);
+}
+
+RowVectorPtr StreamingEnforceDistinct::getOutput() {
+  if (isFinished() || !input_) {
+    return nullptr;
+  }
+
+  auto output = fillOutput(input_->size(), nullptr);
+  input_ = nullptr;
+  return output;
+}
+
+bool StreamingEnforceDistinct::isFinished() {
+  return noMoreInput_ && !input_;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/StreamingEnforceDistinct.h
+++ b/velox/exec/StreamingEnforceDistinct.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+/// Streaming implementation of EnforceDistinct for pre-grouped input.
+/// Compares each row with the previous row to detect duplicates.
+/// Memory usage is O(1) - only stores the previous row's key values.
+///
+/// Use this operator when input is clustered on distinct keys, i.e., rows with
+/// the same key values are guaranteed to be adjacent.
+class StreamingEnforceDistinct : public Operator {
+ public:
+  StreamingEnforceDistinct(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::EnforceDistinctNode>& planNode);
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ private:
+  const RowTypePtr inputType_;
+  const std::vector<column_index_t> keyChannels_;
+  const std::string errorMessage_;
+
+  // Key values from the last row of the previous batch for cross-batch
+  // comparison. Lazily initialized on first input batch.
+  RowVectorPtr prevKeyValues_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
@@ -92,6 +92,11 @@ class DuckQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
     VELOX_NYI();
   }
 
+  void visit(const core::EnforceDistinctNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::MergeExchangeNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
@@ -95,6 +95,11 @@ class PrestoQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
     VELOX_NYI();
   }
 
+  void visit(const core::EnforceDistinctNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::MergeExchangeNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(
   LocalPartitionTest.cpp
   Main.cpp
   MarkDistinctTest.cpp
+  EnforceDistinctTest.cpp
   MemoryReclaimerTest.cpp
   MergeJoinTest.cpp
   MergeTest.cpp
@@ -97,6 +98,7 @@ add_executable(
   SplitTest.cpp
   SqlTest.cpp
   StreamingAggregationTest.cpp
+  StreamingEnforceDistinctTest.cpp
   TableScanTest.cpp
   TableWriterTest.cpp
   TaskListenerTest.cpp

--- a/velox/exec/tests/EnforceDistinctTest.cpp
+++ b/velox/exec/tests/EnforceDistinctTest.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::exec {
+namespace {
+
+class EnforceDistinctTest : public OperatorTestBase {
+ protected:
+  core::PlanNodePtr makePlan(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& keys,
+      const std::string& errorMessage) {
+    return PlanBuilder()
+        .values(input)
+        .enforceDistinct(keys, errorMessage)
+        .planNode();
+  }
+
+  core::PlanNodePtr makePlan(
+      const RowVectorPtr& input,
+      const std::string& key,
+      const std::string& errorMessage) {
+    return makePlan(
+        std::vector<RowVectorPtr>{input},
+        std::vector<std::string>{key},
+        errorMessage);
+  }
+
+  void assertDistinct(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& keys) {
+    auto plan = makePlan(input, keys, "Duplicate key found");
+    AssertQueryBuilder(plan).assertResults(input);
+  }
+};
+
+TEST_F(EnforceDistinctTest, uniqueRowsSingleKey) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, 3, std::nullopt, 5, 6, 7, 8, 9}),
+      makeFlatVector<std::string>(
+          {"a", "a", "b", "b", "a", "a", "b", "b", "a"}),
+  });
+
+  assertDistinct(split(data, 3), {"c0"});
+}
+
+TEST_F(EnforceDistinctTest, uniqueRowsMultipleKeys) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 3, 3, 4, 4, 5}),
+      makeFlatVector<std::string>(
+          {"x", "x", "y", "y", "x", "x", "y", "y", "x"}),
+      makeFlatVector<int64_t>({10, 20, 10, 20, 10, 20, 10, 20, 10}),
+  });
+
+  assertDistinct(split(data, 3), {"c0", "c2"});
+}
+
+TEST_F(EnforceDistinctTest, duplicateWithinBatch) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 2, 5}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(makePlan(data, "c0", "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+TEST_F(EnforceDistinctTest, duplicateAcrossBatches) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({4, 2, 6}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          makePlan({batch1, batch2}, {"c0"}, "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+TEST_F(EnforceDistinctTest, emptyInput) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({}),
+  });
+
+  assertDistinct({data}, {"c0"});
+}
+
+TEST_F(EnforceDistinctTest, singleRow) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({42}),
+  });
+
+  assertDistinct({data}, {"c0"});
+}
+
+TEST_F(EnforceDistinctTest, duplicateNulls) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, std::nullopt, 3, std::nullopt, 5}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(makePlan(data, "c0", "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -177,6 +177,14 @@ TEST_F(PlanNodeSerdeTest, markDistinct) {
   testSerde(plan);
 }
 
+TEST_F(PlanNodeSerdeTest, enforceDistinct) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .enforceDistinct({"c0", "c1", "c2"}, "Test error message")
+                  .planNode();
+  testSerde(plan);
+}
+
 TEST_F(PlanNodeSerdeTest, nestedLoopJoin) {
   auto left = makeRowVector(
       {"t0", "t1", "t2"},

--- a/velox/exec/tests/StreamingEnforceDistinctTest.cpp
+++ b/velox/exec/tests/StreamingEnforceDistinctTest.cpp
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::exec {
+namespace {
+
+class StreamingEnforceDistinctTest : public OperatorTestBase {
+ protected:
+  core::PlanNodePtr makePlan(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& keys,
+      const std::string& errorMessage) {
+    return PlanBuilder()
+        .values(input)
+        .streamingEnforceDistinct(keys, errorMessage)
+        .planNode();
+  }
+
+  core::PlanNodePtr makePlan(
+      const RowVectorPtr& input,
+      const std::string& key,
+      const std::string& errorMessage) {
+    return PlanBuilder()
+        .values({input})
+        .streamingEnforceDistinct({key}, errorMessage)
+        .planNode();
+  }
+
+  void assertDistinct(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& keys) {
+    auto plan = makePlan(input, keys, "Duplicate key found");
+    AssertQueryBuilder(plan).assertResults(input);
+  }
+};
+
+TEST_F(StreamingEnforceDistinctTest, uniqueRowsSingleKey) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, 3, std::nullopt, 5, 6, 7, 8, 9}),
+      makeFlatVector<std::string>(
+          {"a", "a", "b", "b", "a", "a", "b", "b", "a"}),
+  });
+
+  assertDistinct(split(data, 3), {"c0"});
+}
+
+TEST_F(StreamingEnforceDistinctTest, uniqueRowsMultipleKeys) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 3, 3, 4, 4, 5}),
+      makeFlatVector<std::string>(
+          {"x", "x", "y", "y", "x", "x", "y", "y", "x"}),
+      makeFlatVector<int64_t>({10, 20, 10, 20, 10, 20, 10, 20, 10}),
+  });
+
+  assertDistinct(split(data, 3), {"c0", "c2"});
+}
+
+TEST_F(StreamingEnforceDistinctTest, duplicateWithinBatch) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 2, 3, 4}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(makePlan(data, "c0", "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+TEST_F(StreamingEnforceDistinctTest, duplicateAcrossBatches) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({3, 4, 5}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          makePlan({batch1, batch2}, {"c0"}, "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+TEST_F(StreamingEnforceDistinctTest, emptyInput) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({}),
+  });
+
+  assertDistinct({data}, {"c0"});
+}
+
+TEST_F(StreamingEnforceDistinctTest, singleRow) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({42}),
+  });
+
+  assertDistinct({data}, {"c0"});
+}
+
+TEST_F(StreamingEnforceDistinctTest, duplicateNulls) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, std::nullopt, std::nullopt, 4, 5}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(makePlan(data, "c0", "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+TEST_F(StreamingEnforceDistinctTest, duplicateNullsAcrossBatches) {
+  auto batch1 = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, std::nullopt}),
+  });
+
+  auto batch2 = makeRowVector({
+      makeNullableFlatVector<int32_t>({std::nullopt, 4, 5}),
+  });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          makePlan({batch1, batch2}, {"c0"}, "Duplicate key found"))
+          .countResults(),
+      "Duplicate key found");
+}
+
+} // namespace
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2521,6 +2521,27 @@ PlanBuilder& PlanBuilder::markDistinct(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::enforceDistinct(
+    const std::vector<std::string>& distinctKeys,
+    std::string errorMessage,
+    const std::vector<std::string>& preGroupedKeys) {
+  VELOX_CHECK_NOT_NULL(planNode_, "EnforceDistinct cannot be the source node");
+  planNode_ = std::make_shared<core::EnforceDistinctNode>(
+      nextPlanNodeId(),
+      fields(planNode_->outputType(), distinctKeys),
+      fields(planNode_->outputType(), preGroupedKeys),
+      std::move(errorMessage),
+      planNode_);
+  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::streamingEnforceDistinct(
+    const std::vector<std::string>& distinctKeys,
+    std::string errorMessage) {
+  return enforceDistinct(distinctKeys, std::move(errorMessage), distinctKeys);
+}
+
 core::PlanNodeId PlanBuilder::nextPlanNodeId() {
   return planNodeIdGenerator_->next();
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1486,6 +1486,32 @@ class PlanBuilder {
       std::string markerKey,
       const std::vector<std::string>& distinctKeys);
 
+  /// Add an EnforceDistinctNode to ensure input has unique values for the
+  /// specified keys at runtime. Throws with the specified error message if
+  /// duplicates are found.
+  /// @param distinctKeys List of columns that must have unique values.
+  /// @param errorMessage Error message to include in the exception when
+  /// duplicates are found.
+  /// @param preGroupedKeys Optional subset of distinctKeys that input is
+  /// already clustered on. When equal to distinctKeys, uses streaming
+  /// enforcement.
+  PlanBuilder& enforceDistinct(
+      const std::vector<std::string>& distinctKeys,
+      std::string errorMessage,
+      const std::vector<std::string>& preGroupedKeys = {});
+
+  /// Add an EnforceDistinctNode to ensure pre-grouped input has unique
+  /// values for the specified keys. Equivalent to calling enforceDistinct with
+  /// preGroupedKeys equal to distinctKeys, which uses the streaming
+  /// implementation.
+  /// @param distinctKeys List of columns that must have unique values. Input
+  /// must be clustered on these keys.
+  /// @param errorMessage Error message to include in the exception when
+  /// duplicates are found.
+  PlanBuilder& streamingEnforceDistinct(
+      const std::vector<std::string>& distinctKeys,
+      std::string errorMessage);
+
   /// Stores the latest plan node ID into the specified variable. Useful for
   /// capturing IDs of the leaf plan nodes (table scans, exchanges, etc.) to use
   /// when adding splits at runtime.

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
@@ -93,6 +93,11 @@ class SparkQueryRunnerToSqlPlanNodeVisitor
     VELOX_NYI();
   }
 
+  void visit(const core::EnforceDistinctNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::MergeExchangeNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();


### PR DESCRIPTION
Summary:
Add a new EnforceDistinct operator that checks input rows have unique values in specified key columns at runtime. The operator passes through all input rows unchanged, but throws a user-specified exception if duplicate key values are detected.

This operator is useful for validating uniqueness constraints, such as ensuring a scalar subquery returns at most one row per group. Unlike MarkDistinct which adds a boolean marker column, EnforceDistinct enforces uniqueness as a runtime constraint by throwing with a custom error message.

The implementation includes two variants:
- **Hash-based EnforceDistinct**: Uses GroupingSet with hash lookup to detect duplicates across all rows. O(n) memory usage.
- **StreamingEnforceDistinct**: For pre-grouped input where rows with the same key values are adjacent. Only compares each row with the previous row. O(1) memory usage.

The operator is selected based on preGroupedKeys:
- When preGroupedKeys equals distinctKeys, uses StreamingEnforceDistinct
- Otherwise, uses hash-based EnforceDistinct

Differential Revision: D92611585


