### PR TITLE
perf(exec): Combine low-selectivity filter results in HashProbe

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -2236,6 +2236,8 @@ void HashProbe::clearBuffers() {
   if (filter_ == nullptr) {
     return;
   }
+  accumulatedRowMapping_.reset();
+  accumulatedTableRows_.reset();
   filterResult_.clear();
   filterResult_.resize(1);
   filterTableInput_.reset();

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1287,23 +1287,66 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
   // Left semi and anti joins are always cardinality reducing, e.g. for a
   // given row of input they produce zero or 1 row of output. Therefore, if
   // there is no extra filter we can process each batch of input in one go.
-  auto outputBatchSize = (isLeftSemiOrAntiJoinNoFilter || emptyBuildSide)
+  auto maxOutputBatchRows = (isLeftSemiOrAntiJoinNoFilter || emptyBuildSide)
       ? inputSize
       : outputBatchSize_;
-  outputTableRowsCapacity_ = outputBatchSize;
-  if (filter_ &&
-      (isLeftJoin(joinType_) || isFullJoin(joinType_) ||
-       isAntiJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
-       isLeftSemiProjectJoin(joinType_))) {
-    // If we need non-matching probe side row, there is a possibility that such
-    // row exists at end of an input batch and being carried over in the next
-    // output batch, so we need to make extra room of one row in output.
-    ++outputTableRowsCapacity_;
+  outputTableRowsCapacity_ = maxOutputBatchRows;
+  if (filter_) {
+    if (isLeftJoin(joinType_) || isFullJoin(joinType_) ||
+        isAntiJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
+        isLeftSemiProjectJoin(joinType_)) {
+      // If we need non-matching probe side row, there is a possibility that
+      // such row exists at end of an input batch and being carried over in the
+      // next output batch, so we need to make extra room of one row in output.
+      ++outputTableRowsCapacity_;
+    }
   }
-  auto mapping = initializeRowNumberMapping(
-      outputRowMapping_, outputTableRowsCapacity_, pool());
+
+  // The accumulation buffers take over as the working buffers after a flush,
+  // so allocate the working buffers at the same capacity to avoid
+  // reallocations.
+  const auto accumulatedCapacity = outputTableRowsCapacity_ + 1;
+  const auto workingCapacity =
+      filter_ ? accumulatedCapacity : outputTableRowsCapacity_;
+  auto mapping =
+      initializeRowNumberMapping(outputRowMapping_, workingCapacity, pool());
   auto* outputTableRows =
-      initBuffer<char*>(outputTableRows_, outputTableRowsCapacity_, pool());
+      initBuffer<char*>(outputTableRows_, workingCapacity, pool());
+
+  int32_t numOutputRows = 0;
+  uint64_t maxOutputBatchBytes =
+      operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes();
+  const bool accumulateIsNullFlags =
+      filter_ && isLeftSemiProjectJoin(joinType_) && nullAware_;
+  const bool includeMissesFromLeft = joinIncludesMissesFromLeft(joinType_);
+  // Initialize accumulation buffers for combining low-selectivity filter
+  // results across multiple iterations. Use +1 capacity for the potential
+  // extra row from noMatchDetector in the last iteration. evalFilter compacts
+  // passing rows directly into them, and flush swaps them with the working
+  // buffers, so no copies are needed.
+  if (filter_) {
+    initializeRowNumberMapping(
+        accumulatedRowMapping_, accumulatedCapacity, pool());
+    initBuffer<char*>(accumulatedTableRows_, accumulatedCapacity, pool());
+    if (accumulateIsNullFlags) {
+      // Initialize the null flag bitmaps for a null-aware left semi project
+      // join.
+      leftSemiProjectIsNull_.resize(accumulatedCapacity);
+      leftSemiProjectIsNull_.clearAll();
+      accumulatedLeftSemiProjectIsNull_.resize(accumulatedCapacity);
+      accumulatedLeftSemiProjectIsNull_.clearAll();
+    }
+  }
+
+  // Swaps the accumulation buffers into the working buffers so that
+  // fillOutput can produce the final output batch without copying.
+  auto flushAccumulatedResults = [&]() {
+    std::swap(outputRowMapping_, accumulatedRowMapping_);
+    std::swap(outputTableRows_, accumulatedTableRows_);
+    if (accumulateIsNullFlags) {
+      std::swap(leftSemiProjectIsNull_, accumulatedLeftSemiProjectIsNull_);
+    }
+  };
 
   for (;;) {
     // If the task owning this operator has been cancelled, there is no point
@@ -1313,14 +1356,14 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
     if (operatorCtx_->task()->isCancelled()) {
       return nullptr;
     }
-    int numOut = 0;
+    int numJoinedRows = 0;
 
     if (emptyBuildSide) {
       // When build side is empty, anti and left joins return all probe side
       // rows, including ones with null join keys.
       std::iota(mapping.begin(), mapping.begin() + inputSize, 0);
       std::fill(outputTableRows, outputTableRows + inputSize, nullptr);
-      numOut = inputSize;
+      numJoinedRows = inputSize;
     } else if (isAntiJoin(joinType_) && !filter_) {
       if (nullAware_) {
         // When build side is not empty, anti join without a filter returns
@@ -1329,16 +1372,14 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
         for (auto i = 0; i < inputSize; ++i) {
           if (nonNullInputRows_.isValid(i) &&
               (!activeRows_.isValid(i) || !lookup_->hits[i])) {
-            mapping[numOut] = i;
-            ++numOut;
+            mapping[numJoinedRows++] = i;
           }
         }
       } else {
         for (auto i = 0; i < inputSize; ++i) {
           if (!nonNullInputRows_.isValid(i) ||
               (!activeRows_.isValid(i) || !lookup_->hits[i])) {
-            mapping[numOut] = i;
-            ++numOut;
+            mapping[numJoinedRows++] = i;
           }
         }
       }
@@ -1349,8 +1390,8 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       for (auto i = 0; i < inputSize; ++i) {
         auto* hit = lookup_->hits[i];
         if (!activeRows_.isValid(i) || !hit || rows->count(hit) == 0) {
-          mapping[numOut] = i;
-          ++numOut;
+          mapping[numJoinedRows] = i;
+          ++numJoinedRows;
         } else {
           rows->decrementCount(hit);
         }
@@ -1363,27 +1404,37 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
         auto* hit = lookup_->hits[i];
         if (activeRows_.isValid(i) && hit && rows->count(hit) > 0) {
           rows->decrementCount(hit);
-          mapping[numOut] = i;
-          ++numOut;
+          mapping[numJoinedRows] = i;
+          ++numJoinedRows;
         }
       }
     } else {
-      numOut = table_->listJoinResults(
+      // When accumulating filtered results, limit output to remaining
+      // capacity to prevent buffer overflow. Use maxOutputBatchRows (not
+      // outputTableRowsCapacity_) to leave room for the +1 extra row that
+      // evalFilter's noMatchDetector may add for left/full joins.
+      auto remainingCapacity = maxOutputBatchRows - numOutputRows;
+      numJoinedRows = table_->listJoinResults(
           *resultIter_,
-          joinIncludesMissesFromLeft(joinType_),
-          folly::Range(mapping.data(), outputBatchSize),
-          folly::Range(outputTableRows, outputBatchSize),
-          operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes());
+          includeMissesFromLeft,
+          folly::Range(mapping.data(), remainingCapacity),
+          folly::Range(outputTableRows, remainingCapacity),
+          maxOutputBatchBytes);
     }
 
     // We are done processing the input batch if there are no more joined rows
     // to process and the NoMatchDetector isn't carrying forward a row that
     // still needs to be written to the output.
-    if (!numOut && !noMatchDetector_.hasLastMissedRow()) {
+    if (!numJoinedRows && !noMatchDetector_.hasLastMissedRow()) {
+      if (numOutputRows > 0) {
+        flushAccumulatedResults();
+        fillOutput(numOutputRows);
+        input_ = nullptr;
+        return output_;
+      }
       input_ = nullptr;
       return nullptr;
     }
-    VELOX_CHECK_LE(numOut, outputBatchSize);
 
     // Pre-load lazy input vectors within a reclaimable section so that the
     // subsequent non-reclaimable evalFilter/fillOutput does not trigger OOM.
@@ -1399,22 +1450,36 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       VELOX_CHECK_NOT_NULL(table_);
     }
 
-    numOut = evalFilter(numOut);
+    auto numJoinedRowsAfterFilter = evalFilter(numJoinedRows, numOutputRows);
 
-    if (numOut == 0) {
+    if (numJoinedRowsAfterFilter == 0) {
       // The hash probe might get stuck in the output loop if the filter is
       // highly selective. This does not apply if the call is made during
       // spilling, because we cannot break out and resume when the operator is
       // undergoing spilling.
       if (!toSpillOutput && shouldYield()) {
+        if (numOutputRows > 0) {
+          flushAccumulatedResults();
+          fillOutput(numOutputRows);
+          return output_;
+        }
         return nullptr;
       }
       continue;
     }
 
     if (needLastProbe()) {
-      // Mark build-side rows that have a match on the join condition.
-      table_->rows()->setProbedFlag(outputTableRows, numOut);
+      // Mark build-side rows that have a match on the join condition. With a
+      // filter, the passing rows were compacted into the accumulation buffers
+      // by evalFilter().
+      if (filter_) {
+        table_->rows()->setProbedFlag(
+            accumulatedTableRows_->asMutable<char*>() + numOutputRows,
+            numJoinedRowsAfterFilter);
+      } else {
+        table_->rows()->setProbedFlag(
+            outputTableRows, numJoinedRowsAfterFilter);
+      }
     }
 
     // Right semi and right anti joins only return the build side output when
@@ -1427,12 +1492,44 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       return nullptr;
     }
 
-    fillOutput(numOut);
-
-    if (isLeftSemiOrAntiJoinNoFilter || emptyBuildSide) {
-      input_ = nullptr;
+    if (!filter_) {
+      // Without filter, output immediately (no accumulation needed).
+      fillOutput(numJoinedRowsAfterFilter);
+      if (isLeftSemiOrAntiJoinNoFilter || emptyBuildSide) {
+        input_ = nullptr;
+      }
+      return output_;
     }
-    return output_;
+
+    // If the first iteration already filled a full batch or the input is
+    // exhausted, output directly. The passing rows were compacted into the
+    // accumulation buffers by evalFilter(), so swap them in before filling
+    // the output.
+    const bool inputExhausted =
+        resultIter_->atEnd() && !noMatchDetector_.hasLastMissedRow();
+    if (numOutputRows == 0 &&
+        (numJoinedRowsAfterFilter >= maxOutputBatchRows || inputExhausted)) {
+      flushAccumulatedResults();
+      fillOutput(numJoinedRowsAfterFilter);
+      if (inputExhausted) {
+        input_ = nullptr;
+      }
+      return output_;
+    }
+
+    // Accumulate results. evalFilter has compacted the passing rows directly
+    // into the accumulation buffers at the current offset.
+    numOutputRows += numJoinedRowsAfterFilter;
+
+    // Check if accumulated output is large enough or input is exhausted.
+    if (numOutputRows >= maxOutputBatchRows || inputExhausted) {
+      flushAccumulatedResults();
+      fillOutput(numOutputRows);
+      if (inputExhausted) {
+        input_ = nullptr;
+      }
+      return output_;
+    }
   }
 }
 
@@ -1710,15 +1807,22 @@ void HashProbe::prepareNullKeyProbeHashers() {
   }
 }
 
-int32_t HashProbe::evalFilter(int32_t numRows) {
+int32_t HashProbe::evalFilter(int32_t numRows, vector_size_t outputOffset) {
   if (!filter_) {
     return numRows;
   }
 
   const bool filterPropagateNulls = filter_->expr(0)->propagatesNulls();
+  // Read the joined rows written by listJoinResults() into the working
+  // buffers.
+  auto* rawInputProbeRowMapping = outputRowMapping_->asMutable<vector_size_t>();
+  auto* inputTableRows = outputTableRows_->asMutable<char*>();
+  // Compact passing rows directly into the accumulation buffers, avoiding
+  // copies between the working and the accumulation buffers.
   auto* rawOutputProbeRowMapping =
-      outputRowMapping_->asMutable<vector_size_t>();
-  auto* outputTableRows = outputTableRows_->asMutable<char*>();
+      accumulatedRowMapping_->asMutable<vector_size_t>() + outputOffset;
+  auto* outputTableRows =
+      accumulatedTableRows_->asMutable<char*>() + outputOffset;
 
   filterInputRows_.resizeFill(numRows);
 
@@ -1729,7 +1833,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
   // TODO Apply the same to left joins.
   if (isAntiJoin(joinType_) || isLeftSemiProjectJoin(joinType_)) {
     for (auto i = 0; i < numRows; ++i) {
-      if (outputTableRows[i] == nullptr) {
+      if (inputTableRows[i] == nullptr) {
         filterInputRows_.setValid(i, false);
       }
     }
@@ -1772,10 +1876,10 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
       };
       for (auto i = 0; i < numRows; ++i) {
         const bool passed = filterPassed(i);
-        noMatchDetector_.advance(rawOutputProbeRowMapping[i], passed, addMiss);
+        noMatchDetector_.advance(rawInputProbeRowMapping[i], passed, addMiss);
         if (passed) {
-          tempOutputTableRows[numPassed] = outputTableRows[i];
-          tempOutputRowMapping[numPassed++] = rawOutputProbeRowMapping[i];
+          tempOutputTableRows[numPassed] = inputTableRows[i];
+          tempOutputRowMapping[numPassed++] = rawInputProbeRowMapping[i];
         }
       }
       if (resultIter_->atEnd()) {
@@ -1796,10 +1900,10 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
       };
       for (auto i = 0; i < numRows; ++i) {
         const bool passed = filterPassed(i);
-        noMatchDetector_.advance(rawOutputProbeRowMapping[i], passed, addMiss);
+        noMatchDetector_.advance(rawInputProbeRowMapping[i], passed, addMiss);
         if (passed) {
-          outputTableRows[numPassed] = outputTableRows[i];
-          rawOutputProbeRowMapping[numPassed++] = rawOutputProbeRowMapping[i];
+          outputTableRows[numPassed] = inputTableRows[i];
+          rawOutputProbeRowMapping[numPassed++] = rawInputProbeRowMapping[i];
         }
       }
       if (resultIter_->atEnd()) {
@@ -1814,7 +1918,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
     for (auto i = 0; i < numRows; ++i) {
       if (filterPassed(i)) {
         leftSemiFilterJoinTracker_.advance(
-            rawOutputProbeRowMapping[i], addLastMatch);
+            rawInputProbeRowMapping[i], addLastMatch);
       }
     }
     if (resultIter_->atEnd()) {
@@ -1827,15 +1931,13 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
     static const char* kPassed = "passed";
 
     if (nullAware_) {
-      leftSemiProjectIsNull_.resize(numRows);
-      leftSemiProjectIsNull_.clearAll();
-
       auto addLast = [&](auto row, std::optional<bool> passed) {
         if (passed.has_value()) {
           outputTableRows[numPassed] =
               passed.value() ? const_cast<char*>(kPassed) : nullptr;
         } else {
-          leftSemiProjectIsNull_.setValid(numPassed, true);
+          accumulatedLeftSemiProjectIsNull_.setValid(
+              numPassed + outputOffset, true);
         }
         rawOutputProbeRowMapping[numPassed++] = row;
       };
@@ -1846,14 +1948,13 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
         // filterPassed(i) -> TRUE
         // else passed -> NULL
         // else FALSE
-        auto probeRow = rawOutputProbeRowMapping[i];
+        auto probeRow = rawInputProbeRowMapping[i];
         std::optional<bool> passed = filterPassed(i)
             ? std::optional(true)
             : (passedRows.isValid(probeRow) ? std::nullopt
                                             : std::optional(false));
         leftSemiProjectJoinTracker_.advance(probeRow, passed, addLast);
       }
-      leftSemiProjectIsNull_.updateBounds();
       if (resultIter_->atEnd()) {
         leftSemiProjectJoinTracker_.finish(addLast);
       }
@@ -1865,7 +1966,7 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
       };
       for (auto i = 0; i < numRows; ++i) {
         leftSemiProjectJoinTracker_.advance(
-            rawOutputProbeRowMapping[i], filterPassed(i), addLast);
+            rawInputProbeRowMapping[i], filterPassed(i), addLast);
       }
       if (resultIter_->atEnd()) {
         leftSemiProjectJoinTracker_.finish(addLast);
@@ -1880,13 +1981,13 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
       auto passedRows =
           evalFilterForNullAwareJoin(numRows, filterPropagateNulls);
       for (auto i = 0; i < numRows; ++i) {
-        auto probeRow = rawOutputProbeRowMapping[i];
+        auto probeRow = rawInputProbeRowMapping[i];
         bool passed = passedRows.isValid(probeRow);
         noMatchDetector_.advance(probeRow, passed, addMiss);
       }
     } else {
       for (auto i = 0; i < numRows; ++i) {
-        auto probeRow = rawOutputProbeRowMapping[i];
+        auto probeRow = rawInputProbeRowMapping[i];
         noMatchDetector_.advance(probeRow, filterPassed(i), addMiss);
       }
     }
@@ -1896,12 +1997,12 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
   } else {
     for (auto i = 0; i < numRows; ++i) {
       if (filterPassed(i)) {
-        outputTableRows[numPassed] = outputTableRows[i];
-        rawOutputProbeRowMapping[numPassed++] = rawOutputProbeRowMapping[i];
+        outputTableRows[numPassed] = inputTableRows[i];
+        rawOutputProbeRowMapping[numPassed++] = rawInputProbeRowMapping[i];
       }
     }
   }
-  VELOX_CHECK_LE(numPassed, outputTableRowsCapacity_);
+  VELOX_CHECK_LE(outputOffset + numPassed, outputTableRowsCapacity_ + 1);
   return numPassed;
 }
 
@@ -2481,6 +2582,8 @@ void HashProbe::clearBuffers() {
   if (filter_ == nullptr) {
     return;
   }
+  accumulatedRowMapping_.reset();
+  accumulatedTableRows_.reset();
   filterResult_.clear();
   filterResult_.resize(1);
   filterTableInput_.reset();

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -516,6 +516,11 @@ class HashProbe : public Operator {
   BufferPtr outputTableRows_;
   vector_size_t outputTableRowsCapacity_;
 
+  // Accumulation buffers used to combine low-selectivity filter results across
+  // multiple listJoinResults iterations into a single dense output batch.
+  BufferPtr accumulatedRowMapping_;
+  BufferPtr accumulatedTableRows_;
+
   // For left join with filter, we could overwrite the row which we have not
   // checked if there is a carryover.  Use a temporary buffer in this case.
   BufferPtr tempOutputTableRows_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -198,9 +198,10 @@ class HashProbe : public Operator {
   // for right join and full join.
   RowVectorPtr getBuildSideOutput();
 
-  // Applies 'filter_' to 'outputTableRows_' and updates 'outputRowMapping_'.
+  // Applies 'filter_' to 'numRows' joined rows and compacts the passing rows
+  // directly into the accumulation buffers starting at 'outputOffset'.
   // Returns the number of passing rows.
-  vector_size_t evalFilter(vector_size_t numRows);
+  vector_size_t evalFilter(vector_size_t numRows, vector_size_t outputOffset);
 
   inline bool filterPassed(vector_size_t row) {
     return filterInputRows_.isValid(row) &&
@@ -554,6 +555,14 @@ class HashProbe : public Operator {
   // Rows of table found by join probe, later filtered by 'filter_'.
   BufferPtr outputTableRows_;
   vector_size_t outputTableRowsCapacity_;
+
+  // Accumulation buffers used to combine low-selectivity filter results across
+  // multiple listJoinResults iterations into a single dense output batch.
+  BufferPtr accumulatedRowMapping_;
+  BufferPtr accumulatedTableRows_;
+  // Accumulated null flags for the 'match' column of a null-aware left semi
+  // project join.
+  SelectivityVector accumulatedLeftSemiProjectIsNull_;
 
   // For left join with filter, we could overwrite the row which we have not
   // checked if there is a carryover.  Use a temporary buffer in this case.

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -2213,5 +2213,376 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
       return TestParamToName(info.param);
     });
 
+// Test that hash join spill uses the hash_join_spill_file_create_config when
+// set, and other spillable operators use the default spill_file_create_config.
+DEBUG_ONLY_TEST_P(HashJoinTest, hashJoinSpillFileCreateConfig) {
+  const auto rowType =
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});
+  const auto probeVectors = createVectors(rowType, 128, 10);
+  const auto buildVectors = createVectors(rowType, 128, 10);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  // Build a plan with hash join and orderBy. Hash join operators should use
+  // hash_join_spill_file_create_config and orderBy should use the default
+  // spill_file_create_config.
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors, true)
+                  .hashJoin(
+                      {"c0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors, true)
+                          .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                          .planNode(),
+                      "",
+                      {"c0", "c1", "c2"},
+                      core::JoinType::kInner)
+                  .orderBy({"c0 ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto spillDirectory = TempDirectoryPath::create();
+
+  std::atomic_bool hashJoinConfigVerified{false};
+  std::atomic_bool defaultConfigVerified{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Driver::runInternal::isBlocked",
+      std::function<void(exec::Operator*)>([&](exec::Operator* op) {
+        const auto* spillConfig = op->testingSpillConfig();
+        if (spillConfig == nullptr) {
+          return;
+        }
+        const auto& opType = op->operatorType();
+        if (opType == "HashBuild" || opType == "HashProbe") {
+          // Hash join operators should use hash_join_spill_file_create_config.
+          ASSERT_EQ(spillConfig->fileCreateConfig, "test_hashjoin_config")
+              << "Operator: " << opType;
+          hashJoinConfigVerified = true;
+        } else {
+          // Other spillable operators (e.g., OrderBy) should use the default
+          // spill_file_create_config.
+          ASSERT_EQ(spillConfig->fileCreateConfig, "test_default_config")
+              << "Operator: " << opType;
+          defaultConfigVerified = true;
+        }
+      }));
+
+  TestScopedSpillInjection scopedSpillInjection(100);
+  AssertQueryBuilder(plan)
+      .spillDirectory(spillDirectory->getPath())
+      .config(core::QueryConfig::kSpillEnabled, true)
+      .config(core::QueryConfig::kJoinSpillEnabled, true)
+      .config(core::QueryConfig::kOrderBySpillEnabled, true)
+      .config(core::QueryConfig::kSpillFileCreateConfig, "test_default_config")
+      .config(
+          core::QueryConfig::kHashJoinSpillFileCreateConfig,
+          "test_hashjoin_config")
+      .copyResults(pool_.get());
+
+  ASSERT_TRUE(hashJoinConfigVerified.load());
+  ASSERT_TRUE(defaultConfigVerified.load());
+}
+
+/// Verifies that HashProbe combines low-selectivity filter results across
+/// multiple listJoinResults iterations into fewer output batches instead of
+/// emitting many small vectors.
+TEST_P(HashJoinTest, outputBatchCombine) {
+  // Build data: 5000 rows with integer keys 0..4999 and values.
+  auto buildVectors = makeRowVector(
+      {"u0", "u1"},
+      {
+          makeFlatVector<int32_t>(5'000, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              5'000,
+              [](auto row) { return -1000 + (row / 5) * 10; },
+              nullEvery(300)),
+      });
+
+  // Probe data: 10000 rows with keys 0..9999 and values.
+  auto probeVectors = makeRowVector(
+      {"t0", "t1"},
+      {
+          makeFlatVector<int32_t>(10'000, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(
+              10'000,
+              [](auto row) { return -1000 + (row / 5) * 10; },
+              nullEvery(300)),
+      });
+
+  std::shared_ptr<TempFilePath> probeFile = TempFilePath::create();
+  writeToFile(probeFile->getPath(), {probeVectors});
+
+  std::shared_ptr<TempFilePath> buildFile = TempFilePath::create();
+  writeToFile(buildFile->getPath(), {buildVectors});
+
+  createDuckDbTable("t", {probeVectors});
+  createDuckDbTable("u", {buildVectors});
+  core::PlanNodeId probeScanId;
+  core::PlanNodeId buildScanId;
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto verifyJoinResult = [&](core::JoinType joinType,
+                              const std::string& refQuery,
+                              bool nullAware = false,
+                              bool flipJoinSide = false) {
+    std::vector<std::string> output = {"t0", "t1"};
+    if (joinType == core::JoinType::kLeftSemiProject) {
+      output.emplace_back("match");
+    }
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .tableScan(asRowType(probeVectors->type()))
+                    .capturePlanNodeId(probeScanId)
+                    .hashJoin(
+                        {"t0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator)
+                            .tableScan(asRowType(buildVectors->type()))
+                            .capturePlanNodeId(buildScanId)
+                            .planNode(),
+                        "(t1 + u1) % 3 = 0",
+                        output,
+                        joinType,
+                        nullAware)
+                    .planNode();
+
+    SplitPath splitPaths = {
+        {probeScanId, {probeFile->getPath()}},
+        {buildScanId, {buildFile->getPath()}},
+    };
+    if (flipJoinSide) {
+      plan = flipJoinSides(plan);
+    }
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .planNode(plan)
+        .inputSplits(splitPaths)
+        .checkSpillStats(false)
+        .config(core::QueryConfig::kPreferredOutputBatchRows, "1000")
+        .config(core::QueryConfig::kPreferredOutputBatchBytes, "6000")
+        .referenceQuery(refQuery)
+        .run();
+  };
+  {
+    SCOPED_TRACE("inner join");
+    verifyJoinResult(
+        core::JoinType::kInner,
+        "SELECT t0, t1 FROM t, u WHERE t0 = u0 AND (t1 + u1) % 3 = 0");
+  }
+  {
+    SCOPED_TRACE("full join");
+    verifyJoinResult(
+        core::JoinType::kFull,
+        "SELECT t0, t1 FROM t FULL OUTER JOIN u ON t0 = u0 AND (t1 + u1) % 3 = 0");
+  }
+  {
+    SCOPED_TRACE("left join");
+    verifyJoinResult(
+        core::JoinType::kLeft,
+        "SELECT t0, t1 FROM t LEFT JOIN u ON t0 = u0 AND (t1 + u1) % 3 = 0");
+  }
+  {
+    SCOPED_TRACE("semi project join");
+    verifyJoinResult(
+        core::JoinType::kLeftSemiProject,
+        "SELECT t0, t1, EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0) FROM t");
+    verifyJoinResult(
+        core::JoinType::kLeftSemiProject,
+        "SELECT t0, t1, t0 IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0) FROM t",
+        true);
+    verifyJoinResult(
+        core::JoinType::kLeftSemiProject,
+        "SELECT t0, t1, EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0) FROM t",
+        false,
+        true);
+  }
+  {
+    SCOPED_TRACE("semi filter join");
+    verifyJoinResult(
+        core::JoinType::kLeftSemiFilter,
+        "SELECT t0, t1 FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0)");
+    verifyJoinResult(
+        core::JoinType::kLeftSemiFilter,
+        "SELECT t0, t1 FROM t WHERE EXISTS (SELECT u0 FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0)",
+        false,
+        true);
+  }
+  {
+    SCOPED_TRACE("anti join");
+    verifyJoinResult(
+        core::JoinType::kAnti,
+        "SELECT t0, t1 FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE t0 = u0 AND (t1 + u1) % 3 = 0)");
+    verifyJoinResult(
+        core::JoinType::kAnti,
+        "SELECT t0, t1 FROM t WHERE t0 NOT IN (SELECT u0 FROM u WHERE (t1 + u1) % 3 = 0)",
+        true);
+  }
+}
+
+/// Regression test for the dictionary vector corruption bug that caused
+/// PR #12711 to revert the original batch-combine implementation. The original
+/// approach modified evalFilter to accept a buffer offset, which corrupted
+/// dictionary-encoded output vectors when accumulating across multiple
+/// listJoinResults iterations. This test exercises: RIGHT JOIN + filter +
+/// VARCHAR columns (dictionary-encoded) + small output batch to force multiple
+/// iterations + high selectivity filter to trigger buffer reuse conflicts.
+TEST_P(HashJoinTest, outputBatchCombineWithDictionary) {
+  // Build side: string keys with duplicates to create multi-row chains.
+  std::vector<RowVectorPtr> buildVectors = makeBatches(1, [&](auto) {
+    return makeRowVector(
+        {"u0", "u1", "u2"},
+        {
+            makeFlatVector<int32_t>(2'000, [](auto row) { return row % 500; }),
+            makeFlatVector<StringView>(
+                2'000,
+                [](auto row) {
+                  return StringView::makeInline(fmt::format("bv{}", row % 100));
+                }),
+            makeFlatVector<int64_t>(
+                2'000, [](auto row) { return row * 10; }, nullEvery(50)),
+        });
+  });
+
+  // Probe side: dictionary-encoded columns including a bool filter column,
+  // matching the production scenario where the filter evaluation flattens a
+  // dictionary-encoded bool vector.
+  std::vector<RowVectorPtr> probeVectors = makeBatches(1, [&](auto) {
+    auto indices = makeIndices(3'000, [](auto row) { return row; });
+    auto reversedIndices =
+        makeIndices(3'000, [](auto row) { return 2'999 - row; });
+    return makeRowVector(
+        {"t0", "t1", "t2", "t3"},
+        {
+            wrapInDictionary(
+                indices,
+                3'000,
+                makeFlatVector<int32_t>(
+                    3'000, [](auto row) { return row % 700; })),
+            wrapInDictionary(
+                indices,
+                3'000,
+                makeFlatVector<StringView>(
+                    3'000,
+                    [](auto row) {
+                      return StringView::makeInline(
+                          fmt::format("pv{}", row % 200));
+                    })),
+            wrapInDictionary(
+                reversedIndices,
+                3'000,
+                makeFlatVector<int64_t>(
+                    3'000, [](auto row) { return row * 7; }, nullEvery(30))),
+            wrapInDictionary(
+                reversedIndices,
+                3'000,
+                makeFlatVector<bool>(
+                    3'000, [](auto row) { return row % 5 != 0; })),
+        });
+  });
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  // Small batch size forces multiple iterations, stressing buffer management.
+  // The filter is selective enough to trigger accumulation.
+  auto runTest = [&](core::JoinType joinType, const std::string& refQuery) {
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+        .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+        .probeKeys({"t0"})
+        .buildKeys({"u0"})
+        .joinType(joinType)
+        .joinFilter("t3 AND (t2 + u2) % 7 = 0")
+        .joinOutputLayout({"t0", "t1", "u1"})
+        .config(core::QueryConfig::kPreferredOutputBatchRows, "100")
+        .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+        .referenceQuery(refQuery)
+        .checkSpillStats(false)
+        .run();
+  };
+
+  {
+    SCOPED_TRACE("right join with filter and string columns");
+    runTest(
+        core::JoinType::kRight,
+        "SELECT t0, t1, u1 FROM t RIGHT JOIN u ON t0 = u0 AND t3 AND (t2 + u2) % 7 = 0");
+  }
+  {
+    SCOPED_TRACE("left join with filter and string columns");
+    runTest(
+        core::JoinType::kLeft,
+        "SELECT t0, t1, u1 FROM t LEFT JOIN u ON t0 = u0 AND t3 AND (t2 + u2) % 7 = 0");
+  }
+  {
+    SCOPED_TRACE("full join with filter and string columns");
+    runTest(
+        core::JoinType::kFull,
+        "SELECT t0, t1, u1 FROM t FULL OUTER JOIN u ON t0 = u0 AND t3 AND (t2 + u2) % 7 = 0");
+  }
+  {
+    SCOPED_TRACE("inner join with filter and string columns");
+    runTest(
+        core::JoinType::kInner,
+        "SELECT t0, t1, u1 FROM t, u WHERE t0 = u0 AND t3 AND (t2 + u2) % 7 = 0");
+  }
+}
+
+// Verifies that null-aware left semi project join with a low-selectivity
+// filter combines results correctly across multiple iterations. Exercises
+// the accumulation of 'match' column null flags across iterations.
+TEST_P(HashJoinTest, outputBatchCombineWithNullAwareLeftSemiProject) {
+  // Build side: 2'000 rows with null join keys to enable the null-aware path.
+  auto buildVectors = makeBatches(1, [&](auto) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {
+            makeFlatVector<int32_t>(
+                2'000, [](auto row) { return row % 500; }, nullEvery(50)),
+            makeFlatVector<int64_t>(
+                2'000, [](auto row) { return row * 3; }, nullEvery(70)),
+        });
+  });
+
+  // Probe side: 3'000 rows, dictionary-encoded join key, no null keys. Null
+  // semantics come from the null keys on the build side.
+  auto probeVectors = makeBatches(1, [&](auto) {
+    auto indices = makeIndices(3'000, [](auto row) { return row; });
+    return makeRowVector(
+        {"t0", "t1"},
+        {
+            wrapInDictionary(
+                indices,
+                3'000,
+                makeFlatVector<int32_t>(
+                    3'000, [](auto row) { return row % 700; })),
+            makeFlatVector<int64_t>(
+                3'000, [](auto row) { return row * 7; }, nullEvery(30)),
+        });
+  });
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  // Small batch size forces multiple iterations, stressing buffer management.
+  // The filter is selective enough to trigger accumulation.
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+      .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+      .probeKeys({"t0"})
+      .buildKeys({"u0"})
+      .joinType(core::JoinType::kLeftSemiProject)
+      .nullAware(true)
+      .joinFilter("u0 IS NULL OR (t1 + u1) % 7 = 0")
+      .joinOutputLayout({"t0", "t1", "match"})
+      .config(core::QueryConfig::kPreferredOutputBatchRows, "100")
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .referenceQuery(
+          "SELECT t0, t1, CASE WHEN EXISTS (SELECT 1 FROM u WHERE u0 = t0 AND "
+          "(u0 IS NULL OR (t1 + u1) % 7 = 0)) THEN true "
+          "WHEN EXISTS (SELECT 1 FROM u WHERE u0 IS NULL) THEN NULL "
+          "ELSE false END FROM t")
+      .checkSpillStats(false)
+      .run();
+}
+
 } // namespace
 } // namespace facebook::velox::exec


### PR DESCRIPTION
When a hash join has a post-join filter with low selectivity, each
listJoinResults / evalFilter iteration may produce only a fraction of
the target output batch size, causing many small output vectors and
high per-vector overhead in downstream operators.

Accumulate filtered results across iterations in separate buffers
(accumulatedRowMapping_, accumulatedTableRows_) until the target batch
size is reached, then copy back and emit one dense output batch.

The separate-buffer approach avoids the dictionary-vector corruption
that caused PR #11739 to be reverted (PR #12711): the original design
wrote filtered results at an offset inside the shared outputRowMapping_
buffer while the next listJoinResults call overwrote it from index 0,
producing a malformed DictionaryVector in fillOutput / wrapChild.

Design notes:
- evalFilter signature is unchanged; each call writes to [0, numPassed).
- listJoinResults range is limited to (maxOutputBatchRows - numOutputRows)
  so the +1 extra row from noMatchDetector still fits.
- No HashTable changes needed: byte tracking uses the existing per-call
  maxOutputBatchBytes limit; termination is row-count-based.
- The no-filter path is unchanged (immediate single-iteration output).

Test coverage:
- outputBatchCombine: 10 join-type / filter scenarios verified against
  DuckDB reference queries.
- outputBatchCombineWithDictionary: regression test for the PR #12711
  bug, exercising RIGHT/LEFT/FULL/INNER JOIN with filter, VARCHAR
  columns, and a small batch size (100 rows / 1024 bytes) to force
  multiple accumulation iterations.