### PR TITLE
feat: Add kindName() API to IExpr

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -17,6 +17,23 @@
 
 namespace facebook::velox::core {
 
+namespace {
+const auto& kindNames() {
+  static const folly::F14FastMap<IExpr::Kind, std::string_view> kNames = {
+      {IExpr::Kind::kInput, "Input"},
+      {IExpr::Kind::kFieldAccess, "FieldAccess"},
+      {IExpr::Kind::kCall, "Call"},
+      {IExpr::Kind::kCast, "Cast"},
+      {IExpr::Kind::kConstant, "Constant"},
+      {IExpr::Kind::kLambda, "Lambda"},
+      {IExpr::Kind::kSubquery, "Subquery"},
+  };
+  return kNames;
+}
+} // namespace
+
+VELOX_DEFINE_EMBEDDED_ENUM_NAME(IExpr, Kind, kindNames)
+
 bool FieldAccessExpr::operator==(const IExpr& other) const {
   if (!other.is(Kind::kFieldAccess)) {
     return false;

--- a/velox/parse/IExpr.h
+++ b/velox/parse/IExpr.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include "velox/common/Enums.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -43,6 +44,8 @@ class IExpr {
     kSubquery = 6,
   };
 
+  VELOX_DECLARE_EMBEDDED_ENUM_NAME(Kind)
+
   explicit IExpr(
       Kind kind,
       std::vector<ExprPtr> inputs,
@@ -53,6 +56,10 @@ class IExpr {
 
   Kind kind() const {
     return kind_;
+  }
+
+  std::string_view kindName() const {
+    return toName(kind_);
   }
 
   bool is(Kind kind) const {


### PR DESCRIPTION
Summary:
Add VELOX_DEFINE_EMBEDDED_ENUM_NAME for IExpr::Kind, providing
toName(), toKind(), tryToKind() and a kindName() convenience method.
This enables readable error messages when encountering unsupported
IExpr kinds.

Differential Revision: D94782075


