### PR TITLE
feat: Add $internal$variadic_vector_sum aggregate function

### DIFF
--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -32,6 +32,7 @@ velox_add_library(
   EntropyAggregates.cpp
   GeometricMeanAggregate.cpp
   HistogramAggregate.cpp
+  InternalVariadicVectorSumAggregate.cpp
   KHyperLogLogAggregate.cpp
   MapAggAggregate.cpp
   MapUnionAggregate.cpp

--- a/velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/expression/FunctionSignature.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+
+template <typename T>
+inline void addToSum(T& sum, T value) {
+  if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
+    sum += value;
+  } else {
+    T checkedSum;
+    auto overflow = __builtin_add_overflow(sum, value, &checkedSum);
+
+    if (UNLIKELY(overflow)) {
+      auto errorValue = (int128_t(sum) + int128_t(value));
+
+      if (errorValue < 0) {
+        VELOX_ARITHMETIC_ERROR(
+            "Value {} is less than {}",
+            errorValue,
+            std::numeric_limits<T>::min());
+      } else {
+        VELOX_ARITHMETIC_ERROR(
+            "Value {} exceeds {}", errorValue, std::numeric_limits<T>::max());
+      }
+    }
+    sum = checkedSum;
+  }
+}
+
+/// Simple aggregate implementation for $internal$variadic_vector_sum.
+/// Takes variadic scalar arguments (T, T, ..., T) and returns array(T).
+/// Each argument position represents an element of a virtual array,
+/// and sums are accumulated across rows.
+/// Null values are treated as 0.
+template <typename T>
+class SimpleInternalVariadicVectorSumAggregate {
+ public:
+  using InputType = exec::AggregateInputType<Variadic<T>>;
+
+  using IntermediateType = Array<T>;
+
+  using OutputType = Array<T>;
+
+  /// Disable default null behavior so that rows with null variadic elements
+  /// are still processed (nulls are treated as 0).
+  static constexpr bool default_null_behavior_ = false;
+
+  struct AccumulatorType {
+    using SumsVector = std::vector<T, AlignedStlAllocator<T, 16>>;
+    SumsVector sums_;
+
+    AccumulatorType() = delete;
+
+    explicit AccumulatorType(
+        HashStringAllocator* allocator,
+        SimpleInternalVariadicVectorSumAggregate* /*fn*/)
+        : sums_{AlignedStlAllocator<T, 16>(allocator)} {}
+
+    static constexpr bool is_fixed_size_ = false;
+    static constexpr bool use_external_memory_ = true;
+
+    /// Process variadic arguments, treating nulls as 0.
+    /// Returns true to indicate the accumulator is non-null.
+    bool addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::optional_arg_type<Variadic<T>> variadicArgs) {
+      if (!variadicArgs.has_value()) {
+        return !sums_.empty();
+      }
+
+      const auto& args = variadicArgs.value();
+      const auto size = args.size();
+      if (sums_.empty()) {
+        sums_.resize(size, T{0});
+        for (auto i = size; i-- > 0;) {
+          if (args.at(i).has_value()) {
+            sums_[i] = args.at(i).value();
+          }
+        }
+        return !sums_.empty();
+      }
+
+      VELOX_USER_CHECK_EQ(
+          size,
+          sums_.size(),
+          "All arrays must have the same length. Expected {}, but got {}.",
+          sums_.size(),
+          size);
+
+      for (auto i = size; i-- > 0;) {
+        if (args.at(i).has_value()) {
+          auto value = args.at(i).value();
+          if (value != T{0}) {
+            addToSum(sums_[i], value);
+          }
+        }
+      }
+      return true;
+    }
+
+    /// Combine with intermediate result (array).
+    bool combine(
+        HashStringAllocator* /*allocator*/,
+        exec::optional_arg_type<Array<T>> other) {
+      if (!other.has_value()) {
+        return !sums_.empty();
+      }
+
+      const auto& arr = other.value();
+      const auto size = arr.size();
+      if (sums_.empty()) {
+        sums_.resize(size, T{0});
+        for (auto i = size; i-- > 0;) {
+          if (arr.at(i).has_value()) {
+            sums_[i] = arr.at(i).value();
+          }
+        }
+        return !sums_.empty();
+      }
+
+      VELOX_USER_CHECK_EQ(
+          size,
+          sums_.size(),
+          "All arrays must have the same length. Expected {}, but got {}.",
+          sums_.size(),
+          size);
+
+      for (auto i = size; i-- > 0;) {
+        if (arr.at(i).has_value()) {
+          auto value = arr.at(i).value();
+          if (value != T{0}) {
+            addToSum(sums_[i], value);
+          }
+        }
+      }
+      return true;
+    }
+
+    bool writeFinalResult(bool nonNullGroup, exec::out_type<Array<T>>& out) {
+      if (!nonNullGroup) {
+        return false;
+      }
+      for (const auto& sum : sums_) {
+        out.add_item() = sum;
+      }
+      return true;
+    }
+
+    bool writeIntermediateResult(
+        bool nonNullGroup,
+        exec::out_type<Array<T>>& out) {
+      if (!nonNullGroup) {
+        return false;
+      }
+      for (const auto& sum : sums_) {
+        out.add_item() = sum;
+      }
+      return true;
+    }
+  };
+};
+
+template <typename T>
+std::unique_ptr<exec::Aggregate> createSimpleInternalVariadicVectorSumAggregate(
+    core::AggregationNode::Step step,
+    const std::vector<TypePtr>& argTypes,
+    const TypePtr& resultType) {
+  return std::make_unique<exec::SimpleAggregateAdapter<
+      SimpleInternalVariadicVectorSumAggregate<T>>>(step, argTypes, resultType);
+}
+
+} // namespace
+
+void registerInternalVariadicVectorSumAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite) {
+  const std::vector<std::string> elementTypes = {
+      "tinyint", "smallint", "integer", "bigint", "double", "real"};
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  signatures.reserve(elementTypes.size());
+  for (const auto& elementType : elementTypes) {
+    // T, T... -> array(T) variadic signature.
+    signatures.push_back(
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType(fmt::format("array({})", elementType))
+            .intermediateType(fmt::format("array({})", elementType))
+            .argumentType(elementType)
+            .variableArity(elementType)
+            .build());
+  }
+
+  exec::registerAggregateFunction(
+      names,
+      signatures,
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_GE(argTypes.size(), 1);
+
+        // For merge companion functions, the input is already array(T),
+        // so we need to extract the element type from the array.
+        TypeKind elementTypeKind;
+        if (argTypes[0]->kind() == TypeKind::ARRAY) {
+          elementTypeKind = argTypes[0]->childAt(0)->kind();
+        } else {
+          elementTypeKind = argTypes[0]->kind();
+        }
+
+        switch (elementTypeKind) {
+          case TypeKind::TINYINT:
+            return createSimpleInternalVariadicVectorSumAggregate<int8_t>(
+                step, argTypes, resultType);
+          case TypeKind::SMALLINT:
+            return createSimpleInternalVariadicVectorSumAggregate<int16_t>(
+                step, argTypes, resultType);
+          case TypeKind::INTEGER:
+            return createSimpleInternalVariadicVectorSumAggregate<int32_t>(
+                step, argTypes, resultType);
+          case TypeKind::BIGINT:
+            return createSimpleInternalVariadicVectorSumAggregate<int64_t>(
+                step, argTypes, resultType);
+          case TypeKind::REAL:
+            return createSimpleInternalVariadicVectorSumAggregate<float>(
+                step, argTypes, resultType);
+          case TypeKind::DOUBLE:
+            return createSimpleInternalVariadicVectorSumAggregate<double>(
+                step, argTypes, resultType);
+          default:
+            VELOX_UNREACHABLE(
+                "Unexpected element type {}",
+                TypeKindName::toName(elementTypeKind));
+        }
+      },
+      withCompanionFunctions,
+      overwrite);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.h
+++ b/velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace facebook::velox::aggregate::prestosql {
+
+/// Registers the internal variadic vector_sum aggregate function.
+/// $internal$variadic_vector_sum(T, T, ..., T) -> array(T)
+/// This is hidden from users and used for optimizer transformations.
+/// Each argument position represents an element of a virtual array,
+/// and sums are accumulated across rows.
+void registerInternalVariadicVectorSumAggregate(
+    const std::vector<std::string>& names,
+    bool withCompanionFunctions,
+    bool overwrite);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -33,6 +33,7 @@
 #include "velox/functions/prestosql/aggregates/EntropyAggregates.h"
 #include "velox/functions/prestosql/aggregates/GeometricMeanAggregate.h"
 #include "velox/functions/prestosql/aggregates/HistogramAggregate.h"
+#include "velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.h"
 #include "velox/functions/prestosql/aggregates/KHyperLogLogAggregate.h"
 #include "velox/functions/prestosql/aggregates/MapAggAggregate.h"
 #include "velox/functions/prestosql/aggregates/MapUnionAggregate.h"
@@ -479,6 +480,10 @@ void registerInternalAggregateFunctions(const std::string& prefix) {
       {prefix + "$internal$count_distinct"}, withCompanionFunctions, overwrite);
   registerInternalArrayAggAggregate(
       {prefix + "$internal$array_agg"}, withCompanionFunctions, overwrite);
+  registerInternalVariadicVectorSumAggregate(
+      {prefix + "$internal$variadic_vector_sum"},
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   EntropyAggregationTest.cpp
   GeometricMeanTest.cpp
   HistogramTest.cpp
+  InternalVariadicVectorSumTest.cpp
   KHyperLogLogAggregateTest.cpp
   Main.cpp
   MapAccumulatorTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/InternalVariadicVectorSumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/InternalVariadicVectorSumTest.cpp
@@ -1,0 +1,614 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+#include "velox/functions/prestosql/aggregates/InternalVariadicVectorSumAggregate.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+/// Tests for the internal variadic vector sum aggregate function:
+/// $internal$variadic_vector_sum(T, T, ..., T) -> array(T)
+/// This is an internal function used by optimizer transformations.
+class InternalVariadicVectorSumTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    prestosql::registerInternalAggregateFunctions("");
+  }
+};
+
+TEST_F(InternalVariadicVectorSumTest, globalTwoColumns) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 10, 9}),
+      makeNullableFlatVector<int64_t>({2, 5, std::nullopt}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{20, 7}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, globalThreeColumns) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 10, 9}),
+      makeNullableFlatVector<int64_t>({2, 5, std::nullopt}),
+      makeNullableFlatVector<int64_t>({3, 4, 5}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{20, 7, 12}}),
+  });
+
+  testAggregations(
+      {data},
+      {},
+      {"\"$internal$variadic_vector_sum\"(c0, c1, c2)"},
+      {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, globalWithNulls) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 9}),
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+      makeNullableFlatVector<int64_t>({3, 4, std::nullopt}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{10, 0, 7}}),
+  });
+
+  testAggregations(
+      {data},
+      {},
+      {"\"$internal$variadic_vector_sum\"(c0, c1, c2)"},
+      {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, globalWithZeros) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({0, 0, 5}),
+      makeNullableFlatVector<int64_t>({0, 3, 0}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{5, 3}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, rowWithAllNullColumns) {
+  // Verify behavior when one row has ALL columns null.
+  // Row 0: (1, 2) -> sums = [1, 2]
+  // Row 1: (null, null) -> all null, treated as [0, 0]
+  // Row 2: (3, 4) -> sums += [3, 4]
+  // Expected: [4, 6]
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+      makeNullableFlatVector<int64_t>({2, std::nullopt, 4}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{4, 6}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, firstRowAllNulls) {
+  // Verify behavior when FIRST row has all nulls - important for
+  // initialization. Row 0: (null, null) -> initialize sums = [0, 0] Row 1: (10,
+  // 20) -> sums = [10, 20] Row 2: (5, 5) -> sums = [15, 25] Expected: [15, 25]
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({std::nullopt, 10, 5}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 20, 5}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{15, 25}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, multipleBatchesWithNulls) {
+  // Test with multiple batches to verify partial aggregation + merge works.
+  auto batch1 = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt}),
+      makeNullableFlatVector<int64_t>({2, 3}),
+  });
+  auto batch2 = makeRowVector({
+      makeNullableFlatVector<int64_t>({4, 5}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 6}),
+  });
+
+  // batch1: [1+0, 2+3] = [1, 5]
+  // batch2: [4+5, 0+6] = [9, 6]
+  // total: [1+9, 5+6] = [10, 11]
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{10, 11}}),
+  });
+
+  testAggregations(
+      {batch1, batch2},
+      {},
+      {"\"$internal$variadic_vector_sum\"(c0, c1)"},
+      {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, allRowsAllNulls) {
+  // Edge case: ALL rows have ALL columns null.
+  // Should return [0, 0] since nulls are treated as 0.
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{0, 0}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, groupBy) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2}),
+      makeNullableFlatVector<int64_t>({1, 10, 100}),
+      makeNullableFlatVector<int64_t>({2, 5, 200}),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int64_t>({{11, 7}, {100, 200}}),
+  });
+
+  testAggregations(
+      {batch1},
+      {"c0"},
+      {"\"$internal$variadic_vector_sum\"(c1, c2)"},
+      {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, singleColumn) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 10, 9}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{20}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, doubleType) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<double>({1.5, 10.5}),
+      makeNullableFlatVector<double>({2.5, 5.5}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({{12.0, 8.0}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, manyColumns) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1}),
+      makeFlatVector<int64_t>({2, 2}),
+      makeFlatVector<int64_t>({3, 3}),
+      makeFlatVector<int64_t>({4, 4}),
+      makeFlatVector<int64_t>({5, 5}),
+      makeFlatVector<int64_t>({6, 6}),
+      makeFlatVector<int64_t>({7, 7}),
+      makeFlatVector<int64_t>({8, 8}),
+      makeFlatVector<int64_t>({9, 9}),
+      makeFlatVector<int64_t>({10, 10}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{2, 4, 6, 8, 10, 12, 14, 16, 18, 20}}),
+  });
+
+  testAggregations(
+      {data},
+      {},
+      {"\"$internal$variadic_vector_sum\"(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9)"},
+      {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, tinyintOverflow) {
+  // c0 = {100, 30} -> sum = 130 -> overflow (exceeds 127)
+  // c1 = {50, 50} -> sum = 100 -> no overflow
+  auto data = makeRowVector({
+      makeNullableFlatVector<int8_t>({100, 30}),
+      makeNullableFlatVector<int8_t>({50, 50}),
+  });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()), "Value 130 exceeds 127");
+
+  // Test negative overflow.
+  auto negData = makeRowVector({
+      makeNullableFlatVector<int8_t>({-100, -30}),
+      makeNullableFlatVector<int8_t>({-50, -50}),
+  });
+
+  auto negPlan =
+      PlanBuilder()
+          .values({negData})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(negPlan).copyResults(pool()),
+      "Value -130 is less than -128");
+}
+
+TEST_F(InternalVariadicVectorSumTest, smallintOverflow) {
+  const int16_t largeValue = std::numeric_limits<int16_t>::max() - 20;
+  const int16_t smallValue = std::numeric_limits<int16_t>::min() + 20;
+
+  // c0 = {largeValue, 30} -> sum overflows (exceeds 32767)
+  // c1 = {50, 50} -> sum = 100 -> no overflow
+  auto data = makeRowVector({
+      makeNullableFlatVector<int16_t>({largeValue, 30}),
+      makeNullableFlatVector<int16_t>({50, 50}),
+  });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value 32777 exceeds 32767");
+
+  // Test negative overflow.
+  auto negData = makeRowVector({
+      makeNullableFlatVector<int16_t>({smallValue, -30}),
+      makeNullableFlatVector<int16_t>({-50, -50}),
+  });
+
+  auto negPlan =
+      PlanBuilder()
+          .values({negData})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(negPlan).copyResults(pool()),
+      "Value -32778 is less than -32768");
+}
+
+TEST_F(InternalVariadicVectorSumTest, integerOverflow) {
+  const int32_t largeValue = std::numeric_limits<int32_t>::max() - 20;
+  const int32_t smallValue = std::numeric_limits<int32_t>::min() + 20;
+
+  // c0 = {largeValue, 30} -> sum overflows (exceeds 2147483647)
+  // c1 = {50, 50} -> sum = 100 -> no overflow
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({largeValue, 30}),
+      makeNullableFlatVector<int32_t>({50, 50}),
+  });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "Value 2147483657 exceeds 2147483647");
+
+  // Test negative overflow.
+  auto negData = makeRowVector({
+      makeNullableFlatVector<int32_t>({smallValue, -30}),
+      makeNullableFlatVector<int32_t>({-50, -50}),
+  });
+
+  auto negPlan =
+      PlanBuilder()
+          .values({negData})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(negPlan).copyResults(pool()),
+      "Value -2147483658 is less than -2147483648");
+}
+
+TEST_F(InternalVariadicVectorSumTest, bigintOverflow) {
+  const int64_t largeValue = std::numeric_limits<int64_t>::max() - 10;
+
+  // c0 = {largeValue, 20} -> sum = largeValue + 20 = max + 10 -> overflow
+  // c1 = {1, 1} -> sum = 2 -> no overflow
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({largeValue, 20}),
+      makeNullableFlatVector<int64_t>({1, 1}),
+  });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+          .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "exceeds 9223372036854775807");
+}
+
+TEST_F(InternalVariadicVectorSumTest, realType) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<float>({1.5F, 10.5F}),
+      makeNullableFlatVector<float>({2.5F, 5.5F}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({{12.0F, 8.0F}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, floatNan) {
+  constexpr float kInf = std::numeric_limits<float>::infinity();
+  constexpr float kNan = std::numeric_limits<float>::quiet_NaN();
+
+  auto data = makeRowVector({
+      makeNullableFlatVector<float>({10.0F, kNan, 30.0F}),
+      makeNullableFlatVector<float>({20.0F, 30.0F, kInf}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<float>({{kNan, kInf}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+TEST_F(InternalVariadicVectorSumTest, doubleNan) {
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
+
+  auto data = makeRowVector({
+      makeNullableFlatVector<double>({10.0, kNan, 30.0}),
+      makeNullableFlatVector<double>({20.0, 30.0, kInf}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<double>({{kNan, kInf}}),
+  });
+
+  testAggregations(
+      {data}, {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"}, {expected});
+}
+
+/// SQL equivalence tests
+
+TEST_F(InternalVariadicVectorSumTest, mismatchedIntermediateArraySizes) {
+  // Test that mismatched intermediate array sizes throw an error.
+  // This can occur when combining partial aggregation results from different
+  // workers where the intermediate arrays have different lengths.
+
+  // Register with companion functions to enable the _merge function.
+  prestosql::registerInternalVariadicVectorSumAggregate(
+      {"test_variadic_vector_sum"}, true, true);
+
+  // Create intermediate results with different array sizes.
+  // First batch: arrays of size 2
+  auto batch1 = makeRowVector({
+      makeArrayVector<int64_t>({{10, 20}}),
+  });
+
+  // Second batch: arrays of size 3 (mismatched!)
+  auto batch2 = makeRowVector({
+      makeArrayVector<int64_t>({{1, 2, 3}}),
+  });
+
+  // Combining these intermediate results should fail because array sizes
+  // don't match.
+  auto plan = PlanBuilder()
+                  .values({batch1, batch2})
+                  .singleAggregation({}, {"test_variadic_vector_sum_merge(c0)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan).copyResults(pool()),
+      "All arrays must have the same length");
+}
+
+/// SQL equivalence tests verify that $internal$variadic_vector_sum(c0, c1, ...)
+/// produces the same result as array[sum(coalesce(c0,0)), sum(coalesce(c1,0)),
+/// ...] This demonstrates the function is equivalent to element-wise column
+/// sums.
+class InternalVariadicVectorSumSqlEquivalenceTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    prestosql::registerInternalAggregateFunctions("");
+  }
+};
+
+TEST_F(InternalVariadicVectorSumSqlEquivalenceTest, equivalentToColumnSums) {
+  // $internal$variadic_vector_sum(c0, c1, c2) should equal
+  // array[sum(c0), sum(c1), sum(c2)]
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 10, 100}),
+      makeFlatVector<int64_t>({2, 20, 200}),
+      makeFlatVector<int64_t>({3, 30, 300}),
+  });
+
+  // Using the internal variadic function
+  auto variadicResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .singleAggregation(
+                  {}, {"\"$internal$variadic_vector_sum\"(c0, c1, c2)"})
+              .planNode())
+          .copyResults(pool());
+
+  // Using individual sum() calls and constructing an array
+  // sum(c0) = 111, sum(c1) = 222, sum(c2) = 333
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{111, 222, 333}}),
+  });
+
+  assertEqualResults({expected}, {variadicResult});
+}
+
+TEST_F(
+    InternalVariadicVectorSumSqlEquivalenceTest,
+    withNullsEquivalentToCoalesce) {
+  // With nulls, $internal$variadic_vector_sum treats them as 0
+  // This is equivalent to sum(coalesce(col, 0))
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 100}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 20, std::nullopt}),
+  });
+
+  // Using the internal variadic function
+  auto variadicResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .singleAggregation(
+                  {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+              .planNode())
+          .copyResults(pool());
+
+  // sum(coalesce(c0, 0)) = 1 + 0 + 100 = 101
+  // sum(coalesce(c1, 0)) = 0 + 20 + 0 = 20
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{101, 20}}),
+  });
+
+  assertEqualResults({expected}, {variadicResult});
+}
+
+TEST_F(InternalVariadicVectorSumSqlEquivalenceTest, groupByEquivalence) {
+  // For group by, each group's column sums should match
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 100, 200}),
+      makeFlatVector<int64_t>({1, 2, 10, 20}),
+  });
+
+  auto variadicResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .singleAggregation(
+                  {"c0"}, {"\"$internal$variadic_vector_sum\"(c1, c2)"})
+              .planNode())
+          .copyResults(pool());
+
+  // Group 1: sum(c1) = 10+20 = 30, sum(c2) = 1+2 = 3 -> [30, 3]
+  // Group 2: sum(c1) = 100+200 = 300, sum(c2) = 10+20 = 30 -> [300, 30]
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeArrayVector<int64_t>({{30, 3}, {300, 30}}),
+  });
+
+  assertEqualResults({expected}, {variadicResult});
+}
+
+TEST_F(InternalVariadicVectorSumSqlEquivalenceTest, floatingPointEquivalence) {
+  // Verify floating point sums match
+  auto data = makeRowVector({
+      makeFlatVector<double>({0.1, 0.2, 0.3}),
+      makeFlatVector<double>({1.0, 2.0, 3.0}),
+  });
+
+  auto variadicResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .singleAggregation(
+                  {}, {"\"$internal$variadic_vector_sum\"(c0, c1)"})
+              .planNode())
+          .copyResults(pool());
+
+  // sum(c0) = 0.1 + 0.2 + 0.3 = 0.6
+  // sum(c1) = 1.0 + 2.0 + 3.0 = 6.0
+  auto expected = makeRowVector({
+      makeArrayVector<double>({{0.6, 6.0}}),
+  });
+
+  assertEqualResults({expected}, {variadicResult});
+}
+
+TEST_F(InternalVariadicVectorSumSqlEquivalenceTest, singleColumnEquivalence) {
+  // Single column case: $internal$variadic_vector_sum(c0) = array[sum(c0)]
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+
+  auto variadicResult =
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .singleAggregation({}, {"\"$internal$variadic_vector_sum\"(c0)"})
+              .planNode())
+          .copyResults(pool());
+
+  // sum(c0) = 10 + 20 + 30 + 40 = 100
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({{100}}),
+  });
+
+  assertEqualResults({expected}, {variadicResult});
+}
+
+} // namespace
+
+} // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
Add the internal variadic form of vector_sum that takes variadic scalar arguments and returns an array.

$internal$variadic_vector_sum(T, T, ..., T) -> array(T)

Each argument position represents an element of a virtual array, and sums are accumulated across rows. This function is hidden from users (due to $internal$ prefix) and is intended for optimizer transformations.

This uses the Vector API (exec::Aggregate) rather than Simple API to properly handle nulls in any argument position using DecodedVector. The implementation follows the pattern established by $internal$variadic_array_union_sum in D90476644.

Supports tinyint, smallint, integer, bigint, real, and double types with proper overflow checking for integer types using __builtin_add_overflow.

Differential Revision: D94320509


