### PR TITLE
feat(cudf): Add CudfLocalMerge and allow PartitionOutput without Fallback

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   CudfGroupby.cpp
   CudfHashJoin.cpp
   CudfLimit.cpp
+  CudfLocalMerge.cpp
   CudfLocalPartition.cpp
   CudfMarkDistinct.cpp
   CudfNestedLoopJoin.cpp

--- a/velox/experimental/cudf/exec/CudfLocalMerge.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalMerge.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/CudfLocalMerge.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+
+#include "velox/exec/Task.h"
+
+#include <cudf/merge.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+CudfLocalMerge::CudfLocalMerge(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::LocalMergeNode>& localMergeNode)
+    : CudfSourceOperatorBase(
+          operatorId,
+          driverCtx,
+          localMergeNode->outputType(),
+          localMergeNode->id(),
+          "CudfLocalMerge",
+          nvtx3::rgb{0, 206, 209}) { // Dark Turquoise
+  VELOX_CHECK_EQ(
+      operatorCtx_->driverCtx()->driverId,
+      0,
+      "CudfLocalMerge needs to run single-threaded");
+
+  const auto& sortingKeys = localMergeNode->sortingKeys();
+  const auto& sortingOrders = localMergeNode->sortingOrders();
+  const auto numSortingKeys = sortingKeys.size();
+  sortKeys_.reserve(numSortingKeys);
+  columnOrder_.reserve(numSortingKeys);
+  nullOrder_.reserve(numSortingKeys);
+
+  for (size_t i = 0; i < numSortingKeys; ++i) {
+    const auto channel = exec::exprToChannel(sortingKeys[i].get(), outputType_);
+    VELOX_CHECK(
+        channel != kConstantChannel,
+        "LocalMerge doesn't allow constant sorting keys");
+    sortKeys_.push_back(channel);
+    const auto& order = sortingOrders[i];
+    columnOrder_.push_back(
+        order.isAscending() ? cudf::order::ASCENDING : cudf::order::DESCENDING);
+    nullOrder_.push_back(
+        (order.isNullsFirst() ^ !order.isAscending())
+            ? cudf::null_order::BEFORE
+            : cudf::null_order::AFTER);
+  }
+}
+
+void CudfLocalMerge::addMergeSources() {
+  if (!sourcesAdded_) {
+    sources_ = operatorCtx_->task()->getLocalMergeSources(
+        operatorCtx_->driverCtx()->splitGroupId, planNodeId());
+    sourceData_.resize(sources_.size());
+    sourceDone_.resize(sources_.size(), false);
+    sourcesAdded_ = true;
+  }
+}
+
+exec::BlockingReason CudfLocalMerge::isBlocked(ContinueFuture* future) {
+  addMergeSources();
+
+  if (sources_.empty()) {
+    finished_ = true;
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  if (!sourcesStarted_) {
+    for (auto& source : sources_) {
+      source->start();
+    }
+    sourcesStarted_ = true;
+  }
+
+  if (!blockingFutures_.empty()) {
+    *future = std::move(blockingFutures_.back());
+    blockingFutures_.pop_back();
+    return exec::BlockingReason::kWaitForProducer;
+  }
+
+  return exec::BlockingReason::kNotBlocked;
+}
+
+bool CudfLocalMerge::isFinished() {
+  return finished_;
+}
+
+RowVectorPtr CudfLocalMerge::doGetOutput() {
+  if (finished_) {
+    return nullptr;
+  }
+
+  // Buffer every source fully before merging. Produces no output while any
+  // source is still blocked waiting for input.
+  if (!drainSources()) {
+    return nullptr;
+  }
+
+  // The merge emits the entire result in a single call.
+  auto output = mergeSources();
+  finished_ = true;
+  return output;
+}
+
+bool CudfLocalMerge::drainSources() {
+  for (size_t i = 0; i < sources_.size(); ++i) {
+    if (sourceDone_[i]) {
+      continue;
+    }
+
+    while (true) {
+      RowVectorPtr data;
+      ContinueFuture future;
+      bool drained = false;
+      auto reason = sources_[i]->next(data, &future, drained);
+
+      if (reason != exec::BlockingReason::kNotBlocked) {
+        blockingFutures_.push_back(std::move(future));
+        return false;
+      }
+
+      if (!data || data->size() == 0) {
+        sourceDone_[i] = true;
+        break;
+      }
+
+      auto cudfData = std::dynamic_pointer_cast<CudfVector>(data);
+      VELOX_CHECK_NOT_NULL(
+          cudfData,
+          "CudfLocalMerge expected CudfVector input from MergeSource");
+      sourceData_[i].push_back(std::move(cudfData));
+    }
+  }
+
+  // Reaching here means no source blocked, so every source has drained to
+  // end-of-data and all batches are buffered in 'sourceData_'.
+  return true;
+}
+
+RowVectorPtr CudfLocalMerge::mergeSources() {
+  auto stream = cudfGlobalStreamPool().get_stream();
+  auto mr = get_output_mr();
+
+  const auto numNonEmptySources =
+      std::count_if(sourceData_.begin(), sourceData_.end(), [](const auto& v) {
+        return !v.empty();
+      });
+
+  if (numNonEmptySources == 0) {
+    return nullptr;
+  }
+
+  // A single source is already globally sorted; concatenate its batches in
+  // order instead of running a k-way merge.
+  if (numNonEmptySources == 1) {
+    auto it =
+        std::find_if(sourceData_.begin(), sourceData_.end(), [](const auto& v) {
+          return !v.empty();
+        });
+    VELOX_CHECK(it != sourceData_.end());
+    if (it->size() == 1) {
+      return std::move(it->front());
+    }
+    auto concatenated =
+        getConcatenatedTable(std::move(*it), outputType_, stream, mr);
+    auto numRows = concatenated->num_rows();
+    return std::make_shared<CudfVector>(
+        pool(), outputType_, numRows, std::move(concatenated), stream);
+  }
+
+  // Multiple sorted sources: k-way merge all of their batches together.
+  size_t numBatches = 0;
+  for (const auto& batches : sourceData_) {
+    numBatches += batches.size();
+  }
+
+  std::vector<cudf::table_view> tableViews;
+  std::vector<rmm::cuda_stream_view> inputStreams;
+  std::vector<CudfVectorPtr> inputs;
+  tableViews.reserve(numBatches);
+  inputStreams.reserve(numBatches);
+  inputs.reserve(numBatches);
+  for (auto& batches : sourceData_) {
+    for (auto& tbl : batches) {
+      tableViews.push_back(tbl->getTableView());
+      inputStreams.push_back(tbl->stream());
+      inputs.push_back(std::move(tbl));
+    }
+  }
+  sourceData_.clear();
+
+  cudf::detail::join_streams(inputStreams, stream);
+  auto mergedTable =
+      cudf::merge(tableViews, sortKeys_, columnOrder_, nullOrder_, stream, mr);
+  // Order the source deallocations after the merge by rebinding their buffers
+  // to `stream` (with an event-wait fallback). This frees the inputs promptly
+  // without forcing the pooled producer streams to wait on the merge.
+  orderCudfVectorDeallocationsAfterStream(inputs, inputStreams, stream);
+
+  auto numRows = mergedTable->num_rows();
+  return std::make_shared<CudfVector>(
+      pool(), outputType_, numRows, std::move(mergedTable), stream);
+}
+
+void CudfLocalMerge::doClose() {
+  for (auto& source : sources_) {
+    source->close();
+  }
+  sourceData_.clear();
+  CudfSourceOperatorBase::doClose();
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfLocalMerge.cpp
+++ b/velox/experimental/cudf/exec/CudfLocalMerge.cpp
@@ -203,7 +203,6 @@ RowVectorPtr CudfLocalMerge::mergeSources() {
       inputs.push_back(std::move(tbl));
     }
   }
-  sourceData_.clear();
 
   cudf::detail::join_streams(inputStreams, stream);
   auto mergedTable =

--- a/velox/experimental/cudf/exec/CudfLocalMerge.h
+++ b/velox/experimental/cudf/exec/CudfLocalMerge.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/exec/MergeSource.h"
+
+#include <cudf/types.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+/// GPU-accelerated LocalMerge operator. Replaces the CPU LocalMerge by
+/// draining all MergeSource queues (which carry CudfVectors as RowVectorPtrs),
+/// then performing a k-way sorted merge via cudf::merge() on the GPU.
+///
+/// Inherits from CudfSourceOperatorBase (not from Merge) because the base
+/// Merge class's SourceMerger/TreeOfLosers/SourceStream all require CPU child
+/// vectors that CudfVector does not have.
+class CudfLocalMerge : public CudfSourceOperatorBase {
+ public:
+  CudfLocalMerge(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::LocalMergeNode>& localMergeNode);
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
+
+ protected:
+  RowVectorPtr doGetOutput() override;
+
+  void doClose() override;
+
+ private:
+  void addMergeSources();
+
+  // Drains all sources into 'sourceData_'. Returns false if a source blocked,
+  // stashing the wait future in 'blockingFutures_'.
+  bool drainSources();
+
+  // Merges the drained per-source batches into a single sorted output.
+  RowVectorPtr mergeSources();
+
+  std::vector<std::shared_ptr<exec::MergeSource>> sources_;
+  bool sourcesAdded_{false};
+  bool sourcesStarted_{false};
+
+  std::vector<cudf::size_type> sortKeys_;
+  std::vector<cudf::order> columnOrder_;
+  std::vector<cudf::null_order> nullOrder_;
+
+  /// Per-source accumulated batches. sourceData_[i] holds all CudfVectors
+  /// received from sources_[i].
+  std::vector<std::vector<CudfVectorPtr>> sourceData_;
+  /// Per-source done flag. True when sources_[i] has been fully drained.
+  std::vector<bool> sourceDone_;
+
+  std::vector<ContinueFuture> blockingFutures_;
+  bool finished_{false};
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -172,4 +172,63 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
   const NvtxMethodFlag nvtxMethods_;
 };
 
+/// Base class for cuDF source operators (first operator in a Driver pipeline).
+///
+/// This mirrors CudfOperatorBase but inherits from exec::SourceOperator instead
+/// of exec::Operator. Source operators never accept input (addInput/noMoreInput
+/// are disabled by SourceOperator), so this class only wraps getOutput and
+/// close with NVTX profiling and checkCudaErrorInDebug.
+///
+/// Derived classes override:
+///   - doGetOutput()   -- produces output rows; called by getOutput()
+///   - doClose()       -- releases resources; called by close()
+///                        (defaults to SourceOperator::close())
+class CudfSourceOperatorBase : public exec::SourceOperator, public NvtxHelper {
+ public:
+  CudfSourceOperatorBase(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      RowTypePtr outputType,
+      const core::PlanNodeId& planNodeId,
+      const std::string& operatorName,
+      std::optional<nvtx3::color> color = std::nullopt,
+      NvtxMethodFlag nvtxMethods = NvtxMethodFlag::kGetOutput |
+          NvtxMethodFlag::kClose)
+      : SourceOperator(
+            driverCtx,
+            outputType,
+            operatorId,
+            planNodeId,
+            operatorName),
+        NvtxHelper(color, operatorId, fmt::format("[{}]", planNodeId)),
+        className_(operatorName),
+        nvtxMethods_(nvtxMethods) {}
+
+  RowVectorPtr getOutput() final {
+    VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
+        nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
+    auto result = doGetOutput();
+    checkCudaErrorInDebug();
+    return result;
+  }
+
+  void close() final {
+    VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
+        nvtxMethods_ & NvtxMethodFlag::kClose, className_);
+    doClose();
+    checkCudaErrorInDebug();
+  }
+
+ protected:
+  virtual RowVectorPtr doGetOutput() = 0;
+
+  virtual void doClose() {
+    SourceOperator::close();
+  }
+
+ private:
+  const std::string className_;
+  const NvtxMethodFlag nvtxMethods_;
+};
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -56,6 +56,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/NestedLoopJoinProbe.h"
 #include "velox/exec/OrderBy.h"
