### PR TITLE
feat: Add vector_sum aggregate function using Simple API (#16498)

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -307,6 +307,33 @@ Map Aggregate Functions
     Returns the union of all the input maps summing the values of matching keys in all
     the maps. All null values in the original maps are coalesced to 0.
 
+Array Aggregate Functions
+-------------------------
+
+.. function:: vector_sum(array(T)) -> array(T)
+
+    Returns the element-wise sum of all input arrays. Equivalent to
+    ``ARRAY[SUM(a[1]), SUM(a[2]), ...]``, with the same null-handling
+    semantics as :func:`sum`: null elements are skipped, and positions
+    where all input values are null produce null in the output.
+    All input arrays must have the same length; an error is raised if
+    arrays of different lengths are encountered.
+    Supported types for T are: TINYINT, SMALLINT, INTEGER, BIGINT, REAL
+    and DOUBLE.
+    For integer types, arithmetic overflow results in an error,
+    consistent with the behavior of :func:`sum`. For floating-point
+    types (REAL, DOUBLE), NaN values propagate through the sum and
+    overflow produces Infinity, following standard IEEE 754 semantics.
+
+    This is useful when rows contain fixed-dimension vectors (e.g.
+    embedding vectors or feature arrays) and you need to compute a
+    component-wise sum across all rows::
+
+        SELECT vector_sum(embedding) FROM item_embeddings;
+
+        -- With 3 rows: [1, 2, 3], [10, 20, 30], [100, 200, 300]
+        -- Returns:     [111, 222, 333]
+
 Approximate Aggregate Functions
 -------------------------------
 

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -88,6 +88,7 @@ const char* const kTDigestAgg = "tdigest_agg";
 const char* const kVariance = "variance"; // Alias for var_samp.
 const char* const kVarPop = "var_pop";
 const char* const kVarSamp = "var_samp";
+const char* const kVectorSum = "vector_sum";
 const char* const kMaxSizeForStats = "max_data_size_for_stats";
 const char* const kSumDataSizeForStats = "sum_data_size_for_stats";
 const char* const kNoisyApproxSetSfm = "noisy_approx_set_sfm";

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -60,6 +60,7 @@ velox_add_library(
   SumDataSizeForStatsAggregate.cpp
   TDigestAggregate.cpp
   VarianceAggregates.cpp
+  VectorSumAggregate.cpp
 )
 
 velox_link_libraries(

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -57,6 +57,7 @@
 #include "velox/functions/prestosql/aggregates/SumAggregate.h"
 #include "velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.h"
 #include "velox/functions/prestosql/aggregates/VarianceAggregates.h"
+#include "velox/functions/prestosql/aggregates/VectorSumAggregate.h"
 #include "velox/functions/prestosql/types/JsonRegistration.h"
 #include "velox/functions/prestosql/types/KHyperLogLogRegistration.h"
 #include "velox/functions/prestosql/types/SetDigestRegistration.h"
@@ -338,6 +339,8 @@ void registerAllAggregateFunctions(
       overwrite);
   registerArrayAggAggregate(
       {prefix + kArrayAgg}, withCompanionFunctions, overwrite);
+  registerVectorSumAggregate(
+      {prefix + kVectorSum}, withCompanionFunctions, overwrite);
   registerAverageAggregate({prefix + kAvg}, withCompanionFunctions, overwrite);
   registerBitwiseAndAggregate(
       {prefix + kBitwiseAnd},

--- a/velox/functions/prestosql/aggregates/VectorSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/VectorSumAggregate.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/VectorSumAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/expression/FunctionSignature.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+
+template <typename T>
+inline void addToSum(T& sum, T value) {
+  if constexpr (std::is_floating_point_v<T>) {
+    sum += value;
+  } else {
+    T checkedSum;
+    auto overflow = __builtin_add_overflow(sum, value, &checkedSum);
+
+    if (UNLIKELY(overflow)) {
+      VELOX_ARITHMETIC_ERROR(
+          "integer overflow: {} + {}", (int64_t)sum, (int64_t)value);
+    }
+    sum = checkedSum;
+  }
+}
+
+/// Simple aggregate implementation for vector_sum(array(T)) -> array(T).
+/// Computes element-wise sums of arrays across rows. All input arrays must
+/// have the same length. Null elements follow standard sum aggregate semantics:
+/// they are skipped, and positions where all inputs are null produce null in
+/// the output.
+template <typename T>
+class SimpleVectorSumAggregate {
+ public:
+  using InputType = Row<Array<T>>;
+
+  using IntermediateType = Array<T>;
+
+  using OutputType = Array<T>;
+
+  struct AccumulatorType {
+    using SumsVector = std::vector<T, AlignedStlAllocator<T, 16>>;
+    SumsVector sums_;
+    /// Tracks whether each position has received at least one non-null value.
+    /// Positions where all inputs are null produce null in the output,
+    /// consistent with standard sum aggregate semantics.
+    std::vector<bool, StlAllocator<bool>> hasValue_;
+    bool initialized_{false};
+
+    AccumulatorType() = delete;
+
+    explicit AccumulatorType(
+        HashStringAllocator* allocator,
+        SimpleVectorSumAggregate* /*fn*/)
+        : sums_{AlignedStlAllocator<T, 16>(allocator)},
+          hasValue_{StlAllocator<bool>(allocator)} {}
+
+    static constexpr bool is_fixed_size_ = false;
+    static constexpr bool use_external_memory_ = true;
+
+    void addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<Array<T>> arrayInput) {
+      mergeArray(arrayInput);
+    }
+
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<Array<T>> other) {
+      mergeArray(other);
+    }
+
+    bool writeFinalResult(exec::out_type<Array<T>>& out) {
+      return writeResult(out);
+    }
+
+    bool writeIntermediateResult(exec::out_type<Array<T>>& out) {
+      return writeResult(out);
+    }
+
+   private:
+    void mergeArray(exec::arg_type<Array<T>> input) {
+      if (!initialized_) {
+        sums_.resize(input.size(), T{0});
+        hasValue_.resize(input.size(), false);
+        size_t idx = 0;
+        for (const auto& element : input) {
+          if (element.has_value()) {
+            sums_[idx] = element.value();
+            hasValue_[idx] = true;
+          }
+          ++idx;
+        }
+        initialized_ = true;
+        return;
+      }
+
+      VELOX_USER_CHECK_EQ(
+          input.size(), sums_.size(), "All arrays must have the same length.");
+
+      size_t idx = 0;
+      for (const auto& element : input) {
+        if (element.has_value()) {
+          hasValue_[idx] = true;
+          auto value = element.value();
+          if (value != T{0}) {
+            addToSum(sums_[idx], value);
+          }
+        }
+        ++idx;
+      }
+    }
+
+    bool writeResult(exec::out_type<Array<T>>& out) {
+      VELOX_DCHECK_EQ(sums_.size(), hasValue_.size());
+      if (!initialized_) {
+        return false;
+      }
+      for (size_t i = 0; i < sums_.size(); ++i) {
+        if (hasValue_[i]) {
+          out.add_item() = sums_[i];
+        } else {
+          out.add_null();
+        }
+      }
+      return true;
+    }
+  };
+};
+
+template <typename T>
+std::unique_ptr<exec::Aggregate> createSimpleVectorSumAggregate(
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& argTypes,
+    const TypePtr& resultType) {
+  return std::make_unique<
+      exec::SimpleAggregateAdapter<SimpleVectorSumAggregate<T>>>(
+      step, argTypes, resultType);
+}
+
+} // namespace
+
+void registerVectorSumAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  const std::vector<std::string> elementTypes = {
+      "tinyint", "smallint", "integer", "bigint", "double", "real"};
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  signatures.reserve(elementTypes.size());
+  for (const auto& elementType : elementTypes) {
+    // array(T) -> array(T) signature.
+    signatures.push_back(
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType(fmt::format("array({})", elementType))
+            .intermediateType(fmt::format("array({})", elementType))
+            .argumentType(fmt::format("array({})", elementType))
+            .build());
+  }
+
+  exec::registerAggregateFunction(
+      names,
+      signatures,
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(argTypes.size(), 1);
+        VELOX_CHECK(argTypes[0]->isArray());
+
+        auto& arrayType = argTypes[0]->asArray();
+        auto elementTypeKind = arrayType.elementType()->kind();
+        switch (elementTypeKind) { // NOLINT(clang-diagnostic-switch-enum)
+          case TypeKind::TINYINT:
+            return createSimpleVectorSumAggregate<int8_t>(
+                step, argTypes, resultType);
+          case TypeKind::SMALLINT:
+            return createSimpleVectorSumAggregate<int16_t>(
+                step, argTypes, resultType);
+          case TypeKind::INTEGER:
+            return createSimpleVectorSumAggregate<int32_t>(
+                step, argTypes, resultType);
+          case TypeKind::BIGINT:
+            return createSimpleVectorSumAggregate<int64_t>(
+                step, argTypes, resultType);
+          case TypeKind::REAL:
+            return createSimpleVectorSumAggregate<float>(
+                step, argTypes, resultType);
+          case TypeKind::DOUBLE:
+            return createSimpleVectorSumAggregate<double>(
+                step, argTypes, resultType);
+          default:
+            VELOX_UNREACHABLE(
+                "Unexpected element type: {}",
+                TypeKindName::toName(elementTypeKind));
+        }
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VectorSumAggregate.h
+++ b/velox/functions/prestosql/aggregates/VectorSumAggregate.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace facebook::velox::aggregate::prestosql {
+
+/// Registers the vector_sum aggregate function.
+/// vector_sum(array(T)) -> array(T)
+/// Computes element-wise sums of all input arrays. Null elements are skipped,
+/// consistent with standard sum aggregate semantics.
+void registerVectorSumAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(
   ApproxPercentileTest.cpp
   ArbitraryTest.cpp
   ArrayAggTest.cpp
+  VectorSumTest.cpp
   AverageAggregationTest.cpp
   BitwiseAggregationTest.cpp
   BoolAndOrTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/VectorSumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VectorSumTest.cpp
@@ -1,0 +1,633 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+class VectorSumTest : public AggregationTestBase {};
+
+TEST_F(VectorSumTest, global) {
+  auto data = makeRowVector({
+      makeArrayVectorFromJson<int64_t>({
+          "[1, 2, 3, 0]",
+          "[10, 5, 4, 1]",
+          "[9, null, 5, 4]",
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {20, 7, 12, 5},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, globalWithNulls) {
+  auto data = makeRowVector({
+      makeArrayVectorFromJson<int64_t>({
+          "[1, null, 3]",
+          "[10, 5, null]",
+          "[null, null, 5]",
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {11, 5, 8},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, differentLengthsThrowsError) {
+  auto data = makeRowVector({
+      makeArrayVectorFromJson<int64_t>({
+          "[1, 2]",
+          "[10, 5, 4, 1]",
+      }),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"vector_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "All arrays must have the same length.");
+}
+
+TEST_F(VectorSumTest, emptyArrays) {
+  auto allEmptyArrays = makeRowVector({
+      makeArrayVector<int64_t>({
+          {},
+          {},
+          {},
+      }),
+  });
+
+  auto expectedEmpty = makeRowVector({
+      makeArrayVector<int64_t>({
+          {},
+      }),
+  });
+
+  testAggregations({allEmptyArrays}, {}, {"vector_sum(c0)"}, {expectedEmpty});
+}
+
+TEST_F(VectorSumTest, nullArrays) {
+  auto allNullArrays = makeRowVector(
+      {BaseVector::createNullConstant(ARRAY(BIGINT()), 3, pool())});
+
+  auto expectedNull = makeRowVector(
+      {BaseVector::createNullConstant(ARRAY(BIGINT()), 1, pool())});
+
+  testAggregations({allNullArrays}, {}, {"vector_sum(c0)"}, {expectedNull});
+}
+
+TEST_F(VectorSumTest, tinyintOverflow) {
+  const std::vector<std::vector<std::optional<int8_t>>> inputData = {
+      {{10, 20}},
+      {{100, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"vector_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: 110 + 30");
+
+  const std::vector<std::vector<std::optional<int8_t>>> negInputData = {
+      {{-10, -20}},
+      {{-100, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"vector_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: -110 + -30");
+}
+
+TEST_F(VectorSumTest, smallintOverflow) {
+  const int16_t largeValue = std::numeric_limits<int16_t>::max() - 20;
+  const int16_t smallValue = std::numeric_limits<int16_t>::min() + 20;
+
+  const std::vector<std::vector<std::optional<int16_t>>> inputData = {
+      {{10, 20}},
+      {{largeValue, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"vector_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: 32757 + 30");
+
+  const std::vector<std::vector<std::optional<int16_t>>> negInputData = {
+      {{-10, -20}},
+      {{smallValue, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"vector_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: -32758 + -30");
+}
+
+TEST_F(VectorSumTest, integerOverflow) {
+  const int32_t largeValue = std::numeric_limits<int32_t>::max() - 20;
+  const int32_t smallValue = std::numeric_limits<int32_t>::min() + 20;
+
+  const std::vector<std::vector<std::optional<int32_t>>> inputData = {
+      {{10, 20}},
+      {{largeValue, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"vector_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: 2147483637 + 30");
+
+  const std::vector<std::vector<std::optional<int32_t>>> negInputData = {
+      {{-10, -20}},
+      {{smallValue, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"vector_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: -2147483638 + -30");
+}
+
+TEST_F(VectorSumTest, bigintOverflow) {
+  const int64_t largeValue = std::numeric_limits<int64_t>::max() - 20;
+  const int64_t smallValue = std::numeric_limits<int64_t>::min() + 20;
+
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{10, 20}},
+      {{largeValue, 30}},
+      {{30, 50}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"vector_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: 9223372036854775797 + 30");
+
+  const std::vector<std::vector<std::optional<int64_t>>> negInputData = {
+      {{-10, -20}},
+      {{smallValue, -30}},
+      {{-30, -50}},
+  };
+  data = makeRowVector({makeNullableArrayVector(negInputData)});
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({}, {"vector_sum(c0)"})
+             .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "integer overflow: -9223372036854775798 + -30");
+}
+
+TEST_F(VectorSumTest, floatNan) {
+  constexpr float kInf = std::numeric_limits<float>::infinity();
+  constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+
+  const std::vector<std::vector<std::optional<float>>> inputData = {
+      {{10.0F, 20.0F}},
+      {{kNan, 30.0F}},
+      {{30.0F, kInf}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({
+          {kNan, kInf},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, doubleNan) {
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
+
+  const std::vector<std::vector<std::optional<double>>> inputData = {
+      {{10.0, 20.0}},
+      {{kNan, 30.0}},
+      {{30.0, kInf}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({
+          {kNan, kInf},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, groupBy) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData1 = {
+      {{1, 2, 3}},
+  };
+  const std::vector<std::vector<std::optional<int64_t>>> inputData2 = {
+      {{10, 5, 4}},
+  };
+  const std::vector<std::vector<std::optional<int64_t>>> inputData3 = {
+      {{1, 2, 7}},
+  };
+  const std::vector<std::vector<std::optional<int64_t>>> inputData4 = {
+      {{9, 0, 5}},
+  };
+
+  auto batch1 = makeRowVector({
+      makeFlatVector<int64_t>({1}),
+      makeNullableArrayVector(inputData1),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int64_t>({1}),
+      makeNullableArrayVector(inputData2),
+  });
+  auto batch3 = makeRowVector({
+      makeFlatVector<int64_t>({2}),
+      makeNullableArrayVector(inputData3),
+  });
+  auto batch4 = makeRowVector({
+      makeFlatVector<int64_t>({1}),
+      makeNullableArrayVector(inputData4),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int64_t>({
+          {20, 7, 12},
+          {1, 2, 7},
+      }),
+  });
+
+  testAggregations(
+      {batch1, batch2, batch3, batch4}, {"c0"}, {"vector_sum(c1)"}, {expected});
+}
+
+TEST_F(VectorSumTest, zerosSkipped) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{0, 0, 0, 0}},
+      {{0, 0, 0, 0}},
+      {{0, 0, 0, 0}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {0, 0, 0, 0},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, mixedZerosNullsAndValues) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{0, std::nullopt, 5, 0}},
+      {{std::nullopt, 0, 0, 3}},
+      {{7, 0, std::nullopt, 0}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {7, 0, 5, 3},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, allZerosAndNulls) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{0, std::nullopt}},
+      {{std::nullopt, 0}},
+      {{0, 0}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {0, 0},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, zerosWithFloats) {
+  const std::vector<std::vector<std::optional<float>>> inputData = {
+      {{0.0F, 1.5F, 0.0F}},
+      {{3.5F, 0.0F, 0.0F}},
+      {{0.0F, 0.0F, 2.5F}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({
+          {3.5F, 1.5F, 2.5F},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, zerosWithDoubles) {
+  const std::vector<std::vector<std::optional<double>>> inputData = {
+      {{0.0, 1.5, 0.0}},
+      {{3.5, 0.0, 0.0}},
+      {{0.0, 0.0, 2.5}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({
+          {3.5, 1.5, 2.5},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, singleElement) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{100}},
+      {{200}},
+      {{300}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {600},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, allNullElements) {
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt}},
+      {{std::nullopt, std::nullopt}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  const std::vector<std::vector<std::optional<int64_t>>> expectedData = {
+      {{std::nullopt, std::nullopt}},
+  };
+  auto expected = makeRowVector({makeNullableArrayVector(expectedData)});
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, realType) {
+  const std::vector<std::vector<std::optional<float>>> inputData = {
+      {{1.5F, 2.5F, 0.0F}},
+      {{10.5F, 5.5F, 4.0F}},
+      {{9.0F, std::nullopt, 5.5F}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({
+          {21.0F, 8.0F, 9.5F},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, doubleType) {
+  const std::vector<std::vector<std::optional<double>>> inputData = {
+      {{1.5, 2.5, 0.0}},
+      {{10.5, 5.5, 4.0}},
+      {{9.0, std::nullopt, 5.5}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({
+          {21.0, 8.0, 9.5},
+      }),
+  });
+
+  testAggregations({data}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+TEST_F(VectorSumTest, multipleBatches) {
+  auto batch1 = makeRowVector({
+      makeArrayVector<int64_t>({{1, 2, 3}, {4, 5, 6}}),
+  });
+  auto batch2 = makeRowVector({
+      makeArrayVector<int64_t>({{10, 20, 30}, {40, 50, 60}}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{55, 77, 99}}),
+  });
+
+  testAggregations({batch1, batch2}, {}, {"vector_sum(c0)"}, {expected});
+}
+
+/// SQL equivalence tests verify vector_sum results by comparing against
+/// element-wise sums computed using individual sum() aggregations.
+/// This verifies that vector_sum(array[a,b,c]) equals array[sum(a), sum(b),
+/// sum(c)] when arrays are of equal length.
+class VectorSumSqlEquivalenceTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+};
+
+TEST_F(VectorSumSqlEquivalenceTest, equivalentToElementWiseSum) {
+  // Create data where we can verify vector_sum against element-wise sums.
+  // If we have rows with arrays [a0, a1], [b0, b1], [c0, c1]
+  // then vector_sum should equal [a0+b0+c0, a1+b1+c1]
+  // which is [sum of first elements, sum of second elements]
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({{1, 2}, {10, 20}, {100, 200}}),
+  });
+
+  // vector_sum result
+  auto vectorSumResult = AssertQueryBuilder(
+                             PlanBuilder()
+                                 .values({data})
+                                 .singleAggregation({}, {"vector_sum(c0)"})
+                                 .planNode())
+                             .copyResults(pool());
+
+  // Expected: [1+10+100, 2+20+200] = [111, 222]
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{111, 222}}),
+  });
+
+  assertEqualResults({expected}, {vectorSumResult});
+}
+
+TEST_F(VectorSumSqlEquivalenceTest, groupByEquivalence) {
+  // For group by, vector_sum should accumulate arrays within each group.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeArrayVector<int64_t>({{1, 2}, {10, 20}, {100, 200}, {1000, 2000}}),
+  });
+
+  auto vectorSumResult = AssertQueryBuilder(
+                             PlanBuilder()
+                                 .values({data})
+                                 .singleAggregation({"c0"}, {"vector_sum(c1)"})
+                                 .planNode())
+                             .copyResults(pool());
+
+  // Group 1: [1,2] + [10,20] = [11, 22]
+  // Group 2: [100,200] + [1000,2000] = [1100, 2200]
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int64_t>({{11, 22}, {1100, 2200}}),
+  });
+
+  assertEqualResults({expected}, {vectorSumResult});
+}
+
+TEST_F(VectorSumSqlEquivalenceTest, floatingPointPrecision) {
+  // Verify floating point accumulation works correctly
+  auto data = makeRowVector({
+      makeArrayVector<double>({{0.1, 0.2}, {0.3, 0.4}, {0.5, 0.6}}),
+  });
+
+  auto vectorSumResult = AssertQueryBuilder(
+                             PlanBuilder()
+                                 .values({data})
+                                 .singleAggregation({}, {"vector_sum(c0)"})
+                                 .planNode())
+                             .copyResults(pool());
+
+  // Expected: [0.1+0.3+0.5, 0.2+0.4+0.6] = [0.9, 1.2]
+  auto expected = makeRowVector({
+      makeArrayVector<double>({{0.9, 1.2}}),
+  });
+
+  assertEqualResults({expected}, {vectorSumResult});
+}
+
+TEST_F(VectorSumSqlEquivalenceTest, nullElementsSkipped) {
+  // Null elements are skipped, consistent with standard sum aggregate.
+  // Only positions where ALL inputs are null produce null in the output.
+  const std::vector<std::vector<std::optional<int64_t>>> inputData = {
+      {{1, std::nullopt, 3}},
+      {{10, 20, std::nullopt}},
+      {{std::nullopt, 30, 40}},
+  };
+  auto data = makeRowVector({makeNullableArrayVector(inputData)});
+
+  auto vectorSumResult = AssertQueryBuilder(
+                             PlanBuilder()
+                                 .values({data})
+                                 .singleAggregation({}, {"vector_sum(c0)"})
+                                 .planNode())
+                             .copyResults(pool());
+
+  // Expected: [1+10, 20+30, 3+40] = [11, 50, 43]
+  // Nulls are skipped (not treated as 0); all positions have at least
+  // one non-null value so no output element is null.
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{11, 50, 43}}),
+  });
+
+  assertEqualResults({expected}, {vectorSumResult});
+}
+
+TEST_F(VectorSumSqlEquivalenceTest, differentLengthArraysThrowsError) {
+  // Arrays of different lengths now throw an error
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({{1, 2, 3, 4}, {10, 20}, {100}}),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"vector_sum(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "All arrays must have the same length.");
+}
+
+} // namespace
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
+++ b/velox/functions/prestosql/fuzzer/AggregationFuzzerTest.cpp
@@ -265,6 +265,8 @@ int main(int argc, char** argv) {
           {"convex_hull_agg_merge_extract", nullptr},
           {"make_set_digest", std::make_shared<SetDigestResultVerifier>()},
           {"merge_set_digest", std::make_shared<SetDigestResultVerifier>()},
+          // Velox-only function, not available in Presto.
+          {"vector_sum", nullptr},
       };
 
   using Runner = facebook::velox::exec::test::AggregationFuzzerRunner;


### PR DESCRIPTION
Summary:

Motivation

This introduces vector_sum, a new aggregate function that computes element-wise sums of arrays across rows. It addresses both usability and performance needs:

UX: Today, computing element-wise sums across array-typed columns requires manually unnesting arrays, aggregating individual elements by position, and re-assembling the result — a verbose and error-prone pattern. vector_sum reduces this to a single function call: vector_sum(array_column).

Performance: For large aggregation workloads (e.g., summing embedding vectors, histogram bins, or feature arrays across millions of rows), vector_sum avoids the overhead of N separate sum() aggregations plus the unnest/re-nest scaffolding. A single native C++ pass over the data is significantly more efficient, particularly for high-dimensional arrays.

Function signature

vector_sum(array(T)) -> array(T)

Supported element types: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE.

Semantics

Null handling follows standard sum aggregate semantics:

Null array elements are skipped (not coerced to zero).
Positions where all inputs are null produce null in the output array.
Positions with at least one non-null input produce the sum of non-null values.
All input arrays must have the same length; a user error is raised if a length mismatch is detected.

Integer types include overflow checking via __builtin_add_overflow.

Implementation

Uses SimpleAggregateAdapter for a cleaner, less error-prone implementation. This is a Velox-only function (not available in Presto) and is added to the expression fuzzer skip lists accordingly.

https://github.com/facebookincubator/velox/issues/16756

Reviewed By: kaikalur

Differential Revision: D94039944


