### PR TITLE
refactor: Extract operator runtime stat keys into constants

### DIFF
--- a/velox/exec/DriverStats.h
+++ b/velox/exec/DriverStats.h
@@ -16,15 +16,28 @@
 
 #pragma once
 
+#include <string_view>
 #include <unordered_map>
 #include "velox/common/base/RuntimeMetrics.h"
 
 namespace facebook::velox::exec {
 
 struct DriverStats {
-  static constexpr const char* kTotalPauseTime = "totalDriverPauseWallNanos";
-  static constexpr const char* kTotalOffThreadTime =
+  static constexpr std::string_view kTotalPauseTime =
+      "totalDriverPauseWallNanos";
+  static constexpr std::string_view kTotalOffThreadTime =
       "totalDriverOffThreadWallNanos";
+
+  /// Number of silent Velox throws during operator execution.
+  static constexpr std::string_view kNumSilentThrow = "numSilentThrow";
+  /// Time an operator spent queued before execution.
+  static constexpr std::string_view kQueuedWallNanos = "queuedWallNanos";
+  /// Number of dynamic filters accepted by an operator.
+  static constexpr std::string_view kDynamicFiltersAccepted =
+      "dynamicFiltersAccepted";
+  /// Number of dynamic filters produced by an operator.
+  static constexpr std::string_view kDynamicFiltersProduced =
+      "dynamicFiltersProduced";
 
   std::unordered_map<std::string, RuntimeMetric> runtimeStats;
 };

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -241,13 +241,13 @@ void HashAggregation::updateRuntimeStats() {
     }
   }
 
-  runtimeStats[BaseHashTable::kCapacity] =
+  runtimeStats[std::string(BaseHashTable::kCapacity)] =
       RuntimeMetric(hashTableStats.capacity);
-  runtimeStats[BaseHashTable::kNumRehashes] =
+  runtimeStats[std::string(BaseHashTable::kNumRehashes)] =
       RuntimeMetric(hashTableStats.numRehashes);
-  runtimeStats[BaseHashTable::kNumDistinct] =
+  runtimeStats[std::string(BaseHashTable::kNumDistinct)] =
       RuntimeMetric(hashTableStats.numDistinct);
-  runtimeStats[BaseHashTable::kNumTombstones] =
+  runtimeStats[std::string(BaseHashTable::kNumTombstones)] =
       RuntimeMetric(hashTableStats.numTombstones);
 }
 
@@ -272,10 +272,13 @@ void HashAggregation::resetPartialOutputIfNeed() {
   {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
-        "flushRowCount", RuntimeCounter(numOutputRows_));
-    lockedStats->addRuntimeStat("flushTimes", RuntimeCounter(1));
+        std::string(HashAggregation::kFlushRowCount),
+        RuntimeCounter(numOutputRows_));
     lockedStats->addRuntimeStat(
-        "partialAggregationPct", RuntimeCounter(aggregationPct));
+        std::string(HashAggregation::kFlushTimes), RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        std::string(HashAggregation::kPartialAggregationPct),
+        RuntimeCounter(static_cast<int64_t>(aggregationPct)));
   }
   groupingSet_->resetTable(/*freeTable=*/false);
   partialFull_ = false;
@@ -299,7 +302,9 @@ void HashAggregation::maybeIncreasePartialAggregationMemoryUsage(
            maxExtendedPartialAggregationMemoryUsage_)) {
     groupingSet_->abandonPartialAggregation();
     pool()->release();
-    addRuntimeStat("abandonedPartialAggregation", RuntimeCounter(1));
+    addRuntimeStat(
+        std::string(HashAggregation::kAbandonedPartialAggregation),
+        RuntimeCounter(1));
     abandonedPartialAggregation_ = true;
     return;
   }

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "velox/exec/GroupingSet.h"
 #include "velox/exec/Operator.h"
 
