### PR TITLE
feat: Add Paimon connector data structures and scaffolding

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -16,6 +16,7 @@ velox_add_library(velox_hive_config OBJECT HiveConfig.cpp)
 velox_link_libraries(velox_hive_config velox_core velox_exception)
 
 add_subdirectory(iceberg)
+add_subdirectory(paimon)
 
 velox_add_library(
   velox_hive_connector

--- a/velox/connectors/hive/paimon/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+velox_add_library(
+  velox_hive_paimon_split
+  PaimonConnectorSplit.cpp
+  PaimonDataFileMeta.cpp
+  PaimonDeletionFile.cpp
+  PaimonRowKind.cpp
+)
+
+velox_link_libraries(
+  velox_hive_paimon_split
+  velox_connector
+  velox_hive_connector
+  fmt::fmt
+)
+
+velox_add_library(
+  velox_hive_paimon_connector
+  PaimonConnector.cpp
+  PaimonDataSource.cpp
+)
+
+velox_link_libraries(
+  velox_hive_paimon_connector
+  velox_hive_paimon_split
+  velox_hive_connector
+)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/connectors/hive/paimon/PaimonConfig.h
+++ b/velox/connectors/hive/paimon/PaimonConfig.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/config/Config.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Paimon-specific connector configuration.
+/// Wraps the shared ConfigBase and provides accessors for Paimon settings.
+class PaimonConfig {
+ public:
+  explicit PaimonConfig(std::shared_ptr<const config::ConfigBase> config)
+      : config_(std::move(config)) {
+    VELOX_CHECK_NOT_NULL(config_);
+  }
+
+  const std::shared_ptr<const config::ConfigBase>& config() const {
+    return config_;
+  }
+
+ private:
+  const std::shared_ptr<const config::ConfigBase> config_;
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonConnector.cpp
+++ b/velox/connectors/hive/paimon/PaimonConnector.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonConnector.h"
+
+#include "velox/connectors/hive/paimon/PaimonDataSource.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+PaimonConnector::PaimonConnector(
+    const std::string& id,
+    std::shared_ptr<const config::ConfigBase> config,
+    folly::Executor* ioExecutor)
+    : HiveConnector(id, config, ioExecutor),
+      paimonConfig_(std::make_shared<PaimonConfig>(connectorConfig())) {}
+
+std::unique_ptr<DataSource> PaimonConnector::createDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& columnHandles,
+    ConnectorQueryCtx* connectorQueryCtx) {
+  return std::make_unique<PaimonDataSource>(
+      outputType,
+      tableHandle,
+      columnHandles,
+      &fileHandleFactory_,
+      ioExecutor_,
+      connectorQueryCtx,
+      hiveConfig_);
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonConnector.h
+++ b/velox/connectors/hive/paimon/PaimonConnector.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/paimon/PaimonConfig.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Provides Paimon table format support by extending HiveConnector.
+///
+/// Creates PaimonDataSource instances that handle Paimon's multi-file splits
+/// (one split = one bucket with multiple data files across LSM-tree levels).
+/// Reuses HiveConnector's ORC/Parquet readers directly — no Arrow bridge.
+class PaimonConnector final : public HiveConnector {
+ public:
+  PaimonConnector(
+      const std::string& id,
+      std::shared_ptr<const config::ConfigBase> config,
+      folly::Executor* ioExecutor);
+
+  /// Creates PaimonDataSource for reading from Paimon tables.
+  std::unique_ptr<DataSource> createDataSource(
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& columnHandles,
+      ConnectorQueryCtx* connectorQueryCtx) override;
+
+ private:
+  const std::shared_ptr<PaimonConfig> paimonConfig_;
+};
+
+class PaimonConnectorFactory final : public ConnectorFactory {
+ public:
+  static constexpr const char* kPaimonConnectorName = "paimon";
+
+  PaimonConnectorFactory() : ConnectorFactory(kPaimonConnectorName) {}
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const config::ConfigBase> config,
+      folly::Executor* ioExecutor = nullptr,
+      [[maybe_unused]] folly::Executor* cpuExecutor = nullptr) override {
+    return std::make_shared<PaimonConnector>(id, config, ioExecutor);
+  }
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonConnectorSplit.cpp
+++ b/velox/connectors/hive/paimon/PaimonConnectorSplit.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonConnectorSplit.h"
+
+#include <fmt/format.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+std::string paimonTableTypeString(PaimonTableType type) {
+  switch (type) {
+    case PaimonTableType::kAppendOnly:
+      return "APPEND_ONLY";
+    case PaimonTableType::kPrimaryKey:
+      return "PRIMARY_KEY";
+    default:
+      VELOX_FAIL("Unknown PaimonTableType: {}", static_cast<int>(type));
+  }
+}
+
+PaimonTableType paimonTableTypeFromString(const std::string& str) {
+  if (str == "APPEND_ONLY") {
+    return PaimonTableType::kAppendOnly;
+  }
+  if (str == "PRIMARY_KEY") {
+    return PaimonTableType::kPrimaryKey;
+  }
+  VELOX_FAIL("Unknown PaimonTableType: {}", str);
+}
+
+PaimonConnectorSplit::PaimonConnectorSplit(
+    const std::string& connectorId,
+    int64_t snapshotId,
+    PaimonTableType tableType,
+    dwio::common::FileFormat fileFormat,
+    const std::vector<PaimonDataFile>& dataFiles,
+    std::unordered_map<std::string, std::optional<std::string>> partitionKeys,
+    std::optional<int32_t> tableBucketNumber,
+    bool rawConvertible)
+    : ConnectorSplit(connectorId),
+      snapshotId_(snapshotId),
+      tableType_(tableType),
+      fileFormat_(fileFormat),
+      dataFiles_(dataFiles),
+      partitionKeys_(std::move(partitionKeys)),
+      tableBucketNumber_(tableBucketNumber),
+      rawConvertible_(rawConvertible) {
+  VELOX_CHECK(
+      !dataFiles_.empty(), "PaimonConnectorSplit requires non-empty dataFiles");
+
+  if (rawConvertible_) {
+    for (const auto& file : dataFiles_) {
+      VELOX_CHECK_EQ(
+          file.deleteRowCount,
+          0,
+          "rawConvertible split cannot have files with deleteRowCount > 0: {}",
+          file.toString());
+    }
+  }
+}
+
+std::string PaimonConnectorSplit::toString() const {
+  std::string dataFilesStr;
+  for (const auto& file : dataFiles_) {
+    if (!dataFilesStr.empty()) {
+      dataFilesStr += ", ";
+    }
+    dataFilesStr += file.toString();
+  }
+
+  return fmt::format(
+      "PaimonConnectorSplit[snapshot {}, type {}, rawConvertible {}, "
+      "connector '{}', dataFiles=[{}]]",
+      snapshotId_,
+      paimonTableTypeString(tableType_),
+      rawConvertible_,
+      connectorId,
+      dataFilesStr);
+}
+
+folly::dynamic PaimonConnectorSplit::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "PaimonConnectorSplit";
+  obj["connectorId"] = connectorId;
+  obj["snapshotId"] = snapshotId_;
+  obj["tableType"] = paimonTableTypeString(tableType_);
+  obj["rawConvertible"] = rawConvertible_;
+
+  folly::dynamic filesArray = folly::dynamic::array;
+  for (const auto& file : dataFiles_) {
+    filesArray.push_back(file.serialize());
+  }
+  obj["dataFiles"] = filesArray;
+
+  folly::dynamic partitionKeysObj = folly::dynamic::object;
+  for (const auto& [key, value] : partitionKeys_) {
+    partitionKeysObj[key] =
+        value.has_value() ? folly::dynamic(value.value()) : nullptr;
+  }
+  obj["partitionKeys"] = partitionKeysObj;
+
+  obj["tableBucketNumber"] = tableBucketNumber_.has_value()
+      ? folly::dynamic(tableBucketNumber_.value())
+      : nullptr;
+
+  obj["fileFormat"] = dwio::common::toString(fileFormat_);
+
+  return obj;
+}
+
+// static
+std::shared_ptr<PaimonConnectorSplit> PaimonConnectorSplit::create(
+    const folly::dynamic& obj) {
+  const auto connectorId = obj["connectorId"].asString();
+  const auto snapshotId = obj["snapshotId"].asInt();
+  const auto tableType = paimonTableTypeFromString(obj["tableType"].asString());
+  const auto rawConvertible = obj["rawConvertible"].asBool();
+
+  std::vector<PaimonDataFile> dataFiles;
+  for (const auto& fileObj : obj["dataFiles"]) {
+    dataFiles.emplace_back(PaimonDataFile::create(fileObj));
+  }
+
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys;
+  for (const auto& [key, value] : obj["partitionKeys"].items()) {
+    partitionKeys[key.asString()] = value.isNull()
+        ? std::nullopt
+        : std::optional<std::string>(value.asString());
+  }
+
+  const auto tableBucketNumber = obj["tableBucketNumber"].isNull()
+      ? std::nullopt
+      : std::optional<int32_t>(obj["tableBucketNumber"].asInt());
+
+  const auto fileFormat =
+      dwio::common::toFileFormat(obj["fileFormat"].asString());
+
+  return std::make_shared<PaimonConnectorSplit>(
+      connectorId,
+      snapshotId,
+      tableType,
+      fileFormat,
+      dataFiles,
+      std::move(partitionKeys),
+      tableBucketNumber,
+      rawConvertible);
+}
+
+// static
+void PaimonConnectorSplit::registerSerDe() {
+  auto& registry = DeserializationRegistryForSharedPtr();
+  registry.Register("PaimonConnectorSplit", PaimonConnectorSplit::create);
+}
+
+// --- Builder ---
+
+PaimonConnectorSplitBuilder& PaimonConnectorSplitBuilder::addFile(
+    std::string filePath,
+    uint64_t fileSize,
+    int32_t level) {
+  PaimonDataFile meta;
+  meta.path = std::move(filePath);
+  meta.size = fileSize;
+  meta.level = level;
+  dataFiles_.emplace_back(std::move(meta));
+  return *this;
+}
+
+PaimonConnectorSplitBuilder& PaimonConnectorSplitBuilder::partitionKey(
+    std::string name,
+    std::optional<std::string> value) {
+  partitionKeys_.emplace(std::move(name), std::move(value));
+  return *this;
+}
+
+PaimonConnectorSplitBuilder& PaimonConnectorSplitBuilder::tableBucketNumber(
+    int32_t bucketId) {
+  tableBucketNumber_ = bucketId;
+  return *this;
+}
+
+PaimonConnectorSplitBuilder& PaimonConnectorSplitBuilder::rawConvertible(
+    bool value) {
+  rawConvertible_ = value;
+  return *this;
+}
+
+std::shared_ptr<PaimonConnectorSplit> PaimonConnectorSplitBuilder::build() {
+  return std::make_shared<PaimonConnectorSplit>(
+      connectorId_,
+      snapshotId_,
+      tableType_,
+      fileFormat_,
+      dataFiles_,
+      partitionKeys_,
+      tableBucketNumber_,
+      rawConvertible_);
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonConnectorSplit.h
+++ b/velox/connectors/hive/paimon/PaimonConnectorSplit.h
@@ -1,0 +1,587 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <folly/CPortability.h>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/paimon/PaimonDataFileMeta.h"
+#include "velox/dwio/common/Options.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Paimon table type determines read and write semantics.
+///
+/// # Table Types
+///
+/// Append-only: No primary key. Each write appends new independent files. All
+/// files are at LSM level 0 and rawConvertible is always true. Files can be
+/// read in any order for batch queries. No merge-on-read needed. Compaction
+/// only reduces the number of small files (concatenation, no deduplication).
+///
+/// Primary-key: Uses an LSM tree to organize data files per bucket. New writes
+/// go to level 0; background compaction merges files into higher levels,
+/// deduplicating by primary key. The merge engine determines how duplicate
+/// keys are resolved:
+///
+///   Deduplicate (upsert): Latest write wins — entire row replaced.
+///     Write {id=1, name="Alice"} then {id=1, name="Bob"}
+///     → result: {id=1, name="Bob"}
+///
+///   Partial-update: Only non-null columns in new record overwrite old values.
+///     Write {id=1, name="Alice", age=25} then {id=1, name=NULL, age=26}
+///     → result: {id=1, name="Alice", age=26}
+///
+/// # Partitioning and Bucketing
+///
+/// Paimon uses a fixed physical layout: partition-dirs / bucket-dir / files.
+/// The hierarchy is strictly partition → bucket → files with no nesting or
+/// reordering (no bucket-before-partition or bucket-after-bucket).
+///
+/// Partitioning: Hive-style directory partitioning by column values. Zero or
+/// more partition columns, ordered. Each unique combination of partition values
+/// creates a physical directory. Partition columns are NOT stored in the data
+/// files (values are in the directory path). Enables partition pruning.
+///
+/// Bucketing: Hash-distributes rows within a partition into N buckets. Each
+/// bucket is a physical directory (bucket-0/, bucket-1/, ...) and acts as an
+/// independent LSM tree instance. For primary-key tables, the bucket key
+/// defaults to the primary key, ensuring each key maps to exactly one bucket
+/// (merge-on-read only needs to look within a single bucket). For append-only
+/// tables, bucket key can be any column(s) for write parallelism.
+///
+/// Unbucketed tables use a single implicit bucket-0/ directory. All four
+/// combinations of partitioned/unpartitioned × bucketed/unbucketed are valid:
+///
+///   Partitioned + bucketed:   dt=2024-01-01/bucket-0/data.orc
+///   Partitioned + unbucketed: dt=2024-01-01/bucket-0/data.orc  (bucket-0 only)
+///   Unpartitioned + bucketed: bucket-0/data.orc, bucket-1/data.orc, ...
+///   Unpartitioned + unbucketed: bucket-0/data.orc  (bucket-0 only)
+///
+/// Each PaimonConnectorSplit represents one partition + one bucket. The
+/// partitionKeys field carries partition column values, and tableBucketNumber
+/// identifies the bucket (nullopt for unbucketed tables).
+///
+/// # LSM Tree Structure (Primary-Key Tables)
+///
+/// Level 0: Newest data. Each flush creates a new file. Files within level 0
+///   CAN have overlapping keys (multiple files may contain the same key).
+///   minSequenceNumber == maxSequenceNumber (single commit per file).
+///
+/// Level 1+: Compacted data. Compaction merges lower-level files, deduplicating
+///   keys and producing non-overlapping key ranges. No two files at the same
+///   level share a key. minSequenceNumber < maxSequenceNumber (merged from
+///   multiple commits).
+///
+/// # Compaction Strategy (Universal Compaction)
+///
+/// Primary-key tables use Universal Compaction (similar to RocksDB):
+///
+/// Sorted runs: Each L0 file is its own sorted run. All files at the same
+///   higher level (L1, L2, ...) together form one sorted run with
+///   non-overlapping keys. Compaction merges sorted runs.
+///
+/// Trigger: When the number of sorted runs exceeds
+///   num-sorted-run.compaction-trigger (default: 5), compaction is triggered.
+///
+/// Picking strategy: Compaction picks the OLDEST sorted runs first and merges
+///   them until the count drops below the trigger threshold. The output level
+///   depends on which sorted runs are merged. Multiple non-L0 levels can
+///   exist (L1, L2, ...). Within each level, files have non-overlapping key
+///   ranges. L0 files can overlap with any level.
+///
+/// Who runs compaction:
+///   - Default: the writer process (Flink task) runs compaction asynchronously
+///     after each commit.
+///   - Dedicated mode: a separate compaction job can be configured to offload
+///     compaction from writers.
+///   - Either way, compaction creates a new snapshot with updated manifest
+///     entries (REMOVE old files, ADD compacted file).
+///
+/// Compaction output:
+///   - Data file: deduplicated keys, latest value wins (by sequence number).
+///   - With changelog-producer=lookup: also generates a changelog file.
+///   - With deletion-vectors.enabled: may generate deletion bitmaps instead of
+///     rewriting data files.
+///
+/// Append-only compaction: Only concatenates small files into larger ones (no
+///   key deduplication). All files stay at level 0. Triggered when the number
+///   of small files exceeds a threshold.
+///
+/// rawConvertible: Per-split flag set by the Paimon planner.
+///   false = keys overlap across levels, merge-on-read required.
+///   true  = fully compacted (single level, no overlapping keys), read
+///   directly. Always true for append-only tables.
+///
+/// # Snapshots and Manifests
+///
+/// Every Paimon read (batch or streaming) goes through snapshots — immutable
+/// point-in-time views of the table. A snapshot points to a manifest-list,
+/// which references manifest files that record which data files are active.
+///
+/// Physical layout on storage:
+///
+///   table-path/
+///     snapshot/
+///       snapshot-1      ← JSON: points to manifest-list-1
+///       snapshot-2      ← JSON: points to manifest-list-2
+///     manifest/
+///       manifest-list-1 ← lists which manifest files to read
+///       manifest-1      ← data file entries (ADD/REMOVE)
+///       manifest-2
+///     dt=2024-01-01/
+///       bucket-0/
+///         data-001.orc  ← actual data files
+///         data-002.orc
+///     schema/
+///       schema-0        ← table schema
+///
+/// Each manifest entry contains both structured metadata and the file path:
+///
+///   {action: ADD,
+///    partition: {dt: "2024-01-01"},       ← structured, for fast pruning
+///    bucket: 0,                           ← structured, for fast pruning
+///    filePath: "dt=2024-01-01/bucket-0/data-001.orc",  ← for I/O
+///    level: 0, minSeq: 10, maxSeq: 10, ...}
+///
+/// The partition/bucket values are redundant with the file path (which
+/// encodes them in the directory structure) — the structured fields enable
+/// fast partition/bucket pruning without path parsing.
+///
+/// The Paimon planner reads the manifest, applies partition pruning, and
+/// generates one PaimonConnectorSplit per partition × bucket combination:
+///
+///   Manifest entries after pruning for dt='2024-01-01':
+///     partition={dt: "2024-01-01"}, bucket=0: [data-001.orc, data-002.orc]
+///     partition={dt: "2024-01-01"}, bucket=1: [data-001.orc]
+///   → Split 1: partitionKeys={dt: "2024-01-01"}, bucket=0, 2 files
+///   → Split 2: partitionKeys={dt: "2024-01-01"}, bucket=1, 1 file
+///
+/// Snapshot isolation: Readers see only files referenced by their snapshot.
+/// Concurrent writers creating new snapshots don't affect in-flight reads.
+/// Old data files are only deleted after snapshot expiration (no snapshot
+/// references them). The manifest is authoritative — partition directories
+/// may contain old compacted-away files that no snapshot references.
+///
+/// # Read Modes
+///
+/// All reads are snapshot-based. The mode determines how many snapshots are
+/// read and what output is produced:
+///
+/// Batch (snapshot read): Reads the full file set at ONE snapshot. For
+///   primary-key tables, merge-on-read ALWAYS required to deduplicate by key
+///   and return the current state — regardless of changelog mode. This is the
+///   Velox/Presto read path.
+///
+/// Time travel: Batch read at a user-specified older snapshot (instead of
+///   the latest). Same mechanism, different snapshot ID. Only works if the
+///   snapshot hasn't been expired.
+///
+/// Streaming: Reads DELTAS between consecutive snapshots (N→N+1→N+2→...).
+///   Only processes newly added files (the manifest diff), emitting changelog
+///   records. Runs continuously, polling for new snapshots. Specifies only a
+///   start snapshot — the end is unbounded. Merge-on-read is NOT needed for
+///   streaming — the reader only sees delta files, not the full file set, so
+///   there is nothing to merge against. For input changelog mode, RowKind is
+///   stored in the files and emitted directly. For upsert mode, the reader
+///   infers changelog from the delta. Compaction deltas are a special case:
+///   the changelog is collapsed, so changelog-producer=lookup is needed to
+///   regenerate meaningful changelog records during compaction.
+///
+/// Incremental: Bounded streaming — reads deltas from snapshot N to M, then
+///   stops. Same delta mechanism as streaming but with an end bound.
+///
+/// Merge-on-read summary for primary-key tables:
+///   Batch/time-travel: Always required (full file set, must deduplicate).
+///   Streaming/incremental: Never required (delta files only, no merge).
+///
+/// # Coordinator/Reader Responsibility Split
+///
+/// Split generation follows a coordinator/reader architecture (mirrors
+/// Flink's enumerator/reader pattern):
+///
+/// Coordinator (Java planner):
+///   - Batch: reads manifest at one snapshot, groups files by partition ×
+///     bucket, generates one PaimonConnectorSplit per group.
+///   - Streaming: starts at a given snapshot, continuously polls for new
+///     snapshots. For each new snapshot (N→N+1), computes the manifest diff
+///     (newly added files), groups delta files by partition × bucket, and
+///     generates one split per group. Repeats indefinitely.
+///   - Incremental: same as streaming but stops at the end snapshot M.
+///   - With changelog-producer=lookup: sends changelog files (kCompact) for
+///     streaming, data files (kAppend) for batch.
+///   - Without changelog-producer: sends data files (kAppend) for all modes.
+///
+/// Reader (Velox worker):
+///   - Stateless — receives splits and reads files. Does not track snapshots,
+///     does not compute deltas, does not decide which file type to read.
+///   - For batch: performs merge-on-read if rawConvertible is false.
+///   - For streaming: emits rows directly (as +I without changelog-producer,
+///     or with stored RowKind for changelog files / input changelog mode).
+///
+/// # Changelog Semantics
+///
+/// Primary-key tables can produce a changelog stream with four row kinds:
+///   +I (INSERT):        New key added.
+///   -U (UPDATE_BEFORE): Old value being replaced (for retraction).
+///   +U (UPDATE_AFTER):  New value replacing it.
+///   -D (DELETE):        Key removed.
+///
+/// -U and +U are always emitted as a consecutive pair for the same key.
+/// Intermediate updates are collapsed — the consumer sees only the net
+/// change (oldest value → newest value), not every step.
+///
+/// # RowKind and the _rowkind Column
+///
+/// Every primary-key table supports a hidden system column `_rowkind` that
+/// encodes the change type per row. At the file format level (Parquet, ORC,
+/// Nimble), `_rowkind` is a regular TINYINT column — the file format has no
+/// special knowledge of it. It is "hidden" only at the SQL layer (not shown
+/// in SELECT *). Values: 0=+I, 1=-U, 2=+U, 3=-D.
+///
+/// Whether `_rowkind` is actually written to data files depends on the mode:
+///
+/// Upsert mode (normal writes): `_rowkind` is omitted from data files since
+///   all records are implicitly +I/+U (insert or update, latest wins). The
+///   streaming reader INFERS -U/+U pairs during merge-on-read by comparing
+///   old vs new values for the same key across LSM levels. When a SQL DELETE
+///   is issued, Paimon writes a record with `_rowkind=-D` to level 0, along
+///   with the full before-image (all column values populated). Compaction
+///   removes the key entirely.
+///
+///   Limitation: Streaming reads in upsert mode only process delta files
+///   (newly added files between snapshots) — the reader does NOT look back
+///   at previous snapshots. A key appearing once in the delta is emitted as
+///   +I, even if that key already existed in a prior snapshot (should be +U).
+///   For correct +I vs +U distinction, use changelog-producer=lookup which
+///   looks up old values from existing files to determine the actual change
+///   type. This limitation does NOT apply to input changelog mode — the
+///   source provides the correct RowKind (+I/+U/-U/-D) explicitly.
+///
+/// Input changelog mode (CDC source writes): `_rowkind` IS written for every
+///   row. The external source (Flink CDC, Kafka) provides the change type.
+///   The streaming reader emits rows with their stored RowKind directly — no
+///   merge inference needed for uncompacted data. Files must be read in
+///   sequence-number order since -U/+U pairs may span files. Compaction
+///   collapses the stored changelog; use changelog-producer=lookup to
+///   regenerate it during compaction.
+///
+/// rowkind.field mode: Instead of the hidden `_rowkind` column, the table
+///   designates a user-visible column (e.g., "op") to carry the change type.
+///   Useful when the CDC source provides change type as a regular field. At
+///   the file level, it's just a regular column — the Paimon engine
+///   interprets its values as RowKind.
+///
+/// # Deletes
+///
+/// A delete record is NOT a row with null values. It's a complete row (full
+/// before-image) tagged with RowKind=-D. The mechanism depends on the source:
+///
+///   SQL DELETE:       Paimon engine writes {_rowkind=-D, id=1, name="Alice"}
+///   CDC source:       External source provides -D record with full values
+///   rowkind.field:    User column carries the delete marker
+///
+/// The full old column values (before-image) are carried for streaming/
+/// changelog consumers that need retraction semantics. Without old values,
+/// the consumer would need its own state lookup to know what was deleted:
+///
+///   Example — aggregation counting users by country:
+///     State: {id=1, name="Alice", country="US"}  → US count = 1
+///
+///     -D {id=1} (key only):
+///       Consumer doesn't know which country to decrement — must look up.
+///     -D {id=1, name="Alice", country="US"} (full before-image):
+///       Consumer decrements US count directly. No lookup needed.
+///
+/// Same reason -U (UPDATE_BEFORE) carries the full old row — the consumer
+/// retracts old values before applying +U (UPDATE_AFTER) with new values.
+/// For batch reads, the old values don't matter (compaction removes the key).
+///
+/// Separately, deletion files (PaimonDeletionFile) are a bitmap-based
+/// mechanism that marks row positions as deleted within an existing data
+/// file without rewriting it. This is orthogonal to RowKind-based deletes.
+///
+/// For batch/snapshot reads (Presto), changelog semantics don't apply — the
+/// reader returns the current state of each row, not the change history.
+///
+/// Append-only tables only produce +I (INSERT) records — no updates or
+/// deletes since there's no primary key to identify rows. Streaming reads
+/// from append-only tables emit all new rows as +I; file read order doesn't
+/// matter since there are no retraction pairs.
+///
+/// # Sequence Numbers
+///
+/// Auto-generated per-commit, monotonically increasing. Used within a
+/// snapshot for merge-on-read ordering (higher sequence number wins for
+/// duplicate keys). NOT used for snapshot isolation (that's handled by the
+/// manifest chain). Sequence numbers are per-file metadata, not per-row —
+/// after compaction, per-row attribution is lost but the LSM level order
+/// makes it unnecessary.
+///
+/// # changelog-producer=lookup
+///
+/// When configured on a primary-key table, the compactor generates TWO
+/// outputs per compaction: (1) a data file (no `_rowkind` in upsert mode)
+/// and (2) a separate changelog file containing the pre-computed changelog
+/// with correct RowKind (+I/+U/-U/-D, includes `_rowkind`). Both files are
+/// marked as PaimonFileSource::kCompact (produced by compaction). Without
+/// this flag, compaction produces only a data file.
+///
+/// The coordinator (Java planner) sends the right files based on read mode:
+///
+///   Batch read:      sends data files only → merge-on-read as usual
+///   Streaming read:  sends changelog files only → RowKind already correct,
+///                    no inference or merge needed
+///
+/// Without changelog-producer=lookup, streaming reads work as follows:
+///
+///   Streaming read (no changelog-producer):
+///     Coordinator sends the delta data files (newly added between snapshots).
+///     The reader does NOT do merge-on-read — it only processes delta files,
+///     not the full file set. Each row in the delta is emitted as +I. The
+///     limitation is that the reader cannot distinguish +I (new key) from +U
+///     (existing key updated) because it doesn't look back at previous
+///     snapshots. For many use cases (e.g., downstream upsert sinks) this is
+///     acceptable since the consumer treats +I and +U identically.
+///
+///   Compaction snapshots are problematic without changelog-producer: the
+///   compacted file contains ALL keys (not just changed ones), so the reader
+///   would emit +I for every key — including unchanged ones. With
+///   changelog-producer=lookup, the compactor compares old vs new values and
+///   generates a changelog file with only actual changes.
+///
+///   If the same key is updated across multiple consecutive snapshots (N→N+1,
+///   N+1→N+2, ...), each delta is processed independently. The reader emits
+///   one +I per delta that touches the key. The downstream consumer must be
+///   idempotent (e.g., upsert by key) to handle this correctly. Without
+///   merge-on-read, the reader has no version information — it does not know
+///   whether a key is new or updated, nor can it deduplicate across deltas.
+///   This is by design: streaming reads trade correctness of change types for
+///   simplicity and performance.
+///
+///   Example — key updated across two snapshots without changelog-producer:
+///
+///     Delta N→N+1:   {id=1, name="Alice"}  → emitted as +I
+///     Delta N+1→N+2: {id=1, name="Bob"}    → emitted as +I (not +U)
+///
+///   This works for upsert sinks (consumer does INSERT-or-UPDATE by key —
+///   final state is correct regardless of +I vs +U). It breaks for retraction
+///   sinks (e.g., aggregation counting by name):
+///
+///     Correct:    +I "Alice" (count=1), -U "Alice" + +U "Bob" (count=1)
+///     Without changelog-producer: +I "Alice" (count=1), +I "Bob" (count=2) ✗
+///
+///   For exact changelog semantics, use changelog-producer=lookup.
+///
+/// The file origin (write vs compaction) is indicated by PaimonFileSource in
+/// PaimonDataFile::fileSource. Both data files and changelog files use
+/// the same physical file format. Note that PaimonFileSource indicates HOW
+/// the file was produced, not WHETHER it is a data or changelog file — both
+/// are marked kCompact when produced by compaction. The coordinator tracks
+/// which is which via separate manifest entries.
+///
+/// Schema difference: In upsert mode (no input changelog), data files do NOT
+/// contain the `_rowkind` column (all records are implicitly +I/+U). Changelog
+/// files generated by changelog-producer=lookup DO contain `_rowkind` since
+/// they carry explicit change types. The coordinator knows which file type it
+/// is sending, so the reader schema is adjusted accordingly. In input changelog
+/// mode, both data and changelog files contain `_rowkind`.
+///
+/// # Velox Connector Scope
+///
+/// Currently only batch reads (Presto) are supported. Only data files are
+/// needed — changelog files and streaming semantics are not required.
+///
+/// Future streaming support: We will require changelog-producer=lookup (or
+/// full-compaction) to be enabled on the table. This means the compactor
+/// generates pre-computed changelog files, and the streaming reader consumes
+/// them directly. We do NOT plan to support beforeFiles-based diffing (where
+/// the reader merges old and new file sets to infer changelog at read time).
+/// This avoids expensive read-time merge and simplifies the reader — the
+/// coordinator sends changelog files for compaction snapshots and delta data
+/// files for non-compaction snapshots.
+enum class PaimonTableType {
+  /// No primary key. Data files are independent — no merge-on-read needed.
+  /// All files at level 0, rawConvertible always true.
+  kAppendOnly,
+  /// Has a primary key. Uses LSM tree with merge-on-read to deduplicate
+  /// records by key when data spans multiple compaction levels.
+  kPrimaryKey,
+};
+
+/// Returns the string name of the table type (e.g., "APPEND_ONLY").
+std::string paimonTableTypeString(PaimonTableType type);
+
+/// Parses a table type from its string name.
+PaimonTableType paimonTableTypeFromString(const std::string& str);
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    PaimonTableType type) {
+  os << paimonTableTypeString(type);
+  return os;
+}
+
+} // namespace facebook::velox::connector::hive::paimon
+
+template <>
+struct fmt::formatter<facebook::velox::connector::hive::paimon::PaimonTableType>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::paimon::PaimonTableType type,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::paimon::paimonTableTypeString(type),
+        ctx);
+  }
+};
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Represents a Paimon DataSplit — a collection of data files in one
+/// partition/bucket.
+///
+/// Unlike HiveConnectorSplit (one file per split), a Paimon split maps to a
+/// logical bucket which may contain multiple physical files across LSM-tree
+/// levels.
+///
+/// NOTE: Table-wide metadata (primary key columns, merge engine, table schema)
+/// is NOT carried in the split. A future PaimonTableHandle (extending
+/// HiveTableHandle) will carry this information, needed for merge-on-read
+/// (key deduplication) and schema evolution. For batch reads of
+/// rawConvertible=true splits, the existing HiveTableHandle suffices.
+class PaimonConnectorSplit : public connector::ConnectorSplit {
+ public:
+  /// @param connectorId Connector identifier.
+  /// @param snapshotId Paimon table snapshot version this split was generated
+  ///        from.
+  /// @param tableType Whether this is an append-only or primary-key table.
+  /// @param fileFormat File format of the data files (e.g., ORC, Parquet).
+  /// @param dataFiles Data files in this split, each representing a physical
+  ///        file in the LSM-tree.
+  /// @param partitionKeys Partition key-value pairs. Keys map to partition
+  ///        column names; values are nullopt for null partitions.
+  /// @param tableBucketNumber Bucket number within the Paimon table's bucket
+  ///        distribution. Nullopt for unbucketed tables.
+  /// @param rawConvertible Per-split flag indicating whether all files in this
+  ///        split (partition × bucket) can be read without merge-on-read (no
+  ///        key deduplication needed across LSM levels). Set by the Paimon
+  ///        planner based on the compaction state of the entire bucket. Only
+  ///        meaningful for primary-key tables.
+  PaimonConnectorSplit(
+      const std::string& connectorId,
+      int64_t snapshotId,
+      PaimonTableType tableType,
+      dwio::common::FileFormat fileFormat,
+      const std::vector<PaimonDataFile>& dataFiles,
+      std::unordered_map<std::string, std::optional<std::string>> partitionKeys,
+      std::optional<int32_t> tableBucketNumber,
+      bool rawConvertible = true);
+
+  int64_t snapshotId() const {
+    return snapshotId_;
+  }
+
+  PaimonTableType tableType() const {
+    return tableType_;
+  }
+
+  const std::vector<PaimonDataFile>& dataFiles() const {
+    return dataFiles_;
+  }
+
+  const std::unordered_map<std::string, std::optional<std::string>>&
+  partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  std::optional<int32_t> tableBucketNumber() const {
+    return tableBucketNumber_;
+  }
+
+  bool rawConvertible() const {
+    return rawConvertible_;
+  }
+
+  dwio::common::FileFormat fileFormat() const {
+    return fileFormat_;
+  }
+
+  std::string toString() const override;
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<PaimonConnectorSplit> create(
+      const folly::dynamic& obj);
+
+  static void registerSerDe();
+
+ private:
+  const int64_t snapshotId_;
+  const PaimonTableType tableType_;
+  const dwio::common::FileFormat fileFormat_;
+  const std::vector<PaimonDataFile> dataFiles_;
+  const std::unordered_map<std::string, std::optional<std::string>>
+      partitionKeys_;
+  const std::optional<int32_t> tableBucketNumber_;
+  const bool rawConvertible_;
+};
+
+/// Builder for PaimonConnectorSplit construction.
+class PaimonConnectorSplitBuilder {
+ public:
+  PaimonConnectorSplitBuilder(
+      std::string connectorId,
+      int64_t snapshotId,
+      PaimonTableType tableType,
+      dwio::common::FileFormat fileFormat)
+      : connectorId_(std::move(connectorId)),
+        snapshotId_(snapshotId),
+        tableType_(tableType),
+        fileFormat_(fileFormat) {}
+
+  PaimonConnectorSplitBuilder&
+  addFile(std::string filePath, uint64_t fileSize, int32_t level = 0);
+
+  PaimonConnectorSplitBuilder& partitionKey(
+      std::string name,
+      std::optional<std::string> value);
+
+  PaimonConnectorSplitBuilder& tableBucketNumber(int32_t bucketId);
+
+  PaimonConnectorSplitBuilder& rawConvertible(bool value);
+
+  std::shared_ptr<PaimonConnectorSplit> build();
+
+ private:
+  const std::string connectorId_;
+  const int64_t snapshotId_;
+  const PaimonTableType tableType_;
+  const dwio::common::FileFormat fileFormat_;
+  std::vector<PaimonDataFile> dataFiles_;
+  std::unordered_map<std::string, std::optional<std::string>> partitionKeys_;
+  std::optional<int32_t> tableBucketNumber_;
+  bool rawConvertible_{true};
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDataFileMeta.cpp
+++ b/velox/connectors/hive/paimon/PaimonDataFileMeta.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonDataFileMeta.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+// static
+std::string PaimonDataFile::typeString(Type type) {
+  switch (type) {
+    case Type::kData:
+      return "DATA";
+    case Type::kChangelog:
+      return "CHANGELOG";
+    default:
+      VELOX_FAIL("Unknown PaimonDataFile::Type: {}", static_cast<int>(type));
+  }
+}
+
+// static
+PaimonDataFile::Type PaimonDataFile::typeFromString(const std::string& str) {
+  if (str == "DATA") {
+    return Type::kData;
+  }
+  if (str == "CHANGELOG") {
+    return Type::kChangelog;
+  }
+  VELOX_FAIL("Unknown PaimonDataFile::Type: {}", str);
+}
+
+// static
+std::string PaimonDataFile::sourceString(Source source) {
+  switch (source) {
+    case Source::kAppend:
+      return "APPEND";
+    case Source::kCompact:
+      return "COMPACT";
+    default:
+      VELOX_FAIL(
+          "Unknown PaimonDataFile::Source: {}", static_cast<int>(source));
+  }
+}
+
+// static
+PaimonDataFile::Source PaimonDataFile::sourceFromString(
+    const std::string& str) {
+  if (str == "APPEND") {
+    return Source::kAppend;
+  }
+  if (str == "COMPACT") {
+    return Source::kCompact;
+  }
+  VELOX_FAIL("Unknown PaimonDataFile::Source: {}", str);
+}
+
+std::string PaimonDataFile::toString() const {
+  return fmt::format(
+      "{{path={}, size={}, rows={}, level={}, type={}, source={}, "
+      "deletionFile={}}}",
+      path,
+      size,
+      rowCount,
+      level,
+      typeString(type),
+      sourceString(source),
+      deletionFile.has_value() ? deletionFile->toString() : "none");
+}
+
+folly::dynamic PaimonDataFile::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["filePath"] = path;
+  obj["fileSize"] = size;
+  obj["rowCount"] = rowCount;
+  obj["level"] = level;
+  obj["minSequenceNumber"] = minSequenceNumber;
+  obj["maxSequenceNumber"] = maxSequenceNumber;
+  obj["deleteRowCount"] = deleteRowCount;
+  obj["creationTimeMs"] = creationTimeMs;
+  obj["fileType"] = typeString(type);
+  obj["sourceType"] = sourceString(source);
+  if (deletionFile.has_value()) {
+    obj["deletionFile"] = deletionFile->serialize();
+  }
+  return obj;
+}
+
+// static
+PaimonDataFile PaimonDataFile::create(const folly::dynamic& obj) {
+  PaimonDataFile file;
+  file.path = obj["filePath"].asString();
+  file.size = static_cast<uint64_t>(obj["fileSize"].asInt());
+  file.rowCount = static_cast<uint64_t>(obj["rowCount"].asInt());
+  file.level = static_cast<int32_t>(obj["level"].asInt());
+  file.minSequenceNumber = obj["minSequenceNumber"].asInt();
+  file.maxSequenceNumber = obj["maxSequenceNumber"].asInt();
+  file.deleteRowCount = obj["deleteRowCount"].asInt();
+  file.creationTimeMs = obj["creationTimeMs"].asInt();
+  file.type = typeFromString(obj["fileType"].asString());
+  file.source = sourceFromString(obj["sourceType"].asString());
+  if (obj.count("deletionFile") > 0) {
+    file.deletionFile = PaimonDeletionFile::create(obj["deletionFile"]);
+  }
+  return file;
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDataFileMeta.h
+++ b/velox/connectors/hive/paimon/PaimonDataFileMeta.h
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+#include <folly/dynamic.h>
+#include <cstdint>
+#include <optional>
+#include <ostream>
+#include <string>
+
+#include <folly/CPortability.h>
+
+#include "velox/connectors/hive/paimon/PaimonDeletionFile.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Represents a single Paimon file (data or changelog) within a split.
+/// Mirrors Apache Paimon's DataFileMeta structure.
+///
+/// Both data files and changelog files use the same physical file format
+/// (Parquet, ORC, Nimble) and carry the same metadata. The distinction is
+/// captured by `type`:
+///   - kData: regular data file (current state of records).
+///   - kChangelog: changelog file with RowKind (+I/-U/+U/-D) for streaming.
+struct PaimonDataFile {
+  /// Whether this file is a data file or a changelog file. Both use the
+  /// same physical format — this enum distinguishes their semantic role.
+  ///
+  /// Data files contain the current state of records. Changelog files
+  /// contain the change history with RowKind tags. The coordinator sends
+  /// data files for batch reads and changelog files for streaming reads
+  /// (when changelog-producer=lookup is configured).
+  enum class Type {
+    /// Regular data file containing current record state.
+    kData,
+
+    /// Changelog file containing records tagged with RowKind (+I/-U/+U/-D).
+    /// Only produced when changelog-producer=lookup is configured on the table.
+    /// The coordinator sends these for streaming reads instead of data files.
+    kChangelog,
+  };
+
+  /// Origin of a Paimon file — how it was produced, not what it contains.
+  /// Mirrors Paimon's DataFileMeta.FileSource enum.
+  ///
+  /// This does NOT indicate whether the file contains `_rowkind`. The presence
+  /// of `_rowkind` depends on the changelog mode (upsert vs input changelog),
+  /// not the source type.
+  enum class Source {
+    /// File produced by a normal write (flush/append).
+    kAppend,
+
+    /// File produced by compaction. This could be:
+    ///   - Without changelog-producer=lookup: a regular data file (same as
+    ///     kAppend but produced by compaction instead of a write).
+    ///   - With changelog-producer=lookup: compaction produces TWO files —
+    ///     (1) a data file (no `_rowkind` in upsert mode) and (2) a separate
+    ///     changelog file (with `_rowkind` containing correct +I/-U/+U/-D).
+    ///     Both are marked kCompact. The coordinator sends the right one based
+    ///     on the read mode (data file for batch, changelog file for
+    ///     streaming).
+    kCompact,
+  };
+
+  /// Returns the string name of the file type (e.g., "DATA").
+  static std::string typeString(Type type);
+
+  /// Parses a file type from its string name.
+  static Type typeFromString(const std::string& str);
+
+  /// Returns the string name of the source type (e.g., "APPEND").
+  static std::string sourceString(Source source);
+
+  /// Parses a source type from its string name.
+  static Source sourceFromString(const std::string& str);
+
+  /// Path to the file (ORC, Parquet, etc.).
+  std::string path;
+
+  /// Size of the file in bytes.
+  uint64_t size{0};
+
+  /// Number of rows in this file.
+  uint64_t rowCount{0};
+
+  /// LSM-tree level of this file. Level 0 contains the newest (unflushed)
+  /// data; higher levels contain progressively more compacted data. Within
+  /// level 0, files CAN have overlapping keys. Within level 1+, compaction
+  /// guarantees non-overlapping key ranges across files.
+  /// Always 0 for append-only tables (no compaction).
+  int32_t level{0};
+
+  /// Sequence number range of records in this file. Auto-generated per-commit,
+  /// monotonically increasing. For level 0 files, min == max (single commit).
+  /// For compacted files (level 1+), min < max (merged from multiple commits).
+  /// Used during merge-on-read to resolve duplicate keys — higher sequence
+  /// number wins. Per-file metadata only (not per-row); after compaction,
+  /// per-row sequence attribution is lost but LSM level order makes it
+  /// unnecessary.
+  int64_t minSequenceNumber{0};
+  int64_t maxSequenceNumber{0};
+
+  /// Number of rows in this file with RowKind = DELETE or UPDATE_BEFORE.
+  /// row_count = addRowCount + deleteRowCount, where addRowCount is the
+  /// number of INSERT or UPDATE_AFTER rows.
+  ///
+  /// Only applicable to primary-key tables. Append-only tables have no
+  /// _rowkind column and every row is implicitly +I, so deleteRowCount is
+  /// always 0.
+  ///
+  /// This is independent of deletionFile — deleteRowCount counts changelog
+  /// records stored inside the file, while deletionFile is an external bitmap
+  /// of positionally deleted rows.
+  ///
+  /// Used to determine rawConvertible: if deleteRowCount > 0, the file
+  /// contains changelog records and cannot be read raw (needs RowKind
+  /// filtering during merge-on-read).
+  int64_t deleteRowCount{0};
+
+  /// Timestamp (epoch millis) when this file was created.
+  int64_t creationTimeMs{0};
+
+  /// Whether this is a data file or changelog file.
+  Type type{Type::kData};
+
+  /// How this file was produced (write vs compaction).
+  Source source{Source::kAppend};
+
+  /// Deletion file for this data file. Contains a roaring bitmap of deleted
+  /// row positions. Nullopt if no rows have been deleted from this file.
+  /// Applies to both primary-key and append-only tables (when
+  /// deletion-vectors.enabled is set). Orthogonal to deleteRowCount —
+  /// deletionFile marks positional deletes, while deleteRowCount counts
+  /// RowKind-based changelog records.
+  /// See PaimonDeletionFile for details.
+  std::optional<PaimonDeletionFile> deletionFile;
+
+  std::string toString() const;
+  folly::dynamic serialize() const;
+  static PaimonDataFile create(const folly::dynamic& obj);
+};
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    PaimonDataFile::Type type) {
+  os << PaimonDataFile::typeString(type);
+  return os;
+}
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    PaimonDataFile::Source source) {
+  os << PaimonDataFile::sourceString(source);
+  return os;
+}
+
+} // namespace facebook::velox::connector::hive::paimon
+
+template <>
+struct fmt::formatter<
+    facebook::velox::connector::hive::paimon::PaimonDataFile::Type>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::paimon::PaimonDataFile::Type type,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::paimon::PaimonDataFile::typeString(
+            type),
+        ctx);
+  }
+};
+
+template <>
+struct fmt::formatter<
+    facebook::velox::connector::hive::paimon::PaimonDataFile::Source>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::paimon::PaimonDataFile::Source source,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::paimon::PaimonDataFile::sourceString(
+            source),
+        ctx);
+  }
+};

