### PR TITLE
feat: Add Rust code generation for RemoteFunction.thrift

### DIFF
--- a/velox/functions/remote/if/RemoteFunction.thrift
+++ b/velox/functions/remote/if/RemoteFunction.thrift
@@ -19,6 +19,7 @@ package "facebook.com/velox/functions"
 namespace cpp2 facebook.velox.functions.remote
 namespace java.swift com.facebook.spark.remotefunctionserver.api
 namespace py3 facebook.velox.functions.remote
+namespace rust velox_functions_remote
 
 cpp_include "folly/io/IOBuf.h"
 


### PR DESCRIPTION
Summary:
This enables Rust thrift types for RemoteFunctionPage and related structs.
Required for Rust sink support in XStream pipelines, since CustomSink.thrift
depends on RemoteFunction.thrift for the RemoteFunctionPage type used in
SinkWriteRequest.

Differential Revision: D93173363


