### PR TITLE
refactor: Remove VELOX_ENABLE_BACKWARD_COMPATIBILITY shim for filterPushdownEnabled in HiveTableHandle

### DIFF
--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -185,30 +185,6 @@ class HiveTableHandle : public ConnectorTableHandle {
       std::vector<HiveColumnHandlePtr> filterColumnHandles,
       double sampleRate = 1.0);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  /// Backward-compatible constructors that accept and ignore the deprecated
-  /// 'filterPushdownEnabled' param.
-  HiveTableHandle(
-      std::string connectorId,
-      const std::string& tableName,
-      bool /*filterPushdownEnabled*/,
-      common::SubfieldFilters subfieldFilters,
-      const core::TypedExprPtr& remainingFilter,
-      const RowTypePtr& dataColumns = nullptr,
-      const std::unordered_map<std::string, std::string>& tableParameters = {},
-      std::vector<HiveColumnHandlePtr> filterColumnHandles = {},
-      double sampleRate = 1.0)
-      : HiveTableHandle(
-            std::move(connectorId),
-            tableName,
-            std::move(subfieldFilters),
-            remainingFilter,
-            dataColumns,
-            tableParameters,
-            std::move(filterColumnHandles),
-            sampleRate) {}
-#endif
-
   const std::string& tableName() const {
     return tableName_;
   }


### PR DESCRIPTION
Summary:
Remove the backward-compatible constructor guarded by
`VELOX_ENABLE_BACKWARD_COMPATIBILITY` that accepted and ignored the deprecated
`filterPushdownEnabled` parameter. This was added in the parent diff to give
OSS callers (e.g. Gluten) time to update, but can be removed once they have.

Differential Revision: D94836653


