### PR TITLE
refactor: Extract connector data source stat keys into constants

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -485,27 +485,28 @@ HiveDataSource::getRuntimeStats() {
              RuntimeCounter::Unit::kNanos)});
   }
   res.insert(
-      {{"numPrefetch", RuntimeMetric(ioStatistics_->prefetch().count())},
-       {"prefetchBytes",
+      {{std::string(kNumPrefetch),
+        RuntimeMetric(ioStatistics_->prefetch().count())},
+       {std::string(kPrefetchBytes),
         RuntimeMetric(
             ioStatistics_->prefetch().sum(),
             ioStatistics_->prefetch().count(),
             ioStatistics_->prefetch().min(),
             ioStatistics_->prefetch().max(),
             RuntimeCounter::Unit::kBytes)},
-       {"totalScanTime",
+       {std::string(kTotalScanTime),
         RuntimeMetric(
             ioStatistics_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
        {Connector::kTotalRemainingFilterTime,
         RuntimeMetric(
             totalRemainingFilterTime_.load(std::memory_order_relaxed),
             RuntimeCounter::Unit::kNanos)},
-       {"overreadBytes",
+       {std::string(kOverreadBytes),
         RuntimeMetric(
             ioStatistics_->rawOverreadBytes(), RuntimeCounter::Unit::kBytes)}});
   if (ioStatistics_->read().count() > 0) {
     res.insert(
-        {"storageReadBytes",
+        {std::string(kStorageReadBytes),
          RuntimeMetric(
              ioStatistics_->read().sum(),
              ioStatistics_->read().count(),
@@ -515,9 +516,10 @@ HiveDataSource::getRuntimeStats() {
   }
   if (ioStatistics_->ssdRead().count() > 0) {
     res.insert(
-        {"numLocalRead", RuntimeMetric(ioStatistics_->ssdRead().count())});
+        {std::string(kNumLocalRead),
+         RuntimeMetric(ioStatistics_->ssdRead().count())});
     res.insert(
-        {"localReadBytes",
+        {std::string(kLocalReadBytes),
          RuntimeMetric(
              ioStatistics_->ssdRead().sum(),
              ioStatistics_->ssdRead().count(),
@@ -526,9 +528,11 @@ HiveDataSource::getRuntimeStats() {
              RuntimeCounter::Unit::kBytes)});
   }
   if (ioStatistics_->ramHit().count() > 0) {
-    res.insert({"numRamRead", RuntimeMetric(ioStatistics_->ramHit().count())});
     res.insert(
-        {"ramReadBytes",
+        {std::string(kNumRamRead),
+         RuntimeMetric(ioStatistics_->ramHit().count())});
+    res.insert(
+        {std::string(kRamReadBytes),
          RuntimeMetric(
              ioStatistics_->ramHit().sum(),
              ioStatistics_->ramHit().count(),
@@ -537,7 +541,9 @@ HiveDataSource::getRuntimeStats() {
              RuntimeCounter::Unit::kBytes)});
   }
   if (numBucketConversion_ > 0) {
-    res.insert({"numBucketConversion", RuntimeMetric(numBucketConversion_)});
+    res.insert(
+        {std::string(kNumBucketConversion),
+         RuntimeMetric(numBucketConversion_)});
   }
 
   const auto ioStatsMap = ioStats_->stats();

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -34,6 +34,18 @@ class HiveConfig;
 
 class HiveDataSource : public DataSource {
  public:
+  /// Runtime stat keys for Hive data source.
+  static constexpr std::string_view kNumPrefetch{"numPrefetch"};
+  static constexpr std::string_view kPrefetchBytes{"prefetchBytes"};
+  static constexpr std::string_view kTotalScanTime{"totalScanTime"};
+  static constexpr std::string_view kOverreadBytes{"overreadBytes"};
+  static constexpr std::string_view kStorageReadBytes{"storageReadBytes"};
+  static constexpr std::string_view kNumLocalRead{"numLocalRead"};
+  static constexpr std::string_view kLocalReadBytes{"localReadBytes"};
+  static constexpr std::string_view kNumRamRead{"numRamRead"};
+  static constexpr std::string_view kRamReadBytes{"ramReadBytes"};
+  static constexpr std::string_view kNumBucketConversion{"numBucketConversion"};
+
   HiveDataSource(
       const RowTypePtr& outputType,
       const connector::ConnectorTableHandlePtr& tableHandle,

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -32,6 +32,7 @@
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/expression/FieldReference.h"
 
@@ -569,10 +570,10 @@ std::unordered_map<std::string, RuntimeMetric>
 CudfHiveDataSource::getRuntimeStats() {
   auto res = runtimeStats_.toRuntimeMetricMap();
   res.insert({
-      {"totalScanTime",
+      {std::string(connector::hive::HiveDataSource::kTotalScanTime),
        RuntimeMetric(
            ioStatistics_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
-      {"totalRemainingFilterTime",
+      {Connector::kTotalRemainingFilterTime,
        RuntimeMetric(
            totalRemainingFilterTime_.load(std::memory_order_relaxed),
            RuntimeCounter::Unit::kNanos)},


### PR DESCRIPTION
Summary:
Replace hardcoded runtime stat string literals in HiveDataSource::getRuntimeStats() with centralized static inline const std::string constants on the HiveDataSource class. Also updated CudfHiveDataSource to use HiveDataSource::kTotalScanTime and Connector::kTotalRemainingFilterTime instead of hardcoded strings.

Constants added: kNumPrefetch, kPrefetchBytes, kTotalScanTime, kOverreadBytes, kStorageReadBytes, kNumLocalRead, kLocalReadBytes, kNumRamRead, kRamReadBytes, kNumBucketConversion.

Differential Revision: D93369914


