### PR TITLE
feat: Add ANSI overflow check to Spark round function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -307,6 +307,8 @@ Mathematical Functions
     Returns ``x`` rounded to ``d`` decimal places using HALF_UP rounding mode.
     In HALF_UP rounding, the digit 5 is rounded up.
     Supported types for ``x`` are integral and floating point types.
+    For integral types with negative ``d``, an error is thrown if the rounded
+    result overflows the type when ``spark.sql.ansi.enabled`` is set to true.
 
 .. spark:function:: sec(x) -> double
 

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -60,16 +60,19 @@ void registerMathFunctions(const std::string& prefix) {
   registerBinaryFloatingPoint<PModFloatFunction>({prefix + "pmod"});
   registerFunction<PowerFunction, double, double, double>({prefix + "power"});
   registerFunction<RIntFunction, double, double>({prefix + "rint"});
-  registerUnaryNumeric<RoundFunction>({prefix + "round"});
-  registerFunction<RoundFunction, int8_t, int8_t, int32_t>({prefix + "round"});
-  registerFunction<RoundFunction, int16_t, int16_t, int32_t>(
+  registerUnaryNumeric<sparksql::RoundFunction>({prefix + "round"});
+  registerFunction<sparksql::RoundFunction, int8_t, int8_t, int32_t>(
       {prefix + "round"});
-  registerFunction<RoundFunction, int32_t, int32_t, int32_t>(
+  registerFunction<sparksql::RoundFunction, int16_t, int16_t, int32_t>(
       {prefix + "round"});
-  registerFunction<RoundFunction, int64_t, int64_t, int32_t>(
+  registerFunction<sparksql::RoundFunction, int32_t, int32_t, int32_t>(
       {prefix + "round"});
-  registerFunction<RoundFunction, double, double, int32_t>({prefix + "round"});
-  registerFunction<RoundFunction, float, float, int32_t>({prefix + "round"});
+  registerFunction<sparksql::RoundFunction, int64_t, int64_t, int32_t>(
+      {prefix + "round"});
+  registerFunction<sparksql::RoundFunction, double, double, int32_t>(
+      {prefix + "round"});
+  registerFunction<sparksql::RoundFunction, float, float, int32_t>(
+      {prefix + "round"});
   registerFunction<UnHexFunction, Varbinary, Varchar>({prefix + "unhex"});
   // In Spark only long, double, and decimal have ceil/floor
   registerFunction<sparksql::CeilFunction, int64_t, int64_t>({prefix + "ceil"});


### PR DESCRIPTION

## Summary

Add a Spark-specific `RoundFunction` that reads `sparkAnsiEnabled` config to throw on integer overflow when rounding with negative scale.

Spark's `round(value, scale)` with negative scale rounds integers to the nearest 10/100/1000 etc:
```sql
round(124, -1)  → 120   -- nearest 10
round(125, -1)  → 130   -- 5 rounds up
round(1234, -2) → 1200  -- nearest 100
```

This can overflow when the value is near the type's max:
```sql
-- TINYINT range: -128 to 127
round(125, -1)  → 130   -- overflows TINYINT
round(-128, -1) → -130  -- overflows TINYINT
```

Previously, Spark's `round` reused Presto's `RoundFunction` which has no overflow check. This PR adds a Spark-specific `RoundFunction` that:
- When `spark.sql.ansi.enabled = false` (default): unchanged behavior
- When `spark.sql.ansi.enabled = true`: throws on integer overflow

Follows the same config-based pattern as `AbsFunction`.

## Test plan
- [x] `RoundAnsiTest.integerNegativeScaleNoOverflow` — ANSI off/on, no overflow
- [x] `RoundAnsiTest.integerOverflowAnsiOff` — overflow wraps silently
- [x] `RoundAnsiTest.integerOverflowAnsiOn` — overflow throws, try() returns NULL
- [x] `RoundAnsiTest.integerNoScale` — scale >= 0 is no-op for integers
- [x] `RoundAnsiTest.floatingPoint` — floats unaffected
- [x] Existing `DecimalRoundTest` passes (no regression)
```