### PR TITLE
fix: Clear barrier flag when task terminates

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2503,6 +2503,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     exchangeClients.swap(exchangeClients_);
 
     barrierPromises.swap(barrierFinishPromises_);
+    // Clear the barrier flag to ensure underBarrier() returns false after task
+    // termination.
+    barrierRequested_ = false;
   }
 
   taskCompletionNotifier.notify();

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -2915,7 +2915,7 @@ TEST_F(TaskTest, addSplitAfterBarrier) {
 
   {
     const auto task = Task::create(
-        "invalidPlanNodeForBarrier",
+        "barrierAfterNoMoreSplits",
         plan,
         0,
         core::QueryCtx::create(executor_.get()),
@@ -2932,7 +2932,6 @@ TEST_F(TaskTest, addSplitAfterBarrier) {
     auto future = task->requestBarrier();
     future.wait();
     ASSERT_FALSE(task->underBarrier());
-    ASSERT_TRUE(task->isRunning());
     task->requestAbort().wait();
     ASSERT_TRUE(!task->isRunning());
   }
@@ -3007,6 +3006,65 @@ TEST_F(TaskTest, testTerminateDuringBarrier) {
     ASSERT_TRUE(barrierFuture.isReady());
     ASSERT_EQ(task->taskStats().numBarriers, 1);
   }
+}
+
+TEST_F(TaskTest, testBarrierClearedOnTerminate) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+  });
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), {data});
+
+  core::PlanNodeId scanId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data->type()))
+                  .capturePlanNodeId(scanId)
+                  .project({"c0"})
+                  .planFragment();
+
+  // Verify that barrierRequested_ is cleared when task is aborted while under
+  // barrier in serial execution mode.
+  {
+    const auto task = Task::create(
+        "barrierClearedOnTerminate.serial",
+        plan,
+        0,
+        core::QueryCtx::create(),
+        Task::ExecutionMode::kSerial);
+    task->addSplit(
+        scanId, exec::Split(makeHiveConnectorSplit(filePath->getPath())));
+    auto barrierFuture = task->requestBarrier();
+    ASSERT_TRUE(task->underBarrier());
+    task->requestAbort().wait();
+    ASSERT_FALSE(task->isRunning());
+    ASSERT_FALSE(task->underBarrier());
+    ASSERT_TRUE(barrierFuture.isReady());
+  }
+
+  // Verify that barrierRequested_ is cleared when task is aborted while under
+  // barrier in parallel execution mode.
+  {
+    const auto task = Task::create(
+        "barrierClearedOnTerminate.parallel",
+        plan,
+        0,
+        core::QueryCtx::create(executor_.get()),
+        Task::ExecutionMode::kParallel,
+        [](const RowVectorPtr& /*vector*/,
+           bool /*drained*/,
+           velox::ContinueFuture* /*future*/) {
+          return BlockingReason::kNotBlocked;
+        });
+    task->start(2);
+    task->addSplit(
+        scanId, exec::Split(makeHiveConnectorSplit(filePath->getPath())));
+    auto barrierFuture = task->requestBarrier();
+    task->requestAbort().wait();
+    ASSERT_FALSE(task->isRunning());
+    ASSERT_FALSE(task->underBarrier());
+    ASSERT_TRUE(barrierFuture.isReady());
+  }
+  waitForAllTasksToBeDeleted();
 }
 
 namespace {


### PR DESCRIPTION
Summary:
When a task terminates while under barrier (e.g., via requestAbort()), the barrier promises are fulfilled but barrierRequested_ was not cleared. This caused underBarrier() to return true even after task termination, which is inconsistent with the fulfilled promises and could confuse code checking barrier state post-termination.

The fix clears barrierRequested_ in terminate() alongside the promise fulfillment to ensure consistent barrier state after task termination.

Differential Revision: D94463659


