### PR TITLE
fix(parquet): Avoid generate negative nanoseconds for Timestamp type

### DIFF
--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <arrow/io/memory.h>
 #include <arrow/type.h>
 #include <folly/init/Init.h>
 #include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
@@ -29,6 +30,8 @@
 #include "velox/dwio/parquet/reader/PageReader.h"
 #include "velox/dwio/parquet/tests/ParquetTestBase.h"
 #include "velox/dwio/parquet/writer/WriterConfig.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
 #include "velox/exec/Cursor.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -42,6 +45,7 @@ using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::parquet;
 using namespace facebook::velox::common::testutil;
+namespace parquetArrow = facebook::velox::parquet::arrow;
 
 class ParquetWriterTest : public ParquetTestBase {
  protected:
@@ -672,6 +676,74 @@ TEST_F(ParquetWriterTest, parquetWriteWithArrowMemoryPool) {
   writerOptions.arrowMemoryPool = std::make_shared<ArrowMemoryPool>();
 
   write(data, writerOptions);
+}
+
+TEST_F(ParquetWriterTest, preEpochInt96Timestamp) {
+  auto schema = ROW({"c0"}, {TIMESTAMP()});
+  auto data = makeRowVector({makeFlatVector<Timestamp>({
+      Timestamp(-86'401, 0),
+      Timestamp(-86'400, 0),
+      Timestamp(-3'600, 0),
+      Timestamp(-1, 0),
+      Timestamp(0, 0),
+      Timestamp(1, 0),
+  })});
+
+  parquet::WriterOptions writerOptions;
+  writerOptions.memoryPool = rootPool_.get();
+  writerOptions.parquetWriteTimestampUnit = TimestampPrecision::kNanoseconds;
+  writerOptions.writeInt96AsTimestamp = true;
+
+  auto* sinkPtr = write(data, writerOptions);
+
+  dwio::common::ReaderOptions readerOptions(leafPool_.get());
+  readerOptions.setDataIoStats(dataIoStats_);
+  readerOptions.setMetadataIoStats(metadataIoStats_);
+  auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+
+  ASSERT_EQ(reader->numberOfRows(), data->size());
+  ASSERT_EQ(*reader->rowType(), *schema);
+
+  auto rowReader = createRowReaderWithSchema(std::move(reader), schema);
+  assertReadWithReaderAndExpected(schema, *rowReader, data, *leafPool_);
+
+  // Read the Int96 values directly to verify the correctness of the conversion
+  // from Timestamp to Int96.
+  std::string_view sinkData(sinkPtr->data(), sinkPtr->size());
+  auto arrowBufferReader = std::make_shared<::arrow::io::BufferReader>(
+      std::make_shared<::arrow::Buffer>(
+          reinterpret_cast<const uint8_t*>(sinkData.data()), sinkData.size()));
+  auto fileReader = parquetArrow::ParquetFileReader::open(arrowBufferReader);
+  auto int96Reader = std::dynamic_pointer_cast<parquetArrow::Int96Reader>(
+      fileReader->rowGroup(0)->column(0));
+  ASSERT_NE(int96Reader, nullptr);
+
+  std::vector<parquetArrow::Int96> values(data->size());
+  int64_t valuesRead = 0;
+  ASSERT_EQ(
+      int96Reader->readBatch(
+          data->size(), nullptr, nullptr, values.data(), &valuesRead),
+      data->size());
+  ASSERT_EQ(valuesRead, data->size());
+
+  const std::vector<std::pair<int32_t, uint64_t>> expected = {
+      {-2, 86'399'000'000'000},
+      {-1, 0},
+      {-1, 23LL * 3'600 * 1'000'000'000},
+      {-1, 86'399'000'000'000},
+      {0, 0},
+      {0, 1'000'000'000},
+  };
+
+  for (auto i = 0; i < values.size(); ++i) {
+    const auto decoded = parquetArrow::decodeInt96Timestamp(values[i]);
+    EXPECT_EQ(
+        values[i].value[2],
+        static_cast<uint32_t>(
+            parquetArrow::kJulianToUnixEpochDays + expected[i].first));
+    EXPECT_EQ(decoded.nanoseconds, expected[i].second);
+    EXPECT_LT(decoded.nanoseconds, parquetArrow::kNanosecondsPerDay);
+  }
 }
 
 TEST_F(ParquetWriterTest, updateWriterOptionsFromHiveConfig) {

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.h
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.h
@@ -290,10 +290,10 @@ constexpr int64_t kJulianEpochOffsetDays = INT64_C(2440588);
 
 template <int64_t UnitPerDay, int64_t NanosecondsPerUnit>
 inline void arrowTimestampToImpalaTimestamp(
-    const int64_t Time,
+    const int64_t time,
     Int96* impalaTimestamp) {
-  int64_t julianDays = (Time / UnitPerDay) + kJulianEpochOffsetDays;
-  int64_t lastDayUnits = Time % UnitPerDay;
+  int64_t julianDays = (time / UnitPerDay) + kJulianEpochOffsetDays;
+  int64_t lastDayUnits = time % UnitPerDay;
 
   // Avoid negative nanos.
   if (lastDayUnits < 0) {
@@ -301,7 +301,7 @@ inline void arrowTimestampToImpalaTimestamp(
     julianDays -= 1;
   }
 
-  (*impalaTimestamp).value[2] = julianDays;
+  (*impalaTimestamp).value[2] = static_cast<uint32_t>(julianDays);
 
   auto lastDayNanos = lastDayUnits * NanosecondsPerUnit;
   // impalaTimestamp will be unaligned every other entry so do memcpy instead

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -42,6 +42,7 @@ namespace bit_util = arrow::bit_util;
 
 namespace facebook::velox::parquet::arrow {
 
+using arrow::internal::kJulianEpochOffsetDays;
 using schema::GroupNode;
 using schema::NodePtr;
 using schema::PrimitiveNode;
@@ -514,6 +515,7 @@ using TestValuesWriterInt32Type = TestPrimitiveWriter<Int32Type>;
 using TestValuesWriterInt64Type = TestPrimitiveWriter<Int64Type>;
 using TestByteArrayValuesWriter = TestPrimitiveWriter<ByteArrayType>;
 using TestFixedLengthByteArrayValuesWriter = TestPrimitiveWriter<FLBAType>;
+using TestTimestampValuesWriter = TestPrimitiveWriter<Int96Type>;
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlain) {
   this->testRequiredWithEncoding(Encoding::kPlain);
@@ -903,6 +905,45 @@ TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
   writer->close();
 
   ASSERT_TRUE(this->metadataIsStatsSet());
+}
+
+TEST_F(TestTimestampValuesWriter, TimestampConventions) {
+  auto testTimestamp = [](int64_t seconds, Int96 expected) {
+    Int96 actual;
+    arrow::internal::secondsToImpalaTimestamp(seconds, &actual);
+    EXPECT_EQ(actual, expected);
+  };
+
+  auto makeInt96 = [](int32_t julianDay, uint64_t nanoseconds) {
+#if ARROW_LITTLE_ENDIAN
+    return Int96{
+        {static_cast<uint32_t>(nanoseconds),
+         static_cast<uint32_t>(nanoseconds >> 32),
+         static_cast<uint32_t>(julianDay)}};
+#else
+    return Int96{
+        {static_cast<uint32_t>(nanoseconds >> 32),
+         static_cast<uint32_t>(nanoseconds),
+         static_cast<uint32_t>(julianDay)}};
+#endif
+  };
+
+  // Positive timestamps.
+  testTimestamp(0, makeInt96(kJulianEpochOffsetDays, 0));
+  testTimestamp(1, makeInt96(kJulianEpochOffsetDays, 1'000'000'000));
+  testTimestamp(3600, makeInt96(kJulianEpochOffsetDays, 3'600'000'000'000));
+  testTimestamp(86400, makeInt96(kJulianEpochOffsetDays + 1, 0));
+  testTimestamp(
+      1767229259, makeInt96(kJulianEpochOffsetDays + 20454, 3'659'000'000'000));
+
+  // negative timestamps.
+  testTimestamp(-1, makeInt96(kJulianEpochOffsetDays - 1, 86'399'000'000'000));
+  testTimestamp(
+      -3600,
+      makeInt96(kJulianEpochOffsetDays - 1, 23LL * 3600 * 1'000'000'000));
+  testTimestamp(-86400, makeInt96(kJulianEpochOffsetDays - 1, 0));
+  testTimestamp(
+      -86401, makeInt96(kJulianEpochOffsetDays - 2, 86'399'000'000'000));
 }
 
 TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -908,42 +908,37 @@ TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
 }
 
 TEST_F(TestTimestampValuesWriter, TimestampConventions) {
-  auto testTimestamp = [](int64_t seconds, Int96 expected) {
-    Int96 actual;
-    arrow::internal::secondsToImpalaTimestamp(seconds, &actual);
-    EXPECT_EQ(actual, expected);
-  };
-
-  auto makeInt96 = [](int32_t julianDay, uint64_t nanoseconds) {
+  auto testTimestamp =
+      [](int64_t seconds, int32_t dayDelta, uint64_t nanoseconds) {
+        Int96 actual;
+        arrow::internal::secondsToImpalaTimestamp(seconds, &actual);
+        auto julianDay = kJulianEpochOffsetDays + dayDelta;
 #if ARROW_LITTLE_ENDIAN
-    return Int96{
-        {static_cast<uint32_t>(nanoseconds),
-         static_cast<uint32_t>(nanoseconds >> 32),
-         static_cast<uint32_t>(julianDay)}};
+        Int96 expected = {
+            {static_cast<uint32_t>(nanoseconds),
+             static_cast<uint32_t>(nanoseconds >> 32),
+             static_cast<uint32_t>(julianDay)}};
 #else
-    return Int96{
-        {static_cast<uint32_t>(nanoseconds >> 32),
-         static_cast<uint32_t>(nanoseconds),
-         static_cast<uint32_t>(julianDay)}};
+        Int96 expected = {
+            {static_cast<uint32_t>(nanoseconds >> 32),
+             static_cast<uint32_t>(nanoseconds),
+             static_cast<uint32_t>(julianDay)}};
 #endif
-  };
+        EXPECT_EQ(actual, expected);
+      };
 
   // Positive timestamps.
-  testTimestamp(0, makeInt96(kJulianEpochOffsetDays, 0));
-  testTimestamp(1, makeInt96(kJulianEpochOffsetDays, 1'000'000'000));
-  testTimestamp(3600, makeInt96(kJulianEpochOffsetDays, 3'600'000'000'000));
-  testTimestamp(86400, makeInt96(kJulianEpochOffsetDays + 1, 0));
-  testTimestamp(
-      1767229259, makeInt96(kJulianEpochOffsetDays + 20454, 3'659'000'000'000));
+  testTimestamp(0, 0, 0);
+  testTimestamp(1, 0, 1'000'000'000);
+  testTimestamp(3600, 0, 3'600'000'000'000);
+  testTimestamp(86400, 1, 0);
+  testTimestamp(1767229259, 20454, 3'659'000'000'000);
 
-  // negative timestamps.
-  testTimestamp(-1, makeInt96(kJulianEpochOffsetDays - 1, 86'399'000'000'000));
-  testTimestamp(
-      -3600,
-      makeInt96(kJulianEpochOffsetDays - 1, 23LL * 3600 * 1'000'000'000));
-  testTimestamp(-86400, makeInt96(kJulianEpochOffsetDays - 1, 0));
-  testTimestamp(
-      -86401, makeInt96(kJulianEpochOffsetDays - 2, 86'399'000'000'000));
+  // Negative timestamps.
+  testTimestamp(-1, -1, 86'399'000'000'000);
+  testTimestamp(-3600, -1, 23LL * 3600 * 1'000'000'000);
+  testTimestamp(-86400, -1, 0);
+  testTimestamp(-86401, -2, 86'399'000'000'000);
 }
 
 TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -42,7 +42,6 @@ namespace bit_util = arrow::bit_util;
 
 namespace facebook::velox::parquet::arrow {
 
-using arrow::internal::kJulianEpochOffsetDays;
 using schema::GroupNode;
 using schema::NodePtr;
 using schema::PrimitiveNode;
@@ -515,7 +514,6 @@ using TestValuesWriterInt32Type = TestPrimitiveWriter<Int32Type>;
 using TestValuesWriterInt64Type = TestPrimitiveWriter<Int64Type>;
 using TestByteArrayValuesWriter = TestPrimitiveWriter<ByteArrayType>;
 using TestFixedLengthByteArrayValuesWriter = TestPrimitiveWriter<FLBAType>;
-using TestTimestampValuesWriter = TestPrimitiveWriter<Int96Type>;
 
 TYPED_TEST(TestPrimitiveWriter, RequiredPlain) {
   this->testRequiredWithEncoding(Encoding::kPlain);
@@ -905,40 +903,6 @@ TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
   writer->close();
 
   ASSERT_TRUE(this->metadataIsStatsSet());
-}
-
-TEST_F(TestTimestampValuesWriter, TimestampConventions) {
-  auto testTimestamp =
-      [](int64_t seconds, int32_t dayDelta, uint64_t nanoseconds) {
-        Int96 actual;
-        arrow::internal::secondsToImpalaTimestamp(seconds, &actual);
-        auto julianDay = kJulianEpochOffsetDays + dayDelta;
-#if ARROW_LITTLE_ENDIAN
-        Int96 expected = {
-            {static_cast<uint32_t>(nanoseconds),
-             static_cast<uint32_t>(nanoseconds >> 32),
-             static_cast<uint32_t>(julianDay)}};
-#else
-        Int96 expected = {
-            {static_cast<uint32_t>(nanoseconds >> 32),
-             static_cast<uint32_t>(nanoseconds),
-             static_cast<uint32_t>(julianDay)}};
-#endif
-        EXPECT_EQ(actual, expected);
-      };
-
-  // Positive timestamps.
-  testTimestamp(0, 0, 0);
-  testTimestamp(1, 0, 1'000'000'000);
-  testTimestamp(3600, 0, 3'600'000'000'000);
-  testTimestamp(86400, 1, 0);
-  testTimestamp(1767229259, 20454, 3'659'000'000'000);
-
-  // Negative timestamps.
-  testTimestamp(-1, -1, 86'399'000'000'000);
-  testTimestamp(-3600, -1, 23LL * 3600 * 1'000'000'000);
-  testTimestamp(-86400, -1, 0);
-  testTimestamp(-86401, -2, 86'399'000'000'000);
 }
 
 TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {

--- a/velox/dwio/parquet/writer/arrow/tests/TypesTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/TypesTest.cpp
@@ -21,6 +21,7 @@
 #include <string>
 
 #include "arrow/util/endian.h"
+#include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
 #include "velox/dwio/parquet/writer/arrow/Types.h"
 
 namespace facebook::velox::parquet::arrow {
@@ -180,6 +181,40 @@ TEST(TestInt96Timestamp, Decoding) {
   check(2547330, 0x123456789abcdefULL);
   check(2547330, 0xfedcba9876543210ULL);
   check(2547339, 0xffffffffffffffffULL);
+}
+
+TEST(TestInt96Timestamp, timestampConventions) {
+  auto testTimestamp =
+      [](int64_t seconds, int32_t dayDelta, uint64_t nanoseconds) {
+        Int96 actual;
+        internal::secondsToImpalaTimestamp(seconds, &actual);
+        auto julianDay = internal::kJulianEpochOffsetDays + dayDelta;
+#if ARROW_LITTLE_ENDIAN
+        Int96 expected = {
+            {static_cast<uint32_t>(nanoseconds),
+             static_cast<uint32_t>(nanoseconds >> 32),
+             static_cast<uint32_t>(julianDay)}};
+#else
+        Int96 expected = {
+            {static_cast<uint32_t>(nanoseconds >> 32),
+             static_cast<uint32_t>(nanoseconds),
+             static_cast<uint32_t>(julianDay)}};
+#endif
+        EXPECT_EQ(actual, expected);
+      };
+
+  // Positive timestamps.
+  testTimestamp(0, 0, 0);
+  testTimestamp(1, 0, 1'000'000'000);
+  testTimestamp(3600, 0, 3'600'000'000'000);
+  testTimestamp(86400, 1, 0);
+  testTimestamp(1767229259, 20454, 3'659'000'000'000);
+
+  // Negative timestamps.
+  testTimestamp(-1, -1, 86'399'000'000'000);
+  testTimestamp(-3600, -1, 23LL * 3600 * 1'000'000'000);
+  testTimestamp(-86400, -1, 0);
+  testTimestamp(-86401, -2, 86'399'000'000'000);
 }
 
 #if !(defined(_WIN32) || defined(__CYGWIN__))


### PR DESCRIPTION
fix https://github.com/facebookincubator/velox/issues/16324