### PR TITLE
feat: Add option to collect column decoding time for selective readers

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -264,6 +264,13 @@ bool HiveConfig::indexEnabled(const config::ConfigBase* session) const {
       kIndexEnabledSession, config_->get<bool>(kIndexEnabled, false));
 }
 
+bool HiveConfig::readerCollectColumnStats(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kReaderCollectColumnStatsSession,
+      config_->get<bool>(kReaderCollectColumnStats, false));
+}
+
 uint32_t HiveConfig::maxRowsPerIndexRequest(
     const config::ConfigBase* session) const {
   return session->get<uint32_t>(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -214,6 +214,13 @@ class HiveConfig {
   static constexpr const char* kIndexEnabled = "index-enabled";
   static constexpr const char* kIndexEnabledSession = "index_enabled";
 
+  /// Whether to collect per-column timing stats (decode/decompress CPU time).
+  /// Disabled by default to avoid overhead (~100ns per operation).
+  static constexpr const char* kReaderCollectColumnStats =
+      "hive.reader.collect-column-stats";
+  static constexpr const char* kReaderCollectColumnStatsSession =
+      "hive.reader.collect_column_stats";
+
   /// Maximum number of output rows to return per index lookup request.
   /// The limit is applied to the actual output rows after filtering.
   /// 0 means no limit (default).
@@ -318,6 +325,10 @@ class HiveConfig {
 
   /// Whether to use the cluster index for filter-based row pruning.
   bool indexEnabled(const config::ConfigBase* session) const;
+
+  /// Whether to collect per-column timing stats (decode/decompress CPU time).
+  /// Disabled by default to avoid overhead (~100ns per operation).
+  bool readerCollectColumnStats(const config::ConfigBase* session) const;
 
   /// Returns the maximum number of rows to read per index lookup request.
   /// 0 means no limit (default).

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -688,6 +688,8 @@ void configureRowReaderOptions(
         hiveConfig->parallelUnitLoadCount(sessionProperties));
     rowReaderOptions.setIndexEnabled(
         hiveConfig->indexEnabled(sessionProperties));
+    rowReaderOptions.setCollectColumnStats(
+        hiveConfig->readerCollectColumnStats(sessionProperties));
   }
   rowReaderOptions.setSerdeParameters(hiveSplit->serdeParameters);
 }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -824,6 +824,20 @@ Each query can override the config by setting corresponding query session proper
      - Whether to cache file metadata (footer, stripes, index) in the process-wide AsyncDataCache. When enabled,
        the first reader performs a speculative tail read and populates the cache; subsequent readers on the same file
        serve metadata from cache with zero file IO. Currently only supported by Nimble format.
+  * - hive.max-rows-per-index-request
+    - hive.max_rows_per_index_request
+    - integer
+    - 0
+    - Maximum number of output rows to return per index lookup request. The limit is applied to the actual output rows
+      after filtering. 0 means no limit (default).
+  * - hive.reader.collect-column-stats
+    - hive.reader.collect_column_stats
+    - bool
+    - false
+    - If true, enables collection of per-column timing statistics during file reading. This includes
+      decompression and decode CPU time metrics for each column, reported as runtime metrics in the format
+      ``column_<nodeId>.<type>.decompressCPUTimeNanos`` and ``column_<nodeId>.<type>.decodeCPUTimeNanos``.
+      Useful for performance analysis and identifying slow columns.
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -56,7 +56,7 @@ RowSet read(
 
   structReader->advanceFieldReader(fieldReader, offset);
   fieldReader->scanSpec()->setValueHook(hook);
-  fieldReader->read(offset, effectiveRows, incomingNulls);
+  fieldReader->readWithTiming(offset, effectiveRows, incomingNulls);
   if (fieldReader->fileType().type()->isRow() ||
       fieldReader->scanSpec()->isFlatMapAsStruct()) {
     // 'fieldReader_' may itself produce LazyVectors. For this it must have its

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwio::common {
@@ -57,6 +58,25 @@ SelectiveColumnReader::SelectiveColumnReader(
       innerNonNullRows_(memoryPool_) {
   scanState_.rowsCopy = raw_vector<vector_size_t>(memoryPool_);
   scanState_.filterCache = raw_vector<uint8_t>(memoryPool_);
+  // Initialize per-column metrics if collection is enabled.
+  if (params.runtimeStatistics().columnMetricsSet) {
+    columnMetrics_ = params.runtimeStatistics().columnMetricsSet->getOrCreate(
+        fileType_->id());
+  }
+}
+
+void SelectiveColumnReader::readWithTiming(
+    int64_t offset,
+    const RowSet& rows,
+    const uint64_t* incomingNulls) {
+  if (columnMetrics_ && fileType_->type()->isPrimitiveType()) {
+    DeltaCpuWallTimer timer([this](const CpuWallTiming& timing) {
+      columnMetrics_->decodeCPUTimeNanos.increment(timing.cpuNanos);
+    });
+    read(offset, rows, incomingNulls);
+  } else {
+    read(offset, rows, incomingNulls);
+  }
 }
 
 void SelectiveColumnReader::filterRowGroups(

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -27,6 +27,8 @@
 
 namespace facebook::velox::dwio::common {
 
+struct ColumnMetrics;
+
 using ScanSpec = velox::common::ScanSpec;
 
 /// Generalized representation of a set of distinct values for dictionary
@@ -174,6 +176,14 @@ class SelectiveColumnReader {
   // constant between this and the next call to read.
   virtual void
   read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls) = 0;
+
+  /// Wraps read() to collect decode timing stats for leaf columns.
+  /// Only times primitive types to avoid double-counting in complex types
+  /// (struct/map/array) which recursively call children's readWithTiming.
+  void readWithTiming(
+      int64_t offset,
+      const RowSet& rows,
+      const uint64_t* incomingNulls);
 
   virtual uint64_t skip(uint64_t numValues) {
     return formatData_->skip(numValues);
@@ -648,6 +658,10 @@ class SelectiveColumnReader {
   // spec is assigned at construction and the contents may change at
   // run time based on adaptation. Owned by caller.
   velox::common::ScanSpec* const scanSpec_;
+
+  // Per-column metrics for timing stats. May be nullptr if collection is
+  // disabled.
+  ColumnMetrics* columnMetrics_{nullptr};
 
   // Row number after last read row, relative to the ORC stripe or Parquet
   // Rowgroup start.

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -253,7 +253,7 @@ void SelectiveListColumnReader::read(
           std::numeric_limits<vector_size_t>::max();
   makeNestedRowSet(activeRows, rows.back());
   if (child_ && !nestedRows_.empty()) {
-    child_->read(child_->readOffset(), nestedRows_, nullptr);
+    child_->readWithTiming(child_->readOffset(), nestedRows_, nullptr);
     nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
         nestedRows_.size() == child_->outputRows().size();
     nestedRows_ = child_->outputRows();
@@ -327,12 +327,13 @@ void SelectiveMapColumnReaderBase::read(
       std::numeric_limits<vector_size_t>::max());
   makeNestedRowSet(activeRows, rows.back());
   if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
-    keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
+    keyReader_->readWithTiming(keyReader_->readOffset(), nestedRows_, nullptr);
     nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
         nestedRows_.size() == keyReader_->outputRows().size();
     nestedRows_ = keyReader_->outputRows();
     if (!nestedRows_.empty()) {
-      elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);
+      elementReader_->readWithTiming(
+          elementReader_->readOffset(), nestedRows_, nullptr);
       nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
           nestedRows_.size() == elementReader_->outputRows().size();
       nestedRows_ = elementReader_->outputRows();

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -461,7 +461,7 @@ void SelectiveStructColumnReaderBase::read(
         SelectivityTimer timer(childSpec->selectivity(), activeRows.size());
 
         reader->resetInitTimeClocks();
-        reader->read(offset, activeRows, structNulls);
+        reader->readWithTiming(offset, activeRows, structNulls);
 
         // Exclude initialization time.
         timer.subtract(reader->initTimeClocks());
@@ -473,7 +473,7 @@ void SelectiveStructColumnReaderBase::read(
         break;
       }
     } else {
-      reader->read(offset, activeRows, structNulls);
+      reader->readWithTiming(offset, activeRows, structNulls);
     }
   }
 

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -339,7 +339,7 @@ void SelectiveFlatMapColumnReaderHelper<T, KeyNode, FormatData>::read(
     reader_.advanceFieldReader(child, offset);
   }
   for (auto* child : reader_.children_) {
-    child->read(offset, activeRows, mapNulls);
+    child->readWithTiming(offset, activeRows, mapNulls);
     child->addParentNulls(offset, mapNulls, rows);
   }
   reader_.lazyVectorReadOffset_ = offset;

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -574,10 +574,12 @@ struct ColumnMetrics {
 
   TypeKind typeKind;
   io::IoCounter decompressCPUTimeNanos;
+  io::IoCounter decodeCPUTimeNanos;
 
   /// Merges stats from another ColumnMetrics instance.
   void merge(const ColumnMetrics& other) {
     decompressCPUTimeNanos.merge(other.decompressCPUTimeNanos);
+    decodeCPUTimeNanos.merge(other.decodeCPUTimeNanos);
   }
 };
 
@@ -617,21 +619,36 @@ struct ColumnMetricsSet {
       std::unordered_map<std::string, RuntimeMetric>& result) const {
     auto statsLocked = map_.rlock();
     for (const auto& [nodeId, stats] : *statsLocked) {
-      const auto& counter = stats->decompressCPUTimeNanos;
-      if (counter.count() == 0) {
-        continue;
+      // Export decompression timing.
+      const auto& decompressCounter = stats->decompressCPUTimeNanos;
+      if (decompressCounter.count() > 0) {
+        result.emplace(
+            fmt::format(
+                "column_{}.{}.decompressCPUTimeNanos",
+                nodeId,
+                TypeKindName::toName(stats->typeKind)),
+            RuntimeMetric{
+                static_cast<int64_t>(decompressCounter.sum()),
+                static_cast<int64_t>(decompressCounter.count()),
+                static_cast<int64_t>(decompressCounter.min()),
+                static_cast<int64_t>(decompressCounter.max()),
+                RuntimeCounter::Unit::kNanos});
       }
-      result.emplace(
-          fmt::format(
-              "column.{}.{}.decompressCPUTimeNanos",
-              TypeKindName::toName(stats->typeKind),
-              nodeId),
-          RuntimeMetric{
-              static_cast<int64_t>(counter.sum()),
-              static_cast<int64_t>(counter.count()),
-              static_cast<int64_t>(counter.min()),
-              static_cast<int64_t>(counter.max()),
-              RuntimeCounter::Unit::kNanos});
+      // Export decode timing.
+      const auto& decodeCounter = stats->decodeCPUTimeNanos;
+      if (decodeCounter.count() > 0) {
+        result.emplace(
+            fmt::format(
+                "column_{}.{}.decodeCPUTimeNanos",
+                nodeId,
+                TypeKindName::toName(stats->typeKind)),
+            RuntimeMetric{
+                static_cast<int64_t>(decodeCounter.sum()),
+                static_cast<int64_t>(decodeCounter.count()),
+                static_cast<int64_t>(decodeCounter.min()),
+                static_cast<int64_t>(decodeCounter.max()),
+                RuntimeCounter::Unit::kNanos});
+      }
     }
   }
 

--- a/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
+++ b/velox/dwio/common/tests/ColumnReaderStatisticsTests.cpp
@@ -95,8 +95,8 @@ TEST(ColumnMetricsSetTest, GetOrCreateWithTypeKind) {
   // Verify types are used in toRuntimeMetrics.
   std::unordered_map<std::string, RuntimeMetric> metrics;
   metricsSet.toRuntimeMetrics(metrics);
-  EXPECT_EQ(metrics["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
-  EXPECT_EQ(metrics["column.VARCHAR.2.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(metrics["column_1.BIGINT.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(metrics["column_2.VARCHAR.decompressCPUTimeNanos"].sum, 2'000);
 }
 
 TEST(ColumnMetricsSetTest, ToRuntimeMetrics) {
@@ -122,18 +122,18 @@ TEST(ColumnMetricsSetTest, ToRuntimeMetrics) {
   metricsSet.toRuntimeMetrics(result);
 
   // RuntimeMetric has sum/count/min/max, metric name includes type.
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 8'000);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].count, 2);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].min, 3'000);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].max, 5'000);
-  EXPECT_EQ(result["column.VARCHAR.42.decompressCPUTimeNanos"].sum, 2'000);
-  EXPECT_EQ(result["column.VARCHAR.42.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 8'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].count, 2);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].min, 3'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].max, 5'000);
+  EXPECT_EQ(result["column_42.VARCHAR.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(result["column_42.VARCHAR.decompressCPUTimeNanos"].count, 1);
 
   // Zero values are not included.
   metricsSet.getOrCreate(99);
   result.clear();
   metricsSet.toRuntimeMetrics(result);
-  EXPECT_EQ(result.count("column.DOUBLE.99.decompressCPUTimeNanos"), 0);
+  EXPECT_EQ(result.count("column_99.DOUBLE.decompressCPUTimeNanos"), 0);
 }
 
 TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithInvalidType) {
@@ -147,7 +147,35 @@ TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithInvalidType) {
   metricsSet.toRuntimeMetrics(result);
 
   // Should use INVALID as type name.
-  EXPECT_EQ(result["column.INVALID.1.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column_1.INVALID.decompressCPUTimeNanos"].sum, 5'000);
+}
+
+TEST(ColumnMetricsSetTest, ToRuntimeMetricsWithDecodeTime) {
+  ColumnMetricsSet metricsSet;
+
+  // Add both decompress and decode timing data.
+  auto* col1 = metricsSet.getOrCreate(1, TypeKind::BIGINT);
+  col1->decompressCPUTimeNanos.increment(5'000);
+  col1->decodeCPUTimeNanos.increment(10'000);
+  col1->decodeCPUTimeNanos.increment(8'000);
+
+  auto* col2 = metricsSet.getOrCreate(2, TypeKind::VARCHAR);
+  col2->decodeCPUTimeNanos.increment(3'000);
+
+  std::unordered_map<std::string, RuntimeMetric> result;
+  metricsSet.toRuntimeMetrics(result);
+
+  // Column 1 has both decompress and decode metrics.
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].sum, 18'000);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].count, 2);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].min, 8'000);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].max, 10'000);
+
+  // Column 2 has only decode metrics.
+  EXPECT_EQ(result.count("column_2.VARCHAR.decompressCPUTimeNanos"), 0);
+  EXPECT_EQ(result["column_2.VARCHAR.decodeCPUTimeNanos"].sum, 3'000);
+  EXPECT_EQ(result["column_2.VARCHAR.decodeCPUTimeNanos"].count, 1);
 }
 
 TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
@@ -169,6 +197,7 @@ TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
   auto* colMetrics = stats.columnReaderStats.columnMetricsSet->getOrCreate(
       1, TypeKind::BIGINT);
   colMetrics->decompressCPUTimeNanos.increment(5'000);
+  colMetrics->decodeCPUTimeNanos.increment(12'000);
 
   auto result = stats.toRuntimeMetricMap();
 
@@ -178,8 +207,10 @@ TEST(RuntimeStatisticsTest, ToRuntimeMetricMap) {
   EXPECT_EQ(result["processedStrides"].sum, 30);
   EXPECT_EQ(result["numStripes"].sum, 4);
   EXPECT_EQ(result["flattenStringDictionaryValues"].sum, 1'000);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 5'000);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].sum, 12'000);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].count, 1);
 }
 
 TEST(ColumnMetricsSetConcurrencyTest, ConcurrentGetOrCreate) {
@@ -210,7 +241,7 @@ TEST(ColumnMetricsSetConcurrencyTest, ConcurrentGetOrCreate) {
   metricsSet.toRuntimeMetrics(result);
 
   for (uint32_t colId = 0; colId < kNumColumns; ++colId) {
-    auto key = fmt::format("column.BIGINT.{}.decompressCPUTimeNanos", colId);
+    auto key = fmt::format("column_{}.BIGINT.decompressCPUTimeNanos", colId);
     EXPECT_EQ(result[key].sum, kNumThreads * 100);
     EXPECT_EQ(result[key].count, kNumThreads);
   }
@@ -235,23 +266,30 @@ TEST(ColumnMetricsSetTest, MergeFromWithOverlappingNodeIds) {
   auto* srcCol1 = src.getOrCreate(1, TypeKind::BIGINT);
   srcCol1->decompressCPUTimeNanos.increment(5'000);
   srcCol1->decompressCPUTimeNanos.increment(3'000);
+  srcCol1->decodeCPUTimeNanos.increment(10'000);
 
   auto* srcCol2 = src.getOrCreate(2, TypeKind::VARCHAR);
   srcCol2->decompressCPUTimeNanos.increment(2'000);
+  srcCol2->decodeCPUTimeNanos.increment(4'000);
 
   ColumnMetricsSet dst;
   auto* dstCol1 = dst.getOrCreate(1, TypeKind::BIGINT);
   dstCol1->decompressCPUTimeNanos.increment(1'000);
+  dstCol1->decodeCPUTimeNanos.increment(6'000);
 
   dst.mergeFrom(src);
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.toRuntimeMetrics(result);
 
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 9'000);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].count, 3);
-  EXPECT_EQ(result["column.VARCHAR.2.decompressCPUTimeNanos"].sum, 2'000);
-  EXPECT_EQ(result["column.VARCHAR.2.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 9'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].count, 3);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].sum, 16'000);
+  EXPECT_EQ(result["column_1.BIGINT.decodeCPUTimeNanos"].count, 2);
+  EXPECT_EQ(result["column_2.VARCHAR.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(result["column_2.VARCHAR.decompressCPUTimeNanos"].count, 1);
+  EXPECT_EQ(result["column_2.VARCHAR.decodeCPUTimeNanos"].sum, 4'000);
+  EXPECT_EQ(result["column_2.VARCHAR.decodeCPUTimeNanos"].count, 1);
 }
 
 TEST(ColumnMetricsSetTest, MergeFromWithDisjointNodeIds) {
@@ -274,10 +312,10 @@ TEST(ColumnMetricsSetTest, MergeFromWithDisjointNodeIds) {
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.toRuntimeMetrics(result);
 
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
-  EXPECT_EQ(result["column.VARCHAR.2.decompressCPUTimeNanos"].sum, 2'000);
-  EXPECT_EQ(result["column.DOUBLE.3.decompressCPUTimeNanos"].sum, 3'000);
-  EXPECT_EQ(result["column.BOOLEAN.4.decompressCPUTimeNanos"].sum, 4'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(result["column_2.VARCHAR.decompressCPUTimeNanos"].sum, 2'000);
+  EXPECT_EQ(result["column_3.DOUBLE.decompressCPUTimeNanos"].sum, 3'000);
+  EXPECT_EQ(result["column_4.BOOLEAN.decompressCPUTimeNanos"].sum, 4'000);
 }
 
 TEST(ColumnMetricsSetTest, MergeFromEmpty) {
@@ -291,14 +329,14 @@ TEST(ColumnMetricsSetTest, MergeFromEmpty) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   nonEmpty.toRuntimeMetrics(result);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 5'000);
 
   ColumnMetricsSet empty2;
   empty2.mergeFrom(nonEmpty);
 
   result.clear();
   empty2.toRuntimeMetrics(result);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 5'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 5'000);
 }
 
 TEST(ColumnReaderStatisticsTest, MergeFromWithColumnMetrics) {
@@ -318,7 +356,7 @@ TEST(ColumnReaderStatisticsTest, MergeFromWithColumnMetrics) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.columnMetricsSet->toRuntimeMetrics(result);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 1'000);
 }
 
 TEST(ColumnReaderStatisticsTest, MergeFromBothWithColumnMetrics) {
@@ -341,7 +379,7 @@ TEST(ColumnReaderStatisticsTest, MergeFromBothWithColumnMetrics) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.columnMetricsSet->toRuntimeMetrics(result);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 3'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 3'000);
 }
 
 TEST(ColumnReaderStatisticsTest, MergeFromWithoutColumnMetrics) {
@@ -361,5 +399,5 @@ TEST(ColumnReaderStatisticsTest, MergeFromWithoutColumnMetrics) {
 
   std::unordered_map<std::string, RuntimeMetric> result;
   dst.columnMetricsSet->toRuntimeMetrics(result);
-  EXPECT_EQ(result["column.BIGINT.1.decompressCPUTimeNanos"].sum, 1'000);
+  EXPECT_EQ(result["column_1.BIGINT.decompressCPUTimeNanos"].sum, 1'000);
 }


### PR DESCRIPTION
Summary: Add per-column decode CPU time collection to selective readers. When collectColumnStats is enabled, tracks decode timing for primitive type columns alongside existing decompression metrics. Exports as column.<type>.<nodeId>.decodeCPUTimeNanos runtime metrics for performance analysis.

Reviewed By: Yuhta

Differential Revision: D94554467


