### PR TITLE
docs: Update Spark rand documentation

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -278,8 +278,8 @@ Mathematical Functions
     `spark.partition_id` to each thread (in a deterministic way) .
     ``seed`` must be constant. NULL ``seed`` is identical to zero ``seed``. ::
 
-        SELECT rand(0);    -- 0.5488135024422883
-        SELECT rand(NULL); -- 0.5488135024422883
+        SELECT rand(0);    -- 0.7604953758285915
+        SELECT rand(NULL); -- 0.7604953758285915
 
 .. spark:function:: random() -> double
 


### PR DESCRIPTION
Correct the Spark rand documentation so that the examples return the proper results.
Follow-up for: https://github.com/facebookincubator/velox/commit/8830b83f2f52b6828b3145be64003f42981fc22b