### PR TITLE
feat(cudf): Enable JIT to filter join indices

### DIFF
--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -53,15 +53,10 @@ set(
 )
 velox_resolve_dependency_url(kvikio)
 
-# cudf commit e6ba1fe from 2026-02-11
+# cudf from shrshi fork, branch join-indices-jit-filter
 set(VELOX_cudf_VERSION 26.04 CACHE STRING "cudf version")
-set(VELOX_cudf_COMMIT e6ba1feee8f056ce2e245f771403cfa5f598d813)
-set(
-  VELOX_cudf_BUILD_SHA256_CHECKSUM
-  19137d306db0ddbf4eebb4333e0257de4815563039b1e805829ce2dcc525c3f5
-)
-set(VELOX_cudf_SOURCE_URL "https://github.com/rapidsai/cudf/archive/${VELOX_cudf_COMMIT}.tar.gz")
-velox_resolve_dependency_url(cudf)
+set(VELOX_cudf_GIT_REPO "https://github.com/shrshi/cudf.git")
+set(VELOX_cudf_GIT_TAG "join-indices-jit-filter")
 
 # Use block so we don't leak variables
 block(SCOPE_FOR VARIABLES)
@@ -97,8 +92,8 @@ block(SCOPE_FOR VARIABLES)
 
   FetchContent_Declare(
     cudf
-    URL ${VELOX_cudf_SOURCE_URL}
-    URL_HASH ${VELOX_cudf_BUILD_SHA256_CHECKSUM}
+    GIT_REPOSITORY ${VELOX_cudf_GIT_REPO}
+    GIT_TAG ${VELOX_cudf_GIT_TAG}
     SOURCE_SUBDIR
     cpp
     UPDATE_DISCONNECTED 1

--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -56,7 +56,7 @@ velox_resolve_dependency_url(kvikio)
 # cudf from shrshi fork, branch join-indices-jit-filter
 set(VELOX_cudf_VERSION 26.04 CACHE STRING "cudf version")
 set(VELOX_cudf_GIT_REPO "https://github.com/shrshi/cudf.git")
-set(VELOX_cudf_GIT_TAG "join-indices-jit-filter")
+set(VELOX_cudf_GIT_TAG "jit-null-handling")
 
 # Use block so we don't leak variables
 block(SCOPE_FOR VARIABLES)

--- a/velox/experimental/cudf/CudfConfig.h
+++ b/velox/experimental/cudf/CudfConfig.h
@@ -39,6 +39,8 @@ struct CudfConfig {
       "cudf.jit_expression_priority"};
   static constexpr const char* kCudfAllowCpuFallback{"cudf.allow_cpu_fallback"};
   static constexpr const char* kCudfLogFallback{"cudf.log_fallback"};
+  static constexpr const char* kCudfJitFilterJoinIndicesEnabled{
+      "cudf.jit_filter_join_indices_enabled"};
 
   /// Singleton CudfConfig instance.
   /// Clients must set the configs below before invoking registerCudf().
@@ -88,6 +90,9 @@ struct CudfConfig {
 
   /// Whether to log a reason for falling back to Velox CPU execution.
   bool logFallback{true};
+
+  /// Enable JIT-based filtering of join indices.
+  bool jitFilterJoinIndicesEnabled{false};
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -405,6 +405,10 @@ void CudfConfig::initialize(
   if (config.find(kCudfLogFallback) != config.end()) {
     logFallback = folly::to<bool>(config[kCudfLogFallback]);
   }
+  if (config.find(kCudfJitFilterJoinIndicesEnabled) != config.end()) {
+    jitFilterJoinIndicesEnabled =
+        folly::to<bool>(config[kCudfJitFilterJoinIndicesEnabled]);
+  }
 }
 
 } // namespace facebook::velox::cudf_velox


### PR DESCRIPTION
Depends on https://github.com/rapidsai/cudf/pull/21570

This PR adds an optional JIT-based implementation for filtering join indices in cuDF hash joins, with a configuration flag to enable/disable it.

### Changes

**New Configuration Option** (`CudfConfig.h`)
- Added `jitFilterJoinIndicesEnabled` config flag (default: `false`)
- Allows runtime switching between JIT and non-JIT filtering

**Core Implementation** (`CudfHashJoin.cpp`)
- Modified `filteredOutputIndices()` and `fullJoin()` methods to conditionally use `cudf::jit_filter_join_indices()` vs `cudf::filter_join_indices()` based on config

**Test Parameterization** (`HashJoinTest.cpp`)
- Added JIT enabled/disabled as a test parameter using `testing::Combine`
- All tests now run with both JIT on and JIT off configurations
- Changed test fixture to use `std::tuple<TestParam, bool>` parameter
- Converted `TEST_F` tests to `TEST_P` for full coverage
- All hash join tests run with 4 configurations: `{1 driver, 3 drivers} × {JIT on, JIT off}`
