### PR TITLE
refactor: Trivial cleanup in FieldReader, FieldWriter, StreamUtil

### DIFF
--- a/velox/dwio/common/StreamUtil.h
+++ b/velox/dwio/common/StreamUtil.h
@@ -159,15 +159,15 @@ inline void loopOverBuffers(
   int32_t rowOffset = initialRow;
   int32_t rowIndex = 0;
   while (rowIndex < rows.size()) {
-    auto available = (bufferEnd - bufferStart) / sizeof(T);
-    auto numRowsInBuffer = rows.back() - rowOffset < available
+    const auto available = (bufferEnd - bufferStart) / sizeof(T);
+    const auto numRowsInBuffer = rows.back() - rowOffset < available
         ? rows.size() - rowIndex
         : numBelow(
               folly::Range<const int32_t*>(
                   &rows[rowIndex], rows.size() - rowIndex),
               rowOffset + available);
 
-    if (!numRowsInBuffer) {
+    if (numRowsInBuffer == 0) {
       skipBytes(
           (rows[rowIndex] - rowOffset) * sizeof(T),
           &input,


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/505

Minor style improvements:
- Use const auto where applicable
- Brace initialization
- Explicit null checks (if (ptr != nullptr) instead of if (ptr))
- Use asChecked<> instead of as<> with separate null check
- NIMBLE_DCHECK_EQ instead of NIMBLE_DCHECK for equality checks

Differential Revision: D94037387


