### PR TITLE
fix: Clear AsyncDataCache in test SetUp to fix flakiness

### DIFF
--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
+#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/file/tests/FaultyFileSystem.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -37,6 +38,13 @@ HiveConnectorTestBase::HiveConnectorTestBase() {
 
 void HiveConnectorTestBase::SetUp() {
   OperatorTestBase::SetUp();
+
+  // Clear any stale cache entries from previous tests to avoid reading
+  // corrupted/stale data when temp files are reused (same inode/fileNum).
+  if (auto* cache = cache::AsyncDataCache::getInstance()) {
+    cache->clear();
+  }
+
   connector::hive::HiveConnectorFactory factory;
   auto hiveConnector = factory.newConnector(
       kHiveConnectorId,


### PR DESCRIPTION
Summary:
Some tests using HiveConnectorTestBase were experiencing flaky failures with "read past EOF" errors in PagedInputStream. This was caused by stale cache entries in AsyncDataCache being returned when temp files were reused between tests (same inode/fileNum leading to cache key collisions).

The fix clears all unpinned cache entries at the start of each test to ensure tests start with a clean cache state. This prevents corrupted/stale data from being read when temp file paths or inodes are recycled by the OS.

Differential Revision: D94400710


