### PR TITLE
prepare for folly::storeUnaligned to require an explicit type param

### DIFF
--- a/velox/common/compression/Lz4Compression.cpp
+++ b/velox/common/compression/Lz4Compression.cpp
@@ -588,8 +588,9 @@ Expected<uint64_t> Lz4HadoopCodec::compress(
             folly::Endian::big(static_cast<uint32_t>(inputLength));
         const uint32_t compressedLength =
             folly::Endian::big(static_cast<uint32_t>(compressedSize));
-        folly::storeUnaligned(output, decompressedLength);
-        folly::storeUnaligned(output + sizeof(uint32_t), compressedLength);
+        folly::storeUnaligned<uint32_t>(output, decompressedLength);
+        folly::storeUnaligned<uint32_t>(
+            output + sizeof(uint32_t), compressedLength);
         return kPrefixLength + compressedSize;
       });
 }

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -415,7 +415,7 @@ class ByteOutputStream {
         auto* buffer = current_->buffer + (position >> 3);
         auto value = folly::loadUnaligned<uint64_t>(buffer);
         value = (value & mask) | (bits[0] << offset);
-        folly::storeUnaligned(buffer, value);
+        folly::storeUnaligned<uint64_t>(buffer, value);
         current_->position += end;
         return;
       }

--- a/velox/functions/lib/QuantileDigest.h
+++ b/velox/functions/lib/QuantileDigest.h
@@ -299,7 +299,7 @@ T read(const char*& input) {
 
 template <typename T>
 void write(T value, char*& out) {
-  folly::storeUnaligned(out, value);
+  folly::storeUnaligned<T>(out, value);
   out += sizeof(T);
 }
 } // namespace detail

--- a/velox/functions/lib/TDigest.h
+++ b/velox/functions/lib/TDigest.h
@@ -568,7 +568,7 @@ static_assert(folly::kIsLittleEndian);
 
 template <typename T>
 void write(T value, char*& out) {
-  folly::storeUnaligned(out, value);
+  folly::storeUnaligned<T>(out, value);
   out += sizeof(T);
 }
 

--- a/velox/serializers/PrestoSerializerSerializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerSerializationUtils.cpp
@@ -560,8 +560,8 @@ void copyWords(
     const T* values,
     Conv&& conv = {}) {
   for (auto i = 0; i < numIndices; ++i) {
-    folly::storeUnaligned(
-        destination + i * sizeof(T), conv(values[indices[i]]));
+    folly::storeUnaligned<T>(
+        destination + i * sizeof(T), static_cast<T>(conv(values[indices[i]])));
   }
 }
 
@@ -578,8 +578,9 @@ void copyWordsWithRows(
     return;
   }
   for (auto i = 0; i < numIndices; ++i) {
-    folly::storeUnaligned(
-        destination + i * sizeof(T), conv(values[rows[indices[i]]]));
+    folly::storeUnaligned<T>(
+        destination + i * sizeof(T),
+        static_cast<T>(conv(values[rows[indices[i]]])));
   }
 }
 
@@ -763,7 +764,7 @@ void serializeFlatVector<TypeKind::BOOLEAN>(
     uint64_t word = bitsToBytes(reinterpret_cast<uint8_t*>(valueBits)[i]);
     auto* target = output + i * 8;
     if (i < numBytes - 1) {
-      folly::storeUnaligned(target, word);
+      folly::storeUnaligned<uint64_t>(target, word);
     } else {
       memcpy(target, &word, numValueBits - i * 8);
     }

--- a/velox/serializers/VectorStream.h
+++ b/velox/serializers/VectorStream.h
@@ -80,7 +80,8 @@ class VectorStream {
       VELOX_CHECK_EQ(header_.size, kHeaderSize);
     }
     header_.size = name.size() + sizeof(int32_t);
-    folly::storeUnaligned<int32_t>(header_.buffer, name.size());
+    folly::storeUnaligned<int32_t>(
+        header_.buffer, static_cast<int32_t>(name.size()));
     ::memcpy(header_.buffer + sizeof(int32_t), &name[0], name.size());
   }
 


### PR DESCRIPTION
Summary:
Addresses problems like this:

```
void* buf = /*...*/;
uint16_t word = /*...*/;
storeUnaligned(buf, word & 0xffff); // oops, 32-bit store due to implicit integer promotion
```

Differential Revision: D93190551


