### PR TITLE
perf: Arbitrary with clustered mode can return the input directly instead of slicing when returning the whole Vector

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -206,8 +206,13 @@ class NonNumericArbitrary : public exec::Aggregate {
           result->get()->copyRanges(currentSource->get(), copyRanges_);
         } else {
           if (copyRanges_.size() == 1 && copyRanges_[0].count == numGroups) {
-            *result = currentSource->get()->slice(
-                copyRanges_[0].sourceIndex, copyRanges_[0].count);
+            if (copyRanges_[0].sourceIndex == 0 &&
+                currentSource->get()->size() == numGroups) {
+              *result = *currentSource;
+            } else {
+              *result = currentSource->get()->slice(
+                  copyRanges_[0].sourceIndex, copyRanges_[0].count);
+            }
           } else {
             prepareGroupIndices(numGroups, result->get()->pool());
             applyToEachRange(


### PR DESCRIPTION
Summary:
Today when the Arbitrary aggregate is run in clustered mode, when it sees that output groups
are just a consecutive sequence of rows from the input, it will return a slice of the input 
Vector.

This operator can be surprisingly expensive for RowVectors with many fields as it requires
constructing new Vectors for each of the children.

It's a quick check to see if the consecutive range covers the entire length of the input Vector,
and if it is, simply return the input Vector directly. This is actually a somewhat common 
pattern where you have an Unnest followed by some operations that don't change the order 
of the rows or the values of most fields, followed by an aggregation to merge them back to 
their original rows.

Differential Revision: D94108578


