### PR TITLE
feat: Add TIME_MICRO_UTC type

### DIFF
--- a/velox/common/fuzzer/Utils.cpp
+++ b/velox/common/fuzzer/Utils.cpp
@@ -120,7 +120,7 @@ int32_t randDate(FuzzerGenerator& rng) {
 }
 
 int32_t randTime(FuzzerGenerator& rng) {
-  return rand<int64_t>(rng, TimeType::kMin, TimeType::kMax);
+  return rand<int64_t>(rng, TIME()->getMin(), TIME()->getMax());
 }
 
 /// Unicode character ranges. Ensure the vector indexes match the UTF8CharList

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -116,6 +116,7 @@ DECIMAL                 BIGINT if precision <= 18, HUGEINT if precision >= 19
 INTERVAL DAY TO SECOND  BIGINT
 INTERVAL YEAR TO MONTH  INTEGER
 TIME                    BIGINT
+TIME_MICRO_UTC          BIGINT
 ======================  ======================================================
 
 DECIMAL type carries additional `precision`,
@@ -131,8 +132,9 @@ upto 38 precision, with a range of :math:`[-10^{38} + 1, +10^{38} - 1]`.
 All the three values, precision, scale, unscaled value are required to represent a
 decimal value.
 
-TIME type represents time in milliseconds from midnight UTC. Thus min/max value can  range from UTC-14:00 at 00:00:00 to UTC+14:00 at 23:59:59.999 modulo 24 hours.
-TIME type is backed by BIGINT physical type.
+TIME type represents time in milliseconds of local timezone from midnight. Thus min/max value can range from 0 to 23:59:59.999.
+TIME_MICRO_UTC type represents time in microseconds from midnight, timezone unaware. Thus min/max value can range from 00:00:00.000000 to 23:59:59.999999.
+The TIME and TIME_MICRO_UTC types are backed by BIGINT physical type.
 
 Custom Types
 ~~~~~~~~~~~~
@@ -303,6 +305,12 @@ key differences are listed below.
               (cast('2014-03-08 09:00:00.012345678' as timestamp))
       ) AS t(ts);
       -- 2014-03-08 09:00:00.012345
+
+* Spark operates on the TIME_MICRO_UTC type for "microsecond" precision and timezone unawareness,
+  while Presto uses the standard TIME type.
+  Example::
+
+      SELECT cast('12:30:45.123456' as time)  -- 12:30:45.123456
 
 * In function comparisons, nested null values are handled as values.
   Example::

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -237,7 +237,7 @@ VectorPtr CastExpr::castFromTime(
       auto* resultFlatVector = castResult->as<FlatVector<StringView>>();
 
       Buffer* buffer = resultFlatVector->getBufferWithSpace(
-          rows.countSelected() * TimeType::kTimeToVarcharRowSize,
+          rows.countSelected() * TIME()->timeToVarcharRowSize(),
           true /*exactSize*/);
       char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -157,6 +157,13 @@ struct resolver<Time> {
   using out_type = int64_t;
 };
 
+template <>
+struct resolver<TimeMicroUtc> {
+  using in_type = int64_t;
+  using null_free_in_type = in_type;
+  using out_type = int64_t;
+};
+
 template <typename T>
 struct resolver<std::shared_ptr<T>> {
   using in_type = std::shared_ptr<T>;

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -1657,12 +1657,16 @@ TEST_F(SimpleFunctionTest, toDebugString) {
       "Priority: 999997\nDefaultNullBehavior: true");
 }
 
-template <typename T>
+template <typename T, typename TimeType>
 struct TimePlusOneFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  void call(out_type<Time>& out, const arg_type<Time>& input) {
-    out = input + 1;
+  void call(out_type<TimeType>& out, const arg_type<TimeType>& input) {
+    if constexpr (std::is_same_v<TimeType, Time>) {
+      out = input + 1;
+    } else if constexpr (std::is_same_v<TimeType, TimeMicroUtc>) {
+      out = input / 1000 + 1;
+    }
   }
 };
 
@@ -1677,16 +1681,29 @@ struct ArrayTimeFunction {
       }
     }
   }
