### PR TITLE
feat(operator): Add MarkSorted operator (#16652)

### DIFF
--- a/velox/core/PlanConsistencyChecker.cpp
+++ b/velox/core/PlanConsistencyChecker.cpp
@@ -156,6 +156,11 @@ class Checker : public PlanNodeVisitor {
     visitSources(&node, ctx);
   }
 
+  void visit(const MarkSortedNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    visitSources(&node, ctx);
+  }
+
   void visit(const MergeExchangeNode& node, PlanNodeVisitorContext& ctx)
       const override {
     visitSources(&node, ctx);

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -2506,6 +2506,78 @@ PlanNodePtr EnforceDistinctNode::create(
       source);
 }
 
+RowTypePtr getMarkSortedOutputType(
+    const RowTypePtr& inputType,
+    const std::string& markerName) {
+  std::vector<std::string> names = inputType->names();
+  std::vector<TypePtr> types = inputType->children();
+
+  names.emplace_back(markerName);
+  types.emplace_back(BOOLEAN());
+  return ROW(std::move(names), std::move(types));
+}
+
+MarkSortedNode::MarkSortedNode(
+    PlanNodeId id,
+    std::string markerName,
+    std::vector<FieldAccessTypedExprPtr> sortingKeys,
+    std::vector<SortOrder> sortingOrders,
+    PlanNodePtr source)
+    : PlanNode(std::move(id)),
+      markerName_(std::move(markerName)),
+      sortingKeys_(std::move(sortingKeys)),
+      sortingOrders_(std::move(sortingOrders)),
+      sources_{std::move(source)},
+      outputType_(
+          getMarkSortedOutputType(sources_[0]->outputType(), markerName_)) {
+  VELOX_USER_CHECK_GT(markerName_.size(), 0);
+  VELOX_USER_CHECK_GT(sortingKeys_.size(), 0);
+  VELOX_USER_CHECK_EQ(
+      sortingKeys_.size(),
+      sortingOrders_.size(),
+      "Number of sorting keys and sorting orders must be the same");
+}
+
+void MarkSortedNode::addDetails(std::stringstream& stream) const {
+  stream << "marker: " << markerName_ << ", keys: [";
+  for (auto i = 0; i < sortingKeys_.size(); ++i) {
+    if (i > 0) {
+      stream << ", ";
+    }
+    stream << sortingKeys_[i]->name() << " " << sortingOrders_[i].toString();
+  }
+  stream << "]";
+}
+
+folly::dynamic MarkSortedNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["markerName"] = this->markerName_;
+  obj["sortingKeys"] = ISerializable::serialize(this->sortingKeys_);
+  obj["sortingOrders"] = ISerializable::serialize(this->sortingOrders_);
+  return obj;
+}
+
+void MarkSortedNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+// static
+PlanNodePtr MarkSortedNode::create(const folly::dynamic& obj, void* context) {
+  auto source = deserializeSingleSource(obj, context);
+  auto markerName = obj["markerName"].asString();
+  auto sortingKeys = deserializeFields(obj["sortingKeys"], context);
+  auto sortingOrders = deserializeSortingOrders(obj["sortingOrders"]);
+
+  return std::make_shared<MarkSortedNode>(
+      deserializePlanNodeId(obj),
+      markerName,
+      sortingKeys,
+      sortingOrders,
+      source);
+}
+
 namespace {
 RowTypePtr getRowNumberOutputType(
     const RowTypePtr& inputType,
@@ -3806,6 +3878,8 @@ void PlanNode::registerSerDe() {
   registry.Register("LimitNode", LimitNode::create);
   registry.Register("LocalMergeNode", LocalMergeNode::create);
   registry.Register("LocalPartitionNode", LocalPartitionNode::create);
+  registry.Register("MarkDistinctNode", MarkDistinctNode::create);
+  registry.Register("MarkSortedNode", MarkSortedNode::create);
   registry.Register("OrderByNode", OrderByNode::create);
   registry.Register("PartitionedOutputNode", PartitionedOutputNode::create);
   registry.Register("ProjectNode", ProjectNode::create);

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -5577,6 +5577,137 @@ class EnforceDistinctNode : public PlanNode {
 
 using EnforceDistinctNodePtr = std::shared_ptr<const EnforceDistinctNode>;
 
+/// The MarkSorted operator marks rows where the sort key changes.
+/// The result is put in a new markerName column alongside the original input.
+/// The first row is always marked true. Subsequent rows are marked true if
+/// they compare as sorted relative to the previous row based on sortingKeys
+/// and sortingOrders.
+/// @param markerName Name of the output marker channel.
+/// @param sortingKeys Keys to check for sorted order.
+/// @param sortingOrders Sort orders (ascending/descending, nulls first/last).
+class MarkSortedNode : public PlanNode {
+ public:
+  MarkSortedNode(
+      PlanNodeId id,
+      std::string markerName,
+      std::vector<FieldAccessTypedExprPtr> sortingKeys,
+      std::vector<SortOrder> sortingOrders,
+      PlanNodePtr source);
+
+  class Builder {
+   public:
+    Builder() = default;
+
+    explicit Builder(const MarkSortedNode& other) {
+      id_ = other.id();
+      markerName_ = other.markerName();
+      sortingKeys_ = other.sortingKeys();
+      sortingOrders_ = other.sortingOrders();
+      VELOX_CHECK_EQ(other.sources().size(), 1);
+      source_ = other.sources()[0];
+    }
+
+    Builder& id(PlanNodeId id) {
+      id_ = std::move(id);
+      return *this;
+    }
+
+    Builder& markerName(std::string markerName) {
+      markerName_ = std::move(markerName);
+      return *this;
+    }
+
+    Builder& sortingKeys(std::vector<FieldAccessTypedExprPtr> sortingKeys) {
+      sortingKeys_ = std::move(sortingKeys);
+      return *this;
+    }
+
+    Builder& sortingOrders(std::vector<SortOrder> sortingOrders) {
+      sortingOrders_ = std::move(sortingOrders);
+      return *this;
+    }
+
+    Builder& source(PlanNodePtr source) {
+      source_ = std::move(source);
+      return *this;
+    }
+
+    std::shared_ptr<MarkSortedNode> build() const {
+      VELOX_USER_CHECK(id_.has_value(), "MarkSortedNode id is not set");
+      VELOX_USER_CHECK(
+          markerName_.has_value(), "MarkSortedNode markerName is not set");
+      VELOX_USER_CHECK(
+          sortingKeys_.has_value(), "MarkSortedNode sortingKeys is not set");
+      VELOX_USER_CHECK(
+          sortingOrders_.has_value(),
+          "MarkSortedNode sortingOrders is not set");
+      VELOX_USER_CHECK(source_.has_value(), "MarkSortedNode source is not set");
+
+      return std::make_shared<MarkSortedNode>(
+          id_.value(),
+          markerName_.value(),
+          sortingKeys_.value(),
+          sortingOrders_.value(),
+          source_.value());
+    }
+
+   private:
+    std::optional<PlanNodeId> id_;
+    std::optional<std::string> markerName_;
+    std::optional<std::vector<FieldAccessTypedExprPtr>> sortingKeys_;
+    std::optional<std::vector<SortOrder>> sortingOrders_;
+    std::optional<PlanNodePtr> source_;
+  };
+
+  const std::vector<PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+  /// The outputType is the concatenation of the input columns and marker
+  /// column.
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  std::string_view name() const override {
+    return "MarkSorted";
+  }
+
+  const std::string& markerName() const {
+    return markerName_;
+  }
+
+  const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
+    return sortingKeys_;
+  }
+
+  const std::vector<SortOrder>& sortingOrders() const {
+    return sortingOrders_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  const std::string markerName_;
+
+  const std::vector<FieldAccessTypedExprPtr> sortingKeys_;
+
+  const std::vector<SortOrder> sortingOrders_;
+
+  const std::vector<PlanNodePtr> sources_;
+
+  const RowTypePtr outputType_;
+};
+
+using MarkSortedNodePtr = std::shared_ptr<const MarkSortedNode>;
+
 /// Optimized version of a WindowNode for a single row_number, rank or
 /// dense_rank function with a limit over sorted partitions. The output of this
 /// node contains all input columns followed by an optional
@@ -5986,6 +6117,9 @@ class PlanNodeVisitor {
   virtual void visit(
       const EnforceDistinctNode& node,
       PlanNodeVisitorContext& ctx) const = 0;
+
+  virtual void visit(const MarkSortedNode& node, PlanNodeVisitorContext& ctx)
+      const = 0;
 
   virtual void visit(const MergeExchangeNode& node, PlanNodeVisitorContext& ctx)
       const = 0;

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -52,6 +52,7 @@ velox_add_library(
   LocalPartition.cpp
   LocalPlanner.cpp
   MarkDistinct.cpp
+  MarkSorted.cpp
   EnforceDistinct.cpp
   MemoryReclaimer.cpp
   Merge.cpp

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -30,6 +30,7 @@
 #include "velox/exec/IndexLookupJoin.h"
 #include "velox/exec/Limit.h"
 #include "velox/exec/MarkDistinct.h"
+#include "velox/exec/MarkSorted.h"
 #include "velox/exec/Merge.h"
 #include "velox/exec/MergeJoin.h"
 #include "velox/exec/MixedUnion.h"
@@ -642,6 +643,11 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
             std::make_unique<EnforceDistinct>(
                 id, ctx.get(), enforceDistinctNode));
       }
+    } else if (
+        auto markSortedNode =
+            std::dynamic_pointer_cast<const core::MarkSortedNode>(planNode)) {
+      operators.push_back(
+          std::make_unique<MarkSorted>(id, ctx.get(), markSortedNode));
     } else if (
         auto localMerge =
             std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {

--- a/velox/exec/MarkSorted.cpp
+++ b/velox/exec/MarkSorted.cpp
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MarkSorted.h"
+#include "velox/common/base/CompareFlags.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::exec {
+
+MarkSorted::MarkSorted(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::MarkSortedNode>& planNode)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "MarkSorted"),
+      markerName_(planNode->markerName()) {
+  const auto& inputType = planNode->sources()[0]->outputType();
+  const auto& sortingKeys = planNode->sortingKeys();
+  const auto& sortingOrders = planNode->sortingOrders();
+
+  // Set all input columns as identity projection.
+  for (auto i = 0; i < inputType->size(); ++i) {
+    identityProjections_.emplace_back(i, i);
+  }
+
+  // Map the marker result (results_[0]) to the last column position in output,
+  // immediately after all input columns.
+  resultProjections_.emplace_back(0, inputType->size());
+
+  // Extract channel indices for sorting keys.
+  sortingKeyChannels_.reserve(sortingKeys.size());
+  compareFlags_.reserve(sortingKeys.size());
+
+  for (auto i = 0; i < sortingKeys.size(); ++i) {
+    const auto& key = sortingKeys[i];
+    auto channel = inputType->getChildIdx(key->name());
+    sortingKeyChannels_.push_back(channel);
+
+    // Build CompareFlags from SortOrder.
+    const auto& order = sortingOrders[i];
+    compareFlags_.push_back(
+        {order.isNullsFirst(),
+         order.isAscending(),
+         false, // equalsOnly
+         CompareFlags::NullHandlingMode::kNullAsValue});
+  }
+
+  // Precompute type for lastRow_ (contains only sorting key columns).
+  std::vector<std::string> keyNames;
+  std::vector<TypePtr> keyTypes;
+  keyNames.reserve(sortingKeys.size());
+  keyTypes.reserve(sortingKeys.size());
+  for (auto i = 0; i < sortingKeys.size(); ++i) {
+    auto channel = sortingKeyChannels_[i];
+    keyNames.push_back(inputType->nameOf(channel));
+    keyTypes.push_back(inputType->childAt(channel));
+  }
+  lastRowType_ = ROW(std::move(keyNames), std::move(keyTypes));
+
+  results_.resize(1);
+}
+
+void MarkSorted::addInput(RowVectorPtr input) {
+  input_ = std::move(input);
+}
+
+bool MarkSorted::isSortedRelativeTo(
+    const RowVectorPtr& currentData,
+    vector_size_t currentIndex,
+    const RowVectorPtr& prevData,
+    vector_size_t prevIndex) {
+  // Compare each sorting key column.
+  // For sorted data, each row should be >= previous (ascending) or <= previous
+  // (descending). The compare function respects ascending/descending flags,
+  // so we just check if compare() returns >= 0 for each key.
+  for (auto i = 0; i < sortingKeyChannels_.size(); ++i) {
+    auto channel = sortingKeyChannels_[i];
+    const auto& currentColumn = currentData->childAt(channel);
+    const auto& prevColumn = prevData->childAt(channel);
+
+    auto result = currentColumn->compare(
+        prevColumn.get(), currentIndex, prevIndex, compareFlags_[i]);
+
+    if (result.has_value()) {
+      if (result.value() < 0) {
+        // Current row is less than previous (in sort order), NOT sorted.
+        return false;
+      } else if (result.value() > 0) {
+        // Current row is greater than previous, sorted (no need to check more
+        // keys).
+        return true;
+      }
+      // Equal on this key, continue to next key.
+    }
+  }
+
+  // All keys are equal - this is still considered sorted.
+  return true;
+}
+
+RowVectorPtr MarkSorted::getOutput() {
+  if (isFinished() || !input_) {
+    return nullptr;
+  }
+
+  auto outputSize = input_->size();
+
+  // Handle empty batches.
+  if (outputSize == 0) {
+    input_ = nullptr;
+    return nullptr;
+  }
+
+  // Re-use memory for the marker vector if possible.
+  VectorPtr& result = results_[0];
+  if (result && result.use_count() == 1) {
+    BaseVector::prepareForReuse(result, outputSize);
+  } else {
+    result = BaseVector::create(BOOLEAN(), outputSize, operatorCtx_->pool());
+  }
+
+  auto resultBits =
+      results_[0]->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
+
+  // Initialize all bits to true (sorted), then set false for violations.
+  bits::fillBits(resultBits, 0, outputSize, true);
+
+  // First row of first batch is always marked true (already initialized).
+  // First row of subsequent batches is compared with lastRow_.
+  if (lastRow_) {
+    // Compare first row of current batch with stored last row.
+    // lastRow_ has key columns at sequential indices (0, 1, 2, ...) so we
+    // cannot use isSortedRelativeTo which expects the same schema on both
+    // sides.
+    bool sorted = true;
+    for (auto i = 0; i < sortingKeyChannels_.size(); ++i) {
+      auto channel = sortingKeyChannels_[i];
+      const auto& currentColumn = input_->childAt(channel);
+      const auto& prevColumn = lastRow_->childAt(i);
+
+      auto result =
+          currentColumn->compare(prevColumn.get(), 0, 0, compareFlags_[i]);
+
+      if (result.has_value()) {
+        if (result.value() < 0) {
+          sorted = false;
+          break;
+        } else if (result.value() > 0) {
+          break;
+        }
+      }
+    }
+    if (!sorted) {
+      bits::setBit(resultBits, 0, false);
+    }
+  }
+
+  // Process remaining rows in batch.
+  for (auto i = 1; i < outputSize; ++i) {
+    bool sorted = isSortedRelativeTo(input_, i, input_, i - 1);
+    if (!sorted) {
+      bits::setBit(resultBits, i, false);
+    }
+  }
+
+  // Copy only sorting key columns of the last row for cross-batch comparison.
+  // Avoids holding a reference to the entire batch, preventing OOM on wide
+  // schemas and allowing the upstream producer to reuse memory.
+  copyLastRowKeyColumns();
+
+  auto output = fillOutput(outputSize, nullptr);
+
+  // Drop reference to input_ to make it singly-referenced at the producer and
+  // allow for memory reuse.
+  input_ = nullptr;
+
+  return output;
+}
+
+void MarkSorted::copyLastRowKeyColumns() {
+  auto lastIndex = input_->size() - 1;
+  auto numKeys = sortingKeyChannels_.size();
+
+  std::vector<VectorPtr> keyChildren(numKeys);
+  for (auto i = 0; i < numKeys; ++i) {
+    auto channel = sortingKeyChannels_[i];
+    const auto& sourceColumn = input_->childAt(channel);
+    keyChildren[i] =
+        BaseVector::create(sourceColumn->type(), 1, operatorCtx_->pool());
+    keyChildren[i]->copy(sourceColumn.get(), 0, lastIndex, 1);
+  }
+
+  lastRow_ = std::make_shared<RowVector>(
+      operatorCtx_->pool(),
+      lastRowType_,
+      nullptr, // no nulls
+      1, // single row
+      std::move(keyChildren));
+}
+
+void MarkSorted::noMoreInput() {
+  Operator::noMoreInput();
+  lastRow_.reset();
+}
+
+bool MarkSorted::isFinished() {
+  return noMoreInput_ && !input_;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/MarkSorted.h
+++ b/velox/exec/MarkSorted.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+/// Marks each row with a boolean indicating whether it maintains sort order
+/// relative to its predecessor. The first row is always marked true.
+/// Subsequent rows are marked true if they are sorted relative to the
+/// previous row based on the configured sorting keys and orders.
+class MarkSorted : public Operator {
+ public:
+  MarkSorted(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::MarkSortedNode>& planNode);
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool isFilter() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+  void noMoreInput() override;
+
+ private:
+  /// Compare row at currentIndex in currentData with row at prevIndex in
+  /// prevData. Both vectors must share the same schema (uses
+  /// sortingKeyChannels_ to access columns).
+  bool isSortedRelativeTo(
+      const RowVectorPtr& currentData,
+      vector_size_t currentIndex,
+      const RowVectorPtr& prevData,
+      vector_size_t prevIndex);
+
+  /// Copy only sorting key columns of the last row from input_ into lastRow_.
+  /// Creates a single-row RowVector with key columns at sequential indices
+  /// (0, 1, 2, ...) to avoid holding a reference to the entire input batch.
+  void copyLastRowKeyColumns();
+
+  const std::string markerName_;
+  std::vector<column_index_t> sortingKeyChannels_;
+  std::vector<CompareFlags> compareFlags_;
+
+  /// Key-only RowType for lastRow_ construction. Columns are at sequential
+  /// indices (0, 1, 2, ...) mapping to sortingKeyChannels_ in the input.
+  RowTypePtr lastRowType_;
+
+  /// Stores only sorting key column values of the last row from the previous
+  /// batch, for cross-batch comparison. Has a different schema than input_
+  /// (key columns only), so cross-batch comparison uses inline logic instead
+  /// of isSortedRelativeTo().
+  RowVectorPtr lastRow_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.h
@@ -97,6 +97,11 @@ class DuckQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
     VELOX_NYI();
   }
 
+  void visit(const core::MarkSortedNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::MergeExchangeNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();

--- a/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/exec/fuzzer/PrestoQueryRunnerToSqlPlanNodeVisitor.h
@@ -100,6 +100,11 @@ class PrestoQueryRunnerToSqlPlanNodeVisitor : public PrestoSqlPlanNodeVisitor {
     VELOX_NYI();
   }
 
+  void visit(const core::MarkSortedNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::MergeExchangeNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(
   LocalPartitionTest.cpp
   Main.cpp
   MarkDistinctTest.cpp
+  MarkSortedTest.cpp
   EnforceDistinctTest.cpp
   MemoryReclaimerTest.cpp
   MergeJoinTest.cpp

--- a/velox/exec/tests/MarkSortedTest.cpp
+++ b/velox/exec/tests/MarkSortedTest.cpp
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class MarkSortedTest : public OperatorTestBase {
+ protected:
+  void assertMarkSortedResults(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders,
+      const std::string& markerName,
+      const std::vector<bool>& expectedMarkers) {
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .markSorted(markerName, sortingKeys, sortingOrders)
+                    .planNode();
+
+    auto results = AssertQueryBuilder(plan).copyResults(pool());
+
+    // Verify marker column exists and has correct values
+    auto markerVector = results->childAt(results->childrenSize() - 1);
+    ASSERT_EQ(markerVector->size(), expectedMarkers.size());
+
+    auto flatMarker = markerVector->as<FlatVector<bool>>();
+    for (vector_size_t i = 0; i < expectedMarkers.size(); ++i) {
+      ASSERT_EQ(flatMarker->valueAt(i), expectedMarkers[i])
+          << "Mismatch at row " << i;
+    }
+  }
+};
+
+TEST_F(MarkSortedTest, singleKeyAscSorted) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, singleKeyDescSorted) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({5, 4, 3, 2, 1}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kDescNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, singleKeyAscUnsorted) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 3, 2, 4, 5}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, false, true, true});
+}
+
+TEST_F(MarkSortedTest, singleKeyDescUnsorted) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({5, 4, 6, 2, 1}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kDescNullsLast},
+      "is_sorted",
+      {true, true, false, true, true});
+}
+
+TEST_F(MarkSortedTest, multipleKeysSorted) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 3}),
+      makeFlatVector<int32_t>({1, 2, 1, 2, 1}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0", "c1"},
+      {core::kAscNullsLast, core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, multipleKeysUnsorted) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 3}),
+      makeFlatVector<int32_t>({1, 3, 2, 1, 1}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0", "c1"},
+      {core::kAscNullsLast, core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, false, true});
+}
+
+TEST_F(MarkSortedTest, nullsFirstSorted) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({std::nullopt, std::nullopt, 1, 2, 3}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsFirst},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, nullsLastSorted) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, 3, std::nullopt, std::nullopt}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, nullsFirstUnsorted) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, std::nullopt, 2, 3, 4}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsFirst},
+      "is_sorted",
+      {true, false, true, true, true});
+}
+
+TEST_F(MarkSortedTest, crossBatchSorted) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({4, 5, 6}),
+  });
+
+  assertMarkSortedResults(
+      {batch1, batch2},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, crossBatchUnsorted) {
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 5}),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({3, 4, 6}),
+  });
+
+  assertMarkSortedResults(
+      {batch1, batch2},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, false, true, true});
+}
+
+TEST_F(MarkSortedTest, emptyBatch) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({}),
+  });
+
+  assertMarkSortedResults(
+      {data}, {"c0"}, {core::kAscNullsLast}, "is_sorted", {});
+}
+
+TEST_F(MarkSortedTest, allNullValues) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+
+  assertMarkSortedResults(
+      {data}, {"c0"}, {core::kAscNullsLast}, "is_sorted", {true, true, true});
+}
+
+TEST_F(MarkSortedTest, firstRowAlwaysTrue) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({100, 1, 2, 3}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, false, true, true});
+}
+
+TEST_F(MarkSortedTest, singleRow) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({42}),
+  });
+
+  assertMarkSortedResults(
+      {data}, {"c0"}, {core::kAscNullsLast}, "is_sorted", {true});
+}
+
+TEST_F(MarkSortedTest, stringKey) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({"apple", "banana", "cherry", "date"}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, stringKeyUnsorted) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({"apple", "cherry", "banana", "date"}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, false, true});
+}

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -2550,6 +2550,28 @@ PlanBuilder& PlanBuilder::streamingEnforceDistinct(
   return enforceDistinct(distinctKeys, std::move(errorMessage), distinctKeys);
 }
 
