### PR TITLE
docs: Add DWIO documentation to Velox developer guide (#16629)

### DIFF
--- a/velox/docs/develop.rst
+++ b/velox/docs/develop.rst
@@ -19,6 +19,7 @@ This guide is intended for Velox contributors and developers of Velox-based appl
     develop/hash-table
     develop/aggregations
     develop/connectors
+    develop/dwio
     develop/joins
     develop/anti-join
     develop/operators

--- a/velox/docs/develop/dwio.rst
+++ b/velox/docs/develop/dwio.rst
@@ -1,0 +1,71 @@
+****
+DWIO
+****
+
+DWIO (Data Warehouse I/O) is Velox's format-agnostic I/O layer for reading and
+writing columnar file formats. It provides a unified abstraction over multiple
+file formats so that the rest of the engine -- connectors, operators, and the
+execution framework -- can work with data files without depending on
+format-specific details.
+
+Supported Formats
+=================
+
+.. list-table::
+   :widths: 15 50
+   :header-rows: 1
+
+   * - Format
+     - Description
+   * - DWRF
+     - Meta's columnar format derived from ORC. Supports FlatMap encoding,
+       column-level encryption, and stripe-level indexing.
+   * - Parquet
+     - Apache Parquet. Supports Dremel encoding for nested types, dictionary
+       encoding, and multiple compression codecs.
+   * - ORC
+     - Apache ORC. Read support shares much of the DWRF code path.
+   * - Text
+     - Delimited text (CSV / TSV) files.
+   * - Nimble
+     - Experimental next-generation columnar format.
+
+Relationship to Connectors
+==========================
+
+DWIO sits below the :doc:`Connector <connectors>` layer. A connector such as the
+Hive Connector creates a ``HiveDataSource`` which in turn uses a DWIO
+``Reader`` to decode file data. The boundary is:
+
+* **Connector** -- understands splits, partitioning, bucketing, and dynamic
+  filter pushdown. Owns the ``DataSource`` / ``DataSink`` interfaces.
+* **DWIO** -- understands file layouts, encoding, I/O scheduling, and column
+  projection. Owns the ``Reader`` / ``Writer`` interfaces and their factories.
+
+.. code-block:: text
+
+   ┌──────────────┐
+   │  Connector   │   HiveDataSource / HiveDataSink
+   └──────┬───────┘
+          │ creates
+   ┌──────▼───────┐
+   │  DWIO Layer  │   ReaderFactory / WriterFactory
+   └──────┬───────┘
+          │ reads / writes
+   ┌──────▼───────┐
+   │  Storage     │   S3, HDFS, GCS, ABFS, local FS
+   └──────────────┘
+
+Topics
+======
+
+.. toctree::
+    :maxdepth: 1
+
+    dwio/architecture
+    dwio/scan-and-filter
+    dwio/io-buffering
+    dwio/dwrf
+    dwio/parquet
+    dwio/nimble
+    dwio/writers

--- a/velox/docs/develop/dwio/architecture.rst
+++ b/velox/docs/develop/dwio/architecture.rst
@@ -1,0 +1,157 @@
+============
+Architecture
+============
+
+DWIO provides a layered architecture for reading and writing columnar files.
+Format-specific logic is isolated behind abstract interfaces so that connectors
+and operators interact with a single API regardless of the underlying file
+format.
+
+Reader/Writer Factory Pattern
+=============================
+
+Readers and writers are created through static registries.
+
+**Reader registration** (``dwio/common/ReaderFactory.h``):
+
+.. code-block:: cpp
+
+   // Registration (typically called once during startup)
+   dwio::common::registerReaderFactory(std::make_shared<DwrfReaderFactory>());
+
+   // Lookup
+   auto factory = dwio::common::getReaderFactory(FileFormat::DWRF);
+   auto reader = factory->createReader(input, options);
+
+**Writer registration** (``dwio/common/WriterFactory.h``):
+
+.. code-block:: cpp
+
+   dwio::common::registerWriterFactory(std::make_shared<DwrfWriterFactory>());
+   auto factory = dwio::common::getWriterFactory(FileFormat::DWRF);
+   auto writer = factory->createWriter(sink, options);
+
+Each factory is keyed by a ``FileFormat`` enum value (``DWRF``, ``PARQUET``,
+``ORC``, ``TEXT``, ``NIMBLE``, etc.).
+
+Reader Hierarchy
+================
+
+The read path is a three-level hierarchy defined in
+``dwio/common/Reader.h``:
+
+.. list-table::
+   :widths: 15 45
+   :header-rows: 1
+
+   * - Class
+     - Role
+   * - ``Reader``
+     - Wraps a file handle. Parses file-level metadata (footer, schema,
+       encryption). Provides ``createRowReader()`` to begin scanning.
+   * - ``RowReader``
+     - Iterates over row groups / stripes. Owns the ``ScanSpec`` (column
+       projection + filters). Calls ``next()`` to produce output
+       ``RowVector`` batches.
+   * - ``SelectiveColumnReader``
+     - Per-column decoder. Reads encoded data, applies inline filters via
+       ``ColumnVisitor``, and materializes passing rows into vectors. Delegates
+       format-specific operations to ``FormatData``.
+
+Writer Hierarchy
+================
+
+The write path is modeled as a state machine defined in
+``dwio/common/Writer.h``:
+
+.. code-block:: text
+
+   ┌──────┐   write()   ┌─────────┐   flush()   ┌──────────┐   close()   ┌────────┐
+   │ Init ├────────────►│ Running ├────────────►│ Finishing ├───────────►│ Closed │
+   └──────┘             └────┬────┘             └──────────┘            └────────┘
+                             │ abort()
+                        ┌────▼────┐
+                        │ Aborted │
+                        └─────────┘
+
+* ``write(RowVectorPtr)`` -- appends a batch of rows.
+* ``flush()`` -- writes buffered data (e.g. a complete stripe).
+* ``close()`` -- finalizes the file (writes footer, closes sink).
+* ``abort()`` -- discards state; no file is produced.
+
+FormatData Abstraction
+======================
+
+``SelectiveColumnReader`` is format-agnostic. It delegates format-specific
+operations to a ``FormatData`` object (``dwio/common/FormatData.h``):
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Method
+     - Purpose
+   * - ``readNulls()``
+     - Decodes the null bitmap in the format's native encoding.
+   * - ``seekToRowGroup()``
+     - Positions streams to the start of a specific row group or stride.
+   * - ``filterRowGroups()``
+     - Tests column-level statistics against the filter to decide whether a row
+       group can be skipped entirely.
+
+Each file format (DWRF, Parquet, ...) provides its own ``FormatData``
+subclass.
+
+End-to-End Read Pipeline
+========================
+
+.. code-block:: text
+
+   Connector
+     │
+     ▼
+   ReaderFactory::createReader(input, options)
+     │
+     ▼
+   Reader          ← parses footer, schema, encryption
+     │
+     │ createRowReader(scanSpec)
+     ▼
+   RowReader        ← iterates stripes / row groups
+     │
+     │ next(batchSize, output)
+     ▼
+   UnitLoader       ← loads / prefetches stripe data
+     │
+     ▼
+   BufferedInput    ← coalesces I/O, optional caching
+     │
+     ▼
+   SelectiveColumnReader  ← decodes + filters per column
+     │
+     ▼
+   Output RowVector
+
+End-to-End Write Pipeline
+=========================
+
+.. code-block:: text
+
+   Connector
+     │
+     ▼
+   WriterFactory::createWriter(sink, options)
+     │
+     ▼
+   Writer           ← state machine (Init → Running → Closed)
+     │
+     │ write(RowVector)
+     ▼
+   ColumnWriter     ← encodes columns (dictionary, RLE, etc.)
+     │
+     │ flush triggered by FlushPolicy
+     ▼
+   FlushPolicy      ← decides stripe boundaries
+     │
+     ▼
+   FileSink         ← writes bytes to storage

--- a/velox/docs/develop/dwio/dwrf.rst
+++ b/velox/docs/develop/dwio/dwrf.rst
@@ -1,0 +1,205 @@
+===========
+DWRF Format
+===========
+
+DWRF is Meta's columnar file format derived from Apache ORC. It adds FlatMap
+encoding, column-level encryption, and several performance optimizations. The
+reader and writer live under ``dwio/dwrf/``.
+
+File Layout
+===========
+
+A DWRF file is structured as follows (read from tail to head):
+
+.. code-block:: text
+
+   ┌─────────────────────────────────┐
+   │           Stripe 0              │
+   │  ┌──────────────────────────┐   │
+   │  │  Row Index Streams       │   │  Per-column stride statistics + positions
+   │  ├──────────────────────────┤   │
+   │  │  Data Streams            │   │  Encoded column data (PRESENT, DATA, etc.)
+   │  ├──────────────────────────┤   │
+   │  │  Stripe Footer           │   │  Stream directory + encoding info
+   │  └──────────────────────────┘   │
+   ├─────────────────────────────────┤
+   │           Stripe 1              │
+   │           ...                   │
+   ├─────────────────────────────────┤
+   │    (optional) Stripe Cache      │  Inline cache of stripe index/footer
+   ├─────────────────────────────────┤
+   │       File Footer               │  Schema, stripe offsets, file statistics
+   ├─────────────────────────────────┤
+   │       PostScript                │  Footer length, compression codec, version
+   ├─────────────────────────────────┤
+   │    PostScript length (1 byte)   │  Last byte of file
+   └─────────────────────────────────┘
+
+Reading starts from the last byte (PostScript length), then reads the
+PostScript, then the File Footer, and finally seeks to individual stripes on
+demand.
+
+Streams
+=======
+
+Each column in a stripe is stored as one or more *streams*. The ``StreamKind``
+enum identifies the stream type:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - StreamKind
+     - Purpose
+   * - ``PRESENT``
+     - Null bitmap. One bit per row (ByteRLE encoded).
+   * - ``DATA``
+     - Primary data stream (integer values, string bytes, etc.).
+   * - ``LENGTH``
+     - Lengths for variable-width types (strings, arrays, maps).
+   * - ``DICTIONARY_DATA``
+     - Dictionary entries for dictionary-encoded string columns.
+   * - ``IN_MAP``
+     - FlatMap: per-key bitmap indicating whether the key is present in each
+       row.
+   * - ``STRIDE_DICT``
+     - Per-stride dictionary (used when the global dictionary is too large).
+
+A stream is uniquely identified by a ``DwrfStreamIdentifier`` consisting of
+``(node, sequence, column, kind)``.
+
+Encoding
+========
+
+**RLE v1** (``dwio/dwrf/common/RLEv1.h``): Simple run-length encoding. A
+*run* header encodes either a run of repeated values or a sequence of
+literals.
+
+**RLE v2** (``dwio/dwrf/common/RLEv2.h``): A more compact encoding with four
+sub-encodings:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Sub-encoding
+     - When used
+   * - ``SHORT_REPEAT``
+     - Short runs of identical values (3--10 values).
+   * - ``DIRECT``
+     - Values stored with bit-packing at the minimum required width.
+   * - ``PATCHED_BASE``
+     - Values close to a base with a few outliers stored as patches.
+   * - ``DELTA``
+     - Monotonic or near-monotonic sequences stored as a base + deltas.
+
+**ByteRLE** (``dwio/dwrf/common/ByteRLE.h``): Specialized for boolean and
+byte streams. Encodes runs and literals at the byte level.
+
+Compression
+===========
+
+Each stream is independently compressed using 3-byte page headers. A page
+header stores the compressed length and an ``isOriginal`` flag (set when the
+compressed output would be larger than the original). Supported codecs
+include ZLIB, ZSTD, LZO, LZ4, and Snappy. The codec is recorded in the
+PostScript. See ``dwio/dwrf/common/Compression.h``.
+
+Row Group Index (Strides)
+=========================
+
+DWRF divides each stripe into *strides* (default 10,000 rows). For each
+stride, a ``RowIndexEntry`` records:
+
+* The byte offset into each stream.
+* The decompressor position (bytes consumed in the current compression page).
+* The RLE run position (values consumed in the current RLE run).
+
+This three-level positioning allows the reader to seek directly to any stride
+within a stripe, skipping strides whose statistics prove no rows can match the
+filter.
+
+FlatMap Encoding
+================
+
+FlatMap is a DWRF-specific encoding for MAP columns where the set of keys is
+known at write time.
+
+Instead of storing a single ``key`` stream and a single ``value`` stream, the
+writer creates a separate ``value`` stream and ``IN_MAP`` bitmap for each
+distinct key. This turns a map into a struct-like layout:
+
+.. code-block:: text
+
+   MAP<K, V>  →  key₁ : (IN_MAP₁, value₁),
+                 key₂ : (IN_MAP₂, value₂),
+                 ...
+
+Benefits:
+
+* **Key-level projection pushdown.** The reader can skip keys that are not
+  referenced by the query.
+* **Per-key statistics.** Stride statistics are maintained per key, enabling
+  fine-grained stride skipping.
+* **Efficient scanning.** The ``IN_MAP`` bitmap is cheaper to decode than a
+  variable-length key stream.
+
+Writer: ``dwio/dwrf/writer/FlatMapColumnWriter.h``.
+Reader: ``dwio/dwrf/reader/SelectiveFlatMapColumnReader.h``.
+
+Column-Level Encryption
+=======================
+
+DWRF supports encrypting individual columns or groups of columns.
+
+``EncryptionHandler`` (``dwio/dwrf/common/Encryption.h``,
+``Decryption.h``) maps column node IDs to ``Encrypter`` / ``Decrypter``
+objects. Encryption is applied **after** compression so that the compression
+ratio is not affected by the randomness of encrypted data.
+
+Encrypted columns store their stripe footer and statistics in separate
+encrypted sections that are only accessible with the appropriate key.
+
+Configuration
+=============
+
+Key ``Config`` entries (``dwio/dwrf/common/Config.h``):
+
+.. list-table::
+   :widths: 30 15 30
+   :header-rows: 1
+
+   * - Config Key
+     - Default
+     - Description
+   * - ``STRIPE_SIZE``
+     - 64 MB
+     - Target uncompressed stripe size.
+   * - ``ROW_INDEX_STRIDE``
+     - 10,000
+     - Number of rows per stride (row group).
+   * - ``FLATTEN_MAP``
+     - false
+     - Enable FlatMap encoding for map columns.
+   * - ``MAP_FLAT_COLS``
+     - (empty)
+     - Column IDs to flatten.
+   * - ``DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD``
+     - 0.8
+     - Fraction of distinct values above which dictionary encoding is
+       abandoned in favor of direct encoding.
+
+Stripe Cache
+============
+
+When a DWRF file is written with stripe caching enabled, the index and footer
+of each stripe are duplicated at the end of the file (just before the File
+Footer). This allows the reader to fetch all stripe metadata in a single read
+during file open, avoiding one seek per stripe.
+
+Writer Version Evolution
+========================
+
+DWRF writer versions track format changes over time, from ``ORIGINAL``
+through ``DWRF_7_0``. The version is stored in the PostScript and controls
+which features the reader expects to find in the file.

--- a/velox/docs/develop/dwio/io-buffering.rst
+++ b/velox/docs/develop/dwio/io-buffering.rst
@@ -1,0 +1,121 @@
+=================
+I/O and Buffering
+=================
+
+DWIO decouples logical data access from physical I/O through a layered
+buffering system. This allows read coalescing, caching, and prefetching
+without any changes to the column readers.
+
+BufferedInput
+=============
+
+``BufferedInput`` (``dwio/common/BufferedInput.h``) is the basic I/O
+scheduler:
+
+1. Column readers call ``enqueue(region)`` to declare byte ranges they will
+   need.
+2. The caller invokes ``load()`` which coalesces nearby regions into larger
+   reads. Two regions are merged if the gap between them is smaller than the
+   *merge distance* (default ~1.25 MB). This reduces the number of I/O
+   requests at the cost of reading a small amount of unused data.
+3. After ``load()`` returns, column readers access the data through
+   ``SeekableInputStream`` handles that serve bytes from the in-memory
+   buffers.
+
+DirectBufferedInput
+===================
+
+``DirectBufferedInput`` (``dwio/common/DirectBufferedInput.h``) extends
+``BufferedInput`` for direct (non-cached) I/O. It coalesces multiple read
+requests into larger single I/O operations via ``DirectCoalescedLoad``,
+reducing the number of storage round-trips without requiring a cache layer.
+This is suitable for workloads where data reuse is low and caching overhead
+is not justified.
+
+CachedBufferedInput
+===================
+
+``CachedBufferedInput`` (``dwio/common/CachedBufferedInput.h``) extends
+``BufferedInput`` with a two-level cache:
+
+.. list-table::
+   :widths: 15 50
+   :header-rows: 1
+
+   * - Level
+     - Description
+   * - DRAM
+     - ``AsyncDataCache`` stores recently accessed regions in memory. Cache
+       entries are reference-counted and evicted in LRU order.
+   * - NVMe SSD
+     - ``SsdCache`` acts as a second-level victim cache. Evicted DRAM entries
+       are written to SSD and can be promoted back on a subsequent hit,
+       avoiding a storage round-trip.
+
+Background prefetch is executed on a ``folly::Executor`` thread pool so that
+I/O can overlap with CPU-bound decoding.
+
+``ScanTracker`` tracks per-column access frequency to inform prefetch
+decisions and cache admission policies.
+
+UnitLoader Abstraction
+======================
+
+A *unit* is a logically independent chunk of data that can be loaded and
+unloaded independently -- typically a DWRF stripe or a Parquet row group.
+The ``UnitLoader`` abstraction (``dwio/common/UnitLoader.h``) manages the
+lifecycle:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Interface
+     - Role
+   * - ``LoadUnit``
+     - Represents one unit. Provides ``load()`` and ``unload()`` methods.
+       Also exposes the unit's row count and I/O size for scheduling decisions.
+   * - ``UnitLoaderFactory``
+     - Creates a ``UnitLoader`` from a list of ``LoadUnit`` objects.
+   * - ``UnitLoader``
+     - Orchestrates the loading strategy for a sequence of units.
+
+OnDemandUnitLoader
+------------------
+
+``OnDemandUnitLoader`` (``dwio/common/OnDemandUnitLoader.h``) is the default
+strategy. It loads each unit synchronously when the ``RowReader`` first
+accesses it. No prefetching is performed. This is the simplest strategy and
+is suitable when I/O latency is low (e.g. local SSD).
+
+ParallelUnitLoader
+------------------
+
+``ParallelUnitLoader`` (``dwio/common/ParallelUnitLoader.h``) prefetches
+*N* units ahead of the current read position on an I/O executor thread pool.
+This hides I/O latency behind the CPU time spent decoding the current unit.
+The look-ahead count is configurable.
+
+Statistics and Metrics
+======================
+
+``RuntimeStatistics`` (``dwio/common/Statistics.h``) collects per-scan
+metrics:
+
+.. list-table::
+   :widths: 25 40
+   :header-rows: 1
+
+   * - Metric
+     - Description
+   * - ``skippedStrides``
+     - Number of row groups skipped by filter pushdown.
+   * - ``processedStrides``
+     - Number of row groups actually decoded.
+   * - ``skippedSplits``
+     - Entire splits skipped (e.g. when all row groups are filtered out).
+   * - ``rawBytesRead``
+     - Total bytes read from storage before decompression.
+
+``ColumnReaderStatistics`` provides per-column counters such as the number of
+null values decoded, dictionary hits, and flat-map key misses.

--- a/velox/docs/develop/dwio/nimble.rst
+++ b/velox/docs/develop/dwio/nimble.rst
@@ -1,0 +1,379 @@
+=============
+Nimble Format
+=============
+
+Nimble is Meta's next-generation columnar file format designed for
+high-performance analytics. The format provides a flexible encoding system
+with cost-based encoding selection and supports advanced features such as
+FlatMap encoding, cluster indexing, and chunk-based memory management. The
+implementation lives under ``dwio/nimble/``.
+
+.. note::
+
+   Nimble is currently experimental and under active development. The API
+   and file format may change without notice.
+
+File Layout
+===========
+
+A Nimble file (called a *tablet*) organizes data into stripes, grouped into
+*stripe groups*. The file is read from the tail (last 20 bytes):
+
+.. code-block:: text
+
+   ┌─────────────────────────────────────────┐
+   │  Stripe 0..M Streams (Stripe Group 0)   │
+   ├─────────────────────────────────────────┤
+   │  Stripe Group 0 Metadata                │  Per-stream offsets and sizes
+   ├─────────────────────────────────────────┤
+   │  (optional) Index Group 0 Metadata      │  Cluster index data
+   ├─────────────────────────────────────────┤
+   │  ... more stripe groups ...             │
+   ├─────────────────────────────────────────┤
+   │  Stripes Metadata                       │  Row counts, offsets, sizes,
+   │                                         │  group indices per stripe
+   ├─────────────────────────────────────────┤
+   │  Optional Sections                      │  "schema", "stats", "index"
+   ├─────────────────────────────────────────┤
+   │  Footer                                 │  Total row count, section refs
+   ├─────────────────────────────────────────┤
+   │  Postscript (20 bytes)                  │
+   │  ┌───────────────────────────────────┐  │
+   │  │ Footer Size (4B)                  │  │
+   │  │ Compression Type (1B)             │  │
+   │  │ Checksum Type (1B)                │  │
+   │  │ Checksum (8B, XXH3_64)            │  │
+   │  │ Major Version (2B)                │  │
+   │  │ Minor Version (2B)                │  │
+   │  │ Magic "NI" (2B)                   │  │
+   │  └───────────────────────────────────┘  │
+   └─────────────────────────────────────────┘
+
+Reading starts from the last 2 bytes (magic ``"NI"``), then reads the full
+20-byte Postscript, then the Footer, and finally seeks to individual stripes
+on demand. The ``TabletReader`` (``tablet/TabletReader.h``) performs a
+speculative tail read (default 8 MB) to fetch the postscript, footer, and
+trailing metadata in a single I/O.
+
+Metadata is serialized using FlatBuffers (``tablet/Footer.fbs``,
+``velox/Schema.fbs``, ``velox/Stats.fbs``).
+
+Schema and Type System
+======================
+
+Nimble has its own schema system bridged to Velox types during read and write.
+
+**Schema kinds** (``velox/SchemaTypes.h``):
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Kind
+     - Description
+   * - ``Scalar``
+     - Single data stream (integers, floats, bools, strings).
+   * - ``Row``
+     - Nulls stream + named children (struct).
+   * - ``Array``
+     - Lengths stream + elements.
+   * - ``Map``
+     - Lengths stream + keys + values.
+   * - ``FlatMap``
+     - Nulls stream + per-key ``IN_MAP`` descriptors + per-key value children.
+   * - ``ArrayWithOffsets``
+     - Offsets + lengths + elements (dictionary arrays).
+   * - ``SlidingWindowMap``
+     - Offsets + lengths + keys + values.
+
+The schema is stored as a flat DFS list of ``SchemaNode`` entries in the file
+footer. ``SchemaReader`` (``velox/SchemaReader.h``) reconstructs the tree on
+read. ``SchemaBuilder`` (``velox/SchemaBuilder.h``) constructs it
+incrementally during writing, supporting dynamic FlatMap key addition across
+stripes.
+
+Encoding Types
+==============
+
+Nimble supports a variety of encodings (``common/Types.h``):
+
+.. list-table::
+   :widths: 20 50
+   :header-rows: 1
+
+   * - Encoding
+     - Description
+   * - ``Trivial``
+     - Native encoding for numerics, packed chars with offsets for strings,
+       bitpacked for booleans. All data types supported.
+   * - ``RLE``
+     - Run-length encoding. Run lengths are bit-packed; run values use
+       trivial encoding. All data types supported.
+   * - ``Dictionary``
+     - Unique values stored in a dictionary with indices into that
+       dictionary. All data types except booleans supported.
+   * - ``FixedBitWidth``
+     - Integer types packed into a fixed number of bits (smallest width
+       required to represent the largest element). Non-negative values only.
+   * - ``Nullable``
+     - Wraps one sub-encoding for non-null values with another sub-encoding
+       marking which rows are null.
+   * - ``Sentinel``
+     - Stores nullable data using a sentinel value to represent nulls in a
+       single non-nullable encoding.
+   * - ``SparseBool``
+     - Stores indices to set (or unset) bits. Useful for sparse data such as
+       columns where only a few rows are non-null.
+   * - ``Varint``
+     - Variable-length integer encoding for non-negative values.
+   * - ``Delta``
+     - Stores integer types with delta encoding (positive deltas only).
+   * - ``Constant``
+     - Stores constant data (single unique value repeated for all rows).
+   * - ``MainlyConstant``
+     - Stores mainly-constant data. One value is treated as special; a bool
+       child vector marks which rows have the special value; non-special
+       values are stored separately.
+   * - ``Prefix``
+     - Sorted string prefix compression.
+
+Encodings can be nested. For example, a ``Nullable`` encoding wraps a
+non-null encoding and a null-indicator encoding.
+
+Encoding Prefix
+===============
+
+Every Nimble encoding begins with a 6-byte prefix
+(``encodings/Encoding.h``):
+
+.. list-table::
+   :widths: 15 15 35
+   :header-rows: 1
+
+   * - Offset
+     - Size
+     - Field
+   * - 0
+     - 1 byte
+     - ``EncodingType`` (Trivial, RLE, Dictionary, etc.)
+   * - 1
+     - 1 byte
+     - ``DataType`` (Int8, Int32, Float, String, etc.)
+   * - 2
+     - 4 bytes
+     - Row count (number of values in this encoding)
+
+This uniform prefix allows the decoder to quickly determine how to
+interpret the remaining bytes.
+
+Encoding Selection
+==================
+
+Nimble uses a cost-based encoding selection framework. The default
+``ManualEncodingSelectionPolicy`` (``encodings/EncodingSelectionPolicy.h``)
+works as follows:
+
+1. Compute ``Statistics<T>`` for the data: run-length characteristics
+   (min/max repeat counts), value range (min/max), cardinality (unique
+   counts), and string-specific metrics.
+2. Iterate candidate encodings and estimate compressed size via
+   ``EncodingSizeEstimation``.
+3. Apply read-factor weights to balance write size against read cost
+   (e.g. ``Trivial`` gets a 0.7 boost since it is cheapest to decode).
+4. Pick the encoding with minimum weighted cost.
+5. Recursively encode nested sub-streams (e.g. dictionary indices).
+
+Post-encoding, a ``CompressionPolicy`` decides whether to apply Zstd
+compression (accepted if the compression ratio is below 0.98).
+
+An ``EncodingLayoutTree`` (``velox/EncodingLayoutTree.h``) can capture and
+replay encoding decisions, bypassing runtime selection for deterministic
+output.
+
+Data Types
+==========
+
+Nimble supports the following data types (``common/Types.h``):
+
+.. list-table::
+   :widths: 20 35
+   :header-rows: 1
+
+   * - DataType
+     - Description
+   * - ``Int8`` / ``Uint8``
+     - 8-bit signed / unsigned integers
+   * - ``Int16`` / ``Uint16``
+     - 16-bit signed / unsigned integers
+   * - ``Int32`` / ``Uint32``
+     - 32-bit signed / unsigned integers
+   * - ``Int64`` / ``Uint64``
+     - 64-bit signed / unsigned integers
+   * - ``Float``
+     - 32-bit floating-point
+   * - ``Double``
+     - 64-bit floating-point
+   * - ``Bool``
+     - Boolean values (bitpacked)
+   * - ``String``
+     - Variable-length byte arrays
+
+Compression
+===========
+
+Nimble supports chunk-level compression:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - CompressionType
+     - Description
+   * - ``Uncompressed``
+     - No compression applied.
+   * - ``Zstd``
+     - Zstandard compression. Level is configurable (default 1).
+   * - ``MetaInternal``
+     - Internal Meta compression codec.
+
+Reader Architecture
+===================
+
+Nimble provides two reader implementations.
+
+**Batch reader** (``velox/VeloxReader.h``): A standalone reader that reads
+Nimble files into ``velox::VectorPtr`` batches. It owns a ``TabletReader``
+for file I/O and a tree of ``FieldReader`` objects for per-column decoding.
+Each ``FieldReader`` wraps a ``Decoder`` that interprets the Nimble encoding.
+Supports column projection and FlatMap feature selection.
+
+**Selective reader** (``velox/selective/SelectiveNimbleReader.h``): Integrates
+with the DWIO ``SelectiveColumnReader`` framework for filter pushdown.
+``SelectiveNimbleReaderFactory`` registers as the DWIO reader factory for
+``FileFormat::NIMBLE``. Key classes:
+
+.. list-table::
+   :widths: 25 45
+   :header-rows: 1
+
+   * - Class
+     - Role
+   * - ``SelectiveNimbleReader``
+     - Implements ``dwio::common::Reader``. Creates row readers with
+       pushdown support.
+   * - ``ColumnReader``
+     - Builds ``SelectiveColumnReader`` trees for pushdown evaluation via
+       ``buildColumnReader()``.
+   * - ``ChunkedDecoder``
+     - Handles multi-chunk decoding within a single stripe, enabling
+       efficient ``readWithVisitor`` pushdown.
+
+Read Path
+---------
+
+1. ``SelectiveNimbleReaderFactory::createReader()`` initializes a
+   ``TabletReader`` (parses postscript and footer).
+2. ``createRowReader()`` builds a tree of ``SelectiveColumnReader`` nodes.
+3. On each ``next()`` call:
+
+   a. Load the current stripe's streams from ``TabletReader::load()``.
+   b. Decode using ``ChunkedDecoder`` which wraps Nimble ``Encoding`` objects.
+   c. Apply pushdown filters during decoding via ``readWithVisitor``.
+
+Writer Architecture
+===================
+
+``VeloxWriter`` (``velox/VeloxWriter.h``) is the top-level writer:
+
+.. code-block:: cpp
+
+   VeloxWriter writer(type, std::move(file), pool, options);
+   writer.write(vector);   // append a batch
+   writer.flush();         // flush a stripe
+   writer.close();         // finalize the file
+
+Key classes:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Class
+     - Role
+   * - ``VeloxWriter``
+     - Top-level writer. Owns a ``FieldWriter`` tree, a ``TabletWriter``,
+       and optionally an ``IndexWriter``.
+   * - ``FieldWriter``
+     - Abstract per-field writer. Decomposes Velox vectors into typed
+       ``StreamData`` buffers. Supports row, array, map, flat map, dictionary
+       array, sliding window map, and array-with-offsets types.
+   * - ``TabletWriter``
+     - Low-level file writer. Writes stripes, stripe groups, optional
+       sections, footer, and postscript. Supports stream deduplication and
+       checksum computation (XXH3_64).
+   * - ``FlushPolicy``
+     - Controls when to flush stripes. Default: ``StripeRawSizeFlushPolicy``
+       at 256 MB raw size threshold.
+
+Write Path
+----------
+
+1. ``VeloxWriter::write(VectorPtr)`` decomposes the vector via the
+   ``FieldWriter`` tree into typed ``StreamData`` buffers.
+2. ``FlushPolicy`` checks if a stripe should be flushed.
+3. On flush, each stream's data is encoded via ``EncodingFactory::encode()``
+   using the configured ``EncodingSelectionPolicy``.
+4. Encoded streams are written to the file via ``TabletWriter::writeStripe()``.
+5. On ``close()``, schema, metadata, column statistics, and optional sections
+   are written, followed by the footer and postscript.
+
+Statistics and Index Filtering
+==============================
+
+**Column statistics** (``velox/stats/ColumnStatistics.h``): The writer
+collects per-column statistics during encoding, including value count, null
+count, logical size, and physical size. Subclasses provide type-specific
+statistics (min/max for integrals and floats, total length for strings).
+Statistics are serialized via ``Stats.fbs`` and stored as an optional section
+in the file.
+
+**Cluster index filtering** (``index/IndexFilter.h``): When a file is written
+with indexing enabled, ``IndexWriter`` records key boundaries per chunk and
+stripe for designated index columns. At read time,
+``convertFilterToIndexBounds()`` converts ``ScanSpec`` filters into
+``IndexBounds`` for stripe and chunk pruning. This supports prefix-contiguous
+filters on sorted columns, analogous to a B-tree key prefix scan.
+
+Configuration
+=============
+
+Key writer options (``velox/VeloxWriterOptions.h``):
+
+.. list-table::
+   :widths: 30 15 30
+   :header-rows: 1
+
+   * - Option
+     - Default
+     - Description
+   * - ``flushPolicyFactory``
+     - 256 MB
+     - Stripe flush threshold (raw data size).
+   * - ``flatMapColumns``
+     - (empty)
+     - Columns to encode as FlatMaps.
+   * - ``dictionaryArrayColumns``
+     - (empty)
+     - Columns to encode with dictionary arrays.
+   * - ``encodingSelectionPolicyFactory``
+     - Manual
+     - Factory for encoding selection (cost-based by default).
+   * - ``compressionOptions``
+     - Zstd
+     - Compression codec and settings.
+   * - ``enableChunking``
+     - false
+     - Enable chunk-based writing for memory pressure management.
+   * - ``indexConfig``
+     - (none)
+     - Cluster index configuration for indexed writes.

--- a/velox/docs/develop/dwio/parquet.rst
+++ b/velox/docs/develop/dwio/parquet.rst
@@ -1,0 +1,180 @@
+==============
+Parquet Format
+==============
+
+Velox supports reading and writing Apache Parquet files through the DWIO
+layer. The Parquet reader is a native C++ implementation that plugs into the
+``SelectiveColumnReader`` framework. The writer bridges to the Arrow Parquet
+library.
+
+File Layout
+===========
+
+.. code-block:: text
+
+   ┌────────────────────────────────┐
+   │  Magic: "PAR1" (4 bytes)      │
+   ├────────────────────────────────┤
+   │  Row Group 0                  │
+   │  ┌─────────────────────────┐  │
+   │  │  Column Chunk 0         │  │
+   │  │  ┌───────────────────┐  │  │
+   │  │  │ Dictionary Page   │  │  │  Optional dictionary
+   │  │  ├───────────────────┤  │  │
+   │  │  │ Data Page 0       │  │  │  Encoded values + rep/def levels
+   │  │  │ Data Page 1       │  │  │
+   │  │  │ ...               │  │  │
+   │  │  └───────────────────┘  │  │
+   │  │  Column Chunk 1         │  │
+   │  │  ...                    │  │
+   │  └─────────────────────────┘  │
+   ├────────────────────────────────┤
+   │  Row Group 1                  │
+   │  ...                          │
+   ├────────────────────────────────┤
+   │  File Footer (Thrift)         │  Schema, row group metadata, statistics
+   ├────────────────────────────────┤
+   │  Footer Length (4 bytes)       │
+   ├────────────────────────────────┤
+   │  Magic: "PAR1" (4 bytes)      │
+   └────────────────────────────────┘
+
+Encodings
+=========
+
+The Velox Parquet reader supports the following page encodings:
+
+.. list-table::
+   :widths: 25 40
+   :header-rows: 1
+
+   * - Encoding
+     - Description
+   * - ``PLAIN``
+     - Values stored directly in their binary representation.
+   * - ``RLE_DICTIONARY``
+     - Dictionary encoding with RLE/bit-packed indices.
+   * - ``DELTA_BINARY_PACKED``
+     - Delta encoding for integers. See ``dwio/parquet/reader/DeltaBpDecoder.h``.
+   * - ``DELTA_BYTE_ARRAY``
+     - Prefix + suffix delta encoding for byte arrays.
+   * - ``BYTE_STREAM_SPLIT``
+     - Byte-interleaved encoding for floating-point values. Currently
+       supported in the writer only; the reader does not yet support this
+       encoding.
+
+Repetition and definition levels are always RLE/bit-packed. See
+``dwio/parquet/reader/RleBpDecoder.h``.
+
+Dremel Encoding for Nested Types
+================================
+
+Parquet uses the Dremel encoding scheme to flatten nested structures (structs,
+lists, maps) into flat columns with *repetition levels* and *definition
+levels*:
+
+* **Definition level** -- how many optional/repeated ancestors are defined
+  (non-null) for this value.
+* **Repetition level** -- which repeated ancestor has a new entry at this
+  position.
+
+Velox preloads all repetition and definition levels for an entire column chunk
+before decoding values. ``NestedStructureDecoder``
+(``dwio/parquet/reader/NestedStructureDecoder.h``) converts the flat
+rep/def arrays into the offsets and null bitmaps needed to reconstruct the
+nested Velox vectors.
+
+Type Mapping
+============
+
+Parquet physical types are mapped to Velox types using a combination of the
+physical type and the logical type annotation:
+
+.. list-table::
+   :widths: 20 20 20
+   :header-rows: 1
+
+   * - Parquet Physical
+     - Logical Type
+     - Velox Type
+   * - ``BOOLEAN``
+     - --
+     - ``BOOLEAN``
+   * - ``INT32``
+     - --
+     - ``INTEGER``
+   * - ``INT32``
+     - ``DATE``
+     - ``DATE``
+   * - ``INT32``
+     - ``DECIMAL(p <= 9)``
+     - ``SHORT_DECIMAL``
+   * - ``INT64``
+     - --
+     - ``BIGINT``
+   * - ``INT64``
+     - ``DECIMAL(9 < p <= 18)``
+     - ``SHORT_DECIMAL``
+   * - ``INT64``
+     - ``TIMESTAMP_MILLIS``
+     - ``TIMESTAMP``
+   * - ``INT64``
+     - ``TIMESTAMP_MICROS``
+     - ``TIMESTAMP``
+   * - ``INT96``
+     - --
+     - ``TIMESTAMP`` (legacy Hive/Impala)
+   * - ``FLOAT``
+     - --
+     - ``REAL``
+   * - ``DOUBLE``
+     - --
+     - ``DOUBLE``
+   * - ``BYTE_ARRAY``
+     - --
+     - ``VARCHAR``
+   * - ``BYTE_ARRAY``
+     - ``STRING``
+     - ``VARCHAR``
+   * - ``FIXED_LEN_BYTE_ARRAY``
+     - ``DECIMAL(p > 18)``
+     - ``LONG_DECIMAL``
+
+Schema evolution rules and type promotion are handled in
+``dwio/parquet/reader/ParquetTypeWithId.h``.
+
+Read Path
+=========
+
+1. **Footer parsing.** The reader reads the file footer (Thrift-encoded) to
+   obtain the schema, row group metadata, and column statistics.
+2. **Row group selection.** ``filterRowGroups()`` tests column statistics
+   against the ``ScanSpec`` filters to skip entire row groups.
+3. **Page-level decoding.** ``PageReader``
+   (``dwio/parquet/reader/PageReader.h``) reads dictionary and data pages
+   within each column chunk. It feeds decoded values into the
+   ``SelectiveColumnReader`` pipeline.
+
+Write Path
+==========
+
+The Velox Parquet writer (``dwio/parquet/writer/Writer.h``) uses the Arrow C
+Data Interface to pass Velox vectors to the Arrow Parquet ``FileWriter``:
+
+.. code-block:: text
+
+   RowVector
+     │
+     │  Arrow C Data Interface (zero-copy when possible)
+     ▼
+   Arrow RecordBatch
+     │
+     ▼
+   Arrow Parquet FileWriter
+     │
+     ▼
+   FileSink (DWIO)
+
+Writer options include compression codec selection, encoding preferences
+(e.g. dictionary vs. plain), timestamp units (millis vs. micros), and Iceberg
+field IDs.

--- a/velox/docs/develop/dwio/scan-and-filter.rst
+++ b/velox/docs/develop/dwio/scan-and-filter.rst
@@ -1,0 +1,112 @@
+============================
+Scanning and Filter Pushdown
+============================
+
+DWIO pushes filter evaluation as close to the data as possible: first at the
+row-group / stride level using statistics, then inline during column decoding.
+This section covers the key abstractions.
+
+ScanSpec
+========
+
+``ScanSpec`` (``dwio/common/ScanSpec.h``) is a tree-shaped descriptor that
+mirrors the column tree of the schema. Each node carries:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Field
+     - Description
+   * - ``filter``
+     - A ``common::Filter`` applied to this column during decoding (e.g.
+       ``BigintRange``, ``BytesRange``, ``IsNull``).
+   * - ``projectOut``
+     - Whether this column should appear in the output ``RowVector``.
+   * - ``channel``
+     - The output column index in the result ``RowVector``.
+   * - ``constantValue``
+     - A literal value to use instead of reading from the file (e.g. for
+       partition columns).
+
+**Adaptive filter reordering.** ``ScanSpec`` tracks per-filter selectivity at
+runtime. Columns with higher rejection rates are evaluated first so that
+subsequent columns decode fewer rows.
+
+**Dynamic filter pushdown.** During execution the connector may receive new
+filters (e.g. from a hash-join build side). It calls
+``ScanSpec::setFilter()`` followed by ``RowReader::resetFilterCaches()`` to
+inject the filter into subsequent row groups.
+
+SelectiveColumnReader
+=====================
+
+``SelectiveColumnReader`` (``dwio/common/SelectiveColumnReader.h``) is the
+core of the read path. Each column in the file gets its own reader instance.
+The key methods are:
+
+.. list-table::
+   :widths: 15 50
+   :header-rows: 1
+
+   * - Method
+     - Behavior
+   * - ``read()``
+     - Decodes rows and applies the column's filter inline via a
+       ``ColumnVisitor``. Rows that fail the filter are dropped immediately
+       without materializing values.
+   * - ``getValues()``
+     - Extracts the passing rows into the output vector. Only called for
+       columns that are projected out.
+
+**SIMD bulk path.** For simple filters on flat integer/float columns the
+reader uses a bulk SIMD path that processes multiple values per instruction.
+
+**Dictionary filter caching.** When a column uses dictionary encoding, the
+reader evaluates the filter against dictionary entries once and caches a
+bitmap of passing entries. Subsequent rows are tested against the bitmap
+instead of re-evaluating the filter.
+
+Row Group Skipping
+==================
+
+Before decoding any rows in a row group (DWRF stride or Parquet row group),
+DWIO tests column-level statistics against the scan filters:
+
+1. ``RowReader::filterRowGroups()`` calls ``FormatData::filterRowGroups()``
+   for each column that has a filter.
+2. ``MetadataFilter`` (``dwio/common/MetadataFilter.h``) combines the
+   per-column results according to the AND/OR tree of the overall predicate.
+   A row group is skipped only if the combined result proves no rows can pass.
+3. Skipped row groups avoid all I/O and decoding for that range of rows.
+
+Mutation
+========
+
+``Mutation`` (``dwio/common/Mutation.h``) supports row-level modifications
+during the scan:
+
+* **Row deletes.** A ``deletedRows`` bitmask marks rows that should be
+  excluded from the output (e.g. for ACID delete files).
+* **Random sampling.** ``RandomSkipTracker`` probabilistically skips rows to
+  implement sampling scans.
+* **Delta column updates.** Columns can be replaced or augmented with values
+  from a delta file.
+
+ColumnSelector (Deprecated)
+===========================
+
+.. note::
+
+   ``ColumnSelector`` is deprecated and should not be used in future designs.
+   It is still used in current code by the legacy bulk reader path. New code
+   should use ``ScanSpec`` for column projection.
+
+``ColumnSelector`` (``dwio/common/ColumnSelector.h``) handles column
+projection:
+
+* Columns can be selected by **name** or by **Hive column ID**.
+* Supports schema evolution: when the file schema has a different column
+  order or a subset of the requested columns, ``ColumnSelector`` maps between
+  the file schema and the scan schema.
+* Projected columns that do not exist in the file produce ``NULL`` vectors.

--- a/velox/docs/develop/dwio/writers.rst
+++ b/velox/docs/develop/dwio/writers.rst
@@ -1,0 +1,151 @@
+=======
+Writers
+=======
+
+This section covers the common writer abstractions and format-specific writer
+details.
+
+Writer State Machine
+====================
+
+Every DWIO writer follows a state machine defined in
+``dwio/common/Writer.h``:
+
+.. code-block:: text
+
+   Init ──write()──► Running ──finish()──► Finishing ──close()──► Closed
+                        │                      │
+                        │ abort()              │ (time-sliced)
+                        ▼                      │
+                     Aborted                   │
+                                               ▼
+                                            Closed
+
+   Running may also transition directly to Closed via close() when the
+   writer has nothing to finalize (e.g. some physical file writers).
+
+* ``write(RowVectorPtr)`` -- appends a batch. Transitions from Init to
+  Running on the first call.
+* ``finish()`` -- signals that no more data will be written. For sorting
+  writers this triggers the sort and output phase, which may be time-sliced
+  across multiple ``finish()`` calls.
+* ``close()`` -- writes the file footer and closes the ``FileSink``.
+* ``abort()`` -- discards all buffered data. The writer cannot be reused.
+
+FlushPolicy
+===========
+
+``FlushPolicy`` (``dwio/common/FlushPolicy.h``) decides when a stripe (or
+row group) should be flushed to the output:
+
+.. code-block:: cpp
+
+   bool shouldFlush(const StripeProgress& progress);
+
+``StripeProgress`` provides:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Field
+     - Description
+   * - ``stripeIndex``
+     - Index of the current stripe being written.
+   * - ``stripeRowCount``
+     - Number of rows written to the current stripe.
+   * - ``totalMemoryUsage``
+     - Total memory usage across all buffered data.
+   * - ``stripeSizeEstimate``
+     - Estimated size of the stripe in bytes.
+
+A typical policy flushes when ``stripeSizeEstimate`` exceeds a threshold
+(default 64 MB for DWRF, 128 MB for Parquet).
+
+SortingWriter
+=============
+
+``SortingWriter`` (``dwio/common/SortingWriter.h``) wraps another writer to
+produce globally sorted output:
+
+1. ``write()`` -- all incoming batches are appended to a ``SortBuffer`` in
+   memory.
+2. ``finish()`` -- the ``SortBuffer`` sorts all rows by the specified sort
+   columns. Output is written to the underlying writer in time-sliced chunks
+   so that a single ``finish()`` call does not block the thread for too long.
+3. When memory pressure is high, the ``SortBuffer`` can spill sorted runs to
+   disk and merge-sort them during output.
+
+FileSink
+========
+
+``FileSink`` (``dwio/common/FileSink.h``) is the abstract output interface.
+Writers write bytes to a ``FileSink``; the sink handles storage-specific
+details.
+
+Built-in sinks:
+
+.. list-table::
+   :widths: 20 45
+   :header-rows: 1
+
+   * - Sink
+     - Description
+   * - ``LocalFileSink``
+     - Writes to the local filesystem.
+   * - ``WriteFileSink``
+     - Writes through an abstract ``WriteFile`` interface (e.g. S3, HDFS).
+   * - ``MemorySink``
+     - Writes to an in-memory buffer. Useful for testing.
+
+Custom sinks are registered through a factory pattern similar to
+``ReaderFactory``.
+
+DWRF Writer Specifics
+=====================
+
+The DWRF writer (``dwio/dwrf/writer/Writer.h``) adds several layers on top
+of the common writer framework:
+
+**ColumnWriter tree.** Each column in the schema has a corresponding
+``ColumnWriter`` that encodes values into streams. Complex types (struct,
+list, map) create a tree of writers mirroring the schema.
+
+**Dictionary encoding selection.** String columns start in dictionary mode.
+If the dictionary grows beyond a configurable fraction of distinct values
+(``DICTIONARY_NUMERIC_KEY_SIZE_THRESHOLD``), the writer falls back to direct
+encoding for subsequent stripes.
+
+**Memory pools.** The DWRF writer uses three memory pools:
+
+.. list-table::
+   :widths: 25 40
+   :header-rows: 1
+
+   * - Pool
+     - Purpose
+   * - ``DICTIONARY``
+     - Stores dictionary entries during encoding.
+   * - ``OUTPUT_STREAM``
+     - Buffers compressed stream output before writing to the sink.
+   * - ``GENERAL``
+     - General allocations (row index, stripe footer serialization).
+
+**Compression ratio tracking.** The writer tracks the observed compression
+ratio per stream to estimate stripe sizes before flushing.
+
+Parquet Writer Specifics
+========================
+
+The Parquet writer (``dwio/parquet/writer/Writer.h``) bridges Velox to the
+Arrow Parquet library:
+
+* **Arrow bridge.** Velox vectors are exported via the Arrow C Data Interface
+  and written by Arrow's ``parquet::arrow::FileWriter``.
+* **WriterOptions.** Key options include:
+
+  * ``compression`` -- per-column or global compression codec.
+  * ``encoding`` -- prefer dictionary, plain, or format-default encoding.
+  * ``timestampUnit`` -- MILLIS or MICROS for timestamp columns.
+  * ``parquetFieldIds`` -- Iceberg-style field IDs written into the schema
+    metadata.


### PR DESCRIPTION
Summary:

Add comprehensive documentation for the DWIO (Data Warehouse I/O) layer
to the Velox developer guide. The existing connectors.rst covers the Hive
Connector at a high level but does not explain the reader/writer
architecture, file format internals, I/O buffering, filter pushdown, or
encoding details.

New documentation structure:
- dwio.rst: Overview, supported formats, relationship to connectors
- dwio/architecture.rst: Reader/Writer factory pattern, hierarchy, FormatData,
  end-to-end read/write pipeline diagrams
- dwio/scan-and-filter.rst: ScanSpec, SelectiveColumnReader, row group
  skipping, Mutation, ColumnSelector
- dwio/io-buffering.rst: BufferedInput, CachedBufferedInput, UnitLoader,
  OnDemand/Parallel loaders, statistics
- dwio/dwrf.rst: DWRF file layout, streams, RLE encoding, FlatMap encoding,
  column-level encryption, configuration
- dwio/parquet.rst: Parquet file layout, encodings, Dremel rep/def levels,
  type mapping, read/write paths
- dwio/writers.rst: Writer state machine, FlushPolicy, SortingWriter,
  FileSink, DWRF/Parquet writer specifics

Reviewed By: Yuhta

Differential Revision: D95106838


