### PR TITLE
refactor: Add checked cast APIs and code cleanup

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -955,7 +955,7 @@ void AsyncDataCache::possibleSsdSave(uint64_t bytes) {
 void AsyncDataCache::saveToSsd(bool saveAll) {
   std::vector<CachePin> pins;
   VELOX_CHECK(ssdCache_->writeInProgress());
-  ssdSaveable_ = 0;
+  ssdSaveable_ = false;
   for (auto& shard : shards_) {
     shard->appendSsdSaveable(saveAll, pins);
   }

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -108,16 +108,13 @@ void addSubfields(
     }
   }
   subfields.resize(newSize);
+
   switch (type.kind()) {
     case TypeKind::ROW: {
       folly::F14FastMap<std::string, std::vector<SubfieldSpec>> required;
       for (auto& subfield : subfields) {
         auto* element = subfield.subfield->path()[level].get();
-        auto* nestedField = element->as<common::Subfield::NestedField>();
-        VELOX_CHECK(
-            nestedField,
-            "Unsupported for row subfields pruning: {}",
-            element->toString());
+        auto* nestedField = element->asChecked<common::Subfield::NestedField>();
         required[nestedField->name()].push_back(subfield);
       }
       const auto& rowType = type.asRow();

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -88,6 +88,14 @@ class Subfield {
       return dynamic_cast<const T*>(this);
     }
 
+    template <typename T>
+    const T* asChecked() const {
+      auto* ptr = dynamic_cast<const T*>(this);
+      VELOX_CHECK_NOT_NULL(
+          ptr, "PathElement is not of expected type. Actual kind: {}", kind_);
+      return ptr;
+    }
+
    private:
     const SubfieldKind kind_;
   };


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/494

This diff introduces checked cast APIs (`asChecked`, `checkedContext`) across Nimble's type system to provide safer dynamic casting with clear error messages when casts fail. It also includes several code quality improvements and test file renames for consistency.

**Key changes:**

1. **Checked cast APIs:**
   - `StatisticsCollector::asChecked<T>()` - Casts with `NIMBLE_DCHECK_NOT_NULL` assertion
   - `StreamDescriptorBuilder::checkedContext<T>()` - Safe context retrieval
   - `TypeBuilder::checkedContext<T>()` - Safe context retrieval

2. **API rename:** `isShared()` → `shared()` for consistency with naming conventions

3. **Code cleanup:**
   - Replace `as<>()` with `asChecked<>()` where cast is expected to succeed
   - Use `asChecked<velox::FlatMapVector>()` instead of manual null check
   - Add `const` qualifiers where appropriate
   - Replace `VELOX_CHECK` with `NIMBLE_CHECK` for consistency
   - Flatten nested if-else in `initializeEncodingLayouts` with early return for FlatMap
   - Rename macro `_SET_STREAM_CONTEXT` to `SET_STREAM_CONTEXT` (remove leading underscore)

4. **Test file renames:** Standardize test file naming from `*Tests.cpp` to `*Test.cpp`

Differential Revision: D93427282
