### PR TITLE
refactor: Migrate remaining string constants to string_view

### DIFF
--- a/velox/common/base/RuntimeMetrics.cpp
+++ b/velox/common/base/RuntimeMetrics.cpp
@@ -113,7 +113,7 @@ BaseRuntimeStatWriter* getThreadLocalRunTimeStatWriter() {
 }
 
 void addThreadLocalRuntimeStat(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value) {
   if (localRuntimeStatWriter) {
     localRuntimeStatWriter->addRuntimeStat(name, value);

--- a/velox/common/base/RuntimeMetrics.h
+++ b/velox/common/base/RuntimeMetrics.h
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 #include <folly/CppAttributes.h>
 #include <limits>
+#include <string_view>
 
 namespace facebook::velox {
 
@@ -77,7 +78,7 @@ class BaseRuntimeStatWriter {
   virtual ~BaseRuntimeStatWriter() = default;
 
   virtual void addRuntimeStat(
-      const std::string& /* name */,
+      std::string_view /* name */,
       const RuntimeCounter& /* value */) {}
 };
 
@@ -93,7 +94,7 @@ BaseRuntimeStatWriter* getThreadLocalRunTimeStatWriter();
 
 /// Writes runtime counter to the current Operator running on that thread.
 void addThreadLocalRuntimeStat(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value);
 
 /// Scope guard to conveniently set and revert back the current stat writer.

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -284,17 +284,17 @@ class SharedArbitrator : public memory::MemoryArbitrator {
 
   /// Operator level runtime stats reported for an arbitration operation
   /// execution.
-  static inline const std::string kMemoryArbitrationWallNanos{
+  static constexpr std::string_view kMemoryArbitrationWallNanos{
       "memoryArbitrationWallNanos"};
-  static inline const std::string kLocalArbitrationCount{
+  static constexpr std::string_view kLocalArbitrationCount{
       "localArbitrationCount"};
-  static inline const std::string kLocalArbitrationWaitWallNanos{
+  static constexpr std::string_view kLocalArbitrationWaitWallNanos{
       "localArbitrationWaitWallNanos"};
-  static inline const std::string kLocalArbitrationExecutionWallNanos{
+  static constexpr std::string_view kLocalArbitrationExecutionWallNanos{
       "localArbitrationExecutionWallNanos"};
-  static inline const std::string kGlobalArbitrationWaitCount{
+  static constexpr std::string_view kGlobalArbitrationWaitCount{
       "globalArbitrationWaitCount"};
-  static inline const std::string kGlobalArbitrationWaitWallNanos{
+  static constexpr std::string_view kGlobalArbitrationWaitWallNanos{
       "globalArbitrationWaitWallNanos"};
 
  private:

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -49,7 +49,7 @@ class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
       std::unordered_map<std::string, RuntimeMetric>& stats)
       : stats_{stats} {}
 
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
     addOperatorRuntimeStats(name, value, stats_);
   }
@@ -1451,12 +1451,21 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, localArbitrationsFromSameQuery) {
     setThreadLocalRunTimeStatWriter(statsWriter.get());
     runPool->allocate(memoryCapacity / 2);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        0);
     ++allocationCount;
   });
 
@@ -1467,13 +1476,24 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, localArbitrationsFromSameQuery) {
     setThreadLocalRunTimeStatWriter(statsWriter.get());
     waitPool->allocate(memoryCapacity / 2 + MB);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 1);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].sum, 1);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        1);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].sum,
+        1);
     ++allocationCount;
   });
 
@@ -1534,12 +1554,21 @@ DEBUG_ONLY_TEST_F(
     op1->allocate(MB);
     ASSERT_EQ(task1->capacity(), 8 * MB);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        1);
     ++allocationCount;
   });
 
@@ -1550,12 +1579,21 @@ DEBUG_ONLY_TEST_F(
     op2->allocate(MB);
     ASSERT_EQ(task2->capacity(), 8 * MB);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        1);
     ++allocationCount;
   });
 
@@ -1780,20 +1818,37 @@ DEBUG_ONLY_TEST_F(
     }
     // We expect global arbitration has been triggered.
     ASSERT_GE(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
-    ASSERT_GT(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 0);
-    ASSERT_GT(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].sum, 0);
-    ASSERT_GT(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitWallNanos].count,
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
         0);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitWallNanos].sum,
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        0);
+    ASSERT_GT(
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .sum,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].sum,
+        0);
+    ASSERT_GT(
+        runtimeStats[std::string(
+                         SharedArbitrator::kGlobalArbitrationWaitWallNanos)]
+            .count,
+        0);
+    ASSERT_GT(
+        runtimeStats[std::string(
+                         SharedArbitrator::kGlobalArbitrationWaitWallNanos)]
+            .sum,
         1'000'000'000);
   });
 
@@ -1863,20 +1918,38 @@ DEBUG_ONLY_TEST_F(
     }
     // We expect global arbitration has been triggered.
     ASSERT_GE(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
-    ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
-    ASSERT_GE(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
-    ASSERT_GE(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].sum, 0);
-    ASSERT_GE(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitWallNanos].count,
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
         1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitWallNanos].sum, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
+    ASSERT_GE(
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        1);
+    ASSERT_GE(
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .sum,
+        1);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        0);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].sum,
+        0);
+    ASSERT_GE(
+        runtimeStats[std::string(
+                         SharedArbitrator::kGlobalArbitrationWaitWallNanos)]
+            .count,
+        1);
+    ASSERT_GT(
+        runtimeStats[std::string(
+                         SharedArbitrator::kGlobalArbitrationWaitWallNanos)]
+            .sum,
+        1);
   });
 
   std::atomic_bool globalArbitrationStarted{false};
@@ -1912,10 +1985,19 @@ DEBUG_ONLY_TEST_F(
   globalArbitrationTriggerThread.join();
   ASSERT_EQ(localArbitrationOp->capacity(), memoryPoolReservedCapacity);
   ASSERT_EQ(
-      runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 0);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 0);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 1);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].sum, 1);
+      runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+          .count,
+      0);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+          .sum,
+      0);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].count,
+      1);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].sum,
+      1);
 
   // Global arbitration thread may still be running in the background,
   // triggerring ASAN failure. Wait until it exits.
@@ -1966,14 +2048,25 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, globalArbitrationAbortTimeRatio) {
     op1->allocate(memoryCapacity / 2);
 
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        1);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .sum,
+        1);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        0);
     ASSERT_TRUE(task1->error() == nullptr);
     ASSERT_EQ(task1->capacity(), memoryCapacity);
     ASSERT_TRUE(task2->error() != nullptr);
@@ -2019,12 +2112,24 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationWithoutSpill) {
   triggerOp->allocate(memoryCapacity / 2);
 
   ASSERT_EQ(
-      runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
-  ASSERT_GT(runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+      runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+          .count,
+      1);
+  ASSERT_GT(
+      runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+          .sum,
+      0);
   ASSERT_EQ(
-      runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+      runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+          .count,
+      1);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+          .sum,
+      1);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].count,
+      0);
 
   ASSERT_TRUE(triggerTask->error() == nullptr);
   ASSERT_EQ(triggerTask->capacity(), memoryCapacity);
@@ -2066,12 +2171,24 @@ TEST_F(MockSharedArbitrationTest, globalArbitrationSmallParticipantLargeGrow) {
   VELOX_ASSERT_THROW(op0->allocate(kMemoryCapacity / 2), "aborted");
 
   ASSERT_EQ(
-      runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
-  ASSERT_GT(runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+      runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+          .count,
+      1);
+  ASSERT_GT(
+      runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+          .sum,
+      0);
   ASSERT_EQ(
-      runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
-  ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+      runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+          .count,
+      1);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+          .sum,
+      1);
+  ASSERT_EQ(
+      runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)].count,
+      0);
 
   ASSERT_TRUE(task1->error() == nullptr);
   ASSERT_EQ(task1->capacity(), kMemoryCapacity / 2);
@@ -2277,14 +2394,25 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, multipleGlobalRuns) {
     setThreadLocalRunTimeStatWriter(statsWriter.get());
     waitPool->allocate(memoryCapacity / 2);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        1);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .sum,
+        1);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        0);
     ++allocations;
   });
 
