### PR TITLE
feat: Add decimal remainder and checked_remainder for Spark arithmetic

### DIFF
--- a/velox/docs/functions/spark/decimal.rst
+++ b/velox/docs/functions/spark/decimal.rst
@@ -143,6 +143,23 @@ Arithmetic Functions
     Division by zero or overflow results in an error.
     Corresponds to Spark's operator ``div`` with ``spark.sql.ansi.enabled`` set to true.
 
+.. spark:function:: remainder(x: decimal(p1, s1), y: decimal(p2, s2)) -> r: decimal(p3, s3)
+
+    Returns the remainder of ``x`` divided by ``y``. The result type is determined
+    by the precision and scale computation rules described above.
+    Returns NULL when the result overflows or ``y`` is zero.
+    Corresponds to Spark's operator ``%`` with ``spark.sql.ansi.enabled`` set to false.  ::
+
+        SELECT CAST(1.0 as DECIMAL(3, 1)) % CAST(3.0 as DECIMAL(3, 1)); -- 1.0
+        SELECT CAST(1.0 as DECIMAL(3, 1)) % CAST(0.0 as DECIMAL(3, 1)); -- NULL
+
+.. spark:function:: checked_remainder(x: decimal(p1, s1), y: decimal(p2, s2)) -> r: decimal(p3, s3)
+
+    Returns the remainder of ``x`` divided by ``y``. The result type is determined
+    by the precision and scale computation rules described above.
+    Throws an error when the result overflows or ``y`` is zero.
+    Corresponds to Spark's operator ``%`` with ``spark.sql.ansi.enabled`` set to true.
+
 Decimal Functions
 -----------------
 .. spark:function:: ceil(x: decimal(p, s)) -> r: decimal(pr, 0)

--- a/velox/functions/sparksql/DecimalArithmetic.cpp
+++ b/velox/functions/sparksql/DecimalArithmetic.cpp
@@ -474,6 +474,85 @@ struct DecimalDivideFunction {
   uint8_t rPrecision_;
 };
 
