### PR TITLE
feat: Add flag `AggregationNode::preferStreamingAggregation` to create StreamingAggregation for global aggregation node

### DIFF
--- a/velox/core/tests/PlanConsistencyCheckerTest.cpp
+++ b/velox/core/tests/PlanConsistencyCheckerTest.cpp
@@ -161,6 +161,7 @@ TEST_F(PlanConsistencyCheckerTest, aggregation) {
         },
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         projectNode);
     VELOX_ASSERT_THROW(
         PlanConsistencyChecker::check(aggregationNode), "Field not found: x");
@@ -186,6 +187,7 @@ TEST_F(PlanConsistencyCheckerTest, aggregation) {
         },
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         projectNode);
     VELOX_ASSERT_THROW(
         PlanConsistencyChecker::check(aggregationNode), "Field not found: y");
@@ -212,6 +214,7 @@ TEST_F(PlanConsistencyCheckerTest, aggregation) {
         },
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         projectNode);
     VELOX_ASSERT_THROW(
         PlanConsistencyChecker::check(aggregationNode), "Field not found: z");
@@ -237,6 +240,7 @@ TEST_F(PlanConsistencyCheckerTest, aggregation) {
         },
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         projectNode);
     VELOX_ASSERT_THROW(
         PlanConsistencyChecker::check(aggregationNode),

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -190,6 +190,7 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
         testData.isDistinct ? emptyAggregates : aggregates,
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         valueNode_);
     auto queryCtx = getSpillQueryCtx(
         testData.isSpillEnabled,

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -586,10 +586,133 @@ TEST_F(PlanNodeTest, aggregationNodeNoGroupsSpanBatches) {
         values);
     ASSERT_FALSE(aggNode->noGroupsSpanBatches());
     ASSERT_FALSE(aggNode->isPreGrouped());
-    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
+    ASSERT_FALSE(aggNode->shouldUseStreamingAggregation());
     ASSERT_EQ(
         aggNode->toString(true),
         "-- Aggregation[agg][SINGLE [c0] sum := sum()] -> c0:BIGINT, sum:BIGINT\n");
+  }
+}
+
+TEST_F(PlanNodeTest, aggregationNodePreferStreamingAggregation) {
+  auto values = std::make_shared<ValuesNode>("values", rowData_);
+
+  const std::vector<std::string> aggregateNames{"sum", "count"};
+  const std::vector<AggregationNode::Aggregate> aggregates{
+      {.call = std::make_shared<CallTypedExpr>(BIGINT(), "sum"),
+       .rawInputTypes = {BIGINT()}},
+      {.call = std::make_shared<CallTypedExpr>(BIGINT(), "count"),
+       .rawInputTypes = {BIGINT()}}};
+
+  // Global aggregation with preferStreamingAggregation=true.
+  // Should use streaming aggregation.
+  {
+    auto aggNode = std::make_shared<AggregationNode>(
+        "agg",
+        AggregationNode::Step::kSingle,
+        /*groupingKeys=*/std::vector<FieldAccessTypedExprPtr>{},
+        /*preGroupedKeys=*/std::vector<FieldAccessTypedExprPtr>{},
+        aggregateNames,
+        aggregates,
+        /*ignoreNullKeys=*/false,
+        /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/true,
+        values);
+    ASSERT_TRUE(aggNode->preferStreamingAggregation());
+    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
+    ASSERT_FALSE(aggNode->isPreGrouped());
+    ASSERT_EQ(
+        aggNode->toString(true),
+        "-- Aggregation[agg][SINGLE STREAMING sum := sum(), count := count()] -> sum:BIGINT, count:BIGINT\n");
+  }
+
+  // Global aggregation with preferStreamingAggregation=false (default).
+  // Should use hash aggregation.
+  {
+    auto aggNode = std::make_shared<AggregationNode>(
+        "agg",
+        AggregationNode::Step::kSingle,
+        /*groupingKeys=*/std::vector<FieldAccessTypedExprPtr>{},
+        /*preGroupedKeys=*/std::vector<FieldAccessTypedExprPtr>{},
+        aggregateNames,
+        aggregates,
+        /*ignoreNullKeys=*/false,
+        /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
+        values);
+    ASSERT_FALSE(aggNode->preferStreamingAggregation());
+    ASSERT_FALSE(aggNode->shouldUseStreamingAggregation());
+    ASSERT_FALSE(aggNode->isPreGrouped());
+    ASSERT_EQ(
+        aggNode->toString(true),
+        "-- Aggregation[agg][SINGLE sum := sum(), count := count()] -> sum:BIGINT, count:BIGINT\n");
+  }
+
+  // Grouped aggregation with preferStreamingAggregation=true.
+  // Should NOT use streaming aggregation (grouping keys present, not
+  // pre-grouped).
+  {
+    const std::vector<FieldAccessTypedExprPtr> groupingKeys{
+        std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+    auto aggNode = std::make_shared<AggregationNode>(
+        "agg",
+        AggregationNode::Step::kSingle,
+        groupingKeys,
+        /*preGroupedKeys=*/std::vector<FieldAccessTypedExprPtr>{},
+        aggregateNames,
+        aggregates,
+        /*ignoreNullKeys=*/false,
+        /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/true,
+        values);
+    ASSERT_TRUE(aggNode->preferStreamingAggregation());
+    ASSERT_FALSE(aggNode->shouldUseStreamingAggregation());
+    ASSERT_FALSE(aggNode->isPreGrouped());
+    ASSERT_EQ(
+        aggNode->toString(true),
+        "-- Aggregation[agg][SINGLE [c0] sum := sum(), count := count()] -> c0:BIGINT, sum:BIGINT, count:BIGINT\n");
+  }
+
+  // Pre-grouped aggregation with preferStreamingAggregation=false.
+  // Should still use streaming aggregation (pre-grouped takes precedence).
+  {
+    const std::vector<FieldAccessTypedExprPtr> groupingKeys{
+        std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+    const std::vector<FieldAccessTypedExprPtr> preGroupedKeys{
+        std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
+    auto aggNode = std::make_shared<AggregationNode>(
+        "agg",
+        AggregationNode::Step::kSingle,
+        groupingKeys,
+        preGroupedKeys,
+        aggregateNames,
+        aggregates,
+        /*ignoreNullKeys=*/false,
+        /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
+        values);
+    ASSERT_FALSE(aggNode->preferStreamingAggregation());
+    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
+    ASSERT_TRUE(aggNode->isPreGrouped());
+    ASSERT_EQ(
+        aggNode->toString(true),
+        "-- Aggregation[agg][SINGLE STREAMING [c0] sum := sum(), count := count()] -> c0:BIGINT, sum:BIGINT, count:BIGINT\n");
+  }
+
+  // Builder pattern with preferStreamingAggregation.
+  {
+    auto aggNode = AggregationNode::Builder()
+                       .id("agg")
+                       .step(AggregationNode::Step::kSingle)
+                       .groupingKeys({})
+                       .preGroupedKeys({})
+                       .aggregateNames(aggregateNames)
+                       .aggregates(aggregates)
+                       .ignoreNullKeys(false)
+                       .preferStreamingAggregation(true)
+                       .source(values)
+                       .build();
+    ASSERT_TRUE(aggNode->preferStreamingAggregation());
+    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
   }
 }
 } // namespace

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -523,9 +523,11 @@ TEST_F(PlanNodeTest, aggregationNodeNoGroupsSpanBatches) {
         aggregates,
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/true,
+        /*preferStreamingAggregation=*/false,
         values);
     ASSERT_TRUE(aggNode->noGroupsSpanBatches());
     ASSERT_TRUE(aggNode->isPreGrouped());
+    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
     ASSERT_EQ(
         aggNode->toString(true),
         "-- Aggregation[agg][SINGLE STREAMING [c0] sum := sum() noGroupsSpanBatches] -> c0:BIGINT, sum:BIGINT\n");
@@ -543,9 +545,11 @@ TEST_F(PlanNodeTest, aggregationNodeNoGroupsSpanBatches) {
         aggregates,
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         values);
     ASSERT_FALSE(aggNode->noGroupsSpanBatches());
     ASSERT_TRUE(aggNode->isPreGrouped());
+    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
     ASSERT_EQ(
         aggNode->toString(true),
         "-- Aggregation[agg][SINGLE STREAMING [c0] sum := sum()] -> c0:BIGINT, sum:BIGINT\n");
@@ -563,6 +567,7 @@ TEST_F(PlanNodeTest, aggregationNodeNoGroupsSpanBatches) {
           aggregates,
           /*ignoreNullKeys=*/false,
           /*noGroupsSpanBatches=*/true,
+          /*preferStreamingAggregation=*/false,
           values),
       "noGroupsSpanBatches can only be set for streaming aggregation (pre-grouped)");
 
@@ -577,9 +582,11 @@ TEST_F(PlanNodeTest, aggregationNodeNoGroupsSpanBatches) {
         aggregates,
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         values);
     ASSERT_FALSE(aggNode->noGroupsSpanBatches());
     ASSERT_FALSE(aggNode->isPreGrouped());
+    ASSERT_TRUE(aggNode->shouldUseStreamingAggregation());
     ASSERT_EQ(
         aggNode->toString(true),
         "-- Aggregation[agg][SINGLE [c0] sum := sum()] -> c0:BIGINT, sum:BIGINT\n");

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -634,7 +634,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     } else if (
         auto aggregationNode =
             std::dynamic_pointer_cast<const core::AggregationNode>(planNode)) {
-      if (aggregationNode->isPreGrouped()) {
+      if (aggregationNode->shouldUseStreamingAggregation()) {
         operators.push_back(
             std::make_unique<StreamingAggregation>(
                 id, ctx.get(), aggregationNode));

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -485,6 +485,7 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
               aggregates,
               /*ignoreNullKeys=*/false,
               /*noGroupsSpanBatches=*/false,
+              /*preferStreamingAggregation=*/false,
               std::move(source));
         })
         .planNode();