+
+  void call(
+      out_type<Array<TimeMicroUtc>>& out,
+      const arg_type<Array<TimeMicroUtc>>& input) {
+    for (int i = 0; i < input.size(); i++) {
+      if (input[i].has_value()) {
+        out.push_back(input[i].value() + 1);
+      }
+    }
+  }
 };
 
 TEST_F(SimpleFunctionTest, timeTypeTest) {
-  registerFunction<TimePlusOneFunction, Time, Time>({"time_plus_one"});
-  auto data = makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3}, TIME()),
-  });
-  auto result = evaluate("time_plus_one(c0)", data);
-  auto expected = makeFlatVector<int64_t>({2, 3, 4}, TIME());
-  assertEqualVectors(expected, result);
+  {
+    registerFunction<ParameterBinder<TimePlusOneFunction, Time>, Time, Time>(
+        {"time_plus_one"});
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({1000, 2000, 3000}, TIME()),
+    });
+    auto result = evaluate("time_plus_one(c0)", data);
+    auto expected = makeFlatVector<int64_t>({1001, 2001, 3001}, TIME());
+    assertEqualVectors(expected, result);
+  }
 
   // Test out Time in complex type.
   {
@@ -1699,6 +1716,38 @@ TEST_F(SimpleFunctionTest, timeTypeTest) {
 
     auto result = evaluate("array_time(c0)", data);
     auto expected = makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 6}}, TIME());
