### PR TITLE
fix(fuzzer): Generate PrestoSQL for functions without parenthesis

### DIFF
--- a/velox/exec/fuzzer/PrestoSql.cpp
+++ b/velox/exec/fuzzer/PrestoSql.cpp
@@ -173,6 +173,21 @@ const std::unordered_map<std::string, std::string>& binaryOperatorMap() {
   return binaryOperatorMap;
 }
 
+// Returns a list of presto functions that do not use ()
+// Date-time functions affected:
+// https://prestodb.io/docs/current/functions/datetime.html#date-and-time-functions
+const std::unordered_set<std::string>& functionsWithoutParenthesisList() {
+  static const std::unordered_set<std::string> functionsWithoutParenthesisList =
+      {
+          "current_date",
+          "current_time",
+          "current_timestamp",
+          "localtime",
+          "localtimestamp",
+      };
+  return functionsWithoutParenthesisList;
+}
+
 std::string toCallSql(const core::CallTypedExprPtr& call) {
   std::stringstream sql;
   // Some functions require special SQL syntax, so handle them first.
@@ -300,6 +315,9 @@ std::string toCallSql(const core::CallTypedExprPtr& call) {
       toCallInputsSql({call->inputs()[i]}, sql);
     }
     sql << " end";
+  } else if (functionsWithoutParenthesisList().contains(call->name())) {
+    // Functions that don't use () to represent no arguments.
+    sql << call->name();
   } else {
     // Regular function call syntax.
     sql << call->name() << "(";

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -456,7 +456,6 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "map_keys",
     "map_values",
     "clamp", // Function clamp not registered
-    "current_date", // Non-deterministic
     "xxhash64_internal",
     "combine_hash_internal",
     "noisy_avg_gaussian", // Non-deterministic
@@ -481,10 +480,6 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "$internal$split_to_map",
     "$internal$canonicalize",
     "$internal$contains",
-    "current_time", // current_time cannot be called with parenthesis
-    "localtime", // localtime cannot be called with parenthesis:
-                 // https://github.com/facebookincubator/velox/issues/14937,
-    "localtimestamp", // localtimestamp cannot be called with parenthesis
     "jarowinkler_similarity", // https://github.com/facebookincubator/velox/issues/15736
     // Fuzzer and the underlying engine are confused about SetDigest functions
     // (since KHLL is a user defined type), and tries to pass a


### PR DESCRIPTION
Some PrestoSQL functions do not use parenthesis to wrap arguments. Some functions may be used by the fuzzer such as current_date that are deterministic enough to run through the fuzzer. This PR adds the known functions even though they may not be exercised by the fuzzer for various reasons.

Addresses https://github.com/facebookincubator/velox/issues/14937