+PlanBuilder& PlanBuilder::markSorted(
+    const std::string& markerKey,
+    const std::vector<std::string>& sortingKeys,
+    const std::vector<core::SortOrder>& sortingOrders) {
+  VELOX_CHECK_NOT_NULL(planNode_, "MarkSorted cannot be the source node");
+  VELOX_CHECK_EQ(sortingKeys.size(), sortingOrders.size());
+
+  std::vector<core::FieldAccessTypedExprPtr> keyExprs;
+  for (const auto& key : sortingKeys) {
+    keyExprs.push_back(field(planNode_->outputType(), key));
+  }
+
+  planNode_ = core::MarkSortedNode::Builder()
+                  .id(nextPlanNodeId())
+                  .markerName(markerKey)
+                  .sortingKeys(keyExprs)
+                  .sortingOrders(sortingOrders)
+                  .source(planNode_)
+                  .build();
+  return *this;
+}
+
 core::PlanNodeId PlanBuilder::nextPlanNodeId() {
   return planNodeIdGenerator_->next();
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1601,6 +1601,15 @@ class PlanBuilder {
       const std::vector<std::string>& distinctKeys,
       std::string errorMessage);
 
+  /// Add a MarkSortedNode to mark rows indicating sortedness.
+  /// @param markerKey Name of output marker column (boolean).
+  /// @param sortingKeys List of columns used for sorting.
+  /// @param sortingOrders Sort orders for each sorting key.
+  PlanBuilder& markSorted(
+      const std::string& markerKey,
+      const std::vector<std::string>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders);
+
   /// Stores the latest plan node ID into the specified variable. Useful for
   /// capturing IDs of the leaf plan nodes (table scans, exchanges, etc.) to use
   /// when adding splits at runtime.

--- a/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
+++ b/velox/functions/sparksql/fuzzer/SparkQueryRunnerToSqlPlanNodeVisitor.h
@@ -93,6 +93,11 @@ class SparkQueryRunnerToSqlPlanNodeVisitor
     VELOX_NYI();
   }
 
