### PR TITLE
feat(parquet): Add page-row-limit config

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -907,6 +907,11 @@ Each query can override the config by setting corresponding query session proper
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
+   * - parquet.writer.page-row-limit
+     - parquet.writer.page_row_limit
+     - integer
+     - 0 (no limit)
+     - Parquet data page row number limit. This configuration is shared between Hive and Iceberg connectors, hence no connector-specific prefix.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1139,7 +1139,11 @@ Parquet Options (prefix ``hive.parquet.``)
      - 0 (no limit)
      - Data page row-count limit used when writing into Parquet through the Arrow bridge. The writer
        flushes a data page once it buffers this many rows, even before the byte-size page limit is
-       reached. Zero means no limit. Session: ``hive.parquet.writer.page_row_limit``.
+       reached. A non-zero limit also makes data pages of columns nested inside an ARRAY or MAP
+       (Parquet repeated columns) end on row boundaries, which V1 pages written without the page
+       index do not otherwise guarantee, because rows cannot be counted across a page that splits
+       one. Zero means no limit.
+       Session: ``hive.parquet.writer.page_row_limit``.
 
 Nimble Options (prefix ``hive.nimble.``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1134,6 +1134,12 @@ Parquet Options (prefix ``hive.parquet.``)
        Parquet through the Arrow bridge. When enabled, per-page statistics are stored in the page
        index instead of the data page headers, letting readers skip pages that cannot match a filter.
        Session: ``hive.parquet.writer.enable_page_index``.
+   * - ``writer.page-row-limit``
+     - integer
+     - 0 (no limit)
+     - Data page row-count limit used when writing into Parquet through the Arrow bridge. The writer
+       flushes a data page once it buffers this many rows, even before the byte-size page limit is
+       reached. Zero means no limit. Session: ``hive.parquet.writer.page_row_limit``.
 
 Nimble Options (prefix ``hive.nimble.``)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/parquet/common/ParquetConfig.h
+++ b/velox/dwio/parquet/common/ParquetConfig.h
@@ -124,6 +124,16 @@ class ParquetConfig {
       "1024",
       "Write batch size for the Parquet writer.")
   VELOX_FORMAT_CONFIG_PROPERTY(
+      kWriterPageRowLimitSession,
+      kWriterPageRowLimit,
+      "writer_page_row_limit",
+      "writer.page-row-limit",
+      int64_t,
+      0,
+      "Data page row-count limit for the Parquet writer. The writer flushes a "
+      "data page once it buffers this many rows, even before the byte-size "
+      "page limit is reached. Zero (default) means no limit.")
+  VELOX_FORMAT_CONFIG_PROPERTY(
       kWriterEnablePageIndexSession,
       kWriterEnablePageIndex,
       "writer_enable_page_index",
@@ -193,6 +203,13 @@ class ParquetConfig {
         kWriterBatchSizeSession, connectorConfig, kWriterBatchSize);
   }
 
+  static std::optional<std::string> writerPageRowLimit(
+      const config::ConfigBase& connectorConfig,
+      const config::ConfigBase& session) {
+    return session.getLegacyWithFallback<std::string>(
+        kWriterPageRowLimitSession, connectorConfig, kWriterPageRowLimit);
+  }
+
   static std::optional<std::string> writerEnablePageIndex(
       const config::ConfigBase& connectorConfig,
       const config::ConfigBase& session) {
@@ -243,6 +260,8 @@ class ParquetConfig {
         properties, sessionPrefix);
     dwio::common::registerFormatConfigProperty<kWriterBatchSizeSessionProperty>(
         properties, sessionPrefix);
+    dwio::common::registerFormatConfigProperty<
+        kWriterPageRowLimitSessionProperty>(properties, sessionPrefix);
     dwio::common::registerFormatConfigProperty<
         kWriterEnablePageIndexSessionProperty>(properties, sessionPrefix);
   }

--- a/velox/dwio/parquet/common/ParquetConfig.h
+++ b/velox/dwio/parquet/common/ParquetConfig.h
@@ -132,7 +132,9 @@ class ParquetConfig {
       0,
       "Data page row-count limit for the Parquet writer. The writer flushes a "
       "data page once it buffers this many rows, even before the byte-size "
-      "page limit is reached. Zero (default) means no limit.")
+      "page limit is reached. A non-zero limit also makes data pages of "
+      "repeated columns end on record boundaries. Zero (default) means no "
+      "limit.")
   VELOX_FORMAT_CONFIG_PROPERTY(
       kWriterEnablePageIndexSession,
       kWriterEnablePageIndex,

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -2158,6 +2158,75 @@ TEST_F(ParquetWriterTest, flushEstimationFlatColumns) {
   ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
 }
 
+TEST_F(ParquetWriterTest, dataPageRowLimitPrecedesSizeLimit) {
+  constexpr int64_t kRows = 5'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  // Set the row count limit to 1500. The default page size is 1MB, which is
+  // large enough to hold all 5000 rows. With batch size 500, it checks limits
+  // every 500 rows. It should cut exactly at 1500 elements since 1500 < 5000
+  // rows and 1500 smallints < 1MB.
+  const std::unordered_map<std::string, std::string> rowLimitFirstConfig = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "1500"},
+      {std::string(parquet::ParquetConfig::kWriterBatchSize), "500"},
+  };
+  auto* sinkPtr = write(data, rowLimitFirstConfig, {});
+  const auto rowLimitFirstHeader = readPageHeader(sinkPtr, 0);
+
+  EXPECT_EQ(*rowLimitFirstHeader.type(), thrift::PageType::DATA_PAGE);
+  EXPECT_EQ(*rowLimitFirstHeader.data_page_header()->num_values(), 1'500);
+}
+
+TEST_F(ParquetWriterTest, dataPageRowLimitAfterSizeLimit) {
+  constexpr int64_t kRows = 5'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  // Similar to testPageSizeAndBatchSizeConfiguration, 2KB page size cuts at
+  // 1067 rows given batch size 97. If we set row limit to 2000, the byte size
+  // limit should trigger first and the page should be cut at 1067 rows.
+  const std::unordered_map<std::string, std::string> sizeLimitFirstConfig = {
+      {std::string(parquet::ParquetConfig::kWriterPageSize), "2KB"},
+      {std::string(parquet::ParquetConfig::kWriterBatchSize), "97"},
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "2000"},
+  };
+  auto* sinkPtr = write(data, sizeLimitFirstConfig, {});
+  const auto sizeLimitFirstHeader = readPageHeader(sinkPtr, 0);
+
+  EXPECT_EQ(*sizeLimitFirstHeader.type(), thrift::PageType::DATA_PAGE);
+  EXPECT_EQ(*sizeLimitFirstHeader.data_page_header()->num_values(), 1'067);
+}
+
+TEST_F(ParquetWriterTest, dataPageRowLimitSessionOverride) {
+  constexpr int64_t kRows = 5'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  const std::unordered_map<std::string, std::string> configFromFile = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "1000"},
+      {std::string(parquet::ParquetConfig::kWriterBatchSize), "500"},
+  };
+  const std::unordered_map<std::string, std::string> sessionProps = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimitSession), "2000"},
+  };
+  auto* sinkPtr = write(data, configFromFile, sessionProps);
+  const auto overrideHeader = readPageHeader(sinkPtr, 0);
+
+  EXPECT_EQ(*overrideHeader.type(), thrift::PageType::DATA_PAGE);
+  EXPECT_EQ(*overrideHeader.data_page_header()->num_values(), 2'000);
+}
+
+TEST_F(ParquetWriterTest, dataPageRowLimitIncorrectConfig) {
+  constexpr int64_t kRows = 5'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  const std::string invalidConfigValue{"A1B2"};
+  const std::unordered_map<std::string, std::string> incorrectConfigFromFile = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit),
+       invalidConfigValue},
+  };
+
+  VELOX_ASSERT_THROW(write(data, incorrectConfigFromFile, {}), "");
+}
+
 } // namespace
 
 int main(int argc, char** argv) {

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -707,6 +707,72 @@ TEST_F(ParquetWriterTest, testPageSizeAndBatchSizeConfiguration) {
           invalidPageSizeAndBatchSizeValue));
 }
 
