### PR TITLE
feat: Add cache lookup and zero-copy APIs to BufferedInput

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -162,6 +162,50 @@ std::unique_ptr<AsyncDataCacheEntry> CacheShard::getFreeEntryLocked() {
   return newEntry;
 }
 
+std::optional<CachePin> CacheShard::lookupLocked(
+    RawFileCacheKey key,
+    uint64_t size,
+    folly::SemiFuture<bool>* wait) {
+  ++eventCounter_;
+  auto it = entryMap_.find(key);
+  if (it == entryMap_.end()) {
+    return std::nullopt;
+  }
+  auto* foundEntry = it->second;
+  if (foundEntry->isExclusive()) {
+    ++numWaitExclusive_;
+    if (wait != nullptr) {
+      *wait = foundEntry->getFutureLocked();
+    }
+    return CachePin{};
+  }
+  // size=0 (from find()) always passes since entry size is non-negative.
+  if (foundEntry->size() < size) {
+    // This can happen if different load quanta apply to access via different
+    // connectors. This is not an error but still worth logging.
+    VELOX_CACHE_LOG_EVERY_MS(WARNING, 1'000)
+        << "Requested larger entry. Found size " << foundEntry->size()
+        << " requested size " << size;
+    RECORD_METRIC_VALUE(kMetricMemoryCacheNumStaleEntries);
+    ++numStales_;
+    foundEntry->key_.fileNum.clear();
+    entryMap_.erase(it);
+    return std::nullopt;
+  }
+  foundEntry->touch();
+  if (foundEntry->isPrefetch()) {
+    foundEntry->isFirstUse_ = true;
+    foundEntry->setPrefetch(false);
+  } else {
+    ++numHit_;
+    hitBytes_ += foundEntry->size();
+  }
+  ++foundEntry->numPins_;
+  CachePin pin;
+  pin.setEntry(foundEntry);
+  return pin;
+}
+
 CachePin CacheShard::findOrCreate(
     RawFileCacheKey key,
     uint64_t size,
@@ -169,47 +213,9 @@ CachePin CacheShard::findOrCreate(
   AsyncDataCacheEntry* entryToInit = nullptr;
   {
     std::lock_guard<std::mutex> l(mutex_);
-    ++eventCounter_;
-    auto it = entryMap_.find(key);
-    if (it != entryMap_.end()) {
-      auto* foundEntry = it->second;
-      if (foundEntry->isExclusive()) {
-        ++numWaitExclusive_;
-        if (wait != nullptr) {
-          *wait = foundEntry->getFutureLocked();
-        }
-        return CachePin();
-      }
-
-      if (foundEntry->size() >= size) {
-        foundEntry->touch();
-        // The entry is in a readable state. Add a pin.
-        if (foundEntry->isPrefetch()) {
-          foundEntry->isFirstUse_ = true;
-          foundEntry->setPrefetch(false);
-        } else {
-          ++numHit_;
-          hitBytes_ += foundEntry->size();
-        }
-        ++foundEntry->numPins_;
-        CachePin pin;
-        pin.setEntry(foundEntry);
-        return pin;
-      }
-
-      // TODO: add stats to report or send alert in production.
-
-      // This can happen if different load quanta apply to access via different
-      // connectors. This is not an error but still worth logging.
-      VELOX_CACHE_LOG_EVERY_MS(WARNING, 1'000)
-          << "Requested larger entry. Found size " << foundEntry->size()
-          << " requested size " << size;
-      // The old entry is superseded. Possible readers of the old entry still
-      // retain a valid read pin.
-      RECORD_METRIC_VALUE(kMetricMemoryCacheNumStaleEntries);
-      ++numStales_;
-      foundEntry->key_.fileNum.clear();
-      entryMap_.erase(it);
+    auto result = lookupLocked(key, size, wait);
+    if (result.has_value()) {
+      return std::move(result.value());
     }
 
     auto newEntry = getFreeEntryLocked();
@@ -232,6 +238,15 @@ CachePin CacheShard::findOrCreate(
     entryToInit->isFirstUse_ = true;
   }
   return initEntry(key, entryToInit);
+}
+
+std::optional<CachePin> CacheShard::find(
+    RawFileCacheKey key,
+    folly::SemiFuture<bool>* wait) {
+  std::lock_guard<std::mutex> l(mutex_);
+  // size=0 means any cached entry size is acceptable, so lookupLocked will
+  // never trigger the stale-entry eviction path.
+  return lookupLocked(key, 0, wait);
 }
 
 void CacheShard::makeEvictable(RawFileCacheKey key) {
@@ -748,6 +763,13 @@ CachePin AsyncDataCache::findOrCreate(
     folly::SemiFuture<bool>* wait) {
   const int shard = std::hash<RawFileCacheKey>()(key) & shardMask_;
   return shards_[shard]->findOrCreate(key, size, wait);
+}
+
+std::optional<CachePin> AsyncDataCache::find(
+    RawFileCacheKey key,
+    folly::SemiFuture<bool>* waitFuture) {
+  const int shard = std::hash<RawFileCacheKey>()(key) & shardMask_;
+  return shards_[shard]->find(key, waitFuture);
 }
 
 void AsyncDataCache::makeEvictable(RawFileCacheKey key) {

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -574,6 +574,15 @@ class CacheShard {
       uint64_t size,
       folly::SemiFuture<bool>* readyFuture);
 
+  /// Finds a cache entry for 'key'. Returns a shared-mode pin if the entry
+  /// exists and is not exclusive. Returns an empty pin (inside optional) if
+  /// the entry is exclusive; if 'waitFuture' is not nullptr it is set to a
+  /// future realized when the entry is no longer exclusive. Returns
+  /// std::nullopt on miss. Does not create entries.
+  std::optional<CachePin> find(
+      RawFileCacheKey key,
+      folly::SemiFuture<bool>* waitFuture = nullptr);
+
   /// Marks the cache entry with given cache 'key' as immediate evictable.
   void makeEvictable(RawFileCacheKey key);
 
@@ -652,6 +661,16 @@ class CacheShard {
   std::unique_ptr<AsyncDataCacheEntry> getFreeEntryLocked();
 
   CachePin initEntry(RawFileCacheKey key, AsyncDataCacheEntry* entry);
+
+  // Looks up 'key' in the cache under mutex_. 'size' is the minimum acceptable
+  // entry size: pass 0 from find() to accept any size, or the required size
+  // from findOrCreate() to trigger stale-entry eviction when too small.
+  // Returns std::nullopt on miss (or after evicting a stale entry),
+  // an empty CachePin if the entry is exclusive, or a shared CachePin on hit.
+  std::optional<CachePin> lookupLocked(
+      RawFileCacheKey key,
+      uint64_t size,
+      folly::SemiFuture<bool>* waitFuture);
 
   void freeAllocations(std::vector<memory::Allocation>& allocations);
 
@@ -806,6 +825,15 @@ class AsyncDataCache : public memory::Cache {
   CachePin findOrCreate(
       RawFileCacheKey key,
       uint64_t size,
+      folly::SemiFuture<bool>* waitFuture = nullptr);
+
+  /// Finds a cache entry for 'key'. Returns a shared-mode pin if the entry
+  /// exists and is not exclusive. Returns an empty pin (inside optional) if
+  /// the entry is exclusive; if 'waitFuture' is not nullptr it is set to a
+  /// future realized when the entry is no longer exclusive. Returns
+  /// std::nullopt on miss.
+  std::optional<CachePin> find(
+      RawFileCacheKey key,
       folly::SemiFuture<bool>* waitFuture = nullptr);
 
   /// Marks the cache entry with given cache 'key' as immediate evictable.

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -1679,6 +1679,191 @@ TEST_P(AsyncDataCacheTest, numShardsInvalid) {
   }
 }
 
+TEST_P(AsyncDataCacheTest, findMiss) {
+  constexpr int64_t kRamBytes = 32 << 20;
+  initializeMemoryManager(kRamBytes);
+  initializeCache(kRamBytes);
+
+  RawFileCacheKey key{filenames_[0].id(), 0};
+  auto result = cache_->find(key);
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_P(AsyncDataCacheTest, findHit) {
+  constexpr int64_t kRamBytes = 32 << 20;
+  constexpr int32_t kEntrySize = 4096;
+  initializeMemoryManager(kRamBytes);
+  initializeCache(kRamBytes);
+
+  RawFileCacheKey key{filenames_[0].id(), 1000};
+
+  // Populate the entry via findOrCreate.
+  {
+    auto pin = cache_->findOrCreate(key, kEntrySize, nullptr);
+    ASSERT_FALSE(pin.empty());
+    ASSERT_TRUE(pin.entry()->isExclusive());
+    initializeContents(key.offset + key.fileNum, pin.entry()->data());
+    pin.entry()->setExclusiveToShared();
+  }
+
+  // find should return a shared pin with correct data.
+  auto result = cache_->find(key);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->empty());
+  auto* entry = result->checkedEntry();
+  ASSERT_TRUE(entry->isShared());
+  ASSERT_EQ(entry->size(), kEntrySize);
+  checkContents(*entry);
+}
+
+TEST_P(AsyncDataCacheTest, findExclusiveWithWait) {
+  constexpr int64_t kRamBytes = 32 << 20;
+  constexpr int32_t kEntrySize = 4096;
+  initializeMemoryManager(kRamBytes);
+  initializeCache(kRamBytes);
+
+  RawFileCacheKey key{filenames_[0].id(), 2000};
+
+  // Create an exclusive entry.
+  auto exclusivePin = cache_->findOrCreate(key, kEntrySize, nullptr);
+  ASSERT_FALSE(exclusivePin.empty());
+  ASSERT_TRUE(exclusivePin.entry()->isExclusive());
+
+  // find without wait returns empty pin (entry exists but is exclusive).
+  {
+    auto result = cache_->find(key);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->empty());
+  }
+
+  // find with wait returns empty pin and sets a future.
+  folly::SemiFuture<bool> waitFuture(false);
+  {
+    auto result = cache_->find(key, &waitFuture);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->empty());
+  }
+
+  // The future should not be ready while the entry is exclusive.
+  ASSERT_FALSE(waitFuture.isReady());
+
+  // Timed wait should time out while the entry is still exclusive.
+  {
+    auto waitCopy = std::move(waitFuture);
+    auto timedResult =
+        std::move(waitCopy).via(&folly::QueuedImmediateExecutor::instance());
+    ASSERT_FALSE(
+        std::move(timedResult).wait(std::chrono::seconds(1)).isReady());
+  }
+
+  // Re-issue find with wait after the timed-out future was consumed.
+  waitFuture = folly::SemiFuture<bool>(false);
+  {
+    auto result = cache_->find(key, &waitFuture);
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result->empty());
+  }
+  ASSERT_FALSE(waitFuture.isReady());
+
+  // Transition to shared makes the future ready.
+  initializeContents(key.offset + key.fileNum, exclusivePin.entry()->data());
+  exclusivePin.entry()->setExclusiveToShared();
+  exclusivePin.clear();
+
+  auto& exec = folly::QueuedImmediateExecutor::instance();
+  ASSERT_TRUE(std::move(waitFuture).via(&exec).wait().isReady());
+
+  // Now find should return a shared pin.
+  auto result = cache_->find(key);
+  ASSERT_TRUE(result.has_value());
+  ASSERT_FALSE(result->empty());
+  checkContents(*result->checkedEntry());
+}
+
+TEST_P(AsyncDataCacheTest, fuzz) {
+  constexpr int64_t kRamBytes = 64 << 20;
+  constexpr int32_t kNumThreads = 8;
+  constexpr int32_t kNumFiles = 10;
+  constexpr int32_t kNumOffsets = 20;
+  constexpr int32_t kEntrySize = 4096;
+  constexpr int32_t kTestDurationMs = 10'000;
+
+  initializeMemoryManager(kRamBytes);
+  initializeCache(kRamBytes);
+
+  std::atomic_bool stop{false};
+
+  // Worker threads: findOrCreate/find entries, verify content.
+  auto workerFunc = [&](int32_t threadId) {
+    std::mt19937 rng(threadId);
+    while (!stop.load(std::memory_order_relaxed)) {
+      const auto fileIdx = rng() % kNumFiles;
+      const auto offsetIdx = rng() % kNumOffsets;
+      const uint64_t offset = offsetIdx * kEntrySize;
+      RawFileCacheKey key{filenames_[fileIdx].id(), offset};
+
+      // Randomly choose between find and findOrCreate.
+      if (rng() % 3 == 0) {
+        // find: lookup only.
+        auto result = cache_->find(key);
+        if (result.has_value() && !result->empty()) {
+          checkContents(*result->checkedEntry());
+        }
+      } else {
+        // findOrCreate: populate if new.
+        folly::SemiFuture<bool> waitFuture(false);
+        auto pin = cache_->findOrCreate(key, kEntrySize, &waitFuture);
+        if (pin.empty()) {
+          auto& exec = folly::QueuedImmediateExecutor::instance();
+          std::move(waitFuture).via(&exec).wait();
+          continue;
+        }
+        auto* entry = pin.checkedEntry();
+        if (entry->isExclusive()) {
+          initializeContents(key.offset + key.fileNum, entry->data());
+          entry->setExclusiveToShared();
+        }
+        checkContents(*entry);
+      }
+    }
+  };
+
+  // Eviction thread: periodically remove a subset of files.
+  auto evictFunc = [&]() {
+    std::mt19937 rng(kNumThreads + 1);
+    while (!stop.load(std::memory_order_relaxed)) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50)); // NOLINT
+      folly::F14FastSet<uint64_t> filesToRemove;
+      // Remove a random subset of files.
+      const auto numToRemove = (rng() % kNumFiles) + 1;
+      for (uint32_t i = 0; i < numToRemove; ++i) {
+        filesToRemove.insert(filenames_[rng() % kNumFiles].id());
+      }
+      folly::F14FastSet<uint64_t> filesRetained;
+      cache_->removeFileEntries(filesToRemove, filesRetained);
+    }
+  };
+
+  std::vector<std::thread> threads;
+  for (int32_t i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back(workerFunc, i);
+  }
+  threads.emplace_back(evictFunc);
+
+  std::this_thread::sleep_for(
+      std::chrono::milliseconds(kTestDurationMs)); // NOLINT
+  stop.store(true, std::memory_order_relaxed);
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  auto stats = cache_->refreshStats();
+  LOG(INFO) << "fuzz stats: " << stats.numEntries << " entries, "
+            << stats.numHit << " hits, " << stats.numNew << " new, "
+            << stats.numEvict << " evicts";
+}
+
 INSTANTIATE_TEST_SUITE_P(
     AsyncDataCacheTest,
     AsyncDataCacheTest,

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -271,6 +271,13 @@ uint32_t HiveConfig::maxRowsPerIndexRequest(
       config_->get<uint32_t>(kMaxRowsPerIndexRequest, 0));
 }
 
+bool HiveConfig::fileMetadataCacheEnabled(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kFileMetadataCacheEnabledSession,
+      config_->get<bool>(kFileMetadataCacheEnabled, false));
+}
+
 std::string HiveConfig::user(const config::ConfigBase* session) const {
   return session->get<std::string>(kUser, config_->get<std::string>(kUser, ""));
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -222,6 +222,15 @@ class HiveConfig {
   static constexpr const char* kMaxRowsPerIndexRequestSession =
       "hive.max_rows_per_index_request";
 
+  /// Whether to cache file metadata (footer, stripes, index) in the
+  /// process-wide AsyncDataCache. When enabled, the first reader performs a
+  /// speculative tail read and populates the cache; subsequent readers on the
+  /// same file hit the cache for zero-IO metadata init.
+  static constexpr const char* kFileMetadataCacheEnabled =
+      "file-metadata-cache-enabled";
+  static constexpr const char* kFileMetadataCacheEnabledSession =
+      "file_metadata_cache_enabled";
+
   static constexpr const char* kUser = "user";
   static constexpr const char* kSource = "source";
   static constexpr const char* kSchema = "schema";
@@ -313,6 +322,9 @@ class HiveConfig {
   /// Returns the maximum number of rows to read per index lookup request.
   /// 0 means no limit (default).
   uint32_t maxRowsPerIndexRequest(const config::ConfigBase* session) const;
+
+  /// Whether to cache file metadata in the process-wide AsyncDataCache.
+  bool fileMetadataCacheEnabled(const config::ConfigBase* session) const;
 
   /// User of the query. Used for storage logging.
   std::string user(const config::ConfigBase* session) const;

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -638,6 +638,8 @@ void configureReaderOptions(
       connectorQueryCtx->adjustTimestampToTimezone());
   readerOptions.setSelectiveNimbleReaderEnabled(
       connectorQueryCtx->selectiveNimbleReaderEnabled());
+  readerOptions.setFileMetadataCacheEnabled(
+      hiveConfig->fileMetadataCacheEnabled(sessionProperties));
 
   if (readerOptions.fileFormat() != dwio::common::FileFormat::UNKNOWN) {
     VELOX_CHECK(

--- a/velox/connectors/hive/tests/HiveConfigTest.cpp
+++ b/velox/connectors/hive/tests/HiveConfigTest.cpp
@@ -56,6 +56,7 @@ TEST(HiveConfigTest, defaultConfig) {
   ASSERT_EQ(hiveConfig.loadQuantum(emptySession.get()), 8 << 20);
   ASSERT_FALSE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
   ASSERT_FALSE(hiveConfig.indexEnabled(emptySession.get()));
+  ASSERT_FALSE(hiveConfig.fileMetadataCacheEnabled(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideConfig) {
@@ -80,7 +81,8 @@ TEST(HiveConfigTest, overrideConfig) {
       {HiveConfig::kLoadQuantum, std::to_string(4 << 20)},
       {HiveConfig::kMaxBucketCount, std::to_string(100'000)},
       {HiveConfig::kPreserveFlatMapsInMemory, "true"},
-      {HiveConfig::kIndexEnabled, "true"}};
+      {HiveConfig::kIndexEnabled, "true"},
+      {HiveConfig::kFileMetadataCacheEnabled, "true"}};
   HiveConfig hiveConfig(
       std::make_shared<config::ConfigBase>(std::move(configFromFile)));
   auto emptySession = std::make_shared<config::ConfigBase>(
@@ -113,6 +115,7 @@ TEST(HiveConfigTest, overrideConfig) {
   ASSERT_EQ(hiveConfig.maxBucketCount(emptySession.get()), 100'000);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(emptySession.get()));
   ASSERT_TRUE(hiveConfig.indexEnabled(emptySession.get()));
+  ASSERT_TRUE(hiveConfig.fileMetadataCacheEnabled(emptySession.get()));
 }
 
 TEST(HiveConfigTest, overrideSession) {
@@ -134,6 +137,7 @@ TEST(HiveConfigTest, overrideSession) {
       {HiveConfig::kLoadQuantumSession, std::to_string(4 << 20)},
       {HiveConfig::kPreserveFlatMapsInMemorySession, "true"},
       {HiveConfig::kIndexEnabledSession, "true"},
+      {HiveConfig::kFileMetadataCacheEnabledSession, "true"},
   };
   const auto session =
       std::make_unique<config::ConfigBase>(std::move(sessionOverride));
@@ -162,4 +166,5 @@ TEST(HiveConfigTest, overrideSession) {
   ASSERT_EQ(hiveConfig.loadQuantum(session.get()), 4 << 20);
   ASSERT_TRUE(hiveConfig.preserveFlatMapsInMemory(session.get()));
   ASSERT_TRUE(hiveConfig.indexEnabled(session.get()));
+  ASSERT_TRUE(hiveConfig.fileMetadataCacheEnabled(session.get()));
 }

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -173,6 +173,9 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
+  EXPECT_EQ(
+      readerOptions.fileMetadataCacheEnabled(),
+      hiveConfig->fileMetadataCacheEnabled(&sessionProperties));
 
   // Modify field delimiter and change the file format.
   clearDynamicParameters(FileFormat::TEXT);
@@ -263,6 +266,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   customHiveConfigProps[hive::HiveConfig::kFooterEstimatedSize] = "1111";
   customHiveConfigProps[hive::HiveConfig::kFilePreloadThreshold] = "9999";
   customHiveConfigProps[hive::HiveConfig::kPrefetchRowGroups] = "10";
+  customHiveConfigProps[hive::HiveConfig::kFileMetadataCacheEnabled] = "true";
   hiveConfig = std::make_shared<hive::HiveConfig>(
       std::make_shared<config::ConfigBase>(std::move(customHiveConfigProps)));
   performConfigure();
@@ -282,12 +286,60 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
   EXPECT_EQ(readerOptions.prefetchRowGroups(), hiveConfig->prefetchRowGroups());
+  EXPECT_TRUE(readerOptions.fileMetadataCacheEnabled());
   clearDynamicParameters(FileFormat::ORC);
   performConfigure();
   checkUseColumnNamesForColumnMapping();
   clearDynamicParameters(FileFormat::PARQUET);
   performConfigure();
   checkUseColumnNamesForColumnMapping();
+}
+
+TEST_F(HiveConnectorUtilTest, fileMetadataCacheEnabledSessionOverride) {
+  // Verify default is off.
+  dwio::common::ReaderOptions defaultOptions(pool_.get());
+  ASSERT_FALSE(defaultOptions.fileMetadataCacheEnabled());
+
+  for (bool enabled : {true, false}) {
+    SCOPED_TRACE(fmt::format("fileMetadataCacheEnabled={}", enabled));
+
+    config::ConfigBase sessionProperties(
+        std::unordered_map<std::string, std::string>{
+            {hive::HiveConfig::kFileMetadataCacheEnabledSession,
+             enabled ? "true" : "false"}});
+    auto connectorQueryCtx = std::make_unique<connector::ConnectorQueryCtx>(
+        pool_.get(),
+        pool_.get(),
+        &sessionProperties,
+        nullptr,
+        common::PrefixSortConfig(),
+        nullptr,
+        nullptr,
+        "query.HiveConnectorUtilTest",
+        "task.HiveConnectorUtilTest",
+        "planNodeId.HiveConnectorUtilTest",
+        0,
+        "");
+    auto hiveConfig =
+        std::make_shared<hive::HiveConfig>(std::make_shared<config::ConfigBase>(
+            std::unordered_map<std::string, std::string>()));
+    dwio::common::ReaderOptions readerOptions(pool_.get());
+
+    auto tableHandle = std::make_shared<hive::HiveTableHandle>(
+        "testConnectorId",
+        "testTable",
+        false,
+        common::SubfieldFilters{},
+        nullptr,
+        nullptr,
+        std::vector<std::string>{},
+        std::unordered_map<std::string, std::string>{});
+    auto split = std::make_shared<hive::HiveConnectorSplit>(
+        "testConnectorId", "/tmp/", FileFormat::DWRF);
+    configureReaderOptions(
+        hiveConfig, connectorQueryCtx.get(), tableHandle, split, readerOptions);
+    ASSERT_EQ(readerOptions.fileMetadataCacheEnabled(), enabled);
+  }
 }
 
 TEST_F(HiveConnectorUtilTest, cacheRetention) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -811,6 +811,13 @@ Each query can override the config by setting corresponding query session proper
      - 0
      - Maximum number of output rows to return per index lookup request. The limit is applied to the actual output rows
        after filtering. 0 means no limit (default).
+   * - file-metadata-cache-enabled
+     - file_metadata_cache_enabled
+     - bool
+     - false
+     - Whether to cache file metadata (footer, stripes, index) in the process-wide AsyncDataCache. When enabled,
+       the first reader performs a speculative tail read and populates the cache; subsequent readers on the same file
+       serve metadata from cache with zero file IO. Currently only supported by Nimble format.
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -27,6 +27,42 @@ using ::facebook::velox::common::Region;
 
 namespace facebook::velox::dwio::common {
 
+CachedRegion::CachedRegion(cache::CachePin pin) : pin_(std::move(pin)) {
+  VELOX_CHECK(!pin_.empty(), "CachedRegion requires a non-empty cache pin");
+  auto* entry = pin_.checkedEntry();
+  VELOX_CHECK(
+      !entry->isExclusive(),
+      "CachedRegion requires a shared (non-exclusive) cache pin");
+  size_ = entry->size();
+  if (entry->tinyData() != nullptr) {
+    ranges_.push_back(folly::Range<const char*>(entry->tinyData(), size_));
+  } else {
+    auto& allocation = entry->data();
+    ranges_.reserve(allocation.numRuns());
+    uint64_t offset{0};
+    for (int i = 0; i < allocation.numRuns() && offset < size_; ++i) {
+      auto run = allocation.runAt(i);
+      const uint64_t bytes =
+          run.numPages() * memory::AllocationTraits::kPageSize;
+      const uint64_t readSize = std::min(bytes, size_ - offset);
+      ranges_.push_back(
+          folly::Range<const char*>(run.data<const char>(), readSize));
+      offset += readSize;
+    }
+  }
+}
+
+folly::IOBuf CachedRegion::toIOBuf() const {
+  VELOX_CHECK(!ranges_.empty());
+  auto iobuf =
+      folly::IOBuf::wrapBufferAsValue(ranges_[0].data(), ranges_[0].size());
+  for (size_t i = 1; i < ranges_.size(); ++i) {
+    iobuf.appendToChain(
+        folly::IOBuf::wrapBuffer(ranges_[i].data(), ranges_[i].size()));
+  }
+  return iobuf;
+}
+
 static_assert(std::is_move_constructible<BufferedInput>());
 
 namespace {

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include "folly/io/IOBuf.h"
+#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/memory/AllocationPool.h"
 #include "velox/dwio/common/SeekableInputStream.h"
@@ -25,6 +27,37 @@
 DECLARE_bool(wsVRLoad);
 
 namespace facebook::velox::dwio::common {
+
+/// Provides read-only access to cached data without copying. Holds a
+/// shared-mode pin on the cache entry, keeping it alive while the caller
+/// accesses the data buffers.
+class CachedRegion {
+ public:
+  /// The pin must be non-empty and in shared (non-exclusive) mode.
+  explicit CachedRegion(cache::CachePin pin);
+
+  uint64_t size() const {
+    return size_;
+  }
+
+  /// Returns buffer ranges covering the cached data. For small entries the
+  /// result is a single contiguous range; for larger entries there may be
+  /// multiple non-contiguous ranges from the backing allocation.
+  const std::vector<folly::Range<const char*>>& ranges() const {
+    return ranges_;
+  }
+
+  /// Returns an IOBuf chain wrapping the cached data ranges without copying.
+  /// The returned IOBuf references memory owned by this CachedRegion, so
+  /// the caller must not outlive this object.
+  folly::IOBuf toIOBuf() const;
+
+ private:
+  cache::CachePin pin_;
+  // Cached data size in bytes.
+  uint64_t size_{0};
+  std::vector<folly::Range<const char*>> ranges_;
+};
 
 class BufferedInput {
  public:
@@ -151,6 +184,42 @@ class BufferedInput {
 
   virtual folly::Executor* executor() const {
     return nullptr;
+  }
+
+  /// Returns true if this BufferedInput has a backing cache (e.g.,
+  /// AsyncDataCache). When true, callers may skip their own caching of raw
+  /// bytes since the BufferedInput will handle caching.
+  virtual bool hasCache() const {
+    return false;
+  }
+
+  /// Offers pre-read data for a file region to the backing cache. Throws if
+  /// hasCache() is false. Override in subclasses with a backing cache.
+  virtual void cacheRegion(
+      uint64_t /*offset*/,
+      uint64_t /*length*/,
+      std::string_view /*data*/) {
+    VELOX_UNSUPPORTED("cacheRegion requires a backing cache");
+  }
+
+  /// Overload that copies from an IOBuf (possibly chained) into the cache
+  /// entry, avoiding the need to coalesce the IOBuf first. 'bufferOffset' is
+  /// the byte offset within the IOBuf chain where the region data starts.
+  /// Throws if hasCache() is false.
+  virtual void cacheRegion(
+      uint64_t /*offset*/,
+      uint64_t /*length*/,
+      const folly::IOBuf& /*buffer*/,
+      uint64_t /*bufferOffset*/) {
+    VELOX_UNSUPPORTED("cacheRegion requires a backing cache");
+  }
+
+  /// Finds a cached region at the given offset. Returns a CachedRegion holding
+  /// a shared-mode pin on the cache entry if found, or std::nullopt on cache
+  /// miss. Throws if hasCache() is false.
+  virtual std::optional<CachedRegion> findCachedRegion(
+      uint64_t /*offset*/) const {
+    VELOX_UNSUPPORTED("findCachedRegion requires a backing cache");
   }
 
   virtual uint64_t nextFetchSize() const;

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -36,7 +36,7 @@ velox_add_library(
   DirectBufferedInput.cpp
   DirectDecoder.cpp
   DirectInputStream.cpp
-  DwioMetricsLog.cpp
+  MetricsLog.cpp
   ExecutorBarrier.cpp
   FileSink.cpp
   FlatMapHelper.cpp

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/common/CachedBufferedInput.h"
+#include "folly/io/Cursor.h"
 #include "velox/common/Casts.h"
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/process/TraceContext.h"
@@ -597,6 +598,79 @@ bool CachedBufferedInput::prefetch(Region region) {
   // cache entry will be accessed.
   coalescedLoad(stream.get());
   return true;
+}
+
+void CachedBufferedInput::cacheRegion(
+    uint64_t offset,
+    uint64_t length,
+    std::string_view data) {
+  VELOX_CHECK_EQ(data.size(), length);
+  auto iobuf = folly::IOBuf::wrapBufferAsValue(data.data(), data.size());
+  cacheRegion(offset, length, iobuf, 0);
+}
+
+void CachedBufferedInput::cacheRegion(
+    uint64_t offset,
+    uint64_t length,
+    const folly::IOBuf& buffer,
+    uint64_t bufferOffset) {
+  auto pin = cache_->findOrCreate(
+      RawFileCacheKey{fileNum_.id(), offset}, length, nullptr);
+  // Empty pin means the cache is at capacity and cannot accept new entries.
+  // Non-exclusive means another thread already cached this region; skip the
+  // duplicate write.
+  if (pin.empty() || !pin.checkedEntry()->isExclusive()) {
+    return;
+  }
+
+  folly::io::Cursor cursor(&buffer);
+  cursor.skip(bufferOffset);
+  VELOX_CHECK_GE(
+      cursor.totalLength(),
+      length,
+      "IOBuf has {} bytes after offset {}, need {}",
+      cursor.totalLength(),
+      bufferOffset,
+      length);
+
+  auto* entry = pin.checkedEntry();
+  if (entry->size() < cache::AsyncDataCacheEntry::kTinyDataSize) {
+    cursor.pull(entry->tinyData(), length);
+  } else {
+    auto& allocation = entry->data();
+    uint64_t copyBytes = 0;
+    for (int i = 0; i < allocation.numRuns() && copyBytes < length; ++i) {
+      const auto run = allocation.runAt(i);
+      const uint64_t copySize =
+          std::min<uint64_t>(run.numBytes(), length - copyBytes);
+      cursor.pull(run.data(), copySize);
+      copyBytes += copySize;
+    }
+    VELOX_CHECK_EQ(copyBytes, length);
+  }
+
+  entry->setExclusiveToShared();
+}
+
+std::optional<CachedRegion> CachedBufferedInput::findCachedRegion(
+    uint64_t offset) const {
+  const cache::RawFileCacheKey key{fileNum_.id(), offset};
+  for (;;) {
+    folly::SemiFuture<bool> waitFuture(false);
+    auto result = cache_->find(key, &waitFuture);
+    if (!result.has_value()) {
+      return std::nullopt;
+    }
+    if (!result->empty()) {
+      auto* entry = result->checkedEntry();
+      if (!entry->getAndClearFirstUseFlag()) {
+        ioStatistics_->ramHit().increment(entry->size());
+      }
+      return CachedRegion{std::move(*result)};
+    }
+    // Entry is exclusive — wait for it to become shared, then retry.
+    std::move(waitFuture).wait();
+  }
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -83,6 +83,7 @@ class CachedBufferedInput : public BufferedInput {
         executor_(executor),
         fileSize_(input_->getLength()),
         options_(readerOptions) {
+    VELOX_CHECK_NOT_NULL(cache_, "CachedBufferedInput requires a cache");
     checkLoadQuantum();
   }
 
@@ -106,6 +107,7 @@ class CachedBufferedInput : public BufferedInput {
         executor_(executor),
         fileSize_(input_->getLength()),
         options_(readerOptions) {
+    VELOX_CHECK_NOT_NULL(cache_, "CachedBufferedInput requires a cache");
     checkLoadQuantum();
   }
 
@@ -163,6 +165,21 @@ class CachedBufferedInput : public BufferedInput {
   cache::AsyncDataCache* cache() const {
     return cache_;
   }
+
+  bool hasCache() const override {
+    return true;
+  }
+
+  void cacheRegion(uint64_t offset, uint64_t length, std::string_view data)
+      override;
+
+  void cacheRegion(
+      uint64_t offset,
+      uint64_t length,
+      const folly::IOBuf& buffer,
+      uint64_t bufferOffset) override;
+
+  std::optional<CachedRegion> findCachedRegion(uint64_t offset) const override;
 
   /// Returns the CoalescedLoad that contains the correlated loads for 'stream'
   /// or nullptr if none. Returns nullptr on all but first call for 'stream'

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -75,7 +75,7 @@ void ReadFileInputStream::read(
     void* buf,
     uint64_t length,
     uint64_t offset,
-    MetricsLog::MetricsType purpose) {
+    MetricsLog::Type purpose) {
   VELOX_CHECK_NOT_NULL(buf);
   logRead(offset, length, purpose);
   uint64_t readTimeUs{0};

--- a/velox/dwio/common/MetricsLog.cpp
+++ b/velox/dwio/common/MetricsLog.cpp
@@ -35,6 +35,42 @@ std::shared_ptr<DwioMetricsLogFactory>& metricsLogFactory() {
 }
 } // namespace
 
+/* static */ std::shared_ptr<const MetricsLog> MetricsLog::voidLog() {
+  static const MetricsLog kInstance{{}};
+  return {std::shared_ptr<const MetricsLog>{}, &kInstance};
+}
+
+/* static */ std::string MetricsLog::getMetricTypeName(Type type) {
+  switch (type) {
+    case Type::HEADER:
+      return "HEADER";
+    case Type::FOOTER:
+      return "FOOTER";
+    case Type::FILE:
+      return "FILE";
+    case Type::STRIPE:
+      return "STRIPE";
+    case Type::STRIPE_INDEX:
+      return "STRIPE_INDEX";
+    case Type::STRIPE_FOOTER:
+      return "STRIPE_FOOTER";
+    case Type::STREAM:
+      return "STREAM";
+    case Type::STREAM_BUNDLE:
+      return "STREAM_BUNDLE";
+    case Type::GROUP:
+      return "GROUP";
+    case Type::GROUP_INDEX:
+      return "GROUP_INDEX";
+    case Type::BLOCK:
+      return "BLOCK";
+    case Type::TEST:
+      return "TEST";
+    default:
+      VELOX_UNREACHABLE("Unknown MetricsLog type: {}", static_cast<int>(type));
+  }
+}
+
 void registerMetricsLogFactory(std::shared_ptr<DwioMetricsLogFactory> factory) {
   metricsLogFactory() = std::move(factory);
 }

--- a/velox/dwio/common/MetricsLog.h
+++ b/velox/dwio/common/MetricsLog.h
@@ -26,7 +26,8 @@ class MetricsLog {
   static constexpr std::string_view LIB_VERSION_STRING{"1.1"};
   static constexpr std::string_view WRITE_OPERATION{"WRITE"};
 
-  enum class MetricsType {
+  /// Identifies the type of metadata being read or logged for metrics purposes.
+  enum class Type {
     HEADER,
     FOOTER,
     FILE,
@@ -36,6 +37,7 @@ class MetricsLog {
     STREAM,
     STREAM_BUNDLE,
     GROUP,
+    GROUP_INDEX,
     BLOCK,
     TEST
   };
@@ -51,7 +53,7 @@ class MetricsLog {
       uint64_t footerSize,
       uint64_t readOffset,
       uint64_t readSize,
-      MetricsType type,
+      Type type,
       uint32_t numFileRead,
       uint32_t numStripeCache) const {}
 
@@ -124,45 +126,17 @@ class MetricsLog {
 
   virtual void logFileClose(const FileCloseMetrics& /* metrics */) const {}
 
-  static std::shared_ptr<const MetricsLog> voidLog() {
-    static const MetricsLog kInstance{{}};
-    return {std::shared_ptr<const MetricsLog>{}, &kInstance};
-  }
+  static std::shared_ptr<const MetricsLog> voidLog();
 
  protected:
   MetricsLog(const std::string& file) : file_{file} {}
 
-  static std::string getMetricTypeName(MetricsType type) {
-    switch (type) {
-      case MetricsType::HEADER:
-        return "HEADER";
-      case MetricsType::FOOTER:
-        return "FOOTER";
-      case MetricsType::FILE:
-        return "FILE";
-      case MetricsType::STRIPE:
-        return "STRIPE";
-      case MetricsType::STRIPE_INDEX:
-        return "STRIPE_INDEX";
-      case MetricsType::STRIPE_FOOTER:
-        return "STRIPE_FOOTER";
-      case MetricsType::STREAM:
-        return "STREAM";
-      case MetricsType::STREAM_BUNDLE:
-        return "STREAM_BUNDLE";
-      case MetricsType::GROUP:
-        return "GROUP";
-      case MetricsType::BLOCK:
-        return "BLOCK";
-      case MetricsType::TEST:
-        return "TEST";
-    }
-  }
+  static std::string getMetricTypeName(Type type);
 
   std::string file_;
 };
 
-using LogType = MetricsLog::MetricsType;
+using LogType = MetricsLog::Type;
 using MetricsLogPtr = std::shared_ptr<const MetricsLog>;
 
 class DwioMetricsLogFactory {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -733,6 +733,18 @@ class ReaderOptions : public io::ReaderOptions {
     selectiveNimbleReaderEnabled_ = value;
   }
 
+  /// Whether to cache file metadata (footer, stripes, index) in the
+  /// process-wide AsyncDataCache. When enabled, the first reader performs a
+  /// speculative tail read and populates the cache; subsequent readers on the
+  /// same file initialize from the cache with zero additional IO.
+  bool fileMetadataCacheEnabled() const {
+    return fileMetadataCacheEnabled_;
+  }
+
+  void setFileMetadataCacheEnabled(bool value) {
+    fileMetadataCacheEnabled_ = value;
+  }
+
   bool allowEmptyFile() const {
     return allowEmptyFile_;
   }
@@ -758,6 +770,7 @@ class ReaderOptions : public io::ReaderOptions {
   const tz::TimeZone* sessionTimezone_{nullptr};
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
+  bool fileMetadataCacheEnabled_{false};
   bool allowEmptyFile_{false};
 };
 

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -16,16 +16,20 @@
 
 #include "velox/dwio/common/BufferedInput.h"
 
+#include <fmt/core.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/caching/FileIds.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/dwio/common/DirectBufferedInput.h"
 #include "velox/dwio/dwrf/test/TestReadFile.h"
 
 using namespace facebook::velox::dwio::common;
+namespace cache = facebook::velox::cache;
+using facebook::velox::StringIdLease;
 using facebook::velox::common::Region;
 using namespace facebook::velox::memory;
 using namespace ::testing;
@@ -150,6 +154,128 @@ class BufferedInputTest : public testing::Test {
 
   const std::shared_ptr<MemoryPool> pool_ = memoryManager()->addLeafPool();
 };
+
+TEST_F(BufferedInputTest, hasCache) {
+  auto readFile =
+      std::make_shared<facebook::velox::InMemoryReadFile>(std::string("test"));
+  BufferedInput input(readFile, *pool_);
+  // Base BufferedInput does not have cache.
+  EXPECT_FALSE(input.hasCache());
+
+  // Cache APIs throw when there is no backing cache.
+  VELOX_ASSERT_THROW(
+      input.cacheRegion(0, 4, std::string_view("test")),
+      "cacheRegion requires a backing cache");
+  VELOX_ASSERT_THROW(
+      input.findCachedRegion(0), "findCachedRegion requires a backing cache");
+}
+
+TEST_F(BufferedInputTest, cachedRegion) {
+  auto dataCache = cache::AsyncDataCache::create(memoryManager()->allocator());
+
+  // Empty pin throws.
+  VELOX_ASSERT_THROW(
+      CachedRegion(cache::CachePin{}),
+      "CachedRegion requires a non-empty cache pin");
+
+  // Exclusive pin throws.
+  auto& ids = facebook::velox::fileIds();
+  {
+    StringIdLease fileId(ids, "exclusiveTestFile");
+    cache::RawFileCacheKey key{fileId.id(), 0};
+    auto pin = dataCache->findOrCreate(key, 100, nullptr);
+    ASSERT_FALSE(pin.empty());
+    ASSERT_TRUE(pin.checkedEntry()->isExclusive());
+    VELOX_ASSERT_THROW(
+        CachedRegion(std::move(pin)),
+        "CachedRegion requires a shared (non-exclusive) cache pin");
+  }
+
+  struct TestParam {
+    uint64_t entrySize;
+    bool expectTinyData;
+
+    std::string debugString() const {
+      return fmt::format(
+          "entrySize {}, expectTinyData {}", entrySize, expectTinyData);
+    }
+  };
+  std::vector<TestParam> testSettings = {
+      // Small entry uses tinyData (single contiguous range).
+      {100, true},
+      // Entry just below tinyData boundary still uses tinyData.
+      {cache::AsyncDataCacheEntry::kTinyDataSize - 1, true},
+      // Entry at tinyData boundary uses allocation.
+      {cache::AsyncDataCacheEntry::kTinyDataSize, false},
+      // One page allocation (single run).
+      {AllocationTraits::kPageSize, false},
+      // Large allocation (possibly multiple runs).
+      {128 << 10, false},
+  };
+
+  for (size_t i = 0; i < testSettings.size(); ++i) {
+    const auto& testData = testSettings[i];
+    SCOPED_TRACE(testData.debugString());
+
+    const auto entrySize = testData.entrySize;
+    std::string expected(entrySize, '\0');
+    for (uint64_t j = 0; j < entrySize; ++j) {
+      expected[j] = static_cast<char>('a' + (j % 26));
+    }
+
+    StringIdLease fileId(ids, fmt::format("cachedRegionTestFile_{}", i));
+    cache::RawFileCacheKey key{fileId.id(), 0};
+    auto pin = dataCache->findOrCreate(key, entrySize, nullptr);
+    ASSERT_FALSE(pin.empty());
+    auto* entry = pin.checkedEntry();
+    ASSERT_TRUE(entry->isExclusive());
+
+    // Populate the entry with test data.
+    if (testData.expectTinyData) {
+      ASSERT_NE(entry->tinyData(), nullptr);
+      memcpy(entry->tinyData(), expected.data(), entrySize);
+    } else {
+      auto& allocation = entry->data();
+      ASSERT_GT(allocation.numRuns(), 0);
+      uint64_t offset = 0;
+      for (int i = 0; i < allocation.numRuns() && offset < entrySize; ++i) {
+        auto run = allocation.runAt(i);
+        const uint64_t bytes = run.numPages() * AllocationTraits::kPageSize;
+        const uint64_t copySize = std::min(bytes, entrySize - offset);
+        memcpy(run.data<char>(), expected.data() + offset, copySize);
+        offset += copySize;
+      }
+    }
+    entry->setExclusiveToShared();
+
+    CachedRegion region(std::move(pin));
+    EXPECT_EQ(region.size(), entrySize);
+    ASSERT_FALSE(region.ranges().empty());
+
+    if (testData.expectTinyData) {
+      EXPECT_EQ(region.ranges().size(), 1);
+    }
+
+    // Verify content through ranges.
+    uint64_t verified = 0;
+    for (const auto& range : region.ranges()) {
+      EXPECT_EQ(
+          std::string_view(range.data(), range.size()),
+          std::string_view(expected.data() + verified, range.size()));
+      verified += range.size();
+    }
+    EXPECT_EQ(verified, entrySize);
+
+    // Verify toIOBuf produces identical content.
+    auto iobuf = region.toIOBuf();
+    EXPECT_EQ(iobuf.computeChainDataLength(), entrySize);
+    iobuf.coalesce();
+    EXPECT_EQ(
+        std::string_view(
+            reinterpret_cast<const char*>(iobuf.data()), iobuf.length()),
+        expected);
+  }
+}
 
 TEST_F(BufferedInputTest, zeroLengthStream) {
   auto readFile =

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/common/testutil/TestValue.h"
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/io/IOBuf.h>
 #include <folly/synchronization/Baton.h>
 
 #include <thread>
@@ -79,6 +80,59 @@ class CachedBufferedInputTest : public testing::Test {
   std::shared_ptr<AsyncDataCache> cache_;
   std::shared_ptr<IoStatistics> ioStatistics_;
   std::shared_ptr<ScanTracker> tracker_;
+};
+
+enum class CacheRegionApi {
+  kStringView,
+  kIOBuf,
+};
+
+std::string cacheRegionApiString(CacheRegionApi api) {
+  switch (api) {
+    case CacheRegionApi::kStringView:
+      return "StringView";
+    case CacheRegionApi::kIOBuf:
+      return "IOBuf";
+  }
+  VELOX_UNREACHABLE();
+}
+
+class CacheRegionTest : public CachedBufferedInputTest,
+                        public testing::WithParamInterface<CacheRegionApi> {
+ protected:
+  // Calls cacheRegion using the API selected by the test parameter.
+  // For IOBuf mode, splits the source data into multiple chained buffers
+  // to exercise the multi-buffer path.
+  void cacheRegionWithApi(
+      CachedBufferedInput& input,
+      uint64_t offset,
+      uint64_t length,
+      const char* data) {
+    switch (GetParam()) {
+      case CacheRegionApi::kStringView: {
+        input.cacheRegion(offset, length, std::string_view(data, length));
+        break;
+      }
+      case CacheRegionApi::kIOBuf: {
+        // Split data into 3 chained IOBufs to exercise multi-buffer cursor
+        // path. Also prepend a prefix to exercise non-zero bufferOffset.
+        constexpr uint64_t kPrefix = 37;
+        const std::string prefix(kPrefix, 'Z');
+        const uint64_t chunk1 = length / 3;
+        const uint64_t chunk2 = length / 3;
+        const uint64_t chunk3 = length - chunk1 - chunk2;
+
+        auto iobuf = folly::IOBuf::copyBuffer(prefix);
+        iobuf->appendToChain(folly::IOBuf::copyBuffer(data, chunk1));
+        iobuf->appendToChain(folly::IOBuf::copyBuffer(data + chunk1, chunk2));
+        iobuf->appendToChain(
+            folly::IOBuf::copyBuffer(data + chunk1 + chunk2, chunk3));
+        ASSERT_EQ(iobuf->computeChainDataLength(), kPrefix + length);
+        input.cacheRegion(offset, length, *iobuf, kPrefix);
+        break;
+      }
+    }
+  }
 };
 
 TEST_F(CachedBufferedInputTest, reset) {
@@ -479,4 +533,459 @@ DEBUG_ONLY_TEST_F(CachedBufferedInputTest, resetInputWithAfterLoading) {
   EXPECT_EQ(stats.numEntries, 2);
   EXPECT_EQ(stats.numExclusive, 0);
 }
+
+TEST_F(CachedBufferedInputTest, hasCache) {
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content;
+  content.resize(kContentSize);
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  // CachedBufferedInput always has cache.
+  EXPECT_TRUE(input.hasCache());
+}
+
+TEST_P(CacheRegionTest, cacheAndFind) {
+  SCOPED_TRACE(cacheRegionApiString(GetParam()));
+  constexpr int32_t kContentSize = 1 << 20; // 1MB
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile_cacheAndFind");
+  StringIdLease groupId(ids, "testGroup_cacheAndFind");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  // Initially no regions are cached.
+  EXPECT_FALSE(input.findCachedRegion(0).has_value());
+  EXPECT_FALSE(input.findCachedRegion(1000).has_value());
+
+  // Cache a small region (fits in tinyData path).
+  constexpr uint64_t kSmallSize = 100;
+  cacheRegionWithApi(input, 0, kSmallSize, content.data());
+
+  EXPECT_TRUE(input.findCachedRegion(0).has_value());
+  EXPECT_FALSE(input.findCachedRegion(1000).has_value());
+
+  // Verify cached data is readable via read().
+  auto stream = input.read(0, kSmallSize, LogType::FILE);
+  auto next = getNext(*stream);
+  ASSERT_TRUE(next.has_value());
+  EXPECT_EQ(next.value(), content.substr(0, kSmallSize));
+
+  // Cache a larger region.
+  constexpr uint64_t kLargeOffset = 1000;
+  constexpr uint64_t kLargeSize = 64 * 1024; // 64KB
+  cacheRegionWithApi(
+      input, kLargeOffset, kLargeSize, content.data() + kLargeOffset);
+
+  EXPECT_TRUE(input.findCachedRegion(kLargeOffset).has_value());
+
+  // Verify large cached data is readable.
+  auto stream2 = input.read(kLargeOffset, kLargeSize, LogType::FILE);
+  std::string readBack;
+  readBack.resize(kLargeSize);
+  stream2->readFully(readBack.data(), kLargeSize);
+  EXPECT_EQ(readBack, content.substr(kLargeOffset, kLargeSize));
+
+  // Caching the same region again is a no-op (already cached).
+  cacheRegionWithApi(input, 0, kSmallSize, content.data());
+  EXPECT_TRUE(input.findCachedRegion(0).has_value());
+
+  auto stats = cache_->refreshStats();
+  EXPECT_EQ(stats.numEntries, 2);
+}
+
+TEST_P(CacheRegionTest, smallEntry) {
+  SCOPED_TRACE(cacheRegionApiString(GetParam()));
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile_smallEntry");
+  StringIdLease groupId(ids, "testGroup_smallEntry");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr uint64_t kOffset = 0;
+  constexpr uint64_t kSize = 100;
+  static_assert(kSize < AsyncDataCacheEntry::kTinyDataSize);
+
+  EXPECT_FALSE(input.findCachedRegion(kOffset).has_value());
+
+  cacheRegionWithApi(input, kOffset, kSize, content.data() + kOffset);
+
+  auto result = input.findCachedRegion(kOffset);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->size(), kSize);
+
+  // Small entry should have exactly one contiguous range.
+  const auto& ranges = result->ranges();
+  ASSERT_EQ(ranges.size(), 1);
+  EXPECT_EQ(ranges[0].size(), kSize);
+  EXPECT_EQ(
+      std::string_view(ranges[0].data(), ranges[0].size()),
+      std::string_view(content.data() + kOffset, kSize));
+
+  // toIOBuf on a small (single-range) entry produces a single IOBuf.
+  auto iobuf = result->toIOBuf();
+  EXPECT_FALSE(iobuf.isChained());
+  EXPECT_EQ(iobuf.length(), kSize);
+  EXPECT_EQ(
+      std::string_view(
+          reinterpret_cast<const char*>(iobuf.data()), iobuf.length()),
+      std::string_view(content.data() + kOffset, kSize));
+}
+
+TEST_P(CacheRegionTest, largeEntry) {
+  SCOPED_TRACE(cacheRegionApiString(GetParam()));
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile_largeEntry");
+  StringIdLease groupId(ids, "testGroup_largeEntry");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr uint64_t kOffset = 0;
+  constexpr uint64_t kSize = 64 * 1024; // 64KB
+  static_assert(kSize >= AsyncDataCacheEntry::kTinyDataSize);
+
+  cacheRegionWithApi(input, kOffset, kSize, content.data() + kOffset);
+
+  auto result = input.findCachedRegion(kOffset);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->size(), kSize);
+
+  // Large entry may have multiple ranges. Verify total size and content.
+  const auto& ranges = result->ranges();
+  ASSERT_GT(ranges.size(), 0);
+
+  uint64_t totalSize = 0;
+  std::string reassembled;
+  reassembled.reserve(kSize);
+  for (const auto& range : ranges) {
+    EXPECT_GT(range.size(), 0);
+    reassembled.append(range.data(), range.size());
+    totalSize += range.size();
+  }
+  EXPECT_EQ(totalSize, kSize);
+  EXPECT_EQ(reassembled, content.substr(kOffset, kSize));
+
+  // toIOBuf total length matches and content matches.
+  auto iobuf = result->toIOBuf();
+  EXPECT_EQ(iobuf.computeChainDataLength(), kSize);
+
+  std::string fromIobuf;
+  fromIobuf.reserve(kSize);
+  const auto* current = &iobuf;
+  do {
+    fromIobuf.append(
+        reinterpret_cast<const char*>(current->data()), current->length());
+    current = current->next();
+  } while (current != &iobuf);
+  EXPECT_EQ(fromIobuf, content.substr(kOffset, kSize));
+}
+
+TEST_P(CacheRegionTest, miss) {
+  SCOPED_TRACE(cacheRegionApiString(GetParam()));
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content(kContentSize, 'x');
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile_miss");
+  StringIdLease groupId(ids, "testGroup_miss");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  EXPECT_FALSE(input.findCachedRegion(0).has_value());
+  EXPECT_FALSE(input.findCachedRegion(12345).has_value());
+}
+
+TEST_P(CacheRegionTest, pinKeepsDataAlive) {
+  SCOPED_TRACE(cacheRegionApiString(GetParam()));
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile_pinAlive");
+  StringIdLease groupId(ids, "testGroup_pinAlive");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr uint64_t kSize = 100;
+  cacheRegionWithApi(input, 0, kSize, content.data());
+
+  auto cached = input.findCachedRegion(0);
+  ASSERT_TRUE(cached.has_value());
+
+  auto stats = cache_->refreshStats();
+  EXPECT_GT(stats.sharedPinnedBytes, 0);
+
+  const auto& ranges = cached->ranges();
+  ASSERT_EQ(ranges.size(), 1);
+  EXPECT_EQ(
+      std::string_view(ranges[0].data(), ranges[0].size()),
+      std::string_view(content.data(), kSize));
+
+  // Move into a new optional — pin transfers, data stays valid.
+  auto moved = std::move(cached);
+  ASSERT_TRUE(moved.has_value());
+  EXPECT_EQ(moved->size(), kSize);
+  EXPECT_EQ(moved->ranges().size(), 1);
+  EXPECT_EQ(
+      std::string_view(moved->ranges()[0].data(), moved->ranges()[0].size()),
+      std::string_view(content.data(), kSize));
+
+  stats = cache_->refreshStats();
+  EXPECT_GT(stats.sharedPinnedBytes, 0);
+
+  // Dropping the moved CachedRegion releases the pin.
+  moved.reset();
+  stats = cache_->refreshStats();
+  EXPECT_EQ(stats.sharedPinnedBytes, 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CacheRegionTest,
+    CacheRegionTest,
+    testing::Values(CacheRegionApi::kStringView, CacheRegionApi::kIOBuf),
+    [](const testing::TestParamInfo<CacheRegionApi>& info) {
+      return cacheRegionApiString(info.param);
+    });
+
+TEST_F(CachedBufferedInputTest, findCachedRegionExclusiveWithWait) {
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  const std::string fileName = "testFile_findWait";
+  StringIdLease fileId(ids, fileName);
+  StringIdLease groupId(ids, "testGroup_findWait");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr uint64_t kOffset = 0;
+  constexpr uint64_t kSize = 100;
+
+  // Create an exclusive entry using the same file ID as the
+  // CachedBufferedInput.
+  StringIdLease sameFileId(ids, fileName);
+  RawFileCacheKey key{sameFileId.id(), kOffset};
+  auto exclusivePin = cache_->findOrCreate(key, kSize, nullptr);
+  ASSERT_FALSE(exclusivePin.empty());
+  ASSERT_TRUE(exclusivePin.entry()->isExclusive());
+
+  // Spawn a thread that calls findCachedRegion — it will block waiting for
+  // the exclusive entry to become shared.
+  std::atomic_bool findFinished{false};
+  std::optional<CachedRegion> findResult;
+  std::thread findThread([&]() {
+    findResult = input.findCachedRegion(kOffset);
+    findFinished.store(true, std::memory_order_release);
+  });
+
+  // Give the thread time to enter the wait state.
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  ASSERT_FALSE(findFinished.load(std::memory_order_acquire));
+
+  // Populate the entry and transition to shared.
+  auto* entry = exclusivePin.entry();
+  ASSERT_LT(kSize, AsyncDataCacheEntry::kTinyDataSize);
+  ::memcpy(entry->tinyData(), content.data() + kOffset, kSize);
+  entry->setExclusiveToShared();
+  exclusivePin.clear();
+
+  // The findCachedRegion thread should now complete.
+  findThread.join();
+  ASSERT_TRUE(findFinished.load(std::memory_order_acquire));
+
+  // Verify the returned CachedRegion has correct data.
+  ASSERT_TRUE(findResult.has_value());
+  EXPECT_EQ(findResult->size(), kSize);
+  const auto& ranges = findResult->ranges();
+  ASSERT_EQ(ranges.size(), 1);
+  EXPECT_EQ(
+      std::string_view(ranges[0].data(), ranges[0].size()),
+      std::string_view(content.data() + kOffset, kSize));
+}
+
+TEST_F(CachedBufferedInputTest, cacheRegionSkipsOngoingInsert) {
+  constexpr int32_t kContentSize = 1 << 20;
+  std::string content;
+  content.resize(kContentSize);
+  for (int32_t i = 0; i < kContentSize; ++i) {
+    content[i] = static_cast<char>('a' + (i % 26));
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  auto& ids = fileIds();
+  const std::string fileName = "testFile_skipInsert";
+  StringIdLease fileId(ids, fileName);
+  StringIdLease groupId(ids, "testGroup_skipInsert");
+
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  constexpr uint64_t kOffset = 0;
+  constexpr uint64_t kSize = 100;
+
+  // Simulate an ongoing insert by creating an exclusive entry directly.
+  StringIdLease sameFileId(ids, fileName);
+  RawFileCacheKey key{sameFileId.id(), kOffset};
+  auto exclusivePin = cache_->findOrCreate(key, kSize, nullptr);
+  ASSERT_FALSE(exclusivePin.empty());
+  ASSERT_TRUE(exclusivePin.entry()->isExclusive());
+
+  // cacheRegion with different data should return immediately without blocking
+  // or overwriting (the entry is already exclusively held by another
+  // operation).
+  const std::string differentData(kSize, 'X');
+  input.cacheRegion(kOffset, kSize, std::string_view(differentData));
+
+  // The entry should still be exclusive — cacheRegion gave up.
+  ASSERT_TRUE(exclusivePin.entry()->isExclusive());
+
+  // Complete the original insert with the real data.
+  auto* entry = exclusivePin.entry();
+  ASSERT_LT(kSize, AsyncDataCacheEntry::kTinyDataSize);
+  ::memcpy(entry->tinyData(), content.data() + kOffset, kSize);
+  entry->setExclusiveToShared();
+  exclusivePin.clear();
+
+  // findCachedRegion should return the original data, not the 'X' data
+  // that cacheRegion tried to write.
+  auto cached = input.findCachedRegion(kOffset);
+  ASSERT_TRUE(cached.has_value());
+  EXPECT_EQ(cached->size(), kSize);
+  const auto& ranges = cached->ranges();
+  ASSERT_EQ(ranges.size(), 1);
+  EXPECT_EQ(
+      std::string_view(ranges[0].data(), ranges[0].size()),
+      std::string_view(content.data() + kOffset, kSize));
+  // Verify it's NOT the data passed to cacheRegion.
+  EXPECT_NE(
+      std::string_view(ranges[0].data(), ranges[0].size()),
+      std::string_view(differentData));
+}
+
 } // namespace

--- a/velox/dwio/common/tests/DirectBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/DirectBufferedInputTest.cpp
@@ -486,4 +486,33 @@ DEBUG_ONLY_TEST_F(DirectBufferedInputTest, resetInputWithAfterLoading) {
   }
 }
 
+TEST_F(DirectBufferedInputTest, hasCache) {
+  std::string content(1024, 'x');
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  DirectBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      nullptr,
+      executor_.get(),
+      readerOptions);
+
+  ASSERT_FALSE(input.hasCache());
+  VELOX_ASSERT_THROW(
+      input.cacheRegion(0, 10, std::string_view("0123456789")),
+      "cacheRegion requires a backing cache");
+  VELOX_ASSERT_THROW(
+      input.findCachedRegion(0), "findCachedRegion requires a backing cache");
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
CONTEXT:
Nimble's TabletReader needs to probe the Velox async data cache for
metadata entries and populate cache from speculative tail reads. The
existing APIs require findOrCreate (which creates exclusive entries on
miss that must be immediately discarded) and contiguous buffers for
cache population.

WHAT:
- Add CacheShard::find() / AsyncDataCache::find() — lookup-only cache
  probe that returns a shared-mode pin on hit, empty pin on miss,
  without creating exclusive entries.
- Add CachedRegion wrapper — holds a shared-mode pin and exposes
  zero-copy access to cached data via buffer ranges and toIOBuf().
- Add BufferedInput::findCachedRegion() — returns CachedRegion on cache
  hit for a given offset.
- Add BufferedInput::cacheRegion(IOBuf) overload — populates cache
  directly from IOBuf chain using folly::io::Cursor, avoiding the need
  to coalesce the IOBuf first. The string_view overload delegates to
  the IOBuf overload.

Differential Revision: D94871321