@@ -547,6 +548,7 @@ TEST_F(AggregationTest, missingLambdaFunction) {
                         aggregates,
                         /*ignoreNullKeys=*/false,
                         /*noGroupsSpanBatches=*/false,
+                        /*preferStreamingAggregation=*/false,
                         std::move(source));
                   })
                   .planNode();

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -1484,5 +1484,63 @@ TEST_P(StreamingAggregationTest, needsInputWhenSplitOutput) {
       velox::exec::toPlanStats(taskStats).at(aggregationNodeId).outputVectors,
       9);
 }
+
+TEST_P(StreamingAggregationTest, globalAggregation) {
+  // Create test data with multiple batches
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+  });
+
+  createDuckDbTable({data});
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .streamingAggregation(
+                        {}, // No grouping keys - global aggregation
+                        {"count(1)", "sum(c0)", "min(c1)", "max(c1)"},
+                        {},
+                        core::AggregationNode::Step::kSingle,
+                        false)
+                    .planNode();
+
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults("SELECT count(1), sum(c0), min(c1), max(c1) FROM tmp");
+  }
+}
+
+TEST_P(StreamingAggregationTest, globalAggregationMultipleBatches) {
+  std::vector<RowVectorPtr> data = {
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({4, 5, 6}),
+          makeFlatVector<int64_t>({40, 50, 60}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({7, 8, 9}),
+          makeFlatVector<int64_t>({70, 80, 90}),
+      }),
+  };
+
+  createDuckDbTable(data);
+
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .streamingAggregation(
+                      {}, // No grouping keys - global aggregation
+                      {"count(1)", "sum(c0)", "avg(c1)", "min(c0)", "max(c1)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults(
+          "SELECT count(1), sum(c0), avg(c1), min(c0), max(c1) FROM tmp");
+}
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -937,9 +937,11 @@ core::PlanNodePtr PlanBuilder::createIntermediateOrFinalAggregation(
       aggregates,
       partialAggNode->ignoreNullKeys(),
       partialAggNode->noGroupsSpanBatches(),
+      partialAggNode->preferStreamingAggregation(),
       planNode_);
   VELOX_CHECK_EQ(
-      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+      aggregationNode->supportsBarrier(),
+      aggregationNode->shouldUseStreamingAggregation());
   return aggregationNode;
 }
 
