### PR TITLE
fix: Fix flaky SkewedPartitionRebalancerTest.serializedRebalanceExecution

### DIFF
--- a/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
+++ b/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
@@ -330,10 +330,18 @@ DEBUG_ONLY_TEST_F(SkewedPartitionRebalancerTest, serializedRebalanceExecution) {
   SkewedPartitionRebalancerTestHelper helper(balancer.get());
   folly::EventCount rebalanceWait;
   std::atomic_bool rebalanceWaitFlag{true};
+
+  // Used to signal that the background thread has entered the test value
+  // callback.
+  folly::EventCount mainThreadRebalancerWait;
+  std::atomic_bool mainThreadRebalancerWaitFlag{true};
   SCOPED_TESTVALUE_SET(
       "facebook::velox::common::SkewedPartitionRebalancer::rebalancePartitions",
       std::function<void(SkewedPartitionRebalancer*)>(
           [&](SkewedPartitionRebalancer*) {
+            // Signal that we've entered the callback.
+            mainThreadRebalancerWaitFlag = false;
+            mainThreadRebalancerWait.notifyAll();
             rebalanceWait.await([&] { return !rebalanceWaitFlag.load(); });
           }));
 
@@ -343,6 +351,12 @@ DEBUG_ONLY_TEST_F(SkewedPartitionRebalancerTest, serializedRebalanceExecution) {
   }
 
   std::thread rebalanceThread([&]() { balancer->rebalance(); });
+
+  // Wait for the background thread to enter the test value callback and block
+  // there. This ensures that when we call rebalance() from the main thread,
+  // rebalancing_ is already true and our rebalance() call will return early.
+  mainThreadRebalancerWait.await(
+      [&] { return mainThreadRebalancerWaitFlag.load(); });
 
   balancer->rebalance();
 


### PR DESCRIPTION
Summary:
The test was flaky because background thread might have already finished rebalancing before main thread starts. This results in 2 rebalancing happening.

The fix adds an additional EventCount to make sure when the main thread starts to rebalance, the background thread's rebalancing hasn't finished.

Reviewed By: xiaoxmeng

Differential Revision: D92632923


