### PR TITLE
fix: Skip first() in Spark aggregation fuzzer to fix CI crashes

### DIFF
--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -78,6 +78,10 @@ int main(int argc, char** argv) {
   // following names.
   std::unordered_set<std::string> skipFunctions = {
       "bloom_filter_agg",
+      // Crashes with SIGSEGV during streaming aggregation + LocalMerge +
+      // abandon-partial-aggregation with complex ROW group-by keys.
+      // https://github.com/facebookincubator/velox/issues/16632
+      "first",
       "first_ignore_null",
       "last_ignore_null",
       "regr_replacement",


### PR DESCRIPTION
Summary:
The Spark aggregation fuzzer consistently crashes (SIGSEGV) when testing
the `first` aggregate function with complex ROW-typed group-by keys in
a streaming aggregation + LocalMerge + abandon-partial-aggregation plan.

This was confirmed across multiple CI runs (seeds 5500 and 9886) where
the fuzzer crashes on plan #14 (FINAL STREAMING over LocalMerge with
forced abandon-partial-aggregation). 
Adding first to the skip list until the root cause in the streaming
aggregation framework is fixed.

Differential Revision: D95251892