+#include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/Task.h"
@@ -1024,6 +1025,43 @@ class LocalMergeAdapter : public OperatorAdapter {
   }
 };
 
+/// PartitionedOutputAdapter - Keeps original operator (CPU sink for shuffle)
+class PartitionedOutputAdapter : public OperatorAdapter {
+ public:
+  PartitionedOutputAdapter() : OperatorAdapter("PartitionedOutput") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::PartitionedOutput*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/) const override {
+    return false;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return false;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/,
+      int32_t /*operatorId*/) const override {
+    return {}; // Keep original operator
+  }
+
+  bool keepOperator() const override {
+    return true;
+  }
+};
+
 // WindowAdapter - Replaces with CudfWindow
 class WindowAdapter : public OperatorAdapter {
  public:
@@ -1144,6 +1182,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<GroupIdAdapter>());
   registry.registerAdapter(std::make_unique<ValuesAdapter>());
   registry.registerAdapter(std::make_unique<CallbackSinkAdapter>());
+  registry.registerAdapter(std::make_unique<PartitionedOutputAdapter>());
   registry.registerAdapter(std::make_unique<WindowAdapter>());
 }
 

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -27,6 +27,7 @@
 #include "velox/experimental/cudf/exec/CudfGroupby.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/CudfLimit.h"
