### PR TITLE
misc: Fix typo `duckDbVefifySql` in test parameter

### DIFF
--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
@@ -421,13 +421,13 @@ bool IndexLookupJoinTestBase::isFilter(const std::string& conditionSql) const {
 std::shared_ptr<Task> IndexLookupJoinTestBase::runLookupQuery(
     const PlanNodePtr& plan,
     int numPrefetchBatches,
-    const std::string& duckDbVefifySql) {
+    const std::string& duckDbVerifySql) {
   return AssertQueryBuilder(duckDbQueryRunner_)
       .plan(plan)
       .config(
           QueryConfig::kIndexLookupJoinMaxPrefetchBatches,
           std::to_string(numPrefetchBatches))
-      .assertResults(duckDbVefifySql);
+      .assertResults(duckDbVerifySql);
 }
 
 std::shared_ptr<Task> IndexLookupJoinTestBase::runLookupQuery(
@@ -438,7 +438,7 @@ std::shared_ptr<Task> IndexLookupJoinTestBase::runLookupQuery(
     int maxOutputRows,
     int numPrefetchBatches,
     bool needsIndexSplit,
-    const std::string& duckDbVefifySql) {
+    const std::string& duckDbVerifySql) {
   AssertQueryBuilder queryBuilder(duckDbQueryRunner_);
   queryBuilder.plan(plan)
       .splits(probeScanNodeId_, makeHiveConnectorSplits(probeFiles))
@@ -458,7 +458,7 @@ std::shared_ptr<Task> IndexLookupJoinTestBase::runLookupQuery(
             std::make_shared<TestIndexConnectorSplit>(
                 kTestIndexConnectorName)));
   }
-  return queryBuilder.assertResults(duckDbVefifySql);
+  return queryBuilder.assertResults(duckDbVerifySql);
 }
 
 void IndexLookupJoinTestBase::verifyResultWithMatchColumn(

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -165,7 +165,7 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
   std::shared_ptr<Task> runLookupQuery(
       const PlanNodePtr& plan,
       int numPrefetchBatches,
-      const std::string& duckDbVefifySql);
+      const std::string& duckDbVerifySql);
 
   std::shared_ptr<Task> runLookupQuery(
       const PlanNodePtr& plan,
@@ -175,7 +175,7 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
       int maxBatchRows,
       int numPrefetchBatches,
       bool needsIndexSplit,
-      const std::string& duckDbVefifySql);
+      const std::string& duckDbVerifySql);
 
   /// Verifies the results of the index lookup join query with and without match
   /// column.


### PR DESCRIPTION
Summary: Fix typos in test parameter names across multiple files by renaming `duckDbVefifySql` → `duckDbVerifySql`.

Differential Revision: D95618384


