### PR TITLE
feat: Add template information to createEmptyLike

### DIFF
--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -439,8 +439,8 @@ RowVectorPtr SourceMerger::createOutputVector() {
   const RowVector* source = nullptr;
   for (const auto* stream : streams_) {
     if (stream->hasData() && (source = stream->data())) {
-      return std::static_pointer_cast<RowVector>(
-          BaseVector::createEmptyLike(source, outputBatchRows_, pool_));
+      return BaseVector::createEmptyLike<RowVector>(
+          source, outputBatchRows_, pool_);
     }
   }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -478,7 +478,7 @@ VectorPtr BaseVector::createInternal(
 }
 
 // static
-VectorPtr BaseVector::createEmptyLike(
+VectorPtr BaseVector::createEmptyLikeInternal(
     const BaseVector* source,
     vector_size_t size,
     memory::MemoryPool* pool) {
@@ -494,7 +494,7 @@ VectorPtr BaseVector::createEmptyLike(
       children.reserve(rowType.size());
       for (size_t i = 0; i < rowType.size(); ++i) {
         children.push_back(
-            createEmptyLike(sourceRow->childAt(i).get(), size, pool));
+            createEmptyLikeInternal(sourceRow->childAt(i).get(), size, pool));
       }
       return std::make_shared<RowVector>(
           pool, type, nullptr, size, std::move(children));
@@ -503,7 +503,8 @@ VectorPtr BaseVector::createEmptyLike(
       auto offsets = allocateOffsets(size, pool);
       auto sizes = allocateSizes(size, pool);
       auto* sourceArray = wrapped->as<ArrayVector>();
-      auto elements = createEmptyLike(sourceArray->elements().get(), 0, pool);
+      auto elements =
+          createEmptyLikeInternal(sourceArray->elements().get(), 0, pool);
       return std::make_shared<ArrayVector>(
           pool,
           type,
@@ -530,8 +531,9 @@ VectorPtr BaseVector::createEmptyLike(
       auto offsets = allocateOffsets(size, pool);
       auto sizes = allocateSizes(size, pool);
       auto* sourceMap = wrapped->as<MapVector>();
-      auto keys = createEmptyLike(sourceMap->mapKeys().get(), 0, pool);
-      auto values = createEmptyLike(sourceMap->mapValues().get(), 0, pool);
+      auto keys = createEmptyLikeInternal(sourceMap->mapKeys().get(), 0, pool);
+      auto values =
+          createEmptyLikeInternal(sourceMap->mapValues().get(), 0, pool);
       return std::make_shared<MapVector>(
           pool,
           type,

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -752,10 +752,14 @@ class BaseVector {
   /// BaseVector::create builds from type, without reference to encodings. This
   /// will still flatten other encodings (e.g. dictionary, constant and lazy),
   /// only preserving flat map as FlatMapVector.
-  static VectorPtr createEmptyLike(
+  template <typename T = BaseVector>
+  static std::shared_ptr<T> createEmptyLike(
       const BaseVector* source,
       vector_size_t size,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool) {
+    return std::static_pointer_cast<T>(
+        createEmptyLikeInternal(source, size, pool));
+  }
 
   /// Set 'nulls' to be the nulls buffer of this vector. This API should not be
   /// used on ConstantVector.
@@ -1048,6 +1052,11 @@ class BaseVector {
       const TypePtr& type,
       vector_size_t size,
       velox::memory::MemoryPool* pool);
+
+  static VectorPtr createEmptyLikeInternal(
+      const BaseVector* source,
+      vector_size_t size,
+      memory::MemoryPool* pool);
 
   friend class LazyVector;
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -4533,29 +4533,29 @@ TEST_F(VectorTest, createEmptyLikeComplexTypes) {
       makeFlatVector<int64_t>({1, 2}),
       makeFlatVector<StringView>({"a"_sv, "b"_sv}),
   });
-  auto emptyRow = BaseVector::createEmptyLike(rowVector.get(), 5, pool());
+  auto emptyRow =
+      BaseVector::createEmptyLike<RowVector>(rowVector.get(), 5, pool());
   EXPECT_EQ(emptyRow->size(), 5);
   EXPECT_EQ(emptyRow->type()->kind(), TypeKind::ROW);
-  auto emptyRowVector = emptyRow->as<RowVector>();
-  EXPECT_EQ(emptyRowVector->childrenSize(), 2);
-  EXPECT_EQ(emptyRowVector->childAt(0)->size(), 5);
-  EXPECT_EQ(emptyRowVector->childAt(1)->size(), 5);
+  EXPECT_EQ(emptyRow->childrenSize(), 2);
+  EXPECT_EQ(emptyRow->childAt(0)->size(), 5);
+  EXPECT_EQ(emptyRow->childAt(1)->size(), 5);
 
   auto arrayVector = makeArrayVector<int32_t>({{1, 2}, {3}});
-  auto emptyArray = BaseVector::createEmptyLike(arrayVector.get(), 3, pool());
+  auto emptyArray =
+      BaseVector::createEmptyLike<ArrayVector>(arrayVector.get(), 3, pool());
   EXPECT_EQ(emptyArray->size(), 3);
   EXPECT_EQ(emptyArray->type()->kind(), TypeKind::ARRAY);
-  auto emptyArrayVector = emptyArray->as<ArrayVector>();
-  EXPECT_EQ(emptyArrayVector->elements()->size(), 0);
+  EXPECT_EQ(emptyArray->elements()->size(), 0);
 
   auto mapVector = makeMapVector<int32_t, StringView>({{{1, "a"_sv}}});
-  auto emptyMap = BaseVector::createEmptyLike(mapVector.get(), 4, pool());
+  auto emptyMap =
+      BaseVector::createEmptyLike<MapVector>(mapVector.get(), 4, pool());
   EXPECT_EQ(emptyMap->size(), 4);
   EXPECT_EQ(emptyMap->type()->kind(), TypeKind::MAP);
   EXPECT_EQ(emptyMap->encoding(), VectorEncoding::Simple::MAP);
-  auto emptyMapVector = emptyMap->as<MapVector>();
-  EXPECT_EQ(emptyMapVector->mapKeys()->size(), 0);
-  EXPECT_EQ(emptyMapVector->mapValues()->size(), 0);
+  EXPECT_EQ(emptyMap->mapKeys()->size(), 0);
+  EXPECT_EQ(emptyMap->mapValues()->size(), 0);
 }
 
 TEST_F(VectorTest, createEmptyLikeFlatMap) {
@@ -4583,14 +4583,12 @@ TEST_F(VectorTest, createEmptyLikeNestedFlatMap) {
       flatMapVector,
   });
 
-  auto emptyRow = BaseVector::createEmptyLike(rowWithFlatMap.get(), 3, pool());
+  auto emptyRow =
+      BaseVector::createEmptyLike<RowVector>(rowWithFlatMap.get(), 3, pool());
   EXPECT_EQ(emptyRow->size(), 3);
-  auto emptyRowVector = emptyRow->as<RowVector>();
-  EXPECT_EQ(emptyRowVector->childrenSize(), 2);
-  EXPECT_EQ(
-      emptyRowVector->childAt(0)->encoding(), VectorEncoding::Simple::FLAT);
-  EXPECT_EQ(
-      emptyRowVector->childAt(1)->encoding(), VectorEncoding::Simple::FLAT_MAP);
+  EXPECT_EQ(emptyRow->childrenSize(), 2);
+  EXPECT_EQ(emptyRow->childAt(0)->encoding(), VectorEncoding::Simple::FLAT);
+  EXPECT_EQ(emptyRow->childAt(1)->encoding(), VectorEncoding::Simple::FLAT_MAP);
 
   // ARRAY of FlatMapVector.
   auto arrayType = ARRAY(MAP(BIGINT(), BIGINT()));
@@ -4603,13 +4601,11 @@ TEST_F(VectorTest, createEmptyLikeNestedFlatMap) {
       allocateSizes(2, pool()),
       flatMapVector);
 
-  auto emptyArray =
-      BaseVector::createEmptyLike(arrayOfFlatMaps.get(), 4, pool());
+  auto emptyArray = BaseVector::createEmptyLike<ArrayVector>(
+      arrayOfFlatMaps.get(), 4, pool());
   EXPECT_EQ(emptyArray->size(), 4);
-  auto emptyArrayVector = emptyArray->as<ArrayVector>();
   EXPECT_EQ(
-      emptyArrayVector->elements()->encoding(),
-      VectorEncoding::Simple::FLAT_MAP);
+      emptyArray->elements()->encoding(), VectorEncoding::Simple::FLAT_MAP);
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Adds template information to `createEmptyLike` to make it congruent with `create` by adding a wrapper to an internal function.

Differential Revision: D93548236


