### PR TITLE
fix: Hive unit test flushPolicyWithParquet

### DIFF
--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1149,7 +1149,7 @@ TEST_F(HiveDataSinkTest, insertTableHandleToString) {
 TEST_F(HiveDataSinkTest, flushPolicyWithParquet) {
   const auto outputDirectory = TempDirectoryPath::create();
   auto flushPolicyFactory = []() {
-    return std::make_unique<parquet::DefaultFlushPolicy>(1234, 0);
+    return std::make_unique<parquet::DefaultFlushPolicy>(1234, 1);
   };
   auto writeOptions = std::make_shared<parquet::WriterOptions>();
   writeOptions->flushPolicyFactory = flushPolicyFactory;


### PR DESCRIPTION
Fix hive UT error https://github.com/facebookincubator/velox/actions/runs/21786681207/job/62859220521?pr=16295

`/home/runner/work/velox/velox/velox/./velox/dwio/parquet/writer/arrow/Properties.h:407:  Check failed: (maxRowGroupBytes) > (0) maxRowGroupBytes must be positive`