@@ -1143,9 +1145,11 @@ PlanBuilder& PlanBuilder::aggregation(
       groupId,
       ignoreNullKeys,
       /*noGroupsSpanBatches=*/false,
+      /*preferStreamingAggregation=*/false,
       planNode_);
   VELOX_CHECK_EQ(
-      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+      aggregationNode->supportsBarrier(),
+      aggregationNode->shouldUseStreamingAggregation());
   planNode_ = std::move(aggregationNode);
   return *this;
 }
@@ -1168,9 +1172,11 @@ PlanBuilder& PlanBuilder::streamingAggregation(
       aggregatesAndNames.aggregates,
       ignoreNullKeys,
       noGroupsSpanBatches,
+      true,
       planNode_);
   VELOX_CHECK_EQ(
-      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+      aggregationNode->supportsBarrier(),
+      aggregationNode->shouldUseStreamingAggregation());
   planNode_ = std::move(aggregationNode);
   return *this;
 }

--- a/velox/exec/trace/TraceUtil.cpp
+++ b/velox/exec/trace/TraceUtil.cpp
@@ -351,6 +351,7 @@ core::PlanNodePtr getTraceNode(
         aggregationNode->groupId(),
         aggregationNode->ignoreNullKeys(),
         aggregationNode->noGroupsSpanBatches(),
+        aggregationNode->preferStreamingAggregation(),
         std::make_shared<DummySourceNode>(
             aggregationNode->sources().front()->outputType()));
   }

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -73,6 +73,7 @@ class AverageAggregationTest : public AggregationTestBase {
         std::vector{avgAggregate},
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         std::move(child));
   }
 };

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -716,6 +716,7 @@ TEST_F(SumAggregationTest, dummySum) {
       std::move(aggregates),
       /*ignoreNullKeys=*/false,
       /*noGroupsSpanBatches=*/false,
+      /*preferStreamingAggregation=*/false,
       std::move(child));
 
   assertQuery(plan, "SELECT sum(distinct c0), avg(c1) from tmp");

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -497,6 +497,7 @@ PlanNodePtr toVeloxPlan(
       std::move(aggregates),
       /*ignoreNullKeys=*/false,
       /*noGroupsSpanBatches=*/false,
+      /*preferStreamingAggregation=*/false,
       source);
 }
 

