### PR TITLE
misc: Add benchmark for simple aggregate functions with variadic arguments

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -306,7 +306,9 @@ target_link_libraries(
   GTest::gtest_main
 )
 
-add_library(velox_simple_aggregate SimpleAverageAggregate.cpp SimpleArrayAggAggregate.cpp)
+add_library(
+  velox_simple_aggregate SimpleAverageAggregate.cpp SimpleArrayAggAggregate.cpp
+  SimpleVariadicArrayAggAggregate.cpp SimpleVariadicSumAggregate.cpp)
 
 target_link_libraries(
   velox_simple_aggregate

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -307,8 +307,15 @@ target_link_libraries(
 )
 
 add_library(
-  velox_simple_aggregate SimpleAverageAggregate.cpp SimpleArrayAggAggregate.cpp
-  SimpleVariadicArrayAggAggregate.cpp SimpleVariadicSumAggregate.cpp)
+  velox_simple_aggregate
+  SimpleAverageAggregate.cpp
+  SimpleArrayAggAggregate.cpp
+  SimpleVariadicArrayAggAggregate.cpp
+  SimpleVariadicSumAggregateDefaultNull.cpp
+  SimpleVariadicSumAggregateNonDefaultNull.cpp
+  VariadicSumAggregateDefaultNull.cpp
+  VariadicSumAggregateNonDefaultNull.cpp
+)
 
 target_link_libraries(
   velox_simple_aggregate
@@ -316,6 +323,8 @@ target_link_libraries(
   velox_expression
   velox_expression_functions
   velox_aggregates
+  velox_vector
+  velox_memory
 )
 
 add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp Main.cpp)
@@ -379,6 +388,14 @@ if(VELOX_ENABLE_BENCHMARKS)
     velox_exec
     velox_exec_test_lib
     velox_spiller_aggregate_benchmark_base
+  )
+
+  add_executable(simple_variadic_sum_benchmark SimpleVariadicSumAggregateBenchmark.cpp)
+  target_link_libraries(
+    simple_variadic_sum_benchmark
+    simple_aggregate
+    velox_exec_test_lib
+    Folly::folly
   )
 endif()
 

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -608,7 +608,7 @@ class SimpleVariadicSumAggregationTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    registerSimpleVariadicSumAggregate(kSimpleVariadicSum);
+    registerSimpleVariadicSumAggregateDefaultNull(kSimpleVariadicSum);
   }
 };
 

--- a/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
+++ b/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
@@ -28,10 +28,19 @@ exec::AggregateRegistrationResult registerSimpleAverageAggregate(
 exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
     const std::string& name);
 
-exec::AggregateRegistrationResult registerSimpleVariadicSumAggregate(
+exec::AggregateRegistrationResult registerSimpleVariadicSumAggregateDefaultNull(
     const std::string& name);
 
 exec::AggregateRegistrationResult registerSimpleVariadicArrayAggAggregate(
+    const std::string& name);
+
+exec::AggregateRegistrationResult registerVariadicSumAggregateDefaultNull(
+    const std::string& name);
+
+exec::AggregateRegistrationResult
+registerSimpleVariadicSumAggregateNonDefaultNull(const std::string& name);
+
+exec::AggregateRegistrationResult registerVariadicSumAggregateNonDefaultNull(
     const std::string& name);
 
 } // namespace facebook::velox::aggregate

--- a/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
+++ b/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
@@ -28,4 +28,10 @@ exec::AggregateRegistrationResult registerSimpleAverageAggregate(
 exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
     const std::string& name);
 
+exec::AggregateRegistrationResult registerSimpleVariadicSumAggregate(
+    const std::string& name);
+
+exec::AggregateRegistrationResult registerSimpleVariadicArrayAggAggregate(
+    const std::string& name);
+
 } // namespace facebook::velox::aggregate

--- a/velox/exec/tests/SimpleVariadicArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleVariadicArrayAggAggregate.cpp
@@ -17,7 +17,6 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/expression/VectorWriters.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
 
 using namespace facebook::velox::exec;