--- a/velox/connectors/hive/paimon/PaimonDataSource.cpp
+++ b/velox/connectors/hive/paimon/PaimonDataSource.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonDataSource.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+PaimonDataSource::PaimonDataSource(
+    const RowTypePtr& outputType,
+    const ConnectorTableHandlePtr& tableHandle,
+    const ColumnHandleMap& assignments,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* ioExecutor,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<HiveConfig>& hiveConfig)
+    : HiveDataSource(
+          outputType,
+          tableHandle,
+          assignments,
+          fileHandleFactory,
+          ioExecutor,
+          connectorQueryCtx,
+          hiveConfig) {}
+
+void PaimonDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  VELOX_NYI("PaimonDataSource::addSplit");
+}
+
+std::optional<RowVectorPtr> PaimonDataSource::next(
+    uint64_t size,
+    velox::ContinueFuture& future) {
+  VELOX_NYI("PaimonDataSource::next");
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDataSource.h
+++ b/velox/connectors/hive/paimon/PaimonDataSource.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveDataSource.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Paimon-specific data source that extends HiveDataSource.
+///
+/// Handles PaimonConnectorSplit which may contain multiple data files
+/// in a single logical split (one per LSM-tree level in a bucket).
+/// Currently only supports append-only tables with rawConvertible=true.
+class PaimonDataSource : public HiveDataSource {
+ public:
+  PaimonDataSource(
+      const RowTypePtr& outputType,
+      const ConnectorTableHandlePtr& tableHandle,
+      const ColumnHandleMap& assignments,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* ioExecutor,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<HiveConfig>& hiveConfig);
+
+  void addSplit(std::shared_ptr<ConnectorSplit> split) override;
+
+  std::optional<RowVectorPtr> next(uint64_t size, velox::ContinueFuture& future)
+      override;
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDeletionFile.cpp
+++ b/velox/connectors/hive/paimon/PaimonDeletionFile.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonDeletionFile.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+PaimonDeletionFile::PaimonDeletionFile(
+    std::string _path,
+    uint64_t _offset,
+    uint64_t _length,
+    uint64_t _cardinality)
+    : path(std::move(_path)),
+      offset(_offset),
+      length(_length),
+      cardinality(_cardinality) {
+  VELOX_CHECK_GT(length, 0, "PaimonDeletionFile length must be > 0");
+  VELOX_CHECK_GT(cardinality, 0, "PaimonDeletionFile cardinality must be > 0");
+}
+
+std::string PaimonDeletionFile::toString() const {
+  return fmt::format(
+      "{{path={}, offset={}, length={}, cardinality={}}}",
+      path,
+      offset,
+      length,
+      cardinality);
+}
+
+folly::dynamic PaimonDeletionFile::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["path"] = path;
+  obj["offset"] = offset;
+  obj["length"] = length;
+  obj["cardinality"] = cardinality;
+  return obj;
+}
+
+// static
+PaimonDeletionFile PaimonDeletionFile::create(const folly::dynamic& obj) {
+  return PaimonDeletionFile(
+      obj["path"].asString(),
+      static_cast<uint64_t>(obj["offset"].asInt()),
+      static_cast<uint64_t>(obj["length"].asInt()),
+      static_cast<uint64_t>(obj["cardinality"].asInt()));
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDeletionFile.h
+++ b/velox/connectors/hive/paimon/PaimonDeletionFile.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+#include <folly/dynamic.h>
+#include <cstdint>
+#include <string>
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Paimon deletion file — a serialized Roaring Bitmap tracking deleted row
+/// positions within an existing data file. Only used for primary-key tables
+/// with deletion-vectors.enabled=true. Append-only tables have no concept of
+/// row-level deletes (no primary key to identify specific rows).
+///
+/// # How Deletion Vectors Work
+///
+/// When a primary-key table has deletion vectors enabled, an UPDATE or DELETE
+/// does not rewrite the original data file. Instead:
+///   1. The new/updated record is written to a new L0 data file (as usual).
+///   2. A deletion bitmap is written marking the old row's position in the
+///      original data file (0-based row index).
+///   3. The reader loads the bitmap and skips those positions during scanning.
+///
+/// This improves read performance: without deletion vectors, the reader must
+/// do merge-on-read to discover that a key in an older file has been superseded
+/// by a newer file. With deletion vectors, the reader skips deleted rows
+/// immediately — no merge needed. A split with deletion vectors can be
+/// rawConvertible=true because the bitmaps already tell the reader which rows
+/// to skip (old and new values don't overlap from the reader's perspective).
+///
+/// Similar to Iceberg's positional delete files.
+///
+/// # Manifest Integration
+///
+/// When deletion vectors are written, Paimon creates a new snapshot with
+/// updated manifest entries for the affected data file:
+///   REMOVE: old manifest entry (without or with old deletion file)
+///   ADD:    same data file, now with deletion file reference attached
+/// The data file itself is NOT rewritten — only the manifest entry changes.
+///
+/// Each data file has at most ONE deletion file at any point in time. If more
+/// rows are deleted later, the bitmap is replaced with a new one containing
+/// all deleted positions (old + new, merged). The old bitmap becomes obsolete.
+///
+/// Deletion files can be attached to data files at ANY LSM level (L0, L1,
+/// L2, etc.), not just L0.
+///
+/// # File Format
+///
+/// Deletion files are NOT stored in a columnar format (not Parquet/ORC/Nimble)
+/// and not in a row-based format (not compact row). They use a custom binary
+/// format:
+///   - Core payload: standard RoaringBitmap portable binary serialization
+///     (cross-language spec from RoaringFormatSpec). C++ can read this with
+///     the CRoaring library; Java uses org.roaringbitmap.RoaringBitmap.
+///   - Container packing: when multiple bitmaps are packed into a single file,
+///     Paimon uses a simple custom binary layout with length-prefixed entries
+///     mapping data file names to their bitmap bytes.
+///
+/// Each bitmap contains 0-based row positions of deleted rows within its
+/// associated data file.
+///
+/// Multiple deletion bitmaps can be packed into a single container file.
+/// 'offset' and 'length' specify the byte range within the container where
+/// this bitmap's data lives. For standalone deletion files, offset is 0 and
+/// length equals the file size.
+///
+/// # Relationship to RowKind-Based Deletes
+///
+/// Deletion files are orthogonal to RowKind-based deletes:
+///
+///   RowKind=-D: A full record written to a NEW data file at level 0,
+///     containing the key + all column values tagged with -D. Used for logical
+///     deletes (CDC source, SQL DELETE). Compaction resolves it by removing the
+///     key entirely.
+///
+///   Deletion file (this struct): A bitmap referencing row positions in an
+///     EXISTING data file. No new data record written. Used as a physical
+///     optimization to avoid rewriting files during compaction or partial
+///     deletes.
+///
+/// For batch reads, the reader loads deletion bitmaps and filters out deleted
+/// row positions during scanning.
+struct PaimonDeletionFile {
+  /// @param path Path to the deletion file.
+  /// @param offset Byte offset within the container file.
+  /// @param length Number of bytes of bitmap data (must be > 0).
+  /// @param cardinality Number of deleted rows (must be > 0).
+  PaimonDeletionFile(
+      std::string path,
+      uint64_t offset,
+      uint64_t length,
+      uint64_t cardinality);
+
+  std::string path;
+
+  // Byte offset within the container file where this bitmap starts.
+  uint64_t offset;
+
+  // Number of bytes of bitmap data. Must be > 0.
+  uint64_t length;
+
+  // Number of deleted rows (pre-computed for stats without reading bitmap).
+  // Must be > 0.
+  uint64_t cardinality;
+
+  std::string toString() const;
+  folly::dynamic serialize() const;
+  static PaimonDeletionFile create(const folly::dynamic& obj);
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonRowKind.cpp
+++ b/velox/connectors/hive/paimon/PaimonRowKind.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonRowKind.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+std::string paimonRowKindString(PaimonRowKind kind) {
+  switch (kind) {
+    case PaimonRowKind::kInsert:
+      return "+I";
+    case PaimonRowKind::kUpdateBefore:
+      return "-U";
+    case PaimonRowKind::kUpdateAfter:
+      return "+U";
+    case PaimonRowKind::kDelete:
+      return "-D";
+    default:
+      VELOX_FAIL("Unknown PaimonRowKind: {}", static_cast<int>(kind));
+  }
+}
+
+PaimonRowKind paimonRowKindFromValue(int8_t value) {
+  switch (value) {
+    case 0:
+      return PaimonRowKind::kInsert;
+    case 1:
+      return PaimonRowKind::kUpdateBefore;
+    case 2:
+      return PaimonRowKind::kUpdateAfter;
+    case 3:
+      return PaimonRowKind::kDelete;
+    default:
+      VELOX_FAIL("Unknown PaimonRowKind value: {}", value);
+  }
+}
+
+std::string paimonChangelogModeString(PaimonChangelogMode mode) {
+  switch (mode) {
+    case PaimonChangelogMode::kNone:
+      return "NONE";
+    case PaimonChangelogMode::kInput:
+      return "INPUT";
+    case PaimonChangelogMode::kLookup:
+      return "LOOKUP";
+    case PaimonChangelogMode::kFullCompaction:
+      return "FULL_COMPACTION";
+    default:
+      VELOX_FAIL("Unknown PaimonChangelogMode: {}", static_cast<int>(mode));
+  }
+}
+
+PaimonChangelogMode paimonChangelogModeFromString(const std::string& str) {
+  if (str == "NONE") {
+    return PaimonChangelogMode::kNone;
+  }
+  if (str == "INPUT") {
+    return PaimonChangelogMode::kInput;
+  }
+  if (str == "LOOKUP") {
+    return PaimonChangelogMode::kLookup;
+  }
+  if (str == "FULL_COMPACTION") {
+    return PaimonChangelogMode::kFullCompaction;
+  }
+  VELOX_FAIL("Unknown PaimonChangelogMode: {}", str);
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonRowKind.h
+++ b/velox/connectors/hive/paimon/PaimonRowKind.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <fmt/format.h>
+#include <cstdint>
+#include <ostream>
+#include <string>
+
+#include <folly/CPortability.h>
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Name of the hidden system column that stores the change type per row.
+/// Only present in primary-key table files — append-only tables do not
+/// have this column (every row is implicitly +I).
+/// At the file format level (Parquet, ORC, Nimble), this is a regular
+/// TINYINT column — the file format has no special knowledge of it.
+/// It is "hidden" only at the SQL layer (not shown in SELECT *).
+static constexpr std::string_view kRowKindColumn = "_rowkind";
+
+/// Row-level change type stored in the `_rowkind` column.
+/// Values match the Paimon Java RowKind enum (0-3).
+///
+/// Only meaningful for primary-key tables. Append-only tables have no
+/// concept of updates or deletes — every row is implicitly +I.
+enum class PaimonRowKind : int8_t {
+  /// +I: New row inserted.
+  kInsert = 0,
+  /// -U: Old value being replaced (retraction). Always followed by +U.
+  kUpdateBefore = 1,
+  /// +U: New value replacing the old one. Always preceded by -U.
+  kUpdateAfter = 2,
+  /// -D: Row deleted. Carries the full before-image (all column values).
+  kDelete = 3,
+};
+
+std::string paimonRowKindString(PaimonRowKind kind);
+PaimonRowKind paimonRowKindFromValue(int8_t value);
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    PaimonRowKind kind) {
+  os << paimonRowKindString(kind);
+  return os;
+}
+
+/// Changelog mode determines how a table produces changelog records and
+/// whether `_rowkind` is physically stored in data files. This is a
+/// table-level property set via the `changelog-producer` option.
+/// Only meaningful for primary-key tables — append-only tables have no
+/// updates or deletes, so every row is implicitly +I regardless of this
+/// setting.
+///
+/// # _rowkind Presence in Files
+///
+///   Mode             | Data files  | Changelog files (from compaction)
+///   -----------------+-------------+----------------------------------
+///   kNone            | No          | N/A (no changelog files produced)
+///   kInput           | Yes         | Yes
+///   kLookup          | No          | Yes
+///   kFullCompaction   | No          | Yes
+///
+/// For batch reads, `_rowkind` is not needed — the reader returns
+/// current state, not changelog. This enum becomes relevant for streaming.
+enum class PaimonChangelogMode {
+  /// Default for primary-key tables. No changelog producer configured.
+  /// Data files do NOT contain `_rowkind`. Compaction does NOT generate
+  /// changelog files. Streaming reads emit all delta rows as +I (cannot
+  /// distinguish INSERT from UPDATE).
+  kNone,
+  /// Source provides RowKind explicitly (CDC/input changelog).
+  /// Data files DO contain `_rowkind` for every row.
+  kInput,
+  /// Compactor generates changelog files by looking up old values during
+  /// every compaction (both partial and full). Data files do NOT contain
+  /// `_rowkind`, but changelog files do. Provides low-latency changelog
+  /// for streaming consumers at the cost of higher write amplification.
+  kLookup,
+  /// Same mechanism as kLookup (looking up old values to produce changelog),
+  /// but changelog files are only generated during full compaction — partial
+  /// compactions do NOT produce changelog. Between full compactions,
+  /// streaming consumers get degraded output (all rows emitted as +I).
+  /// Lower write cost than kLookup, but higher changelog latency.
+  kFullCompaction,
+};
+
+std::string paimonChangelogModeString(PaimonChangelogMode mode);
+PaimonChangelogMode paimonChangelogModeFromString(const std::string& str);
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    PaimonChangelogMode mode) {
+  os << paimonChangelogModeString(mode);
+  return os;
+}
+
+} // namespace facebook::velox::connector::hive::paimon
+
+template <>
+struct fmt::formatter<facebook::velox::connector::hive::paimon::PaimonRowKind>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::paimon::PaimonRowKind kind,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::paimon::paimonRowKindString(kind),
+        ctx);
+  }
+};
+
+template <>
+struct fmt::formatter<
+    facebook::velox::connector::hive::paimon::PaimonChangelogMode>
+    : formatter<std::string> {
+  auto format(
+      facebook::velox::connector::hive::paimon::PaimonChangelogMode mode,
+      format_context& ctx) const {
+    return formatter<std::string>::format(
+        facebook::velox::connector::hive::paimon::paimonChangelogModeString(
+            mode),
+        ctx);
+  }
+};

