### PR TITLE
docs: Add CLAUDE.md and update CODING_STYLE.md

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -233,6 +233,12 @@ buffer.reserve(1024);
       i)`
     * Note that the values of v1 and v2 are already included in the exception
       message by default.
+* Put runtime information (names, values, types) at the **end** of error
+  messages, after the static description.
+
+  | ❌ Avoid | ✅ Prefer |
+  |----------|-----------|
+  | `VELOX_USER_FAIL("Column '{}' is ambiguous", name);` | `VELOX_USER_FAIL("Column is ambiguous: {}", name);` |
 
 ## Variables
 
@@ -480,3 +486,32 @@ using ContinuePromise = VeloxPromise<bool>;
   namespace) rather than a static or private method.
 * **Keep method implementations in .cpp.** Except for trivial one-liners,
   define methods in the .cpp file to keep headers small and reduce build times.
+* **Avoid default arguments** when all callers can pass values explicitly.
+
+## Tests
+
+* **Place new tests next to related existing tests**, not at the end of the
+  file. Group tests by topic (e.g., place `tryCast` next to `types`,
+  `notBetween` next to `ifClause` which uses `between`).
+* **Use gtest container matchers** (`testing::ElementsAre`, etc.) for
+  verifying collections:
+
+  ```cpp
+  // ❌ Avoid - multiple individual assertions
+  EXPECT_EQ(result.size(), 3);
+  EXPECT_EQ(result[0], "a");
+  EXPECT_EQ(result[1], "b");
+  EXPECT_EQ(result[2], "c");
+
+  // ✅ Prefer - single matcher assertion
+  EXPECT_THAT(result, testing::ElementsAre("a", "b", "c"));
+  ```
+
+  Common matchers:
+  * `ElementsAre(...)` - exact ordered match
+  * `UnorderedElementsAre(...)` - exact unordered match
+  * `Contains(...)` - at least one element matches
+  * `IsEmpty()` - collection is empty
+  * `SizeIs(n)` - collection has n elements
+
+  Requires `#include <gmock/gmock.h>`.


### PR DESCRIPTION
Summary:
Add configuration files for Claude Code and document coding style rules that were established in practice but not yet written down.

- CLAUDE.md — auto-loaded by Claude Code on every interaction in the OSS repo. Contains build/test/format commands and key coding style rules with examples. Rules are included inline (not just referenced from CODING_STYLE.md) because Claude Code only auto-loads CLAUDE.md itself, not files it references.

New rules added to CODING_STYLE.md:

- Put runtime information at the end of error messages, after the static
description.
- Avoid default arguments when all callers can pass values explicitly.
- Place new tests next to related existing tests, group by topic.
- Prefer gtest container matchers (ElementsAre, etc.) over individual
assertions.

Differential Revision: D94071637


