### PR TITLE
fix: Fix linker errors in HiveIndexReader

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -38,7 +38,12 @@ velox_add_library(
 
 velox_link_libraries(
   velox_hive_connector
-  PRIVATE velox_common_io velox_connector velox_dwio_catalog_fbhive velox_hive_partition_function
+  PRIVATE
+    velox_common_io
+    velox_connector
+    velox_dwio_catalog_fbhive
+    velox_hive_partition_function
+    velox_key_encoder
 )
 
 velox_add_library(velox_hive_partition_function HivePartitionFunction.cpp)

--- a/velox/connectors/hive/HiveIndexReader.cpp
+++ b/velox/connectors/hive/HiveIndexReader.cpp
@@ -23,6 +23,7 @@
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/ReaderFactory.h"
+#include "velox/serializers/KeyEncoder.h"
 
 namespace facebook::velox::connector::hive {
 namespace {


### PR DESCRIPTION
```C++
Undefined symbols for architecture arm64:
  "facebook::velox::serializer::IndexBounds::set(facebook::velox::serializer::IndexBound, facebook::velox::serializer::IndexBound)", referenced from:
      facebook::velox::connector::hive::HiveIndexReader::buildRequestIndexBounds(std::__1::shared_ptr<facebook::velox::RowVector> const&) in libvelox_exec_test_lib.a[10](HiveIndexReader.cpp.o)
ld: symbol(s) not found for architecture arm64
c++: error: linker command failed with exit code 1 (use -v to see invocation)
```