### PR TITLE
build: Move StringCore.h include and computeAndSetIsAscii to .cpp

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -19,6 +19,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/StringWriter.h"
+#include "velox/functions/lib/string/StringCore.h"
 #include "velox/type/Type.h"
 #include "velox/vector/SelectivityVector.h"
 

--- a/velox/python/legacy/pyvelox.cpp
+++ b/velox/python/legacy/pyvelox.cpp
@@ -19,6 +19,11 @@
 #include "conversion.h"
 #include "serde.h"
 #include "signatures.h"
+#include "velox/external/utf8proc/utf8procImpl.h"
+
+#ifndef PYVELOX_VERSION
+#define PYVELOX_VERSION dev
+#endif
 
 namespace facebook::velox::py {
 using namespace velox;

--- a/velox/vector/SimpleVector.cpp
+++ b/velox/vector/SimpleVector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/vector/SimpleVector.h"
+#include "velox/functions/lib/string/StringCore.h"
 
 namespace facebook::velox {
 
@@ -28,6 +29,36 @@ void SimpleVector<StringView>::validate(
   if (rlockedAsciiComputedRows->hasSelections()) {
     VELOX_CHECK_GE(rlockedAsciiComputedRows->size(), size());
   }
+}
+
+template <>
+template <>
+bool SimpleVector<StringView>::computeAndSetIsAscii<StringView>(
+    const SelectivityVector& rows) {
+  if (rows.isSubset(*asciiInfo.readLockedAsciiComputedRows())) {
+    return asciiInfo.isAllAscii();
+  }
+  ensureIsAsciiCapacity();
+  bool isAllAscii = true;
+  rows.applyToSelected([&](auto row) {
+    if (!isNullAt(row)) {
+      auto string = valueAt(row);
+      isAllAscii &=
+          functions::stringCore::isAscii(string.data(), string.size());
+    }
+  });
+
+  auto wlockedAsciiComputedRows = asciiInfo.writeLockedAsciiComputedRows();
+  if (!wlockedAsciiComputedRows->hasSelections()) {
+    asciiInfo.setIsAllAscii(isAllAscii);
+  } else {
+    asciiInfo.setIsAllAscii(asciiInfo.isAllAscii() & isAllAscii);
+  }
+
+  wlockedAsciiComputedRows->select(rows);
+  asciiInfo.setAsciiComputedRowsEmpty(
+      !wlockedAsciiComputedRows->hasSelections());
+  return asciiInfo.isAllAscii();
 }
 
 } // namespace facebook::velox

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -27,7 +27,6 @@
 #include <folly/hash/Hash.h>
 #include <glog/logging.h>
 
-#include "velox/functions/lib/string/StringCore.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/FloatingPointUtil.h"
 #include "velox/type/Type.h"
@@ -310,33 +309,7 @@ class SimpleVector : public BaseVector {
   /// present. Returns computed value.
   template <typename U = T>
   typename std::enable_if_t<std::is_same_v<U, StringView>, bool>
-  computeAndSetIsAscii(const SelectivityVector& rows) {
-    if (rows.isSubset(*asciiInfo.readLockedAsciiComputedRows())) {
-      return asciiInfo.isAllAscii();
-    }
-    ensureIsAsciiCapacity();
-    bool isAllAscii = true;
-    rows.applyToSelected([&](auto row) {
-      if (!isNullAt(row)) {
-        auto string = valueAt(row);
-        isAllAscii &=
-            functions::stringCore::isAscii(string.data(), string.size());
-      }
-    });
-
-    // Set isAllAscii flag, it will unset if we encounter any utf.
-    auto wlockedAsciiComputedRows = asciiInfo.writeLockedAsciiComputedRows();
-    if (!wlockedAsciiComputedRows->hasSelections()) {
-      asciiInfo.setIsAllAscii(isAllAscii);
-    } else {
-      asciiInfo.setIsAllAscii(asciiInfo.isAllAscii() & isAllAscii);
-    }
-
-    wlockedAsciiComputedRows->select(rows);
-    asciiInfo.setAsciiComputedRowsEmpty(
-        !wlockedAsciiComputedRows->hasSelections());
-    return asciiInfo.isAllAscii();
-  }
+  computeAndSetIsAscii(const SelectivityVector& rows);
 
   /// Clears asciiness state.
   template <typename U = T>


### PR DESCRIPTION
Summary:
SimpleVector.h is included by many translation units. Moving the `#include StringCore.h` and
`computeAndSetIsAscii` method body to the .cpp file via explicit template
specialization reduces compile-time work for every includer. Most of the compile time savings comes from moving the `#include StringCore.h`.

The SFINAE guard already ensures the method only compiles for
T = StringView, so an explicit specialization for
SimpleVector<StringView>::computeAndSetIsAscii<StringView> is the
natural approach.

AUTODEPS moved the velox_functions_string dependency from exported_deps
to deps since the header no longer needs it.

Differential Revision: D94973899


