### PR TITLE
build: Use CMAKE_CURRENT_BINARY_DIR for test WORKING_DIRECTORY so tests can run without source tree

### DIFF
--- a/velox/common/fuzzer/tests/CMakeLists.txt
+++ b/velox/common/fuzzer/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(velox_constrained_input_generators_test ConstrainedGeneratorsTest
 add_test(
   NAME velox_constrained_input_generators_test
   COMMAND velox_constrained_input_generators_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -82,7 +82,7 @@ add_executable(velox_s3read_test S3ReadTest.cpp)
 add_test(
   NAME velox_s3read_test
   COMMAND velox_s3read_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(
   velox_s3read_test

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -74,7 +74,7 @@ add_executable(velox_dwio_dwrf_decompression_test TestDecompression.cpp)
 add_test(
   NAME velox_dwio_dwrf_decompression_test
   COMMAND velox_dwio_dwrf_decompression_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -421,7 +421,7 @@ add_executable(velox_dwio_dwrf_reader_test ReaderTest.cpp)
 add_test(
   NAME velox_dwio_dwrf_reader_test
   COMMAND velox_dwio_dwrf_reader_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -626,3 +626,5 @@ target_link_libraries(
   ZLIB::ZLIB
   ${TEST_LINK_LIBS}
 )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/examples DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/velox/dwio/orc/test/CMakeLists.txt
+++ b/velox/dwio/orc/test/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(velox_dwio_orc_reader_test ReaderTest.cpp)
 add_test(
   NAME velox_dwio_orc_reader_test
   COMMAND velox_dwio_orc_reader_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -32,7 +32,7 @@ add_executable(velox_dwio_orc_reader_filter_test ReaderFilterTest.cpp)
 add_test(
   NAME velox_dwio_orc_reader_filter_test
   COMMAND velox_dwio_orc_reader_filter_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(velox_dwio_parquet_tpch_test ParquetTpchTest.cpp)
 add_test(
   NAME velox_dwio_parquet_tpch_test
   COMMAND velox_dwio_parquet_tpch_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(
   velox_dwio_parquet_tpch_test

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(velox_dwio_parquet_page_reader_test ParquetPageReaderTest.cpp)
 add_test(
   NAME velox_dwio_parquet_page_reader_test
   COMMAND velox_dwio_parquet_page_reader_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(
   velox_dwio_parquet_page_reader_test
@@ -65,7 +65,7 @@ add_executable(
 add_test(
   NAME velox_dwio_parquet_reader_test
   COMMAND velox_dwio_parquet_reader_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(
   velox_dwio_parquet_reader_test
@@ -78,7 +78,7 @@ add_executable(velox_dwio_parquet_structure_decoder_test NestedStructureDecoderT
 add_test(
   NAME velox_dwio_parquet_structure_decoder_test
   COMMAND velox_dwio_parquet_structure_decoder_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(
   velox_dwio_parquet_structure_decoder_test
@@ -101,7 +101,7 @@ add_executable(velox_dwio_parquet_table_scan_test ParquetTableScanTest.cpp)
 add_test(
   NAME velox_dwio_parquet_table_scan_test
   COMMAND velox_dwio_parquet_table_scan_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 target_link_libraries(
   velox_dwio_parquet_table_scan_test
@@ -120,7 +120,7 @@ if(${VELOX_ENABLE_ARROW})
   add_test(
     NAME velox_dwio_parquet_rlebp_decoder_test
     COMMAND velox_dwio_parquet_rlebp_decoder_test
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
   target_link_libraries(
     velox_dwio_parquet_rlebp_decoder_test

--- a/velox/dwio/parquet/tests/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/writer/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(velox_parquet_writer_sink_test SinkTests.cpp)
 add_test(
   NAME velox_parquet_writer_sink_test
   COMMAND velox_parquet_writer_sink_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -38,7 +38,7 @@ add_executable(velox_parquet_writer_test ParquetWriterFieldIdTest.cpp ParquetWri
 add_test(
   NAME velox_parquet_writer_test
   COMMAND velox_parquet_writer_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/dwio/text/tests/reader/CMakeLists.txt
+++ b/velox/dwio/text/tests/reader/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(velox_text_reader_test TextReaderTest.cpp)
 add_test(
   NAME velox_text_reader_test
   COMMAND velox_text_reader_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(velox_text_reader_test velox_dwio_text_reader_register ${TEST_LINK_LIBS})

--- a/velox/dwio/text/tests/writer/CMakeLists.txt
+++ b/velox/dwio/text/tests/writer/CMakeLists.txt
@@ -22,7 +22,7 @@ add_executable(
 add_test(
   NAME velox_text_writer_test
   COMMAND velox_text_writer_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/exec/prefixsort/tests/CMakeLists.txt
+++ b/velox/exec/prefixsort/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(velox_exec_prefixsort_test PrefixSortAlgorithmTest.cpp PrefixEnco
 add_test(
   NAME velox_exec_prefixsort_test
   COMMAND velox_exec_prefixsort_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_tests_properties(velox_exec_prefixsort_test PROPERTIES TIMEOUT 3000)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(
 add_test(
   NAME aggregate_companion_functions_test
   COMMAND aggregate_companion_functions_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -136,7 +136,7 @@ add_executable(
   TreeOfLosersTest.cpp
 )
 
-add_test(NAME velox_exec_test COMMAND velox_exec_test WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME velox_exec_test COMMAND velox_exec_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # TODO: Revert back to 3000 once is fixed.
 # https://github.com/facebookincubator/velox/issues/13879
@@ -145,7 +145,7 @@ set_tests_properties(velox_exec_test PROPERTIES TIMEOUT 6000)
 add_test(
   NAME velox_exec_infra_test
   COMMAND velox_exec_infra_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -293,7 +293,7 @@ target_link_libraries(
 add_test(
   NAME velox_table_evolution_fuzzer_test
   COMMAND velox_table_evolution_fuzzer_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_executable(velox_aggregation_runner_test AggregationRunnerTest.cpp)
@@ -392,7 +392,9 @@ add_executable(velox_driver_test OperatorReplacementTest.cpp Main.cpp)
 add_test(
   NAME velox_driver_test
   COMMAND velox_driver_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(velox_driver_test velox_exec velox_exec_test_lib GTest::gtest)
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -41,105 +41,105 @@ add_executable(velox_cudf_topn_test Main.cpp TopNTest.cpp)
 add_test(
   NAME velox_cudf_aggregation_test
   COMMAND velox_cudf_aggregation_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_assign_unique_id_test
   COMMAND velox_cudf_assign_unique_id_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_config_test
   COMMAND velox_cudf_config_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_expression_selection_test
   COMMAND velox_cudf_expression_selection_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_filter_project_test
   COMMAND velox_cudf_filter_project_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_hash_join_test
   COMMAND velox_cudf_hash_join_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_limit_test
   COMMAND velox_cudf_limit_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_local_partition_test
   COMMAND velox_cudf_local_partition_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_order_by_test
   COMMAND velox_cudf_order_by_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 if(VELOX_ENABLE_S3)
   add_test(
     NAME velox_cudf_s3_read_test
     COMMAND velox_cudf_s3_read_test
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   )
 endif()
 
 add_test(
   NAME velox_cudf_subfield_filter_ast_test
   COMMAND velox_cudf_subfield_filter_ast_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_table_scan_test
   COMMAND velox_cudf_table_scan_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 # add_test(
 #   NAME velox_cudf_table_write_test
 #   COMMAND velox_cudf_table_write_test
-#   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+#   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 # )
 
 add_test(
   NAME velox_cudf_topn_test
   COMMAND velox_cudf_topn_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_aggregation_selection_test
   COMMAND velox_cudf_aggregation_selection_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_tocudf_selection_test
   COMMAND velox_cudf_tocudf_selection_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_test(
   NAME velox_cudf_step_aware_aggregation_registry_test
   COMMAND velox_cudf_step_aware_aggregation_registry_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_tests_properties(velox_cudf_hash_join_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)

--- a/velox/experimental/cudf/tests/sparksql/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/sparksql/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(velox_cudf_spark_aggregates_test AggregationTest.cpp Main.cpp)
 add_test(
   NAME velox_cudf_spark_aggregates_test
   COMMAND velox_cudf_spark_aggregates_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_tests_properties(velox_cudf_spark_aggregates_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
@@ -42,7 +42,7 @@ add_executable(velox_cudf_spark_filter_project_test FilterProjectTest.cpp Main.c
 add_test(
   NAME velox_cudf_spark_filter_project_test
   COMMAND velox_cudf_spark_filter_project_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_tests_properties(

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -62,7 +62,7 @@ endif()
 add_test(
   NAME velox_expression_test
   COMMAND velox_expression_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/functions/iceberg/tests/CMakeLists.txt
+++ b/velox/functions/iceberg/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ add_executable(
 add_test(
   NAME velox_functions_iceberg_test
   COMMAND velox_functions_iceberg_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(
 add_test(
   NAME velox_functions_lib_test
   COMMAND velox_functions_lib_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -54,3 +54,5 @@ target_link_libraries(
   GTest::gtest_main
   GTest::gmock
 )
+
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -65,7 +65,7 @@ if(${VELOX_ENABLE_GEO})
   target_link_libraries(velox_aggregates_test velox_functions_geo)
 endif()
 
-add_test(NAME velox_aggregates_test COMMAND velox_aggregates_test WORKING_DIRECTORY .)
+add_test(NAME velox_aggregates_test COMMAND velox_aggregates_test)
 
 target_link_libraries(
   velox_aggregates_test

--- a/velox/functions/prestosql/window/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/window/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_WINDOW_TEST_MAIN_FILES Main.cpp)
 
 add_executable(velox_windows_rank_test NtileTest.cpp RankTest.cpp ${CMAKE_WINDOW_TEST_MAIN_FILES})
 
-add_test(NAME velox_windows_rank_test COMMAND velox_windows_rank_test WORKING_DIRECTORY .)
+add_test(NAME velox_windows_rank_test COMMAND velox_windows_rank_test)
 
 target_link_libraries(velox_windows_rank_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
 
@@ -40,12 +40,12 @@ add_executable(
   ${CMAKE_WINDOW_TEST_MAIN_FILES}
 )
 
-add_test(NAME velox_windows_value_test COMMAND velox_windows_value_test WORKING_DIRECTORY .)
+add_test(NAME velox_windows_value_test COMMAND velox_windows_value_test)
 
 target_link_libraries(velox_windows_value_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})
 
 add_executable(velox_windows_agg_test AggregateWindowTest.cpp ${CMAKE_WINDOW_TEST_MAIN_FILES})
 
-add_test(NAME velox_windows_agg_test COMMAND velox_windows_agg_test WORKING_DIRECTORY .)
+add_test(NAME velox_windows_agg_test COMMAND velox_windows_agg_test)
 
 target_link_libraries(velox_windows_agg_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})

--- a/velox/functions/sparksql/fuzzer/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/fuzzer/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(velox_spark_query_runner_test SparkQueryRunnerTest.cpp)
 add_test(
   NAME velox_spark_query_runner_test
   COMMAND velox_spark_query_runner_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/functions/sparksql/window/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/window/tests/CMakeLists.txt
@@ -29,6 +29,6 @@ set(CMAKE_WINDOW_TEST_MAIN_FILES Main.cpp)
 
 add_executable(velox_spark_windows_test SparkWindowTest.cpp ${CMAKE_WINDOW_TEST_MAIN_FILES})
 
-add_test(NAME velox_spark_windows_test COMMAND velox_spark_windows_test WORKING_DIRECTORY .)
+add_test(NAME velox_spark_windows_test COMMAND velox_spark_windows_test)
 
 target_link_libraries(velox_spark_windows_test ${CMAKE_WINDOW_TEST_LINK_LIBRARIES})

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(velox_key_encoder_test KeyEncoderTest.cpp)
 add_test(
   NAME velox_key_encoder_test
   COMMAND velox_key_encoder_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/tool/trace/tests/CMakeLists.txt
+++ b/velox/tool/trace/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(
 add_test(
   NAME velox_tool_trace_test
   COMMAND velox_tool_trace_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 set_tests_properties(velox_tool_trace_test PROPERTIES TIMEOUT 3000)

--- a/velox/type/fbhive/tests/CMakeLists.txt
+++ b/velox/type/fbhive/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(velox_type_fbhive_test HiveTypeParserTests.cpp)
 add_test(
   NAME velox_type_fbhive_test
   COMMAND velox_type_fbhive_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(
@@ -34,7 +34,7 @@ add_executable(velox_type_serializer_fbhive_test HiveTypeSerializerTests.cpp)
 add_test(
   NAME velox_type_serializer_fbhive_test
   COMMAND velox_type_serializer_fbhive_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(

--- a/velox/vector/fuzzer/tests/CMakeLists.txt
+++ b/velox/vector/fuzzer/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(velox_constrained_vector_generator_test ConstrainedVectorGenerato
 add_test(
   NAME velox_constrained_vector_generator_test
   COMMAND velox_constrained_vector_generator_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_link_libraries(


### PR DESCRIPTION
The CTest `WORKING_DIRECTORY` was set to `CMAKE_CURRENT_SOURCE_DIR`, baking absolute source paths into `CTestTestfile.cmake`. Tests fail with `'Failed to change working directory'` when run in environments where only the build directory exists.

This PR:
- Switches all `add_test()` `WORKING_DIRECTORY` from `CMAKE_CURRENT_SOURCE_DIR` to `CMAKE_CURRENT_BINARY_DIR`
- Adds `file(COPY)` for test data directories (`dwrf/test/examples`, `exec/tests/data`, `functions/lib/tests/data`) that were not already being copied to the build tree
- Removes redundant `WORKING_DIRECTORY .`, CTest defaults to the build directory

With these changes, test executables should be installable and runnable with no further reliance on the source tree.

(Note: This is in draft until I can run some further tests.)