### PR TITLE
fix: Iceberg positional delete compare base64 encoded value with raw value

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergMetadataColumns.h
+++ b/velox/connectors/hive/iceberg/IcebergMetadataColumns.h
@@ -28,6 +28,11 @@ struct IcebergMetadataColumn {
   std::shared_ptr<const Type> type;
   std::string doc;
 
+  // Position delete file's metadata column ID, see
+  // https://iceberg.apache.org/spec/#position-delete-files.
+  static constexpr int32_t kPosId = 2'147'483'545;
+  static constexpr int32_t kFilePathId = 2'147'483'546;
+
   IcebergMetadataColumn(
       int _id,
       const std::string& _name,
@@ -37,7 +42,7 @@ struct IcebergMetadataColumn {
 
   static std::shared_ptr<IcebergMetadataColumn> icebergDeleteFilePathColumn() {
     return std::make_shared<IcebergMetadataColumn>(
-        2147483546,
+        kFilePathId,
         "file_path",
         VARCHAR(),
         "Path of a file in which a deleted row is stored");
@@ -45,7 +50,7 @@ struct IcebergMetadataColumn {
 
   static std::shared_ptr<IcebergMetadataColumn> icebergDeletePosColumn() {
     return std::make_shared<IcebergMetadataColumn>(
-        2147483545,
+        kPosId,
         "pos",
         BIGINT(),
         "Ordinal position of a deleted row in the data file");

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -16,6 +16,9 @@
 
 #include "velox/connectors/hive/iceberg/IcebergSplitReader.h"
 
+#include <folly/lang/Bits.h>
+
+#include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
@@ -82,11 +85,19 @@ void IcebergSplitReader::prepareSplit(
         // Skip the delete file if all delete positions are before this split.
         // TODO: Skip delete files where all positions are after the split, if
         // split row count becomes available.
-        auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
-        if (auto posUpperBoundIt = deleteFile.upperBounds.find(posColumn->id);
-            posUpperBoundIt != deleteFile.upperBounds.end()) {
-          auto deleteUpperBound = folly::to<uint64_t>(posUpperBoundIt->second);
-          if (deleteUpperBound < splitOffset_) {
+        if (auto iter =
+                deleteFile.upperBounds.find(IcebergMetadataColumn::kPosId);
+            iter != deleteFile.upperBounds.end()) {
+          auto decodedBound = encoding::Base64::decode(iter->second);
+          VELOX_CHECK_EQ(
+              decodedBound.size(),
+              sizeof(uint64_t),
+              "Unexpected decoded size for positional delete upper bound.");
+          uint64_t posDeleteUpperBound;
+          std::memcpy(
+              &posDeleteUpperBound, decodedBound.data(), sizeof(uint64_t));
+          posDeleteUpperBound = folly::Endian::little(posDeleteUpperBound);
+          if (posDeleteUpperBound < splitOffset_) {
             continue;
           }
         }

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -15,7 +15,9 @@
  */
 
 #include <folly/Singleton.h>
+#include <folly/lang/Bits.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/encode/Base64.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/iceberg/IcebergConnector.h"
@@ -920,7 +922,13 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
        makeFlatVector<int64_t>({0, 1, 2})})};
   writeToFile(deleteFilePath->getPath(), deleteVectors);
 
-  // upperBound "2" is the max position in the delete file.
+  // upperBound "2" is the max position in the delete file. Iceberg stores
+  // long bounds as 8-byte little-endian binary, then Base64 encodes them.
+  uint64_t upperBound = 2;
+  auto upperBoundLE = folly::Endian::little(upperBound);
+  auto encodedUpperBound = encoding::Base64::encode(
+      std::string_view(
+          reinterpret_cast<const char*>(&upperBoundLE), sizeof(upperBoundLE)));
   IcebergDeleteFile deleteFile(
       FileContent::kPositionalDeletes,
       deleteFilePath->getPath(),
@@ -930,7 +938,7 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
           std::fopen(deleteFilePath->getPath().c_str(), "r")),
       {},
       {},
-      {{posColumn->id, "2"}});
+      {{posColumn->id, encodedUpperBound}});
 
   auto plan = PlanBuilder()
                   .startTableScan()


### PR DESCRIPTION
When reading Iceberg positional delete files, the IcebergSplitReader optimizes away irrelevant delete files by comparing the delete file's **upper_bounds** statistic against the current split's starting row offset.
This PR fixes a bugs in that logic. Iceberg stores column statistics (lower_bounds / upper_bounds) in manifests as Base64-encoded, little-endian binary values (for long type). For a long column (such as the positional delete `pos` column), the value is an 8-byte little-endian integer, Base64-encoded.
Previously it passed the raw Base64 string directly to folly::to<uint64_t>(), which attempts to parse it as a decimal string. For example, the value `CgAAAAAAAAA=` should be decoded to integer 10, but folly::to<uint64_t>("CgAAAAAAAAA=") throws exception.
This PR fix this by decoding the upper bound first and then reinterpret the bytes as uint64_t and then apply `folly::Endian::little()` to convert from the iceberg spec specified little-endian encoding to host byte order before comparing against splitOffset_.

This fixes the issue https://github.com/prestodb/presto/issues/27237