### PR TITLE
feat(writer): Make Writer Base Class state_ variable Automic

### DIFF
--- a/velox/dwio/common/Writer.cpp
+++ b/velox/dwio/common/Writer.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/dwio/common/Writer.h"
 
+#include "velox/common/base/Exceptions.h"
+
 namespace facebook::velox::dwio::common {
 
 void Writer::checkStateTransition(State oldState, State newState) {
@@ -80,13 +82,6 @@ bool Writer::isFinishing() const {
 }
 
 void Writer::checkRunning() const {
-  // Typically represents writer misuse.
-  VELOX_USER_CHECK_NE(
-      state_,
-      State::kClosed,
-      "Writer is not running: {}. Write operations are not allowed on a closed writer.",
-      Writer::stateString(state_));
-
   VELOX_CHECK_EQ(
       state_,
       State::kRunning,

--- a/velox/dwio/common/Writer.h
+++ b/velox/dwio/common/Writer.h
@@ -16,12 +16,11 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
-#include <optional>
+#include <ostream>
 #include <string>
 
-#include "velox/vector/ComplexVector.h"
+#include "velox/common/base/Portability.h"
+#include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -91,7 +90,7 @@ class Writer {
   /// Validates the state transition from 'oldState' to 'newState'.
   static void checkStateTransition(State oldState, State newState);
 
-  State state_{State::kInit};
+  tsan_atomic<State> state_{State::kInit};
 };
 
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(

--- a/velox/dwio/common/tests/WriterTest.cpp
+++ b/velox/dwio/common/tests/WriterTest.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "velox/dwio/common/Writer.h"
+
 #include <gtest/gtest.h>
+
 #include "velox/common/base/tests/GTestUtils.h"
 
 using namespace ::testing;
@@ -33,6 +35,10 @@ class MockWriter : public Writer {
 
   void callCheckRunning() const {
     checkRunning();
+  }
+
+  bool callIsRunning() const {
+    return isRunning();
   }
 
   void write(const VectorPtr& /*data*/) override {}
@@ -64,9 +70,84 @@ TEST(WriterTest, checkRunning) {
   writer.setStateForTest(Writer::State::kRunning);
   ASSERT_NO_THROW(writer.callCheckRunning());
   writer.setStateForTest(Writer::State::kClosed);
-  VELOX_ASSERT_USER_THROW(
-      writer.callCheckRunning(),
-      "Writer is not running: CLOSED. Write operations are not allowed on a closed writer.");
+  VELOX_ASSERT_THROW(
+      writer.callCheckRunning(), "Writer is not running: CLOSED");
 }
+
+TEST(WriterTest, stateTransitions) {
+  MockWriter writer;
+  ASSERT_EQ(writer.state(), Writer::State::kInit);
+
+  // Valid transition: kInit -> kRunning
+  writer.setStateForTest(Writer::State::kRunning);
+  ASSERT_EQ(writer.state(), Writer::State::kRunning);
+
+  // Valid transition: kRunning -> kFinishing
+  writer.setStateForTest(Writer::State::kFinishing);
+  ASSERT_EQ(writer.state(), Writer::State::kFinishing);
+
+  // Valid transition: kFinishing -> kFinishing (reentry)
+  writer.setStateForTest(Writer::State::kFinishing);
+  ASSERT_EQ(writer.state(), Writer::State::kFinishing);
+
+  // Valid transition: kFinishing -> kClosed
+  writer.setStateForTest(Writer::State::kClosed);
+  ASSERT_EQ(writer.state(), Writer::State::kClosed);
+}
+
+TEST(WriterTest, invalidStateTransitions) {
+  {
+    MockWriter writer;
+    // Invalid: kInit -> kClosed
+    VELOX_ASSERT_THROW(
+        writer.setStateForTest(Writer::State::kClosed),
+        "Unexpected state transition from INIT to CLOSED");
+  }
+  {
+    MockWriter writer;
+    // Invalid: kInit -> kFinishing
+    VELOX_ASSERT_THROW(
+        writer.setStateForTest(Writer::State::kFinishing),
+        "Unexpected state transition from INIT to FINISHING");
+  }
+  {
+    MockWriter writer;
+    writer.setStateForTest(Writer::State::kRunning);
+    writer.setStateForTest(Writer::State::kClosed);
+    // Invalid: kClosed -> kRunning
+    VELOX_ASSERT_THROW(
+        writer.setStateForTest(Writer::State::kRunning),
+        "Unexpected state transition from CLOSED to RUNNING");
+  }
+}
+
+TEST(WriterTest, stateGetter) {
+  MockWriter writer;
+  ASSERT_EQ(writer.state(), Writer::State::kInit);
+
+  writer.setStateForTest(Writer::State::kRunning);
+  ASSERT_EQ(writer.state(), Writer::State::kRunning);
+
+  writer.setStateForTest(Writer::State::kFinishing);
+  ASSERT_EQ(writer.state(), Writer::State::kFinishing);
+
+  writer.setStateForTest(Writer::State::kClosed);
+  ASSERT_EQ(writer.state(), Writer::State::kClosed);
+}
+
+TEST(WriterTest, isRunning) {
+  MockWriter writer;
+  ASSERT_FALSE(writer.callIsRunning());
+
+  writer.setStateForTest(Writer::State::kRunning);
+  ASSERT_TRUE(writer.callIsRunning());
+
+  writer.setStateForTest(Writer::State::kFinishing);
+  ASSERT_FALSE(writer.callIsRunning());
+
+  writer.setStateForTest(Writer::State::kClosed);
+  ASSERT_FALSE(writer.callIsRunning());
+}
+
 } // namespace
 } // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Summary: make state_ atomic to be used in SST writer parallel encode

Differential Revision: D93561815


