### PR TITLE
feat(spark): Add assert_not_null function

### DIFF
--- a/velox/docs/functions/spark/misc.rst
+++ b/velox/docs/functions/spark/misc.rst
@@ -2,6 +2,19 @@
 Miscellaneous Functions
 =======================
 
+.. spark:function:: assert_not_null(value) -> value
+
+    Returns the input ``value`` if it is not null. Throws an error if
+    ``value`` is null. Used to enforce NOT NULL column constraints during
+    table inserts.
+
+.. spark:function:: assert_not_null(value, errMsg) -> value
+   :noindex:
+
+    A version of ``assert_not_null`` that uses a custom error message.
+    ``errMsg`` is a constant VARCHAR specifying the error message to throw
+    when ``value`` is null.
+
 .. spark:function:: at_least_n_non_nulls(n, value1, value2, ..., valueN) -> bool
 
     Returns true if there are at least ``n`` non-null and non-NaN values,

--- a/velox/functions/sparksql/AssertNotNull.cpp
+++ b/velox/functions/sparksql/AssertNotNull.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/sparksql/AssertNotNull.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+// Asserts that the input value is not null. If any value in the specified rows
+// is null, throws a user error. Used by Spark's TableOutputResolver to enforce
+// NOT NULL column constraints during table inserts.
+class AssertNotNullFunction final : public exec::VectorFunction {
+ public:
+  explicit AssertNotNullFunction(
+      std::string errMsg = "Null value appeared in non-nullable field")
+      : errMsg_(std::move(errMsg)) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx& context,
+      VectorPtr& result) const final {
+    const auto& input = args[0];
+    if (input->mayHaveNulls() && input->rawNulls()) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+        VELOX_USER_CHECK(!input->isNullAt(row), "{}", errMsg_);
+      });
+    }
+    context.moveOrCopyResult(input, rows, result);
+  }
+
+ private:
+  const std::string errMsg_;
+};
+} // namespace
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+assertNotNullSignatures() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("T")
+          .argumentType("T")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("T")
+          .argumentType("T")
+          .constantArgumentType("varchar")
+          .build()};
+}
+
+std::shared_ptr<exec::VectorFunction> makeAssertNotNull(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /* config */) {
+  if (inputArgs.size() == 2 && inputArgs[1].constantValue &&
+      !inputArgs[1].constantValue->isNullAt(0)) {
+    auto constantExpr =
+        inputArgs[1].constantValue->as<ConstantVector<StringView>>();
+    return std::make_shared<AssertNotNullFunction>(
+        constantExpr->valueAt(0).str());
+  }
+  return std::make_shared<AssertNotNullFunction>();
+}
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/AssertNotNull.h
+++ b/velox/functions/sparksql/AssertNotNull.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions::sparksql {
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> assertNotNullSignatures();
+
+std::shared_ptr<exec::VectorFunction> makeAssertNotNull(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   velox_functions_spark_impl
   ArrayGetFunction.cpp
   ArraySort.cpp
+  AssertNotNull.cpp
   Transform.cpp
   CharVarcharUtils.cpp
   Comparisons.cpp

--- a/velox/functions/sparksql/registration/RegisterMisc.cpp
+++ b/velox/functions/sparksql/registration/RegisterMisc.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/sparksql/AssertNotNull.h"
 #include "velox/functions/sparksql/In.h"
 #include "velox/functions/sparksql/MonotonicallyIncreasingId.h"
 #include "velox/functions/sparksql/RaiseError.h"
@@ -24,6 +25,11 @@
 
 namespace facebook::velox::functions::sparksql {
 void registerMiscFunctions(const std::string& prefix) {
+  exec::registerStatefulVectorFunction(
+      prefix + "assert_not_null",
+      assertNotNullSignatures(),
+      makeAssertNotNull,
+      exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
   registerFunction<MonotonicallyIncreasingIdFunction, int64_t>(
       {prefix + "monotonically_increasing_id"});
   registerFunction<RaiseErrorFunction, UnknownValue, Varchar>(

--- a/velox/functions/sparksql/tests/AssertNotNullTest.cpp
+++ b/velox/functions/sparksql/tests/AssertNotNullTest.cpp
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class AssertNotNullTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  void testAssertNotNull(
+      const std::vector<std::optional<T>>& input,
+      const std::vector<T>& expected) {
+    auto inputVector = makeNullableFlatVector<T>(input);
+    auto result = evaluate("assert_not_null(c0)", makeRowVector({inputVector}));
+    auto expectedVector = makeFlatVector<T>(expected);
+    velox::test::assertEqualVectors(expectedVector, result);
+  }
+};
+
+TEST_F(AssertNotNullTest, integer) {
+  testAssertNotNull<int32_t>({1, 2, 3}, {1, 2, 3});
+}
+
+TEST_F(AssertNotNullTest, bigint) {
+  testAssertNotNull<int64_t>({10, 20, 30}, {10, 20, 30});
+}
+
+TEST_F(AssertNotNullTest, varchar) {
+  testAssertNotNull<StringView>(
+      {StringView("hello"), StringView("world")},
+      {StringView("hello"), StringView("world")});
+}
+
+TEST_F(AssertNotNullTest, boolean) {
+  testAssertNotNull<bool>({true, false, true}, {true, false, true});
+}
+
+TEST_F(AssertNotNullTest, nullInput) {
+  auto input = makeNullableFlatVector<int32_t>({1, std::nullopt, 3});
+  VELOX_ASSERT_THROW(
+      evaluate("assert_not_null(c0)", makeRowVector({input})),
+      "Null value appeared in non-nullable field");
+}
+
+TEST_F(AssertNotNullTest, allNulls) {
+  auto input = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  VELOX_ASSERT_THROW(
+      evaluate("assert_not_null(c0)", makeRowVector({input})),
+      "Null value appeared in non-nullable field");
+}
+
+TEST_F(AssertNotNullTest, complexType) {
+  auto arrayVector = makeNullableArrayVector<int32_t>(
+      std::vector<std::vector<std::optional<int32_t>>>{
+          {{1, 2, 3}}, {{4, 5}}, {{6}}});
+  auto row = makeRowVector(std::vector<VectorPtr>{arrayVector});
+  auto result = evaluate("assert_not_null(c0)", row);
+  velox::test::assertEqualVectors(arrayVector, result);
+}
+
+TEST_F(AssertNotNullTest, complexTypeWithNull) {
+  auto arrayVector = makeNullableArrayVector<int32_t>(
+      std::vector<std::optional<std::vector<std::optional<int32_t>>>>{
+          {{{1, 2, 3}}}, std::nullopt, {{{6}}}});
+  auto row = makeRowVector(std::vector<VectorPtr>{arrayVector});
+  VELOX_ASSERT_THROW(
+      evaluate("assert_not_null(c0)", row),
+      "Null value appeared in non-nullable field");
+}
+
+TEST_F(AssertNotNullTest, customErrorMessage) {
+  auto input = makeNullableFlatVector<int32_t>({1, std::nullopt, 3});
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "assert_not_null(c0, 'custom error message')",
+          makeRowVector({input})),
+      "custom error message");
+}
+
+TEST_F(AssertNotNullTest, nullErrorMessage) {
+  // When errMsg constant is NULL, use default error message.
+  auto input = makeNullableFlatVector<int32_t>({1, std::nullopt, 3});
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "assert_not_null(c0, cast(null as varchar))", makeRowVector({input})),
+      "Null value appeared in non-nullable field");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(
   ArrayShuffleTest.cpp
   ArrayUnionTest.cpp
   ArgTypesGeneratorTest.cpp
+  AssertNotNullTest.cpp
   AtLeastNNonNullsTest.cpp
   Base64Test.cpp
   BitwiseTest.cpp


### PR DESCRIPTION
## Summary

Add Spark's `AssertNotNull` expression to Velox as `assert_not_null`.

This function asserts that the input value is not null, throwing a user error if it is. It is used by Spark's `TableOutputResolver` to enforce NOT NULL column constraints during table inserts. When a nullable column is inserted into a non-nullable target column, Spark wraps the expression with `AssertNotNull` to validate at runtime.



- Implemented as a `VectorFunction` with `defaultNullBehavior=false` for zero-copy pass-through of non-null values
- If any selected row has a null value, throws `VeloxUserError`
- Supports all types via generic type variable `T`

