### PR TITLE
perf(exec): Add AMAC prefetch optimization for listJoinResults

### DIFF
--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -442,7 +442,9 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
     return BaseHashTable::JoinResultIterator(
         std::move(varSizeListColumns),
         fixedSizeListColumnsSizeSum,
-        std::nullopt);
+        fixedSizeListColumnsSizeSum > 0
+            ? std::optional<uint64_t>(fixedSizeListColumnsSizeSum)
+            : std::nullopt);
   }
 
   // Hash probe and list join result.
@@ -544,7 +546,7 @@ int main(int argc, char** argv) {
   std::vector<HashTableBenchmarkResult> results;
 
   auto hashTableSize = (2L << 20) - 3;
-  auto probeRowSize = 100000000L;
+  auto probeRowSize = 10'000'000L;
 
   TypePtr onlyKeyType{ROW({"k1"}, {BIGINT()})};
 


### PR DESCRIPTION
Add listJoinResultsAmac() that prefetches up to 6 duplicate chains in
round-robin, hiding DRAM latency during nextRow() pointer chasing.
While emitting a result from slot[i], prefetched data for slots
[i+1..N] arrives in the cache, overlapping computation with memory
access.

Applicable when all four conditions hold:
  1. nextOffset_ is set (join build table, not group-by).
  2. hasDuplicates_ is true (at least one key has multiple build rows).
  3. !includeMisses (inner, right, semi joins only).
  4. estimatedRowSize.has_value() (no extreme variable-size skew,
 enables precise byte budget tracking).

Round-robin interleaving produces output rows in non-sequential probe-
row order. This is incompatible with NoMatchDetector (used by LEFT,
FULL, ANTI joins that require includeMisses), so those join types fall
through to the serial path.

LeftSemiFilterJoinTracker rewritten from sequential state machine to
bitmap (std::vector<bool>) to correctly de-duplicate probe rows whose
results arrive in interleaved order across multiple output batches.

```
Benchmark (HashJoinListResultBenchmark, 10M probe, 2M build):
  array  100%:25  31.88s -> 7.99s  (-75%)
  array  100%:20  22.57s -> 6.33s  (-72%)
  array  100%:10   7.07s -> 3.13s  (-56%)
  norm   100%:25  32.44s -> 8.14s  (-75%)
  hash   100%:25  32.65s -> 8.96s  (-73%)
  array  20%:50   14.35s -> 3.47s  (-76%)
  array  20%:204.65s -> 1.50s  (-68%)
```
