### PR TITLE
feat: Add window function result type resolution APIs

### DIFF
--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -179,6 +179,23 @@ bool registerWindowFunction(
 std::optional<std::vector<FunctionSignaturePtr>> getWindowFunctionSignatures(
     const std::string& name);
 
+/// Resolves the return type of a window function.
+/// Throws if no matching signature is found.
+TypePtr resolveWindowResultType(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes);
+
+/// Like 'resolveWindowResultType', but with support for applying type
+/// coercions if a function signature doesn't match 'argTypes' exactly.
+///
+/// @param coercions A list of optional type coercions applied to resolve the
+/// function. Contains one entry per argument. The entry is null if no coercion
+/// is required for that argument.
+TypePtr resolveWindowResultTypeWithCoercions(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions);
+
 struct WindowFunctionEntry {
   std::vector<FunctionSignaturePtr> signatures;
   WindowFunctionFactory factory;

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -199,4 +199,14 @@ class SignatureBinder : private SignatureBinderBase {
   const std::vector<TypePtr>& actualTypes_;
 };
 
+/// Try to resolve the return type from a list of function signatures with
+/// coercion support. Returns the resolved return type if a matching signature
+/// is found, nullptr otherwise. On success, 'coercions' contains one entry per
+/// argument: nullptr if no coercion needed, or the target type if coercion is
+/// required. Exact matches (no coercions) are preferred over coerced matches.
+TypePtr tryResolveReturnTypeWithCoercions(
+    const std::vector<FunctionSignaturePtr>& signatures,
+    const std::vector<TypePtr>& argTypes,
+    std::vector<TypePtr>& coercions);
+
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Add `resolveWindowResultType` and `resolveWindowResultTypeWithCoercions`
to the window function registry, mirroring the existing aggregate
function APIs (`resolveResultType`, `resolveResultTypeWithCoercions`).

Both APIs try window function signatures first, then fall back to
aggregate function signatures since all aggregate functions can be used
as window functions.

Differential Revision: D93990936


