### PR TITLE
feat: Add max scan rows limit for index lookup

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -259,6 +259,13 @@ bool HiveConfig::preserveFlatMapsInMemory(
       config_->get<bool>(kPreserveFlatMapsInMemory, false));
 }
 
+uint32_t HiveConfig::maxRowsPerIndexRequest(
+    const config::ConfigBase* session) const {
+  return session->get<uint32_t>(
+      kMaxRowsPerIndexRequestSession,
+      config_->get<uint32_t>(kMaxRowsPerIndexRequest, 0));
+}
+
 std::string HiveConfig::user(const config::ConfigBase* session) const {
   return session->get<std::string>(kUser, config_->get<std::string>(kUser, ""));
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -208,6 +208,14 @@ class HiveConfig {
   static constexpr const char* kPreserveFlatMapsInMemorySession =
       "hive.preserve_flat_maps_in_memory";
 
+  /// Maximum number of output rows to return per index lookup request.
+  /// The limit is applied to the actual output rows after filtering.
+  /// 0 means no limit (default).
+  static constexpr const char* kMaxRowsPerIndexRequest =
+      "hive.max-rows-per-index-request";
+  static constexpr const char* kMaxRowsPerIndexRequestSession =
+      "hive.max_rows_per_index_request";
+
   static constexpr const char* kUser = "user";
   static constexpr const char* kSource = "source";
   static constexpr const char* kSchema = "schema";
@@ -292,6 +300,10 @@ class HiveConfig {
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.
   bool preserveFlatMapsInMemory(const config::ConfigBase* session) const;
+
+  /// Returns the maximum number of rows to read per index lookup request.
+  /// 0 means no limit (default).
+  uint32_t maxRowsPerIndexRequest(const config::ConfigBase* session) const;
 
   /// User of the query. Used for storage logging.
   std::string user(const config::ConfigBase* session) const;

--- a/velox/connectors/hive/HiveIndexReader.cpp
+++ b/velox/connectors/hive/HiveIndexReader.cpp
@@ -302,7 +302,9 @@ HiveIndexReader::createIndexReader() {
   return fileReader_->createIndexReader(rowReaderOpts);
 }
 
-void HiveIndexReader::startLookup(const Request& request) {
+void HiveIndexReader::startLookup(
+    const Request& request,
+    const Options& options) {
   VELOX_CHECK(
       !indexReader_->hasNext(),
       "Previous request not finished. Call next() first.");
@@ -311,7 +313,7 @@ void HiveIndexReader::startLookup(const Request& request) {
 
   // Build index bounds from request and pass to the index reader.
   auto indexBounds = buildRequestIndexBounds(request.input);
-  indexReader_->startLookup(indexBounds);
+  indexReader_->startLookup(indexBounds, options);
 }
 
 serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(

--- a/velox/connectors/hive/HiveIndexReader.h
+++ b/velox/connectors/hive/HiveIndexReader.h
@@ -63,13 +63,16 @@ class HiveIndexReader {
 
   using Request = IndexSource::Request;
   using Result = IndexSource::Result;
+  using Options = dwio::common::IndexReader::Options;
 
   /// Sets the input for index lookup. Each row in 'input' will be converted
   /// to index bounds and passed to the format-specific IndexReader.
   ///
   /// @param request The lookup request containing input row vector with lookup
   /// keys.
-  void startLookup(const Request& request);
+  /// @param options Options controlling index reader behavior (e.g.,
+  ///        maxRowsPerRequest). Defaults to no limit.
+  void startLookup(const Request& request, const Options& options = {});
 
   /// Returns true if there are more results to fetch from the current lookup.
   bool hasNext() const;

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -68,6 +68,10 @@ class HiveIndexSource : public IndexSource,
     return pool_;
   }
 
+  uint32_t maxRowsPerIndexRequest() const {
+    return maxRowsPerIndexRequest_;
+  }
+
   const RowTypePtr& outputType() const {
     return outputType_;
   }
@@ -121,6 +125,7 @@ class HiveIndexSource : public IndexSource,
   const std::shared_ptr<HiveConfig> hiveConfig_;
   memory::MemoryPool* const pool_;
   core::ExpressionEvaluator* const expressionEvaluator_;
+  const uint32_t maxRowsPerIndexRequest_;
 
   const HiveTableHandlePtr tableHandle_;
   const RowTypePtr requestType_;

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -791,6 +791,12 @@ Each query can override the config by setting corresponding query session proper
      - bool
      - false
      - Whether to preserve flat maps in memory as FlatMapVectors instead of converting them to MapVectors. This is only applied during data reading inside the DWRF and Nimble readers, not during downstream processing like expression evaluation etc.
+   * - hive.max-rows-per-index-request
+     - hive.max_rows_per_index_request
+     - integer
+     - 0
+     - Maximum number of output rows to return per index lookup request. The limit is applied to the actual output rows
+       after filtering. 0 means no limit (default).
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -229,16 +229,28 @@ class IndexReader {
 
   virtual ~IndexReader() = default;
 
+  /// Options for controlling index reader behavior.
+  struct Options {
+    /// Maximum number of rows to read per index lookup request.
+    /// When set to non-zero, the index reader will stop fetching or truncate
+    /// stripes once the total row range (before filtering) reaches this limit.
+    /// 0 means no limit (default).
+    vector_size_t maxRowsPerRequest{0};
+  };
+
   /// Starts a new batch lookup with the given index bounds.
   /// Each index bound in the vector represents a separate lookup request.
   /// After calling startLookup(), call next() repeatedly to get results.
   ///
   /// @param indexBounds Index bounds for the lookup request. Contains
   ///        column names and lower/upper bound values.
+  /// @param options Options controlling index reader behavior (e.g.,
+  ///        maxRowsPerRequest). Defaults to no limit.
   /// @throws if lookup is not supported by the implementation or if any
   ///         index bound is invalid.
   virtual void startLookup(
-      const velox::serializer::IndexBounds& indexBounds) = 0;
+      const velox::serializer::IndexBounds& indexBounds,
+      const Options& options) = 0;
 
   /// Returns true if there are more results to fetch from the current lookup.
   virtual bool hasNext() const = 0;


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/490

This diff adds a `maxRowsPerIndexRequest` configuration option that limits the number of rows returned per index lookup request. This is useful for controlling memory usage and query performance when index lookups could potentially return very large result sets.

The implementation works differently based on whether filters are applied:
- **Without filters**: Stripes can be pruned upfront based on pre-filter row counts since input rows == output rows. Middle stripes are considered for truncation (first/last stripes may be partial with unknown row counts until `lookupRowRanges()`).
- **With filters**: Truncation is applied during output tracking in `trackStripeSegmentOutputRefs()` since we don't know output rows ahead of time.

- Add `maxRowsPerIndexRequest` config in `HiveConfig` (both session and config-level)
- Extend `IndexReader::Options` to pass `maxRowsPerRequest` to the reader
- Implement stripe pruning and row range truncation in `SelectiveNimbleIndexReader`
- Add `removeRequestFromSubsequentStripes()` helper for cleaning up requests that have reached their limit
- Add comprehensive unit tests for both `HiveIndexReader` and `HiveIndexSource` APIs

Differential Revision: D93313029


