### PR TITLE
feat: Add checked_divide for Spark decimal arithmetic

### DIFF
--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -204,6 +204,23 @@ Arithmetic Functions
         SELECT CAST(1.1 as DECIMAL(3, 1)) - CAST(2.2 as DECIMAL(3, 1)); -- -1.1
         SELECT CAST('-99999999999999999999999999999999999999' as DECIMAL(38, 0)) - CAST(1 as DECIMAL(38, 0)); -- NULL
 
+.. spark:function:: divide(x: decimal(p1, s1), y: decimal(p2, s2)) -> r: decimal(p3, s3)
+
+    Returns the result of dividing ``x`` by ``y``. The result type is determined
+    by the precision and scale computation rules described above.
+    Returns NULL when the result overflows or ``y`` is zero.
+    Corresponds to Spark's operator ``/`` with ``spark.sql.ansi.enabled`` set to false.  ::
+
+        SELECT CAST(1.0 as DECIMAL(3, 1)) / CAST(2.0 as DECIMAL(3, 1)); -- 0.500000
+        SELECT CAST(1.0 as DECIMAL(3, 1)) / CAST(0.0 as DECIMAL(3, 1)); -- NULL
+
+.. spark:function:: checked_divide(x: decimal(p1, s1), y: decimal(p2, s2)) -> r: decimal(p3, s3)
+
+    Returns the result of dividing ``x`` by ``y``. The result type is determined
+    by the precision and scale computation rules described above.
+    Throws an error when the result overflows or ``y`` is zero.
+    Corresponds to Spark's operator ``/`` with ``spark.sql.ansi.enabled`` set to true.
+
 Decimal Functions
 -----------------
 .. spark:function:: ceil(x: decimal(p, s)) -> r: decimal(pr, 0)

--- a/velox/functions/sparksql/DecimalArithmetic.cpp
+++ b/velox/functions/sparksql/DecimalArithmetic.cpp
@@ -540,6 +540,43 @@ struct DecimalDivideFunction {
   uint8_t rPrecision_;
 };
 
