### PR TITLE
refactor: Use explicit types in Cursor::write

### DIFF
--- a/velox/exec/OperatorTraceWriter.cpp
+++ b/velox/exec/OperatorTraceWriter.cpp
@@ -152,9 +152,9 @@ std::unique_ptr<folly::IOBuf> OperatorTraceSplitWriter::serialize(
   auto ioBuf =
       folly::IOBuf::create(sizeof(length) + split.size() + sizeof(crc32));
   folly::io::Appender appender(ioBuf.get(), 0);
-  appender.writeLE(length);
+  appender.writeLE<uint32_t>(length);
   appender.push(reinterpret_cast<const uint8_t*>(split.data()), length);
-  appender.writeLE(crc32);
+  appender.writeLE<uint32_t>(crc32);
   return ioBuf;
 }
 

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -857,12 +857,12 @@ TEST_F(OperatorTraceTest, traceSplitPartial) {
   auto ioBuf = folly::IOBuf::create(12 + 16);
   folly::io::Appender appender(ioBuf.get(), 0);
   // Writes an invalid split without crc.
-  appender.writeLE(length);
+  appender.writeLE<uint32_t>(length);
   appender.push(reinterpret_cast<const uint8_t*>(split.data()), length);
   // Writes a valid spilt.
-  appender.writeLE(length);
+  appender.writeLE<uint32_t>(length);
   appender.push(reinterpret_cast<const uint8_t*>(split.data()), length);
-  appender.writeLE(crc32);
+  appender.writeLE<uint32_t>(crc32);
   splitInfoFile->append(std::move(ioBuf));
   splitInfoFile->close();
 
@@ -946,13 +946,13 @@ TEST_F(OperatorTraceTest, traceSplitCorrupted) {
   auto ioBuf = folly::IOBuf::create(16 * 2);
   folly::io::Appender appender(ioBuf.get(), 0);
   // Writes an invalid split with a wrong checksum.
-  appender.writeLE(length);
+  appender.writeLE<uint32_t>(length);
   appender.push(reinterpret_cast<const uint8_t*>(split.data()), length);
-  appender.writeLE(crc32 - 1);
+  appender.writeLE<uint32_t>(crc32 - 1);
   // Writes a valid split.
-  appender.writeLE(length);
+  appender.writeLE<uint32_t>(length);
   appender.push(reinterpret_cast<const uint8_t*>(split.data()), length);
-  appender.writeLE(crc32);
+  appender.writeLE<uint32_t>(crc32);
   splitInfoFile->append(std::move(ioBuf));
   splitInfoFile->close();
 


### PR DESCRIPTION
Summary:
Addresses problems like this:

```
void* buf = /*...*/;
uint16_t word = /*...*/;
cursor.write(word & 0xffff); // oops, 32-bit store due to implicit integer promotion
```

Differential Revision: D94252973


