### PR TITLE
perf: Batch fill output indices in MergeJoin cross product

### DIFF
--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #pragma once
+#include <algorithm>
+#include <numeric>
 #include <string_view>
 
 #include <folly/container/F14Map.h>
@@ -261,6 +263,19 @@ class MergeJoin : public Operator {
       vector_size_t leftRow,
       const RowVectorPtr& rightBatch,
       vector_size_t rightRow);
+
+  // Batch-fills output indices for a contiguous range of inner rows paired with
+  // a single outer row. Uses std::fill/std::iota instead of per-row stores.
+  // Returns the number of rows added (may be less than requested if output is
+  // full). Falls back to per-row tryAddOutputRow when filter or anti-join
+  // tracking is needed.
+  template <bool IsLeftJoin>
+  vector_size_t addOutputRowsForRange(
+      const RowVectorPtr& outerBatch,
+      vector_size_t outerRow,
+      const RowVectorPtr& innerBatch,
+      vector_size_t innerStartRow,
+      vector_size_t innerEndRow);
 
   // If the right side projected columns in the current output vector happen to
   // span more than one vector from the right side, they cannot be simply

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -567,17 +567,25 @@ TEST_F(MergeJoinTest, mixedCardinalityKeys) {
   auto leftKeys = makeFlatVector<int32_t>(600, [](auto row) {
     // key=1 for rows 0-199, key=2 for row 200, key=3 for rows 201-400,
     // key=4 for row 401, ...
-    if (row <= 199) return 1;
-    if (row == 200) return 2;
-    if (row <= 400) return 3;
-    if (row == 401) return 4;
+    if (row <= 199)
+      return 1;
+    if (row == 200)
+      return 2;
+    if (row <= 400)
+      return 3;
+    if (row == 401)
+      return 4;
     return 5;
   });
   auto rightKeys = makeFlatVector<int32_t>(600, [](auto row) {
-    if (row <= 199) return 1;
-    if (row == 200) return 2;
-    if (row <= 400) return 3;
-    if (row == 401) return 4;
+    if (row <= 199)
+      return 1;
+    if (row == 200)
+      return 2;
+    if (row <= 400)
+      return 3;
+    if (row == 401)
+      return 4;
     return 5;
   });
 

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -517,6 +517,73 @@ TEST_F(MergeJoinTest, keySkew) {
       [](auto row) { return row < 10 ? row : row + 10240; });
 }
 
+// Tests for batch-filled output indices in addOutputRowsForRange.
+TEST_F(MergeJoinTest, highCardinalityCrossProduct) {
+  // 500 left rows (2 batches) × 300 right rows = 150,000 output rows.
+  // Small batch size forces many cursor save/restore cycles.
+  std::vector<VectorPtr> leftKeys = {
+      makeFlatVector<int32_t>(250, [](auto) { return 42; }),
+      makeFlatVector<int32_t>(250, [](auto) { return 42; }),
+  };
+  std::vector<VectorPtr> rightKeys = {
+      makeFlatVector<int32_t>(300, [](auto) { return 42; }),
+  };
+
+  testJoin(leftKeys, rightKeys);
+  testJoin(rightKeys, leftKeys);
+}
+
+TEST_F(MergeJoinTest, multiBatchMatch) {
+  // Both sides span 2 batches with the same key, stressing cursor logic.
+  std::vector<VectorPtr> leftKeys = {
+      makeFlatVector<int32_t>(100, [](auto) { return 7; }),
+      makeFlatVector<int32_t>(100, [](auto) { return 7; }),
+  };
+  std::vector<VectorPtr> rightKeys = {
+      makeFlatVector<int32_t>(150, [](auto) { return 7; }),
+      makeFlatVector<int32_t>(50, [](auto) { return 7; }),
+  };
+
+  testJoin(leftKeys, rightKeys);
+  testJoin(rightKeys, leftKeys);
+}
+
+TEST_F(MergeJoinTest, asymmetricMatch) {
+  // 1 left row × many right rows, and vice versa.
+  std::vector<VectorPtr> leftKeys = {
+      makeFlatVector<int32_t>(1, [](auto) { return 10; }),
+  };
+  std::vector<VectorPtr> rightKeys = {
+      makeFlatVector<int32_t>(5000, [](auto) { return 10; }),
+  };
+
+  testJoin(leftKeys, rightKeys);
+  testJoin(rightKeys, leftKeys);
+}
+
+TEST_F(MergeJoinTest, mixedCardinalityKeys) {
+  // Alternating high-cardinality and single-row keys tests state cleanup
+  // between matches.
+  auto leftKeys = makeFlatVector<int32_t>(600, [](auto row) {
+    // key=1 for rows 0-199, key=2 for row 200, key=3 for rows 201-400,
+    // key=4 for row 401, ...
+    if (row <= 199) return 1;
+    if (row == 200) return 2;
+    if (row <= 400) return 3;
+    if (row == 401) return 4;
+    return 5;
+  });
+  auto rightKeys = makeFlatVector<int32_t>(600, [](auto row) {
+    if (row <= 199) return 1;
+    if (row == 200) return 2;
+    if (row <= 400) return 3;
+    if (row == 401) return 4;
+    return 5;
+  });
+
+  testJoin({leftKeys}, {rightKeys});
+}
+
 TEST_F(MergeJoinTest, aggregationOverJoin) {
   auto left =
       makeRowVector({"t_c0"}, {makeFlatVector<int32_t>({1, 2, 3, 4, 5})});


### PR DESCRIPTION
This PR optimizes `MergeJoin::addToOutputImpl()` by replacing per row `tryAddOutputRow` calls with a new `addOutputRowsForRange` method that batch-fills output dictionary indices using `std::fill`, `std::iota` for contiguous inner row ranges. `addOutputRowsForRange<IsLeftJoin>()` precomputes how many rows fit and:
- Fast path (no filter, no anti-join): uses `std::fill` for the constant-side indices and `std::iota` for the sequential-side indices, replacing n scalar stores with two vectorizable bulk operations. Handles `isRightFlattened`_ with batched copy().
- Fallback path (filter or anti-join): delegates to per row `tryAddOutputRow` since `joinTracker::addMatch` has per row state dependencies.