### PR TITLE
feat(cudf): Add varchar support to cuDF min/max aggregation registry

### DIFF
--- a/velox/experimental/cudf/exec/CudfHashAggregation.cpp
+++ b/velox/experimental/cudf/exec/CudfHashAggregation.cpp
@@ -1431,6 +1431,10 @@ bool registerStepAwareBuiltinAggregationFunctions(const std::string& prefix) {
       FunctionSignatureBuilder()
           .returnType("double")
           .argumentType("double")
+          .build(),
+      FunctionSignatureBuilder()
+          .returnType("varchar")
+          .argumentType("varchar")
           .build()};
 
   registerAggregationFunctionForStep(

--- a/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationSelectionTest.cpp
@@ -511,6 +511,18 @@ TEST_F(CudfAggregationSelectionTest, comprehensiveTypeSupportValidation) {
           std::make_shared<core::FieldAccessTypedExpr>(DOUBLE(), "c3")},
       "max");
 
+  // MIN/MAX VARCHAR signatures
+  auto minVarcharExpr = std::make_shared<core::CallTypedExpr>(
+      VARCHAR(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c6")},
+      "min");
+  auto maxVarcharExpr = std::make_shared<core::CallTypedExpr>(
+      VARCHAR(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c6")},
+      "max");
+
   // AVG signatures
   auto avgSmallintExpr = std::make_shared<core::CallTypedExpr>(
       DOUBLE(),
@@ -581,6 +593,11 @@ TEST_F(CudfAggregationSelectionTest, comprehensiveTypeSupportValidation) {
   ASSERT_TRUE(canAggregationBeEvaluatedByCudf(*maxDoubleExpr, queryCtx_.get()));
 
   ASSERT_TRUE(
+      canAggregationBeEvaluatedByCudf(*minVarcharExpr, queryCtx_.get()));
+  ASSERT_TRUE(
+      canAggregationBeEvaluatedByCudf(*maxVarcharExpr, queryCtx_.get()));
+
+  ASSERT_TRUE(
       canAggregationBeEvaluatedByCudf(*avgSmallintExpr, queryCtx_.get()));
   ASSERT_TRUE(
       canAggregationBeEvaluatedByCudf(*avgIntegerExpr, queryCtx_.get()));
@@ -604,12 +621,7 @@ TEST_F(CudfAggregationSelectionTest, invalidTypeCombinationsRejected) {
           std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c6")},
       "sum");
 
-  // min/max on varchar and boolean
-  auto minVarcharExpr = std::make_shared<core::CallTypedExpr>(
-      VARCHAR(),
-      std::vector<core::TypedExprPtr>{
-          std::make_shared<core::FieldAccessTypedExpr>(VARCHAR(), "c6")},
-      "min");
+  // max on boolean
   auto maxBooleanExpr = std::make_shared<core::CallTypedExpr>(
       BOOLEAN(),
       std::vector<core::TypedExprPtr>{
@@ -620,8 +632,6 @@ TEST_F(CudfAggregationSelectionTest, invalidTypeCombinationsRejected) {
       canAggregationBeEvaluatedByCudf(*avgVarcharExpr, queryCtx_.get()));
   ASSERT_FALSE(
       canAggregationBeEvaluatedByCudf(*sumVarcharExpr, queryCtx_.get()));
-  ASSERT_FALSE(
-      canAggregationBeEvaluatedByCudf(*minVarcharExpr, queryCtx_.get()));
   ASSERT_FALSE(
       canAggregationBeEvaluatedByCudf(*maxBooleanExpr, queryCtx_.get()));
 }

--- a/velox/experimental/cudf/tests/AggregationTest.cpp
+++ b/velox/experimental/cudf/tests/AggregationTest.cpp
@@ -286,6 +286,37 @@ TEST_F(AggregationTest, aggregateOfNulls) {
   assertQuery(op, "SELECT sum(c1), min(c1), max(c1) FROM tmp");
 }
 
+TEST_F(AggregationTest, varcharMinMax) {
+  auto vectors = makeVectors(rowType_, 10, 100);
+  createDuckDbTable(vectors);
+
+  // Groupby with varchar min/max.
+  auto op = PlanBuilder()
+                .values(vectors)
+                .aggregation(
+                    {"c0"},
+                    {"min(c6)", "max(c6)"},
+                    {},
+                    core::AggregationNode::Step::kPartial,
+                    false)
+                .planNode();
+
+  assertQuery(op, "SELECT c0, min(c6), max(c6) FROM tmp GROUP BY c0");
+
+  // Global aggregation with varchar min/max.
+  op = PlanBuilder()
+           .values(vectors)
+           .aggregation(
+               {},
+               {"min(c6)", "max(c6)"},
+               {},
+               core::AggregationNode::Step::kPartial,
+               false)
+           .planNode();
+
+  assertQuery(op, "SELECT min(c6), max(c6) FROM tmp");
+}
+
 TEST_F(AggregationTest, allKeyTypes) {
   // Covers different key types. Unlike the integer/string tests, the
   // hash table begins life in the generic mode, not array or


### PR DESCRIPTION
The cuDF aggregation registry was missing varchar in minMaxSignatures, causing MAX(varchar) to fall back to Velox CPU.