### PR TITLE
feat(expr-eval):Adaptive per-function CPU sampling for Velox expression evaluation (#16646)

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -87,6 +87,25 @@ class QueryConfig {
   static constexpr const char* kExprTrackCpuUsageForFunctions =
       "expression.track_cpu_usage_for_functions";
 
+  /// Enables adaptive per-function CPU usage sampling. When enabled, each
+  /// function is calibrated over the first 6 batches (1 warmup + 5
+  /// calibration) to measure the overhead of CPU tracking (clock_gettime).
+  /// Functions where tracking overhead exceeds
+  /// kExprAdaptiveCpuSamplingMaxOverheadPct are automatically sampled at a
+  /// rate proportional to their overhead. Functions with low overhead are
+  /// always tracked. Disabled by default.
+  static constexpr const char* kExprAdaptiveCpuSampling =
+      "expression.adaptive_cpu_sampling";
+
+  /// Maximum acceptable overhead percentage for CPU tracking per function.
+  /// Used with kExprAdaptiveCpuSampling. Functions whose CPU tracking overhead
+  /// exceeds this threshold are sampled at a rate of
+  /// ceil(overhead_pct / max_overhead_pct). For example, with max_overhead=1.0,
+  /// a function with 70% tracking overhead is sampled every 70th batch.
+  /// Default: 1.0 (1% overhead target).
+  static constexpr const char* kExprAdaptiveCpuSamplingMaxOverheadPct =
+      "expression.adaptive_cpu_sampling_max_overhead_pct";
+
   /// Controls whether non-deterministic expressions are deduplicated during
   /// compilation. This is intended for testing and debugging purposes. By
   /// default, this is set to true to preserve standard behavior. If set to
@@ -1385,6 +1404,14 @@ class QueryConfig {
 
   std::string exprTrackCpuUsageForFunctions() const {
     return get<std::string>(kExprTrackCpuUsageForFunctions, "");
+  }
+
+  bool exprAdaptiveCpuSampling() const {
+    return get<bool>(kExprAdaptiveCpuSampling, false);
+  }
+
+  double exprAdaptiveCpuSamplingMaxOverheadPct() const {
+    return get<double>(kExprAdaptiveCpuSamplingMaxOverheadPct, 1.0);
   }
 
   bool exprDedupNonDeterministic() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -286,6 +286,22 @@ Expression Evaluation Configuration
        ``expression.track_cpu_usage`` is set to false. Function names are case-insensitive and will be normalized
        to lowercase. This allows fine-grained control over CPU tracking overhead when only specific functions need to
        be monitored.
+   * - expression.adaptive_cpu_sampling
+     - boolean
+     - false
+     - Enables adaptive per-function CPU usage sampling. Each function is calibrated over 6 batches (1 warmup + 5
+       calibration) to measure the overhead of CPU tracking (clock_gettime) relative to the function's execution time.
+       The timer overhead is measured once per ExprSet and shared across all functions. Functions where tracking overhead
+       is acceptable are always tracked; functions where overhead exceeds ``expression.adaptive_cpu_sampling_max_overhead_pct``
+       are sampled at a rate proportional to their overhead. Sampled timing stats are extrapolated to approximate
+       full-population values.
+   * - expression.adaptive_cpu_sampling_max_overhead_pct
+     - float
+     - 1.0
+     - Maximum acceptable CPU tracking overhead percentage per function, used with ``expression.adaptive_cpu_sampling``.
+       Functions whose tracking overhead exceeds this threshold are sampled at a rate of
+       ceil(overhead_pct / max_overhead_pct). For example, with max_overhead=1.0, a function with 70% tracking overhead
+       is sampled every 70th batch, bounding its effective overhead to ~1%. Must be greater than 0.
    * - legacy_cast
      - bool
      - false

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -539,6 +539,34 @@ class EvalCtx {
     return execCtx_->optimizationParams().dictionaryMemoizationEnabled;
   }
 
+  /// Returns true if adaptive per-function CPU sampling is enabled.
+  bool adaptiveCpuSamplingEnabled() const {
+    return adaptiveCpuSamplingEnabled_;
+  }
+
+  void setAdaptiveCpuSamplingEnabled(bool enabled) {
+    adaptiveCpuSamplingEnabled_ = enabled;
+  }
+
+  /// Returns the maximum acceptable overhead pct for adaptive sampling.
+  double adaptiveCpuSamplingMaxOverheadPct() const {
+    return adaptiveCpuSamplingMaxOverheadPct_;
+  }
+
+  void setAdaptiveCpuSamplingMaxOverheadPct(double pct) {
+    adaptiveCpuSamplingMaxOverheadPct_ = pct;
+  }
+
+  /// Returns the measured CpuWallTimer overhead in nanoseconds (per
+  /// invocation). Measured once per ExprSet and shared across all Expr nodes.
+  uint64_t timerOverheadNanos() const {
+    return timerOverheadNanos_;
+  }
+
+  void setTimerOverheadNanos(uint64_t nanos) {
+    timerOverheadNanos_ = nanos;
+  }
+
   /// Returns the maximum number of distinct inputs to cache results for in a
   /// given shared subexpression.
   uint32_t maxSharedSubexprResultsCached() const {
@@ -610,6 +638,15 @@ class EvalCtx {
   // If 'captureErrorDetails()' is false, stores flags indicating which rows had
   // errors without storing actual exceptions.
   EvalErrorsPtr errors_;
+
+  // Whether adaptive per-function CPU sampling is enabled.
+  bool adaptiveCpuSamplingEnabled_{false};
+
+  // Maximum acceptable overhead percentage for adaptive CPU sampling.
+  double adaptiveCpuSamplingMaxOverheadPct_{1.0};
+
+  // Measured CpuWallTimer overhead (nanos per invocation), shared across Exprs.
+  uint64_t timerOverheadNanos_{0};
 };
 
 /// Utility wrapper struct that is used to temporarily reset the value of the

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -16,6 +16,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <cmath>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Fs.h"
@@ -1587,13 +1588,94 @@ bool Expr::applyFunctionWithPeeling(
   return true;
 }
 
+std::unique_ptr<CpuWallTimer> Expr::cpuWallTimer(const EvalCtx& context) {
+  // 1. Compile-time tracking (set via trackCpuUsage_) always wins.
+  if (trackCpuUsage_) {
+    return std::make_unique<CpuWallTimer>(stats_.timing);
+  }
+
+  // 2. Adaptive per-function sampling.
+  if (context.adaptiveCpuSamplingEnabled()) {
+    switch (adaptiveState_) {
+      case AdaptiveCpuSamplingState::kWarmup:
+        // Warmup batch: just run the function, no timing.
+        return nullptr;
+      case AdaptiveCpuSamplingState::kCalibrating: {
+        // Measure function execution time (without CpuWallTimer).
+        // Timer overhead is measured once per ExprSet and shared via EvalCtx.
+        calibrationStopWatch_.emplace();
+        return nullptr;
+      }
+      case AdaptiveCpuSamplingState::kAlwaysTrack:
+        return std::make_unique<CpuWallTimer>(stats_.timing);
+      case AdaptiveCpuSamplingState::kSampling:
+        if (++adaptiveSamplingCounter_ % adaptiveSamplingRate_ == 0) {
+          return std::make_unique<CpuWallTimer>(stats_.timing);
+        }
+        return nullptr;
+    }
+  }
+
+  return nullptr;
+}
+
+void Expr::finalizeAdaptiveCalibration(
+    double maxOverheadPct,
+    uint64_t timerOverheadNanos) {
+  switch (adaptiveState_) {
+    case AdaptiveCpuSamplingState::kWarmup: {
+      adaptiveState_ = AdaptiveCpuSamplingState::kCalibrating;
+      break;
+    }
+    case AdaptiveCpuSamplingState::kCalibrating: {
+      calibrationFunctionWallNanos_ +=
+          calibrationStopWatch_->elapsed().wallNanos;
+      calibrationStopWatch_.reset();
+
+      if (++calibrationBatchCount_ < kCalibrationBatches) {
+        break;
+      }
+
+      // Use the shared timer overhead measurement, scaled by calibration
+      // batch count. The overhead per invocation is a platform constant
+      // measured once per ExprSet.
+      auto totalTimerOverhead = timerOverheadNanos * calibrationBatchCount_;
+
+      if (calibrationFunctionWallNanos_ > 0 && maxOverheadPct > 0) {
+        double overheadPct = 100.0 * static_cast<double>(totalTimerOverhead) /
+            static_cast<double>(calibrationFunctionWallNanos_);
+
+        if (overheadPct > maxOverheadPct) {
+          adaptiveSamplingRate_ =
+              static_cast<uint32_t>(std::ceil(overheadPct / maxOverheadPct));
+          // Start counter at rate-1 so the first post-calibration batch is
+          // always timed (++counter hits rate, which passes % rate == 0).
+          adaptiveSamplingCounter_ = adaptiveSamplingRate_ - 1;
+          adaptiveState_ = AdaptiveCpuSamplingState::kSampling;
+        } else {
+          adaptiveState_ = AdaptiveCpuSamplingState::kAlwaysTrack;
+        }
+      } else {
+        // Function ~0ns — timer dominates. Aggressive sampling.
+        adaptiveSamplingRate_ = 100;
+        adaptiveSamplingCounter_ = adaptiveSamplingRate_ - 1;
+        adaptiveState_ = AdaptiveCpuSamplingState::kSampling;
+      }
+      break;
+    }
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected adaptive sampling state in finalizeAdaptiveCalibration");
+  }
+}
+
 void Expr::applyFunction(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
   stats_.numProcessedVectors += 1;
   stats_.numProcessedRows += rows.countSelected();
-  auto timer = cpuWallTimer();
+  auto timer = cpuWallTimer(context);
 
   computeIsAsciiForInputs(vectorFunction_.get(), inputValues_, rows);
   auto isAscii = type()->isVarchar()
@@ -1633,6 +1715,14 @@ void Expr::applyFunction(
     result->asUnchecked<SimpleVector<StringView>>()->setIsAscii(
         isAscii.value(), rows);
   }
+
+  // Only do Adaptive Calibration if the adaptive sampling is on and we are in
+  // warmup or calibrating state.
+  if (context.adaptiveCpuSamplingEnabled() && isCalibrating()) {
+    finalizeAdaptiveCalibration(
+        context.adaptiveCpuSamplingMaxOverheadPct(),
+        context.timerOverheadNanos());
+  }
 }
 
 void Expr::evalSpecialFormWithStats(
@@ -1641,9 +1731,17 @@ void Expr::evalSpecialFormWithStats(
     VectorPtr& result) {
   stats_.numProcessedVectors += 1;
   stats_.numProcessedRows += rows.countSelected();
-  auto timer = cpuWallTimer();
+  auto timer = cpuWallTimer(context);
 
   evalSpecialForm(rows, context, result);
+
+  // Only do Adaptive Calibration if the adaptive sampling is on and we are in
+  // warmup or calibrating state.
+  if (context.adaptiveCpuSamplingEnabled() && isCalibrating()) {
+    finalizeAdaptiveCalibration(
+        context.adaptiveCpuSamplingMaxOverheadPct(),
+        context.timerOverheadNanos());
+  }
 }
 
 namespace {
@@ -1873,7 +1971,14 @@ ExprSet::ExprSet(
     core::ExecCtx* execCtx,
     bool enableConstantFolding,
     bool lazyDereference)
-    : execCtx_(execCtx), lazyDereference_(lazyDereference) {
+    : execCtx_(execCtx),
+      lazyDereference_(lazyDereference),
+      adaptiveCpuSampling_(
+          execCtx->queryCtx()->queryConfig().exprAdaptiveCpuSampling()),
+      adaptiveCpuSamplingMaxOverheadPct_(
+          execCtx->queryCtx()
+              ->queryConfig()
+              .exprAdaptiveCpuSamplingMaxOverheadPct()) {
   exprs_ = compileExpressions(sources, execCtx, this, enableConstantFolding);
   if (lazyDereference_) {
     validateLazyDereference(exprs_);
@@ -1886,6 +1991,24 @@ ExprSet::ExprSet(
 }
 
 namespace {
+
+/// If the expression is in adaptive sampling mode, extrapolate timing stats
+/// to approximate full-population values. Otherwise, return raw stats.
+exec::ExprStats adjustStats(const exec::Expr& expr) {
+  if (expr.isAdaptiveSampling() && expr.stats().timing.count > 0) {
+    exec::ExprStats adjusted = expr.stats();
+    double ratio = static_cast<double>(adjusted.numProcessedVectors) /
+        static_cast<double>(adjusted.timing.count);
+    adjusted.timing.cpuNanos = static_cast<uint64_t>(
+        static_cast<double>(adjusted.timing.cpuNanos) * ratio);
+    adjusted.timing.wallNanos = static_cast<uint64_t>(
+        static_cast<double>(adjusted.timing.wallNanos) * ratio);
+    adjusted.timing.count = adjusted.numProcessedVectors;
+    return adjusted;
+  }
+  return expr.stats();
+}
+
 void addStats(
     const exec::Expr& expr,
     std::unordered_map<std::string, exec::ExprStats>& stats,
@@ -1904,7 +2027,7 @@ void addStats(
   bool emptyStats =
       !expr.stats().numProcessedRows && !expr.stats().defaultNullRowsSkipped;
   if (!emptyStats && !excludeSplFormExpr) {
-    stats[expr.name()].add(expr.stats());
+    stats[expr.name()].add(adjustStats(expr));
   }
 
   for (const auto& input : expr.inputs()) {
@@ -2016,6 +2139,24 @@ void printInputAndExprs(
 }
 } // namespace
 
+void ExprSet::initializeAdaptiveCpuSampling(EvalCtx& context) {
+  context.setAdaptiveCpuSamplingEnabled(true);
+  context.setAdaptiveCpuSamplingMaxOverheadPct(
+      adaptiveCpuSamplingMaxOverheadPct_);
+
+  // Measure CpuWallTimer overhead once per ExprSet (platform constant).
+  if (!timerOverheadMeasured_) {
+    CpuWallTiming dummyTiming;
+    DeltaCpuWallTimeStopWatch overheadWatch;
+    {
+      auto dummy = std::make_unique<CpuWallTimer>(dummyTiming);
+    }
+    timerOverheadNanos_ = overheadWatch.elapsed().wallNanos;
+    timerOverheadMeasured_ = true;
+  }
+  context.setTimerOverheadNanos(timerOverheadNanos_);
+}
+
 void ExprSet::eval(
     int32_t begin,
     int32_t end,
@@ -2027,6 +2168,11 @@ void ExprSet::eval(
   result.resize(exprs_.size());
   if (initialize) {
     clearSharedSubexprs();
+  }
+
+  // Apply adaptive per-function CPU sampling if configured.
+  if (adaptiveCpuSampling_) {
+    initializeAdaptiveCpuSampling(context);
   }
 
   if (!lazyDereference_) {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
 
 #include <folly/container/F14Map.h>
@@ -406,6 +407,16 @@ class Expr {
     return stats_;
   }
 
+  /// Returns true if this expression is in adaptive sampling mode.
+  bool isAdaptiveSampling() const {
+    return adaptiveState_ == AdaptiveCpuSamplingState::kSampling;
+  }
+
+  /// Returns the adaptive sampling rate (0 = always track, N = sample 1/N).
+  uint32_t adaptiveSamplingRate() const {
+    return adaptiveSamplingRate_;
+  }
+
   void addNulls(
       const SelectivityVector& rows,
       const uint64_t* rawNulls,
@@ -592,11 +603,26 @@ class Expr {
       EvalCtx& context,
       VectorPtr& result);
 
-  /// Returns an instance of CpuWallTimer if cpu usage tracking is enabled. Null
-  /// otherwise.
-  std::unique_ptr<CpuWallTimer> cpuWallTimer() {
-    return trackCpuUsage_ ? std::make_unique<CpuWallTimer>(stats_.timing)
-                          : nullptr;
+  /// Returns an instance of CpuWallTimer based on the tracking mode:
+  /// 1. trackCpuUsage_ (set via QueryConfig) — always creates timer
+  /// 2. Adaptive per-function sampling — creates timer based on calibration
+  ///    state and per-function overhead
+  std::unique_ptr<CpuWallTimer> cpuWallTimer(const EvalCtx& context);
+
+  /// Finalizes adaptive calibration after function execution. Called from
+  /// applyFunction() and evalSpecialFormWithStats() when adaptive sampling
+  /// is enabled. Transitions the per-function state machine based on
+  /// measured overhead.
+  void finalizeAdaptiveCalibration(
+      double maxOverheadPct,
+      uint64_t timerOverheadNanos);
+
+  /// Returns true if adaptive calibration is still in progress (warmup or
+  /// calibrating). Used to skip the finalizeAdaptiveCalibration() call on
+  /// the hot path once calibration is complete.
+  bool isCalibrating() const {
+    return adaptiveState_ == AdaptiveCpuSamplingState::kWarmup ||
+        adaptiveState_ == AdaptiveCpuSamplingState::kCalibrating;
   }
 
   // Should be called only after computeMetadata() has been called on 'inputs_'.
@@ -710,6 +736,34 @@ class Expr {
   /// Runtime statistics. CPU time, wall time and number of processed rows.
   ExprStats stats_;
 
+  /// Per-function adaptive CPU sampling state machine.
+  enum class AdaptiveCpuSamplingState : uint8_t {
+    /// First batch: warm up caches, discard timing.
+    kWarmup,
+    /// Next N batches: measure CpuWallTimer overhead and function cost.
+    kCalibrating,
+    /// Calibration complete: overhead is acceptable, always track.
+    kAlwaysTrack,
+    /// Calibration complete: overhead is too high, sample at computed rate.
+    kSampling,
+  };
+
+  /// Number of calibration batches (more batches = less noise).
+  static constexpr uint32_t kCalibrationBatches = 5;
+
+  AdaptiveCpuSamplingState adaptiveState_{AdaptiveCpuSamplingState::kWarmup};
+
+  /// Stopwatch for measuring function execution wall time during calibration.
+  std::optional<DeltaCpuWallTimeStopWatch> calibrationStopWatch_;
+  /// Accumulated function wall time (without timer) during calibration.
+  uint64_t calibrationFunctionWallNanos_{0};
+  /// Counter for calibration batches.
+  uint32_t calibrationBatchCount_{0};
+  /// Computed sampling rate: 0 = always track, N = track every N-th batch.
+  uint32_t adaptiveSamplingRate_{0};
+  /// Counter for sampling cadence.
+  uint32_t adaptiveSamplingCounter_{0};
+
   // If true computeMetaData returns, otherwise meta data is computed and the
   // flag is set to true.
   bool metaDataComputed_ = false;
@@ -819,6 +873,11 @@ class ExprSet {
  protected:
   void clearSharedSubexprs();
 
+  /// Initializes adaptive CPU sampling state on the EvalCtx. Sets
+  /// sampling flags, max overhead percentage, and measures CpuWallTimer
+  /// overhead once per ExprSet.
+  void initializeAdaptiveCpuSampling(EvalCtx& context);
+
   std::vector<std::shared_ptr<Expr>> exprs_;
 
   // The distinct references to input columns among all expressions in ExprSet.
@@ -835,6 +894,16 @@ class ExprSet {
   std::unordered_set<Expr*> memoizingExprs_;
   core::ExecCtx* const execCtx_;
   const bool lazyDereference_;
+
+  // Cached from QueryConfig at construction time to avoid repeated map lookups.
+  const bool adaptiveCpuSampling_;
+  const double adaptiveCpuSamplingMaxOverheadPct_;
+
+  // Measured CpuWallTimer overhead (nanos per invocation). Measured once on
+  // the first eval() call and shared across all Expr nodes via EvalCtx.
+  // This is a platform constant — does not vary by expression or data.
+  uint64_t timerOverheadNanos_{0};
+  bool timerOverheadMeasured_{false};
 };
 
 class ExprSetSimplified : public ExprSet {

--- a/velox/expression/benchmarks/CpuTimeTrackingBenchmark.cpp
+++ b/velox/expression/benchmarks/CpuTimeTrackingBenchmark.cpp
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Microbenchmark to measure the overhead of CPU time tracking
+/// (expression.track_cpu_usage) and adaptive per-function sampling
+/// (expression.adaptive_cpu_sampling) on simple scalar function evaluation.
+///
+/// CPU time tracking uses clock_gettime(CLOCK_THREAD_CPUTIME_ID) on every
+/// function invocation, which can be expensive relative to the function body
+/// for cheap functions like multiply. Adaptive sampling calibrates per-function
+/// overhead and applies variable sampling rates to keep overhead bounded.
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "velox/functions/Macros.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/ArithmeticImpl.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(
+    fuzzer_seed,
+    99'887'766,
+    "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+template <typename T>
+struct MultiplyFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void
+  call(TInput& result, const TInput& a, const TInput& b) {
+    result = functions::multiply(a, b);
+  }
+};
+
+/// Element-wise >= comparison on two int64 arrays. Mirrors the core logic of
+/// array_gte UDF — a representative "expensive" function because it
+/// iterates over array elements, allocates an output array, and touches more
+/// memory per row than a simple scalar op like multiply.
+template <typename T>
+struct ArrayGteFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void callNullFree(
+      out_type<Array<bool>>& out,
+      const null_free_arg_type<Array<int64_t>>& lhs,
+      const null_free_arg_type<Array<int64_t>>& rhs) {
+    auto size = std::min(lhs.size(), rhs.size());
+    out.reserve(size);
+    for (auto i = 0; i < size; ++i) {
+      out.push_back(lhs[i] >= rhs[i]);
+    }
+  }
+};
+
+class CpuTimeTrackingBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  CpuTimeTrackingBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<MultiplyFunction, double, double, double>({"multiply"});
+
+    inputType_ = ROW({{"a", DOUBLE()}, {"b", DOUBLE()}});
+
+    smallRowVector_ = makeRowVector(100);
+    mediumRowVector_ = makeRowVector(1'000);
+    largeRowVector_ = makeRowVector(10'000);
+
+    // Compile with CPU tracking OFF (default).
+    exprSetNoTracking_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "false"},
+    });
+
+    // Compile with CPU tracking ON.
+    exprSetWithTracking_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "true"},
+    });
+
+    // Compile with adaptive CPU sampling (1% max overhead).
+    exprSetAdaptive1Pct_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "false"},
+        {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+        {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "1.0"},
+    });
+
+    // Compile with adaptive CPU sampling (0.5% max overhead).
+    exprSetAdaptiveHalfPct_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "false"},
+        {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+        {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "0.5"},
+    });
+  }
+
+  void runNoTracking(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetNoTracking_, input, iterations);
+  }
+
+  void runWithTracking(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetWithTracking_, input, iterations);
+  }
+
+  void runAdaptive1Pct(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetAdaptive1Pct_, input, iterations);
+  }
+
+  void runAdaptiveHalfPct(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetAdaptiveHalfPct_, input, iterations);
+  }
+
+  RowVectorPtr smallRowVector_;
+  RowVectorPtr mediumRowVector_;
+  RowVectorPtr largeRowVector_;
+
+ private:
+  RowVectorPtr makeRowVector(vector_size_t size) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = size;
+    opts.nullRatio = 0;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<VectorPtr> children;
+    children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+    children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+    return std::make_shared<RowVector>(
+        pool(), inputType_, nullptr, size, std::move(children));
+  }
+
+  std::unique_ptr<ExprSet> compileWithConfig(
+      std::unordered_map<std::string, std::string> config) {
+    queryCtx_->testingOverrideConfigUnsafe(std::move(config));
+    return std::make_unique<ExprSet>(
+        compileExpression("multiply(a, b)", inputType_));
+  }
+
+  void run(ExprSet& exprSet, const RowVectorPtr& input, size_t iterations) {
+    folly::BenchmarkSuspender suspender;
+    SelectivityVector rows(input->size());
+    suspender.dismiss();
+
+    std::vector<VectorPtr> results(1);
+    size_t count{0};
+    for (size_t i = 0; i < iterations; ++i) {
+      EvalCtx evalCtx(&execCtx_, &exprSet, input.get());
+      exprSet.eval(rows, evalCtx, results);
+      count += results[0]->size();
+      results[0]->prepareForReuse();
+    }
+    folly::doNotOptimizeAway(count);
+  }
+
+  TypePtr inputType_;
+  std::unique_ptr<ExprSet> exprSetNoTracking_;
+  std::unique_ptr<ExprSet> exprSetWithTracking_;
+  std::unique_ptr<ExprSet> exprSetAdaptive1Pct_;
+  std::unique_ptr<ExprSet> exprSetAdaptiveHalfPct_;
+};
+
+/// Benchmark for array_gte — an expensive UDF that iterates over array
+/// elements. Measures CPU tracking and adaptive sampling overhead on a function
+/// whose per-row cost is much higher than a simple scalar op.
+class ArrayGteBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  ArrayGteBenchmark() : FunctionBenchmarkBase() {
+    registerFunction<
+        ArrayGteFunction,
+        Array<bool>,
+        Array<int64_t>,
+        Array<int64_t>>({"array_gte"});
+
+    inputType_ = ROW({{"a", ARRAY(BIGINT())}, {"b", ARRAY(BIGINT())}});
+
+    smallRowVector_ = makeRowVector(100);
+    mediumRowVector_ = makeRowVector(1'000);
+    largeRowVector_ = makeRowVector(10'000);
+
+    exprSetNoTracking_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "false"},
+    });
+    exprSetWithTracking_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "true"},
+    });
+    exprSetAdaptive1Pct_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "false"},
+        {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+        {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "1.0"},
+    });
+    exprSetAdaptiveHalfPct_ = compileWithConfig({
+        {core::QueryConfig::kExprTrackCpuUsage, "false"},
+        {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+        {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "0.5"},
+    });
+  }
+
+  void runNoTracking(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetNoTracking_, input, iterations);
+  }
+
+  void runWithTracking(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetWithTracking_, input, iterations);
+  }
+
+  void runAdaptive1Pct(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetAdaptive1Pct_, input, iterations);
+  }
+
+  void runAdaptiveHalfPct(const RowVectorPtr& input, size_t iterations) {
+    run(*exprSetAdaptiveHalfPct_, input, iterations);
+  }
+
+  RowVectorPtr smallRowVector_;
+  RowVectorPtr mediumRowVector_;
+  RowVectorPtr largeRowVector_;
+
+ private:
+  RowVectorPtr makeRowVector(vector_size_t size) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = size;
+    opts.nullRatio = 0;
+    opts.containerLength = 50;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<VectorPtr> children;
+    children.emplace_back(fuzzer.fuzzFlat(ARRAY(BIGINT())));
+    children.emplace_back(fuzzer.fuzzFlat(ARRAY(BIGINT())));
+    return std::make_shared<RowVector>(
+        pool(), inputType_, nullptr, size, std::move(children));
+  }
+
+  std::unique_ptr<ExprSet> compileWithConfig(
+      std::unordered_map<std::string, std::string> config) {
+    queryCtx_->testingOverrideConfigUnsafe(std::move(config));
+    return std::make_unique<ExprSet>(
+        compileExpression("array_gte(a, b)", inputType_));
+  }
+
+  void run(ExprSet& exprSet, const RowVectorPtr& input, size_t iterations) {
+    folly::BenchmarkSuspender suspender;
+    SelectivityVector rows(input->size());
+    suspender.dismiss();
+
+    std::vector<VectorPtr> results(1);
+    size_t count{0};
+    for (size_t i = 0; i < iterations; ++i) {
+      EvalCtx evalCtx(&execCtx_, &exprSet, input.get());
+      exprSet.eval(rows, evalCtx, results);
+      count += results[0]->size();
+      results[0]->prepareForReuse();
+    }
+    folly::doNotOptimizeAway(count);
+  }
+
+  TypePtr inputType_;
+  std::unique_ptr<ExprSet> exprSetNoTracking_;
+  std::unique_ptr<ExprSet> exprSetWithTracking_;
+  std::unique_ptr<ExprSet> exprSetAdaptive1Pct_;
+  std::unique_ptr<ExprSet> exprSetAdaptiveHalfPct_;
+};
+
+constexpr size_t kIterationsSmall{10'000};
+constexpr size_t kIterationsMedium{1'000};
+constexpr size_t kIterationsLarge{100};
+
+std::unique_ptr<CpuTimeTrackingBenchmark> benchmark;
+std::unique_ptr<ArrayGteBenchmark> arrayBenchmark;
+
+// --- Batch size 100 ---
+
+BENCHMARK(noTrackingSmall) {
+  benchmark->runNoTracking(benchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_RELATIVE(withTrackingSmall) {
+  benchmark->runWithTracking(benchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_RELATIVE(adaptive1PctSmall) {
+  benchmark->runAdaptive1Pct(benchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_RELATIVE(adaptiveHalfPctSmall) {
+  benchmark->runAdaptiveHalfPct(benchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// --- Batch size 1,000 ---
+
+BENCHMARK(noTrackingMedium) {
+  benchmark->runNoTracking(benchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_RELATIVE(withTrackingMedium) {
+  benchmark->runWithTracking(benchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_RELATIVE(adaptive1PctMedium) {
+  benchmark->runAdaptive1Pct(benchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_RELATIVE(adaptiveHalfPctMedium) {
+  benchmark->runAdaptiveHalfPct(benchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// --- Batch size 10,000 ---
+
+BENCHMARK(noTrackingLarge) {
+  benchmark->runNoTracking(benchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_RELATIVE(withTrackingLarge) {
+  benchmark->runWithTracking(benchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_RELATIVE(adaptive1PctLarge) {
+  benchmark->runAdaptive1Pct(benchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_RELATIVE(adaptiveHalfPctLarge) {
+  benchmark->runAdaptiveHalfPct(benchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// --- array_gte: Batch size 100, 50-element arrays ---
+
+BENCHMARK(arrayGteNoTrackingSmall) {
+  arrayBenchmark->runNoTracking(
+      arrayBenchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_RELATIVE(arrayGteWithTrackingSmall) {
+  arrayBenchmark->runWithTracking(
+      arrayBenchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_RELATIVE(arrayGteAdaptive1PctSmall) {
+  arrayBenchmark->runAdaptive1Pct(
+      arrayBenchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_RELATIVE(arrayGteAdaptiveHalfPctSmall) {
+  arrayBenchmark->runAdaptiveHalfPct(
+      arrayBenchmark->smallRowVector_, kIterationsSmall);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// --- array_gte: Batch size 1,000, 50-element arrays ---
+
+BENCHMARK(arrayGteNoTrackingMedium) {
+  arrayBenchmark->runNoTracking(
+      arrayBenchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_RELATIVE(arrayGteWithTrackingMedium) {
+  arrayBenchmark->runWithTracking(
+      arrayBenchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_RELATIVE(arrayGteAdaptive1PctMedium) {
+  arrayBenchmark->runAdaptive1Pct(
+      arrayBenchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_RELATIVE(arrayGteAdaptiveHalfPctMedium) {
+  arrayBenchmark->runAdaptiveHalfPct(
+      arrayBenchmark->mediumRowVector_, kIterationsMedium);
+}
+
+BENCHMARK_DRAW_LINE();
+
+// --- array_gte: Batch size 10,000, 50-element arrays ---
+
+BENCHMARK(arrayGteNoTrackingLarge) {
+  arrayBenchmark->runNoTracking(
+      arrayBenchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_RELATIVE(arrayGteWithTrackingLarge) {
+  arrayBenchmark->runWithTracking(
+      arrayBenchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_RELATIVE(arrayGteAdaptive1PctLarge) {
+  arrayBenchmark->runAdaptive1Pct(
+      arrayBenchmark->largeRowVector_, kIterationsLarge);
+}
+
+BENCHMARK_RELATIVE(arrayGteAdaptiveHalfPctLarge) {
+  arrayBenchmark->runAdaptiveHalfPct(
+      arrayBenchmark->largeRowVector_, kIterationsLarge);
+}
+
+} // namespace
+
+int main(int argc, char* argv[]) {
+  folly::Init init{&argc, &argv};
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  benchmark = std::make_unique<CpuTimeTrackingBenchmark>();
+  arrayBenchmark = std::make_unique<ArrayGteBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  arrayBenchmark.reset();
+  return 0;
+}

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/core/Expressions.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/Expr.h"
+#include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/parse/Expressions.h"
@@ -26,6 +27,21 @@
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
+
+/// A deliberately expensive scalar function used to test adaptive CPU sampling.
+/// The loop makes the per-row cost high enough that clock_gettime overhead is
+/// negligible. volatile prevents the compiler from optimizing away the loop.
+template <typename T>
+struct SlowAddFunction {
+  template <typename TInput>
+  void call(TInput& result, const TInput& a, const TInput& b) {
+    result = a + b;
+    volatile TInput sink = result;
+    for (int i = 0; i < 50'000; ++i) {
+      sink = sink + 1;
+    }
+  }
+};
 
 class ExprStatsTest : public functions::test::FunctionBaseTest {
  protected:
@@ -506,4 +522,238 @@ TEST_F(ExprStatsTest, selectiveCpuTrackingForUdfs) {
       "plus,pow",
       {"(c0 + c1) * c1", "pow(c0 + c1, 2)"},
       {"plus", "pow", "multiply", "cast"});
+}
+
+TEST_F(ExprStatsTest, adaptiveCpuSampling) {
+  // Test that adaptive CPU sampling calibrates per-function and produces
+  // timing data after calibration completes.
+  constexpr vector_size_t kInputSize{100};
+  // Need 1 warmup + 5 calibration + enough steady-state batches.
+  constexpr int kNumBatches{50};
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row % 7; }),
+  });
+
+  auto rowType = asRowType(data->type());
+
+  // Enable adaptive CPU sampling with 5% max overhead threshold.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kExprTrackCpuUsage, "false"},
+      {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+      {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "5.0"},
+  });
+
+  auto exprSet = compileExpressions({"c0 + c1", "c0 * c1"}, rowType);
+  SelectivityVector rows(data->size());
+
+  for (int i = 0; i < kNumBatches; ++i) {
+    exec::EvalCtx evalCtx(&execCtx_, exprSet.get(), data.get());
+    std::vector<VectorPtr> results(exprSet->size());
+    exprSet->eval(rows, evalCtx, results);
+  }
+
+  auto stats = exprSet->stats();
+
+  // All batches should be counted in numProcessedVectors.
+  ASSERT_TRUE(stats.count("plus"));
+  ASSERT_EQ(stats["plus"].numProcessedVectors, kNumBatches);
+
+  // After calibration (1 warmup + 5 calibration), the function should have
+  // timing data from steady-state batches (either always-track or sampled).
+  // With 50 batches and 6 calibration, 44 steady-state batches remain.
+  // Even with sampling, stats adjustment extrapolates timing.count.
+  ASSERT_GT(stats["plus"].timing.count, 0u);
+
+  // If the function was classified as needing sampling (likely for cheap
+  // builtins), timing.count should be less than numProcessedVectors.
+  // If classified as always-track, timing.count == numProcessedVectors.
+  // Either way, stats should have been adjusted, so cpuNanos > 0.
+  ASSERT_GT(stats["plus"].timing.cpuNanos, 0u);
+}
+
+TEST_F(ExprStatsTest, adaptiveCpuSamplingDisabledByDefault) {
+  constexpr vector_size_t kInputSize{100};
+  constexpr int kNumBatches{10};
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row % 7; }),
+  });
+
+  auto rowType = asRowType(data->type());
+
+  // Disable everything — no tracking, no sampling, no adaptive.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kExprTrackCpuUsage, "false"},
+  });
+
+  auto exprSet = compileExpressions({"c0 + c1"}, rowType);
+  SelectivityVector rows(data->size());
+
+  for (int i = 0; i < kNumBatches; ++i) {
+    exec::EvalCtx evalCtx(&execCtx_, exprSet.get(), data.get());
+    std::vector<VectorPtr> results(exprSet->size());
+    exprSet->eval(rows, evalCtx, results);
+  }
+
+  auto stats = exprSet->stats();
+
+  // All batches processed but no CPU timing recorded (adaptive is off).
+  ASSERT_TRUE(stats.count("plus"));
+  ASSERT_EQ(stats["plus"].numProcessedVectors, kNumBatches);
+  ASSERT_EQ(stats["plus"].timing.count, 0u);
+  ASSERT_EQ(stats["plus"].timing.cpuNanos, 0u);
+}
+
+TEST_F(ExprStatsTest, adaptiveCpuSamplingStatsAdjustment) {
+  // Test that stats are properly adjusted (extrapolated) for functions
+  // in sampling mode.
+  constexpr vector_size_t kInputSize{100};
+  // Need enough batches: 6 calibration + enough steady-state for sampling.
+  constexpr int kNumBatches{50};
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row % 7; }),
+  });
+
+  auto rowType = asRowType(data->type());
+
+  // Use 5% overhead threshold. Built-in plus (~13% overhead in ASAN) will be
+  // classified as needing sampling, and stats should be extrapolated.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kExprTrackCpuUsage, "false"},
+      {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+      {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "5.0"},
+  });
+
+  std::vector<Event> events;
+  auto listener = std::make_shared<TestListener>(events);
+  ASSERT_TRUE(exec::registerExprSetListener(listener));
+
+  {
+    auto exprSet = compileExpressions({"c0 + c1"}, rowType);
+    SelectivityVector rows(data->size());
+
+    for (int i = 0; i < kNumBatches; ++i) {
+      exec::EvalCtx evalCtx(&execCtx_, exprSet.get(), data.get());
+      std::vector<VectorPtr> results(exprSet->size());
+      exprSet->eval(rows, evalCtx, results);
+    }
+
+    auto stats = exprSet->stats();
+    ASSERT_TRUE(stats.count("plus"));
+
+    // If function is being sampled, the adjusted stats should have
+    // timing.count == numProcessedVectors (extrapolated to full count).
+    if (stats["plus"].timing.count == stats["plus"].numProcessedVectors) {
+      // Stats were adjusted. cpuNanos should be extrapolated.
+      ASSERT_GT(stats["plus"].timing.cpuNanos, 0u);
+    }
+  }
+
+  // Listener should also receive adjusted stats.
+  ASSERT_EQ(1, events.size());
+  auto listenerStats = events.back().stats;
+  ASSERT_TRUE(listenerStats.count("plus"));
+  ASSERT_GT(listenerStats["plus"].timing.cpuNanos, 0u);
+
+  ASSERT_TRUE(exec::unregisterExprSetListener(listener));
+}
+
+TEST_F(ExprStatsTest, adaptiveCpuSamplingPerFunctionRates) {
+  // Test that adaptive sampling assigns different rates to cheap vs expensive
+  // functions. A cheap built-in (plus) should get sampling while an expensive
+  // UDF (slow_add) should always track.
+  //
+  // Use a small batch so that clock_gettime overhead is significant relative
+  // to the cheap function (plus) but negligible relative to the expensive one
+  // (slow_add with 50k volatile iterations per row).
+  constexpr vector_size_t kInputSize{10};
+  constexpr int kNumBatches{2'000};
+
+  registerFunction<SlowAddFunction, int32_t, int32_t, int32_t>({"slow_add"});
+
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(kInputSize, [](auto row) { return row % 7; }),
+  });
+
+  auto rowType = asRowType(data->type());
+
+  // Enable adaptive CPU sampling with 5% max overhead. For cheap functions
+  // like plus on 10 rows, clock_gettime overhead is very significant (>>5%).
+  // For slow_add (50k iterations/row), the overhead is negligible (<<5%).
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kExprTrackCpuUsage, "false"},
+      {core::QueryConfig::kExprAdaptiveCpuSampling, "true"},
+      {core::QueryConfig::kExprAdaptiveCpuSamplingMaxOverheadPct, "5.0"},
+  });
+
+  auto exprSet = compileExpressions({"c0 + c1", "slow_add(c0, c1)"}, rowType);
+  SelectivityVector rows(data->size());
+
+  for (int i = 0; i < kNumBatches; ++i) {
+    exec::EvalCtx evalCtx(&execCtx_, exprSet.get(), data.get());
+    std::vector<VectorPtr> results(exprSet->size());
+    exprSet->eval(rows, evalCtx, results);
+  }
+
+  // Traverse the expression tree to find the plus and slow_add Expr nodes.
+  const exec::Expr* plusExpr = nullptr;
+  const exec::Expr* slowAddExpr = nullptr;
+
+  std::function<void(const exec::Expr*)> findExprs =
+      [&](const exec::Expr* expr) {
+        if (expr->name() == "plus") {
+          plusExpr = expr;
+        } else if (expr->name() == "slow_add") {
+          slowAddExpr = expr;
+        }
+        for (const auto& input : expr->inputs()) {
+          findExprs(input.get());
+        }
+      };
+
+  for (const auto& expr : exprSet->exprs()) {
+    findExprs(expr.get());
+  }
+
+  ASSERT_NE(plusExpr, nullptr) << "Failed to find 'plus' expression";
+  ASSERT_NE(slowAddExpr, nullptr) << "Failed to find 'slow_add' expression";
+
+  // Cheap function (plus) should be in sampling mode with rate > 1.
+  ASSERT_TRUE(plusExpr->isAdaptiveSampling())
+      << "Expected cheap function 'plus' to be in sampling mode";
+  ASSERT_GT(plusExpr->adaptiveSamplingRate(), 1u)
+      << "Expected sampling rate > 1 for cheap function";
+
+  // Expensive function (slow_add) should always track (not sampling).
+  ASSERT_FALSE(slowAddExpr->isAdaptiveSampling())
+      << "Expected expensive function 'slow_add' to always track";
+
+  // Both functions should have timing data.
+  auto stats = exprSet->stats();
+  ASSERT_GT(stats["plus"].timing.cpuNanos, 0u);
+  ASSERT_GT(stats["slow_add"].timing.cpuNanos, 0u);
+
+  // slow_add is always-track after calibration. It won't have timing for the
+  // warmup + calibration batches (1 + 5 = 6), but all post-calibration batches
+  // should be tracked.
+  constexpr uint64_t kCalibrationOverhead = 6; // 1 warmup + 5 calibration
+  ASSERT_EQ(
+      stats["slow_add"].timing.count,
+      stats["slow_add"].numProcessedVectors - kCalibrationOverhead);
+
+  // plus is in sampling mode. Stats should be adjusted (extrapolated) so
+  // timing.count matches numProcessedVectors.
+  ASSERT_EQ(stats["plus"].timing.count, stats["plus"].numProcessedVectors);
+  ASSERT_GT(stats["plus"].timing.cpuNanos, 0u);
+
+  // Verify the sampling rate for plus is reasonable (should be > 1).
+  LOG(INFO) << "plus sampling rate: " << plusExpr->adaptiveSamplingRate()
+            << ", slow_add sampling rate: "
+            << slowAddExpr->adaptiveSamplingRate();
 }


### PR DESCRIPTION
Summary:

**Problem:** Enabling CPU time collection for all functions can cause massive regression in Velox. Disabling tracking entirely loses performance visibility. Uniform sampling applies the same rate to all functions regardless of cost.

**Solution:** Adaptive per-function CPU sampling that automatically calibrates overhead per function:
  1. Warmup batch: run without timing to warm caches
  2. Calibration (5 batches): measure clock_gettime overhead vs function execution time
  3. Classify: if overhead < threshold → always track; if overhead > threshold → sample at rate proportional to overhead
  4. Stats extrapolation: sampled timing is scaled up to approximate full-population stats

**Config:**
  - expression.adaptive_cpu_sampling (bool, default false) — enables adaptive sampling
  - expression.adaptive_cpu_sampling_max_overhead_pct (double, default 1.0) — max acceptable overhead %

**Key properties:**
  - Cheap functions (e.g. multiply) get high sampling rates (e.g. 1/70)
  - Expensive functions (e.g. array_gte) are always tracked (overhead is negligible)
  - Each function calibrates independently — no one-size-fits-all rate

Benchmark Results:
```sh
============================================================================
[...]nchmarks/CpuTimeTrackingBenchmark.cpp     relative  time/iter   iters/s
============================================================================
noTrackingSmall                                             2.13ms    469.68
withTrackingSmall                               36.361%     5.86ms    170.78
adaptive1PctSmall                               97.113%     2.19ms    456.12
adaptiveHalfPctSmall                            98.384%     2.16ms    462.09
----------------------------------------------------------------------------
noTrackingMedium                                          298.73us     3.35K
withTrackingMedium                              44.495%   671.38us     1.49K
adaptive1PctMedium                              98.178%   304.28us     3.29K
adaptiveHalfPctMedium                           98.611%   302.94us     3.30K
----------------------------------------------------------------------------
noTrackingLarge                                           193.36us     5.17K
withTrackingLarge                               86.279%   224.10us     4.46K
adaptive1PctLarge                               117.05%   165.19us     6.05K
adaptiveHalfPctLarge                            100.08%   193.21us     5.18K
----------------------------------------------------------------------------
arrayGteNoTrackingSmall                                   188.32ms      5.31
arrayGteWithTrackingSmall                       97.694%   192.77ms      5.19
arrayGteAdaptive1PctSmall                       99.832%   188.64ms      5.30
arrayGteAdaptiveHalfPctSmall                    100.23%   187.90ms      5.32
----------------------------------------------------------------------------
arrayGteNoTrackingMedium                                   31.75ms     31.50
arrayGteWithTrackingMedium                      98.366%    32.27ms     30.99
arrayGteAdaptive1PctMedium                      99.461%    31.92ms     31.33
arrayGteAdaptiveHalfPctMedium                   99.495%    31.91ms     31.34
----------------------------------------------------------------------------
arrayGteNoTrackingLarge                                    10.60ms     94.32
arrayGteWithTrackingLarge                       99.304%    10.68ms     93.67
arrayGteAdaptive1PctLarge                       100.15%    10.59ms     94.46
arrayGteAdaptiveHalfPctLarge                    100.07%    10.59ms     94.39
```

Reviewed By: pedroerp

Differential Revision: D95149629