@@ -22,6 +24,18 @@ namespace facebook::velox::exec {
 
 class HashAggregation : public Operator {
  public:
+  /// Runtime stat keys for hash aggregation.
+  /// Number of rows flushed in partial aggregation output.
+  static constexpr std::string_view kFlushRowCount = "flushRowCount";
+  /// Number of partial aggregation flush operations.
+  static constexpr std::string_view kFlushTimes = "flushTimes";
+  /// Ratio of output to input rows in partial aggregation as a percentage.
+  static constexpr std::string_view kPartialAggregationPct =
+      "partialAggregationPct";
+  /// Whether partial aggregation was abandoned due to insufficient reduction.
+  static constexpr std::string_view kAbandonedPartialAggregation =
+      "abandonedPartialAggregation";
+
   HashAggregation(
       int32_t operatorId,
       DriverCtx* driverCtx,

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -176,7 +176,7 @@ bool HashBuild::getHashTableFromCache() {
   if (!cacheEntry_->buildComplete) {
     // Cache miss - we need to build the table.
     stats_.wlock()->addRuntimeStat(
-        BaseHashTable::kHashTableCacheMiss, RuntimeCounter(1));
+        std::string(BaseHashTable::kHashTableCacheMiss), RuntimeCounter(1));
     return false;
   }
 
@@ -188,7 +188,7 @@ bool HashBuild::getHashTableFromCache() {
       cacheEntry_->table, {}, cacheEntry_->hasNullKeys, nullptr);
   // Record cache hit metric.
   stats_.wlock()->addRuntimeStat(
-      BaseHashTable::kHashTableCacheHit, RuntimeCounter(1));
+      std::string(BaseHashTable::kHashTableCacheHit), RuntimeCounter(1));
   return true;
 }
 
@@ -891,7 +891,7 @@ bool HashBuild::finishHashBuild() {
                                : nullptr);
   }
   stats_.wlock()->addRuntimeStat(
-      BaseHashTable::kBuildWallNanos,
+      std::string(BaseHashTable::kBuildWallNanos),
       RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos));
 
   addRuntimeStats();
@@ -1049,20 +1049,20 @@ void HashBuild::addRuntimeStats() {
   for (const auto& timing : table_->parallelJoinBuildStats().partitionTimings) {
     lockedStats->getOutputTiming.add(timing);
     lockedStats->addRuntimeStat(
-        BaseHashTable::kParallelJoinPartitionWallNanos,
+        std::string(BaseHashTable::kParallelJoinPartitionWallNanos),
         RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos));
     lockedStats->addRuntimeStat(
-        BaseHashTable::kParallelJoinPartitionCpuNanos,
+        std::string(BaseHashTable::kParallelJoinPartitionCpuNanos),
         RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos));
   }
 
   for (const auto& timing : table_->parallelJoinBuildStats().buildTimings) {
     lockedStats->getOutputTiming.add(timing);
     lockedStats->addRuntimeStat(
-        BaseHashTable::kParallelJoinBuildWallNanos,
+        std::string(BaseHashTable::kParallelJoinBuildWallNanos),
         RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos));
     lockedStats->addRuntimeStat(
-        BaseHashTable::kParallelJoinBuildCpuNanos,
+        std::string(BaseHashTable::kParallelJoinBuildCpuNanos),
         RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos));
   }
 
@@ -1071,12 +1071,13 @@ void HashBuild::addRuntimeStats() {
     lockedStats->getOutputTiming.add(timing);
     if (timing.wallNanos > 0) {
       lockedStats->addRuntimeStat(
-          BaseHashTable::kParallelJoinBloomFilterPartitionWallNanos,
+          std::string(
+              BaseHashTable::kParallelJoinBloomFilterPartitionWallNanos),
           RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos));
     }
     if (timing.cpuNanos > 0) {
       lockedStats->addRuntimeStat(
-          BaseHashTable::kParallelJoinBloomFilterPartitionCpuNanos,
+          std::string(BaseHashTable::kParallelJoinBloomFilterPartitionCpuNanos),
           RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos));
     }
   }
@@ -1086,12 +1087,12 @@ void HashBuild::addRuntimeStats() {
     lockedStats->getOutputTiming.add(timing);
     if (timing.wallNanos > 0) {
       lockedStats->addRuntimeStat(
-          BaseHashTable::kParallelJoinBloomFilterBuildWallNanos,
+          std::string(BaseHashTable::kParallelJoinBloomFilterBuildWallNanos),
           RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos));
     }
     if (timing.cpuNanos > 0) {
       lockedStats->addRuntimeStat(
-          BaseHashTable::kParallelJoinBloomFilterBuildCpuNanos,
+          std::string(BaseHashTable::kParallelJoinBloomFilterBuildCpuNanos),
           RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos));
     }
   }
