### PR TITLE
feat: Add Aggregate::setConstantInputs hook for constant argument initialization

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -93,6 +93,17 @@ class Aggregate {
     setAllocatorInternal(allocator);
   }
 
+  /// Called after construction to pass constant input values to the aggregate.
+  /// Non-constant inputs have null entries in 'constantInputs'. This is called
+  /// before any data is processed, allowing the aggregate to read constant
+  /// arguments (e.g., flags, configuration values) at initialization time
+  /// rather than extracting them from 'args' at runtime.
+  ///
+  /// Default implementation is a no-op. Override in subclasses that need
+  /// access to constant arguments.
+  virtual void setConstantInputs(
+      const std::vector<VectorPtr>& /*constantInputs*/) {}
+
   /// Called for functions that take one or more lambda expression as input.
   /// These expressions must appear after all non-lambda inputs.
   /// These expressions cannot use captures.

--- a/velox/exec/AggregateInfo.cpp
+++ b/velox/exec/AggregateInfo.cpp
@@ -104,6 +104,12 @@ std::vector<AggregateInfo> toAggregateInfo(
         aggResultType,
         operatorCtx.driverCtx()->queryConfig());
 
+    // Pass constant inputs to the aggregate so it can read constant arguments
+    // (e.g., flags) at initialization time.
+    if (!constants.empty()) {
+      info.function->setConstantInputs(constants);
+    }
+
     auto lambdas = extractLambdaInputs(aggregate);
     if (!lambdas.empty()) {
       if (expressionEvaluator == nullptr) {


### PR DESCRIPTION
## Summary

Add a virtual `setConstantInputs` method to the `Aggregate` base class that is called after construction with the constant input values. This allows aggregate functions to read constant arguments (e.g., flags, configuration values) at initialization time rather than extracting them from the `args` vector at runtime.

### Motivation

Currently, the `AggregateFunctionFactory` only receives `argTypes` (type information) but not constant values. Constant inputs are stored in `AggregateInfo::constantInputs` and only reach the aggregate at runtime via `addRawInput`'s `args` vector. This creates a gap for aggregates that need constant values in methods like `toIntermediate()` or `addIntermediateResults()`, which don't receive raw input args.

For example, `collect_set(x, ignoreNulls)` needs the boolean `ignoreNulls` constant in `toIntermediate()` to correctly handle null elements during the abandon-partial-aggregation flow. Without this hook, the aggregate must cache the constant from `addRawInput` at runtime, which is indirect and confusing.

### Changes

- **`velox/exec/Aggregate.h`**: Add `virtual void setConstantInputs(const std::vector<VectorPtr>&)` with default no-op implementation.
- **`velox/exec/AggregateInfo.cpp`**: Call `setConstantInputs` after `Aggregate::create()` and before any data processing.

### Testing

All 140 existing Spark aggregate tests pass. The hook is a no-op by default, so no existing behavior changes.

This is a prerequisite for https://github.com/facebookincubator/velox/pull/16416.