### PR TITLE
docs: Update coverage.rst for localtimestamp and current_time

### DIFF
--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -174,6 +174,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(7) {background-color: #6BA81E;}
@@ -436,6 +437,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     table.coverage tr:nth-child(75) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(75) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(76) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(76) td:nth-child(4) {background-color: #6BA81E;}
@@ -500,7 +502,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     :func:`array_sort_desc`                   :func:`flatten`                           :func:`line_locate_point`                 :func:`sha1`                              tdigest_agg                                   :func:`entropy`
     array_split_into_chunks                   :func:`flatten_geometry_collections`      :func:`ln`                                :func:`sha256`                            :func:`timezone_hour`                         evaluate_classifier_predictions
     :func:`array_sum`                         :func:`floor`                             :func:`localtime`                         :func:`sha512`                            :func:`timezone_minute`                       :func:`every`
-    :func:`array_top_n`                       :func:`fnv1_32`                           localtimestamp                            :func:`shuffle`                           :func:`to_base`                               :func:`geometric_mean`
+    :func:`array_top_n`                       :func:`fnv1_32`                           :func:`localtimestamp`                    :func:`shuffle`                           :func:`to_base`                               :func:`geometric_mean`
     :func:`array_union`                       :func:`fnv1_64`                           :func:`log10`                             :func:`sign`                              to_base32                                     geometry_union_agg
     :func:`arrays_overlap`                    :func:`fnv1a_32`                          :func:`log2`                              :func:`simplify_geometry`                 :func:`to_base64`                             :func:`histogram`
     :func:`asin`                              :func:`fnv1a_64`                          :func:`longest_common_prefix`             :func:`sin`                               :func:`to_base64url`                          khyperloglog_agg
@@ -548,7 +550,7 @@ Here is a list of all scalar, aggregate, and window functions from Presto, with 
     :func:`cosine_similarity`                 :func:`inverse_laplace_cdf`               :func:`pi`                                :func:`st_isring`                         :func:`year`                                  :func:`stddev_samp`
     :func:`crc32`                             :func:`inverse_normal_cdf`                pinot_binary_decimal_to_double            :func:`st_issimple`                       :func:`year_of_week`                          :func:`sum`
     :func:`current_date`                      :func:`inverse_poisson_cdf`               :func:`poisson_cdf`                       :func:`st_isvalid`                        :func:`yow`                                   :func:`tdigest_agg`
-    current_time                              :func:`inverse_weibull_cdf`               :func:`pow`                               :func:`st_length`                         :func:`zip`                                   :func:`var_pop`
+    :func:`current_time`                      :func:`inverse_weibull_cdf`               :func:`pow`                               :func:`st_length`                         :func:`zip`                                   :func:`var_pop`
     :func:`current_timestamp`                 :func:`ip_prefix`                         :func:`power`                             :func:`st_linefromtext`                   :func:`zip_with`                              :func:`var_samp`
     :func:`current_timezone`                  :func:`ip_prefix_collapse`                :func:`quantile_at_value`                 :func:`st_linestring`                                                                   :func:`variance`
     :func:`date`                              :func:`ip_prefix_subnets`                 :func:`quarter`                           :func:`st_multipoint`


### PR DESCRIPTION
Updated function coverage map for https://github.com/facebookincubator/velox/pull/15605/ and https://github.com/facebookincubator/velox/pull/15603/