### PR TITLE
feat: Support move/swap sematics in StlAllocator

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -1111,27 +1111,29 @@ template <typename T>
 class StlAllocator {
  public:
   typedef T value_type;
-  MemoryPool& pool;
+  MemoryPool* pool;
 
-  /* implicit */ StlAllocator(MemoryPool& pool) : pool{pool} {}
+  /* implicit */ StlAllocator(MemoryPool& pool) : pool{&pool} {}
 
-  explicit StlAllocator(MemoryPool* pool) : pool{*pool} {}
+  explicit StlAllocator(MemoryPool* pool) : pool{pool} {
+    VELOX_CHECK_NOT_NULL(pool);
+  }
 
   template <typename U>
   /* implicit */ StlAllocator(const StlAllocator<U>& a) : pool{a.pool} {}
 
   T* allocate(size_t n) {
-    return static_cast<T*>(pool.allocate(checkedMultiply(n, sizeof(T))));
+    return static_cast<T*>(pool->allocate(checkedMultiply(n, sizeof(T))));
   }
 
   void deallocate(T* p, size_t n) {
-    pool.free(p, checkedMultiply(n, sizeof(T)));
+    pool->free(p, checkedMultiply(n, sizeof(T)));
   }
 
   template <typename T1>
   bool operator==(const StlAllocator<T1>& rhs) const {
     if constexpr (std::is_same_v<T, T1>) {
-      return &this->pool == &rhs.pool;
+      return this->pool == rhs.pool;
     }
     return false;
   }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -1062,6 +1062,22 @@ TEST_P(MemoryPoolTest, allocatorOverflow) {
   EXPECT_THROW(alloc.deallocate(nullptr, 1ULL << 62), VeloxException);
 }
 
+TEST_P(MemoryPoolTest, allocatorSwap) {
+  MemoryManager& manager = *getMemoryManager();
+  auto root = manager.addRootPool("swapRoot");
+  auto leaf1 = root->addLeafChild("leaf1");
+  auto leaf2 = root->addLeafChild("leaf2");
+
+  StlAllocator<int64_t> alloc1(*leaf1);
+  StlAllocator<int64_t> alloc2(*leaf2);
+  ASSERT_EQ(alloc1.pool, leaf1.get());
+  ASSERT_EQ(alloc2.pool, leaf2.get());
+
+  std::swap(alloc1, alloc2);
+  EXPECT_EQ(alloc1.pool, leaf2.get());
+  EXPECT_EQ(alloc2.pool, leaf1.get());
+}
+
 TEST_P(MemoryPoolTest, contiguousAllocate) {
   auto manager = getMemoryManager();
   auto pool = manager->addLeafPool("contiguousAllocate");


### PR DESCRIPTION
Summary:
Current Apache Datasketches library accepts custom allocator, but also swaps them:
In fbcode:
https://www.internalfb.com/code/fbsource/[0f8ab6a3a8ff]/third-party/datasketches-cpp/tuple/include/array_tuple_sketch.hpp?lines=61-63
In github:
https://github.com/apache/datasketches-cpp/blob/master/tuple/include/array_tuple_sketch.hpp#L61-L63

In order to be able to pass velox::memory::StlAllocator to the lib, we need to make allocator swappable.

Differential Revision: D93637571


