### PR TITLE
refactor: Trivial code cleanup in Field reader

### DIFF
--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -945,13 +945,13 @@ TEST_P(UnnestTest, spiltOutput) {
 
   struct {
     bool produceSingleOutput;
-    int expectedNumOutputExectors;
+    int expectedNumOutputVectors;
 
     std::string toString() const {
       return fmt::format(
-          "produceSingleOutput {}, expectedNumOutputExectors {}",
+          "produceSingleOutput {}, expectedNumOutputVectors {}",
           produceSingleOutput,
-          expectedNumOutputExectors);
+          expectedNumOutputVectors);
     }
   } testSettings[] = {
       {true, numBatches},
@@ -969,7 +969,7 @@ TEST_P(UnnestTest, spiltOutput) {
     const auto taskStats = task->taskStats();
     ASSERT_EQ(
         exec::toPlanStats(taskStats).at(unnestPlanNodeId).outputVectors,
-        testData.expectedNumOutputExectors);
+        testData.expectedNumOutputVectors);
   }
 }
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/497

This change updates `FieldReader` and `FieldReaderFactory` classes to store `velox::memory::MemoryPool` as a pointer (`pool_`) rather than a reference. This provides more flexibility in how the pool is managed and passed around, particularly when used with various Velox APIs that expect pool pointers.

The change also includes several code quality improvements:
- Removed `FOLLY_NULLABLE` annotations from function signatures
- Changed `VELOX_CHECK_NOT_NULL` to `NIMBLE_CHECK_NOT_NULL` for consistency with the nimble codebase
- Converted comments to use `///` doc-comment style in the header
- Added `const` qualifiers to local variables where appropriate
- Changed struct member initialization from `= 0` to `{0}` for consistency

Reviewed By: HuamengJiang, srsuryadev

Differential Revision: D93515000


