### PR TITLE
misc(cudf): Disable test AggregationTest.countStarGlobal pending a fix for global COUNT(*)

### DIFF
--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -426,7 +426,10 @@ TEST_F(AggregationTest, avgPartialFinalGlobal) {
   assertQuery(op, "SELECT avg(c1), avg(c2), avg(c4), avg(c5) FROM tmp");
 }
 
-TEST_F(AggregationTest, countStarGlobal) {
+// @TODO dm/se
+// Re-enable this test once we support COUNT(*) in global aggregation.
+// See issue #16492
+TEST_F(AggregationTest, DISABLED_countStarGlobal) {
   auto vectors = makeVectors(rowType_, 10, 100);
 
   createDuckDbTable(vectors);


### PR DESCRIPTION
`COUNT(*)` is only implemented for `GROUP BY` aggregrations, not global.

Re-enable this test once that is resolved.

See Issue #16492