### PR TITLE
feat: Add FileLayout API for optimized reader IO and writer state tracking

### DIFF
--- a/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTestUtil.cpp
+++ b/velox/experimental/wave/dwio/nimble/tests/NimbleReaderTestUtil.cpp
@@ -365,7 +365,7 @@ std::vector<std::unique_ptr<StreamLoader>> writeToNimbleAndGetStreamLoaders(
     auto numChildren = chunkVectors[0]->as<RowVector>()->childrenSize();
 
     auto readFile = std::make_unique<InMemoryReadFile>(file);
-    auto tablet = TabletReader::create(std::move(readFile), *pool);
+    auto tablet = TabletReader::create(std::move(readFile), pool, {});
     auto stripeIdentifier = tablet->stripeIdentifier(0);
     // VELOX_CHECK_EQ(numChildren + 1, tablet.streamCount(stripeIdentifier));
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/517

CONTEXT:
When opening Nimble files, TabletReader performs a discovery phase that reads the
postscript to determine footer size, then reads the footer, and potentially re-reads
stripes if they weren't captured in the initial IO. In scenarios where file layout
metadata is available externally (e.g., from a coordinator or catalog), this discovery
IO can be skipped entirely by providing precomputed layout information.

Additionally, TabletWriter lacked validation to prevent operations after close(),
which could lead to undefined behavior.

WHAT:
1. **FileLayout API for TabletReader**:
   - Add `Options::fileLayout` to accept precomputed file metadata
   - Add `initFromFileLayout()` path that skips postscript discovery IO
   - Refactor `init()` into cleaner helper functions: `initPostScriptAndFooter()`,
     `initStripes()`, `initFooter()`
   - Consolidate TabletReader::create() API to use Options struct consistently

2. **Writer state tracking**:
   - Add State enum (kActive, kClosed) to TabletWriter
   - Add validation in close(), writeStripe(), writeOptionalSection() to prevent
     operations after close
   - Clear error messages for invalid state transitions

3. **TabletReader IO modes**:
   - FileLayout mode: Single coalesced read for footer+stripes+index (0 discovery IO)
   - Adaptive mode (footerIoBytes=0): Reads postscript first, then exact footer size
   - Speculative mode (footerIoBytes>0): Speculative tail read, re-reads if needed

4. **Test coverage**:
   - Add `fileLayoutSkipsPostScriptIo` test verifying IO behavior differences
   - Add `writeAfterCloseThrows` test for writer state validation
   - Add `readerOptionsFileLayoutMismatch` test for error handling
   - Update tests to use NIMBLE_ASSERT_USER_THROW for better error verification

The followup is the cache integration

Reviewed By: srsuryadev

Differential Revision: D94470250