@@ -2294,14 +2422,25 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, multipleGlobalRuns) {
     setThreadLocalRunTimeStatWriter(statsWriter.get());
     runPool->allocate(memoryCapacity / 2);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .count,
+        1);
     ASSERT_GT(
-        runtimeStats[SharedArbitrator::kMemoryArbitrationWallNanos].sum, 0);
+        runtimeStats[std::string(SharedArbitrator::kMemoryArbitrationWallNanos)]
+            .sum,
+        0);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].count, 1);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .count,
+        1);
     ASSERT_EQ(
-        runtimeStats[SharedArbitrator::kGlobalArbitrationWaitCount].sum, 1);
-    ASSERT_EQ(runtimeStats[SharedArbitrator::kLocalArbitrationCount].count, 0);
+        runtimeStats[std::string(SharedArbitrator::kGlobalArbitrationWaitCount)]
+            .sum,
+        1);
+    ASSERT_EQ(
+        runtimeStats[std::string(SharedArbitrator::kLocalArbitrationCount)]
+            .count,
+        0);
     ++allocations;
   });
 

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -292,23 +292,30 @@ class SharedArbitrationTest : public testing::WithParamInterface<TestParam>,
     if (expectGlobalArbitration) {
       VELOX_CHECK_EQ(
           stats.customStats.count(
-              SharedArbitrator::kGlobalArbitrationWaitCount),
+              std::string(SharedArbitrator::kGlobalArbitrationWaitCount)),
           1);
       VELOX_CHECK_GE(
-          stats.customStats.at(SharedArbitrator::kGlobalArbitrationWaitCount)
+          stats.customStats
+              .at(std::string(SharedArbitrator::kGlobalArbitrationWaitCount))
               .sum,
           1);
       VELOX_CHECK_EQ(
-          stats.customStats.count(SharedArbitrator::kLocalArbitrationCount), 0);
+          stats.customStats.count(
+              std::string(SharedArbitrator::kLocalArbitrationCount)),
+          0);
     } else {
       VELOX_CHECK_EQ(
-          stats.customStats.count(SharedArbitrator::kLocalArbitrationCount), 1);
+          stats.customStats.count(
+              std::string(SharedArbitrator::kLocalArbitrationCount)),
+          1);
       VELOX_CHECK_EQ(
-          stats.customStats.at(SharedArbitrator::kLocalArbitrationCount).sum,
+          stats.customStats
+              .at(std::string(SharedArbitrator::kLocalArbitrationCount))
+              .sum,
           1);
       VELOX_CHECK_EQ(
           stats.customStats.count(
-              SharedArbitrator::kGlobalArbitrationWaitCount),
+              std::string(SharedArbitrator::kGlobalArbitrationWaitCount)),
           0);
     }
   }

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -717,7 +717,7 @@ class Connector {
 
   /// The name of the common runtime stats collected and reported by connector
   /// data/index sources.
-  static inline const std::string kTotalRemainingFilterTime{
+  static constexpr std::string_view kTotalRemainingFilterTime{
       "totalRemainingFilterWallNanos"};
 
   /// Total CPU time spent on remaining filter evaluation.
@@ -726,25 +726,26 @@ class Connector {
 
   /// Total time spent waiting for synchronously issued IO or for an in-progress
   /// read-ahead to finish.
-  static inline const std::string kIoWaitWallNanos{"ioWaitWallNanos"};
+  static constexpr std::string_view kIoWaitWallNanos{"ioWaitWallNanos"};
 
   /// Time spent waiting for remote storage reads (S3, HDFS, etc.)
-  static inline const std::string kStorageReadWallNanos{"storageReadWallNanos"};
+  static constexpr std::string_view kStorageReadWallNanos{
+      "storageReadWallNanos"};
 
   /// Time spent waiting for SSD cache reads.
-  static inline const std::string kSsdCacheReadWallNanos{
+  static constexpr std::string_view kSsdCacheReadWallNanos{
       "ssdCacheReadWallNanos"};
 
   /// Time spent waiting for EXCLUSIVE cache entries (another thread is
   /// loading).
-  static inline const std::string kCacheWaitWallNanos{"cacheWaitWallNanos"};
+  static constexpr std::string_view kCacheWaitWallNanos{"cacheWaitWallNanos"};
 
   /// Time spent waiting for coalesced loads from SSD cache.
-  static inline const std::string kCoalescedSsdLoadWallNanos{
+  static constexpr std::string_view kCoalescedSsdLoadWallNanos{
       "coalescedSsdLoadWallNanos"};
 
   /// Time spent waiting for coalesced loads from remote storage.
-  static inline const std::string kCoalescedStorageLoadWallNanos{
+  static constexpr std::string_view kCoalescedStorageLoadWallNanos{
       "coalescedStorageLoadWallNanos"};
 
  private:

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -427,7 +427,7 @@ std::unordered_map<std::string, RuntimeMetric>
 HiveDataSource::getRuntimeStats() {
   auto res = runtimeStats_.toRuntimeMetricMap();
   res.insert(
-      {Connector::kIoWaitWallNanos,
+      {std::string(Connector::kIoWaitWallNanos),
        RuntimeMetric(
            ioStatistics_->queryThreadIoLatencyUs().sum() * 1'000,
            ioStatistics_->queryThreadIoLatencyUs().count(),
@@ -437,7 +437,7 @@ HiveDataSource::getRuntimeStats() {
   // Breakdown of ioWaitWallNanos by I/O type
   if (ioStatistics_->storageReadLatencyUs().count() > 0) {
     res.insert(
-        {Connector::kStorageReadWallNanos,
+        {std::string(Connector::kStorageReadWallNanos),
          RuntimeMetric(
              ioStatistics_->storageReadLatencyUs().sum() * 1'000,
              ioStatistics_->storageReadLatencyUs().count(),
@@ -447,7 +447,7 @@ HiveDataSource::getRuntimeStats() {
   }
   if (ioStatistics_->ssdCacheReadLatencyUs().count() > 0) {
     res.insert(
-        {Connector::kSsdCacheReadWallNanos,
+        {std::string(Connector::kSsdCacheReadWallNanos),
          RuntimeMetric(
              ioStatistics_->ssdCacheReadLatencyUs().sum() * 1'000,
              ioStatistics_->ssdCacheReadLatencyUs().count(),
@@ -457,7 +457,7 @@ HiveDataSource::getRuntimeStats() {
   }
   if (ioStatistics_->cacheWaitLatencyUs().count() > 0) {
     res.insert(
-        {Connector::kCacheWaitWallNanos,
+        {std::string(Connector::kCacheWaitWallNanos),
          RuntimeMetric(
              ioStatistics_->cacheWaitLatencyUs().sum() * 1'000,
              ioStatistics_->cacheWaitLatencyUs().count(),
@@ -467,7 +467,7 @@ HiveDataSource::getRuntimeStats() {
   }
   if (ioStatistics_->coalescedSsdLoadLatencyUs().count() > 0) {
     res.insert(
-        {Connector::kCoalescedSsdLoadWallNanos,
+        {std::string(Connector::kCoalescedSsdLoadWallNanos),
          RuntimeMetric(
              ioStatistics_->coalescedSsdLoadLatencyUs().sum() * 1'000,
              ioStatistics_->coalescedSsdLoadLatencyUs().count(),
@@ -477,7 +477,7 @@ HiveDataSource::getRuntimeStats() {
   }
   if (ioStatistics_->coalescedStorageLoadLatencyUs().count() > 0) {
     res.insert(
-        {Connector::kCoalescedStorageLoadWallNanos,
+        {std::string(Connector::kCoalescedStorageLoadWallNanos),
          RuntimeMetric(
              ioStatistics_->coalescedStorageLoadLatencyUs().sum() * 1'000,
              ioStatistics_->coalescedStorageLoadLatencyUs().count(),
@@ -498,7 +498,7 @@ HiveDataSource::getRuntimeStats() {
        {std::string(kTotalScanTime),
         RuntimeMetric(
             ioStatistics_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
-       {Connector::kTotalRemainingFilterTime,
+       {std::string(Connector::kTotalRemainingFilterTime),
         RuntimeMetric(
             totalRemainingFilterTime_.load(std::memory_order_relaxed),
             RuntimeCounter::Unit::kNanos)},

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -664,7 +664,7 @@ std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
 std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
   std::unordered_map<std::string, RuntimeMetric> stats;
   if (remainingFilterTimeNs_ != 0) {
-    stats[Connector::kTotalRemainingFilterTime] =
+    stats[std::string(Connector::kTotalRemainingFilterTime)] =
         RuntimeMetric(remainingFilterTimeNs_, RuntimeCounter::Unit::kNanos);
   }
   return stats;

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -50,11 +50,11 @@ class RowReader {
   /// Tracks the number of index columns that were converted from ScanSpec
   /// filters to index bounds for index-based filtering (e.g., cluster index
   /// pruning in Nimble).
-  static inline const std::string kNumIndexFilterConversions =
+  static constexpr std::string_view kNumIndexFilterConversions =
       "numIndexFilterConversions";
 
   /// Tracks the number of times a stripe has been loaded during index lookup.
-  static inline const std::string kNumStripeLoads = "numStripeLoads";
+  static constexpr std::string_view kNumStripeLoads = "numStripeLoads";
 
   virtual ~RowReader() = default;
 
@@ -210,13 +210,13 @@ class IndexReader {
   /// Tracks the number of index lookup requests submitted in startLookup().
   /// Each request corresponds to one set of index bounds and may match rows
   /// across multiple stripes.
-  static inline const std::string kNumIndexLookupRequests =
+  static constexpr std::string_view kNumIndexLookupRequests =
       "numIndexLookupRequests";
 
   /// Tracks the total number of stripes that need to be read for all requests.
   /// Multiple requests may share the same stripe, and each shared stripe is
   /// counted once per request that needs it.
-  static inline const std::string kNumIndexLookupStripes =
+  static constexpr std::string_view kNumIndexLookupStripes =
       "numIndexLookupStripes";
 
   /// Tracks the total number of read segments across all stripes. A read
@@ -224,7 +224,7 @@ class IndexReader {
   /// When filters are present, overlapping request ranges are split at
   /// boundaries to enable per-request output tracking. Without filters,
   /// overlapping ranges are merged to minimize I/O.
-  static inline const std::string kNumIndexLookupReadSegments =
+  static constexpr std::string_view kNumIndexLookupReadSegments =
       "numIndexLookupReadSegments";
 
   virtual ~IndexReader() = default;

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -367,7 +367,8 @@ void Exchange::recordExchangeClientStats() {
     lockedStats->runtimeStats.insert({name, value});
   }
 
-  const auto iter = exchangeClientStats.find(Operator::kBackgroundCpuTimeNanos);
+  const auto iter =
+      exchangeClientStats.find(std::string(Operator::kBackgroundCpuTimeNanos));
   if (iter != exchangeClientStats.end()) {
     const CpuWallTiming backgroundTiming{
         static_cast<uint64_t>(iter->second.count),

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -140,33 +140,33 @@ class BaseHashTable {
 
   /// The name of the runtime stats collected and reported by operators that use
   /// the HashTable (HashBuild, HashAggregation).
-  static inline const std::string kCapacity{"hashtable.capacity"};
-  static inline const std::string kNumRehashes{"hashtable.numRehashes"};
-  static inline const std::string kNumDistinct{"hashtable.numDistinct"};
-  static inline const std::string kNumTombstones{"hashtable.numTombstones"};
+  static constexpr std::string_view kCapacity{"hashtable.capacity"};
+  static constexpr std::string_view kNumRehashes{"hashtable.numRehashes"};
+  static constexpr std::string_view kNumDistinct{"hashtable.numDistinct"};
+  static constexpr std::string_view kNumTombstones{"hashtable.numTombstones"};
 
   /// The same as above but only reported by the HashBuild operator.
-  static inline const std::string kBuildWallNanos{"hashtable.buildWallNanos"};
-  static inline const std::string kParallelJoinPartitionWallNanos{
+  static constexpr std::string_view kBuildWallNanos{"hashtable.buildWallNanos"};
+  static constexpr std::string_view kParallelJoinPartitionWallNanos{
       "hashtable.parallelJoinPartitionWallNanos"};
-  static inline const std::string kParallelJoinPartitionCpuNanos{
+  static constexpr std::string_view kParallelJoinPartitionCpuNanos{
       "hashtable.parallelJoinPartitionCpuNanos"};
-  static inline const std::string kParallelJoinBuildWallNanos{
+  static constexpr std::string_view kParallelJoinBuildWallNanos{
       "hashtable.parallelJoinBuildWallNanos"};
-  static inline const std::string kParallelJoinBuildCpuNanos{
+  static constexpr std::string_view kParallelJoinBuildCpuNanos{
       "hashtable.parallelJoinBuildCpuNanos"};
-  static inline const std::string kParallelJoinBloomFilterPartitionWallNanos{
+  static constexpr std::string_view kParallelJoinBloomFilterPartitionWallNanos{
       "hashtable.parallelJoinBloomFilterPartitionWallNanos"};
-  static inline const std::string kParallelJoinBloomFilterPartitionCpuNanos{
+  static constexpr std::string_view kParallelJoinBloomFilterPartitionCpuNanos{
       "hashtable.parallelJoinBloomFilterPartitionCpuNanos"};
-  static inline const std::string kParallelJoinBloomFilterBuildWallNanos{
+  static constexpr std::string_view kParallelJoinBloomFilterBuildWallNanos{
       "hashtable.parallelJoinBloomFilterBuildWallNanos"};
-  static inline const std::string kParallelJoinBloomFilterBuildCpuNanos{
+  static constexpr std::string_view kParallelJoinBloomFilterBuildCpuNanos{
       "hashtable.parallelJoinBloomFilterBuildCpuNanos"};
-  static inline const std::string kVectorHasherMergeCpuNanos{
+  static constexpr std::string_view kVectorHasherMergeCpuNanos{
       "hashtable.vectorHasherMergeCpuNanos"};
-  static inline const std::string kHashTableCacheHit{"hashtable.cacheHit"};
-  static inline const std::string kHashTableCacheMiss{"hashtable.cacheMiss"};
+  static constexpr std::string_view kHashTableCacheHit{"hashtable.cacheHit"};
+  static constexpr std::string_view kHashTableCacheMiss{"hashtable.cacheMiss"};
 
   /// Returns the string of the given 'mode'.
   static std::string modeString(HashMode mode);

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -1391,15 +1391,18 @@ void IndexLookupJoin::recordConnectorStats() {
     lockedStats->runtimeStats.erase(name);
     lockedStats->runtimeStats.emplace(name, std::move(value));
   }
-  if (connectorStats.count(kConnectorLookupWallTime) != 0) {
+  if (connectorStats.count(std::string(kConnectorLookupWallTime)) != 0) {
     const CpuWallTiming backgroundTiming{
-        static_cast<uint64_t>(connectorStats[kConnectorLookupWallTime].count),
-        static_cast<uint64_t>(connectorStats[kConnectorLookupWallTime].sum),
+        static_cast<uint64_t>(
+            connectorStats[std::string(kConnectorLookupWallTime)].count),
+        static_cast<uint64_t>(
+            connectorStats[std::string(kConnectorLookupWallTime)].sum),
         // NOTE: this might not be accurate as it doesn't include the time
         // spent inside the index storage client.
-        static_cast<uint64_t>(connectorStats[kConnectorResultPrepareTime].sum) +
-            connectorStats[kClientRequestProcessTime].sum +
-            connectorStats[kClientResultProcessTime].sum};
+        static_cast<uint64_t>(
+            connectorStats[std::string(kConnectorResultPrepareTime)].sum) +
+            connectorStats[std::string(kClientRequestProcessTime)].sum +
+            connectorStats[std::string(kClientResultProcessTime)].sum};
     lockedStats->backgroundTiming.clear();
     lockedStats->backgroundTiming.add(backgroundTiming);
   }

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -47,39 +47,39 @@ class IndexLookupJoin : public Operator {
   /// Defines lookup runtime stats.
   /// The end-to-end walltime in nanoseconds that the index connector do the
   /// lookup.
-  static inline const std::string kConnectorLookupWallTime{
+  static constexpr std::string_view kConnectorLookupWallTime{
       "connectorLookupWallNanos"};
   /// The cpu time in nanoseconds that the index connector process response from
   /// storage client for followup processing by index join operator.
-  static inline const std::string kConnectorResultPrepareTime{
+  static constexpr std::string_view kConnectorResultPrepareTime{
       "connectorResultPrepareCpuNanos"};
   /// The cpu time in nanoseconds that the storage client process request for
   /// remote storage lookup such as encoding the lookup input data into remotr
   /// storage request.
-  static inline const std::string kClientRequestProcessTime{
+  static constexpr std::string_view kClientRequestProcessTime{
       "clientRequestProcessCpuNanos"};
   /// The walltime in nanoseconds that the storage client wait for the lookup
   /// from remote storage.
-  static inline const std::string kClientLookupWaitWallTime{
+  static constexpr std::string_view kClientLookupWaitWallTime{
       "clientlookupWaitWallNanos"};
   /// The number of split requests sent to remote storage for a client lookup
   /// request.
-  static inline const std::string kClientNumStorageRequests{
+  static constexpr std::string_view kClientNumStorageRequests{
       "clientNumStorageRequests"};
   /// The cpu time in nanoseconds that the storage client process response from
   /// remote storage lookup such as decoding the response data into velox
   /// vectors.
-  static inline const std::string kClientResultProcessTime{
+  static constexpr std::string_view kClientResultProcessTime{
       "clientResultProcessCpuNanos"};
   /// The byte size of the raw result received from the remote storage lookup.
-  static inline const std::string kClientLookupResultRawSize{
+  static constexpr std::string_view kClientLookupResultRawSize{
       "clientLookupResultRawSize"};
   /// The byte size of the result data in velox vectors that are decoded from
   /// the raw data received from the remote storage lookup.
-  static inline const std::string kClientLookupResultSize{
+  static constexpr std::string_view kClientLookupResultSize{
       "clientLookupResultSize"};
   /// The number of lookup results received from remote storage with error.
-  static inline const std::string kClientNumErrorResults{
+  static constexpr std::string_view kClientNumErrorResults{
       "clientNumErrorResults"};
 
  private:

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -61,12 +61,12 @@ class Merge : public SourceOperator {
   /// The running wall time of the merge operator reading from the streaming
   /// source. If spilling is enabled for local merge, this also includes the
   /// time that writes to the spilled source.
-  static inline const std::string kStreamingSourceReadWallNanos{
+  static constexpr std::string_view kStreamingSourceReadWallNanos{
       "streamingSourceReadWallNanos"};
   /// The running wall time of the merge operator reading from the spilled
   /// source to produce the final output. This only applies when spilling is
   /// enabled for local merge.
-  static inline const std::string kSpilledSourceReadWallNanos{
+  static constexpr std::string_view kSpilledSourceReadWallNanos{
       "spilledSourceReadWallNanos"};
 
  protected:

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -538,7 +538,7 @@ std::vector<column_index_t> calculateOutputChannels(
 }
 
 void OperatorStats::addRuntimeStat(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value) {
   addOperatorRuntimeStats(name, value, runtimeStats);
 }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -156,7 +156,7 @@ class Operator : public BaseRuntimeStatWriter {
 
   /// The name for background cpu time metric if operator has background cpu
   /// usages outside its driver thread.
-  static inline const std::string kBackgroundCpuTimeNanos =
+  static constexpr std::string_view kBackgroundCpuTimeNanos =
       "backgroundCpuTimeNanos";
 
   /// The name of the runtime spill stats collected and reported by operators
@@ -165,34 +165,34 @@ class Operator : public BaseRuntimeStatWriter {
   /// This indicates the spill not supported for a spillable operator when the
   /// spill config is enabled. This is due to the spill limitation in certain
   /// plan node config such as unpartition window operator.
-  static inline const std::string kSpillNotSupported{"spillNotSupported"};
+  static constexpr std::string_view kSpillNotSupported{"spillNotSupported"};
   /// The spill write stats.
-  static inline const std::string kSpillFillTime{"spillFillWallNanos"};
-  static inline const std::string kSpillSortTime{"spillSortWallNanos"};
-  static inline const std::string kSpillExtractVectorTime{
+  static constexpr std::string_view kSpillFillTime{"spillFillWallNanos"};
+  static constexpr std::string_view kSpillSortTime{"spillSortWallNanos"};
+  static constexpr std::string_view kSpillExtractVectorTime{
       "spillExtractVectorWallNanos"};
-  static inline const std::string kSpillSerializationTime{
+  static constexpr std::string_view kSpillSerializationTime{
       "spillSerializationWallNanos"};
-  static inline const std::string kSpillFlushTime{"spillFlushWallNanos"};
-  static inline const std::string kSpillWrites{"spillWrites"};
-  static inline const std::string kSpillWriteTime{"spillWriteWallNanos"};
-  static inline const std::string kSpillRuns{"spillRuns"};
-  static inline const std::string kExceededMaxSpillLevel{
+  static constexpr std::string_view kSpillFlushTime{"spillFlushWallNanos"};
+  static constexpr std::string_view kSpillWrites{"spillWrites"};
+  static constexpr std::string_view kSpillWriteTime{"spillWriteWallNanos"};
+  static constexpr std::string_view kSpillRuns{"spillRuns"};
+  static constexpr std::string_view kExceededMaxSpillLevel{
       "exceededMaxSpillLevel"};
   /// The spill read stats.
-  static inline const std::string kSpillReadBytes{"spillReadBytes"};
-  static inline const std::string kSpillReads{"spillReads"};
-  static inline const std::string kSpillReadTime{"spillReadWallNanos"};
-  static inline const std::string kSpillDeserializationTime{
+  static constexpr std::string_view kSpillReadBytes{"spillReadBytes"};
+  static constexpr std::string_view kSpillReads{"spillReads"};
+  static constexpr std::string_view kSpillReadTime{"spillReadWallNanos"};
+  static constexpr std::string_view kSpillDeserializationTime{
       "spillDeserializationWallNanos"};
 
   /// The vector serde kind used by an operator for shuffle. The recorded
   /// runtime stats value is the corresponding enum value.
-  static inline const std::string kShuffleSerdeKind{"shuffleSerdeKind"};
+  static constexpr std::string_view kShuffleSerdeKind{"shuffleSerdeKind"};
 
   /// The compression kind used by an operator for shuffle. The recorded
   /// runtime stats value is the corresponding enum value.
-  static inline const std::string kShuffleCompressionKind{
+  static constexpr std::string_view kShuffleCompressionKind{
       "shuffleCompressionKind"};
 
   /// 'operatorId' is the initial index of the 'this' in the Driver's list of
@@ -348,7 +348,7 @@ class Operator : public BaseRuntimeStatWriter {
 
   /// Add a single runtime stat to the operator stats under the write lock.
   /// This member overrides BaseRuntimeStatWriter's member.
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
     stats_.wlock()->addRuntimeStat(name, value);
   }

--- a/velox/exec/OperatorStats.h
+++ b/velox/exec/OperatorStats.h
@@ -234,7 +234,7 @@ struct OperatorStats {
     outputVectors += 1;
   }
 
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value);
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value);
   void add(const OperatorStats& other);
   void clear();
 };

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -470,21 +470,21 @@ std::string makeOperatorSpillPath(
 }
 
 void setOperatorRuntimeStats(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value,
     std::unordered_map<std::string, RuntimeMetric>& stats) {
-  stats[name] = RuntimeMetric(value.unit);
-  stats[name].addValue(value.value);
+  auto [it, _] =
+      stats.insert_or_assign(std::string(name), RuntimeMetric(value.unit));
+  it->second.addValue(value.value);
 }
 
 void addOperatorRuntimeStats(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value,
     std::unordered_map<std::string, RuntimeMetric>& stats) {
-  auto statIt = stats.find(name);
-  if (UNLIKELY(statIt == stats.end())) {
-    statIt = stats.insert(std::pair(name, RuntimeMetric(value.unit))).first;
-  } else {
+  auto [statIt, inserted] =
+      stats.emplace(std::string(name), RuntimeMetric(value.unit));
+  if (!inserted) {
     VELOX_CHECK_EQ(statIt->second.unit, value.unit);
   }
   statIt->second.addValue(value.value);

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -151,13 +151,13 @@ std::string makeOperatorSpillPath(
 
 /// Set a named runtime metric in operator 'stats'.
 void setOperatorRuntimeStats(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value,
     std::unordered_map<std::string, RuntimeMetric>& stats);
 
 /// Add a named runtime metric to operator 'stats'.
 void addOperatorRuntimeStats(
-    const std::string& name,
+    std::string_view name,
     const RuntimeCounter& value,
     std::unordered_map<std::string, RuntimeMetric>& stats);
 

--- a/velox/exec/PrefixSort.h
+++ b/velox/exec/PrefixSort.h
@@ -161,7 +161,7 @@ class PrefixSort {
 
   /// The runtime stats name collected for prefix sort.
   /// The number of prefix sort keys.
-  static inline const std::string kNumPrefixSortKeys{"numPrefixSortKeys"};
+  static constexpr std::string_view kNumPrefixSortKeys{"numPrefixSortKeys"};
 
  private:
   /// Fallback to stdSort when prefix sort conditions such as config and memory

--- a/velox/exec/ScaleWriterLocalPartition.h
+++ b/velox/exec/ScaleWriterLocalPartition.h
@@ -44,9 +44,9 @@ class ScaleWriterPartitioningLocalPartition : public LocalPartition {
 
   /// The name of the runtime stats of writer scaling.
   /// The number of times that we triggers the rebalance of table partitions.
-  static inline const std::string kRebalanceTriggers{"rebalanceTriggers"};
+  static constexpr std::string_view kRebalanceTriggers{"rebalanceTriggers"};
   /// The number of times that we scale a partition processing.
-  static inline const std::string kScaledPartitions{"scaledPartitions"};
+  static constexpr std::string_view kScaledPartitions{"scaledPartitions"};
 
  private:
   void prepareForWriterAssignments(vector_size_t numInput);
@@ -98,7 +98,7 @@ class ScaleWriterLocalPartition : public LocalPartition {
 
   /// The name of the runtime stats of writer scaling.
   /// The number of scaled writers.
-  static inline const std::string kScaledWriters{"scaledWriters"};
+  static constexpr std::string_view kScaledWriters{"scaledWriters"};
 
  private:
   // Gets the writer id to process the next input in a round-robin manner.

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -372,7 +372,8 @@ void SortWindowBuild::loadNextPartitionBatchFromSpill() {
     numSpillReadBatches_--;
 
     auto lockedOpStats = opStats_->wlock();
-    lockedOpStats->runtimeStats[Window::kWindowSpillReadNumBatches] =
+    lockedOpStats
+        ->runtimeStats[std::string(Window::kWindowSpillReadNumBatches)] =
         RuntimeMetric(numSpillReadBatches_);
   }
 }

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -77,15 +77,15 @@ class TableWriter : public Operator {
 
   /// The name of runtime stats specific to table writer.
   /// The running wall time of a writer operator from creation to close.
-  static inline const std::string kRunningWallNanos{"runningWallNanos"};
+  static constexpr std::string_view kRunningWallNanos{"runningWallNanos"};
   /// The number of files written by this writer operator.
-  static inline const std::string kNumWrittenFiles{"numWrittenFiles"};
+  static constexpr std::string_view kNumWrittenFiles{"numWrittenFiles"};
   /// The file write IO walltime.
-  static inline const std::string kWriteIOTime{"writeIOWallNanos"};
+  static constexpr std::string_view kWriteIOTime{"writeIOWallNanos"};
   /// The walltime spend on file write data recoding.
-  static inline const std::string kWriteRecodeTime{"writeRecodeWallNanos"};
+  static constexpr std::string_view kWriteRecodeTime{"writeRecodeWallNanos"};
   /// The walltime spent on file write data compression.
-  static inline const std::string kWriteCompressionTime{
+  static constexpr std::string_view kWriteCompressionTime{
       "writeCompressionWallNanos"};
 
  private:

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -57,7 +57,8 @@ Window::Window(
   if (spillConfig == nullptr &&
       operatorCtx_->driverCtx()->queryConfig().windowSpillEnabled()) {
     auto lockedStats = stats_.wlock();
-    lockedStats->runtimeStats.emplace(kSpillNotSupported, RuntimeMetric(1));
+    lockedStats->runtimeStats.emplace(
+        std::string(kSpillNotSupported), RuntimeMetric(1));
   }
   if (windowNode->inputsSorted()) {
     if (supportRowsStreaming()) {

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -69,7 +69,7 @@ class Window : public Operator {
 
   /// Runtime statistics holding total number of batches read from spilled data.
   /// 0 if no spilling occurred.
-  static inline const std::string kWindowSpillReadNumBatches{
+  static constexpr std::string_view kWindowSpillReadNumBatches{
       "windowSpillReadNumBatches"};
 
  private:

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -114,35 +114,43 @@ void checkSpillStats(PlanNodeStats& stats, bool expectedSpill) {
     ASSERT_GT(stats.spilledInputBytes, 0);
     ASSERT_GT(stats.spilledBytes, 0);
     ASSERT_GT(stats.spilledPartitions, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillRuns].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillFillTime].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillSortTime].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillSerializationTime].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillFlushTime].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillWrites].sum, 0);
-    ASSERT_GT(stats.customStats[Operator::kSpillWriteTime].sum, 0);
+    ASSERT_GT(stats.customStats[std::string(Operator::kSpillRuns)].sum, 0);
+    ASSERT_GT(stats.customStats[std::string(Operator::kSpillFillTime)].sum, 0);
+    ASSERT_GT(stats.customStats[std::string(Operator::kSpillSortTime)].sum, 0);
+    ASSERT_GT(
+        stats.customStats[std::string(Operator::kSpillExtractVectorTime)].sum,
+        0);
+    ASSERT_GT(
+        stats.customStats[std::string(Operator::kSpillSerializationTime)].sum,
+        0);
+    ASSERT_GT(stats.customStats[std::string(Operator::kSpillFlushTime)].sum, 0);
+    ASSERT_GT(stats.customStats[std::string(Operator::kSpillWrites)].sum, 0);
+    ASSERT_GT(stats.customStats[std::string(Operator::kSpillWriteTime)].sum, 0);
   } else {
     ASSERT_EQ(stats.spilledRows, 0);
     ASSERT_EQ(stats.spilledInputBytes, 0);
     ASSERT_EQ(stats.spilledBytes, 0);
     ASSERT_EQ(stats.spilledPartitions, 0);
     ASSERT_EQ(stats.spilledFiles, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillRuns].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillFillTime].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillSortTime].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillSerializationTime].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillFlushTime].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillWrites].sum, 0);
-    ASSERT_EQ(stats.customStats[Operator::kSpillWriteTime].sum, 0);
+    ASSERT_EQ(stats.customStats[std::string(Operator::kSpillRuns)].sum, 0);
+    ASSERT_EQ(stats.customStats[std::string(Operator::kSpillFillTime)].sum, 0);
+    ASSERT_EQ(stats.customStats[std::string(Operator::kSpillSortTime)].sum, 0);
+    ASSERT_EQ(
+        stats.customStats[std::string(Operator::kSpillExtractVectorTime)].sum,
+        0);
+    ASSERT_EQ(
+        stats.customStats[std::string(Operator::kSpillSerializationTime)].sum,
+        0);
+    ASSERT_EQ(stats.customStats[std::string(Operator::kSpillFlushTime)].sum, 0);
+    ASSERT_EQ(stats.customStats[std::string(Operator::kSpillWrites)].sum, 0);
+    ASSERT_EQ(stats.customStats[std::string(Operator::kSpillWriteTime)].sum, 0);
   }
   ASSERT_EQ(
-      stats.customStats[Operator::kSpillSerializationTime].count,
-      stats.customStats[Operator::kSpillFlushTime].count);
+      stats.customStats[std::string(Operator::kSpillSerializationTime)].count,
+      stats.customStats[std::string(Operator::kSpillFlushTime)].count);
   ASSERT_EQ(
-      stats.customStats[Operator::kSpillWrites].count,
-      stats.customStats[Operator::kSpillWriteTime].count);
+      stats.customStats[std::string(Operator::kSpillWrites)].count,
+      stats.customStats[std::string(Operator::kSpillWriteTime)].count);
 }
 
 class AggregationTest : public OperatorTestBase {
@@ -1240,7 +1248,11 @@ TEST_F(AggregationTest, spillAll) {
 
     auto stats = task->taskStats().pipelineStats;
     ASSERT_LT(
-        0, stats[0].operatorStats[1].runtimeStats[Operator::kSpillRuns].count);
+        0,
+        stats[0]
+            .operatorStats[1]
+            .runtimeStats[std::string(Operator::kSpillRuns)]
+            .count);
     // Check spilled bytes.
     ASSERT_LT(0, stats[0].operatorStats[1].spilledInputBytes);
     ASSERT_LT(0, stats[0].operatorStats[1].spilledBytes);
@@ -2373,16 +2385,22 @@ TEST_F(AggregationTest, spillPrefixSortOptimization) {
       checkSpillStats(stats, true);
       if (testData.expectedNumPrefixSortKeys > 0) {
         ASSERT_GE(
-            stats.customStats.at(PrefixSort::kNumPrefixSortKeys).sum,
+            stats.customStats.at(std::string(PrefixSort::kNumPrefixSortKeys))
+                .sum,
             testData.expectedNumPrefixSortKeys);
         ASSERT_EQ(
-            stats.customStats.at(PrefixSort::kNumPrefixSortKeys).max,
+            stats.customStats.at(std::string(PrefixSort::kNumPrefixSortKeys))
+                .max,
             testData.expectedNumPrefixSortKeys);
         ASSERT_EQ(
-            stats.customStats.at(PrefixSort::kNumPrefixSortKeys).min,
+            stats.customStats.at(std::string(PrefixSort::kNumPrefixSortKeys))
+                .min,
             testData.expectedNumPrefixSortKeys);
       } else {
-        ASSERT_EQ(stats.customStats.count(PrefixSort::kNumPrefixSortKeys), 0);
+        ASSERT_EQ(
+            stats.customStats.count(
+                std::string(PrefixSort::kNumPrefixSortKeys)),
+            0);
       }
       OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
     };
@@ -3768,7 +3786,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimFromAggregation) {
     // reporting in unit test.
     ASSERT_GE(
         planStats
-            .customStats[memory::SharedArbitrator::kMemoryArbitrationWallNanos]
+            .customStats[std::string(
+                memory::SharedArbitrator::kMemoryArbitrationWallNanos)]
             .sum,
         0);
     task.reset();

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -6614,22 +6614,22 @@ DEBUG_ONLY_TEST_P(HashJoinTest, exceededMaxSpillLevel) {
         auto opStats = toOperatorStats(task->taskStats());
         ASSERT_EQ(
             opStats.at("HashProbe")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .sum,
             8);
         ASSERT_EQ(
             opStats.at("HashProbe")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .count,
             1);
         ASSERT_EQ(
             opStats.at("HashBuild")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .sum,
             8);
         ASSERT_EQ(
             opStats.at("HashBuild")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .count,
             1);
       })
@@ -7076,7 +7076,9 @@ DEBUG_ONLY_TEST_P(HashJoinTest, reclaimDuringTableBuild) {
       .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
         auto opStats = toOperatorStats(task->taskStats());
         ASSERT_GT(
-            opStats.at("HashBuild").runtimeStats[Operator::kSpillWrites].sum,
+            opStats.at("HashBuild")
+                .runtimeStats[std::string(Operator::kSpillWrites)]
+                .sum,
             0);
       })
       .run();
@@ -7929,12 +7931,12 @@ DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeSpillExceedLimit) {
           }
           ASSERT_GT(
               opStats.at("HashProbe")
-                  .runtimeStats[Operator::kExceededMaxSpillLevel]
+                  .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                   .sum,
               0);
           ASSERT_GT(
               opStats.at("HashBuild")
-                  .runtimeStats[Operator::kExceededMaxSpillLevel]
+                  .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                   .sum,
               0);
         })

--- a/velox/exec/tests/HashJoinWithCacheTest.cpp
+++ b/velox/exec/tests/HashJoinWithCacheTest.cpp
@@ -134,14 +134,20 @@ TEST_F(HashJoinWithCacheTest, sequential) {
 
   // The last driver that finishes building reports the cache miss stat.
   ASSERT_EQ(
-      hashBuildStats1.runtimeStats.count(BaseHashTable::kHashTableCacheMiss), 1)
+      hashBuildStats1.runtimeStats.count(
+          std::string(BaseHashTable::kHashTableCacheMiss)),
+      1)
       << "First task should report cache miss";
   EXPECT_EQ(
-      hashBuildStats1.runtimeStats.at(BaseHashTable::kHashTableCacheMiss).count,
+      hashBuildStats1.runtimeStats
+          .at(std::string(BaseHashTable::kHashTableCacheMiss))
+          .count,
       1)
       << "Exactly one driver should report cache miss (the one that builds)";
   EXPECT_EQ(
-      hashBuildStats1.runtimeStats.count(BaseHashTable::kHashTableCacheHit), 0)
+      hashBuildStats1.runtimeStats.count(
+          std::string(BaseHashTable::kHashTableCacheHit)),
+      0)
       << "First task should not have any cache hits";
 
   // Second task - should reuse the cached table (cache hit).
@@ -154,14 +160,20 @@ TEST_F(HashJoinWithCacheTest, sequential) {
 
   // The last driver that finishes reports the cache hit stat.
   ASSERT_EQ(
-      hashBuildStats2.runtimeStats.count(BaseHashTable::kHashTableCacheHit), 1)
+      hashBuildStats2.runtimeStats.count(
+          std::string(BaseHashTable::kHashTableCacheHit)),
+      1)
       << "Second task should report cache hit";
   EXPECT_EQ(
-      hashBuildStats2.runtimeStats.at(BaseHashTable::kHashTableCacheHit).count,
+      hashBuildStats2.runtimeStats
+          .at(std::string(BaseHashTable::kHashTableCacheHit))
+          .count,
       1)
       << "Exactly one driver should report cache hit (the one after barrier)";
   EXPECT_EQ(
-      hashBuildStats2.runtimeStats.count(BaseHashTable::kHashTableCacheMiss), 0)
+      hashBuildStats2.runtimeStats.count(
+          std::string(BaseHashTable::kHashTableCacheMiss)),
+      0)
       << "Second task should not have any cache misses";
 
   // Clean up cache entry before tasks are destroyed.
@@ -300,15 +312,18 @@ TEST_F(HashJoinWithCacheTest, concurrent) {
     ASSERT_EQ(opStats.count("HashBuild"), 1);
     auto& hashBuildStats = opStats.at("HashBuild");
 
-    if (hashBuildStats.runtimeStats.count(BaseHashTable::kHashTableCacheMiss)) {
+    if (hashBuildStats.runtimeStats.count(
+            std::string(BaseHashTable::kHashTableCacheMiss))) {
       totalCacheMisses +=
-          hashBuildStats.runtimeStats.at(BaseHashTable::kHashTableCacheMiss)
+          hashBuildStats.runtimeStats
+              .at(std::string(BaseHashTable::kHashTableCacheMiss))
               .count;
     }
-    if (hashBuildStats.runtimeStats.count(BaseHashTable::kHashTableCacheHit)) {
-      totalCacheHits +=
-          hashBuildStats.runtimeStats.at(BaseHashTable::kHashTableCacheHit)
-              .count;
+    if (hashBuildStats.runtimeStats.count(
+            std::string(BaseHashTable::kHashTableCacheHit))) {
+      totalCacheHits += hashBuildStats.runtimeStats
+                            .at(std::string(BaseHashTable::kHashTableCacheHit))
+                            .count;
     }
   }
 

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -2864,22 +2864,44 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
   ASSERT_GT(operatorStats.backgroundTiming.wallNanos, 0);
   auto runtimeStats = operatorStats.customStats;
   ASSERT_EQ(
-      runtimeStats.at(IndexLookupJoin::kConnectorLookupWallTime).count,
-      numProbeBatches);
-  ASSERT_GT(runtimeStats.at(IndexLookupJoin::kConnectorLookupWallTime).sum, 0);
-  ASSERT_EQ(
-      runtimeStats.at(IndexLookupJoin::kClientLookupWaitWallTime).count,
-      numProbeBatches);
-  ASSERT_GT(runtimeStats.at(IndexLookupJoin::kClientLookupWaitWallTime).sum, 0);
-  ASSERT_EQ(
-      runtimeStats.at(IndexLookupJoin::kConnectorResultPrepareTime).count,
+      runtimeStats.at(std::string(IndexLookupJoin::kConnectorLookupWallTime))
+          .count,
       numProbeBatches);
   ASSERT_GT(
-      runtimeStats.at(IndexLookupJoin::kConnectorResultPrepareTime).sum, 0);
-  ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientRequestProcessTime), 0);
-  ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientResultProcessTime), 0);
-  ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientLookupResultSize), 0);
-  ASSERT_EQ(runtimeStats.count(IndexLookupJoin::kClientLookupResultRawSize), 0);
+      runtimeStats.at(std::string(IndexLookupJoin::kConnectorLookupWallTime))
+          .sum,
+      0);
+  ASSERT_EQ(
+      runtimeStats.at(std::string(IndexLookupJoin::kClientLookupWaitWallTime))
+          .count,
+      numProbeBatches);
+  ASSERT_GT(
+      runtimeStats.at(std::string(IndexLookupJoin::kClientLookupWaitWallTime))
+          .sum,
+      0);
+  ASSERT_EQ(
+      runtimeStats.at(std::string(IndexLookupJoin::kConnectorResultPrepareTime))
+          .count,
+      numProbeBatches);
+  ASSERT_GT(
+      runtimeStats.at(std::string(IndexLookupJoin::kConnectorResultPrepareTime))
+          .sum,
+      0);
+  ASSERT_EQ(
+      runtimeStats.count(
+          std::string(IndexLookupJoin::kClientRequestProcessTime)),
+      0);
+  ASSERT_EQ(
+      runtimeStats.count(
+          std::string(IndexLookupJoin::kClientResultProcessTime)),
+      0);
+  ASSERT_EQ(
+      runtimeStats.count(std::string(IndexLookupJoin::kClientLookupResultSize)),
+      0);
+  ASSERT_EQ(
+      runtimeStats.count(
+          std::string(IndexLookupJoin::kClientLookupResultRawSize)),
+      0);
   ASSERT_THAT(
       operatorStats.toString(true, true),
       testing::MatchesRegex(".*Runtime stats.*connectorLookupWallNanos:.*"));

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -403,9 +403,13 @@ class MergeTest : public OperatorTestBase {
       ASSERT_EQ(planStats.spilledFiles, 0);
       ASSERT_EQ(planStats.spilledRows, 0);
       ASSERT_EQ(
-          planStats.customStats.count(Merge::kSpilledSourceReadWallNanos), 0);
+          planStats.customStats.count(
+              std::string(Merge::kSpilledSourceReadWallNanos)),
+          0);
       ASSERT_GE(
-          planStats.customStats.count(Merge::kStreamingSourceReadWallNanos), 0);
+          planStats.customStats.count(
+              std::string(Merge::kStreamingSourceReadWallNanos)),
+          0);
     } else {
       const auto expectedFiles =
           (inputVectors.size() + numMaxMergeSources - 1) / numMaxMergeSources;
@@ -415,9 +419,13 @@ class MergeTest : public OperatorTestBase {
       ASSERT_EQ(planStats.spilledFiles, expectedFiles);
       ASSERT_EQ(planStats.spilledRows, expectedSpillRows);
       ASSERT_GE(
-          planStats.customStats.count(Merge::kSpilledSourceReadWallNanos), 0);
+          planStats.customStats.count(
+              std::string(Merge::kSpilledSourceReadWallNanos)),
+          0);
       ASSERT_GE(
-          planStats.customStats.count(Merge::kStreamingSourceReadWallNanos), 0);
+          planStats.customStats.count(
+              std::string(Merge::kStreamingSourceReadWallNanos)),
+          0);
     }
     ASSERT_EQ(
         planStats.outputRows,

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/OperatorUtils.h"
 #include <gtest/gtest.h>
+#include <string_view>
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/tests/utils/MergeTestBase.h"
@@ -563,56 +564,56 @@ TEST_F(OperatorUtilsTest, wrap) {
 
 TEST_F(OperatorUtilsTest, addOperatorRuntimeStats) {
   std::unordered_map<std::string, RuntimeMetric> stats;
-  const std::string statsName("stats");
+  constexpr std::string_view statsName{"stats"};
   const RuntimeCounter minStatsValue(100, RuntimeCounter::Unit::kBytes);
   const RuntimeCounter maxStatsValue(200, RuntimeCounter::Unit::kBytes);
   addOperatorRuntimeStats(statsName, minStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 1);
-  ASSERT_EQ(stats[statsName].sum, 100);
-  ASSERT_EQ(stats[statsName].max, 100);
-  ASSERT_EQ(stats[statsName].min, 100);
+  ASSERT_EQ(stats[std::string(statsName)].count, 1);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 100);
+  ASSERT_EQ(stats[std::string(statsName)].max, 100);
+  ASSERT_EQ(stats[std::string(statsName)].min, 100);
 
   addOperatorRuntimeStats(statsName, maxStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 2);
-  ASSERT_EQ(stats[statsName].sum, 300);
-  ASSERT_EQ(stats[statsName].max, 200);
-  ASSERT_EQ(stats[statsName].min, 100);
+  ASSERT_EQ(stats[std::string(statsName)].count, 2);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 300);
+  ASSERT_EQ(stats[std::string(statsName)].max, 200);
+  ASSERT_EQ(stats[std::string(statsName)].min, 100);
 
   addOperatorRuntimeStats(statsName, maxStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 3);
-  ASSERT_EQ(stats[statsName].sum, 500);
-  ASSERT_EQ(stats[statsName].max, 200);
-  ASSERT_EQ(stats[statsName].min, 100);
+  ASSERT_EQ(stats[std::string(statsName)].count, 3);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 500);
+  ASSERT_EQ(stats[std::string(statsName)].max, 200);
+  ASSERT_EQ(stats[std::string(statsName)].min, 100);
 }
 
 TEST_F(OperatorUtilsTest, setOperatorRuntimeStats) {
   std::unordered_map<std::string, RuntimeMetric> stats;
-  const std::string statsName("stats");
+  constexpr std::string_view statsName{"stats"};
   const RuntimeCounter minStatsValue(100, RuntimeCounter::Unit::kBytes);
   const RuntimeCounter maxStatsValue(200, RuntimeCounter::Unit::kBytes);
   setOperatorRuntimeStats(statsName, minStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 1);
-  ASSERT_EQ(stats[statsName].sum, 100);
-  ASSERT_EQ(stats[statsName].max, 100);
-  ASSERT_EQ(stats[statsName].min, 100);
+  ASSERT_EQ(stats[std::string(statsName)].count, 1);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 100);
+  ASSERT_EQ(stats[std::string(statsName)].max, 100);
+  ASSERT_EQ(stats[std::string(statsName)].min, 100);
 
   setOperatorRuntimeStats(statsName, maxStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 1);
-  ASSERT_EQ(stats[statsName].sum, 200);
-  ASSERT_EQ(stats[statsName].max, 200);
-  ASSERT_EQ(stats[statsName].min, 200);
+  ASSERT_EQ(stats[std::string(statsName)].count, 1);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 200);
+  ASSERT_EQ(stats[std::string(statsName)].max, 200);
+  ASSERT_EQ(stats[std::string(statsName)].min, 200);
 
   addOperatorRuntimeStats(statsName, maxStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 2);
-  ASSERT_EQ(stats[statsName].sum, 400);
-  ASSERT_EQ(stats[statsName].max, 200);
-  ASSERT_EQ(stats[statsName].min, 200);
+  ASSERT_EQ(stats[std::string(statsName)].count, 2);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 400);
+  ASSERT_EQ(stats[std::string(statsName)].max, 200);
+  ASSERT_EQ(stats[std::string(statsName)].min, 200);
 
   setOperatorRuntimeStats(statsName, minStatsValue, stats);
-  ASSERT_EQ(stats[statsName].count, 1);
-  ASSERT_EQ(stats[statsName].sum, 100);
-  ASSERT_EQ(stats[statsName].max, 100);
-  ASSERT_EQ(stats[statsName].min, 100);
+  ASSERT_EQ(stats[std::string(statsName)].count, 1);
+  ASSERT_EQ(stats[std::string(statsName)].sum, 100);
+  ASSERT_EQ(stats[std::string(statsName)].max, 100);
+  ASSERT_EQ(stats[std::string(statsName)].min, 100);
 }
 
 TEST_F(OperatorUtilsTest, initializeRowNumberMapping) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -510,20 +510,29 @@ TEST_F(OrderByTest, spill) {
   ASSERT_GT(planStats.spilledInputBytes, 0);
   ASSERT_EQ(planStats.spilledPartitions, 1);
   ASSERT_GT(planStats.spilledFiles, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillRuns].count, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillFillTime].sum, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillSortTime].sum, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillSerializationTime].sum, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillFlushTime].sum, 0);
+  ASSERT_GT(planStats.customStats[std::string(Operator::kSpillRuns)].count, 0);
+  ASSERT_GT(
+      planStats.customStats[std::string(Operator::kSpillFillTime)].sum, 0);
+  ASSERT_GT(
+      planStats.customStats[std::string(Operator::kSpillSortTime)].sum, 0);
+  ASSERT_GT(
+      planStats.customStats[std::string(Operator::kSpillExtractVectorTime)].sum,
+      0);
+  ASSERT_GT(
+      planStats.customStats[std::string(Operator::kSpillSerializationTime)].sum,
+      0);
+  ASSERT_GT(
+      planStats.customStats[std::string(Operator::kSpillFlushTime)].sum, 0);
   ASSERT_EQ(
-      planStats.customStats[Operator::kSpillSerializationTime].count,
-      planStats.customStats[Operator::kSpillFlushTime].count);
-  ASSERT_GT(planStats.customStats[Operator::kSpillWrites].sum, 0);
-  ASSERT_GT(planStats.customStats[Operator::kSpillWriteTime].sum, 0);
+      planStats.customStats[std::string(Operator::kSpillSerializationTime)]
+          .count,
+      planStats.customStats[std::string(Operator::kSpillFlushTime)].count);
+  ASSERT_GT(planStats.customStats[std::string(Operator::kSpillWrites)].sum, 0);
+  ASSERT_GT(
+      planStats.customStats[std::string(Operator::kSpillWriteTime)].sum, 0);
   ASSERT_EQ(
-      planStats.customStats[Operator::kSpillWrites].count,
-      planStats.customStats[Operator::kSpillWriteTime].count);
+      planStats.customStats[std::string(Operator::kSpillWrites)].count,
+      planStats.customStats[std::string(Operator::kSpillWriteTime)].count);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
 

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -159,7 +159,8 @@ TEST_P(PartitionedOutputTest, flush) {
 
   auto planStats = toPlanStats(task->taskStats());
   const auto serdeKindRuntimsStats =
-      planStats.at(partitionNodeId).customStats.at(Operator::kShuffleSerdeKind);
+      planStats.at(partitionNodeId)
+          .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
   ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
@@ -270,7 +271,8 @@ TEST_P(PartitionedOutputTest, multipleFlushCycles) {
 
   auto planStats = toPlanStats(task->taskStats());
   const auto serdeKindRuntimsStats =
-      planStats.at(partitionNodeId).customStats.at(Operator::kShuffleSerdeKind);
+      planStats.at(partitionNodeId)
+          .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
   ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -239,11 +239,13 @@ TEST_F(RowNumberTest, spill) {
         task->taskStats().pipelineStats.back().operatorStats.at(1);
     auto runtimeStats = operatorStats.runtimeStats;
     ASSERT_EQ(
-        runtimeStats.at(Operator::kSpillReadBytes).sum,
+        runtimeStats.at(std::string(Operator::kSpillReadBytes)).sum,
         operatorStats.spilledBytes);
-    ASSERT_GT(runtimeStats.at(Operator::kSpillReads).sum, 0);
-    ASSERT_GT(runtimeStats.at(Operator::kSpillReadTime).sum, 0);
-    ASSERT_GT(runtimeStats.at(Operator::kSpillDeserializationTime).sum, 0);
+    ASSERT_GT(runtimeStats.at(std::string(Operator::kSpillReads)).sum, 0);
+    ASSERT_GT(runtimeStats.at(std::string(Operator::kSpillReadTime)).sum, 0);
+    ASSERT_GT(
+        runtimeStats.at(std::string(Operator::kSpillDeserializationTime)).sum,
+        0);
 
     task.reset();
     waitForAllTasksToBeDeleted();

--- a/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
+++ b/velox/exec/tests/ScaleWriterLocalPartitionTest.cpp
@@ -680,22 +680,26 @@ TEST_F(ScaleWriterLocalPartitionTest, unpartitionBasic) {
     if (testData.expectedRebalance) {
       ASSERT_GT(
           planStats.at(exchnangeNodeId)
-              .customStats.at(ScaleWriterLocalPartition::kScaledWriters)
+              .customStats
+              .at(std::string(ScaleWriterLocalPartition::kScaledWriters))
               .sum,
           0);
       ASSERT_LE(
           planStats.at(exchnangeNodeId)
-              .customStats.at(ScaleWriterLocalPartition::kScaledWriters)
+              .customStats
+              .at(std::string(ScaleWriterLocalPartition::kScaledWriters))
               .sum,
           planStats.at(exchnangeNodeId)
-                  .customStats.at(ScaleWriterLocalPartition::kScaledWriters)
+                  .customStats
+                  .at(std::string(ScaleWriterLocalPartition::kScaledWriters))
                   .count *
               (testData.numConsumers - 1));
       ASSERT_GT(nonEmptyConsumers, 1);
     } else {
       ASSERT_EQ(
           planStats.at(exchnangeNodeId)
-              .customStats.count(ScaleWriterLocalPartition::kScaledWriters),
+              .customStats.count(
+                  std::string(ScaleWriterLocalPartition::kScaledWriters)),
           0);
       ASSERT_EQ(nonEmptyConsumers, 1);
     }
@@ -893,40 +897,51 @@ TEST_F(ScaleWriterLocalPartitionTest, partitionBasic) {
       ASSERT_LE(
           planStats.at(exchnangeNodeId)
               .customStats.count(
-                  ScaleWriterPartitioningLocalPartition::kScaledPartitions),
+                  std::string(
+                      ScaleWriterPartitioningLocalPartition::
+                          kScaledPartitions)),
           1);
       if (planStats.at(exchnangeNodeId)
               .customStats.count(
-                  ScaleWriterPartitioningLocalPartition::kScaledPartitions) ==
-          1) {
+                  std::string(
+                      ScaleWriterPartitioningLocalPartition::
+                          kScaledPartitions)) == 1) {
         ASSERT_GT(
             planStats.at(exchnangeNodeId)
                 .customStats
-                .at(ScaleWriterPartitioningLocalPartition::kScaledPartitions)
+                .at(std::string(
+                    ScaleWriterPartitioningLocalPartition::kScaledPartitions))
                 .sum,
             0);
       }
       ASSERT_EQ(
           planStats.at(exchnangeNodeId)
               .customStats.count(
-                  ScaleWriterPartitioningLocalPartition::kRebalanceTriggers),
+                  std::string(
+                      ScaleWriterPartitioningLocalPartition::
+                          kRebalanceTriggers)),
           1);
       ASSERT_GT(
           planStats.at(exchnangeNodeId)
               .customStats
-              .at(ScaleWriterPartitioningLocalPartition::kRebalanceTriggers)
+              .at(std::string(
+                  ScaleWriterPartitioningLocalPartition::kRebalanceTriggers))
               .sum,
           0);
     } else {
       ASSERT_EQ(
           planStats.at(exchnangeNodeId)
               .customStats.count(
-                  ScaleWriterPartitioningLocalPartition::kScaledPartitions),
+                  std::string(
+                      ScaleWriterPartitioningLocalPartition::
+                          kScaledPartitions)),
           0);
       ASSERT_EQ(
           planStats.at(exchnangeNodeId)
               .customStats.count(
-                  ScaleWriterPartitioningLocalPartition::kRebalanceTriggers),
+                  std::string(
+                      ScaleWriterPartitioningLocalPartition::
+                          kRebalanceTriggers)),
           0);
       verifyDisjointPartitionKeys(testController.get());
     }

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -41,7 +41,7 @@ class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
       std::unordered_map<std::string, RuntimeMetric>& stats)
       : stats_{stats} {}
 
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
     addOperatorRuntimeStats(name, value, stats_);
   }
@@ -204,16 +204,16 @@ TEST_P(SortBufferTest, singleKey) {
     }
     if (GetParam()) {
       ASSERT_EQ(
-          stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
           sortColumnIndices_.size());
     } else {
-      ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+      ASSERT_EQ(stats_.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
     }
     stats_.clear();
   }
@@ -266,16 +266,16 @@ TEST_P(SortBufferTest, multipleKeys) {
   ASSERT_EQ(output->childAt(1)->asFlatVector<int32_t>()->valueAt(9), 5);
   if (GetParam()) {
     ASSERT_EQ(
-        stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+        stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
         sortColumnIndices_.size());
     ASSERT_EQ(
-        stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+        stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
         sortColumnIndices_.size());
     ASSERT_EQ(
-        stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+        stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
         sortColumnIndices_.size());
   } else {
-    ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+    ASSERT_EQ(stats_.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
   }
 }
 
@@ -550,16 +550,16 @@ TEST_P(SortBufferTest, spill) {
     }
     if (GetParam()) {
       ASSERT_GE(
-          stats_.at(PrefixSort::kNumPrefixSortKeys).sum,
+          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).sum,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(PrefixSort::kNumPrefixSortKeys).max,
+          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).max,
           sortColumnIndices_.size());
       ASSERT_EQ(
-          stats_.at(PrefixSort::kNumPrefixSortKeys).min,
+          stats_.at(std::string(PrefixSort::kNumPrefixSortKeys)).min,
           sortColumnIndices_.size());
     } else {
-      ASSERT_EQ(stats_.count(PrefixSort::kNumPrefixSortKeys), 0);
+      ASSERT_EQ(stats_.count(std::string(PrefixSort::kNumPrefixSortKeys)), 0);
     }
     stats_.clear();
   }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -45,7 +45,7 @@ class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
       std::unordered_map<std::string, RuntimeMetric>& stats)
       : stats_{stats} {}
 
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
     addOperatorRuntimeStats(name, value, stats_);
   }

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -57,7 +57,7 @@ class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
       std::unordered_map<std::string, RuntimeMetric>& stats)
       : stats_{stats} {}
 
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
     addOperatorRuntimeStats(name, value, stats_);
   }

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -1560,10 +1560,16 @@ TEST_P(UnpartitionedTableWriterTest, runtimeStatsCheck) {
     }
     ASSERT_EQ(
         stats[1].runtimeStats["stripeSize"].count, testData.expectedNumStripes);
-    ASSERT_EQ(stats[1].runtimeStats[TableWriter::kNumWrittenFiles].sum, 1);
-    ASSERT_EQ(stats[1].runtimeStats[TableWriter::kNumWrittenFiles].count, 1);
-    ASSERT_GE(stats[1].runtimeStats[TableWriter::kWriteIOTime].sum, 0);
-    ASSERT_EQ(stats[1].runtimeStats[TableWriter::kWriteIOTime].count, 1);
+    ASSERT_EQ(
+        stats[1].runtimeStats[std::string(TableWriter::kNumWrittenFiles)].sum,
+        1);
+    ASSERT_EQ(
+        stats[1].runtimeStats[std::string(TableWriter::kNumWrittenFiles)].count,
+        1);
+    ASSERT_GE(
+        stats[1].runtimeStats[std::string(TableWriter::kWriteIOTime)].sum, 0);
+    ASSERT_EQ(
+        stats[1].runtimeStats[std::string(TableWriter::kWriteIOTime)].count, 1);
   }
 }
 
@@ -2352,17 +2358,17 @@ TEST_P(AllTableWriterTest, tableWriterStats) {
       fixedWrittenBytes);
   ASSERT_EQ(
       stats.operatorStats.at("TableWrite")
-          ->customStats.at(TableWriter::kNumWrittenFiles)
+          ->customStats.at(std::string(TableWriter::kNumWrittenFiles))
           .sum,
       numWrittenFiles);
   ASSERT_GE(
       stats.operatorStats.at("TableWrite")
-          ->customStats.at(TableWriter::kWriteIOTime)
+          ->customStats.at(std::string(TableWriter::kWriteIOTime))
           .sum,
       0);
   ASSERT_GE(
       stats.operatorStats.at("TableWrite")
-          ->customStats.at(TableWriter::kRunningWallNanos)
+          ->customStats.at(std::string(TableWriter::kRunningWallNanos))
           .sum,
       0);
 }
@@ -2511,14 +2517,16 @@ TEST_P(BucketSortOnlyTableWriterTest, sortWriterSpill) {
   // One spilled partition per each written files.
   const int numWrittenFiles = stats.customStats["numWrittenFiles"].sum;
   ASSERT_GE(stats.spilledPartitions, numWrittenFiles);
-  ASSERT_GT(stats.customStats[Operator::kSpillRuns].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillFillTime].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillSortTime].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillExtractVectorTime].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillSerializationTime].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillFlushTime].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillWrites].sum, 0);
-  ASSERT_GT(stats.customStats[Operator::kSpillWriteTime].sum, 0);
+  ASSERT_GT(stats.customStats[std::string(Operator::kSpillRuns)].sum, 0);
+  ASSERT_GT(stats.customStats[std::string(Operator::kSpillFillTime)].sum, 0);
+  ASSERT_GT(stats.customStats[std::string(Operator::kSpillSortTime)].sum, 0);
+  ASSERT_GT(
+      stats.customStats[std::string(Operator::kSpillExtractVectorTime)].sum, 0);
+  ASSERT_GT(
+      stats.customStats[std::string(Operator::kSpillSerializationTime)].sum, 0);
+  ASSERT_GT(stats.customStats[std::string(Operator::kSpillFlushTime)].sum, 0);
+  ASSERT_GT(stats.customStats[std::string(Operator::kSpillWrites)].sum, 0);
+  ASSERT_GT(stats.customStats[std::string(Operator::kSpillWriteTime)].sum, 0);
 }
 
 DEBUG_ONLY_TEST_P(BucketSortOnlyTableWriterTest, outputBatchRows) {

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -165,7 +165,7 @@ TEST_F(WindowTest, spillBatchReadTinyPartitions) {
   ASSERT_GT(stats.spilledPartitions, 0);
   ASSERT_EQ(
       stats.operatorStats.at("Window")
-          ->customStats[Window::kWindowSpillReadNumBatches]
+          ->customStats[std::string(Window::kWindowSpillReadNumBatches)]
           .sum,
       size / minReadBatchRows);
 }
@@ -218,7 +218,7 @@ TEST_F(WindowTest, spillBatchReadHugePartitions) {
   ASSERT_GT(stats.spilledPartitions, 0);
   ASSERT_EQ(
       stats.operatorStats.at("Window")
-          ->customStats[Window::kWindowSpillReadNumBatches]
+          ->customStats[std::string(Window::kWindowSpillReadNumBatches)]
           .sum,
       size / partitionRows);
 }
@@ -264,7 +264,10 @@ TEST_F(WindowTest, spillUnsupported) {
   ASSERT_EQ(stats.spilledPartitions, 0);
   auto opStats = toOperatorStats(task->taskStats());
   ASSERT_GT(
-      opStats.at("Window").runtimeStats[Operator::kSpillNotSupported].sum, 1);
+      opStats.at("Window")
+          .runtimeStats[std::string(Operator::kSpillNotSupported)]
+          .sum,
+      1);
 }
 
 TEST_F(WindowTest, rowBasedStreamingWindowOOM) {

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -102,52 +102,87 @@ void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
       if ((op.operatorType == OperatorType::kHashBuild) ||
           (op.operatorType == OperatorType::kHashProbe)) {
         if (!expectedSpill) {
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillRuns].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillFillTime].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillSortTime].count, 0);
           ASSERT_EQ(
-              op.runtimeStats[Operator::kSpillExtractVectorTime].count, 0);
+              op.runtimeStats[std::string(Operator::kSpillRuns)].count, 0);
           ASSERT_EQ(
-              op.runtimeStats[Operator::kSpillSerializationTime].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillFlushTime].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillWrites].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillWriteTime].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillReadBytes].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillReads].count, 0);
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillReadTime].count, 0);
+              op.runtimeStats[std::string(Operator::kSpillFillTime)].count, 0);
           ASSERT_EQ(
-              op.runtimeStats[Operator::kSpillDeserializationTime].count, 0);
+              op.runtimeStats[std::string(Operator::kSpillSortTime)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillExtractVectorTime)]
+                  .count,
+              0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillSerializationTime)]
+                  .count,
+              0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillFlushTime)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillWrites)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillWriteTime)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillReadBytes)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillReads)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillReadTime)].count, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillDeserializationTime)]
+                  .count,
+              0);
         } else {
           if (op.operatorType == OperatorType::kHashBuild) {
-            ASSERT_GT(op.runtimeStats[Operator::kSpillRuns].count, 0);
-            ASSERT_GT(op.runtimeStats[Operator::kSpillFillTime].sum, 0);
             ASSERT_GT(
-                op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
+                op.runtimeStats[std::string(Operator::kSpillRuns)].count, 0);
+            ASSERT_GT(
+                op.runtimeStats[std::string(Operator::kSpillFillTime)].sum, 0);
+            ASSERT_GT(
+                op.runtimeStats[std::string(Operator::kSpillExtractVectorTime)]
+                    .sum,
+                0);
           } else {
             // The table spilling might also be triggered from hash probe side.
-            ASSERT_GE(op.runtimeStats[Operator::kSpillRuns].count, 0);
-            ASSERT_GE(op.runtimeStats[Operator::kSpillFillTime].sum, 0);
             ASSERT_GE(
-                op.runtimeStats[Operator::kSpillExtractVectorTime].sum, 0);
+                op.runtimeStats[std::string(Operator::kSpillRuns)].count, 0);
+            ASSERT_GE(
+                op.runtimeStats[std::string(Operator::kSpillFillTime)].sum, 0);
+            ASSERT_GE(
+                op.runtimeStats[std::string(Operator::kSpillExtractVectorTime)]
+                    .sum,
+                0);
           }
-          ASSERT_EQ(op.runtimeStats[Operator::kSpillSortTime].sum, 0);
-          ASSERT_GT(op.runtimeStats[Operator::kSpillSerializationTime].sum, 0);
-          ASSERT_GE(op.runtimeStats[Operator::kSpillFlushTime].sum, 0);
-          // NOTE: spill flush might take less than one microsecond.
-          ASSERT_GE(
-              op.runtimeStats[Operator::kSpillSerializationTime].count,
-              op.runtimeStats[Operator::kSpillFlushTime].count);
-          ASSERT_GT(op.runtimeStats[Operator::kSpillWrites].sum, 0);
-          ASSERT_GE(op.runtimeStats[Operator::kSpillWriteTime].sum, 0);
-          // NOTE: spill flush might take less than one microsecond.
-          ASSERT_GE(
-              op.runtimeStats[Operator::kSpillWrites].count,
-              op.runtimeStats[Operator::kSpillWriteTime].count);
-          ASSERT_GT(op.runtimeStats[Operator::kSpillReadBytes].sum, 0);
-          ASSERT_GT(op.runtimeStats[Operator::kSpillReads].sum, 0);
-          ASSERT_GT(op.runtimeStats[Operator::kSpillReadTime].sum, 0);
+          ASSERT_EQ(
+              op.runtimeStats[std::string(Operator::kSpillSortTime)].sum, 0);
           ASSERT_GT(
-              op.runtimeStats[Operator::kSpillDeserializationTime].sum, 0);
+              op.runtimeStats[std::string(Operator::kSpillSerializationTime)]
+                  .sum,
+              0);
+          ASSERT_GE(
+              op.runtimeStats[std::string(Operator::kSpillFlushTime)].sum, 0);
+          // NOTE: spill flush might take less than one microsecond.
+          ASSERT_GE(
+              op.runtimeStats[std::string(Operator::kSpillSerializationTime)]
+                  .count,
+              op.runtimeStats[std::string(Operator::kSpillFlushTime)].count);
+          ASSERT_GT(
+              op.runtimeStats[std::string(Operator::kSpillWrites)].sum, 0);
+          ASSERT_GE(
+              op.runtimeStats[std::string(Operator::kSpillWriteTime)].sum, 0);
+          // NOTE: spill flush might take less than one microsecond.
+          ASSERT_GE(
+              op.runtimeStats[std::string(Operator::kSpillWrites)].count,
+              op.runtimeStats[std::string(Operator::kSpillWriteTime)].count);
+          ASSERT_GT(
+              op.runtimeStats[std::string(Operator::kSpillReadBytes)].sum, 0);
+          ASSERT_GT(op.runtimeStats[std::string(Operator::kSpillReads)].sum, 0);
+          ASSERT_GT(
+              op.runtimeStats[std::string(Operator::kSpillReadTime)].sum, 0);
+          ASSERT_GT(
+              op.runtimeStats[std::string(Operator::kSpillDeserializationTime)]
+                  .sum,
+              0);
         }
       }
     }

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -191,7 +191,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
         {"localExchangeSource.numPages", RuntimeMetric(numPages_)},
         {"localExchangeSource.totalBytes",
          RuntimeMetric(totalBytes_, RuntimeCounter::Unit::kBytes)},