--- a/velox/connectors/hive/paimon/tests/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/tests/CMakeLists.txt
@@ -1,0 +1,68 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if(NOT VELOX_DISABLE_GOOGLETEST)
+  add_executable(velox_hive_paimon_split_test PaimonConnectorSplitTest.cpp)
+  add_test(velox_hive_paimon_split_test velox_hive_paimon_split_test)
+
+  target_link_libraries(
+    velox_hive_paimon_split_test
+    velox_hive_paimon_split
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+  )
+
+  add_executable(
+    velox_hive_paimon_data_file_meta_test PaimonDataFileMetaTest.cpp)
+  add_test(
+    velox_hive_paimon_data_file_meta_test
+    velox_hive_paimon_data_file_meta_test)
+
+  target_link_libraries(
+    velox_hive_paimon_data_file_meta_test
+    velox_hive_paimon_split
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+  )
+
+  add_executable(
+    velox_hive_paimon_deletion_file_test PaimonDeletionFileTest.cpp)
+  add_test(
+    velox_hive_paimon_deletion_file_test
+    velox_hive_paimon_deletion_file_test)
+
+  target_link_libraries(
+    velox_hive_paimon_deletion_file_test
+    velox_hive_paimon_split
+    GTest::gtest
+    GTest::gtest_main
+    GTest::gmock
+  )
+
+  add_executable(
+    velox_hive_paimon_row_kind_test PaimonRowKindTest.cpp)
+  add_test(
+    velox_hive_paimon_row_kind_test
+    velox_hive_paimon_row_kind_test)
+
+  target_link_libraries(
+    velox_hive_paimon_row_kind_test
+    velox_hive_paimon_split
+    GTest::gtest
+    GTest::gtest_main
+    fmt::fmt
+  )
+endif()

