### PR TITLE
refactor: Rename join terminology to indexLookupCondition in HiveIndexReader/HiveIndexSource

### DIFF
--- a/velox/connectors/hive/HiveIndexReader.cpp
+++ b/velox/connectors/hive/HiveIndexReader.cpp
@@ -87,7 +87,7 @@ HiveIndexReader::HiveIndexReader(
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
     const std::shared_ptr<common::ScanSpec>& scanSpec,
-    const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+    const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions,
     const RowTypePtr& requestType,
     const RowTypePtr& outputType,
     const std::shared_ptr<io::IoStatistics>& ioStatistics,
@@ -108,43 +108,50 @@ HiveIndexReader::HiveIndexReader(
       scanSpec_{scanSpec},
       fileReader_{createFileReader()},
       indexReader_{createIndexReader()},
-      joinConditions_{joinConditions} {
-  parseJoinConditions();
+      indexLookupConditions_{indexLookupConditions} {
+  parseIndexLookupConditions();
 }
 
-void HiveIndexReader::parseJoinConditions() {
-  VELOX_CHECK(!joinConditions_.empty(), "Join conditions cannot be empty");
+void HiveIndexReader::parseIndexLookupConditions() {
+  VELOX_CHECK(
+      !indexLookupConditions_.empty(),
+      "Index lookup conditions cannot be empty");
   const auto& indexColumns = tableHandle_->indexColumns();
   VELOX_CHECK(
       !indexColumns.empty(), "Index columns not set in hive table handle");
-  VELOX_CHECK_LE(joinConditions_.size(), indexColumns.size());
+  VELOX_CHECK_LE(indexLookupConditions_.size(), indexColumns.size());
   VELOX_CHECK_LE(
-      joinConditions_.size(), indexColumns.size(), "Too many join conditions");
-  const auto numJoinConditions = joinConditions_.size();
-  requestColumnIndices_.resize(numJoinConditions);
-  constantBoundValues_.resize(numJoinConditions);
+      indexLookupConditions_.size(),
+      indexColumns.size(),
+      "Too many index lookup conditions");
+  const auto numIndexLookupConditions = indexLookupConditions_.size();
+  requestColumnIndices_.resize(numIndexLookupConditions);
+  constantBoundValues_.resize(numIndexLookupConditions);
 
   // For building indexBoundType_ during condition processing.
   std::vector<std::string> indexColumnNames;
-  indexColumnNames.reserve(numJoinConditions);
+  indexColumnNames.reserve(numIndexLookupConditions);
   std::vector<TypePtr> indexColumnTypes;
-  indexColumnTypes.reserve(numJoinConditions);
+  indexColumnTypes.reserve(numIndexLookupConditions);
 
-  // Validate and process join conditions:
-  // - Join conditions combined with index filters must cover all table index
+  // Validate and process index lookup conditions:
+  // - Index lookup conditions combined with index filters must cover all table
+  // index
   //   columns in order.
-  // - For each index column, it must have either a join condition OR a filter
+  // - For each index column, it must have either an index lookup condition OR a
+  // filter
   //   in the scan spec, but not both.
-  // - At least one join condition must have a non-constant value (field access
+  // - At least one index lookup condition must have a non-constant value (field
+  // access
   //   from probe side).
   // - For between conditions, at least one bound must be non-constant.
   // - Processing stops when we encounter a range filter or between condition.
-  size_t numValidJoinConditions{0};
+  size_t numValidIndexLookupConditions{0};
   bool hasNonConstantCondition{false};
-  for (size_t i = 0; i < joinConditions_.size(); ++i) {
+  for (size_t i = 0; i < indexLookupConditions_.size(); ++i) {
     const auto& indexColumn = indexColumns[i];
-    // Process the join condition for this index column.
-    const auto& condition = joinConditions_[i];
+    // Process the index lookup condition for this index column.
+    const auto& condition = indexLookupConditions_[i];
     // Validate that the condition's key column matches the expected index
     // column.
     const auto& conditionKeyName =
@@ -152,12 +159,12 @@ void HiveIndexReader::parseJoinConditions() {
     VELOX_CHECK_EQ(
         conditionKeyName,
         indexColumn,
-        "Join condition key column does not match expected index column at position {}. Join conditions must follow index column order.",
+        "Index lookup condition key column does not match expected index column at position {}. Index lookup conditions must follow index column order.",
         i);
     const auto* spec = scanSpec_->childByName(indexColumn);
     VELOX_CHECK(
         spec == nullptr || !spec->hasFilter(),
-        "Index column '{}' cannot have both a join condition and a filter at position {}",
+        "Index column '{}' cannot have both an index lookup condition and a filter at position {}",
         indexColumn,
         i);
 
@@ -192,7 +199,7 @@ void HiveIndexReader::parseJoinConditions() {
       // Collect column name and type for indexBoundType_.
       indexColumnNames.push_back(indexColumn);
       indexColumnTypes.push_back(condition->key->type());
-      ++numValidJoinConditions;
+      ++numValidIndexLookupConditions;
       continue;
     }
 
@@ -226,17 +233,18 @@ void HiveIndexReader::parseJoinConditions() {
       // Collect column name and type for indexBoundType_.
       indexColumnNames.push_back(indexColumn);
       indexColumnTypes.push_back(condition->key->type());
-      ++numValidJoinConditions;
+      ++numValidIndexLookupConditions;
       // Between condition is a range condition, stop processing further.
       break;
     }
 
-    VELOX_FAIL("Unsupported join condition type: {}", condition->toString());
+    VELOX_FAIL(
+        "Unsupported index lookup condition type: {}", condition->toString());
   }
-  VELOX_CHECK_EQ(numValidJoinConditions, joinConditions_.size());
+  VELOX_CHECK_EQ(numValidIndexLookupConditions, indexLookupConditions_.size());
   VELOX_CHECK(
       hasNonConstantCondition,
-      "At least one join condition must have a non-constant value");
+      "At least one index lookup condition must have a non-constant value");
 
   // Build and cache the index bound row type.
   indexBoundType_ =
@@ -325,11 +333,11 @@ serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(
   const auto numRows = request->size();
 
   // Resize and clear reusable column vectors.
-  lowerBoundColumns_.resize(joinConditions_.size());
-  upperBoundColumns_.resize(joinConditions_.size());
+  lowerBoundColumns_.resize(indexLookupConditions_.size());
+  upperBoundColumns_.resize(indexLookupConditions_.size());
 
-  for (size_t i = 0; i < joinConditions_.size(); ++i) {
-    const auto& condition = joinConditions_[i];
+  for (size_t i = 0; i < indexLookupConditions_.size(); ++i) {
+    const auto& condition = indexLookupConditions_[i];
     const auto& type = condition->key->type();
 
     if (auto equalCondition =
@@ -371,7 +379,8 @@ serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(
         upperBoundColumns_[i] = request->childAt(colIdx);
       }
     } else {
-      VELOX_FAIL("Unsupported join condition type: {}", condition->toString());
+      VELOX_FAIL(
+          "Unsupported index lookup condition type: {}", condition->toString());
     }
   }
 
@@ -383,7 +392,7 @@ serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(
 
   // Collect column names for indexBounds.
   std::vector<std::string> indexColumnNames;
-  indexColumnNames.reserve(joinConditions_.size());
+  indexColumnNames.reserve(indexLookupConditions_.size());
   for (const auto& col : indexBoundType_->names()) {
     indexColumnNames.push_back(col);
   }

--- a/velox/connectors/hive/HiveIndexReader.h
+++ b/velox/connectors/hive/HiveIndexReader.h
@@ -36,7 +36,7 @@ class HiveConfig;
 
 /// HiveIndexReader handles index lookups for Hive tables with cluster indexes.
 /// It focuses on:
-/// - Creating index bounds from join conditions
+/// - Creating index bounds from index lookup conditions
 /// - Delegating actual index lookups to the format-specific IndexReader
 ///
 /// The format-specific IndexReader (e.g., SelectiveNimbleIndexReader) handles:
@@ -51,7 +51,7 @@ class HiveIndexReader {
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,
       const std::shared_ptr<common::ScanSpec>& scanSpec,
-      const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+      const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions,
       const RowTypePtr& requestType,
       const RowTypePtr& outputType,
       const std::shared_ptr<io::IoStatistics>& ioStats,
@@ -95,8 +95,9 @@ class HiveIndexReader {
   // Creates the format-specific index reader.
   std::unique_ptr<dwio::common::IndexReader> createIndexReader();
 
-  // Parses join conditions to extract column indices and constant values.
-  void parseJoinConditions();
+  // Parses index lookup conditions to extract column indices and constant
+  // values.
+  void parseIndexLookupConditions();
 
   // Builds IndexBounds from the request row vector.
   serializer::IndexBounds buildRequestIndexBounds(const RowVectorPtr& request);
@@ -117,22 +118,23 @@ class HiveIndexReader {
   const std::shared_ptr<common::ScanSpec> scanSpec_;
   const std::unique_ptr<dwio::common::Reader> fileReader_;
   const std::unique_ptr<dwio::common::IndexReader> indexReader_;
-  // Join conditions (including equal conditions converted from join keys).
-  const std::vector<core::IndexLookupConditionPtr> joinConditions_;
+  // Index lookup conditions (including equal conditions converted from lookup
+  // keys).
+  const std::vector<core::IndexLookupConditionPtr> indexLookupConditions_;
 
-  // Request column indices for each join condition (for probe side columns).
-  // For EqualIndexLookupCondition, stores {valueIndex}.
-  // For BetweenIndexLookupCondition, stores {lowerIndex, upperIndex}.
+  // Request column indices for each index lookup condition (for probe side
+  // columns). For EqualIndexLookupCondition, stores {valueIndex}. For
+  // BetweenIndexLookupCondition, stores {lowerIndex, upperIndex}.
   std::vector<std::vector<column_index_t>> requestColumnIndices_;
 
   // For BetweenIndexLookupCondition with constant bounds, stores the constant
-  // values directly. The outer vector is indexed by join condition index. The
-  // inner vector has size 2 for between conditions (lower, upper). If a bound
-  // is a constant, the corresponding optional contains the value; otherwise
-  // it's std::nullopt and the value should be decoded from request.
+  // values directly. The outer vector is indexed by index lookup condition
+  // index. The inner vector has size 2 for between conditions (lower, upper).
+  // If a bound is a constant, the corresponding optional contains the value;
+  // otherwise it's std::nullopt and the value should be decoded from request.
   std::vector<std::vector<std::optional<variant>>> constantBoundValues_;
 
-  // Cached row type for index bounds (column names and types from join
+  // Cached row type for index bounds (column names and types from index lookup
   // conditions).
   RowTypePtr indexBoundType_;
 

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -179,8 +179,8 @@ core::FieldAccessTypedExprPtr renameFieldAccess(
   return std::make_shared<core::FieldAccessTypedExpr>(field->type(), newName);
 }
 
-// Converts a join condition's key name from input column name to table column
-// name. Returns a new condition with the converted key name.
+// Converts an index lookup condition's key name from input column name to table
+// column name. Returns a new condition with the converted key name.
 core::IndexLookupConditionPtr convertConditionKeyName(
     const core::IndexLookupConditionPtr& condition,
     const connector::ColumnHandleMap& assignments) {
@@ -376,7 +376,7 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
 
 HiveIndexSource::HiveIndexSource(
     const RowTypePtr& requestType,
-    const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+    const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions,
     const RowTypePtr& outputType,
     HiveTableHandlePtr tableHandle,
     const ColumnHandleMap& columnHandles,
@@ -397,49 +397,53 @@ HiveIndexSource::HiveIndexSource(
       executor_(executor),
       ioStatistics_(std::make_shared<io::IoStatistics>()),
       ioStats_(std::make_shared<IoStats>()) {
-  init(columnHandles, joinConditions);
+  init(columnHandles, indexLookupConditions);
 }
 
-void HiveIndexSource::initJoinConditions(
-    const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+void HiveIndexSource::initIndexLookupConditions(
+    const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions,
     const ColumnHandleMap& assignments) {
   const auto& indexColumns = tableHandle_->indexColumns();
   const auto& dataColumns = tableHandle_->dataColumns();
 
-  // Build a map from join condition key name to condition for quick lookup.
-  // The key name in IndexLookupCondition references input column name, we need
-  // to convert it to the table column name using assignments.
+  // Build a map from index lookup condition key name to condition for quick
+  // lookup. The key name in IndexLookupCondition references input column name,
+  // we need to convert it to the table column name using assignments.
   folly::F14FastMap<std::string, core::IndexLookupConditionPtr>
-      joinConditionMap;
-  for (const auto& condition : joinConditions) {
+      indexLookupConditionMap;
+  for (const auto& condition : indexLookupConditions) {
     auto convertedCondition = convertConditionKeyName(condition, assignments);
     const auto& columnName = convertedCondition->key->name();
     VELOX_USER_CHECK(
-        joinConditionMap.emplace(columnName, std::move(convertedCondition))
+        indexLookupConditionMap
+            .emplace(columnName, std::move(convertedCondition))
             .second,
-        "Duplicate join key found in joinConditions: {}",
+        "Duplicate lookup key found in indexLookupConditions: {}",
         columnName);
   }
 
-  joinConditions_.reserve(indexColumns.size());
-  size_t numValidJoinConditions{0};
-  // Process index columns in order, converting filters to join conditions
-  // where possible. A range filter/condition stops further processing.
+  indexLookupConditions_.reserve(indexColumns.size());
+  size_t numValidIndexLookupConditions{0};
+  // Process index columns in order, converting filters to index lookup
+  // conditions where possible. A range filter/condition stops further
+  // processing.
   for (const auto& indexColumn : indexColumns) {
     const common::Subfield subfield(indexColumn);
     const auto filterIt = filters_.find(subfield);
     const bool hasFilter = filterIt != filters_.end();
-    const auto conditionIt = joinConditionMap.find(indexColumn);
-    const bool hasJoinCondition = conditionIt != joinConditionMap.end();
+    const auto conditionIt = indexLookupConditionMap.find(indexColumn);
+    const bool hasIndexLookupCondition =
+        conditionIt != indexLookupConditionMap.end();
 
-    // Cannot have both a filter and a join condition on the same column.
+    // Cannot have both a filter and an index lookup condition on the same
+    // column.
     VELOX_CHECK(
-        !(hasFilter && hasJoinCondition),
-        "Cannot have both filter and join condition on index column {}",
+        !(hasFilter && hasIndexLookupCondition),
+        "Cannot have both filter and index lookup condition on index column {}",
         indexColumn);
 
-    if (!hasFilter && !hasJoinCondition) {
-      // No filter or join condition on this column - stop processing.
+    if (!hasFilter && !hasIndexLookupCondition) {
+      // No filter or index lookup condition on this column - stop processing.
       break;
     }
 
@@ -450,12 +454,12 @@ void HiveIndexSource::initJoinConditions(
         "Index column {} not found in data columns",
         indexColumn);
 
-    if (hasJoinCondition) {
-      // Use the existing join condition as-is.
+    if (hasIndexLookupCondition) {
+      // Use the existing index lookup condition as-is.
       const auto& condition = conditionIt->second;
-      joinConditions_.push_back(condition);
+      indexLookupConditions_.push_back(condition);
       VELOX_CHECK(!condition->isFilter());
-      ++numValidJoinConditions;
+      ++numValidIndexLookupConditions;
 
       // Check if this is a range condition (Between) - stops further
       // processing.
@@ -466,7 +470,7 @@ void HiveIndexSource::initJoinConditions(
       continue;
     }
 
-    // Has filter - try to convert to join condition.
+    // Has filter - try to convert to index lookup condition.
     VELOX_CHECK(hasFilter);
     const auto& columnType = dataColumns->childAt(*typeIdx);
     const auto* filter = filterIt->second.get();
@@ -475,7 +479,7 @@ void HiveIndexSource::initJoinConditions(
     if (pointValue.has_value()) {
       auto condition = createEqualConditionWithConstant(
           indexColumn, columnType, pointValue.value());
-      joinConditions_.push_back(condition);
+      indexLookupConditions_.push_back(condition);
       // Remove converted filter from filters_ map.
       filters_.erase(filterIt);
       continue;
@@ -486,7 +490,7 @@ void HiveIndexSource::initJoinConditions(
     if (rangeBounds.has_value()) {
       auto condition = createBetweenConditionWithConstants(
           indexColumn, columnType, rangeBounds->first, rangeBounds->second);
-      joinConditions_.push_back(condition);
+      indexLookupConditions_.push_back(condition);
       // Remove converted filter from filters_ map.
       filters_.erase(filterIt);
       // Range condition stops further processing.
@@ -499,9 +503,9 @@ void HiveIndexSource::initJoinConditions(
   }
 
   VELOX_CHECK_EQ(
-      numValidJoinConditions,
-      joinConditions.size(),
-      "Not all join conditions were processed");
+      numValidIndexLookupConditions,
+      indexLookupConditions.size(),
+      "Not all index lookup conditions were processed");
 }
 
 void HiveIndexSource::initRemainingFilter(
@@ -562,7 +566,7 @@ void HiveIndexSource::initRemainingFilter(
 
 void HiveIndexSource::init(
     const ColumnHandleMap& assignments,
-    const std::vector<core::IndexLookupConditionPtr>& joinConditions) {
+    const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions) {
   VELOX_CHECK_NOT_NULL(tableHandle_);
 
   folly::F14FastMap<std::string_view, const HiveColumnHandle*> columnHandles;
@@ -619,7 +623,7 @@ void HiveIndexSource::init(
 
   initRemainingFilter(readColumnNames, readColumnTypes);
 
-  initJoinConditions(joinConditions, assignments);
+  initIndexLookupConditions(indexLookupConditions, assignments);
 
   readerOutputType_ =
       ROW(std::move(readColumnNames), std::move(readColumnTypes));
@@ -734,7 +738,7 @@ void HiveIndexSource::createHiveIndexReader(
       connectorQueryCtx_,
       hiveConfig_,
       scanSpec_,
-      joinConditions_,
+      indexLookupConditions_,
       requestType_,
       readerOutputType_,
       ioStatistics_,

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -35,7 +35,7 @@ class HiveConfig;
 
 /// HiveIndexSource provides index lookup for Hive tables.
 /// Currently supports Nimble file format with TabletIndex for efficient
-/// key-based stripe lookups to enable IndexLookupJoin.
+/// key-based stripe lookups.
 ///
 /// NOTE: This is a scaffold implementation that assumes a single Nimble file.
 /// The user may need to optimize and extend this for production use cases.
@@ -44,7 +44,7 @@ class HiveIndexSource : public IndexSource,
  public:
   HiveIndexSource(
       const RowTypePtr& requestType,
-      const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+      const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions,
       const RowTypePtr& outputType,
       HiveTableHandlePtr tableHandle,
       const ColumnHandleMap& columnHandles,
@@ -98,13 +98,13 @@ class HiveIndexSource : public IndexSource,
 
   void init(
       const ColumnHandleMap& assignments,
-      const std::vector<core::IndexLookupConditionPtr>& joinConditions);
+      const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions);
 
-  // Validates and initializes join conditions:
+  // Validates and initializes index lookup conditions:
   // - Converts filter conditions (with constant values) to filters_.
-  // - Non-filter conditions are stored in joinConditions_.
-  void initJoinConditions(
-      const std::vector<core::IndexLookupConditionPtr>& joinConditions,
+  // - Non-filter conditions are stored in indexLookupConditions_.
+  void initIndexLookupConditions(
+      const std::vector<core::IndexLookupConditionPtr>& indexLookupConditions,
       const ColumnHandleMap& assignments);
 
   // Initializes the remaining filter:
@@ -132,13 +132,13 @@ class HiveIndexSource : public IndexSource,
   const RowTypePtr outputType_;
   folly::Executor* const executor_;
 
-  // All join conditions including equal join keys converted to
-  // EqualIndexLookupConditions and original non-filter join conditions.
+  // All index lookup conditions including equal lookup keys converted to
+  // EqualIndexLookupConditions and original non-filter index lookup conditions.
   // This is passed to HiveIndexReader.
-  std::vector<core::IndexLookupConditionPtr> joinConditions_;
+  std::vector<core::IndexLookupConditionPtr> indexLookupConditions_;
 
   // Filters for pushdown. Includes subfield filters from table handle and
-  // filters converted from constant join conditions.
+  // filters converted from constant index lookup conditions.
   common::SubfieldFilters filters_;
 
   // Remaining filter expression set after filter pushdown.


### PR DESCRIPTION
Summary:
Rename join-specific terminology in HiveIndexReader and HiveIndexSource to use
generic index lookup condition naming. These classes serve a broader purpose
beyond just joins, so the naming should reflect that.

Renames include:
- joinConditions_ -> indexLookupConditions_
- parseJoinConditions() -> parseIndexLookupConditions()
- initJoinConditions() -> initIndexLookupConditions()
- joinConditionMap -> indexLookupConditionMap
- hasJoinCondition -> hasIndexLookupCondition
- numJoinConditions -> numIndexLookupConditions
- numValidJoinConditions -> numValidIndexLookupConditions
- Updated all comments and error messages accordingly

Differential Revision: D95229461


