### PR TITLE
fix: Add BaseVector::reusable() to recursively check vector reusability

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -827,6 +827,16 @@ class BaseVector {
   /// hasn't been loaded yet.
   virtual uint64_t estimateFlatSize() const;
 
+  /// Recursively checks if a vector and all its children are reusable.
+  /// A vector is reusable only if:
+  /// 1. It has use_count == 1 (singly-referenced)
+  /// 2. It has a reusable encoding (FLAT, ARRAY, MAP, ROW)
+  /// 3. All its children are also reusable (recursively)
+  ///
+  /// This prevents bugs where reusing a vector with shared nested children
+  /// would cause corruption when prepareForReuse resets those shared children.
+  static bool recursivelyReusable(const VectorPtr& vector);
+
   /// To safely reuse a vector one needs to (1) ensure that the vector as well
   /// as all its buffers and child vectors are singly-referenced and mutable
   /// (for buffers); (2) clear append-only string buffers and child vectors

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -633,7 +633,9 @@ void RowVector::validate(const VectorValidateOptions& options) const {
       if (child->size() < size()) {
         VELOX_CHECK_NOT_NULL(
             nulls_,
-            "Child vector has size less than parent and parent has no nulls.");
+            "Child vector has size {} less than parent and parent has no nulls {}.",
+            child->size(),
+            size());
 
         VELOX_CHECK_GT(
             child->size(),


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/502

This change adds a new static method BaseVector::reusable() that recursively checks if a vector and all its nested children are reusable (have use_count == 1).

The existing verifyVectorState() check in nimble FieldReader only verified the top-level vector's use_count, but complex types like ARRAY<ROW<BIGINT, REAL>> can have nested children that are shared across different parent vectors. When prepareForReuse() is called on a vector whose nested children are still referenced elsewhere, it corrupts those shared children by resetting them to size 0.

Adds BaseVector::reusable() which recursively checks use_count for ROW children, ARRAY elements, and MAP keys/values
Updates verifyVectorState() in nimble FieldReader to use the new recursive check
Adds unit tests for the new method

Differential Revision: D93790972


