### PR TITLE
perf(expr): Remove batch size limit for FlatNoNulls fast path

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -107,6 +107,13 @@ target_link_libraries(
 add_executable(velox_cast_benchmark CastBenchmark.cpp)
 target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps} velox_vector_test_lib)
 
+add_executable(velox_benchmark_expr_flat_no_nulls ExprFlatNoNullsBenchmark.cpp)
+target_link_libraries(
+  velox_benchmark_expr_flat_no_nulls
+  ${velox_benchmark_deps}
+  velox_functions_prestosql
+)
+
 add_executable(velox_format_datetime_benchmark FormatDateTimeBenchmark.cpp)
 target_link_libraries(
   velox_format_datetime_benchmark

--- a/velox/benchmarks/basic/ExprFlatNoNullsBenchmark.cpp
+++ b/velox/benchmarks/basic/ExprFlatNoNullsBenchmark.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Benchmark comparing expression evaluation with FlatNoNulls fast path
+/// enabled vs disabled via the expression.eval_flat_no_nulls config.
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+
+namespace {
+
+void addArithmeticBenchmarks(
+    ExpressionBenchmarkBuilder& builder,
+    const std::string& prefix) {
+  for (auto vectorSize : {1'024, 4'096, 40'960, 99'999}) {
+    builder
+        .addBenchmarkSet(
+            fmt::format("{}_arith_batch{}", prefix, vectorSize),
+            ROW({"a", "b", "c", "d"}, {DOUBLE(), DOUBLE(), DOUBLE(), DOUBLE()}))
+        .withFuzzerOptions(
+            {.vectorSize = static_cast<size_t>(vectorSize), .nullRatio = 0.0})
+        // Simple arithmetic — 1 node.
+        .addExpression("add_ab", "a + b")
+        // Complex arithmetic — 7 nodes.
+        .addExpression("complex_7n", "(a + b) * c + (a - d) * b")
+        // Deep tree — 15 nodes, depth 8 (left-skewed chain).
+        .addExpression(
+            "deep_15n_d8", "((((((a + b) * c - d) + a) * b - c) + d) * a - b)")
+        .withIterations(1'000);
+  }
+}
+
+void addComparisonBenchmarks(
+    ExpressionBenchmarkBuilder& builder,
+    const std::string& prefix) {
+  for (auto vectorSize : {1'024, 4'096, 40'960, 99'999}) {
+    builder
+        .addBenchmarkSet(
+            fmt::format("{}_cmp_batch{}", prefix, vectorSize),
+            ROW({"a", "b"}, {DOUBLE(), DOUBLE()}))
+        .withFuzzerOptions(
+            {.vectorSize = static_cast<size_t>(vectorSize), .nullRatio = 0.0})
+        // Comparison — 1 node.
+        .addExpression("eq_ab", "a = b")
+        .withIterations(1'000);
+  }
+}
+
+void addConstMixedBenchmarks(
+    ExpressionBenchmarkBuilder& builder,
+    const std::string& prefix) {
+  for (auto vectorSize : {1'024, 4'096, 40'960, 99'999}) {
+    builder
+        .addBenchmarkSet(
+            fmt::format("{}_const_batch{}", prefix, vectorSize),
+            ROW({"a", "b"}, {DOUBLE(), DOUBLE()}))
+        .withFuzzerOptions(
+            {.vectorSize = static_cast<size_t>(vectorSize), .nullRatio = 0.0})
+        // 1 constant.
+        .addExpression("const_1", "a + 1.5")
+        // 2 constants.
+        .addExpression("const_2", "(a + 1.5) * 2.0")
+        // 3 constants mixed with columns — 7 nodes.
+        .addExpression("const_3_7n", "(a + 1.5) * 2.0 + (a - 3.0) * b")
+        .withIterations(1'000);
+  }
+}
+
+/// Extends ExpressionBenchmarkBuilder to allow setting query config.
+class ConfigurableBenchmarkBuilder : public ExpressionBenchmarkBuilder {
+ public:
+  void setConfig(const std::string& key, const std::string& value) {
+    queryCtx_->testingOverrideConfigUnsafe({{key, value}});
+  }
+};
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  functions::prestosql::registerAllScalarFunctions();
+
+  // Fast path ON (default).
+  ConfigurableBenchmarkBuilder fastPathOn;
+  addArithmeticBenchmarks(fastPathOn, "on");
+  addComparisonBenchmarks(fastPathOn, "on");
+  addConstMixedBenchmarks(fastPathOn, "on");
+
+  // Fast path OFF via config.
+  ConfigurableBenchmarkBuilder fastPathOff;
+  fastPathOff.setConfig(core::QueryConfig::kExprEvalFlatNoNulls, "false");
+  addArithmeticBenchmarks(fastPathOff, "off");
+  addComparisonBenchmarks(fastPathOff, "off");
+  addConstMixedBenchmarks(fastPathOff, "off");
+
+  fastPathOn.registerBenchmarks();
+  fastPathOff.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -68,6 +68,12 @@ class QueryConfig {
   static constexpr const char* kExprEvalSimplified =
       "expression.eval_simplified";
 
+  /// Whether to enable the FlatNoNulls fast path for expression evaluation.
+  /// When enabled, expressions skip null checking and vector decoding when all
+  /// inputs are flat-encoded with no nulls. True by default.
+  static constexpr const char* kExprEvalFlatNoNulls =
+      "expression.eval_flat_no_nulls";
+
   /// Whether to track CPU usage for individual expressions (supported by call
   /// and cast expressions). False by default. Can be expensive when processing
   /// small batches, e.g. < 10K rows.
@@ -1124,6 +1130,10 @@ class QueryConfig {
 
   bool exprEvalSimplified() const {
     return get<bool>(kExprEvalSimplified, false);
+  }
+
+  bool exprEvalFlatNoNulls() const {
+    return get<bool>(kExprEvalFlatNoNulls, true);
   }
 
   bool parallelOutputJoinBuildRowsEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -263,6 +263,12 @@ Expression Evaluation Configuration
      - boolean
      - false
      - Whether to use the simplified expression evaluation path.
+   * - expression.eval_flat_no_nulls
+     - boolean
+     - true
+     - Whether to enable the FlatNoNulls fast path for expression evaluation. When enabled, expressions skip null
+       checking and vector decoding when all inputs are flat-encoded with no nulls. Set to false to disable this
+       optimization.
    * - expression.track_cpu_usage
      - boolean
      - false

--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -371,13 +371,13 @@ depth-first order. For each node a sequence of operations is performed.
 Flat No-Nulls Fast Path
 ```````````````````````
 
-When evaluating simple expressions on short vectors (< 1000 rows), the overhead
-of handling nulls and encodings is visible. To optimize these use cases,
-expression evaluation takes flat-no-nulls fast path
-(Expr::evalFlatNoNulls). This path applies automatically when inputs are flat
-vectors or constants with no nulls and all sub-expressions are guaranteed to
-produce flat-or-constant-no-nulls results given flat-or-constant-no-nulls
-inputs.
+When evaluating simple expressions, the overhead of handling nulls and encodings
+is visible. To optimize these use cases, expression evaluation takes
+flat-no-nulls fast path (Expr::evalFlatNoNulls). This path applies automatically
+when inputs are flat vectors or constants with no nulls and all sub-expressions
+are guaranteed to produce flat-or-constant-no-nulls results given
+flat-or-constant-no-nulls inputs. The optimization can be disabled by setting the
+``expression.eval_flat_no_nulls`` configuration property to false.
 
 An example of a workload that benefits from this optimization is basic arithmetic
 over non-null floats found in many machine learning pre-processing workloads.

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -814,7 +814,8 @@ void Expr::eval(
     VectorPtr& result,
     const ExprSet* parentExprSet) {
   if (supportsFlatNoNullsFastPath_ && context.throwOnError() &&
-      context.inputFlatNoNulls() && rows.countSelected() < 1'000) {
+      context.inputFlatNoNulls() &&
+      context.execCtx()->queryCtx()->queryConfig().exprEvalFlatNoNulls()) {
     evalFlatNoNulls(rows, context, result, parentExprSet);
     checkResultInternalState(result);
     return;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3343,6 +3343,30 @@ TEST_P(ParameterizedExprTest, flatNoNullsFastPath) {
   ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath());
 }
 
+TEST_P(ParameterizedExprTest, flatNoNullsFastPathDisabledByConfig) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int32_t>({10, 20, 30}),
+      });
+
+  // Evaluate with fast path enabled (default).
+  auto result = evaluate("a + b", data);
+  auto expected = makeFlatVector<int32_t>({11, 22, 33});
+  assertEqualVectors(expected, result);
+
+  // Evaluate with fast path disabled via config.
+  std::unordered_map<std::string, std::string> configData(
+      {{core::QueryConfig::kExprEvalFlatNoNulls, "false"}});
+  auto queryCtx = velox::core::QueryCtx::create(
+      nullptr, core::QueryConfig(std::move(configData)));
+  auto execCtx = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx.get());
+
+  result = evaluateMultiple({"a + b"}, data, std::nullopt, execCtx.get())[0];
+  assertEqualVectors(expected, result);
+}
+
 TEST_P(ParameterizedExprTest, commonSubExpressionWithEncodedInput) {
   // This test case does a sanity check of the code path that re-uses
   // precomputed results for common sub-expressions.


### PR DESCRIPTION
Remove the < 1'000 batch size limit that effectively disabled the
FlatNoNulls fast path for most workloads (Velox default batch = 1024,
Spark batch = 4096).

Add expression.eval_flat_no_nulls config (default true) to allow
disabling the optimization if needed.

For  details, pelase see https://github.com/facebookincubator/velox/discussions/16563#discussion-9542683