### PR TITLE
feat: Add messageTemplate field to VeloxException for error categorization

### DIFF
--- a/velox/common/base/ExceptionHelper.h
+++ b/velox/common/base/ExceptionHelper.h
@@ -34,6 +34,24 @@ struct CompileTimeEmptyString {
   }
 };
 
+/// Wraps a const char* that must originate from a string literal (or other
+/// compile-time constant). Provides a distinct type to resolve overload
+/// ambiguity with std::string_view parameters in exception constructors.
+class CompileTimeStringLiteral {
+  const char* data_;
+
+ public:
+  /* implicit */ constexpr CompileTimeStringLiteral(const char* data)
+      : data_{data} {}
+
+  constexpr operator const char*() const {
+    return data_;
+  }
+  constexpr operator std::string_view() const {
+    return data_ ? std::string_view(data_) : std::string_view();
+  }
+};
+
 // When there is no message passed, we can statically detect this case
 // and avoid passing even a single unnecessary argument pointer,
 // minimizing size and thus maximizing eligibility for inlining.

--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -44,6 +44,8 @@ struct VeloxCheckFailArgs {
 // inline it when it is large. Having an out-of-line error path helps
 // otherwise-small functions that call error-checking macros stay
 // small and thus stay eligible for inlining.
+
+// Overload without messageTemplate: message IS the template (0 or 1 args).
 template <typename Exception, typename StringType>
 [[noreturn]] void veloxCheckFail(const VeloxCheckFailArgs& args, StringType s) {
   static_assert(
@@ -67,6 +69,39 @@ template <typename Exception, typename StringType>
       args.errorSource,
       args.errorCode,
       args.isRetriable);
+}
+
+// Overload with messageTemplate: template is the format string before
+// interpolation (>=2 args, format string + arguments). The template should
+// be a string literal; for runtime format strings, use the single-arg
+// VELOX_FAIL("{}", runtimeStr) pattern instead.
+template <typename Exception, typename StringType>
+[[noreturn]] void veloxCheckFail(
+    const VeloxCheckFailArgs& args,
+    StringType s,
+    CompileTimeStringLiteral messageTemplate) {
+  static_assert(
+      !std::is_same_v<StringType, std::string>,
+      "BUG: we should not pass std::string by value to veloxCheckFail");
+  if constexpr (!std::is_same_v<Exception, VeloxUserError>) {
+    LOG(ERROR) << "Line: " << args.file << ":" << args.line
+               << ", Function:" << args.function
+               << ", Expression: " << args.expression << " " << s
+               << ", Source: " << args.errorSource
+               << ", ErrorCode: " << args.errorCode;
+  }
+
+  ++threadNumVeloxThrow();
+  throw Exception(
+      args.file,
+      args.line,
+      args.function,
+      args.expression,
+      s,
+      args.errorSource,
+      args.errorCode,
+      args.isRetriable,
+      messageTemplate);
 }
 
 // VeloxCheckFailStringType helps us pass by reference to
@@ -106,21 +141,99 @@ struct VeloxCheckFailStringType<std::string> {
   extern template void veloxCheckFail<exception_type, const std::string&>(     \
       const VeloxCheckFailArgs& args,                                          \
       const std::string&);                                                     \
+  extern template void veloxCheckFail<exception_type, CompileTimeEmptyString>( \
+      const VeloxCheckFailArgs& args,                                          \
+      CompileTimeEmptyString,                                                  \
+      CompileTimeStringLiteral);                                               \
+  extern template void veloxCheckFail<exception_type, const char*>(            \
+      const VeloxCheckFailArgs& args,                                          \
+      const char*,                                                             \
+      CompileTimeStringLiteral);                                               \
+  extern template void veloxCheckFail<exception_type, const std::string&>(     \
+      const VeloxCheckFailArgs& args,                                          \
+      const std::string&,                                                      \
+      CompileTimeStringLiteral);                                               \
   } // namespace detail
 
 // Definitions corresponding to DECLARE_CHECK_FAIL_TEMPLATES. Should
 // only be used in Exceptions.cpp.
-#define DEFINE_CHECK_FAIL_TEMPLATES(exception_type)                     \
-  template void veloxCheckFail<exception_type, CompileTimeEmptyString>( \
-      const VeloxCheckFailArgs& args, CompileTimeEmptyString);          \
-  template void veloxCheckFail<exception_type, const char*>(            \
-      const VeloxCheckFailArgs& args, const char*);                     \
-  template void veloxCheckFail<exception_type, const std::string&>(     \
-      const VeloxCheckFailArgs& args, const std::string&);
+#define DEFINE_CHECK_FAIL_TEMPLATES(exception_type)                           \
+  template void veloxCheckFail<exception_type, CompileTimeEmptyString>(       \
+      const VeloxCheckFailArgs& args, CompileTimeEmptyString);                \
+  template void veloxCheckFail<exception_type, const char*>(                  \
+      const VeloxCheckFailArgs& args, const char*);                           \
+  template void veloxCheckFail<exception_type, const std::string&>(           \
+      const VeloxCheckFailArgs& args, const std::string&);                    \
+  template void veloxCheckFail<exception_type, CompileTimeEmptyString>(       \
+      const VeloxCheckFailArgs& args,                                         \
+      CompileTimeEmptyString,                                                 \
+      CompileTimeStringLiteral);                                              \
+  template void veloxCheckFail<exception_type, const char*>(                  \
+      const VeloxCheckFailArgs& args, const char*, CompileTimeStringLiteral); \
+  template void veloxCheckFail<exception_type, const std::string&>(           \
+      const VeloxCheckFailArgs& args,                                         \
+      const std::string&,                                                     \
+      CompileTimeStringLiteral);
 
 } // namespace detail
 
