### PR TITLE
feat(sparksql): Register arrays_overlap function for Spark

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -211,6 +211,16 @@ Array Functions
         SELECT array_union(array(1, 2, float('nan')), array(1, 3, float('nan'))); -- [1, 2, NaN, 3]
         SELECT array_union(array(array(1)), array(array(null))); -- [[1], [null]]
 
+.. spark:function:: arrays_overlap(x, y) -> boolean
+
+    Tests if arrays ``x`` and ``y`` have any non-null elements in common.
+    Returns null if there are no non-null elements in common but either array contains null.
+    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal. ::
+
+        SELECT arrays_overlap(array(1, 2, 3), array(3, 4, 5)); -- true
+        SELECT arrays_overlap(array(1, 2, 3), array(4, 5, 6)); -- false
+        SELECT arrays_overlap(array(1, 2, NULL), array(4, 5, NULL)); -- NULL
+
 .. spark::function:: arrays_zip(array(T), array(U),..) -> array(row(T,U, ...))
 
     Returns the merge of the given arrays, element-wise into a single array of rows.

--- a/velox/functions/sparksql/registration/RegisterArray.cpp
+++ b/velox/functions/sparksql/registration/RegisterArray.cpp
@@ -44,6 +44,7 @@ void registerSparkArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_array_intersect, prefix + "array_intersect");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, prefix + "array_position");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, prefix + "arrays_overlap");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_zip, prefix + "arrays_zip");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_any_match, prefix + "exists");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, prefix + "filter");

--- a/velox/functions/sparksql/tests/ArraysOverlapTest.cpp
+++ b/velox/functions/sparksql/tests/ArraysOverlapTest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArraysOverlapTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  void testOverlap(
+      const std::vector<std::optional<std::vector<std::optional<T>>>>& array1,
+      const std::vector<std::optional<std::vector<std::optional<T>>>>& array2,
+      const std::vector<std::optional<bool>>& expected) {
+    auto input1 = makeNullableArrayVector(array1);
+    auto input2 = makeNullableArrayVector(array2);
+    auto result =
+        evaluate("arrays_overlap(c0, c1)", makeRowVector({input1, input2}));
+    auto expectedVector = makeNullableFlatVector(expected);
+    assertEqualVectors(expectedVector, result);
+  }
+};
+
+TEST_F(ArraysOverlapTest, intArrays) {
+  // Basic overlap.
+  testOverlap<int32_t>({{{{1, 2, 3}}}}, {{{{3, 4, 5}}}}, {{true}});
+
+  // No overlap.
+  testOverlap<int32_t>({{{{1, 2, 3}}}}, {{{{4, 5, 6}}}}, {{false}});
+}
+
+TEST_F(ArraysOverlapTest, nullHandling) {
+  // No overlap but both have NULLs -> NULL.
+  testOverlap<int32_t>(
+      {{{{1, 2, std::nullopt}}}}, {{{{4, 5, std::nullopt}}}}, {{std::nullopt}});
+
+  // Overlap found despite NULLs -> true.
+  testOverlap<int32_t>(
+      {{{{1, std::nullopt, 3}}}}, {{{{3, std::nullopt, 5}}}}, {{true}});
+
+  // NULL array -> NULL.
+  testOverlap<int32_t>({{std::nullopt}}, {{{{1, 2, 3}}}}, {{std::nullopt}});
+}
+
+TEST_F(ArraysOverlapTest, emptyArrays) {
+  // Empty arrays -> false.
+  auto emptyArray = makeArrayVector<int32_t>({{}, {}});
+  auto result = evaluate(
+      "arrays_overlap(c0, c1)",
+      makeRowVector({emptyArray, makeArrayVector<int32_t>({{}, {}})}));
+  assertEqualVectors(makeNullableFlatVector<bool>({false, false}), result);
+
+  // Empty vs non-empty -> false.
+  auto nonEmpty = makeArrayVector<int32_t>({{1, 2, 3}, {4, 5}});
+  result =
+      evaluate("arrays_overlap(c0, c1)", makeRowVector({emptyArray, nonEmpty}));
+  assertEqualVectors(makeNullableFlatVector<bool>({false, false}), result);
+}
+
+TEST_F(ArraysOverlapTest, stringArrays) {
+  testOverlap<StringView>(
+      {{{{StringView("a"), StringView("b")}}}},
+      {{{{StringView("b"), StringView("c")}}}},
+      {{true}});
+
+  testOverlap<StringView>(
+      {{{{StringView("a")}}}},
+      {{{{StringView("c"), StringView("d")}}}},
+      {{false}});
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
   ArrayPrependTest.cpp
   ArraySortTest.cpp
   ArrayShuffleTest.cpp
+  ArraysOverlapTest.cpp
   ArrayUnionTest.cpp
   ArgTypesGeneratorTest.cpp
   AtLeastNNonNullsTest.cpp


### PR DESCRIPTION
Register the existing Presto `arrays_overlap` (`udf_arrays_overlap`) function in the Spark namespace. The Presto implementation has identical semantics to Spark's `arrays_overlap`:

- Returns `true` if arrays have any common non-null elements
- Returns `null` if no common elements but either array contains null
- Returns `false` if no overlap and no nulls
- NaN values are considered equal for REAL/DOUBLE

### Changes
- **RegisterArray.cpp**: Added `VELOX_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, prefix + "arrays_overlap")`
- **array.rst**: Added documentation with examples
- **coverage.rst**: Marked `arrays_overlap` as implemented
- **ArraysOverlapTest.cpp**: Added Spark-specific tests (int arrays, null handling, empty arrays, string arrays)
- **CMakeLists.txt**: Registered new test file