### PR TITLE
feat: Add ANSI mode support for unaryminus overflow detection

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -349,6 +349,10 @@ Mathematical Functions
 
     Returns the negative of `x`.  Corresponds to Spark's operator ``-``.
 
+    For integral types, when ``x`` is the minimum value of its type, returns
+    the same value as ``x`` following the behavior when Spark ANSI mode is
+    disabled, and throws an exception when Spark ANSI mode is enabled.
+
 .. spark:function:: unhex(x) -> varbinary
 
     Converts hexadecimal varchar ``x`` to varbinary.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -23,6 +23,7 @@
 
 #include "velox/common/base/Doubles.h"
 #include "velox/common/base/Status.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/lib/ToHex.h"
 #include "velox/functions/sparksql/SparkQueryConfig.h"
@@ -147,15 +148,34 @@ struct PModFloatFunction {
 template <typename T>
 struct UnaryMinusFunction {
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput a) {
-    if constexpr (std::is_integral_v<TInput>) {
-      // Avoid undefined integer overflow.
-      result = a == std::numeric_limits<TInput>::min() ? a : -a;
-    } else {
-      result = -a;
-    }
-    return true;
+  FOLLY_ALWAYS_INLINE void initialize(
+      const std::vector<TypePtr>& /*inputTypes*/,
+      const core::QueryConfig& config,
+      const TInput* /*a*/) {
+    ansiEnabled_ = SparkQueryConfig{config}.ansiEnabled();
   }
+
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE Status call(TInput& result, const TInput a) {
+    if constexpr (std::is_integral_v<TInput>) {
+      if (FOLLY_UNLIKELY(a == std::numeric_limits<TInput>::min())) {
+        if (ansiEnabled_) {
+          if (threadSkipErrorDetails()) {
+            return Status::UserError();
+          }
+          return Status::UserError("Arithmetic overflow: -({}).", a);
+        }
+        // In non-ANSI mode, returns the same negative minimum value.
+        result = a;
+        return Status::OK();
+      }
+    }
+    result = -a;
+    return Status::OK();
+  }
+
+ private:
+  bool ansiEnabled_ = false;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -310,14 +310,35 @@ TEST_F(ArithmeticTest, UnaryMinus) {
 }
 
 TEST_F(ArithmeticTest, UnaryMinusOverflow) {
+  // Float/double cases are unaffected by ANSI mode.
+  for (const auto& ansiEnabled : {"false", "true"}) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled),
+          ansiEnabled}});
+
+    EXPECT_EQ(unaryminus<float>(-kInf), kInf);
+    EXPECT_TRUE(std::isnan(unaryminus<float>(kNan).value_or(0)));
+    EXPECT_EQ(unaryminus<double>(-kInf), kInf);
+    EXPECT_TRUE(std::isnan(unaryminus<double>(kNan).value_or(0)));
+  }
+
+  // With ANSI off, negating MIN returns MIN (wraps silently).
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "false"}});
+
   EXPECT_EQ(unaryminus<int8_t>(INT8_MIN), INT8_MIN);
   EXPECT_EQ(unaryminus<int16_t>(INT16_MIN), INT16_MIN);
   EXPECT_EQ(unaryminus<int32_t>(INT32_MIN), INT32_MIN);
   EXPECT_EQ(unaryminus<int64_t>(INT64_MIN), INT64_MIN);
-  EXPECT_EQ(unaryminus<float>(-kInf), kInf);
-  EXPECT_TRUE(std::isnan(unaryminus<float>(kNan).value_or(0)));
-  EXPECT_EQ(unaryminus<double>(-kInf), kInf);
-  EXPECT_TRUE(std::isnan(unaryminus<double>(kNan).value_or(0)));
+
+  // With ANSI on, negating MIN throws.
+  queryCtx_->testingOverrideConfigUnsafe(
+      {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled), "true"}});
+
+  VELOX_ASSERT_THROW(unaryminus<int8_t>(INT8_MIN), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(unaryminus<int16_t>(INT16_MIN), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(unaryminus<int32_t>(INT32_MIN), "Arithmetic overflow");
+  VELOX_ASSERT_THROW(unaryminus<int64_t>(INT64_MIN), "Arithmetic overflow");
 }
 
 TEST_F(ArithmeticTest, Divide) {


### PR DESCRIPTION
## Summary
  - Make `unaryminus` config-based: when `spark.ansi.enabled` is true, negating the minimum value of an integer type (e.g., `-(-128)` for tinyint) throws an arithmetic overflow error instead of silently returning the minimum value
  - Follows the same pattern as `abs`, which already reads `sparkAnsiEnabled` from `QueryConfig`
  - Float/double types are unaffected by ANSI mode

  Picks up the `unaryminus` portion from #16361, which has been inactive.

  ## Test plan
  - [x] Existing `UnaryMinus` tests pass (normal cases unaffected)
  - [x] ANSI off: negating MIN returns MIN unchanged (existing behavior)
  - [x] ANSI on: negating MIN throws arithmetic overflow for all integer types
  - [x] TRY wrapping returns null instead of throwing
