### PR TITLE
feat(connector): Add dbName field to HiveTableHandle and inject table identity into fileReadOps

### DIFF
--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -344,6 +344,12 @@ void SplitReader::createReader(
 
   auto fileProperties = hiveSplit_->properties.value_or(FileProperties{});
   fileProperties.fileReadOps = fileReadOps;
+  if (!hiveTableHandle_->dbName().empty()) {
+    fileProperties.fileReadOps["dbName"] = hiveTableHandle_->dbName();
+  }
+  if (!hiveTableHandle_->tableName().empty()) {
+    fileProperties.fileReadOps["tableName"] = hiveTableHandle_->tableName();
+  }
 
   try {
     fileHandleCachePtr = fileHandleFactory_->generate(

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -113,7 +113,8 @@ HiveTableHandle::HiveTableHandle(
     std::vector<std::string> indexColumns,
     const std::unordered_map<std::string, std::string>& tableParameters,
     std::vector<HiveColumnHandlePtr> filterColumnHandles,
-    double sampleRate)
+    double sampleRate,
+    std::string dbName)
     : ConnectorTableHandle(std::move(connectorId)),
       tableName_(tableName),
       subfieldFilters_(std::move(subfieldFilters)),
@@ -122,7 +123,8 @@ HiveTableHandle::HiveTableHandle(
       dataColumns_(dataColumns),
       indexColumns_(std::move(indexColumns)),
       tableParameters_(tableParameters),
-      filterColumnHandles_(std::move(filterColumnHandles)) {
+      filterColumnHandles_(std::move(filterColumnHandles)),
+      dbName_(std::move(dbName)) {
   VELOX_CHECK_GT(sampleRate_, 0.0, "Sample rate must be positive");
   VELOX_CHECK_LE(sampleRate_, 1.0, "Sample rate must not exceed 1.0");
 }
@@ -250,6 +252,10 @@ folly::dynamic HiveTableHandle::serialize() const {
     obj["indexColumns"] = indexColumns;
   }
 
+  if (!dbName_.empty()) {
+    obj["dbName"] = dbName_;
+  }
+
   return obj;
 }
 
@@ -307,6 +313,11 @@ ConnectorTableHandlePtr HiveTableHandle::create(
     }
   }
 
+  std::string dbName;
+  if (auto it = obj.find("dbName"); it != obj.items().end()) {
+    dbName = it->second.asString();
+  }
+
   return std::make_shared<const HiveTableHandle>(
       connectorId,
       tableName,
@@ -316,7 +327,8 @@ ConnectorTableHandlePtr HiveTableHandle::create(
       std::move(indexColumns),
       tableParameters,
       std::move(filterColumnHandles),
-      sampleRate);
+      sampleRate,
+      std::move(dbName));
 }
 
 void HiveTableHandle::registerSerDe() {

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -171,7 +171,8 @@ class HiveTableHandle : public ConnectorTableHandle {
       std::vector<std::string> indexColumns = {},
       const std::unordered_map<std::string, std::string>& tableParameters = {},
       std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
-      double sampleRate = 1.0);
+      double sampleRate = 1.0,
+      std::string dbName = "");
 
   /// Legacy constructor without indexColumns parameter for backward
   /// compatibility.
@@ -273,6 +274,12 @@ class HiveTableHandle : public ConnectorTableHandle {
     return filterColumnHandles_;
   }
 
+  /// Database or namespace name for this table. Used to pass per-table identity
+  /// through the Velox pipeline for token dispatch.
+  const std::string& dbName() const {
+    return dbName_;
+  }
+
   std::string toString() const override;
 
   folly::dynamic serialize() const override;
@@ -292,6 +299,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const std::vector<std::string> indexColumns_;
   const std::unordered_map<std::string, std::string> tableParameters_;
   const std::vector<HiveColumnHandlePtr> filterColumnHandles_;
+  const std::string dbName_;
 };
 
 using HiveTableHandlePtr = std::shared_ptr<const HiveTableHandle>;

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -56,6 +56,48 @@ TEST(FileHandleTest, hiveColumnHandle) {
       "data type ROW<c0c0:BIGINT,c0c1:ARRAY<MAP<VARCHAR,ROW<c0c1c0:BIGINT,c0c1c1:BIGINT>>>> and hive type ROW<c0c0:BIGINT,c0c1:BIGINT> do not match");
 }
 
+TEST(TableHandleTest, hiveTableHandleDbName) {
+  connector::hive::HiveTableHandle::registerSerDe();
+
+  // Default dbName is empty.
+  auto handleNoDb = std::make_shared<connector::hive::HiveTableHandle>(
+      "test-connector",
+      "test_table",
+      common::SubfieldFilters{},
+      /*remainingFilter=*/nullptr);
+  ASSERT_TRUE(handleNoDb->dbName().empty());
+  ASSERT_EQ(handleNoDb->tableName(), "test_table");
+
+  // Explicit dbName is preserved.
+  auto handleWithDb = std::make_shared<connector::hive::HiveTableHandle>(
+      "test-connector",
+      "test_table",
+      common::SubfieldFilters{},
+      /*remainingFilter=*/nullptr,
+      /*dataColumns=*/nullptr,
+      /*indexColumns=*/std::vector<std::string>{},
+      /*tableParameters=*/std::unordered_map<std::string, std::string>{},
+      /*filterColumnHandles=*/
+      std::vector<connector::hive::HiveColumnHandlePtr>{},
+      /*sampleRate=*/1.0,
+      /*dbName=*/"test_db");
+  ASSERT_EQ(handleWithDb->dbName(), "test_db");
+  ASSERT_EQ(handleWithDb->tableName(), "test_table");
+
+  // Serialization round-trip preserves dbName.
+  auto obj = handleWithDb->serialize();
+  auto clone = ISerializable::deserialize<connector::hive::HiveTableHandle>(
+      obj, /*context=*/nullptr);
+  ASSERT_EQ(clone->dbName(), "test_db");
+  ASSERT_EQ(clone->tableName(), "test_table");
+
+  // Round-trip with empty dbName omits the field.
+  auto objNoDb = handleNoDb->serialize();
+  auto cloneNoDb = ISerializable::deserialize<connector::hive::HiveTableHandle>(
+      objNoDb, /*context=*/nullptr);
+  ASSERT_TRUE(cloneNoDb->dbName().empty());
+}
+
 TEST(TableHandleTest, hiveTableHandleIndexSupport) {
   // Test HiveTableHandle without index columns.
   auto tableHandleWithoutIndex =


### PR DESCRIPTION
Summary:
Add a dbName field to HiveTableHandle so that per-table identity (namespace
and table name) can flow through the Velox pipeline for token dispatch.

- Add dbName_ field and accessor to HiveTableHandle, with a new constructor
  parameter (default empty string).
- In SplitReader::createReader(), inject hiveTableHandle_->dbName() and
  tableName() into fileProperties.fileReadOps under keys "dbName" and
  "tableName".

Differential Revision: D94580016
