### PR TITLE
feat(type): Add IntervalDayTimeMicrosType for microsecond-precision day-time intervals

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -204,6 +204,12 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const TypePtr& toType);
 
+  VectorPtr castFromIntervalDayTimeMicros(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType);
+
   VectorPtr castFromTime(
       const SelectivityVector& rows,
       const BaseVector& input,

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -168,6 +168,13 @@ void appendSqlLiteral(
             << " MILLISECOND";
         break;
       }
+      if (vector.type()->isIntervalDayTimeMicros()) {
+        auto* intervalVector =
+            vector.wrappedVector()->as<SimpleVector<int64_t>>();
+        out << "INTERVAL " << intervalVector->valueAt(vector.wrappedIndex(row))
+            << " MICROSECOND";
+        break;
+      }
       [[fallthrough]];
     }
     case TypeKind::HUGEINT:

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -214,6 +214,11 @@ struct IntervalDayTime {
   IntervalDayTime() {}
 };
 
+struct IntervalDayTimeMicros {
+ private:
+  IntervalDayTimeMicros() {}
+};
+
 struct IntervalYearMonth {
  private:
   IntervalYearMonth() {}
@@ -361,6 +366,11 @@ struct SimpleTypeTrait<Date> : public TypeTraits<TypeKind::INTEGER> {
 template <>
 struct SimpleTypeTrait<IntervalDayTime> : public TypeTraits<TypeKind::BIGINT> {
   static constexpr const char* name = "INTERVAL DAY TO SECOND";
+};
+
+template <>
+struct SimpleTypeTrait<IntervalDayTimeMicros> : public TypeTraits<TypeKind::BIGINT> {
+  static constexpr const char* name = "INTERVAL DAY TO SECOND MICROS";
 };
 
 template <>

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -390,6 +390,11 @@ TEST_F(VectorSaverTest, flatIntervalDayTime) {
   testRoundTrip(opts, INTERVAL_DAY_TIME());
 }
 
+TEST_F(VectorSaverTest, flatIntervalDayTimeMicros) {
+  VectorFuzzer::Options opts = fuzzerOptions();
+  testRoundTrip(opts, INTERVAL_DAY_TIME_MICROS());
+}
+
 TEST_F(VectorSaverTest, row) {
   auto opts = fuzzerOptions();
 


### PR DESCRIPTION
Summary

  - Adds `IntervalDayTimeMicrosType`, a singleton type storing day-time intervals as microseconds in `int64_t`, complementing the existing millisecond-precision `IntervalDayTimeType`
  - Spark's `DayTimeIntervalType` uses microsecond precision, while Presto's `IntervalDayTimeType` uses millisecond precision — without this type, Spark-based frontends
  like Gluten must either lose sub-millisecond precision or fall back to JVM execution for all `DayTimeInterval` operations
  - Includes cast to VARCHAR, constant expression display, serialization support, and test coverage (TypeTest, CastExprTest, VectorSaverTest)

Please let me know if you have a better idea to absorb this difference between Presto and Spark.
- Pretso (msecs) https://prestodb.io/docs/current/language/types.html#interval-day-to-second
- Spark (microsecs) https://spark.apache.org/docs/latest/sql-ref-datatypes.html no mention in the doc, but from the code I can see that micros is expected https://github.com/n0r0shi/spark/blob/5412fb0590e55d635e9e31887ec5c72d10011899/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkIntervalUtils.scala#L382

  Test plan

  - TypeTest.intervalDayTimeMicros — type basics, valueToString, equivalence, serde
  - CastExprTest.intervalDayTimeMicrosToVarchar — cast to VARCHAR with sub-ms precision, negative values, edge cases, reverse cast error
  - VectorSaverTest.flatIntervalDayTimeMicros — flat vector round-trip serialization
