### PR TITLE
feat: Add CastRulesRegistry for custom type cast rules (#16461)

### DIFF
--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(fbhive)
 
 velox_add_library(
   velox_type
+  CastRegistry.cpp
   Conversions.cpp
   DecimalUtil.cpp
   Filter.cpp
@@ -38,6 +39,8 @@ velox_add_library(
   TypeUtil.cpp
   Variant.cpp
   HEADERS
+  CastRegistry.h
+  CastRule.h
   Conversions.h
   CppToType.h
   DecimalUtil.h

--- a/velox/type/CastRegistry.cpp
+++ b/velox/type/CastRegistry.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/CastRegistry.h"
+
+namespace facebook::velox {
+
+// static
+CastRulesRegistry& CastRulesRegistry::instance() {
+  static CastRulesRegistry registry;
+  return registry;
+}
+
+void CastRulesRegistry::registerCastRules(const std::vector<CastRule>& rules) {
+  auto lockedRules = rules_.wlock();
+
+  for (const auto& rule : rules) {
+    auto key = std::make_pair(rule.fromType, rule.toType);
+
+    auto it = lockedRules->find(key);
+    if (it != lockedRules->end()) {
+      VELOX_CHECK(
+          it->second == rule,
+          "Conflicting CastRule for {} -> {}: existing={}, new={}",
+          rule.fromType,
+          rule.toType,
+          it->second.toString(),
+          rule.toString());
+      continue;
+    }
+
+    (*lockedRules)[key] = rule;
+  }
+}
+
+void CastRulesRegistry::unregisterCastRules(const std::string& typeName) {
+  auto lockedRules = rules_.wlock();
+
+  for (auto it = lockedRules->begin(); it != lockedRules->end();) {
+    if (it->second.fromType == typeName || it->second.toType == typeName) {
+      it = lockedRules->erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+bool CastRulesRegistry::canCast(const TypePtr& fromType, const TypePtr& toType)
+    const {
+  return canCastImpl(fromType, toType, /*requireImplicit=*/false);
+}
+
+bool CastRulesRegistry::canCoerce(
+    const TypePtr& fromType,
+    const TypePtr& toType) const {
+  return canCastImpl(fromType, toType, /*requireImplicit=*/true);
+}
+
+bool CastRulesRegistry::canCastImpl(
+    const TypePtr& fromType,
+    const TypePtr& toType,
+    bool requireImplicit) const {
+  VELOX_CHECK_NOT_NULL(fromType, "fromType must not be null");
+  VELOX_CHECK_NOT_NULL(toType, "toType must not be null");
+
+  // Cast rules are only registered for non-parametric (leaf) types. Parametric
+  // types (ARRAY, MAP, ROW, and custom types with children like IPPREFIX) are
+  // handled by callers (TypeCoercer::coercible, leastCommonSuperType) which
+  // recurse into children before reaching this method. Return false for
+  // parametric types rather than throwing — this is a query function.
+  if (fromType->size() != 0 || toType->size() != 0) {
+    return false;
+  }
+
+  // Same type is always allowed.
+  if (fromType->equivalent(*toType)) {
+    return true;
+  }
+
+  auto rule = findRule(fromType->name(), toType->name());
+  if (!rule) {
+    return false;
+  }
+  if (requireImplicit && !rule->implicitAllowed) {
+    return false;
+  }
+  if (rule->validator && !rule->validator(fromType, toType)) {
+    return false;
+  }
+  return true;
+}
+
+std::optional<CastRule> CastRulesRegistry::findRule(
+    const std::string& fromTypeName,
+    const std::string& toTypeName) const {
+  auto lockedRules = rules_.rlock();
+  auto it = lockedRules->find(std::make_pair(fromTypeName, toTypeName));
+  if (it == lockedRules->end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+void CastRulesRegistry::clear() {
+  rules_.wlock()->clear();
+}
+
+void registerCastRules(const std::vector<CastRule>& rules) {
+  for (const auto& rule : rules) {
+    // At least one side must be a registered custom type with a CastOperator,
+    // otherwise the cast has no execution path.
+    VELOX_CHECK(
+        getCustomTypeCastOperator(rule.fromType) != nullptr ||
+            getCustomTypeCastOperator(rule.toType) != nullptr,
+        "CastRule {} -> {} requires at least one side to be a registered "
+        "custom type with a CastOperator",
+        rule.fromType,
+        rule.toType);
+  }
+  CastRulesRegistry::instance().registerCastRules(rules);
+}
+
+void unregisterCastRules(const std::string& typeName) {
+  CastRulesRegistry::instance().unregisterCastRules(typeName);
+}
+
+} // namespace facebook::velox

--- a/velox/type/CastRegistry.h
+++ b/velox/type/CastRegistry.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <folly/Hash.h>
+#include <folly/Synchronized.h>
+
+#include "velox/type/CastRule.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+/// Registry for cast rules between types. Provides lookup for determining
+/// whether casts are supported and whether they can be implicit (coercible).
+///
+/// Rules are registered via the registerCastRules() free function, typically
+/// called alongside registerCustomType() in register*Type() functions.
+/// This keeps rules co-located with the type while storing them in a global
+/// registry for centralized querying.
+class CastRulesRegistry {
+ public:
+  static CastRulesRegistry& instance();
+
+  /// Register cast rules. Rules are validated for duplicates — if a rule
+  /// for the same (fromType, toType) pair already exists, it must be
+  /// identical, otherwise registration fails.
+  void registerCastRules(const std::vector<CastRule>& rules);
+
+  /// Unregister all rules involving the given type name.
+  void unregisterCastRules(const std::string& typeName);
+
+  /// Check if cast is supported (explicit or implicit). Only for
+  /// non-parametric (leaf) types — callers handle container types by recursing
+  /// into children themselves.
+  bool canCast(const TypePtr& fromType, const TypePtr& toType) const;
+
+  /// Check if implicit coercion is allowed. Only for non-parametric (leaf)
+  /// types — callers handle container types by recursing into children
+  /// themselves.
+  bool canCoerce(const TypePtr& fromType, const TypePtr& toType) const;
+
+  /// Clear all registered rules. Used for testing.
+  void clear();
+
+ private:
+  CastRulesRegistry() = default;
+
+  bool canCastImpl(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      bool requireImplicit) const;
+
+  std::optional<CastRule> findRule(
+      const std::string& fromTypeName,
+      const std::string& toTypeName) const;
+
+  struct PairHash {
+    size_t operator()(const std::pair<std::string, std::string>& p) const {
+      return folly::hash::hash_combine(
+          std::hash<std::string>{}(p.first),
+          std::hash<std::string>{}(p.second));
+    }
+  };
+
+  // Maps (fromType, toType) pairs to their cast rules.
+  folly::Synchronized<std::unordered_map<
+      std::pair<std::string, std::string>,
+      CastRule,
+      PairHash>>
+      rules_;
+};
+
+/// Register cast rules for custom types. Call this after registerCustomType()
+/// in register*Type() functions. Validates that at least one type in each rule
+/// has a registered CastOperator.
+///
+/// Example:
+///   registerCastRules({
+///       {"TIMESTAMP", "TIMESTAMP WITH TIME ZONE", true},
+///       {"DATE", "TIMESTAMP WITH TIME ZONE", true},
+///   });
+void registerCastRules(const std::vector<CastRule>& rules);
+
+/// Unregister all cast rules involving the given type name.
+void unregisterCastRules(const std::string& typeName);
+
+} // namespace facebook::velox

--- a/velox/type/CastRule.h
+++ b/velox/type/CastRule.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace facebook::velox {
+
+class Type;
+using TypePtr = std::shared_ptr<const Type>;
+
+/// Optional validator for type-specific compatibility checks
+/// (e.g., DECIMAL precision/scale).
+using CastValidator =
+    std::function<bool(const TypePtr& from, const TypePtr& to)>;
+
+/// Represents a cast rule between two types.
+struct CastRule {
+  /// Source type name (e.g., "BIGINT", "TIMESTAMP").
+  std::string fromType;
+
+  /// Target type name (e.g., "DOUBLE", "VARCHAR").
+  std::string toType;
+
+  /// If true, cast can happen implicitly during type coercion.
+  bool implicitAllowed{false};
+
+  /// Cost of this cast for overload resolution. Lower cost is preferred.
+  /// Built-in coercions use incrementing costs (e.g., TINYINT->SMALLINT=1,
+  /// TINYINT->INTEGER=2). Custom type rules should use costs that make
+  /// sense relative to built-in costs.
+  int32_t cost{1};
+
+  /// Optional validator for parameter-aware type checks.
+  CastValidator validator;
+
+  /// Compare rules by type names, implicitAllowed, and cost. Excludes
+  /// 'validator' because std::function has no meaningful equality semantics.
+  bool operator==(const CastRule& other) const {
+    return fromType == other.fromType && toType == other.toType &&
+        implicitAllowed == other.implicitAllowed && cost == other.cost;
+  }
+
+  std::string toString() const {
+    return fmt::format(
+        "CastRule({} -> {}, implicit={}, cost={}, hasValidator={})",
+        fromType,
+        toType,
+        implicitAllowed,
+        cost,
+        validator != nullptr);
+  }
+};
+
+} // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -25,6 +25,7 @@
 #include <typeindex>
 
 #include "velox/external/tzdb/exception.h"
+#include "velox/type/CastRegistry.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/Time.h"
 #include "velox/type/TimestampConversion.h"
@@ -1169,7 +1170,11 @@ std::unordered_set<std::string> getCustomTypeNames() {
 
 bool unregisterCustomType(const std::string& name) {
   auto uppercaseName = boost::algorithm::to_upper_copy(name);
-  return typeFactories().erase(uppercaseName) == 1;
+  bool removed = typeFactories().erase(uppercaseName) == 1;
+  if (removed) {
+    CastRulesRegistry::instance().unregisterCastRules(uppercaseName);
+  }
+  return removed;
 }
 
 const CustomTypeFactory* FOLLY_NULLABLE

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -15,6 +15,8 @@
  */
 #include "velox/type/TypeCoercer.h"
 
+#include "velox/type/CastRegistry.h"
+
 namespace facebook::velox {
 
 int64_t Coercion::overallCost(const std::vector<Coercion>& coercions) {
@@ -74,9 +76,22 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
     return Coercion{.type = fromType, .cost = 0};
   }
 
+  // Check built-in coercions first.
   auto it = kAllowedCoercions.find({fromType->name(), toTypeName});
   if (it != kAllowedCoercions.end()) {
     return it->second;
+  }
+
+  // Check custom type coercions from CastRulesRegistry. Built-in coercions
+  // are already handled by kAllowedCoercions above. Use getCustomType (not
+  // getType) because parametric built-in factories (ARRAY, ROW, DECIMAL)
+  // throw when called with empty parameters.
+  if (fromType->size() == 0) {
+    auto toType = getCustomType(toTypeName, {});
+    if (toType != nullptr &&
+        CastRulesRegistry::instance().canCoerce(fromType, toType)) {
+      return Coercion{.type = std::move(toType), .cost = 1};
+    }
   }
 
   return std::nullopt;

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(utils)
 
 add_executable(
   velox_type_test
+  CastRegistryTest.cpp
   ConversionsTest.cpp
   DecimalTest.cpp
   FilterTest.cpp

--- a/velox/type/tests/CastRegistryTest.cpp
+++ b/velox/type/tests/CastRegistryTest.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/CastRegistry.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+namespace {
+
+class CastRulesRegistryTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    CastRulesRegistry::instance().clear();
+  }
+
+  void TearDown() override {
+    CastRulesRegistry::instance().clear();
+  }
+
+  // Register rules directly on the registry, bypassing the free function's
+  // CastOperator validation. Used for testing registry mechanics with
+  // synthetic type names.
+  void registerRules(const std::vector<CastRule>& rules) {
+    CastRulesRegistry::instance().registerCastRules(rules);
+  }
+};
+
+TEST_F(CastRulesRegistryTest, canCastAndCanCoerce) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = {}},
+      {.fromType = "DOUBLE",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
+
+  // Same type is always allowed.
+  EXPECT_TRUE(CastRulesRegistry::instance().canCast(BIGINT(), BIGINT()));
+  EXPECT_TRUE(CastRulesRegistry::instance().canCoerce(BIGINT(), BIGINT()));
+
+  // Implicit rule: BIGINT -> DOUBLE allows both cast and coerce.
+  EXPECT_TRUE(CastRulesRegistry::instance().canCast(BIGINT(), DOUBLE()));
+  EXPECT_TRUE(CastRulesRegistry::instance().canCoerce(BIGINT(), DOUBLE()));
+
+  // Explicit-only rule: DOUBLE -> VARCHAR allows cast but not coerce.
+  EXPECT_TRUE(CastRulesRegistry::instance().canCast(DOUBLE(), VARCHAR()));
+  EXPECT_FALSE(CastRulesRegistry::instance().canCoerce(DOUBLE(), VARCHAR()));
+
+  // Unregistered: VARCHAR -> BIGINT.
+  EXPECT_FALSE(CastRulesRegistry::instance().canCast(VARCHAR(), BIGINT()));
+  EXPECT_FALSE(CastRulesRegistry::instance().canCoerce(VARCHAR(), BIGINT()));
+}
+
+TEST_F(CastRulesRegistryTest, unregisterRules) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = true,
+       .validator = {}},
+      {.fromType = "CUSTOM_TYPE",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
+
+  unregisterCastRules("CUSTOM_TYPE");
+
+  // After unregistering, re-registering with different flags should work
+  // (no conflict because old rules were removed).
+  EXPECT_NO_THROW(registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = false,
+       .validator = {}},
+  }));
+}
+
+TEST_F(CastRulesRegistryTest, duplicateRulesAllowedIfIdentical) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // Identical rule should not throw.
+  EXPECT_NO_THROW(registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = true,
+       .validator = {}},
+  }));
+}
+
+TEST_F(CastRulesRegistryTest, conflictingRulesThrow) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // Different implicitAllowed flag should throw.
+  EXPECT_THROW(
+      registerRules({
+          {.fromType = "BIGINT",
+           .toType = "CUSTOM_TYPE",
+           .implicitAllowed = false,
+           .validator = {}},
+      }),
+      VeloxException);
+}
+
+TEST_F(CastRulesRegistryTest, parametricTypesReturnFalse) {
+  // Parametric types (ARRAY, MAP, ROW, custom types with children like
+  // IPPREFIX) are handled by callers recursing into children. The registry
+  // only stores leaf-to-leaf rules, so parametric types return false.
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCast(ARRAY(BIGINT()), ARRAY(DOUBLE())));
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCoerce(
+          ROW({BIGINT()}), ROW({DOUBLE()})));
+}
+
+TEST_F(CastRulesRegistryTest, clearRemovesAllRules) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  CastRulesRegistry::instance().clear();
+
+  // After clear, the previously registered rule should no longer be found.
+  // Re-registering with different flags should not conflict.
+  EXPECT_NO_THROW(registerRules({
+      {.fromType = "BIGINT",
+       .toType = "CUSTOM_TYPE",
+       .implicitAllowed = false,
+       .validator = {}},
+  }));
+}
+
+TEST_F(CastRulesRegistryTest, explicitOnlyCastNotCoercible) {
+  // Register an explicit-only rule (implicitAllowed=false).
+  registerRules({
+      {.fromType = "VARCHAR",
+       .toType = "BIGINT",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
+
+  // Explicit cast is allowed.
+  EXPECT_TRUE(CastRulesRegistry::instance().canCast(VARCHAR(), BIGINT()));
+
+  // Implicit coercion is not allowed.
+  EXPECT_FALSE(CastRulesRegistry::instance().canCoerce(VARCHAR(), BIGINT()));
+}
+
+TEST_F(CastRulesRegistryTest, validatorRejectsCast) {
+  auto rejectAll = [](const TypePtr&, const TypePtr&) { return false; };
+
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = rejectAll},
+  });
+
+  // Rule exists but validator rejects — both canCast and canCoerce return
+  // false.
+  EXPECT_FALSE(CastRulesRegistry::instance().canCast(BIGINT(), DOUBLE()));
+  EXPECT_FALSE(CastRulesRegistry::instance().canCoerce(BIGINT(), DOUBLE()));
+}
+
+TEST_F(CastRulesRegistryTest, decimalPrecisionValidator) {
+  auto decimalWideningValidator = [](const TypePtr& from, const TypePtr& to) {
+    if (!from->isDecimal() || !to->isDecimal()) {
+      return false;
+    }
+    const auto [fromPrecision, fromScale] = getDecimalPrecisionScale(*from);
+    const auto [toPrecision, toScale] = getDecimalPrecisionScale(*to);
+    return toPrecision >= fromPrecision && toScale >= fromScale;
+  };
+
+  registerRules({
+      {.fromType = "DECIMAL",
+       .toType = "DECIMAL",
+       .implicitAllowed = true,
+       .validator = decimalWideningValidator},
+  });
+
+  // Widening: DECIMAL(10,2) -> DECIMAL(15,4).
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCast(DECIMAL(10, 2), DECIMAL(15, 4)));
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCoerce(DECIMAL(10, 2), DECIMAL(15, 4)));
+
+  // Narrowing: DECIMAL(15,4) -> DECIMAL(10,2) — rejected by validator.
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCast(DECIMAL(15, 4), DECIMAL(10, 2)));
+
+  // Same type: always allowed (short-circuits before validator).
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCast(DECIMAL(10, 2), DECIMAL(10, 2)));
+}
+
+TEST_F(CastRulesRegistryTest, standaloneRegistration) {
+  registerRules({
+      {.fromType = "TIMESTAMP",
+       .toType = "CUSTOM_TZ",
+       .implicitAllowed = true,
+       .validator = {}},
+      {.fromType = "CUSTOM_TZ",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
+
+  // Verify rules were registered (test via unregister + re-register).
+  unregisterCastRules("CUSTOM_TZ");
+
+  // After unregister, can re-register with different flags.
+  EXPECT_NO_THROW(registerRules({
+      {.fromType = "TIMESTAMP",
+       .toType = "CUSTOM_TZ",
+       .implicitAllowed = false,
+       .validator = {}},
+  }));
+}
+
+TEST_F(CastRulesRegistryTest, rejectsRulesWithoutCastOperator) {
+  // The free function registerCastRules() validates that at least one side
+  // has a registered custom type with a CastOperator.
+  EXPECT_THROW(
+      registerCastRules({
+          {.fromType = "BIGINT",
+           .toType = "NONEXISTENT_TYPE",
+           .implicitAllowed = true,
+           .validator = {}},
+      }),
+      VeloxException);
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:

**Motivation**
Currently, Velox's type coercion system (TypeCoercer) only handles built-in primitive types. Custom types like TIMESTAMP WITH TIME ZONE cannot participate in implicit coercion because there's no mechanism to declare their coercion rules.

E.g. a function expects TIMESTAMP WITH TIME ZONE but receives TIMESTAMP, the planner cannot automatically insert an implicit cast — it fails with a type mismatch error. 

Axiom/Velox can support multiple SQL dialects (Presto, Spark), each with its own type semantics, so it needs to support custom types. Presto/Trino are single-dialect engines and don't need this.

Design doc: https://docs.google.com/document/d/1k94mXo5sVWH1kdtrme-wOOkTxZqyTxU6p8pmOdVYrok

Combines elements of Design 2 and Design 3 from the design doc:

From Design 2: Declarative CastRule structs with implicitAllowed flag, registered alongside registerCustomType() in each type's registration function. Rules are co-located with the type they belong to.
From Design 3: Rules stored in a single global CastRulesRegistry singleton for centralized querying.

**Components**
- CastRule: Declares a cast between two types with an implicitAllowed flag and optional validator.
- CastRulesRegistry: Global singleton registry storing rules, with lookup by (fromType, toType). Provides canCast() and canCoerce() APIs.
- registerCastRules() function: Registers rules after registerCustomType(), with validation that at least one side has a registered CastOperator.

**Logic**
- Custom type registration calls registerCastRules() after registerCustomType() with its supported casts.
- TypeCoercer checks CastRulesRegistry when built-in rules don't match.
- If a rule exists with implicitAllowed=true, coercion is allowed.
- Registration validates that at least one side of each rule has a registered CastOperator.

**What stays the same**
- Built-in type coercion (INTEGER -> BIGINT, etc.)
- Existing custom type behavior - they work as before unless they add getCastRules()
- CastOperator's isSupportedFromType/isSupportedToType - will follow-up to consolidate

**Follow-up**
1. Consolidate isSupportedFromType/isSupportedToType to use CastRulesRegistry, update all other custom types. 
2. Add new cast rules for TIMESTAMP WITH TIME ZONE, TIME WITH TIME ZONE Presto custom types
3. Add Additional Presto custom types rules that exist in Presto in Axiom-Velox.

=== 

V2: Removed cost, TypeCompatibility, getCommonSuperType, etc. that was in V1. Not needed now.

Reviewed By: kevinwilfong

Differential Revision: D93655335


