### PR TITLE
fix: Check for corrupted repeat/define lengths in Parquet headers (#16511)

### DIFF
--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -65,11 +65,13 @@ class PageReader {
       common::CompressionKind codec,
       int64_t chunkSize,
       dwio::common::ColumnReaderStatistics& stats,
-      const tz::TimeZone* sessionTimezone = nullptr)
+      const tz::TimeZone* sessionTimezone = nullptr,
+      int32_t maxRepeat = 0,
+      int32_t maxDefine = 1)
       : pool_(pool),
         inputStream_(std::move(stream)),
-        maxRepeat_(0),
-        maxDefine_(1),
+        maxRepeat_(maxRepeat),
+        maxDefine_(maxDefine),
         isTopLevel_(maxRepeat_ == 0 && maxDefine_ <= 1),
         codec_(codec),
         chunkSize_(chunkSize),

--- a/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -15,7 +15,12 @@
  */
 
 #include "velox/dwio/parquet/reader/PageReader.h"
+
+#include <thrift/protocol/TCompactProtocol.h>
+#include <thrift/transport/TBufferTransports.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/parquet/tests/ParquetTestBase.h"
+#include "velox/dwio/parquet/thrift/ParquetThriftTypes.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::common;
@@ -115,4 +120,317 @@ TEST(CompressionOptionsTest, testCompressionOptions) {
   EXPECT_EQ(
       options.format.zlib.windowBits,
       dwio::common::compression::Compressor::PARQUET_ZLIB_WINDOW_BITS);
+}
+
+namespace {
+
+// Helper to serialize a PageHeader using Thrift compact protocol.
+std::string serializePageHeader(const thrift::PageHeader& header) {
+  auto transport = std::make_shared<apache::thrift::transport::TMemoryBuffer>();
+  apache::thrift::protocol::TCompactProtocolT<
+      apache::thrift::transport::TMemoryBuffer>
+      protocol(transport);
+  header.write(&protocol);
+  return transport->getBufferAsString();
+}
+
+// Helper to create a DATA_PAGE header with specified sizes.
+thrift::PageHeader createDataPageV1Header(
+    int32_t uncompressedSize,
+    int32_t compressedSize,
+    int32_t numValues) {
+  thrift::PageHeader header;
+  header.__set_type(thrift::PageType::DATA_PAGE);
+  header.__set_uncompressed_page_size(uncompressedSize);
+  header.__set_compressed_page_size(compressedSize);
+
+  thrift::DataPageHeader dataHeader;
+  dataHeader.__set_num_values(numValues);
+  dataHeader.__set_encoding(thrift::Encoding::PLAIN);
+  dataHeader.__set_definition_level_encoding(thrift::Encoding::RLE);
+  dataHeader.__set_repetition_level_encoding(thrift::Encoding::RLE);
+  header.__set_data_page_header(dataHeader);
+
+  return header;
+}
+
+// Helper to create a DATA_PAGE_V2 header with specified sizes.
+thrift::PageHeader createDataPageV2Header(
+    int32_t uncompressedSize,
+    int32_t compressedSize,
+    int32_t numValues,
+    int32_t definitionLevelsByteLength,
+    int32_t repetitionLevelsByteLength) {
+  thrift::PageHeader header;
+  header.__set_type(thrift::PageType::DATA_PAGE_V2);
+  header.__set_uncompressed_page_size(uncompressedSize);
+  header.__set_compressed_page_size(compressedSize);
+
+  thrift::DataPageHeaderV2 dataHeader;
+  dataHeader.__set_num_values(numValues);
+  dataHeader.__set_num_nulls(0);
+  dataHeader.__set_num_rows(numValues);
+  dataHeader.__set_encoding(thrift::Encoding::PLAIN);
+  dataHeader.__set_definition_levels_byte_length(definitionLevelsByteLength);
+  dataHeader.__set_repetition_levels_byte_length(repetitionLevelsByteLength);
+  dataHeader.__set_is_compressed(false);
+  header.__set_data_page_header_v2(dataHeader);
+
+  return header;
+}
+
+} // namespace
+
+// Test that prepareDataPageV1 rejects pages with defineLength exceeding page
+// size. This guards against heap buffer overflow from corrupt Parquet files.
+TEST_F(ParquetPageReaderTest, corruptDefineLengthV1) {
+  // Create a DATA_PAGE header with small page size.
+  constexpr int32_t kPageSize = 20;
+  auto pageHeader = createDataPageV1Header(kPageSize, kPageSize, 100);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Create corrupt page data where defineLength (first 4 bytes after
+  // decompression for maxDefine > 0) is huge. Since compression is NONE, the
+  // "decompressed" data is the raw page data.
+  std::string pageData(kPageSize, '\0');
+  // Set defineLength to a huge value (0x7FFFFFF0) that exceeds page size.
+  uint32_t corruptDefineLength = 0x7FFFFFF0;
+  memcpy(pageData.data(), &corruptDefineLength, sizeof(uint32_t));
+
+  // Combine header and page data.
+  std::string fullData = headerBytes + pageData;
+
+  // Create an input stream from the crafted data.
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  // Create PageReader with maxRepeat=0, maxDefine=1 (so defineLength is read)
+  // and no compression (so page data is used directly).
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      0,
+      1);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV1().
+  // The bounds check should throw when defineLength exceeds page size.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1), "Definition level length 2147483632 exceeds");
+}
+
+// Test that prepareDataPageV1 rejects pages with repeatLength exceeding page
+// size. This guards against heap buffer overflow from corrupt Parquet files.
+TEST_F(ParquetPageReaderTest, corruptRepeatLengthV1) {
+  // Create a DATA_PAGE header with small page size.
+  constexpr int32_t kPageSize = 20;
+  auto pageHeader = createDataPageV1Header(kPageSize, kPageSize, 100);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Create corrupt page data where repeatLength (first 4 bytes after
+  // decompression for maxRepeat > 0) is huge. Since compression is NONE, the
+  // "decompressed" data is the raw page data.
+  std::string pageData(kPageSize, '\0');
+  // Set repeatLength to a huge value (0x7FFFFFF0) that exceeds page size.
+  uint32_t corruptRepeatLength = 0x7FFFFFF0;
+  memcpy(pageData.data(), &corruptRepeatLength, sizeof(uint32_t));
+
+  // Combine header and page data.
+  std::string fullData = headerBytes + pageData;
+
+  // Create an input stream from the crafted data.
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  // Create PageReader with maxRepeat=1 (so repeatLength is read), maxDefine=0,
+  // and no compression (so page data is used directly).
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      0);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV1().
+  // The bounds check should throw when repeatLength exceeds page size.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1), "Repetition level length 2147483632 exceeds");
+}
+
+// Test that prepareDataPageV2 rejects pages where repetition + definition
+// level lengths exceed compressed page size.
+TEST_F(ParquetPageReaderTest, corruptLevelLengthsV2) {
+  // Create a DATA_PAGE_V2 header with small page size but huge level lengths.
+  constexpr int32_t kPageSize = 20;
+  // Set level lengths that exceed the page size.
+  constexpr int32_t kCorruptRepeatLength = 0x7FFFFFF0;
+  constexpr int32_t kCorruptDefineLength = 100;
+  auto pageHeader = createDataPageV2Header(
+      kPageSize, kPageSize, 100, kCorruptDefineLength, kCorruptRepeatLength);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Create page data (content doesn't matter since validation should fail
+  // before reading it).
+  std::string pageData(kPageSize, '\0');
+
+  // Combine header and page data.
+  std::string fullData = headerBytes + pageData;
+
+  // Create an input stream from the crafted data.
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  // maxRepeat and maxDefine don't affect V2 validation since the lengths
+  // are in the header, not the page data.
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      1);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV2().
+  // The bounds check should throw when level lengths exceed page size.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1),
+      "Repetition and definition level lengths (2147483632 + 100) exceed");
+}
+
+// Test that prepareDataPageV1 rejects pages that are too small to contain
+// the repetition level length field (4 bytes).
+TEST_F(ParquetPageReaderTest, insufficientBytesForRepeatLengthV1) {
+  // Create a DATA_PAGE header with page size too small for the 4-byte
+  // repetition level length field.
+  constexpr int32_t kPageSize = 2; // Less than sizeof(int32_t)
+  auto pageHeader = createDataPageV1Header(kPageSize, kPageSize, 100);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Create minimal page data.
+  std::string pageData(kPageSize, '\0');
+
+  // Combine header and page data.
+  std::string fullData = headerBytes + pageData;
+
+  // Create an input stream from the crafted data.
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  // PageReader with maxRepeat > 0 would try to read repeatLength but page
+  // is too small.
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      0);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV1().
+  // The bounds check should throw when page is too small to hold repeatLength.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1), "Insufficient bytes for repetition level length");
+}
+
+// Test that prepareDataPageV1 rejects pages where there are insufficient bytes
+// remaining for the definition level length field after reading repetition
+// levels.
+TEST_F(ParquetPageReaderTest, insufficientBytesForDefineLengthV1) {
+  // Create a DATA_PAGE header with page size that can hold repetition level
+  // length (4 bytes) plus a small repeatLength value, but not enough remaining
+  // for the definition level length field.
+  constexpr int32_t kPageSize = 6; // 4 bytes for repeatLength field + 2 bytes
+  auto pageHeader = createDataPageV1Header(kPageSize, kPageSize, 100);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Create page data with a small repeatLength that leaves insufficient bytes
+  // for defineLength.
+  std::string pageData(kPageSize, '\0');
+  // Set repeatLength to 0 (valid), leaving only 2 bytes which is insufficient
+  // for the 4-byte defineLength field.
+  uint32_t repeatLength = 0;
+  memcpy(pageData.data(), &repeatLength, sizeof(uint32_t));
+
+  // Combine header and page data.
+  std::string fullData = headerBytes + pageData;
+
+  // Create an input stream from the crafted data.
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  // PageReader with both maxRepeat > 0 and maxDefine > 0 would read
+  // repeatLength (0), advance past it, then try to read defineLength but
+  // there are insufficient bytes remaining.
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      1);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV1().
+  // The bounds check should throw when there are insufficient bytes for
+  // defineLength.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1), "Insufficient bytes for definition level length");
+}
+
+// Test that prepareDataPageV2 rejects pages where only the repetition level
+// length exceeds the page size (without combining with definition length).
+TEST_F(ParquetPageReaderTest, corruptRepeatLengthOnlyV2) {
+  // Create a DATA_PAGE_V2 header where just the repetition level length
+  // exceeds the page size.
+  constexpr int32_t kPageSize = 20;
+  constexpr int32_t kCorruptRepeatLength = 0x7FFFFFF0;
+  constexpr int32_t kDefineLength = 0; // No definition levels
+  auto pageHeader = createDataPageV2Header(
+      kPageSize, kPageSize, 100, kDefineLength, kCorruptRepeatLength);
+  std::string headerBytes = serializePageHeader(pageHeader);
+
+  // Create page data.
+  std::string pageData(kPageSize, '\0');
+
+  // Combine header and page data.
+  std::string fullData = headerBytes + pageData;
+
+  // Create an input stream from the crafted data.
+  auto inputStream = std::make_unique<SeekableArrayInputStream>(
+      fullData.data(), fullData.size());
+
+  dwio::common::ColumnReaderStatistics stats;
+  // maxRepeat and maxDefine don't affect V2 validation since the lengths
+  // are in the header, not the page data.
+  auto pageReader = std::make_unique<PageReader>(
+      std::move(inputStream),
+      *leafPool_,
+      common::CompressionKind::CompressionKind_NONE,
+      fullData.size(),
+      stats,
+      nullptr,
+      1,
+      0);
+
+  // Calling skip(1) triggers seekToPage() which calls prepareDataPageV2().
+  // The bounds check should throw when repeatLength exceeds page size.
+  VELOX_ASSERT_THROW(
+      pageReader->skip(1),
+      "Repetition and definition level lengths (2147483632 + 0) exceed");
 }


### PR DESCRIPTION
Summary:

We currently do not validate the correctness of the repeat/define lengths we read in the Parquet header,
this can lead us to access memory outside the data buffer.

Add checks to validate we do not go off the end of the pageData_ buffer.

Differential Revision: D94270200
