### PR TITLE
feat(parquet): Add compression level

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -907,6 +907,11 @@ Each query can override the config by setting corresponding query session proper
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
+   * - parquet.writer.compression-level
+     - parquet.writer.compression_level
+     - integer
+     -
+     - The compression level of compression codec. This configuration is shared between Hive and Iceberg connectors, hence no connector-specific prefix.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -98,6 +98,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   arrow::Encoding::type encoding = arrow::Encoding::kPlain;
 
   std::shared_ptr<CodecOptions> codecOptions;
+  std::optional<int32_t> compressionLevel;
   std::unordered_map<std::string, common::CompressionKind>
       columnCompressionsMap;
 
@@ -153,6 +154,10 @@ struct WriterOptions : public dwio::common::WriterOptions {
       "hive.parquet.writer.batch-size";
   static constexpr const char* kParquetHiveConnectorCreatedBy =
       "hive.parquet.writer.created-by";
+  static constexpr const char* kParquetSessionCompressionLevel =
+      "parquet.writer.compression_level";
+  static constexpr const char* kParquetHiveConnectorCompressionLevel =
+      "parquet.writer.compression-level";
 
   // Serde parameter keys for timestamp settings. These can be set via
   // serdeParameters map to override the default timestamp behavior.


### PR DESCRIPTION
Add parquet compression-level config.
This config is shared between hive and iceberg.
