### PR TITLE
fix(cudf): Extract filters from remainingFilter for predicate pushdown

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSource.cpp
@@ -102,17 +102,26 @@ CudfHiveDataSource::CudfHiveDataSource(
   // Copy subfield filters
   for (const auto& [k, v] : tableHandle_->subfieldFilters()) {
     subfieldFilters_.emplace(k.clone(), v->clone());
-    // Add fields in the filter to the columns to read if not there
-    for (const auto& [field, _] : subfieldFilters_) {
-      if (readColumnSet_.count(field.toString()) == 0) {
-        readColumnSet_.emplace(field.toString());
-        readColumnNames_.emplace_back(field.toString());
-      }
-    }
   }
 
-  // Create remaining filter
-  auto remainingFilter = tableHandle_->remainingFilter();
+  // Extract additional simple filters from remainingFilter (same as CPU path).
+  // This extracts single-column filters like "col = 'X'" or "col <> 'Y'" from
+  // complex expressions and adds them to subfieldFilters_ for pushdown.
+  double sampleRate = 1.0;
+  auto remainingFilter =
+      facebook::velox::connector::hive::extractFiltersFromRemainingFilter(
+          tableHandle_->remainingFilter(),
+          expressionEvaluator_,
+          subfieldFilters_,
+          sampleRate);
+
+  // Add fields in the filter to the columns to read if not there
+  for (const auto& [field, _] : subfieldFilters_) {
+    if (readColumnSet_.count(field.toString()) == 0) {
+      readColumnSet_.emplace(field.toString());
+      readColumnNames_.emplace_back(field.toString());
+    }
+  }
   if (remainingFilter) {
     remainingFilterExprSet_ = expressionEvaluator_->compile(remainingFilter);
     for (const auto& field : remainingFilterExprSet_->distinctFields()) {

--- a/velox/experimental/cudf/tests/TableScanTest.cpp
+++ b/velox/experimental/cudf/tests/TableScanTest.cpp
@@ -563,3 +563,42 @@ TEST_F(TableScanTest, splitOffsetAndLength) {
       makeCudfHiveConnectorSplit(filePath->getPath(), fileSize),
       "SELECT * FROM tmp LIMIT 0");
 }
+
+// Verify that extractFiltersFromRemainingFilter extracts simple single-column
+// filters from the remaining filter into subfield filters for pushdown.
+// When a filter like "c0 = 1" is fully extracted, remainingFilterExprSet_ is
+// null and totalRemainingFilterWallNanos is 0. Without extraction, the filter
+// runs post-read on the GPU and the stat is > 0.
+TEST_F(TableScanTest, remainingFilterExtraction) {
+  auto rowType = ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(5, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->getPath(), vectors, "c");
+  createDuckDbTable(vectors);
+
+  auto assignments =
+      facebook::velox::exec::test::HiveConnectorTestBase::allRegularColumns(
+          rowType);
+
+  // "c0 = 1" is a single-column equality that should be fully extracted into
+  // a subfield filter, leaving no remaining filter to evaluate post-read.
+  auto plan = PlanBuilder(pool_.get())
+                  .startTableScan()
+                  .connectorId(kCudfHiveConnectorId)
+                  .outputType(rowType)
+                  .dataColumns(rowType)
+                  .assignments(assignments)
+                  .remainingFilter("c0 = 1")
+                  .endTableScan()
+                  .planNode();
+
+  auto task = assertQuery(plan, {filePath}, "SELECT * FROM tmp WHERE c0 = 1");
+
+  // Verify the filter was fully extracted: no post-read remaining filter ran.
+  auto planStats = toPlanStats(task->taskStats());
+  const auto& scanStats = planStats.at(plan->id());
+  auto it = scanStats.customStats.find("totalRemainingFilterWallNanos");
+  ASSERT_NE(it, scanStats.customStats.end());
+  EXPECT_EQ(it->second.sum, 0)
+      << "Expected no remaining filter time when filter is fully extracted";
+}


### PR DESCRIPTION
The CPU HiveDataSource calls extractFiltersFromRemainingFilter() to extract simple single-column filters from complex expressions, but CudfHiveDataSource was missing this call. This caused the GPU path to read significantly more data than necessary.

This fix adds the extractFiltersFromRemainingFilter() call to match the CPU path behavior. Simple filters like equality (`col = 'X'`) and not-equal (`col <> 'Y'`) can now be extracted from complex expressions and pushed down to the cuDF Parquet reader.