### PR TITLE
feat(FileSink): Propagate fileSystemStats from WriteFileSink to FileSink Base Class

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -52,7 +52,8 @@ std::unique_ptr<velox::dwio::common::FileSink> abfsWriteFileSinkGenerator(
         fileSystem->openFileForWrite(fileURI),
         fileURI,
         options.metricLogger,
-        options.stats);
+        options.stats,
+        options.fileSystemStats);
   }
   return nullptr;
 }

--- a/velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/RegisterGcsFileSystem.cpp
@@ -103,7 +103,8 @@ std::unique_ptr<velox::dwio::common::FileSink> gcsWriteFileSinkGenerator(
         fileSystem->openFileForWrite(fileURI, {{}, options.pool, std::nullopt}),
         fileURI,
         options.metricLogger,
-        options.stats);
+        options.stats,
+        options.fileSystemStats);
   }
   return nullptr;
 }

--- a/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
@@ -89,7 +89,8 @@ hdfsWriteFileSinkGenerator() {
               fileSystem->openFileForWrite(pathSuffix),
               fileURI,
               options.metricLogger,
-              options.stats);
+              options.stats,
+              options.fileSystemStats);
         }
         return static_cast<std::unique_ptr<dwio::common::WriteFileSink>>(
             nullptr);

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -102,7 +102,8 @@ std::unique_ptr<velox::dwio::common::FileSink> s3WriteFileSinkGenerator(
         fileSystem->openFileForWrite(fileURI, {{}, options.pool, std::nullopt}),
         fileURI,
         options.metricLogger,
-        options.stats);
+        options.stats,
+        options.fileSystemStats);
   }
   return nullptr;
 }

--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -111,10 +111,13 @@ WriteFileSink::WriteFileSink(
     std::unique_ptr<WriteFile> writeFile,
     std::string name,
     MetricsLogPtr metricLogger,
-    IoStatistics* stats)
+    IoStatistics* stats,
+    velox::IoStats* fileSystemStats)
     : FileSink(
           std::move(name),
-          {.metricLogger = std::move(metricLogger), .stats = stats}),
+          {.metricLogger = std::move(metricLogger),
+           .stats = stats,
+           .fileSystemStats = fileSystemStats}),
       writeFile_{std::move(writeFile)} {
   VELOX_CHECK_NOT_NULL(writeFile_);
 }

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -105,6 +105,10 @@ class FileSink : public Closeable {
     return stats_;
   }
 
+  velox::IoStats* getFileSystemStats() {
+    return fileSystemStats_;
+  }
+
  protected:
   // General write wrapper with logging. All concrete subclasses gets logging
   // for free if they call a public method that goes through this method.
@@ -131,7 +135,8 @@ class WriteFileSink final : public FileSink {
       std::unique_ptr<WriteFile> writeFile,
       std::string name,
       MetricsLogPtr metricLogger = MetricsLog::voidLog(),
-      IoStatistics* stats = nullptr);
+      IoStatistics* stats = nullptr,
+      velox::IoStats* fileSystemStats = nullptr);
 
   ~WriteFileSink() override {
     destroy();

--- a/velox/dwio/common/tests/LocalFileSinkTest.cpp
+++ b/velox/dwio/common/tests/LocalFileSinkTest.cpp
@@ -79,4 +79,74 @@ TEST_F(LocalFileSinkTest, existFileCheck) {
       "File exists");
 }
 
