### PR TITLE
refactor: Extract operator type strings into constants

### DIFF
--- a/velox/exec/ArrowStream.cpp
+++ b/velox/exec/ArrowStream.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/ArrowStream.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/vector/arrow/Bridge.h"
 
 namespace facebook::velox::exec {
@@ -27,7 +28,7 @@ ArrowStream::ArrowStream(
           arrowStreamNode->outputType(),
           operatorId,
           arrowStreamNode->id(),
-          "ArrowStream") {
+          OperatorType::kArrowStream) {
   arrowStream_ = arrowStreamNode->arrowStream();
 }
 

--- a/velox/exec/AssignUniqueId.cpp
+++ b/velox/exec/AssignUniqueId.cpp
@@ -18,6 +18,8 @@
 #include <algorithm>
 #include <utility>
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 AssignUniqueId::AssignUniqueId(
@@ -31,7 +33,7 @@ AssignUniqueId::AssignUniqueId(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "AssignUniqueId"),
+          OperatorType::kAssignUniqueId),
       rowIdPool_(std::move(rowIdPool)) {
   VELOX_USER_CHECK_LT(
       uniqueTaskId,

--- a/velox/exec/CallbackSink.h
+++ b/velox/exec/CallbackSink.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::exec {
@@ -28,7 +29,12 @@ class CallbackSink : public Operator {
       Consumer consumeCb,
       std::function<BlockingReason(ContinueFuture*)> startedCb = nullptr,
       const std::string& planNodeId = "N/A")
-      : Operator(driverCtx, nullptr, operatorId, planNodeId, "CallbackSink"),
+      : Operator(
+            driverCtx,
+            nullptr,
+            operatorId,
+            planNodeId,
+            OperatorType::kCallbackSink),
         startedCb_{std::move(startedCb)},
         consumeCb_{std::move(consumeCb)} {}
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -20,6 +20,7 @@
 
 #include "velox/common/process/TraceContext.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 #include "velox/vector/LazyVector.h"
 
@@ -114,18 +115,20 @@ velox::memory::MemoryPool* DriverCtx::addOperatorPool(
 }
 
 namespace {
-bool isHashJoinSpillOperator(const std::string& operatorType) {
-  return operatorType == "HashBuild" || operatorType == "HashProbe";
+bool isHashJoinSpillOperator(std::string_view operatorType) {
+  return operatorType == OperatorType::kHashBuild ||
+      operatorType == OperatorType::kHashProbe;
 }
 
-bool isAggregationSpillOperator(const std::string& operatorType) {
-  return operatorType == "Aggregation" || operatorType == "PartialAggregation";
+bool isAggregationSpillOperator(std::string_view operatorType) {
+  return operatorType == OperatorType::kAggregation ||
+      operatorType == OperatorType::kPartialAggregation;
 }
 } // namespace
 
 std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
     int32_t operatorId,
-    const std::string& operatorType) const {
+    std::string_view operatorType) const {
   const auto& queryConfig = task->queryCtx()->queryConfig();
   if (!queryConfig.spillEnabled()) {
     return std::nullopt;

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <memory>
+#include <string_view>
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/futures/Future.h>
@@ -262,7 +263,7 @@ struct DriverCtx {
   /// 'operatorType'.
   std::optional<common::SpillConfig> makeSpillConfig(
       int32_t operatorId,
-      const std::string& operatorType) const;
+      std::string_view operatorType) const;
 
   common::PrefixSortConfig prefixSortConfig() const {
     return common::PrefixSortConfig{

--- a/velox/exec/EnforceDistinct.cpp
+++ b/velox/exec/EnforceDistinct.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/exec/EnforceDistinct.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 EnforceDistinct::EnforceDistinct(
@@ -27,7 +29,7 @@ EnforceDistinct::EnforceDistinct(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "EnforceDistinct"),
+          OperatorType::kEnforceDistinct),
       errorMessage_{planNode->errorMessage()} {
   const auto& inputType = planNode->sources()[0]->outputType();
 

--- a/velox/exec/EnforceSingleRow.cpp
+++ b/velox/exec/EnforceSingleRow.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/exec/EnforceSingleRow.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 EnforceSingleRow::EnforceSingleRow(
@@ -26,7 +28,7 @@ EnforceSingleRow::EnforceSingleRow(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "EnforceSingleRow") {
+          OperatorType::kEnforceSingleRow) {
   isIdentityProjection_ = true;
 }
 

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -63,7 +63,7 @@ Exchange::Exchange(
     DriverCtx* driverCtx,
     const std::shared_ptr<const core::ExchangeNode>& exchangeNode,
     std::shared_ptr<ExchangeClient> exchangeClient,
-    const std::string& operatorType)
+    std::string_view operatorType)
     : SourceOperator(
           driverCtx,
           exchangeNode->outputType(),

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -19,6 +19,7 @@
 
 #include "velox/exec/ExchangeClient.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/serializers/RowSerializer.h"
@@ -50,7 +51,7 @@ class Exchange : public SourceOperator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::ExchangeNode>& exchangeNode,
       std::shared_ptr<ExchangeClient> exchangeClient,
-      const std::string& operatorType = "Exchange");
+      std::string_view operatorType = OperatorType::kExchange);
 
   ~Exchange() override {
     close();

--- a/velox/exec/Expand.cpp
+++ b/velox/exec/Expand.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/exec/Expand.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 Expand::Expand(
@@ -26,7 +28,7 @@ Expand::Expand(
           expandNode->outputType(),
           operatorId,
           expandNode->id(),
-          "Expand") {
+          OperatorType::kExpand) {
   const auto& inputType = expandNode->inputType();
   const auto numRows = expandNode->projections().size();
   fieldProjections_.reserve(numRows);

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/FilterProject.h"
 #include "velox/core/Expressions.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
 
@@ -143,7 +144,7 @@ FilterProject::FilterProject(
           project ? project->outputType() : filter->outputType(),
           operatorId,
           project ? project->id() : filter->id(),
-          "FilterProject"),
+          OperatorType::kFilterProject),
       hasFilter_(filter != nullptr),
       lazyDereference_(
           dynamic_cast<const core::LazyDereferenceNode*>(project.get()) !=

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/exec/GroupId.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 GroupId::GroupId(
@@ -26,7 +28,7 @@ GroupId::GroupId(
           groupIdNode->outputType(),
           operatorId,
           groupIdNode->id(),
-          "GroupId") {
+          OperatorType::kGroupId) {
   const auto& inputType = groupIdNode->sources()[0]->outputType();
 
   std::unordered_map<column_index_t, column_index_t>

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -16,6 +16,7 @@
 #include "velox/exec/HashAggregation.h"
 
 #include <optional>
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/PrefixSort.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
@@ -32,15 +33,15 @@ HashAggregation::HashAggregation(
           operatorId,
           aggregationNode->id(),
           aggregationNode->step() == core::AggregationNode::Step::kPartial
-              ? "PartialAggregation"
-              : "Aggregation",
+              ? OperatorType::kPartialAggregation
+              : OperatorType::kAggregation,
           aggregationNode->canSpill(driverCtx->queryConfig())
               ? driverCtx->makeSpillConfig(
                     operatorId,
                     aggregationNode->step() ==
                             core::AggregationNode::Step::kPartial
-                        ? "PartialAggregation"
-                        : "Aggregation")
+                        ? OperatorType::kPartialAggregation
+                        : OperatorType::kAggregation)
               : std::nullopt),
       aggregationNode_(aggregationNode),
       isPartialOutput_(isPartialOutput(aggregationNode->step())),

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/HashTableCache.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/VectorHasher.h"
@@ -56,9 +57,9 @@ HashBuild::HashBuild(
           nullptr,
           operatorId,
           joinNode->id(),
-          "HashBuild",
+          OperatorType::kHashBuild,
           joinNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "HashBuild")
+              ? driverCtx->makeSpillConfig(operatorId, OperatorType::kHashBuild)
               : std::nullopt),
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/FieldReference.h"
@@ -118,9 +119,9 @@ HashProbe::HashProbe(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          "HashProbe",
+          OperatorType::kHashProbe,
           joinNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "HashProbe")
+              ? driverCtx->makeSpillConfig(operatorId, OperatorType::kHashProbe)
               : std::nullopt),
       outputBatchSize_{outputBatchRows()},
       joinNode_(std::move(joinNode)),

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -18,6 +18,7 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/Connector.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
@@ -184,7 +185,7 @@ IndexLookupJoin::IndexLookupJoin(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          "IndexLookupJoin"),
+          OperatorType::kIndexLookupJoin),
       splitOutput_{driverCtx->queryConfig().indexLookupJoinSplitOutput()},
       // TODO: support to update output batch size with output size stats during
       // the lookup processing.

--- a/velox/exec/Limit.cpp
+++ b/velox/exec/Limit.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/exec/Limit.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 Limit::Limit(
     int32_t operatorId,
@@ -25,7 +27,7 @@ Limit::Limit(
           limitNode->outputType(),
           operatorId,
           limitNode->id(),
-          "Limit"),
+          OperatorType::kLimit),
       remainingOffset_{limitNode->offset()},
       remainingLimit_{limitNode->count()} {
   isIdentityProjection_ = true;

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/LocalPartition.h"
 #include "velox/common/Casts.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 #include "velox/vector/EncodedVectorCopy.h"
 
@@ -264,7 +265,7 @@ LocalExchange::LocalExchange(
           std::move(outputType),
           operatorId,
           planNodeId,
-          "LocalExchange"),
+          OperatorType::kLocalExchange),
       partition_{partition},
       queue_{operatorCtx_->task()->getLocalExchangeQueue(
           ctx->splitGroupId,
@@ -333,7 +334,7 @@ LocalPartition::LocalPartition(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "LocalPartition"),
+          OperatorType::kLocalPartition),
       queues_{
           ctx->task->getLocalExchangeQueues(ctx->splitGroupId, planNode->id())},
       numPartitions_{queues_.size()},

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/MarkDistinct.h"
 #include "velox/common/base/Range.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/vector/FlatVector.h"
 
 #include <algorithm>
@@ -32,7 +33,7 @@ MarkDistinct::MarkDistinct(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "MarkDistinct") {
+          OperatorType::kMarkDistinct) {
   const auto& inputType = planNode->sources()[0]->outputType();
 
   // Set all input columns as identity projection.

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -18,6 +18,7 @@
 #include <folly/Traits.h>
 #include <exception>
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 
@@ -33,7 +34,7 @@ Merge::Merge(
         sortingKeys,
     const std::vector<core::SortOrder>& sortingOrders,
     const std::string& planNodeId,
-    const std::string& operatorType,
+    std::string_view operatorType,
     const std::optional<common::SpillConfig>& spillConfig)
     : SourceOperator(
           driverCtx,
@@ -724,9 +725,11 @@ LocalMerge::LocalMerge(
           localMergeNode->sortingKeys(),
           localMergeNode->sortingOrders(),
           localMergeNode->id(),
-          "LocalMerge",
+          OperatorType::kLocalMerge,
           localMergeNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "LocalMerge")
+              ? driverCtx->makeSpillConfig(
+                    operatorId,
+                    OperatorType::kLocalMerge)
               : std::nullopt) {
   VELOX_CHECK_EQ(
       operatorCtx_->driverCtx()->driverId,
@@ -761,7 +764,7 @@ MergeExchange::MergeExchange(
           mergeExchangeNode->sortingKeys(),
           mergeExchangeNode->sortingOrders(),
           mergeExchangeNode->id(),
-          "MergeExchange"),
+          OperatorType::kMergeExchange),
       serde_(getNamedVectorSerde(mergeExchangeNode->serdeKind())),
       serdeOptions_(getVectorSerdeOptions(
           common::stringToCompressionKind(

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -40,7 +40,7 @@ class Merge : public SourceOperator {
           sortingKeys,
       const std::vector<core::SortOrder>& sortingOrders,
       const std::string& planNodeId,
-      const std::string& operatorType,
+      std::string_view operatorType,
       const std::optional<common::SpillConfig>& spillConfig = std::nullopt);
 
   void initialize() override;

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/MergeJoin.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/FieldReference.h"
@@ -48,7 +49,7 @@ MergeJoin::MergeJoin(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          "MergeJoin"),
+          OperatorType::kMergeJoin),
       preferredOutputBatchBytes_{
           driverCtx->queryConfig().preferredOutputBatchBytes()},
       preferredOutputBatchRows_{

--- a/velox/exec/MixedUnion.cpp
+++ b/velox/exec/MixedUnion.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/MixedUnion.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 
@@ -29,7 +30,7 @@ MixedUnion::MixedUnion(
           unionNode->outputType(),
           operatorId,
           unionNode->id(),
-          "MixedUnion"),
+          OperatorType::kMixedUnion),
       unionNode_(unionNode),
       maxOutputBatchRows_(outputBatchRows()),
       maxOutputBatchBytes_(

--- a/velox/exec/NestedLoopJoinBuild.cpp
+++ b/velox/exec/NestedLoopJoinBuild.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/NestedLoopJoinBuild.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -50,7 +51,7 @@ NestedLoopJoinBuild::NestedLoopJoinBuild(
           nullptr,
           operatorId,
           joinNode->id(),
-          "NestedLoopJoinBuild") {}
+          OperatorType::kNestedLoopJoinBuild) {}
 
 void NestedLoopJoinBuild::addInput(RowVectorPtr input) {
   if (input->size() > 0) {

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/NestedLoopJoinProbe.h"
 #include "velox/exec/DriverStats.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/FieldReference.h"
@@ -56,7 +57,7 @@ NestedLoopJoinProbe::NestedLoopJoinProbe(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          "NestedLoopJoinProbe"),
+          OperatorType::kNestedLoopJoinProbe),
       joinType_(joinNode->joinType()),
       outputBatchSize_{outputBatchRows()},
       joinNode_(joinNode) {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -32,12 +32,12 @@ OperatorCtx::OperatorCtx(
     DriverCtx* driverCtx,
     const core::PlanNodeId& planNodeId,
     int32_t operatorId,
-    const std::string& operatorType)
+    std::string_view operatorType)
     : driverCtx_(driverCtx),
       planNodeId_(planNodeId),
       operatorId_(operatorId),
       operatorType_(operatorType),
-      pool_(driverCtx_->addOperatorPool(planNodeId, operatorType)) {}
+      pool_(driverCtx_->addOperatorPool(planNodeId, operatorType_)) {}
 
 core::ExecCtx* OperatorCtx::execCtx() const {
   if (!execCtx_) {
@@ -83,7 +83,7 @@ Operator::Operator(
     RowTypePtr outputType,
     int32_t operatorId,
     std::string planNodeId,
-    std::string operatorType,
+    std::string_view operatorType,
     std::optional<common::SpillConfig> spillConfig)
     : operatorCtx_(
           std::make_unique<OperatorCtx>(
@@ -101,7 +101,7 @@ Operator::Operator(
               operatorId,
               driverCtx->pipelineId,
               std::move(planNodeId),
-              std::move(operatorType)}) {}
+              std::string(operatorType)}) {}
 
 void Operator::maybeSetReclaimer() {
   VELOX_CHECK_NULL(pool()->reclaimer());

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include <folly/Synchronized.h>
+#include <string_view>
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Driver.h"
@@ -44,7 +45,7 @@ class OperatorCtx {
       DriverCtx* driverCtx,
       const core::PlanNodeId& planNodeId,
       int32_t operatorId,
-      const std::string& operatorType = "");
+      std::string_view operatorType = "");
 
   const std::shared_ptr<Task>& task() const {
     return driverCtx_->task;
@@ -209,7 +210,7 @@ class Operator : public BaseRuntimeStatWriter {
       RowTypePtr outputType,
       int32_t operatorId,
       std::string planNodeId,
-      std::string operatorType,
+      std::string_view operatorType,
       std::optional<common::SpillConfig> spillConfig = std::nullopt);
 
   virtual ~Operator() = default;
@@ -704,7 +705,7 @@ class SourceOperator : public Operator {
       RowTypePtr outputType,
       int32_t operatorId,
       const std::string& planNodeId,
-      const std::string& operatorType,
+      std::string_view operatorType,
       const std::optional<common::SpillConfig>& spillConfig = std::nullopt)
       : Operator(
             driverCtx,

--- a/velox/exec/OperatorTraceScan.cpp
+++ b/velox/exec/OperatorTraceScan.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/OperatorTraceScan.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/trace/TraceUtil.h"
 
 namespace facebook::velox::exec::trace {
@@ -28,7 +29,7 @@ OperatorTraceScan::OperatorTraceScan(
           traceScanNode->outputType(),
           operatorId,
           traceScanNode->id(),
-          "OperatorTraceScan") {
+          OperatorType::kOperatorTraceScan) {
   traceReader_ = std::make_unique<OperatorTraceInputReader>(
       getOpTraceDirectory(
           traceScanNode->traceDir(),

--- a/velox/exec/OperatorTraceWriter.cpp
+++ b/velox/exec/OperatorTraceWriter.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/trace/Trace.h"
 #include "velox/exec/trace/TraceUtil.h"
 
@@ -32,7 +33,7 @@ namespace {
 void recordOperatorSummary(Operator* op, folly::dynamic& obj) {
   obj[OperatorTraceTraits::kOpTypeKey] = op->operatorType();
   const auto stats = op->stats(/*clear=*/false);
-  if (op->operatorType() == "TableScan") {
+  if (op->operatorType() == OperatorType::kTableScan) {
     obj[OperatorTraceTraits::kNumSplitsKey] = stats.numSplits;
   }
   obj[OperatorTraceTraits::kPeakMemoryKey] =

--- a/velox/exec/OperatorType.h
+++ b/velox/exec/OperatorType.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+namespace facebook::velox::exec {
+
+/// Centralized constants for operator type strings used in operator
+/// constructors and comparison sites throughout the execution engine.
+struct OperatorType {
+  static constexpr std::string_view kAggregation = "Aggregation";
+  static constexpr std::string_view kArrowStream = "ArrowStream";
+  static constexpr std::string_view kAssignUniqueId = "AssignUniqueId";
+  static constexpr std::string_view kBlockedOperator = "BlockedOperator";
+  static constexpr std::string_view kCallbackSink = "CallbackSink";
+  static constexpr std::string_view kEnforceDistinct = "EnforceDistinct";
+  static constexpr std::string_view kEnforceSingleRow = "EnforceSingleRow";
+  static constexpr std::string_view kExchange = "Exchange";
+  static constexpr std::string_view kExpand = "Expand";
+  static constexpr std::string_view kFilterProject = "FilterProject";
+  static constexpr std::string_view kGroupId = "GroupId";
+  static constexpr std::string_view kHashBuild = "HashBuild";
+  static constexpr std::string_view kHashProbe = "HashProbe";
+  static constexpr std::string_view kIndexLookupJoin = "IndexLookupJoin";
+  static constexpr std::string_view kLimit = "Limit";
+  static constexpr std::string_view kLocalExchange = "LocalExchange";
+  static constexpr std::string_view kLocalMerge = "LocalMerge";
+  static constexpr std::string_view kLocalPartition = "LocalPartition";
+  static constexpr std::string_view kMarkDistinct = "MarkDistinct";
+  static constexpr std::string_view kMergeExchange = "MergeExchange";
+  static constexpr std::string_view kMergeJoin = "MergeJoin";
+  static constexpr std::string_view kMixedUnion = "MixedUnion";
+  static constexpr std::string_view kNestedLoopJoinBuild =
+      "NestedLoopJoinBuild";
+  static constexpr std::string_view kNestedLoopJoinProbe =
+      "NestedLoopJoinProbe";
+  static constexpr std::string_view kOperatorTraceScan = "OperatorTraceScan";
+  static constexpr std::string_view kOrderBy = "OrderBy";
+  static constexpr std::string_view kParallelProject = "ParallelProject";
+  static constexpr std::string_view kPartialAggregation = "PartialAggregation";
+  static constexpr std::string_view kPartitionedOutput = "PartitionedOutput";
+  static constexpr std::string_view kRowNumber = "RowNumber";
+  static constexpr std::string_view kSpatialJoinBuild = "SpatialJoinBuild";
+  static constexpr std::string_view kSpatialJoinProbe = "SpatialJoinProbe";
+  static constexpr std::string_view kStreamingEnforceDistinct =
+      "StreamingEnforceDistinct";
+  static constexpr std::string_view kTableScan = "TableScan";
+  static constexpr std::string_view kTableWrite = "TableWrite";
+  static constexpr std::string_view kTableWriteMerge = "TableWriteMerge";
+  static constexpr std::string_view kTopN = "TopN";
+  static constexpr std::string_view kTopNRowNumber = "TopNRowNumber";
+  static constexpr std::string_view kUnnest = "Unnest";
+  static constexpr std::string_view kValues = "Values";
+  static constexpr std::string_view kWindow = "Window";
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -18,6 +18,7 @@
 #include <optional>
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Spiller.h"
 #include "velox/vector/VectorStream.h"
 
@@ -232,7 +233,12 @@ class BlockedOperator : public Operator {
       int32_t id,
       core::PlanNodePtr node,
       BlockedOperatorCb&& blockedCb)
-      : Operator(ctx, node->outputType(), id, node->id(), "BlockedOperator"),
+      : Operator(
+            ctx,
+            node->outputType(),
+            id,
+            node->id(),
+            OperatorType::kBlockedOperator),
         blockedCb_(std::move(blockedCb)) {}
 
   BlockingReason isBlocked(ContinueFuture* future) override {

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/OrderBy.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/vector/FlatVector.h"
@@ -39,9 +40,9 @@ OrderBy::OrderBy(
           orderByNode->outputType(),
           operatorId,
           orderByNode->id(),
-          "OrderBy",
+          OperatorType::kOrderBy,
           orderByNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "OrderBy")
+              ? driverCtx->makeSpillConfig(operatorId, OperatorType::kOrderBy)
               : std::nullopt) {
   maxOutputRows_ = outputBatchRows(std::nullopt);
   VELOX_CHECK(pool()->trackUsage());

--- a/velox/exec/ParallelProject.cpp
+++ b/velox/exec/ParallelProject.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/ParallelProject.h"
 #include "velox/common/base/AsyncSource.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -30,7 +31,7 @@ ParallelProject::ParallelProject(
           node->outputType(),
           operatorId,
           node->id(),
-          "ParallelProject"),
+          OperatorType::kParallelProject),
       node_(node) {}
 
 namespace {

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
@@ -165,7 +166,7 @@ PartitionedOutput::PartitionedOutput(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "PartitionedOutput"),
+          OperatorType::kPartitionedOutput),
       keyChannels_(toChannels(planNode->inputType(), planNode->keys())),
       numDestinations_(planNode->numPartitions()),
       replicateNullsAndAny_(planNode->isReplicateNullsAndAny()),

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/RowNumber.h"
 #include "velox/common/memory/MemoryArbitrator.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::exec {
@@ -28,9 +29,9 @@ RowNumber::RowNumber(
           rowNumberNode->outputType(),
           operatorId,
           rowNumberNode->id(),
-          "RowNumber",
+          OperatorType::kRowNumber,
           rowNumberNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "RowNumber")
+              ? driverCtx->makeSpillConfig(operatorId, OperatorType::kRowNumber)
               : std::nullopt),
       limit_{rowNumberNode->limit()},
       generateRowNumber_{rowNumberNode->generateRowNumber()} {

--- a/velox/exec/SpatialJoinBuild.cpp
+++ b/velox/exec/SpatialJoinBuild.cpp
@@ -20,6 +20,7 @@
 #ifdef VELOX_ENABLE_GEO
 #include "velox/common/geospatial/GeometrySerde.h"
 #endif
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -58,7 +59,7 @@ SpatialJoinBuild::SpatialJoinBuild(
           nullptr,
           operatorId,
           joinNode->id(),
-          "SpatialJoinBuild") {
+          OperatorType::kSpatialJoinBuild) {
   const auto& buildType = joinNode->rightNode()->outputType();
   buildGeometryChannel_ =
       buildType->getChildIdx(joinNode->buildGeometry()->name());

--- a/velox/exec/SpatialJoinProbe.cpp
+++ b/velox/exec/SpatialJoinProbe.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/SpatialJoinProbe.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/SpatialJoinBuild.h"
 #include "velox/exec/Task.h"
@@ -152,7 +153,7 @@ SpatialJoinProbe::SpatialJoinProbe(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          "SpatialJoinProbe"),
+          OperatorType::kSpatialJoinProbe),
       joinType_(joinNode->joinType()),
       outputBatchSize_{outputBatchRows()},
       joinNode_(joinNode),

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/exec/StreamingAggregation.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 StreamingAggregation::StreamingAggregation(
@@ -28,8 +30,8 @@ StreamingAggregation::StreamingAggregation(
           operatorId,
           aggregationNode->id(),
           aggregationNode->step() == core::AggregationNode::Step::kPartial
-              ? "PartialAggregation"
-              : "Aggregation"),
+              ? OperatorType::kPartialAggregation
+              : OperatorType::kAggregation),
       maxOutputBatchSize_{outputBatchRows()},
       minOutputBatchSize_{
           operatorCtx_->driverCtx()

--- a/velox/exec/StreamingEnforceDistinct.cpp
+++ b/velox/exec/StreamingEnforceDistinct.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/exec/StreamingEnforceDistinct.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 namespace {
@@ -46,7 +48,7 @@ StreamingEnforceDistinct::StreamingEnforceDistinct(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          "StreamingEnforceDistinct"),
+          OperatorType::kStreamingEnforceDistinct),
       inputType_{planNode->sources()[0]->outputType()},
       keyChannels_{toChannels(
           inputType_,

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -16,6 +16,7 @@
 #include "velox/exec/TableScan.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/Timer.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 
 using facebook::velox::common::testutil::TestValue;
@@ -76,7 +77,7 @@ TableScan::TableScan(
           tableScanNode->outputType(),
           operatorId,
           tableScanNode->id(),
-          "TableScan"),
+          OperatorType::kTableScan),
       tableHandle_(tableScanNode->tableHandle()),
       columnHandles_(tableScanNode->assignments()),
       driverCtx_(driverCtx),

--- a/velox/exec/TableWriteMerge.cpp
+++ b/velox/exec/TableWriteMerge.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/TableWriteMerge.h"
 
 #include "HashAggregation.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/Task.h"
 
@@ -57,7 +58,7 @@ TableWriteMerge::TableWriteMerge(
           tableWriteMergeNode->outputType(),
           operatorId,
           tableWriteMergeNode->id(),
-          "TableWriteMerge") {
+          OperatorType::kTableWriteMerge) {
   if (tableWriteMergeNode->outputType()->size() == 1) {
     VELOX_USER_CHECK(!tableWriteMergeNode->hasColumnStatsSpec());
   } else {

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/TableWriter.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -28,9 +29,11 @@ TableWriter::TableWriter(
           tableWriteNode->outputType(),
           operatorId,
           tableWriteNode->id(),
-          "TableWrite",
+          OperatorType::kTableWrite,
           tableWriteNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "TableWrite")
+              ? driverCtx->makeSpillConfig(
+                    operatorId,
+                    OperatorType::kTableWrite)
               : std::nullopt),
       driverCtx_(driverCtx),
       connectorPool_(driverCtx_->task->addConnectorPoolLocked(

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -31,6 +31,7 @@
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/OperatorTraceCtx.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -185,7 +186,8 @@ std::string makeUuid() {
 
 // Returns true if an operator is a hash join operator given 'operatorType'.
 bool isHashJoinOperator(const std::string& operatorType) {
-  return (operatorType == "HashBuild") || (operatorType == "HashProbe");
+  return (operatorType == OperatorType::kHashBuild) ||
+      (operatorType == OperatorType::kHashProbe);
 }
 
 class QueueSplitsStore : public SplitsStore {

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -16,6 +16,7 @@
 #include <folly/container/F14Map.h>
 
 #include "velox/exec/ContainerRowSerde.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/TopN.h"
 #include "velox/vector/FlatVector.h"
 
@@ -29,7 +30,7 @@ TopN::TopN(
           topNNode->outputType(),
           operatorId,
           topNNode->id(),
-          "TopN"),
+          OperatorType::kTopN),
       count_(topNNode->count()),
       data_(std::make_unique<RowContainer>(outputType_->children(), pool())),
       comparator_(

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/exec/TopNRowNumber.h"
 
+#include "velox/exec/OperatorType.h"
+
 namespace facebook::velox::exec {
 
 namespace {
@@ -131,9 +133,11 @@ TopNRowNumber::TopNRowNumber(
           node->outputType(),
           operatorId,
           node->id(),
-          "TopNRowNumber",
+          OperatorType::kTopNRowNumber,
           node->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "TopNRowNumber")
+              ? driverCtx->makeSpillConfig(
+                    operatorId,
+                    OperatorType::kTopNRowNumber)
               : std::nullopt),
       rankFunction_(node->rankFunction()),
       limit_{node->limit()},

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/Unnest.h"
 #include "velox/common/base/Nulls.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::exec {
@@ -40,7 +41,7 @@ Unnest::Unnest(
           unnestNode->outputType(),
           operatorId,
           unnestNode->id(),
-          "Unnest"),
+          OperatorType::kUnnest),
       withOrdinality_(unnestNode->hasOrdinality()),
       withMarker_(unnestNode->hasMarker()),
       maxOutputSize_(

--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/Values.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/OperatorType.h"
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
@@ -28,7 +29,7 @@ Values::Values(
           values->outputType(),
           operatorId,
           values->id(),
-          "Values"),
+          OperatorType::kValues),
       valueNodes_(std::move(values)),
       roundsLeft_(valueNodes_->repeatTimes()) {}
 

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/Window.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/PartitionStreamingWindowBuild.h"
 #include "velox/exec/RowsStreamingWindowBuild.h"
@@ -43,9 +44,9 @@ Window::Window(
           windowNode->outputType(),
           operatorId,
           windowNode->id(),
-          "Window",
+          OperatorType::kWindow,
           windowNode->canSpill(driverCtx->queryConfig())
-              ? driverCtx->makeSpillConfig(operatorId, "Window")
+              ? driverCtx->makeSpillConfig(operatorId, OperatorType::kWindow)
               : std::nullopt),
       numInputColumns_(windowNode->inputType()->size()),
       windowNode_(windowNode),

--- a/velox/exec/trace/TraceUtil.cpp
+++ b/velox/exec/trace/TraceUtil.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/file/File.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/core/TableWriteTraits.h"
+#include "velox/exec/OperatorType.h"
 #include "velox/exec/trace/Trace.h"
 
 namespace facebook::velox::exec::trace {
@@ -236,23 +237,23 @@ std::vector<uint32_t> extractDriverIds(const std::string& driverIds) {
 }
 
 bool canTrace(const std::string& operatorType) {
-  static const std::unordered_set<std::string> kSupportedOperatorTypes{
-      "Aggregation",
-      "CallbackSink",
-      "Exchange",
-      "FilterProject",
-      "HashBuild",
-      "HashProbe",
-      "IndexLookupJoin",
-      "MergeExchange",
-      "MergeJoin",
-      "OrderBy",
-      "PartialAggregation",
-      "PartitionedOutput",
-      "TableScan",
-      "TableWrite",
-      "TopNRowNumber",
-      "Unnest"};
+  static const std::unordered_set<std::string_view> kSupportedOperatorTypes{
+      OperatorType::kAggregation,
+      OperatorType::kCallbackSink,
+      OperatorType::kExchange,
+      OperatorType::kFilterProject,
+      OperatorType::kHashBuild,
+      OperatorType::kHashProbe,
+      OperatorType::kIndexLookupJoin,
+      OperatorType::kMergeExchange,
+      OperatorType::kMergeJoin,
+      OperatorType::kOrderBy,
+      OperatorType::kPartialAggregation,
+      OperatorType::kPartitionedOutput,
+      OperatorType::kTableScan,
+      OperatorType::kTableWrite,
+      OperatorType::kTopNRowNumber,
+      OperatorType::kUnnest};
   if (kSupportedOperatorTypes.count(operatorType) > 0 ||
       traceNodeRegistry().count(operatorType) > 0) {
     return true;


### PR DESCRIPTION
Summary:
Replace hardcoded operator type string literals scattered across operator constructors and comparison sites with centralized `static constexpr const char*` constants in a new `OperatorType.h` header.

Test-only operators (e.g., "Pauser", "Throw") are intentionally excluded and can be addressed in a follow-up.

Differential Revision: D93187082
