### PR TITLE
feat: Support stripe level batched index read

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -376,6 +376,30 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
     const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
         outputSubfields,
     const common::SubfieldFilters& subfieldFilters,
+    const RowTypePtr& dataColumns,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>& partitionKeys,
+    const std::unordered_map<std::string, HiveColumnHandlePtr>& infoColumns,
+    const SpecialColumnNames& specialColumns,
+    bool disableStatsBasedFilterReorder,
+    memory::MemoryPool* pool) {
+  return makeScanSpec(
+      rowType,
+      outputSubfields,
+      subfieldFilters,
+      /*indexColumns=*/{},
+      dataColumns,
+      partitionKeys,
+      infoColumns,
+      specialColumns,
+      disableStatsBasedFilterReorder,
+      pool);
+}
+
+std::shared_ptr<common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType,
+    const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
+        outputSubfields,
+    const common::SubfieldFilters& subfieldFilters,
     const std::vector<std::string>& indexColumns,
     const RowTypePtr& dataColumns,
     const std::unordered_map<std::string, HiveColumnHandlePtr>& partitionKeys,

--- a/velox/connectors/hive/HiveConnectorUtil.h
+++ b/velox/connectors/hive/HiveConnectorUtil.h
@@ -92,6 +92,25 @@ std::shared_ptr<common::ScanSpec> makeScanSpec(
     const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
         outputSubfields,
     const common::SubfieldFilters& subfieldFilters,
+    const RowTypePtr& dataColumns,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& partitionKeys,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<const HiveColumnHandle>>& infoColumns,
+    const SpecialColumnNames& specialColumns,
+    bool disableStatsBasedFilterReorder,
+    memory::MemoryPool* pool);
+
+/// @deprecated Use the overload without indexColumns parameter instead.
+/// This overload is kept for backward compatibility and will be removed in a
+/// future release.
+std::shared_ptr<common::ScanSpec> makeScanSpec(
+    const RowTypePtr& rowType,
+    const folly::F14FastMap<std::string, std::vector<const common::Subfield*>>&
+        outputSubfields,
+    const common::SubfieldFilters& subfieldFilters,
     const std::vector<std::string>& indexColumns,
     const RowTypePtr& dataColumns,
     const std::unordered_map<

--- a/velox/connectors/hive/HiveIndexReader.cpp
+++ b/velox/connectors/hive/HiveIndexReader.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/connectors/hive/HiveIndexReader.h"
 
-#include <folly/container/F14Set.h>
-
 #include "velox/common/Casts.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/HiveConfig.h"
@@ -25,7 +23,6 @@
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/ReaderFactory.h"
-#include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::connector::hive {
 namespace {
@@ -41,73 +38,46 @@ std::shared_ptr<const HiveConnectorSplit> getSingleSplit(
   return hiveSplits[0];
 }
 
-template <TypeKind kind>
-variant extractValue(const DecodedVector& decoded, vector_size_t row) {
-  using T = typename TypeTraits<kind>::NativeType;
-  return variant(decoded.valueAt<T>(row));
-}
-
-// Checks if a filter is a point lookup (single value equality filter).
-// Returns true if the filter represents a point lookup, false if it's a range
-// filter or unsupported filter type.
-// This is used to determine if we can continue processing join conditions after
-// an index column has a filter. Only point lookup filters allow subsequent
-// index columns to be used for join conditions.
-bool isPointLookupFilter(const common::Filter* filter) {
-  VELOX_CHECK_NOT_NULL(filter);
-
-  switch (filter->kind()) {
-    case common::FilterKind::kBigintRange: {
-      const auto* range = filter->as<common::BigintRange>();
-      return range->isSingleValue();
-    }
-    case common::FilterKind::kDoubleRange: {
-      const auto* range = filter->as<common::DoubleRange>();
-      return !range->lowerUnbounded() && !range->upperUnbounded() &&
-          range->lower() == range->upper() && !range->lowerExclusive() &&
-          !range->upperExclusive();
-    }
-    case common::FilterKind::kFloatRange: {
-      const auto* range = filter->as<common::FloatRange>();
-      return !range->lowerUnbounded() && !range->upperUnbounded() &&
-          range->lower() == range->upper() && !range->lowerExclusive() &&
-          !range->upperExclusive();
-    }
-    case common::FilterKind::kBytesRange: {
-      const auto* range = filter->as<common::BytesRange>();
-      return range->isSingleValue();
-    }
-    case common::FilterKind::kBytesValues: {
-      const auto* values = filter->as<common::BytesValues>();
-      return values->values().size() == 1;
-    }
-    case common::FilterKind::kBoolValue:
-      // These are always point lookups or not convertible.
-      return true;
-    default:
-      // Unsupported filter types are not point lookups.
-      return false;
-  }
-}
-
-// Extracts bound value for between condition: either from constant or decoded
-// request.
-variant extractBoundValue(
-    const std::optional<variant>& constantValue,
-    const DecodedVector& decoded,
-    const TypePtr& type,
-    vector_size_t row,
-    bool isLowerBound) {
-  if (constantValue.has_value()) {
-    return constantValue.value();
-  }
+// Gets the index of a column in the request type by name.
+// Throws if the column is not found.
+column_index_t getRequestColumnIndex(
+    const std::string& name,
+    const RowTypePtr& requestType) {
+  const auto idxOpt = requestType->getChildIdxIfExists(name);
   VELOX_CHECK(
-      !decoded.isNullAt(row),
-      "Null value not allowed for {} bound",
-      isLowerBound ? "lower" : "upper");
-  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      extractValue, type->kind(), decoded, row);
+      idxOpt.has_value(), "Request column {} not found in request type", name);
+  return idxOpt.value();
 }
+
+// Processes a between condition bound (lower or upper).
+// Returns true if the bound is a field access (non-constant).
+void processBetweenBound(
+    const core::TypedExprPtr& bound,
+    size_t boundIndex,
+    const char* boundName,
+    std::vector<std::optional<variant>>& constantBoundValues,
+    std::vector<column_index_t>& requestColumnIndices,
+    const RowTypePtr& requestType) {
+  if (auto constantExpr =
+          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(bound)) {
+    VELOX_CHECK(
+        !constantExpr->hasValueVector(),
+        "Complex constant values not supported for between condition {} bound",
+        boundName);
+    VELOX_CHECK(
+        !constantExpr->value().isNull(),
+        "Null constant value not allowed for between condition {} bound",
+        boundName);
+    constantBoundValues[boundIndex] = constantExpr->value();
+    requestColumnIndices[boundIndex] = kConstantChannel;
+  } else {
+    auto fieldAccess =
+        checkedPointerCast<const core::FieldAccessTypedExpr>(bound);
+    requestColumnIndices[boundIndex] =
+        getRequestColumnIndex(fieldAccess->name(), requestType);
+  }
+}
+
 } // namespace
 
 HiveIndexReader::HiveIndexReader(
@@ -136,170 +106,140 @@ HiveIndexReader::HiveIndexReader(
       pool_{connectorQueryCtx->memoryPool()},
       scanSpec_{scanSpec},
       fileReader_{createFileReader()},
-      rowReader_{createRowReader()},
+      indexReader_{createIndexReader()},
       joinConditions_{joinConditions} {
-  initJoinConditions();
+  parseJoinConditions();
 }
 
-void HiveIndexReader::initJoinConditions() {
+void HiveIndexReader::parseJoinConditions() {
   VELOX_CHECK(!joinConditions_.empty(), "Join conditions cannot be empty");
+  const auto& indexColumns = tableHandle_->indexColumns();
   VELOX_CHECK(
-      !tableHandle_->indexColumns().empty(),
-      "Index columns not set in hive table handle");
-  VELOX_CHECK(joinIndexColumnSpecs_.empty());
-  VELOX_CHECK(requestColumnIndices_.empty());
-
-  const auto& tableIndexColumns = tableHandle_->indexColumns();
+      !indexColumns.empty(), "Index columns not set in hive table handle");
+  VELOX_CHECK_LE(joinConditions_.size(), indexColumns.size());
   VELOX_CHECK_LE(
-      joinConditions_.size(),
-      tableIndexColumns.size(),
-      "Too many join conditions");
-  joinIndexColumnSpecs_.resize(joinConditions_.size());
-  requestColumnIndices_.resize(joinConditions_.size());
-  decodedRequestVectors_.resize(joinConditions_.size());
-  constantBoundValues_.resize(joinConditions_.size());
+      joinConditions_.size(), indexColumns.size(), "Too many join conditions");
+  const auto numJoinConditions = joinConditions_.size();
+  requestColumnIndices_.resize(numJoinConditions);
+  constantBoundValues_.resize(numJoinConditions);
 
-  auto getRequestColumnIndex = [&](const std::string& name) {
-    const auto idxOpt = requestType_->getChildIdxIfExists(name);
-    VELOX_CHECK(
-        idxOpt.has_value(),
-        "Request column {} not found in request type",
-        name);
-    return idxOpt.value();
-  };
+  // For building indexBoundType_ during condition processing.
+  std::vector<std::string> indexColumnNames;
+  indexColumnNames.reserve(numJoinConditions);
+  std::vector<TypePtr> indexColumnTypes;
+  indexColumnTypes.reserve(numJoinConditions);
 
   // Validate and process join conditions:
   // - Join conditions combined with index filters must cover all table index
   //   columns in order.
   // - For each index column, it must have either a join condition OR a filter
   //   in the scan spec, but not both.
+  // - At least one join condition must have a non-constant value (field access
+  //   from probe side).
+  // - For between conditions, at least one bound must be non-constant.
   // - Processing stops when we encounter a range filter or between condition.
-  size_t conditionIdx = 0;
-  for (size_t i = 0; i < tableIndexColumns.size(); ++i) {
-    const auto& indexColumn = tableIndexColumns[i];
-    auto* spec = scanSpec_->childByName(indexColumn);
-    if (spec == nullptr) {
-      break;
-    }
-
-    // Check if this index column has a filter in scanSpec.
-    const bool hasFilter = spec->hasFilter();
-
-    // Check if there's a join condition for this index column.
-    const bool hasJoinCondition =
-        (conditionIdx < joinConditions_.size() &&
-         joinConditions_[conditionIdx]->key->name() == indexColumn);
-
-    if (!hasFilter && !hasJoinCondition) {
-      break;
-    }
-    VELOX_CHECK(
-        !(hasFilter && hasJoinCondition),
-        "Index column '{}' cannot have both a join condition and a pushdown filter",
-        indexColumn);
-
-    if (hasFilter) {
-      // If the filter is not a point lookup (range filter), we cannot continue
-      // processing join conditions after this point.
-      if (!isPointLookupFilter(spec->filter())) {
-        break;
-      }
-      continue;
-    }
-
-    joinIndexColumnSpecs_[conditionIdx] = spec;
+  size_t numValidJoinConditions{0};
+  bool hasNonConstantCondition{false};
+  for (size_t i = 0; i < joinConditions_.size(); ++i) {
+    const auto& indexColumn = indexColumns[i];
     // Process the join condition for this index column.
-    const auto& condition = joinConditions_[conditionIdx];
+    const auto& condition = joinConditions_[i];
+    // Validate that the condition's key column matches the expected index
+    // column.
+    const auto& conditionKeyName =
+        condition->key->asUnchecked<core::FieldAccessTypedExpr>()->name();
+    VELOX_CHECK_EQ(
+        conditionKeyName,
+        indexColumn,
+        "Join condition key column does not match expected index column at position {}. Join conditions must follow index column order.",
+        i);
+    const auto* spec = scanSpec_->childByName(indexColumn);
     VELOX_CHECK(
-        !condition->isFilter(),
-        "Join condition on index column '{}' cannot be a filter",
-        indexColumn);
+        spec == nullptr || !spec->hasFilter(),
+        "Index column '{}' cannot have both a join condition and a filter at position {}",
+        indexColumn,
+        i);
 
     // Determine the request column index for the condition value.
     if (auto equalCondition =
             std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
                 condition)) {
-      const auto requestFieldAccess =
-          checkedPointerCast<const core::FieldAccessTypedExpr>(
-              equalCondition->value);
-      requestColumnIndices_[conditionIdx] = {
-          getRequestColumnIndex(requestFieldAccess->name())};
-      decodedRequestVectors_[conditionIdx].resize(1);
-      ++conditionIdx;
+      // Check if the value is a constant or a field access.
+      if (auto constantValue =
+              std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+                  equalCondition->value)) {
+        // Constant value - store in constantBoundValues_ and use
+        // kConstantChannel.
+        VELOX_CHECK(
+            !constantValue->hasValueVector(),
+            "Complex constant values not supported for equal condition value");
+        VELOX_CHECK(
+            !constantValue->value().isNull(),
+            "Null constant value not allowed for equal condition value");
+        constantBoundValues_[i].resize(1);
+        constantBoundValues_[i][0] = constantValue->value();
+        requestColumnIndices_[i] = {kConstantChannel};
+      } else {
+        // Field access - get request column index.
+        const auto requestFieldAccess =
+            checkedPointerCast<const core::FieldAccessTypedExpr>(
+                equalCondition->value);
+        requestColumnIndices_[i] = {
+            getRequestColumnIndex(requestFieldAccess->name(), requestType_)};
+        hasNonConstantCondition = true;
+      }
+      // Collect column name and type for indexBoundType_.
+      indexColumnNames.push_back(indexColumn);
+      indexColumnTypes.push_back(condition->key->type());
+      ++numValidJoinConditions;
       continue;
     }
 
     if (auto betweenCondition =
             std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
                 condition)) {
-      constantBoundValues_[conditionIdx].resize(2);
-      requestColumnIndices_[conditionIdx].resize(2);
-      decodedRequestVectors_[conditionIdx].resize(2);
+      constantBoundValues_[i].resize(2);
+      requestColumnIndices_[i].resize(2);
 
-      bool hasNonConstantBound = false;
+      processBetweenBound(
+          betweenCondition->lower,
+          0,
+          "lower",
+          constantBoundValues_[i],
+          requestColumnIndices_[i],
+          requestType_);
+      processBetweenBound(
+          betweenCondition->upper,
+          1,
+          "upper",
+          constantBoundValues_[i],
+          requestColumnIndices_[i],
+          requestType_);
 
-      // Check if lower bound is constant or field access.
-      if (auto lowerConstant =
-              std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
-                  betweenCondition->lower)) {
-        VELOX_CHECK(
-            !lowerConstant->hasValueVector(),
-            "Complex constant values not supported for between condition lower bound");
-        VELOX_CHECK(
-            !lowerConstant->value().isNull(),
-            "Null constant value not allowed for between condition lower bound");
-        constantBoundValues_[conditionIdx][0] = lowerConstant->value();
-        requestColumnIndices_[conditionIdx][0] = kConstantChannel;
-      } else {
-        auto lowerFieldAccess =
-            checkedPointerCast<const core::FieldAccessTypedExpr>(
-                betweenCondition->lower);
-        requestColumnIndices_[conditionIdx][0] =
-            getRequestColumnIndex(lowerFieldAccess->name());
-        hasNonConstantBound = true;
+      // Track if this between condition has at least one non-constant bound.
+      if (requestColumnIndices_[i][0] != kConstantChannel ||
+          requestColumnIndices_[i][1] != kConstantChannel) {
+        hasNonConstantCondition = true;
       }
 
-      // Check if upper bound is constant or field access.
-      if (auto upperConstant =
-              std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
-                  betweenCondition->upper)) {
-        VELOX_CHECK(
-            !upperConstant->hasValueVector(),
-            "Complex constant values not supported for between condition upper bound");
-        VELOX_CHECK(
-            !upperConstant->value().isNull(),
-            "Null constant value not allowed for between condition upper bound");
-        constantBoundValues_[conditionIdx][1] = upperConstant->value();
-        requestColumnIndices_[conditionIdx][1] = kConstantChannel;
-      } else {
-        auto upperFieldAccess =
-            checkedPointerCast<const core::FieldAccessTypedExpr>(
-                betweenCondition->upper);
-        requestColumnIndices_[conditionIdx][1] =
-            getRequestColumnIndex(upperFieldAccess->name());
-        hasNonConstantBound = true;
-      }
-
-      // At least one bound must be a field access (not constant). If both
-      // bounds are constants, the condition should be pushed down as a filter.
-      VELOX_CHECK(
-          hasNonConstantBound,
-          "Join condition on index column '{}' cannot have both bounds as constants. "
-          "Use a pushdown filter instead.",
-          condition->key->name());
-
-      ++conditionIdx;
+      // Collect column name and type for indexBoundType_.
+      indexColumnNames.push_back(indexColumn);
+      indexColumnTypes.push_back(condition->key->type());
+      ++numValidJoinConditions;
       // Between condition is a range condition, stop processing further.
       break;
     }
 
     VELOX_FAIL("Unsupported join condition type: {}", condition->toString());
   }
