### PR TITLE
feat: Add IndexReader interface for index-based lookups

### DIFF
--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -211,5 +211,17 @@ TEST_F(ReaderTest, projectColumnsMutation) {
   EXPECT_NE(0, numNonMax);
 }
 
+TEST_F(ReaderTest, rowRangeEmpty) {
+  // Empty when startRow >= endRow
+  EXPECT_TRUE((RowRange{0, 0}.empty()));
+  EXPECT_TRUE((RowRange{5, 5}.empty()));
+  EXPECT_TRUE((RowRange{10, 5}.empty()));
+
+  // Not empty when startRow < endRow
+  EXPECT_FALSE((RowRange{0, 1}.empty()));
+  EXPECT_FALSE((RowRange{0, 10}.empty()));
+  EXPECT_FALSE((RowRange{5, 10}.empty()));
+}
+
 } // namespace
 } // namespace facebook::velox::dwio::common

--- a/velox/serializers/KeyEncoder.h
+++ b/velox/serializers/KeyEncoder.h
@@ -174,14 +174,12 @@ class KeyEncoder {
   /// Increment fails when values are at their maximum (e.g., INT_MAX, strings
   /// with all \xFF characters, or nulls in NULLS_LAST ordering).
   ///
-  /// For multi-row bounds, returns a vector with one EncodedKeyBounds per row.
-  /// Each row is processed independently.
-  /// Encodes index bounds into byte-comparable key strings.
   /// Takes an IndexBounds containing lower and/or upper bounds and encodes them
-  /// into EncodedKeyBounds for efficient range comparison.
-  /// Throws if any lower bound fails to bump up (for exclusive bounds).
-  /// For upper bound bump up failures, the upperKey is set to std::nullopt
-  /// (unbounded).
+  /// into EncodedKeyBounds for efficient range comparison. Returns a vector
+  /// with one EncodedKeyBounds per row in 'indexBounds'. Each row is encoded
+  /// into a byte-comparable key string. Throws if any lower bound fails to bump
+  /// up (for exclusive bounds). For upper bound bump up failures, the upperKey
+  /// is set to std::nullopt (unbounded).
   std::vector<EncodedKeyBounds> encodeIndexBounds(
       const IndexBounds& indexBounds);
 
@@ -204,8 +202,10 @@ class KeyEncoder {
   std::vector<std::string> encode(const RowVectorPtr& input);
 
   // Creates a new row vector with the key columns incremented by 1 for multiple
-  // rows. Returns nullptr if any row fails to increment (all key columns
-  // overflow), otherwise returns RowVectorPtr with incremented values.
+  // rows. For each row, the increment takes place from the rightmost (least
+  // significant) column.
+  // Returns nullptr if any row fails to increment (all key columns overflow),
+  // otherwise returns RowVectorPtr with incremented values.
   RowVectorPtr createIncrementedBounds(const RowVectorPtr& bounds) const;
 
   // Encodes a single column for all rows.


### PR DESCRIPTION
Summary:
This diff introduces the `IndexReader` interface in `Reader.h` to provide a clean abstraction for index-based data lookups, separate from the general-purpose `RowReader` interface.

**New `IndexReader` class** - Abstract interface for index-based lookups with methods:
   - `encodeIndexBounds()` - Encodes index bounds into format-specific encoded key bounds
   - `lookupStripes()` - Looks up stripes that contain data matching the encoded key bounds
   - `setStripeRowRanges()` - Sets up row ranges for reading a specific stripe based on encoded bounds
   - `next()` - Pure virtual method to fetch the next portion of rows (without mutation support)

**New `createIndexReader()` method in `Reader`** - Factory method to create an `IndexReader` instance. Default implementation throws `VELOX_UNSUPPORTED`, allowing format-specific readers (e.g., Nimble) to override and provide index reading support.

**Supporting data structures** - `RowRange`, `StripeRowRanges`, and `StripeLookupResult` structs for representing row ranges and stripe lookup results.

This separation allows `HiveIndexReader` to use a dedicated `IndexReader` interface optimized for batched key-based lookups, while keeping the `RowReader` interface focused on sequential row-by-row reading with mutation support.

Differential Revision: D92851481


