### PR TITLE
fix(cudf): Set functionEngine to spark in ExpressionEvaluatorSelection test

### DIFF
--- a/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
+++ b/velox/experimental/cudf/tests/ExpressionEvaluatorSelectionTest.cpp
@@ -48,6 +48,7 @@ class CudfExpressionSelectionTest : public ::testing::Test {
     pool_ = memory::memoryManager()->addLeafPool("", false);
     queryCtx_ = core::QueryCtx::create();
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
+    CudfConfig::getInstance().functionEngine = "spark";
     cudf_velox::registerCudf();
     rowType_ = ROW({
         {"a", BIGINT()},


### PR DESCRIPTION
## Description

This PR fixes the failing `signatureVarargsHashWithSeed` test in `CudfExpressionSelection` suite by registering the `hash_with_seed` function. This function is no longer registered by default; rather it is available when the cuDF function engine is set to `spark`.