### PR TITLE
feat: Impl memory compact in Aggregate and GroupingSet

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -223,6 +223,14 @@ class QueryConfig {
   static constexpr const char* kAggregationCompactionUnusedMemoryRatio =
       "aggregation_compaction_unused_memory_ratio";
 
+  /// If true, enables lightweight memory compaction before spilling during
+  /// memory reclaim in aggregation. When enabled, the aggregation operator
+  /// will try to compact aggregate function state (e.g., free dead strings)
+  /// before resorting to spilling.
+  /// Disabled by default.
+  static constexpr const char* kAggregationMemoryCompactionReclaimEnabled =
+      "aggregation_memory_compaction_reclaim_enabled";
+
   static constexpr const char* kAbandonPartialTopNRowNumberMinRows =
       "abandon_partial_topn_row_number_min_rows";
 
@@ -927,6 +935,10 @@ class QueryConfig {
 
   double aggregationCompactionUnusedMemoryRatio() const {
     return get<double>(kAggregationCompactionUnusedMemoryRatio, 0.25);
+  }
+
+  bool aggregationMemoryCompactionReclaimEnabled() const {
+    return get<bool>(kAggregationMemoryCompactionReclaimEnabled, false);
   }
 
   int32_t abandonPartialTopNRowNumberMinRows() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -546,6 +546,13 @@ Aggregation
        The value is in the range of [0, 1). Currently only applies to approx_most_frequent
        aggregate with StringView type during global aggregation. May be extended
        to other aggregation types on-demand.
+   * - aggregation_memory_compaction_reclaim_enabled
+     - bool
+     - false
+     - If true, enables lightweight memory compaction before spilling during
+       memory reclaim in aggregation. When enabled, the aggregation operator
+       will try to compact aggregate function state (e.g., free dead strings)
+       before resorting to spilling.
    * - streaming_aggregation_min_output_batch_rows
      - integer
      - 0

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -305,6 +305,18 @@ class Aggregate {
     }
   }
 
+  /// Returns true if this aggregate function supports lightweight memory
+  /// compaction via compact().
+  virtual bool supportsCompact() const {
+    return false;
+  }
+
+  /// Invoked by GroupingSet::compact() to perform lightweight memory compaction
+  /// on the given 'groups', freeing unused memory without spilling to disk.
+  virtual uint64_t compact(folly::Range<char**> /*groups*/) {
+    return 0;
+  }
+
   // Clears state between reuses, e.g. this is called before reusing
   // the aggregation operator's state after flushing a partial
   // aggregation.

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -128,6 +128,17 @@ class GroupingSet {
   /// Returns true if spilling has triggered on this grouping set.
   bool hasSpilled() const;
 
+  /// Performs lightweight memory compaction across all aggregates before
+  /// spilling. Iterates over all groups and calls Aggregate::compact() on each
+  /// aggregate function. Returns the total number of bytes freed.
+  uint64_t compact();
+
+  /// Returns true if any aggregate function supports lightweight memory
+  /// compaction.
+  bool hasCompactableAggregates() const {
+    return hasCompactableAggregates_;
+  }
+
   /// Returns the hashtable stats.
   HashTableStats hashTableStats() const {
     return table_ ? table_->stats() : HashTableStats{};
@@ -324,6 +335,9 @@ class GroupingSet {
   AggregationMasks masks_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;
   std::vector<std::unique_ptr<DistinctAggregations>> distinctAggregations_;
+
+  // Boolean indicating whether any aggregate supports compact().
+  bool hasCompactableAggregates_{false};
 
   uint64_t numInputRows_ = 0;
 


### PR DESCRIPTION
Summary:
This diff integrates lightweight memory compaction with the memory arbitration
framework for aggregations.

Previously, ApproxMostFrequentAggregate::compact() was called proactively but
not integrated with memory arbitration. It also used pool-tracked memory for
temporary storage during compaction, causing peak memory to double temporary

Changes:
1. Add Aggregate::compact() virtual interface and GroupingSet::compact() to
   enable memory arbitration to trigger compaction before spilling.
2. HashAggregation::reclaim() now calls compact() first before attempting spill.
3. ApproxMostFrequentAggregate::compact() now uses untracked heap memory as temporary buffer, avoiding peak memory spike in tracked pool memory during compaction.

Differential Revision: D93785285


