### PR TITLE
feat: Add checked_avg aggregate for Spark ANSI mode decimal overflow

### DIFF
--- a/velox/functions/sparksql/aggregates/AverageAggregate.h
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.h
@@ -27,4 +27,9 @@ exec::AggregateRegistrationResult registerAverage(
     bool withCompanionFunctions,
     bool overwrite);
 
+exec::AggregateRegistrationResult registerCheckedAverage(
+    const std::string& name,
+    bool withCompanionFunctions,
+    bool overwrite);
+
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -60,6 +60,8 @@ void registerAggregateFunctions(
   registerBloomFilterAggAggregate(
       prefix + "bloom_filter_agg", withCompanionFunctions, overwrite);
   registerAverage(prefix + "avg", withCompanionFunctions, overwrite);
+  registerCheckedAverage(
+      prefix + "checked_avg", withCompanionFunctions, overwrite);
   registerSum(prefix + "sum", withCompanionFunctions, overwrite);
   registerCentralMomentsAggregate(prefix, withCompanionFunctions, overwrite);
   registerCollectSetAggAggregate(prefix, withCompanionFunctions, overwrite);


### PR DESCRIPTION
## Summary

  - Add `checked_avg` aggregate for Spark ANSI mode (`spark.sql.ansi.enabled=true`)
  - Decimal-only — integer/float AVG returns `DOUBLE` which cannot overflow
  - Add `throwOnOverflow` template parameter to existing `DecimalAverageAggregate`
  - On decimal overflow: throws instead of returning null
  - Same pattern as `checked_sum` (#16435)

  Closes #16438

  ## Test plan

  - [x] `checkedDecimalAvgOverflow` — 10 max-precision decimals overflow at final result
  - [x] `checkedDecimalAvgNormal` — normal decimal average computation
