### PR TITLE
feat: Add column type info to decompression metrics

### DIFF
--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -28,6 +28,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/io/IoStatistics.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::dwio::common {
 
@@ -569,6 +570,9 @@ auto withDecompressStats(io::IoCounter* counter, F&& func)
 /// different types of measurements (decompression, encoding, etc.).
 /// Can be used by any file format reader (DWRF, Nimble, Parquet, etc.).
 struct ColumnMetrics {
+  explicit ColumnMetrics(TypeKind type = TypeKind::INVALID) : typeKind(type) {}
+
+  TypeKind typeKind;
   io::IoCounter decompressCPUTimeNanos;
 
   /// Merges stats from another ColumnMetrics instance.
@@ -580,12 +584,15 @@ struct ColumnMetrics {
 /// Thread-safe collection of per-column metrics keyed by nodeId.
 /// Can be used by any file format reader (DWRF, Nimble, Parquet, etc.).
 struct ColumnMetricsSet {
-  /// Gets or creates a ColumnMetrics for a column.
-  ColumnMetrics* getOrCreate(uint32_t nodeId) {
+  /// Gets or creates a ColumnMetrics for a column. Sets typeKind when creating.
+  ColumnMetrics* getOrCreate(
+      uint32_t nodeId,
+      TypeKind typeKind = TypeKind::INVALID) {
     auto locked = map_.wlock();
     auto it = locked->find(nodeId);
     if (it == locked->end()) {
-      it = locked->emplace(nodeId, std::make_unique<ColumnMetrics>()).first;
+      it = locked->emplace(nodeId, std::make_unique<ColumnMetrics>(typeKind))
+               .first;
     }
     return it->second.get();
   }
@@ -599,6 +606,7 @@ struct ColumnMetricsSet {
       if (it == dstLocked->end()) {
         it =
             dstLocked->emplace(nodeId, std::make_unique<ColumnMetrics>()).first;
+        it->second->typeKind = srcStats->typeKind;
       }
       it->second->merge(*srcStats);
     }
@@ -614,7 +622,10 @@ struct ColumnMetricsSet {
         continue;
       }
       result.emplace(
-          fmt::format("column_{}.decompressCPUTimeNanos", nodeId),
+          fmt::format(
+              "column.{}.{}.decompressCPUTimeNanos",
+              TypeKindName::toName(stats->typeKind),
+              nodeId),
           RuntimeMetric{
               static_cast<int64_t>(counter.sum()),
               static_cast<int64_t>(counter.count()),
@@ -625,8 +636,6 @@ struct ColumnMetricsSet {
   }
 
  private:
-  // Per-column stats keyed by nodeId. Uses unique_ptr because IoCounter
-  // contains std::atomic and is not copyable.
   folly::Synchronized<
       folly::F14FastMap<uint32_t, std::unique_ptr<ColumnMetrics>>>
       map_;

--- a/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
+++ b/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
@@ -18,9 +18,11 @@
 #include <thread>
 #include <vector>
 #include "velox/dwio/common/Statistics.h"
+#include "velox/type/Type.h"
 
 using namespace facebook::velox::dwio::common;
 using facebook::velox::RuntimeMetric;
+using facebook::velox::TypeKind;
 
 TEST(IoCounterTest, BasicOperations) {
   facebook::velox::io::IoCounter counter;
@@ -73,6 +75,30 @@ TEST(ColumnMetricsSetTest, GetOrCreate) {
   EXPECT_NE(result2, result);
 }
 
+TEST(ColumnMetricsSetTest, GetOrCreateWithTypeKind) {
+  ColumnMetricsSet metricsSet;
+
+  // Pass type when calling getOrCreate.
+  auto* result = metricsSet.getOrCreate(1, TypeKind::BIGINT);
+  ASSERT_NE(result, nullptr);
+  result->decompressCPUTimeNanos.increment(1'000);
+
+  // Returns same instance for same nodeId.
+  auto* result2 = metricsSet.getOrCreate(1);
+  EXPECT_EQ(result2, result);
+
+  // Different nodeId with different type.
+  auto* result3 = metricsSet.getOrCreate(2, TypeKind::VARCHAR);
+  EXPECT_NE(result3, result);
+  result3->decompressCPUTimeNanos.increment(2'000);
+
+  // Verify types are used in toRuntimeMetrics.
+  std::unordered_map<std::string, RuntimeMetric> metrics;
+  metricsSet.toRuntimeMetrics(metrics);
+  EXPECT_EQ(metrics["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(metrics["column.VARCHAR.2.decompressCPUTimeNanos"].sum, 2'000);
+}
+
 TEST(ColumnMetricsSetTest, ToRuntimeMetrics) {
   ColumnMetricsSet metricsSet;
 
@@ -81,30 +107,47 @@ TEST(ColumnMetricsSetTest, ToRuntimeMetrics) {
   metricsSet.toRuntimeMetrics(result);
   EXPECT_TRUE(result.empty());
 
-  // Add timing data.
-  auto* col1 = metricsSet.getOrCreate(1);
+  // Add timing data with type information.
+  auto* col1 = metricsSet.getOrCreate(1, TypeKind::BIGINT);
   col1->decompressCPUTimeNanos.increment(5'000);
   col1->decompressCPUTimeNanos.increment(3'000);
 
-  auto* col2 = metricsSet.getOrCreate(42);
+  auto* col2 = metricsSet.getOrCreate(42, TypeKind::VARCHAR);
   col2->decompressCPUTimeNanos.increment(2'000);
+
+  // Create a column with type but no data.
+  metricsSet.getOrCreate(99, TypeKind::DOUBLE);
 
   result.clear();
   metricsSet.toRuntimeMetrics(result);
 
-  // RuntimeMetric has sum/count/min/max, so we only need one metric per column.
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 8'000);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].count, 2);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].min, 3'000);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].max, 5'000);
-  EXPECT_EQ(result["column_42.decompressCPUTimeNanos"].sum, 2'000);
-  EXPECT_EQ(result["column_42.decompressCPUTimeNanos"].count, 1);
+  // RuntimeMetric has sum/count/min/max, metric name includes type.
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 8'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].count, 2);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].min, 3'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].max, 5'000);
+  EXPECT_EQ(result["column.VARCHAR.42.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(result["column.VARCHAR.42.decompressCPUTimeNanos"].count, 1);
 
   // Zero values are not included.
   metricsSet.getOrCreate(99);
   result.clear();
   metricsSet.toRuntimeMetrics(result);
-  EXPECT_EQ(result.count("column_99.decompressCPUTimeNanos"), 0);
+  EXPECT_EQ(result.count("column.DOUBLE.99.decompressCPUTimeNanos"), 0);
+}
+
+TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithInvalidType) {
+  ColumnMetricsSet metricsSet;
+
+  // Add timing data without type information (INVALID type).
+  auto* col1 = metricsSet.getOrCreate(1);
+  col1->decompressCPUTimeNanos.increment(5'000);
+
+  std::unordered_map<std::string, RuntimeMetric> result;
+  metricsSet.toRuntimeMetrics(result);
+
+  // Should use INVALID as type name.
+  EXPECT_EQ(result["column.INVALID.1.decompressCPUTimeNanos"].sum, 5'000);
 }
 
 TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
@@ -121,9 +164,10 @@ TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
   stats.numStripes = 4;
   stats.columnReaderStats.flattenStringDictionaryValues = 1'000;
 
-  // Add per-column stats.
+  // Add per-column stats with type.
   stats.columnReaderStats.columnMetricsSet.emplace();
-  auto* colMetrics = stats.columnReaderStats.columnMetricsSet->getOrCreate(1);
+  auto* colMetrics = stats.columnReaderStats.columnMetricsSet->getOrCreate(
+      1, TypeKind::BIGINT);
   colMetrics->decompressCPUTimeNanos.increment(5'000);
 
   auto result = stats.toRuntimeMetricMap();
@@ -134,14 +178,19 @@ TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
   EXPECT_EQ(result["processedStrides"].sum, 30);
   EXPECT_EQ(result["numStripes"].sum, 4);
   EXPECT_EQ(result["flattenStringDictionaryValues"].sum, 1'000);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 5'000);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].count, 1);
 }
 
 TEST(ColumnMetricsSetConcurrencyTest, ConcurrentGetOrCreate) {
   ColumnMetricsSet metricsSet;
   constexpr int kNumThreads = 4;
   constexpr int kNumColumns = 10;
+
+  // Pre-populate columns with types before concurrent access.
+  for (uint32_t colId = 0; colId < kNumColumns; ++colId) {
+    metricsSet.getOrCreate(colId, TypeKind::BIGINT);
+  }
 
   std::vector<std::thread> threads;
   threads.reserve(kNumThreads);
@@ -161,7 +210,7 @@ TEST(ColumnMetricsSetConcurrencyTest, ConcurrentGetOrCreate) {
   metricsSet.toRuntimeMetrics(result);
 
   for (uint32_t colId = 0; colId < kNumColumns; ++colId) {
-    auto key = fmt::format("column_{}.decompressCPUTimeNanos", colId);
+    auto key = fmt::format("column.BIGINT.{}.decompressCPUTimeNanos", colId);
     EXPECT_EQ(result[key].sum, kNumThreads * 100);
     EXPECT_EQ(result[key].count, kNumThreads);
   }
@@ -183,17 +232,15 @@ TEST(IoCounterTest, MergeStats) {
 
 TEST(ColumnMetricsSetTest, MergeFromWithOverlappingNodeIds) {
   ColumnMetricsSet src;
-
-  auto* srcCol1 = src.getOrCreate(1);
+  auto* srcCol1 = src.getOrCreate(1, TypeKind::BIGINT);
   srcCol1->decompressCPUTimeNanos.increment(5'000);
   srcCol1->decompressCPUTimeNanos.increment(3'000);
 
-  auto* srcCol2 = src.getOrCreate(2);
+  auto* srcCol2 = src.getOrCreate(2, TypeKind::VARCHAR);
   srcCol2->decompressCPUTimeNanos.increment(2'000);
 
   ColumnMetricsSet dst;
-
-  auto* dstCol1 = dst.getOrCreate(1);
+  auto* dstCol1 = dst.getOrCreate(1, TypeKind::BIGINT);
   dstCol1->decompressCPUTimeNanos.increment(1'000);
 
   dst.mergeFrom(src);
@@ -201,27 +248,25 @@ TEST(ColumnMetricsSetTest, MergeFromWithOverlappingNodeIds) {
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.toRuntimeMetrics(result);
 
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 9'000);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].count, 3);
-  EXPECT_EQ(result["column_2.decompressCPUTimeNanos"].sum, 2'000);
-  EXPECT_EQ(result["column_2.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 9'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].count, 3);
+  EXPECT_EQ(result["column.VARCHAR.2.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(result["column.VARCHAR.2.decompressCPUTimeNanos"].count, 1);
 }
 
 TEST(ColumnMetricsSetTest, MergeFromWithDisjointNodeIds) {
   ColumnMetricsSet src;
-
-  auto* srcCol3 = src.getOrCreate(3);
+  auto* srcCol3 = src.getOrCreate(3, TypeKind::DOUBLE);
   srcCol3->decompressCPUTimeNanos.increment(3'000);
 
-  auto* srcCol4 = src.getOrCreate(4);
+  auto* srcCol4 = src.getOrCreate(4, TypeKind::BOOLEAN);
   srcCol4->decompressCPUTimeNanos.increment(4'000);
 
   ColumnMetricsSet dst;
-
-  auto* dstCol1 = dst.getOrCreate(1);
+  auto* dstCol1 = dst.getOrCreate(1, TypeKind::BIGINT);
   dstCol1->decompressCPUTimeNanos.increment(1'000);
 
-  auto* dstCol2 = dst.getOrCreate(2);
+  auto* dstCol2 = dst.getOrCreate(2, TypeKind::VARCHAR);
   dstCol2->decompressCPUTimeNanos.increment(2'000);
 
   dst.mergeFrom(src);
@@ -229,16 +274,15 @@ TEST(ColumnMetricsSetTest, MergeFromWithDisjointNodeIds) {
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.toRuntimeMetrics(result);
 
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 1'000);
-  EXPECT_EQ(result["column_2.decompressCPUTimeNanos"].sum, 2'000);
-  EXPECT_EQ(result["column_3.decompressCPUTimeNanos"].sum, 3'000);
-  EXPECT_EQ(result["column_4.decompressCPUTimeNanos"].sum, 4'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(result["column.VARCHAR.2.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(result["column.DOUBLE.3.decompressCPUTimeNanos"].sum, 3'000);
+  EXPECT_EQ(result["column.BOOLEAN.4.decompressCPUTimeNanos"].sum, 4'000);
 }
 
 TEST(ColumnMetricsSetTest, MergeFromEmpty) {
   ColumnMetricsSet nonEmpty;
-
-  auto* col = nonEmpty.getOrCreate(1);
+  auto* col = nonEmpty.getOrCreate(1, TypeKind::BIGINT);
   col->decompressCPUTimeNanos.increment(5'000);
 
   ColumnMetricsSet empty;
@@ -247,21 +291,22 @@ TEST(ColumnMetricsSetTest, MergeFromEmpty) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   nonEmpty.toRuntimeMetrics(result);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 5'000);
 
   ColumnMetricsSet empty2;
   empty2.mergeFrom(nonEmpty);
 
   result.clear();
   empty2.toRuntimeMetrics(result);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 5'000);
 }
 
 TEST(ColumnReaderStatisticsTest, MergeFromWithColumnMetrics) {
   ColumnReaderStatistics src;
   src.flattenStringDictionaryValues = 100;
   src.columnMetricsSet.emplace();
-  src.columnMetricsSet->getOrCreate(1)->decompressCPUTimeNanos.increment(1'000);
+  src.columnMetricsSet->getOrCreate(1, TypeKind::BIGINT)
+      ->decompressCPUTimeNanos.increment(1'000);
 
   // Merge into stats without columnMetricsSet - creates and populates it.
   ColumnReaderStatistics dst;
@@ -273,19 +318,21 @@ TEST(ColumnReaderStatisticsTest, MergeFromWithColumnMetrics) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.columnMetricsSet->toRuntimeMetrics(result);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
 }
 
 TEST(ColumnReaderStatisticsTest, MergeFromBothWithColumnMetrics) {
   ColumnReaderStatistics src;
   src.flattenStringDictionaryValues = 100;
   src.columnMetricsSet.emplace();
-  src.columnMetricsSet->getOrCreate(1)->decompressCPUTimeNanos.increment(1'000);
+  src.columnMetricsSet->getOrCreate(1, TypeKind::BIGINT)
+      ->decompressCPUTimeNanos.increment(1'000);
 
   ColumnReaderStatistics dst;
   dst.flattenStringDictionaryValues = 50;
   dst.columnMetricsSet.emplace();
-  dst.columnMetricsSet->getOrCreate(1)->decompressCPUTimeNanos.increment(2'000);
+  dst.columnMetricsSet->getOrCreate(1, TypeKind::BIGINT)
+      ->decompressCPUTimeNanos.increment(2'000);
 
   dst.mergeFrom(src);
 
@@ -294,7 +341,7 @@ TEST(ColumnReaderStatisticsTest, MergeFromBothWithColumnMetrics) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.columnMetricsSet->toRuntimeMetrics(result);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 3'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 3'000);
 }
 
 TEST(ColumnReaderStatisticsTest, MergeFromWithoutColumnMetrics) {
@@ -304,7 +351,8 @@ TEST(ColumnReaderStatisticsTest, MergeFromWithoutColumnMetrics) {
   ColumnReaderStatistics dst;
   dst.flattenStringDictionaryValues = 50;
   dst.columnMetricsSet.emplace();
-  dst.columnMetricsSet->getOrCreate(1)->decompressCPUTimeNanos.increment(1'000);
+  dst.columnMetricsSet->getOrCreate(1, TypeKind::BIGINT)
+      ->decompressCPUTimeNanos.increment(1'000);
 
   dst.mergeFrom(src);
 
@@ -313,5 +361,5 @@ TEST(ColumnReaderStatisticsTest, MergeFromWithoutColumnMetrics) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.columnMetricsSet->toRuntimeMetrics(result);
-  EXPECT_EQ(result["column_1.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
 }

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -250,6 +250,17 @@ const velox::common::ScanSpec* getChildScanSpec(
       : nullptr;
 }
 
+void registerColumnMetrics(
+    const dwio::common::TypeWithId& node,
+    dwio::common::ColumnMetricsSet& metricsSet) {
+  metricsSet.getOrCreate(node.id(), node.type()->kind());
+  for (uint32_t i = 0; i < node.size(); ++i) {
+    if (const auto* child = node.childAt(i).get()) {
+      registerColumnMetrics(*child, metricsSet);
+    }
+  }
+}
+
 } // namespace
 
 DwrfRowReader::DwrfRowReader(
@@ -270,6 +281,8 @@ DwrfRowReader::DwrfRowReader(
       currentUnit_{nullptr} {
   if (options_.collectColumnStats()) {
     columnReaderStats_->columnMetricsSet.emplace();
+    registerColumnMetrics(
+        *getReader().schemaWithId(), *columnReaderStats_->columnMetricsSet);
   }
   const auto& fileFooter = getReader().footer();
   const uint32_t numberOfStripes = fileFooter.stripesSize();


### PR DESCRIPTION
Summary:
Add column type info to decompression metrics
- Add TypeKind to ColumnMetrics
- Change metric format: column.{TYPE}.{nodeId}.decompressCPUTimeNanos
- Build type map once per file in DwrfRowReader

Differential Revision: D94979517


