### PR TITLE
test: Support null map rows in createMapOfArraysVector()

### DIFF
--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -4608,5 +4608,45 @@ TEST_F(VectorTest, createEmptyLikeNestedFlatMap) {
       emptyArray->elements()->encoding(), VectorEncoding::Simple::FLAT_MAP);
 }
 
+TEST_F(VectorTest, createMapOfArraysVectorWithNullRows) {
+  // Row 0: {1 → [10, 20]}
+  // Row 1: null
+  // Row 2: {2 → [30]}
+  auto vector = createMapOfArraysVector<int64_t, int64_t>(
+      {{{1, {{10, 20}}}}, {}, {{2, {{30}}}}}, {1});
+
+  ASSERT_EQ(vector->size(), 3);
+  auto* map = vector->as<MapVector>();
+  ASSERT_NE(map, nullptr);
+
+  // Row 0: non-null, size 1.
+  EXPECT_FALSE(map->isNullAt(0));
+  EXPECT_EQ(map->sizeAt(0), 1);
+
+  // Row 1: null.
+  EXPECT_TRUE(map->isNullAt(1));
+
+  // Row 2: non-null, size 1.
+  EXPECT_FALSE(map->isNullAt(2));
+  EXPECT_EQ(map->sizeAt(2), 1);
+
+  // Verify keys and values.
+  auto* keys = map->mapKeys()->as<FlatVector<int64_t>>();
+  EXPECT_EQ(keys->valueAt(0), 1);
+  EXPECT_EQ(keys->valueAt(1), 2);
+
+  auto* arrays = map->mapValues()->as<ArrayVector>();
+  auto* elements = arrays->elements()->as<FlatVector<int64_t>>();
+
+  // Row 0, key 1 → [10, 20].
+  EXPECT_EQ(arrays->sizeAt(0), 2);
+  EXPECT_EQ(elements->valueAt(arrays->offsetAt(0)), 10);
+  EXPECT_EQ(elements->valueAt(arrays->offsetAt(0) + 1), 20);
+
+  // Row 2, key 2 → [30].
+  EXPECT_EQ(arrays->sizeAt(1), 1);
+  EXPECT_EQ(elements->valueAt(arrays->offsetAt(1)), 30);
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -25,6 +25,7 @@
 
 #include <gtest/gtest.h>
 #include <optional>
+#include <unordered_set>
 #include "velox/type/CppToType.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -756,15 +757,24 @@ class VectorTestBase {
   //      {{{1, std::nullopt}},
   //       {{2, {{4, 5, std::nullopt}}}},
   //       {{std::nullopt, {{7, 8, 9}}}}});
+  //
+  // Null map rows are supported via the nullRows parameter:
+  //    createMapOfArraysVector<int64_t, int64_t>(
+  //      {{{1, {{1, 2}}}}, {}, {{3, {{7, 8, 9}}}}},
+  //      {1}); // row 1 is null
   template <typename K, typename V>
   VectorPtr createMapOfArraysVector(
       std::vector<std::map<
           std::optional<K>,
-          std::optional<std::vector<std::optional<V>>>>> maps) {
+          std::optional<std::vector<std::optional<V>>>>> maps,
+      std::unordered_set<vector_size_t> nullRows = {}) {
     std::vector<std::optional<K>> keys;
     std::vector<std::optional<std::vector<std::optional<V>>>> values;
-    for (auto& map : maps) {
-      for (const auto& [key, value] : map) {
+    for (vector_size_t i = 0; i < maps.size(); i++) {
+      if (nullRows.count(i)) {
+        continue;
+      }
+      for (const auto& [key, value] : maps[i]) {
         keys.push_back(key);
         values.push_back(value);
       }
@@ -780,17 +790,30 @@ class VectorTestBase {
     auto rawOffsets = offsets->template asMutable<vector_size_t>();
     auto rawSizes = sizes->template asMutable<vector_size_t>();
 
+    BufferPtr nulls = nullptr;
+    uint64_t* rawNulls = nullptr;
     vector_size_t offset = 0;
+
+    if (nullRows.size() > 0) {
+      nulls = allocateNulls(size, pool_.get());
+      rawNulls = nulls->asMutable<uint64_t>();
+    }
+
     for (vector_size_t i = 0; i < size; i++) {
-      rawSizes[i] = maps[i].size();
+      if (nullRows.count(i)) {
+        rawSizes[i] = 0;
+        bits::setNull(rawNulls, i, true);
+      } else {
+        rawSizes[i] = maps[i].size();
+      }
       rawOffsets[i] = offset;
-      offset += maps[i].size();
+      offset += rawSizes[i];
     }
 
     return std::make_shared<MapVector>(
         pool_.get(),
         MAP(CppToType<K>::create(), ARRAY(CppToType<V>::create())),
-        nullptr,
+        nulls,
         size,
         offsets,
         sizes,


### PR DESCRIPTION
Summary:
Because the top level maps of createMapOfArraysVector() cannot be
std::optional because of nested initializer_list construction limitations,
adding an optional parameter to let API users to specify which top level rows
are null.

Differential Revision: D95489921


