### PR TITLE
fix(tpch): Fix scale_factor clamping causing FK range violations at scale_factor < 1

### DIFF
--- a/velox/tpch/gen/DBGenIterator.cpp
+++ b/velox/tpch/gen/DBGenIterator.cpp
@@ -57,11 +57,7 @@ DBGenIterator::DBGenIterator(double scaleFactor) {
   auto dbgenBackend = DBGenBackendSingleton.try_get();
   VELOX_CHECK_NOT_NULL(dbgenBackend, "Unable to initialize dbgen's dbgunk.");
   VELOX_CHECK_GE(scaleFactor, 0, "Tpch scale factor must be non-negative");
-  if (scaleFactor < MIN_SCALE && scaleFactor > 0) {
-    dbgenCtx_.scale_factor = 1;
-  } else {
-    dbgenCtx_.scale_factor = static_cast<long>(scaleFactor);
-  }
+  dbgenCtx_.scale_factor = scaleFactor;
 }
 
 void DBGenIterator::initNation(size_t offset) {

--- a/velox/tpch/gen/dbgen/build.cpp
+++ b/velox/tpch/gen/dbgen/build.cpp
@@ -44,15 +44,15 @@ namespace facebook::velox::tpch::dbgen {
 #define JDAY_BASE 8035 /* start from 1/1/70 a la unix */
 #define JMNTH_BASE (-70 * 12) /* start from 1/1/70 a la unix */
 #define JDAY(date) ((date) - STARTDATE + JDAY_BASE + 1)
-#define PART_SUPP_BRIDGE(tgt, p, s)                                \
-  {                                                                \
-    DSS_HUGE tot_scnt = ctx->tdefs[SUPP].base * ctx->scale_factor; \
-    tgt = (p +                                                     \
-           s *                                                     \
-               (tot_scnt / SUPP_PER_PART +                         \
-                static_cast<long>((p - 1) / tot_scnt))) %          \
-            tot_scnt +                                             \
-        1;                                                         \
+#define PART_SUPP_BRIDGE(tgt, p, s)                        \
+  {                                                        \
+    DSS_HUGE tot_scnt = SCALED_VAL(ctx->tdefs[SUPP].base); \
+    tgt = (p +                                             \
+           s *                                             \
+               (tot_scnt / SUPP_PER_PART +                 \
+                static_cast<long>((p - 1) / tot_scnt))) %  \
+            tot_scnt +                                     \
+        1;                                                 \
   }
 #define V_STR(avg, seed, tgt)            \
   tpch_a_rnd(                            \
@@ -187,7 +187,7 @@ long mk_order(DSS_HUGE index, order_t* o, DBGenContext* ctx, long upd_num) {
   RANDOM(
       clk_num,
       1,
-      MAX((ctx->scale_factor * O_CLRK_SCL), O_CLRK_SCL),
+      static_cast<DSS_HUGE>(MAX((ctx->scale_factor * O_CLRK_SCL), O_CLRK_SCL)),
       &ctx->Seed[O_CLRK_SD]);
   sprintf(o->clerk, orderSzFormat, O_CLRK_TAG, clk_num);
   TEXT(O_CMNT_LEN, &ctx->Seed[O_CMNT_SD], o->comment);

--- a/velox/tpch/gen/dbgen/include/dbgen/dss.h
+++ b/velox/tpch/gen/dbgen/include/dbgen/dss.h
@@ -262,6 +262,11 @@ EXTERN int delete_segment;
  */
 
 /*
+ * helper macros
+ */
+#define SCALED_VAL(v) static_cast<decltype(v)>((v) * ctx->scale_factor)
+
+/*
  * defines which control the parts table
  */
 #define P_SIZE 126
@@ -305,7 +310,7 @@ EXTERN int delete_segment;
  */
 #define PS_SIZE 145
 #define PS_SKEY_MIN 0
-#define PS_SKEY_MAX ((ctx->tdefs[SUPP].base - 1) * ctx->scale_factor)
+#define PS_SKEY_MAX SCALED_VAL(ctx->tdefs[SUPP].base - 1)
 #define PS_SCST_MIN 100
 #define PS_SCST_MAX 100000
 #define PS_QTY_MIN 1
@@ -324,7 +329,7 @@ EXTERN int delete_segment;
  */
 #define O_SIZE 109
 #define O_CKEY_MIN 1
-#define O_CKEY_MAX (ctx->tdefs[CUST].base * ctx->scale_factor)
+#define O_CKEY_MAX SCALED_VAL(ctx->tdefs[CUST].base)
 #define O_ODATE_MIN STARTDATE
 #define O_ODATE_MAX (STARTDATE + TOTDATE - (L_SDTE_MAX + L_RDTE_MAX) - 1)
 #define O_CLRK_TAG "Clerk#"
@@ -344,7 +349,7 @@ EXTERN int delete_segment;
 #define L_DCNT_MIN 0
 #define L_DCNT_MAX 10
 #define L_PKEY_MIN 1
-#define L_PKEY_MAX (ctx->tdefs[PART].base * ctx->scale_factor)
+#define L_PKEY_MAX SCALED_VAL(ctx->tdefs[PART].base)
 #define L_SDTE_MIN 1
 #define L_SDTE_MAX 121
 #define L_CDTE_MIN 30
@@ -599,7 +604,7 @@ struct DBGenContext {
       {"region.tbl", "region table", NATIONS_MAX, NULL, NULL, NONE, 0},
   };
 
-  long scale_factor = 1;
+  double scale_factor = 1.0;
   long* permute = nullptr;
 };
 

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -849,6 +849,116 @@ TEST_F(TpchGenTestCustomerTest, reproducible) {
   }
 }
 
+class TpchGenTestForeignKeyTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = memory::memoryManager()->addLeafPool("TpchGenTestForeignKeyTest");
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+// Ensures that FK values are within the range of the actual row counts.
+TEST_F(TpchGenTestForeignKeyTest, smallScaleFactorFKMismatch) {
+  constexpr double scaleFactor = 0.01;
+
+  // Expected row counts at SF=0.01.
+  size_t supplierCount = getRowCount(Table::TBL_SUPPLIER, scaleFactor); // 100
+  size_t partCount = getRowCount(Table::TBL_PART, scaleFactor); // 2,000
+  size_t customerCount = getRowCount(Table::TBL_CUSTOMER, scaleFactor); // 1,500
+  size_t orderCount = getRowCount(Table::TBL_ORDERS, scaleFactor); // 15,000
+  size_t partSuppCount = getRowCount(Table::TBL_PARTSUPP, scaleFactor); // 8,000
+
+  LOG(INFO) << "Row counts for scale_factor 0.01 - supplier: " << supplierCount
+            << ", part: " << partCount << ", customer: " << customerCount
+            << ", order: " << orderCount << ", partsupp: " << partSuppCount;
+
+  // Check lineitem FK values (l_suppkey, l_partkey)
+  auto lineItems = genTpchLineItem(pool_.get(), orderCount, 0, scaleFactor);
+  auto lineItemCount = lineItems->size();
+
+  auto suppKeyVector = lineItems->childAt(2)->asFlatVector<int64_t>();
+  auto partKeyVector = lineItems->childAt(1)->asFlatVector<int64_t>();
+
+  int64_t maxSuppKey = 0;
+  int64_t maxPartKey = 0;
+  size_t suppKeyViolations = 0;
+  size_t partKeyViolations = 0;
+
+  for (size_t i = 0; i < lineItemCount; ++i) {
+    auto sk = suppKeyVector->valueAt(i);
+    auto pk = partKeyVector->valueAt(i);
+
+    if (sk > maxSuppKey)
+      maxSuppKey = sk;
+    if (pk > maxPartKey)
+      maxPartKey = pk;
+
+    if (sk > static_cast<int64_t>(supplierCount))
+      ++suppKeyViolations;
+    if (pk > static_cast<int64_t>(partCount))
+      ++partKeyViolations;
+  }
+
+  LOG(INFO) << "lineitem rows: " << lineItemCount;
+  LOG(INFO) << "l_suppkey: max=" << maxSuppKey
+            << ", violations=" << suppKeyViolations << "/" << lineItemCount;
+  LOG(INFO) << "l_partkey: max=" << maxPartKey
+            << ", violations=" << partKeyViolations << "/" << lineItemCount;
+
+  EXPECT_LE(maxSuppKey, static_cast<int64_t>(supplierCount));
+  EXPECT_LE(maxPartKey, static_cast<int64_t>(partCount));
+  EXPECT_EQ(suppKeyViolations, 0);
+  EXPECT_EQ(partKeyViolations, 0);
+
+  // Check orders FK values (o_custkey)
+  auto orders = genTpchOrders(pool_.get(), orderCount, 0, scaleFactor);
+  auto custKeyVector = orders->childAt(1)->asFlatVector<int64_t>();
+
+  int64_t maxCustKey = 0;
+  size_t custKeyViolations = 0;
+
+  for (size_t i = 0; i < orders->size(); ++i) {
+    auto ck = custKeyVector->valueAt(i);
+    if (ck > maxCustKey)
+      maxCustKey = ck;
+    if (ck > static_cast<int64_t>(customerCount))
+      ++custKeyViolations;
+  }
+
+  LOG(INFO) << "o_custkey: max=" << maxCustKey
+            << ", violations=" << custKeyViolations << "/" << orders->size();
+
+  EXPECT_LE(maxCustKey, static_cast<int64_t>(customerCount));
+  EXPECT_EQ(custKeyViolations, 0);
+
+  // Check partsupp FK values (ps_suppkey)
+  auto partSupps = genTpchPartSupp(pool_.get(), partSuppCount, 0, scaleFactor);
+  auto psSuppKeyVector = partSupps->childAt(1)->asFlatVector<int64_t>();
+
+  int64_t maxPsSuppKey = 0;
+  size_t psSuppKeyViolations = 0;
+
+  for (size_t i = 0; i < partSupps->size(); ++i) {
+    auto sk = psSuppKeyVector->valueAt(i);
+    if (sk > maxPsSuppKey)
+      maxPsSuppKey = sk;
+    if (sk > static_cast<int64_t>(supplierCount))
+      ++psSuppKeyViolations;
+  }
+
+  LOG(INFO) << "ps_suppkey: max=" << maxPsSuppKey
+            << ", violations=" << psSuppKeyViolations << "/"
+            << partSupps->size();
+
+  EXPECT_LE(maxPsSuppKey, static_cast<int64_t>(supplierCount));
+  EXPECT_EQ(psSuppKeyViolations, 0);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Change DBGenContext::scale_factor from long to double to correctly support fractional scale factors.

The fix removes the clamping logic and assigns the actual double value directly to scale_factor. Kept SCALED_VAL() macro to safely multiply and pass appropriate value to all downstream macros and functions.

Added test cases to verify FK integrity.

Issue: #16399 