### PR TITLE
Fix (fuzzer): Fix l2_norm fuzzer failure: bool → void return

### DIFF
--- a/velox/functions/prestosql/L2Norm.h
+++ b/velox/functions/prestosql/L2Norm.h
@@ -40,10 +40,10 @@ struct ArrayL2NormFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(double& out, const TInput& inputArray) {
+  FOLLY_ALWAYS_INLINE void call(double& out, const TInput& inputArray) {
     if (inputArray.size() == 0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double maxAbs = 0.0;
@@ -55,7 +55,7 @@ struct ArrayL2NormFunction {
 
     if (maxAbs == 0.0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double sumOfSquares = 0.0;
@@ -67,14 +67,14 @@ struct ArrayL2NormFunction {
     }
 
     out = maxAbs * std::sqrt(sumOfSquares);
-    return true;
+    return;
   }
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool callNullFree(double& out, const TInput& inputArray) {
+  FOLLY_ALWAYS_INLINE void callNullFree(double& out, const TInput& inputArray) {
     if (inputArray.size() == 0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double maxAbs = 0.0;
@@ -84,7 +84,7 @@ struct ArrayL2NormFunction {
 
     if (maxAbs == 0.0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double sumOfSquares = 0.0;
@@ -94,7 +94,7 @@ struct ArrayL2NormFunction {
     }
 
     out = maxAbs * std::sqrt(sumOfSquares);
-    return true;
+    return;
   }
 };
 
@@ -114,12 +114,12 @@ template <typename TExec, typename K, typename V>
 struct MapL2NormFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       double& out,
       const arg_type<Map<K, V>>& inputMap) {
     if (inputMap.size() == 0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double maxAbs = 0.0;
@@ -132,7 +132,7 @@ struct MapL2NormFunction {
 
     if (maxAbs == 0.0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double sumOfSquares = 0.0;
@@ -144,15 +144,15 @@ struct MapL2NormFunction {
     }
 
     out = maxAbs * std::sqrt(sumOfSquares);
-    return true;
+    return;
   }
 
-  FOLLY_ALWAYS_INLINE bool callNullFree(
+  FOLLY_ALWAYS_INLINE void callNullFree(
       double& out,
       const null_free_arg_type<Map<K, V>>& inputMap) {
     if (inputMap.size() == 0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double maxAbs = 0.0;
@@ -162,7 +162,7 @@ struct MapL2NormFunction {
 
     if (maxAbs == 0.0) {
       out = 0.0;
-      return true;
+      return;
     }
 
     double sumOfSquares = 0.0;
@@ -172,7 +172,7 @@ struct MapL2NormFunction {
     }
 
     out = maxAbs * std::sqrt(sumOfSquares);
-    return true;
+    return;
   }
 };
 


### PR DESCRIPTION
Summary:
The `ArrayL2NormFunction` and `MapL2NormFunction` declared `call()` and `callNullFree()` with `bool` return type but always returned `true` — the functions never produce null output for non-null input. This is semantically incorrect and causes a framework-level behavioral divergence that breaks the expression fuzzer.

In `SimpleFunctionAdapter`, a `bool` return sets `can_produce_null_output = true`, which disables `supportsFlatNoNullsFastPath()`. This forces the common eval path to always be used, while the simplified eval path (used by the expression fuzzer for verification) takes a different code path for null-buffer handling. The divergence produces different results when the expression is wrapped in `TRY()` during the fuzzer's `retryWithTry` check.

Changing to `void` return (matching the proven `ArraySumFunction` pattern) correctly declares that the function never returns null for non-null input, keeps the `callNullFree` optimization, and eliminates the eval-path divergence.

Fixes: https://github.com/facebookincubator/velox/actions/runs/21961460229/job/63445628704

Differential Revision: D93158245