+#include "velox/experimental/cudf/exec/CudfLocalMerge.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
 #include "velox/experimental/cudf/exec/CudfMarkDistinct.h"
 #include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
@@ -51,6 +52,7 @@
 #include "velox/exec/Limit.h"
 #include "velox/exec/LocalPartition.h"
 #include "velox/exec/MarkDistinct.h"
+#include "velox/exec/Merge.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/NestedLoopJoinProbe.h"
 #include "velox/exec/OrderBy.h"
@@ -931,7 +933,8 @@ class EnforceSingleRowAdapter : public OperatorAdapter {
   }
 };
 
-/// CallbackSinkAdapter - Keeps original operator
+/// CallbackSinkAdapter - Keeps original operator (accepts GPU input when part
+/// of LocalMergeNode)
 class CallbackSinkAdapter : public OperatorAdapter {
  public:
   CallbackSinkAdapter() : OperatorAdapter("CallbackSink") {}
@@ -944,14 +947,19 @@ class CallbackSinkAdapter : public OperatorAdapter {
       const exec::Operator* /*op*/,
       const core::PlanNodePtr& planNode,
       exec::DriverCtx* /*ctx*/) const override {
-    LOG_FALLBACK(
-        "CallbackSink operator not supported on cuDF, PlanNode id: {}",
-        planNode->id());
-    return false;
+    auto supported = planNode &&
+        std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode) !=
+            nullptr;
+    if (!supported) {
+      LOG_FALLBACK(
+          "CallbackSink operator not supported on cuDF, PlanNode id: {}",
+          planNode ? planNode->id() : "null");
+    }
+    return supported;
   }
 
   bool acceptsGpuInput() const override {
-    return false;
+    return true;
   }
 
   bool producesGpuOutput() const override {
@@ -968,6 +976,51 @@ class CallbackSinkAdapter : public OperatorAdapter {
 
   bool keepOperator() const override {
     return true;
+  }
+};
+
+/// LocalMergeAdapter - Replaces CPU LocalMerge with GPU CudfLocalMerge
+class LocalMergeAdapter : public OperatorAdapter {
+ public:
+  LocalMergeAdapter() : OperatorAdapter("LocalMerge") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::LocalMerge*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* /*ctx*/) const override {
+    return planNode &&
+        std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode) !=
+        nullptr;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* op,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto localMergePlanNode =
+        std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode);
+
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfLocalMerge>(operatorId, ctx, localMergePlanNode));
+    return result;
+  }
+
+  bool keepOperator() const override {
+    return false;
   }
 };
 
