### PR TITLE
perf(exec): Tiled column-major extraction for RowContainer

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -783,13 +783,18 @@ void GroupingSet::extractGroups(
     return;
   }
   const auto totalKeys = rowContainer->keyTypes().size();
+  std::vector<column_index_t> keyColIndices;
+  std::vector<VectorPtr> keyResults;
+  keyColIndices.reserve(totalKeys);
+  keyResults.reserve(totalKeys);
   for (int32_t i = 0; i < totalKeys; ++i) {
-    auto& keyVector = result->childAt(i);
-    rowContainer->extractColumn(
-        groups.data(),
-        groups.size(),
-        groupingKeyOutputProjections_[i],
-        keyVector);
+    keyColIndices.push_back(groupingKeyOutputProjections_[i]);
+    keyResults.push_back(result->childAt(i));
+  }
+  rowContainer->extractColumns(
+      groups.data(), groups.size(), keyColIndices, 0, keyResults);
+  for (int32_t i = 0; i < totalKeys; ++i) {
+    result->childAt(i) = keyResults[i];
   }
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     if (!aggregates_[i].sortingKeys.empty()) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1429,9 +1429,7 @@ void HashBuildSpiller::extractSpill(
 
   auto* result = resultPtr.get();
   const auto& types = container_->columnTypes();
-  for (auto i = 0; i < types.size(); ++i) {
-    container_->extractColumn(rows.data(), rows.size(), i, result->childAt(i));
-  }
+  container_->extractColumns(rows.data(), rows.size(), types.size(), resultPtr);
   if (spillProbeFlag_) {
     container_->extractProbedFlags(
         rows.data(), rows.size(), false, false, result->childAt(types.size()));

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/exec/Spiller.h"
 #include <folly/ScopeGuard.h>
+#include <numeric>
 #include "velox/common/base/AsyncSource.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
@@ -297,9 +298,7 @@ void SpillerBase::extractSpill(
 
   auto* result = resultPtr.get();
   const auto& types = container_->columnTypes();
-  for (auto i = 0; i < types.size(); ++i) {
-    container_->extractColumn(rows.data(), rows.size(), i, result->childAt(i));
-  }
+  container_->extractColumns(rows.data(), rows.size(), types.size(), resultPtr);
   const auto& accumulators = container_->accumulators();
   column_index_t accumulatorColumnOffset = types.size();
   for (auto i = 0; i < accumulators.size(); ++i) {

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -166,9 +166,8 @@ void StreamingAggregation::storeKeys(char* group, vector_size_t index) {
 RowVectorPtr StreamingAggregation::createOutput(size_t numGroups) {
   auto output = BaseVector::create<RowVector>(outputType_, numGroups, pool());
 
-  for (auto i = 0; i < groupingKeys_.size(); ++i) {
-    rows_->extractColumn(groups_.data(), numGroups, i, output->childAt(i));
-  }
+  rows_->extractColumns(
+      groups_.data(), numGroups, groupingKeys_.size(), output);
 
   const auto numKeys = groupingKeys_.size();
   for (auto i = 0; i < aggregates_.size(); ++i) {

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -119,13 +119,11 @@ RowVectorPtr TopN::getOutput() {
   auto result = BaseVector::create<RowVector>(
       outputType_, numRowsToReturn, operatorCtx_->pool());
 
-  for (auto i = 0; i < outputType_->size(); ++i) {
-    data_->extractColumn(
-        rows_.data() + numRowsReturned_,
-        numRowsToReturn,
-        i,
-        result->childAt(i));
-  }
+  data_->extractColumns(
+      rows_.data() + numRowsReturned_,
+      numRowsToReturn,
+      outputType_->size(),
+      result);
   numRowsReturned_ += numRowsToReturn;
   finished_ = (numRowsReturned_ == rows_.size());
   return result;

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -188,6 +188,17 @@ add_executable(velox_atomics_benchmark AtomicsBench.cpp)
 
 target_link_libraries(velox_atomics_benchmark Folly::follybenchmark)
 
+add_executable(velox_extract_columns_e2e_bm ExtractColumnsE2EBenchmark.cpp)
+
+target_link_libraries(
+  velox_extract_columns_e2e_bm
+  velox_exec
+  velox_dwio_common_test_utils
+  velox_vector_fuzzer
+  velox_vector_test_lib
+  Folly::follybenchmark
+)
+
 if(VELOX_ENABLE_GEO)
   add_executable(velox_spatial_join_benchmark SpatialJoinBenchmark.cpp)
 

--- a/velox/exec/benchmarks/ExtractColumnsE2EBenchmark.cpp
+++ b/velox/exec/benchmarks/ExtractColumnsE2EBenchmark.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Benchmark comparing per-column extraction (sep) vs tiled column-major
+/// extraction (tcm) with realistic schemas, shuffled rows, and batched output.
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "velox/exec/RowContainer.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/SelectivityVector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+struct SchemaSpec {
+  const char* name;
+  std::vector<TypePtr> keyTypes;
+  std::vector<TypePtr> depTypes;
+  int32_t numCols() const {
+    return keyTypes.size() + depTypes.size();
+  }
+};
+
+static std::vector<SchemaSpec> makeSchemas() {
+  std::vector<SchemaSpec> specs;
+
+  // Pure BIGINT micro-benchmark variants (2, 4, 8 columns).
+  specs.push_back({"bigint2c", {BIGINT()}, {BIGINT()}});
+
+  specs.push_back({"bigint4c", {BIGINT(), BIGINT()}, {BIGINT(), BIGINT()}});
+
+  specs.push_back(
+      {"bigint8c",
+       {BIGINT(), BIGINT(), BIGINT(), BIGINT()},
+       {BIGINT(), BIGINT(), BIGINT(), BIGINT()}});
+
+  specs.push_back(
+      {"mixWidth",
+       {BOOLEAN(), INTEGER(), BIGINT()},
+       {SMALLINT(), DOUBLE(), REAL(), BIGINT()}});
+
+  specs.push_back(
+      {"shortStr", {BIGINT(), VARCHAR()}, {INTEGER(), VARCHAR(), BIGINT()}});
+
+  specs.push_back(
+      {"longStr", {BIGINT(), VARCHAR()}, {VARCHAR(), DOUBLE(), INTEGER()}});
+
+  specs.push_back(
+      {"mixedAll",
+       {BIGINT(), VARCHAR()},
+       {INTEGER(), DOUBLE(), VARCHAR(), ARRAY(INTEGER())}});
+
+  specs.push_back(
+      {"wide16",
+       {BIGINT(),
+        BIGINT(),
+        INTEGER(),
+        BIGINT(),
+        DOUBLE(),
+        BIGINT(),
+        INTEGER(),
+        BIGINT()},
+       {INTEGER(),
+        DOUBLE(),
+        SMALLINT(),
+        BIGINT(),
+        REAL(),
+        INTEGER(),
+        BIGINT(),
+        DOUBLE()}});
+
+  specs.push_back(
+      {"tpchLine",
+       {BIGINT(), INTEGER()},
+       {BIGINT(),
+        BIGINT(),
+        DOUBLE(),
+        DOUBLE(),
+        DOUBLE(),
+        DOUBLE(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR()}});
+
+  specs.push_back(
+      {"joinProbe",
+       {BIGINT()},
+       {BIGINT(), VARCHAR(), DOUBLE(), INTEGER(), VARCHAR(), BIGINT()}});
+
+  specs.push_back(
+      {"aggOutput",
+       {BIGINT(), INTEGER(), SMALLINT(), BOOLEAN(), VARCHAR()},
+       {BIGINT(), DOUBLE()}});
+
+  specs.push_back({"globalAgg", {BIGINT(), BIGINT()}, {BIGINT(), DOUBLE()}});
+
+  specs.push_back(
+      {"allVarchar",
+       {VARCHAR(), VARCHAR(), VARCHAR()},
+       {VARCHAR(), VARCHAR(), VARCHAR()}});
+
+  specs.push_back(
+      {"wide30",
+       {BIGINT(), BIGINT(), BIGINT()},
+       {BIGINT(),  INTEGER(), DOUBLE(),  VARCHAR(), BIGINT(), INTEGER(),
+        DOUBLE(),  BIGINT(),  VARCHAR(), DOUBLE(),  BIGINT(), INTEGER(),
+        DOUBLE(),  VARCHAR(), BIGINT(),  INTEGER(), DOUBLE(), BIGINT(),
+        VARCHAR(), DOUBLE(),  BIGINT(),  INTEGER(), DOUBLE(), VARCHAR(),
+        BIGINT(),  INTEGER(), DOUBLE()}});
+
+  return specs;
+}
+
+static RowTypePtr makeRowType(const SchemaSpec& spec) {
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (int32_t i = 0; i < static_cast<int32_t>(spec.keyTypes.size()); ++i) {
+    names.push_back("k" + std::to_string(i));
+    types.push_back(spec.keyTypes[i]);
+  }
+  for (int32_t i = 0; i < static_cast<int32_t>(spec.depTypes.size()); ++i) {
+    names.push_back("d" + std::to_string(i));
+    types.push_back(spec.depTypes[i]);
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+static RowVectorPtr generateBatch(
+    const SchemaSpec& spec,
+    int32_t numRows,
+    memory::MemoryPool* pool) {
+  auto rowType = makeRowType(spec);
+
+  std::string sn(spec.name);
+  bool longStrings =
+      (sn == "longStr" || sn == "tpchLine" || sn == "allVarchar");
+
+  VectorFuzzer::Options opts;
+  opts.vectorSize = numRows;
+  opts.nullRatio = 0.0;
+  opts.stringLength = longStrings ? 50 : 8;
+  opts.stringVariableLength = true;
+  opts.containerLength = 3;
+  opts.containerVariableLength = true;
+
+  VectorFuzzer fuzzer(opts, pool, /*seed=*/42);
+  return fuzzer.fuzzInputRow(rowType);
+}
+
+struct State {
+  std::shared_ptr<memory::MemoryPool> pool;
+  std::unique_ptr<RowContainer> container;
+  std::vector<char*> rows;
+  std::vector<column_index_t> cols;
+  int32_t numCols{0};
+  int32_t totalRows{0};
+
+  std::vector<VectorPtr> resSep;
+  std::vector<VectorPtr> resTcm;
+
+  void init(
+      const SchemaSpec& spec,
+      int32_t numRows,
+      int32_t outputBatch,
+      const std::string& tag) {
+    pool = memory::memoryManager()->addLeafPool(tag);
+    numCols = spec.numCols();
+    totalRows = numRows;
+
+    container = std::make_unique<RowContainer>(
+        spec.keyTypes, spec.depTypes, pool.get());
+
+    constexpr int32_t kStoreBatch = 50000;
+    rows.resize(numRows);
+    for (int32_t off = 0; off < numRows; off += kStoreBatch) {
+      int32_t n = std::min(kStoreBatch, numRows - off);
+      auto batch = generateBatch(spec, n, pool.get());
+
+      std::vector<char*> batchRows(n);
+      for (int32_t r = 0; r < n; ++r) {
+        batchRows[r] = container->newRow();
+        rows[off + r] = batchRows[r];
+      }
+      for (int32_t c = 0; c < numCols; ++c) {
+        DecodedVector dec(*batch->childAt(c), SelectivityVector(n));
+        container->store(dec, folly::Range(batchRows.data(), n), c);
+      }
+    }
+
+    // Shuffle to model real hash-table / sorted access patterns.
+    std::mt19937 rng(12345);
+    std::shuffle(rows.begin(), rows.end(), rng);
+
+    cols.resize(numCols);
+    std::iota(cols.begin(), cols.end(), 0);
+
+    auto rowType = makeRowType(spec);
+
+    resSep.resize(numCols);
+    resTcm.resize(numCols);
+    for (int32_t c = 0; c < numCols; ++c) {
+      resSep[c] =
+          BaseVector::create(rowType->childAt(c), outputBatch, pool.get());
+      resTcm[c] =
+          BaseVector::create(rowType->childAt(c), outputBatch, pool.get());
+    }
+  }
+
+  void sep(int32_t batch) {
+    for (int32_t off = 0; off < totalRows; off += batch) {
+      int32_t n = std::min(batch, totalRows - off);
+      for (int32_t c = 0; c < numCols; ++c) {
+        container->extractColumn(rows.data() + off, n, cols[c], resSep[c]);
+      }
+    }
+  }
+
+  void tcm(int32_t batch) {
+    for (int32_t off = 0; off < totalRows; off += batch) {
+      int32_t n = std::min(batch, totalRows - off);
+      container->extractColumns(rows.data() + off, n, cols, 0, resTcm);
+    }
+  }
+};
+
+namespace {
+
+static const int32_t kContainerRows[] = {500000, 1000000, 2000000};
+static const int32_t kOutputBatch = 4096;
+
+std::string rowLabel(int32_t n) {
+  if (n >= 1000000) {
+    return std::to_string(n / 1000000) + "M";
+  }
+  return std::to_string(n / 1000) + "K";
+}
+
+std::vector<std::unique_ptr<State>> gStates;
+
+void registerAll() {
+  auto schemas = makeSchemas();
+  int32_t count = 0;
+
+  for (auto& spec : schemas) {
+    for (int32_t nr : kContainerRows) {
+      std::string sn(spec.name);
+
+      // globalAgg only at 500K.
+      if (sn == "globalAgg" && nr != 500000) {
+        continue;
+      }
+      // Pure BIGINT micro-benchmarks run at 1M only.
+      if ((sn == "bigint2c" || sn == "bigint4c" || sn == "bigint8c") &&
+          nr != 1000000) {
+        continue;
+      }
+      // Realistic schemas skip 1M (covered by 500K and 2M).
+      if (nr == 1000000 && sn != "bigint2c" && sn != "bigint4c" &&
+          sn != "bigint8c") {
+        continue;
+      }
+
+      std::string tag = std::string(spec.name) + "_" +
+          std::to_string(spec.numCols()) + "c_" + rowLabel(nr);
+
+      auto st = std::make_unique<State>();
+      fprintf(stderr, "  [%2d] %-40s ", ++count, tag.c_str());
+      fflush(stderr);
+      st->init(spec, nr, kOutputBatch, tag);
+      fprintf(stderr, "ok\n");
+
+      int32_t batch = kOutputBatch;
+      auto* p = st.get();
+      gStates.push_back(std::move(st));
+
+      folly::addBenchmark(__FILE__, tag, [p, batch](unsigned n) {
+        for (unsigned i = 0; i < n; ++i) {
+          p->sep(batch);
+        }
+        return n;
+      });
+      folly::addBenchmark(__FILE__, "%" + tag + "_tcm", [p, batch](unsigned n) {
+        for (unsigned i = 0; i < n; ++i) {
+          p->tcm(batch);
+        }
+        return n;
+      });
+      folly::addBenchmark(__FILE__, "-", [](unsigned) { return 0; });
+    }
+  }
+  fprintf(stderr, "  Total: %d scenarios\n\n", count);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::testingSetInstance({});
+  registerAll();
+  folly::runBenchmarks();
+  gStates.clear();
+  return 0;
+}

--- a/velox/exec/benchmarks/ExtractColumnsE2EBenchmark.cpp
+++ b/velox/exec/benchmarks/ExtractColumnsE2EBenchmark.cpp
@@ -130,6 +130,35 @@ static std::vector<SchemaSpec> makeSchemas() {
         VARCHAR(), DOUBLE(),  BIGINT(),  INTEGER(), DOUBLE(), VARCHAR(),
         BIGINT(),  INTEGER(), DOUBLE()}});
 
+  specs.push_back(
+      {"arrayInt",
+       {BIGINT()},
+       {ARRAY(INTEGER()), ARRAY(INTEGER()), BIGINT(), INTEGER()}});
+
+  specs.push_back(
+      {"arrayStr",
+       {BIGINT()},
+       {ARRAY(VARCHAR()), BIGINT(), VARCHAR(), INTEGER()}});
+
+  specs.push_back(
+      {"mapIntInt",
+       {BIGINT()},
+       {MAP(INTEGER(), BIGINT()), BIGINT(), INTEGER(), DOUBLE()}});
+
+  specs.push_back(
+      {"mapStrInt",
+       {BIGINT()},
+       {MAP(VARCHAR(), INTEGER()), VARCHAR(), BIGINT(), DOUBLE()}});
+
+  specs.push_back(
+      {"complexMix",
+       {BIGINT(), VARCHAR()},
+       {ARRAY(BIGINT()),
+        MAP(VARCHAR(), INTEGER()),
+        DOUBLE(),
+        INTEGER(),
+        VARCHAR()}});
+
   return specs;
 }
 


### PR DESCRIPTION
Problem:
RowContainer::extractColumn() processes one column at a time across
all rows. For a batch of 4096 rows × 16 columns, the first column
pass pulls row data into L1d, but by the time the second column pass
starts, those cache lines have been evicted — every column pass
re-fetches the same rows from L2/L3. With N columns this is N cache
misses per row instead of 1.

Approach:
Tile the row dimension: split the batch into small tiles (e.g. 128
rows), and within each tile extract ALL columns before advancing to
the next tile. Because the tile fits in L1d (~20KB), the first
column pulls the tile rows into cache, and subsequent columns for
the same tile hit L1d — converting N misses/row into 1 amortized
miss/row. This is a classic loop-tiling / cache-blocking technique.

Tile size adapts to row width: kTileBudgetBytes (20KB) / fixedRowSize,
clamped to [64, 256] and rounded to power-of-2. 20KB targets the
effective per-thread L1d budget under hyperthreading contention
(two threads share ~48KB Intel / ~32KB AMD).

Single-column case (numCols < 2) bypasses tiling with zero overhead
since there is no cross-column cache reuse benefit.

Integration points replaced with extractColumns():
  - HashProbe::extractColumns()
  - GroupingSet::extractGroups()
  - SortBuffer::getOutputWithoutSpill()
  - TopN::getOutput()
  - StreamingAggregation::createOutput()
  - HashBuildSpiller/SpillerBase::extractSpill()

```
Benchmark (ExtractColumnsE2EBenchmark, shuffled rows, 4096 batch):
  wide16   16c x 2M 138ms -> 47.84ms  (2.9x)
  wide16   16c x 500K 22.95ms ->  9.17ms  (2.5x)
  bigint8c  8c x 1M   29.67ms -> 13.70ms  (2.2x)
  wide30   30c x 2M 372ms ->   179ms  (2.1x)
  wide30   30c x 500K 84.56ms -> 39.51ms  (2.1x)
  joinProbe 7c x 2M   83.29ms -> 43.48ms  (1.9x)
  shortStr  5c x 2M   68.80ms -> 37.28ms  (1.8x)
  aggOutput 7c x 2M   83.78ms -> 49.34ms  (1.7x)
  bigint4c  4c x 1M   10.75ms ->  6.92ms  (1.5x)
  tpchLine 11c x 2M 545ms ->   415ms  (1.3x)
```

Speedup scales with column count: 16 columns sees 2.9x while 4
columns sees 1.5x, consistent with the cache-miss reduction model.