### PR TITLE
fix(cuda): Scope -G debug flag to Velox targets only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,7 +479,7 @@ if(VELOX_ENABLE_WAVE OR VELOX_ENABLE_CUDF)
     message(FATAL_ERROR "-DCMAKE_CUDA_ARCHITECTURES= must be set")
   endif()
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-G>")
+    set(VELOX_CUDA_DEBUG_FLAGS "$<$<COMPILE_LANGUAGE:CUDA>:-G>")
   endif()
   find_package(CUDAToolkit REQUIRED)
   # Suppress deprecated GPU targets warning for CUDA 12.8.x

--- a/velox/experimental/gpu/tests/CMakeLists.txt
+++ b/velox/experimental/gpu/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(CUB REQUIRED)
 find_package(Thrust REQUIRED)
 
 add_executable(velox_gpu_hash_table_test HashTableTest.cu)
+target_compile_options(velox_gpu_hash_table_test PRIVATE ${VELOX_CUDA_DEBUG_FLAGS})
 target_link_libraries(
   velox_gpu_hash_table_test
   Folly::folly

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -24,6 +24,8 @@ add_library(
   ResultStaging.cpp
 )
 
+target_compile_options(velox_wave_common PRIVATE ${VELOX_CUDA_DEBUG_FLAGS})
+
 target_link_libraries(
   velox_wave_common
   velox_exception

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -29,6 +29,8 @@ add_executable(
 add_test(velox_wave_common_test velox_wave_common_test)
 set_tests_properties(velox_wave_common_test PROPERTIES LABELS cuda_driver)
 
+target_compile_options(velox_wave_common_test PRIVATE ${VELOX_CUDA_DEBUG_FLAGS})
+
 if(VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST)
   target_compile_definitions(velox_wave_common_test PRIVATE VELOX_SKIP_WAVE_BRANCH_KERNEL_TEST=1)
 endif()

--- a/velox/experimental/wave/dwio/decode/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/CMakeLists.txt
@@ -17,4 +17,6 @@ endif()
 
 add_library(velox_wave_decode GpuDecoder.cu)
 
+target_compile_options(velox_wave_decode PRIVATE ${VELOX_CUDA_DEBUG_FLAGS})
+
 target_link_libraries(velox_wave_decode velox_wave_common CUDA::cudart breeze_cuda)

--- a/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
+++ b/velox/experimental/wave/dwio/decode/tests/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 add_executable(velox_wave_decode_test GpuDecoderTest.cu)
 
+target_compile_options(velox_wave_decode_test PRIVATE ${VELOX_CUDA_DEBUG_FLAGS})
+
 add_test(velox_wave_decode_test velox_wave_decode_test)
 set_tests_properties(velox_wave_decode_test PROPERTIES LABELS cuda_driver)
 

--- a/velox/experimental/wave/exec/CMakeLists.txt
+++ b/velox/experimental/wave/exec/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(
   WaveSplitReader.cpp
 )
 
+target_compile_options(velox_wave_exec PRIVATE ${VELOX_CUDA_DEBUG_FLAGS})
+
 target_link_libraries(
   velox_wave_exec
   velox_wave_vector


### PR DESCRIPTION
## Summary

- The `-G` nvcc flag (CUDA device-side debugging) was applied globally via `add_compile_options`, leaking into third-party dependencies like cuDF brought in via FetchContent.
- cuDF is not compatible with `-G` because its ORC dictionary encoding kernels use `cuco` hash maps with indirect function dispatch, which prevents `ptxas` from statically determining stack sizes. This causes a hard build failure on `dict_enc.cu`.
- Replace the global `add_compile_options` with a `VELOX_CUDA_DEBUG_FLAGS` variable, and apply it via `target_compile_options` to each Velox-owned CUDA target (wave, decode, gpu tests). This preserves device-side debugging for Velox code while allowing cuDF to compile without `-G`.

## Reproduction

Configuring with `-DCMAKE_BUILD_TYPE=Debug -DPRESTO_ENABLE_CUDF=ON` and building cuDF's `dict_enc.cu` produces:

```
ptxas error: Stack size for entry function '...populate_dictionary_hash_maps_kernel...' cannot be statically determined
ptxas error: Stack size for entry function '...collect_map_entries_kernel...' cannot be statically determined
```

Discovered via https://github.com/prestodb/presto/pull/27160.

## Testing

Verified locally inside the `prestodb/presto-native-dependency:0.297-202602190453-8d6d9543` container:
1. Reproduced the original failure (cuDF `dict_enc.cu` fails with `-G`).
2. Applied the fix, confirmed `-G` is absent from cuDF compile flags in `build.ninja`.
3. Confirmed `dict_enc.cu` compiles successfully with the fix.