### PR TITLE
fix: Fix crashes, memory leaks, and format string bugs in NumericHistogramAggregate

### DIFF
--- a/velox/functions/prestosql/aggregates/NumericHistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/NumericHistogramAggregate.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <queue>
 
 #include <vector>
@@ -187,20 +188,23 @@ class NumericHistogram {
 
   // Initialize a priority queue with Entries for each value and weight
   std::priority_queue<Entry*, std::vector<Entry*>, Entry::Compare> initQueue(
-      std::vector<Entry*>& allocatedEntries) {
+      std::vector<std::unique_ptr<Entry>>& allocatedEntries) {
     VELOX_CHECK_GE(values_.size(), nextIndex_);
     VELOX_CHECK_GE(weights_.size(), nextIndex_);
 
     std::priority_queue<Entry*, std::vector<Entry*>, Entry::Compare> queue;
-    Entry* right = new Entry(
+    auto right = std::make_unique<Entry>(
         nextIndex_ - 1, values_[nextIndex_ - 1], weights_[nextIndex_ - 1]);
-    allocatedEntries.push_back(right);
-    queue.push(right);
+    auto* rightPtr = right.get();
+    queue.push(rightPtr);
+    allocatedEntries.push_back(std::move(right));
     for (int i = nextIndex_ - 2; i >= 0; i--) {
-      Entry* current = new Entry(i, values_[i], weights_[i], right);
-      queue.push(current);
-      allocatedEntries.push_back(current);
-      right = current;
+      auto current =
+          std::make_unique<Entry>(i, values_[i], weights_[i], rightPtr);
+      auto* currentPtr = current.get();
+      queue.push(currentPtr);
+      allocatedEntries.push_back(std::move(current));
+      rightPtr = currentPtr;
     }
 
     return queue;
@@ -212,7 +216,7 @@ class NumericHistogram {
       return;
     }
 
-    std::vector<Entry*> allocatedEntries;
+    std::vector<std::unique_ptr<Entry>> allocatedEntries;
     auto queue = initQueue(allocatedEntries);
 
     // Merge and reduce entries in queue until the count is equal to targetCount
@@ -243,11 +247,11 @@ class NumericHistogram {
                          right->value_ * right->weight_) /
           newWeight;
 
-      Entry* merged =
-          new Entry(current->id_, newValue, newWeight, right->right_);
-
-      allocatedEntries.push_back(merged);
-      queue.push(merged);
+      auto merged = std::make_unique<Entry>(
+          current->id_, newValue, newWeight, right->right_);
+      auto* mergedPtr = merged.get();
+      queue.push(mergedPtr);
+      allocatedEntries.push_back(std::move(merged));
 
       // Update left's penalty
       Entry* left = current->left_;
@@ -255,10 +259,10 @@ class NumericHistogram {
         VELOX_CHECK(left->valid_, "Left entry is not valid");
 
         left->invalidate();
-        Entry* newLeft = new Entry(
-            left->id_, left->value_, left->weight_, merged, left->left_);
-        allocatedEntries.push_back(newLeft);
-        queue.push(newLeft);
+        auto newLeft = std::make_unique<Entry>(
+            left->id_, left->value_, left->weight_, mergedPtr, left->left_);
+        queue.push(newLeft.get());
+        allocatedEntries.push_back(std::move(newLeft));
       }
     }
     // Re populate values_ and weights_ with the reduced queue
@@ -274,9 +278,6 @@ class NumericHistogram {
     }
 
     sortValuesAndWeights();
-    for (Entry* entry : allocatedEntries) {
-      delete entry;
-    }
   }
   // Following Java Standard:
   // https://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#compare(double,%20double)
@@ -302,6 +303,9 @@ class NumericHistogram {
 
   // Merge same buckets in place and update nextIndex_
   void mergeSameBuckets() {
+    if (nextIndex_ <= 1) {
+      return;
+    }
     sortValuesAndWeights();
     VELOX_CHECK_GE(values_.size(), nextIndex_);
     VELOX_CHECK_GE(weights_.size(), nextIndex_);
@@ -519,14 +523,14 @@ void registerNumericHistogramAggregate(
             argTypes.size(), 3, "{} takes at most three arguments", name);
         if (argTypes[0]->kind() != TypeKind::BIGINT) {
           VELOX_USER_FAIL(
-              "Aggregation {}: Buckets must be bigint {}, but is {}",
+              "Aggregation {}: Buckets must be bigint, but is {}",
               name,
               argTypes[0]->kindName());
         }
         if (argTypes[1]->kind() != TypeKind::REAL &&
             argTypes[1]->kind() != TypeKind::DOUBLE) {
           VELOX_USER_FAIL(
-              "Aggregation {}: Value must be REAL or DOUBLE {}, but is {}",
+              "Aggregation {}: Value must be REAL or DOUBLE, but is {}",
               name,
               argTypes[1]->kindName());
         }
@@ -542,16 +546,16 @@ void registerNumericHistogramAggregate(
                   step, argTypes, resultType);
 
             default:
-              VELOX_USER_FAIL("Unknown input type for {} aggregation {}", name);
+              VELOX_USER_FAIL("Unknown input type for aggregation {}", name);
           }
         } else {
           // argTypes.size() == 3
           if (argTypes[2]->kind() != TypeKind::REAL &&
               argTypes[2]->kind() != TypeKind::DOUBLE) {
             VELOX_USER_FAIL(
-                "Aggregation {}: Weight must be REAL or DOUBLE {}, but is {}",
+                "Aggregation {}: Weight must be REAL or DOUBLE, but is {}",
                 name,
-                argTypes[1]->kindName());
+                argTypes[2]->kindName());
           }
           switch (argTypes[1]->kind()) {
             case TypeKind::REAL:
@@ -583,7 +587,7 @@ void registerNumericHistogramAggregate(
                       "Unknown weight type for aggregation {}", name);
               }
             default:
-              VELOX_USER_FAIL("Unknown input type for {} aggregation {}", name);
+              VELOX_USER_FAIL("Unknown input type for aggregation {}", name);
           }
         }
       },

