### PR TITLE
refactor: VectorSerde named serde API from Kind to string

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2080,11 +2080,13 @@ using GroupIdNodePtr = std::shared_ptr<const GroupIdNode>;
 
 class ExchangeNode : public PlanNode {
  public:
-  ExchangeNode(
-      const PlanNodeId& id,
-      RowTypePtr type,
-      VectorSerde::Kind serdeKind)
-      : PlanNode(id), outputType_(type), serdeKind_(serdeKind) {}
+  ExchangeNode(const PlanNodeId& id, RowTypePtr type, std::string serdeKind)
+      : PlanNode(id), outputType_(type), serdeKind_(std::move(serdeKind)) {}
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  ExchangeNode(const PlanNodeId& id, RowTypePtr type, VectorSerde::Kind kind)
+      : ExchangeNode(id, std::move(type), VectorSerde::kindName(kind)) {}
+#endif
 
   class Builder {
    public:
@@ -2106,10 +2108,17 @@ class ExchangeNode : public PlanNode {
       return *this;
     }
 
-    Builder& serdeKind(VectorSerde::Kind serdeKind) {
-      serdeKind_ = serdeKind;
+    Builder& serdeKind(std::string serdeKind) {
+      serdeKind_ = std::move(serdeKind);
       return *this;
     }
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+    Builder& serdeKind(VectorSerde::Kind kind) {
+      serdeKind_ = VectorSerde::kindName(kind);
+      return *this;
+    }
+#endif
 
     std::shared_ptr<ExchangeNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "ExchangeNode id is not set");
@@ -2125,7 +2134,7 @@ class ExchangeNode : public PlanNode {
    private:
     std::optional<PlanNodeId> id_;
     std::optional<RowTypePtr> outputType_;
-    std::optional<VectorSerde::Kind> serdeKind_;
+    std::optional<std::string> serdeKind_;
   };
 
   const RowTypePtr& outputType() const override {
@@ -2149,7 +2158,7 @@ class ExchangeNode : public PlanNode {
     return "Exchange";
   }
 
-  VectorSerde::Kind serdeKind() const {
+  const std::string& serdeKind() const {
     return serdeKind_;
   }
 
@@ -2161,7 +2170,7 @@ class ExchangeNode : public PlanNode {
   void addDetails(std::stringstream& stream) const override;
 
   const RowTypePtr outputType_;
-  const VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
 };
 
 using ExchangeNodePtr = std::shared_ptr<const ExchangeNode>;
@@ -2173,7 +2182,22 @@ class MergeExchangeNode : public ExchangeNode {
       const RowTypePtr& type,
       const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
       const std::vector<SortOrder>& sortingOrders,
-      VectorSerde::Kind serdeKind);
+      std::string serdeKind);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  MergeExchangeNode(
+      const PlanNodeId& id,
+      const RowTypePtr& type,
+      const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
+      const std::vector<SortOrder>& sortingOrders,
+      VectorSerde::Kind kind)
+      : MergeExchangeNode(
+            id,
+            type,
+            sortingKeys,
+            sortingOrders,
+            VectorSerde::kindName(kind)) {}
+#endif
 
   class Builder {
    public:
@@ -2207,10 +2231,17 @@ class MergeExchangeNode : public ExchangeNode {
       return *this;
     }
 
-    Builder& serdeKind(VectorSerde::Kind serdeKind) {
-      serdeKind_ = serdeKind;
+    Builder& serdeKind(std::string serdeKind) {
+      serdeKind_ = std::move(serdeKind);
       return *this;
     }
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+    Builder& serdeKind(VectorSerde::Kind kind) {
+      serdeKind_ = VectorSerde::kindName(kind);
+      return *this;
+    }
+#endif
 
     std::shared_ptr<MergeExchangeNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "MergeExchangeNode id is not set");
@@ -2237,7 +2268,7 @@ class MergeExchangeNode : public ExchangeNode {
     std::optional<RowTypePtr> outputType_;
     std::optional<std::vector<FieldAccessTypedExprPtr>> sortingKeys_;
     std::optional<std::vector<SortOrder>> sortingOrders_;
-    std::optional<VectorSerde::Kind> serdeKind_;
+    std::optional<std::string> serdeKind_;
   };
 
   const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
@@ -2617,27 +2648,94 @@ class PartitionedOutputNode : public PlanNode {
       bool replicateNullsAndAny,
       PartitionFunctionSpecPtr partitionFunctionSpec,
       RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
+      std::string serdeKind,
       PlanNodePtr source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PartitionedOutputNode(
+      const PlanNodeId& id,
+      Kind kind,
+      const std::vector<TypedExprPtr>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      PartitionFunctionSpecPtr partitionFunctionSpec,
+      RowTypePtr outputType,
+      VectorSerde::Kind serdeKind,
+      PlanNodePtr source)
+      : PartitionedOutputNode(
+            id,
+            kind,
+            keys,
+            numPartitions,
+            replicateNullsAndAny,
+            std::move(partitionFunctionSpec),
+            std::move(outputType),
+            VectorSerde::kindName(serdeKind),
+            std::move(source)) {}
+#endif
 
   static std::shared_ptr<PartitionedOutputNode> broadcast(
       const PlanNodeId& id,
       int numPartitions,
       RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
+      std::string serdeKind,
       PlanNodePtr source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  static std::shared_ptr<PartitionedOutputNode> broadcast(
+      const PlanNodeId& id,
+      int numPartitions,
+      RowTypePtr outputType,
+      VectorSerde::Kind serdeKind,
+      PlanNodePtr source) {
+    return broadcast(
+        id,
+        numPartitions,
+        std::move(outputType),
+        VectorSerde::kindName(serdeKind),
+        std::move(source));
+  }
+#endif
 
   static std::shared_ptr<PartitionedOutputNode> arbitrary(
       const PlanNodeId& id,
       RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
+      std::string serdeKind,
       PlanNodePtr source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  static std::shared_ptr<PartitionedOutputNode> arbitrary(
+      const PlanNodeId& id,
+      RowTypePtr outputType,
+      VectorSerde::Kind serdeKind,
+      PlanNodePtr source) {
+    return arbitrary(
+        id,
+        std::move(outputType),
+        VectorSerde::kindName(serdeKind),
+        std::move(source));
+  }
+#endif
 
   static std::shared_ptr<PartitionedOutputNode> single(
       const PlanNodeId& id,
       RowTypePtr outputType,
-      VectorSerde::Kind VectorSerde,
+      std::string serdeKind,
       PlanNodePtr source);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  static std::shared_ptr<PartitionedOutputNode> single(
+      const PlanNodeId& id,
+      RowTypePtr outputType,
+      VectorSerde::Kind serdeKind,
+      PlanNodePtr source) {
+    return single(
+        id,
+        std::move(outputType),
+        VectorSerde::kindName(serdeKind),
+        std::move(source));
+  }
+#endif
 
   class Builder {
    public:
@@ -2691,10 +2789,17 @@ class PartitionedOutputNode : public PlanNode {
       return *this;
     }
 
-    Builder& serdeKind(VectorSerde::Kind serdeKind) {
-      serdeKind_ = serdeKind;
+    Builder& serdeKind(std::string serdeKind) {
+      serdeKind_ = std::move(serdeKind);
       return *this;
     }
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+    Builder& serdeKind(VectorSerde::Kind kind) {
+      serdeKind_ = VectorSerde::kindName(kind);
+      return *this;
+    }
+#endif
 
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);
@@ -2744,7 +2849,7 @@ class PartitionedOutputNode : public PlanNode {
     std::optional<bool> replicateNullsAndAny_;
     std::optional<PartitionFunctionSpecPtr> partitionFunctionSpec_;
     std::optional<RowTypePtr> outputType_;
-    std::optional<VectorSerde::Kind> serdeKind_;
+    std::optional<std::string> serdeKind_;
     std::optional<PlanNodePtr> source_;
   };
 
@@ -2787,7 +2892,7 @@ class PartitionedOutputNode : public PlanNode {
     return kind_;
   }
 
-  VectorSerde::Kind serdeKind() const {
+  const std::string& serdeKind() const {
     return serdeKind_;
   }
 
@@ -2825,7 +2930,7 @@ class PartitionedOutputNode : public PlanNode {
   const int numPartitions_;
   const bool replicateNullsAndAny_;
   const PartitionFunctionSpecPtr partitionFunctionSpec_;
-  const VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
   const RowTypePtr outputType_;
 };
 

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -496,7 +496,7 @@ TEST_F(PlanNodeBuilderTest, groupIdNode) {
 TEST_F(PlanNodeBuilderTest, exchangeNode) {
   const PlanNodeId id = "exchange_node_id";
   const RowTypePtr type = ROW({"c0"}, {BIGINT()});
-  const auto serdeKind = VectorSerde::Kind::kPresto;
+  const auto serdeKind = "Presto";
 
   const auto verify = [&](const std::shared_ptr<const ExchangeNode>& node) {
     EXPECT_EQ(node->id(), id);
@@ -518,7 +518,7 @@ TEST_F(PlanNodeBuilderTest, exchangeNode) {
 TEST_F(PlanNodeBuilderTest, mergeExchangeNode) {
   const PlanNodeId id = "merge_exchange_node_id";
   const RowTypePtr type = ROW({"c0"}, {BIGINT()});
-  const auto serdeKind = VectorSerde::Kind::kPresto;
+  const auto serdeKind = "Presto";
   const std::vector<FieldAccessTypedExprPtr> sortingKeys = {
       std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c1")};
   const std::vector<SortOrder> sortingOrders = {SortOrder(true, false)};
@@ -611,7 +611,7 @@ TEST_F(PlanNodeBuilderTest, partitionedOutputNode) {
   const auto partitionFunctionSpec =
       std::make_shared<GatherPartitionFunctionSpec>();
   const RowTypePtr outputType = ROW({"c0"}, {BIGINT()});
-  const auto serdeKind = VectorSerde::Kind::kPresto;
+  const auto serdeKind = "Presto";
 
   const auto verify =
       [&](const std::shared_ptr<const PartitionedOutputNode>& node) {

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -397,7 +397,7 @@ TEST_F(PlanNodeTest, partitionedOutputNode) {
       std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c0")};
   const PartitionFunctionSpecPtr partitionFunctionSpec =
       std::make_shared<GatherPartitionFunctionSpec>();
-  const VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto;
+  const std::string serdeKind = "Presto";
   PlanNodePtr source = std::make_shared<ValuesNode>("source", rowData_);
 
   {

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -348,7 +348,8 @@ void Exchange::close() {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
         Operator::kShuffleSerdeKind,
-        RuntimeCounter(static_cast<int64_t>(serdeKind_)));
+        RuntimeCounter(
+            static_cast<int64_t>(VectorSerde::kindByName(serdeKind_))));
     lockedStats->addRuntimeStat(
         Operator::kShuffleCompressionKind,
         RuntimeCounter(static_cast<int64_t>(serdeOptions_->compressionKind)));

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -97,7 +97,7 @@ class Exchange : public SourceOperator {
 
   const uint64_t preferredOutputBatchBytes_;
 
-  const VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
 
   const std::unique_ptr<VectorSerde::Options> serdeOptions_;
 

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -861,7 +861,8 @@ void MergeExchange::close() {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
         Operator::kShuffleSerdeKind,
-        RuntimeCounter(static_cast<int64_t>(serde_->kind())));
+        RuntimeCounter(
+            static_cast<int64_t>(VectorSerde::kindByName(serde_->kind()))));
     lockedStats->addRuntimeStat(
         Operator::kShuffleCompressionKind,
         RuntimeCounter(static_cast<int64_t>(serdeOptions_->compressionKind)));

--- a/velox/exec/OperatorTraceReader.cpp
+++ b/velox/exec/OperatorTraceReader.cpp
@@ -31,7 +31,7 @@ OperatorTraceInputReader::OperatorTraceInputReader(
       fs_(filesystems::getFileSystem(traceDir_, nullptr)),
       dataType_(std::move(dataType)),
       pool_(pool),
-      serde_(getNamedVectorSerde(VectorSerde::Kind::kPresto)),
+      serde_(getNamedVectorSerde("Presto")),
       inputStream_(getInputStream()) {
   VELOX_CHECK_NOT_NULL(dataType_);
 }

--- a/velox/exec/OperatorTraceWriter.cpp
+++ b/velox/exec/OperatorTraceWriter.cpp
@@ -55,7 +55,7 @@ OperatorTraceInputWriter::OperatorTraceInputWriter(
       traceDir_(std::move(traceDir)),
       fs_(filesystems::getFileSystem(traceDir_, nullptr)),
       pool_(pool),
-      serde_(getNamedVectorSerde(VectorSerde::Kind::kPresto)),
+      serde_(getNamedVectorSerde("Presto")),
       updateAndCheckTraceLimitCB_(std::move(updateAndCheckTraceLimitCB)) {
   traceFile_ = fs_->openFileForWrite(getOpTraceInputFilePath(traceDir_));
   VELOX_CHECK_NOT_NULL(traceFile_);

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -585,10 +585,9 @@ std::unique_ptr<Operator> BlockedOperatorFactory::toOperator(
 
 std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     common::CompressionKind compressionKind,
-    VectorSerde::Kind kind,
+    const std::string& kind,
     std::optional<float> minCompressionRatio) {
-  std::unique_ptr<VectorSerde::Options> options =
-      kind == VectorSerde::Kind::kPresto
+  std::unique_ptr<VectorSerde::Options> options = kind == "Presto"
       ? std::make_unique<serializer::presto::PrestoVectorSerde::PrestoOptions>()
       : std::make_unique<VectorSerde::Options>();
   options->compressionKind = compressionKind;

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -321,7 +321,17 @@ class BlockedOperatorFactory : public Operator::PlanNodeTranslator {
 /// settings. Optionally configures minimum compression ratio.
 std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     common::CompressionKind compressionKind,
-    VectorSerde::Kind kind,
+    const std::string& kind,
     std::optional<float> minCompressionRatio = std::nullopt);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+inline std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
+    common::CompressionKind compressionKind,
+    VectorSerde::Kind kind,
+    std::optional<float> minCompressionRatio = std::nullopt) {
+  return getVectorSerdeOptions(
+      compressionKind, VectorSerde::kindName(kind), minCompressionRatio);
+}
+#endif
 
 } // namespace facebook::velox::exec

--- a/velox/exec/SpillFile.cpp
+++ b/velox/exec/SpillFile.cpp
@@ -50,7 +50,7 @@ SpillWriter::SpillWriter(
               compressionKind,
               0.8,
               /*_nullsFirst=*/true),
-          getNamedVectorSerde(VectorSerde::Kind::kPresto),
+          getNamedVectorSerde("Presto"),
           pool,
           &stats->ioStats),
       type_(type),
@@ -165,7 +165,7 @@ SpillReadFile::SpillReadFile(
           path,
           bufferSize,
           type,
-          getNamedVectorSerde(VectorSerde::Kind::kPresto),
+          getNamedVectorSerde("Presto"),
           std::make_unique<
               serializer::presto::PrestoVectorSerde::PrestoOptions>(
               kDefaultUseLosslessTimestamp,

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -162,7 +162,7 @@ class ExchangeBenchmark : public VectorTestBase {
       std::vector<std::string> finalAggTaskIds;
       core::PlanNodePtr finalAggPlan =
           exec::test::PlanBuilder()
-              .exchange(leafPlan->outputType(), VectorSerde::Kind::kPresto)
+              .exchange(leafPlan->outputType(), "Presto")
               .capturePlanNodeId(exchangeId)
               .singleAggregation({}, {"count(1)"})
               .partitionedOutput({}, 1)
@@ -184,11 +184,10 @@ class ExchangeBenchmark : public VectorTestBase {
       })});
 
       // plan: Agg/kSingle(1) <-- Exchange (0)
-      plan =
-          exec::test::PlanBuilder()
-              .exchange(finalAggPlan->outputType(), VectorSerde::Kind::kPresto)
-              .singleAggregation({}, {"sum(a0)"})
-              .planNode();
+      plan = exec::test::PlanBuilder()
+                 .exchange(finalAggPlan->outputType(), "Presto")
+                 .singleAggregation({}, {"sum(a0)"})
+                 .planNode();
     };
 
     exec::test::AssertQueryBuilder(plan)
@@ -600,7 +599,7 @@ int main(int argc, char** argv) {
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
   exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);

--- a/velox/exec/fuzzer/AggregationFuzzerRunner.h
+++ b/velox/exec/fuzzer/AggregationFuzzerRunner.h
@@ -107,13 +107,13 @@ class AggregationFuzzerRunner {
     facebook::velox::parse::registerTypeResolver();
     facebook::velox::serializer::presto::PrestoVectorSerde::
         registerVectorSerde();
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    if (!isRegisteredNamedVectorSerde("CompactRow")) {
       serializer::CompactRowVectorSerde::registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
       serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
     }
     facebook::velox::filesystems::registerLocalFileSystem();

--- a/velox/exec/fuzzer/ExchangeFuzzer.cpp
+++ b/velox/exec/fuzzer/ExchangeFuzzer.cpp
@@ -143,7 +143,7 @@ class ExchangeFuzzer : public VectorTestBase {
     }
     auto partialAggPlan =
         exec::test::PlanBuilder()
-            .exchange(leafPlan->outputType(), VectorSerde::Kind::kPresto)
+            .exchange(leafPlan->outputType(), "Presto")
             .partialAggregation({}, makeAggregates(rowType, 1))
             .partitionedOutput({}, 1)
             .planNode();
@@ -158,14 +158,13 @@ class ExchangeFuzzer : public VectorTestBase {
       addRemoteSplits(task, leafTaskIds);
     }
 
-    auto plan =
-        exec::test::PlanBuilder()
-            .exchange(partialAggPlan->outputType(), VectorSerde::Kind::kPresto)
-            .finalAggregation(
-                {},
-                makeAggregates(*partialAggPlan->outputType(), 0),
-                rawInputTypes)
-            .planNode();
+    auto plan = exec::test::PlanBuilder()
+                    .exchange(partialAggPlan->outputType(), "Presto")
+                    .finalAggregation(
+                        {},
+                        makeAggregates(*partialAggPlan->outputType(), 0),
+                        rawInputTypes)
+                    .planNode();
 
     try {
       // Create the Task to do the final aggregation using a TaskCursor so we
@@ -574,13 +573,13 @@ int main(int argc, char** argv) {
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+  if (!isRegisteredNamedVectorSerde("CompactRow")) {
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+  if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
   exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);

--- a/velox/exec/fuzzer/JoinFuzzerRunner.cpp
+++ b/velox/exec/fuzzer/JoinFuzzerRunner.cpp
@@ -101,18 +101,15 @@ int main(int argc, char** argv) {
   facebook::velox::filesystems::registerLocalFileSystem();
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
   facebook::velox::parse::registerTypeResolver();
-  if (!isRegisteredNamedVectorSerde(
-          facebook::velox::VectorSerde::Kind::kPresto)) {
+  if (!facebook::velox::isRegisteredNamedVectorSerde("Presto")) {
     facebook::velox::serializer::presto::PrestoVectorSerde::
         registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(
-          facebook::velox::VectorSerde::Kind::kCompactRow)) {
+  if (!facebook::velox::isRegisteredNamedVectorSerde("CompactRow")) {
     facebook::velox::serializer::CompactRowVectorSerde::
         registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(
-          facebook::velox::VectorSerde::Kind::kUnsafeRow)) {
+  if (!facebook::velox::isRegisteredNamedVectorSerde("UnsafeRow")) {
     facebook::velox::serializer::spark::UnsafeRowVectorSerde::
         registerNamedVectorSerde();
   }

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -284,13 +284,13 @@ MemoryArbitrationFuzzer::MemoryArbitrationFuzzer(size_t initialSeed)
   // paritition key, and presto doesn't supports nanosecond precision.
   vectorFuzzer_.getMutableOptions().timestampPrecision =
       fuzzer::FuzzerTimestampPrecision::kMilliSeconds;
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+  if (!isRegisteredNamedVectorSerde("CompactRow")) {
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+  if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
   // Make sure not to run out of open file descriptors.

--- a/velox/exec/fuzzer/RowNumberFuzzerBase.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzerBase.cpp
@@ -83,13 +83,13 @@ void RowNumberFuzzerBase::setupReadWrite() {
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();
 
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+  if (!isRegisteredNamedVectorSerde("CompactRow")) {
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+  if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
 

--- a/velox/exec/fuzzer/SpatialJoinFuzzerRunner.cpp
+++ b/velox/exec/fuzzer/SpatialJoinFuzzerRunner.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
   parse::registerTypeResolver();
 
   // Register serializers.
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -36,20 +36,19 @@ namespace {
 
 static constexpr int32_t kDefaultMinExchangeOutputBatchBytes{2 << 20}; // 2 MB.
 
-class ExchangeClientTest
-    : public testing::Test,
-      public velox::test::VectorTestBase,
-      public testing::WithParamInterface<VectorSerde::Kind> {
+class ExchangeClientTest : public testing::Test,
+                           public velox::test::VectorTestBase,
+                           public testing::WithParamInterface<std::string> {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    if (!isRegisteredNamedVectorSerde("CompactRow")) {
       serializer::CompactRowVectorSerde::registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
       serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
     }
   }
@@ -160,7 +159,7 @@ class ExchangeClientTest
     return executor_.get();
   }
 
-  VectorSerde::Kind serdeKind_;
+  std::string serdeKind_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
   std::shared_ptr<OutputBufferManager> bufferManager_;
 };
@@ -1166,11 +1165,8 @@ TEST_P(ExchangeClientTest, hasNoMoreSourcesApi) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ExchangeClientTest,
     ExchangeClientTest,
-    testing::Values(
-        VectorSerde::Kind::kPresto,
-        VectorSerde::Kind::kCompactRow,
-        VectorSerde::Kind::kUnsafeRow),
-    [](const testing::TestParamInfo<VectorSerde::Kind>& info) {
+    testing::Values("Presto", "CompactRow", "UnsafeRow"),
+    [](const testing::TestParamInfo<std::string>& info) {
       return fmt::format("{}", info.param);
     });
 

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -42,12 +42,10 @@ using namespace facebook::velox::common::testutil;
 namespace {
 
 struct TestParam {
-  VectorSerde::Kind serdeKind;
+  std::string serdeKind;
   common::CompressionKind compressionKind;
 
-  TestParam(
-      VectorSerde::Kind _serdeKind,
-      common::CompressionKind _compressionKind)
+  TestParam(std::string _serdeKind, common::CompressionKind _compressionKind)
       : serdeKind(_serdeKind), compressionKind(_compressionKind) {}
 };
 
@@ -56,18 +54,12 @@ class MultiFragmentTest : public HiveConnectorTestBase,
  public:
   static std::vector<TestParam> getTestParams() {
     std::vector<TestParam> params;
-    params.emplace_back(
-        VectorSerde::Kind::kPresto, common::CompressionKind_NONE);
-    params.emplace_back(
-        VectorSerde::Kind::kCompactRow, common::CompressionKind_NONE);
-    params.emplace_back(
-        VectorSerde::Kind::kUnsafeRow, common::CompressionKind_NONE);
-    params.emplace_back(
-        VectorSerde::Kind::kPresto, common::CompressionKind_LZ4);
-    params.emplace_back(
-        VectorSerde::Kind::kCompactRow, common::CompressionKind_LZ4);
-    params.emplace_back(
-        VectorSerde::Kind::kUnsafeRow, common::CompressionKind_LZ4);
+    params.emplace_back("Presto", common::CompressionKind_NONE);
+    params.emplace_back("CompactRow", common::CompressionKind_NONE);
+    params.emplace_back("UnsafeRow", common::CompressionKind_NONE);
+    params.emplace_back("Presto", common::CompressionKind_LZ4);
+    params.emplace_back("CompactRow", common::CompressionKind_LZ4);
+    params.emplace_back("UnsafeRow", common::CompressionKind_LZ4);
     return params;
   }
 
@@ -386,9 +378,11 @@ TEST_P(MultiFragmentTest, aggregationSingleKey) {
           .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 4);
   ASSERT_EQ(
-      serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.min,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
   ASSERT_EQ(
-      serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.max,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
 
   for (const auto& finalTask : finalTasks) {
     auto finalPlanStats = toPlanStats(finalTask->taskStats());
@@ -397,9 +391,11 @@ TEST_P(MultiFragmentTest, aggregationSingleKey) {
             .customStats.at(std::string(Operator::kShuffleSerdeKind));
     ASSERT_EQ(serdeKindRuntimsStats.count, 1);
     ASSERT_EQ(
-        serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam().serdeKind));
+        serdeKindRuntimsStats.min,
+        static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
     ASSERT_EQ(
-        serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam().serdeKind));
+        serdeKindRuntimsStats.max,
+        static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
   }
 }
 
@@ -686,9 +682,11 @@ TEST_P(MultiFragmentTest, mergeExchange) {
       std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
-      serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.min,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
   ASSERT_EQ(
-      serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.max,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
 }
 
 // Test reordering and dropping columns in PartitionedOutput operator.
@@ -1003,9 +1001,11 @@ TEST_P(MultiFragmentTest, mergeExchangeWithSpill) {
       std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
-      serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.min,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
   ASSERT_EQ(
-      serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.max,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
 }
 
 TEST_P(MultiFragmentTest, noHashPartitionSkew) {
@@ -1678,7 +1678,7 @@ namespace {
 core::PlanNodePtr makeJoinOverExchangePlan(
     const RowTypePtr& exchangeType,
     const RowVectorPtr& buildData,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   return PlanBuilder(planNodeIdGenerator)
       .exchange(exchangeType, serdeKind)
@@ -2096,14 +2096,14 @@ class TestCustomExchangeNode : public core::PlanNode {
   TestCustomExchangeNode(
       const core::PlanNodeId& id,
       const RowTypePtr type,
-      VectorSerde::Kind serdeKind)
+      std::string serdeKind)
       : PlanNode(id), outputType_(type), serdeKind_(serdeKind) {}
 
   const RowTypePtr& outputType() const override {
     return outputType_;
   }
 
-  VectorSerde::Kind serdeKind() const {
+  const std::string& serdeKind() const {
     return serdeKind_;
   }
 
@@ -2130,7 +2130,7 @@ class TestCustomExchangeNode : public core::PlanNode {
   }
 
   const RowTypePtr outputType_;
-  const VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
 };
 
 class TestCustomExchange : public exec::Exchange {
@@ -2221,9 +2221,11 @@ TEST_P(MultiFragmentTest, customPlanNodeWithExchangeClient) {
           .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
-      serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.min,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
   ASSERT_EQ(
-      serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam().serdeKind));
+      serdeKindRuntimsStats.max,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
 }
 
 // This test is to reproduce the race condition between task terminate and no
@@ -2916,12 +2918,12 @@ TEST_P(MultiFragmentTest, mergeSmallBatchesInExchange) {
     ASSERT_EQ(numPages, stats.customStats.at("numReceivedPages").sum);
   };
 
-  if (GetParam().serdeKind == VectorSerde::Kind::kPresto) {
+  if (GetParam().serdeKind == "Presto") {
     test(1, 1'000);
     test(1'000, 56);
     test(10'000, 7);
     test(100'000, 2);
-  } else if (GetParam().serdeKind == VectorSerde::Kind::kCompactRow) {
+  } else if (GetParam().serdeKind == "CompactRow") {
     test(1, 1'000);
     test(1'000, 39);
     test(10'000, 5);
@@ -2935,7 +2937,7 @@ TEST_P(MultiFragmentTest, mergeSmallBatchesInExchange) {
 }
 
 TEST_P(MultiFragmentTest, splitLargeCompactRowsInExchange) {
-  if (GetParam().serdeKind != VectorSerde::Kind::kCompactRow) {
+  if (GetParam().serdeKind != "CompactRow") {
     return;
   }
   const uint64_t kNumColumns = 100;
@@ -2961,14 +2963,13 @@ TEST_P(MultiFragmentTest, splitLargeCompactRowsInExchange) {
                               {"c0"},
                               kNumPartitions,
                               /*outputLayout=*/{},
-                              VectorSerde::Kind::kCompactRow)
+                              "CompactRow")
                           .planNode();
   const auto producerTaskId = "local://t1";
 
-  auto plan =
-      test::PlanBuilder()
-          .exchange(asRowType(data->type()), VectorSerde::Kind::kCompactRow)
-          .planNode();
+  auto plan = test::PlanBuilder()
+                  .exchange(asRowType(data->type()), "CompactRow")
+                  .planNode();
 
   auto expected = makeRowVector(columns);
 
@@ -3391,7 +3392,7 @@ TEST_P(MultiFragmentTest, batchBytes) {
   // The fix prevents INT32_MAX overflow by controlling the merge size, but
   // fine-grained batch control requires deeper changes to PrestoVectorSerde.
 
-  if (GetParam().serdeKind == VectorSerde::Kind::kPresto) {
+  if (GetParam().serdeKind == "Presto") {
     // Current implementation merges all pages and processes in one batch
     // The key improvement is preventing overflow, not fine-grained batching
     test(100, 100, 1, 1); // Expect single batch with all data
@@ -3412,7 +3413,7 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     [](const testing::TestParamInfo<TestParam>& info) {
       return fmt::format(
           "{}_{}",
-          VectorSerde::kindName(info.param.serdeKind),
+          info.param.serdeKind,
           compressionKindToString(info.param.compressionKind));
     });
 } // namespace

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -34,23 +34,21 @@ using facebook::velox::test::BatchMaker;
 
 struct TestParam {
   PartitionedOutputNode::Kind outputKind;
-  VectorSerde::Kind serdeKind;
+  std::string serdeKind;
 
-  TestParam(
-      PartitionedOutputNode::Kind _outputKind,
-      VectorSerde::Kind _serdeKind)
+  TestParam(PartitionedOutputNode::Kind _outputKind, std::string _serdeKind)
       : outputKind(_outputKind), serdeKind(_serdeKind) {}
 };
 
 class OutputBufferManagerTest : public testing::Test {
  protected:
-  OutputBufferManagerTest() : serdeKind_(VectorSerde::Kind::kPresto) {
+  OutputBufferManagerTest() : serdeKind_("Presto") {
     std::vector<std::string> names = {"c0", "c1"};
     std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
     rowType_ = ROW(std::move(names), std::move(types));
   }
 
-  explicit OutputBufferManagerTest(VectorSerde::Kind serdeKind)
+  explicit OutputBufferManagerTest(std::string serdeKind)
       : serdeKind_(serdeKind) {
     std::vector<std::string> names = {"c0", "c1"};
     std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
@@ -72,14 +70,14 @@ class OutputBufferManagerTest : public testing::Test {
             serializer::presto::PrestoOutputStreamListener>();
       });
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    if (!isRegisteredNamedVectorSerde("CompactRow")) {
       serializer::CompactRowVectorSerde::registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
       serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
     }
   }
@@ -435,7 +433,7 @@ class OutputBufferManagerTest : public testing::Test {
     }
   }
 
-  const VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           folly::hardware_concurrency())};
@@ -446,13 +444,11 @@ class OutputBufferManagerTest : public testing::Test {
 
 class OutputBufferManagerWithDifferentSerdeKindsTest
     : public OutputBufferManagerTest,
-      public testing::WithParamInterface<VectorSerde::Kind> {
+      public testing::WithParamInterface<std::string> {
  public:
-  static std::vector<VectorSerde::Kind> getTestParams() {
-    static std::vector<VectorSerde::Kind> params = {
-        VectorSerde::Kind::kPresto,
-        VectorSerde::Kind::kCompactRow,
-        VectorSerde::Kind::kUnsafeRow};
+  static std::vector<std::string> getTestParams() {
+    static std::vector<std::string> params = {
+        "Presto", "CompactRow", "UnsafeRow"};
     return params;
   }
 };
@@ -463,21 +459,15 @@ class AllOutputBufferManagerTest
  public:
   static std::vector<TestParam> getTestParams() {
     static std::vector<TestParam> params = {
-        {PartitionedOutputNode::Kind::kBroadcast, VectorSerde::Kind::kPresto},
-        {PartitionedOutputNode::Kind::kBroadcast,
-         VectorSerde::Kind::kCompactRow},
-        {PartitionedOutputNode::Kind::kBroadcast,
-         VectorSerde::Kind::kUnsafeRow},
-        {PartitionedOutputNode::Kind::kPartitioned, VectorSerde::Kind::kPresto},
-        {PartitionedOutputNode::Kind::kPartitioned,
-         VectorSerde::Kind::kCompactRow},
-        {PartitionedOutputNode::Kind::kPartitioned,
-         VectorSerde::Kind::kUnsafeRow},
-        {PartitionedOutputNode::Kind::kArbitrary, VectorSerde::Kind::kPresto},
-        {PartitionedOutputNode::Kind::kArbitrary,
-         VectorSerde::Kind::kCompactRow},
-        {PartitionedOutputNode::Kind::kArbitrary,
-         VectorSerde::Kind::kUnsafeRow}};
+        {PartitionedOutputNode::Kind::kBroadcast, "Presto"},
+        {PartitionedOutputNode::Kind::kBroadcast, "CompactRow"},
+        {PartitionedOutputNode::Kind::kBroadcast, "UnsafeRow"},
+        {PartitionedOutputNode::Kind::kPartitioned, "Presto"},
+        {PartitionedOutputNode::Kind::kPartitioned, "CompactRow"},
+        {PartitionedOutputNode::Kind::kPartitioned, "UnsafeRow"},
+        {PartitionedOutputNode::Kind::kArbitrary, "Presto"},
+        {PartitionedOutputNode::Kind::kArbitrary, "CompactRow"},
+        {PartitionedOutputNode::Kind::kArbitrary, "UnsafeRow"}};
     return params;
   }
 

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -23,15 +23,11 @@
 
 namespace facebook::velox::exec::test {
 
-class PartitionedOutputTest
-    : public OperatorTestBase,
-      public testing::WithParamInterface<VectorSerde::Kind> {
+class PartitionedOutputTest : public OperatorTestBase,
+                              public testing::WithParamInterface<std::string> {
  public:
-  static std::vector<VectorSerde::Kind> getTestParams() {
-    const std::vector<VectorSerde::Kind> kinds(
-        {VectorSerde::Kind::kPresto,
-         VectorSerde::Kind::kCompactRow,
-         VectorSerde::Kind::kUnsafeRow});
+  static std::vector<std::string> getTestParams() {
+    const std::vector<std::string> kinds({"Presto", "CompactRow", "UnsafeRow"});
     return kinds;
   }
 
@@ -162,8 +158,12 @@ TEST_P(PartitionedOutputTest, flush) {
       planStats.at(partitionNodeId)
           .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
-  ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
-  ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
+  ASSERT_EQ(
+      serdeKindRuntimsStats.min,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
+  ASSERT_EQ(
+      serdeKindRuntimsStats.max,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
 }
 
 TEST_P(PartitionedOutputTest, keyChannelNotAtBeginningWithNulls) {
@@ -274,8 +274,12 @@ TEST_P(PartitionedOutputTest, multipleFlushCycles) {
       planStats.at(partitionNodeId)
           .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
-  ASSERT_EQ(serdeKindRuntimsStats.min, static_cast<int64_t>(GetParam()));
-  ASSERT_EQ(serdeKindRuntimsStats.max, static_cast<int64_t>(GetParam()));
+  ASSERT_EQ(
+      serdeKindRuntimsStats.min,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
+  ASSERT_EQ(
+      serdeKindRuntimsStats.max,
+      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -232,10 +232,8 @@ TEST_F(PlanNodeSerdeTest, enforceSingleRow) {
 }
 
 TEST_F(PlanNodeSerdeTest, exchange) {
-  for (auto serdeKind : std::vector<VectorSerde::Kind>{
-           VectorSerde::Kind::kPresto,
-           VectorSerde::Kind::kCompactRow,
-           VectorSerde::Kind::kUnsafeRow}) {
+  for (auto serdeKind :
+       std::vector<std::string>{"Presto", "CompactRow", "UnsafeRow"}) {
     SCOPED_TRACE(fmt::format("serdeKind: {}", serdeKind));
     auto plan = PlanBuilder()
                     .exchange(
@@ -319,10 +317,8 @@ TEST_F(PlanNodeSerdeTest, limit) {
 }
 
 TEST_F(PlanNodeSerdeTest, mergeExchange) {
-  for (auto serdeKind : std::vector<VectorSerde::Kind>{
-           VectorSerde::Kind::kPresto,
-           VectorSerde::Kind::kCompactRow,
-           VectorSerde::Kind::kUnsafeRow}) {
+  for (auto serdeKind :
+       std::vector<std::string>{"Presto", "CompactRow", "UnsafeRow"}) {
     auto plan = PlanBuilder()
                     .mergeExchange(
                         ROW({"a", "b", "c"}, {BIGINT(), DOUBLE(), VARCHAR()}),
@@ -429,10 +425,8 @@ TEST_F(PlanNodeSerdeTest, orderBy) {
 }
 
 TEST_F(PlanNodeSerdeTest, partitionedOutput) {
-  for (auto serdeKind : std::vector<VectorSerde::Kind>{
-           VectorSerde::Kind::kPresto,
-           VectorSerde::Kind::kCompactRow,
-           VectorSerde::Kind::kUnsafeRow}) {
+  for (auto serdeKind :
+       std::vector<std::string>{"Presto", "CompactRow", "UnsafeRow"}) {
     SCOPED_TRACE(fmt::format("serdeKind: {}", serdeKind));
 
     auto plan = PlanBuilder()

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -592,10 +592,8 @@ TEST_F(PlanNodeToStringTest, localPartition) {
 }
 
 TEST_F(PlanNodeToStringTest, partitionedOutput) {
-  for (auto serdeKind : std::vector<VectorSerde::Kind>{
-           VectorSerde::Kind::kPresto,
-           VectorSerde::Kind::kCompactRow,
-           VectorSerde::Kind::kUnsafeRow}) {
+  for (auto serdeKind :
+       std::vector<std::string>{"Presto", "CompactRow", "UnsafeRow"}) {
     SCOPED_TRACE(fmt::format("serdeKind: {}", serdeKind));
     auto plan =
         PlanBuilder()
@@ -698,10 +696,8 @@ TEST_F(PlanNodeToStringTest, localMerge) {
 }
 
 TEST_F(PlanNodeToStringTest, exchange) {
-  for (auto serdeKind : std::vector<VectorSerde::Kind>{
-           VectorSerde::Kind::kPresto,
-           VectorSerde::Kind::kCompactRow,
-           VectorSerde::Kind::kUnsafeRow}) {
+  for (auto serdeKind :
+       std::vector<std::string>{"Presto", "CompactRow", "UnsafeRow"}) {
     SCOPED_TRACE(fmt::format("serdeKind: {}", serdeKind));
 
     auto plan = PlanBuilder()
@@ -716,10 +712,8 @@ TEST_F(PlanNodeToStringTest, exchange) {
 }
 
 TEST_F(PlanNodeToStringTest, mergeExchange) {
-  for (auto serdeKind : std::vector<VectorSerde::Kind>{
-           VectorSerde::Kind::kPresto,
-           VectorSerde::Kind::kCompactRow,
-           VectorSerde::Kind::kUnsafeRow}) {
+  for (auto serdeKind :
+       std::vector<std::string>{"Presto", "CompactRow", "UnsafeRow"}) {
     SCOPED_TRACE(fmt::format("serdeKind: {}", serdeKind));
 
     auto plan =

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -129,7 +129,7 @@ class SpillTest : public ::testing::TestWithParam<uint32_t>,
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerNamedVectorSerde();
     }

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1711,8 +1711,7 @@ DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
   auto leafTaskId = "local://leaf-0";
   auto leafPlan = PlanBuilder()
                       .values(vectors)
-                      .partitionedOutput(
-                          {}, 1, {"c0", "c1", "c2"}, VectorSerde::Kind::kPresto)
+                      .partitionedOutput({}, 1, {"c0", "c1", "c2"}, "Presto")
                       .planNode();
   std::unordered_map<std::string, std::string> config;
   auto queryCtx = core::QueryCtx::create(
@@ -1731,23 +1730,22 @@ DEBUG_ONLY_TEST_F(TableScanTest, tableScanSplitsAndWeights) {
   // Main task plan with table scan and remote exchange.
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   core::PlanNodeId scanNodeId, exchangeNodeId;
-  auto planNode =
-      PlanBuilder(planNodeIdGenerator, pool_.get())
-          .tableScan(rowType_)
-          .capturePlanNodeId(scanNodeId)
-          .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
-          .hashJoin(
-              {"t0"},
-              {"u0"},
-              PlanBuilder(planNodeIdGenerator, pool_.get())
-                  .exchange(leafPlan->outputType(), VectorSerde::Kind::kPresto)
-                  .capturePlanNodeId(exchangeNodeId)
-                  .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
-                  .planNode(),
-              "",
-              {"t1"},
-              core::JoinType::kAnti)
-          .planNode();
+  auto planNode = PlanBuilder(planNodeIdGenerator, pool_.get())
+                      .tableScan(rowType_)
+                      .capturePlanNodeId(scanNodeId)
+                      .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                      .hashJoin(
+                          {"t0"},
+                          {"u0"},
+                          PlanBuilder(planNodeIdGenerator, pool_.get())
+                              .exchange(leafPlan->outputType(), "Presto")
+                              .capturePlanNodeId(exchangeNodeId)
+                              .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                              .planNode(),
+                          "",
+                          {"t1"},
+                          core::JoinType::kAnti)
+                      .planNode();
 
   // Create task, cursor, start the task and supply the table scan splits.
   const int32_t numDrivers = 6;

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -126,13 +126,13 @@ void OperatorTestBase::SetUp() {
   if (!isRegisteredVectorSerde()) {
     this->registerVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+  if (!isRegisteredNamedVectorSerde("CompactRow")) {
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+  if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
   driverExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(3);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -519,7 +519,7 @@ PlanBuilder& PlanBuilder::traceScan(
 
 PlanBuilder& PlanBuilder::exchange(
     const RowTypePtr& outputType,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   VELOX_CHECK_NULL(planNode_, "Exchange must be the source node");
   planNode_ = std::make_shared<core::ExchangeNode>(
       nextPlanNodeId(), outputType, serdeKind);
@@ -559,7 +559,7 @@ parseOrderByClauses(
 PlanBuilder& PlanBuilder::mergeExchange(
     const RowTypePtr& outputType,
     const std::vector<std::string>& keys,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   VELOX_CHECK_NULL(planNode_, "MergeExchange must be the source node");
   auto [sortingKeys, sortingOrders] =
       parseOrderByClauses(keys, outputType, pool_);
@@ -1447,7 +1447,7 @@ PlanBuilder& PlanBuilder::partitionedOutput(
     const std::vector<std::string>& keys,
     int numPartitions,
     const std::vector<std::string>& outputLayout,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   return partitionedOutput(keys, numPartitions, false, outputLayout, serdeKind);
 }
 
@@ -1456,7 +1456,7 @@ PlanBuilder& PlanBuilder::partitionedOutput(
     int numPartitions,
     bool replicateNullsAndAny,
     const std::vector<std::string>& outputLayout,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   VELOX_CHECK_NOT_NULL(
       planNode_, "PartitionedOutput cannot be the source node");
 
@@ -1476,7 +1476,7 @@ PlanBuilder& PlanBuilder::partitionedOutput(
     bool replicateNullsAndAny,
     core::PartitionFunctionSpecPtr partitionFunctionSpec,
     const std::vector<std::string>& outputLayout,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   VELOX_CHECK_NOT_NULL(
       planNode_, "PartitionedOutput cannot be the source node");
   auto outputType = outputLayout.empty()
@@ -1498,7 +1498,7 @@ PlanBuilder& PlanBuilder::partitionedOutput(
 
 PlanBuilder& PlanBuilder::partitionedOutputBroadcast(
     const std::vector<std::string>& outputLayout,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   VELOX_CHECK_NOT_NULL(
       planNode_, "PartitionedOutput cannot be the source node");
   auto outputType = outputLayout.empty()
@@ -1512,7 +1512,7 @@ PlanBuilder& PlanBuilder::partitionedOutputBroadcast(
 
 PlanBuilder& PlanBuilder::partitionedOutputArbitrary(
     const std::vector<std::string>& outputLayout,
-    VectorSerde::Kind serdeKind) {
+    std::string serdeKind) {
   VELOX_CHECK_NOT_NULL(
       planNode_, "PartitionedOutput cannot be the source node");
   auto outputType = outputLayout.empty()

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -682,9 +682,13 @@ class PlanBuilder {
   ///
   /// @param outputType The type of the data coming in and out of the exchange.
   /// @param serdekind The kind of seralized data format.
-  PlanBuilder& exchange(
-      const RowTypePtr& outputType,
-      VectorSerde::Kind serdekind);
+  PlanBuilder& exchange(const RowTypePtr& outputType, std::string serdekind);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& exchange(const RowTypePtr& outputType, VectorSerde::Kind kind) {
+    return exchange(outputType, VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Add a MergeExchangeNode using specified ORDER BY clauses.
   ///
@@ -697,7 +701,16 @@ class PlanBuilder {
   PlanBuilder& mergeExchange(
       const RowTypePtr& outputType,
       const std::vector<std::string>& keys,
-      VectorSerde::Kind serdekind);
+      std::string serdekind);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& mergeExchange(
+      const RowTypePtr& outputType,
+      const std::vector<std::string>& keys,
+      VectorSerde::Kind kind) {
+    return mergeExchange(outputType, keys, VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Add a ProjectNode using specified SQL expressions.
   ///
@@ -1178,14 +1191,41 @@ class PlanBuilder {
       int numPartitions,
       bool replicateNullsAndAny,
       const std::vector<std::string>& outputLayout = {},
-      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+      std::string serdeKind = "Presto");
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& partitionedOutput(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      const std::vector<std::string>& outputLayout,
+      VectorSerde::Kind kind) {
+    return partitionedOutput(
+        keys,
+        numPartitions,
+        replicateNullsAndAny,
+        outputLayout,
+        VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Same as above, but assumes 'replicateNullsAndAny' is false.
   PlanBuilder& partitionedOutput(
       const std::vector<std::string>& keys,
       int numPartitions,
       const std::vector<std::string>& outputLayout = {},
-      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+      std::string serdeKind = "Presto");
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& partitionedOutput(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      const std::vector<std::string>& outputLayout,
+      VectorSerde::Kind kind) {
+    return partitionedOutput(
+        keys, numPartitions, outputLayout, VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Same as above, but allows to provide custom partition function.
   PlanBuilder& partitionedOutput(
@@ -1194,7 +1234,25 @@ class PlanBuilder {
       bool replicateNullsAndAny,
       core::PartitionFunctionSpecPtr partitionFunctionSpec,
       const std::vector<std::string>& outputLayout = {},
-      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+      std::string serdeKind = "Presto");
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& partitionedOutput(
+      const std::vector<std::string>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      core::PartitionFunctionSpecPtr partitionFunctionSpec,
+      const std::vector<std::string>& outputLayout,
+      VectorSerde::Kind kind) {
+    return partitionedOutput(
+        keys,
+        numPartitions,
+        replicateNullsAndAny,
+        std::move(partitionFunctionSpec),
+        outputLayout,
+        VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Adds a PartitionedOutputNode to broadcast the input data.
   ///
@@ -1204,12 +1262,30 @@ class PlanBuilder {
   /// duplicated in the output.
   PlanBuilder& partitionedOutputBroadcast(
       const std::vector<std::string>& outputLayout = {},
-      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+      std::string serdeKind = "Presto");
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& partitionedOutputBroadcast(
+      const std::vector<std::string>& outputLayout,
+      VectorSerde::Kind kind) {
+    return partitionedOutputBroadcast(
+        outputLayout, VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Adds a PartitionedOutputNode to put data into arbitrary buffer.
   PlanBuilder& partitionedOutputArbitrary(
       const std::vector<std::string>& outputLayout = {},
-      VectorSerde::Kind serdeKind = VectorSerde::Kind::kPresto);
+      std::string serdeKind = "Presto");
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  PlanBuilder& partitionedOutputArbitrary(
+      const std::vector<std::string>& outputLayout,
+      VectorSerde::Kind kind) {
+    return partitionedOutputArbitrary(
+        outputLayout, VectorSerde::kindName(kind));
+  }
+#endif
 
   /// Adds a LocalPartitionNode to hash-partition the input on the specified
   /// keys using exec::HashPartitionFunction. Number of partitions is determined

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -48,15 +48,15 @@ class RowContainerTestBase : public testing::Test,
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+    if (!isRegisteredNamedVectorSerde("CompactRow")) {
       facebook::velox::serializer::CompactRowVectorSerde::
           registerNamedVectorSerde();
     }
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+    if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
       facebook::velox::serializer::spark::UnsafeRowVectorSerde::
           registerNamedVectorSerde();
     }

--- a/velox/exec/tests/utils/SerializedPageUtil.cpp
+++ b/velox/exec/tests/utils/SerializedPageUtil.cpp
@@ -22,7 +22,7 @@ namespace facebook::velox::exec::test {
 
 std::unique_ptr<SerializedPageBase> toSerializedPage(
     const RowVectorPtr& vector,
-    VectorSerde::Kind serdeKind,
+    std::string serdeKind,
     const std::shared_ptr<OutputBufferManager>& bufferManager,
     memory::MemoryPool* pool) {
   auto data =

--- a/velox/exec/tests/utils/SerializedPageUtil.h
+++ b/velox/exec/tests/utils/SerializedPageUtil.h
@@ -25,7 +25,7 @@ namespace facebook::velox::exec::test {
 /// Helper function for serializing RowVector to PrestoPage format.
 std::unique_ptr<SerializedPageBase> toSerializedPage(
     const RowVectorPtr& vector,
-    VectorSerde::Kind serdeKind,
+    std::string serdeKind,
     const std::shared_ptr<OutputBufferManager>& bufferManager,
     memory::MemoryPool* pool);
 

--- a/velox/exec/trace/TraceUtil.cpp
+++ b/velox/exec/trace/TraceUtil.cpp
@@ -366,7 +366,7 @@ core::PlanNodePtr getTraceNode(
         partitionedOutputNode->isReplicateNullsAndAny(),
         partitionedOutputNode->partitionFunctionSpecPtr(),
         partitionedOutputNode->outputType(),
-        VectorSerde::Kind::kPresto,
+        "Presto",
         std::make_shared<DummySourceNode>(
             partitionedOutputNode->sources().front()->outputType()));
   }

--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -56,18 +56,15 @@ int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
 
   facebook::velox::functions::prestosql::registerInternalFunctions();
-  if (!isRegisteredNamedVectorSerde(
-          facebook::velox::VectorSerde::Kind::kPresto)) {
+  if (!facebook::velox::isRegisteredNamedVectorSerde("Presto")) {
     facebook::velox::serializer::presto::PrestoVectorSerde::
         registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(
-          facebook::velox::VectorSerde::Kind::kCompactRow)) {
+  if (!facebook::velox::isRegisteredNamedVectorSerde("CompactRow")) {
     facebook::velox::serializer::CompactRowVectorSerde::
         registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(
-          facebook::velox::VectorSerde::Kind::kUnsafeRow)) {
+  if (!facebook::velox::isRegisteredNamedVectorSerde("UnsafeRow")) {
     facebook::velox::serializer::spark::UnsafeRowVectorSerde::
         registerNamedVectorSerde();
   }

--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -174,8 +174,7 @@ void CompactRowVectorSerde::registerVectorSerde() {
 // static
 void CompactRowVectorSerde::registerNamedVectorSerde() {
   velox::registerNamedVectorSerde(
-      VectorSerde::Kind::kCompactRow,
-      std::make_unique<CompactRowVectorSerde>());
+      "CompactRow", std::make_unique<CompactRowVectorSerde>());
 }
 
 } // namespace facebook::velox::serializer

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -22,7 +22,7 @@ namespace facebook::velox::serializer {
 
 class CompactRowVectorSerde : public VectorSerde {
  public:
-  CompactRowVectorSerde() : VectorSerde(VectorSerde::Kind::kCompactRow) {}
+  CompactRowVectorSerde() : VectorSerde("CompactRow") {}
 
   void estimateSerializedSize(
       const row::CompactRow* compactRow,

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -266,7 +266,7 @@ void PrestoVectorSerde::registerVectorSerde() {
 void PrestoVectorSerde::registerNamedVectorSerde() {
   detail::initBitsToMapOnce();
   velox::registerNamedVectorSerde(
-      VectorSerde::Kind::kPresto, std::make_unique<PrestoVectorSerde>());
+      "Presto", std::make_unique<PrestoVectorSerde>());
 }
 
 /* static */ Status PrestoVectorSerde::lex(

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -88,7 +88,7 @@ class PrestoVectorSerde : public VectorSerde {
     bool preserveEncodings{false};
   };
 
-  PrestoVectorSerde() : VectorSerde(Kind::kPresto) {}
+  PrestoVectorSerde() : VectorSerde("Presto") {}
 
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
   /// '*sizes[i]'.

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -130,7 +130,7 @@ void UnsafeRowVectorSerde::registerVectorSerde() {
 // static
 void UnsafeRowVectorSerde::registerNamedVectorSerde() {
   velox::registerNamedVectorSerde(
-      VectorSerde::Kind::kUnsafeRow, std::make_unique<UnsafeRowVectorSerde>());
+      "UnsafeRow", std::make_unique<UnsafeRowVectorSerde>());
 }
 
 } // namespace facebook::velox::serializer::spark

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -21,7 +21,7 @@ namespace facebook::velox::serializer::spark {
 
 class UnsafeRowVectorSerde : public VectorSerde {
  public:
-  UnsafeRowVectorSerde() : VectorSerde(VectorSerde::Kind::kUnsafeRow) {}
+  UnsafeRowVectorSerde() : VectorSerde("UnsafeRow") {}
 
   void estimateSerializedSize(
       const row::UnsafeRowFast* unsafeRow,

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -67,13 +67,11 @@ class CompactRowSerializerTest : public ::testing::Test,
   void SetUp() override {
     pool_ = memory::memoryManager()->addLeafPool();
     deregisterVectorSerde();
-    deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+    deregisterNamedVectorSerde("CompactRow");
     serializer::CompactRowVectorSerde::registerVectorSerde();
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
-    ASSERT_EQ(getVectorSerde()->kind(), VectorSerde::Kind::kCompactRow);
-    ASSERT_EQ(
-        getNamedVectorSerde(VectorSerde::Kind::kCompactRow)->kind(),
-        VectorSerde::Kind::kCompactRow);
+    ASSERT_EQ(getVectorSerde()->kind(), "CompactRow");
+    ASSERT_EQ(getNamedVectorSerde("CompactRow")->kind(), "CompactRow");
     appendRow_ = GetParam().appendRow;
     compressionKind_ = GetParam().compressionKind;
     microBatchDeserialize_ = GetParam().microBatchDeserialize;
@@ -82,7 +80,7 @@ class CompactRowSerializerTest : public ::testing::Test,
 
   void TearDown() override {
     deregisterVectorSerde();
-    deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+    deregisterNamedVectorSerde("CompactRow");
   }
 
   void serialize(RowVectorPtr rowVector, std::ostream* output) {

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1971,13 +1971,11 @@ class PrestoSerializerBatchEstimateSizeTest : public testing::Test,
     if (!isRegisteredVectorSerde()) {
       serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }
-    ASSERT_EQ(getVectorSerde()->kind(), VectorSerde::Kind::kPresto);
-    if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+    ASSERT_EQ(getVectorSerde()->kind(), "Presto");
+    if (!isRegisteredNamedVectorSerde("Presto")) {
       serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
     }
-    ASSERT_EQ(
-        getNamedVectorSerde(VectorSerde::Kind::kPresto)->kind(),
-        VectorSerde::Kind::kPresto);
+    ASSERT_EQ(getNamedVectorSerde("Presto")->kind(), "Presto");
 
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }

--- a/velox/serializers/tests/SerializedPageFileTest.cpp
+++ b/velox/serializers/tests/SerializedPageFileTest.cpp
@@ -52,9 +52,9 @@ class SerializedPageFileTest : public ::testing::TestWithParam<TestParams>,
     const auto& params = GetParam();
 
     deregisterVectorSerde();
-    deregisterNamedVectorSerde(VectorSerde::Kind::kPresto);
-    deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
-    deregisterNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
+    deregisterNamedVectorSerde("Presto");
+    deregisterNamedVectorSerde("CompactRow");
+    deregisterNamedVectorSerde("UnsafeRow");
 
     setupSerde(params.serdeType);
     filesystems::registerLocalFileSystem();
@@ -64,9 +64,9 @@ class SerializedPageFileTest : public ::testing::TestWithParam<TestParams>,
 
   void TearDown() override {
     deregisterVectorSerde();
-    deregisterNamedVectorSerde(VectorSerde::Kind::kPresto);
-    deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
-    deregisterNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
+    deregisterNamedVectorSerde("Presto");
+    deregisterNamedVectorSerde("CompactRow");
+    deregisterNamedVectorSerde("UnsafeRow");
   }
 
   void setupSerde(SerdeType serdeType) {
@@ -74,17 +74,17 @@ class SerializedPageFileTest : public ::testing::TestWithParam<TestParams>,
       case SerdeType::kPresto:
         serializer::presto::PrestoVectorSerde::registerVectorSerde();
         serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
-        serde_ = getNamedVectorSerde(VectorSerde::Kind::kPresto);
+        serde_ = getNamedVectorSerde("Presto");
         break;
       case SerdeType::kCompactRow:
         serializer::CompactRowVectorSerde::registerVectorSerde();
         serializer::CompactRowVectorSerde::registerNamedVectorSerde();
-        serde_ = getNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+        serde_ = getNamedVectorSerde("CompactRow");
         break;
       case SerdeType::kUnsafeRow:
         serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
         serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
-        serde_ = getNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
+        serde_ = getNamedVectorSerde("UnsafeRow");
         break;
     }
   }

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -66,13 +66,11 @@ class UnsafeRowSerializerTest : public ::testing::Test,
   void SetUp() override {
     pool_ = memory::memoryManager()->addLeafPool();
     deregisterVectorSerde();
-    deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+    deregisterNamedVectorSerde("CompactRow");
     serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
-    ASSERT_EQ(getVectorSerde()->kind(), VectorSerde::Kind::kUnsafeRow);
-    ASSERT_EQ(
-        getNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)->kind(),
-        VectorSerde::Kind::kUnsafeRow);
+    ASSERT_EQ(getVectorSerde()->kind(), "UnsafeRow");
+    ASSERT_EQ(getNamedVectorSerde("UnsafeRow")->kind(), "UnsafeRow");
     appendRow_ = GetParam().appendRow;
     compressionKind_ = GetParam().compressionKind;
     microBatchDeserialize_ = GetParam().microBatchDeserialize;
@@ -81,7 +79,7 @@ class UnsafeRowSerializerTest : public ::testing::Test,
 
   void TearDown() override {
     deregisterVectorSerde();
-    deregisterNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
+    deregisterNamedVectorSerde("UnsafeRow");
   }
 
   void serialize(RowVectorPtr rowVector, std::ostream* output) {

--- a/velox/tool/trace/PartitionedOutputReplayer.cpp
+++ b/velox/tool/trace/PartitionedOutputReplayer.cpp
@@ -109,7 +109,7 @@ PartitionedOutputReplayer::PartitionedOutputReplayer(
     const std::string& queryId,
     const std::string& taskId,
     const std::string& nodeId,
-    VectorSerde::Kind serdeKind,
+    std::string serdeKind,
     const std::string& operatorType,
     const std::string& driverIds,
     uint64_t queryCapacity,

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -46,7 +46,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       const std::string& queryId,
       const std::string& taskId,
       const std::string& nodeId,
-      VectorSerde::Kind serdeKind,
+      std::string serdeKind,
       const std::string& operatorType,
       const std::string& driverIds,
       uint64_t queryCapacity,
@@ -62,7 +62,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       const core::PlanNodePtr& source) const override;
 
   const core::PartitionedOutputNode* const originalNode_;
-  const VectorSerde::Kind serdeKind_;
+  const std::string serdeKind_;
   const std::shared_ptr<exec::OutputBufferManager> bufferManager_{
       exec::OutputBufferManager::getInstanceRef()};
   const std::unique_ptr<folly::Executor> executor_{

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -124,14 +124,14 @@ DEFINE_string(
 
 namespace facebook::velox::tool::trace {
 namespace {
-VectorSerde::Kind getVectorSerdeKind() {
+std::string getVectorSerdeKind() {
   switch (FLAGS_shuffle_serialization_format) {
     case 0:
-      return VectorSerde::Kind::kPresto;
+      return "Presto";
     case 1:
-      return VectorSerde::Kind::kCompactRow;
+      return "CompactRow";
     case 2:
-      return VectorSerde::Kind::kUnsafeRow;
+      return "UnsafeRow";
     default:
       VELOX_UNSUPPORTED(
           "Unsupported shuffle serialization format: {}",
@@ -311,13 +311,13 @@ void TraceReplayRunner::init() {
   if (!isRegisteredVectorSerde()) {
     serializer::presto::PrestoVectorSerde::registerVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
+  if (!isRegisteredNamedVectorSerde("Presto")) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
+  if (!isRegisteredNamedVectorSerde("CompactRow")) {
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
+  if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
 

--- a/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
+++ b/velox/tool/trace/tests/PartitionedOutputReplayerTest.cpp
@@ -41,13 +41,10 @@ using namespace facebook::velox::common::testutil;
 namespace facebook::velox::tool::trace::test {
 class PartitionedOutputReplayerTest
     : public HiveConnectorTestBase,
-      public testing::WithParamInterface<VectorSerde::Kind> {
+      public testing::WithParamInterface<std::string> {
  public:
-  static std::vector<VectorSerde::Kind> getTestParams() {
-    const std::vector<VectorSerde::Kind> kinds(
-        {VectorSerde::Kind::kPresto,
-         VectorSerde::Kind::kCompactRow,
-         VectorSerde::Kind::kUnsafeRow});
+  static std::vector<std::string> getTestParams() {
+    const std::vector<std::string> kinds({"Presto", "CompactRow", "UnsafeRow"});
     return kinds;
   }
 

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -66,9 +66,9 @@ std::unique_ptr<VectorSerde>& getVectorSerdeImpl() {
   return serde;
 }
 
-std::unordered_map<VectorSerde::Kind, std::unique_ptr<VectorSerde>>&
+std::unordered_map<std::string, std::unique_ptr<VectorSerde>>&
 getNamedVectorSerdeImpl() {
-  static std::unordered_map<VectorSerde::Kind, std::unique_ptr<VectorSerde>>
+  static std::unordered_map<std::string, std::unique_ptr<VectorSerde>>
       namedSerdes;
   return namedSerdes;
 }
@@ -147,7 +147,7 @@ bool isRegisteredVectorSerde() {
 
 /// Named serde helper functions.
 void registerNamedVectorSerde(
-    VectorSerde::Kind kind,
+    const std::string& kind,
     std::unique_ptr<VectorSerde> serdeToRegister) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   VELOX_CHECK(
@@ -157,17 +157,17 @@ void registerNamedVectorSerde(
   namedSerdeMap[kind] = std::move(serdeToRegister);
 }
 
-void deregisterNamedVectorSerde(VectorSerde::Kind kind) {
+void deregisterNamedVectorSerde(const std::string& kind) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   namedSerdeMap.erase(kind);
 }
 
-bool isRegisteredNamedVectorSerde(VectorSerde::Kind kind) {
+bool isRegisteredNamedVectorSerde(const std::string& kind) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   return namedSerdeMap.find(kind) != namedSerdeMap.end();
 }
 
-VectorSerde* getNamedVectorSerde(VectorSerde::Kind kind) {
+VectorSerde* getNamedVectorSerde(const std::string& kind) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   auto it = namedSerdeMap.find(kind);
   VELOX_CHECK(

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -239,7 +239,7 @@ class VectorSerde {
     float minCompressionRatio{0.8};
   };
 
-  Kind kind() const {
+  const std::string& kind() const {
     return kind_;
   }
 
@@ -352,9 +352,9 @@ class VectorSerde {
   }
 
  protected:
-  explicit VectorSerde(Kind kind) : kind_(kind) {}
+  explicit VectorSerde(std::string kind) : kind_(std::move(kind)) {}
 
-  const Kind kind_;
+  const std::string kind_;
 };
 
 std::ostream& operator<<(std::ostream& out, VectorSerde::Kind kind);
@@ -372,16 +372,48 @@ VectorSerde* getVectorSerde();
 /// Register/deregister a named vector serde. `serdeName` is a handle that
 /// allows users to register multiple serde formats.
 void registerNamedVectorSerde(
-    VectorSerde::Kind kind,
+    const std::string& kind,
     std::unique_ptr<VectorSerde> serdeToRegister);
-void deregisterNamedVectorSerde(VectorSerde::Kind kind);
+void deregisterNamedVectorSerde(const std::string& kind);
 
 /// Check if a named vector serde has been registered with `serdeName` as a
 /// handle.
-bool isRegisteredNamedVectorSerde(VectorSerde::Kind kind);
+bool isRegisteredNamedVectorSerde(const std::string& kind);
 
 /// Get the vector serde identified by `serdeName`. Throws if not found.
-VectorSerde* getNamedVectorSerde(VectorSerde::Kind kind);
+VectorSerde* getNamedVectorSerde(const std::string& kind);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+/// Legacy overloads accepting VectorSerde::Kind for backward compatibility.
+inline void registerNamedVectorSerde(
+    VectorSerde::Kind kind,
+    std::unique_ptr<VectorSerde> serdeToRegister) {
+  registerNamedVectorSerde(
+      VectorSerde::kindName(kind), std::move(serdeToRegister));
+}
+
+inline void deregisterNamedVectorSerde(VectorSerde::Kind kind) {
+  deregisterNamedVectorSerde(VectorSerde::kindName(kind));
+}
+
+inline bool isRegisteredNamedVectorSerde(VectorSerde::Kind kind) {
+  return isRegisteredNamedVectorSerde(VectorSerde::kindName(kind));
+}
+
+inline VectorSerde* getNamedVectorSerde(VectorSerde::Kind kind) {
+  return getNamedVectorSerde(VectorSerde::kindName(kind));
+}
+
+/// Allow comparing std::string with VectorSerde::Kind for backward
+/// compatibility (e.g. serdeKind() == VectorSerde::Kind::kCompactRow).
+inline bool operator==(const std::string& lhs, VectorSerde::Kind rhs) {
+  return lhs == VectorSerde::kindName(rhs);
+}
+
+inline bool operator==(VectorSerde::Kind lhs, const std::string& rhs) {
+  return VectorSerde::kindName(lhs) == rhs;
+}
+#endif
 
 class VectorStreamGroup : public StreamArena {
  public:

--- a/velox/vector/tests/VectorStreamGroupTest.cpp
+++ b/velox/vector/tests/VectorStreamGroupTest.cpp
@@ -27,28 +27,27 @@
 
 namespace facebook::velox {
 namespace {
-class VectorStreamGroupTest
-    : public testing::Test,
-      public velox::test::VectorTestBase,
-      public testing::WithParamInterface<VectorSerde::Kind> {
+class VectorStreamGroupTest : public testing::Test,
+                              public velox::test::VectorTestBase,
+                              public testing::WithParamInterface<std::string> {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
   void SetUp() override {
-    if (isRegisteredNamedVectorSerde(VectorSerde::Kind::kPresto)) {
-      deregisterNamedVectorSerde(VectorSerde::Kind::kPresto);
+    if (isRegisteredNamedVectorSerde("Presto")) {
+      deregisterNamedVectorSerde("Presto");
     }
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
 
-    if (isRegisteredNamedVectorSerde(VectorSerde::Kind::kCompactRow)) {
-      deregisterNamedVectorSerde(VectorSerde::Kind::kCompactRow);
+    if (isRegisteredNamedVectorSerde("CompactRow")) {
+      deregisterNamedVectorSerde("CompactRow");
     }
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
 
-    if (isRegisteredNamedVectorSerde(VectorSerde::Kind::kUnsafeRow)) {
-      deregisterNamedVectorSerde(VectorSerde::Kind::kUnsafeRow);
+    if (isRegisteredNamedVectorSerde("UnsafeRow")) {
+      deregisterNamedVectorSerde("UnsafeRow");
     }
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
@@ -89,7 +88,7 @@ TEST_P(VectorStreamGroupTest, clear) {
   OStreamOutputStream outputStream(&output);
   vectorGroup.flush(&outputStream);
   vectorGroup.clear();
-  if (GetParam() == VectorSerde::Kind::kPresto) {
+  if (GetParam() == "Presto") {
     // We expect two pages for header after clear.
     ASSERT_EQ(
         vectorGroup.size(),
@@ -114,9 +113,9 @@ TEST_P(VectorStreamGroupTest, clear) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     VectorStreamGroupTest,
     VectorStreamGroupTest,
-    testing::ValuesIn(
-        {VectorSerde::Kind::kPresto,
-         VectorSerde::Kind::kCompactRow,
-         VectorSerde::Kind::kUnsafeRow}));
+    testing::Values(
+        std::string("Presto"),
+        std::string("CompactRow"),
+        std::string("UnsafeRow")));
 } // namespace
 } // namespace facebook::velox

--- a/velox/vector/tests/VectorStreamTest.cpp
+++ b/velox/vector/tests/VectorStreamTest.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::test {
 
 class MockVectorSerde : public VectorSerde {
  public:
-  MockVectorSerde() : VectorSerde(VectorSerde::Kind::kPresto) {}
+  MockVectorSerde() : VectorSerde("Presto") {}
 
   void estimateSerializedSize(
       const BaseVector* /*vector*/,
@@ -71,7 +71,7 @@ TEST(VectorStreamTest, serdeRegistration) {
 }
 
 TEST(VectorStreamTest, namedSerdeRegistration) {
-  const VectorSerde::Kind kind = VectorSerde::Kind::kPresto;
+  const std::string kind = "Presto";
 
   // Nothing registered yet.
   deregisterNamedVectorSerde(kind);
@@ -87,7 +87,7 @@ TEST(VectorStreamTest, namedSerdeRegistration) {
   EXPECT_NE(serde, nullptr);
   EXPECT_NE(dynamic_cast<MockVectorSerde*>(serde), nullptr);
 
-  const VectorSerde::Kind otherKind = VectorSerde::Kind::kUnsafeRow;
+  const std::string otherKind = "UnsafeRow";
   EXPECT_FALSE(isRegisteredNamedVectorSerde(otherKind));
   VELOX_ASSERT_THROW(
       getNamedVectorSerde(otherKind),


### PR DESCRIPTION
Summary:
Change getNamedVectorSerde, registerNamedVectorSerde, deregisterNamedVectorSerde,
and isRegisteredNamedVectorSerde to accept const std::string& instead of
VectorSerde::Kind. Change VectorSerde::kind_ member from Kind to std::string.
Update all callers, PlanNodes, serializers, and tests.

Differential Revision: D94569860
