### PR TITLE
refactor: Move aggregate and window parsing types to SqlExpressionsParser

### DIFF
--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -74,7 +74,7 @@ class PlanNodeBuilderTest : public testing::Test, public test::VectorTestBase {
         agg.rawInputTypes = rawInputArgs[i];
       }
 
-      VELOX_CHECK_NULL(untypedExpr.maskExpr);
+      VELOX_CHECK_NULL(untypedExpr.filter);
       VELOX_CHECK(!untypedExpr.distinct);
       VELOX_CHECK(untypedExpr.orderBy.empty());
 

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -22,6 +22,7 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::duckdb;
+using namespace facebook::velox::parse;
 
 namespace {
 std::shared_ptr<const core::IExpr> parseExpr(const std::string& exprString) {
@@ -128,8 +129,8 @@ std::string parseAgg(const std::string& expression) {
     out << " " << toString(aggregateExpr.orderBy);
   }
 
-  if (aggregateExpr.maskExpr != nullptr) {
-    out << " FILTER " << aggregateExpr.maskExpr->toString();
+  if (aggregateExpr.filter != nullptr) {
+    out << " FILTER " << aggregateExpr.filter->toString();
   }
 
   return out.str();
@@ -695,6 +696,24 @@ TEST(DuckParserTest, windowWithIntegerConstant) {
   auto constant = std::dynamic_pointer_cast<const core::ConstantExpr>(param);
   ASSERT_TRUE(constant != nullptr) << param->toString() << " is not a constant";
   EXPECT_EQ(*constant->type(), *INTEGER());
+}
+
+TEST(DuckParserTest, parseScalarOrWindowExpr) {
+  ParseOptions options;
+
+  // Scalar expression returns ExprPtr.
+  auto scalar = parseScalarOrWindowExpr("a + b", options);
+  ASSERT_TRUE(std::holds_alternative<core::ExprPtr>(scalar));
+  EXPECT_EQ(std::get<core::ExprPtr>(scalar)->toString(), "plus(\"a\",\"b\")");
+
+  // Window expression returns WindowExpr.
+  auto window =
+      parseScalarOrWindowExpr("row_number() over (order by a)", options);
+  ASSERT_TRUE(std::holds_alternative<WindowExpr>(window));
+  auto& windowExpr = std::get<WindowExpr>(window);
+  EXPECT_EQ(windowExpr.functionCall->toString(), "row_number()");
+  EXPECT_EQ(windowExpr.orderBy.size(), 1);
+  EXPECT_TRUE(windowExpr.orderBy[0].ascending);
 }
 
 TEST(DuckParserTest, invalidExpression) {

--- a/velox/exec/tests/ColumnStatsCollectorTest.cpp
+++ b/velox/exec/tests/ColumnStatsCollectorTest.cpp
@@ -70,7 +70,7 @@ class ColumnStatsCollectorTest : public OperatorTestBase {
         agg.rawInputTypes.push_back(input->type());
       }
 
-      VELOX_CHECK_NULL(untypedExpr.maskExpr);
+      VELOX_CHECK_NULL(untypedExpr.filter);
       VELOX_CHECK(!untypedExpr.distinct);
       VELOX_CHECK(untypedExpr.orderBy.empty());
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1046,10 +1046,10 @@ PlanBuilder::AggregatesAndNames PlanBuilder::createAggregateExpressionsAndNames(
       agg.rawInputTypes = rawInputTypes[i];
     }
 
-    if (untypedExpr.maskExpr != nullptr) {
+    if (untypedExpr.filter != nullptr) {
       auto maskExpr =
           std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
-              inferTypes(untypedExpr.maskExpr));
+              inferTypes(untypedExpr.filter));
       VELOX_CHECK_NOT_NULL(
           maskExpr,
           "FILTER clause must use a column name, not an expression: {}",
@@ -2246,26 +2246,26 @@ class WindowTypeResolver {
 };
 
 const core::WindowNode::Frame createWindowFrame(
-    const duckdb::IExprWindowFrame& windowFrame,
+    const parse::WindowFrame& windowFrame,
     const TypePtr& inputRow,
     memory::MemoryPool* pool) {
   core::WindowNode::Frame frame;
-  frame.type = (windowFrame.type == duckdb::WindowType::kRows)
+  frame.type = (windowFrame.type == parse::WindowType::kRows)
       ? core::WindowNode::WindowType::kRows
       : core::WindowNode::WindowType::kRange;
 
   auto boundTypeConversion =
-      [](duckdb::BoundType boundType) -> core::WindowNode::BoundType {
+      [](parse::BoundType boundType) -> core::WindowNode::BoundType {
     switch (boundType) {
-      case duckdb::BoundType::kCurrentRow:
+      case parse::BoundType::kCurrentRow:
         return core::WindowNode::BoundType::kCurrentRow;
-      case duckdb::BoundType::kFollowing:
+      case parse::BoundType::kFollowing:
         return core::WindowNode::BoundType::kFollowing;
-      case duckdb::BoundType::kPreceding:
+      case parse::BoundType::kPreceding:
         return core::WindowNode::BoundType::kPreceding;
-      case duckdb::BoundType::kUnboundedFollowing:
+      case parse::BoundType::kUnboundedFollowing:
         return core::WindowNode::BoundType::kUnboundedFollowing;
-      case duckdb::BoundType::kUnboundedPreceding:
+      case parse::BoundType::kUnboundedPreceding:
         return core::WindowNode::BoundType::kUnboundedPreceding;
     }
     VELOX_UNREACHABLE();
@@ -2282,7 +2282,7 @@ const core::WindowNode::Frame createWindowFrame(
 }
 
 std::vector<core::FieldAccessTypedExprPtr> parsePartitionKeys(
-    const duckdb::IExprWindowFunction& windowExpr,
+    const parse::WindowExpr& windowExpr,
     const std::string& windowString,
     const TypePtr& inputRow,
     memory::MemoryPool* pool) {
@@ -2305,7 +2305,7 @@ std::pair<
     std::vector<core::FieldAccessTypedExprPtr>,
     std::vector<core::SortOrder>>
 parseOrderByKeys(
-    const duckdb::IExprWindowFunction& windowExpr,
+    const parse::WindowExpr& windowExpr,
     const std::string& windowString,
     const TypePtr& inputRow,
     memory::MemoryPool* pool) {

--- a/velox/parse/CMakeLists.txt
+++ b/velox/parse/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(velox_parse_expression Expressions.cpp)
+velox_add_library(velox_parse_expression Expressions.cpp SqlExpressionsParser.cpp)
 velox_link_libraries(velox_parse_expression velox_type velox_parse_utils velox_expression)
 
 velox_add_library(velox_parse_parser ExpressionsParser.cpp QueryPlanner.cpp)

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -43,12 +43,21 @@ std::vector<core::ExprPtr> DuckSqlExpressionsParser::parseExprs(
 
 OrderByClause DuckSqlExpressionsParser::parseOrderByExpr(
     const std::string& expr) {
-  auto orderBy = facebook::velox::duckdb::parseOrderByExpr(expr);
+  return facebook::velox::duckdb::parseOrderByExpr(expr);
+}
 
-  return {
-      .expr = std::move(orderBy.expr),
-      .ascending = orderBy.ascending,
-      .nullsFirst = orderBy.nullsFirst};
+AggregateExpr DuckSqlExpressionsParser::parseAggregateExpr(
+    const std::string& expr) {
+  return facebook::velox::duckdb::parseAggregateExpr(expr, options_);
+}
+
+WindowExpr DuckSqlExpressionsParser::parseWindowExpr(const std::string& expr) {
+  return facebook::velox::duckdb::parseWindowExpr(expr, options_);
+}
+
+std::variant<core::ExprPtr, WindowExpr>
+DuckSqlExpressionsParser::parseScalarOrWindowExpr(const std::string& expr) {
+  return facebook::velox::duckdb::parseScalarOrWindowExpr(expr, options_);
 }
 
 } // namespace facebook::velox::parse

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -47,6 +47,13 @@ class DuckSqlExpressionsParser : public SqlExpressionsParser {
 
   OrderByClause parseOrderByExpr(const std::string& expr) override;
 
+  AggregateExpr parseAggregateExpr(const std::string& expr) override;
+
+  WindowExpr parseWindowExpr(const std::string& expr) override;
+
+  std::variant<core::ExprPtr, WindowExpr> parseScalarOrWindowExpr(
+      const std::string& expr) override;
+
  private:
   const facebook::velox::duckdb::ParseOptions options_;
 };

--- a/velox/parse/SqlExpressionsParser.cpp
+++ b/velox/parse/SqlExpressionsParser.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/parse/SqlExpressionsParser.h"
+
+namespace facebook::velox::parse {
+
+namespace {
+const auto& windowTypeNames() {
+  static const folly::F14FastMap<WindowType, std::string_view> kNames = {
+      {WindowType::kRows, "ROWS"},
+      {WindowType::kRange, "RANGE"},
+  };
+  return kNames;
+}
+
+const auto& boundTypeNames() {
+  static const folly::F14FastMap<BoundType, std::string_view> kNames = {
+      {BoundType::kCurrentRow, "CURRENT ROW"},
+      {BoundType::kUnboundedPreceding, "UNBOUNDED PRECEDING"},
+      {BoundType::kUnboundedFollowing, "UNBOUNDED FOLLOWING"},
+      {BoundType::kPreceding, "PRECEDING"},
+      {BoundType::kFollowing, "FOLLOWING"},
+  };
+  return kNames;
+}
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(WindowType, windowTypeNames);
+VELOX_DEFINE_ENUM_NAME(BoundType, boundTypeNames);
+
+std::string OrderByClause::toString() const {
+  return fmt::format(
+      "{} {} NULLS {}",
+      expr->toString(),
+      (ascending ? "ASC" : "DESC"),
+      (nullsFirst ? "FIRST" : "LAST"));
+}
+
+} // namespace facebook::velox::parse

--- a/velox/parse/SqlExpressionsParser.h
+++ b/velox/parse/SqlExpressionsParser.h
@@ -15,14 +15,84 @@
  */
 #pragma once
 
+#include <string>
+#include <variant>
+#include "velox/common/Enums.h"
 #include "velox/parse/IExpr.h"
 
 namespace facebook::velox::parse {
 
+/// Represents a single ORDER BY key with sort direction and nulls ordering.
 struct OrderByClause {
   core::ExprPtr expr;
   bool ascending;
   bool nullsFirst;
+
+  std::string toString() const;
+};
+
+/// Parsed aggregate function call, e.g. "sum(a)", "array_agg(x ORDER BY y)",
+/// "count(DISTINCT x) FILTER (WHERE y > 0)".
+struct AggregateExpr {
+  /// Aggregate function call expression.
+  core::ExprPtr expr;
+
+  /// Optional ORDER BY clause within the aggregate, e.g.
+  /// array_agg(x ORDER BY y DESC).
+  std::vector<OrderByClause> orderBy;
+
+  /// True if DISTINCT keyword is present.
+  bool distinct{false};
+
+  /// Optional FILTER clause expression, e.g.
+  /// count(*) FILTER (WHERE x > 0).
+  core::ExprPtr filter;
+};
+
+/// Window frame type: ROWS or RANGE.
+enum class WindowType { kRows, kRange };
+
+VELOX_DECLARE_ENUM_NAME(WindowType);
+
+/// Window frame bound type.
+enum class BoundType {
+  kCurrentRow,
+  kUnboundedPreceding,
+  kUnboundedFollowing,
+  kPreceding,
+  kFollowing,
+};
+
+VELOX_DECLARE_ENUM_NAME(BoundType);
+
+/// Window frame specification, e.g. ROWS BETWEEN 1 PRECEDING AND CURRENT ROW.
+struct WindowFrame {
+  WindowType type;
+  BoundType startType;
+  /// Optional bound value expression for kPreceding or kFollowing start.
+  core::ExprPtr startValue;
+  BoundType endType;
+  /// Optional bound value expression for kPreceding or kFollowing end.
+  core::ExprPtr endValue;
+};
+
+/// Parsed window function expression, e.g.
+/// "row_number() OVER (PARTITION BY a ORDER BY b)".
+struct WindowExpr {
+  /// Window function call expression.
+  core::ExprPtr functionCall;
+
+  /// Window frame specification.
+  WindowFrame frame;
+
+  /// True if IGNORE NULLS is specified.
+  bool ignoreNulls;
+
+  /// PARTITION BY expressions.
+  std::vector<core::ExprPtr> partitionBy;
+
+  /// ORDER BY clause within the OVER specification.
+  std::vector<OrderByClause> orderBy;
 };
 
 class SqlExpressionsParser {
@@ -37,6 +107,18 @@ class SqlExpressionsParser {
 
   /// Parses an expression that represents an ORDER BY clause. Throws on error.
   virtual OrderByClause parseOrderByExpr(const std::string& expr) = 0;
+
+  /// Parses an aggregate function call with optional FILTER, ORDER BY,
+  /// and DISTINCT. Throws on error.
+  virtual AggregateExpr parseAggregateExpr(const std::string& expr) = 0;
+
+  /// Parses a window function expression. Throws on error.
+  virtual WindowExpr parseWindowExpr(const std::string& expr) = 0;
+
+  /// Parses an expression that can be either a scalar expression or a window
+  /// function. Returns the appropriate type based on the parsed result.
+  virtual std::variant<core::ExprPtr, WindowExpr> parseScalarOrWindowExpr(
+      const std::string& expr) = 0;
 };
 
 } // namespace facebook::velox::parse


### PR DESCRIPTION
Summary:
Move shared types (OrderByClause, AggregateExpr, WindowType, BoundType,
WindowFrame, WindowExpr) from DuckParser.h to SqlExpressionsParser.h as
single source of truth. 

Add parseAggregateExpr, parseWindowExpr, and parseScalarOrWindowExpr
pure virtual methods to SqlExpressionsParser. Implement in
DuckSqlExpressionsParser.

Rename AggregateExpr::maskExpr to filter for clarity.

Differential Revision: D93997347


