### PR TITLE
fix: Sanitize file name parts when generating file name in HiveDataSink

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -32,6 +32,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <re2/re2.h>
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -1240,6 +1241,8 @@ std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
         connectorQueryCtx.queryId(),
         hiveConfig->maxBucketCount(connectorQueryCtx.sessionProperties()),
         bucketId.value());
+    // queryId may contain unsafe characters.
+    sanitizeFileName(targetFileName);
   } else if (generateFileName) {
     // targetFileName includes planNodeId and Uuid. As a result, different
     // table writers run by the same task driver or the same table writer
@@ -1250,7 +1253,10 @@ std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
         connectorQueryCtx.driverId(),
         connectorQueryCtx.planNodeId(),
         makeUuid());
+    // taskId, planNodeId may contain unsafe characters.
+    sanitizeFileName(targetFileName);
   }
+  // do not try to sanitize user provided targetFileName
   VELOX_CHECK(!targetFileName.empty());
   const std::string writeFileName = commitRequired
       ? fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid())
@@ -1262,6 +1268,11 @@ std::pair<std::string, std::string> HiveInsertFileNameGenerator::gen(
         fmt::format("{}{}", writeFileName, ".parquet")};
   }
   return {targetFileName, writeFileName};
+}
+
+void HiveInsertFileNameGenerator::sanitizeFileName(std::string& name) {
+  static const re2::RE2 re("[^a-zA-Z0-9._-]");
+  re2::RE2::GlobalReplace(&name, re, "_");
 }
 
 folly::dynamic HiveInsertFileNameGenerator::serialize() const {

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -232,6 +232,9 @@ class HiveInsertFileNameGenerator : public FileNameGenerator {
       void* context);
 
   std::string toString() const override;
+
+  /// Replaces potentially unsafe characters in a file name with underscores
+  static void sanitizeFileName(std::string& name);
 };
 
 /// Represents a request for Hive write.

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1932,6 +1932,17 @@ TEST_F(HiveDataSinkTest, sharedWriterOptionsWithMultipleWriters) {
       outputDirectory->getPath(), static_cast<uint32_t>(partitions.size()));
 }
 
+TEST_F(HiveDataSinkTest, sanitizeFileName) {
+  auto sanitizeFileName = [](std::string fileName) {
+    HiveInsertFileNameGenerator::sanitizeFileName(fileName);
+    return fileName;
+  };
+  ASSERT_EQ(sanitizeFileName("abc"), "abc");
+  ASSERT_EQ(sanitizeFileName("abc_.-ABC012"), "abc_.-ABC012");
+  ASSERT_EQ(sanitizeFileName("abc_.-ABC012\\/"), "abc_.-ABC012__");
+  ASSERT_EQ(sanitizeFileName("local://abc/bcd/"), "local___abc_bcd_");
+}
+
 } // namespace
 } // namespace facebook::velox::connector::hive
 


### PR DESCRIPTION
Summary:
taskId, queryId and planNodeId are just strings, and may contain slashes or
other problematic symbols.

Differential Revision: D94996993