-        {Operator::kBackgroundCpuTimeNanos,
+        {std::string(Operator::kBackgroundCpuTimeNanos),
          RuntimeMetric(123 * 1000000, RuntimeCounter::Unit::kNanos)},
     };
   }

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -342,13 +342,13 @@ void TestIndexSource::recordCpuTiming(const CpuWallTiming& timing) {
   std::lock_guard<std::mutex> l(mutex_);
   if (timing.wallNanos != 0) {
     addOperatorRuntimeStats(
-        IndexLookupJoin::kConnectorLookupWallTime,
+        std::string(IndexLookupJoin::kConnectorLookupWallTime),
         RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos),
         runtimeStats_);
     // This is just for testing purpose to check if the runtime stats has been
     // set properly.
     addOperatorRuntimeStats(
-        IndexLookupJoin::kClientLookupWaitWallTime,
+        std::string(IndexLookupJoin::kClientLookupWaitWallTime),
         RuntimeCounter(timing.wallNanos, RuntimeCounter::Unit::kNanos),
         runtimeStats_);
   }
@@ -356,7 +356,7 @@ void TestIndexSource::recordCpuTiming(const CpuWallTiming& timing) {
     // This is just for testing purpose to check if the runtime stats has been
     // set properly.
     addOperatorRuntimeStats(
-        IndexLookupJoin::kConnectorResultPrepareTime,
+        std::string(IndexLookupJoin::kConnectorResultPrepareTime),
         RuntimeCounter(timing.cpuNanos, RuntimeCounter::Unit::kNanos),
         runtimeStats_);
   }

