### PR TITLE
feat: Make 'QueryAssertions::readCursor' can hold and check future returned by addSplit

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1360,13 +1360,31 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(TaskCursor*)> addSplits,
     uint64_t maxWaitMicros) {
+  return readCursorAsync(
+      params,
+      [addSplitsVoid = std::move(addSplits)](TaskCursor* cursor) {
+        addSplitsVoid(cursor);
+        return ContinueFuture::makeEmpty();
+      },
+      maxWaitMicros);
+}
+
+std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
+readCursorAsync(
+    const CursorParameters& params,
+    std::function<ContinueFuture(TaskCursor*)> addSplits,
+    uint64_t maxWaitMicros) {
   auto cursor = TaskCursor::create(params);
   // 'result' borrows memory from cursor so the life cycle must be shorter.
   std::vector<RowVectorPtr> result;
   auto* task = cursor->task().get();
   cursor->start();
+  auto future = ContinueFuture::makeEmpty();
   while (!cursor->noMoreSplits()) {
-    addSplits(cursor.get());
+    if (future.valid()) {
+      future.wait();
+    }
+    future = addSplits(cursor.get());
     while (cursor->moveNext()) {
       auto vector = cursor->current();
       vector->loadedVector();

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -188,6 +188,19 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
         },
     uint64_t maxWaitMicros = 5'000'000);
 
+std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
+readCursorAsync(
+    const CursorParameters& params,
+    std::function<ContinueFuture(TaskCursor*)> addSplits =
+        [](TaskCursor* taskCursor) {
+          if (taskCursor->noMoreSplits()) {
+            return ContinueFuture::makeEmpty();
+          }
+          taskCursor->setNoMoreSplits();
+          return ContinueFuture::makeEmpty();
+        },
+    uint64_t maxWaitMicros = 5'000'000);
+
 /// The Task can return results before the Driver is finished executing.
 /// Wait upto maxWaitMicros for the Task to finish as 'expectedState' before
 /// returning to ensure it's stable e.g. the Driver isn't updating it anymore.


### PR DESCRIPTION
Make 'QueryAssertions::readCursor' can hold and check future returned by addSplit.
Part of #16352 