### PR TITLE
fix(dwio): Preserve top level nulls in projectColumns

### DIFF
--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -223,5 +223,249 @@ TEST_F(ReaderTest, rowRangeEmpty) {
   EXPECT_FALSE((RowRange{5, 10}.empty()));
 }
 
+// Test that projectColumns preserves top level nulls when the input RowVector
+// has null rows.
+TEST_F(ReaderTest, projectColumnsTopLevelNulls) {
+  constexpr int kSize = 10;
+  // All nulls
+  {
+    SCOPED_TRACE("All nulls");
+    auto child = makeFlatVector<int64_t>(kSize, folly::identity);
+    auto input = makeRowVector({child});
+
+    auto nulls = AlignedBuffer::allocate<bool>(kSize, pool());
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+    // Set all bits to 0 (all null)
+    memset(rawNulls, 0, bits::nbytes(kSize));
+    input->setNulls(nulls);
+
+    ASSERT_EQ(BaseVector::countNulls(input->nulls(), kSize), kSize);
+
+    common::ScanSpec spec("<root>");
+    spec.addAllChildFields(*input->type());
+
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
+
+    ASSERT_NE(actual->nulls(), nullptr);
+    EXPECT_EQ(BaseVector::countNulls(actual->nulls(), actual->size()), kSize);
+
+    // Verify the output has the same size
+    EXPECT_EQ(actual->size(), kSize);
+  }
+
+  // Partial nulls.
+  {
+    SCOPED_TRACE("Partial nulls");
+    auto child = makeFlatVector<int64_t>(kSize, folly::identity);
+    auto input = makeRowVector({child});
+
+    auto nulls = AlignedBuffer::allocate<bool>(kSize, pool());
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+
+    // Set rows 0, 2, 4, 6, 8 as null (even indices)
+    memset(rawNulls, 0xFF, bits::nbytes(kSize));
+    for (int i = 0; i < kSize; i += 2) {
+      bits::setNull(rawNulls, i);
+    }
+    input->setNulls(nulls);
+
+    ASSERT_EQ(BaseVector::countNulls(input->nulls(), kSize), 5); // 5 null rows
+
+    common::ScanSpec spec("<root>");
+    spec.addAllChildFields(*input->type());
+
+    // Test without mutation (no filtering)
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
+
+    // Verify nulls are preserved
+    ASSERT_NE(actual->nulls(), nullptr);
+    EXPECT_EQ(BaseVector::countNulls(actual->nulls(), actual->size()), 5);
+    EXPECT_EQ(actual->size(), kSize);
+
+    // Verify specific null positions
+    for (int i = 0; i < kSize; ++i) {
+      EXPECT_EQ(actual->isNullAt(i), (i % 2 == 0))
+          << "Row " << i << " null status mismatch";
+    }
+  }
+
+  // Partial nulls with constant encoding child
+  {
+    SCOPED_TRACE("Constant encoding child");
+    // Create a constant vector (all values are the same)
+    auto constantChild =
+        BaseVector::createConstant(INTEGER(), 42, kSize, pool());
+    auto input = makeRowVector({constantChild});
+
+    auto nulls = AlignedBuffer::allocate<bool>(kSize, pool());
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+
+    // Set rows 0, 2, 4, 6, 8 as null (even indices)
+    memset(rawNulls, 0xFF, bits::nbytes(kSize));
+    for (int i = 0; i < kSize; i += 2) {
+      bits::setNull(rawNulls, i);
+    }
+    input->setNulls(nulls);
+
+    ASSERT_EQ(BaseVector::countNulls(input->nulls(), kSize), 5); // 5 null rows
+    ASSERT_TRUE(constantChild->isConstantEncoding());
+
+    common::ScanSpec spec("<root>");
+    spec.addAllChildFields(*input->type());
+
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
+
+    // Verify nulls are preserved
+    ASSERT_NE(actual->nulls(), nullptr);
+    EXPECT_EQ(BaseVector::countNulls(actual->nulls(), actual->size()), 5);
+    EXPECT_EQ(actual->size(), kSize);
+
+    // Verify specific null positions
+    for (int i = 0; i < kSize; ++i) {
+      EXPECT_EQ(actual->isNullAt(i), (i % 2 == 0))
+          << "Row " << i << " null status mismatch";
+    }
+  }
+
+  // Partial nulls with dictionary encoding child
+  {
+    SCOPED_TRACE("Dictionary encoding child");
+    // Create a dictionary vector wrapping a flat vector
+    auto baseValues = makeFlatVector<int64_t>({10, 20, 30, 40, 50});
+    // Create indices that map to the base values
+    auto indices = makeIndices(kSize, [](auto i) { return i % 5; });
+    auto dictionaryChild =
+        BaseVector::wrapInDictionary(nullptr, indices, kSize, baseValues);
+    auto input = makeRowVector({dictionaryChild});
+
+    auto nulls = AlignedBuffer::allocate<bool>(kSize, pool());
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+
+    // Set rows 0, 2, 4, 6, 8 as null (even indices)
+    memset(rawNulls, 0xFF, bits::nbytes(kSize));
+    for (int i = 0; i < kSize; i += 2) {
+      bits::setNull(rawNulls, i);
+    }
+    input->setNulls(nulls);
+
+    ASSERT_EQ(BaseVector::countNulls(input->nulls(), kSize), 5); // 5 null rows
+    ASSERT_EQ(dictionaryChild->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+    common::ScanSpec spec("<root>");
+    spec.addAllChildFields(*input->type());
+
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
+
+    // Verify nulls are preserved
+    ASSERT_NE(actual->nulls(), nullptr);
+    EXPECT_EQ(BaseVector::countNulls(actual->nulls(), actual->size()), 5);
+    EXPECT_EQ(actual->size(), kSize);
+
+    // Verify specific null positions
+    for (int i = 0; i < kSize; ++i) {
+      EXPECT_EQ(actual->isNullAt(i), (i % 2 == 0))
+          << "Row " << i << " null status mismatch";
+    }
+  }
+
+  // Two columns: constant encoding and dictionary encoding
+  {
+    SCOPED_TRACE("Two columns: constant and dictionary encoding");
+    // Create a constant vector
+    auto constantChild =
+        BaseVector::createConstant(INTEGER(), 42, kSize, pool());
+
+    // Create a dictionary vector
+    auto baseValues = makeFlatVector<int64_t>({100, 200, 300, 400, 500});
+    auto indices = makeIndices(kSize, [](auto i) { return i % 5; });
+    auto dictionaryChild =
+        BaseVector::wrapInDictionary(nullptr, indices, kSize, baseValues);
+
+    auto input = makeRowVector({constantChild, dictionaryChild});
+
+    auto nulls = AlignedBuffer::allocate<bool>(kSize, pool());
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+
+    // Set rows 0, 2, 4, 6, 8 as null (even indices)
+    memset(rawNulls, 0xFF, bits::nbytes(kSize));
+    for (int i = 0; i < kSize; i += 2) {
+      bits::setNull(rawNulls, i);
+    }
+    input->setNulls(nulls);
+
+    ASSERT_EQ(BaseVector::countNulls(input->nulls(), kSize), 5);
+    ASSERT_TRUE(constantChild->isConstantEncoding());
+    ASSERT_EQ(dictionaryChild->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+    common::ScanSpec spec("<root>");
+    spec.addAllChildFields(*input->type());
+
+    auto actual = RowReader::projectColumns(input, spec, nullptr);
+
+    // Verify nulls are preserved
+    ASSERT_NE(actual->nulls(), nullptr);
+    EXPECT_EQ(BaseVector::countNulls(actual->nulls(), actual->size()), 5);
+    EXPECT_EQ(actual->size(), kSize);
+
+    // Verify both children exist
+    auto rowResult = actual->as<RowVector>();
+    ASSERT_EQ(rowResult->childrenSize(), 2);
+
+    // Verify specific null positions
+    for (int i = 0; i < kSize; ++i) {
+      EXPECT_EQ(actual->isNullAt(i), (i % 2 == 0))
+          << "Row " << i << " null status mismatch";
+    }
+  }
+}
+
+// Test that projectColumns correctly filters row-level nulls with mutation
+TEST_F(ReaderTest, projectColumnsFiltersRowNullsWithMutation) {
+  constexpr int kSize = 10;
+
+  // Create a RowVector with some null rows
+  auto child = makeFlatVector<int64_t>(kSize, folly::identity);
+  auto input = makeRowVector({child});
+
+  // Set rows 0, 2, 4, 6, 8 as null (even indices)
+  auto nulls = AlignedBuffer::allocate<bool>(kSize, pool());
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  memset(rawNulls, 0xFF, bits::nbytes(kSize));
+  for (int i = 0; i < kSize; i += 2) {
+    bits::setNull(rawNulls, i);
+  }
+  input->setNulls(nulls);
+
+  common::ScanSpec spec("<root>");
+  spec.addAllChildFields(*input->type());
+
+  // Delete rows 1 and 3 (odd indices, which are not null)
+  std::vector<uint64_t> deleted(bits::nwords(kSize));
+  bits::setBit(deleted.data(), 1);
+  bits::setBit(deleted.data(), 3);
+  Mutation mutation;
+  mutation.deletedRows = deleted.data();
+
+  auto actual = RowReader::projectColumns(input, spec, &mutation);
+
+  // 8 rows should remain (10 - 2 deleted)
+  EXPECT_EQ(actual->size(), 8);
+
+  // Verify nulls buffer exists
+  ASSERT_NE(actual->nulls(), nullptr);
+
+  // After filtering, the remaining rows are: 0, 2, 4, 5, 6, 7, 8, 9
+  // Of these, 0, 2, 4, 6, 8 were null in the original (indices 0, 1, 2, 4, 6)
+  // So in the output: positions 0, 1, 2, 4, 6 should be null
+  EXPECT_TRUE(actual->isNullAt(0)); // was row 0
+  EXPECT_TRUE(actual->isNullAt(1)); // was row 2
+  EXPECT_TRUE(actual->isNullAt(2)); // was row 4
+  EXPECT_FALSE(actual->isNullAt(3)); // was row 5
+  EXPECT_TRUE(actual->isNullAt(4)); // was row 6
+  EXPECT_FALSE(actual->isNullAt(5)); // was row 7
+  EXPECT_TRUE(actual->isNullAt(6)); // was row 8
+  EXPECT_FALSE(actual->isNullAt(7)); // was row 9
+}
+
 } // namespace
 } // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/481

Fix a class of issues on validation service: https://fburl.com/scuba/dwrf_reader_checksum/ku7kyj88

When the full range is null, the batch reader path in checksum stack swallows top level nulls and returns const null children instead. e.g. for schema ROW<c0:int, c1:float>, the correct behavior would be to return null for the whole row, instead of {null, null}.

Turns out the issue came from fb_velox NimbleReader calling projectColumns, which lost the top level nulls.

Differential Revision: D93098105