@@ -25,26 +24,40 @@ using namespace facebook::velox::exec;
 namespace facebook::velox::aggregate {
 
 namespace {
-class ArrayAggAggregate {
- public:
-  // Type(s) of input vector(s) wrapped in Row.
-  using InputType = Row<Generic<T1>>;
 
-  // Type of intermediate result vector.
+// An aggregate function that demonstrates variadic argument support with
+// Generic types and non-default null behavior in SimpleAggregateAdapter. This
+// function takes a variadic list of values of the same type and aggregates all
+// of them into a single array, including nulls.
+//
+// Example:
+//   SELECT variadic_array_agg(a, b, c) FROM (
+//     VALUES (1, 2, 3), (4, 5, 6)
+//   ) AS t(a, b, c)
+//   => [1, 2, 3, 4, 5, 6]
+class VariadicArrayAggAggregate {
+ public:
+  using InputType = AggregateInputType<Variadic<Generic<T1>>>;
+
   using IntermediateType = Array<Generic<T1>>;
 
-  // Type of output vector.
   using OutputType = Array<Generic<T1>>;
 
   static constexpr bool default_null_behavior_ = false;
 
   static bool toIntermediate(
       exec::out_type<Array<Generic<T1>>>& out,
-      exec::optional_arg_type<Generic<T1>> in) {
-    if (in.has_value()) {
-      out.add_item().copy_from(in.value());
-    } else {
-      out.add_null();
+      exec::optional_arg_type<Variadic<Generic<T1>>> variadicArgs) {
+    if (!variadicArgs.has_value()) {
+      VELOX_UNREACHABLE(
+          "simple_variadic_array_agg requires at least one variadic argument.");
+    }
+    for (const auto& arg : variadicArgs.value()) {
+      if (arg.has_value()) {
+        out.add_item().copy_from(arg.value());
+      } else {
+        out.add_null();
+      }
     }
     return true;
   }
@@ -54,32 +67,33 @@ class ArrayAggAggregate {
 
     AccumulatorType() = delete;
 
-    // Constructor used in initializeNewGroups().
     explicit AccumulatorType(
         HashStringAllocator* /*allocator*/,
-        ArrayAggAggregate* /*fn*/)
+        VariadicArrayAggAggregate* /*fn*/)
         : elements_{} {}
 
     static constexpr bool is_fixed_size_ = false;
 
-    // addInput expects one parameter of exec::optional_arg_type<T> for each
-    // child-type T wrapped in InputType.
     bool addInput(
         HashStringAllocator* allocator,
-        exec::optional_arg_type<Generic<T1>> data) {
-      elements_.appendValue(data, allocator);
+        exec::optional_arg_type<Variadic<Generic<T1>>> variadicArgs) {
+      if (!variadicArgs.has_value()) {
+        VELOX_UNREACHABLE(
+            "simple_variadic_array_agg requires at least one variadic argument.");
+      }
+      for (const auto& arg : variadicArgs.value()) {
+        elements_.appendValue(arg, allocator);
+      }
       return true;
     }
 
-    // combine expects one parameter of
-    // exec::optional_arg_type<IntermediateType>.
     bool combine(
         HashStringAllocator* allocator,
         exec::optional_arg_type<Array<Generic<T1>>> other) {
       if (!other.has_value()) {
         return false;
       }
-      for (auto element : other.value()) {
+      for (const auto& element : other.value()) {
         elements_.appendValue(element, allocator);
       }
       return true;
@@ -98,8 +112,6 @@ class ArrayAggAggregate {
     bool writeIntermediateResult(
         bool nonNullGroup,
         exec::out_type<Array<Generic<T1>>>& out) {
-      // If the group's accumulator is null, the corresponding intermediate
-      // result is null too.
       if (!nonNullGroup) {
         return false;
       }
@@ -115,7 +127,7 @@ class ArrayAggAggregate {
 
 } // namespace
 
-exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
+exec::AggregateRegistrationResult registerSimpleVariadicArrayAggAggregate(
     const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
@@ -123,20 +135,22 @@ exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
           .returnType("array(E)")
           .intermediateType("array(E)")
           .argumentType("E")
+          .variableArity()
           .build()};
 
   return exec::registerAggregateFunction(
       name,
-      signatures,
+      std::move(signatures),
       [name](
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(
-            argTypes.size(), 1, "{} takes at most one argument", name);
-        return std::make_unique<SimpleAggregateAdapter<ArrayAggAggregate>>(
+        VELOX_CHECK_GE(
+            argTypes.size(), 1, "{} requires at least 1 argument", name);
+        return std::make_unique<
+            SimpleAggregateAdapter<VariadicArrayAggAggregate>>(
             step, argTypes, resultType);
       },
       true /*registerCompanionFunctions*/,

--- a/velox/exec/tests/SimpleVariadicSumAggregate.cpp
+++ b/velox/exec/tests/SimpleVariadicSumAggregate.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/expression/FunctionSignature.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate {
+
+namespace {
+
+// An aggregate function that demonstrates variadic argument support in
+// SimpleAggregateAdapter. This function takes a dummy integer argument followed
+// by a variadic list of integers. It returns an array where the i-th element is
+// the sum of all i-th variadic arguments across all rows.
+//
+// Example:
+//   SELECT variadic_sum_agg(3, a, b, c) FROM (
+//     VALUES (1, 2, 3), (4, 5, 6)
+//   ) AS t(a, b, c)
+//   => [5, 7, 9]  (i.e., [1+4, 2+5, 3+6])
+class VariadicSumAggregate {
+ public:
+  // Force the function to take a dummy integer before the variadic arguments to
+  // test variadic list not starting from the beginning.
+  using InputType = AggregateInputType<int64_t, Variadic<int64_t>>;
+
+  using IntermediateType = Array<int64_t>;
+
+  using OutputType = Array<int64_t>;
+
+  struct AccumulatorType {
+    std::vector<int64_t> sums_;
+
+    AccumulatorType() = delete;
+
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        VariadicSumAggregate* /*fn*/)
+        : sums_{} {}
+
+    static constexpr bool is_fixed_size_ = false;
+    static constexpr bool use_external_memory_ = true;
+
+    void addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<int64_t> /*dummy*/,
+        exec::arg_type<Variadic<int64_t>> variadicArgs) {
+      // Initialize sums_ based on the actual number of variadic arguments.
+      if (sums_.empty()) {
+        sums_.resize(variadicArgs.size(), 0);
+      }
+
+      size_t idx = 0;
+      for (const auto& arg : variadicArgs) {
+        if (idx >= sums_.size()) {
+          VELOX_USER_FAIL("Different number of elements.");
+        }
+        if (arg.has_value()) {
+          sums_[idx] += arg.value();
+        }
+        ++idx;
+      }
+    }
+
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<Array<int64_t>> other) {
+      // Initialize sums_ based on the incoming array size if not yet
+      // initialized.
+      if (sums_.empty()) {
+        sums_.resize(other.size(), 0);
+      }
+
+      // Add element-wise.
+      size_t idx = 0;
+      for (const auto& element : other) {
+        if (idx >= sums_.size()) {
+          VELOX_USER_FAIL("Different number of elements.");
+        }
+        if (element.has_value()) {
+          sums_[idx] += element.value();
+        }
+        ++idx;
+      }
+    }
+
+    bool writeFinalResult(exec::out_type<Array<int64_t>>& out) {
+      for (const auto& sum : sums_) {
+        out.add_item() = sum;
+      }
+      return true;
+    }
+
+    bool writeIntermediateResult(exec::out_type<Array<int64_t>>& out) {
+      for (const auto& sum : sums_) {
+        out.add_item() = sum;
+      }
+      return true;
+    }
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerSimpleVariadicSumAggregate(
+    const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .variableArity()
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_GE(
+            argTypes.size(), 1, "{} requires at least 1 argument", name);
+        return std::make_unique<SimpleAggregateAdapter<VariadicSumAggregate>>(
+            step, argTypes, resultType);
+      },
+      true /*registerCompanionFunctions*/,
+      true /*overwrite*/);
+}
+
+} // namespace facebook::velox::aggregate

--- a/velox/exec/tests/SimpleVariadicSumAggregateBenchmark.cpp
+++ b/velox/exec/tests/SimpleVariadicSumAggregateBenchmark.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/exec/tests/SimpleAggregateFunctionsRegistration.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+static constexpr int32_t kNumVectors = 1'000;
+static constexpr int32_t kRowsPerVector = 1'000;
+
+class SimpleVariadicSumAggregateBenchmark : public OperatorTestBase {
+ public:
+  SimpleVariadicSumAggregateBenchmark() {
+    OperatorTestBase::SetUp();
+
+    // Register the baseline Aggregate-based implementation (default null
+    // behavior).
+    facebook::velox::aggregate::registerVariadicSumAggregateDefaultNull(
+        "variadic_sum_agg_default_null");
+
+    // Register the SimpleAggregateAdapter-based implementation (default null
+    // behavior).
+    facebook::velox::aggregate::registerSimpleVariadicSumAggregateDefaultNull(
+        "simple_variadic_sum_default_null");
+
+    // Register the non-default-null Aggregate-based implementation.
+    facebook::velox::aggregate::registerVariadicSumAggregateNonDefaultNull(
+        "variadic_sum_agg_non_default_null");
+
+    // Register the non-default-null SimpleAggregateAdapter-based
+    // implementation.
+    facebook::velox::aggregate::
+        registerSimpleVariadicSumAggregateNonDefaultNull(
+            "simple_variadic_sum_non_default_null");
+  }
+
+  ~SimpleVariadicSumAggregateBenchmark() override {
+    OperatorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  std::vector<RowVectorPtr> makeData() {
+    auto vector = makeRowVector(
+        {// Grouping key with ~7 unique values.
+         makeFlatVector<int32_t>(
+             kRowsPerVector, [](auto row) { return row % 7; }),
+         // Dummy argument (required by the function signature).
+         makeFlatVector<int64_t>(
+             kRowsPerVector, [](auto /*row*/) { return 0; }),
+         // Variadic argument 1.
+         makeFlatVector<int64_t>(
+             kRowsPerVector,
+             [](auto row) { return row % 100; },
+             [](auto row) { return row % 23 == 0; }),
+         // Variadic argument 2.
+         makeFlatVector<int64_t>(
+             kRowsPerVector,
+             [](auto row) { return row % 50; },
+             [](auto row) { return row % 17 == 0; }),
+         // Variadic argument 3.
+         makeFlatVector<int64_t>(
+             kRowsPerVector,
+             [](auto row) { return row % 30; },
+             [](auto row) { return row % 13 == 0; })});
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      vectors.push_back(vector);
+    }
+    return vectors;
+  }
+
+  void run(const std::string& aggregate) {
+    folly::BenchmarkSuspender suspender;
+
+    auto vectors = makeData();
+    auto plan = PlanBuilder()
+                    .values(vectors)
+                    .partialAggregation({"c0"}, {aggregate})
+                    .finalAggregation()
+                    .planFragment();
+
+    vector_size_t numResultRows = 0;
+    auto task = Task::create(
+        "t",
+        std::move(plan),
+        0,
+        core::QueryCtx::create(executor_.get()),
+        Task::ExecutionMode::kSerial);
+
+    suspender.dismiss();
+
+    while (auto result = task->next()) {
+      numResultRows += result->size();
+    }
+
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+  void runVariadicSumAggregateDefaultNull() {
+    run("variadic_sum_agg_default_null(c1, c2, c3, c4)");
+  }
+
+  void runSimpleVariadicSumAggregateDefaultNull() {
+    run("simple_variadic_sum_default_null(c1, c2, c3, c4)");
+  }
+
+  void runVariadicSumAggregateNonDefaultNull() {
+    run("variadic_sum_agg_non_default_null(c1, c2, c3, c4)");
+  }
+
+  void runSimpleVariadicSumAggregateNonDefaultNull() {
+    run("simple_variadic_sum_non_default_null(c1, c2, c3, c4)");
+  }
+};
+
+std::unique_ptr<SimpleVariadicSumAggregateBenchmark> benchmark;
+
+BENCHMARK(variadicSumAggregateDefaultNull) {
+  benchmark->runVariadicSumAggregateDefaultNull();
+}
+
+BENCHMARK_RELATIVE(simpleVariadicSumDefaultNull) {
+  benchmark->runSimpleVariadicSumAggregateDefaultNull();
+}
+
+BENCHMARK(variadicSumAggregateNonDefaultNull) {
+  benchmark->runVariadicSumAggregateNonDefaultNull();
+}
+
+BENCHMARK_RELATIVE(simpleVariadicSumNonDefaultNull) {
+  benchmark->runSimpleVariadicSumAggregateNonDefaultNull();
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  OperatorTestBase::SetUpTestCase();
+  benchmark = std::make_unique<SimpleVariadicSumAggregateBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  OperatorTestBase::TearDownTestCase();
+  return 0;
+}

--- a/velox/exec/tests/SimpleVariadicSumAggregateDefaultNull.cpp
+++ b/velox/exec/tests/SimpleVariadicSumAggregateDefaultNull.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/expression/FunctionSignature.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate {
+
+namespace {
+
+// An aggregate function that demonstrates variadic argument support in
+// SimpleAggregateAdapter. This function takes a dummy integer argument followed
+// by a variadic list of integers. It returns an array where the i-th element is
+// the sum of all i-th variadic arguments across all rows.
+//
+// Example:
+//   SELECT variadic_sum_agg(3, a, b, c) FROM (
+//     VALUES (1, 2, 3), (4, 5, 6)
+//   ) AS t(a, b, c)
+//   => [5, 7, 9]  (i.e., [1+4, 2+5, 3+6])
+class VariadicSumAggregateDefaultNull {
+ public:
+  // Force the function to take a dummy integer before the variadic arguments to
+  // test variadic list not starting from the beginning.
+  using InputType = AggregateInputType<int64_t, Variadic<int64_t>>;
+
+  using IntermediateType = Array<int64_t>;
+
+  using OutputType = Array<int64_t>;
+
+  struct AccumulatorType {
+    std::vector<int64_t> sums_;
+
+    AccumulatorType() = delete;
+
+    explicit AccumulatorType(
+        HashStringAllocator* /*allocator*/,
+        VariadicSumAggregateDefaultNull* /*fn*/)
+        : sums_{} {}
+
+    static constexpr bool is_fixed_size_ = false;
+    static constexpr bool use_external_memory_ = true;
+
+    void addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<int64_t> /*dummy*/,
+        exec::arg_type<Variadic<int64_t>> variadicArgs) {
+      // Initialize sums_ based on the actual number of variadic arguments.
+      if (sums_.empty()) {
+        sums_.resize(variadicArgs.size(), 0);
+      }
+
+      for (auto i = 0; i < variadicArgs.size(); ++i) {
+        sums_[i] += variadicArgs.at(i).value();
+      }
+    }
+
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<Array<int64_t>> other) {
+      // Initialize sums_ based on the incoming array size if not yet
+      // initialized.
+      if (sums_.empty()) {
+        sums_.resize(other.size(), 0);
+      }
+
+      // Add element-wise.
+      for (auto i = 0; i < other.size(); ++i) {
+        if (other.at(i).has_value()) {
+          sums_[i] += other.at(i).value();
+        }
+      }
+    }
+
+    bool writeFinalResult(exec::out_type<Array<int64_t>>& out) {
+      for (const auto& sum : sums_) {
+        out.add_item() = sum;
+      }
+      return true;
+    }
+
+    bool writeIntermediateResult(exec::out_type<Array<int64_t>>& out) {
+      for (const auto& sum : sums_) {
+        out.add_item() = sum;
+      }
+      return true;
+    }
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerSimpleVariadicSumAggregateDefaultNull(
+    const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .variableArity()
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_GE(
+            argTypes.size(), 1, "{} requires at least 1 argument", name);
+        return std::make_unique<
+            SimpleAggregateAdapter<VariadicSumAggregateDefaultNull>>(
+            step, argTypes, resultType);
+      },
+      true /*registerCompanionFunctions*/,
+      true /*overwrite*/);
+}
+
+} // namespace facebook::velox::aggregate

--- a/velox/exec/tests/VariadicSumAggregateDefaultNull.cpp
+++ b/velox/exec/tests/VariadicSumAggregateDefaultNull.cpp
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateUtil.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate {
+
+namespace {
+
+// A baseline implementation of VariadicSumAggregate using the Aggregate base
+// class directly (without SimpleAggregateAdapter). This serves as a performance
+// baseline for comparison with SimpleAggregateAdapter-based implementation.
+//
+// This function takes a dummy integer argument followed by a variadic list of
+// integers. It returns an array where the i-th element is the sum of all i-th
+// variadic arguments across all rows.
+//
+// Example:
+//   SELECT variadic_sum_agg(3, a, b, c) FROM (
+//     VALUES (1, 2, 3), (4, 5, 6)
+//   ) AS t(a, b, c)
+//   => [5, 7, 9]  (i.e., [1+4, 2+5, 3+6])
+class VariadicSumAggregateDefaultNull : public Aggregate {
+ public:
+  explicit VariadicSumAggregateDefaultNull(TypePtr resultType)
+      : Aggregate(std::move(resultType)) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(Accumulator);
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return true;
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto arrayVector = (*result)->as<ArrayVector>();
+    arrayVector->resize(numGroups);
+
+    auto* rawOffsets =
+        arrayVector->mutableOffsets(numGroups)->asMutable<vector_size_t>();
+    auto* rawSizes =
+        arrayVector->mutableSizes(numGroups)->asMutable<vector_size_t>();
+
+    vector_size_t totalElements = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      auto* accumulator = value<Accumulator>(groups[i]);
+      totalElements += accumulator->sums.size();
+    }
+
+    auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
+    elementsVector->resize(totalElements);
+    auto* rawElements = elementsVector->mutableRawValues();
+
+    vector_size_t offset = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      auto* accumulator = value<Accumulator>(groups[i]);
+      rawOffsets[i] = offset;
+      rawSizes[i] = accumulator->sums.size();
+      for (size_t j = 0; j < accumulator->sums.size(); ++j) {
+        rawElements[offset + j] = accumulator->sums[j];
+      }
+      offset += accumulator->sums.size();
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    // Decode ALL arguments including dummy arg[0] to match
+    // SimpleAggregateAdapter which decodes all inputs.
+    const auto numArgs = args.size();
+    std::vector<DecodedVector> decodedArgs(numArgs);
+    for (size_t i = 0; i < numArgs; ++i) {
+      decodedArgs[i].decode(*args[i], rows);
+    }
+
+    const auto numVariadicArgs = numArgs - 1;
+
+    rows.applyToSelected([&](vector_size_t row) {
+      // Ignore rows with any nulls.
+      for (size_t i = 0; i < numVariadicArgs; ++i) {
+        if (decodedArgs[i + 1].isNullAt(row)) {
+          return;
+        }
+      }
+
+      // RowSizeTracker to match SimpleAggregateAdapter overhead for
+      // non-fixed-size accumulators.
+      RowSizeTracker<char, uint32_t> tracker(
+          groups[row][rowSizeOffset_], *allocator_);
+
+      auto* group = groups[row];
+      auto* accumulator = value<Accumulator>(group);
+
+      if (accumulator->sums.empty()) {
+        accumulator->sums.resize(numVariadicArgs, 0);
+      }
+
+      for (size_t i = 0; i < numVariadicArgs; ++i) {
+        accumulator->sums[i] += decodedArgs[i + 1].valueAt<int64_t>(row);
+      }
+
+      // clearNull to match SimpleAggregateAdapter which clears null on every
+      // non-null row.
+      clearNull(group);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    const auto numArgs = args.size();
+    const auto numVariadicArgs = numArgs - 1;
+    if (numVariadicArgs == 0) {
+      return;
+    }
+
+    auto* accumulator = value<Accumulator>(group);
+    if (accumulator->sums.empty()) {
+      accumulator->sums.resize(numVariadicArgs, 0);
+    }
+
+    // Decode ALL arguments including dummy arg[0].
+    std::vector<DecodedVector> decodedArgs(numArgs);
+    for (size_t i = 0; i < numArgs; ++i) {
+      decodedArgs[i].decode(*args[i], rows);
+    }
+
+    rows.applyToSelected([&](vector_size_t row) {
+      // Ignore rows with any nulls.
+      for (size_t i = 0; i < numVariadicArgs; ++i) {
+        if (decodedArgs[i + 1].isNullAt(row)) {
+          return;
+        }
+      }
+
+      // RowSizeTracker to match SimpleAggregateAdapter.
+      RowSizeTracker<char, uint32_t> tracker(
+          group[rowSizeOffset_], *allocator_);
+
+      for (size_t i = 0; i < numVariadicArgs; ++i) {
+        accumulator->sums[i] += decodedArgs[i + 1].valueAt<int64_t>(row);
+      }
+
+      clearNull(group);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto arrayVector = args[0]->as<ArrayVector>();
+    auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (arrayVector->isNullAt(row)) {
+        return;
+      }
+
+      auto* group = groups[row];
+      auto* accumulator = value<Accumulator>(group);
+
+      auto offset = arrayVector->offsetAt(row);
+      auto size = arrayVector->sizeAt(row);
+
+      if (accumulator->sums.empty()) {
+        accumulator->sums.resize(size, 0);
+      }
+
+      for (vector_size_t i = 0; i < size; ++i) {
+        if (!elementsVector->isNullAt(offset + i)) {
+          accumulator->sums[i] += elementsVector->valueAt(offset + i);
+        }
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto arrayVector = args[0]->as<ArrayVector>();
+    auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
+    auto* accumulator = value<Accumulator>(group);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (arrayVector->isNullAt(row)) {
+        return;
+      }
+
+      auto offset = arrayVector->offsetAt(row);
+      auto size = arrayVector->sizeAt(row);
+
+      if (accumulator->sums.empty()) {
+        accumulator->sums.resize(size, 0);
+      }
+
+      for (vector_size_t i = 0; i < size; ++i) {
+        if (!elementsVector->isNullAt(offset + i)) {
+          accumulator->sums[i] += elementsVector->valueAt(offset + i);
+        }
+      }
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    // setAllNulls to match SimpleAggregateAdapter which marks new groups as
+    // null (default_null_behavior_: groups start null, cleared on first input).
+    setAllNulls(groups, indices);
+    for (auto index : indices) {
+      new (groups[index] + offset_) Accumulator();
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto* group : groups) {
+      if (isInitialized(group)) {
+        value<Accumulator>(group)->~Accumulator();
+      }
+    }
+  }
+
+ private:
+  struct Accumulator {
+    std::vector<int64_t> sums;
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerVariadicSumAggregateDefaultNull(
+    const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .variableArity()
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& /*argTypes*/,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<VariadicSumAggregateDefaultNull>(resultType);
+      },
+      true /*registerCompanionFunctions*/,
+      true /*overwrite*/);
+}
+
+} // namespace facebook::velox::aggregate

--- a/velox/exec/tests/VariadicSumAggregateNonDefaultNull.cpp
+++ b/velox/exec/tests/VariadicSumAggregateNonDefaultNull.cpp
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateUtil.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate {
+
+namespace {
+
+// A variant of VariadicSumAggregate that ignores nulls but processes all rows.
+// Unlike the original which skips entire rows when ANY argument is null,
+// this version processes all rows and simply ignores null values when summing.
+//
+// This function takes a dummy integer argument followed by a variadic list of
+// integers. It returns an array where the i-th element is the sum of all i-th
+// variadic arguments across all rows (ignoring nulls).
+//
+// Example:
+//   SELECT variadic_sum_agg_ignore_nulls(3, a, b, c) FROM (
+//     VALUES (1, NULL, 3), (4, 5, 6)
+//   ) AS t(a, b, c)
+//   => [5, 5, 9]  (i.e., [1+4, 0+5, 3+6])
+class VariadicSumAggregateNonDefaultNull : public Aggregate {
+ public:
+  explicit VariadicSumAggregateNonDefaultNull(TypePtr resultType)
+      : Aggregate(std::move(resultType)) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(Accumulator);
+  }
+
+  bool accumulatorUsesExternalMemory() const override {
+    return true;
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto arrayVector = (*result)->as<ArrayVector>();
+    arrayVector->resize(numGroups);
+
+    auto* rawOffsets =
+        arrayVector->mutableOffsets(numGroups)->asMutable<vector_size_t>();
+    auto* rawSizes =
+        arrayVector->mutableSizes(numGroups)->asMutable<vector_size_t>();
+
+    vector_size_t totalElements = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      auto* accumulator = value<Accumulator>(groups[i]);
+      totalElements += accumulator->sums.size();
+    }
+
+    auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
+    elementsVector->resize(totalElements);
+    auto* rawElements = elementsVector->mutableRawValues();
+
+    vector_size_t offset = 0;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      auto* accumulator = value<Accumulator>(groups[i]);
+      rawOffsets[i] = offset;
+      rawSizes[i] = accumulator->sums.size();
+      for (size_t j = 0; j < accumulator->sums.size(); ++j) {
+        rawElements[offset + j] = accumulator->sums[j];
+      }
+      offset += accumulator->sums.size();
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    const auto numArgs = args.size();
+    std::vector<DecodedVector> decodedArgs(numArgs);
+    for (size_t i = 0; i < numArgs; ++i) {
+      decodedArgs[i].decode(*args[i], rows);
+    }
+
+    const auto numVariadicArgs = numArgs - 1;
+
+    rows.applyToSelected([&](vector_size_t row) {
+      RowSizeTracker<char, uint32_t> tracker(
+          groups[row][rowSizeOffset_], *allocator_);
+
+      auto* group = groups[row];
+      auto* accumulator = value<Accumulator>(group);
+
+      if (accumulator->sums.empty()) {
+        accumulator->sums.resize(numVariadicArgs, 0);
+      }
+
+      for (size_t i = 0; i < numVariadicArgs; ++i) {
+        if (!decodedArgs[i + 1].isNullAt(row)) {
+          accumulator->sums[i] += decodedArgs[i + 1].valueAt<int64_t>(row);
+        }
+      }
+
+      clearNull(group);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    const auto numArgs = args.size();
+    const auto numVariadicArgs = numArgs - 1;
+    if (numVariadicArgs == 0) {
+      return;
+    }
+
+    auto* accumulator = value<Accumulator>(group);
+    if (accumulator->sums.empty()) {
+      accumulator->sums.resize(numVariadicArgs, 0);
+    }
+
+    std::vector<DecodedVector> decodedArgs(numArgs);
+    for (size_t i = 0; i < numArgs; ++i) {
+      decodedArgs[i].decode(*args[i], rows);
+    }
+
+    rows.applyToSelected([&](vector_size_t row) {
+      RowSizeTracker<char, uint32_t> tracker(
+          group[rowSizeOffset_], *allocator_);
+
+      for (size_t i = 0; i < numVariadicArgs; ++i) {
+        if (!decodedArgs[i + 1].isNullAt(row)) {
+          accumulator->sums[i] += decodedArgs[i + 1].valueAt<int64_t>(row);
+        }
+      }
+
+      clearNull(group);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto arrayVector = args[0]->as<ArrayVector>();
+    auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (arrayVector->isNullAt(row)) {
+        return;
+      }
+
+      auto* group = groups[row];
+      auto* accumulator = value<Accumulator>(group);
+
+      auto offset = arrayVector->offsetAt(row);
+      auto size = arrayVector->sizeAt(row);
+
+      if (accumulator->sums.empty()) {
+        accumulator->sums.resize(size, 0);
+      }
+
+      for (vector_size_t i = 0; i < size; ++i) {
+        if (!elementsVector->isNullAt(offset + i)) {
+          accumulator->sums[i] += elementsVector->valueAt(offset + i);
+        }
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto arrayVector = args[0]->as<ArrayVector>();
+    auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
+    auto* accumulator = value<Accumulator>(group);
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (arrayVector->isNullAt(row)) {
+        return;
+      }
+
+      auto offset = arrayVector->offsetAt(row);
+      auto size = arrayVector->sizeAt(row);
+
+      if (accumulator->sums.empty()) {
+        accumulator->sums.resize(size, 0);
+      }
+
+      for (vector_size_t i = 0; i < size; ++i) {
+        if (!elementsVector->isNullAt(offset + i)) {
+          accumulator->sums[i] += elementsVector->valueAt(offset + i);
+        }
+      }
+    });
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto index : indices) {
+      new (groups[index] + offset_) Accumulator();
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto* group : groups) {
+      if (isInitialized(group)) {
+        value<Accumulator>(group)->~Accumulator();
+      }
+    }
+  }
+
+ private:
+  struct Accumulator {
+    std::vector<int64_t> sums;
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerVariadicSumAggregateNonDefaultNull(
+    const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .variableArity()
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      signatures,
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& /*argTypes*/,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<VariadicSumAggregateNonDefaultNull>(resultType);
+      },
+      true /*registerCompanionFunctions*/,
+      true /*overwrite*/);
+}
+
+} // namespace facebook::velox::aggregate


### PR DESCRIPTION
Summary:
Add a benchmark to measure the performance of aggregation functions with variadic arguments between the 
vector-function implementation and the simple-function implementation.
```
============================================================================
[...]mpleVariadicSumAggregateBenchmark.cpp     relative  time/iter   iters/s
============================================================================
variadicSumAggregateDefaultNull                            16.31ms     61.32
simpleVariadicSumDefaultNull                    88.479%    18.43ms     54.25
variadicSumAggregateNonDefaultNull                         17.07ms     58.60
simpleVariadicSumNonDefaultNull                 101.27%    16.85ms     59.34
```

Differential Revision: D94297590