+TEST_F(LocalFileSinkTest, getIoStatisticsReturnsNullWhenNotProvided) {
+  LocalFileSink::registerFactory();
+  auto root = TempDirectoryPath::create();
+  auto filePath = fs::path(root->getPath()) / "test_stats_null.ext";
+
+  auto localFileSink = FileSink::create(
+      fmt::format("file:{}", filePath.string()), {.pool = pool_.get()});
+
+  EXPECT_EQ(localFileSink->getIoStatistics(), nullptr);
+  localFileSink->close();
+}
+
+TEST_F(LocalFileSinkTest, getIoStatisticsReturnsProvidedStats) {
+  LocalFileSink::registerFactory();
+  auto root = TempDirectoryPath::create();
+  auto filePath = fs::path(root->getPath()) / "test_stats_provided.ext";
+
+  IoStatistics ioStats;
+  auto localFileSink = FileSink::create(
+      fmt::format("file:{}", filePath.string()),
+      {.pool = pool_.get(), .stats = &ioStats});
+
+  EXPECT_EQ(localFileSink->getIoStatistics(), &ioStats);
+  localFileSink->close();
+}
+
+TEST_F(LocalFileSinkTest, getFileSystemStatsReturnsNullWhenNotProvided) {
+  LocalFileSink::registerFactory();
+  auto root = TempDirectoryPath::create();
+  auto filePath = fs::path(root->getPath()) / "test_fs_stats_null.ext";
+
+  auto localFileSink = FileSink::create(
+      fmt::format("file:{}", filePath.string()), {.pool = pool_.get()});
+
+  EXPECT_EQ(localFileSink->getFileSystemStats(), nullptr);
+  localFileSink->close();
+}
+
+TEST_F(LocalFileSinkTest, getFileSystemStatsReturnsProvidedStats) {
+  LocalFileSink::registerFactory();
+  auto root = TempDirectoryPath::create();
+  auto filePath = fs::path(root->getPath()) / "test_fs_stats_provided.ext";
+
+  velox::IoStats fileSystemStats;
+  auto localFileSink = FileSink::create(
+      fmt::format("file:{}", filePath.string()),
+      {.pool = pool_.get(), .fileSystemStats = &fileSystemStats});
+
+  EXPECT_EQ(localFileSink->getFileSystemStats(), &fileSystemStats);
+  localFileSink->close();
+}
+
+TEST_F(LocalFileSinkTest, getFileSystemStatsAndIoStatisticsBothProvided) {
+  LocalFileSink::registerFactory();
+  auto root = TempDirectoryPath::create();
+  auto filePath = fs::path(root->getPath()) / "test_both_stats.ext";
+
+  IoStatistics ioStats;
+  velox::IoStats fileSystemStats;
+  auto localFileSink = FileSink::create(
+      fmt::format("file:{}", filePath.string()),
+      {.pool = pool_.get(),
+       .stats = &ioStats,
+       .fileSystemStats = &fileSystemStats});
+
+  EXPECT_EQ(localFileSink->getIoStatistics(), &ioStats);
+  EXPECT_EQ(localFileSink->getFileSystemStats(), &fileSystemStats);
+  localFileSink->close();
+}
+
 } // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Summary:
previous: WS stats are only populated for read: P2177188609

```
=== Warm Storage I/O Statistics ===
Read I/O Stats Per Table:
  Table: ab77686f27bf4dd2ba92ecdd0a78ed8c_eag
    ws_in_region_read_bytes: 0
    ws_x_region_read_bytes: 56437501634f
    ws_unknown_region_read_bytes: 0
    ws_in_region_read_time_ms: 0
    ws_x_region_read_time_ms: 1462065
    ws_unknown_region_read_time_ms: 0
    ws_read_io_ms: 277115
    ws_read_regions: ['eag']
```

after: WS stats are populated for write: P2177254509

```
=== Warm Storage I/O Statistics ===
Read I/O Stats Per Table:
  Table: ab77686f27bf4dd2ba92ecdd0a78ed8c_eag
    ws_in_region_read_bytes: 0
    ws_x_region_read_bytes: 56443277036
    ws_unknown_region_read_bytes: 0
    ws_in_region_read_time_ms: 0
    ws_x_region_read_time_ms: 1483097
    ws_unknown_region_read_time_ms: 0
    ws_read_io_ms: 277145
    ws_read_regions: ['eag']

Write I/O Stats Per Table:
  Table: 5282dffc0aba41fc83276bb43ac485f9_vll
    ws_in_region_write_bytes: 788116516
    ws_x_region_write_bytes: 0
    ws_unknown_region_write_bytes: 0
    ws_in_region_write_time_ms: 0
    ws_x_region_write_time_ms: 0
    ws_unknown_region_write_time_ms: 0
    ws_write_io_ms: 0
    ws_write_regions: ['vll']
```

Differential Revision: D92430783


