### PR TITLE
fix(cudf): Fix velox_cudf_s3_read_test

### DIFF
--- a/velox/experimental/cudf/tests/S3ReadTest.cpp
+++ b/velox/experimental/cudf/tests/S3ReadTest.cpp
@@ -65,8 +65,9 @@ class S3ReadTest : public S3Test, public ::test::VectorTestBase {
 } // namespace
 
 TEST_F(S3ReadTest, s3ReadTest) {
-  const auto sourceFile =
-      "/velox/velox/dwio/parquet/tests/examples/int.parquet";
+  const auto sourceFile = test::getDataFilePath(
+      "velox/experimental/cudf/tests",
+      "../../../dwio/parquet/tests/examples/int.parquet");
   const char* bucketName = "data";
   const auto destinationFile = S3Test::localPath(bucketName) + "/int.parquet";
   minioServer_->addBucket(bucketName);


### PR DESCRIPTION
This test, unlike it's Hive CPU equivalent, was not using the prescribed helper function to locate files in the source code tree by relative path.

This test has also had issues in the past with a RMM shutdown crash, and is currently disabled in `velox_testing` CI, but I am re-testing it in the hope that the RMM problem has since been resolved.

Update: Test runs successful. RMM problem gone away. This test can then be re-enabled in `velox-testing` CI.