### PR TITLE
misc: Prepare for time type extension

### DIFF
--- a/velox/common/fuzzer/ConstrainedGenerators.h
+++ b/velox/common/fuzzer/ConstrainedGenerators.h
@@ -63,6 +63,7 @@ class RandomInputGenerator : public AbstractInputGenerator {
       return variant(randDate(rng_));
     }
     if (type_->isTime()) {
+      VELOX_DCHECK(type_->equivalent(*TIME()));
       return variant(randTime(rng_));
     }
     return variant(rand<T>(rng_));

--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -80,6 +80,7 @@ LogicalType fromVeloxType(const TypePtr& type) {
         return LogicalType::INTERVAL;
       }
       if (type->isTime()) {
+        VELOX_DCHECK(type->equivalent(*TIME()));
         return LogicalType::TIME;
       }
       return LogicalType::BIGINT;

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -133,6 +133,7 @@ template <>
   }
 
   if (type->isTime()) {
+    VELOX_DCHECK(type->equivalent(*TIME()));
     // TIME is stored as milliseconds since midnight in Velox.
     // DuckDB TIME is stored as microseconds since midnight.
     const auto timeMillis = vector->as<SimpleVector<int64_t>>()->valueAt(index);
@@ -457,6 +458,7 @@ std::vector<MaterializedRow> materialize(
                 dataChunk->GetValue(j, i).GetValue<::duckdb::date_t>()));
         row.push_back(value);
       } else if (type->isTime()) {
+        VELOX_DCHECK(type->equivalent(*TIME()));
         // DuckDB TIME is in microseconds, Velox TIME is in milliseconds.
         auto value = variant(
             dataChunk->GetValue(j, i).GetValue<::duckdb::dtime_t>().micros /

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -844,8 +844,10 @@ void CastExpr::applyPeeled(
         fromType->toString(),
         toType->toString());
   } else if (fromType->isTime()) {
+    VELOX_DCHECK(fromType->equivalent(*TIME()));
     result = castFromTime(rows, input, context, toType);
   } else if (toType->isTime()) {
+    VELOX_DCHECK(toType->equivalent(*TIME()));
     result = castToTime(rows, input, context, fromType);
   } else if (toType->isShortDecimal()) {
     result = applyDecimal<int64_t>(rows, input, context, fromType, toType);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -602,6 +602,7 @@ class TimeIntervalYearMonthVectorFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     VectorPtr& timeVector = args[0]->type()->isTime() ? args[0] : args[1];
+    VELOX_DCHECK(timeVector->type()->equivalent(*TIME()));
 
     // Constant vector case
     // If time input is constant, create constant result - no iteration!

--- a/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
@@ -160,7 +160,7 @@ class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
   bool isSupportedFromType(const TypePtr& other) const override {
     switch (other->kind()) {
       case TypeKind::BIGINT:
-        return other->isTime();
+        return other->equivalent(*TIME());
       case TypeKind::VARCHAR:
         return true;
       default:
@@ -171,7 +171,7 @@ class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
   bool isSupportedToType(const TypePtr& other) const override {
     switch (other->kind()) {
       case TypeKind::BIGINT:
-        return other->isTime();
+        return other->equivalent(*TIME());
       case TypeKind::VARCHAR:
         return true;
       default:
@@ -193,7 +193,7 @@ class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
       return;
     }
 
-    if (input.type()->isTime()) {
+    if (input.type()->equivalent(*TIME())) {
       const auto& config = context.execCtx()->queryCtx()->queryConfig();
       const auto* sessionTimeZone = getTimeZoneFromConfig(config);
       const auto sessionStartTimeMs = config.sessionStartTimeMs();
@@ -246,7 +246,7 @@ class TimeWithTimeZoneCastOperator final : public exec::CastOperator {
 
     switch (resultType->kind()) {
       case TypeKind::BIGINT:
-        if (resultType->isTime()) {
+        if (resultType->equivalent(*TIME())) {
           castToTime(input, context, rows, *result);
           return;
         }

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -256,7 +256,7 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
       case TypeKind::INTEGER:
         return other->isDate();
       case TypeKind::BIGINT:
-        return other->isTime();
+        return other->equivalent(*TIME());
       default:
         return false;
     }
@@ -271,7 +271,7 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
       case TypeKind::INTEGER:
         return other->isDate();
       case TypeKind::BIGINT:
-        return other->isTime();
+        return other->equivalent(*TIME());
       default:
         return false;
     }
@@ -285,7 +285,8 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
       VectorPtr& result) const override {
     context.ensureWritable(rows, resultType, result);
 
-    if (input.typeKind() == TypeKind::BIGINT && input.type()->isTime()) {
+    if (input.typeKind() == TypeKind::BIGINT &&
+        input.type()->equivalent(*TIME())) {
       const auto& config = context.execCtx()->queryCtx()->queryConfig();
       const auto* sessionTimeZone = getTimeZoneFromConfig(config);
       const auto sessionStartTimeMs = config.sessionStartTimeMs();
@@ -368,7 +369,7 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
       VELOX_CHECK(resultType->isDate());
       castToDate(input, context, rows, *result);
     } else if (resultType->kind() == TypeKind::BIGINT) {
-      VELOX_CHECK(resultType->isTime());
+      VELOX_CHECK(resultType->equivalent(*TIME()));
       castToTime(input, context, rows, *result);
     } else {
       VELOX_UNSUPPORTED(

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -294,6 +294,7 @@ const char* exportArrowFormatStr(
       return "i"; // int32
     case TypeKind::BIGINT:
       if (type->isTime()) {
+        VELOX_DCHECK(type->equivalent(*TIME()));
         // TIME is stored as milliseconds since midnight in Velox.
         // Export as Arrow time32 with milliseconds unit.
         return "ttm";
@@ -728,12 +729,16 @@ bool isFlatScalarZeroCopy(const TypePtr& type, const ArrowOptions& options) {
   // - Velox's Timestamp representation (2x 64bit values) does not have an
   // equivalent in Arrow.
   // - Velox's TIME is in milliseconds, Arrow time64 is in microseconds.
+  bool isTime = type->isTime();
+  if (isTime) {
+    VELOX_DCHECK(type->equivalent(*TIME()));
+  }
   if (options.useDecimalTypeWidth) {
     // Short decimal is zero-copy.
-    return !type->isTimestamp() && !type->isTime();
+    return !type->isTimestamp() && !isTime;
   }
   // Short decimal requires conversion.
-  return !type->isShortDecimal() && !type->isTimestamp() && !type->isTime();
+  return !type->isShortDecimal() && !type->isTimestamp() && !isTime;
 }
 
 // Returns the size of a single element of a given `type` in the target arrow
@@ -744,6 +749,7 @@ size_t getArrowElementSize(const TypePtr& type, const ArrowOptions& options) {
   } else if (type->isTimestamp()) {
     return sizeof(int64_t);
   } else if (type->isTime()) {
+    VELOX_DCHECK(type->equivalent(*TIME()));
     // TIME is exported as Arrow time32 (int32_t).
     return sizeof(int32_t);
   }
@@ -778,6 +784,7 @@ void exportValues(
   if (type->kind() == TypeKind::TIMESTAMP) {
     gatherFromTimestampBuffer(vec, rows, options.timestampUnit, *values);
   } else if (type->kind() == TypeKind::BIGINT && type->isTime()) {
+    VELOX_DCHECK(type->equivalent(*TIME()));
     gatherFromTimeBuffer(vec, rows, *values);
   } else {
     gatherFromBuffer(*type, *vec.values(), rows, options, *values);
@@ -2256,6 +2263,7 @@ VectorPtr importFromArrowImpl(
         arrowArray.length,
         arrowArray.null_count);
   } else if (type->isTime()) {
+    VELOX_DCHECK(type->equivalent(*TIME()));
     auto timeUnit = getTimeUnit(arrowSchema);
     bool isTime32 =
         (timeUnit == TimeUnit::kSecond || timeUnit == TimeUnit::kMilli);

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -141,6 +141,7 @@ VectorPtr fuzzConstantPrimitiveImpl(
     return std::make_shared<ConstantVector<int128_t>>(
         pool, size, false, type, randLongDecimal(type, rng));
   } else if (type->isTime()) {
+    VELOX_DCHECK(type->equivalent(*TIME()));
     return std::make_shared<ConstantVector<int64_t>>(
         pool, size, false, type, randTime(rng));
   } else {
@@ -177,6 +178,7 @@ void fuzzFlatPrimitiveImpl(
       } else if (vector->type()->isShortDecimal()) {
         flatVector->set(i, randShortDecimal(vector->type(), rng));
       } else if (vector->type()->isTime()) {
+        VELOX_DCHECK(vector->type()->equivalent(*TIME()));
         flatVector->set(i, randTime(rng));
       } else {
         flatVector->set(i, rand<TCpp>(rng, opts.dataSpec));

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -695,7 +695,7 @@ TEST_F(VectorFuzzerTest, time) {
   // Test flat TIME vector.
   auto timeVector = fuzzer.fuzzFlat(TIME());
   ASSERT_EQ(VectorEncoding::Simple::FLAT, timeVector->encoding());
-  ASSERT_TRUE(timeVector->type()->isTime());
+  ASSERT_TRUE(timeVector->type()->equivalent(*TIME()));
   ASSERT_EQ(vectorSize, timeVector->size());
 
   auto flatTimeVector = timeVector->as<FlatVector<int64_t>>();
@@ -704,7 +704,7 @@ TEST_F(VectorFuzzerTest, time) {
   // Test constant TIME vector.
   auto constTimeVector = fuzzer.fuzzConstant(TIME(), vectorSize);
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, constTimeVector->encoding());
-  ASSERT_TRUE(constTimeVector->type()->isTime());
+  ASSERT_TRUE(constTimeVector->type()->equivalent(*TIME()));
   ASSERT_EQ(vectorSize, constTimeVector->size());
 
   // Verify constant TIME value is in valid range.
@@ -719,7 +719,7 @@ TEST_F(VectorFuzzerTest, time) {
   auto dictTimeVector =
       fuzzer.fuzzDictionary(fuzzer.fuzzFlat(TIME(), 100), 500);
   ASSERT_EQ(VectorEncoding::Simple::DICTIONARY, dictTimeVector->encoding());
-  ASSERT_TRUE(dictTimeVector->type()->isTime());
+  ASSERT_TRUE(dictTimeVector->type()->equivalent(*TIME()));
 
   // Verify all TIME values in dictionary are in valid range.
   auto dictVector = dictTimeVector->as<DictionaryVector<int64_t>>();


### PR DESCRIPTION
Preparation for extending the time type to support additional precisions and 
timezone behaviors. Add TIME type checks to ensure existing functionality 
remains unaffected until it is adapted to support other time types.

TODOs: https://github.com/facebookincubator/velox/issues/16660.