+// Decimal remainder function.
+// Computes a % b by rescaling both operands to the same scale and performing
+// integer modulo. Uses int256_t intermediate to avoid overflow during rescaling.
+template <typename TExec, bool allowPrecisionLoss>
+struct DecimalRemainderFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename A, typename B>
+  void initialize(
+      const std::vector<TypePtr>& inputTypes,
+      const core::QueryConfig& /*config*/,
+      A* /*a*/,
+      B* /*b*/) {
+    auto [aPrecision, aScale] = getDecimalPrecisionScale(*inputTypes[0]);
+    auto [bPrecision, bScale] = getDecimalPrecisionScale(*inputTypes[1]);
+    auto rScale = std::max(aScale, bScale);
+    uint8_t rPrecision =
+        std::min(aPrecision - aScale, bPrecision - bScale) + rScale;
+    if constexpr (allowPrecisionLoss) {
+      rPrecision_ = DecimalUtil::adjustPrecisionScale(rPrecision, rScale).first;
+    } else {
+      rPrecision_ =
+          std::min(rPrecision, LongDecimalType::kMaxPrecision);
+    }
+    aRescale_ = std::max<int8_t>(0, bScale - aScale);
+    bRescale_ = std::max<int8_t>(0, aScale - bScale);
+  }
+
+  template <typename R, typename A, typename B>
+  bool call(R& out, const A& a, const B& b) {
+    if (UNLIKELY(b == 0)) {
+      return false;
+    }
+    // Fast path: if both operands fit in result type after rescaling,
+    // stay in int128 and avoid int256.
+    R aScaled;
+    R bScaled;
+    bool aOverflow = __builtin_mul_overflow(
+        R(a), R(velox::DecimalUtil::kPowersOfTen[aRescale_]), &aScaled);
+    bool bOverflow = __builtin_mul_overflow(
+        R(b), R(velox::DecimalUtil::kPowersOfTen[bRescale_]), &bScaled);
+    if (LIKELY(!aOverflow && !bOverflow)) {
+      out = aScaled % bScaled;
+      return velox::DecimalUtil::valueInPrecisionRange(out, rPrecision_);
+    }
+    // Slow path: use int256_t to avoid overflow during rescaling.
+    int256_t aLarge = a;
+    aLarge *= DecimalUtil::getPowersOfTen(aRescale_);
+    int256_t bLarge = b;
+    bLarge *= DecimalUtil::getPowersOfTen(bRescale_);
+    int256_t resultLarge = aLarge % bLarge;
+    bool overflow = false;
+    out = DecimalUtil::convert<R>(resultLarge, overflow);
+    return !overflow &&
+        velox::DecimalUtil::valueInPrecisionRange(out, rPrecision_);
+  }
+
+ private:
+  uint8_t rPrecision_;
+  uint8_t aRescale_;
+  uint8_t bRescale_;
+};
+
+// Decimal remainder function that returns error on overflow or division by zero.
+template <typename TExec, bool allowPrecisionLoss>
+struct CheckedDecimalRemainderFunction
+    : DecimalRemainderFunction<TExec, allowPrecisionLoss> {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename R, typename A, typename B>
+  Status call(R& out, const A& a, const B& b) {
+    VELOX_USER_RETURN_EQ(b, 0, "Division by zero");
+    bool valid = DecimalRemainderFunction<TExec, allowPrecisionLoss>::
+        template call<R, A, B>(out, a, b);
+    VELOX_USER_RETURN(!valid, "Decimal overflow in remainder");
+    return Status::OK();
+  }
+};
+
 // Decimal integral divide function implementation.
 struct DecimalIntegralDivideBase {
   void initializeBase(const std::vector<TypePtr>& inputTypes) {
@@ -686,6 +765,22 @@ using DivideFunctionAllowPrecisionLoss = DecimalDivideFunction<TExec, true>;
 template <typename TExec>
 using DivideFunctionDenyPrecisionLoss = DecimalDivideFunction<TExec, false>;
 
+template <typename TExec>
+using RemainderFunctionAllowPrecisionLoss =
+    DecimalRemainderFunction<TExec, true>;
+
+template <typename TExec>
+using RemainderFunctionDenyPrecisionLoss =
+    DecimalRemainderFunction<TExec, false>;
+
+template <typename TExec>
+using CheckedRemainderFunctionAllowPrecisionLoss =
+    CheckedDecimalRemainderFunction<TExec, true>;
+
+template <typename TExec>
+using CheckedRemainderFunctionDenyPrecisionLoss =
+    CheckedDecimalRemainderFunction<TExec, false>;
+
 std::vector<exec::SignatureVariable> getDivideConstraintsDenyPrecisionLoss() {
   std::string wholeDigits = fmt::format(
       "min(38, {a_precision} - {a_scale} + {b_scale})",
@@ -820,5 +915,29 @@ void registerDecimalIntegralDivide(const std::string& prefix) {
   registerIntegralDecimalDivide<DecimalIntegralDivideFunction>(prefix + "div");
   registerIntegralDecimalDivide<CheckedDecimalIntegralDivideFunction>(
       prefix + "checked_div");
+}
+
+void registerDecimalRemainder(const std::string& prefix) {
+  std::string rScale = fmt::format(
+      "max({a_scale}, {b_scale})",
+      fmt::arg("a_scale", S1::name()),
+      fmt::arg("b_scale", S2::name()));
+  std::string rPrecision = fmt::format(
+      "min({a_precision} - {a_scale}, {b_precision} - {b_scale}) + max({a_scale}, {b_scale})",
+      fmt::arg("a_precision", P1::name()),
+      fmt::arg("b_precision", P2::name()),
+      fmt::arg("a_scale", S1::name()),
+      fmt::arg("b_scale", S2::name()));
+  registerDecimalBinary<RemainderFunctionAllowPrecisionLoss>(
+      prefix + "remainder", makeConstraints(rPrecision, rScale, true));
+  registerDecimalBinary<RemainderFunctionDenyPrecisionLoss>(
+      prefix + "remainder" + kDenyPrecisionLoss,
+      makeConstraints(rPrecision, rScale, false));
+  registerDecimalBinary<CheckedRemainderFunctionAllowPrecisionLoss>(
+      prefix + "checked_remainder",
+      makeConstraints(rPrecision, rScale, true));
+  registerDecimalBinary<CheckedRemainderFunctionDenyPrecisionLoss>(
+      prefix + "checked_remainder" + kDenyPrecisionLoss,
+      makeConstraints(rPrecision, rScale, false));
 }
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/DecimalArithmetic.h
+++ b/velox/functions/sparksql/DecimalArithmetic.h
@@ -29,4 +29,6 @@ void registerDecimalDivide(const std::string& prefix);
 
 void registerDecimalIntegralDivide(const std::string& prefix);
 
+void registerDecimalRemainder(const std::string& prefix);
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -124,6 +124,7 @@ void registerMathFunctions(const std::string& prefix) {
   registerDecimalMultiply(prefix);
   registerDecimalDivide(prefix);
   registerDecimalIntegralDivide(prefix);
+  registerDecimalRemainder(prefix);
   registerFunction<sparksql::IsNanFunction, bool, float>({prefix + "isnan"});
   registerFunction<sparksql::IsNanFunction, bool, double>({prefix + "isnan"});
 

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -88,6 +88,26 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
       std::optional<U> u) {
     return evaluateOnce<int64_t>("checked_div(c0, c1)", {tType, uType}, t, u);
   }
+
+  template <typename R, typename T, typename U>
+  std::optional<R> decimal_remainder(
+      const TypePtr& tType,
+      const TypePtr& uType,
+      std::optional<T> t,
+      std::optional<U> u) {
+    return evaluateOnce<R>(
+        "remainder(c0, c1)", {tType, uType}, t, u);
+  }
+
+  template <typename R, typename T, typename U>
+  std::optional<R> checked_remainder(
+      const TypePtr& tType,
+      const TypePtr& uType,
+      std::optional<T> t,
+      std::optional<U> u) {
+    return evaluateOnce<R>(
+        "checked_remainder(c0, c1)", {tType, uType}, t, u);
+  }
 };
 
 TEST_F(DecimalArithmeticTest, add) {
@@ -832,6 +852,109 @@ TEST_F(DecimalArithmeticTest, checkedDiv) {
           HugeInt::parse("99999999999999999999999999999999999999"),
           1)),
       "Overflow in integral divide");
+}
+
+TEST_F(DecimalArithmeticTest, remainder) {
+  // Short decimal: DECIMAL(17,3) % DECIMAL(17,3) -> result DECIMAL(17,3).
+  // 10.500 % 3.000 = 1.500 (unscaled: 10500 % 3000 = 1500).
+  EXPECT_EQ(
+      (decimal_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), 10500, 3000)),
+      1500);
+
+  // All 4 input type combos with long decimal result.
+  // DECIMAL(17,3) % DECIMAL(20,3) -> result precision max(14,17)+3=20 (long).
+  EXPECT_EQ(
+      (decimal_remainder<int128_t, int64_t, int128_t>(
+          DECIMAL(17, 3), DECIMAL(20, 3), 10500, 3000)),
+      1500);
+  // DECIMAL(20,3) % DECIMAL(17,3) -> result precision max(17,14)+3=20 (long).
+  EXPECT_EQ(
+      (decimal_remainder<int128_t, int128_t, int64_t>(
+          DECIMAL(20, 3), DECIMAL(17, 3), 10500, 3000)),
+      1500);
+  // DECIMAL(20,3) % DECIMAL(20,3) -> result precision max(17,17)+3=20 (long).
+  EXPECT_EQ(
+      (decimal_remainder<int128_t, int128_t, int128_t>(
+          DECIMAL(20, 3), DECIMAL(20, 3), 10500, 3000)),
+      1500);
+
+  // Remainder with zero dividend: 0 % b = 0.
+  EXPECT_EQ(
+      (decimal_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), 0, 3000)),
+      0);
+
+  // Remainder preserves sign of dividend.
+  // -10.500 % 3.000 = -1.500.
+  EXPECT_EQ(
+      (decimal_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), -10500, 3000)),
+      -1500);
+  // 10.500 % -3.000 = 1.500.
+  EXPECT_EQ(
+      (decimal_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), 10500, -3000)),
+      1500);
+  // -10.500 % -3.000 = -1.500.
+  EXPECT_EQ(
+      (decimal_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), -10500, -3000)),
+      -1500);
+
+  // Different scales: DECIMAL(17,3) % DECIMAL(17,5).
+  // Result precision = max(14,12)+5 = 19 (long decimal).
+  // 10.500 % 3.00000 = 1.50000 (rescale a: 10500*100=1050000, b: 300000).
+  // 1050000 % 300000 = 150000.
+  EXPECT_EQ(
+      (decimal_remainder<int128_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 5), 10500, 300000)),
+      150000);
+
+  // Division by zero returns null.
+  EXPECT_EQ(
+      (decimal_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), 10500, 0)),
+      std::nullopt);
+
+  // Large values: DECIMAL(38,0) % DECIMAL(38,0) -> result DECIMAL(38,0).
+  EXPECT_EQ(
+      (decimal_remainder<int128_t, int128_t, int128_t>(
+          DECIMAL(38, 0), DECIMAL(38, 0), 100, 30)),
+      10);
+
+  // Large values near boundary.
+  EXPECT_EQ(
+      (decimal_remainder<int128_t, int128_t, int128_t>(
+          DECIMAL(38, 0),
+          DECIMAL(38, 0),
+          HugeInt::parse("99999999999999999999999999999999999999"),
+          HugeInt::parse("10000000000000000000"))),
+      HugeInt::parse("9999999999999999999"));
+}
+
+TEST_F(DecimalArithmeticTest, checkedRemainder) {
+  // Normal case.
+  EXPECT_EQ(
+      (checked_remainder<int128_t, int128_t, int128_t>(
+          DECIMAL(20, 3), DECIMAL(20, 3), 10500, 3000)),
+      1500);
+
+  // Sign preservation.
+  EXPECT_EQ(
+      (checked_remainder<int128_t, int128_t, int128_t>(
+          DECIMAL(20, 3), DECIMAL(20, 3), -10500, 3000)),
+      -1500);
+
+  // Division by zero should throw.
+  VELOX_ASSERT_USER_THROW(
+      (checked_remainder<int64_t, int64_t, int64_t>(
+          DECIMAL(17, 3), DECIMAL(17, 3), 10500, 0)),
+      "Division by zero");
+  VELOX_ASSERT_USER_THROW(
+      (checked_remainder<int128_t, int128_t, int128_t>(
+          DECIMAL(20, 3), DECIMAL(20, 3), 10500, 0)),
+      "Division by zero");
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Closes #16354 

## Summary

  - Add `remainder` and `checked_remainder` for decimal types to support
    Spark's `%` operator on decimals. The non-checked variant returns null
    on overflow or division by zero, while the checked variant throws for
    Spark ANSI mode.
  - Uses int128 fast path with `__builtin_mul_overflow` for rescaling,
    falling back to int256 only when the rescaled operands overflow int128.
  - Both `allowPrecisionLoss` and `denyPrecisionLoss` variants registered.

  ## Test plan

  - [x] Normal cases: all 4 input type combinations (short/short, long/long,
        short/long, long/short)
  - [x] Division by zero returns null (non-checked) / throws (checked)
  - [x] Negative operand combinations
  - [x] Remainder with different scales (rescaling required)
  - [x] Overflow detection via precision range check
