### PR TITLE
perf(test): Count result rows without accumulating the data

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1215,8 +1215,7 @@ TEST_F(AggregationTest, spillAll) {
                                     .values(inputs)
                                     .singleAggregation({"c0"}, {}, {})
                                     .planNode())
-                                .copyResults(pool_.get())
-                                ->size();
+                                .countResults();
 
   auto plan = PlanBuilder()
                   .values(inputs)

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -8490,10 +8490,10 @@ TEST_P(HashJoinTest, innerJoinForTypeWithCustomComparisonAndSmallVector) {
              .planNode();
 
   // Result should be empty since the IP addresses are different
-  result = AssertQueryBuilder(plan).copyResults(pool());
-  ASSERT_EQ(result->size(), 0)
+  auto actualRows = AssertQueryBuilder(plan).countResults();
+  ASSERT_EQ(0, actualRows)
       << "Expected no matches between different IP addresses, but got "
-      << result->size() << " rows";
+      << actualRows << " rows";
 }
 
 /// Test hash join where build-side keys have a type that supports custom
@@ -8533,13 +8533,11 @@ TEST_P(HashJoinTest, arrayBasedLookupCustomComparisonType) {
                       core::JoinType::kInner)
                   .planNode();
 
-  auto result = AssertQueryBuilder(plan).copyResults(pool());
-
   // The probe side consists of the values 0-1023, the build side consists of
   // the values 0-255. If custom comparison is not respected, the join will
   // produce 256 values (0-255). When custom comparison is respected equality is
   // treated mod 256 so we get 1024 values (0-1023).
-  EXPECT_EQ(result->size(), 1'024);
+  EXPECT_EQ(AssertQueryBuilder(plan).countResults(), 1'024);
 }
 
 DEBUG_ONLY_TEST_P(
@@ -8800,7 +8798,7 @@ DEBUG_ONLY_TEST_P(HashJoinTest, hashJoinSpillFileCreateConfig) {
       .config(
           core::QueryConfig::kHashJoinSpillFileCreateConfig,
           "test_hashjoin_config")
-      .copyResults(pool_.get());
+      .countResults();
 
   ASSERT_TRUE(hashJoinConfigVerified.load());
   ASSERT_TRUE(defaultConfigVerified.load());

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include <gtest/gtest.h>
 #include "velox/exec/Cursor.h"
 
 namespace facebook::velox::exec::test {
@@ -220,9 +221,10 @@ std::shared_ptr<Task> AssertQueryBuilder::assertResults(
 }
 
 std::shared_ptr<Task> AssertQueryBuilder::assertEmptyResults() {
-  auto [cursor, results] = readCursor();
-  test::assertEmptyResults(results);
-  return cursor->task();
+  std::shared_ptr<Task> task;
+  auto count = countResults(task);
+  EXPECT_EQ(0, count);
+  return task;
 }
 
 std::shared_ptr<Task> AssertQueryBuilder::assertTypeAndNumRows(

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -205,6 +205,12 @@ class AssertQueryBuilder {
   std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
   readCursor();
 
+  std::pair<std::unique_ptr<TaskCursor>, uint64_t> countCursor();
+
+  void prepareQueryCtx();
+
+  std::function<void(exec::TaskCursor*)> makeAddSplits();
+
   static std::unique_ptr<folly::Executor> newExecutor() {
     return std::make_unique<folly::CPUThreadPoolExecutor>(
         folly::hardware_concurrency());

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -929,16 +929,16 @@ std::shared_ptr<Task> assertQueryReturnsEmptyResult(
     const core::PlanNodePtr& plan) {
   CursorParameters params;
   params.planNode = plan;
-  auto [cursor, results] = readCursor(params);
-  assertEmptyResults(results);
+  auto [cursor, count] = countResults(params);
+  EXPECT_EQ(0, count);
   return cursor->task();
 }
 
 std::shared_ptr<Task> assertQueryReturnsEmptyResult(
     const CursorParameters& params) {
   VELOX_DCHECK_NOT_NULL(params.planNode);
-  auto [cursor, results] = readCursor(params);
-  assertEmptyResults(results);
+  auto [cursor, count] = countResults(params);
+  EXPECT_EQ(0, count);
   return cursor->task();
 }
 

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -188,6 +188,18 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
         },
     uint64_t maxWaitMicros = 5'000'000);
 
+/// Run the query and return the number of result rows.
+std::pair<std::unique_ptr<TaskCursor>, uint64_t> countResults(
+    const CursorParameters& params,
+    std::function<void(TaskCursor*)> addSplits =
+        [](TaskCursor* taskCursor) {
+          if (taskCursor->noMoreSplits()) {
+            return;
+          }
+          taskCursor->setNoMoreSplits();
+        },
+    uint64_t maxWaitMicros = 5'000'000);
+
 /// The Task can return results before the Driver is finished executing.
 /// Wait upto maxWaitMicros for the Task to finish as 'expectedState' before
 /// returning to ensure it's stable e.g. the Driver isn't updating it anymore.


### PR DESCRIPTION
This PR introduces a memory-efficient way of counting result rows without materializing the results.

Changes:

- Added countCursor() to AssertQueryBuilder and countResults() to QueryAssertions to count rows batch-by-batch without storing results.
- Extracted makeAddSplits() and prepareQueryCtx() as helper functions to deduplicate logic between the readCursor() and countCursor() execution paths.
- Updated assertEmptyResults and assertQueryReturnsEmptyResult helpers, and AggregationTest and HashJoinTest tests to utilise the above optimisation.

Fixes #16210