### PR TITLE
refactor: Iceberg params to improve type clarity

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -71,7 +71,17 @@ class IcebergInsertTableHandle final : public HiveInsertTableHandle {
     return partitionSpec_;
   }
 
+  /// Returns the Iceberg input columns for this insert.
+  const std::vector<IcebergColumnHandlePtr>& icebergInputColumns() const {
+    return icebergInputColumns_;
+  }
+
  private:
+  // Stored separately from the parent's inputColumns_ (which holds the same
+  // columns as HiveColumnHandlePtr) because the parent HiveDataSink methods
+  // operate on HiveColumnHandle while Iceberg-specific code needs the
+  // IcebergColumnHandle type without downcasting.
+  const std::vector<IcebergColumnHandlePtr> icebergInputColumns_;
   const IcebergPartitionSpecPtr partitionSpec_;
 };
 

--- a/velox/connectors/hive/iceberg/IcebergDataSource.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/connectors/hive/iceberg/IcebergDataSource.h"
 
+#include "velox/common/Casts.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -38,8 +40,9 @@ IcebergDataSource::IcebergDataSource(
           hiveConfig) {}
 
 std::unique_ptr<SplitReader> IcebergDataSource::createSplitReader() {
+  auto icebergSplit = checkedPointerCast<const IcebergConnectorSplit>(split_);
   return std::make_unique<IcebergSplitReader>(
-      split_,
+      icebergSplit,
       hiveTableHandle_,
       &partitionKeys_,
       connectorQueryCtx_,

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -20,7 +20,7 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-HiveIcebergSplit::HiveIcebergSplit(
+IcebergConnectorSplit::IcebergConnectorSplit(
     const std::string& connectorId,
     const std::string& filePath,
     dwio::common::FileFormat fileFormat,
@@ -55,7 +55,7 @@ HiveIcebergSplit::HiveIcebergSplit(
 }
 
 // For tests only
-HiveIcebergSplit::HiveIcebergSplit(
+IcebergConnectorSplit::IcebergConnectorSplit(
     const std::string& connectorId,
     const std::string& filePath,
     dwio::common::FileFormat fileFormat,

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -22,10 +22,10 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
+struct IcebergConnectorSplit : public HiveConnectorSplit {
   std::vector<IcebergDeleteFile> deleteFiles;
 
-  HiveIcebergSplit(
+  IcebergConnectorSplit(
       const std::string& connectorId,
       const std::string& filePath,
       dwio::common::FileFormat fileFormat,
@@ -41,7 +41,7 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       std::optional<FileProperties> fileProperties = std::nullopt);
 
   // For tests only
-  HiveIcebergSplit(
+  IcebergConnectorSplit(
       const std::string& connectorId,
       const std::string& filePath,
       dwio::common::FileFormat fileFormat,

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -29,7 +29,7 @@ using namespace facebook::velox::dwio::common;
 namespace facebook::velox::connector::hive::iceberg {
 
 IcebergSplitReader::IcebergSplitReader(
-    const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
+    const std::shared_ptr<const IcebergConnectorSplit>& icebergSplit,
     const HiveTableHandlePtr& hiveTableHandle,
     const HiveColumnHandleMap* partitionKeys,
     const ConnectorQueryCtx* connectorQueryCtx,
@@ -41,7 +41,7 @@ IcebergSplitReader::IcebergSplitReader(
     folly::Executor* executor,
     const std::shared_ptr<common::ScanSpec>& scanSpec)
     : SplitReader(
-          hiveSplit,
+          icebergSplit,
           hiveTableHandle,
           partitionKeys,
           connectorQueryCtx,
@@ -52,6 +52,7 @@ IcebergSplitReader::IcebergSplitReader(
           fileHandleFactory,
           executor,
           scanSpec),
+      icebergSplit_(icebergSplit),
       baseReadOffset_(0),
       splitOffset_(0),
       deleteBitmap_(nullptr) {}
@@ -73,12 +74,11 @@ void IcebergSplitReader::prepareSplit(
 
   createRowReader(std::move(metadataFilter), std::move(rowType), std::nullopt);
 
-  auto icebergSplit = checkedPointerCast<const HiveIcebergSplit>(hiveSplit_);
   baseReadOffset_ = 0;
   splitOffset_ = baseRowReader_->nextRowNumber();
   positionalDeleteFileReaders_.clear();
 
-  const auto& deleteFiles = icebergSplit->deleteFiles;
+  const auto& deleteFiles = icebergSplit_->deleteFiles;
   for (const auto& deleteFile : deleteFiles) {
     if (deleteFile.content == FileContent::kPositionalDeletes) {
       if (deleteFile.recordCount > 0) {
@@ -104,7 +104,7 @@ void IcebergSplitReader::prepareSplit(
         positionalDeleteFileReaders_.push_back(
             std::make_unique<PositionalDeleteFileReader>(
                 deleteFile,
-                hiveSplit_->filePath,
+                icebergSplit_->filePath,
                 fileHandleFactory_,
                 connectorQueryCtx_,
                 ioExecutor_,
@@ -113,7 +113,7 @@ void IcebergSplitReader::prepareSplit(
                 ioStats_,
                 runtimeStats,
                 splitOffset_,
-                hiveSplit_->connectorId));
+                icebergSplit_->connectorId));
       }
     } else {
       VELOX_NYI();
@@ -171,8 +171,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
   // Iceberg table stores all column's data in data file.
   for (const auto& childSpec : childrenSpecs) {
     const std::string& fieldName = childSpec->fieldName();
-    if (auto iter = hiveSplit_->infoColumns.find(fieldName);
-        iter != hiveSplit_->infoColumns.end()) {
+    if (auto iter = icebergSplit_->infoColumns.find(fieldName);
+        iter != icebergSplit_->infoColumns.end()) {
       auto infoColumnType = readerOutputType_->findChild(fieldName);
       auto constant = newConstantFromString(
           infoColumnType,
@@ -197,8 +197,8 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
         // files, partition column values are stored in partition metadata
         // rather than in the data file itself, following Hive's partitioning
         // convention.
-        if (auto it = hiveSplit_->partitionKeys.find(fieldName);
-            it != hiveSplit_->partitionKeys.end()) {
+        if (auto it = icebergSplit_->partitionKeys.find(fieldName);
+            it != icebergSplit_->partitionKeys.end()) {
           setPartitionValue(childSpec.get(), fieldName, it->second);
         } else {
           childSpec->setConstantValue(

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -18,6 +18,8 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/SplitReader.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -27,7 +29,7 @@ struct IcebergDeleteFile;
 class IcebergSplitReader : public SplitReader {
  public:
   IcebergSplitReader(
-      const std::shared_ptr<const hive::HiveConnectorSplit>& hiveSplit,
+      const std::shared_ptr<const IcebergConnectorSplit>& icebergSplit,
       const HiveTableHandlePtr& hiveTableHandle,
       const HiveColumnHandleMap* partitionKeys,
       const ConnectorQueryCtx* connectorQueryCtx,
@@ -71,7 +73,7 @@ class IcebergSplitReader : public SplitReader {
   ///
   /// 1. Info columns (e.g., $path, $data_sequence_number, $deleted)
   ///    These are virtual columns that provide metadata about the file itself.
-  ///    Values are read from hiveSplit_->infoColumns map and set as constant
+  ///    Values are read from icebergSplit_->infoColumns map and set as constant
   ///    values in the scanSpec so they're materialized for all rows.
   ///
   /// 2. Regular columns present in File:
@@ -81,7 +83,7 @@ class IcebergSplitReader : public SplitReader {
   ///
   /// 3. Columns missing from File:
   ///    a) Partition columns (hive-migrated tables):
-  ///       Column is marked as partition key in hiveSplit_->partitionKeys.
+  ///       Column is marked as partition key in icebergSplit_->partitionKeys.
   ///       In Hive-written Iceberg tables, partition column values are stored
   ///       in partition metadata, not in the data file itself. Value is read
   ///       from partition metadata and set as a constant.
@@ -92,6 +94,8 @@ class IcebergSplitReader : public SplitReader {
   std::vector<TypePtr> adaptColumns(
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
+
+  const std::shared_ptr<const IcebergConnectorSplit> icebergSplit_;
 
   // The read offset to the beginning of the split in number of rows for the
   // current batch for the base data file

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -73,12 +73,18 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
   RowTypePtr deleteFileSchema =
       ROW(std::move(deleteColumnNames), std::move(deleteColumnTypes));
 
-  deleteSplit_ = std::make_shared<HiveConnectorSplit>(
+  deleteSplit_ = std::make_shared<IcebergConnectorSplit>(
       connectorId,
       deleteFile_.filePath,
       deleteFile_.fileFormat,
       0,
-      deleteFile_.fileSizeInBytes);
+      deleteFile_.fileSizeInBytes,
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      /*cacheable=*/true,
+      std::unordered_map<std::string, std::string>{});
 
   // Create the Reader and RowReader
 

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
@@ -22,9 +22,9 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/Reader.h"
 
 namespace facebook::velox::connector::hive::iceberg {
@@ -139,7 +139,7 @@ class PositionalDeleteFileReader {
 
   // Internal split and row reader for the delete file. Reset to nullptr when
   // the delete file is fully consumed or skipped by testFilters().
-  std::shared_ptr<HiveConnectorSplit> deleteSplit_;
+  std::shared_ptr<IcebergConnectorSplit> deleteSplit_;
   std::unique_ptr<dwio::common::RowReader> deleteRowReader_;
 
   // Holds the raw output from reading the delete file. Contains a RowVector

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -19,7 +19,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/common/file/FileSystems.h"
-#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergConnector.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
@@ -291,7 +291,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
 
     for (int i = 0; i < splitCount; ++i) {
       splits.emplace_back(
-          std::make_shared<HiveIcebergSplit>(
+          std::make_shared<IcebergConnectorSplit>(
               kIcebergConnectorId,
               dataFilePath,
               fileFomat_,
@@ -312,20 +312,34 @@ class HiveIcebergTest : public HiveConnectorTestBase {
       const RowTypePtr& rowType,
       const std::unordered_set<int>& partitionIndices = {}) {
     ColumnHandleMap assignments;
+    int32_t fieldId = 1;
+    std::function<parquet::ParquetFieldId(const TypePtr&, int32_t&)> makeField =
+        [&makeField](
+            const TypePtr& type,
+            int32_t& currentFieldId) -> parquet::ParquetFieldId {
+      const int32_t currentId = currentFieldId++;
+      std::vector<parquet::ParquetFieldId> children;
+      children.reserve(type->size());
+      for (auto i = 0; i < type->size(); ++i) {
+        children.push_back(makeField(type->childAt(i), currentFieldId));
+      }
+      return parquet::ParquetFieldId{currentId, children};
+    };
     for (auto i = 0; i < rowType->size(); ++i) {
       const auto& columnName = rowType->nameOf(i);
       const auto& columnType = rowType->childAt(i);
       auto columnHandleType = partitionIndices.contains(i)
-          ? HiveColumnHandle::ColumnType::kPartitionKey
-          : HiveColumnHandle::ColumnType::kRegular;
+          ? IcebergColumnHandle::ColumnType::kPartitionKey
+          : IcebergColumnHandle::ColumnType::kRegular;
 
+      auto field = makeField(columnType, fieldId);
       assignments.insert(
           {columnName,
-           std::make_shared<HiveColumnHandle>(
+           std::make_shared<IcebergColumnHandle>(
                columnName,
                columnHandleType,
                columnType,
-               columnType,
+               field,
                std::vector<common::Subfield>{})});
     }
 
@@ -361,7 +375,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
                         ->size();
 
     std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
-    return {std::make_shared<HiveIcebergSplit>(
+    return {std::make_shared<IcebergConnectorSplit>(
         kIcebergConnectorId,
         path,
         dwio::common::FileFormat::PARQUET,
@@ -954,7 +968,7 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
                   ->openFileForRead(dataFilePath->getPath());
   const int64_t fileSize = file->size();
   std::vector<IcebergDeleteFile> deleteFiles = {deleteFile};
-  auto split = std::make_shared<HiveIcebergSplit>(
+  auto split = std::make_shared<IcebergConnectorSplit>(
       kIcebergConnectorId,
       dataFilePath->getPath(),
       dwio::common::FileFormat::DWRF,

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -94,7 +94,7 @@ std::vector<std::string> IcebergSplitReaderBenchmark::listFiles(
   return files;
 }
 
-std::shared_ptr<HiveConnectorSplit>
+std::shared_ptr<IcebergConnectorSplit>
 IcebergSplitReaderBenchmark::makeIcebergSplit(
     const std::string& dataFilePath,
     const std::vector<IcebergDeleteFile>& deleteFiles) {
@@ -103,7 +103,7 @@ IcebergSplitReaderBenchmark::makeIcebergSplit(
   auto readFile = std::make_shared<LocalReadFile>(dataFilePath);
   const int64_t fileSize = readFile->size();
 
-  return std::make_shared<HiveIcebergSplit>(
+  return std::make_shared<IcebergConnectorSplit>(
       kHiveConnectorId,
       dataFilePath,
       fileFomat_,
@@ -152,11 +152,11 @@ std::string IcebergSplitReaderBenchmark::writePositionDeleteFile(
   return deleteFilePath;
 }
 
-std::vector<std::shared_ptr<HiveConnectorSplit>>
+std::vector<std::shared_ptr<IcebergConnectorSplit>>
 IcebergSplitReaderBenchmark::createIcebergSplitsWithPositionalDelete(
     int32_t deleteRowsPercentage,
     int32_t deleteFilesCount) {
-  std::vector<std::shared_ptr<HiveConnectorSplit>> splits;
+  std::vector<std::shared_ptr<IcebergConnectorSplit>> splits;
 
   std::vector<std::string> deleteFilePaths;
   std::vector<std::string> dataFilePaths = listFiles(fileFolder_->getPath());
@@ -273,7 +273,7 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
   auto scanSpec =
       createScanSpec(*batches, rowType, filterSpecs, hitRows, filters);
 
-  std::vector<std::shared_ptr<HiveConnectorSplit>> splits =
+  std::vector<std::shared_ptr<IcebergConnectorSplit>> splits =
       createIcebergSplitsWithPositionalDelete(deletePct, 1);
 
   core::TypedExprPtr remainingFilterExpr;
@@ -327,7 +327,7 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
   suspender.dismiss();
 
   uint64_t resultSize = 0;
-  for (std::shared_ptr<HiveConnectorSplit> split : splits) {
+  for (const auto& split : splits) {
     scanSpec->resetCachedValues(true);
     std::unique_ptr<IcebergSplitReader> icebergSplitReader =
         std::make_unique<IcebergSplitReader>(

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.h
@@ -88,14 +88,15 @@ class IcebergSplitReaderBenchmark {
       float deleteRate,
       uint32_t nextSize);
 
-  std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
+  std::vector<std::shared_ptr<connector::hive::iceberg::IcebergConnectorSplit>>
   createIcebergSplitsWithPositionalDelete(
       int32_t deleteRowsPercentage,
       int32_t deleteFilesCount);
 
   std::vector<std::string> listFiles(const std::string& dirPath);
 
-  std::shared_ptr<connector::hive::HiveConnectorSplit> makeIcebergSplit(
+  std::shared_ptr<connector::hive::iceberg::IcebergConnectorSplit>
+  makeIcebergSplit(
       const std::string& dataFilePath,
       const std::vector<connector::hive::iceberg::IcebergDeleteFile>&
           deleteFiles = {});

--- a/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergTestBase.cpp
@@ -187,8 +187,8 @@ void addColumnHandles(
         std::make_shared<const IcebergColumnHandle>(
             columnName,
             partitionColumnIds.contains(i)
-                ? HiveColumnHandle::ColumnType::kPartitionKey
-                : HiveColumnHandle::ColumnType::kRegular,
+                ? IcebergColumnHandle::ColumnType::kPartitionKey
+                : IcebergColumnHandle::ColumnType::kRegular,
             type,
             field));
   }
@@ -299,7 +299,7 @@ IcebergTestBase::createSplitsForDirectory(const std::string& directory) {
     const auto file = filesystems::getFileSystem(filePath, nullptr)
                           ->openFileForRead(filePath);
     splits.push_back(
-        std::make_shared<HiveIcebergSplit>(
+        std::make_shared<IcebergConnectorSplit>(
             kIcebergConnectorId,
             filePath,
             fileFormat_,

--- a/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
+++ b/velox/connectors/hive/iceberg/tests/TransformE2ETest.cpp
@@ -746,7 +746,7 @@ TEST_F(TransformE2ETest, dateIdentityPartitionWithFilter) {
       const auto file = filesystems::getFileSystem(filePath, nullptr)
                             ->openFileForRead(filePath);
       splits.push_back(
-          std::make_shared<HiveIcebergSplit>(
+          std::make_shared<IcebergConnectorSplit>(
               test::kIcebergConnectorId,
               filePath,
               fileFormat_,
@@ -766,14 +766,14 @@ TEST_F(TransformE2ETest, dateIdentityPartitionWithFilter) {
       {"c_date",
        std::make_shared<IcebergColumnHandle>(
            "c_date",
-           HiveColumnHandle::ColumnType::kPartitionKey,
+           IcebergColumnHandle::ColumnType::kPartitionKey,
            DATE(),
            parquet::ParquetFieldId{0, {}},
            std::vector<common::Subfield>{})},
       {"c_value",
        std::make_shared<IcebergColumnHandle>(
            "c_value",
-           HiveColumnHandle::ColumnType::kRegular,
+           IcebergColumnHandle::ColumnType::kRegular,
            INTEGER(),
            parquet::ParquetFieldId{1, {}})},
   };


### PR DESCRIPTION
Refactor Iceberg connector types to use Iceberg-specific handles and splits in both production code and tests to improve type clarity.