### PR TITLE
Add checked_remainder for integer and floating-point types

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -95,6 +95,11 @@ Mathematical Functions
     Returns the results of dividing x by y. The types of x and y must be the same.
     Division by zero results in an error. Corresponds to Spark's operator ``/`` with ``failOnError`` as true.
 
+.. function:: checked_remainder(n, m) -> [same as n]
+
+    Returns the modulus (remainder) of ``n`` divided by ``m``. The types of n and m must be the same.
+    Division by zero results in an error. Corresponds to Spark's operator ``%`` with ``failOnError`` as true.
+
 .. function:: checked_multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -131,6 +131,7 @@ void registerMathFunctions(const std::string& prefix) {
   registerBinaryNumeric<CheckedSubtractFunction>({prefix + "checked_subtract"});
   registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "checked_multiply"});
   registerBinaryNumeric<CheckedDivideFunction>({prefix + "checked_divide"});
+  registerBinaryNumeric<CheckedRemainderFunction>({prefix + "checked_remainder"});
   registerBinaryIntegralWithTReturn<CheckedIntegralDivideFunction, int64_t>(
       {prefix + "checked_div"});
   registerFunction<sparksql::FactorialFunction, int64_t, int32_t>(


### PR DESCRIPTION
## Summary
  - Add `checked_remainder` for integer and floating-point types that throws on division by zero, matching Spark's ANSI mode behavior for the `%` operator
  - The decimal version was added in #16353; this adds the integer and floating-point counterpart
  - Unlike `checked_divide`, remainder does not overflow on `INT_MIN % -1` (result is 0), so only division by zero is checked

  ## Test plan
  - Unit tests were added in `ArithmeticTest.checkedRemainder`

Closing https://github.com/facebookincubator/velox/issues/16404