### PR TITLE
fix: Make cacheable default to false in FileIoContext and BufferedInput

### DIFF
--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -80,7 +80,7 @@ struct FileIoContext {
   /// When false, hints to the storage layer that this read should not be cached
   /// or should be evicted soon after reading. This is useful for one-time reads
   /// where caching would waste resources.
-  bool cacheable{true};
+  bool cacheable{false};
 
   FileIoContext() = default;
 
@@ -88,7 +88,7 @@ struct FileIoContext {
       IoStats* stats,
       folly::F14FastMap<std::string, std::string> fileOpts = {},
       std::shared_ptr<FileIoTracer> tracer = nullptr,
-      bool cacheable = true)
+      bool cacheable = false)
       : ioStats(stats),
         fileOpts(std::move(fileOpts)),
         ioTracer(std::move(tracer)),

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -51,6 +51,17 @@ void writeData(WriteFile* writeFile, bool useIOBuf = false) {
   }
 }
 
+TEST(FileIoContextTest, defaultCacheableIsFalse) {
+  FileIoContext defaultContext;
+  EXPECT_FALSE(defaultContext.cacheable);
+
+  FileIoContext explicitContext(nullptr);
+  EXPECT_FALSE(explicitContext.cacheable);
+
+  FileIoContext cacheableContext(nullptr, {}, nullptr, true);
+  EXPECT_TRUE(cacheableContext.cacheable);
+}
+
 void writeDataWithOffset(WriteFile* writeFile) {
   ASSERT_EQ(writeFile->size(), 0);
   writeFile->truncate(15 + kOneMB);

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -39,7 +39,7 @@ class BufferedInput {
       uint64_t maxMergeDistance = kMaxMergeDistance,
       std::optional<bool> wsVRLoad = std::nullopt,
       folly::F14FastMap<std::string, std::string> fileReadOps = {},
-      bool cacheable = true)
+      bool cacheable = false)
       : BufferedInput(
             std::make_shared<ReadFileInputStream>(
                 std::move(readFile),

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -146,7 +146,7 @@ class ReadFileInputStream final : public InputStream {
       IoStatistics* stats = nullptr,
       velox::IoStats* ioStats = nullptr,
       folly::F14FastMap<std::string, std::string> fileReadOps = {},
-      bool cacheable = true);
+      bool cacheable = false);
 
   ~ReadFileInputStream() override = default;
 


### PR DESCRIPTION
Summary: Default cacheable to false so non-caching read paths don't incorrectly cache their reads. Only CachedBufferedInput explicitly opts in via readerOptions.cacheable().

Differential Revision: D95139717


