### PR TITLE
feat(sparksql): Support multi-character delimiters in str_to_map

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -420,12 +420,14 @@ String Functions
 
     Returns a map by splitting ``string`` into entries with ``entryDelimiter`` and splitting
     each entry into key/value with ``keyValueDelimiter``.
-    ``entryDelimiter`` and ``keyValueDelimiter`` must be constant strings with single ascii
-    character. Allows ``keyValueDelimiter`` not found when splitting an entry. Throws exception
+    ``entryDelimiter`` and ``keyValueDelimiter`` must be non-empty constant strings.
+    Delimiters are matched as literal strings, not as regular expressions.
+    Allows ``keyValueDelimiter`` not found when splitting an entry. Throws exception
     when duplicate map keys are found for single row's result, consistent with Spark's default
     behavior. ::
 
         SELECT str_to_map('a:1,b:2,c:3', ',', ':'); -- {"a":"1","b":"2","c":"3"}
+        SELECT str_to_map('a::1,,b::2,,c::3', ',,', '::'); -- {"a":"1","b":"2","c":"3"}
         SELECT str_to_map('a', ',', ':'); -- {"a":NULL}
         SELECT str_to_map('', ',', ':'); -- {"":NULL}
         SELECT str_to_map('a:1,b:2,c:3', ',', ','); -- {"a:1":NULL,"b:2":NULL,"c:3":NULL}

--- a/velox/functions/sparksql/StringToMap.h
+++ b/velox/functions/sparksql/StringToMap.h
@@ -32,10 +32,10 @@ struct StringToMapFunction {
       const arg_type<Varchar>& input,
       const arg_type<Varchar>& entryDelimiter,
       const arg_type<Varchar>& keyValueDelimiter) {
-    VELOX_USER_CHECK_EQ(
-        entryDelimiter.size(), 1, "entryDelimiter's size should be 1.");
-    VELOX_USER_CHECK_EQ(
-        keyValueDelimiter.size(), 1, "keyValueDelimiter's size should be 1.");
+    VELOX_USER_CHECK_GT(
+        entryDelimiter.size(), 0, "entryDelimiter must not be empty.");
+    VELOX_USER_CHECK_GT(
+        keyValueDelimiter.size(), 0, "keyValueDelimiter must not be empty.");
 
     callImpl(
         out,
@@ -65,7 +65,7 @@ struct StringToMapFunction {
           keyValueDelimiter,
           keys);
 
-      pos = nextEntryPos + 1;
+      pos = nextEntryPos + entryDelimiter.size();
       nextEntryPos = input.find(entryDelimiter, pos);
     }
 
@@ -91,7 +91,8 @@ struct StringToMapFunction {
     VELOX_USER_CHECK(
         keys.insert(key).second, "Duplicate keys are not allowed: '{}'.", key);
     const auto value = StringView(
-        entry.data() + delimiterPos + 1, entry.size() - delimiterPos - 1);
+        entry.data() + delimiterPos + keyValueDelimiter.size(),
+        entry.size() - delimiterPos - keyValueDelimiter.size());
 
     auto [keyWriter, valueWriter] = out.add_item();
     keyWriter.setNoCopy(StringView(key));


### PR DESCRIPTION
- Spark's `str_to_map` supports multi-character delimiters (e.g., `str_to_map('a::1,,b::2,,c::3', ',,', '::'))`, but Velox rejected any delimiter longer than 1 character
  - Remove the `size==1` restriction and advance by delimiter length instead of 1 when scanning
  - Delimiters are matched as literal strings, not as regular expressions (documented as a known difference from Spark, which uses regex-based `String.split()` internally)

  Based on #15116 by @weixiuli with all reviewer feedback addressed:
  - @jinchengchenghh: Fixed doc wording and single-line error messages
  - @jkhaliqi: Reorganized tests — valid cases grouped before exception cases
  - @konjac: Documented the regex vs literal string difference

  Fixes #15115
