### PR TITLE
feat: Add MarkDistinct Fuzzer (#16600)

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -148,6 +148,20 @@ add_executable(velox_topn_row_number_fuzzer TopNRowNumberFuzzerRunner.cpp)
 
 target_link_libraries(velox_topn_row_number_fuzzer velox_topn_row_number_fuzzer_lib)
 
+add_library(velox_mark_distinct_fuzzer_lib MarkDistinctFuzzer.cpp)
+
+target_link_libraries(
+  velox_mark_distinct_fuzzer_lib
+  velox_row_number_fuzzer_base_lib
+  velox_type
+  velox_expression_test_utility
+)
+
+# MarkDistinct Fuzzer.
+add_executable(velox_mark_distinct_fuzzer MarkDistinctFuzzerRunner.cpp)
+
+target_link_libraries(velox_mark_distinct_fuzzer velox_mark_distinct_fuzzer_lib velox_aggregates)
+
 # Join Fuzzer.
 add_executable(velox_join_fuzzer JoinFuzzerRunner.cpp JoinFuzzer.cpp JoinMaker.cpp)
 
@@ -201,6 +215,8 @@ target_link_libraries(
   velox_fuzzer_util
   velox_type
   velox_vector_fuzzer
+  velox_dwio_dwrf_reader
+  velox_dwio_dwrf_writer
   velox_exec_test_lib
   velox_expression_test_utility
   velox_functions_prestosql

--- a/velox/exec/fuzzer/MarkDistinctFuzzer.cpp
+++ b/velox/exec/fuzzer/MarkDistinctFuzzer.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/fuzzer/MarkDistinctFuzzer.h"
+
+#include <utility>
+
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/exec/fuzzer/FuzzerUtil.h"
+#include "velox/exec/fuzzer/RowNumberFuzzerBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec {
+using namespace facebook::velox::common::testutil;
+namespace {
+
+class MarkDistinctFuzzer : public RowNumberFuzzerBase {
+ public:
+  explicit MarkDistinctFuzzer(
+      size_t initialSeed,
+      std::unique_ptr<test::ReferenceQueryRunner>);
+
+ private:
+  void runSingleIteration() override;
+
+  std::pair<std::vector<std::string>, std::vector<TypePtr>>
+  generatePartitionKeys();
+
+  std::vector<RowVectorPtr> generateInput(
+      const std::vector<std::string>& keyNames,
+      const std::vector<TypePtr>& keyTypes);
+
+  // Makes the query plan: Values -> MarkDistinct -> Aggregation.
+  // MarkDistinct marks distinct rows for (groupKey, distinctKey) combinations,
+  // then aggregation uses the mask to compute count(distinct distinctKey).
+  static PlanWithSplits makeDefaultPlan(
+      const std::string& groupKey,
+      const std::string& distinctKey,
+      const std::vector<RowVectorPtr>& input);
+
+  static PlanWithSplits makePlanWithTableScan(
+      const RowTypePtr& type,
+      const std::string& groupKey,
+      const std::string& distinctKey,
+      const std::vector<Split>& splits);
+
+  void addPlansWithTableScan(
+      const std::string& tableDir,
+      const std::string& groupKey,
+      const std::string& distinctKey,
+      const std::vector<RowVectorPtr>& input,
+      std::vector<PlanWithSplits>& altPlans);
+};
+
+MarkDistinctFuzzer::MarkDistinctFuzzer(
+    size_t initialSeed,
+    std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner)
+    : RowNumberFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {
+  vectorFuzzer_.getMutableOptions().timestampPrecision =
+      fuzzer::FuzzerTimestampPrecision::kMilliSeconds;
+}
+
+std::pair<std::vector<std::string>, std::vector<TypePtr>>
+MarkDistinctFuzzer::generatePartitionKeys() {
+  // Generate 1-3 keys for grouping/distinct.
+  const auto numKeys = randInt(1, 3);
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+  for (auto i = 0; i < numKeys; ++i) {
+    names.push_back(fmt::format("c{}", i));
+    types.push_back(vectorFuzzer_.randType(/*maxDepth=*/1));
+  }
+  return std::make_pair(names, types);
+}
+
+std::vector<RowVectorPtr> MarkDistinctFuzzer::generateInput(
+    const std::vector<std::string>& keyNames,
+    const std::vector<TypePtr>& keyTypes) {
+  std::vector<std::string> names = keyNames;
+  std::vector<TypePtr> types = keyTypes;
+
+  // Add up to 2 payload columns.
+  const auto numPayload = randInt(0, 2);
+  for (auto i = 0; i < numPayload; ++i) {
+    names.push_back(fmt::format("c{}", i + keyNames.size()));
+    types.push_back(vectorFuzzer_.randType(/*maxDepth=*/2));
+  }
+
+  const auto inputType = ROW(std::move(names), std::move(types));
+  std::vector<RowVectorPtr> input;
+  input.reserve(FLAGS_num_batches);
+  for (auto i = 0; i < FLAGS_num_batches; ++i) {
+    input.push_back(vectorFuzzer_.fuzzInputRow(inputType));
+  }
+
+  return input;
+}
+
+RowNumberFuzzerBase::PlanWithSplits MarkDistinctFuzzer::makeDefaultPlan(
+    const std::string& groupKey,
+    const std::string& distinctKey,
+    const std::vector<RowVectorPtr>& input) {
+  // Build plan: Values -> MarkDistinct -> Aggregation
+  // This is equivalent to: SELECT groupKey, count(DISTINCT distinctKey)
+  //                         FROM input GROUP BY groupKey
+  auto plan = test::PlanBuilder()
+                  .values(input)
+                  .markDistinct("distinct_marker", {groupKey, distinctKey})
+                  .singleAggregation(
+                      {groupKey},
+                      {"count(\"" + distinctKey + "\")"},
+                      {"distinct_marker"})
+                  .planNode();
+  return PlanWithSplits{std::move(plan)};
+}
+
+RowNumberFuzzerBase::PlanWithSplits MarkDistinctFuzzer::makePlanWithTableScan(
+    const RowTypePtr& type,
+    const std::string& groupKey,
+    const std::string& distinctKey,
+    const std::vector<Split>& splits) {
+  auto plan = test::PlanBuilder()
+                  .tableScan(type)
+                  .markDistinct("distinct_marker", {groupKey, distinctKey})
+                  .singleAggregation(
+                      {groupKey},
+                      {"count(\"" + distinctKey + "\")"},
+                      {"distinct_marker"})
+                  .planNode();
+  return PlanWithSplits{plan, splits};
+}
+
+void MarkDistinctFuzzer::addPlansWithTableScan(
+    const std::string& tableDir,
+    const std::string& groupKey,
+    const std::string& distinctKey,
+    const std::vector<RowVectorPtr>& input,
+    std::vector<PlanWithSplits>& altPlans) {
+  VELOX_CHECK(!tableDir.empty());
+
+  if (!isTableScanSupported(input[0]->type())) {
+    return;
+  }
+
+  const std::vector<Split> inputSplits = test::makeSplits(
+      input, fmt::format("{}/mark_distinct", tableDir), writerPool_);
+  altPlans.push_back(makePlanWithTableScan(
+      asRowType(input[0]->type()), groupKey, distinctKey, inputSplits));
+}
+
+void MarkDistinctFuzzer::runSingleIteration() {
+  const auto [keyNames, keyTypes] = generatePartitionKeys();
+
+  // We need at least 2 keys: one for GROUP BY and one for DISTINCT.
+  // If only 1 key was generated, add another one.
+  std::vector<std::string> allNames = keyNames;
+  std::vector<TypePtr> allTypes = keyTypes;
+  if (allNames.size() < 2) {
+    allNames.push_back(fmt::format("c{}", allNames.size()));
+    allTypes.push_back(vectorFuzzer_.randType(/*maxDepth=*/1));
+  }
+
+  const auto input = generateInput(allNames, allTypes);
+  test::logVectors(input);
+
+  // Use first key as group-by key, second as distinct key.
+  const auto& groupKey = allNames[0];
+  const auto& distinctKey = allNames[1];
+
+  auto defaultPlan = makeDefaultPlan(groupKey, distinctKey, input);
+  const auto expected =
+      execute(defaultPlan, pool_, /*injectSpill=*/false, false);
+
+  // Validate against DuckDB using an equivalent plan without MarkDistinct.
+  // DuckDB cannot translate MarkDistinctNode to SQL, so we build a reference
+  // plan that uses count(DISTINCT ...) directly.
+  if (expected != nullptr) {
+    auto referencePlan =
+        test::PlanBuilder()
+            .values(input)
+            .singleAggregation(
+                {groupKey},
+                {fmt::format("count(DISTINCT \"{}\")", distinctKey)})
+            .planNode();
+    validateExpectedResults(referencePlan, input, expected);
+  }
+
+  std::vector<PlanWithSplits> altPlans;
+  altPlans.push_back(std::move(defaultPlan));
+
+  const auto tableScanDir = TempDirectoryPath::create();
+  addPlansWithTableScan(
+      tableScanDir->getPath(), groupKey, distinctKey, input, altPlans);
+
+  for (auto i = 0; i < altPlans.size(); ++i) {
+    testPlan(
+        altPlans[i],
+        i,
+        expected,
+        "core::QueryConfig::kMarkDistinctSpillEnabled");
+  }
+}
+
+} // namespace
+
+void markDistinctFuzzer(
+    size_t seed,
+    std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner) {
+  MarkDistinctFuzzer(seed, std::move(referenceQueryRunner)).run();
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/fuzzer/MarkDistinctFuzzer.h
+++ b/velox/exec/fuzzer/MarkDistinctFuzzer.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstddef>
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+
+namespace facebook::velox::exec {
+void markDistinctFuzzer(
+    size_t seed,
+    std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner);
+}

--- a/velox/exec/fuzzer/MarkDistinctFuzzerRunner.cpp
+++ b/velox/exec/fuzzer/MarkDistinctFuzzerRunner.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "velox/common/memory/SharedArbitrator.h"
+#include "velox/exec/fuzzer/FuzzerUtil.h"
+#include "velox/exec/fuzzer/MarkDistinctFuzzer.h"
+#include "velox/exec/fuzzer/ReferenceQueryRunner.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+/// MarkDistinctFuzzerRunner leverages MarkDistinctFuzzer and VectorFuzzer to
+/// automatically generate and execute tests. It works as follows:
+///
+///  1. Plan Generation: Generate two equivalent query plans, one is
+///     mark-distinct + aggregation over ValuesNode and the other is over
+///     TableScanNode.
+///  2. Executes a variety of logically equivalent query plans and checks the
+///     results are the same.
+///  3. Rinse and repeat.
+///
+/// It is used as follows:
+///
+///  $ ./velox_mark_distinct_fuzzer --duration_sec 600
+///
+/// The flags that configure MarkDistinctFuzzer's behavior are:
+///
+///  --steps: how many iterations to run.
+///  --duration_sec: alternatively, for how many seconds it should run (takes
+///          precedence over --steps).
+///  --seed: pass a deterministic seed to reproduce the behavior (each iteration
+///          will print a seed as part of the logs).
+///  --v=1: verbose logging; print a lot more details about the execution.
+///  --batch_size: size of input vector batches generated.
+///  --num_batches: number of input vector batches to generate.
+///  --enable_spill: test plans with spilling enabled.
+///  --enable_oom_injection: randomly trigger OOM while executing query plans.
+/// e.g:
+///
+///  $ ./velox_mark_distinct_fuzzer \
+///         --seed 123 \
+///         --duration_sec 600 \
+///         --v=1
+
+DEFINE_int64(
+    seed,
+    0,
+    "Initial seed for random number generator used to reproduce previous "
+    "results (0 means start with random seed).");
+
+DEFINE_string(
+    presto_url,
+    "",
+    "Presto coordinator URI along with port. If set, we use Presto "
+    "source of truth. Otherwise, use DuckDB. Example: "
+    "--presto_url=http://127.0.0.1:8080");
+
+DEFINE_uint32(
+    req_timeout_ms,
+    1000,
+    "Timeout in milliseconds for HTTP requests made to reference DB, "
+    "such as Presto. Example: --req_timeout_ms=2000");
+
+DEFINE_int64(allocator_capacity, 8L << 30, "Allocator capacity in bytes.");
+
+DEFINE_int64(arbitrator_capacity, 6L << 30, "Arbitrator capacity in bytes.");
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  exec::test::setupMemory(FLAGS_allocator_capacity, FLAGS_arbitrator_capacity);
+  aggregate::prestosql::registerAllAggregateFunctions();
+  std::shared_ptr<memory::MemoryPool> rootPool{
+      memory::memoryManager()->addRootPool()};
+  auto referenceQueryRunner = exec::test::setupReferenceQueryRunner(
+      rootPool.get(),
+      FLAGS_presto_url,
+      "mark_distinct_fuzzer",
+      FLAGS_req_timeout_ms);
+  const size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
+  exec::markDistinctFuzzer(initialSeed, std::move(referenceQueryRunner));
+}

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -24,8 +24,8 @@
 #include "velox/common/fuzzer/Utils.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/hive/HiveConnector.h"
-#include "velox/dwio/dwrf/RegisterDwrfReader.h" // @manual
-#include "velox/dwio/dwrf/RegisterDwrfWriter.h" // @manual
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"


### PR DESCRIPTION
Summary:


The fuzzer performs **three levels of comparison**:

- **Velox vs DuckDB — Does `MarkDistinct` produce correct results?**  
  - In **Velox**, run: `Values -> MarkDistinct -> Aggregation` → treat this as the *expected* result.  
  - In **DuckDB**, run:
    ```sql
    SELECT groupKey, COUNT(DISTINCT distinctKey)
    GROUP BY groupKey
    ```
  - Compare the outputs. If they differ, the operator is likely incorrect.

- **No-spill vs spill — Does spilling affect correctness?**  
  - Run the same plan while injecting spills at random points.  
  - Compare against the expected result. If they differ, the spill logic is likely incorrect.

- **Values vs TableScan — Does the input source matter?**  
  - Run the same operator chain, but read from files (**TableScan**) instead of in-memory (**Values**).  
  - Compare against the expected result. If they differ, there’s likely a bug in lazy vectors and/or file reading.


**TODO** — In this diff, `MarkDistinctFuzzer` extends `RowNumberFuzzerBase`. In a follow-up diff, we’ll introduce a `SpillUtil` and do some  refactoring.

Reviewed By: tanjialiang

Differential Revision: D94850156