-#define _VELOX_THROW_IMPL(                                            \
+// Macro arg-count detection for dispatching between the no-template
+// and with-template overloads of veloxCheckFail.
+// 0 or 1 args: message IS the template (no-template overload).
+// >=2 args: first arg is the format string template (with-template overload).
+#define _VELOX_NARGS_IMPL( \
+    _0,                    \
+    _1,                    \
+    _2,                    \
+    _3,                    \
+    _4,                    \
+    _5,                    \
+    _6,                    \
+    _7,                    \
+    _8,                    \
+    _9,                    \
+    _10,                   \
+    _11,                   \
+    _12,                   \
+    _13,                   \
+    _14,                   \
+    _15,                   \
+    _16,                   \
+    N,                     \
+    ...)                   \
+  N
+#define _VELOX_NARGS(...) \
+  _VELOX_NARGS_IMPL(      \
+      dummy,              \
+      ##__VA_ARGS__,      \
+      16,                 \
+      15,                 \
+      14,                 \
+      13,                 \
+      12,                 \
+      11,                 \
+      10,                 \
+      9,                  \
+      8,                  \
+      7,                  \
+      6,                  \
+      5,                  \
+      4,                  \
+      3,                  \
+      2,                  \
+      1,                  \
+      0)
+
+// Extract the first argument from __VA_ARGS__ (the format string) as a
+// CompileTimeStringLiteral. Only used for >=2 args path.
+#define _VELOX_MSG_TEMPLATE_PICK(_1, _2, ...) _2
+#define _VELOX_MSG_TEMPLATE(...)               \
+  ::facebook::velox::CompileTimeStringLiteral( \
+      _VELOX_MSG_TEMPLATE_PICK("", ##__VA_ARGS__, ""))
+
+// _VELOX_THROW_IMPL dispatches to the no-template or with-template path
+// based on the number of user-supplied message arguments.
+#define _VELOX_THROW_IMPL_BODY_NO_TEMPLATE(                           \
     exception, exprStr, errorSource, errorCode, isRetriable, ...)     \
   do {                                                                \
     /* GCC 9.2.1 doesn't accept this code with constexpr. */          \
@@ -139,6 +252,54 @@ struct VeloxCheckFailStringType<std::string> {
         typename ::facebook::velox::detail::VeloxCheckFailStringType< \
             decltype(message)>::type>(veloxCheckFailArgs, message);   \
   } while (0)
+
+#define _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE(                           \
+    exception, exprStr, errorSource, errorCode, isRetriable, ...)       \
+  do {                                                                  \
+    /* GCC 9.2.1 doesn't accept this code with constexpr. */            \
+    static const ::facebook::velox::detail::VeloxCheckFailArgs          \
+        veloxCheckFailArgs = {                                          \
+            __FILE__,                                                   \
+            __LINE__,                                                   \
+            __FUNCTION__,                                               \
+            exprStr,                                                    \
+            errorSource,                                                \
+            errorCode,                                                  \
+            isRetriable};                                               \
+    auto message = ::facebook::velox::errorMessage(__VA_ARGS__);        \
+    ::facebook::velox::detail::veloxCheckFail<                          \
+        exception,                                                      \
+        typename ::facebook::velox::detail::VeloxCheckFailStringType<   \
+            decltype(message)>::type>(                                  \
+        veloxCheckFailArgs, message, _VELOX_MSG_TEMPLATE(__VA_ARGS__)); \
+  } while (0)
+
+#define _VELOX_THROW_DISPATCH_0 _VELOX_THROW_IMPL_BODY_NO_TEMPLATE
+#define _VELOX_THROW_DISPATCH_1 _VELOX_THROW_IMPL_BODY_NO_TEMPLATE
+#define _VELOX_THROW_DISPATCH_2 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_3 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_4 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_5 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_6 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_7 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_8 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_9 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_10 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_11 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_12 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_13 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_14 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_15 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+#define _VELOX_THROW_DISPATCH_16 _VELOX_THROW_IMPL_BODY_WITH_TEMPLATE
+
+#define _VELOX_THROW_CONCAT2(a, b) a##b
+#define _VELOX_THROW_CONCAT(a, b) _VELOX_THROW_CONCAT2(a, b)
+#define _VELOX_THROW_SELECT(n) _VELOX_THROW_CONCAT(_VELOX_THROW_DISPATCH_, n)
+
+#define _VELOX_THROW_IMPL(                                        \
+    exception, exprStr, errorSource, errorCode, isRetriable, ...) \
+  _VELOX_THROW_SELECT(_VELOX_NARGS(__VA_ARGS__))(                 \
+      exception, exprStr, errorSource, errorCode, isRetriable, ##__VA_ARGS__)
 
 #define _VELOX_CHECK_AND_THROW_IMPL(                                    \
     expr, exprStr, exception, errorSource, errorCode, isRetriable, ...) \

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -103,6 +103,35 @@ VeloxException::VeloxException(
       })) {}
 
 VeloxException::VeloxException(
+    const char* file,
+    size_t line,
+    const char* function,
+    std::string_view failingExpression,
+    std::string_view message,
+    std::string_view errorSource,
+    std::string_view errorCode,
+    bool isRetriable,
+    CompileTimeStringLiteral messageTemplate,
+    Type exceptionType,
+    std::string_view exceptionName)
+    : VeloxException(State::make(exceptionType, [&](auto& state) {
+        state.exceptionType = exceptionType;
+        state.exceptionName = exceptionName;
+        state.file = file;
+        state.line = line;
+        state.function = function;
+        state.failingExpression = failingExpression;
+        state.message = message;
+        state.messageTemplate = messageTemplate;
+        state.errorSource = errorSource;
+        state.errorCode = errorCode;
+        state.context = getExceptionContext().message(exceptionType);
+        state.additionalContext =
+            getAdditionalExceptionContextString(exceptionType, state.context);
+        state.isRetriable = isRetriable;
+      })) {}
+
+VeloxException::VeloxException(
     const std::exception_ptr& e,
     std::string_view message,
     std::string_view errorSource,

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -28,6 +28,8 @@
 
 #include "velox/common/process/StackTrace.h"
 
+#include "velox/common/base/ExceptionHelper.h"
+
 DECLARE_bool(velox_exception_user_stacktrace_enabled);
 DECLARE_bool(velox_exception_system_stacktrace_enabled);
 
@@ -139,6 +141,8 @@ class VeloxException : public std::exception {
  public:
   enum class Type { kUser = 0, kSystem = 1 };
 
+  /// Construct without an explicit message template. messageTemplate() will
+  /// return the message itself (the message IS the template).
   VeloxException(
       const char* file,
       size_t line,
@@ -148,6 +152,21 @@ class VeloxException : public std::exception {
       std::string_view errorSource,
       std::string_view errorCode,
       bool isRetriable,
+      Type exceptionType = Type::kSystem,
+      std::string_view exceptionName = "VeloxException");
+
+  /// Construct with an explicit message template (the format string before
+  /// fmt::format interpolation).
+  VeloxException(
+      const char* file,
+      size_t line,
+      const char* function,
+      std::string_view expression,
+      std::string_view message,
+      std::string_view errorSource,
+      std::string_view errorCode,
+      bool isRetriable,
+      CompileTimeStringLiteral messageTemplate,
       Type exceptionType = Type::kSystem,
       std::string_view exceptionName = "VeloxException");
 
@@ -202,6 +221,14 @@ class VeloxException : public std::exception {
     return state_->message;
   }
 
+  /// Returns the format template before fmt::format interpolation. Useful for
+  /// grouping exceptions by error category in monitoring systems. When no
+  /// explicit template was provided, returns the message itself.
+  std::string_view messageTemplate() const {
+    return state_->messageTemplate ? std::string_view(state_->messageTemplate)
+                                   : std::string_view(state_->message);
+  }
+
   const std::string& errorCode() const {
     return state_->errorCode;
   }
@@ -248,6 +275,10 @@ class VeloxException : public std::exception {
     const char* function = nullptr;
     std::string failingExpression;
     std::string message;
+    // The format template before fmt::format interpolation. Points to a
+    // string literal (static lifetime) when set explicitly, or nullptr when
+    // the message itself serves as the template.
+    const char* messageTemplate{nullptr};
     std::string errorSource;
     std::string errorCode;
     // The current exception context.
@@ -284,6 +315,8 @@ class VeloxException : public std::exception {
 
 class VeloxUserError : public VeloxException {
  public:
+  static constexpr std::string_view kDefaultName = "VeloxUserError";
+
   VeloxUserError(
       const char* file,
       size_t line,
@@ -293,7 +326,7 @@ class VeloxUserError : public VeloxException {
       std::string_view /* errorSource */,
       std::string_view errorCode,
       bool isRetriable,
-      std::string_view exceptionName = "VeloxUserError")
+      std::string_view exceptionName = kDefaultName)
       : VeloxException(
             file,
             line,
@@ -306,12 +339,36 @@ class VeloxUserError : public VeloxException {
             Type::kUser,
             exceptionName) {}
 
+  VeloxUserError(
+      const char* file,
+      size_t line,
+      const char* function,
+      std::string_view expression,
+      std::string_view message,
+      std::string_view /* errorSource */,
+      std::string_view errorCode,
+      bool isRetriable,
+      CompileTimeStringLiteral messageTemplate,
+      std::string_view exceptionName = kDefaultName)
+      : VeloxException(
+            file,
+            line,
+            function,
+            expression,
+            message,
+            error_source::kErrorSourceUser,
+            errorCode,
+            isRetriable,
+            messageTemplate,
+            Type::kUser,
+            exceptionName) {}
+
   /// Wrap an std::exception.
   VeloxUserError(
       const std::exception_ptr& e,
       std::string_view message,
       bool isRetriable,
-      std::string_view exceptionName = "VeloxUserError")
+      std::string_view exceptionName = kDefaultName)
       : VeloxException(
             e,
             message,
@@ -324,6 +381,8 @@ class VeloxUserError : public VeloxException {
 
 class VeloxRuntimeError final : public VeloxException {
  public:
+  static constexpr std::string_view kDefaultName = "VeloxRuntimeError";
+
   VeloxRuntimeError(
       const char* file,
       size_t line,
@@ -333,7 +392,7 @@ class VeloxRuntimeError final : public VeloxException {
       std::string_view /* errorSource */,
       std::string_view errorCode,
       bool isRetriable,
-      std::string_view exceptionName = "VeloxRuntimeError")
+      std::string_view exceptionName = kDefaultName)
       : VeloxException(
             file,
             line,
@@ -346,12 +405,36 @@ class VeloxRuntimeError final : public VeloxException {
             Type::kSystem,
             exceptionName) {}
 
+  VeloxRuntimeError(
+      const char* file,
+      size_t line,
+      const char* function,
+      std::string_view expression,
+      std::string_view message,
+      std::string_view /* errorSource */,
+      std::string_view errorCode,
+      bool isRetriable,
+      CompileTimeStringLiteral messageTemplate,
+      std::string_view exceptionName = kDefaultName)
+      : VeloxException(
+            file,
+            line,
+            function,
+            expression,
+            message,
+            error_source::kErrorSourceRuntime,
+            errorCode,
+            isRetriable,
+            messageTemplate,
+            Type::kSystem,
+            exceptionName) {}
+
   /// Wrap an std::exception.
   VeloxRuntimeError(
       const std::exception_ptr& e,
       std::string_view message,
       bool isRetriable,
-      std::string_view exceptionName = "VeloxRuntimeError")
+      std::string_view exceptionName = kDefaultName)
       : VeloxException(
             e,
             message,

--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 #include <folly/Random.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/base/Exceptions.h"
@@ -1011,12 +1012,123 @@ TEST(ExceptionTest, exceptionMacroInlining) {
   } catch (const VeloxUserError& ve) {
     ASSERT_EQ(ve.message(), errorStr);
   }
+}
 
-  // Inlined with the method that passes the errorStr and the next argument via
-  // fmt::vformat. Should throw format_error.
+TEST(ExceptionTest, messageTemplate) {
+  using testing::Property;
+  using testing::StrEq;
+  using testing::Throws;
+
+  auto noMsg = [] { VELOX_FAIL(); };
+  EXPECT_THAT(
+      noMsg,
+      Throws<VeloxException>(
+          Property(&VeloxException::messageTemplate, StrEq(""))));
+
+  auto plainMsg = [] { VELOX_FAIL("Something went wrong"); };
+  EXPECT_THAT(
+      plainMsg,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate, StrEq("Something went wrong"))));
+
+  // message() is interpolated, messageTemplate() is not.
+  auto fmtMsg = [] { VELOX_FAIL("Error: {} vs {}", 42, 99); };
+  EXPECT_THAT(
+      fmtMsg,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate, StrEq("Error: {} vs {}"))));
+  EXPECT_THAT(
+      fmtMsg,
+      Throws<VeloxException>(
+          Property(&VeloxException::message, StrEq("Error: 42 vs 99"))));
+
+  auto userFail = [] { VELOX_USER_FAIL("Not supported: {}", "rank"); };
+  EXPECT_THAT(
+      userFail,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate, StrEq("Not supported: {}"))));
+
+  auto checkFail = [] { VELOX_CHECK(false, "Bad state: {}", "disconnected"); };
+  EXPECT_THAT(
+      checkFail,
+      Throws<VeloxException>(
+          Property(&VeloxException::messageTemplate, StrEq("Bad state: {}"))));
+
+  auto checkEq = [] { VELOX_CHECK_EQ(1, 2); };
+  EXPECT_THAT(
+      checkEq,
+      Throws<VeloxException>(
+          Property(&VeloxException::messageTemplate, StrEq("({} vs. {})"))));
+
+  auto checkLt = [] { VELOX_CHECK_LT(10, 5, "Expected smaller"); };
+  EXPECT_THAT(
+      checkLt,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate,
+          StrEq("({} vs. {}) Expected smaller"))));
+
+  auto unsupported = [] { VELOX_UNSUPPORTED("{} not supported", "merge"); };
+  EXPECT_THAT(
+      unsupported,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate, StrEq("{} not supported"))));
+
+  auto nyi = [] { VELOX_NYI("{} not implemented", "windowing"); };
+  EXPECT_THAT(
+      nyi,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate, StrEq("{} not implemented"))));
+
+  // Wrapped exception has no explicit template, so messageTemplate() returns
+  // the message itself.
+  {
+    auto exceptionPtr =
+        std::make_exception_ptr(std::invalid_argument("wrapped"));
+    VeloxUserError ve(exceptionPtr, "wrapped", false);
+    EXPECT_EQ(ve.messageTemplate(), "wrapped");
+  }
+
+  // messageTemplate not in what().
   try {
-    VELOX_USER_FAIL(errorStr, "definitely");
-  } catch (const std::exception& e) {
-    ASSERT_TRUE(std::string_view{e.what()}.starts_with("argument not found"));
+    VELOX_FAIL("Count: {}", 42);
+    FAIL() << "Expected an exception";
+  } catch (const VeloxException& e) {
+    EXPECT_EQ(e.messageTemplate(), "Count: {}");
+    EXPECT_EQ(
+        std::string(e.what()).find("Message Template:"), std::string::npos);
+  }
+
+  // No message arg.
+  auto checkNotNull = [] {
+    int* ptr = nullptr;
+    VELOX_CHECK_NOT_NULL(ptr);
+  };
+  EXPECT_THAT(
+      checkNotNull,
+      Throws<VeloxException>(
+          Property(&VeloxException::messageTemplate, StrEq(""))));
+
+  // VELOX_CHECK_EQ with user-provided format args.
+  auto checkEqFmt = [] { VELOX_CHECK_EQ(1, 2, "Expected {} == {}", 1, 2); };
+  EXPECT_THAT(
+      checkEqFmt,
+      Throws<VeloxException>(Property(
+          &VeloxException::messageTemplate,
+          StrEq("({} vs. {}) Expected {} == {}"))));
+
+  // Exception copy preserves messageTemplate.
+  try {
+    VELOX_FAIL("Copy test: {}", 42);
+    FAIL() << "Expected an exception";
+  } catch (const VeloxException& e) {
+    const VeloxException& copy = e;
+    EXPECT_EQ(copy.messageTemplate(), "Copy test: {}");
+
+    auto rethrown = std::current_exception();
+    try {
+      std::rethrow_exception(rethrown);
+    } catch (const VeloxException& e2) {
+      EXPECT_EQ(e2.messageTemplate(), "Copy test: {}");
+    }
   }
 }

