### PR TITLE
feat: Add array_split_into_chunks function

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -52,6 +52,17 @@ Array Functions
         SELECT array_distinct(ARRAY [1, 2, 1]); -- [1, 2]
         SELECT array_distinct(ARRAY [1, NULL, NULL]); -- [1, NULL]
 
+.. function:: array_split_into_chunks(array(T), sz) -> array(array(T))
+
+    Returns an array of arrays splitting the input array into chunks of given
+    length. The last chunk will be shorter than the chunk length if the array's
+    length is not an integer multiple of the chunk length. Ignores null inputs,
+    but not elements. ::
+
+        SELECT array_split_into_chunks(ARRAY [1, 2, 3, 4, 5], 2); -- [[1, 2], [3, 4], [5]]
+        SELECT array_split_into_chunks(ARRAY [1, 2, 3], 5); -- [[1, 2, 3]]
+        SELECT array_split_into_chunks(ARRAY ['a', 'b', 'c'], 2); -- [['a', 'b'], ['c']]
+
 .. function:: array_duplicates(array(E)) -> array(E)
 
     Returns a set of elements that occur more than once in array.

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -1028,6 +1028,46 @@ struct ArrayNGramsFunctionString {
   }
 };
 
+/// Splits the input array into chunks of the given size. If the array is not
+/// evenly divisible, the last chunk contains the remaining elements.
+///
+/// array_split_into_chunks(array(T), sz) -> array(array(T))
+template <typename TExecParams, typename T>
+struct ArraySplitIntoChunksFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecParams);
+
+  static constexpr int32_t kMaxNumChunks = 10'000;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<velox::Array<velox::Array<T>>>& out,
+      const arg_type<velox::Array<T>>& input,
+      const int32_t& sz) {
+    VELOX_USER_CHECK_GT(
+        sz, 0, "Invalid slice size: {}. Size must be greater than zero.", sz);
+
+    const auto inputSize = input.size();
+    VELOX_USER_CHECK_GT(inputSize, 0, "Cannot split an empty array.");
+
+    VELOX_USER_CHECK_LE(
+        inputSize / sz,
+        kMaxNumChunks,
+        "Cannot split array of size: {} into more than 10000 parts.",
+        inputSize);
+
+    for (auto i = 0; i < inputSize; i += sz) {
+      auto& chunk = out.add_item();
+      const auto end = std::min<int64_t>(i + sz, inputSize);
+      for (auto j = i; j < end; ++j) {
+        if (!input[j].has_value()) {
+          chunk.add_null();
+        } else {
+          chunk.push_back(input[j].value());
+        }
+      }
+    }
+  }
+};
+
 /// This class implements the array union function.
 ///
 /// DEFINITION:

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -34,6 +34,7 @@
 namespace facebook::velox::functions {
 extern void registerArrayConcatFunctions(const std::string& prefix);
 extern void registerArrayNGramsFunctions(const std::string& prefix);
+extern void registerArraySplitIntoChunksFunctions(const std::string& prefix);
 
 template <typename T>
 inline void registerArrayMinMaxFunctions(const std::string& prefix) {
@@ -230,6 +231,7 @@ void registerArrayFunctions(const std::string& prefix) {
 
   registerArrayConcatFunctions(prefix);
   registerArrayNGramsFunctions(prefix);
+  registerArraySplitIntoChunksFunctions(prefix);
 
   registerArrayRemoveFunctions<int8_t>(prefix);
   registerArrayRemoveFunctions<int16_t>(prefix);

--- a/velox/functions/prestosql/registration/ArraySplitIntoChunksRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArraySplitIntoChunksRegistration.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/ArrayFunctions.h"
+
+namespace facebook::velox::functions {
+namespace {
+template <typename T>
+inline void registerArraySplitIntoChunksFunctions(const std::string& prefix) {
+  registerFunction<
+      ParameterBinder<ArraySplitIntoChunksFunction, T>,
+      Array<Array<T>>,
+      Array<T>,
+      int32_t>({prefix + "array_split_into_chunks"});
+}
+
+} // namespace
+void registerArraySplitIntoChunksFunctions(const std::string& prefix) {
+  registerArraySplitIntoChunksFunctions<int8_t>(prefix);
+  registerArraySplitIntoChunksFunctions<int16_t>(prefix);
+  registerArraySplitIntoChunksFunctions<int32_t>(prefix);
+  registerArraySplitIntoChunksFunctions<int64_t>(prefix);
+  registerArraySplitIntoChunksFunctions<int128_t>(prefix);
+  registerArraySplitIntoChunksFunctions<float>(prefix);
+  registerArraySplitIntoChunksFunctions<double>(prefix);
+  registerArraySplitIntoChunksFunctions<bool>(prefix);
+  registerArraySplitIntoChunksFunctions<Timestamp>(prefix);
+  registerArraySplitIntoChunksFunctions<Date>(prefix);
+  registerArraySplitIntoChunksFunctions<Varchar>(prefix);
+  registerArraySplitIntoChunksFunctions<Varbinary>(prefix);
+  registerArraySplitIntoChunksFunctions<Generic<T1>>(prefix);
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   ArrayConcatRegistration.cpp
   ArrayFunctionsRegistration.cpp
   ArrayNGramsRegistration.cpp
+  ArraySplitIntoChunksRegistration.cpp
   BinaryFunctionsRegistration.cpp
   BingTileFunctionsRegistration.cpp
   BitwiseFunctionsRegistration.cpp

--- a/velox/functions/prestosql/tests/ArraySplitIntoChunksTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySplitIntoChunksTest.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <optional>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions {
+namespace {
+class ArraySplitIntoChunksTest : public test::FunctionBaseTest {
+ protected:
+  template <typename T>
+  void testSplitIntoChunks(
+      const std::vector<std::optional<T>>& inputArray,
+      int32_t sz,
+      const std::vector<std::optional<std::vector<std::optional<T>>>>&
+          expectedOutput) {
+    std::vector<std::optional<std::vector<std::optional<T>>>> inputVec(
+        {inputArray});
+    auto input = makeNullableArrayVector<T>(inputVec);
+    auto result = evaluate(
+        fmt::format("array_split_into_chunks(c0, {}::INTEGER)", sz),
+        makeRowVector({input}));
+
+    auto expected = makeNullableNestedArrayVector<T>({expectedOutput});
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(ArraySplitIntoChunksTest, integers) {
+  testSplitIntoChunks<int64_t>({1, 2, 3}, 2, {{{1, 2}}, {{3}}});
+  testSplitIntoChunks<int64_t>({1, 2, 3, 4, 5}, 2, {{{1, 2}}, {{3, 4}}, {{5}}});
+  testSplitIntoChunks<int64_t>({2, 3, 4, 5}, 4, {{{2, 3, 4, 5}}});
+  testSplitIntoChunks<int64_t>(
+      {-66, 3, -66, 5}, 1, {{{-66}}, {{3}}, {{-66}}, {{5}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, evenSplit) {
+  testSplitIntoChunks<int64_t>(
+      {1, 2, 3, 4, 5, 6}, 2, {{{1, 2}}, {{3, 4}}, {{5, 6}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, chunkLargerThanArray) {
+  testSplitIntoChunks<int64_t>({1, 2, 3}, 5, {{{1, 2, 3}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, chunkEqualsArrayLength) {
+  testSplitIntoChunks<int64_t>({1, 2, 3}, 3, {{{1, 2, 3}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, chunkOfOne) {
+  testSplitIntoChunks<int64_t>({1, 2, 3, 4}, 1, {{{1}}, {{2}}, {{3}}, {{4}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, emptyArray) {
+  auto input = makeArrayVector<int64_t>({{}});
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_split_into_chunks(c0, 2::INTEGER)", makeRowVector({input})),
+      "Cannot split an empty array.");
+}
+
+TEST_F(ArraySplitIntoChunksTest, strings) {
+  testSplitIntoChunks<std::string>({"a", "b", "c"}, 2, {{{"a", "b"}}, {{"c"}}});
+  testSplitIntoChunks<std::string>(
+      {"a", "b", "c", "d", "e"}, 2, {{{"a", "b"}}, {{"c", "d"}}, {{"e"}}});
+  testSplitIntoChunks<std::string>(
+      {"a", "b", "c", "d"}, 4, {{{"a", "b", "c", "d"}}});
+  testSplitIntoChunks<std::string>(
+      {"a", "b", "c", "d"}, 1, {{{"a"}}, {{"b"}}, {{"c"}}, {{"d"}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, doubles) {
+  testSplitIntoChunks<double>({1.0, 2.0, 3.0}, 2, {{{1.0, 2.0}}, {{3.0}}});
+  testSplitIntoChunks<double>(
+      {1.0, 2.0, 3.0, 4.0, 5.0}, 2, {{{1.0, 2.0}}, {{3.0, 4.0}}, {{5.0}}});
+  testSplitIntoChunks<double>(
+      {2.0, 3.0, 4.0, 5.0}, 4, {{{2.0, 3.0, 4.0, 5.0}}});
+  testSplitIntoChunks<double>(
+      {1.0, 2.0, 3.0, 4.0}, 1, {{{1.0}}, {{2.0}}, {{3.0}}, {{4.0}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, nullElements) {
+  testSplitIntoChunks<int64_t>(
+      {std::nullopt, 1, std::nullopt, 2},
+      2,
+      {{{std::nullopt, 1}}, {{std::nullopt, 2}}});
+}
+
+TEST_F(ArraySplitIntoChunksTest, nullInputs) {
+  auto input = makeNullableArrayVector<int64_t>(
+      {std::optional<std::vector<std::optional<int64_t>>>(std::nullopt)});
+  auto result = evaluate(
+      "array_split_into_chunks(c0, 2::INTEGER)", makeRowVector({input}));
+  ASSERT_TRUE(result->isNullAt(0));
+}
+
+TEST_F(ArraySplitIntoChunksTest, invalidChunkSize) {
+  auto input = makeArrayVector<int64_t>({{1, 2, 3}});
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_split_into_chunks(c0, 0::INTEGER)", makeRowVector({input})),
+      "Invalid slice size: 0. Size must be greater than zero.");
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_split_into_chunks(c0, -1::INTEGER)", makeRowVector({input})),
+      "Scalar function signature is not supported");
+}
+
+TEST_F(ArraySplitIntoChunksTest, tooManyChunks) {
+  // Create an array with 12001 elements.
+  std::vector<std::optional<int64_t>> largeArray;
+  largeArray.reserve(12'001);
+  for (int i = 0; i < 12'001; ++i) {
+    largeArray.push_back(i);
+  }
+  std::vector<std::optional<std::vector<std::optional<int64_t>>>> inputVec(
+      {largeArray});
+  auto input = makeNullableArrayVector<int64_t>(inputVec);
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_split_into_chunks(c0, 1::INTEGER)", makeRowVector({input})),
+      "Cannot split array of size: 12001 into more than 10000 parts.");
+}
+} // namespace
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(
   ArrayMinMaxByTest.cpp
   ArrayNGramsTest.cpp
   ArrayNoneMatchTest.cpp
+  ArraySplitIntoChunksTest.cpp
   ArrayNormalizeTest.cpp
   ArrayPositionTest.cpp
   ArrayRemoveTest.cpp


### PR DESCRIPTION
**Summary**
- Add array_split_into_chunks(array(T), sz) -> array(array(T)) scalar function matching the Presto Java implementation
- Splits an input array into chunks of the given length, with the last chunk containing any remaining elements
- Supports all element types including primitives, strings (with zero-copy optimization), and complex types


### Test plan
Added unit tests covering:
- Basic splitting for integers, strings, and doubles
- Even/uneven splits, chunk size of 1, chunk larger than array, empty array
- Null element preservation and null input handling
- Error cases: non-positive chunk size, exceeding 10,000 parts limit - this limitation exists in Presto Java: 
```
checkCondition(
    length <= MAX_RESULT_ENTRIES,
    INVALID_FUNCTION_ARGUMENT,
    "result of sequence function must not have more than 10000 entries");

```