### PR TITLE
feat(cuDF): Support function signature retrieval from registry

### DIFF
--- a/velox/experimental/cudf/exec/AggregationRegistry.cpp
+++ b/velox/experimental/cudf/exec/AggregationRegistry.cpp
@@ -16,6 +16,10 @@
 
 #include "velox/experimental/cudf/exec/AggregationRegistry.h"
 
+#include <algorithm>
+#include <optional>
+#include <unordered_set>
+
 namespace facebook::velox::cudf_velox {
 
 namespace {
@@ -28,6 +32,125 @@ void appendAggregationFunctionForStep(
   registry[name][step].push_back(signature);
 }
 
+std::string makeSignatureKey(const exec::FunctionSignaturePtr& signature) {
+  std::string key = signature->variableArity() ? "variadic|" : "fixed|";
+  const auto& argumentTypes = signature->argumentTypes();
+  const auto& constantArguments = signature->constantArguments();
+  for (size_t i = 0; i < argumentTypes.size(); ++i) {
+    const bool isConstantArg =
+        i < constantArguments.size() && constantArguments[i];
+    key.append(isConstantArg ? "constant:" : "argument:");
+    key.append(argumentTypes[i].toString());
+    key.push_back('|');
+  }
+  return key;
+}
+
+exec::AggregateFunctionSignaturePtr buildAggregateSignature(
+    const exec::FunctionSignaturePtr& singleSignature,
+    const exec::FunctionSignaturePtr& partialSignature) {
+  exec::AggregateFunctionSignatureBuilder builder;
+
+  // Preserve declared signature variables.
+  for (const auto& [_, variable] : singleSignature->variables()) {
+    if (variable.isTypeParameter()) {
+      if (variable.knownTypesOnly()) {
+        builder.knownTypeVariable(variable.name());
+      } else if (variable.orderableTypesOnly()) {
+        builder.orderableTypeVariable(variable.name());
+      } else if (variable.comparableTypesOnly()) {
+        builder.comparableTypeVariable(variable.name());
+      } else {
+        builder.typeVariable(variable.name());
+      }
+    } else if (variable.isIntegerParameter()) {
+      builder.integerVariable(
+          variable.name(),
+          variable.constraint().empty()
+              ? std::nullopt
+              : std::make_optional(variable.constraint()));
+    }
+  }
+
+  builder.returnType(singleSignature->returnType().toString());
+  builder.intermediateType(partialSignature->returnType().toString());
+
+  const auto& argumentTypes = singleSignature->argumentTypes();
+  const auto& constantArguments = singleSignature->constantArguments();
+  for (size_t argIndex = 0; argIndex < argumentTypes.size(); ++argIndex) {
+    const auto argType = argumentTypes[argIndex].toString();
+    const bool isConstantArg =
+        argIndex < constantArguments.size() && constantArguments[argIndex];
+    if (isConstantArg) {
+      builder.constantArgumentType(argType);
+    } else {
+      builder.argumentType(argType);
+    }
+  }
+
+  if (singleSignature->variableArity()) {
+    builder.variableArity();
+  }
+
+  return builder.build();
+}
+
+void appendAggregateFunctionSignatures(
+    const StepAwareAggregationRegistry& registry,
+    exec::AggregateFunctionSignatureMap& result) {
+  for (const auto& [name, stepMap] : registry) {
+    const auto singleIt = stepMap.find(core::AggregationNode::Step::kSingle);
+    const auto partialIt = stepMap.find(core::AggregationNode::Step::kPartial);
+
+    // We need both single (for return type) and partial (for intermediate
+    // type) signatures to build AggregateFunctionSignature entries.
+    if (singleIt == stepMap.end() || partialIt == stepMap.end()) {
+      continue;
+    }
+
+    const auto& singleSignatures = singleIt->second;
+    const auto& partialSignatures = partialIt->second;
+    if (singleSignatures.empty() || partialSignatures.empty()) {
+      continue;
+    }
+
+    std::unordered_map<std::string, exec::FunctionSignaturePtr>
+        singleSignatureIndex;
+    for (const auto& signature : singleSignatures) {
+      singleSignatureIndex.emplace(makeSignatureKey(signature), signature);
+    }
+
+    std::unordered_map<std::string, exec::FunctionSignaturePtr>
+        partialSignatureIndex;
+    for (const auto& signature : partialSignatures) {
+      partialSignatureIndex.emplace(makeSignatureKey(signature), signature);
+    }
+
+    auto& aggregateSignatures = result[name];
+    std::unordered_set<std::string> existingSignatures;
+    for (const auto& signature : aggregateSignatures) {
+      existingSignatures.insert(signature->toString());
+    }
+
+    for (const auto& [key, singleSignature] : singleSignatureIndex) {
+      auto partialMatchIt = partialSignatureIndex.find(key);
+      if (partialMatchIt == partialSignatureIndex.end()) {
+        continue;
+      }
+
+      auto aggregateSignature =
+          buildAggregateSignature(singleSignature, partialMatchIt->second);
+      if (existingSignatures.insert(aggregateSignature->toString()).second) {
+        aggregateSignatures.push_back(std::move(aggregateSignature));
+      }
+    }
+
+    if (aggregateSignatures.empty()) {
+      result.erase(name);
+    }
+  }
+}
+
 } // namespace
 
 StepAwareAggregationRegistry& getGroupbyAggregationRegistry() {
@@ -38,6 +161,13 @@ StepAwareAggregationRegistry& getGroupbyAggregationRegistry() {
 StepAwareAggregationRegistry& getReduceAggregationRegistry() {
   static StepAwareAggregationRegistry registry;
   return registry;
+}
+
+exec::AggregateFunctionSignatureMap getCudfAggregationFunctionSignatureMap() {
+  exec::AggregateFunctionSignatureMap result;
+  appendAggregateFunctionSignatures(getGroupbyAggregationRegistry(), result);
+  appendAggregateFunctionSignatures(getReduceAggregationRegistry(), result);
+  return result;
 }
 
 bool registerAggregationFunctionForStep(

--- a/velox/experimental/cudf/exec/AggregationRegistry.h
+++ b/velox/experimental/cudf/exec/AggregationRegistry.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanNode.h"
+#include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 
 #include <string>
@@ -36,6 +37,10 @@ using StepAwareAggregationRegistry = std::unordered_map<
 /// Runtime aggregation registries keyed by physical execution kind.
 StepAwareAggregationRegistry& getGroupbyAggregationRegistry();
 StepAwareAggregationRegistry& getReduceAggregationRegistry();
+
+/// Return aggregate function signatures exported from CUDF registries.
+/// Exhaustive expression metadata for AST/JIT evaluators is follow-up work.
+exec::AggregateFunctionSignatureMap getCudfAggregationFunctionSignatureMap();
 
 /// Shared registration helpers used to populate a target physical registry.
 bool registerAggregationFunctionForStep(

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.cpp
@@ -266,6 +266,26 @@ static bool matchCallAgainstSignatures(
 
 } // namespace
 
+// Get function signatures map from the CUDF registry
+std::unordered_map<std::string, std::vector<const exec::FunctionSignature*>>
+getCudfFunctionSignatureMap() {
+  std::unordered_map<std::string, std::vector<const exec::FunctionSignature*>>
+      result;
+  const auto& registry = getCudfFunctionRegistry();
+
+  for (const auto& [name, spec] : registry) {
+    std::vector<const exec::FunctionSignature*> signatures;
+    for (const auto& sig : spec.signatures) {
+      signatures.push_back(sig.get());
+    }
+    if (!signatures.empty()) {
+      result[name] = signatures;
+    }
+  }
+
+  return result;
+}
+
 class SplitFunction : public CudfFunction {
  public:
   SplitFunction(const std::shared_ptr<velox::exec::Expr>& expr) {

--- a/velox/experimental/cudf/expression/ExpressionEvaluator.h
+++ b/velox/experimental/cudf/expression/ExpressionEvaluator.h
@@ -95,6 +95,12 @@ bool registerBuiltinFunctions(const std::string& prefix);
 
 void unregisterFunctions();
 
+// Returns standalone cuDF function signatures. AST and JIT expression
+// evaluators do not expose signature registries and are checked dynamically via
+// canEvaluate; adding exhaustive AST/JIT metadata is left as follow-up work.
+std::unordered_map<std::string, std::vector<const exec::FunctionSignature*>>
+getCudfFunctionSignatureMap();
+
 class CudfExpression {
  public:
   virtual ~CudfExpression() = default;

--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -283,6 +283,23 @@ TEST_F(CudfExpressionSelectionTest, signatureTypeVariableSwitchIf) {
   ASSERT_TRUE(canBeEvaluatedByCudf(ok1, /*deep=*/true));
 }
 
+TEST_F(CudfExpressionSelectionTest, scalarSignatureExportSanity) {
+  auto signatureMap = getCudfFunctionSignatureMap();
+
+  auto coalesceIt = signatureMap.find("coalesce");
+  ASSERT_NE(coalesceIt, signatureMap.end());
+  ASSERT_FALSE(coalesceIt->second.empty());
+
+  bool foundCoalesceVarArg = false;
+  for (const auto* signature : coalesceIt->second) {
+    if (signature->toString().find("...") != std::string::npos) {
+      foundCoalesceVarArg = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(foundCoalesceVarArg);
+}
+
 TEST_F(CudfExpressionSelectionTest, DISABLED_castAndTryCast) {
   // TODO (dm): This is required for passing of castAndTryCast test but breaks
   // others. This is because ASTExpr agrees to support bad casts. remove after

--- a/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
+++ b/velox/experimental/cudf/tests/StepAwareAggregationRegistryTest.cpp
@@ -551,4 +551,93 @@ TEST_F(
       getReduceAggregationRegistry().end());
 }
 
+TEST_F(StepAwareAggregationRegistryTest, aggregateSignatureMap) {
+  auto exportedMap = getCudfAggregationFunctionSignatureMap();
+  auto avgIt = exportedMap.find("avg");
+  ASSERT_NE(avgIt, exportedMap.end());
+  ASSERT_FALSE(avgIt->second.empty());
+
+  bool foundDoubleToRowIntermediate = false;
+  for (const auto& sig : avgIt->second) {
+    if (sig->argumentTypes().size() == 1 &&
+        sig->argumentTypes()[0].toString() == "double" &&
+        sig->returnType().toString() == "double" &&
+        sig->intermediateType().toString() == "row(double,bigint)") {
+      foundDoubleToRowIntermediate = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(foundDoubleToRowIntermediate);
+}
+
+TEST_F(
+    StepAwareAggregationRegistryTest,
+    aggregateSignatureMapDeterministicKeyMatching) {
+  using exec::FunctionSignatureBuilder;
+
+  const std::string functionName = "deterministic_pairing";
+
+  registerAggregationFunctionForStep(
+      getGroupbyAggregationRegistry(),
+      functionName,
+      core::AggregationNode::Step::kSingle,
+      {
+          FunctionSignatureBuilder()
+              .returnType("bigint")
+              .argumentType("integer")
+              .build(),
+          FunctionSignatureBuilder()
+              .returnType("double")
+              .argumentType("double")
+              .build(),
+      });
+
+  // Reverse order + add an unmatched signature to verify we pair by key,
+  // not by vector position, and we do not silently truncate by index.
+  registerAggregationFunctionForStep(
+      getGroupbyAggregationRegistry(),
+      functionName,
+      core::AggregationNode::Step::kPartial,
+      {
+          FunctionSignatureBuilder()
+              .returnType("varbinary")
+              .argumentType("double")
+              .build(),
+          FunctionSignatureBuilder()
+              .returnType("varchar")
+              .argumentType("integer")
+              .build(),
+          FunctionSignatureBuilder()
+              .returnType("boolean")
+              .argumentType("real")
+              .build(),
+      });
+
+  auto exportedMap = getCudfAggregationFunctionSignatureMap();
+  auto it = exportedMap.find(functionName);
+  ASSERT_NE(it, exportedMap.end());
+
+  const auto& aggregateSigs = it->second;
+  ASSERT_EQ(aggregateSigs.size(), 2);
+
+  bool matchedInteger = false;
+  bool matchedDouble = false;
+  for (const auto& sig : aggregateSigs) {
+    ASSERT_EQ(sig->argumentTypes().size(), 1);
+    const auto argType = sig->argumentTypes()[0].toString();
+    if (argType == "integer") {
+      EXPECT_EQ(sig->returnType().toString(), "bigint");
+      EXPECT_EQ(sig->intermediateType().toString(), "varchar");
+      matchedInteger = true;
+    } else if (argType == "double") {
+      EXPECT_EQ(sig->returnType().toString(), "double");
+      EXPECT_EQ(sig->intermediateType().toString(), "varbinary");
+      matchedDouble = true;
+    }
+  }
+
+  EXPECT_TRUE(matchedInteger);
+  EXPECT_TRUE(matchedDouble);
+}
+
 } // namespace facebook::velox::cudf_velox


### PR DESCRIPTION
## Summary
- Expose the cuDF scalar function registry so Velox can surface fully-qualified function names together with their `exec::FunctionSignature` metadata.
- Add utilities that convert the cuDF scalar and aggregation registries into `FunctionSignatureMap` / `AggregateFunctionSignatureMap`, reusing the existing signature builders to preserve type variables, intermediate types, and varargs info.
- Make these maps available to higher layers (e.g., Presto native sidecar) so external engines can be made aware of GPU function capabilities.

## Motivation
Presto’s native sidecar plugin needs to enumerate function signatures to manage cuDF functions, this is achieved via the [`/v1/functions`](https://prestodb.io/docs/current/presto_cpp/sidecar.html#GET-v1-functions) endpoint on the Presto C++ sidecar. This Velox change exposes cuDF functions metadata to Presto via the sidecar, allowing for seamless integration of cuDF functions into Presto. Making the coordinator aware of function signatures supported for cuDF execution enables intelligent execution-aware planning and unlocks fail-fast behavior.