--- a/velox/functions/prestosql/aggregates/tests/NumericHistogramTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/NumericHistogramTest.cpp
@@ -629,5 +629,93 @@ TEST_F(NumericHistogramTest, threeArgsFloatFloat) {
   runThreeArgsTests<float, float>();
 }
 
+// Verify all-null input produces null output without crashing.
+// Exercises the mergeSameBuckets fix for nextIndex_ == 0.
+TEST_F(NumericHistogramTest, allNullInputTwoArgs) {
+  disableTestIncremental();
+  auto valuesAndWeights = makeRowVector({
+      makeNullableFlatVector<double>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+
+  auto expected = makeRowVector({
+      makeNullableMapVector<double, double>({std::nullopt}),
+  });
+  testAggregations(
+      {valuesAndWeights}, {}, {"numeric_histogram(3, c0)"}, {expected});
+}
+
+// Verify all-null input produces null output for 3-arg variant.
+TEST_F(NumericHistogramTest, allNullInputThreeArgs) {
+  disableTestIncremental();
+  auto valuesAndWeights = makeRowVector({
+      makeNullableFlatVector<double>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+      makeNullableFlatVector<double>({1, 2, 3}),
+  });
+
+  auto expected = makeRowVector({
+      makeNullableMapVector<double, double>({std::nullopt}),
+  });
+  testAggregations(
+      {valuesAndWeights}, {}, {"numeric_histogram(3, c0, c1)"}, {expected});
+}
+
+// Verify grouped aggregation where one group has all-null values.
+// Exercises the empty histogram code path in compact().
+TEST_F(NumericHistogramTest, groupedWithEmptyGroup) {
+  disableTestIncremental();
+  auto data = makeRowVector({
+      // group keys: group 0 gets all nulls, group 1 gets real values
+      makeNullableFlatVector<int32_t>({0, 0, 1, 1, 1}),
+      makeNullableFlatVector<double>(
+          {std::nullopt, std::nullopt, 10.0, 20.0, 30.0}),
+  });
+
+  auto expected = makeRowVector({
+      makeNullableFlatVector<int32_t>({0, 1}),
+      makeNullableMapVector<double, double>(
+          {std::nullopt, {{{10.0, 1}, {20.0, 1}, {30.0, 1}}}}),
+  });
+  testAggregations({data}, {"c0"}, {"numeric_histogram(3, c1)"}, {expected});
+}
+
+// Stress-test with a large number of entries that forces multiple compact
+// cycles. Validates unique_ptr cleanup in mergeAndReduceBuckets.
+TEST_F(NumericHistogramTest, largeInputStressTest) {
+  disableTestIncremental();
+  // Create 200 identical values. This forces multiple compact+reduce cycles
+  // with only 2 buckets, then mergeSameBuckets collapses them all.
+  std::vector<std::optional<double>> values(200, 42.0);
+
+  auto valuesAndWeights = makeRowVector({
+      makeNullableFlatVector<double>(values),
+  });
+
+  auto expected = makeRowVector({
+      makeMapVector<double, double>({
+          {{42.0, 200}},
+      }),
+  });
+  testAggregations(
+      {valuesAndWeights}, {}, {"numeric_histogram(2, c0)"}, {expected});
+}
+
+// Verify duplicate values are merged correctly by mergeSameBuckets.
+TEST_F(NumericHistogramTest, allDuplicateValues) {
+  disableTestIncremental();
+  auto valuesAndWeights = makeRowVector({
+      makeNullableFlatVector<double>({5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0}),
+  });
+
+  auto expected = makeRowVector({
+      makeMapVector<double, double>({
+          {{5.0, 8}},
+      }),
+  });
+  testAggregations(
+      {valuesAndWeights}, {}, {"numeric_histogram(3, c0)"}, {expected});
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Summary:
Fix 4 issues in NumericHistogramAggregate:

1. **CRITICAL: mergeSameBuckets crash on empty histogram** - When `nextIndex_ == 0` (all-null input), the function incorrectly set `nextIndex_ = 1` without any data. Added early return for `nextIndex_ <= 1`.

2. **HIGH: Memory leaks in initQueue and mergeAndReduceBuckets** - Raw `new Entry(...)` allocations leaked on exception since cleanup only ran on successful completion. Replaced with `std::unique_ptr<Entry>` for automatic RAII cleanup.

3. **MEDIUM: Format string argument count mismatches** - Multiple `VELOX_USER_FAIL` calls had more `{}` placeholders than arguments, causing undefined behavior at runtime. Also fixed `argTypes[1]` → `argTypes[2]` for weight type error message.

Added 5 new unit tests covering empty histograms, grouped aggregation with null groups, large input stress testing, and duplicate value deduplication.