### PR TITLE
feat: Add checked_unaryminus for Spark ANSI mode integer overflow detection

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -105,6 +105,11 @@ Mathematical Functions
     Returns the result of subtracting y from x. The types of x and y must be the same.
     For integral types, overflow results in an error. Corresponds to Spark's operator ``-`` with ``failOnError`` as true.
 
+.. function:: checked_unaryminus(x) -> [same as x]
+
+    Returns the negative of ``x``. For integral types, throws an error when ``x`` is the minimum value
+    of the type (e.g., ``-128`` for tinyint). Corresponds to Spark's unary ``-`` operator with ``failOnError`` as true.
+
 .. spark:function:: cos(x) -> double
 
     Returns the cosine of ``x``.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -666,4 +666,21 @@ struct CheckedIntegralDivideFunction {
   }
 };
 
+template <typename TExec>
+struct CheckedUnaryMinusFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE Status call(TInput& result, const TInput a) {
+    if constexpr (std::is_integral_v<TInput>) {
+      VELOX_USER_RETURN(
+          a == std::numeric_limits<TInput>::min(),
+          "Arithmetic overflow: -{}",
+          a);
+      result = -a;
+    } else {
+      result = -a;
+    }
+    return Status::OK();
+  }
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -133,6 +133,8 @@ void registerMathFunctions(const std::string& prefix) {
   registerBinaryNumeric<CheckedDivideFunction>({prefix + "checked_divide"});
   registerBinaryIntegralWithTReturn<CheckedIntegralDivideFunction, int64_t>(
       {prefix + "checked_div"});
+  registerUnaryIntegral<CheckedUnaryMinusFunction>(
+      {prefix + "checked_unaryminus"});
   registerFunction<sparksql::FactorialFunction, int64_t, int32_t>(
       {prefix + "factorial"});
 }


### PR DESCRIPTION
## Summary



  Add `checked_unaryminus` Spark function that throws on integer overflow when negating
  the minimum value of integral types (TINYINT, SMALLINT, INTEGER, BIGINT). This matches
  Spark's ANSI mode behavior where `UnaryMinus` uses `Math.negateExact()`.

  - Returns `Status` to support `TRY()` wrapping (returns null instead of throwing)
  - For non-integral types, behaves identically to regular negation

  ## Test plan

  - Normal negation for all integer types (positive, negative, zero)
  - Overflow detection: negating `MIN_VALUE` throws for int8, int16, int32, int64
  - `TRY(checked_unaryminus(MIN_VALUE))` returns null

  Closes #16355