### PR TITLE
fix(cudf): Fix count(*) global aggregation

### DIFF
--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -52,7 +52,7 @@ struct CudfConfig {
   bool enabled{true};
 
   /// Enable debug printing.
-  bool debugEnabled{false};
+  bool debugEnabled{true};
 
   /// Allow fallback to CPU operators if GPU operator replacement fails.
   bool allowCpuFallback{true};

--- a/velox/experimental/cudf/exec/CudfHashAggregation.h
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.h
@@ -39,6 +39,10 @@ class CudfHashAggregation : public exec::Operator, public NvtxHelper {
     uint32_t inputIndex;
     VectorPtr constant;
     TypePtr resultType;
+    // Total number of input rows, set by CudfHashAggregation before doReduce.
+    // Used by CountAggregator for count(*) on 0-column tables where the cudf
+    // table_view cannot report the row count.
+    vector_size_t totalInputRows = 0;
 
     virtual void addGroupbyRequest(
         cudf::table_view const& tbl,

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -146,10 +146,10 @@ class FilterProjectAdapter : public OperatorAdapter {
     auto filterNode = filterProjectOp->filterNode();
 
     if (projectPlanNode) {
-      if (projectPlanNode->sources()[0]->outputType()->size() == 0 ||
-          projectPlanNode->outputType()->size() == 0) {
-        return false;
-      }
+      // if (projectPlanNode->sources()[0]->outputType()->size() == 0 ||
+      //     projectPlanNode->outputType()->size() == 0) {
+      //   return false;
+      // }
     }
 
     // Check filter separately
@@ -217,12 +217,6 @@ class AggregationAdapter : public OperatorAdapter {
     auto aggregationPlanNode =
         std::dynamic_pointer_cast<const core::AggregationNode>(planNode);
     if (!aggregationPlanNode) {
-      return false;
-    }
-
-    if (aggregationPlanNode->sources()[0]->outputType()->size() == 0) {
-      // We cannot handle RowVectors with a length but no data.
-      // This is the case with count(*) global (without groupby)
       return false;
     }
 


### PR DESCRIPTION
- [x] Enable count(*) global aggregation by tracking size of zero column input vector
- [x] Updated Project to propagate size of output columns for zero column output
- [x] Fixes velox_cudf_aggregation_test --gtest_filter=AggregationTest.countStarGlobal
- [ ] TODO Verify if CudfHiveSource to output zero-columns table but with correct size.
- [ ] TODO Verify if other operators need to do the same.
Fixes https://github.com/facebookincubator/velox/issues/16492