### PR TITLE
fix(fuzzer): Disable file handle cache in Aggregate fuzzer test

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -81,7 +81,11 @@ class AggregationFuzzerBase {
                                       : getFuzzerOptions(timestampPrecision),
             pool_.get()} {
     filesystems::registerLocalFileSystem();
-    registerHiveConnector(hiveConfigs);
+    // Fuzzer test generates a lot of files and directories. Disable file
+    // handle cache to avoid EBADF errors.
+    auto configs = hiveConfigs;
+    configs[connector::hive::HiveConfig::kEnableFileHandleCache] = "false";
+    registerHiveConnector(configs);
     dwrf::registerDwrfReaderFactory();
     dwrf::registerDwrfWriterFactory();
 


### PR DESCRIPTION
This PR addresses a table scan crash error in fuzzer tests by disabling the 
file handle cache. By running many independent queries in rapid succession, the 
fuzzer creates high pressure on the FileHandleCache. This can lead to a 
scenario where a handle for a temporary file is evicted and its descriptor 
closed after one query finishes, but just before a subsequent query attempts to 
reuse it.

https://github.com/facebookincubator/velox/issues/16543, https://github.com/facebookincubator/velox/issues/16509