@@ -1084,6 +1137,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<LimitAdapter>());
   registry.registerAdapter(std::make_unique<LocalPartitionAdapter>());
   registry.registerAdapter(std::make_unique<LocalExchangeAdapter>());
+  registry.registerAdapter(std::make_unique<LocalMergeAdapter>());
   registry.registerAdapter(std::make_unique<AssignUniqueIdAdapter>());
   registry.registerAdapter(std::make_unique<MarkDistinctAdapter>());
   registry.registerAdapter(std::make_unique<EnforceSingleRowAdapter>());

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -27,6 +27,7 @@
 #include "velox/experimental/cudf/exec/CudfGroupby.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/CudfLimit.h"
+#include "velox/experimental/cudf/exec/CudfLocalMerge.h"
 #include "velox/experimental/cudf/exec/CudfLocalPartition.h"
 #include "velox/experimental/cudf/exec/CudfMarkDistinct.h"
 #include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
@@ -53,6 +54,7 @@
 #include "velox/exec/Limit.h"
 #include "velox/exec/LocalPartition.h"
 #include "velox/exec/MarkDistinct.h"
+#include "velox/exec/Merge.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/NestedLoopJoinProbe.h"
 #include "velox/exec/OrderBy.h"
@@ -1007,7 +1009,8 @@ class EnforceSingleRowAdapter : public OperatorAdapter {
   }
 };
 
-/// CallbackSinkAdapter - Keeps original operator
+/// CallbackSinkAdapter - Keeps original operator (accepts GPU input when part
+/// of LocalMergeNode)
 class CallbackSinkAdapter : public OperatorAdapter {
  public:
   CallbackSinkAdapter() : OperatorAdapter("CallbackSink") {}
@@ -1020,14 +1023,19 @@ class CallbackSinkAdapter : public OperatorAdapter {
       const exec::Operator* /*op*/,
       const core::PlanNodePtr& planNode,
       exec::DriverCtx* /*ctx*/) const override {
-    LOG_FALLBACK(
-        "CallbackSink operator not supported on cuDF, PlanNode id: {}",
-        planNode->id());
-    return false;
+    auto supported = planNode &&
+        std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode) !=
+            nullptr;
+    if (!supported) {
+      LOG_FALLBACK(
+          "CallbackSink operator not supported on cuDF, PlanNode id: {}",
+          planNode ? planNode->id() : "null");
+    }
+    return supported;
   }
 
   bool acceptsGpuInput() const override {
-    return false;
+    return true;
   }
 
   bool producesGpuOutput() const override {
@@ -1044,6 +1052,51 @@ class CallbackSinkAdapter : public OperatorAdapter {
 
   bool keepOperator() const override {
     return true;
+  }
+};
+
+/// LocalMergeAdapter - Replaces CPU LocalMerge with GPU CudfLocalMerge
+class LocalMergeAdapter : public OperatorAdapter {
+ public:
+  LocalMergeAdapter() : OperatorAdapter("LocalMerge") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::LocalMerge*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* /*ctx*/) const override {
+    return planNode &&
+        std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode) !=
+        nullptr;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* op,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto localMergePlanNode =
+        std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode);
+
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfLocalMerge>(operatorId, ctx, localMergePlanNode));
+    return result;
+  }
+
+  bool keepOperator() const override {
+    return false;
   }
 };
 
