### PR TITLE
perf(dwio): Improve rowLoop performance to recognize more dense cases

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -753,7 +753,7 @@ inline uint64_t nextPowerOfTwo(uint64_t size) {
   return 2 * lower;
 }
 
-inline bool isPowerOfTwo(uint64_t size) {
+constexpr bool isPowerOfTwo(uint64_t size) {
   return (size & (size - 1)) == 0;
 }
 

--- a/velox/dwio/common/StreamUtil.h
+++ b/velox/dwio/common/StreamUtil.h
@@ -76,19 +76,19 @@ inline bool isDense(const T* values, int32_t size) {
   return (values[size - 1] - values[0] == size - 1);
 }
 
-template <typename Dense, typename Sparse, typename SparseN>
+template <int kStep, typename Dense, typename Sparse, typename SparseN>
 void rowLoop(
     const int32_t* rows,
     int32_t begin,
     int32_t end,
-    int32_t step,
     Dense dense,
     Sparse sparse,
     SparseN sparseN) {
+  static_assert(bits::isPowerOfTwo(kStep));
   int32_t i = begin;
-  auto firstPartial = (end - begin) & ~(step - 1);
-  for (; i < firstPartial; i += step) {
-    if (isDense(&rows[i], step)) {
+  const auto firstPartial = (end - begin) & ~(kStep - 1);
+  for (; i < begin + firstPartial; i += kStep) {
+    if (isDense(&rows[i], kStep)) {
       dense(i);
     } else {
       sparse(i);

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(
   RetryTests.cpp
   ScanSpecTest.cpp
   SortingWriterTest.cpp
+  StreamUtilTest.cpp
   BufferedInputTest.cpp
   CachedBufferedInputTest.cpp
   DirectBufferedInputTest.cpp

--- a/velox/dwio/common/tests/StreamUtilTest.cpp
+++ b/velox/dwio/common/tests/StreamUtilTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/StreamUtil.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::dwio::common {
+namespace {
+
+template <int kStep>
+void testRowLoop(
+    const int32_t* rows,
+    int32_t begin,
+    int32_t end,
+    const std::vector<int32_t>& expectedDense,
+    const std::vector<int32_t>& expectedSparse,
+    const std::vector<std::pair<int32_t, int32_t>>& expectedSparseN) {
+  std::vector<int32_t> actualDense, actualSparse;
+  std::vector<std::pair<int32_t, int32_t>> actualSparseN;
+  rowLoop<kStep>(
+      rows,
+      begin,
+      end,
+      [&](auto i) { actualDense.push_back(i); },
+      [&](auto i) { actualSparse.push_back(i); },
+      [&](auto i, auto size) { actualSparseN.emplace_back(i, size); });
+  ASSERT_EQ(actualDense, expectedDense);
+  ASSERT_EQ(actualSparse, expectedSparse);
+  ASSERT_EQ(actualSparseN, expectedSparseN);
+}
+
+TEST(StreamUtilTest, rowLoop) {
+  const int32_t rows[] = {
+      0,  1,  2,  3,  4, // Dense
+      5,  7,  9,  11, 13, // Sparse
+      14, 15, 16, 17, 18, // Dense
+      19, 21, 23, 25, 27, // Sparse
+  };
+  testRowLoop<2>(rows, 0, 6, {0, 2, 4}, {}, {});
+  testRowLoop<4>(rows, 0, 6, {0}, {}, {{4, 2}});
+  testRowLoop<4>(rows, 0, 10, {0}, {4}, {{8, 2}});
+  testRowLoop<4>(rows, 10, 20, {10}, {14}, {{18, 2}});
+}
+
+} // namespace
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -318,11 +318,10 @@ inline bool SelectiveStringDirectColumnReader::try8Consecutive(
 void SelectiveStringDirectColumnReader::extractSparse(
     const int32_t* rows,
     int32_t numRows) {
-  dwio::common::rowLoop(
+  dwio::common::rowLoop<8>(
       rows,
       0,
       numRows,
-      8,
       [&](int32_t row) {
         auto start = rangeSum(rawLengths_, 0, lengthIndex_, rows[row]);
         lengthIndex_ = rows[row];


### PR DESCRIPTION
Summary:
In the current code when we do the dense loop on `rows` in `rowLoop`,
we stops earlier than necessary.  This results in forwarding most of the work to
the slow `sparseN` calls in case `begin` is not 0, and degrades the performance.
Fix this by considering `begin` when doing dense loop.

Differential Revision: D93424377


