### PR TITLE
feat: Add indexEnabled config property to HiveConfig

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -259,6 +259,11 @@ bool HiveConfig::preserveFlatMapsInMemory(
       config_->get<bool>(kPreserveFlatMapsInMemory, false));
 }
 
+bool HiveConfig::indexEnabled(const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kIndexEnabledSession, config_->get<bool>(kIndexEnabled, false));
+}
+
 uint32_t HiveConfig::maxRowsPerIndexRequest(
     const config::ConfigBase* session) const {
   return session->get<uint32_t>(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -208,6 +208,12 @@ class HiveConfig {
   static constexpr const char* kPreserveFlatMapsInMemorySession =
       "hive.preserve_flat_maps_in_memory";
 
+  /// Whether to use the cluster index for filter-based row pruning.
+  /// When enabled, filters from ScanSpec are converted to index bounds for
+  /// efficient row skipping based on the file's cluster index.
+  static constexpr const char* kIndexEnabled = "index-enabled";
+  static constexpr const char* kIndexEnabledSession = "index_enabled";
+
   /// Maximum number of output rows to return per index lookup request.
   /// The limit is applied to the actual output rows after filtering.
   /// 0 means no limit (default).
@@ -300,6 +306,9 @@ class HiveConfig {
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.
   bool preserveFlatMapsInMemory(const config::ConfigBase* session) const;
+
+  /// Whether to use the cluster index for filter-based row pruning.
+  bool indexEnabled(const config::ConfigBase* session) const;
 
   /// Returns the maximum number of rows to read per index lookup request.
   /// 0 means no limit (default).

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -687,6 +687,8 @@ void configureRowReaderOptions(
         hiveConfig->preserveFlatMapsInMemory(sessionProperties));
     rowReaderOptions.setParallelUnitLoadCount(
         hiveConfig->parallelUnitLoadCount(sessionProperties));
+    rowReaderOptions.setIndexEnabled(
+        hiveConfig->indexEnabled(sessionProperties));
   }
   rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -55,6 +55,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_TRUE(hiveConfig.allowNullPartitionKeys(emptySession.get()));
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 8 << 20);
   ASSERT_FALSE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.indexEnabled(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -78,7 +79,8 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kReadStatsBasedFilterReorderDisabled, "true"},
       {HiveConfig::kLoadQuantum, std::to_string(4 << 20)},
       {HiveConfig::kMaxBucketCount, std::to_string(100'000)},
-      {HiveConfig::kPreserveFlatMapsInMemory, "true"}};
+      {HiveConfig::kPreserveFlatMapsInMemory, "true"},
+      {HiveConfig::kIndexEnabled, "true"}};
   HiveConfig hiveConfig(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)));
   auto emptySession = std::make_shared<config::ConfigBase>(
@@ -110,6 +112,7 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 4 << 20);
   ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 100'000);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.indexEnabled(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -130,6 +133,7 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kReadStatsBasedFilterReorderDisabledSession, "true"},
       {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)},
       {HiveConfig::kPreserveFlatMapsInMemorySession, "true"},
+      {HiveConfig::kIndexEnabledSession, "true"},
   };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -157,4 +161,5 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_TRUE(hiveConfig.readStatsBasedFilterReorderDisabled(session.get()));
   ASSERT_EQ(hiveConfig.loadQuantum(session.get()), 4 << 20);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(session.get()));
+  ASSERT_TRUE(hiveConfig.indexEnabled(session.get()));
 }


### PR DESCRIPTION
Summary: Add `indexEnabled` config property to HiveConfig that controls cluster index-based row pruning. The property is wired into RowReaderOptions via configureRowReaderOptions().

Differential Revision: D93435795