+    assertEqualVectors(expected, result);
+  }
+}
+
+TEST_F(SimpleFunctionTest, timeMicroUtcTypeTest) {
+  {
+    registerFunction<
+        ParameterBinder<TimePlusOneFunction, TimeMicroUtc>,
+        TimeMicroUtc,
+        TimeMicroUtc>({"time_micro_utc_plus_one"});
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({1000, 2000, 3000}, TIME_MICRO_UTC()),
+    });
+    auto result = evaluate("time_micro_utc_plus_one(c0)", data);
+    auto expected = makeFlatVector<int64_t>({2, 3, 4}, TIME_MICRO_UTC());
+    assertEqualVectors(expected, result);
+  }
+
+  // Test out TimeMicroUtc in complex type.
+  {
+    registerFunction<
+        ArrayTimeFunction,
+        Array<TimeMicroUtc>,
+        Array<TimeMicroUtc>>({"array_time_micro_utc"});
+
+    auto data = makeRowVector({
+        makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 6}}, TIME_MICRO_UTC()),
+    });
+
+    auto result = evaluate("array_time_micro_utc(c0)", data);
+    auto expected =
+        makeArrayVector<int64_t>({{2, 3, 4}, {5, 6, 7}}, TIME_MICRO_UTC());
     assertEqualVectors(expected, result);
   }
 }

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -63,6 +63,7 @@ TEST_F(TypeOfTest, basic) {
   EXPECT_EQ("timestamp", typeOf(TIMESTAMP()));
   EXPECT_EQ("date", typeOf(DATE()));
   EXPECT_EQ("time", typeOf(TIME()));
+  EXPECT_EQ("time micro utc", typeOf(TIME_MICRO_UTC()));
 
   EXPECT_EQ("unknown", typeOf(UNKNOWN()));
 

--- a/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
+++ b/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
@@ -112,6 +112,7 @@ TEST_F(TypeParserTest, varbinary) {
 
 TEST_F(TypeParserTest, time) {
   ASSERT_EQ(*parseType("time"), *TIME());
+  ASSERT_EQ(*parseType("time micro utc"), *TIME_MICRO_UTC());
 }
 
 TEST_F(TypeParserTest, timeWithTimeZoneType) {

--- a/velox/type/CppToType.h
+++ b/velox/type/CppToType.h
@@ -92,7 +92,18 @@ template <>
 struct CppToType<Timestamp> : public CppToTypeBase<TypeKind::TIMESTAMP> {};
 
 template <>
-struct CppToType<Time> : public CppToTypeBase<TypeKind::BIGINT> {};
+struct CppToType<Time> : public CppToTypeBase<TypeKind::BIGINT> {
+  static auto create() {
+    return TIME();
+  }
+};
+
+template <>
+struct CppToType<TimeMicroUtc> : public CppToTypeBase<TypeKind::BIGINT> {
+  static auto create() {
+    return TIME_MICRO_UTC();
+  }
+};
 
 // TODO: maybe do something smarter than just matching any shared_ptr, e.g. we
 // can declare "registered" types explicitly

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -374,6 +374,11 @@ struct SimpleTypeTrait<Time> : public TypeTraits<TypeKind::BIGINT> {
   static constexpr const char* name = "TIME";
 };
 
+template <>
+struct SimpleTypeTrait<TimeMicroUtc> : public TypeTraits<TypeKind::BIGINT> {
+  static constexpr const char* name = "TIME MICRO UTC";
+};
+
 template <typename T, bool comparable, bool orderable>
 struct SimpleTypeTrait<Generic<T, comparable, orderable>> {
   static constexpr TypeKind typeKind = TypeKind::INVALID;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -265,7 +265,7 @@ void Type::registerSerDe() {
   registry.Register(
       "IntervalYearMonthType", IntervalYearMonthType::deserialize);
   registry.Register("DateType", DateType::deserialize);
-  registry.Register("TimeType", TimeType::deserialize);
+  registry.Register("TimeType", TimeTypeFactory::deserialize);
 }
 
 std::string ArrayType::toString() const {
@@ -1358,6 +1358,7 @@ const SingletonTypeMap& singletonBuiltInTypes() {
       {"INTERVAL YEAR TO MONTH", INTERVAL_YEAR_MONTH()},
       {"DATE", DATE()},
       {"TIME", TIME()},
+      {"TIME MICRO UTC", TIME_MICRO_UTC()},
       {"UNKNOWN", UNKNOWN()},
   };
   return kTypes;
@@ -1508,19 +1509,69 @@ std::string getOpaqueAliasForTypeId(std::type_index typeIndex) {
   return it->second;
 }
 
-folly::dynamic TimeType::serialize() const {
+namespace {
+
+const auto& timePrecisionNames() {
+  static const folly::F14FastMap<TimePrecision, std::string_view> kNames = {
+      {TimePrecision::kMilliseconds, "MILLISECONDS"},
+      {TimePrecision ::kMicroseconds, "MICROSECONDS"}};
+  return kNames;
+}
+
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(TimePrecision, timePrecisionNames);
+
+template <TimePrecision kPrecision, bool kLocalTime>
+folly::dynamic TimeType<kPrecision, kLocalTime>::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["name"] = "TimeType";
   obj["type"] = name();
+  // Only include precision and localTime if they differ from defaults
+  // (milliseconds and local time) for backward compatibility.
+  if (kPrecision != TimePrecision::kMilliseconds) {
+    obj["precision"] = static_cast<int>(kPrecision);
+  }
+  if (!kLocalTime) {
+    obj["localTime"] = kLocalTime;
+  }
   return obj;
 }
 
-StringView TimeType::valueToString(int64_t value, char* const startPos) const {
+// Explicit template instantiations for TimeType.
+template class TimeType<TimePrecision::kMilliseconds, true>;
+template class TimeType<TimePrecision::kMicroseconds, false>;
+
+// static
+TypePtr TimeTypeFactory::deserialize(const folly::dynamic& obj) {
+  // Default to millseconds and local time for backward compatibility.
+  auto precision = obj.get_ptr("precision")
+      ? static_cast<TimePrecision>(obj["precision"].asInt())
+      : TimePrecision::kMilliseconds;
+  bool localTime = obj.get_ptr("localTime") ? obj["localTime"].asBool() : true;
+
+  if (precision == TimePrecision::kMilliseconds) {
+    VELOX_USER_CHECK(
+        localTime,
+        "TimeType with millisecond precision and local time zone is not used.");
+    return static_cast<TypePtr>(TIME());
+  }
+  VELOX_USER_CHECK(
+      !localTime,
+      "TimeType with microsecond precision and UTC time zone is not used.");
+  return static_cast<TypePtr>(TIME_MICRO_UTC());
+}
+
+StringView TimeMilliPrecisionType::valueToString(
+    int64_t value,
+    char* const startPos) const {
   // Ensure the value is within valid TIME range
   VELOX_USER_CHECK(
-      !(value < 0 || value >= 86400000),
-      "TIME value {} is out of range [0, 86400000)",
-      value);
+      !(value < getMin() || value > getMax()),
+      "TIME value {} is out of range [{}, {}]",
+      value,
+      getMin(),
+      getMax());
 
   int64_t hours = value / kMillisInHour;
   int64_t remainingMs = value % kMillisInHour;
@@ -1531,25 +1582,24 @@ StringView TimeType::valueToString(int64_t value, char* const startPos) const {
 
   // TIME is represented as milliseconds since midnight
   // Convert to HH:mm:ss.SSS format
-
   fmt::format_to_n(
       startPos,
-      kTimeToVarcharRowSize,
+      timeToVarcharRowSize(),
       "{:02d}:{:02d}:{:02d}.{:03d}",
       hours,
       minutes,
       seconds,
       millis);
-  return StringView{startPos, kTimeToVarcharRowSize};
+  return StringView{startPos, timeToVarcharRowSize()};
 }
 
-int64_t TimeType::valueToTime(const StringView& timeStr) const {
+int64_t TimeMilliPrecisionType::valueToTime(const StringView& timeStr) const {
   return util::fromTimeString(timeStr).thenOrThrow(
       folly::identity,
       [&](const Status& status) { VELOX_USER_FAIL("{}", status.message()); });
 }
 
-int64_t TimeType::valueToTime(
+int64_t TimeMilliPrecisionType::valueToTime(
     const StringView& timeStr,
     const tz::TimeZone* timeZone,
     int64_t sessionStartTimeMs) const {
@@ -1604,7 +1654,7 @@ int64_t TimeType::valueToTime(
 }
 
 // static
-std::string TimeType::toCompactIso8601(int64_t microseconds) {
+std::string TimeMicroPrecisionUtcType::toCompactIso8601(int64_t microseconds) {
   int64_t hours = microseconds / util::kMicrosPerHour;
   microseconds %= util::kMicrosPerHour;
   int64_t minutes = microseconds / util::kMicrosPerMinute;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1562,14 +1562,67 @@ FOLLY_ALWAYS_INLINE bool Type::isDate() const {
   return this == DATE().get();
 }
 
-/// Represents TIME as a bigint (milliseconds since midnight).
-class TimeType final : public BigintType {
-  TimeType() = default;
+enum class TimePrecision : int8_t {
+  kMilliseconds = 3, // Presto: milliseconds since midnight (10^3 ms = 1 second)
+  kMicroseconds = 6, // Spark: microseconds since midnight (10^6 μs = 1 second)
+};
 
+VELOX_DECLARE_ENUM_NAME(TimePrecision);
+
+/// Base template class for TIME types with configurable precision and timezone
+/// mode.
+/// - Presto: milliseconds since midnight (local timezone).
+/// - Spark: microseconds since midnight (timezone unaware).
+/// @tparam kPrecision Time precision (milliseconds or microseconds).
+/// @tparam kLocalTime True for local time representation, false for UTC.
+template <TimePrecision kPrecision, bool kLocalTime>
+class TimeType : public BigintType {
  public:
-  static std::shared_ptr<const TimeType> get() {
-    VELOX_CONSTEXPR_SINGLETON TimeType kInstance;
-    return {std::shared_ptr<const TimeType>{}, &kInstance};
+  std::string toString() const override {
+    return name();
+  }
+
+  constexpr int64_t getMin() const {
+    return 0;
+  }
+
+  /// Maximum valid time value based on precision. For milliseconds:
+  /// 23:59:59.999 (86,399,999 ms). For microseconds: 23:59:59.999999
+  /// (86,399,999,999 μs).
+  constexpr int64_t getMax() const {
+    return kPrecision == TimePrecision::kMilliseconds
+        ? kMillisInDay - 1
+        : static_cast<int64_t>(kMillisInDay) * 1000 - 1;
+  }
+
+  /// When casting from TIME to varchar, the resultant varchar size depends on
+  /// precision: 12 bytes for milliseconds (HH:MM:SS.mmm), 15 bytes for
+  /// microseconds (HH:MM:SS.mmmmmm).
+  constexpr int32_t timeToVarcharRowSize() const {
+    return kPrecision == TimePrecision::kMilliseconds ? 12 : 15;
+  }
+
+  folly::dynamic serialize() const override;
+
+ protected:
+  constexpr TimeType() = default;
+};
+
+struct TimeTypeFactory {
+  static TypePtr deserialize(const folly::dynamic& obj);
+};
+
+// TimeType with millisecond precision in local timezone (Presto-compatible).
+class TimeMilliPrecisionType final
+    : public TimeType<TimePrecision::kMilliseconds, true> {
+ public:
+  static std::shared_ptr<const TimeMilliPrecisionType> get() {
+    VELOX_CONSTEXPR_SINGLETON TimeMilliPrecisionType kInstance;
+    return {std::shared_ptr<const TimeMilliPrecisionType>{}, &kInstance};
+  }
+
+  const char* name() const override {
+    return "TIME";
   }
 
   bool equivalent(const Type& other) const override {
@@ -1577,16 +1630,8 @@ class TimeType final : public BigintType {
     return this == &other;
   }
 
-  const char* name() const override {
-    return "TIME";
-  }
-
-  std::string toString() const override {
-    return name();
-  }
-
   /// Returns the time 'value' (milliseconds since midnight) formatted as
-  /// HH:MM:SS.mmm .
+  /// HH:MM:SS.mmm.
   /// It is the callers responsiblity to ensure that the value is in range
   /// and converted to the right time zone.
   StringView valueToString(int64_t value, char* const startPos) const;
@@ -1607,18 +1652,26 @@ class TimeType final : public BigintType {
       const tz::TimeZone* timeZone,
       int64_t sessionStartTimeMs) const;
 
-  folly::dynamic serialize() const override;
+ private:
+  constexpr TimeMilliPrecisionType() = default;
+};
 
-  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
-    return TimeType::get();
+// TimeType with microsecond precision, timezone unaware (Spark compatible).
+class TimeMicroPrecisionUtcType final
+    : public TimeType<TimePrecision::kMicroseconds, false> {
+ public:
+  static std::shared_ptr<const TimeMicroPrecisionUtcType> get() {
+    VELOX_CONSTEXPR_SINGLETON TimeMicroPrecisionUtcType kInstance;
+    return {std::shared_ptr<const TimeMicroPrecisionUtcType>{}, &kInstance};
   }
 
-  bool isOrderable() const override {
-    return true;
+  const char* name() const override {
+    return "TIME MICRO UTC";
   }
 
-  bool isComparable() const override {
-    return true;
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
   }
 
   /// Converts microseconds since midnight to a compact ISO-8601 time string by
@@ -1647,31 +1700,35 @@ class TimeType final : public BigintType {
   /// - 86'399'999'999 -> "23:59:59.999999"
   static std::string toCompactIso8601(int64_t microseconds);
 
-  // When casting from TIME to varchar , the resultant varchar will always
-  // be 12 bytes long (HH:MM:SS.mmm).
-  static const size_t kTimeToVarcharRowSize = 12;
-
-  /// Minimum valid time value (milliseconds since midnight): 00:00:00.000
-  static constexpr int64_t kMin = 0;
-
-  /// Maximum valid time value (milliseconds since midnight): 23:59:59.999
-  static constexpr int64_t kMax = kMillisInDay - 1;
+ private:
+  constexpr TimeMicroPrecisionUtcType() = default;
 };
 
-using TimeTypePtr = std::shared_ptr<const TimeType>;
-
+// Convenience pointer type (defaults to millisecond precision and local
+// timezone).
+using TimeTypePtr = std::shared_ptr<const TimeMilliPrecisionType>;
 FOLLY_ALWAYS_INLINE TimeTypePtr TIME() {
-  return TimeType::get();
+  return TimeMilliPrecisionType::get();
+}
+
+using TimeMicroPrecisionUtcTypePtr =
+    std::shared_ptr<const TimeMicroPrecisionUtcType>;
+FOLLY_ALWAYS_INLINE TimeMicroPrecisionUtcTypePtr TIME_MICRO_UTC() {
+  return TimeMicroPrecisionUtcType::get();
 }
 
 FOLLY_ALWAYS_INLINE bool Type::isTime() const {
-  // Pointer comparison works since this type is a singleton.
-  return (this == TIME().get());
+  return (this == TIME().get()) || (this == TIME_MICRO_UTC().get());
 }
 
 struct Time {
  private:
   Time() {}
+};
+
+struct TimeMicroUtc {
+ private:
+  TimeMicroUtc() {}
 };
 
 /// Used as T for SimpleVector subclasses that wrap another vector when

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -1219,7 +1219,7 @@ TEST(TypeTest, toSummaryString) {
 
 TEST(TypeTest, time) {
   const auto timeType = TIME();
-  ASSERT_EQ(timeType->toString(), "TIME");
+
   ASSERT_EQ(timeType->size(), 0);
   VELOX_ASSERT_THROW(timeType->childAt(0), "scalar type has no children");
   ASSERT_EQ(timeType->kind(), TypeKind::BIGINT); // Physical type
@@ -1238,12 +1238,49 @@ TEST(TypeTest, time) {
   ASSERT_TRUE(timeType->isComparable());
 
   testTypeSerde(timeType);
+
+  ASSERT_EQ(timeType->toString(), "TIME");
+  ASSERT_EQ(timeType->getMin(), 0);
+  ASSERT_EQ(timeType->getMax(), 86'399'999);
+}
+
+TEST(TypeTest, timeMicroUtc) {
+  const auto timeType = TIME_MICRO_UTC();
+  ASSERT_EQ(timeType->size(), 0);
+  VELOX_ASSERT_THROW(timeType->childAt(0), "scalar type has no children");
+  ASSERT_EQ(timeType->kind(), TypeKind::BIGINT); // Physical type
+  EXPECT_STREQ(timeType->kindName(), "BIGINT"); // Physical kind name
+  ASSERT_EQ(timeType->begin(), timeType->end());
+  ASSERT_EQ(approximateTypeEncodingwidth(timeType), 1);
+
+  // Test logical vs physical type behavior (similar to DATE test)
+  ASSERT_TRUE(timeType->kindEquals(BIGINT())); // Same physical kind
+  ASSERT_NE(*timeType, *BIGINT()); // Different logical types
+  ASSERT_FALSE(timeType->equivalent(*BIGINT())); // Not equivalent
+  ASSERT_FALSE(BIGINT()->equivalent(*timeType)); // Not equivalent reverse
+
+  // Test orderability and comparability
+  ASSERT_TRUE(timeType->isOrderable());
+  ASSERT_TRUE(timeType->isComparable());
+
+  testTypeSerde(timeType);
+  ASSERT_EQ(timeType->toString(), "TIME MICRO UTC");
+  ASSERT_EQ(timeType->getMin(), 0);
+  ASSERT_EQ(timeType->getMax(), 86'399'999'999);
+}
+
+TEST(TypeTest, timeTypeComparison) {
+  EXPECT_TRUE(TIME()->equivalent(*TIME()));
+  EXPECT_TRUE(TIME_MICRO_UTC()->equivalent(*TIME_MICRO_UTC()));
+
+  EXPECT_FALSE(TIME()->equivalent(*TIME_MICRO_UTC()));
+  EXPECT_FALSE(TIME_MICRO_UTC()->equivalent(*TIME()));
 }
 
 TEST(TypeTest, timeToIso8601) {
   const auto toIso8601 =
       [](int64_t hours, int64_t minutes, int64_t seconds, int64_t micros) {
-        return TimeType::toCompactIso8601(
+        return TimeMicroPrecisionUtcType::toCompactIso8601(
             hours * util::kMicrosPerHour + minutes * util::kMicrosPerMinute +
             seconds * util::kMicrosPerSec + micros);
       };

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -98,8 +98,8 @@ class VectorFuzzerTest : public testing::Test {
     for (size_t i = 0; i < timeVector->size(); ++i) {
       if (!timeVector->isNullAt(i)) {
         auto timeValue = timeVector->valueAt(i);
-        ASSERT_GE(timeValue, TimeType::kMin);
-        ASSERT_LE(timeValue, TimeType::kMax);
+        ASSERT_GE(timeValue, TIME()->getMin());
+        ASSERT_LE(timeValue, TIME()->getMax());
       }
     }
   }
@@ -711,8 +711,8 @@ TEST_F(VectorFuzzerTest, time) {
   auto constVector = constTimeVector->as<ConstantVector<int64_t>>();
   if (!constVector->isNullAt(0)) {
     auto timeValue = constVector->valueAt(0);
-    ASSERT_GE(timeValue, TimeType::kMin);
-    ASSERT_LE(timeValue, TimeType::kMax);
+    ASSERT_GE(timeValue, TIME()->getMin());
+    ASSERT_LE(timeValue, TIME()->getMax());
   }
 
   // Test dictionary TIME vector.


### PR DESCRIPTION
Both Presto and Spark represent the TIME type using a bigint. The key 
differences are:
1) Spark’s TimeType uses microsecond precision while Presto's TimeType
uses millisecond precision.
2) Presto's TimeType represents a time in the session time zone, while
Spark's TimeType is timezone-unaware.

In Velox, TimeType extends BigintType. To address above differences, this
PR introduces the below four types by adding two template parameters
`kPrecision` and `kLocalTime`.

```
TimeType(ms, local)  --- TIME (Presto compatible)
TimeType(ms, UTC) --- unused
TimeType(μs, local) --- unused
TimeType(μs, UTC) --- TIME_MICRO_UTC (Spark compatible)
```

Spark implementations need to support casting and functions based on the
`TIME_MICRO_UTC` type, and ensure that the time value is not subject to time
zone conversion.

Function registration tests with the `TimeMicroUtc` were added. 

Spark's implementation:
https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/TimeType.scala