### PR TITLE
fix(cudf): Add missing Folly::folly dependency to velox_cudf_config_test

### DIFF
--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -195,7 +195,7 @@ target_link_libraries(
   gtest_main
 )
 
-target_link_libraries(velox_cudf_config_test velox_cudf_exec gtest gtest_main)
+target_link_libraries(velox_cudf_config_test velox_cudf_exec Folly::folly gtest gtest_main)
 
 target_link_libraries(
   velox_cudf_expression_selection_test


### PR DESCRIPTION
`Main.cpp` includes `folly/Unit.h` and `folly/init/Init.h` but the `velox_cudf_config_test` target was not linking `Folly::folly`, causing a missing header error when folly is built as `BUNDLED`.