--- a/velox/common/serialization/Registry.h
+++ b/velox/common/serialization/Registry.h
@@ -114,7 +114,7 @@ class Registry {
         }
 
         VELOX_UNSUPPORTED(
-            typeid(ReturnType).name(), " is not nullable return type");
+            "{} is not nullable return type", typeid(ReturnType).name());
       }
       return it->second(types...);
     }

--- a/velox/dwio/parquet/reader/DeltaBpDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaBpDecoder.h
@@ -127,8 +127,8 @@ class DeltaBpDecoder {
     VELOX_CHECK_EQ(
         valuesPerBlock_ % 128,
         0,
-        "the number of values in a block must be multiple of 128, but it's " +
-            std::to_string(valuesPerBlock_));
+        "the number of values in a block must be multiple of 128, but it's {}",
+        valuesPerBlock_);
     VELOX_CHECK_GT(
         miniBlocksPerBlock_, 0, "cannot have zero miniblock per block");
     valuesPerMiniBlock_ = valuesPerBlock_ / miniBlocksPerBlock_;
@@ -137,8 +137,8 @@ class DeltaBpDecoder {
     VELOX_CHECK_EQ(
         valuesPerMiniBlock_ % 32,
         0,
-        "the number of values in a miniblock must be multiple of 32, but it's " +
-            std::to_string(valuesPerMiniBlock_));
+        "the number of values in a miniblock must be multiple of 32, but it's {}",
+        valuesPerMiniBlock_);
 
     totalValuesRemaining_ = totalValueCount_;
     deltaBitWidths_.resize(miniBlocksPerBlock_);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -755,7 +755,7 @@ TypePtr ReaderBase::convertType(
           schemaElement.__isset.type_length,
       "FIXED_LEN_BYTE_ARRAY requires length to be set");
 
