### PR TITLE
refactor(geo): Use envelope checks to skip deserialization

### DIFF
--- a/velox/functions/prestosql/GeometryFunctions.h
+++ b/velox/functions/prestosql/GeometryFunctions.h
@@ -18,6 +18,7 @@
 
 #include <geos/geom/Coordinate.h>
 #include <geos/geom/CoordinateArraySequence.h>
+#include <geos/geom/CoordinateSequenceFactory.h>
 #include <geos/geom/Envelope.h>
 #include <geos/io/GeoJSON.h>
 #include <geos/io/GeoJSONReader.h>
@@ -230,11 +231,18 @@ struct StContainsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->contains(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->contains(&*rightGeosGeometry);
         , "Failed to check geometry contains");
@@ -251,11 +259,18 @@ struct StCrossesFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->crosses(&*rightGeosGeometry);
         , "Failed to check geometry crosses");
@@ -272,11 +287,18 @@ struct StDisjointFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = true;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->disjoint(&*rightGeosGeometry);
         , "Failed to check geometry disjoint");
@@ -293,11 +315,22 @@ struct StEqualsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        // Technically two empty geometries are not equal, but GEOS treats them
+        // as equal, so we default to GEOS in that case.
+        !(leftGeosGeometry->getEnvelopeInternal()->isNull() &&
+          rightGeosGeometry->getEnvelopeInternal()->isNull()) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->equals(&*rightGeosGeometry);
         , "Failed to check geometry equals");
@@ -314,11 +347,18 @@ struct StIntersectsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->intersects(&*rightGeosGeometry);
         , "Failed to check geometry intersects");
@@ -335,11 +375,18 @@ struct StOverlapsFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->overlaps(&*rightGeosGeometry);
         , "Failed to check geometry overlaps");
@@ -356,11 +403,18 @@ struct StTouchesFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->touches(&*rightGeosGeometry);
         , "Failed to check geometry touches");
@@ -377,11 +431,18 @@ struct StWithinFunction {
       out_type<bool>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !rightGeosGeometry->getEnvelopeInternal()->contains(
+            leftGeosGeometry->getEnvelopeInternal())) {
+      result = false;
+      return Status::OK();
+    }
+
     GEOS_TRY(
         result = leftGeosGeometry->within(&*rightGeosGeometry);
         , "Failed to check geometry within");
