### PR TITLE
fix: Following #16300, fix signal handling in SkewedPartitionRebalancerTest.serializedRebalanceExecution

### DIFF
--- a/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
+++ b/velox/common/base/tests/SkewedPartitionBalancerTest.cpp
@@ -28,10 +28,6 @@ using namespace facebook::velox::common::testutil;
 namespace facebook::velox::common::test {
 class SkewedPartitionRebalancerTestHelper {
  public:
-  static void SetUpTestCase() {
-    TestValue::enable();
-  }
-
   explicit SkewedPartitionRebalancerTestHelper(
       SkewedPartitionRebalancer* balancer)
       : balancer_(balancer) {
@@ -76,6 +72,10 @@ class SkewedPartitionRebalancerTestHelper {
 
 class SkewedPartitionRebalancerTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    TestValue::enable();
+  }
+
   std::unique_ptr<SkewedPartitionRebalancer> createBalancer(
       uint32_t numPartitions = 128,
       uint32_t numTasks = 8,


### PR DESCRIPTION
The signal-waiting code added in #16300 is unlikely correct. This is a fix for it. 

Related: https://github.com/facebookincubator/velox/issues/16158