### PR TITLE
feat: Add table_scan_output_batch_rows_override

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -298,6 +298,12 @@ class QueryConfig {
   static constexpr const char* kTableScanGetOutputTimeLimitMs =
       "table_scan_getoutput_time_limit_ms";
 
+  /// If non-zero, overrides the number of rows in each output batch produced
+  /// by the TableScan operator, bypassing the dynamic batch size calculation.
+  /// Zero means 'no override'.
+  static constexpr const char* kTableScanOutputBatchRowsOverride =
+      "table_scan_output_batch_rows_override";
+
   /// If false, the 'group by' code is forced to use generic hash mode
   /// hashtable.
   static constexpr const char* kHashAdaptivityEnabled =
@@ -1050,6 +1056,10 @@ class QueryConfig {
 
   uint32_t tableScanGetOutputTimeLimitMs() const {
     return get<uint64_t>(kTableScanGetOutputTimeLimitMs, 5'000);
+  }
+
+  uint32_t tableScanOutputBatchRowsOverride() const {
+    return get<uint32_t>(kTableScanOutputBatchRowsOverride, 0);
   }
 
   bool hashAdaptivityEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -584,6 +584,13 @@ Table Scan
        increasing the number of running scan threads, and stop once exceeds this
        ratio. The value is in the range of [0, 1]. This only applies if
        'table_scan_scaled_processing_enabled' is true.
+   * - table_scan_output_batch_rows_override
+     - integer
+     - 0
+     - If non-zero, overrides the number of rows in each output batch produced
+       by the TableScan operator, bypassing the dynamic batch size calculation.
+       This is useful for correctness testing where a fixed batch size is needed
+       to produce deterministic results. Zero means 'no override'.
 
 Table Writer
 ------------

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -147,6 +147,8 @@ class TableScan : public SourceOperator {
   // limit'.
   const size_t getOutputTimeLimitMs_{0};
 
+  const uint32_t outputBatchRowsOverride_;
+
   // If set, used for scan scale processing. It is shared by all the scan
   // operators instantiated from the same table scan node.
   const std::shared_ptr<ScaledScanController> scaledController_;


### PR DESCRIPTION
Summary:
Add `table_scan_output_batch_rows_override` query config to allow overriding
the number of rows in each TableScan output batch. When set to a non-zero
value, `calculateBatchSize` returns this fixed row count instead of dynamically
computing it from estimated row sizes and byte budgets.

This is useful for correctness testing where deterministic batch sizes are
needed - for example, when comparing outputs across different reader
implementations that may produce different dynamic batch sizes, leading to false
positives in checksums involving random seeds.

Differential Revision: D94683035


