### PR TITLE
misc: Move folly/Hash.h include from Type.h to Type.cpp

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -19,7 +19,6 @@
 #include <boost/algorithm/string.hpp>
 #include <fmt/format.h>
 #include <folly/Demangle.h>
-#include <folly/Hash.h>
 #include <re2/re2.h>
 
 #include <sstream>


### PR DESCRIPTION
## Summary

  `Type.h` is one of the most widely included headers in the Velox codebase (200+ downstream files). It included `folly/Hash.h`, which expands to preprocessed lines, but `folly::Hash{}` is only used in `Type.cpp`. This PR moves the include to `Type.cpp` where it actually belongs, following the include-what-you-use (IWYU) principle.

  Only 3 other files in the codebase directly include `folly/Hash.h`, so this eliminates ~76K preprocessed lines from ~205 translation units.

  ## Test plan

  - Full debug build passes (no compilation errors) on CI
