### PR TITLE
feat(cursor): Support planId in moveStep()

### DIFF
--- a/velox/exec/Cursor.h
+++ b/velox/exec/Cursor.h
@@ -153,8 +153,13 @@ class TaskCursor {
   /// with a breakpoint installed, or the next task output. If no breakpoints
   /// are set, then moveStep() == moveNext().
   ///
+  /// If @planId is non-empty, only stops at a breakpoint whose plan node ID
+  /// matches @planId; breakpoints for other plan nodes are skipped
+  /// (unblocked) automatically. When empty (the default), stops at the next
+  /// breakpoint regardless of plan node ID.
+  ///
   /// @return Returns false is the task is done producing output.
-  virtual bool moveStep() = 0;
+  virtual bool moveStep(const core::PlanNodeId& planId = "") = 0;
 
   /// Returns the vector the cursor is currently on.
   virtual RowVectorPtr& current() = 0;

--- a/velox/python/runner/PyLocalRunner.cpp
+++ b/velox/python/runner/PyLocalRunner.cpp
@@ -77,8 +77,8 @@ PyVector PyTaskIterator::next() {
   return PyVector{vector_, outputPool_};
 }
 
-PyVector PyTaskIterator::step() {
-  if (!cursor_->moveStep()) {
+PyVector PyTaskIterator::step(const std::string& planId) {
+  if (!cursor_->moveStep(planId)) {
     vector_ = nullptr;
     throw py::stop_iteration(); // Raise StopIteration when done.
   }

--- a/velox/python/runner/PyLocalRunner.h
+++ b/velox/python/runner/PyLocalRunner.h
@@ -42,7 +42,11 @@ class PyTaskIterator {
   /// Steps through execution, returning either the input to the next operator
   /// with a breakpoint installed, or the next task output. If no breakpoints
   /// are set, then step() behaves like next().
-  PyVector step();
+  ///
+  /// If @p planId is non-empty, only stops at a breakpoint whose plan node ID
+  /// matches @p planId; breakpoints for other plan nodes are skipped
+  /// automatically.
+  PyVector step(const std::string& planId = "");
 
   std::optional<PyVector> current() const {
     if (!vector_) {

--- a/velox/python/runner/runner.cpp
+++ b/velox/python/runner/runner.cpp
@@ -47,11 +47,15 @@ PYBIND11_MODULE(runner, m) {
       .def(
           "step",
           &velox::py::PyTaskIterator::step,
+          py::arg("plan_id") = "",
           py::keep_alive<0, 1>(),
           py::doc(R"(
         Steps through execution, returning either the input to the next
         operator with a breakpoint installed, or the next task output.
         If no breakpoints are set, then step() behaves like next().
+
+        If plan_id is specified, only stops at a breakpoint matching the
+        given plan node ID; breakpoints for other nodes are skipped.
           )"))
       .def(
           "current",


### PR DESCRIPTION
Summary:
When running task debugger cursor with breakpoints installed, adding
an optional parameter to moveStep() to enable user to move the cursor to the
next breakpoint matching a give planId. If planId is not specified, move to the
next breakpoint.

Adding python bindings and test as appropriate.

Differential Revision: D93314252