--- a/velox/tool/trace/AggregationReplayer.cpp
+++ b/velox/tool/trace/AggregationReplayer.cpp
@@ -40,6 +40,7 @@ core::PlanNodePtr AggregationReplayer::createPlanNode(
       aggregationNode->groupId(),
       aggregationNode->ignoreNullKeys(),
       aggregationNode->noGroupsSpanBatches(),
+      aggregationNode->preferStreamingAggregation(),
       source);
 }
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/tests/TableWriterReplayerTest.cpp
+++ b/velox/tool/trace/tests/TableWriterReplayerTest.cpp
@@ -250,6 +250,7 @@ class TableWriterReplayerTest : public HiveConnectorTestBase {
         aggregates,
         /*ignoreNullKeys=*/false,
         /*noGroupsSpanBatches=*/false,
+        /*preferStreamingAggregation=*/false,
         source);
   }
 


### PR DESCRIPTION
The PR adds flag `AggregationNode::preferStreamingAggregation` to hint LocalPlanner to create `StreamingAggregation` instead of `HashAggregation` for global aggregation node.

The main goal of adding the flag is to provide a way to enable **barrier support** for global aggregations. Previously, global aggregations are planned as HashAggregation that doesn't support task barrier. The tests added by this PR also improves the coverage for global StreamingAggregation.