### PR TITLE
feat: Add millisecond(TIME WITH TIMEZONE) Presto function

### DIFF
--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneRegistration.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.h"
 
 namespace facebook::velox::functions {

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -250,6 +250,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "millisecond"});
   registerFunction<MillisecondFunction, int64_t, TimestampWithTimezone>(
       {prefix + "millisecond"});
+  registerFunction<MillisecondTimeWithTimezoneFunction, int64_t, TimeWithTimezone>(
+      {prefix + "millisecond"});
   registerFunction<MillisecondFunction, int64_t, Time>(
       {prefix + "millisecond"});
   registerFunction<MillisecondFromIntervalFunction, int64_t, IntervalDayTime>(


### PR DESCRIPTION
Part of #14633 and #14939.

  ### Context from issue discussion
  From the issue discussion, the gap was that `millisecond(...)` covered existing datetime/time types but not `TIME WITH TIME ZONE`.
  The expected behavior is to extract milliseconds from the local wall-clock representation while preserving existing behavior for all currently supported types.

  ### Changes
  - Added `millisecond` evaluation logic for `TIME WITH TIME ZONE` using timezone-aware local-time conversion before millisecond extraction.
  - Wired function registration so `millisecond(TIME WITH TIME ZONE)` resolves through the normal PrestoSQL function registry path.
  - Added focused test coverage for:
    - null behavior
    - timezone-offset variants
    - vectorized execution path

  ### Behavior / Safety
  - Compatibility behavior:
    - Existing `millisecond` behavior for `TIMESTAMP`, `DATE`, `TIMESTAMP WITH TIME ZONE`, `TIME`, and `INTERVAL DAY TO SECOND` remains unchanged.
  - Fallback/risk boundaries:
    - No runtime feature flag added; behavior is type-driven through existing registration.
    - Scope is limited to `millisecond(TIME WITH TIME ZONE)` plumbing and validation.
    - No semantic changes outside this function path.

### Validation

  Commands run:

-   `cmake --build build --target velox_functions_test -j 8`
-  `./build/velox/functions/prestosql/tests/velox_functions_test --gtest_filter=DateTimeFunctionsTest.millisecondTimeWithTimezone`
-   `python3 scripts/checks/run-clang-tidy.py --commit HEAD~1 -p build <changed-files>`

  Outcome:

  - Build target completed.
  - DateTimeFunctionsTest.millisecondTimeWithTimezone passed.
  - Exit code: 0.
  - clang-tidy was run on PR-scoped files.