### PR TITLE
fix(cudf): Disable passing of split values to Parquet reader pending investigation into Presto breakage in lieu of reverting #14968/#16287

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -635,8 +635,9 @@ CudfHybridScanReaderPtr CudfHiveDataSource::createExperimentalSplitReader() {
   if (not pageIndexByteRange.is_empty()) {
     auto const pageIndexBytes = dataSource_->host_read(
         pageIndexByteRange.offset(), pageIndexByteRange.size());
-    exptSplitReader->setup_page_index(cudf::host_span<uint8_t const>{
-        pageIndexBytes->data(), pageIndexBytes->size()});
+    exptSplitReader->setup_page_index(
+        cudf::host_span<uint8_t const>{
+            pageIndexBytes->data(), pageIndexBytes->size()});
   }
 
   return exptSplitReader;


### PR DESCRIPTION
PRs #14968 (and follow-up fix in #16287) add support for reading splits in Parquet files.

That code is in itself correct, but the incoming `start` value in the Presto context appear to be incorrect.

To allow easier investigation into that, rather than reverting the entire change, this PR simply disables passing of those values to the Parquet reader, thus avoiding the problem.

Posted on behalf of @mhaseeb123 