### PR TITLE
feat: Add fast path to PrefixEncoding when no duplicates

### DIFF
--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.h
@@ -116,6 +116,25 @@ class E2EFilterTestBase : public testing::Test {
       bool ascending,
       memory::MemoryPool* pool);
 
+  // Generates a vector with monotonically increasing/decreasing values that
+  // may contain duplicates (non-strictly sorted). Each unique value is
+  // repeated 1-3 times randomly.
+  // @param type The scalar type of the vector to generate.
+  // @param size The number of rows in this batch.
+  // @param globalRowOffset The starting row offset across all batches.
+  // @param startValue The starting value for the sequence.
+  // @param totalRows The total number of rows across all batches.
+  // @param ascending If true, values increase; if false, values decrease.
+  // @param pool The memory pool to allocate the vector from.
+  static VectorPtr generateSortedVector(
+      const TypePtr& type,
+      size_t size,
+      size_t globalRowOffset,
+      int64_t startValue,
+      size_t totalRows,
+      bool ascending,
+      memory::MemoryPool* pool);
+
  protected:
   static constexpr int32_t kRowsInGroup = 10'000;
 


### PR DESCRIPTION
Summary: The change allows PrefixEncoding to use noDuplicate parameter to go for a fast path searching (terminate early without needing to continuing binary search or scanning).

Differential Revision: D92676762


