### PR TITLE
fix: Setup function `makeData` runs on every iteration in HashTableBenchmark

### DIFF
--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -675,12 +675,11 @@ int main(int argc, char** argv) {
     folly::addBenchmark(
         __FILE__,
         param.title,
-        [param, &bm, &results, initialized = std::make_shared<bool>(false)]() {
-          if (!*initialized) {
+        [param, &bm, &results, once = std::make_shared<std::once_flag>()]() {
+          std::call_once(*once, [&] {
             folly::BenchmarkSuspender suspender;
             bm->makeData(param);
-            *initialized = true;
-          }
+          });
           combineResults(results, bm->run());
           return 1;
         });

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -672,16 +672,18 @@ int main(int argc, char** argv) {
   }
 
   for (auto& param : params) {
-    folly::addBenchmark(__FILE__, param.title, [param, &bm, &results]() {
-      std::string lastCase;
-      if (lastCase != param.title) {
-        lastCase = param.title;
-        folly::BenchmarkSuspender suspender;
-        bm->makeData(param);
-      }
-      combineResults(results, bm->run());
-      return 1;
-    });
+    folly::addBenchmark(
+        __FILE__,
+        param.title,
+        [param, &bm, &results, initialized = std::make_shared<bool>(false)]() {
+          if (!*initialized) {
+            folly::BenchmarkSuspender suspender;
+            bm->makeData(param);
+            *initialized = true;
+          }
+          combineResults(results, bm->run());
+          return 1;
+        });
   }
   folly::runBenchmarks();
   std::cout << "*** Results:" << std::endl;


### PR DESCRIPTION
In `HashTableBenchmark`, `makeData` is designed to be called only once, but it is not because variable `lastCase` is reset for each run.

The patch fixes the bug.