### PR TITLE
fix: Print verbose errors in cudf deps updater

### DIFF
--- a/scripts/update-cudf-deps.sh
+++ b/scripts/update-cudf-deps.sh
@@ -61,12 +61,12 @@ fetch_github_api() {
     echo "Error: gh api failed" >&2
     echo "Response: $response" >&2
   else
-    local curl_opts="-s --max-time 30 -w %{http_code}"
+    local curl_opts=(-s --max-time 30 -w '%{http_code}')
     if [[ -n $GH_TOKEN ]]; then
-      curl_opts="$curl_opts -H \"Authorization: token $GH_TOKEN\""
+      curl_opts+=(-H "Authorization: token $GH_TOKEN")
     fi
     local raw
-    raw=$(curl $curl_opts "https://api.github.com/${endpoint}" 2>&1)
+    raw=$(curl "${curl_opts[@]}" "https://api.github.com/${endpoint}" 2>&1)
     http_code="${raw: -3}"
     response="${raw%???}"
     if [[ $http_code == "200" ]]; then


### PR DESCRIPTION
## Description

This PR updates the `update-cudf-deps.sh` to not silently exit without any message or effect when, for example, `read` fails due to GH rate limiting and throws a verbose message such as

```bash
Error: Failed to fetch VERSION file from branch main
  Try: `gh auth login` (or set GH_TOKEN) before running this script
  Create a GitHub personal access token at https://github.com/settings/tokens/new
  (Select scope: public_repo)
```