### PR TITLE
refactor: Rename footerEstimatedSize to footerSpeculativeIoSize in ReaderOptions

### DIFF
--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -644,20 +644,20 @@ void configureReaderOptions(
   switch (hiveSplit->fileFormat) {
     case dwio::common::FileFormat::DWRF:
     case dwio::common::FileFormat::ORC:
-      readerOptions.setFooterEstimatedSize(
+      readerOptions.setFooterSpeculativeIoSize(
           hiveConfig->orcFooterSpeculativeIoSize(sessionProperties));
       break;
     case dwio::common::FileFormat::PARQUET:
-      readerOptions.setFooterEstimatedSize(
+      readerOptions.setFooterSpeculativeIoSize(
           hiveConfig->parquetFooterSpeculativeIoSize(sessionProperties));
       break;
     case dwio::common::FileFormat::NIMBLE:
-      readerOptions.setFooterEstimatedSize(
+      readerOptions.setFooterSpeculativeIoSize(
           hiveConfig->nimbleFooterSpeculativeIoSize(sessionProperties));
       break;
     default:
       // Use ORC default for unknown formats.
-      readerOptions.setFooterEstimatedSize(
+      readerOptions.setFooterSpeculativeIoSize(
           hiveConfig->orcFooterSpeculativeIoSize(sessionProperties));
       break;
   }

--- a/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorUtilTest.cpp
@@ -279,7 +279,7 @@ TEST_F(HiveConnectorUtilTest, configureReaderOptions) {
       readerOptions.fileColumnNamesReadAsLowerCase(),
       hiveConfig->isFileColumnNamesReadAsLowerCase(&sessionProperties));
   EXPECT_EQ(
-      readerOptions.footerEstimatedSize(),
+      readerOptions.footerSpeculativeIoSize(),
       hiveConfig->orcFooterSpeculativeIoSize(&sessionProperties));
   EXPECT_EQ(
       readerOptions.filePreloadThreshold(), hiveConfig->filePreloadThreshold());
@@ -357,9 +357,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
     configureReaderOptions(
         hiveConfig, connectorQueryCtx.get(), tableHandle, split, readerOptions);
     EXPECT_EQ(
-        readerOptions.footerEstimatedSize(),
+        readerOptions.footerSpeculativeIoSize(),
         hiveConfig->orcFooterSpeculativeIoSize(&sessionProperties));
-    EXPECT_EQ(readerOptions.footerEstimatedSize(), 1111);
+    EXPECT_EQ(readerOptions.footerSpeculativeIoSize(), 1111);
   }
 
   // Test DWRF format (uses ORC config).
@@ -370,9 +370,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
     configureReaderOptions(
         hiveConfig, connectorQueryCtx.get(), tableHandle, split, readerOptions);
     EXPECT_EQ(
-        readerOptions.footerEstimatedSize(),
+        readerOptions.footerSpeculativeIoSize(),
         hiveConfig->orcFooterSpeculativeIoSize(&sessionProperties));
-    EXPECT_EQ(readerOptions.footerEstimatedSize(), 1111);
+    EXPECT_EQ(readerOptions.footerSpeculativeIoSize(), 1111);
   }
 
   // Test Parquet format.
@@ -383,9 +383,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
     configureReaderOptions(
         hiveConfig, connectorQueryCtx.get(), tableHandle, split, readerOptions);
     EXPECT_EQ(
-        readerOptions.footerEstimatedSize(),
+        readerOptions.footerSpeculativeIoSize(),
         hiveConfig->parquetFooterSpeculativeIoSize(&sessionProperties));
-    EXPECT_EQ(readerOptions.footerEstimatedSize(), 2222);
+    EXPECT_EQ(readerOptions.footerSpeculativeIoSize(), 2222);
   }
 
   // Test Nimble format.
@@ -396,9 +396,9 @@ TEST_F(HiveConnectorUtilTest, footerSpeculativeIoSizeByFormat) {
     configureReaderOptions(
         hiveConfig, connectorQueryCtx.get(), tableHandle, split, readerOptions);
     EXPECT_EQ(
-        readerOptions.footerEstimatedSize(),
+        readerOptions.footerSpeculativeIoSize(),
         hiveConfig->nimbleFooterSpeculativeIoSize(&sessionProperties));
-    EXPECT_EQ(readerOptions.footerEstimatedSize(), 3333);
+    EXPECT_EQ(readerOptions.footerSpeculativeIoSize(), 3333);
   }
 }
 

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -554,7 +554,11 @@ class RowReaderOptions {
 /// Options for creating a Reader.
 class ReaderOptions : public io::ReaderOptions {
  public:
-  static constexpr uint64_t kDefaultFooterEstimatedSize = 1024 * 1024; // 1MB
+  static constexpr uint64_t kDefaultFooterSpeculativeIoSize =
+      1024 * 1024; // 1MB
+  /// @deprecated Use kDefaultFooterSpeculativeIoSize instead.
+  static constexpr uint64_t kDefaultFooterEstimatedSize =
+      kDefaultFooterSpeculativeIoSize;
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
 
@@ -606,9 +610,14 @@ class ReaderOptions : public io::ReaderOptions {
     return *this;
   }
 
-  ReaderOptions& setFooterEstimatedSize(uint64_t size) {
-    footerEstimatedSize_ = size;
+  ReaderOptions& setFooterSpeculativeIoSize(uint64_t size) {
+    footerSpeculativeIoSize_ = size;
     return *this;
+  }
+
+  /// @deprecated Use setFooterSpeculativeIoSize instead.
+  ReaderOptions& setFooterEstimatedSize(uint64_t size) {
+    return setFooterSpeculativeIoSize(size);
   }
 
   ReaderOptions& setFilePreloadThreshold(uint64_t threshold) {
@@ -673,8 +682,13 @@ class ReaderOptions : public io::ReaderOptions {
     return decrypterFactory_;
   }
 
+  uint64_t footerSpeculativeIoSize() const {
+    return footerSpeculativeIoSize_;
+  }
+
+  /// @deprecated Use footerSpeculativeIoSize instead.
   uint64_t footerEstimatedSize() const {
-    return footerEstimatedSize_;
+    return footerSpeculativeIoSize();
   }
 
   uint64_t filePreloadThreshold() const {
@@ -760,7 +774,7 @@ class ReaderOptions : public io::ReaderOptions {
   SerDeOptions serDeOptions_;
   std::unordered_map<std::string, std::string> properties_{};
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
-  uint64_t footerEstimatedSize_{kDefaultFooterEstimatedSize};
+  uint64_t footerSpeculativeIoSize_{kDefaultFooterSpeculativeIoSize};
   uint64_t filePreloadThreshold_{kDefaultFilePreloadThreshold};
   bool fileColumnNamesReadAsLowerCase_{false};
   bool useColumnNamesForColumnMapping_{false};

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -1064,8 +1064,8 @@ uint64_t DwrfReader::getMemoryUse(
 
   // Do we need even more memory to read the footer or the metadata?
   const auto footerLength = readerBase.postScript().footerLength();
-  if (memoryBytes < footerLength + readerBase.footerEstimatedSize()) {
-    memoryBytes = footerLength + readerBase.footerEstimatedSize();
+  if (memoryBytes < footerLength + readerBase.footerSpeculativeIoSize()) {
+    memoryBytes = footerLength + readerBase.footerSpeculativeIoSize();
   }
 
   // Account for firstRowOfStripe.

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -119,7 +119,7 @@ ReaderBase::ReaderBase(
 
   const auto preloadFile = fileLength_ <= options_.filePreloadThreshold();
   const int64_t footerBufSize =
-      std::min(fileLength_, options_.footerEstimatedSize());
+      std::min(fileLength_, options_.footerSpeculativeIoSize());
   const uint64_t readSize = preloadFile ? fileLength_ : footerBufSize;
   if (input_->supportSyncLoad()) {
     input_->enqueue({fileLength_ - readSize, readSize, "footer"});

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -160,8 +160,8 @@ class ReaderBase {
     return *handler_;
   }
 
-  uint64_t footerEstimatedSize() const {
-    return options_.footerEstimatedSize();
+  uint64_t footerSpeculativeIoSize() const {
+    return options_.footerSpeculativeIoSize();
   }
 
   uint64_t fileLength() const {

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -271,7 +271,7 @@ void verifyFlatMapReading(
 
   /* If an extra sanity check is desired you can uncomment the 2 below lines and
    * re-run */
-  // readerOpts.setFooterEstimatedSize(257);
+  // readerOpts.setFooterSpeculativeIoSize(257);
   // readerOpts.setFilePreloadThreshold(0);
 
   RowReaderOptions rowReaderOpts;
@@ -1478,7 +1478,7 @@ TEST_F(TestReader, fileColumnNamesReadAsLowerCaseComplexStruct) {
 TEST_F(TestReader, TestStripeSizeCallback) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setFilePreloadThreshold(0);
-  readerOpts.setFooterEstimatedSize(17);
+  readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
 
   std::shared_ptr<const RowType> requestedType = std::dynamic_pointer_cast<
@@ -1506,7 +1506,7 @@ TEST_F(TestReader, TestStripeSizeCallback) {
 TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setFilePreloadThreshold(0);
-  readerOpts.setFooterEstimatedSize(17);
+  readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
 
   std::shared_ptr<const RowType> requestedType = std::dynamic_pointer_cast<
@@ -1535,7 +1535,7 @@ TEST_F(TestReader, TestStripeSizeCallbackLimitsOneStripe) {
 TEST_F(TestReader, TestStripeSizeCallbackLimitsTwoStripe) {
   dwio::common::ReaderOptions readerOpts{pool()};
   readerOpts.setFilePreloadThreshold(0);
-  readerOpts.setFooterEstimatedSize(17);
+  readerOpts.setFooterSpeculativeIoSize(17);
   RowReaderOptions rowReaderOpts;
 
   std::shared_ptr<const RowType> requestedType = std::dynamic_pointer_cast<

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -156,7 +156,7 @@ class ReaderBase {
       bool fileColumnNamesReadAsLowerCase);
 
   memory::MemoryPool& pool_;
-  const uint64_t footerEstimatedSize_;
+  const uint64_t footerSpeculativeIoSize_;
   const uint64_t filePreloadThreshold_;
   // Copy of options. Must be owned by 'this'.
   const dwio::common::ReaderOptions options_;
@@ -177,7 +177,7 @@ ReaderBase::ReaderBase(
     std::unique_ptr<dwio::common::BufferedInput> input,
     const dwio::common::ReaderOptions& options)
     : pool_{options.memoryPool()},
-      footerEstimatedSize_{options.footerEstimatedSize()},
+      footerSpeculativeIoSize_{options.footerSpeculativeIoSize()},
       filePreloadThreshold_{options.filePreloadThreshold()},
       options_{options},
       input_{std::move(input)},
@@ -192,8 +192,8 @@ ReaderBase::ReaderBase(
 
 void ReaderBase::loadFileMetaData() {
   bool preloadFile =
-      fileLength_ <= std::max(filePreloadThreshold_, footerEstimatedSize_);
-  uint64_t readSize = preloadFile ? fileLength_ : footerEstimatedSize_;
+      fileLength_ <= std::max(filePreloadThreshold_, footerSpeculativeIoSize_);
+  uint64_t readSize = preloadFile ? fileLength_ : footerSpeculativeIoSize_;
 
   std::unique_ptr<dwio::common::SeekableInputStream> stream;
   if (preloadFile) {

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -664,7 +664,7 @@ TEST_F(E2EFilterTest, largeMetadata) {
           rowType_, 1000, *leafPool_, nullptr, 0)));
   writeToMemory(rowType_, batches, false);
   dwio::common::ReaderOptions readerOpts{leafPool_.get()};
-  readerOpts.setFooterEstimatedSize(1024);
+  readerOpts.setFooterSpeculativeIoSize(1024);
   readerOpts.setFilePreloadThreshold(1024 * 8);
   dwio::common::RowReaderOptions rowReaderOpts;
   auto input = std::make_unique<BufferedInput>(

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1198,7 +1198,7 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
   const auto fileSize = file->size();
   ASSERT_TRUE(
       fileSize <= dwio::common::ReaderOptions::kDefaultFilePreloadThreshold ||
-      fileSize <= dwio::common::ReaderOptions::kDefaultFooterEstimatedSize);
+      fileSize <= dwio::common::ReaderOptions::kDefaultFooterSpeculativeIoSize);
 
   // Check the whole file already loaded.
   ASSERT_EQ(file->bytesRead(), fileSize);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/nimble/pull/548

The ReaderOptions::footerEstimatedSize naming is misleading — it suggests
"estimated size of the footer" when it actually controls how many bytes to
speculatively read from the tail of the file.

Differential Revision: D95663885
