### PR TITLE
perf: Optimize deduplicated readers when all nested rows are selected

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -130,6 +130,10 @@ struct ScanState {
   RawScanState rawState;
 };
 
+inline bool isDense(const RowSet& rows) {
+  return rows.empty() || rows.size() == rows.back() + 1;
+}
+
 class SelectiveColumnReader {
  public:
   static constexpr uint64_t kStringBufferSize = 16 * 1024;

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(
   ReaderTest.cpp
   RetryTests.cpp
   ScanSpecTest.cpp
+  SelectiveColumnReaderTest.cpp
   SortingWriterTest.cpp
   StreamUtilTest.cpp
   BufferedInputTest.cpp

--- a/velox/dwio/common/tests/SelectiveColumnReaderTest.cpp
+++ b/velox/dwio/common/tests/SelectiveColumnReaderTest.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/SelectiveColumnReader.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::dwio::common {
+namespace {
+
+TEST(IsDenseTest, empty) {
+  const RowSet rows(nullptr, nullptr);
+  EXPECT_TRUE(isDense(rows));
+}
+
+TEST(IsDenseTest, singleElement) {
+  const std::vector<int32_t> data{0};
+  const RowSet rows(data.data(), data.size());
+  EXPECT_TRUE(isDense(rows));
+}
+
+TEST(IsDenseTest, contiguousFromZero) {
+  const std::vector<int32_t> data{0, 1, 2, 3, 4};
+  const RowSet rows(data.data(), data.size());
+  EXPECT_TRUE(isDense(rows));
+}
+
+TEST(IsDenseTest, sparseRows) {
+  const std::vector<int32_t> data{0, 2, 4};
+  const RowSet rows(data.data(), data.size());
+  EXPECT_FALSE(isDense(rows));
+}
+
+TEST(IsDenseTest, startingFromNonZero) {
+  const std::vector<int32_t> data{1, 2, 3};
+  const RowSet rows(data.data(), data.size());
+  EXPECT_FALSE(isDense(rows));
+}
+
+TEST(IsDenseTest, singleNonZeroElement) {
+  const std::vector<int32_t> data{5};
+  const RowSet rows(data.data(), data.size());
+  EXPECT_FALSE(isDense(rows));
+}
+
+} // namespace
+} // namespace facebook::velox::dwio::common


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/514

When all nested rows are selected, we use `velox::iota` to both
allocate memory and (avoid to) initialize the row set values.  This decreases
both memory and cpu usage when no rows are filtered out.

Reviewed By: xiaoxmeng

Differential Revision: D94093080