--- a/velox/connectors/hive/paimon/tests/PaimonConnectorSplitTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonConnectorSplitTest.cpp
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonConnectorSplit.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox::connector::hive::paimon;
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+
+namespace {
+using PartitionKeys =
+    std::unordered_map<std::string, std::optional<std::string>>;
+} // namespace
+
+class PaimonConnectorSplitTest : public testing::Test {
+ protected:
+  const std::string kConnectorId{"test-connector"};
+};
+
+TEST_F(PaimonConnectorSplitTest, basic) {
+  PaimonDataFile file0;
+  file0.path = "s3://bucket/table/dt=2024-01-01/bucket-0/data-001.orc";
+  file0.size = 1024;
+  file0.rowCount = 100;
+  file0.level = 0;
+
+  PaimonDataFile file1;
+  file1.path = "s3://bucket/table/dt=2024-01-01/bucket-0/data-002.orc";
+  file1.size = 2048;
+  file1.rowCount = 200;
+  file1.level = 1;
+
+  std::vector<PaimonDataFile> files{file0, file1};
+  PartitionKeys partitionKeys{{"dt", "2024-01-01"}};
+
+  auto split = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/1,
+      PaimonTableType::kPrimaryKey,
+      FileFormat::DWRF,
+      files,
+      partitionKeys,
+      0);
+
+  EXPECT_EQ(split->snapshotId(), 1);
+  EXPECT_EQ(split->tableType(), PaimonTableType::kPrimaryKey);
+  EXPECT_EQ(split->fileFormat(), FileFormat::DWRF);
+  EXPECT_TRUE(split->rawConvertible());
+  EXPECT_EQ(split->tableBucketNumber(), 0);
+  ASSERT_EQ(split->dataFiles().size(), 2);
+  EXPECT_EQ(split->dataFiles()[0].path, files[0].path);
+  EXPECT_EQ(split->dataFiles()[0].size, 1024);
+  EXPECT_EQ(split->dataFiles()[1].path, files[1].path);
+  EXPECT_EQ(split->dataFiles()[1].size, 2048);
+  ASSERT_EQ(split->partitionKeys().count("dt"), 1);
+  EXPECT_EQ(split->partitionKeys().at("dt"), "2024-01-01");
+}
+
+TEST_F(PaimonConnectorSplitTest, nimbleFormat) {
+  PaimonDataFile file0;
+  file0.path = "s3://bucket/table/data-001.nimble";
+  file0.size = 4096;
+  file0.rowCount = 100;
+  std::vector<PaimonDataFile> files{file0};
+
+  auto split = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/1,
+      PaimonTableType::kAppendOnly,
+      FileFormat::NIMBLE,
+      files,
+      PartitionKeys{},
+      std::nullopt);
+
+  ASSERT_EQ(split->dataFiles().size(), 1);
+  EXPECT_EQ(split->tableType(), PaimonTableType::kAppendOnly);
+  EXPECT_EQ(split->fileFormat(), FileFormat::NIMBLE);
+}
+
+TEST_F(PaimonConnectorSplitTest, parquetFormat) {
+  PaimonDataFile file0;
+  file0.path = "s3://bucket/table/data-001.parquet";
+  file0.size = 4096;
+  file0.rowCount = 100;
+  std::vector<PaimonDataFile> files{file0};
+
+  auto split = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/1,
+      PaimonTableType::kAppendOnly,
+      FileFormat::PARQUET,
+      files,
+      PartitionKeys{},
+      std::nullopt);
+
+  ASSERT_EQ(split->dataFiles().size(), 1);
+  EXPECT_EQ(split->fileFormat(), FileFormat::PARQUET);
+}
+
+TEST_F(PaimonConnectorSplitTest, emptyFilesThrows) {
+  std::vector<PaimonDataFile> noFiles;
+  VELOX_ASSERT_THROW(
+      std::make_shared<PaimonConnectorSplit>(
+          kConnectorId,
+          /*snapshotId=*/1,
+          PaimonTableType::kAppendOnly,
+          FileFormat::NIMBLE,
+          noFiles,
+          PartitionKeys{},
+          std::nullopt),
+      "PaimonConnectorSplit requires non-empty dataFiles");
+}
+
+TEST_F(PaimonConnectorSplitTest, rawConvertibleWithDeleteRowCountThrows) {
+  PaimonDataFile file;
+  file.path = "data-001.orc";
+  file.size = 1024;
+  file.rowCount = 100;
+  file.level = 1;
+  file.deleteRowCount = 5;
+
+  std::vector<PaimonDataFile> files{file};
+  VELOX_ASSERT_THROW(
+      std::make_shared<PaimonConnectorSplit>(
+          kConnectorId,
+          /*snapshotId=*/1,
+          PaimonTableType::kPrimaryKey,
+          FileFormat::DWRF,
+          files,
+          PartitionKeys{},
+          std::nullopt,
+          /*rawConvertible=*/true),
+      "rawConvertible split cannot have files with deleteRowCount > 0");
+}
+
+TEST_F(PaimonConnectorSplitTest, notRawConvertibleWithDeleteRowCount) {
+  PaimonDataFile file;
+  file.path = "data-001.orc";
+  file.size = 1024;
+  file.rowCount = 100;
+  file.level = 1;
+  file.deleteRowCount = 5;
+
+  std::vector<PaimonDataFile> files{file};
+  auto split = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/1,
+      PaimonTableType::kPrimaryKey,
+      FileFormat::DWRF,
+      files,
+      PartitionKeys{},
+      std::nullopt,
+      /*rawConvertible=*/false);
+
+  EXPECT_FALSE(split->rawConvertible());
+  EXPECT_EQ(split->dataFiles()[0].deleteRowCount, 5);
+}
+
+TEST_F(PaimonConnectorSplitTest, toStringOutput) {
+  PaimonDataFile f0;
+  f0.path = "data-001.orc";
+  f0.size = 1024;
+  f0.rowCount = 100;
+
+  PaimonDataFile f1;
+  f1.path = "data-002.orc";
+  f1.size = 2048;
+  f1.rowCount = 200;
+  f1.level = 1;
+
+  PaimonDataFile f2;
+  f2.path = "data-003.orc";
+  f2.size = 512;
+  f2.rowCount = 50;
+  f2.level = 2;
+
+  std::vector<PaimonDataFile> files{f0, f1, f2};
+
+  auto split = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/42,
+      PaimonTableType::kPrimaryKey,
+      FileFormat::DWRF,
+      files,
+      PartitionKeys{},
+      std::nullopt);
+
+  EXPECT_THAT(split->toString(), testing::HasSubstr("snapshot 42"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("PRIMARY_KEY"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr(kConnectorId));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("data-001.orc"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("data-003.orc"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("size=1024"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("rows=100"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("level=1"));
+  EXPECT_THAT(split->toString(), testing::HasSubstr("deletionFile=none"));
+}
+
+TEST_F(PaimonConnectorSplitTest, nullPartitionValue) {
+  PaimonDataFile file0;
+  file0.path = "data-001.orc";
+  file0.size = 1024;
+  file0.rowCount = 100;
+  std::vector<PaimonDataFile> files{file0};
+  PartitionKeys partitionKeys{{"country", std::nullopt}};
+
+  auto split = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/1,
+      PaimonTableType::kAppendOnly,
+      FileFormat::DWRF,
+      files,
+      partitionKeys,
+      std::nullopt);
+
+  ASSERT_EQ(split->partitionKeys().count("country"), 1);
+  EXPECT_EQ(split->partitionKeys().at("country"), std::nullopt);
+}
+
+TEST_F(PaimonConnectorSplitTest, builder) {
+  auto split = PaimonConnectorSplitBuilder(
+                   kConnectorId,
+                   /*snapshotId=*/5,
+                   PaimonTableType::kPrimaryKey,
+                   FileFormat::PARQUET)
+                   .addFile("s3://bucket/data-001.parquet", 1024, 0)
+                   .addFile("s3://bucket/data-002.parquet", 2048, 1)
+                   .partitionKey("dt", "2024-01-01")
+                   .partitionKey("country", std::nullopt)
+                   .tableBucketNumber(3)
+                   .build();
+
+  EXPECT_EQ(split->snapshotId(), 5);
+  EXPECT_EQ(split->fileFormat(), FileFormat::PARQUET);
+  EXPECT_TRUE(split->rawConvertible());
+
+  ASSERT_EQ(split->dataFiles().size(), 2);
+  EXPECT_EQ(split->dataFiles()[0].path, "s3://bucket/data-001.parquet");
+  EXPECT_EQ(split->dataFiles()[0].size, 1024);
+  EXPECT_EQ(split->dataFiles()[1].path, "s3://bucket/data-002.parquet");
+  EXPECT_EQ(split->dataFiles()[1].size, 2048);
+  EXPECT_EQ(split->tableBucketNumber(), 3);
+  EXPECT_EQ(split->partitionKeys().at("dt"), "2024-01-01");
+  EXPECT_EQ(split->partitionKeys().at("country"), std::nullopt);
+}
+
+TEST_F(PaimonConnectorSplitTest, builderDefaults) {
+  auto split = PaimonConnectorSplitBuilder(
+                   kConnectorId,
+                   /*snapshotId=*/1,
+                   PaimonTableType::kAppendOnly,
+                   FileFormat::NIMBLE)
+                   .addFile("data.nimble", 512)
+                   .build();
+
+  ASSERT_EQ(split->dataFiles().size(), 1);
+  EXPECT_EQ(split->fileFormat(), FileFormat::NIMBLE);
+  EXPECT_EQ(split->tableBucketNumber(), std::nullopt);
+  EXPECT_TRUE(split->partitionKeys().empty());
+}
+
+TEST_F(PaimonConnectorSplitTest, serializeRoundTrip) {
+  PaimonDataFile meta;
+  meta.path = "s3://bucket/data-001.parquet";
+  meta.size = 4096;
+  meta.rowCount = 1000;
+  meta.level = 2;
+  meta.minSequenceNumber = 10;
+  meta.maxSequenceNumber = 20;
+  meta.deleteRowCount = 5;
+  meta.creationTimeMs = 1700000000;
+  meta.source = PaimonDataFile::Source::kCompact;
+  meta.deletionFile =
+      PaimonDeletionFile{"s3://bucket/deletion-001.bin", 0, 128, 5};
+
+  std::vector<PaimonDataFile> files{meta};
+  PartitionKeys partitionKeys{{"dt", "2024-01-01"}, {"country", std::nullopt}};
+
+  auto original = std::make_shared<PaimonConnectorSplit>(
+      kConnectorId,
+      /*snapshotId=*/42,
+      PaimonTableType::kPrimaryKey,
+      FileFormat::PARQUET,
+      files,
+      partitionKeys,
+      /*tableBucketNumber=*/7,
+      /*rawConvertible=*/false);
+
+  auto serialized = original->serialize();
+  auto deserialized = PaimonConnectorSplit::create(serialized);
+
+  EXPECT_EQ(deserialized->connectorId, kConnectorId);
+  EXPECT_EQ(deserialized->snapshotId(), 42);
+  EXPECT_EQ(deserialized->tableType(), PaimonTableType::kPrimaryKey);
+  EXPECT_EQ(deserialized->fileFormat(), FileFormat::PARQUET);
+  EXPECT_FALSE(deserialized->rawConvertible());
+  EXPECT_EQ(deserialized->tableBucketNumber(), 7);
+
+  ASSERT_EQ(deserialized->dataFiles().size(), 1);
+  const auto& file = deserialized->dataFiles()[0];
+  EXPECT_EQ(file.path, "s3://bucket/data-001.parquet");
+  EXPECT_EQ(file.size, 4096);
+  EXPECT_EQ(file.rowCount, 1000);
+  EXPECT_EQ(file.level, 2);
+  EXPECT_EQ(file.minSequenceNumber, 10);
+  EXPECT_EQ(file.maxSequenceNumber, 20);
+  EXPECT_EQ(file.deleteRowCount, 5);
+  EXPECT_EQ(file.creationTimeMs, 1700000000);
+  EXPECT_EQ(file.source, PaimonDataFile::Source::kCompact);
+
+  ASSERT_TRUE(file.deletionFile.has_value());
+  EXPECT_EQ(file.deletionFile->path, "s3://bucket/deletion-001.bin");
+  EXPECT_EQ(file.deletionFile->offset, 0);
+  EXPECT_EQ(file.deletionFile->length, 128);
+  EXPECT_EQ(file.deletionFile->cardinality, 5);
+
+  ASSERT_EQ(deserialized->partitionKeys().count("dt"), 1);
+  EXPECT_EQ(deserialized->partitionKeys().at("dt"), "2024-01-01");
+  ASSERT_EQ(deserialized->partitionKeys().count("country"), 1);
+  EXPECT_EQ(deserialized->partitionKeys().at("country"), std::nullopt);
+
+  ASSERT_EQ(deserialized->dataFiles().size(), 1);
+  EXPECT_EQ(deserialized->dataFiles()[0].path, "s3://bucket/data-001.parquet");
+  EXPECT_EQ(deserialized->dataFiles()[0].size, 4096);
+}
+
+TEST_F(PaimonConnectorSplitTest, paimonTableTypeStringAndParse) {
+  EXPECT_EQ(paimonTableTypeString(PaimonTableType::kAppendOnly), "APPEND_ONLY");
+  EXPECT_EQ(paimonTableTypeString(PaimonTableType::kPrimaryKey), "PRIMARY_KEY");
+
+  EXPECT_EQ(
+      paimonTableTypeFromString("APPEND_ONLY"), PaimonTableType::kAppendOnly);
+  EXPECT_EQ(
+      paimonTableTypeFromString("PRIMARY_KEY"), PaimonTableType::kPrimaryKey);
+
+  VELOX_ASSERT_THROW(
+      paimonTableTypeFromString("UNKNOWN"), "Unknown PaimonTableType: UNKNOWN");
+}
+
+TEST_F(PaimonConnectorSplitTest, tableTypeStreamAndFormat) {
+  {
+    std::ostringstream os;
+    os << PaimonTableType::kAppendOnly;
+    EXPECT_EQ(os.str(), "APPEND_ONLY");
+  }
+  {
+    std::ostringstream os;
+    os << PaimonTableType::kPrimaryKey;
+    EXPECT_EQ(os.str(), "PRIMARY_KEY");
+  }
+
+  EXPECT_EQ(fmt::format("{}", PaimonTableType::kAppendOnly), "APPEND_ONLY");
+  EXPECT_EQ(fmt::format("{}", PaimonTableType::kPrimaryKey), "PRIMARY_KEY");
+}

--- a/velox/connectors/hive/paimon/tests/PaimonConnectorTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonConnectorTest.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonConnector.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+
+namespace facebook::velox::connector::hive::paimon {
+namespace {
+
+static const std::string kPaimonConnectorId = "test-paimon";
+
+class PaimonConnectorTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    auto config = std::make_shared<config::ConfigBase>(
+        std::unordered_map<std::string, std::string>{});
+    auto connector =
+        PaimonConnectorFactory().newConnector(kPaimonConnectorId, config);
+    registerConnector(connector);
+  }
+
+  void TearDown() override {
+    unregisterConnector(kPaimonConnectorId);
+    HiveConnectorTestBase::TearDown();
+  }
+};
+
+TEST_F(PaimonConnectorTest, connectorRegistration) {
+  auto connector = getConnector(kPaimonConnectorId);
+  ASSERT_NE(connector, nullptr);
+  ASSERT_NE(connector->connectorConfig(), nullptr);
+}
+
+TEST_F(PaimonConnectorTest, connectorFactory) {
+  PaimonConnectorFactory factory;
+  EXPECT_EQ(
+      std::string(PaimonConnectorFactory::kPaimonConnectorName), "paimon");
+
+  auto config = std::make_shared<config::ConfigBase>(
+      std::unordered_map<std::string, std::string>{
+          {HiveConfig::kEnableFileHandleCache, "true"},
+          {HiveConfig::kNumCacheFileHandles, "500"}});
+
+  auto connector = factory.newConnector("test-paimon-2", config);
+  ASSERT_NE(connector, nullptr);
+
+  HiveConfig hiveConfig(connector->connectorConfig());
+  EXPECT_TRUE(hiveConfig.isFileHandleCacheEnabled());
+  EXPECT_EQ(hiveConfig.numCacheFileHandles(), 500);
+}
+
+} // namespace
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/tests/PaimonDataFileMetaTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonDataFileMetaTest.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonDataFileMeta.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox::connector::hive::paimon;
+using namespace facebook::velox;
+
+TEST(PaimonDataFileTest, serializeRoundTrip) {
+  PaimonDataFile file;
+  file.path = "data.parquet";
+  file.size = 4096;
+  file.rowCount = 500;
+  file.level = 1;
+  file.minSequenceNumber = 5;
+  file.maxSequenceNumber = 15;
+  file.deleteRowCount = 3;
+  file.creationTimeMs = 1700000000;
+  file.type = PaimonDataFile::Type::kChangelog;
+  file.source = PaimonDataFile::Source::kCompact;
+  file.deletionFile = PaimonDeletionFile{"del.bin", 0, 64, 2};
+
+  auto serialized = file.serialize();
+  auto deserialized = PaimonDataFile::create(serialized);
+
+  EXPECT_EQ(deserialized.path, "data.parquet");
+  EXPECT_EQ(deserialized.size, 4096);
+  EXPECT_EQ(deserialized.rowCount, 500);
+  EXPECT_EQ(deserialized.level, 1);
+  EXPECT_EQ(deserialized.minSequenceNumber, 5);
+  EXPECT_EQ(deserialized.maxSequenceNumber, 15);
+  EXPECT_EQ(deserialized.deleteRowCount, 3);
+  EXPECT_EQ(deserialized.creationTimeMs, 1700000000);
+  EXPECT_EQ(deserialized.type, PaimonDataFile::Type::kChangelog);
+  EXPECT_EQ(deserialized.source, PaimonDataFile::Source::kCompact);
+  ASSERT_TRUE(deserialized.deletionFile.has_value());
+  EXPECT_EQ(deserialized.deletionFile->path, "del.bin");
+  EXPECT_EQ(deserialized.deletionFile->offset, 0);
+  EXPECT_EQ(deserialized.deletionFile->length, 64);
+  EXPECT_EQ(deserialized.deletionFile->cardinality, 2);
+}
+
+TEST(PaimonDataFileTest, serializeNoDeletionFile) {
+  PaimonDataFile file;
+  file.path = "data.orc";
+  file.size = 1024;
+
+  auto serialized = file.serialize();
+  auto deserialized = PaimonDataFile::create(serialized);
+
+  EXPECT_EQ(deserialized.path, "data.orc");
+  EXPECT_EQ(deserialized.size, 1024);
+  EXPECT_FALSE(deserialized.deletionFile.has_value());
+}
+
+TEST(PaimonDataFileTest, serializeDefaultValues) {
+  PaimonDataFile file;
+  file.path = "data.orc";
+
+  auto serialized = file.serialize();
+  auto deserialized = PaimonDataFile::create(serialized);
+
+  EXPECT_EQ(deserialized.path, "data.orc");
+  EXPECT_EQ(deserialized.size, 0);
+  EXPECT_EQ(deserialized.rowCount, 0);
+  EXPECT_EQ(deserialized.level, 0);
+  EXPECT_EQ(deserialized.minSequenceNumber, 0);
+  EXPECT_EQ(deserialized.maxSequenceNumber, 0);
+  EXPECT_EQ(deserialized.deleteRowCount, 0);
+  EXPECT_EQ(deserialized.creationTimeMs, 0);
+  EXPECT_EQ(deserialized.type, PaimonDataFile::Type::kData);
+  EXPECT_EQ(deserialized.source, PaimonDataFile::Source::kAppend);
+  EXPECT_FALSE(deserialized.deletionFile.has_value());
+}
+
+TEST(PaimonDataFileTest, toString) {
+  PaimonDataFile file;
+  file.path = "data.orc";
+  file.size = 1024;
+  file.rowCount = 100;
+  file.level = 0;
+
+  auto str = file.toString();
+  EXPECT_THAT(str, testing::HasSubstr("data.orc"));
+  EXPECT_THAT(str, testing::HasSubstr("size=1024"));
+  EXPECT_THAT(str, testing::HasSubstr("rows=100"));
+  EXPECT_THAT(str, testing::HasSubstr("level=0"));
+  EXPECT_THAT(str, testing::HasSubstr("type=DATA"));
+  EXPECT_THAT(str, testing::HasSubstr("source=APPEND"));
+  EXPECT_THAT(str, testing::HasSubstr("deletionFile=none"));
+}
+
+TEST(PaimonDataFileTest, toStringChangelog) {
+  PaimonDataFile file;
+  file.path = "changelog.orc";
+  file.size = 2048;
+  file.rowCount = 200;
+  file.level = 1;
+  file.type = PaimonDataFile::Type::kChangelog;
+  file.source = PaimonDataFile::Source::kCompact;
+  file.deletionFile = PaimonDeletionFile{"del.bin", 0, 64, 2};
+
+  auto str = file.toString();
+  EXPECT_THAT(str, testing::HasSubstr("type=CHANGELOG"));
+  EXPECT_THAT(str, testing::HasSubstr("source=COMPACT"));
+  EXPECT_THAT(str, testing::HasSubstr("del.bin"));
+  EXPECT_THAT(str, testing::HasSubstr("cardinality=2"));
+}
+
+TEST(PaimonDataFileTest, defaultValues) {
+  PaimonDataFile file;
+  EXPECT_TRUE(file.path.empty());
+  EXPECT_EQ(file.size, 0);
+  EXPECT_EQ(file.rowCount, 0);
+  EXPECT_EQ(file.level, 0);
+  EXPECT_EQ(file.minSequenceNumber, 0);
+  EXPECT_EQ(file.maxSequenceNumber, 0);
+  EXPECT_EQ(file.deleteRowCount, 0);
+  EXPECT_EQ(file.creationTimeMs, 0);
+  EXPECT_EQ(file.type, PaimonDataFile::Type::kData);
+  EXPECT_EQ(file.source, PaimonDataFile::Source::kAppend);
+  EXPECT_FALSE(file.deletionFile.has_value());
+}
+
+TEST(PaimonDataFileTest, typeStringAndParse) {
+  EXPECT_EQ(PaimonDataFile::typeString(PaimonDataFile::Type::kData), "DATA");
+  EXPECT_EQ(
+      PaimonDataFile::typeString(PaimonDataFile::Type::kChangelog),
+      "CHANGELOG");
+
+  EXPECT_EQ(
+      PaimonDataFile::typeFromString("DATA"), PaimonDataFile::Type::kData);
+  EXPECT_EQ(
+      PaimonDataFile::typeFromString("CHANGELOG"),
+      PaimonDataFile::Type::kChangelog);
+
+  VELOX_ASSERT_THROW(
+      PaimonDataFile::typeFromString("UNKNOWN"),
+      "Unknown PaimonDataFile::Type: UNKNOWN");
+}
+
+TEST(PaimonDataFileTest, sourceStringAndParse) {
+  EXPECT_EQ(
+      PaimonDataFile::sourceString(PaimonDataFile::Source::kAppend), "APPEND");
+  EXPECT_EQ(
+      PaimonDataFile::sourceString(PaimonDataFile::Source::kCompact),
+      "COMPACT");
+
+  EXPECT_EQ(
+      PaimonDataFile::sourceFromString("APPEND"),
+      PaimonDataFile::Source::kAppend);
+  EXPECT_EQ(
+      PaimonDataFile::sourceFromString("COMPACT"),
+      PaimonDataFile::Source::kCompact);
+
+  VELOX_ASSERT_THROW(
+      PaimonDataFile::sourceFromString("UNKNOWN"),
+      "Unknown PaimonDataFile::Source: UNKNOWN");
+}
+
+TEST(PaimonDataFileTest, typeStreamAndFormat) {
+  {
+    std::ostringstream os;
+    os << PaimonDataFile::Type::kData;
+    EXPECT_EQ(os.str(), "DATA");
+  }
+  {
+    std::ostringstream os;
+    os << PaimonDataFile::Type::kChangelog;
+    EXPECT_EQ(os.str(), "CHANGELOG");
+  }
+
+  EXPECT_EQ(fmt::format("{}", PaimonDataFile::Type::kData), "DATA");
+  EXPECT_EQ(fmt::format("{}", PaimonDataFile::Type::kChangelog), "CHANGELOG");
+}
+
+TEST(PaimonDataFileTest, sourceStreamAndFormat) {
+  {
+    std::ostringstream os;
+    os << PaimonDataFile::Source::kAppend;
+    EXPECT_EQ(os.str(), "APPEND");
+  }
+  {
+    std::ostringstream os;
+    os << PaimonDataFile::Source::kCompact;
+    EXPECT_EQ(os.str(), "COMPACT");
+  }
+
+  EXPECT_EQ(fmt::format("{}", PaimonDataFile::Source::kAppend), "APPEND");
+  EXPECT_EQ(fmt::format("{}", PaimonDataFile::Source::kCompact), "COMPACT");
+}

--- a/velox/connectors/hive/paimon/tests/PaimonDeletionFileTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonDeletionFileTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonDeletionFile.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox::connector::hive::paimon;
+using namespace facebook::velox;
+
+TEST(PaimonDeletionFileTest, serializeRoundTrip) {
+  PaimonDeletionFile df("s3://bucket/deletion.bin", 64, 256, 10);
+
+  auto serialized = df.serialize();
+  auto deserialized = PaimonDeletionFile::create(serialized);
+
+  EXPECT_EQ(deserialized.path, "s3://bucket/deletion.bin");
+  EXPECT_EQ(deserialized.offset, 64);
+  EXPECT_EQ(deserialized.length, 256);
+  EXPECT_EQ(deserialized.cardinality, 10);
+}
+
+TEST(PaimonDeletionFileTest, serializeRoundTripZeroOffset) {
+  PaimonDeletionFile df("deletion-standalone.bin", 0, 512, 42);
+
+  auto serialized = df.serialize();
+  auto deserialized = PaimonDeletionFile::create(serialized);
+
+  EXPECT_EQ(deserialized.path, "deletion-standalone.bin");
+  EXPECT_EQ(deserialized.offset, 0);
+  EXPECT_EQ(deserialized.length, 512);
+  EXPECT_EQ(deserialized.cardinality, 42);
+}
+
+TEST(PaimonDeletionFileTest, serializeRoundTripLargeValues) {
+  PaimonDeletionFile df(
+      "s3://bucket/container.bin", 1ULL << 32, 1ULL << 20, 1000000);
+
+  auto serialized = df.serialize();
+  auto deserialized = PaimonDeletionFile::create(serialized);
+
+  EXPECT_EQ(deserialized.path, "s3://bucket/container.bin");
+  EXPECT_EQ(deserialized.offset, 1ULL << 32);
+  EXPECT_EQ(deserialized.length, 1ULL << 20);
+  EXPECT_EQ(deserialized.cardinality, 1000000);
+}
+
+TEST(PaimonDeletionFileTest, toString) {
+  PaimonDeletionFile df("del.bin", 0, 128, 5);
+
+  auto str = df.toString();
+  EXPECT_THAT(str, testing::HasSubstr("del.bin"));
+  EXPECT_THAT(str, testing::HasSubstr("offset=0"));
+  EXPECT_THAT(str, testing::HasSubstr("length=128"));
+  EXPECT_THAT(str, testing::HasSubstr("cardinality=5"));
+}
+
+TEST(PaimonDeletionFileTest, toStringContainerFile) {
+  PaimonDeletionFile df("s3://bucket/container.bin", 1024, 256, 15);
+
+  auto str = df.toString();
+  EXPECT_THAT(str, testing::HasSubstr("s3://bucket/container.bin"));
+  EXPECT_THAT(str, testing::HasSubstr("offset=1024"));
+  EXPECT_THAT(str, testing::HasSubstr("length=256"));
+  EXPECT_THAT(str, testing::HasSubstr("cardinality=15"));
+}
+
+TEST(PaimonDeletionFileTest, zeroLengthThrows) {
+  VELOX_ASSERT_THROW(
+      PaimonDeletionFile("del.bin", 0, 0, 5),
+      "PaimonDeletionFile length must be > 0");
+}
+
+TEST(PaimonDeletionFileTest, zeroCardinalityThrows) {
+  VELOX_ASSERT_THROW(
+      PaimonDeletionFile("del.bin", 0, 128, 0),
+      "PaimonDeletionFile cardinality must be > 0");
+}
+
+TEST(PaimonDeletionFileTest, zeroLengthAndCardinalityThrows) {
+  VELOX_ASSERT_THROW(
+      PaimonDeletionFile("del.bin", 0, 0, 0),
+      "PaimonDeletionFile length must be > 0");
+}

--- a/velox/connectors/hive/paimon/tests/PaimonRowKindTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonRowKindTest.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonRowKind.h"
+
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox::connector::hive::paimon;
+using namespace facebook::velox;
+
+TEST(PaimonRowKindTest, rowKindString) {
+  EXPECT_EQ(paimonRowKindString(PaimonRowKind::kInsert), "+I");
+  EXPECT_EQ(paimonRowKindString(PaimonRowKind::kUpdateBefore), "-U");
+  EXPECT_EQ(paimonRowKindString(PaimonRowKind::kUpdateAfter), "+U");
+  EXPECT_EQ(paimonRowKindString(PaimonRowKind::kDelete), "-D");
+}
+
+TEST(PaimonRowKindTest, rowKindFromValue) {
+  EXPECT_EQ(paimonRowKindFromValue(0), PaimonRowKind::kInsert);
+  EXPECT_EQ(paimonRowKindFromValue(1), PaimonRowKind::kUpdateBefore);
+  EXPECT_EQ(paimonRowKindFromValue(2), PaimonRowKind::kUpdateAfter);
+  EXPECT_EQ(paimonRowKindFromValue(3), PaimonRowKind::kDelete);
+
+  VELOX_ASSERT_THROW(
+      paimonRowKindFromValue(4), "Unknown PaimonRowKind value: 4");
+  VELOX_ASSERT_THROW(
+      paimonRowKindFromValue(-1), "Unknown PaimonRowKind value: -1");
+}
+
+TEST(PaimonRowKindTest, rowKindStreamAndFormat) {
+  {
+    std::ostringstream os;
+    os << PaimonRowKind::kInsert;
+    EXPECT_EQ(os.str(), "+I");
+  }
+  {
+    std::ostringstream os;
+    os << PaimonRowKind::kDelete;
+    EXPECT_EQ(os.str(), "-D");
+  }
+
+  EXPECT_EQ(fmt::format("{}", PaimonRowKind::kInsert), "+I");
+  EXPECT_EQ(fmt::format("{}", PaimonRowKind::kUpdateBefore), "-U");
+  EXPECT_EQ(fmt::format("{}", PaimonRowKind::kUpdateAfter), "+U");
+  EXPECT_EQ(fmt::format("{}", PaimonRowKind::kDelete), "-D");
+}
+
+TEST(PaimonRowKindTest, rowKindValues) {
+  EXPECT_EQ(static_cast<int8_t>(PaimonRowKind::kInsert), 0);
+  EXPECT_EQ(static_cast<int8_t>(PaimonRowKind::kUpdateBefore), 1);
+  EXPECT_EQ(static_cast<int8_t>(PaimonRowKind::kUpdateAfter), 2);
+  EXPECT_EQ(static_cast<int8_t>(PaimonRowKind::kDelete), 3);
+}
+
+TEST(PaimonRowKindTest, changelogModeStringAndParse) {
+  EXPECT_EQ(paimonChangelogModeString(PaimonChangelogMode::kNone), "NONE");
+  EXPECT_EQ(paimonChangelogModeString(PaimonChangelogMode::kInput), "INPUT");
+  EXPECT_EQ(paimonChangelogModeString(PaimonChangelogMode::kLookup), "LOOKUP");
+  EXPECT_EQ(
+      paimonChangelogModeString(PaimonChangelogMode::kFullCompaction),
+      "FULL_COMPACTION");
+
+  EXPECT_EQ(paimonChangelogModeFromString("NONE"), PaimonChangelogMode::kNone);
+  EXPECT_EQ(
+      paimonChangelogModeFromString("INPUT"), PaimonChangelogMode::kInput);
+  EXPECT_EQ(
+      paimonChangelogModeFromString("LOOKUP"), PaimonChangelogMode::kLookup);
+  EXPECT_EQ(
+      paimonChangelogModeFromString("FULL_COMPACTION"),
+      PaimonChangelogMode::kFullCompaction);
+
+  VELOX_ASSERT_THROW(
+      paimonChangelogModeFromString("UNKNOWN"),
+      "Unknown PaimonChangelogMode: UNKNOWN");
+}
+
+TEST(PaimonRowKindTest, changelogModeStreamAndFormat) {
+  {
+    std::ostringstream os;
+    os << PaimonChangelogMode::kNone;
+    EXPECT_EQ(os.str(), "NONE");
+  }
+  {
+    std::ostringstream os;
+    os << PaimonChangelogMode::kLookup;
+    EXPECT_EQ(os.str(), "LOOKUP");
+  }
+
+  EXPECT_EQ(fmt::format("{}", PaimonChangelogMode::kNone), "NONE");
+  EXPECT_EQ(fmt::format("{}", PaimonChangelogMode::kInput), "INPUT");
+  EXPECT_EQ(fmt::format("{}", PaimonChangelogMode::kLookup), "LOOKUP");
+  EXPECT_EQ(
+      fmt::format("{}", PaimonChangelogMode::kFullCompaction),
+      "FULL_COMPACTION");
+}
+
+TEST(PaimonRowKindTest, rowKindColumnName) {
+  EXPECT_EQ(kRowKindColumn, "_rowkind");
+}


### PR DESCRIPTION
Summary:
Add PaimonConnectorSplit as the first component of the Paimon integration
under velox/connectors/hive/paimon/, following the same pattern as Iceberg
(hive/iceberg/).

A Paimon DataSplit maps to a logical bucket which may contain multiple
physical data files across LSM-tree levels. PaimonConnectorSplit eagerly
converts each data file to a HiveConnectorSplit so that existing Velox
ORC/Parquet readers can be reused directly — no Arrow bridge needed.

Components:
- PaimonDataFileMeta: struct with filePath, fileSize, level
- PaimonConnectorSplit: extends ConnectorSplit, wraps multiple
  HiveConnectorSplits (one per data file)
- PaimonConnectorSplitBuilder: fluent builder for test convenience
- File format inference from extension (.parquet, .orc, .dwrf)

Differential Revision: D95760777