+TEST_F(ParquetWriterTest, dataPageRowLimitPrecedesSizeLimit) {
+  constexpr int64_t kRows = 5'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  // Set the row count limit to 1500. The default page size is 1MB, which is
+  // large enough to hold all 5000 rows. A 1000-row batch does not evenly
+  // divide the limit, so the writer must split the second batch after 500 rows
+  // instead of flushing a 2000-row page.
+  const std::unordered_map<std::string, std::string> rowLimitFirstConfig = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "1500"},
+      {std::string(parquet::ParquetConfig::kWriterBatchSize), "1000"},
+  };
+  auto* sinkPtr = write(data, rowLimitFirstConfig, {});
+  const auto rowLimitFirstHeader = readPageHeader(sinkPtr, 0);
+
+  EXPECT_EQ(*rowLimitFirstHeader.type(), thrift::PageType::DATA_PAGE);
+  EXPECT_EQ(*rowLimitFirstHeader.data_page_header()->num_values(), 1'500);
+}
+
+TEST_F(ParquetWriterTest, dataPageRowLimitAfterSizeLimit) {
+  constexpr int64_t kRows = 5'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  // Similar to testPageSizeAndBatchSizeConfiguration, 2KB page size cuts at
+  // 1067 rows given batch size 97. If we set row limit to 2000, the byte size
+  // limit should trigger first and the page should be cut at 1067 rows.
+  const std::unordered_map<std::string, std::string> sizeLimitFirstConfig = {
+      {std::string(parquet::ParquetConfig::kWriterPageSize), "2KB"},
+      {std::string(parquet::ParquetConfig::kWriterBatchSize), "97"},
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "2000"},
+  };
+  auto* sinkPtr = write(data, sizeLimitFirstConfig, {});
+  const auto sizeLimitFirstHeader = readPageHeader(sinkPtr, 0);
+
+  EXPECT_EQ(*sizeLimitFirstHeader.type(), thrift::PageType::DATA_PAGE);
+  EXPECT_EQ(*sizeLimitFirstHeader.data_page_header()->num_values(), 1'067);
+}
+
+TEST_F(ParquetWriterTest, toggleDataPageRowLimit) {
+  constexpr int64_t kRows = 1'000;
+  const auto data = makeSmallintTestData(kRows);
+
+  const std::unordered_map<std::string, std::string> configFromFile = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "100"},
+      {std::string(parquet::ParquetConfig::kWriterBatchSize), "50"},
+  };
+  const std::unordered_map<std::string, std::string> sessionProps = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimitSession), "200"},
+  };
+  auto* sinkPtr = write(data, configFromFile, sessionProps);
+  const auto overrideHeader = readPageHeader(sinkPtr, 0);
+
+  EXPECT_EQ(*overrideHeader.type(), thrift::PageType::DATA_PAGE);
+  EXPECT_EQ(*overrideHeader.data_page_header()->num_values(), 200);
+
+  const std::string invalidConfigValue{"A1B2"};
+  const std::unordered_map<std::string, std::string> incorrectConfigFromFile = {
+      {std::string(parquet::ParquetConfig::kWriterPageRowLimit),
+       invalidConfigValue},
+  };
+
+  VELOX_ASSERT_THROW(
+      write(data, incorrectConfigFromFile, {}),
+      "Invalid parquet writer data page row limit");
+}
+
 TEST_F(ParquetWriterTest, toggleDataPageVersion) {
   const int64_t kRows = 1;
   const auto data = makeRowVector({
@@ -2156,75 +2222,6 @@ TEST_F(ParquetWriterTest, flushEstimationFlatColumns) {
   // The second write triggers a flush because the first batch (~600KB)
   // exceeds the 500KB threshold.
   ASSERT_EQ(reader->fileMetaData().numRowGroups(), 2);
-}
-
-TEST_F(ParquetWriterTest, dataPageRowLimitPrecedesSizeLimit) {
-  constexpr int64_t kRows = 5'000;
-  const auto data = makeSmallintTestData(kRows);
-
-  // Set the row count limit to 1500. The default page size is 1MB, which is
-  // large enough to hold all 5000 rows. With batch size 500, it checks limits
-  // every 500 rows. It should cut exactly at 1500 elements since 1500 < 5000
-  // rows and 1500 smallints < 1MB.
-  const std::unordered_map<std::string, std::string> rowLimitFirstConfig = {
-      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "1500"},
-      {std::string(parquet::ParquetConfig::kWriterBatchSize), "500"},
-  };
-  auto* sinkPtr = write(data, rowLimitFirstConfig, {});
-  const auto rowLimitFirstHeader = readPageHeader(sinkPtr, 0);
-
-  EXPECT_EQ(*rowLimitFirstHeader.type(), thrift::PageType::DATA_PAGE);
-  EXPECT_EQ(*rowLimitFirstHeader.data_page_header()->num_values(), 1'500);
-}
-
-TEST_F(ParquetWriterTest, dataPageRowLimitAfterSizeLimit) {
-  constexpr int64_t kRows = 5'000;
-  const auto data = makeSmallintTestData(kRows);
-
-  // Similar to testPageSizeAndBatchSizeConfiguration, 2KB page size cuts at
-  // 1067 rows given batch size 97. If we set row limit to 2000, the byte size
-  // limit should trigger first and the page should be cut at 1067 rows.
-  const std::unordered_map<std::string, std::string> sizeLimitFirstConfig = {
-      {std::string(parquet::ParquetConfig::kWriterPageSize), "2KB"},
-      {std::string(parquet::ParquetConfig::kWriterBatchSize), "97"},
-      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "2000"},
-  };
-  auto* sinkPtr = write(data, sizeLimitFirstConfig, {});
-  const auto sizeLimitFirstHeader = readPageHeader(sinkPtr, 0);
-
-  EXPECT_EQ(*sizeLimitFirstHeader.type(), thrift::PageType::DATA_PAGE);
-  EXPECT_EQ(*sizeLimitFirstHeader.data_page_header()->num_values(), 1'067);
-}
-
-TEST_F(ParquetWriterTest, dataPageRowLimitSessionOverride) {
-  constexpr int64_t kRows = 5'000;
-  const auto data = makeSmallintTestData(kRows);
-
-  const std::unordered_map<std::string, std::string> configFromFile = {
-      {std::string(parquet::ParquetConfig::kWriterPageRowLimit), "1000"},
-      {std::string(parquet::ParquetConfig::kWriterBatchSize), "500"},
-  };
-  const std::unordered_map<std::string, std::string> sessionProps = {
-      {std::string(parquet::ParquetConfig::kWriterPageRowLimitSession), "2000"},
-  };
-  auto* sinkPtr = write(data, configFromFile, sessionProps);
-  const auto overrideHeader = readPageHeader(sinkPtr, 0);
-
-  EXPECT_EQ(*overrideHeader.type(), thrift::PageType::DATA_PAGE);
-  EXPECT_EQ(*overrideHeader.data_page_header()->num_values(), 2'000);
-}
-
-TEST_F(ParquetWriterTest, dataPageRowLimitIncorrectConfig) {
-  constexpr int64_t kRows = 5'000;
-  const auto data = makeSmallintTestData(kRows);
-
-  const std::string invalidConfigValue{"A1B2"};
-  const std::unordered_map<std::string, std::string> incorrectConfigFromFile = {
-      {std::string(parquet::ParquetConfig::kWriterPageRowLimit),
-       invalidConfigValue},
-  };
-
-  VELOX_ASSERT_THROW(write(data, incorrectConfigFromFile, {}), "");
 }
 
 } // namespace

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -152,6 +152,10 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   properties = properties->encoding(options.encoding);
   properties = properties->dataPagesize(options.dataPageSize.value_or(
       facebook::velox::parquet::arrow::kDefaultDataPageSize));
+  if (options.dataPageRowNumberLimit.has_value()) {
+    properties = properties->dataPageRowNumberLimit(
+        options.dataPageRowNumberLimit.value());
+  }
   properties = properties->writeBatchSize(options.batchSize.value_or(
       facebook::velox::parquet::arrow::DEFAULT_WRITE_BATCH_SIZE));
   properties = properties->maxRowGroupLength(
@@ -353,7 +357,7 @@ std::optional<int64_t> getParquetPageSize(
   return std::nullopt;
 }
 
-std::optional<int64_t> getParquetBatchSize(
+std::optional<int64_t> getParquetBigintConfig(
     const config::ConfigBase& config,
     const char* configKey) {
   try {
@@ -361,7 +365,8 @@ std::optional<int64_t> getParquetBatchSize(
       return batchSize.value();
     }
   } catch (const folly::ConversionError& e) {
-    VELOX_USER_FAIL("Invalid parquet writer batch size: {}", e.what());
+    VELOX_USER_FAIL(
+        "Invalid config setting of \"{}\": {}", configKey, e.what());
   }
   return std::nullopt;
 }
@@ -691,16 +696,25 @@ void WriterOptions::processConfigs(
   }
 
   if (!batchSize) {
-    batchSize =
-        getParquetBatchSize(session, kParquetSessionWriteBatchSize).has_value()
-        ? getParquetBatchSize(session, kParquetSessionWriteBatchSize)
-        : getParquetBatchSize(
+    batchSize = getParquetBigintConfig(session, kParquetSessionWriteBatchSize)
+                    .has_value()
+        ? getParquetBigintConfig(session, kParquetSessionWriteBatchSize)
+        : getParquetBigintConfig(
               connectorConfig, kParquetHiveConnectorWriteBatchSize);
   }
 
   if (!createdBy) {
     createdBy =
         getParquetCreatedBy(connectorConfig, kParquetHiveConnectorCreatedBy);
+  }
+
+  if (!dataPageRowNumberLimit) {
+    dataPageRowNumberLimit =
+        getParquetBigintConfig(session, kParquetSessionDataPageRowCountLimit)
+            .has_value()
+        ? getParquetBigintConfig(session, kParquetSessionDataPageRowCountLimit)
+        : getParquetBigintConfig(
+              connectorConfig, kParquetConnectorDataPageRowCountLimit);
   }
 }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -133,6 +133,7 @@ void ParquetWriterOptions::merge(
   mergeIfSet(enableWritePageIndex, parquetOverrides->enableWritePageIndex);
   mergeIfSet(dataPageSize, parquetOverrides->dataPageSize);
   mergeIfSet(batchSize, parquetOverrides->batchSize);
+  mergeIfSet(dataPageRowLimit, parquetOverrides->dataPageRowLimit);
   mergeIfSet(createdBy, parquetOverrides->createdBy);
 }
 
@@ -218,6 +219,10 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   properties = properties->encoding(parquetOptions.encoding);
   properties = properties->dataPagesize(parquetOptions.dataPageSize.value_or(
       facebook::velox::parquet::arrow::kDefaultDataPageSize));
+  if (parquetOptions.dataPageRowLimit.has_value()) {
+    properties =
+        properties->dataPageRowLimit(parquetOptions.dataPageRowLimit.value());
+  }
   properties = properties->writeBatchSize(parquetOptions.batchSize.value_or(
       facebook::velox::parquet::arrow::DEFAULT_WRITE_BATCH_SIZE));
   properties = properties->maxRowGroupLength(
@@ -392,15 +397,16 @@ std::optional<bool> toBoolConfigValue(
   }
 }
 
-std::optional<int64_t> toParquetBatchSize(
-    std::optional<std::string> batchSize) {
-  if (!batchSize) {
+std::optional<int64_t> toInt64ConfigValue(
+    std::optional<std::string> value,
+    const char* optionName) {
+  if (!value) {
     return std::nullopt;
   }
   try {
-    return folly::to<int64_t>(*batchSize);
+    return folly::to<int64_t>(*value);
   } catch (const std::exception& e) {
-    VELOX_USER_FAIL("Invalid parquet writer batch size: {}", e.what());
+    VELOX_USER_FAIL("Invalid parquet writer {}: {}", optionName, e.what());
   }
 }
 
@@ -840,8 +846,11 @@ ParquetWriterFactory::createFormatOptions(
       "enable write page index");
   parquetOptions->dataPageSize = toParquetPageSize(
       ParquetConfig::writerPageSize(connectorConfig, session));
-  parquetOptions->batchSize = toParquetBatchSize(
-      ParquetConfig::writerBatchSize(connectorConfig, session));
+  parquetOptions->batchSize = toInt64ConfigValue(
+      ParquetConfig::writerBatchSize(connectorConfig, session), "batch size");
+  parquetOptions->dataPageRowLimit = toInt64ConfigValue(
+      ParquetConfig::writerPageRowLimit(connectorConfig, session),
+      "data page row limit");
   parquetOptions->createdBy = ParquetConfig::writerCreatedBy(connectorConfig);
   return parquetOptions;
 }

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -399,7 +399,7 @@ std::optional<bool> toBoolConfigValue(
 
 std::optional<int64_t> toInt64ConfigValue(
     std::optional<std::string> value,
-    const char* optionName) {
+    std::string_view optionName) {
   if (!value) {
     return std::nullopt;
   }

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -111,6 +111,7 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<int64_t> batchSize;
   std::optional<int64_t> dataPageSize;
   std::optional<int64_t> dictionaryPageSizeLimit;
+  std::optional<int64_t> dataPageRowNumberLimit;
   std::optional<bool> enableDictionary;
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
@@ -153,7 +154,10 @@ struct WriterOptions : public dwio::common::WriterOptions {
       "hive.parquet.writer.batch-size";
   static constexpr const char* kParquetHiveConnectorCreatedBy =
       "hive.parquet.writer.created-by";
-
+  static constexpr const char* kParquetSessionDataPageRowCountLimit =
+      "parquet.writer.page_row_limit";
+  static constexpr const char* kParquetConnectorDataPageRowCountLimit =
+      "parquet.writer.page-row-limit";
   // Serde parameter keys for timestamp settings. These can be set via
   // serdeParameters map to override the default timestamp behavior.
   // The timezone key accepts a timezone string or empty string to disable

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -141,6 +141,7 @@ struct ParquetWriterOptions : public dwio::common::FormatSpecificOptions {
   std::optional<int64_t> batchSize;
   std::optional<int64_t> dataPageSize;
   std::optional<int64_t> dictionaryPageSizeLimit;
+  std::optional<int64_t> dataPageRowLimit;
   std::optional<bool> enableDictionary;
   /// Controls how DECIMAL values are stored by the Writer.
   /// - If unset, the Writer defaults to storing as integer (true),

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -1884,10 +1884,15 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     numBufferedEncodedValues_ += numValues;
     numBufferedNulls_ += numNulls;
 
-    if (checkPageSize &&
-        currentEncoder_->estimatedDataEncodedSize() >=
-            properties_->dataPagesize()) {
-      addDataPage();
+    if (checkPageSize) {
+      const bool sizeLimitExceeded =
+          currentEncoder_->estimatedDataEncodedSize() >=
+          properties_->dataPagesize();
+      const bool rowLimitExceeded = properties_->dataPageRowNumberLimit() > 0 &&
+          numBufferedRows_ >= properties_->dataPageRowNumberLimit();
+      if (sizeLimitExceeded || rowLimitExceeded) {
+        addDataPage();
+      }
     }
   }
 

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -1898,10 +1898,15 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     numBufferedEncodedValues_ += numValues;
     numBufferedNulls_ += numNulls;
 
-    if (checkPageSize &&
-        currentEncoder_->estimatedDataEncodedSize() >=
-            properties_->dataPagesize()) {
-      addDataPage();
+    if (checkPageSize) {
+      const bool sizeLimitExceeded =
+          currentEncoder_->estimatedDataEncodedSize() >=
+          properties_->dataPagesize();
+      const bool rowLimitExceeded = properties_->dataPageRowLimit() > 0 &&
+          numBufferedRows_ >= properties_->dataPageRowLimit();
+      if (sizeLimitExceeded || rowLimitExceeded) {
+        addDataPage();
+      }
     }
   }
 

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.cpp
@@ -1345,66 +1345,153 @@ void ColumnWriterImpl::flushBufferedDataPages() {
 // TypedColumnWriter.
 
 template <typename Action>
-inline void doInBatches(int64_t total, int64_t batchSize, Action&& action) {
-  int64_t numBatches = static_cast<int>(total / batchSize);
-  for (int round = 0; round < numBatches; round++) {
-    action(round * batchSize, batchSize, true);
-  }
-  // Write the remaining values.
-  if (total % batchSize > 0) {
-    action(numBatches * batchSize, total % batchSize, true);
+inline void doInBatches(
+    int64_t total,
+    int64_t batchSize,
+    int64_t pageRowLimit,
+    const int64_t& numBufferedRows,
+    Action&& action) {
+  int64_t offset = 0;
+  while (offset < total) {
+    int64_t numLevels = std::min(batchSize, total - offset);
+    if (pageRowLimit > 0) {
+      // Split before encoding so that a page cannot exceed the row limit by a
+      // full write batch. Every chunk boundary is a record boundary here, so
+      // the previous chunk always closed a full page. The lower bound of one
+      // level only keeps the loop moving if that ever stops holding.
+      VELOX_DCHECK_LT(numBufferedRows, pageRowLimit);
+      numLevels = std::min(
+          numLevels, std::max<int64_t>(pageRowLimit - numBufferedRows, 1));
+    }
+    action(offset, numLevels, true);
+    offset += numLevels;
   }
 }
 
-template <typename Action>
+// Returns the end of the chunk starting at 'offset': the first record boundary
+// at or after 'offset + batchSize', holding at most 'maxRows' records, and
+// never past 'numLevels'. Zero 'maxRows' means the chunk is bounded by
+// 'batchSize' alone. The chunk always covers at least one record or record
+// fragment, so the caller always makes progress.
+inline int64_t nextChunkEnd(
+    const int16_t* repLevels,
+    int64_t numLevels,
+    int64_t offset,
+    int64_t batchSize,
+    int64_t maxRows) {
+  if (maxRows == 0) {
+    // Without a row bound the records in the chunk do not have to be counted,
+    // so skip over the levels the write batch covers instead of walking them
+    // record by record.
+    int64_t endOffset =
+        std::min(offset + std::max<int64_t>(batchSize, 1), numLevels);
+    while (endOffset < numLevels && repLevels[endOffset] != 0) {
+      ++endOffset;
+    }
+    return endOffset;
+  }
+
+  int64_t endOffset = offset;
+  int64_t numRows = 0;
+  do {
+    // Skip past the record, or trailing record fragment, at 'endOffset'.
+    ++endOffset;
+    while (endOffset < numLevels && repLevels[endOffset] != 0) {
+      ++endOffset;
+    }
+    ++numRows;
+  } while (endOffset < numLevels && endOffset - offset < batchSize &&
+           numRows < maxRows);
+  return endOffset;
+}
+
+// Splits a write into chunks so that pages stay within the configured size and
+// row limits.
+//
+// 'action(offset, numLevels, checkPage)' encodes one chunk and, when
+// 'checkPage' is set, closes the page if it has reached a limit. 'checkPage' is
+// false only for a chunk that may end in the middle of a record, because a page
+// must not begin in the middle of one.
+//
+// 'startNewPage()' closes the current page unconditionally. It is called only
+// at a record boundary, when the page has no room left for another record.
+//
+// 'numBufferedRows' aliases the writer's count of rows buffered in the current
+// page; 'action' and 'startNewPage' both update it.
+template <typename Action, typename StartNewPage>
 inline void doInBatches(
-    const int16_t* defLevels,
     const int16_t* repLevels,
     int64_t numLevels,
     int64_t batchSize,
+    int64_t pageRowLimit,
+    const int64_t& numBufferedRows,
     Action&& action,
+    StartNewPage&& startNewPage,
     bool pagesChangeOnRecordBoundaries) {
-  if (!pagesChangeOnRecordBoundaries || !repLevels) {
-    // If repLevels is null, then we are writing a non-repeated column.
-    // In this case, every record contains only one level.
-    return doInBatches(numLevels, batchSize, std::forward<Action>(action));
+  // If repLevels is null, then we are writing a non-repeated column.
+  // In this case, every record contains only one level.
+  if (!repLevels) {
+    return doInBatches(
+        numLevels,
+        batchSize,
+        pageRowLimit,
+        numBufferedRows,
+        std::forward<Action>(action));
+  }
+
+  // Pages may start in the middle of a record and there is no row budget to
+  // spend, so chunking does not need to look at repetition levels. A row limit
+  // always implies record-aligned pages, because rows cannot be counted across
+  // a page boundary that splits one.
+  if (!pagesChangeOnRecordBoundaries && pageRowLimit == 0) {
+    return doInBatches(
+        numLevels,
+        batchSize,
+        /*pageRowLimit=*/0,
+        numBufferedRows,
+        std::forward<Action>(action));
   }
 
   int64_t offset = 0;
   while (offset < numLevels) {
-    int64_t endOffset = std::min(offset + batchSize, numLevels);
-
-    // Find next record boundary (i.e. repLevel = 0).
-    while (endOffset < numLevels && repLevels[endOffset] != 0) {
-      endOffset++;
+    if (pageRowLimit > 0 && numBufferedRows >= pageRowLimit &&
+        repLevels[offset] == 0) {
+      // The page is full and 'offset' is a record boundary, the only place a
+      // page may be cut. Without this the next record would overflow the limit.
+      startNewPage();
     }
+
+    // A chunk holds at least one record, which may be longer than 'batchSize'.
+    // Without a row limit there is no per-chunk row bound to enforce.
+    const int64_t maxRows = pageRowLimit > 0
+        ? std::max<int64_t>(pageRowLimit - numBufferedRows, 1)
+        : 0;
+    const int64_t endOffset =
+        nextChunkEnd(repLevels, numLevels, offset, batchSize, maxRows);
 
     if (endOffset < numLevels) {
-      // This is not the last chunk of batch and endOffset is a record
+      // This is not the last chunk of the batch and endOffset is a record
       // boundary. It is a good chance to check the page size.
       action(offset, endOffset - offset, true);
-    } else {
-      VELOX_DCHECK_EQ(endOffset, numLevels);
-      // This is the last chunk of batch, and we do not know whether endOffset
-      // is a record boundary. Find the offset to beginning of last record in
-      // this chunk, so we can check page size.
-      int64_t lastRecordBeginOffset = numLevels - 1;
-      while (lastRecordBeginOffset >= offset &&
-             repLevels[lastRecordBeginOffset] != 0) {
-        lastRecordBeginOffset--;
-      }
-
-      if (offset < lastRecordBeginOffset) {
-        // We have found the beginning of last record and can check page size.
-        action(offset, lastRecordBeginOffset - offset, true);
-        offset = lastRecordBeginOffset;
-      }
-
-      // There is no record boundary in this chunk and cannot check page size.
-      action(offset, endOffset - offset, false);
+      offset = endOffset;
+      continue;
     }
 
-    offset = endOffset;
+    // This is the last chunk of the batch, and we do not know whether
+    // 'numLevels' is a record boundary. Emit everything up to the beginning of
+    // the last record first, so the page can still be checked there, then emit
+    // the possibly incomplete last record without a check.
+    int64_t lastRecordBeginOffset = numLevels - 1;
+    while (lastRecordBeginOffset > offset &&
+           repLevels[lastRecordBeginOffset] != 0) {
+      --lastRecordBeginOffset;
+    }
+    if (lastRecordBeginOffset > offset) {
+      action(offset, lastRecordBeginOffset - offset, true);
+      offset = lastRecordBeginOffset;
+    }
+    action(offset, numLevels - offset, false);
+    offset = numLevels;
   }
 }
 
@@ -1521,11 +1608,13 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       checkDictionarySizeLimit();
     };
     doInBatches(
-        defLevels,
         repLevels,
         numValues,
         properties_->writeBatchSize(),
+        properties_->dataPageRowLimit(),
+        numBufferedRows_,
         writeChunk,
+        [&]() { addDataPage(); },
         pagesChangeOnRecordBoundaries());
     return valueOffset;
   }
@@ -1582,11 +1671,13 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       checkDictionarySizeLimit();
     };
     doInBatches(
-        defLevels,
         repLevels,
         numValues,
         properties_->writeBatchSize(),
+        properties_->dataPageRowLimit(),
+        numBufferedRows_,
         writeChunk,
+        [&]() { addDataPage(); },
         pagesChangeOnRecordBoundaries());
   }
 
@@ -2138,11 +2229,13 @@ Status TypedColumnWriterImpl<DType>::writeArrowDictionary(
   }
 
   PARQUET_CATCH_NOT_OK(doInBatches(
-      defLevels,
       repLevels,
       numLevels,
       properties_->writeBatchSize(),
+      properties_->dataPageRowLimit(),
+      numBufferedRows_,
       writeIndicesChunk,
+      [&]() { addDataPage(); },
       pagesChangeOnRecordBoundaries()));
   return Status::OK();
 }
@@ -2704,11 +2797,13 @@ Status TypedColumnWriterImpl<ByteArrayType>::writeArrowDense(
   };
 
   PARQUET_CATCH_NOT_OK(doInBatches(
-      defLevels,
       repLevels,
       numLevels,
       properties_->writeBatchSize(),
+      properties_->dataPageRowLimit(),
+      numBufferedRows_,
       writeChunk,
+      [&]() { addDataPage(); },
       pagesChangeOnRecordBoundaries()));
   return Status::OK();
 }

--- a/velox/dwio/parquet/writer/arrow/Properties.h
+++ b/velox/dwio/parquet/writer/arrow/Properties.h
@@ -322,6 +322,7 @@ class PARQUET_EXPORT WriterProperties {
           writeBatchSize_(DEFAULT_WRITE_BATCH_SIZE),
           maxRowGroupLength_(DEFAULT_MAX_ROW_GROUP_LENGTH),
           pagesize_(kDefaultDataPageSize),
+          dataPageRowNumberLimit_(0),
           version_(ParquetVersion::PARQUET_2_6),
           dataPageVersion_(ParquetDataPageVersion::V1),
           createdBy_(
@@ -399,6 +400,13 @@ class PARQUET_EXPORT WriterProperties {
     /// Default 1MB.
     Builder* dataPagesize(int64_t pgSize) {
       pagesize_ = pgSize;
+      return this;
+    }
+
+    /// Specify the data page row number limit.
+    /// Default 0 (no limit).
+    Builder* dataPageRowNumberLimit(int64_t rowNumberLimit) {
+      dataPageRowNumberLimit_ = rowNumberLimit;
       return this;
     }
 
@@ -767,6 +775,7 @@ class PARQUET_EXPORT WriterProperties {
           writeBatchSize_,
           maxRowGroupLength_,
           pagesize_,
+          dataPageRowNumberLimit_,
           version_,
           createdBy_,
           pageChecksumEnabled_,
@@ -784,6 +793,7 @@ class PARQUET_EXPORT WriterProperties {
     int64_t writeBatchSize_;
     int64_t maxRowGroupLength_;
     int64_t pagesize_;
+    int64_t dataPageRowNumberLimit_;
     ParquetVersion::type version_;
     ParquetDataPageVersion dataPageVersion_;
     std::string createdBy_;
@@ -825,6 +835,10 @@ class PARQUET_EXPORT WriterProperties {
 
   inline int64_t dataPagesize() const {
     return pagesize_;
+  }
+
+  inline int64_t dataPageRowNumberLimit() const {
+    return dataPageRowNumberLimit_;
   }
 
   inline ParquetDataPageVersion dataPageVersion() const {
@@ -945,6 +959,7 @@ class PARQUET_EXPORT WriterProperties {
       int64_t writeBatchSize,
       int64_t maxRowGroupLength,
       int64_t pagesize,
+      int64_t dataPageRowNumberLimit,
       ParquetVersion::type version,
       const std::string& createdBy,
       bool pageWriteChecksumEnabled,
@@ -959,6 +974,7 @@ class PARQUET_EXPORT WriterProperties {
         writeBatchSize_(writeBatchSize),
         maxRowGroupLength_(maxRowGroupLength),
         pagesize_(pagesize),
+        dataPageRowNumberLimit_(dataPageRowNumberLimit),
         parquetDataPageVersion_(dataPageVersion),
         parquetVersion_(version),
         parquetCreatedBy_(createdBy),
@@ -974,6 +990,7 @@ class PARQUET_EXPORT WriterProperties {
   int64_t writeBatchSize_;
   int64_t maxRowGroupLength_;
   int64_t pagesize_;
+  int64_t dataPageRowNumberLimit_;
   ParquetDataPageVersion parquetDataPageVersion_;
   ParquetVersion::type parquetVersion_;
   std::string parquetCreatedBy_;

--- a/velox/dwio/parquet/writer/arrow/Properties.h
+++ b/velox/dwio/parquet/writer/arrow/Properties.h
@@ -322,6 +322,7 @@ class PARQUET_EXPORT WriterProperties {
           writeBatchSize_(DEFAULT_WRITE_BATCH_SIZE),
           maxRowGroupLength_(DEFAULT_MAX_ROW_GROUP_LENGTH),
           pagesize_(kDefaultDataPageSize),
+          dataPageRowLimit_(0),
           version_(ParquetVersion::PARQUET_2_6),
           dataPageVersion_(ParquetDataPageVersion::V1),
           createdBy_(
@@ -399,6 +400,13 @@ class PARQUET_EXPORT WriterProperties {
     /// Default 1MB.
     Builder* dataPagesize(int64_t pgSize) {
       pagesize_ = pgSize;
+      return this;
+    }
+
+    /// Specify the data page row number limit.
+    /// Default 0 (no limit).
+    Builder* dataPageRowLimit(int64_t rowLimit) {
+      dataPageRowLimit_ = rowLimit;
       return this;
     }
 
@@ -762,6 +770,7 @@ class PARQUET_EXPORT WriterProperties {
           writeBatchSize_,
           maxRowGroupLength_,
           pagesize_,
+          dataPageRowLimit_,
           version_,
           createdBy_,
           pageChecksumEnabled_,
@@ -779,6 +788,7 @@ class PARQUET_EXPORT WriterProperties {
     int64_t writeBatchSize_;
     int64_t maxRowGroupLength_;
     int64_t pagesize_;
+    int64_t dataPageRowLimit_;
     ParquetVersion::type version_;
     ParquetDataPageVersion dataPageVersion_;
     std::string createdBy_;
@@ -819,6 +829,10 @@ class PARQUET_EXPORT WriterProperties {
 
   inline int64_t dataPagesize() const {
     return pagesize_;
+  }
+
+  inline int64_t dataPageRowLimit() const {
+    return dataPageRowLimit_;
   }
 
   inline ParquetDataPageVersion dataPageVersion() const {
@@ -939,6 +953,7 @@ class PARQUET_EXPORT WriterProperties {
       int64_t writeBatchSize,
       int64_t maxRowGroupLength,
       int64_t pagesize,
+      int64_t dataPageRowLimit,
       ParquetVersion::type version,
       const std::string& createdBy,
       bool pageWriteChecksumEnabled,
@@ -953,6 +968,7 @@ class PARQUET_EXPORT WriterProperties {
         writeBatchSize_(writeBatchSize),
         maxRowGroupLength_(maxRowGroupLength),
         pagesize_(pagesize),
+        dataPageRowLimit_(dataPageRowLimit),
         parquetDataPageVersion_(dataPageVersion),
         parquetVersion_(version),
         parquetCreatedBy_(createdBy),
@@ -968,6 +984,7 @@ class PARQUET_EXPORT WriterProperties {
   int64_t writeBatchSize_;
   int64_t maxRowGroupLength_;
   int64_t pagesize_;
+  int64_t dataPageRowLimit_;
   ParquetDataPageVersion parquetDataPageVersion_;
   ParquetVersion::type parquetVersion_;
   std::string parquetCreatedBy_;

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -1489,6 +1489,125 @@ TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundariesWithSmallBatches) {
   }
 }
 
+TEST(TestColumnWriter, WriteDataPagesRespectRowLimitAcrossWriteBatches) {
+  auto sink = createOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::make(
+      "schema",
+      Repetition::kRequired,
+      {schema::int32("repeated", Repetition::kRepeated)}));
+  auto properties = WriterProperties::Builder()
+                        .disableDictionary()
+                        ->dataPageVersion(ParquetDataPageVersion::V2)
+                        ->dataPagesize(std::numeric_limits<int64_t>::max())
+                        ->dataPageRowLimit(1)
+                        ->build();
+  auto fileWriter = ParquetFileWriter::open(sink, schema, properties);
+  auto rowGroupWriter = fileWriter->appendRowGroup();
+  auto writer = static_cast<Int32Writer*>(rowGroupWriter->nextColumn());
+
+  constexpr int64_t kLevelsPerWrite = 100;
+  constexpr int64_t kLevelsPerRow = 150;
+  std::array<int32_t, kLevelsPerWrite> values;
+  values.fill(1024);
+  std::array<int16_t, kLevelsPerWrite> definitionLevels;
+  definitionLevels.fill(1);
+  std::array<int16_t, kLevelsPerWrite> repetitionLevels;
+
+  // Write two 150-level records in three batches. The first and last batches
+  // end in the middle of a record.
+  repetitionLevels.fill(1);
+  repetitionLevels[0] = 0;
+  writer->writeBatch(
+      kLevelsPerWrite,
+      definitionLevels.data(),
+      repetitionLevels.data(),
+      values.data());
+
+  repetitionLevels.fill(1);
+  repetitionLevels[50] = 0;
+  writer->writeBatch(
+      kLevelsPerWrite,
+      definitionLevels.data(),
+      repetitionLevels.data(),
+      values.data());
+
+  repetitionLevels.fill(1);
+  writer->writeBatch(
+      kLevelsPerWrite,
+      definitionLevels.data(),
+      repetitionLevels.data(),
+      values.data());
+
+  ASSERT_NO_THROW(fileWriter->close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto fileReader = ParquetFileReader::open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      defaultReaderProperties());
+  auto pageReader = fileReader->rowGroup(0)->getColumnPageReader(0);
+  for (int pageIndex = 0; pageIndex < 2; ++pageIndex) {
+    auto page = pageReader->nextPage();
+    ASSERT_NE(page, nullptr);
+    auto dataPage = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(dataPage->numRows(), 1);
+    EXPECT_EQ(dataPage->numValues(), kLevelsPerRow);
+  }
+  EXPECT_EQ(pageReader->nextPage(), nullptr);
+}
+
+// A write batch that ends exactly on the row limit cannot close the page,
+// because its last record may continue in the next batch. The page must then be
+// closed at the start of the next batch rather than after one more record.
+TEST(TestColumnWriter, WriteDataPagesDoNotExceedRowLimitAcrossWriteBatches) {
+  auto sink = createOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::make(
+      "schema",
+      Repetition::kRequired,
+      {schema::int32("repeated", Repetition::kRepeated)}));
+  constexpr int64_t kPageRowLimit = 2;
+  auto properties = WriterProperties::Builder()
+                        .disableDictionary()
+                        ->dataPageVersion(ParquetDataPageVersion::V2)
+                        ->dataPagesize(std::numeric_limits<int64_t>::max())
+                        ->dataPageRowLimit(kPageRowLimit)
+                        ->build();
+  auto fileWriter = ParquetFileWriter::open(sink, schema, properties);
+  auto rowGroupWriter = fileWriter->appendRowGroup();
+  auto writer = static_cast<Int32Writer*>(rowGroupWriter->nextColumn());
+
+  // Each write batch holds exactly two three-level records, so every batch
+  // fills the page exactly and ends on a record boundary the writer cannot see.
+  constexpr int64_t kLevelsPerRow = 3;
+  constexpr int64_t kLevelsPerWrite = kLevelsPerRow * kPageRowLimit;
+  constexpr int64_t kNumWrites = 3;
+  const std::vector<int32_t> values(kLevelsPerWrite, 1024);
+  const std::vector<int16_t> definitionLevels(kLevelsPerWrite, 1);
+  const std::vector<int16_t> repetitionLevels{0, 1, 1, 0, 1, 1};
+
+  for (int64_t i = 0; i < kNumWrites; ++i) {
+    writer->writeBatch(
+        kLevelsPerWrite,
+        definitionLevels.data(),
+        repetitionLevels.data(),
+        values.data());
+  }
+
+  ASSERT_NO_THROW(fileWriter->close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto fileReader = ParquetFileReader::open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      defaultReaderProperties());
+  auto pageReader = fileReader->rowGroup(0)->getColumnPageReader(0);
+  int64_t numPages = 0;
+  std::shared_ptr<Page> page;
+  while ((page = pageReader->nextPage()) != nullptr) {
+    auto dataPage = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(dataPage->numRows(), kPageRowLimit);
+    EXPECT_EQ(dataPage->numValues(), kLevelsPerWrite);
+    ++numPages;
+  }
+  EXPECT_EQ(numPages, kNumWrites);
+}
+
 class ColumnWriterTestSizeEstimated : public ::testing::Test {
  public:
   void SetUp() {


### PR DESCRIPTION
Adds hive.parquet.writer.page-row-limit (session property hive.parquet.writer.page_row_limit), which caps how many rows a Parquet data page may hold. It defaults to 0, which keeps today's behavior of cutting pages on encoded size alone.

The writer splits each write against the page's remaining row budget before encoding it, so a page closes exactly at the limit instead of overshooting by up to a full write batch.

A page may only be cut at a record boundary, because a row split across two pages cannot be counted in either. Setting a non-zero limit therefore also makes data pages of columns nested inside an ARRAY or MAP end on row boundaries, which V1 pages written without the page index do not otherwise guarantee.

This is one of the iceberg write properties https://github.com/apache/iceberg/blob/main/docs/docs/configuration.md?plain=1#L40.

