### PR TITLE
build: Remove unused DecimalUtil.h include from SimpleVector.h (IWYU)

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -23,6 +23,7 @@
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
 #include "velox/dwio/dwrf/reader/FlatMapColumnReader.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Type.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DictionaryVector.h"

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::dwrf {
 

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -23,6 +23,7 @@
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 #include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DictionaryVector.h"

--- a/velox/dwio/orc/test/ReaderTest.cpp
+++ b/velox/dwio/orc/test/ReaderTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"

--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -21,6 +21,7 @@
 
 #include "velox/common/encode/Base64.h"
 #include "velox/dwio/common/exception/Exceptions.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/fbhive/HiveTypeParser.h"
 
 namespace facebook::velox::text {

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -19,6 +19,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/StringWriter.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Type.h"
 #include "velox/vector/SelectivityVector.h"
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Type.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 #include "velox/type/tz/TimeZoneMap.h"

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -28,6 +28,7 @@
 #include "velox/functions/Udf.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"

--- a/velox/functions/iceberg/BucketFunction.cpp
+++ b/velox/functions/iceberg/BucketFunction.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/iceberg/Murmur3Hash32.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::iceberg {
 namespace {

--- a/velox/functions/iceberg/tests/BucketFunctionTest.cpp
+++ b/velox/functions/iceberg/tests/BucketFunctionTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/iceberg/BucketFunction.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/iceberg/tests/IcebergFunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 #include <gtest/gtest.h>
 

--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -18,6 +18,7 @@
 
 #include "velox/common/base/IOUtils.h"
 #include "velox/exec/Aggregate.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/HugeInt.h"
 #include "velox/vector/FlatVector.h"
 

--- a/velox/functions/lib/aggregates/SumAggregateBase.h
+++ b/velox/functions/lib/aggregates/SumAggregateBase.h
@@ -21,6 +21,7 @@
 #include "velox/functions/lib/CheckedArithmeticImpl.h"
 #include "velox/functions/lib/aggregates/DecimalAggregate.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::aggregate {
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/lib/aggregates/DecimalAggregate.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox::exec::test;

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/DecimalUtil.h"
 
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/prestosql/aggregates/PrestoHasher.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/SumTestBase.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/AggregationHook.h"
 
 using facebook::velox::exec::test::PlanBuilder;

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 #include "velox/type/tz/TimeZoneMap.h"
 

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Time.h"
 
 using namespace facebook::velox;

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/functions/prestosql/json/JsonStringUtil.h"
 #include "velox/functions/prestosql/tests/CastBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/type/DecimalUtil.h"
 
 using namespace facebook::velox;
 

--- a/velox/functions/prestosql/tests/UuidFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/UuidFunctionsTest.cpp
@@ -19,6 +19,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::prestosql {
 

--- a/velox/functions/prestosql/types/JsonCastOperator.cpp
+++ b/velox/functions/prestosql/types/JsonCastOperator.cpp
@@ -22,6 +22,7 @@
 #include "velox/functions/prestosql/json/JsonStringUtil.h"
 #include "velox/functions/prestosql/json/SIMDJsonUtil.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox {
 namespace {

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox {
 namespace {

--- a/velox/functions/sparksql/DecimalCeil.cpp
+++ b/velox/functions/sparksql/DecimalCeil.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/expression/DecodedArgs.h"
 #include "velox/functions/lib/Murmur3Hash32Base.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::functions::sparksql {

--- a/velox/functions/sparksql/ToPrettyString.h
+++ b/velox/functions/sparksql/ToPrettyString.h
@@ -19,6 +19,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/Udf.h"
 #include "velox/type/Conversions.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/tz/TimeZoneMap.h"
 

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
+#include "velox/type/DecimalUtil.h"
 
 using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/lib/aggregates/tests/SumTestBase.h"
 #include "velox/functions/sparksql/aggregates/DecimalSumAggregate.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
+#include "velox/type/DecimalUtil.h"
 
 using facebook::velox::exec::test::PlanBuilder;
 using namespace facebook::velox::exec::test;

--- a/velox/functions/sparksql/specialforms/DecimalRound.cpp
+++ b/velox/functions/sparksql/specialforms/DecimalRound.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/DecimalRound.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {

--- a/velox/functions/sparksql/specialforms/MakeDecimal.cpp
+++ b/velox/functions/sparksql/specialforms/MakeDecimal.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/specialforms/MakeDecimal.h"
 #include "velox/expression/ConstantExpr.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 #include <velox/vector/SimpleVector.h>
 

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/testutil/OptionalEmpty.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 #include <stdint.h>
 

--- a/velox/functions/sparksql/tests/InTest.cpp
+++ b/velox/functions/sparksql/tests/InTest.cpp
@@ -19,6 +19,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/type/DecimalUtil.h"
 
 #include <stdint.h>
 

--- a/velox/functions/sparksql/tests/MakeDecimalTest.cpp
+++ b/velox/functions/sparksql/tests/MakeDecimalTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::sparksql::test {
 namespace {

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/common/testutil/OptionalEmpty.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/DecimalUtil.h"
 
 #include <stdint.h>
 

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/row/UnsafeRowFast.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::row {

--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -16,6 +16,7 @@
 #include "velox/serializers/PrestoSerializerDeserializationUtils.h"
 
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::serializer::presto::detail {
 namespace {

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -26,6 +26,7 @@
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/serializers/PrestoBatchVectorSerializer.h"
 #include "velox/serializers/PrestoVectorLexer.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/row/UnsafeRowFast.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -28,7 +28,6 @@
 #include <glog/logging.h>
 
 #include "velox/functions/lib/string/StringCore.h"
-#include "velox/type/DecimalUtil.h"
 #include "velox/type/FloatingPointUtil.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/fuzzer/Utils.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/Timestamp.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/FlatVector.h"


### PR DESCRIPTION
Summary:
`SimpleVector.h` includes `velox/type/DecimalUtil.h` but does not use any symbols from it. This unnecessary transitive include pollutes the include graph — every file that includes `SimpleVector.h` (or `FlatVector.h`) transitively pulls in `DecimalUtil.h`.

Remove the include from `SimpleVector.h` and add direct includes to the 42 files that actually use `DecimalUtil::` symbols.

Differential Revision: D95135580