@@ -400,12 +461,17 @@ struct StDifferenceFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
-    // if envelopes are disjoint
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      result = leftGeometry;
+      return Status::OK();
+    }
 
     std::unique_ptr<geos::geom::Geometry> outputGeometry;
     GEOS_TRY(
@@ -439,18 +505,28 @@ struct StBoundaryFunction {
 
 template <typename T>
 struct StIntersectionFunction {
+  StIntersectionFunction() {
+    factory_ = geos::geom::GeometryFactory::create();
+  }
+
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE Status call(
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
-    // if envelopes are disjoint
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(rightGeometry);
+    if (!geospatial::hasGeometryCollection(
+            *leftGeosGeometry, *rightGeosGeometry) &&
+        !leftGeosGeometry->getEnvelopeInternal()->intersects(
+            rightGeosGeometry->getEnvelopeInternal())) {
+      auto emptyGeometry = factory_->createEmptyGeometry();
+      common::geospatial::GeometrySerializer::serialize(*emptyGeometry, result);
+      return Status::OK();
+    }
 
     std::unique_ptr<geos::geom::Geometry> outputGeometry;
     GEOS_TRY(
@@ -460,6 +536,9 @@ struct StIntersectionFunction {
     common::geospatial::GeometrySerializer::serialize(*outputGeometry, result);
     return Status::OK();
   }
+
+ private:
+  geos::geom::GeometryFactory::Ptr factory_;
 };
 
 template <typename T>
@@ -470,8 +549,6 @@ struct StSymDifferenceFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit
-    // if envelopes are disjoint
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -495,8 +572,6 @@ struct StUnionFunction {
       out_type<Geometry>& result,
       const arg_type<Geometry>& leftGeometry,
       const arg_type<Geometry>& rightGeometry) {
-    // TODO: When #12771 is merged, check envelopes and short-circuit if
-    // one/both are empty
     std::unique_ptr<geos::geom::Geometry> leftGeosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(leftGeometry);
     std::unique_ptr<geos::geom::Geometry> rightGeosGeometry =
@@ -1177,12 +1252,41 @@ struct StNumInteriorRingFunction {
 
 template <typename T>
 struct StConvexHullFunction {
+  StConvexHullFunction() {
+    factory_ = geos::geom::GeometryFactory::create();
+  }
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE Status
   call(out_type<Geometry>& result, const arg_type<Geometry>& geometry) {
     std::unique_ptr<geos::geom::Geometry> geosGeometry =
         common::geospatial::GeometryDeserializer::deserialize(geometry);
+
+    if (!(geosGeometry->getEnvelopeInternal()->isNull() ||
+          geospatial::isGeometryCollection(*geosGeometry))) {
+      auto* env = geosGeometry->getEnvelopeInternal();
+      auto minX = env->getMinX();
+      auto minY = env->getMinY();
+      auto maxX = env->getMaxX();
+      auto maxY = env->getMaxY();
+
+      if ((minX == maxX) && (minY == maxY)) {
+        // Envelope is a point, so that's the minimum convex hull
+        auto res = std::unique_ptr<geos::geom::Point>(
+            factory_->createPoint(geos::geom::Coordinate(minX, minY)));
+        common::geospatial::GeometrySerializer::serialize(*res, result);
+      }
+
+      if ((minX == maxX) || (minY == maxY)) {
+        // Envelope is a line, so that's the minimum convex hull
+        auto coords = factory_->getCoordinateSequenceFactory()->create(
+            {geos::geom::Coordinate(minX, minY),
+             geos::geom::Coordinate(maxX, maxY)});
+
+        common::geospatial::GeometrySerializer::serialize(
+            *(factory_->createLineString(std::move(coords))), result);
+      }
+    }
 
     if (geosGeometry->isEmpty() ||
         geosGeometry->getGeometryTypeId() ==
@@ -1194,7 +1298,11 @@ struct StConvexHullFunction {
     }
     return Status::OK();
   }
+
+ private:
+  geos::geom::GeometryFactory::Ptr factory_;
 };
+
 class StCoordDimFunction : public facebook::velox::exec::VectorFunction {
  public:
   void apply(

--- a/velox/functions/prestosql/geospatial/GeometryUtils.h
+++ b/velox/functions/prestosql/geospatial/GeometryUtils.h
@@ -133,6 +133,18 @@ FOLLY_ALWAYS_INLINE bool isMultiType(const geos::geom::Geometry& geometry) {
   return std::count(multiTypes.begin(), multiTypes.end(), type);
 }
 
+FOLLY_ALWAYS_INLINE bool isGeometryCollection(
+    const geos::geom::Geometry& geometry) {
+  return geometry.getGeometryTypeId() ==
+      geos::geom::GeometryTypeId::GEOS_GEOMETRYCOLLECTION;
+}
+
+FOLLY_ALWAYS_INLINE bool hasGeometryCollection(
+    const geos::geom::Geometry& left,
+    const geos::geom::Geometry& right) {
+  return isGeometryCollection(left) || isGeometryCollection(right);
+}
+
 FOLLY_ALWAYS_INLINE bool isAtomicType(const geos::geom::Geometry& geometry) {
   geos::geom::GeometryTypeId type = geometry.getGeometryTypeId();
 

--- a/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/GeometryFunctionsTest.cpp
@@ -466,6 +466,7 @@ TEST_F(GeometryFunctionsTest, testStContains) {
       false);
   assertRelation(
       "ST_Contains", "LINESTRING (20 20, 30 30)", "POLYGON EMPTY", false);
+  assertRelation("ST_Contains", "POLYGON EMPTY", "POINT EMPTY", false);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -531,6 +532,13 @@ TEST_F(GeometryFunctionsTest, testStCrosses) {
       "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
       "LINESTRING (0 0, 0 4, 4 4, 4 0)",
       false);
+  assertRelation("ST_Crosses", "POLYGON EMPTY", "POINT (0 0)", false);
+  assertRelation(
+      "ST_Crosses",
+      "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
+      "POINT EMPTY",
+      false);
+  assertRelation("ST_Crosses", "POLYGON EMPTY", "POINT EMPTY", false);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -567,6 +575,13 @@ TEST_F(GeometryFunctionsTest, testStDisjoint) {
       "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
       "POLYGON ((4 4, 4 5, 5 5, 5 4, 4 4))",
       true);
+  assertRelation("ST_Disjoint", "POLYGON EMPTY", "POINT (0 0)", true);
+  assertRelation(
+      "ST_Disjoint",
+      "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
+      "POINT EMPTY",
+      true);
+  assertRelation("ST_Disjoint", "POLYGON EMPTY", "POINT EMPTY", true);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -607,6 +622,13 @@ TEST_F(GeometryFunctionsTest, testStEquals) {
       "MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((0 0, 0 2, 2 2, 2 0, 0 0)))",
       "POLYGON ((0 1, 3 1, 3 3, 0 3, 0 1))",
       false);
+  assertRelation("ST_Equals", "POLYGON EMPTY", "POINT (0 0)", false);
+  assertRelation(
+      "ST_Equals", "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))", "POINT EMPTY", false);
+  // According to DE-9IM spec two empty geoms are not equal, but this is the
+  // current GEOS behavior
+  assertRelation("ST_Equals", "POLYGON EMPTY", "POINT EMPTY", true);
+
   // Invalid geometries.  This test might have to change when upgrading GEOS.
   assertRelation(
       "ST_Equals",
@@ -657,6 +679,13 @@ TEST_F(GeometryFunctionsTest, testStIntersects) {
       "POLYGON ((16.5 54, 16.5 54.1, 16.51 54.1, 16.8 54, 16.5 54))",
       "LINESTRING (16.6667 54.25, 16.8667 54.25)",
       false);
+  assertRelation("ST_Intersects", "POLYGON EMPTY", "POINT (0 0)", false);
+  assertRelation(
+      "ST_Intersects",
+      "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
+      "POINT EMPTY",
+      false);
+  assertRelation("ST_Intersects", "POLYGON EMPTY", "POINT EMPTY", false);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -711,6 +740,13 @@ TEST_F(GeometryFunctionsTest, testStOverlaps) {
       "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
       "POLYGON ((4 4, 4 5, 5 5, 5 4, 4 4))",
       false);
+  assertRelation("ST_Overlaps", "POLYGON EMPTY", "POINT (0 0)", false);
+  assertRelation(
+      "ST_Overlaps",
+      "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
+      "POINT EMPTY",
+      false);
+  assertRelation("ST_Overlaps", "POLYGON EMPTY", "POINT EMPTY", false);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -782,6 +818,13 @@ TEST_F(GeometryFunctionsTest, testStTouches) {
       "POLYGON ((1 1, 1 3, 3 3, 3 1, 1 1))",
       "POLYGON ((3 3, 3 5, 5 5, 5 3, 3 3))",
       true);
+  assertRelation("ST_Touches", "POLYGON EMPTY", "POINT (0 0)", false);
+  assertRelation(
+      "ST_Touches",
+      "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
+      "POINT EMPTY",
+      false);
+  assertRelation("ST_Touches", "POLYGON EMPTY", "POINT EMPTY", false);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -857,6 +900,10 @@ TEST_F(GeometryFunctionsTest, testStWithin) {
       "POLYGON ((1 1, 1 5, 5 5, 5 1, 1 1))",
       "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))",
       false);
+  assertRelation("ST_Within", "POLYGON EMPTY", "POINT (0 0)", false);
+  assertRelation(
+      "ST_Within", "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))", "POINT EMPTY", false);
+  assertRelation("ST_Within", "POLYGON EMPTY", "POINT EMPTY", false);
 
   VELOX_ASSERT_USER_THROW(
       assertRelation(
@@ -898,6 +945,22 @@ TEST_F(GeometryFunctionsTest, testStDifference) {
       "MULTIPOLYGON (((1 1, 1 3, 3 3, 3 1, 1 1)), ((0 0, 0 1, 1 1, 1 0, 0 0)))",
       "POLYGON ((0 1, 3 1, 3 3, 0 3, 0 1))",
       "POLYGON ((0 1, 1 1, 1 0, 0 0, 0 1))");
+
+  assertOverlay(
+      "ST_Difference",
+      "POLYGON ((0 1, 1 1, 1 0, 0 0, 0 1))",
+      "POINT EMPTY",
+      "POLYGON ((0 1, 1 1, 1 0, 0 0, 0 1))");
+  assertOverlay(
+      "ST_Difference",
+      "POLYGON EMPTY",
+      "POINT (0 0)",
+      "GEOMETRYCOLLECTION EMPTY");
+  assertOverlay(
+      "ST_Difference",
+      "POLYGON EMPTY",
+      "POINT EMPTY",
+      "GEOMETRYCOLLECTION EMPTY");
 
   ASSERT_THROW(
       assertOverlay(
@@ -947,6 +1010,21 @@ TEST_F(GeometryFunctionsTest, testStIntersection) {
       "POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
       "LINESTRING (0 0, 1 -1, 1 2)",
       "GEOMETRYCOLLECTION (LINESTRING (1 1, 1 0), POINT (0 0))");
+  assertOverlay(
+      "ST_Intersection",
+      "POLYGON ((0 1, 1 1, 1 0, 0 0, 0 1))",
+      "POINT EMPTY",
+      "GEOMETRYCOLLECTION EMPTY");
+  assertOverlay(
+      "ST_Intersection",
+      "POLYGON EMPTY",
+      "POINT (0 0)",
+      "GEOMETRYCOLLECTION EMPTY");
+  assertOverlay(
+      "ST_Intersection",
+      "POLYGON EMPTY",
+      "POINT EMPTY",
+      "GEOMETRYCOLLECTION EMPTY");
 
   ASSERT_THROW(
       assertOverlay(
@@ -2189,6 +2267,13 @@ TEST_F(GeometryFunctionsTest, testStConvexHull) {
   testStConvexHullFunc(
       "GEOMETRYCOLLECTION (POLYGON ((0 0, 4 0, 4 4, 0 4, 2 2, 0 0)))",
       "POLYGON ((0 0, 0 4, 4 4, 4 0, 0 0))");
+
+  // Geometries that should be bounded by a line or point
+  testStConvexHullFunc("LINESTRING (20 20, 20 20)", "POINT (20 20)");
+  testStConvexHullFunc(
+      "POLYGON ((20 20, 20 20, 20 20, 20 20))", "POINT (20 20)");
+  testStConvexHullFunc(
+      "POLYGON ((0 0, 0 20, 0 40, 0 60, 0 0))", "LINESTRING (0 0, 0 60)");
 }
 
 TEST_F(GeometryFunctionsTest, testStCoordDim) {


### PR DESCRIPTION
Summary:
Many spatial predicates (e.g. ST_Intersects) and overlay operations
(e.g. ST_Intersection) can be short-circuited if their envelopes satsify a
predict (e.g. they are disjoint). Envelope checks are 4 float operations, so
very cheap. GEOS and all geometry libraries do this, but this requires
deserializing and instantiating the geometry, which is slow. Futhermore, a
just-created geometry hasn't calculated its envelope yet, so GEOS does a
further O(N) operation to calculate the envelope before it can do the check.

But our serialization format has the envelope encoded in the beginning!
So we can do a quick and cheap deserialization and check before commiting
to the full deserialization.

The main drawback is currently GeometryCollections do _not_ store their
envelopes in the beginning and require a serialization, so this will slow down
operations for GeometryCollections. We want to improve the serialization
format, but we can also have a follow-up diff that checks for GCs explicitly.

Differential Revision: D89379930


