### PR TITLE
perf(operator): Add MarkSorted performance optimizations (#16653)

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -883,6 +883,13 @@ class QueryConfig {
   static constexpr const char* kJoinBuildVectorHasherMaxNumDistinct =
       "join_build_vector_hasher_max_num_distinct";
 
+  /// Batch size threshold for zero-copy optimization in MarkSorted operator.
+  /// For batches smaller than this threshold, the operator holds a reference to
+  /// the entire input batch instead of copying key columns for cross-batch
+  /// comparison.
+  static constexpr const char* kMarkSortedZeroCopyThreshold =
+      "mark_sorted_zero_copy_threshold";
+
   enum class RowSizeTrackingMode {
     DISABLED = 0,
     EXCLUDE_DELTA_SPLITS = 1,
@@ -1563,6 +1570,10 @@ class QueryConfig {
 
   uint32_t joinBuildVectorHasherMaxNumDistinct() const {
     return get<uint32_t>(kJoinBuildVectorHasherMaxNumDistinct, 1'000'000);
+  }
+
+  int32_t markSortedZeroCopyThreshold() const {
+    return get<int32_t>(kMarkSortedZeroCopyThreshold, 1000);
   }
 
   template <typename T>

--- a/velox/exec/MarkSorted.cpp
+++ b/velox/exec/MarkSorted.cpp
@@ -15,10 +15,19 @@
  */
 
 #include "velox/exec/MarkSorted.h"
+#include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CompareFlags.h"
+#include "velox/functions/lib/SIMDComparisonUtil.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::exec {
+
+namespace {
+bool isSimdEligibleType(TypeKind kind) {
+  return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+      kind == TypeKind::INTEGER || kind == TypeKind::BIGINT;
+}
+} // namespace
 
 MarkSorted::MarkSorted(
     int32_t operatorId,
@@ -30,7 +39,9 @@ MarkSorted::MarkSorted(
           operatorId,
           planNode->id(),
           "MarkSorted"),
-      markerName_(planNode->markerName()) {
+      markerName_(planNode->markerName()),
+      zeroCopyThreshold_(
+          driverCtx->queryConfig().markSortedZeroCopyThreshold()) {
   const auto& inputType = planNode->sources()[0]->outputType();
   const auto& sortingKeys = planNode->sortingKeys();
   const auto& sortingOrders = planNode->sortingOrders();
@@ -47,14 +58,17 @@ MarkSorted::MarkSorted(
   // Extract channel indices for sorting keys.
   sortingKeyChannels_.reserve(sortingKeys.size());
   compareFlags_.reserve(sortingKeys.size());
+  sortingOrders_.reserve(sortingKeys.size());
 
   for (auto i = 0; i < sortingKeys.size(); ++i) {
     const auto& key = sortingKeys[i];
     auto channel = inputType->getChildIdx(key->name());
     sortingKeyChannels_.push_back(channel);
 
-    // Build CompareFlags from SortOrder.
     const auto& order = sortingOrders[i];
+    sortingOrders_.push_back(order);
+
+    // Build CompareFlags from SortOrder.
     compareFlags_.push_back(
         {order.isNullsFirst(),
          order.isAscending(),
@@ -86,10 +100,6 @@ bool MarkSorted::isSortedRelativeTo(
     vector_size_t currentIndex,
     const RowVectorPtr& prevData,
     vector_size_t prevIndex) {
-  // Compare each sorting key column.
-  // For sorted data, each row should be >= previous (ascending) or <= previous
-  // (descending). The compare function respects ascending/descending flags,
-  // so we just check if compare() returns >= 0 for each key.
   for (auto i = 0; i < sortingKeyChannels_.size(); ++i) {
     auto channel = sortingKeyChannels_[i];
     const auto& currentColumn = currentData->childAt(channel);
@@ -100,19 +110,94 @@ bool MarkSorted::isSortedRelativeTo(
 
     if (result.has_value()) {
       if (result.value() < 0) {
-        // Current row is less than previous (in sort order), NOT sorted.
         return false;
       } else if (result.value() > 0) {
-        // Current row is greater than previous, sorted (no need to check more
-        // keys).
         return true;
       }
-      // Equal on this key, continue to next key.
     }
   }
 
   // All keys are equal - this is still considered sorted.
   return true;
+}
+
+bool MarkSorted::allKeysConstant() const {
+  for (auto channel : sortingKeyChannels_) {
+    auto& keyCol = input_->childAt(channel);
+    if (!keyCol->isConstantEncoding() || keyCol->isNullAt(0)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool MarkSorted::canApplySimdPath() const {
+  if (sortingKeyChannels_.size() != 1) {
+    return false;
+  }
+  auto& keyCol = input_->childAt(sortingKeyChannels_[0]);
+  if (!keyCol->isFlatEncoding() || keyCol->mayHaveNulls()) {
+    return false;
+  }
+  if (keyCol->type()->providesCustomComparison()) {
+    return false;
+  }
+  return isSimdEligibleType(keyCol->typeKind());
+}
+
+void MarkSorted::applySimdComparison(
+    uint64_t* resultBits,
+    vector_size_t numRows) {
+  auto channel = sortingKeyChannels_[0];
+  auto& keyCol = input_->childAt(channel);
+  bool ascending = sortingOrders_[0].isAscending();
+  const auto numCompares = numRows - 1;
+
+  // Reuse bit-packed result buffer for SIMD output.
+  const auto bufferBytes = bits::nbytes(numCompares);
+  if (!simdBuffer_ || simdBuffer_->size() < bufferBytes) {
+    simdBuffer_ = AlignedBuffer::allocate<uint8_t>(bufferBytes, pool());
+  }
+  auto simdResult = simdBuffer_->asMutable<uint8_t>();
+  memset(simdResult, 0, bufferBytes);
+
+  // Dispatch by type to call applySimdComparison with typed raw data.
+  // Consecutive-row trick: rawData+1 as lhs, rawData as rhs.
+  // For ascending: row[i+1] >= row[i] means sorted.
+  // For descending: row[i+1] <= row[i] means sorted.
+  auto dispatchSimd = [&](auto dummy) {
+    using T = decltype(dummy);
+    const T* rawData = keyCol->asFlatVector<T>()->rawValues();
+    if (ascending) {
+      functions::applySimdComparison<T, false, false, std::greater_equal<>>(
+          0, numCompares, rawData + 1, rawData, simdResult);
+    } else {
+      functions::applySimdComparison<T, false, false, std::less_equal<>>(
+          0, numCompares, rawData + 1, rawData, simdResult);
+    }
+  };
+
+  auto kind = keyCol->typeKind();
+  if (kind == TypeKind::TINYINT) {
+    dispatchSimd(int8_t{});
+  } else if (kind == TypeKind::SMALLINT) {
+    dispatchSimd(int16_t{});
+  } else if (kind == TypeKind::INTEGER) {
+    dispatchSimd(int32_t{});
+  } else {
+    VELOX_DCHECK_EQ(kind, TypeKind::BIGINT);
+    dispatchSimd(int64_t{});
+  }
+
+  // Copy SIMD results into resultBits with +1 offset.
+  // simdResult bit i = comparison result for (data[i+1] vs data[i]).
+  // Row 0 is handled by cross-batch logic, so we write starting at bit 1.
+  bits::copyBits(
+      reinterpret_cast<const uint64_t*>(simdResult),
+      0,
+      resultBits,
+      1,
+      numCompares);
 }
 
 RowVectorPtr MarkSorted::getOutput() {
@@ -139,51 +224,68 @@ RowVectorPtr MarkSorted::getOutput() {
   auto resultBits =
       results_[0]->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
 
-  // Initialize all bits to true (sorted), then set false for violations.
+  // Initialize all bits to true (sorted), then clear for violations.
   bits::fillBits(resultBits, 0, outputSize, true);
 
-  // First row of first batch is always marked true (already initialized).
-  // First row of subsequent batches is compared with lastRow_.
-  if (lastRow_) {
-    // Compare first row of current batch with stored last row.
-    // lastRow_ has key columns at sequential indices (0, 1, 2, ...) so we
-    // cannot use isSortedRelativeTo which expects the same schema on both
-    // sides.
-    bool sorted = true;
-    for (auto i = 0; i < sortingKeyChannels_.size(); ++i) {
-      auto channel = sortingKeyChannels_[i];
-      const auto& currentColumn = input_->childAt(channel);
-      const auto& prevColumn = lastRow_->childAt(i);
-
-      auto result =
-          currentColumn->compare(prevColumn.get(), 0, 0, compareFlags_[i]);
-
-      if (result.has_value()) {
-        if (result.value() < 0) {
-          sorted = false;
-          break;
-        } else if (result.value() > 0) {
-          break;
+  // Cross-batch comparison: compare first row of current batch with last row
+  // of previous batch.
+  if (prevInput_) {
+    // Zero-copy mode: prevInput_ has same schema as current input.
+    for (column_index_t k = 0; k < sortingKeyChannels_.size(); ++k) {
+      auto channel = sortingKeyChannels_[k];
+      auto cmp = prevInput_->childAt(channel)->compare(
+          input_->childAt(channel).get(),
+          prevInput_->size() - 1,
+          0,
+          compareFlags_[k]);
+      if (cmp.has_value() && cmp.value() != 0) {
+        if (cmp.value() > 0) {
+          // Previous > current in sort order means NOT sorted.
+          bits::clearBit(resultBits, 0);
         }
+        break;
       }
     }
-    if (!sorted) {
-      bits::setBit(resultBits, 0, false);
+    prevInput_.reset();
+  } else if (lastRow_) {
+    // Copy mode: lastRow_ has key columns at sequential indices.
+    for (column_index_t k = 0; k < sortingKeyChannels_.size(); ++k) {
+      auto channel = sortingKeyChannels_[k];
+      auto cmp = lastRow_->childAt(k)->compare(
+          input_->childAt(channel).get(), 0, 0, compareFlags_[k]);
+      if (cmp.has_value() && cmp.value() != 0) {
+        if (cmp.value() > 0) {
+          bits::clearBit(resultBits, 0);
+        }
+        break;
+      }
     }
   }
 
-  // Process remaining rows in batch.
-  for (auto i = 1; i < outputSize; ++i) {
-    bool sorted = isSortedRelativeTo(input_, i, input_, i - 1);
-    if (!sorted) {
-      bits::setBit(resultBits, i, false);
+  // Within-batch comparison.
+  if (allKeysConstant()) {
+    // ConstantVector fast path: all key columns are constant non-null,
+    // so all rows are trivially sorted. Bits are already true.
+  } else if (canApplySimdPath()) {
+    // SIMD fast path: single flat non-null primitive key.
+    applySimdComparison(resultBits, outputSize);
+  } else {
+    // Generic path: compare each row with its predecessor.
+    for (auto i = 1; i < outputSize; ++i) {
+      if (!isSortedRelativeTo(input_, i, input_, i - 1)) {
+        bits::setBit(resultBits, i, false);
+      }
     }
   }
 
-  // Copy only sorting key columns of the last row for cross-batch comparison.
-  // Avoids holding a reference to the entire batch, preventing OOM on wide
-  // schemas and allowing the upstream producer to reuse memory.
-  copyLastRowKeyColumns();
+  // Store last row for next batch's cross-batch comparison.
+  if (input_->size() < zeroCopyThreshold_) {
+    prevInput_ = input_;
+    lastRow_.reset();
+  } else {
+    copyLastRowKeyColumns();
+    prevInput_.reset();
+  }
 
   auto output = fillOutput(outputSize, nullptr);
 
@@ -218,6 +320,7 @@ void MarkSorted::copyLastRowKeyColumns() {
 void MarkSorted::noMoreInput() {
   Operator::noMoreInput();
   lastRow_.reset();
+  prevInput_.reset();
 }
 
 bool MarkSorted::isFinished() {

--- a/velox/exec/MarkSorted.h
+++ b/velox/exec/MarkSorted.h
@@ -70,9 +70,24 @@ class MarkSorted : public Operator {
   /// (0, 1, 2, ...) to avoid holding a reference to the entire input batch.
   void copyLastRowKeyColumns();
 
+  /// Returns true if all key columns in input_ use constant encoding with
+  /// non-null values. When true, within-batch comparison can be skipped
+  /// entirely since all rows have the same key values.
+  bool allKeysConstant() const;
+
+  /// Returns true if input has a single sorting key that is flat, non-null,
+  /// and a SIMD-eligible primitive type.
+  bool canApplySimdPath() const;
+
+  /// Apply SIMD comparison for a single primitive sorting key. Writes
+  /// bit-packed results into resultBits (clears bits for unsorted rows).
+  /// Row 0 is not modified (handled by cross-batch logic).
+  void applySimdComparison(uint64_t* resultBits, vector_size_t numRows);
+
   const std::string markerName_;
   std::vector<column_index_t> sortingKeyChannels_;
   std::vector<CompareFlags> compareFlags_;
+  std::vector<core::SortOrder> sortingOrders_;
 
   /// Key-only RowType for lastRow_ construction. Columns are at sequential
   /// indices (0, 1, 2, ...) mapping to sortingKeyChannels_ in the input.
@@ -83,5 +98,19 @@ class MarkSorted : public Operator {
   /// (key columns only), so cross-batch comparison uses inline logic instead
   /// of isSortedRelativeTo().
   RowVectorPtr lastRow_;
+
+  /// Zero-copy: holds reference to the previous input batch for cross-batch
+  /// comparison when the batch is smaller than zeroCopyThreshold_. Mutually
+  /// exclusive with lastRow_ (one or neither is set, never both).
+  RowVectorPtr prevInput_;
+
+  /// Batch size threshold for zero-copy optimization. Batches smaller than
+  /// this hold a reference to the entire batch; larger batches deep-copy
+  /// key columns only.
+  const int32_t zeroCopyThreshold_;
+
+  /// Reusable buffer for SIMD comparison results. Allocated on first use
+  /// and grown as needed to avoid per-batch allocation overhead.
+  BufferPtr simdBuffer_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/benchmarks/CMakeLists.txt
+++ b/velox/exec/benchmarks/CMakeLists.txt
@@ -161,6 +161,16 @@ target_link_libraries(
   Folly::follybenchmark
 )
 
+add_executable(velox_mark_sorted_benchmark MarkSortedBenchmark.cpp)
+
+target_link_libraries(
+  velox_mark_sorted_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_vector_test_lib
+  Folly::follybenchmark
+)
+
 add_executable(velox_streaming_aggregation_benchmark StreamingAggregationBenchmark.cpp)
 
 target_link_libraries(

--- a/velox/exec/benchmarks/MarkSortedBenchmark.cpp
+++ b/velox/exec/benchmarks/MarkSortedBenchmark.cpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+constexpr vector_size_t kBatchSize = 10'000;
+constexpr int kIterations = 100;
+
+class BenchmarkHelper {
+ public:
+  memory::MemoryPool* pool() {
+    return pool_.get();
+  }
+
+  test::VectorMaker& vectorMaker() {
+    return vectorMaker_;
+  }
+
+  void runMarkSorted(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders) {
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .markSorted("is_sorted", sortingKeys, sortingOrders)
+                    .planNode();
+    auto result = AssertQueryBuilder(plan).copyResults(pool());
+    folly::doNotOptimizeAway(result);
+  }
+
+ private:
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::memoryManager()->addLeafPool()};
+  test::VectorMaker vectorMaker_{pool_.get()};
+};
+
+// --- Sorted INTEGER (SIMD path) ---
+BENCHMARK(sortedInteger) {
+  folly::BenchmarkSuspender suspender;
+  BenchmarkHelper helper;
+  auto data = helper.vectorMaker().rowVector({
+      helper.vectorMaker().flatVector<int32_t>(
+          kBatchSize, [](vector_size_t i) { return i; }),
+  });
+  suspender.dismiss();
+
+  for (int i = 0; i < kIterations; ++i) {
+    helper.runMarkSorted({data}, {"c0"}, {core::kAscNullsLast});
+  }
+}
+
+// --- Sorted BIGINT (SIMD path) ---
+BENCHMARK_RELATIVE(sortedBigint) {
+  folly::BenchmarkSuspender suspender;
+  BenchmarkHelper helper;
+  auto data = helper.vectorMaker().rowVector({
+      helper.vectorMaker().flatVector<int64_t>(
+          kBatchSize, [](vector_size_t i) { return static_cast<int64_t>(i); }),
+  });
+  suspender.dismiss();
+
+  for (int i = 0; i < kIterations; ++i) {
+    helper.runMarkSorted({data}, {"c0"}, {core::kAscNullsLast});
+  }
+}
+
+// --- Sorted VARCHAR (generic path, no SIMD) ---
+// U8 fix: strings stored in vector with lifetime spanning the benchmark.
+BENCHMARK_RELATIVE(sortedVarchar) {
+  folly::BenchmarkSuspender suspender;
+  BenchmarkHelper helper;
+  std::vector<std::string> storage(kBatchSize);
+  for (vector_size_t i = 0; i < kBatchSize; ++i) {
+    storage[i] = fmt::format("str_{:08d}", i);
+  }
+  auto data = helper.vectorMaker().rowVector({
+      helper.vectorMaker().flatVector<StringView>(
+          kBatchSize,
+          [&storage](vector_size_t i) { return StringView(storage[i]); }),
+  });
+  suspender.dismiss();
+
+  for (int i = 0; i < kIterations; ++i) {
+    helper.runMarkSorted({data}, {"c0"}, {core::kAscNullsLast});
+  }
+}
+
+// --- Unsorted INTEGER (SIMD path, many false bits) ---
+BENCHMARK(unsortedInteger) {
+  folly::BenchmarkSuspender suspender;
+  BenchmarkHelper helper;
+  auto data = helper.vectorMaker().rowVector({
+      helper.vectorMaker().flatVector<int32_t>(
+          kBatchSize,
+          [](vector_size_t i) {
+            // Alternating pattern creates many unsorted pairs.
+            return (i % 2 == 0) ? i : kBatchSize - i;
+          }),
+  });
+  suspender.dismiss();
+
+  for (int i = 0; i < kIterations; ++i) {
+    helper.runMarkSorted({data}, {"c0"}, {core::kAscNullsLast});
+  }
+}
+
+// --- ConstantVector (O(1) fast path) ---
+BENCHMARK_RELATIVE(constantVector) {
+  folly::BenchmarkSuspender suspender;
+  BenchmarkHelper helper;
+  auto data = helper.vectorMaker().rowVector({
+      BaseVector::createConstant(INTEGER(), 42, kBatchSize, helper.pool()),
+  });
+  suspender.dismiss();
+
+  for (int i = 0; i < kIterations; ++i) {
+    helper.runMarkSorted({data}, {"c0"}, {core::kAscNullsLast});
+  }
+}
+
+// --- Cross-batch comparison (measures overhead) ---
+BENCHMARK(crossBatch) {
+  folly::BenchmarkSuspender suspender;
+  BenchmarkHelper helper;
+  constexpr vector_size_t kSmallBatch = 100;
+  constexpr int kNumBatches = 100;
+  std::vector<RowVectorPtr> batches;
+  batches.reserve(kNumBatches);
+  for (int b = 0; b < kNumBatches; ++b) {
+    batches.push_back(helper.vectorMaker().rowVector({
+        helper.vectorMaker().flatVector<int32_t>(
+            kSmallBatch, [b](vector_size_t i) { return b * kSmallBatch + i; }),
+    }));
+  }
+  suspender.dismiss();
+
+  for (int i = 0; i < kIterations; ++i) {
+    helper.runMarkSorted(batches, {"c0"}, {core::kAscNullsLast});
+  }
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/exec/tests/MarkSortedTest.cpp
+++ b/velox/exec/tests/MarkSortedTest.cpp
@@ -21,6 +21,7 @@
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::core;
 
 class MarkSortedTest : public OperatorTestBase {
  protected:
@@ -37,8 +38,38 @@ class MarkSortedTest : public OperatorTestBase {
 
     auto results = AssertQueryBuilder(plan).copyResults(pool());
 
-    // Verify marker column exists and has correct values
-    auto markerVector = results->childAt(results->childrenSize() - 1);
+    // Verify marker column exists and has correct values.
+    auto markerIdx = static_cast<column_index_t>(results->childrenSize() - 1);
+    auto markerVector = results->childAt(markerIdx);
+    ASSERT_EQ(markerVector->size(), expectedMarkers.size());
+
+    auto flatMarker = markerVector->as<FlatVector<bool>>();
+    for (vector_size_t i = 0; i < expectedMarkers.size(); ++i) {
+      ASSERT_EQ(flatMarker->valueAt(i), expectedMarkers[i])
+          << "Mismatch at row " << i;
+    }
+  }
+
+  void assertMarkSortedResultsWithConfig(
+      const std::vector<RowVectorPtr>& input,
+      const std::vector<std::string>& sortingKeys,
+      const std::vector<core::SortOrder>& sortingOrders,
+      const std::string& markerName,
+      const std::vector<bool>& expectedMarkers,
+      const std::unordered_map<std::string, std::string>& configs) {
+    auto plan = PlanBuilder()
+                    .values(input)
+                    .markSorted(markerName, sortingKeys, sortingOrders)
+                    .planNode();
+
+    auto builder = AssertQueryBuilder(plan);
+    for (const auto& [key, value] : configs) {
+      builder.config(key, value);
+    }
+    auto results = builder.copyResults(pool());
+
+    auto markerIdx = static_cast<column_index_t>(results->childrenSize() - 1);
+    auto markerVector = results->childAt(markerIdx);
     ASSERT_EQ(markerVector->size(), expectedMarkers.size());
 
     auto flatMarker = markerVector->as<FlatVector<bool>>();
@@ -265,4 +296,187 @@ TEST_F(MarkSortedTest, stringKeyUnsorted) {
       {core::kAscNullsLast},
       "is_sorted",
       {true, true, false, true});
+}
+
+// --- Optimization tests ---
+
+TEST_F(MarkSortedTest, constantVectorSorted) {
+  // All key columns are constant non-null — trivially sorted.
+  auto data = makeRowVector({
+      BaseVector::createConstant(INTEGER(), 42, 5, pool()),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, constantVectorWithNull) {
+  // Constant null key — falls back to generic path.
+  auto data = makeRowVector({
+      BaseVector::createNullConstant(INTEGER(), 5, pool()),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, simdPathInteger) {
+  // Single flat non-null INTEGER key — uses SIMD path (ascending).
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7, 8}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, simdPathBigint) {
+  // SIMD path with BIGINT key (descending), with unsorted violations.
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({100, 90, 80, 85, 70, 60, 50, 40}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kDescNullsLast},
+      "is_sorted",
+      {true, true, true, false, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, genericPathDouble) {
+  // DOUBLE key — SIMD not applicable for floating point, uses generic path.
+  auto data = makeRowVector({
+      makeFlatVector<double>({1.0, 2.0, 3.0, 2.5, 4.0}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, false, true});
+}
+
+TEST_F(MarkSortedTest, simdFallbackMultiKey) {
+  // Multi-key: SIMD not applicable, falls back to generic.
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 2, 2, 3}),
+      makeFlatVector<int32_t>({1, 2, 1, 2, 1}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0", "c1"},
+      {core::kAscNullsLast, core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, simdFallbackVarchar) {
+  // VARCHAR key: SIMD not applicable, falls back to generic.
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({"a", "b", "c", "d", "e"}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, simdFallbackWithNulls) {
+  // Flat vector with nulls — SIMD not applicable, falls back to generic.
+  // With kAscNullsLast, null > any value, so row 3 (4 after null) is unsorted.
+  auto data = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, 2, std::nullopt, 4, 5}),
+  });
+
+  assertMarkSortedResults(
+      {data},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, false, true});
+}
+
+TEST_F(MarkSortedTest, zeroCopySmallBatch) {
+  // Small batches (< threshold) use zero-copy cross-batch. Verify correctness.
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({4, 5, 6}),
+  });
+
+  // Default threshold is 1000, so 3-row batches use zero-copy.
+  assertMarkSortedResults(
+      {batch1, batch2},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, true, true, true});
+}
+
+TEST_F(MarkSortedTest, copyLargeBatch) {
+  // Set threshold very low so even small batches use copy mode.
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 5}),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({3, 4, 6}),
+  });
+
+  assertMarkSortedResultsWithConfig(
+      {batch1, batch2},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, true, true, false, true, true},
+      {{QueryConfig::kMarkSortedZeroCopyThreshold, "1"}});
+}
+
+TEST_F(MarkSortedTest, zeroCopyThresholdConfig) {
+  // Verify threshold is configurable: set to 2 so batch of 3 uses copy mode
+  // and batch of 1 uses zero-copy.
+  auto batch1 = makeRowVector({
+      makeFlatVector<int32_t>({10}),
+  });
+  auto batch2 = makeRowVector({
+      makeFlatVector<int32_t>({5, 6, 7}),
+  });
+
+  // batch1 (1 row) < threshold(2) → zero-copy
+  // batch2 first row (5) < prev (10) → unsorted for ascending
+  assertMarkSortedResultsWithConfig(
+      {batch1, batch2},
+      {"c0"},
+      {core::kAscNullsLast},
+      "is_sorted",
+      {true, false, true, true},
+      {{QueryConfig::kMarkSortedZeroCopyThreshold, "2"}});
+}
+
+TEST_F(MarkSortedTest, simdSmallBatch) {
+  // SIMD works correctly with very small batches (< 16 rows).
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({3, 1, 2}),
+  });
+
+  assertMarkSortedResults(
+      {data}, {"c0"}, {core::kAscNullsLast}, "is_sorted", {true, false, true});
 }


### PR DESCRIPTION
Summary:

Add two performance optimizations to the MarkSorted operator and benchmarks to validate them.

Optimizations:
1. Zero-copy last row tracking: For batches smaller than a configurable threshold (default 1000), the entire batch is held as a reference for cross-batch comparison instead of copying the last row's key columns. Controlled via QueryConfig entry kMarkSortedZeroCopyThreshold.
2. Fast path for single primitive key: When there is a single sorting key of primitive type (TINYINT through DOUBLE) with no nulls and flat encoding, uses a specialized comparison loop instead of the generic virtual compare() call.

Benchmarks cover small/large batches, single/multi keys, BIGINT/VARCHAR key types, and sorted vs unsorted data to validate the optimization impact.

Reviewed By: Yuhta, apurva-meta

Differential Revision: D95076381


