### PR TITLE
Fix TPCDS UBSAN and ASAN

### DIFF
--- a/velox/tpcds/gen/dsdgen/include/dist.h
+++ b/velox/tpcds/gen/dsdgen/include/dist.h
@@ -766,8 +766,8 @@ struct DSDGenContext {
   struct DBGEN_VERSION_TBL g_dbgen_version;
 
   struct W_STORE_SALES_TBL g_w_store_sales;
-  int *pStoreSalesItemPermutation, *pCatalogSalesItemPermutation,
-      *pWebSalesItemPermutation;
+  std::vector<int32_t> pStoreSalesItemPermutation, pCatalogSalesItemPermutation,
+      pWebSalesItemPermutation;
   int nStoreSalesItemCount, nCatalogSalesItemCount, nWebSalesItemCount;
   int nStoreSalesItemIndex, nCatalogSalesItemIndex, nWebSalesItemIndex;
   ds_key_t jDate, kNewDateIndex;

--- a/velox/tpcds/gen/dsdgen/include/permute.h
+++ b/velox/tpcds/gen/dsdgen/include/permute.h
@@ -24,7 +24,8 @@
  * THE TPC SOFTWARE IS AVAILABLE WITHOUT CHARGE FROM TPC.
  */
 
-int* makePermutation(int nSize, int nStream, DSDGenContext& dsdGenContext);
+std::vector<int32_t>
+makePermutation(int nSize, int nStream, DSDGenContext& dsdGenContext);
 ds_key_t* makeKeyPermutation(
     ds_key_t* pNumberSet,
     ds_key_t nSize,

--- a/velox/tpcds/gen/dsdgen/permute.cpp
+++ b/velox/tpcds/gen/dsdgen/permute.cpp
@@ -26,9 +26,6 @@
 
 #include "velox/tpcds/gen/dsdgen/include/config.h"
 #include "velox/tpcds/gen/dsdgen/include/porting.h"
-#ifndef USE_STDLIB_H
-#include <malloc.h>
-#endif
 #include <stdio.h>
 #include "velox/tpcds/gen/dsdgen/include/genrand.h"
 
@@ -46,24 +43,20 @@
  * Side Effects:
  * TODO: None
  */
-int* makePermutation(int nSize, int nStream, DSDGenContext& dsdGenContext) {
-  int i, nTemp, nIndex, *pInt;
-
+std::vector<int32_t>
+makePermutation(int nSize, int nStream, DSDGenContext& dsdGenContext) {
   if (nSize <= 0)
-    return (NULL);
+    return {};
 
-  std::vector<int32_t> nNumberSet(nSize);
-  pInt = nNumberSet.data();
-  for (i = 0; i < nSize; i++)
-    *pInt++ = i;
+  std::vector<int32_t> perm(nSize);
+  for (int i = 0; i < nSize; i++)
+    perm[i] = i;
 
-  for (i = 0; i < nSize; i++) {
-    nIndex = genrand_integer(
+  for (int i = 0; i < nSize; i++) {
+    int nIndex = genrand_integer(
         NULL, DIST_UNIFORM, 0, nSize - 1, 0, nStream, dsdGenContext);
-    nTemp = nNumberSet[i];
-    nNumberSet[i] = nNumberSet[nIndex];
-    nNumberSet[nIndex] = nTemp;
+    std::swap(perm[i], perm[nIndex]);
   }
 
-  return std::move(nNumberSet.data());
+  return perm;
 }


### PR DESCRIPTION
Summary:
Fix TPCDS UBSAN and ASAN

1. velox/connectors/tpcds/TpcdsConnector.cpp

- Caps rowCount_ to half of uint64_t max via std::min before computing per-split partition sizes. This prevents UBSAN error for tables with max uint64_t row count. This is the case for all the returns tables.

2. velox/tpcds/gen/dsdgen/permute.cpp

- Rewrites makePermutation to directly build and return a std::vector<int32_t> instead of allocating raw memory and returning a dangling pointer from std::move(nNumberSet.data()) (which was a bug — moving from .data() returns the raw pointer without transferring ownership).
- Uses std::swap instead of manual temp-variable swapping.
- Returns an empty vector {} instead of NULL for the zero-size case.
This resolves a ASAN read after free.

Differential Revision: D92988470