+  VELOX_CHECK_EQ(numValidJoinConditions, joinConditions_.size());
+  VELOX_CHECK(
+      hasNonConstantCondition,
+      "At least one join condition must have a non-constant value");
 
-  VELOX_CHECK_EQ(
-      conditionIdx,
-      joinConditions_.size(),
-      "Not all join conditions were processed.");
+  // Build and cache the index bound row type.
+  indexBoundType_ =
+      ROW(std::move(indexColumnNames), std::move(indexColumnTypes));
 }
 
 std::unique_ptr<dwio::common::Reader> HiveIndexReader::createFileReader() {
@@ -336,7 +276,8 @@ std::unique_ptr<dwio::common::Reader> HiveIndexReader::createFileReader() {
   return reader;
 }
 
-std::unique_ptr<dwio::common::RowReader> HiveIndexReader::createRowReader() {
+std::unique_ptr<dwio::common::IndexReader>
+HiveIndexReader::createIndexReader() {
   VELOX_CHECK_NOT_NULL(fileReader_);
   VELOX_CHECK_EQ(
       hiveSplit_->fileFormat,
@@ -348,7 +289,7 @@ std::unique_ptr<dwio::common::RowReader> HiveIndexReader::createRowReader() {
       tableHandle_->tableParameters(),
       scanSpec_,
       /*metadataFilter=*/nullptr,
-      fileReader_->rowType(),
+      outputType_,
       hiveSplit_,
       hiveConfig_,
       connectorQueryCtx_->sessionProperties(),
@@ -358,181 +299,107 @@ std::unique_ptr<dwio::common::RowReader> HiveIndexReader::createRowReader() {
   // Disable eager first stripe load since HiveIndexReader loads stripes
   // on-demand based on index lookup results.
   rowReaderOpts.setEagerFirstStripeLoad(false);
-  return fileReader_->createRowReader(rowReaderOpts);
+  return fileReader_->createIndexReader(rowReaderOpts);
 }
 
-std::unique_ptr<HiveIndexReader::Result> HiveIndexReader::next(
-    vector_size_t maxOutputRows) {
-  VELOX_CHECK_NOT_NULL(request_, "No request set. Call setRequest first.");
-  VELOX_CHECK(hasNext(), "No more rows to process.");
+void HiveIndexReader::startLookup(const Request& request) {
+  VELOX_CHECK(
+      !indexReader_->hasNext(),
+      "Previous request not finished. Call next() first.");
+  VELOX_CHECK_NOT_NULL(request.input);
+  VELOX_CHECK(requestType_->equivalent(*request.input->type()));
 
-  SCOPE_EXIT {
-    if (requestRow_ == request_->size()) {
-      reset();
-    }
-  };
-
-  std::vector<RowVectorPtr> outputChunks;
-  std::vector<vector_size_t> inputIndices;
-  vector_size_t numOutputRows{0};
-  const vector_size_t numRequestRows = request_->size();
-  // Check the limit before starting a new input row, but once we start
-  // processing an input row, produce all its output rows.
-  for (; requestRow_ < numRequestRows && numOutputRows < maxOutputRows;
-       ++requestRow_) {
-    applyFiltersFromRequest(requestRow_);
-
-    // Read all matching rows for this input row regardless of the limit.
-    // We need a loop here because rowReader_->next() may return partial results
-    // when crossing stripe boundaries.
-    while (true) {
-      VectorPtr output;
-      const uint64_t numRows = readNext(output);
-      if (numRows == 0) {
-        break;
-      }
-      if (output->size() == 0) {
-        continue;
-      }
-
-      numOutputRows += output->size();
-      // Record the input row index for each output row.
-      for (uint64_t i = 0; i < output->size(); ++i) {
-        inputIndices.push_back(requestRow_);
-      }
-      // Load all lazy vectors because lazy loading doesn't work across batches.
-      output->loadedVector();
-      outputChunks.push_back(
-          std::dynamic_pointer_cast<RowVector>(std::move(output)));
-    }
-
-    clearKeyFilters();
-  }
-
-  if (numOutputRows == 0) {
-    return nullptr;
-  }
-
-  // Populate inputHits buffer.
-  auto inputHits = AlignedBuffer::allocate<vector_size_t>(numOutputRows, pool_);
-  auto* rawInputHits = inputHits->asMutable<vector_size_t>();
-  std::copy(inputIndices.begin(), inputIndices.end(), rawInputHits);
-
-  RowVectorPtr output;
-  if (outputChunks.size() == 1) {
-    output = std::move(outputChunks[0]);
-  } else {
-    output = BaseVector::create<RowVector>(outputType_, numOutputRows, pool_);
-    vector_size_t offset = 0;
-    for (const auto& chunk : outputChunks) {
-      output->copy(chunk.get(), offset, 0, chunk->size());
-      offset += chunk->size();
-    }
-  }
-  return std::make_unique<Result>(std::move(inputHits), std::move(output));
+  // Build index bounds from request and pass to the index reader.
+  auto indexBounds = buildRequestIndexBounds(request.input);
+  indexReader_->startLookup(indexBounds);
 }
 
-void HiveIndexReader::setRequest(const Request& request) {
-  VELOX_CHECK_NULL(request_, "Request already set. Call reset first.");
-  VELOX_CHECK_EQ(requestRow_, 0, "Request already set. Call reset first.");
-  request_ = request.input;
-  VELOX_CHECK_NOT_NULL(request_);
-  VELOX_CHECK(requestType_->equivalent(*request_->type()));
-  requestRow_ = 0;
+serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(
+    const RowVectorPtr& request) {
+  VELOX_CHECK_NOT_NULL(request);
+  VELOX_CHECK_NOT_NULL(indexBoundType_);
 
-  // Decode all input vectors used in join conditions.
-  // Skip decoding for constant bounds (indicated by kConstantChannel).
-  SelectivityVector allRows(request_->size());
-  for (size_t i = 0; i < joinConditions_.size(); ++i) {
-    const auto& indices = requestColumnIndices_[i];
-    for (size_t j = 0; j < indices.size(); ++j) {
-      if (indices[j] == kConstantChannel) {
-        // Constant bound, no need to decode.
-        continue;
-      }
-      decodedRequestVectors_[i][j].decode(
-          *request_->childAt(indices[j]), allRows);
-    }
-  }
-}
+  const auto numRows = request->size();
 
-bool HiveIndexReader::hasNext() const {
-  return request_ != nullptr && requestRow_ < request_->size();
-}
-
-void HiveIndexReader::reset() {
-  request_.reset();
-  requestRow_ = 0;
-}
-
-void HiveIndexReader::applyFiltersFromRequest(vector_size_t row) {
-  VELOX_CHECK_NOT_NULL(request_);
-  VELOX_CHECK_EQ(decodedRequestVectors_.size(), joinConditions_.size());
-  VELOX_CHECK_LT(row, request_->size());
+  // Resize and clear reusable column vectors.
+  lowerBoundColumns_.resize(joinConditions_.size());
+  upperBoundColumns_.resize(joinConditions_.size());
 
   for (size_t i = 0; i < joinConditions_.size(); ++i) {
-    auto* spec = joinIndexColumnSpecs_[i];
     const auto& condition = joinConditions_[i];
+    const auto& type = condition->key->type();
 
     if (auto equalCondition =
             std::dynamic_pointer_cast<core::EqualIndexLookupCondition>(
                 condition)) {
-      VELOX_CHECK_EQ(decodedRequestVectors_[i].size(), 1);
-      const auto& decoded = decodedRequestVectors_[i][0];
-      VELOX_CHECK(
-          !decoded.isNullAt(row), "Null value not allowed for equal condition");
-      const auto& type = requestType_->childAt(requestColumnIndices_[i][0]);
-      const auto value = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          extractValue, type->kind(), decoded, row);
-      spec->setFilter(createPointFilter(type, value));
+      // For equal condition, lower and upper bounds have the same value.
+      const auto colIdx = requestColumnIndices_[i][0];
+      if (colIdx == kConstantChannel) {
+        auto constVector = BaseVector::createConstant(
+            type, constantBoundValues_[i][0].value(), numRows, pool_);
+        lowerBoundColumns_[i] = constVector;
+        upperBoundColumns_[i] = constVector;
+      } else {
+        auto valueVector = request->childAt(colIdx);
+        lowerBoundColumns_[i] = valueVector;
+        upperBoundColumns_[i] = valueVector;
+      }
     } else if (
         auto betweenCondition =
             std::dynamic_pointer_cast<core::BetweenIndexLookupCondition>(
                 condition)) {
-      const auto& type = betweenCondition->key->type();
+      // Handle lower bound.
+      if (constantBoundValues_[i][0].has_value()) {
+        auto constVector = BaseVector::createConstant(
+            type, constantBoundValues_[i][0].value(), numRows, pool_);
+        lowerBoundColumns_[i] = constVector;
+      } else {
+        const auto colIdx = requestColumnIndices_[i][0];
+        lowerBoundColumns_[i] = request->childAt(colIdx);
+      }
 
-      const auto lower = extractBoundValue(
-          constantBoundValues_[i][0],
-          decodedRequestVectors_[i][0],
-          type,
-          row,
-          /*isLowerBound=*/true);
-      const auto upper = extractBoundValue(
-          constantBoundValues_[i][1],
-          decodedRequestVectors_[i][1],
-          type,
-          row,
-          /*isLowerBound=*/false);
-      spec->setFilter(createRangeFilter(type, lower, upper));
+      // Handle upper bound.
+      if (constantBoundValues_[i][1].has_value()) {
+        auto constVector = BaseVector::createConstant(
+            type, constantBoundValues_[i][1].value(), numRows, pool_);
+        upperBoundColumns_[i] = constVector;
+      } else {
+        const auto colIdx = requestColumnIndices_[i][1];
+        upperBoundColumns_[i] = request->childAt(colIdx);
+      }
     } else {
       VELOX_FAIL("Unsupported join condition type: {}", condition->toString());
     }
   }
-  scanSpec_->resetCachedValues(/*doReorder=*/false);
-  // Resets the row reader for the new index lookup. This resets internal
-  // state and re-applies index bounds based on the updated filters set above.
-  rowReader_->reset();
-}
 
-void HiveIndexReader::clearKeyFilters() {
-  for (auto* spec : joinIndexColumnSpecs_) {
-    spec->setFilter(nullptr);
+  // Build RowVectors for lower and upper bounds.
+  auto lowerBoundVector = std::make_shared<RowVector>(
+      pool_, indexBoundType_, nullptr, numRows, lowerBoundColumns_);
+  auto upperBoundVector = std::make_shared<RowVector>(
+      pool_, indexBoundType_, nullptr, numRows, upperBoundColumns_);
+
+  // Collect column names for indexBounds.
+  std::vector<std::string> indexColumnNames;
+  indexColumnNames.reserve(joinConditions_.size());
+  for (const auto& col : indexBoundType_->names()) {
+    indexColumnNames.push_back(col);
   }
+
+  serializer::IndexBounds bounds;
+  bounds.indexColumns = std::move(indexColumnNames);
+  bounds.set(
+      serializer::IndexBound{std::move(lowerBoundVector), /*inclusive=*/true},
+      serializer::IndexBound{std::move(upperBoundVector), /*inclusive=*/true});
+  return bounds;
 }
 
-uint64_t HiveIndexReader::readNext(VectorPtr& output) {
-  VELOX_CHECK_NOT_NULL(rowReader_);
-  // Pre-allocate output vector with correct schema to ensure the reader
-  // returns results with expected schema even when no rows match.
-  if (output == nullptr) {
-    output = BaseVector::create(outputType_, 0, pool_);
-  }
-  return rowReader_->next(1024, output);
+bool HiveIndexReader::hasNext() const {
+  return indexReader_->hasNext();
 }
 
-void HiveIndexReader::resetFilterCaches() {
-  VELOX_CHECK_NOT_NULL(rowReader_);
-  rowReader_->resetFilterCaches();
+std::unique_ptr<HiveIndexReader::Result> HiveIndexReader::next(
+    vector_size_t maxOutputRows) {
+  return indexReader_->next(maxOutputRows);
 }
 
 std::string HiveIndexReader::toString() const {

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -99,8 +99,7 @@ class HiveIndexSource : public IndexSource,
   // Validates and initializes join conditions:
   // - Converts filter conditions (with constant values) to filters_.
   // - Non-filter conditions are stored in joinConditions_.
-  // Returns a list of index column names used by joinConditions_.
-  std::vector<std::string> initJoinConditions(
+  void initJoinConditions(
       const std::vector<core::IndexLookupConditionPtr>& joinConditions,
       const ColumnHandleMap& assignments);
 

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -383,3 +383,20 @@ These stats are reported only by connector data or index sources.
      - The number of times a stripe has been loaded during index lookup. This
        metric helps track the I/O efficiency of index-based reads, where lower
        values indicate better stripe reuse across lookups.
+   * - numIndexLookupRequests
+     -
+     - The number of index lookup requests submitted in startLookup(). Each
+       request corresponds to one set of index bounds and may match rows across
+       multiple stripes.
+   * - numIndexLookupStripes
+     -
+     - The total number of stripes that need to be read for all index lookup
+       requests. Multiple requests may share the same stripe, and each shared
+       stripe is counted once per request that needs it.
+   * - numIndexLookupReadSegments
+     -
+     - The total number of read segments across all stripes during index lookup.
+       A read segment is a contiguous row range within a stripe that needs to be
+       read. When filters are present, overlapping request ranges are split at
+       boundaries to enable per-request output tracking. Without filters,
+       overlapping ranges are merged to minimize I/O.

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -21,6 +21,7 @@
 #include <optional>
 #include <string>
 
+#include "velox/connectors/Connector.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/common/Options.h"
@@ -150,25 +151,6 @@ class RowReader {
     return std::nullopt;
   }
 
-  /// Resets the row reader for a new query. This allows reusing the same
-  /// reader instance for different queries on the same data split.
-  ///
-  /// This is primarily used for index reader use cases where the same row
-  /// reader needs to be reused for multiple index lookups with different
-  /// index bounds/filters on the same data split.
-  ///
-  /// After reset:
-  /// - The split boundaries remain the same (data range doesn't change)
-  /// - The actual read range may change based on new index bounds from the
-  ///   scan spec
-  /// - All internal state (row positions, statistics, etc.) is reset
-  /// - Index bounds are re-evaluated based on the current scan spec
-  ///
-  /// @throws if reset is not supported by the implementation
-  virtual void reset() {
-    VELOX_UNSUPPORTED("RowReader::reset() is not supported");
-  }
-
   /**
    * Helper function used by non-selective reader to project top level columns
    * according to the scan spec and mutations.
@@ -205,72 +187,76 @@ struct RowRange {
 /**
  * Abstract index reader interface for index-based lookups.
  *
- * IndexReader provides methods for encoding index bounds, looking up stripes,
- * and reading data within specific row ranges. This interface is used by
+ * IndexReader provides a batch lookup API that takes a vector of index bounds
+ * and returns results via an iterator pattern. This interface is used by
  * HiveIndexReader to perform efficient key-based lookups on indexed files.
+ *
+ * Usage pattern:
+ *   1. Call startLookup() with a vector of index bounds to start a new batch
+ * lookup
+ *   2. Call next() repeatedly to get results until it returns nullptr
+ *   3. Each next() call returns results for one or more request indices
+ *
+ * The implementation is responsible for:
+ *   - Encoding index bounds into format-specific keys
+ *   - Looking up stripes and row ranges
+ *   - Managing stripe iteration and data reading
+ *   - Returning results in the correct order
  */
 class IndexReader {
  public:
+  /// Runtime stat names for index reader.
+
+  /// Tracks the number of index lookup requests submitted in startLookup().
+  /// Each request corresponds to one set of index bounds and may match rows
+  /// across multiple stripes.
+  static inline const std::string kNumIndexLookupRequests =
+      "numIndexLookupRequests";
+
+  /// Tracks the total number of stripes that need to be read for all requests.
+  /// Multiple requests may share the same stripe, and each shared stripe is
+  /// counted once per request that needs it.
+  static inline const std::string kNumIndexLookupStripes =
+      "numIndexLookupStripes";
+
+  /// Tracks the total number of read segments across all stripes. A read
+  /// segment is a contiguous row range within a stripe that needs to be read.
+  /// When filters are present, overlapping request ranges are split at
+  /// boundaries to enable per-request output tracking. Without filters,
+  /// overlapping ranges are merged to minimize I/O.
+  static inline const std::string kNumIndexLookupReadSegments =
+      "numIndexLookupReadSegments";
+
   virtual ~IndexReader() = default;
 
-  using KeyBoundsVector = std::vector<velox::serializer::EncodedKeyBounds>;
-
-  /// Encodes index bounds into format-specific encoded key bounds.
-  /// Different file formats may use different key encoding schemes, so this
-  /// allows the format-specific reader to handle the encoding.
+  /// Starts a new batch lookup with the given index bounds.
+  /// Each index bound in the vector represents a separate lookup request.
+  /// After calling startLookup(), call next() repeatedly to get results.
   ///
-  /// @param indexBounds The index bounds to encode, containing column names
-  ///        and lower/upper bound values.
-  /// @return A vector of encoded key bounds, one for each row in the input
-  ///         bounds.
-  /// @throws if encoding is not supported by the implementation or if any
-  ///         index bound fails to encode.
-  virtual KeyBoundsVector encodeIndexBounds(
+  /// @param indexBounds Index bounds for the lookup request. Contains
+  ///        column names and lower/upper bound values.
+  /// @throws if lookup is not supported by the implementation or if any
+  ///         index bound is invalid.
+  virtual void startLookup(
       const velox::serializer::IndexBounds& indexBounds) = 0;
 
-  /// Looks up stripes that contain data matching the encoded key bounds.
-  /// For each request row, returns the list of stripe indices that may contain
-  /// matching data based on the encoded lower and upper key bounds.
-  ///
-  /// @param keyBounds The encoded key bounds for each request row.
-  /// @return Stripe indices for each request row. Each inner vector contains
-  ///         the indices of stripes that may contain matching data for that
-  ///         request.
-  /// @throws if lookup is not supported by the implementation.
-  virtual std::vector<std::vector<uint32_t>> lookupStripes(
-      const KeyBoundsVector& keyBounds) = 0;
+  /// Returns true if there are more results to fetch from the current lookup.
+  virtual bool hasNext() const = 0;
 
-  /// Looks up row ranges within a specific stripe based on encoded key bounds.
-  /// Computes row ranges per request without setting up state for iteration.
+  /// Returns the next batch of results from the current lookup.
+  /// Results are returned in request order - all results for request N are
+  /// returned before any results for request N+1.
   ///
-  /// @param stripeIndex The index of the stripe to compute row ranges for.
-  /// @param keyBounds The encoded key bounds for each request.
-  /// @return Row ranges for each request, one per input encoded key bounds.
-  ///         Empty ranges (startRow >= endRow) are included for requests with
-  ///         no matching data.
-  /// @throws if lookup is not supported by the implementation.
-  virtual std::vector<RowRange> lookupRowRanges(
-      uint32_t stripeIndex,
-      const KeyBoundsVector& keyBounds) = 0;
-
-  /// Sets row ranges for reading from a specific stripe. Must be called before
-  /// next() to set up the iteration state.
+  /// The Result contains:
+  /// - inputHits: Buffer of request indices for each output row
+  /// - output: RowVector of matching data rows
   ///
-  /// @param stripeIndex The index of the stripe to read from.
-  /// @param rowRanges The row ranges to read within the stripe.
-  /// @throws if setting row ranges is not supported by the implementation.
-  virtual void setRowRanges(
-      uint32_t stripeIndex,
-      const std::vector<RowRange>& rowRanges) = 0;
-
-  /**
-   * Fetch the next portion of rows.
-   * @param size Max number of rows to read
-   * @param result output vector
-   * @return number of rows scanned in the file (including any rows filtered
-   * out), 0 if there are no more rows to read.
-   */
-  virtual uint64_t next(uint64_t size, velox::VectorPtr& result) = 0;
+  /// @param maxOutputRows Maximum number of output rows to return in this
+  ///        batch. The actual number may be less if fewer rows are available.
+  /// @return Result containing inputHits and output rows, or nullptr if no
+  ///         more results are available.
+  virtual std::unique_ptr<connector::IndexSource::Result> next(
+      vector_size_t maxOutputRows) = 0;
 };
 
 /**

--- a/velox/serializers/tests/KeyEncoderTest.cpp
+++ b/velox/serializers/tests/KeyEncoderTest.cpp
@@ -529,6 +529,13 @@ TEST_F(KeyEncoderTest, indexBounds) {
   multiRowBothBounds.lowerBound = IndexBound{multipleRows, true};
   multiRowBothBounds.upperBound = IndexBound{multipleRows, false};
   EXPECT_EQ(multiRowBothBounds.numRows(), 3);
+
+  // Test invalid bounds with empty bound.
+  const auto emptyRows = makeRowVector({makeFlatVector<int32_t>({})});
+  IndexBounds emptyLowerBounds;
+  emptyLowerBounds.indexColumns = {"c0"};
+  emptyLowerBounds.lowerBound = IndexBound{emptyRows, true};
+  EXPECT_FALSE(emptyLowerBounds.validate());
 }
 
 TEST_F(KeyEncoderTest, indexBoundsType) {
@@ -11026,7 +11033,7 @@ TEST_F(KeyEncoderTest, encodeIndexBoundsMultipleRows) {
         "Failed to bump up lower bound");
   }
 
-  // Test Case 3: Multiple rows - one upper bound fails (upper key becomes
+  // Test Case 3: Multiple rows - one upper bound fails (only that row gets
   // nullopt)
   {
     IndexBounds indexBounds;
@@ -11050,7 +11057,7 @@ TEST_F(KeyEncoderTest, encodeIndexBoundsMultipleRows) {
 
     const auto encodedBounds = keyEncoder->encodeIndexBounds(indexBounds);
 
-    // Should succeed but all upper keys become nullopt when any fails
+    // Should succeed with 3 results
     ASSERT_EQ(encodedBounds.size(), 3);
 
     // All rows should have lower keys
@@ -11059,11 +11066,862 @@ TEST_F(KeyEncoderTest, encodeIndexBoundsMultipleRows) {
           << "Row " << i << " should have lowerKey";
     }
 
-    // All upper keys should be nullopt (unbounded) because bump up failed
+    // Only row 1 (max value) should have nullopt upper key
+    EXPECT_TRUE(encodedBounds[0].upperKey.has_value())
+        << "Row 0 should have upperKey";
+    EXPECT_FALSE(encodedBounds[1].upperKey.has_value())
+        << "Row 1 should not have upperKey (unbounded due to overflow)";
+    EXPECT_TRUE(encodedBounds[2].upperKey.has_value())
+        << "Row 2 should have upperKey";
+  }
+
+  // Test Case 4: Multiple rows - multiple upper bounds fail (mixed success)
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    indexBounds.lowerBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>({1, 10, 100, 1000})}),
+        .inclusive = true};
+    // Rows 0 and 2 have max value with inclusive bound - should fail to bump up
+    indexBounds.upperBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>(
+            {std::numeric_limits<int64_t>::max(),
+             50,
+             std::numeric_limits<int64_t>::max(),
+             5000})}),
+        .inclusive = true};
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    const auto encodedBounds = keyEncoder->encodeIndexBounds(indexBounds);
+
+    // Should succeed with 4 results
+    ASSERT_EQ(encodedBounds.size(), 4);
+
+    // All rows should have lower keys
+    for (size_t i = 0; i < 4; ++i) {
+      EXPECT_TRUE(encodedBounds[i].lowerKey.has_value())
+          << "Row " << i << " should have lowerKey";
+    }
+
+    // Rows 0 and 2 (max values) should have nullopt upper key
+    // Rows 1 and 3 should have upper key
+    EXPECT_FALSE(encodedBounds[0].upperKey.has_value())
+        << "Row 0 should not have upperKey (unbounded due to overflow)";
+    EXPECT_TRUE(encodedBounds[1].upperKey.has_value())
+        << "Row 1 should have upperKey";
+    EXPECT_FALSE(encodedBounds[2].upperKey.has_value())
+        << "Row 2 should not have upperKey (unbounded due to overflow)";
+    EXPECT_TRUE(encodedBounds[3].upperKey.has_value())
+        << "Row 3 should have upperKey";
+  }
+
+  // Test Case 5: Multiple rows - some upper bounds fail to bump (exclusive at
+  // max value) - treat as no bound
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    indexBounds.lowerBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>({1, 10, 100, 1000})}),
+        .inclusive = true};
+    // Rows 0 and 2 have max value with exclusive bound - should fail to bump up
+    // and be treated as no upper bound
+    indexBounds.upperBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>(
+            {std::numeric_limits<int64_t>::max(),
+             50,
+             std::numeric_limits<int64_t>::max(),
+             5000})}),
+        .inclusive = true};
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    const auto encodedBounds = keyEncoder->encodeIndexBounds(indexBounds);
+
+    // Should succeed with 4 results
+    ASSERT_EQ(encodedBounds.size(), 4);
+
+    // All rows should have lower keys
+    for (size_t i = 0; i < 4; ++i) {
+      EXPECT_TRUE(encodedBounds[i].lowerKey.has_value())
+          << "Row " << i << " should have lowerKey";
+    }
+
+    // Rows 0 and 2 (max values with exclusive bound) should have nullopt upper
+    // key Rows 1 and 3 should have upper key
+    EXPECT_FALSE(encodedBounds[0].upperKey.has_value())
+        << "Row 0 should not have upperKey (unbounded due to overflow)";
+    EXPECT_TRUE(encodedBounds[1].upperKey.has_value())
+        << "Row 1 should have upperKey";
+    EXPECT_FALSE(encodedBounds[2].upperKey.has_value())
+        << "Row 2 should not have upperKey (unbounded due to overflow)";
+    EXPECT_TRUE(encodedBounds[3].upperKey.has_value())
+        << "Row 3 should have upperKey";
+  }
+
+  // Test Case 6: Multiple rows - multiple lower bounds fail (should throw)
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    // Rows 0 and 2 have max value with exclusive bound - should fail to bump up
+    indexBounds.lowerBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>(
+            {std::numeric_limits<int64_t>::max(),
+             10,
+             std::numeric_limits<int64_t>::max(),
+             1000})}),
+        .inclusive = false};
+    indexBounds.upperBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>({5, 50, 500, 5000})}),
+        .inclusive = true};
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    // Should throw because some lower bounds fail to bump up
+    VELOX_ASSERT_THROW(
+        keyEncoder->encodeIndexBounds(indexBounds),
+        "Failed to bump up lower bound");
+  }
+
+  // Test Case 7: Multiple rows - all upper bounds fail (all rows get nullopt
+  // upper key)
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    indexBounds.lowerBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>({1, 10, 100})}),
+        .inclusive = true};
+    // All rows have max value with inclusive bound - all should fail to bump up
+    indexBounds.upperBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>(
+            {std::numeric_limits<int64_t>::max(),
+             std::numeric_limits<int64_t>::max(),
+             std::numeric_limits<int64_t>::max()})}),
+        .inclusive = true};
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    const auto encodedBounds = keyEncoder->encodeIndexBounds(indexBounds);
+
+    // Should succeed with 3 results
+    ASSERT_EQ(encodedBounds.size(), 3);
+
+    // All rows should have lower keys
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_TRUE(encodedBounds[i].lowerKey.has_value())
+          << "Row " << i << " should have lowerKey";
+    }
+
+    // All rows should have nullopt upper key (all overflowed)
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_FALSE(encodedBounds[i].upperKey.has_value())
+          << "Row " << i
+          << " should not have upperKey (unbounded due to overflow)";
+    }
+  }
+
+  // Test Case 8: Multiple rows - all rows fail for both lower and upper bounds
+  // Lower bound failure takes precedence and throws
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    // All rows have max value with exclusive bound - all should fail to bump up
+    indexBounds.lowerBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>(
+            {std::numeric_limits<int64_t>::max(),
+             std::numeric_limits<int64_t>::max(),
+             std::numeric_limits<int64_t>::max()})}),
+        .inclusive = false};
+    // All rows also have max value with inclusive bound
+    indexBounds.upperBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>(
+            {std::numeric_limits<int64_t>::max(),
+             std::numeric_limits<int64_t>::max(),
+             std::numeric_limits<int64_t>::max()})}),
+        .inclusive = true};
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    // Should throw because all lower bounds fail to bump up
+    VELOX_ASSERT_THROW(
+        keyEncoder->encodeIndexBounds(indexBounds),
+        "Failed to bump up lower bound");
+  }
+
+  // Test Case 9: Multiple rows - lower bound is not specified at all
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    indexBounds.lowerBound = std::nullopt;
+    indexBounds.upperBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>({5, 50, 500})}),
+        .inclusive = true};
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    const auto encodedBounds = keyEncoder->encodeIndexBounds(indexBounds);
+
+    // Should succeed with 3 results
+    ASSERT_EQ(encodedBounds.size(), 3);
+
+    // All rows should NOT have lower keys (unbounded)
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_FALSE(encodedBounds[i].lowerKey.has_value())
+          << "Row " << i << " should not have lowerKey (unbounded)";
+    }
+
+    // All rows should have upper keys
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_TRUE(encodedBounds[i].upperKey.has_value())
+          << "Row " << i << " should have upperKey";
+    }
+  }
+
+  // Test Case 10: Multiple rows - upper bound is not specified at all
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    indexBounds.lowerBound = IndexBound{
+        .bound = makeRowVector({makeFlatVector<int64_t>({1, 10, 100})}),
+        .inclusive = true};
+    indexBounds.upperBound = std::nullopt;
+
+    ASSERT_TRUE(indexBounds.validate());
+
+    const auto inputType = asRowType(indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        indexBounds.indexColumns.size(), velox::core::kAscNullsFirst);
+    auto keyEncoder = KeyEncoder::create(
+        indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    const auto encodedBounds = keyEncoder->encodeIndexBounds(indexBounds);
+
+    // Should succeed with 3 results
+    ASSERT_EQ(encodedBounds.size(), 3);
+
+    // All rows should have lower keys
+    for (size_t i = 0; i < 3; ++i) {
+      EXPECT_TRUE(encodedBounds[i].lowerKey.has_value())
+          << "Row " << i << " should have lowerKey";
+    }
+
+    // All rows should NOT have upper keys (unbounded)
     for (size_t i = 0; i < 3; ++i) {
       EXPECT_FALSE(encodedBounds[i].upperKey.has_value())
           << "Row " << i << " should not have upperKey (unbounded)";
     }
+  }
+
+  // Test Case 11: Multiple rows - both bounds are not specified at all
+  {
+    IndexBounds indexBounds;
+    indexBounds.indexColumns = {"c0"};
+    indexBounds.lowerBound = std::nullopt;
+    indexBounds.upperBound = std::nullopt;
+
+    ASSERT_FALSE(indexBounds.validate());
+  }
+}
+
+// Tests for non-flat encoding types (ConstantVector, DictionaryVector) in index
+// bounds across different data types.
+TEST_F(KeyEncoderTest, encodeIndexBoundsWithNonFlatEncoding) {
+  // Test case struct for non-flat encoding tests
+  struct NonFlatEncodingTestCase {
+    std::string name;
+    IndexBounds indexBounds;
+    velox::core::SortOrder sortOrder;
+    bool expectThrow{false};
+    std::string expectedErrorMsg;
+    // Expected results (only used when expectThrow is false)
+    size_t expectedNumResults{1};
+    std::optional<RowVectorPtr> expectedLowerBound;
+    std::optional<RowVectorPtr> expectedUpperBound;
+
+    std::string debugString() const {
+      return fmt::format(
+          "name={}, sortOrder={} {}",
+          name,
+          sortOrder.isAscending() ? "ASC" : "DESC",
+          sortOrder.isNullsFirst() ? "NULLS_FIRST" : "NULLS_LAST");
+    }
+  };
+
+  auto runTestCase = [this](const NonFlatEncodingTestCase& testCase) {
+    SCOPED_TRACE(testCase.debugString());
+
+    ASSERT_TRUE(testCase.indexBounds.validate());
+
+    const auto inputType = asRowType(testCase.indexBounds.type());
+    const std::vector<velox::core::SortOrder> sortOrders(
+        testCase.indexBounds.indexColumns.size(), testCase.sortOrder);
+    auto keyEncoder = KeyEncoder::create(
+        testCase.indexBounds.indexColumns, inputType, sortOrders, pool_.get());
+
+    if (testCase.expectThrow) {
+      VELOX_ASSERT_THROW(
+          keyEncoder->encodeIndexBounds(testCase.indexBounds),
+          testCase.expectedErrorMsg);
+      return;
+    }
+
+    const auto encodedBounds =
+        keyEncoder->encodeIndexBounds(testCase.indexBounds);
+    ASSERT_EQ(encodedBounds.size(), testCase.expectedNumResults);
+
+    for (size_t i = 0; i < testCase.expectedNumResults; ++i) {
+      EXPECT_EQ(
+          encodedBounds[i].lowerKey.has_value(),
+          testCase.expectedLowerBound.has_value())
+          << "Row " << i;
+      EXPECT_EQ(
+          encodedBounds[i].upperKey.has_value(),
+          testCase.expectedUpperBound.has_value())
+          << "Row " << i;
+    }
+
+    // Verify encoded keys match expected values
+    if (testCase.expectedLowerBound.has_value()) {
+      std::vector<char> expectedBuffer;
+      std::vector<std::string_view> expectedKeys;
+      keyEncoder->encode(
+          testCase.expectedLowerBound.value(),
+          expectedKeys,
+          [&expectedBuffer](size_t size) -> void* {
+            expectedBuffer.resize(size);
+            return expectedBuffer.data();
+          });
+      EXPECT_EQ(
+          encodedBounds[0].lowerKey.value(), std::string(expectedKeys[0]));
+    }
+
+    if (testCase.expectedUpperBound.has_value()) {
+      std::vector<char> expectedBuffer;
+      std::vector<std::string_view> expectedKeys;
+      keyEncoder->encode(
+          testCase.expectedUpperBound.value(),
+          expectedKeys,
+          [&expectedBuffer](size_t size) -> void* {
+            expectedBuffer.resize(size);
+            return expectedBuffer.data();
+          });
+      EXPECT_EQ(
+          encodedBounds[0].upperKey.value(), std::string(expectedKeys[0]));
+    }
+  };
+
+  // Helper to create IndexBounds
+  auto makeIndexBounds = [](const std::vector<std::string>& columns,
+                            std::optional<IndexBound> lower,
+                            std::optional<IndexBound> upper) {
+    IndexBounds bounds;
+    bounds.indexColumns = columns;
+    bounds.lowerBound = std::move(lower);
+    bounds.upperBound = std::move(upper);
+    return bounds;
+  };
+
+  // ==========================================================================
+  // Test BIGINT type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("BIGINT");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    // Test Case 1: ConstantVector for both bounds (inclusive)
+    testCases.push_back({
+        .name = "ConstantVector both bounds inclusive",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int64_t>(10, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int64_t>(100, 1)}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int64_t>({10})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int64_t>({101})}),
+    });
+
+    // Test Case 2: DictionaryVector for both bounds
+    auto baseBigint = makeFlatVector<int64_t>({50, 100, 120});
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseBigint)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseBigint)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int64_t>({100})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int64_t>({120})}),
+    });
+
+    // Test Case 3: Multiple rows with ConstantVector
+    testCases.push_back({
+        .name = "Multiple rows with ConstantVector",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int64_t>(42, 3)}),
+                .inclusive = false},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int64_t>(100, 3)}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedNumResults = 3,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int64_t>({43})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int64_t>({101})}),
+    });
+
+    // Test Case 4: Mixed encoding - ConstantVector lower, FlatVector upper
+    testCases.push_back({
+        .name = "Mixed: ConstantVector lower, FlatVector upper",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int64_t>(5, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeFlatVector<int64_t>({50})}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int64_t>({5})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int64_t>({51})}),
+    });
+
+    // Test Case 5: Null ConstantVector with exclusive lower bound (should
+    // throw)
+    testCases.push_back({
+        .name = "Null ConstantVector lower bound exclusive - throws",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector(
+                    {makeConstant<int64_t>(std::nullopt, 1, BIGINT())}),
+                .inclusive = false},
+            IndexBound{
+                .bound = makeRowVector({makeFlatVector<int64_t>({100})}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsLast,
+        .expectThrow = true,
+        .expectedErrorMsg = "Failed to bump up lower bound",
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test INTEGER type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("INTEGER");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector both bounds inclusive",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int32_t>(10, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int32_t>(100, 1)}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int32_t>({10})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int32_t>({101})}),
+    });
+
+    auto baseInt = makeFlatVector<int32_t>({50, 100, 120});
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseInt)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseInt)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int32_t>({100})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int32_t>({120})}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test SMALLINT type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("SMALLINT");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector both bounds inclusive",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int16_t>(10, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int16_t>(100, 1)}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int16_t>({10})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int16_t>({101})}),
+    });
+
+    auto baseSmallint = makeFlatVector<int16_t>({50, 100, 120});
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseSmallint)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseSmallint)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int16_t>({100})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int16_t>({120})}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test TINYINT type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("TINYINT");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector both bounds inclusive",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int8_t>(10, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<int8_t>(100, 1)}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int8_t>({10})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int8_t>({101})}),
+    });
+
+    auto baseTinyint = makeFlatVector<int8_t>({50, 100, 120});
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseTinyint)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseTinyint)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<int8_t>({100})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<int8_t>({120})}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test DOUBLE type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("DOUBLE");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector both bounds inclusive",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<double>(10.0, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<double>(100.0, 1)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<double>({10.0})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<double>({100.0})}),
+    });
+
+    auto baseDouble = makeFlatVector<double>({50.0, 100.0, 120.0});
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseDouble)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseDouble)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<double>({100.0})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<double>({120.0})}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test REAL type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("REAL");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector both bounds inclusive",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<float>(10.0f, 1)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<float>(100.0f, 1)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<float>({10.0f})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<float>({100.0f})}),
+    });
+
+    auto baseFloat = makeFlatVector<float>({50.0f, 100.0f, 120.0f});
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseFloat)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseFloat)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector({makeFlatVector<float>({100.0f})}),
+        .expectedUpperBound = makeRowVector({makeFlatVector<float>({120.0f})}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test VARCHAR type with non-flat encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("VARCHAR");
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<StringView>(
+                    StringView("apple"), 1, VARCHAR())}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({makeConstant<StringView>(
+                    StringView("orange"), 1, VARCHAR())}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector(
+            {makeFlatVector<StringView>({StringView("apple")}, VARCHAR())}),
+        .expectedUpperBound = makeRowVector(
+            {makeFlatVector<StringView>({StringView("orange")}, VARCHAR())}),
+    });
+
+    auto baseVarchar = makeFlatVector<StringView>(
+        {StringView("apple"), StringView("banana"), StringView("cherry")},
+        VARCHAR());
+    testCases.push_back({
+        .name = "DictionaryVector both bounds",
+        .indexBounds = makeIndexBounds(
+            {"c0"},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({1}), 1, baseVarchar)}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector({BaseVector::wrapInDictionary(
+                    nullptr, makeIndices({2}), 1, baseVarchar)}),
+                .inclusive = false}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector(
+            {makeFlatVector<StringView>({StringView("banana")}, VARCHAR())}),
+        .expectedUpperBound = makeRowVector(
+            {makeFlatVector<StringView>({StringView("cherry")}, VARCHAR())}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+
+  // ==========================================================================
+  // Test multi-column with mixed encodings
+  // ==========================================================================
+  {
+    SCOPED_TRACE("Multi-column mixed encodings");
+
+    auto baseC0 = makeFlatVector<int64_t>({20, 30, 40});
+
+    std::vector<NonFlatEncodingTestCase> testCases;
+
+    testCases.push_back({
+        .name = "ConstantVector + FlatVector lower, DictionaryVector + "
+                "ConstantVector upper",
+        .indexBounds = makeIndexBounds(
+            {"c0", "c1"},
+            IndexBound{
+                .bound = makeRowVector(
+                    {makeConstant<int64_t>(10, 1),
+                     makeFlatVector<int64_t>({100})}),
+                .inclusive = true},
+            IndexBound{
+                .bound = makeRowVector(
+                    {BaseVector::wrapInDictionary(
+                         nullptr, makeIndices({1}), 1, baseC0),
+                     makeConstant<int64_t>(200, 1)}),
+                .inclusive = true}),
+        .sortOrder = velox::core::kAscNullsFirst,
+        .expectedLowerBound = makeRowVector(
+            {makeFlatVector<int64_t>({10}), makeFlatVector<int64_t>({100})}),
+        .expectedUpperBound = makeRowVector(
+            {makeFlatVector<int64_t>({30}), makeFlatVector<int64_t>({201})}),
+    });
+
+    for (const auto& testCase : testCases) {
+      runTestCase(testCase);
+    }
+  }
+}
+TEST_F(KeyEncoderTest, encodedKeyBoundsToString) {
+  // Test case 1: Both bounds populated
+  {
+    EncodedKeyBounds bounds;
+    bounds.lowerKey = std::string("\x01\x02\x03", 3);
+    bounds.upperKey = std::string("\xAB\xCD\xEF", 3);
+    const auto str = bounds.toString();
+    EXPECT_EQ(str, "EncodedKeyBounds{lowerKey=010203, upperKey=abcdef}");
+  }
+
+  // Test case 2: Lower bound only (upper is unbounded)
+  {
+    EncodedKeyBounds bounds;
+    bounds.lowerKey = std::string("\x00\xFF", 2);
+    bounds.upperKey = std::nullopt;
+    const auto str = bounds.toString();
+    EXPECT_EQ(str, "EncodedKeyBounds{lowerKey=00ff, upperKey=unbounded}");
+  }
+
+  // Test case 3: Upper bound only (lower is unbounded)
+  {
+    EncodedKeyBounds bounds;
+    bounds.lowerKey = std::nullopt;
+    bounds.upperKey = std::string("\xDE\xAD\xBE\xEF", 4);
+    const auto str = bounds.toString();
+    EXPECT_EQ(str, "EncodedKeyBounds{lowerKey=unbounded, upperKey=deadbeef}");
+  }
+
+  // Test case 4: Both unbounded
+  {
+    EncodedKeyBounds bounds;
+    bounds.lowerKey = std::nullopt;
+    bounds.upperKey = std::nullopt;
+    const auto str = bounds.toString();
+    EXPECT_EQ(str, "EncodedKeyBounds{lowerKey=unbounded, upperKey=unbounded}");
+  }
+
+  // Test case 5: Empty strings
+  {
+    EncodedKeyBounds bounds;
+    bounds.lowerKey = "";
+    bounds.upperKey = "";
+    const auto str = bounds.toString();
+    EXPECT_EQ(str, "EncodedKeyBounds{lowerKey=, upperKey=}");
   }
 }
 } // namespace facebook::velox::serializer::test


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/480

This diff implements stripe-level batched index read support for Nimble files in Velox. The key motivation is to improve index lookup performance by processing multiple lookup requests in batches at the stripe level, rather than processing each request individually.

**New `SelectiveNimbleIndexReader` class**: A new format-specific index reader that handles:
   - Encoding index bounds into Nimble-specific encoded keys
   - Looking up stripes and row ranges using the tablet index
   - Managing stripe iteration and data reading with batched processing
   - Returning results in request order via an iterator pattern (`startLookup`/`hasNext`/`next`)

**Batched stripe processing**: Instead of loading stripes per-request, the reader:
   - Maps all lookup requests to their matching stripes upfront
   - Merges overlapping row ranges within stripes for efficient reading
   - Tracks output references with ref-counting to share read data across requests

**Optimized row range handling**:
   - Without filters: Merges overlapping row ranges and each request extracts its portion
   - With filters: Splits overlapping ranges into non-overlapping segments to preserve filter semantics

**HiveIndexReader refactoring**: Simplified to focus on index bounds creation and result assembly, delegating control logic to format-specific readers.

**KeyEncoder enhancements**: Added support for encoding index bounds with constant values for more efficient range queries.

**New runtime stats**: Added metrics for tracking index lookup performance:
   - `kNumIndexLookupRequests`: Total lookup requests
   - `kNumIndexLookupStripes`: Number of stripes accessed
   - `kNumIndexLookupReadSegments`: Number of read segments processed

Differential Revision: D92848948


