### PR TITLE
feat: Add equivalent check for decimal type

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -828,13 +828,23 @@ class DecimalType : public ScalarType<KIND> {
   static constexpr uint8_t kMaxPrecision = KIND == TypeKind::BIGINT ? 18 : 38;
   static constexpr uint8_t kMinPrecision = KIND == TypeKind::BIGINT ? 1 : 19;
 
-  inline bool equivalent(const Type& other) const override {
+  inline bool equals(const Type& other) const override {
     if (!Type::hasSameTypeId(other)) {
       return false;
     }
     const auto& otherDecimal = static_cast<const DecimalType<KIND>&>(other);
     return (
         otherDecimal.precision() == precision() &&
+        otherDecimal.scale() == scale());
+  }
+
+  inline bool equivalent(const Type& other) const override {
+    if (!Type::hasSameTypeId(other)) {
+      return false;
+    }
+    const auto& otherDecimal = static_cast<const DecimalType<KIND>&>(other);
+    return (
+        otherDecimal.precision() >= precision() &&
         otherDecimal.scale() == scale());
   }
 

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -845,6 +845,10 @@ TEST(TypeTest, equivalent) {
   EXPECT_TRUE(DECIMAL(30, 5)->equivalent(*DECIMAL(30, 5)));
   EXPECT_FALSE(DECIMAL(30, 6)->equivalent(*DECIMAL(30, 5)));
   EXPECT_FALSE(DECIMAL(31, 5)->equivalent(*DECIMAL(30, 5)));
+  EXPECT_TRUE(DECIMAL(4, 2)->equivalent(*DECIMAL(10, 2)));
+  EXPECT_FALSE(DECIMAL(10, 2)->equivalent(*DECIMAL(4, 2)));
+  EXPECT_FALSE(DECIMAL(18, 2)->equivalent(*DECIMAL(30, 2)));
+  EXPECT_FALSE(DECIMAL(30, 2)->equivalent(*DECIMAL(18, 2)));
   auto complexTypeA = ROW(
       {{"a0", ARRAY(ROW({{"a1", DECIMAL(20, 8)}}))},
        {"a2", MAP(VARCHAR(), ROW({{"a3", DECIMAL(10, 5)}}))}});
@@ -862,6 +866,20 @@ TEST(TypeTest, equivalent) {
       {{"b0", ARRAY(ROW({{"b1", DECIMAL(20, 8)}}))},
        {"b2", MAP(VARCHAR(), ROW({{"b3", DECIMAL(20, 5)}}))}});
   EXPECT_FALSE(complexTypeA->equivalent(*complexTypeB));
+}
+
+TEST(TypeTest, decimalEquals) {
+  EXPECT_TRUE(*DECIMAL(10, 5) == *DECIMAL(10, 5));
+  EXPECT_FALSE(*DECIMAL(10, 6) == *DECIMAL(10, 5));
+  EXPECT_FALSE(*DECIMAL(11, 5) == *DECIMAL(10, 5));
+  EXPECT_TRUE(*DECIMAL(30, 5) == *DECIMAL(30, 5));
+  EXPECT_FALSE(*DECIMAL(30, 6) == *DECIMAL(30, 5));
+  EXPECT_FALSE(*DECIMAL(31, 5) == *DECIMAL(30, 5));
+  // Both precision and scale need to match unlike equivalent()
+  EXPECT_FALSE(*DECIMAL(4, 2) == *DECIMAL(10, 2));
+  EXPECT_FALSE(*DECIMAL(10, 2) == *DECIMAL(4, 2));
+  EXPECT_FALSE(*DECIMAL(30, 2) == *DECIMAL(18, 2));
+  EXPECT_FALSE(*DECIMAL(18, 2) == *DECIMAL(30, 2));
 }
 
 TEST(TypeTest, kindEquals) {

--- a/velox/vector/tests/utils/VectorTestBase.cpp
+++ b/velox/vector/tests/utils/VectorTestBase.cpp
@@ -146,7 +146,7 @@ VectorPtr VectorTestBase::asArray(VectorPtr elements) {
 
 void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual) {
   ASSERT_EQ(expected->size(), actual->size());
-  ASSERT_TRUE(expected->type()->equivalent(*actual->type()))
+  ASSERT_TRUE(actual->type()->equivalent(*expected->type()))
       << "Expected " << expected->type()->toString() << ", but got "
       << actual->type()->toString();
   for (auto i = 0; i < expected->size(); i++) {


### PR DESCRIPTION
Update Decimal type validation to allow precision values that are greater than or equal to the required precision, as long as the scale remains the same.