--- a/velox/exec/trace/Trace.h
+++ b/velox/exec/trace/Trace.h
@@ -19,32 +19,33 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace facebook::velox::exec::trace {
 
 /// Defines the shared constants used by query trace implementation.
 struct TraceTraits {
-  static inline const std::string kPlanNodeKey = "planNode";
-  static inline const std::string kQueryConfigKey = "queryConfig";
-  static inline const std::string kConnectorPropertiesKey =
+  static constexpr std::string_view kPlanNodeKey = "planNode";
+  static constexpr std::string_view kQueryConfigKey = "queryConfig";
+  static constexpr std::string_view kConnectorPropertiesKey =
       "connectorProperties";
 
-  static inline const std::string kTaskMetaFileName = "task_trace_meta.json";
+  static constexpr std::string_view kTaskMetaFileName = "task_trace_meta.json";
 };
 
 struct OperatorTraceTraits {
-  static inline const std::string kSummaryFileName = "op_trace_summary.json";
-  static inline const std::string kInputFileName = "op_input_trace.data";
-  static inline const std::string kSplitFileName = "op_split_trace.split";
+  static constexpr std::string_view kSummaryFileName = "op_trace_summary.json";
+  static constexpr std::string_view kInputFileName = "op_input_trace.data";
+  static constexpr std::string_view kSplitFileName = "op_split_trace.split";
 
   /// Keys for operator trace summary file.
-  static inline const std::string kOpTypeKey = "opType";
-  static inline const std::string kPeakMemoryKey = "peakMemory";
-  static inline const std::string kInputRowsKey = "inputRows";
-  static inline const std::string kInputBytesKey = "inputBytes";
-  static inline const std::string kRawInputRowsKey = "rawInputRows";
-  static inline const std::string kRawInputBytesKey = "rawInputBytes";
-  static inline const std::string kNumSplitsKey = "numSplits";
+  static constexpr std::string_view kOpTypeKey = "opType";
+  static constexpr std::string_view kPeakMemoryKey = "peakMemory";
+  static constexpr std::string_view kInputRowsKey = "inputRows";
+  static constexpr std::string_view kInputBytesKey = "inputBytes";
+  static constexpr std::string_view kRawInputRowsKey = "rawInputRows";
+  static constexpr std::string_view kRawInputBytesKey = "rawInputBytes";
+  static constexpr std::string_view kNumSplitsKey = "numSplits";
 };
 
 /// Contains the summary of an operator trace.

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -573,7 +573,7 @@ CudfHiveDataSource::getRuntimeStats() {
       {std::string(connector::hive::HiveDataSource::kTotalScanTime),
        RuntimeMetric(
            ioStatistics_->totalScanTime(), RuntimeCounter::Unit::kNanos)},
-      {Connector::kTotalRemainingFilterTime,
+      {std::string(Connector::kTotalRemainingFilterTime),
        RuntimeMetric(
            totalRemainingFilterTime_.load(std::memory_order_relaxed),
            RuntimeCounter::Unit::kNanos)},

--- a/velox/experimental/cudf/tests/HashJoinTest.cpp
+++ b/velox/experimental/cudf/tests/HashJoinTest.cpp
@@ -6691,22 +6691,22 @@ DEBUG_ONLY_TEST_F(HashJoinTest, exceededMaxSpillLevel) {
         auto opStats = toOperatorStats(task->taskStats());
         ASSERT_EQ(
             opStats.at("HashProbe")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .sum,
             8);
         ASSERT_EQ(
             opStats.at("HashProbe")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .count,
             1);
         ASSERT_EQ(
             opStats.at("HashBuild")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .sum,
             8);
         ASSERT_EQ(
             opStats.at("HashBuild")
-                .runtimeStats[Operator::kExceededMaxSpillLevel]
+                .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                 .count,
             1);
       })
@@ -7028,7 +7028,9 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringTableBuild) {
       .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
         auto opStats = toOperatorStats(task->taskStats());
         ASSERT_GT(
-            opStats.at("HashBuild").runtimeStats[Operator::kSpillWrites].sum,
+            opStats.at("HashBuild")
+                .runtimeStats[std::string(Operator::kSpillWrites)]
+                .sum,
             0);
       })
       .run();
