### PR TITLE
feat(sparksql): Register cardinality function for Spark

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -219,6 +219,15 @@ Array Functions
 
         SELECT arrays_zip(ARRAY[1, 2], ARRAY['1b', null, '3b']); -- [ROW(1, '1b'), ROW(2, null), ROW(null, '3b')]
 
+.. spark:function:: cardinality(x) -> integer
+
+    Returns the size of an array or a map.
+    Returns NULL if the input is NULL. ::
+
+        SELECT cardinality(array(1, 2, 3)); -- 3
+        SELECT cardinality(map(1, 'a', 2, 'b')); -- 2
+        SELECT cardinality(array()); -- 0
+
 .. spark:function:: concat(array1, array2, ..., arrayN) -> array
 
     Concatenates the arrays ``array1``, ``array2``, ..., ``arrayN``. All parameters have the same type.

--- a/velox/functions/sparksql/Cardinality.h
+++ b/velox/functions/sparksql/Cardinality.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+
+/// Spark cardinality function returns int32_t (INTEGER), unlike Presto which
+/// returns int64_t (BIGINT).
+template <typename T>
+struct CardinalityFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void call(int32_t& out, const arg_type<Array<Generic<T1>>>& input) {
+    out = input.size();
+  }
+
+  void call(
+      int32_t& out,
+      const arg_type<Map<Generic<T1>, Generic<T2>>>& input) {
+    out = input.size();
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterMap.cpp
+++ b/velox/functions/sparksql/registration/RegisterMap.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/functions/lib/MapConcat.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/sparksql/Cardinality.h"
 #include "velox/functions/sparksql/Size.h"
 
 namespace facebook::velox::functions {
@@ -43,6 +44,12 @@ void registerMapFunctions(const std::string& prefix) {
   // This is the semantics of spark.sql.ansi.enabled = false.
   registerElementAtFunction(prefix + "element_at", true);
   registerSize(prefix + "size");
+  registerFunction<sparksql::CardinalityFunction, int32_t, Array<Generic<T1>>>(
+      {prefix + "cardinality"});
+  registerFunction<
+      sparksql::CardinalityFunction,
+      int32_t,
+      Map<Generic<T1>, Generic<T2>>>({prefix + "cardinality"});
 }
 } // namespace sparksql
 } // namespace facebook::velox::functions

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   ArgTypesGeneratorTest.cpp
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
+  CardinalityTest.cpp
   BitwiseTest.cpp
   CharTypeWriteSideCheckTest.cpp
   ComparisonsTest.cpp

--- a/velox/functions/sparksql/tests/CardinalityTest.cpp
+++ b/velox/functions/sparksql/tests/CardinalityTest.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <optional>
+
+#include <gtest/gtest.h>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+class CardinalityTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  std::optional<int32_t> cardinalityArray(
+      const std::vector<std::optional<T>>& input) {
+    auto row = makeRowVector({makeNullableArrayVector(
+        std::vector<std::vector<std::optional<T>>>{input})});
+    return evaluateOnce<int32_t>("cardinality(c0)", row);
+  }
+};
+
+TEST_F(CardinalityTest, arrayBasic) {
+  EXPECT_EQ(cardinalityArray<int32_t>({1, 2, 3}), 3);
+  EXPECT_EQ(cardinalityArray<int32_t>({1}), 1);
+  EXPECT_EQ(cardinalityArray<int32_t>({}), 0);
+}
+
+TEST_F(CardinalityTest, arrayWithNullElements) {
+  // NULL elements are counted.
+  EXPECT_EQ(cardinalityArray<int32_t>({1, std::nullopt, 3}), 3);
+  EXPECT_EQ(cardinalityArray<int32_t>({std::nullopt}), 1);
+  EXPECT_EQ(
+      cardinalityArray<int32_t>({std::nullopt, std::nullopt, std::nullopt}), 3);
+}
+
+TEST_F(CardinalityTest, arrayNullInput) {
+  // NULL array returns NULL.
+  auto result = evaluateOnce<int32_t>(
+      "cardinality(c0)",
+      makeRowVector(
+          {BaseVector::createNullConstant(ARRAY(INTEGER()), 1, pool())}));
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(CardinalityTest, arrayStringElements) {
+  EXPECT_EQ(cardinalityArray<std::string>({"a", "b", "c"}), 3);
+  EXPECT_EQ(cardinalityArray<std::string>({}), 0);
+}
+
+TEST_F(CardinalityTest, mapBasic) {
+  auto mapVector = makeMapVector<int32_t, int32_t>({{{1, 10}, {2, 20}}});
+  auto result =
+      evaluateOnce<int32_t>("cardinality(c0)", makeRowVector({mapVector}));
+  EXPECT_EQ(result, 2);
+
+  auto emptyMap = makeMapVector<int32_t, int32_t>({{}});
+  result = evaluateOnce<int32_t>("cardinality(c0)", makeRowVector({emptyMap}));
+  EXPECT_EQ(result, 0);
+}
+
+TEST_F(CardinalityTest, mapNullInput) {
+  // NULL map returns NULL.
+  auto result = evaluateOnce<int32_t>(
+      "cardinality(c0)",
+      makeRowVector({BaseVector::createNullConstant(
+          MAP(INTEGER(), INTEGER()), 1, pool())}));
+  EXPECT_FALSE(result.has_value());
+}
+
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
## Summary

Register the `cardinality` function for Spark SQL in Velox.

Spark's `cardinality` returns the size of an array or map as `int32_t` (INTEGER), unlike Presto's `cardinality` which returns `int64_t` (BIGINT). This PR adds a Spark-specific `CardinalityFunction` with the correct return type.

## Changes

- **velox/functions/sparksql/Cardinality.h**: New Spark-specific `CardinalityFunction` returning `int32_t`
- **velox/functions/sparksql/registration/RegisterMap.cpp**: Register `cardinality` for both `Array` and `Map` types
- **velox/functions/sparksql/tests/CardinalityTest.cpp**: Tests for arrays, maps, null handling
- **velox/docs/functions/spark/array.rst**: Function documentation

## Test Plan

```
./build/velox/functions/sparksql/tests/velox_functions_spark_test --gtest_filter="CardinalityTest*"
[==========] Running 6 tests from 1 test suite.
[  PASSED  ] 6 tests.
```