@@ -1108,27 +1109,27 @@ void HashBuild::addRuntimeStats() {
     }
   }
 
-  lockedStats->runtimeStats[BaseHashTable::kCapacity] =
+  lockedStats->runtimeStats[std::string(BaseHashTable::kCapacity)] =
       RuntimeMetric(hashTableStats.capacity);
-  lockedStats->runtimeStats[BaseHashTable::kNumRehashes] =
+  lockedStats->runtimeStats[std::string(BaseHashTable::kNumRehashes)] =
       RuntimeMetric(hashTableStats.numRehashes);
-  lockedStats->runtimeStats[BaseHashTable::kNumDistinct] =
+  lockedStats->runtimeStats[std::string(BaseHashTable::kNumDistinct)] =
       RuntimeMetric(hashTableStats.numDistinct);
   if (hashTableStats.numTombstones != 0) {
-    lockedStats->runtimeStats[BaseHashTable::kNumTombstones] =
+    lockedStats->runtimeStats[std::string(BaseHashTable::kNumTombstones)] =
         RuntimeMetric(hashTableStats.numTombstones);
   }
 
   // Add max spilling level stats if spilling has been triggered.
   if (spiller_ != nullptr && spiller_->spillTriggered()) {
     lockedStats->addRuntimeStat(
-        "maxSpillLevel",
+        std::string(HashBuild::kMaxSpillLevel),
         RuntimeCounter(
             spillConfig()->spillLevel(spiller_->hashBits().begin())));
   }
 
   lockedStats->addRuntimeStat(
-      BaseHashTable::kVectorHasherMergeCpuNanos,
+      std::string(BaseHashTable::kVectorHasherMergeCpuNanos),
       RuntimeCounter(
           table_->vectorHasherMergeTiming().cpuNanos,
           RuntimeCounter::Unit::kNanos));