@@ -7865,12 +7867,12 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeSpillExceedLimit) {
           }
           ASSERT_GT(
               opStats.at("HashProbe")
-                  .runtimeStats[Operator::kExceededMaxSpillLevel]
+                  .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                   .sum,
               0);
           ASSERT_GT(
               opStats.at("HashBuild")
-                  .runtimeStats[Operator::kExceededMaxSpillLevel]
+                  .runtimeStats[std::string(Operator::kExceededMaxSpillLevel)]
                   .sum,
               0);
         })

--- a/velox/serializers/PrestoIterativeVectorSerializer.cpp
+++ b/velox/serializers/PrestoIterativeVectorSerializer.cpp
@@ -122,18 +122,18 @@ PrestoIterativeVectorSerializer::runtimeStats() {
   std::unordered_map<std::string, RuntimeCounter> map;
   if (stats_.compressionInputBytes != 0) {
     map.emplace(
-        kCompressionInputBytes,
+        std::string(kCompressionInputBytes),
         RuntimeCounter(
             stats_.compressionInputBytes, RuntimeCounter::Unit::kBytes));
   }
   if (stats_.compressedBytes != 0) {
     map.emplace(
-        kCompressedBytes,
+        std::string(kCompressedBytes),
         RuntimeCounter(stats_.compressedBytes, RuntimeCounter::Unit::kBytes));
   }
   if (stats_.compressionSkippedBytes != 0) {
     map.emplace(
-        kCompressionSkippedBytes,
+        std::string(kCompressionSkippedBytes),
         RuntimeCounter(
             stats_.compressionSkippedBytes, RuntimeCounter::Unit::kBytes));
   }

--- a/velox/serializers/RowSerializer.h
+++ b/velox/serializers/RowSerializer.h
@@ -173,18 +173,18 @@ class RowSerializer : public IterativeVectorSerializer {
     std::unordered_map<std::string, RuntimeCounter> map;
     if (stats_.compressionInputBytes != 0) {
       map.emplace(
-          kCompressionInputBytes,
+          std::string(kCompressionInputBytes),
           RuntimeCounter(
               stats_.compressionInputBytes, RuntimeCounter::Unit::kBytes));
     }
     if (stats_.compressedBytes != 0) {
       map.emplace(
-          kCompressedBytes,
+          std::string(kCompressedBytes),
           RuntimeCounter(stats_.compressedBytes, RuntimeCounter::Unit::kBytes));
     }
     if (stats_.compressionSkippedBytes != 0) {
       map.emplace(
-          kCompressionSkippedBytes,
+          std::string(kCompressionSkippedBytes),
           RuntimeCounter(
               stats_.compressionSkippedBytes, RuntimeCounter::Unit::kBytes));
     }

--- a/velox/tool/trace/tests/HashJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/HashJoinReplayerTest.cpp
@@ -455,7 +455,10 @@ DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashBuildSpill) {
   const auto& stats = taskStats.at(traceNodeId_);
   auto opStats = toOperatorStats(task->taskStats());
   ASSERT_GT(
-      opStats.at("HashBuild").runtimeStats[Operator::kSpillWrites].sum, 0);
+      opStats.at("HashBuild")
+          .runtimeStats[std::string(Operator::kSpillWrites)]
+          .sum,
+      0);
   ASSERT_GT(stats.spilledBytes, 0);
   ASSERT_GT(stats.spilledRows, 0);
   ASSERT_GT(stats.spilledFiles, 0);
@@ -537,7 +540,10 @@ DEBUG_ONLY_TEST_F(HashJoinReplayerTest, hashProbeSpill) {
   const auto& stats = taskStats.at(traceNodeId_);
   auto opStats = toOperatorStats(task->taskStats());
   ASSERT_GT(
-      opStats.at("HashProbe").runtimeStats[Operator::kSpillWrites].sum, 0);
+      opStats.at("HashProbe")
+          .runtimeStats[std::string(Operator::kSpillWrites)]
+          .sum,
+      0);
 
   ASSERT_GT(stats.spilledBytes, 0);
   ASSERT_GT(stats.spilledRows, 0);

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -128,12 +128,12 @@ class IterativeVectorSerializer {
 
   /// Defines the exported runtime stats.
   /// The number of bytes before compression.
-  static inline const std::string kCompressionInputBytes{
+  static constexpr std::string_view kCompressionInputBytes{
       "compressionInputBytes"};
   /// The number of bytes after compression.
-  static inline const std::string kCompressedBytes{"compressedBytes"};
+  static constexpr std::string_view kCompressedBytes{"compressedBytes"};
   /// The number of bytes that skip in-efficient compression.
-  static inline const std::string kCompressionSkippedBytes{
+  static constexpr std::string_view kCompressionSkippedBytes{
       "compressionSkippedBytes"};
 
   /// Returns serializer-dependent counters, e.g. about compression, data

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -857,9 +857,9 @@ class VectorTestBase {
 
 class TestRuntimeStatWriter : public BaseRuntimeStatWriter {
  public:
-  void addRuntimeStat(const std::string& name, const RuntimeCounter& value)
+  void addRuntimeStat(std::string_view name, const RuntimeCounter& value)
       override {
-    stats_.emplace_back(name, value);
+    stats_.emplace_back(std::string(name), value);
   }
 
   const std::vector<std::pair<std::string, RuntimeCounter>>& stats() const {


### PR DESCRIPTION
Summary:
Migrate all remaining `static inline const std::string` constants to `static constexpr std::string_view` across the velox codebase. This follows the same pattern already applied in D93369906 (HashBuild, HashAggregation, TableScan, etc.) and D93369914 (HiveDataSource).

Constants migrated across 13 header files (72+ total):
- exec/Operator.h (17 spill/shuffle stats)
- exec/HashTable.h (16 hash table stats)
- exec/IndexLookupJoin.h (9 index lookup stats)
- exec/TableWriter.h (5 writer stats)
- exec/ScaleWriterLocalPartition.h (3 scale writer stats)
- exec/Merge.h (2 merge stats)
- exec/Window.h (1 window stat)
- exec/PrefixSort.h (1 prefix sort stat)
- exec/trace/Trace.h (14 trace metadata keys)
- connectors/Connector.h (7 connector stats)
- common/memory/SharedArbitrator.h (6 arbitration stats)
- vector/VectorStream.h (3 compression stats)
- dwio/common/Reader.h (5 reader stats)

All usages updated with explicit std::string() wrapping where needed for std::unordered_map<std::string, ...> operations (operator[], .at(), .count(), .find(), .emplace(), .insert()) and for addRuntimeStat/addThreadLocalRuntimeStat/addOperatorRuntimeStats calls which take const std::string&.

Differential Revision: D93702689
