### PR TITLE
feat(cuDF): Register `not` in cuDF function registry

### DIFF
--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -260,6 +260,23 @@ class CardinalityFunction : public CudfFunction {
   }
 };
 
+class NotFunction : public CudfFunction {
+ public:
+  NotFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
+    VELOX_CHECK_EQ(expr->inputs().size(), 1, "not expects exactly 1 input");
+    VELOX_CHECK(
+        expr->inputs()[0]->type()->isBoolean(), "not expects a boolean input");
+  }
+
+  ColumnOrView eval(
+      std::vector<ColumnOrView>& inputColumns,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const override {
+    auto inputCol = asView(inputColumns[0]);
+    return cudf::unary_operation(inputCol, cudf::unary_operator::NOT, stream);
+  }
+};
+
 class RoundFunction : public CudfFunction {
  public:
   explicit RoundFunction(const std::shared_ptr<velox::exec::Expr>& expr) {
@@ -842,6 +859,16 @@ bool registerBuiltinFunctions(const std::string& prefix) {
       {FunctionSignatureBuilder()
            .returnType("integer")
            .argumentType("array(any)")
+           .build()});
+
+  registerCudfFunction(
+      prefix + "not",
+      [](const std::string&, const std::shared_ptr<velox::exec::Expr>& expr) {
+        return std::make_shared<NotFunction>(expr);
+      },
+      {FunctionSignatureBuilder()
+           .returnType("boolean")
+           .argumentType("boolean")
            .build()});
 
   registerCudfFunctions(


### PR DESCRIPTION
### Motivation
Presto's planner and optimizer build `not(...)` call expressions during analysis and rewrite phases and resolve them using functions in the active function namespace. In native execution, the function namespace is populated from the sidecar's `/v1/functions` endpoint and when cuDF execution is enabled this list contains cuDF functions only. If `not` is missing in this list, function resolution fails on coordinator for simple queries with sidecar.

### Change
Adding `not` to the cuDF built-in registry ensures it appears in the sidecar's function list and is resolvable during planning in cuDF-backed Presto C++ deployments with sidecar. 