### PR TITLE
fix: Handle empty keyNodes in SelectiveFlatMapAsStructReader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -215,7 +215,7 @@ class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
                 scanSpec,
                 dwio::common::flatmap::FlatMapOutput::kStruct)) {
     VELOX_CHECK(
-        !keyNodes_.empty(),
+        !scanSpec.children().empty(),
         "For struct encoding, keys to project must be configured");
     children_.resize(keyNodes_.size());
     for (auto& childSpec : scanSpec.children()) {


### PR DESCRIPTION
Summary:
SelectiveFlatMapAsStructReader crashed with INVALID_STATE when reading a
flatmap column as struct and no requested keys existed in the file/stripe.

The assertion `!keyNodes_.empty()` was too strict — it conflated two cases:
1. Caller didn't configure any keys (genuine misconfiguration).
2. Caller configured keys but none matched streams in this stripe (legitimate).

Case 2 occurs in production when a DWRF file has stripes where a flatmap
column contains no data for any of the projected keys. 

The fix changes the assertion to check `scanSpec.children().empty()` instead
of `keyNodes_.empty()`. This still catches genuine misconfiguration (case 1)
while allowing empty keyNodes (case 2). The downstream code already handles
empty keyNodes correctly: all scan spec children get
`kConstantChildSpecSubscript`, causing `isChildConstant()` to return true in
`read()` and `setNullField()` to produce null output in `getValues()`.

Reviewed By: Yuhta

Differential Revision: D94726405


