### PR TITLE
refactor: Extract apply lambda utility function

### DIFF
--- a/velox/functions/lib/ArraySort.cpp
+++ b/velox/functions/lib/ArraySort.cpp
@@ -20,7 +20,6 @@
 #include "velox/expression/Expr.h"
 #include "velox/functions/lib/ArraySort.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
-#include "velox/functions/lib/RowsTranslationUtil.h"
 #include "velox/type/FloatingPointUtil.h"
 
 namespace facebook::velox::functions {
@@ -347,36 +346,22 @@ class ArraySortLambdaFunction : public exec::VectorFunction {
 
     auto flatArray = flattenArray(rows, args[0], decodedArray);
 
-    std::vector<VectorPtr> lambdaArgs = {flatArray->elements()};
-    auto newNumElements = flatArray->elements()->size();
-
+    auto numElements = flatArray->elements()->size();
+    const std::vector<VectorPtr> lambdaArgs = {flatArray->elements()};
     SelectivityVector validRowsInReusedResult =
-        toElementRows<ArrayVector>(newNumElements, rows, flatArray.get());
+        toElementRows<ArrayVector>(numElements, rows, flatArray.get());
 
-    // Compute sorting keys.
     VectorPtr newElements;
-
-    auto elementToTopLevelRows = getElementToTopLevelRows(
-        newNumElements, rows, flatArray.get(), context.pool());
-
-    // Loop over lambda functions and apply these to elements of the base array.
-    // In most cases there will be only one function and the loop will run once.
-    auto it = args[1]->asUnchecked<FunctionVector>()->iterator(&rows);
-    while (auto entry = it.next()) {
-      auto elementRows = toElementRows<ArrayVector>(
-          newNumElements, *entry.rows, flatArray.get());
-      auto wrapCapture = toWrapCapture<ArrayVector>(
-          newNumElements, entry.callable, *entry.rows, flatArray);
-
-      entry.callable->apply(
-          elementRows,
-          &validRowsInReusedResult,
-          wrapCapture,
-          &context,
-          lambdaArgs,
-          elementToTopLevelRows,
-          &newElements);
-    }
+    // Compute sorting keys.
+    applyLambdaToElements<ArrayVector>(
+        args[1],
+        rows,
+        numElements,
+        flatArray,
+        lambdaArgs,
+        validRowsInReusedResult,
+        context,
+        newElements);
 
     // Sort 'newElements'.
     auto indices = sortElements(


### PR DESCRIPTION
### Summary 
Multiple vector functions that apply a lambda to array/map elements duplicated the same ~15-line loop pattern: iterating over [FunctionVector](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) entries, computing element rows, wrapping captures, and calling [entry.callable->apply()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html). This PR extracts that pattern into a single reusable [applyLambdaToElements<ContainerType>()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) template in [LambdaFunctionUtil.h](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and migrates all existing callers.