### PR TITLE
feat: Add checked_element_at for Spark ANSI mode array/map access

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -230,6 +230,24 @@ Array Functions
         SELECT concat(array(1, 2), array(1, 2), array(1, null)); -- [1, 2, 1, 2, 1, NULL]
         SELECT concat(array(array(1, 2)), array(array(1, null))); -- [[1, 2], [1, NULL]]
 
+.. spark:function:: element_at(array(E), index) -> E
+
+    Returns element of ``array`` at given 1-based ``index``. If ``index`` < 0, accesses elements
+    from the last to the first. Throws an error if ``index`` is 0. Returns ``NULL`` if the index
+    exceeds the length of the array.
+    Corresponds to Spark's ``element_at`` with ``spark.sql.ansi.enabled`` set to false.  ::
+
+        SELECT element_at(array(1, 2, 3), 2); -- 2
+        SELECT element_at(array(1, 2, 3), -1); -- 3
+        SELECT element_at(array(1, 2, 3), 0); -- error
+        SELECT element_at(array(1, 2, 3), 5); -- NULL
+
+.. spark:function:: checked_element_at(array(E), index) -> E
+
+    Returns element of ``array`` at given 1-based ``index``. If ``index`` < 0, accesses elements
+    from the last to the first. Throws an error if ``index`` is 0 or exceeds the length of the array.
+    Corresponds to Spark's ``element_at`` with ``spark.sql.ansi.enabled`` set to true.
+
 .. spark:function:: exists(array(T), function(T, boolean)) → boolean
 
     Returns whether at least one element of an array matches the given predicate.

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -6,6 +6,11 @@ Map Functions
 
     Returns value for given ``key``, or ``NULL`` if the key is not contained in the map.
 
+.. spark:function:: checked_element_at(map(K,V), key) -> V
+
+    Returns value for given ``key``. Throws an error if the key is not contained in the map.
+    Corresponds to Spark's ``element_at`` with ``spark.sql.ansi.enabled`` set to true.
+
 .. spark:function:: map(K, V, K, V, ...) -> map(K,V)
 
     Returns a map created using the given key/value pairs. If there is duplicate key, by default that

--- a/velox/functions/sparksql/registration/RegisterMap.cpp
+++ b/velox/functions/sparksql/registration/RegisterMap.cpp
@@ -22,6 +22,9 @@ namespace facebook::velox::functions {
 extern void registerElementAtFunction(
     const std::string& name,
     bool enableCaching);
+extern void registerCheckedElementAtFunction(
+    const std::string& name,
+    bool enableCaching);
 
 void registerSparkMapFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(
@@ -45,6 +48,8 @@ void registerMapFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
   // This is the semantics of spark.sql.ansi.enabled = false.
   registerElementAtFunction(prefix + "element_at", true);
+  // This is the semantics of spark.sql.ansi.enabled = true.
+  registerCheckedElementAtFunction(prefix + "checked_element_at", true);
   registerSize(prefix + "size");
 }
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/ElementAtTest.cpp
+++ b/velox/functions/sparksql/tests/ElementAtTest.cpp
@@ -76,4 +76,67 @@ TEST_F(ElementAtTest, allFlavors2) {
   EXPECT_EQ(elementAtSimple("element_at(C0, -3)", {arrayVector}), 10);
   EXPECT_EQ(elementAtSimple("element_at(C0, -4)", {arrayVector}), std::nullopt);
 }
+
+// Spark's checked_element_at behavior (spark.sql.ansi.enabled = true):
+// #1 - start indices at 1. If Index is 0 will throw an error.
+// #2 - throw on out of bounds access for arrays (instead of returning null).
+// #3 - throw on missing map key (instead of returning null).
+// #4 - allow negative indices (return elements from the last to the first).
+// #5 - throw when negative index is out of bounds.
+TEST_F(ElementAtTest, checkedElementAt) {
+  auto arrayVector = makeArrayVector<int64_t>({{10, 11, 12}});
+
+  // Create a simple vector containing a single map ([10=>10, 11=>11, 12=>12]).
+  auto keyAt = [](auto idx) { return idx + 10; };
+  auto sizeAt = [](auto) { return 3; };
+  auto mapValueAt = [](auto idx) { return idx + 10; };
+  auto mapVector =
+      makeMapVector<int64_t, int64_t>(1, sizeAt, keyAt, mapValueAt);
+
+  // #1 - Normal array access works.
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, 1)", {arrayVector}), 10);
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, 2)", {arrayVector}), 11);
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, 3)", {arrayVector}), 12);
+
+  // Index 0 throws.
+  VELOX_ASSERT_THROW(
+      elementAtSimple("checked_element_at(C0, 0)", {arrayVector}),
+      "SQL array indices start at 1");
+
+  // #2 - Out of bounds throws instead of returning null.
+  VELOX_ASSERT_THROW(
+      elementAtSimple("checked_element_at(C0, 4)", {arrayVector}),
+      "Array subscript index out of bounds");
+  VELOX_ASSERT_THROW(
+      elementAtSimple("checked_element_at(C0, 5)", {arrayVector}),
+      "Array subscript index out of bounds");
+
+  // #3 - Missing map key throws instead of returning null.
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, 10)", {mapVector}), 10);
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, 11)", {mapVector}), 11);
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, 12)", {mapVector}), 12);
+  VELOX_ASSERT_THROW(
+      elementAtSimple("checked_element_at(C0, 1001)", {mapVector}),
+      "Key not found in map");
+
+  // #4 - Negative indices still work.
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, -1)", {arrayVector}), 12);
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, -2)", {arrayVector}), 11);
+  EXPECT_EQ(
+      elementAtSimple("checked_element_at(C0, -3)", {arrayVector}), 10);
+
+  // #5 - Negative index out of bounds throws.
+  VELOX_ASSERT_THROW(
+      elementAtSimple("checked_element_at(C0, -4)", {arrayVector}),
+      "Array subscript index out of bounds");
+}
+
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
## Summary



  Add `checked_element_at` that throws on array out-of-bounds access and missing
  map keys, instead of returning null. This matches Spark's ANSI mode behavior
  where `ElementAt` with `failOnError=true` raises exceptions.

  Reuses the existing `SubscriptImpl` template with `allowOutOfBound=false` and
  `throwOnMissingMapKey=true`. Both error paths support `TRY()` wrapping.

  ## Test plan

  - Array: normal access, out-of-bounds throws, `TRY()` returns null
  - Map: normal access, missing key throws, `TRY()` returns null

  Closes #16358