### PR TITLE
fix(cudf): Fix Velox cuDF table scan tests

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
@@ -19,11 +19,7 @@
 #include "velox/connectors/Connector.h"
 #include "velox/dwio/common/Options.h"
 
-namespace cudf {
-namespace io {
-struct source_info;
-}
-} // namespace cudf
+#include <cudf/io/types.hpp>
 
 #include <memory>
 #include <string>

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConnectorSplit.h
@@ -101,7 +101,7 @@ class CudfHiveConnectorSplitBuilder {
 
   std::shared_ptr<CudfHiveConnectorSplit> build() const {
     return std::make_shared<CudfHiveConnectorSplit>(
-        connectorId_, filePath_, splitWeight_);
+        connectorId_, filePath_, start_, length_, splitWeight_, infoColumns_);
   }
 
  private:

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -580,9 +580,6 @@ void CudfHiveDataSource::setupCudfDataSourceAndOptions() {
           .timestamp_type(cudfHiveConfig_->timestampType())
           .build();
 
-  // TODO(mh): Temporarily disable these until we figure out why Presto-GPU
-  // passes incorrect values for split `start` and `length` fields
-#if 0
   // Set skip_bytes and num_bytes if available
   if (split_->start != 0) {
     readerOptions_.set_skip_bytes(split_->start);
@@ -590,16 +587,6 @@ void CudfHiveDataSource::setupCudfDataSourceAndOptions() {
   if (split_->size() != std::numeric_limits<uint64_t>::max()) {
     readerOptions_.set_num_bytes(split_->size());
   }
-#else
-  VELOX_CHECK_EQ(
-      split_->start,
-      0,
-      "CudfHiveDataSource cannot process splits with non-zero offset");
-  VELOX_CHECK_EQ(
-      split_->size(),
-      std::numeric_limits<uint64_t>::max(),
-      "CudfHiveDataSource cannot process splits with finite length");
-#endif
 
   if (subfieldFilterExpr_ != nullptr) {
     readerOptions_.set_filter(*subfieldFilterExpr_);

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -573,7 +573,6 @@ void CudfHiveDataSource::setupCudfDataSourceAndOptions() {
   // Reader options
   readerOptions_ =
       cudf::io::parquet_reader_options::builder(std::move(sourceInfo))
-          .skip_bytes(split_->start)
           .use_pandas_metadata(cudfHiveConfig_->isUsePandasMetadata())
           .use_arrow_schema(cudfHiveConfig_->isUseArrowSchema())
           .allow_mismatched_pq_schemas(
@@ -581,10 +580,26 @@ void CudfHiveDataSource::setupCudfDataSourceAndOptions() {
           .timestamp_type(cudfHiveConfig_->timestampType())
           .build();
 
-  // Set num_bytes only if available
+  // TODO(mh): Temporarily disable these until we figure out why Presto-GPU
+  // passes incorrect values for split `start` and `length` fields
+#if 0
+  // Set skip_bytes and num_bytes if available
+  if (split_->start != 0) {
+    readerOptions_.set_skip_bytes(split_->start);
+  }
   if (split_->size() != std::numeric_limits<uint64_t>::max()) {
     readerOptions_.set_num_bytes(split_->size());
   }
+#else
+  VELOX_CHECK_EQ(
+      split_->start,
+      0,
+      "CudfHiveDataSource cannot process splits with non-zero offset");
+  VELOX_CHECK_EQ(
+      split_->size(),
+      std::numeric_limits<uint64_t>::max(),
+      "CudfHiveDataSource cannot process splits with finite length");
+#endif
 
   if (subfieldFilterExpr_ != nullptr) {
     readerOptions_.set_filter(*subfieldFilterExpr_);

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -532,15 +532,34 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
   writeToFile(filePath->getPath(), vectors);
   createDuckDbTable(vectors);
 
+  // Note that the number of row groups selected within `halfFileSize` may
+  // change in the future and this test may start failing. In such a case,
+  // just adjust the duckdb sql string accordingly.
+  const auto halfFileSize = fs::file_size(filePath->getPath()) / 2;
+
+  // First half of file - OFFSET 0 LIMIT 6000
   assertQuery(
       tableScanNode(),
-      makeCudfHiveConnectorSplit(
-          filePath->getPath(), 0, fs::file_size(filePath->getPath()) / 2),
+      makeCudfHiveConnectorSplit(filePath->getPath(), 0, halfFileSize),
+      "SELECT * FROM tmp OFFSET 0 LIMIT 6000");
+
+  // Second half of file - OFFSET 6000 LIMIT 4000
+  assertQuery(
+      tableScanNode(),
+      makeCudfHiveConnectorSplit(filePath->getPath(), halfFileSize),
+      "SELECT * FROM tmp OFFSET 6000 LIMIT 4000");
+
+  const auto fileSize = fs::file_size(filePath->getPath());
+
+  // All row groups
+  assertQuery(
+      tableScanNode(),
+      makeCudfHiveConnectorSplit(filePath->getPath(), 0, fileSize),
       "SELECT * FROM tmp");
 
+  // No row groups
   assertQuery(
       tableScanNode(),
-      makeCudfHiveConnectorSplit(
-          filePath->getPath(), fs::file_size(filePath->getPath()) / 2),
+      makeCudfHiveConnectorSplit(filePath->getPath(), fileSize),
       "SELECT * FROM tmp LIMIT 0");
 }

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -532,11 +532,6 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
   writeToFile(filePath->getPath(), vectors);
   createDuckDbTable(vectors);
 
-  // TODO(mh): Enable this when we start using split's `start` and `length`
-  // fields in the `CudfHiveDataSource`. Currently temporarily disabled until we
-  // figure out why Presto-GPU passes incorrect values for split `start` and
-  // `length` fields.
-#if 0
   // Note that the number of row groups selected within `halfFileSize` may
   // change in the future and this test may start failing. In such a case,
   // just adjust the duckdb sql string accordingly.
@@ -567,13 +562,4 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       tableScanNode(),
       makeCudfHiveConnectorSplit(filePath->getPath(), fileSize),
       "SELECT * FROM tmp LIMIT 0");
-#else
-  VELOX_ASSERT_THROW(
-      AssertQueryBuilder(duckDbQueryRunner_)
-          .plan(tableScanNode())
-          .splits(
-              {makeCudfHiveConnectorSplit(filePath->getPath(), 1 /* start */)})
-          .assertEmptyResults(),
-      "CudfHiveDataSource cannot process splits with non-zero offset");
-#endif
 }

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -532,6 +532,11 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
   writeToFile(filePath->getPath(), vectors);
   createDuckDbTable(vectors);
 
+  // TODO(mh): Enable this when we start using split's `start` and `length`
+  // fields in the `CudfHiveDataSource`. Currently temporarily disabled until we
+  // figure out why Presto-GPU passes incorrect values for split `start` and
+  // `length` fields.
+#if 0
   // Note that the number of row groups selected within `halfFileSize` may
   // change in the future and this test may start failing. In such a case,
   // just adjust the duckdb sql string accordingly.
@@ -562,4 +567,13 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       tableScanNode(),
       makeCudfHiveConnectorSplit(filePath->getPath(), fileSize),
       "SELECT * FROM tmp LIMIT 0");
+#else
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .plan(tableScanNode())
+          .splits(
+              {makeCudfHiveConnectorSplit(filePath->getPath(), 1 /* start */)})
+          .assertEmptyResults(),
+      "CudfHiveDataSource cannot process splits with non-zero offset");
+#endif
 }

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
@@ -295,6 +295,8 @@ CudfHiveConnectorTestBase::makeCudfHiveConnectorSplit(
     uint64_t start,
     uint64_t length) {
   return facebook::velox::connector::hive::HiveConnectorSplitBuilder(filePath)
+      .connectorId(kCudfHiveConnectorId)
+      .fileFormat(facebook::velox::dwio::common::FileFormat::PARQUET)
       .infoColumn("$file_size", fmt::format("{}", fileSize))
       .infoColumn("$file_modified_time", fmt::format("{}", fileModifiedTime))
       .start(start)


### PR DESCRIPTION
## Description

Supersedes #16312

This PR fixes the `velox_cudf_table_scan_tests` that broke due to missing connector ID and file format in the splits constructed in `CudfHiveConnectorTestBase.cpp` after #14968.

## Checklist
- [x] Build succeeds
- [x] Velox-cuDF Tests succeed
- [x] I am familiar with the contribution guide