@@ -1161,6 +1214,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<LimitAdapter>());
   registry.registerAdapter(std::make_unique<LocalPartitionAdapter>());
   registry.registerAdapter(std::make_unique<LocalExchangeAdapter>());
+  registry.registerAdapter(std::make_unique<LocalMergeAdapter>());
   registry.registerAdapter(std::make_unique<AssignUniqueIdAdapter>());
   registry.registerAdapter(std::make_unique<MarkDistinctAdapter>());
   registry.registerAdapter(std::make_unique<EnforceSingleRowAdapter>());

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -58,6 +58,7 @@
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/NestedLoopJoinProbe.h"
 #include "velox/exec/OrderBy.h"
+#include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/Task.h"
@@ -1100,6 +1101,43 @@ class LocalMergeAdapter : public OperatorAdapter {
   }
 };
 
+/// PartitionedOutputAdapter - Keeps original operator (CPU sink for shuffle)
+class PartitionedOutputAdapter : public OperatorAdapter {
+ public:
+  PartitionedOutputAdapter() : OperatorAdapter("PartitionedOutput") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::PartitionedOutput*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/) const override {
+    return false;
+  }
+
+  bool acceptsGpuInput() const override {
+    return false;
+  }
+
+  bool producesGpuOutput() const override {
+    return false;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& /*planNode*/,
+      exec::DriverCtx* /*ctx*/,
+      int32_t /*operatorId*/) const override {
+    return {}; // Keep original operator
+  }
+
+  bool keepOperator() const override {
+    return true;
+  }
+};
+
 // WindowAdapter - Replaces with CudfWindow
 class WindowAdapter : public OperatorAdapter {
  public:
@@ -1221,6 +1259,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<GroupIdAdapter>());
   registry.registerAdapter(std::make_unique<ValuesAdapter>());
   registry.registerAdapter(std::make_unique<CallbackSinkAdapter>());
+  registry.registerAdapter(std::make_unique<PartitionedOutputAdapter>());
   registry.registerAdapter(std::make_unique<WindowAdapter>());
 }
 

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -68,6 +68,15 @@ core::PlanNodePtr CompileState::getPlanNode(const core::PlanNodeId& id) const {
   return driverFactory_.consumerNode;
 }
 