-  static std::string_view kTypeMappingErrorFmtStr =
+  static constexpr const char* kTypeMappingErrorFmtStr =
       "Converted type {} is not allowed for requested type {}";
   const bool isRepeated = schemaElement.__isset.repetition_type &&
       schemaElement.repetition_type == thrift::FieldRepetitionType::REPEATED;

--- a/velox/functions/lib/ArraySort.cpp
+++ b/velox/functions/lib/ArraySort.cpp
@@ -533,7 +533,7 @@ core::TypedExprPtr rewriteArraySortCall(
   if (lambda->signature()->size() != 2) {
     return nullptr;
   }
-  static const std::string kNotSupported =
+  static constexpr const char* kNotSupported =
       "array_sort with comparator lambda that cannot be rewritten "
       "into a transform is not supported: {}";
 

--- a/velox/functions/lib/CheckDuplicateKeys.cpp
+++ b/velox/functions/lib/CheckDuplicateKeys.cpp
@@ -24,7 +24,8 @@ void checkDuplicateKeys(
   if (rows.end() == 0) {
     return;
   }
-  static const char* kDuplicateKey = "Duplicate map keys ({}) are not allowed";
+  static constexpr const char* kDuplicateKey =
+      "Duplicate map keys ({}) are not allowed";
 
   MapVector::canonicalize(mapVector);
 

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -359,7 +359,7 @@ class MapFunction : public exec::VectorFunction {
   void checkDuplicateConstantKeys(
       const std::vector<vector_size_t>& sortedIndices,
       const VectorPtr& keysElements) const {
-    static const char* kDuplicateKey =
+    static constexpr const char* kDuplicateKey =
         "Duplicate map keys ({}) are not allowed";
 
     if (auto duplicateIndex = findDuplicateKeys(sortedIndices, keysElements)) {

--- a/velox/functions/prestosql/SplitToMap.cpp
+++ b/velox/functions/prestosql/SplitToMap.cpp
@@ -63,7 +63,7 @@ core::TypedExprPtr rewriteSplitToMapCall(
   }
 
   if (!keepFirst.has_value()) {
-    static const std::string kNotSupported =
+    static constexpr const char* kNotSupported =
         "split_to_map with arbitrary lambda is not supported: {}";
     VELOX_USER_FAIL(kNotSupported, lambda->toString());
   }

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -1297,8 +1297,6 @@ int32_t parseDecimalBitWidthOrDefault(const std::string_view format) {
 }
 
 TypePtr parseDecimalFormat(const std::string_view format) {
-  const std::string_view invalidFormatMsg =
-      "Unable to convert '{}' ArrowSchema decimal format to Velox decimal";
   try {
     std::string_view::size_type sz;
 
@@ -1309,7 +1307,9 @@ TypePtr parseDecimalFormat(const std::string_view format) {
         format.size() == firstCommaIdx + 1 ||
         (secondCommaIdx != std::string_view::npos &&
          format.size() == secondCommaIdx + 1)) {
-      VELOX_USER_FAIL(invalidFormatMsg, format);
+      VELOX_USER_FAIL(
+          "Unable to convert '{}' ArrowSchema decimal format to Velox decimal",
+          format);
     }
 
     // Parse "d:".
@@ -1331,7 +1331,9 @@ TypePtr parseDecimalFormat(const std::string_view format) {
     // Otherwise return type depends on precision.
     return DECIMAL(precision, scale);
   } catch (std::invalid_argument&) {
-    VELOX_USER_FAIL(invalidFormatMsg, format);
+    VELOX_USER_FAIL(
+        "Unable to convert '{}' ArrowSchema decimal format to Velox decimal",
+        format);
   }
 }
 


### PR DESCRIPTION
Summary: Add messageTemplate to VeloxException to preserve the original format string used to construct an exception message.

This enables downstream logging/monitoring to group errors by template instead of the fully-formatted message (which often contains runtime-specific values).

Example:
For, VELOX_USER_FAIL("Function not supported: {}", name);
  
message():         "Function not supported: at_timezone(TIMESTAMP, VARCHAR)"
messageTemplate(): "Function not supported: {}"

Why capture the template at throw-time (vs. recovering it later)? 

Once fmt::format/fmt::vformat has produced the final string, the original format string isn’t available anymore, and inferring a stable template from the formatted message would be brittle/unsafe (and would typically require heuristics/regex, which is exactly what we want to avoid). 

Capturing the first variadic macro argument avoids double-evaluating formatting args and reliably preserves the template.


Notes:
- Additive change; existing message() / what() output is unchanged.
- Minimal overhead (only on throw path).

Fixes #16544

Differential Revision: D95092474