+// Decimal divide function that returns error on division by zero or overflow.
+template <typename TExec, bool allowPrecisionLoss>
+struct CheckedDecimalDivideFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename A, typename B>
+  void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& /*config*/,
+      A* /*a*/,
+      B* /*b*/) {
+    auto [aPrecision, aScale] = getDecimalPrecisionScale(*inputTypes[0]);
+    auto [bPrecision, bScale] = getDecimalPrecisionScale(*inputTypes[1]);
+    auto [rPrecision, rScale] =
+        DecimalUtil::computeDivideResultPrecisionScale<allowPrecisionLoss>(
+            aPrecision, aScale, bPrecision, bScale);
+    rPrecision_ = rPrecision;
+    aRescale_ = rScale - aScale + bScale;
+  }
+
+  template <typename R, typename A, typename B>
+  Status call(R& out, const A& a, const B& b) {
+    VELOX_USER_RETURN_EQ(b, 0, "Division by zero");
+    bool overflow = false;
+    DecimalUtil::divideWithRoundUp<R, A, B>(out, a, b, aRescale_, overflow);
+    VELOX_USER_RETURN(
+        overflow ||
+            !velox::DecimalUtil::valueInPrecisionRange(out, rPrecision_),
+        "Decimal overflow in divide");
+    return Status::OK();
+  }
+
+ private:
+  uint8_t aRescale_;
+  uint8_t rPrecision_;
+};
+
 // Decimal integral divide function implementation.
 struct DecimalIntegralDivideBase {
   void initializeBase(const std::vector<TypePtr>& inputTypes) {
@@ -776,6 +813,14 @@ template <typename TExec>
 using CheckedMultiplyFunctionDenyPrecisionLoss =
     CheckedDecimalMultiplyFunction<TExec, false>;
 
+template <typename TExec>
+using CheckedDivideFunctionAllowPrecisionLoss =
+    CheckedDecimalDivideFunction<TExec, true>;
+
+template <typename TExec>
+using CheckedDivideFunctionDenyPrecisionLoss =
+    CheckedDecimalDivideFunction<TExec, false>;
+
 std::vector<exec::SignatureVariable> getDivideConstraintsDenyPrecisionLoss() {
   std::string wholeDigits = fmt::format(
       "min(38, {a_precision} - {a_scale} + {b_scale})",
@@ -918,6 +963,11 @@ void registerDecimalDivide(const std::string& prefix) {
       prefix + "divide", getDivideConstraintsAllowPrecisionLoss());
   registerDecimalDivide<DivideFunctionDenyPrecisionLoss>(
       prefix + "divide" + kDenyPrecisionLoss,
+      getDivideConstraintsDenyPrecisionLoss());
+  registerDecimalDivide<CheckedDivideFunctionAllowPrecisionLoss>(
+      prefix + "checked_divide", getDivideConstraintsAllowPrecisionLoss());
+  registerDecimalDivide<CheckedDivideFunctionDenyPrecisionLoss>(
+      prefix + "checked_divide" + kDenyPrecisionLoss,
       getDivideConstraintsDenyPrecisionLoss());
 }
 

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -181,6 +181,26 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
         "checked_multiply", tType, uType, t, u, errorMessage);
   }
 
+  template <typename T, typename U>
+  std::optional<int128_t> checkedDivide(
+      const TypePtr& tType,
+      const TypePtr& uType,
+      std::optional<T> t,
+      std::optional<U> u) {
+    return checkedDecimalArithmetic("checked_divide", tType, uType, t, u);
+  }
+
+  template <typename T, typename U>
+  void assertErrorForCheckedDivide(
+      const TypePtr& tType,
+      const TypePtr& uType,
+      std::optional<T> t,
+      std::optional<U> u,
+      const std::string& errorMessage) {
+    assertErrorForCheckedDecimalArithmetic(
+        "checked_divide", tType, uType, t, u, errorMessage);
+  }
+
   /// Runs the common normal and overflow test cases for checked add.
   void testCheckedAddCommon(const std::string& suffix = "") {
     const std::string func = "checked_add" + suffix;
@@ -1230,6 +1250,53 @@ TEST_F(DecimalArithmeticTest, checkedMultiply) {
       HugeInt::parse("-10000000000000000000"),
       HugeInt::parse("-10000000000000000000"),
       "Decimal overflow in multiply");
+}
+
+TEST_F(DecimalArithmeticTest, checkedDivide) {
+  // Normal cases for all input type combinations.
+  // short / short -> long: DECIMAL(17,3) / DECIMAL(17,3) → DECIMAL(38,21)
+  // 500/1000 = 0.5 → unscaled 0.5 * 10^21 = 500000000000000000000
+  EXPECT_EQ(
+      (checkedDivide<int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), 500, 1000)),
+      HugeInt::parse("500000000000000000000"));
+
+  // long / long -> long: DECIMAL(20,2) / DECIMAL(20,2) → DECIMAL(38,18)
+  EXPECT_EQ(
+      (checkedDivide<int128_t, int128_t>(
+          DECIMAL(20, 2), DECIMAL(20, 2), 2500, 500)),
+      HugeInt::parse("5" + std::string(18, '0')));
+
+  // short / long -> long: DECIMAL(17,3) / DECIMAL(20,2) → DECIMAL(38,22)
+  EXPECT_EQ(
+      (checkedDivide<int64_t, int128_t>(
+          DECIMAL(17, 3), DECIMAL(20, 2), 500, 1000)),
+      HugeInt::parse("500000000000000000000"));
+
+  // long / short -> long: DECIMAL(20,2) / DECIMAL(17,3) → DECIMAL(38,17)
+  EXPECT_EQ(
+      (checkedDivide<int128_t, int64_t>(
+          DECIMAL(20, 2), DECIMAL(17, 3), 500, 1000)),
+      HugeInt::parse("500000000000000000"));
+
+  // Division by zero throws (and try() returns null) for all type combos.
+  assertErrorForCheckedDivide<int64_t, int64_t>(
+      DECIMAL(17, 3), DECIMAL(17, 3), 500, 0, "Division by zero");
+  assertErrorForCheckedDivide<int128_t, int128_t>(
+      DECIMAL(20, 2), DECIMAL(20, 2), 500, 0, "Division by zero");
+  assertErrorForCheckedDivide<int64_t, int128_t>(
+      DECIMAL(17, 3), DECIMAL(20, 2), 500, 0, "Division by zero");
+  assertErrorForCheckedDivide<int128_t, int64_t>(
+      DECIMAL(20, 2), DECIMAL(17, 3), 500, 0, "Division by zero");
+
+  // Overflow throws (and try() returns null).
+  // Dividing a large value by a very small value can overflow.
+  assertErrorForCheckedDivide<int128_t, int128_t>(
+      DECIMAL(38, 0),
+      DECIMAL(38, 6),
+      HugeInt::parse("99999999999999999999999999999999999999"),
+      1,
+      "Decimal overflow in divide");
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Closes #16322

  ## Summary

  - Add `checked_divide` for decimal types that throws on overflow and division by zero instead of returning null, enabling Spark ANSI mode support for decimal division

  ## Test plan

  - [x] Normal cases: all 4 input type combinations (short/short, long/long, short/long, long/short)
  - [x] Division by zero throws error for all type combinations
  - [x] Overflow throws error (max 38-digit decimal divided by tiny value)
  - [x] Both `allowPrecisionLoss` and `denyPrecisionLoss` variants registered

 ## Notes on naming conventions

  In Spark, `Divide` (true division) maps to Velox's `divide`, and `IntegralDivide` (integer division) maps to Velox's `div`. Their ANSI-mode counterparts are `checked_divide` and `checked_div`, respectively.

  In Spark, there are no separate "checked" expression classes. The same expression handles both ANSI and non-ANSI behavior, controlled by the [EvalMode flag](https://github.com/apache/spark/blob/branch-3.5/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala#L854-L857).
In Velox, the checked variants are registered as separate functions.
