### PR TITLE
fix(JSON): Disable incorrect JSON to DECIMAL cast

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -1187,6 +1187,17 @@ TEST_F(JsonCastTest, toBoolean) {
   testThrow<JsonNativeType>(JSON(), BOOLEAN(), {""_sv}, "no JSON found");
 }
 
+TEST_F(JsonCastTest, toDecimal) {
+  // Casting DECIMAL to JSON is currently unsupported because precision and
+  // scale are not handled yet. The query below is expected to return 123456789,
+  // but currently returns 1234567.
+  testThrow<JsonNativeType>(
+      JSON(),
+      DECIMAL(10, 2),
+      {"1234567.89"_sv},
+      "Cannot cast JSON to DECIMAL(10, 2).");
+}
+
 TEST_F(JsonCastTest, toArray) {
   auto data = makeNullableFlatVector<JsonNativeType>(
       {R"(["red","blue"])"_sv,

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -1187,10 +1187,6 @@ bool isSupportedBasicType(const TypePtr& type) {
 } // namespace
 
 bool JsonCastOperator::isSupportedFromType(const TypePtr& other) const {
-  if (other->isDecimal()) {
-    return false;
-  }
-
   if (isSupportedBasicType(other)) {
     return true;
   }
@@ -1269,7 +1265,7 @@ void JsonCastOperator::castFromJson(
 }
 
 bool JsonCastOperator::isSupportedToType(const TypePtr& other) const {
-  if (other->isDate()) {
+  if (other->isDate() || other->isDecimal()) {
     return false;
   }
 

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -1187,6 +1187,10 @@ bool isSupportedBasicType(const TypePtr& type) {
 } // namespace
 
 bool JsonCastOperator::isSupportedFromType(const TypePtr& other) const {
+  if (other->isDecimal()) {
+    return false;
+  }
+
   if (isSupportedBasicType(other)) {
     return true;
   }


### PR DESCRIPTION
The current implementation of CAST(JSON AS DECIMAL) produces incorrect results because it fails to respect the precision and scale of the target decimal type.

We encountered the same issue in production as reported in [#11674](https://github.com/facebookincubator/velox/issues/11674 ).

For instance, `CAST(JSON '1234567.89' AS DECIMAL(10, 2))` incorrectly returns `12345.68` instead of the expected `1234567.89`.

Silent data corruption is more critical than a functional error. This commit disables the cast to ensure data integrity and prevent incorrect results until a proper fix is developed.