### PR TITLE
feat: Add checked_sum aggregate for Spark ANSI mode overflow detection

### DIFF
--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -61,6 +61,8 @@ void registerAggregateFunctions(
       prefix + "bloom_filter_agg", withCompanionFunctions, overwrite);
   registerAverage(prefix + "avg", withCompanionFunctions, overwrite);
   registerSum(prefix + "sum", withCompanionFunctions, overwrite);
+  registerCheckedSum(
+      prefix + "checked_sum", withCompanionFunctions, overwrite);
   registerCentralMomentsAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectSetAggAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectListAggregate(prefix, withCompanionFunctions, overwrite);

--- a/velox/functions/sparksql/aggregates/SumAggregate.h
+++ b/velox/functions/sparksql/aggregates/SumAggregate.h
@@ -27,4 +27,9 @@ exec::AggregateRegistrationResult registerSum(
     bool withCompanionFunctions,
     bool overwrite);
 
+exec::AggregateRegistrationResult registerCheckedSum(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite);
+
 } // namespace facebook::velox::functions::aggregate::sparksql


### PR DESCRIPTION
## Summary

  - Add `checked_sum` aggregate for Spark ANSI mode (`spark.sql.ansi.enabled=true`)
  - **Integers**: reuse `SumAggregateBase` with `Overflow=false` (Presto's checked arithmetic
    via `checkedPlus()`), which throws on integer overflow.
  - **Decimals**: add `throwOnOverflow` template parameter to `DecimalSumAggregate` — allows
    intermediate overflow (tracked via overflow counter), throws only if the final result
    exceeds decimal precision, matching Spark's `CheckOverflowInSum` semantics

  ## Test plan

  - [x] `checkedDecimalSumOverflow` — two max-precision decimals overflow at final result
  - [x] `checkedDecimalSumAllNull` — all-null inputs return null (no false overflow)
  - [x] `checkedDecimalSumNormal` — normal decimal summation
  - [x] `checkedIntegerSumOverflow` — two INT64_MAX values throw on overflow
  - [x] `checkedIntegerSumNormal` — normal integer summation
  - [x] `checkedIntegerSumAllNull` — all-null inputs return null

Closing https://github.com/facebookincubator/velox/issues/16436