### PR TITLE
feat: Add operator stats for IndexSource in query plan output

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -28,6 +28,90 @@ using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
 namespace {
+
+// Runtime stat names for IndexSource output tracking (rows before join filter).
+constexpr std::string_view kIndexSourceOutputPositions{
+    "indexSourceOutputPositions"};
+constexpr std::string_view kIndexSourceOutputBytes{"indexSourceOutputBytes"};
+constexpr std::string_view kIndexSourceOutputVectors{
+    "indexSourceOutputVectors"};
+
+// Runtime stat names for IndexSource input tracking (lookup keys sent to
+// connector).
+constexpr std::string_view kIndexSourceInputPositions{
+    "indexSourceInputPositions"};
+constexpr std::string_view kIndexSourceInputBytes{"indexSourceInputBytes"};
+
+/// Splits operator stats to provide separate entries for the IndexLookupJoin
+/// node and the IndexSource node. This ensures the IndexSource appears with its
+/// own operator stats in the query plan visualization, rather than being hidden
+/// inside the join operator.
+std::vector<OperatorStats> splitIndexLookupJoinStats(
+    const OperatorStats& combinedStats,
+    const core::PlanNodeId& indexSourceNodeId) {
+  // Create stats for the IndexSource node. These represent the lookup side
+  // of the join which is processed internally by IndexLookupJoin but should
+  // be reported as a separate plan node.
+  OperatorStats indexSourceStats;
+  indexSourceStats.operatorId = combinedStats.operatorId;
+  indexSourceStats.pipelineId = combinedStats.pipelineId;
+  indexSourceStats.planNodeId = indexSourceNodeId;
+  indexSourceStats.operatorType = "IndexSource";
+  indexSourceStats.numDrivers = combinedStats.numDrivers;
+
+  // The backgroundTiming contains the lookup time from the index source.
+  // Use this as the CPU/wall time for IndexSource.
+  indexSourceStats.addInputTiming = combinedStats.backgroundTiming;
+  indexSourceStats.getOutputTiming.count = combinedStats.backgroundTiming.count;
+
+  // Use the tracked IndexSource stats. These are stored as runtime stats so
+  // they aggregate correctly across multiple drivers.
+  auto getTrackedStat = [&](std::string_view name) -> uint64_t {
+    auto it = combinedStats.runtimeStats.find(std::string(name));
+    if (it != combinedStats.runtimeStats.end()) {
+      return static_cast<uint64_t>(it->second.sum);
+    }
+    return 0;
+  };
+
+  // Input stats (lookup keys sent to connector).
+  indexSourceStats.inputPositions = getTrackedStat(kIndexSourceInputPositions);
+  indexSourceStats.inputBytes = getTrackedStat(kIndexSourceInputBytes);
+
+  // Output stats (rows received from connector, before join filter).
+  indexSourceStats.outputPositions =
+      getTrackedStat(kIndexSourceOutputPositions);
+  indexSourceStats.outputBytes = getTrackedStat(kIndexSourceOutputBytes);
+  indexSourceStats.outputVectors = getTrackedStat(kIndexSourceOutputVectors);
+
+  // Copy runtime stats to IndexSource - these include connector lookup metrics.
+  // Remove the internal tracking stats that were only used for splitting.
+  indexSourceStats.runtimeStats = combinedStats.runtimeStats;
+  indexSourceStats.runtimeStats.erase(std::string(kIndexSourceInputPositions));
+  indexSourceStats.runtimeStats.erase(std::string(kIndexSourceInputBytes));
+  indexSourceStats.runtimeStats.erase(std::string(kIndexSourceOutputPositions));
+  indexSourceStats.runtimeStats.erase(std::string(kIndexSourceOutputBytes));
+  indexSourceStats.runtimeStats.erase(std::string(kIndexSourceOutputVectors));
+
+  // Create stats for the IndexLookupJoin node. This is the main join operator
+  // that receives probe input from the left side and performs the join logic.
+  auto joinStats = combinedStats;
+
+  // Clear backgroundTiming from join stats since it's now attributed to
+  // IndexSource. This avoids double counting when aggregating CPU/wall time
+  // across operators.
+  joinStats.backgroundTiming.clear();
+
+  // Remove the internal tracking stats that were only used for splitting.
+  joinStats.runtimeStats.erase(std::string(kIndexSourceInputPositions));
+  joinStats.runtimeStats.erase(std::string(kIndexSourceInputBytes));
+  joinStats.runtimeStats.erase(std::string(kIndexSourceOutputPositions));
+  joinStats.runtimeStats.erase(std::string(kIndexSourceOutputBytes));
+  joinStats.runtimeStats.erase(std::string(kIndexSourceOutputVectors));
+
+  return {std::move(joinStats), std::move(indexSourceStats)};
+}
+
 void duplicateJoinKeyCheck(
     const std::vector<core::FieldAccessTypedExprPtr>& keys) {
   folly::F14FastSet<std::string> lookupKeyNames;
@@ -220,6 +304,18 @@ IndexLookupJoin::IndexLookupJoin(
       joinNode_{joinNode} {
   duplicateJoinKeyCheck(joinNode_->leftKeys());
   duplicateJoinKeyCheck(joinNode_->rightKeys());
+
+  // Set up StatsSplitter to report separate operator stats for both
+  // IndexLookupJoin and IndexSource nodes. This must be done in the constructor
+  // (not initialize()) because operator stats are copied to task stats before
+  // initialize() is called.
+  folly::Synchronized<OperatorStats>& opStats = Operator::stats();
+  opStats.withWLock([&](auto& stats) {
+    stats.setStatSplitter(
+        [indexSourceId = indexSourceNodeId_](const auto& combinedStats) {
+          return splitIndexLookupJoinStats(combinedStats, indexSourceId);
+        });
+  });
 }
 
 void IndexLookupJoin::initialize() {
@@ -795,6 +891,22 @@ void IndexLookupJoin::startLookup(InputBatchState& batch) {
     return;
   }
 
+  // Track IndexSource input stats (lookup keys sent to connector). Store as
+  // runtime stats so they aggregate correctly across multiple drivers.
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kIndexSourceInputPositions,
+        RuntimeCounter(
+            static_cast<int64_t>(batch.lookupInput->size()),
+            RuntimeCounter::Unit::kNone));
+    lockedStats->addRuntimeStat(
+        kIndexSourceInputBytes,
+        RuntimeCounter(
+            static_cast<int64_t>(batch.lookupInput->estimateFlatSize()),
+            RuntimeCounter::Unit::kBytes));
+  }
+
   // Create the lookup result iterator.
   batch.lookupResultIter =
       indexSource_->lookup(connector::IndexSource::Request{batch.lookupInput});
@@ -858,6 +970,28 @@ RowVectorPtr IndexLookupJoin::produceRemainingOutput(InputBatchState& batch) {
 
 void IndexLookupJoin::prepareLookupResult(InputBatchState& batch) {
   VELOX_CHECK_NOT_NULL(batch.lookupResult);
+
+  // Track IndexSource output stats (rows received from connector, before join
+  // filter is applied). Store as runtime stats so they aggregate correctly
+  // across multiple drivers.
+  {
+    auto lockedStats = stats_.wlock();
+    lockedStats->addRuntimeStat(
+        kIndexSourceOutputPositions,
+        RuntimeCounter(
+            static_cast<int64_t>(batch.lookupResult->size()),
+            RuntimeCounter::Unit::kNone));
+    lockedStats->addRuntimeStat(
+        kIndexSourceOutputBytes,
+        RuntimeCounter(
+            static_cast<int64_t>(
+                batch.lookupResult->output->estimateFlatSize()),
+            RuntimeCounter::Unit::kBytes));
+    lockedStats->addRuntimeStat(
+        kIndexSourceOutputVectors,
+        RuntimeCounter(1, RuntimeCounter::Unit::kNone));
+  }
+
   if (rawLookupInputHitIndices_ != nullptr) {
     return;
   }

--- a/velox/exec/tests/IndexLookupJoinTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinTest.cpp
@@ -2858,11 +2858,22 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
       "SELECT u.c3, t.c5 FROM t, u WHERE t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2");
 
   auto taskStats = toPlanStats(task->taskStats());
+
+  // Check IndexSource stats - lookup timing should be here, not on join stats.
+  auto& indexSourceStats = taskStats.at(indexScanNodeId_);
+  ASSERT_EQ(indexSourceStats.addInputTiming.count, numProbeBatches);
+  ASSERT_GT(indexSourceStats.addInputTiming.cpuNanos, 0);
+  ASSERT_GT(indexSourceStats.addInputTiming.wallNanos, 0);
+
+  // Verify that backgroundTiming was cleared from join stats (moved to
+  // IndexSource to avoid double counting).
   auto& operatorStats = taskStats.at(joinNodeId_);
-  ASSERT_EQ(operatorStats.backgroundTiming.count, numProbeBatches);
-  ASSERT_GT(operatorStats.backgroundTiming.cpuNanos, 0);
-  ASSERT_GT(operatorStats.backgroundTiming.wallNanos, 0);
-  auto runtimeStats = operatorStats.customStats;
+  ASSERT_EQ(operatorStats.backgroundTiming.count, 0);
+  ASSERT_EQ(operatorStats.backgroundTiming.cpuNanos, 0);
+  ASSERT_EQ(operatorStats.backgroundTiming.wallNanos, 0);
+
+  // Check runtime stats are present on IndexSource.
+  auto runtimeStats = indexSourceStats.customStats;
   ASSERT_EQ(
       runtimeStats.at(std::string(IndexLookupJoin::kConnectorLookupWallTime))
           .count,
@@ -2903,15 +2914,229 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, runtimeStats) {
           std::string(IndexLookupJoin::kClientLookupResultRawSize)),
       0);
   ASSERT_THAT(
-      operatorStats.toString(true, true),
+      indexSourceStats.toString(true, true),
       testing::MatchesRegex(".*Runtime stats.*connectorLookupWallNanos:.*"));
   ASSERT_THAT(
-      operatorStats.toString(true, true),
+      indexSourceStats.toString(true, true),
       testing::MatchesRegex(".*Runtime stats.*clientlookupWaitWallNanos.*"));
   ASSERT_THAT(
-      operatorStats.toString(true, true),
+      indexSourceStats.toString(true, true),
       testing::MatchesRegex(
           ".*Runtime stats.*connectorResultPrepareCpuNanos.*"));
+}
+
+/// Verifies that IndexLookupJoin's StatsSplitter correctly reports separate
+/// operator stats for both the IndexLookupJoin node and the IndexSource node.
+/// This ensures IndexSource appears with its own CPU/Scheduled/Output stats
+/// in the query plan visualization.
+DEBUG_ONLY_TEST_P(IndexLookupJoinTest, statsSplitter) {
+  IndexTableData tableData;
+  generateIndexTableData({100, 1, 1}, tableData, pool_);
+  const int numProbeBatches{2};
+  const int batchSize{100};
+  const std::vector<RowVectorPtr> probeVectors = generateProbeInput(
+      numProbeBatches,
+      batchSize,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      GetParam().hasNullKeys,
+      {},
+      {},
+      100);
+  std::vector<std::shared_ptr<TempFilePath>> probeFiles =
+      createProbeFiles(probeVectors);
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", {tableData.tableVectors});
+
+  // Add a small delay in async lookup to ensure timing stats are captured.
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::test::TestIndexSource::ResultIterator::asyncLookup",
+      std::function<void(void*)>([&](void*) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
+      }));
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, GetParam().needsIndexSplit);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+      makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+  auto plan = makeLookupPlan(
+      planNodeIdGenerator,
+      indexScanNode,
+      {"t0", "t1", "t2"},
+      {"u0", "u1", "u2"},
+      {},
+      /*filter=*/"",
+      /*hasMarker=*/false,
+      core::JoinType::kInner,
+      {"u3", "t5"});
+  auto task = runLookupQuery(
+      plan,
+      probeFiles,
+      GetParam().serialExecution,
+      GetParam().serialExecution,
+      100,
+      0,
+      GetParam().needsIndexSplit,
+      "SELECT u.c3, t.c5 FROM t, u WHERE t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2");
+
+  auto taskStats = toPlanStats(task->taskStats());
+
+  // Verify that both the IndexLookupJoin node and IndexSource node have stats.
+  ASSERT_TRUE(taskStats.count(joinNodeId_) > 0)
+      << "IndexLookupJoin node stats missing";
+  ASSERT_TRUE(taskStats.count(indexScanNodeId_) > 0)
+      << "IndexSource node stats missing";
+
+  const auto& joinStats = taskStats.at(joinNodeId_);
+  const auto& indexSourceStats = taskStats.at(indexScanNodeId_);
+
+  // Verify join stats have input from probe side.
+  EXPECT_GT(joinStats.inputRows, 0);
+  EXPECT_GT(joinStats.outputRows, 0);
+
+  // Verify IndexSource stats have output positions (the lookup results).
+  EXPECT_GT(indexSourceStats.outputRows, 0);
+  EXPECT_EQ(indexSourceStats.outputRows, joinStats.outputRows);
+
+  // Verify IndexSource stats have input positions (lookup keys sent to
+  // connector).
+  EXPECT_GT(indexSourceStats.inputRows, 0);
+  EXPECT_GT(indexSourceStats.inputBytes, 0);
+  // For inner join without filter, input rows should match join input rows
+  // (all probe rows are sent as lookup keys).
+  EXPECT_EQ(indexSourceStats.inputRows, joinStats.inputRows);
+
+  // Verify IndexSource stats have timing from backgroundTiming (lookup time).
+  // The addInputTiming should contain the lookup wall/cpu time.
+  EXPECT_GT(indexSourceStats.addInputTiming.count, 0);
+
+  // Verify runtime stats are present on IndexSource (connector metrics).
+  // These include connector lookup wall time, etc.
+  EXPECT_TRUE(
+      indexSourceStats.customStats.count(
+          std::string(IndexLookupJoin::kConnectorLookupWallTime)) > 0)
+      << "IndexSource should have connector lookup wall time";
+  EXPECT_GT(
+      indexSourceStats.customStats
+          .at(std::string(IndexLookupJoin::kConnectorLookupWallTime))
+          .sum,
+      0);
+
+  // Verify that backgroundTiming was cleared from join stats (moved to
+  // IndexSource to avoid double counting).
+  EXPECT_EQ(joinStats.backgroundTiming.count, 0);
+  EXPECT_EQ(joinStats.backgroundTiming.cpuNanos, 0);
+  EXPECT_EQ(joinStats.backgroundTiming.wallNanos, 0);
+}
+
+/// Verifies that IndexSource stats report rows BEFORE the join filter is
+/// applied, while IndexLookupJoin stats report rows AFTER the filter.
+DEBUG_ONLY_TEST_P(IndexLookupJoinTest, statsSplitterWithFilter) {
+  // Skip serial execution tests for simplicity - the stats behavior is the
+  // same.
+  if (GetParam().serialExecution || GetParam().hasNullKeys) {
+    return;
+  }
+
+  IndexTableData tableData;
+  generateIndexTableData({100, 1, 1}, tableData, pool_);
+  const int numProbeBatches{2};
+  const int batchSize{100};
+  const std::vector<RowVectorPtr> probeVectors = generateProbeInput(
+      numProbeBatches,
+      batchSize,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      /*hasNullKeys=*/false,
+      {},
+      {},
+      100);
+  std::vector<std::shared_ptr<TempFilePath>> probeFiles =
+      createProbeFiles(probeVectors);
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", {tableData.tableVectors});
+
+  // Add a small delay in async lookup to ensure timing stats are captured.
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::test::TestIndexSource::ResultIterator::asyncLookup",
+      std::function<void(void*)>([&](void*) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
+      }));
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, GetParam().needsIndexSplit);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+      makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+  // Add a filter that should filter out approximately half the rows.
+  // The filter "u3 % 2 = 0" will keep only even values of u3.
+  auto plan = makeLookupPlan(
+      planNodeIdGenerator,
+      indexScanNode,
+      {"t0", "t1", "t2"},
+      {"u0", "u1", "u2"},
+      {},
+      /*filter=*/"u3 % 2 = 0",
+      /*hasMarker=*/false,
+      core::JoinType::kInner,
+      {"u3", "t5"});
+  auto task = runLookupQuery(
+      plan,
+      probeFiles,
+      GetParam().serialExecution,
+      GetParam().serialExecution,
+      100,
+      0,
+      GetParam().needsIndexSplit,
+      "SELECT u.c3, t.c5 FROM t, u WHERE t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2 AND u.c3 % 2 = 0");
+
+  auto taskStats = toPlanStats(task->taskStats());
+
+  // Verify that both the IndexLookupJoin node and IndexSource node have stats.
+  ASSERT_TRUE(taskStats.count(joinNodeId_) > 0)
+      << "IndexLookupJoin node stats missing";
+  ASSERT_TRUE(taskStats.count(indexScanNodeId_) > 0)
+      << "IndexSource node stats missing";
+
+  const auto& joinStats = taskStats.at(joinNodeId_);
+  const auto& indexSourceStats = taskStats.at(indexScanNodeId_);
+
+  // Verify join stats have input from probe side.
+  EXPECT_GT(joinStats.inputRows, 0);
+  EXPECT_GT(joinStats.outputRows, 0);
+
+  // Verify IndexSource stats have output positions (rows before filter).
+  EXPECT_GT(indexSourceStats.outputRows, 0);
+
+  // KEY ASSERTION: IndexSource should have MORE rows than IndexLookupJoin
+  // because IndexSource reports rows BEFORE the filter ("u3 % 2 = 0") is
+  // applied.
+  EXPECT_GT(indexSourceStats.outputRows, joinStats.outputRows)
+      << "IndexSource should report more rows (before filter) than "
+      << "IndexLookupJoin (after filter)";
 }
 
 TEST_P(IndexLookupJoinTest, DISABLED_barrier) {


### PR DESCRIPTION
Summary:
IndexSource appears in Presto query plans but has no operator stats (CPU, Scheduled, Output rows) because it's embedded inside the IndexLookupJoin operator in Velox rather than being a separate operator.

This change uses the existing StatsSplitter mechanism (same pattern as FilterProject) to split operator stats between the IndexLookupJoin node and the IndexSource node. This ensures IndexSource appears with its own operator stats in the query plan visualization.

**Before:**
```
- InnerJoinIndexJoin[PlanNodeId 545]
    CPU: 8.23s (0.98%), Scheduled: 3.83m (9.24%), Output: 2,367 rows
- IndexSource[PlanNodeId 544]
    (no CPU/Scheduled/Output stats - only column mappings)
```

**After:**
```
- InnerJoinIndexJoin[PlanNodeId 545]
    CPU: Xs (Y%), Scheduled: Zs (W%), Output: 2,367 rows
- IndexSource[PlanNodeId 544]
    CPU: Xs (Y%), Scheduled: Zs (W%), Output: 2,367 rows  <- NOW HAS STATS
```

Differential Revision: D95315155