+  void visit(const core::MarkSortedNode&, core::PlanNodeVisitorContext&)
+      const override {
+    VELOX_NYI();
+  }
+
   void visit(const core::EnforceDistinctNode&, core::PlanNodeVisitorContext&)
       const override {
     VELOX_NYI();


### PR DESCRIPTION
Summary:

Add a new MarkSorted operator that validates data sortedness by specified keys and adds a boolean marker column. This enables detection of data corruption before downstream pipelines that depend on sorted input.

The implementation includes:
- MarkSortedNode plan node with Builder pattern, serialization, and visitor support
- MarkSorted operator with cross-batch comparison logic using CompareFlags
- LocalPlanner translation to create the operator from the plan node
- PlanBuilder::markSorted() helper for fluent test plan construction
- Comprehensive unit tests covering single/multiple keys, ASC/DESC, NULLS FIRST/LAST, cross-batch boundaries, empty batches, null values, and VARCHAR/numeric key types

The marker column is set to true for the first row of each batch if it maintains sort order relative to the previous batch's last row, and true for subsequent rows that maintain sort order relative to their predecessor.

Key design decisions:
- Store only sorting key columns (not full row) for cross-batch comparison
- Use CompareFlags built from SortOrder for proper null handling
- Match MarkDistinct pattern for consistency with existing operators

Reviewed By: Yuhta

Differential Revision: D92365997