+core::PlanNodePtr CompileState::resolveOperatorPlanNode(
+    const exec::Operator* op) const {
+  const auto& id = op->planNodeId();
+  if (!id.empty() && id != "N/A") {
+    return getPlanNode(id);
+  }
+  return driverFactory_.consumerNode;
+}
+
 bool CompileState::compile(bool allowCpuFallback) {
   auto operators = driver_.operators();
 
@@ -85,12 +94,6 @@ bool CompileState::compile(bool allowCpuFallback) {
   bool replacementsMade = false;
   auto ctx = driver_.driverCtx();
 
-  // Helper to check if planNodeId is valid (some operators like CallbackSink
-  // have "N/A")
-  auto isValidPlanNodeId = [](const core::PlanNodeId& id) {
-    return !id.empty() && id != "N/A";
-  };
-
   // Use adapter registry for GPU Operator Replacement
   auto& registry = OperatorAdapterRegistry::getInstance();
 
@@ -100,13 +103,16 @@ bool CompileState::compile(bool allowCpuFallback) {
   };
 
   auto getOperatorProperties =
-      [&registry, this, &isValidPlanNodeId, ctx](const exec::Operator* op) {
+      [&registry, this, ctx](const exec::Operator* op) {
         OperatorProperties props;
         auto adapter = registry.findAdapter(op);
         props.adapter = adapter;
-        if (adapter && isValidPlanNodeId(op->planNodeId())) {
-          static_cast<OperatorAdapter::Properties&>(props) =
-              adapter->properties(op, getPlanNode(op->planNodeId()), ctx);
+        if (adapter) {
+          auto planNode = resolveOperatorPlanNode(op);
+          if (planNode) {
+            static_cast<OperatorAdapter::Properties&>(props) =
+                adapter->properties(op, planNode, ctx);
+          }
         }
         if (isAnyOf<CudfOperator>(op)) {
           // CudfOperator is always fully GPU compatible
@@ -146,11 +152,7 @@ bool CompileState::compile(bool allowCpuFallback) {
 
     auto id = oper->operatorId();
 
-    // Cache planNode for this operator (avoid multiple lookups)
-    core::PlanNodePtr planNode = nullptr;
-    if (isValidPlanNodeId(oper->planNodeId())) {
-      planNode = getPlanNode(oper->planNodeId());
-    }
+    auto planNode = resolveOperatorPlanNode(oper);
 
     if (previousOperatorIsNotGpu and thisOpProps.acceptsGpuInput and planNode) {
       replaceOp.push_back(

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -16,13 +16,9 @@
 
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/CudfConversion.h"
-#include "velox/experimental/cudf/exec/CudfGroupby.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
 #include "velox/experimental/cudf/exec/CudfNestedLoopJoin.h"
 #include "velox/experimental/cudf/exec/CudfOperator.h"
-#include "velox/experimental/cudf/exec/CudfOrderBy.h"
-#include "velox/experimental/cudf/exec/CudfReduce.h"
-#include "velox/experimental/cudf/exec/CudfTopN.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
 #include "velox/experimental/cudf/exec/OperatorAdapters.h"
 #include "velox/experimental/cudf/exec/PrestoAggregateFunctions.h"
@@ -32,16 +28,11 @@
 #include "velox/experimental/cudf/expression/JitExpression.h"
 
 #include "folly/Conv.h"
-#include "velox/exec/Driver.h"
-#include "velox/exec/Operator.h"
-#include "velox/exec/Values.h"
 
 #include <cudf/detail/nvtx/ranges.hpp>
 #include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda.h>
-
-#include <iostream>
 
 static const std::string kCudfAdapterName = "cuDF";
 
@@ -215,32 +206,33 @@ bool CompileState::compile(bool allowCpuFallback) {
     }
 
     if (debugEnabled) {
-      VLOG(1) << "Operator: ID " << oper->operatorId() << ": "
-              << oper->toString() << ", keepOperator = " << keepOperator
-              << ", isPureCpuOperator = " << isPureCpuOperator
-              << ", replaceOp.size() = " << replaceOp.size()
-              << ", previousOperatorIsNotGpu = " << previousOperatorIsNotGpu
-              << ", nextOperatorIsNotGpu = " << nextOperatorIsNotGpu
-              << ", isLastOperatorOfTask = " << isLastOperatorOfTask
-              << ", canRunOnGPU[" << operatorIndex
-              << "] = " << thisOpProps.canRunOnGPU << ", acceptsGpuInput["
-              << operatorIndex << "] = " << thisOpProps.acceptsGpuInput
-              << ", producesGpuOutput[" << operatorIndex
-              << "] = " << thisOpProps.producesGpuOutput
-              << ", planNode = " << bool(planNode);
+      LOG(INFO) << "Operator: ID " << oper->operatorId() << ": "
+                << oper->toString() << ", keepOperator = " << keepOperator
+                << ", isPureCpuOperator = " << isPureCpuOperator
+                << ", replaceOp.size() = " << replaceOp.size()
+                << ", previousOperatorIsNotGpu = " << previousOperatorIsNotGpu
+                << ", nextOperatorIsNotGpu = " << nextOperatorIsNotGpu
+                << ", isLastOperatorOfTask = " << isLastOperatorOfTask
+                << ", canRunOnGPU[" << operatorIndex
+                << "] = " << thisOpProps.canRunOnGPU << ", acceptsGpuInput["
+                << operatorIndex << "] = " << thisOpProps.acceptsGpuInput
+                << ", producesGpuOutput[" << operatorIndex
+                << "] = " << thisOpProps.producesGpuOutput
+                << ", planNode = " << bool(planNode);
+    }
+    if (isPureCpuOperator) {
+      LOG(WARNING) << "Replacement with cuDF operator failed. "
+                   << (allowCpuFallback ? "Falling back to CPU execution"
+                                        : "No fallback allowed");
+      LOG(WARNING) << "Replacement Failed Operator: " << oper->toString();
+      LOG(WARNING) << "Replacement Failed PlanNode: "
+                   << (planNode ? planNode->toString(true, false) : "null");
     }
     if (!allowCpuFallback) {
       // condition is if GPU replacement success or if CPU operators itself is
       // GPU compatible. or if specific CPU operator is allowed even when
       // fallback is disabled.
       VELOX_CHECK(!isPureCpuOperator, "Replacement with cuDF operator failed");
-    } else if (isPureCpuOperator) {
-      LOG(WARNING)
-          << "Replacement with cuDF operator failed. Falling back to CPU execution";
-      LOG(WARNING) << "Replacement Failed Operator: " << oper->toString();
-      auto planNode = getPlanNode(oper->planNodeId());
-      LOG(WARNING) << "Replacement Failed PlanNode: "
-                   << planNode->toString(true, false);
     }
 
     if (not replaceOp.empty()) {

--- a/velox/experimental/cudf/exec/ToCudf.h
+++ b/velox/experimental/cudf/exec/ToCudf.h
@@ -30,8 +30,13 @@ class CompileState {
     return driver_;
   }
 
-  // Get plan node by id lookup.
+  // Get plan node by id lookup (asserts the id exists).
   core::PlanNodePtr getPlanNode(const core::PlanNodeId& id) const;
+
+  // Resolve the plan node for an operator. Falls back to
+  // driverFactory_.consumerNode for operators like CallbackSink whose
+  // planNodeId is "N/A". May return nullptr.
+  core::PlanNodePtr resolveOperatorPlanNode(const exec::Operator* op) const;
 
   // Replaces sequences of Operators in the Driver given at construction with
   // cuDF equivalents. Returns true if the Driver was changed.

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -183,6 +183,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_local_merge_test
+  SOURCES Main.cpp LocalMergeTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_local_partition_test
   SOURCES Main.cpp LocalPartitionTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -189,6 +189,12 @@ velox_add_cudf_test(
 )
 
 velox_add_cudf_test(
+  NAME velox_cudf_local_merge_test
+  SOURCES Main.cpp LocalMergeTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt
+)
+
+velox_add_cudf_test(
   NAME velox_cudf_local_partition_test
   SOURCES Main.cpp LocalPartitionTest.cpp
   LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt

--- a/velox/experimental/cudf/tests/LocalMergeTest.cpp
+++ b/velox/experimental/cudf/tests/LocalMergeTest.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/core/QueryConfig.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+#include <fmt/format.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::common::testutil;
+
+namespace {
+
+class LocalMergeTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    filesystems::registerLocalFileSystem();
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    OperatorTestBase::TearDown();
+  }
+
+  void testSingleKey(
+      const std::vector<RowVectorPtr>& inputVectors,
+      const std::string& key) {
+    auto keyIndex = inputVectors[0]->type()->asRow().getChildIdx(key);
+
+    std::vector<std::string> sortOrderSqls = {
+        "NULLS LAST", "NULLS FIRST", "DESC NULLS FIRST", "DESC NULLS LAST"};
+    for (const auto& sortOrderSql : sortOrderSqls) {
+      const auto orderByClause = fmt::format("{} {}", key, sortOrderSql);
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto plan = PlanBuilder(planNodeIdGenerator)
+                      .localMerge(
+                          {orderByClause},
+                          {PlanBuilder(planNodeIdGenerator)
+                               .values(inputVectors)
+                               .orderBy({orderByClause}, true)
+                               .planNode()})
+                      .planNode();
+      CursorParameters params;
+      params.planNode = plan;
+      params.maxDrivers = 1;
+      assertQueryOrdered(
+          params,
+          "SELECT * FROM (SELECT * FROM tmp) ORDER BY " + orderByClause,
+          {keyIndex});
+
+      std::vector<std::shared_ptr<const core::PlanNode>> sources;
+      for (const auto& input : inputVectors) {
+        sources.push_back(PlanBuilder(planNodeIdGenerator)
+                              .values({input})
+                              .orderBy({orderByClause}, true)
+                              .planNode());
+      }
+      plan = PlanBuilder(planNodeIdGenerator)
+                 .localMerge({orderByClause}, std::move(sources))
+                 .planNode();
+
+      assertQueryOrdered(
+          plan, "SELECT * FROM tmp ORDER BY " + orderByClause, {keyIndex});
+    }
+  }
+
+  void testTwoKeys(
+      const std::vector<RowVectorPtr>& inputVectors,
+      const std::string& key1,
+      const std::string& key2) {
+    auto& rowType = inputVectors[0]->type()->asRow();
+    auto sortingKeys = {rowType.getChildIdx(key1), rowType.getChildIdx(key2)};
+
+    std::vector<std::string> sortOrderSqls = {
+        "NULLS LAST", "NULLS FIRST", "DESC NULLS FIRST", "DESC NULLS LAST"};
+
+    for (auto i = 0; i < sortOrderSqls.size(); ++i) {
+      for (auto j = 0; j < sortOrderSqls.size(); ++j) {
+        const std::vector<std::string> orderByClauses = {
+            fmt::format("{} {}", key1, sortOrderSqls[i]),
+            fmt::format("{} {}", key2, sortOrderSqls[j])};
+        const auto orderBySql = fmt::format(
+            "ORDER BY {}, {}", orderByClauses[0], orderByClauses[1]);
+        auto planNodeIdGenerator =
+            std::make_shared<core::PlanNodeIdGenerator>();
+        auto plan = PlanBuilder(planNodeIdGenerator)
+                        .localMerge(
+                            orderByClauses,
+                            {PlanBuilder(planNodeIdGenerator)
+                                 .values(inputVectors)
+                                 .orderBy(orderByClauses, true)
+                                 .planNode()})
+                        .planNode();
+        CursorParameters params;
+        params.planNode = plan;
+        params.maxDrivers = 1;
+        assertQueryOrdered(
+            params,
+            "SELECT * FROM (SELECT * FROM tmp) " + orderBySql,
+            sortingKeys);
+
+        std::vector<std::shared_ptr<const core::PlanNode>> sources;
+        for (const auto& input : inputVectors) {
+          sources.push_back(PlanBuilder(planNodeIdGenerator)
+                                .values({input})
+                                .orderBy(orderByClauses, true)
+                                .planNode());
+        }
+        plan = PlanBuilder(planNodeIdGenerator)
+                   .localMerge(orderByClauses, std::move(sources))
+                   .planNode();
+
+        assertQueryOrdered(
+            plan, "SELECT * FROM tmp " + orderBySql, sortingKeys);
+      }
+    }
+  }
+};
+
+TEST_F(LocalMergeTest, localMerge) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 3; ++i) {
+    static constexpr vector_size_t kBatchSize = 100;
+    auto c0 = makeFlatVector<int64_t>(
+        kBatchSize,
+        [&](auto row) { return kBatchSize * i + row; },
+        nullEvery(5));
+    auto c1 = makeFlatVector<int64_t>(
+        kBatchSize, [&](auto row) { return row; }, nullEvery(5));
+    auto c2 = makeFlatVector<double>(
+        kBatchSize, [](auto row) { return row * 0.1; }, nullEvery(11));
+    auto c3 = makeFlatVector<StringView>(kBatchSize, [](auto row) {
+      return StringView::makeInline(std::to_string(row));
+    });
+    vectors.push_back(makeRowVector({c0, c1, c2, c3}));
+  }
+  createDuckDbTable(vectors);
+
+  testSingleKey(vectors, "c0");
+  testSingleKey(vectors, "c3");
+
+  testTwoKeys(vectors, "c0", "c3");
+  testTwoKeys(vectors, "c3", "c0");
+}
+
+TEST_F(LocalMergeTest, offByOne) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({0, 1, 10}),
+  });
+
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({2, 3, 4, 5}),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {
+                  PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+                  PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+              })
+          .planNode();
+
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = core::QueryCtx::create(executor_.get());
+  params.queryCtx->testingOverrideConfigUnsafe(
+      {{core::QueryConfig::kPreferredOutputBatchRows, "6"}});
+  assertQueryOrdered(params, "VALUES (0), (1), (2), (3), (4), (5), (10)", {0});
+}
+
+} // namespace


### PR DESCRIPTION
### Summary

Several Presto TPC-H plans fall back to CPU at `PartitionedOutput` and `LocalMerge`, which breaks end-to-end GPU execution for every query that ends in a shuffle or an ordered merge. This PR removes both fallbacks.

`PartitionedOutput` is the higher-volume of the two: it appears in the output stage of nearly every TPC-H query, whereas `LocalMerge` only appears in plans with a final ordered merge.

#### PartitionedOutput without fallback

- New `PartitionedOutputAdapter` keeps the CPU `PartitionedOutput` operator but marks it GPU-compatible in the adapter registry, so a GPU pipeline can terminate in partition/shuffle output even when CPU fallback is disabled.

#### CudfLocalMerge

- New `CudfLocalMerge` operator drains all `MergeSource` inputs, then performs a k-way sorted merge with `cudf::merge()`.
- Built on a new `CudfSourceOperatorBase` rather than the CPU `Merge` path, whose `SourceMerger`/`TreeOfLosers`/`SourceStream` all assume CPU child vectors that `CudfVector` does not have.
- `LocalMergeAdapter` replaces CPU `LocalMerge`. `CallbackSinkAdapter` keeps the CPU sink on merge-source drivers but accepts GPU input when the consumer is a `LocalMergeNode`.
- `ToCudf` resolves plan nodes for operators whose `planNodeId` is `"N/A"` (e.g. `CallbackSink`) via `resolveOperatorPlanNode()`.

#### Fallback logging

- The per-operator adaptation decision moves from `VLOG(1)` to `LOG(INFO)` under `cudf.debug_enabled`, so which operators were replaced is visible without a rebuild.
- The fallback log path now null-guards the plan node. Operators whose `planNodeId` is `"N/A"` can resolve to null, so the previous unguarded `planNode->toString()` could crash the worker while it was reporting a fallback.

#### Tests

- `LocalMergeTest` covers single-key and two-key sort orders across all four null-ordering/direction combinations, plus a preferred-output-batch-size edge case that previously produced an off-by-one.
