### PR TITLE
fix: Iceberg commit message when writer rotated

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -426,6 +426,8 @@ struct HiveFileInfo {
   std::string targetFileName;
   /// Size of the file in bytes.
   uint64_t fileSize{0};
+  /// Number of rows in the file.
+  uint64_t numRows{0};
 };
 
 struct HiveWriterInfo {
@@ -449,8 +451,11 @@ struct HiveWriterInfo {
   const std::shared_ptr<memory::MemoryPool> writerPool;
   const std::shared_ptr<memory::MemoryPool> sinkPool;
   const std::shared_ptr<memory::MemoryPool> sortPool;
-  int64_t numWrittenRows = 0;
-  int64_t inputSizeInBytes = 0;
+  /// Total rows written by this writer across all files.
+  uint64_t numWrittenRows = 0;
+  /// Rows written to the current file; reset to 0 when the file is finalized.
+  uint64_t currentFileWrittenRows{0};
+  uint64_t inputSizeInBytes = 0;
   /// File sequence number for tracking multiple files written due to size-based
   /// splitting. Incremented each time the writer rotates to a new file.
   /// Used to generate sequenced file names (e.g., file_1.orc, file_2.orc).

--- a/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
@@ -280,6 +280,7 @@ class TransformE2ETest : public test::IcebergTestBase {
     const auto dataSink = createDataSinkAndAppendData(
         {rowVector}, outputDirectory->getPath(), partitionTransforms);
 
+    dataSink->close();
     auto commitMessages = dataSink->commitMessage();
     VELOX_CHECK_EQ(commitMessages.size(), 1);
     auto commitData = folly::parseJson(commitMessages[0]);
@@ -287,7 +288,6 @@ class TransformE2ETest : public test::IcebergTestBase {
         folly::parseJson(commitData["partitionDataJson"].asString());
     auto partitionValues = partitionDataJson["partitionValues"];
     VELOX_CHECK_EQ(partitionValues.size(), 1);
-    dataSink->close();
     return partitionValues[0];
   }
 };


### PR DESCRIPTION
Fixes commit message correctness for multi-file writes by updating Iceberg writer rotation handling and tracking per-file row counts and emitting one commit task per rotated file.
Fix parquet writer does not honor smaller values of `max-target-file-size` config.

These are the adjustments required after #16077.