@@ -1447,7 +1448,8 @@ void HashBuild::abandonHashBuildDedup() {
   // The hash table is no longer directly constructed in addInput. The data
   // that was previously inserted into the hash table is already in the
   // RowContainer.
-  addRuntimeStat("abandonBuildNoDupHash", RuntimeCounter(1));
+  addRuntimeStat(
+      std::string(HashBuild::kAbandonBuildNoDupHash), RuntimeCounter(1));
   abandonHashBuildDedup_ = true;
   table_->setAllowDuplicates(true);
   lookup_.reset();

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "velox/exec/HashJoinBridge.h"
 #include "velox/exec/HashTable.h"
 #include "velox/exec/HashTableCache.h"
@@ -54,6 +56,13 @@ class HashBuild final : public Operator {
     kFinish = 5,
   };
   static std::string stateName(State state);
+
+  /// Runtime stat keys for hash build.
+  /// Maximum spill level reached during hash join build.
+  static constexpr std::string_view kMaxSpillLevel = "maxSpillLevel";
+  /// Whether dedup hash build was abandoned.
+  static constexpr std::string_view kAbandonBuildNoDupHash =
+      "abandonBuildNoDupHash";
 
   HashBuild(
       int32_t operatorId,

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -399,7 +399,8 @@ void HashProbe::pushdownDynamicFilters() {
               checkedPointerCast<const common::BigintValuesUsingBloomFilter>(
                   filter.get());
           addRuntimeStat(
-              "bloomFilterSize", RuntimeCounter(bloomFilter->blocksByteSize()));
+              std::string(HashProbe::kBloomFilterSize),
+              RuntimeCounter(bloomFilter->blocksByteSize()));
         }
         dynamicFiltersProducedOnChannels_.insert(sourceChannel);
         for (auto* peer : findPeerOperators()) {
@@ -1122,7 +1123,9 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
   const auto inputSize = input_->size();
 
   if (replacedWithDynamicFilter_) {
-    addRuntimeStat("replacedWithDynamicFilterRows", RuntimeCounter(inputSize));
+    addRuntimeStat(
+        std::string(HashProbe::kReplacedWithDynamicFilterRows),
+        RuntimeCounter(inputSize));
     auto output = Operator::fillOutput(inputSize, nullptr);
     input_ = nullptr;
     return output;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "velox/exec/HashBuild.h"
 #include "velox/exec/HashTable.h"
 #include "velox/exec/Operator.h"
@@ -26,6 +28,13 @@ namespace facebook::velox::exec {
 // Probes a hash table made by HashBuild.
 class HashProbe : public Operator {
  public:
+  /// Runtime stat keys for hash probe.
+  /// Size of the bloom filter in bytes.
+  static constexpr std::string_view kBloomFilterSize = "bloomFilterSize";
+  /// Number of rows bypassed via dynamic filter replacement.
+  static constexpr std::string_view kReplacedWithDynamicFilterRows =
+      "replacedWithDynamicFilterRows";
+
   HashProbe(
       int32_t operatorId,
       DriverCtx* driverCtx,
@@ -380,8 +389,8 @@ class HashProbe : public Operator {
 
   // Flag to indicate whether this hash probe operator can output build-side
   // rows in parallel with the peer operators for the current hash table.
-  // Outputing build-side rows in parallel is currently not allowed in either of
-  // the following cases:
+  // Outputting build-side rows in parallel is currently not allowed in either
+  // of the following cases:
   // 1. QueryConfig::kParallelOutputJoinBuildRowsEnabled is false.
   // 2. Spill is enabled.
   const bool canOutputBuildRowsInParallel_;

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -1522,9 +1522,11 @@ void MergeJoin::close() {
   {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
-        "matchedLeftRows", RuntimeCounter(matchedLeftRows_));
+        std::string(MergeJoin::kMatchedLeftRows),
+        RuntimeCounter(matchedLeftRows_));
     lockedStats->addRuntimeStat(
-        "matchedRightRows", RuntimeCounter(matchedRightRows_));
+        std::string(MergeJoin::kMatchedRightRows),
+        RuntimeCounter(matchedRightRows_));
   }
   if (rightSource_) {
     rightSource_->close();

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #pragma once
+#include <string_view>
+
 #include <folly/container/F14Map.h>
 
 #include "velox/exec/MergeSource.h"
@@ -44,6 +46,12 @@ namespace facebook::velox::exec {
 /// than one right vector, it gets copied and flattened.
 class MergeJoin : public Operator {
  public:
+  /// Runtime stat keys for merge join.
+  /// Number of left rows matched in merge join.
+  static constexpr std::string_view kMatchedLeftRows = "matchedLeftRows";
+  /// Number of right rows matched in merge join.
+  static constexpr std::string_view kMatchedRightRows = "matchedRightRows";
+
   MergeJoin(
       int32_t operatorId,
       DriverCtx* driverCtx,

--- a/velox/exec/OperatorStats.h
+++ b/velox/exec/OperatorStats.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/memory/MemoryPool.h"
 #include "velox/common/time/CpuWallTimer.h"
@@ -93,6 +95,14 @@ struct OperatorStats {
   /// blocked time) for this operator. The max field will contain the CPU time
   /// from the longest running single driver.
   static constexpr const char* kDriverCpuTime = "driverCpuTimeNanos";
+
+  /// Running time metrics from CpuWallTiming structures, aggregated per thread.
+  static constexpr std::string_view kRunningAddInputWallNanos =
+      "runningAddInputWallNanos";
+  static constexpr std::string_view kRunningGetOutputWallNanos =
+      "runningGetOutputWallNanos";
+  static constexpr std::string_view kRunningFinishWallNanos =
+      "runningFinishWallNanos";
 
   /// Initial ordinal position in the operator's pipeline.
   int32_t operatorId = 0;

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -200,7 +200,7 @@ RowVectorPtr TableScan::getOutput() {
     {
       auto lockedStats = stats_.wlock();
       lockedStats->addRuntimeStat(
-          "dataSourceReadWallNanos",
+          std::string(TableScan::kDataSourceReadWallNanos),
           RuntimeCounter(ioTimeUs * 1'000, RuntimeCounter::Unit::kNanos));
 
       if (!dataOptional.has_value()) {
@@ -243,12 +243,14 @@ RowVectorPtr TableScan::getOutput() {
       auto lockedStats = stats_.wlock();
       if (numPreloadedSplits_ > 0) {
         lockedStats->addRuntimeStat(
-            "preloadedSplits", RuntimeCounter(numPreloadedSplits_));
+            std::string(TableScan::kPreloadedSplits),
+            RuntimeCounter(numPreloadedSplits_));
         numPreloadedSplits_ = 0;
       }
       if (numReadyPreloadedSplits_ > 0) {
         lockedStats->addRuntimeStat(
-            "readyPreloadedSplits", RuntimeCounter(numReadyPreloadedSplits_));
+            std::string(TableScan::kReadyPreloadedSplits),
+            RuntimeCounter(numReadyPreloadedSplits_));
         numReadyPreloadedSplits_ = 0;
       }
       currNumRawInputRows = lockedStats->rawInputPositions;
@@ -316,7 +318,8 @@ bool TableScan::getSplit() {
   }
 
   stats_.wlock()->addRuntimeStat(
-      "connectorSplitSize", RuntimeCounter(split.connectorSplit->size()));
+      std::string(TableScan::kConnectorSplitSize),
+      RuntimeCounter(static_cast<int64_t>(split.connectorSplit->size())));
   const auto& connectorSplit = split.connectorSplit;
   currentSplitWeight_ = connectorSplit->splitWeight;
   needNewSplit_ = false;
@@ -362,7 +365,7 @@ bool TableScan::getSplit() {
     auto preparedDataSource = connectorSplit->dataSource->move();
     auto endTimeNs = getCurrentTimeNano();
     stats_.wlock()->addRuntimeStat(
-        "waitForPreloadSplitNanos",
+        std::string(TableScan::kWaitForPreloadSplitNanos),
         RuntimeCounter(endTimeNs - startTimeNs, RuntimeCounter::Unit::kNanos));
     if (preparedDataSource == nullptr) {
       // There must be a cancellation.
@@ -370,7 +373,7 @@ bool TableScan::getSplit() {
       return false;
     }
     stats_.wlock()->addRuntimeStat(
-        "preloadSplitPrepareTimeNanos",
+        std::string(TableScan::kPreloadSplitPrepareTimeNanos),
         RuntimeCounter(
             connectorSplit->dataSource->prepareTiming().wallNanos,
             RuntimeCounter::Unit::kNanos));
@@ -383,7 +386,7 @@ bool TableScan::getSplit() {
       dataSource_->addSplit(connectorSplit);
     }
     stats_.wlock()->addRuntimeStat(
-        "dataSourceAddSplitWallNanos",
+        std::string(TableScan::kDataSourceAddSplitWallNanos),
         RuntimeCounter(addSplitTimeUs * 1'000, RuntimeCounter::Unit::kNanos));
   }
   ++stats_.wlock()->numSplits;
@@ -541,7 +544,7 @@ void TableScan::close() {
   const auto scaledStats = scaledController_->stats();
   auto lockedStats = stats_.wlock();
   lockedStats->addRuntimeStat(
-      TableScan::kNumRunningScaleThreads,
+      std::string(TableScan::kNumRunningScaleThreads),
       RuntimeCounter(scaledStats.numRunningDrivers));
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/ScaledScanController.h"
@@ -61,8 +63,34 @@ class TableScan : public SourceOperator {
   ///
   /// NOTE: we only report the number of running scan drivers at the point that
   /// all the splits have been dispatched.
-  static inline const std::string kNumRunningScaleThreads{
-      "numRunningScaleThreads"};
+  static constexpr std::string_view kNumRunningScaleThreads =
+      "numRunningScaleThreads";
+
+  /// Time spent reading from the data source.
+  static constexpr std::string_view kDataSourceReadWallNanos =
+      "dataSourceReadWallNanos";
+
+  /// Number of splits that started background preload.
+  static constexpr std::string_view kPreloadedSplits = "preloadedSplits";
+
+  /// Number of preloaded splits that finished before being read.
+  static constexpr std::string_view kReadyPreloadedSplits =
+      "readyPreloadedSplits";
+
+  /// Size of the connector split.
+  static constexpr std::string_view kConnectorSplitSize = "connectorSplitSize";
+
+  /// Time waiting for a preloaded split to become available.
+  static constexpr std::string_view kWaitForPreloadSplitNanos =
+      "waitForPreloadSplitNanos";
+
+  /// Time for preload split preparation.
+  static constexpr std::string_view kPreloadSplitPrepareTimeNanos =
+      "preloadSplitPrepareTimeNanos";
+
+  /// Time spent adding a split to the data source.
+  static constexpr std::string_view kDataSourceAddSplitWallNanos =
+      "dataSourceAddSplitWallNanos";
 
   std::shared_ptr<ScaledScanController> testingScaledController() const {
     return scaledController_;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -132,11 +132,11 @@ inline size_t numSourceNodes(const core::PlanNode* planNode) {
 // Add 'running time' metrics from CpuWallTiming structures to have them
 // available aggregated per thread.
 void addRunningTimeOperatorMetrics(exec::OperatorStats& op) {
-  op.runtimeStats["runningAddInputWallNanos"] =
+  op.runtimeStats[std::string(OperatorStats::kRunningAddInputWallNanos)] =
       RuntimeMetric(op.addInputTiming.wallNanos, RuntimeCounter::Unit::kNanos);
-  op.runtimeStats["runningGetOutputWallNanos"] =
+  op.runtimeStats[std::string(OperatorStats::kRunningGetOutputWallNanos)] =
       RuntimeMetric(op.getOutputTiming.wallNanos, RuntimeCounter::Unit::kNanos);
-  op.runtimeStats["runningFinishWallNanos"] =
+  op.runtimeStats[std::string(OperatorStats::kRunningFinishWallNanos)] =
       RuntimeMetric(op.finishTiming.wallNanos, RuntimeCounter::Unit::kNanos);
 }
 

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -255,7 +255,8 @@ void TopNRowNumber::addInput(RowVectorPtr input) {
     // the processing.
     if (abandonPartialEarly()) {
       abandonedPartial_ = true;
-      addRuntimeStat("abandonedPartial", RuntimeCounter(1));
+      addRuntimeStat(
+          std::string(TopNRowNumber::kAbandonedPartial), RuntimeCounter(1));
 
       updateEstimatedOutputRowSize();
       outputBatchSize_ = outputBatchRows(estimatedOutputRowSize_);

--- a/velox/exec/TopNRowNumber.h
+++ b/velox/exec/TopNRowNumber.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 #include "velox/exec/HashTable.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/Spiller.h"
@@ -76,6 +78,9 @@ class TopNRowNumberSpiller;
 
 class TopNRowNumber : public Operator {
  public:
+  /// Runtime stat key indicating partial TopN was abandoned.
+  static constexpr std::string_view kAbandonedPartial = "abandonedPartial";
+
   TopNRowNumber(
       int32_t operatorId,
       DriverCtx* driverCtx,

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -3208,29 +3208,32 @@ TEST_P(MultiFragmentTest, scaledTableScan) {
     if (testData.scaleEnabled) {
       ASSERT_EQ(
           planStats.at(scanNodeId)
-              .customStats.count(TableScan::kNumRunningScaleThreads),
+              .customStats.count(
+                  std::string(TableScan::kNumRunningScaleThreads)),
           1);
       if (testData.expectScaleUp) {
         ASSERT_GE(
             planStats.at(scanNodeId)
-                .customStats[TableScan::kNumRunningScaleThreads]
+                .customStats[std::string(TableScan::kNumRunningScaleThreads)]
                 .sum,
             1);
         ASSERT_LE(
             planStats.at(scanNodeId)
-                .customStats[TableScan::kNumRunningScaleThreads]
+                .customStats[std::string(TableScan::kNumRunningScaleThreads)]
                 .sum,
             numLeafDrivers);
       } else {
         ASSERT_EQ(
             planStats.at(scanNodeId)
-                .customStats.count(TableScan::kNumRunningScaleThreads),
+                .customStats.count(
+                    std::string(TableScan::kNumRunningScaleThreads)),
             1);
       }
     } else {
       ASSERT_EQ(
           planStats.at(scanNodeId)
-              .customStats.count(TableScan::kNumRunningScaleThreads),
+              .customStats.count(
+                  std::string(TableScan::kNumRunningScaleThreads)),
           0);
     }
   }

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -2502,11 +2502,11 @@ DEBUG_ONLY_TEST_F(TaskTest, taskPauseTime) {
   ASSERT_EQ(taskStats.pipelineStats[0].driverStats.size(), 1);
   const auto& driverStats = taskStats.pipelineStats[0].driverStats[0];
   const auto& totalPauseTime =
-      driverStats.runtimeStats.at(DriverStats::kTotalPauseTime);
+      driverStats.runtimeStats.at(std::string(DriverStats::kTotalPauseTime));
   ASSERT_EQ(totalPauseTime.count, 1);
   ASSERT_GE(totalPauseTime.sum, 0);
-  const auto& totalOffThreadTime =
-      driverStats.runtimeStats.at(DriverStats::kTotalOffThreadTime);
+  const auto& totalOffThreadTime = driverStats.runtimeStats.at(
+      std::string(DriverStats::kTotalOffThreadTime));
   ASSERT_EQ(totalOffThreadTime.count, 1);
   ASSERT_GE(totalOffThreadTime.sum, 0);
 
@@ -2543,9 +2543,11 @@ TEST_F(TaskTest, updateStatsWhileCloseOffThreadDriver) {
   ASSERT_EQ(taskStats.pipelineStats.size(), 1);
   ASSERT_EQ(taskStats.pipelineStats[0].driverStats.size(), 4);
   const auto& driverStats = taskStats.pipelineStats[0].driverStats[0];
-  ASSERT_EQ(driverStats.runtimeStats.count(DriverStats::kTotalPauseTime), 0);
-  const auto& totalOffThreadTime =
-      driverStats.runtimeStats.at(DriverStats::kTotalOffThreadTime);
+  ASSERT_EQ(
+      driverStats.runtimeStats.count(std::string(DriverStats::kTotalPauseTime)),
+      0);
+  const auto& totalOffThreadTime = driverStats.runtimeStats.at(
+      std::string(DriverStats::kTotalOffThreadTime));
   ASSERT_EQ(totalOffThreadTime.count, 1);
   ASSERT_GE(totalOffThreadTime.sum, 0);
 }

--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/exec/HashAggregation.h"
 #include "velox/exec/PrefixSort.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
@@ -1110,10 +1111,14 @@ CudfVectorPtr CudfHashAggregation::releaseAndResetPartialOutput() {
       numOutputRows == 0 ? 0 : (numOutputRows * 1.0) / numInputRows_ * 100;
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->addRuntimeStat("flushRowCount", RuntimeCounter(numOutputRows));
-    lockedStats->addRuntimeStat("flushTimes", RuntimeCounter(1));
     lockedStats->addRuntimeStat(
-        "partialAggregationPct", RuntimeCounter(aggregationPct));
+        std::string(exec::HashAggregation::kFlushRowCount),
+        RuntimeCounter(numOutputRows));
+    lockedStats->addRuntimeStat(
+        std::string(exec::HashAggregation::kFlushTimes), RuntimeCounter(1));
+    lockedStats->addRuntimeStat(
+        std::string(exec::HashAggregation::kPartialAggregationPct),
+        RuntimeCounter(aggregationPct));
   }
 
   numInputRows_ = 0;


### PR DESCRIPTION
Summary:
Replace hardcoded runtime stat string literals scattered across operator files with centralized static inline const std::string constants on each operator's class, following the existing pattern (Operator::kSpill*, TableWriter::kNumWrittenFiles, etc.). This makes stat keys discoverable, eliminates typo risk, and enables programmatic access.

Constants added to: TableScan (7 stats), HashAggregation (4 stats), HashBuild (2 stats), HashProbe (2 stats), DriverStats (4 stats), OperatorStats (3 running time stats), MergeJoin (2 stats), TopNRowNumber (1 stat). Also updated CudfHashAggregation.cpp to use the shared HashAggregation constants.

Differential Revision: D93369906
