### PR TITLE
fix(test): Fix HiveDataSinkTest.flushPolicyWithParquet crash

### DIFF
--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1149,7 +1149,10 @@ TEST_F(HiveDataSinkTest, insertTableHandleToString) {
 TEST_F(HiveDataSinkTest, flushPolicyWithParquet) {
   const auto outputDirectory = TempDirectoryPath::create();
   auto flushPolicyFactory = []() {
-    return std::make_unique<parquet::DefaultFlushPolicy>(1234, 0);
+    // Use a large bytesInRowGroup so flushing is controlled by row count only.
+    // bytesInRowGroup must be positive (enforced by Arrow's WriterProperties).
+    return std::make_unique<parquet::DefaultFlushPolicy>(
+        1234, 128 * 1024 * 1024);
   };
   auto writeOptions = std::make_shared<parquet::WriterOptions>();
   writeOptions->flushPolicyFactory = flushPolicyFactory;


### PR DESCRIPTION
## Summary

`HiveDataSinkTest.flushPolicyWithParquet` has been crashing with:

```
Check failed: (maxRowGroupBytes) > (0) maxRowGroupBytes must be positive
```

## Root Cause

PR #15751 added `ARROW_CHECK_GT(maxRowGroupBytes, 0)` validation in Arrow's `WriterProperties::Builder`. The test at line 1152 creates `DefaultFlushPolicy(1234, 0)` where `0` is the `bytesInRowGroup` parameter. This value flows through to `WriterProperties::Builder::maxRowGroupBytes(0)`, triggering the assertion failure (`SIGABRT`).

## Fix

Replace `bytesInRowGroup=0` with `128 * 1024 * 1024` (the default value). This preserves the test's intent of controlling flushing by row count only (1234 rows), while satisfying the positive-value constraint.