### PR TITLE
feat: Add ssdFlushThresholdBytes options to SSD cache

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -935,11 +935,15 @@ void AsyncDataCache::possibleSsdSave(uint64_t bytes) {
 
   ssdSaveable_ += bytes;
   if (memory::AllocationTraits::numPages(ssdSaveable_) >
-      std::max<int32_t>(
-          static_cast<int32_t>(
-              memory::AllocationTraits::numPages(opts_.minSsdSavableBytes)),
-          static_cast<int32_t>(
-              static_cast<double>(cachedPages_) * opts_.ssdSavableRatio))) {
+          std::max<int32_t>(
+              static_cast<int32_t>(
+                  memory::AllocationTraits::numPages(opts_.minSsdSavableBytes)),
+              static_cast<int32_t>(
+                  static_cast<double>(cachedPages_) * opts_.ssdSavableRatio)) ||
+      (opts_.ssdFlushThresholdBytes > 0 &&
+       memory::AllocationTraits::numPages(ssdSaveable_) >
+           static_cast<int32_t>(memory::AllocationTraits::numPages(
+               opts_.ssdFlushThresholdBytes)))) {
     // Do not start a new save if another one is in progress.
     if (!ssdCache_->startWrite()) {
       return;

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -714,11 +714,13 @@ class AsyncDataCache : public memory::Cache {
         double _maxWriteRatio = 0.7,
         double _ssdSavableRatio = 0.125,
         int32_t _minSsdSavableBytes = 1 << 24,
-        int32_t _numShards = kDefaultNumShards)
+        int32_t _numShards = kDefaultNumShards,
+        uint64_t _ssdFlushThresholdBytes = 0)
         : maxWriteRatio(_maxWriteRatio),
           ssdSavableRatio(_ssdSavableRatio),
           minSsdSavableBytes(_minSsdSavableBytes),
-          numShards(_numShards) {}
+          numShards(_numShards),
+          ssdFlushThresholdBytes(_ssdFlushThresholdBytes) {}
 
     /// The max ratio of the number of in-memory cache entries being written to
     /// SSD cache over the total number of cache entries. This is to control SSD
@@ -742,6 +744,11 @@ class AsyncDataCache : public memory::Cache {
     /// shards to decrease contention on the mutex for the key to entry mapping
     /// and other housekeeping. Must be a power of 2.
     int32_t numShards;
+
+    /// The maximum threshold in bytes for triggering SSD flush. When the
+    /// accumulated SSD-savable bytes exceed this value, a flush to SSD is
+    /// triggered. Set to 0 to disable this threshold (default).
+    uint64_t ssdFlushThresholdBytes;
   };
 
   AsyncDataCache(

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -1504,6 +1504,65 @@ TEST_P(AsyncDataCacheTest, ssdWriteOptions) {
   }
 }
 
+TEST_P(AsyncDataCacheTest, ssdFlushThresholdBytes) {
+  constexpr uint64_t kRamBytes = 16UL << 20; // 16 MB
+  constexpr uint64_t kSsdBytes = 64UL << 20; // 64 MB
+
+  struct {
+    double maxWriteRatio;
+    double ssdSavableRatio;
+    int32_t minSsdSavableBytes;
+    uint64_t ssdFlushThresholdBytes;
+    bool expectedSaveToSsd;
+
+    std::string debugString() const {
+      return fmt::format(
+          "maxWriteRatio {}, ssdSavableRatio {}, minSsdSavableBytes {}, ssdFlushThresholdBytes {}, expectedSaveToSsd {}",
+          maxWriteRatio,
+          ssdSavableRatio,
+          minSsdSavableBytes,
+          ssdFlushThresholdBytes,
+          expectedSaveToSsd);
+    }
+  } testSettings[] = {
+      // Ratio-based threshold not met, ssdFlushThresholdBytes disabled (0).
+      // No flush expected.
+      {0.8, 0.95, 32 << 20, 0, false},
+      // Ratio-based threshold not met, but ssdFlushThresholdBytes is small
+      // (1MB).
+      // Flush expected due to absolute threshold.
+      {0.8, 0.95, 32 << 20, 1UL << 20, true},
+      // Ratio-based threshold met. ssdFlushThresholdBytes disabled.
+      // Flush expected due to ratio.
+      {0.8, 0.3, 4 << 20, 0, true},
+      // Both thresholds could trigger. Flush expected.
+      {0.8, 0.3, 4 << 20, 1UL << 20, true}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    initializeCache(
+        kRamBytes,
+        kSsdBytes,
+        0,
+        true,
+        AsyncDataCache::Options(
+            testData.maxWriteRatio,
+            testData.ssdSavableRatio,
+            testData.minSsdSavableBytes,
+            AsyncDataCache::kDefaultNumShards,
+            testData.ssdFlushThresholdBytes));
+    // Load data half of the in-memory capacity.
+    loadLoop(0, kRamBytes / 2);
+    waitForPendingLoads();
+    auto stats = cache_->refreshStats();
+    if (testData.expectedSaveToSsd) {
+      EXPECT_GT(stats.ssdStats->entriesWritten, 0);
+    } else {
+      EXPECT_EQ(stats.ssdStats->entriesWritten, 0);
+    }
+  }
+}
+
 TEST_P(AsyncDataCacheTest, appendSsdSaveable) {
   constexpr uint64_t kRamBytes = 64UL << 20; // 64 MB
   constexpr uint64_t kSsdBytes = 128UL << 20; // 128 MB


### PR DESCRIPTION
Summary:
Adds a new `ssdFlushThresholdBytes` option to AsyncDataCache for triggering SSD flush based on an absolute byte threshold.

The existing ratio-based thresholds can result in delayed flushes when cache sizes are large.  And it has cause the savable eviction to be large.

This option provides an upper bound on SSD-savable bytes regardless of cache size, enabling more predictable flush behavior. Defaults to 0 (disabled) for backward compatibility.

Differential Revision: D92323049


