### PR TITLE
perf: Fix readRegions prefetch incorrectly submitting non-prefetch loads

### DIFF
--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -531,10 +531,10 @@ void CachedBufferedInput::readRegions(
             });
       }
     }
-    // Remove completed loads from the entire vector. This cleans up loads from
-    // previous cycles that have completed asynchronously.
+    // Remove the loads that were complete. There can be done loads if the same
+    // CachedBufferedInput has multiple cycles of enqueues and loads.
     std::vector<int32_t> doneIndices;
-    for (auto i = 0; i < coalescedLoads_.size(); ++i) {
+    for (int32_t i = 0; i < startIndex; ++i) {
       if (coalescedLoads_[i]->state() != CoalescedLoad::State::kPlanned) {
         doneIndices.push_back(i);
       }

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -1020,6 +1020,23 @@ TEST_F(CachedBufferedInputTest, prefetchScope) {
   auto readFile = std::make_shared<InMemoryReadFile>(content);
 
   io::ReaderOptions readerOptions(pool_.get());
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
   // Enqueue non-prefetch requests (with stream IDs).
   constexpr int32_t kNumRequests = 3;
   constexpr uint64_t kRequestSize = 500;
@@ -1058,5 +1075,4 @@ TEST_F(CachedBufferedInputTest, prefetchScope) {
 
   EXPECT_EQ(ioStatistics_->prefetch().sum(), kNumRequests * kRequestSize);
 }
-
 } // namespace


### PR DESCRIPTION
Summary:
In CachedBufferedInput::readRegions, when prefetch is true and an executor is available, the code iterated over the entire coalescedLoads_ vector and submitted any load in kPlanned state to the executor. This caused loads that were intentionally classified as non-prefetch (loadIndex=0) or stale loads from previous enqueue-load cycles to be incorrectly submitted for async prefetching, resulting in unnecessary I/O and inflated prefetch statistics.

Fix:
- Record the starting index of coalescedLoads_ before appending new loads, and only submit loads from startIndex onwards to the executor.
- Separate the cleanup logic to scan the entire vector for completed loads from previous cycles that finished asynchronously.

Test Plan:
- Added CachedBufferedInputTest.prefetchScope to verify non-prefetch loads remain in kPlanned state across load cycles.

Fix #16573