### PR TITLE
refactor: Remove deprecated filterPushdownEnabled from HiveTableHandle

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -107,7 +107,6 @@ void HiveColumnHandle::registerSerDe() {
 HiveTableHandle::HiveTableHandle(
     std::string connectorId,
     const std::string& tableName,
-    bool filterPushdownEnabled,
     common::SubfieldFilters subfieldFilters,
     const core::TypedExprPtr& remainingFilter,
     const RowTypePtr& dataColumns,
@@ -117,7 +116,6 @@ HiveTableHandle::HiveTableHandle(
     double sampleRate)
     : ConnectorTableHandle(std::move(connectorId)),
       tableName_(tableName),
-      filterPushdownEnabled_(filterPushdownEnabled),
       subfieldFilters_(std::move(subfieldFilters)),
       remainingFilter_(remainingFilter),
       sampleRate_(sampleRate),
@@ -132,7 +130,6 @@ HiveTableHandle::HiveTableHandle(
 HiveTableHandle::HiveTableHandle(
     std::string connectorId,
     const std::string& tableName,
-    bool filterPushdownEnabled,
     common::SubfieldFilters subfieldFilters,
     const core::TypedExprPtr& remainingFilter,
     const RowTypePtr& dataColumns,
@@ -142,7 +139,6 @@ HiveTableHandle::HiveTableHandle(
     : HiveTableHandle(
           std::move(connectorId),
           tableName,
-          filterPushdownEnabled,
           std::move(subfieldFilters),
           remainingFilter,
           dataColumns,
@@ -213,7 +209,6 @@ std::string HiveTableHandle::toString() const {
 folly::dynamic HiveTableHandle::serialize() const {
   folly::dynamic obj = ConnectorTableHandle::serializeBase("HiveTableHandle");
   obj["tableName"] = tableName_;
-  obj["filterPushdownEnabled"] = filterPushdownEnabled_;
 
   folly::dynamic subfieldFilters = folly::dynamic::array;
   for (const auto& [subfield, filter] : subfieldFilters_) {
@@ -263,7 +258,6 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     void* context) {
   auto connectorId = obj["connectorId"].asString();
   auto tableName = obj["tableName"].asString();
-  auto filterPushdownEnabled = obj["filterPushdownEnabled"].asBool();
 
   core::TypedExprPtr remainingFilter;
   if (auto it = obj.find("remainingFilter"); it != obj.items().end()) {
@@ -316,7 +310,6 @@ ConnectorTableHandlePtr HiveTableHandle::create(
   return std::make_shared<const HiveTableHandle>(
       connectorId,
       tableName,
-      filterPushdownEnabled,
       std::move(subfieldFilters),
       remainingFilter,
       dataColumns,

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -165,7 +165,6 @@ class HiveTableHandle : public ConnectorTableHandle {
   HiveTableHandle(
       std::string connectorId,
       const std::string& tableName,
-      bool filterPushdownEnabled,
       common::SubfieldFilters subfieldFilters,
       const core::TypedExprPtr& remainingFilter,
       const RowTypePtr& dataColumns = nullptr,
@@ -179,13 +178,36 @@ class HiveTableHandle : public ConnectorTableHandle {
   HiveTableHandle(
       std::string connectorId,
       const std::string& tableName,
-      bool filterPushdownEnabled,
       common::SubfieldFilters subfieldFilters,
       const core::TypedExprPtr& remainingFilter,
       const RowTypePtr& dataColumns,
       const std::unordered_map<std::string, std::string>& tableParameters,
       std::vector<HiveColumnHandlePtr> filterColumnHandles,
       double sampleRate = 1.0);
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  /// Backward-compatible constructors that accept and ignore the deprecated
+  /// 'filterPushdownEnabled' param.
+  HiveTableHandle(
+      std::string connectorId,
+      const std::string& tableName,
+      bool /*filterPushdownEnabled*/,
+      common::SubfieldFilters subfieldFilters,
+      const core::TypedExprPtr& remainingFilter,
+      const RowTypePtr& dataColumns = nullptr,
+      const std::unordered_map<std::string, std::string>& tableParameters = {},
+      std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
+      double sampleRate = 1.0)
+      : HiveTableHandle(
+            std::move(connectorId),
+            tableName,
+            std::move(subfieldFilters),
+            remainingFilter,
+            dataColumns,
+            tableParameters,
+            std::move(filterColumnHandles),
+            sampleRate) {}
+#endif
 
   const std::string& tableName() const {
     return tableName_;
@@ -201,10 +223,6 @@ class HiveTableHandle : public ConnectorTableHandle {
 
   bool needsIndexSplit() const override {
     return true;
-  }
-
-  [[deprecated]] bool isFilterPushdownEnabled() const {
-    return filterPushdownEnabled_;
   }
 
   /// Single field filters that can be applied efficiently during file reading.
@@ -267,7 +285,6 @@ class HiveTableHandle : public ConnectorTableHandle {
 
  private:
   const std::string tableName_;
-  const bool filterPushdownEnabled_;
   const common::SubfieldFilters subfieldFilters_;
   const core::TypedExprPtr remainingFilter_;
   const double sampleRate_;

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -282,7 +282,6 @@ void IcebergSplitReaderBenchmark::readSingleColumn(
       std::make_shared<HiveTableHandle>(
           "kHiveConnectorId",
           "tableName",
-          false,
           std::move(filters),
           remainingFilterExpr,
           rowType);

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -141,7 +141,6 @@ TEST_F(HiveConnectorSerDeTest, hiveTableHandle) {
         "hive_table",
         ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}),
         indexColumns,
-        /*filterPushdownEnabled=*/true,
         {{dwio::common::TableParameter::kSkipHeaderLineCount, "1"}});
 
     EXPECT_EQ(tableHandle->supportsIndexLookup(), withIndexColumns);

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -103,7 +103,6 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
     return std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",
         "testTable",
-        false,
         common::SubfieldFilters{},
         nullptr,
         nullptr,
@@ -330,7 +329,6 @@ TEST_F(HiveConnectorUtilTest, cacheRetention) {
     auto tableHandle = std::make_shared<hive::HiveTableHandle>(
         "testConnectorId",
         "testTable",
-        false,
         common::SubfieldFilters{},
         nullptr,
         nullptr,

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -62,7 +62,6 @@ TEST(TableHandleTest, hiveTableHandleIndexSupport) {
       std::make_shared<connector::hive::HiveTableHandle>(
           "test-connector",
           "test_table",
-          /*filterPushdownEnabled=*/true,
           common::SubfieldFilters{},
           /*remainingFilter=*/nullptr,
           /*dataColumns=*/nullptr,
@@ -77,7 +76,6 @@ TEST(TableHandleTest, hiveTableHandleIndexSupport) {
       std::make_shared<connector::hive::HiveTableHandle>(
           "test-connector",
           "test_table",
-          /*filterPushdownEnabled=*/true,
           common::SubfieldFilters{},
           /*remainingFilter=*/nullptr,
           /*dataColumns=*/nullptr,

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1132,7 +1132,7 @@ TEST_F(TableScanTest, missingColumns) {
   common::SubfieldFilters filters;
   filters[common::Subfield("c1")] = lessThanOrEqualDouble(1050.0, true);
   auto tableHandle = std::make_shared<HiveTableHandle>(
-      kHiveConnectorId, "tmp", true, std::move(filters), nullptr, dataColumns);
+      kHiveConnectorId, "tmp", std::move(filters), nullptr, dataColumns);
   connector::ColumnHandleMap assignments;
   assignments["c0"] = regularColumn("c0", BIGINT());
   op = PlanBuilder(pool_.get())
@@ -2017,7 +2017,7 @@ TEST_F(TableScanTest, partitionedTableDateKey) {
         18506, std::numeric_limits<int64_t>::max(), false);
 
     auto tableHandle = std::make_shared<HiveTableHandle>(
-        "test-hive", "hive_table", true, std::move(filters), nullptr, nullptr);
+        "test-hive", "hive_table", std::move(filters), nullptr, nullptr);
     auto op = std::make_shared<TableScanNode>(
         "0",
         std::move(outputType),
@@ -2203,12 +2203,7 @@ TEST_F(TableScanTest, partitionedTableTimestampKey) {
       filters[common::Subfield("pkey")] =
           std::make_unique<common::TimestampRange>(lower, lower, false);
       auto tableHandle = std::make_shared<HiveTableHandle>(
-          "test-hive",
-          "hive_table",
-          true,
-          std::move(filters),
-          nullptr,
-          nullptr);
+          "test-hive", "hive_table", std::move(filters), nullptr, nullptr);
 
       return PlanBuilder()
           .startTableScan()

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -135,13 +135,11 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::string& tableName = "hive_table",
       const RowTypePtr& dataColumns = nullptr,
       const std::vector<std::string>& indexColumns = {},
-      bool filterPushdownEnabled = true,
       const std::unordered_map<std::string, std::string>& tableParameters =
           {}) {
     return std::make_shared<connector::hive::HiveTableHandle>(
         kHiveConnectorId,
         tableName,
-        filterPushdownEnabled,
         std::move(subfieldFilters),
         remainingFilter,
         dataColumns,

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -386,7 +386,6 @@ core::PlanNodePtr PlanBuilder::TableScanBuilder::build(core::PlanNodeId id) {
     tableHandle_ = std::make_shared<HiveTableHandle>(
         connectorId_,
         tableName_,
-        true,
         std::move(subfieldFiltersMap_),
         remainingFilterExpr,
         dataColumns_,

--- a/velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.cpp
@@ -36,13 +36,11 @@ std::string CudfHiveColumnHandle::toString() const {
 CudfHiveTableHandle::CudfHiveTableHandle(
     std::string connectorId,
     const std::string& tableName,
-    bool filterPushdownEnabled,
     const core::TypedExprPtr& subfieldFilterExpr,
     const core::TypedExprPtr& remainingFilter,
     const RowTypePtr& dataColumns)
     : ConnectorTableHandle(std::move(connectorId)),
       tableName_(tableName),
-      filterPushdownEnabled_(filterPushdownEnabled),
       subfieldFilterExpr_(subfieldFilterExpr),
       remainingFilter_(remainingFilter),
       dataColumns_(dataColumns) {}

--- a/velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveTableHandle.h
@@ -74,17 +74,12 @@ class CudfHiveTableHandle : public ConnectorTableHandle {
   CudfHiveTableHandle(
       std::string connectorId,
       const std::string& tableName,
-      bool filterPushdownEnabled,
       const core::TypedExprPtr& subfieldFilterExpr,
       const core::TypedExprPtr& remainingFilter = nullptr,
       const RowTypePtr& dataColumns = nullptr);
 
   const std::string& name() const override {
     return tableName_;
-  }
-
-  bool isFilterPushdownEnabled() const {
-    return filterPushdownEnabled_;
   }
 
   const core::TypedExprPtr& subfieldFilterExpr() const {
@@ -108,7 +103,6 @@ class CudfHiveTableHandle : public ConnectorTableHandle {
 
  private:
   const std::string tableName_;
-  const bool filterPushdownEnabled_;
   // This expression is used for predicate pushdown.
   const core::TypedExprPtr subfieldFilterExpr_;
   // This expression is used for post-scan filtering.

--- a/velox/experimental/cudf/tests/S3ReadTest.cpp
+++ b/velox/experimental/cudf/tests/S3ReadTest.cpp
@@ -84,9 +84,7 @@ TEST_F(S3ReadTest, s3ReadTest) {
       std::make_shared<facebook::velox::connector::hive::HiveTableHandle>(
           kCudfHiveConnectorId,
           "int_table",
-          false,
           common::SubfieldFilters{},
-          nullptr,
           nullptr);
   auto plan = PlanBuilder(pool())
                   .startTableScan()

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -449,7 +449,7 @@ TEST_F(TableScanTest, filterPushdown) {
           .build();
 
   auto tableHandle = makeTableHandle(
-      "parquet_table", rowType, true, std::move(subfieldFilters), nullptr);
+      "parquet_table", rowType, std::move(subfieldFilters), nullptr);
 
   auto assignments =
       facebook::velox::exec::test::HiveConnectorTestBase::allRegularColumns(

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.h
@@ -114,13 +114,11 @@ class CudfHiveConnectorTestBase
   makeTableHandle(
       const std::string& tableName = "parquet_table",
       const RowTypePtr& dataColumns = nullptr,
-      bool filterPushdownEnabled = false,
       common::SubfieldFilters subfieldFilters = {},
       const core::TypedExprPtr& remainingFilterExpr = nullptr) {
     return std::make_shared<facebook::velox::connector::hive::HiveTableHandle>(
         kCudfHiveConnectorId,
         tableName,
-        filterPushdownEnabled,
         std::move(subfieldFilters),
         remainingFilterExpr,
         dataColumns);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axiom/pull/983

`HiveTableHandle::filterPushdownEnabled_` is stored but never read by the Velox
engine. The getter `isFilterPushdownEnabled()` was already marked `[[deprecated]]`.
The Java coordinator sends both `true` and `false` values, but the C++ side
ignores them. This diff removes the field, getter, and constructor parameter
entirely to simplify the API and reduce confusion.

Changes:
- Remove `filterPushdownEnabled` param from both `HiveTableHandle` constructors
- Remove `[[deprecated]] isFilterPushdownEnabled()` getter and `filterPushdownEnabled_` field
- Add backward-compat constructors guarded by `VELOX_ENABLE_BACKWARD_COMPATIBILITY` (for OSS callers like Presto)
- Remove from `CudfHiveTableHandle` (same pattern)
- `serialize()`: Stop writing `filterPushdownEnabled`
- `create()`: Tolerate field being present or absent in serialized data
- Remove `isPushdownFilterEnabled` param from Presto/Iceberg connector conversion utils
- Update all call sites across velox, fb_velox, axiom, koski, gluten, astra, presto, xldb
- Update expected JSON in Python tests (field no longer serialized)

#buildall

Differential Revision: D94835939


