### PR TITLE
fix: Fix StreamArenaTest.randomRange flakiness

### DIFF
--- a/velox/common/memory/tests/StreamArenaTest.cpp
+++ b/velox/common/memory/tests/StreamArenaTest.cpp
@@ -127,9 +127,11 @@ TEST_F(StreamArenaTest, randomRange) {
   ByteRange range;
   for (int i = 0; i < numRanges; ++i) {
     if (folly::Random::oneIn(3)) {
-      const int requestSize =
-          AllocationTraits::pageBytes(pool_->largestSizeClass()) +
-          (folly::Random::rand32() % (4 << 20));
+      const int requestSize = std::min(
+          static_cast<int>(
+              AllocationTraits::pageBytes(pool_->largestSizeClass()) +
+              (folly::Random::rand32() % (4 << 20))),
+          2 << 20);
       arena->newRange(requestSize, nullptr, &range);
       ASSERT_EQ(AllocationTraits::roundUpPageBytes(requestSize), range.size);
     } else {


### PR DESCRIPTION
Summary:
The test can be failed as
```
Exceeded memory allocator limit when allocating 1151 new pages for total allocation of 1151 pages, the memory allocator capacity is 16384 pages, the allocated pages is 17512, Source: RUNTIME, ErrorCode: MEM_ALLOC_ERROR
```

before, the total random size can be 	~50-70MB
after, the total random size got reduced to 	~40-55 MB

Differential Revision: D93629537


