### PR TITLE
perf: Avoid raw_vector iota allocation in more cases

### DIFF
--- a/velox/common/memory/RawVector.cpp
+++ b/velox/common/memory/RawVector.cpp
@@ -24,7 +24,7 @@ namespace {
 raw_vector<int32_t> iotaData;
 
 bool initializeIota() {
-  iotaData.resize(10000);
+  iotaData.resize(1'000'000);
   iotaData.resize(iotaData.capacity());
   std::iota(iotaData.begin(), iotaData.end(), 0);
   return true;

--- a/velox/common/memory/tests/RawVectorTest.cpp
+++ b/velox/common/memory/tests/RawVectorTest.cpp
@@ -148,12 +148,18 @@ TEST_P(RawVectorTest, copyAndMove) {
 }
 
 TEST_P(RawVectorTest, iota) {
+  constexpr int kSizeThreshold = 1'000'000;
   raw_vector<int32_t> storage =
       makeRawVector(0, GetParam().useMemoryPool ? pool_.get() : nullptr);
   // Small sizes are preallocated.
   EXPECT_EQ(11, iota(12, storage)[11]);
+  EXPECT_EQ(6, iota(12, storage, 5)[1]);
+  EXPECT_EQ(
+      kSizeThreshold - 1, iota(kSizeThreshold, storage)[kSizeThreshold - 1]);
   EXPECT_TRUE(storage.empty());
-  EXPECT_EQ(110000, iota(110001, storage)[110000]);
+  EXPECT_EQ(
+      2 * kSizeThreshold - 1,
+      iota(2 * kSizeThreshold, storage)[2 * kSizeThreshold - 1]);
   // Larger sizes are allocated in 'storage'.
   EXPECT_FALSE(storage.empty());
 }


### PR DESCRIPTION
Summary:
Currently we are using 10000 as the threshold for the fast path, and in
case of nested data structure (ARRAY and MAP), we often see the number of values
in a batch can be up to 1000000.  Improve this by increase the threshold
accordingly.  This is a per-process singleton and will not increase the overall
memory usage in any significant way.

Differential Revision: D93424384


