### PR TITLE
feat: Add spill for MarkDistinct

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -5420,6 +5420,10 @@ class MarkDistinctNode : public PlanNode {
     return "MarkDistinct";
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return queryConfig.markDistinctSpillEnabled();
+  }
+
   const std::string& markerName() const {
     return markerName_;
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -368,6 +368,10 @@ class QueryConfig {
   static constexpr const char* kRowNumberSpillEnabled =
       "row_number_spill_enabled";
 
+  /// MarkDistinct spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kMarkDistinctSpillEnabled =
+      "mark_distinct_spill_enabled";
+
   /// TopNRowNumber spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kTopNRowNumberSpillEnabled =
       "topn_row_number_spill_enabled";
@@ -1183,6 +1187,10 @@ class QueryConfig {
 
   bool rowNumberSpillEnabled() const {
     return get<bool>(kRowNumberSpillEnabled, true);
+  }
+
+  bool markDistinctSpillEnabled() const {
+    return get<bool>(kMarkDistinctSpillEnabled, true);
   }
 
   bool topNRowNumberSpillEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -413,6 +413,10 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether TopNRowNumber operator can spill to disk under memory pressure.
+   * - mark_distinct_spill_enabled
+     - boolean
+     - false
+     - When `spill_enabled` is true, determines whether MarkDistinct operator can spill to disk under memory pressure.
    * - writer_spill_enabled
      - boolean
      - true

--- a/velox/docs/develop/memory.rst
+++ b/velox/docs/develop/memory.rst
@@ -667,7 +667,7 @@ Here is the memory reclaim process within a query:
    reclamation through disk spilling and table writer flush. *Operator::reclaim*
    is added to support memory reclamation with the default implementation does
    nothing. Only spillable operators override that method: *OrderBy*, *HashBuild*,
-   *HashAggregation*, *RowNumber*, *TopNRowNumber*, *Window* and *TableWriter*.
+   *HashAggregation*, *RowNumber*, *TopNRowNumber*, *MarkDistinct*, *Window* and *TableWriter*.
    As for now, we simply spill everything from the spillable operator’s row
    container to free up memory. After we add memory compaction support for row
    containers, we could leverage fine-grained disk spilling features in Velox

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -1018,6 +1018,11 @@ MarkDistinctNode
 The MarkDistinct operator is used to produce aggregate mask columns for aggregations over distinct values, e.g. agg(DISTINCT a).
 Mask is a boolean column set to true for a subset of input rows that collectively represent a set of unique values of 'distinctKeys'.
 
+This operator supports spilling. The spill mechanism follows the same pattern as RowNumber: when memory pressure
+triggers spilling, the hash table contents and future input are partitioned and written to disk. During restore,
+each partition's hash table is rebuilt from the spilled data, preserving knowledge of which keys were already seen.
+Disabled by default; enable with `mark_distinct_spill_enabled` configuration property.
+
 .. list-table::
   :widths: 10 30
   :align: left

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -276,7 +276,7 @@ void GroupingSet::addInputForActiveRows(
     const RowVectorPtr& input,
     bool mayPushdown) {
   VELOX_CHECK(!isGlobal_);
-  if (!table_) {
+  if (table_ == nullptr) {
     createHashTable();
   }
   ensureInputFits(input);

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -149,6 +149,12 @@ class GroupingSet {
     return table_ ? table_->rows()->numRows() : 0;
   }
 
+  /// Returns the underlying hash table, or nullptr if it has not been created
+  /// yet.
+  BaseHashTable* table() const {
+    return table_.get();
+  }
+
   /// Frees hash tables and other state when giving up partial aggregation as
   /// non-productive. Must be called before toIntermediate() is used.
   void abandonPartialAggregation();

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -15,8 +15,11 @@
  */
 
 #include "velox/exec/MarkDistinct.h"
-#include "velox/common/base/Range.h"
+
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/exec/OperatorType.h"
+#include "velox/exec/OperatorUtils.h"
 #include "velox/vector/FlatVector.h"
 
 #include <algorithm>
@@ -33,40 +36,161 @@ MarkDistinct::MarkDistinct(
           planNode->outputType(),
           operatorId,
           planNode->id(),
-          OperatorType::kMarkDistinct) {
-  const auto& inputType = planNode->sources()[0]->outputType();
+          OperatorType::kMarkDistinct,
+          planNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(operatorId, planNode->name())
+              : std::nullopt) {
+  inputType_ = planNode->sources()[0]->outputType();
 
   // Set all input columns as identity projection.
-  for (auto i = 0; i < inputType->size(); ++i) {
+  for (auto i = 0; i < inputType_->size(); ++i) {
     identityProjections_.emplace_back(i, i);
   }
 
-  // We will use result[0] for distinct mask output.
-  resultProjections_.emplace_back(0, inputType->size());
+  // Use result[0] for distinct mask output.
+  resultProjections_.emplace_back(0, inputType_->size());
+
+  for (const auto& key : planNode->distinctKeys()) {
+    distinctKeyChannels_.push_back(inputType_->getChildIdx(key->name()));
+  }
 
   groupingSet_ = GroupingSet::createForDistinct(
-      inputType,
-      createVectorHashers(inputType, planNode->distinctKeys()),
+      inputType_,
+      createVectorHashers(inputType_, planNode->distinctKeys()),
       /*preGroupedKeys=*/{},
       operatorCtx_.get(),
       &nonReclaimableSection_);
 
   results_.resize(1);
+
+  if (spillEnabled()) {
+    setSpillPartitionBits();
+  }
 }
 
 void MarkDistinct::addInput(RowVectorPtr input) {
-  groupingSet_->addInput(input, /*mayPushdown=*/false);
+  ensureInputFits(input);
 
+  if (inputSpiller_ != nullptr) {
+    spillInput(input, pool());
+    return;
+  }
+
+  // Don't add to the hash table here. We defer it to getOutput() so that if
+  // spill() is called between addInput() and getOutput(), the hash table spill
+  // won't include this input's keys. This prevents those keys from being
+  // re-suppressed during restore.
   input_ = std::move(input);
 }
 
+void MarkDistinct::noMoreInput() {
+  Operator::noMoreInput();
+
+  if (inputSpiller_ != nullptr) {
+    finishSpillInputAndRestoreNext();
+  }
+}
+
+void MarkDistinct::finishSpillInputAndRestoreNext() {
+  VELOX_CHECK_NOT_NULL(inputSpiller_);
+  inputSpiller_->finishSpill(spillInputPartitionSet_);
+  inputSpiller_.reset();
+  removeEmptyPartitions(spillInputPartitionSet_);
+  restoreNextSpillPartition();
+}
+
+void MarkDistinct::restoreNextSpillPartition() {
+  if (spillInputPartitionSet_.empty()) {
+    return;
+  }
+
+  auto it = spillInputPartitionSet_.begin();
+  restoringPartitionId_ = it->first;
+
+  spillInputReader_ = it->second->createUnorderedReader(
+      spillConfig_->readBufferSize, pool(), spillStats_.get());
+
+  auto hashTableIt = spillHashTablePartitionSet_.find(it->first);
+  if (hashTableIt != spillHashTablePartitionSet_.end()) {
+    auto reader = hashTableIt->second->createUnorderedReader(
+        spillConfig_->readBufferSize, pool(), spillStats_.get());
+
+    setSpillPartitionBits(&(it->first));
+
+    auto* table = groupingSet_->table();
+    const auto& hashers = table->hashers();
+    auto lookup = std::make_unique<HashLookup>(hashers, pool());
+
+    std::vector<VectorPtr> columns(inputType_->size());
+    RowVectorPtr data;
+    while (reader->nextBatch(data)) {
+      for (auto i = 0; i < hashers.size(); ++i) {
+        columns[hashers[i]->channel()] = data->childAt(i);
+      }
+
+      auto input = std::make_shared<RowVector>(
+          pool(), inputType_, nullptr, data->size(), std::move(columns));
+
+      SelectivityVector rows(data->size());
+      table->prepareForGroupProbe(
+          *lookup, input, rows, spillConfig_->startPartitionBit);
+      table->groupProbe(*lookup, spillConfig_->startPartitionBit);
+
+      columns.assign(inputType_->size(), nullptr);
+    }
+  }
+
+  spillInputPartitionSet_.erase(it);
+
+  RowVectorPtr spilledInput;
+  spillInputReader_->nextBatch(spilledInput);
+  VELOX_CHECK_NOT_NULL(spilledInput);
+  addInput(std::move(spilledInput));
+}
+
+void MarkDistinct::recursiveSpillInput() {
+  RowVectorPtr spilledInput;
+  while (spillInputReader_->nextBatch(spilledInput)) {
+    spillInput(spilledInput, pool());
+
+    if (shouldYield()) {
+      yield_ = true;
+      return;
+    }
+  }
+
+  finishSpillInputAndRestoreNext();
+}
+
 RowVectorPtr MarkDistinct::getOutput() {
-  if (isFinished() || !input_) {
+  if (isFinished()) {
     return nullptr;
   }
 
-  auto outputSize = input_->size();
-  // Re-use memory for the ID vector if possible.
+  if (input_ == nullptr) {
+    if (spillInputReader_ == nullptr) {
+      return nullptr;
+    }
+
+    recursiveSpillInput();
+    if (yield_) {
+      yield_ = false;
+      return nullptr;
+    }
+
+    if (input_ == nullptr) {
+      return nullptr;
+    }
+  }
+
+  // Add the current input to the hash table now, just before producing output.
+  // This is deferred from addInput() so that if spill() is called between
+  // addInput() and getOutput(), the hash table doesn't contain this input's
+  // keys — ensuring they are correctly marked as new during restore.
+  groupingSet_->addInput(input_, /*mayPushdown=*/false);
+
+  const auto outputSize = input_->size();
+
   VectorPtr& result = results_[0];
   if (result && result.use_count() == 1) {
     BaseVector::prepareForReuse(result, outputSize);
@@ -74,26 +198,262 @@ RowVectorPtr MarkDistinct::getOutput() {
     result = BaseVector::create(BOOLEAN(), outputSize, operatorCtx_->pool());
   }
 
-  // newGroups contains the indices of distinct rows.
-  // For each index in newGroups, we mark the index'th bit true in the result
-  // vector.
-  auto resultBits =
+  auto* resultBits =
       results_[0]->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
-
   bits::fillBits(resultBits, 0, outputSize, false);
   for (const auto i : groupingSet_->hashLookup().newGroups) {
     bits::setBit(resultBits, i, true);
   }
-  auto output = fillOutput(outputSize, nullptr);
 
-  // Drop reference to input_ to make it singly-referenced at the producer and
-  // allow for memory reuse.
+  auto output = fillOutput(outputSize, nullptr);
   input_ = nullptr;
+
+  if (spillInputReader_ != nullptr) {
+    RowVectorPtr spilledInput;
+    if (spillInputReader_->nextBatch(spilledInput)) {
+      addInput(std::move(spilledInput));
+    } else {
+      spillInputReader_.reset();
+      restoringPartitionId_.reset();
+      groupingSet_->resetTable(true);
+      restoreNextSpillPartition();
+    }
+  }
 
   return output;
 }
 
 bool MarkDistinct::isFinished() {
-  return noMoreInput_ && !input_;
+  return noMoreInput_ && input_ == nullptr && spillInputReader_ == nullptr;
+}
+
+void MarkDistinct::ensureInputFits(const RowVectorPtr& input) {
+  if (!spillEnabled() || inputSpiller_ != nullptr) {
+    return;
+  }
+
+  const auto numDistinct = groupingSet_->numDistinct();
+  if (numDistinct == 0) {
+    return;
+  }
+
+  auto* table = groupingSet_->table();
+  auto* rows = table->rows();
+  const auto [freeRows, outOfLineFreeBytes] = rows->freeSpace();
+  const auto outOfLineBytes =
+      rows->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  const auto outOfLineBytesPerRow = outOfLineBytes / numDistinct;
+
+  if (testingTriggerSpill(pool()->name())) {
+    Operator::ReclaimableSectionGuard guard(this);
+    memory::testingRunArbitration(pool());
+    return;
+  }
+
+  const auto currentUsage = pool()->usedBytes();
+  const auto minReservationBytes =
+      currentUsage * spillConfig_->minSpillableReservationPct / 100;
+  const auto availableReservationBytes = pool()->availableReservation();
+  const auto tableIncrementBytes =
+      static_cast<int64_t>(table->hashTableSizeIncrease(input->size()));
+  const auto incrementBytes =
+      static_cast<int64_t>(rows->sizeIncrement(
+          input->size(), outOfLineBytesPerRow * input->size())) +
+      tableIncrementBytes;
+
+  if (availableReservationBytes >= minReservationBytes) {
+    if ((tableIncrementBytes == 0) && (freeRows > input->size()) &&
+        (outOfLineBytes == 0 ||
+         outOfLineFreeBytes >= outOfLineBytesPerRow * input->size())) {
+      return;
+    }
+
+    if (availableReservationBytes > 2 * incrementBytes) {
+      return;
+    }
+  }
+
+  const auto targetIncrementBytes = std::max<int64_t>(
+      incrementBytes * 2,
+      currentUsage * spillConfig_->spillableReservationGrowthPct / 100);
+  {
+    Operator::ReclaimableSectionGuard guard(this);
+    if (pool()->maybeReserve(targetIncrementBytes)) {
+      if (inputSpiller_ != nullptr) {
+        pool()->release();
+      }
+      return;
+    }
+  }
+
+  LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
+               << " for memory pool " << pool()->name()
+               << ", usage: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+}
+
+void MarkDistinct::reclaim(
+    uint64_t /* unused */,
+    memory::MemoryReclaimer::Stats& /* unused */) {
+  VELOX_CHECK(canReclaim());
+  VELOX_CHECK(!nonReclaimableSection_);
+
+  if (groupingSet_->numDistinct() == 0) {
+    return;
+  }
+
+  if (exceededMaxSpillLevelLimit_) {
+    LOG(WARNING) << "Exceeded mark distinct spill level limit: "
+                 << spillConfig_->maxSpillLevel
+                 << ", and abandon spilling for memory pool: "
+                 << pool()->name();
+    spillStats_->spillMaxLevelExceededCount.fetch_add(
+        1, std::memory_order_relaxed);
+    return;
+  }
+
+  spill();
+}
+
+SpillPartitionIdSet MarkDistinct::spillHashTable() {
+  VELOX_CHECK_GT(groupingSet_->numDistinct(), 0);
+
+  auto* table = groupingSet_->table();
+  auto columnTypes = table->rows()->columnTypes();
+  auto tableType = ROW(std::move(columnTypes));
+
+  auto hashTableSpiller = std::make_unique<MarkDistinctHashTableSpiller>(
+      table->rows(),
+      restoringPartitionId_,
+      tableType,
+      spillPartitionBits_,
+      &spillConfig_.value(),
+      spillStats_.get());
+
+  hashTableSpiller->spill();
+  hashTableSpiller->finishSpill(spillHashTablePartitionSet_);
+
+  groupingSet_->resetTable(true);
+  pool()->release();
+  return hashTableSpiller->state().spilledPartitionIdSet();
+}
+
+void MarkDistinct::setupInputSpiller(
+    const SpillPartitionIdSet& spillPartitionIdSet) {
+  VELOX_CHECK(!spillPartitionIdSet.empty());
+
+  inputSpiller_ = std::make_unique<NoRowContainerSpiller>(
+      inputType_,
+      restoringPartitionId_,
+      spillPartitionBits_,
+      &spillConfig_.value(),
+      spillStats_.get());
+
+  spillHashFunction_ = std::make_unique<HashPartitionFunction>(
+      inputSpiller_->hashBits(), inputType_, distinctKeyChannels_);
+}
+
+void MarkDistinct::spill() {
+  VELOX_CHECK(spillEnabled());
+
+  spilled_ = true;
+
+  const auto spillPartitionIdSet = spillHashTable();
+  VELOX_CHECK_EQ(groupingSet_->numDistinct(), 0);
+
+  setupInputSpiller(spillPartitionIdSet);
+  if (input_ != nullptr) {
+    spillInput(input_, memory::spillMemoryPool());
+    input_ = nullptr;
+  }
+  results_.clear();
+  results_.resize(1);
+}
+
+void MarkDistinct::spillInput(
+    const RowVectorPtr& input,
+    memory::MemoryPool* pool) {
+  const auto numRows = input->size();
+
+  std::vector<uint32_t> partitionAssignments(numRows);
+  const auto singlePartition =
+      spillHashFunction_->partition(*input, partitionAssignments);
+
+  const auto numPartitions = spillHashFunction_->numPartitions();
+
+  std::vector<BufferPtr> partitionIndices(numPartitions);
+  std::vector<vector_size_t*> rawPartitionIndices(numPartitions);
+
+  for (auto i = 0; i < numPartitions; ++i) {
+    partitionIndices[i] = allocateIndices(numRows, pool);
+    rawPartitionIndices[i] = partitionIndices[i]->asMutable<vector_size_t>();
+  }
+
+  std::vector<vector_size_t> numSpillInputs(numPartitions, 0);
+
+  for (auto row = 0; row < numRows; ++row) {
+    const auto partition = singlePartition.has_value()
+        ? singlePartition.value()
+        : partitionAssignments[row];
+    rawPartitionIndices[partition][numSpillInputs[partition]++] = row;
+  }
+
+  // Ensure vector are lazy loaded before spilling.
+  for (auto i = 0; i < input->childrenSize(); ++i) {
+    input->childAt(i)->loadedVector();
+  }
+
+  for (auto partition = 0; partition < numSpillInputs.size(); ++partition) {
+    const auto numInputs = numSpillInputs[partition];
+    if (numInputs == 0) {
+      continue;
+    }
+
+    inputSpiller_->spill(
+        SpillPartitionId(partition),
+        wrap(numInputs, partitionIndices[partition], input));
+  }
+}
+
+void MarkDistinct::setSpillPartitionBits(
+    const SpillPartitionId* restoredPartitionId) {
+  const auto startPartitionBitOffset = restoredPartitionId == nullptr
+      ? spillConfig_->startPartitionBit
+      : partitionBitOffset(
+            *restoredPartitionId,
+            spillConfig_->startPartitionBit,
+            spillConfig_->numPartitionBits) +
+          spillConfig_->numPartitionBits;
+  if (spillConfig_->exceedSpillLevelLimit(startPartitionBitOffset)) {
+    exceededMaxSpillLevelLimit_ = true;
+    return;
+  }
+
+  exceededMaxSpillLevelLimit_ = false;
+  spillPartitionBits_ = HashBitRange(
+      startPartitionBitOffset,
+      startPartitionBitOffset + spillConfig_->numPartitionBits);
+}
+
+MarkDistinctHashTableSpiller::MarkDistinctHashTableSpiller(
+    RowContainer* container,
+    std::optional<SpillPartitionId> parentId,
+    RowTypePtr rowType,
+    HashBitRange bits,
+    const common::SpillConfig* spillConfig,
+    exec::SpillStats* spillStats)
+    : SpillerBase(
+          container,
+          std::move(rowType),
+          bits,
+          {},
+          spillConfig->maxFileSize,
+          spillConfig->maxSpillRunRows,
+          parentId,
+          spillConfig,
+          spillStats) {}
+
+void MarkDistinctHashTableSpiller::spill() {
+  SpillerBase::spill(nullptr);
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/MarkDistinct.h
+++ b/velox/exec/MarkDistinct.h
@@ -17,10 +17,21 @@
 #pragma once
 
 #include "velox/exec/GroupingSet.h"
+#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/Operator.h"
+#include "velox/exec/Spiller.h"
 
 namespace facebook::velox::exec {
 
+/// Marks distinct rows based on a set of grouping keys. For each input row,
+/// produces a boolean output column indicating whether the row's key
+/// combination is seen for the first time.
+///
+/// Supports spilling by persisting the hash table state to disk (like
+/// RowNumber). When spill is triggered, the hash table contents and future
+/// input are partitioned and written to disk. During restore, each partition's
+/// hash table is rebuilt from the spilled data, preserving knowledge of which
+/// keys were already seen before spill.
 class MarkDistinct : public Operator {
  public:
   MarkDistinct(
@@ -29,7 +40,7 @@ class MarkDistinct : public Operator {
       const std::shared_ptr<const core::MarkDistinctNode>& planNode);
 
   bool preservesOrder() const override {
-    return true;
+    return false;
   }
 
   bool needsInput() const override {
@@ -37,6 +48,8 @@ class MarkDistinct : public Operator {
   }
 
   void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
 
   RowVectorPtr getOutput() override;
 
@@ -46,8 +59,85 @@ class MarkDistinct : public Operator {
 
   bool isFinished() override;
 
+  void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
+      override;
+
  private:
-  // TODO: Document spilling configuration in spilling.rst.
+  bool spillEnabled() const {
+    return spillConfig_.has_value();
+  }
+
+  void ensureInputFits(const RowVectorPtr& input);
+
+  void spill();
+
+  void spillInput(const RowVectorPtr& input, memory::MemoryPool* pool);
+
+  void setupInputSpiller(const SpillPartitionIdSet& spillPartitionIdSet);
+
+  void setSpillPartitionBits(
+      const SpillPartitionId* restoredPartitionId = nullptr);
+
+  SpillPartitionIdSet spillHashTable();
+
+  void restoreNextSpillPartition();
+
+  void finishSpillInputAndRestoreNext();
+
+  /// Drains remaining batches from the current spill partition reader and
+  /// spills them when a recursive spill was triggered during restore.
+  void recursiveSpillInput();
+
+  RowTypePtr inputType_;
+
   std::unique_ptr<GroupingSet> groupingSet_;
+
+  HashBitRange spillPartitionBits_;
+
+  std::unique_ptr<NoRowContainerSpiller> inputSpiller_;
+
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> spillInputReader_;
+
+  std::optional<SpillPartitionId> restoringPartitionId_;
+
+  SpillPartitionSet spillInputPartitionSet_;
+
+  std::unique_ptr<HashPartitionFunction> spillHashFunction_;
+
+  SpillPartitionSet spillHashTablePartitionSet_;
+
+  bool exceededMaxSpillLevelLimit_{false};
+
+  bool spilled_{false};
+
+  bool yield_{false};
+
+  std::vector<column_index_t> distinctKeyChannels_;
+};
+
+/// Spills the hash table contents (distinct keys) from MarkDistinct's
+/// GroupingSet to disk, partitioned by key hash.
+class MarkDistinctHashTableSpiller : public SpillerBase {
+ public:
+  static constexpr std::string_view kType = "MarkDistinctHashTableSpiller";
+
+  MarkDistinctHashTableSpiller(
+      RowContainer* container,
+      std::optional<SpillPartitionId> parentId,
+      RowTypePtr rowType,
+      HashBitRange bits,
+      const common::SpillConfig* spillConfig,
+      exec::SpillStats* spillStats);
+
+  void spill();
+
+ private:
+  bool needSort() const override {
+    return false;
+  }
+
+  std::string type() const override {
+    return std::string(kType);
+  }
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/MarkDistinctTest.cpp
+++ b/velox/exec/tests/MarkDistinctTest.cpp
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
 
 using namespace facebook::velox;
-using namespace facebook::velox::test;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::test;
+using facebook::velox::exec::Operator;
+using facebook::velox::exec::TestScopedSpillInjection;
+using facebook::velox::memory::testingRunArbitration;
 
 class MarkDistinctTest : public OperatorTestBase {
  public:
@@ -42,6 +49,18 @@ class MarkDistinctTest : public OperatorTestBase {
     auto results = AssertQueryBuilder(plan).copyResults(pool());
     assertEqualVectors(expectedResults, results);
   }
+
+ protected:
+  MarkDistinctTest() {
+    filesystems::registerLocalFileSystem();
+  }
+
+  RowTypePtr rowType_{ROW({"c0", "c1"}, {BIGINT(), BIGINT()})};
+
+  VectorFuzzer::Options fuzzerOpts_{
+      .vectorSize = 1024,
+      .nullRatio = 0,
+      .allowLazyVector = false};
 };
 
 template <typename T>
@@ -140,4 +159,386 @@ TEST_F(MarkDistinctTest, aggregation) {
   AssertQueryBuilder(plan, duckDbQueryRunner_)
       .assertResults(
           "SELECT c0, sum(distinct c1), sum(distinct c2) FROM tmp GROUP BY 1");
+}
+
+TEST_F(MarkDistinctTest, spill) {
+  auto vectors = createVectors(8, rowType_, fuzzerOpts_);
+  createDuckDbTable(vectors);
+
+  struct {
+    uint32_t spillPartitionBits;
+    uint32_t numSpills;
+    uint32_t cpuTimeSliceLimitMs;
+
+    std::string debugString() const {
+      return fmt::format(
+          "spillPartitionBits {}, numSpills {}, cpuTimeSliceLimitMs {}",
+          spillPartitionBits,
+          numSpills,
+          cpuTimeSliceLimitMs);
+    }
+  } testSettings[] = {{2, 1, 0}, {3, 1, 0}, {2, 2, 0}, {2, 2, 10}, {2, 3, 10}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+    TestScopedSpillInjection scopedSpillInjection(
+        100, ".*", testData.numSpills);
+
+    core::PlanNodeId markDistinctId;
+    auto task =
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .spillDirectory(spillDirectory->getPath())
+            .config(core::QueryConfig::kSpillEnabled, true)
+            .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
+            .config(
+                core::QueryConfig::kSpillNumPartitionBits,
+                testData.spillPartitionBits)
+            .config(
+                core::QueryConfig::kDriverCpuTimeSliceLimitMs,
+                testData.cpuTimeSliceLimitMs)
+            .config(core::QueryConfig::kAggregationSpillEnabled, false)
+            .queryCtx(queryCtx)
+            .plan(
+                PlanBuilder()
+                    .values(vectors)
+                    .markDistinct("c1_distinct", {"c0", "c1"})
+                    .capturePlanNodeId(markDistinctId)
+                    .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                    .planNode())
+            .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
+
+    auto taskStats = exec::toPlanStats(task->taskStats());
+    auto& planStats = taskStats.at(markDistinctId);
+    ASSERT_GT(planStats.spilledBytes, 0);
+    ASSERT_GT(planStats.spilledFiles, 0);
+    ASSERT_GT(planStats.spilledRows, 0);
+    ASSERT_GT(planStats.spilledPartitions, 0);
+
+    task.reset();
+    waitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(MarkDistinctTest, reclaimDuringInputOrOutput) {
+  auto vectors = createVectors(8, rowType_, fuzzerOpts_);
+  createDuckDbTable(vectors);
+
+  struct {
+    std::string spillInjectionPoint;
+    uint32_t spillPartitionBits;
+
+    std::string debugString() const {
+      return fmt::format(
+          "spillInjectionPoint {}, spillPartitionBits {}",
+          spillInjectionPoint,
+          spillPartitionBits);
+    }
+  } testSettings[] = {
+      {"facebook::velox::exec::Driver::runInternal::addInput", 2},
+      {"facebook::velox::exec::Driver::runInternal::getOutput", 2},
+      {"facebook::velox::exec::Driver::runInternal::addInput", 3},
+      {"facebook::velox::exec::Driver::runInternal::getOutput", 3}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+
+    std::atomic_int numRound{0};
+    SCOPED_TESTVALUE_SET(
+        testData.spillInjectionPoint,
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "MarkDistinct") {
+            return;
+          }
+          if (++numRound != 5) {
+            return;
+          }
+          testingRunArbitration(op->pool(), 0);
+        })));
+
+    core::PlanNodeId markDistinctId;
+    auto task =
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .spillDirectory(spillDirectory->getPath())
+            .config(core::QueryConfig::kSpillEnabled, true)
+            .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
+            .config(
+                core::QueryConfig::kSpillNumPartitionBits,
+                testData.spillPartitionBits)
+            .config(core::QueryConfig::kAggregationSpillEnabled, false)
+            .queryCtx(queryCtx)
+            .plan(
+                PlanBuilder()
+                    .values(vectors)
+                    .markDistinct("c1_distinct", {"c0", "c1"})
+                    .capturePlanNodeId(markDistinctId)
+                    .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                    .planNode())
+            .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
+
+    auto taskStats = exec::toPlanStats(task->taskStats());
+    auto& planStats = taskStats.at(markDistinctId);
+    ASSERT_GT(planStats.spilledBytes, 0);
+    ASSERT_GT(planStats.spilledFiles, 0);
+    ASSERT_GT(planStats.spilledRows, 0);
+    ASSERT_GT(planStats.spilledPartitions, 0);
+
+    task.reset();
+    waitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(MarkDistinctTest, recursiveSpill) {
+  auto vectors = createVectors(32, rowType_, fuzzerOpts_);
+  createDuckDbTable(vectors);
+
+  struct {
+    int32_t numSpills;
+    int32_t maxSpillLevel;
+
+    std::string debugString() const {
+      return fmt::format(
+          "numSpills {}, maxSpillLevel {}", numSpills, maxSpillLevel);
+    }
+  } testSettings[] = {{2, 3}, {8, 4}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+
+    std::atomic_int numSpills{0};
+    std::atomic_int numInputs{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "MarkDistinct") {
+            return;
+          }
+          if (++numInputs != 5) {
+            return;
+          }
+          ++numSpills;
+          testingRunArbitration(op->pool(), 0);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::getOutput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "MarkDistinct") {
+            return;
+          }
+          if (!op->testingNoMoreInput()) {
+            return;
+          }
+          if (numSpills++ >= testData.numSpills) {
+            return;
+          }
+          testingRunArbitration(op->pool(), 0);
+        })));
+
+    core::PlanNodeId markDistinctId;
+    auto task =
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .spillDirectory(spillDirectory->getPath())
+            .config(core::QueryConfig::kSpillEnabled, true)
+            .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
+            .config(
+                core::QueryConfig::kMaxSpillLevel, testData.maxSpillLevel - 1)
+            .config(core::QueryConfig::kAggregationSpillEnabled, false)
+            .queryCtx(queryCtx)
+            .plan(
+                PlanBuilder()
+                    .values(vectors)
+                    .markDistinct("c1_distinct", {"c0", "c1"})
+                    .capturePlanNodeId(markDistinctId)
+                    .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                    .planNode())
+            .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
+
+    auto taskStats = exec::toPlanStats(task->taskStats());
+    auto& planStats = taskStats.at(markDistinctId);
+    ASSERT_GT(planStats.spilledBytes, 0);
+    ASSERT_GT(planStats.spilledFiles, 0);
+    ASSERT_GT(planStats.spilledRows, 0);
+
+    auto runTimeStats =
+        task->taskStats().pipelineStats.back().operatorStats.at(1).runtimeStats;
+    if (testData.numSpills > testData.maxSpillLevel) {
+      ASSERT_GT(runTimeStats["exceededMaxSpillLevel"].sum, 0);
+    } else {
+      ASSERT_EQ(runTimeStats.count("exceededMaxSpillLevel"), 0);
+    }
+
+    task.reset();
+    waitForAllTasksToBeDeleted();
+  }
+}
+
+TEST_F(MarkDistinctTest, spillWithDuplicateKeys) {
+  // Verifies correctness when the same key appears in both pre-spill and
+  // post-spill input batches. The hash table state must be preserved through
+  // spill/restore so that keys already marked as distinct before spill are not
+  // re-marked during restore.
+  auto vectors = {
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2, 6, 7, 8}),
+          makeFlatVector<int64_t>({10, 20, 60, 70, 80}),
+      }),
+      makeRowVector({
+          makeFlatVector<int64_t>({1, 2, 3, 9, 10}),
+          makeFlatVector<int64_t>({10, 20, 30, 90, 100}),
+      }),
+  };
+  createDuckDbTable(vectors);
+
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  // Trigger spill after the second batch so pre-spill output includes keys
+  // that also appear in post-spill batches.
+  TestScopedSpillInjection scopedSpillInjection(100, ".*", 1);
+
+  core::PlanNodeId markDistinctId;
+  auto task =
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .spillDirectory(spillDirectory->getPath())
+          .config(core::QueryConfig::kSpillEnabled, true)
+          .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
+          .config(core::QueryConfig::kAggregationSpillEnabled, false)
+          .queryCtx(queryCtx)
+          .plan(
+              PlanBuilder()
+                  .values(vectors)
+                  .markDistinct("c1_distinct", {"c0", "c1"})
+                  .capturePlanNodeId(markDistinctId)
+                  .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                  .planNode())
+          .assertResults("SELECT c0, count(distinct c1) FROM tmp GROUP BY 1");
+
+  auto taskStats = exec::toPlanStats(task->taskStats());
+  auto& planStats = taskStats.at(markDistinctId);
+  ASSERT_GT(planStats.spilledBytes, 0);
+  ASSERT_GT(planStats.spilledRows, 0);
+
+  task.reset();
+  waitForAllTasksToBeDeleted();
+}
+
+TEST_F(MarkDistinctTest, memoryUsage) {
+  const auto rowType =
+      ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});
+  const auto vectors = createVectors(rowType, 1024, 100 << 20);
+
+  core::PlanNodeId markDistinctId;
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .markDistinct("c1_distinct", {"c0", "c1"})
+                  .capturePlanNodeId(markDistinctId)
+                  .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                  .planNode();
+
+  struct {
+    uint8_t numSpills;
+
+    std::string debugString() const {
+      return fmt::format("numSpills {}", numSpills);
+    }
+  } testSettings[] = {{1}, {3}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    int64_t peakBytesWithSpilling = 0;
+    int64_t peakBytesWithOutSpilling = 0;
+
+    for (const auto& spillEnable : {false, true}) {
+      auto queryCtx = core::QueryCtx::create(executor_.get());
+      auto spillDirectory = exec::test::TempDirectoryPath::create();
+      const std::string spillEnableConfig = std::to_string(spillEnable);
+
+      std::shared_ptr<exec::Task> task;
+      TestScopedSpillInjection scopedSpillInjection(
+          100, ".*", testData.numSpills);
+      AssertQueryBuilder(plan)
+          .spillDirectory(spillDirectory->getPath())
+          .queryCtx(queryCtx)
+          .config(core::QueryConfig::kSpillEnabled, spillEnableConfig)
+          .config(
+              core::QueryConfig::kMarkDistinctSpillEnabled, spillEnableConfig)
+          .config(core::QueryConfig::kAggregationSpillEnabled, "false")
+          .copyResults(pool_.get(), task);
+
+      if (spillEnable) {
+        peakBytesWithSpilling = queryCtx->pool()->peakBytes();
+        auto taskStats = exec::toPlanStats(task->taskStats());
+        const auto& stats = taskStats.at(markDistinctId);
+
+        ASSERT_GT(stats.spilledBytes, 0);
+        ASSERT_GT(stats.spilledRows, 0);
+        ASSERT_GT(stats.spilledFiles, 0);
+        ASSERT_GT(stats.spilledPartitions, 0);
+      } else {
+        peakBytesWithOutSpilling = queryCtx->pool()->peakBytes();
+      }
+    }
+
+    ASSERT_GT(peakBytesWithOutSpilling, peakBytesWithSpilling);
+  }
+}
+
+TEST_F(MarkDistinctTest, maxSpillBytes) {
+  auto rowType = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), VARCHAR()});
+  auto vectors = createVectors(rowType, 1024, 15 << 20);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .markDistinct("c1_distinct", {"c0", "c1"})
+                  .singleAggregation({"c0"}, {"count(c1)"}, {"c1_distinct"})
+                  .planNode();
+
+  struct {
+    int32_t maxSpilledBytes;
+    bool expectedExceedLimit;
+
+    std::string debugString() const {
+      return fmt::format("maxSpilledBytes {}", maxSpilledBytes);
+    }
+  } testSettings[] = {{1 << 30, false}, {1 << 20, true}, {0, false}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto spillDirectory = exec::test::TempDirectoryPath::create();
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+    try {
+      TestScopedSpillInjection scopedSpillInjection(100, ".*", 1);
+      AssertQueryBuilder(plan)
+          .spillDirectory(spillDirectory->getPath())
+          .queryCtx(queryCtx)
+          .config(core::QueryConfig::kSpillEnabled, true)
+          .config(core::QueryConfig::kMarkDistinctSpillEnabled, true)
+          .config(core::QueryConfig::kAggregationSpillEnabled, false)
+          .config(core::QueryConfig::kMaxSpillBytes, testData.maxSpilledBytes)
+          .copyResults(pool_.get());
+      ASSERT_FALSE(testData.expectedExceedLimit);
+    } catch (const VeloxRuntimeError& e) {
+      ASSERT_TRUE(testData.expectedExceedLimit);
+      ASSERT_NE(
+          e.message().find(
+              "Query exceeded per-query local spill limit of 1.00MB"),
+          std::string::npos);
+      ASSERT_EQ(
+          e.errorCode(), facebook::velox::error_code::kSpillLimitExceeded);
+    }
+  }
 }


### PR DESCRIPTION
Summary:
### Added Spill for MarkDistinct

This diff adds a new feature to MarkDistinct to allow spilling. 

Here are the highlights of the change: 

### Changed Files include 
* GroupingSet.h
* core/QueryConfig.h
*  exec/EnforceDistinct.cpp
* exec/GroupingSet.cpp
* core/PlanNode.h in addition to configured spilling flag in QueryConfig.h
* Added SpillConfig to GroupingSet.h’s constructor to allow spilling in GroupingSet.cpp
* Added a canSpill() function to MarkDistinct’s PlanNode to enforce spilling support 
In addition to updating all GroupingSet.h’s function

Added spilling support for operator MarkDistinct

disabled by default

Differential Revision: D90342763


