### PR TITLE
Add checked_pmod for integer and floating-point types

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -95,6 +95,11 @@ Mathematical Functions
     Returns the results of dividing x by y. The types of x and y must be the same.
     Division by zero results in an error. Corresponds to Spark's operator ``/`` with ``failOnError`` as true.
 
+.. function:: checked_pmod(n, m) -> [same as n]
+
+    Returns the positive modulus (remainder) of ``n`` divided by ``m``. The types of n and m must be the same.
+    Division by zero results in an error. Corresponds to Spark's ``pmod`` function with ``failOnError`` as true.
+
 .. function:: checked_multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -131,6 +131,9 @@ void registerMathFunctions(const std::string& prefix) {
   registerBinaryNumeric<CheckedSubtractFunction>({prefix + "checked_subtract"});
   registerBinaryNumeric<CheckedMultiplyFunction>({prefix + "checked_multiply"});
   registerBinaryNumeric<CheckedDivideFunction>({prefix + "checked_divide"});
+  registerBinaryIntegral<CheckedPModIntFunction>({prefix + "checked_pmod"});
+  registerBinaryFloatingPoint<CheckedPModFloatFunction>(
+      {prefix + "checked_pmod"});
   registerBinaryIntegralWithTReturn<CheckedIntegralDivideFunction, int64_t>(
       {prefix + "checked_div"});
   registerFunction<sparksql::FactorialFunction, int64_t, int32_t>(


### PR DESCRIPTION
Add `checked_pmod` for integer and floating-point Spark arithmetic,
  which returns the positive modulus and throws on division by zero
  (for `spark.sql.ansi.enabled=true`).

  - `CheckedPModIntFunction`: integer types with `INT_MIN % -1` trap guard
  - `CheckedPModFloatFunction`: floating-point types using std::fmod
  - Tests covering division by zero, int8/16/32/64, float/double, edge cases
  - Documentation in `math.rst`
