### PR TITLE
feat: Use emplace_back instead of push_back in Parquet writer Schema

### DIFF
--- a/velox/dwio/parquet/writer/arrow/Schema.cpp
+++ b/velox/dwio/parquet/writer/arrow/Schema.cpp
@@ -634,8 +634,7 @@ std::unique_ptr<Node> unflatten(
       // Group node (may have 0 children, but cannot have a type)
       NodeVector fields;
       for (int i = 0; i < element.num_children; ++i) {
-        std::unique_ptr<Node> field = nextNode();
-        fields.push_back(NodePtr(field.release()));
+        fields.emplace_back(nextNode());
       }
       return GroupNode::fromParquet(opaqueElement, std::move(fields));
     }
@@ -924,7 +923,7 @@ void SchemaDescriptor::buildTree(
         static_cast<int>(leaves_.size());
 
     // Primitive node, append to leaves.
-    leaves_.push_back(ColumnDescriptor(Node, maxDefLevel, maxRepLevel, this));
+    leaves_.emplace_back(Node, maxDefLevel, maxRepLevel, this);
     leafToBase_.emplace(static_cast<int>(leaves_.size()) - 1, base);
     leafToIdx_.emplace(
         Node->path()->toDotString(), static_cast<int>(leaves_.size()) - 1);


### PR DESCRIPTION
Replace `push_back` calls with `emplace_back` in `Schema.cpp` to improve performance by avoiding unnecessary temporary object construction.

**Changes:**
- `fields.push_back(NodePtr(field.release()))` → `fields.emplace_back(field.release())` - Constructs the `shared_ptr` in-place instead of creating a temporary
- `leaves_.push_back(ColumnDescriptor(...))` → `leaves_.emplace_back(...)` - Constructs `ColumnDescriptor` directly in the vector's memory

This eliminates temporary object creation and subsequent move operations, which is a standard C++ modernization recommended by clang-tidy's `modernize-use-emplace` check.

Differential Revision: D93206476


