### PR TITLE
refactor: Migrate rename to folly::available_concurrency in velox (#16393)

### DIFF
--- a/velox/common/base/tests/ConcurrentCounterTest.cpp
+++ b/velox/common/base/tests/ConcurrentCounterTest.cpp
@@ -49,7 +49,7 @@ class ConcurrentCounterTest : public testing::TestWithParam<bool> {
 
   void setupCounter() {
     counter_ = std::make_unique<ConcurrentCounter<int64_t>>(
-        folly::hardware_concurrency());
+        folly::available_concurrency());
   }
 
   const bool useUpdateFn_{GetParam()};
@@ -73,8 +73,8 @@ TEST_P(ConcurrentCounterTest, multithread) {
   const int32_t numUpdatesPerThread = 5'000;
   std::vector<int> numThreads;
   numThreads.push_back(1);
-  numThreads.push_back(folly::hardware_concurrency());
-  numThreads.push_back(folly::hardware_concurrency() * 2);
+  numThreads.push_back(folly::available_concurrency());
+  numThreads.push_back(folly::available_concurrency() * 2);
   for (int numThreads : numThreads) {
     SCOPED_TRACE(fmt::format("numThreads: {}", numThreads));
     counter_->testingClear();

--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -91,7 +91,7 @@ class LocalFileSystem : public FileSystem {
                       std::max(
                           1,
                           static_cast<int32_t>(
-                              folly::hardware_concurrency() / 2)),
+                              folly::available_concurrency() / 2)),
                       std::make_shared<folly::NamedThreadFactory>(
                           "LocalReadahead"))
                 : nullptr) {}

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -201,7 +201,7 @@ class LocalFileTest : public ::testing::TestWithParam<bool> {
   const bool useFaultyFs_;
   const std::unique_ptr<folly::CPUThreadPoolExecutor> executor_ =
       std::make_unique<folly::CPUThreadPoolExecutor>(
-          std::max(1, static_cast<int32_t>(folly::hardware_concurrency() / 2)),
+          std::max(1, static_cast<int32_t>(folly::available_concurrency() / 2)),
           std::make_shared<folly::NamedThreadFactory>(
               "LocalFileReadAheadTest"));
 };

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -34,7 +34,7 @@ MallocAllocator::MallocAllocator(size_t capacity, uint32_t reservationByteLimit)
             decrementUsageWithReservationFunc(counter, decrement, lock);
             return true;
           }),
-      reservations_(folly::hardware_concurrency()) {}
+      reservations_(folly::available_concurrency()) {}
 
 MallocAllocator::~MallocAllocator() {
   // TODO: Remove the check when memory leak issue is resolved.

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -297,7 +297,7 @@ SharedArbitrator::SharedArbitrator(const Config& config)
       "memoryReclaimThreadsHwMultiplier_ needs to be positive");
 
   const uint64_t numReclaimThreads = std::max<size_t>(
-      1, folly::hardware_concurrency() * memoryReclaimThreadsHwMultiplier_);
+      1, folly::available_concurrency() * memoryReclaimThreadsHwMultiplier_);
   memoryReclaimExecutor_ = std::make_unique<folly::CPUThreadPoolExecutor>(
       numReclaimThreads,
       std::make_shared<folly::NamedThreadFactory>("MemoryReclaim"));

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -74,7 +74,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
     setupMemoryPools();
 
     spillExecutor_ = std::make_unique<folly::IOThreadPoolExecutor>(
-        folly::hardware_concurrency());
+        folly::available_concurrency());
   }
 
   void TearDown() override {

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -126,7 +126,7 @@ int main(int argc, char** argv) {
 
   std::shared_ptr<folly::Executor> executor(
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency()));
+          folly::available_concurrency()));
 
   // Task is the top-level execution concept. A task needs a taskId (as a
   // string), the plan fragment to execute, a destination (only used for

--- a/velox/exec/Cursor.cpp
+++ b/velox/exec/Cursor.cpp
@@ -275,7 +275,7 @@ class MultiThreadedTaskCursor : public TaskCursorBase {
       : TaskCursorBase(
             params,
             std::make_shared<folly::CPUThreadPoolExecutor>(
-                folly::hardware_concurrency())),
+                folly::available_concurrency())),
         maxDrivers_{params.maxDrivers},
         numConcurrentSplitGroups_{params.numConcurrentSplitGroups},
         numSplitGroups_{params.numSplitGroups} {
@@ -853,7 +853,7 @@ class TaskDebuggerParallelCursor : public TaskDebuggerCursorBase {
       : TaskDebuggerCursorBase(
             params,
             std::make_shared<folly::CPUThreadPoolExecutor>(
-                folly::hardware_concurrency())),
+                folly::available_concurrency())),
         maxDrivers_(params.maxDrivers),
         numConcurrentSplitGroups_(params.numConcurrentSplitGroups) {
     // Installs the required trace provider.

--- a/velox/exec/SpillStats.cpp
+++ b/velox/exec/SpillStats.cpp
@@ -24,7 +24,7 @@
 namespace facebook::velox::exec {
 namespace {
 std::vector<SpillStats>& allSpillStats() {
-  static std::vector<SpillStats> spillStatsList(folly::hardware_concurrency());
+  static std::vector<SpillStats> spillStatsList(folly::available_concurrency());
   return spillStatsList;
 }
 

--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -274,7 +274,7 @@ class MemoryArbitrationFuzzer {
   VectorFuzzer vectorFuzzer_;
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   folly::Synchronized<Stats> stats_;
 };
 

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -201,7 +201,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
        {"c3", VARCHAR()}});
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   const std::vector<column_index_t> sortColumnIndices_{0, 2};
   const std::vector<CompareFlags> sortCompareFlags_{
       CompareFlags{},

--- a/velox/exec/tests/MergerTest.cpp
+++ b/velox/exec/tests/MergerTest.cpp
@@ -296,7 +296,7 @@ class MergerTest : public OperatorTestBase {
   const RowTypePtr inputType_ = ROW({{"c0", BIGINT()}, {"c1", SMALLINT()}});
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   const std::vector<column_index_t> sortColumnIndices_{0, 1};
   const std::vector<CompareFlags> sortCompareFlags_{
       CompareFlags{.ascending = true},

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -436,7 +436,7 @@ class OutputBufferManagerTest : public testing::Test {
   const std::string serdeKind_;
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::shared_ptr<OutputBufferManager> bufferManager_;
   RowTypePtr rowType_;

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -121,7 +121,7 @@ class SortBufferTest : public OperatorTestBase,
 
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   const std::shared_ptr<memory::MemoryPool> fuzzerPool_ =
       memory::memoryManager()->addLeafPool("SortBufferTest");
 

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -57,7 +57,7 @@ DEFINE_uint32(
     "The number of key columns");
 DEFINE_uint32(
     spiller_benchmark_spill_executor_size,
-    folly::hardware_concurrency(),
+    folly::available_concurrency(),
     "The spiller executor size in number of threads");
 DEFINE_uint32(
     spiller_benchmark_spill_vector_size,

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -100,7 +100,7 @@ class VeloxIn10MinDemo : public VectorTestBase {
 
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   std::shared_ptr<core::QueryCtx> queryCtx_{
       core::QueryCtx::create(executor_.get())};
   std::unique_ptr<core::ExecCtx> execCtx_{

--- a/velox/exec/tests/WindowTest.cpp
+++ b/velox/exec/tests/WindowTest.cpp
@@ -70,7 +70,7 @@ class WindowTest : public OperatorTestBase {
 
   const std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
 
   tsan_atomic<bool> nonReclaimableSection_{false};
 };

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -207,7 +207,7 @@ class AssertQueryBuilder {
 
   static std::unique_ptr<folly::Executor> newExecutor() {
     return std::make_unique<folly::CPUThreadPoolExecutor>(
-        folly::hardware_concurrency());
+        folly::available_concurrency());
   }
 
   // Used by the created task as the default driver executor.

--- a/velox/python/runner/runner.cpp
+++ b/velox/python/runner/runner.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(runner, m) {
   // is about to exit.
   static auto rootPool = velox::memory::memoryManager()->addRootPool();
   static auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(
-      folly::hardware_concurrency());
+      folly::available_concurrency());
 
   // TaskIterator iterates over Vectors.
   py::module::import("pyvelox.vector");

--- a/velox/tool/trace/PartitionedOutputReplayer.h
+++ b/velox/tool/trace/PartitionedOutputReplayer.h
@@ -67,7 +67,7 @@ class PartitionedOutputReplayer final : public OperatorReplayerBase {
       exec::OutputBufferManager::getInstanceRef()};
   const std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency(),
+          folly::available_concurrency(),
           std::make_shared<folly::NamedThreadFactory>("Driver"))};
   const ConsumerCallBack consumerCb_;
   std::unique_ptr<folly::CPUThreadPoolExecutor> consumerExecutor_;

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -250,13 +250,13 @@ void printSummary(
 TraceReplayRunner::TraceReplayRunner()
     : cpuExecutor_(
           std::make_unique<folly::CPUThreadPoolExecutor>(
-              folly::hardware_concurrency() *
+              folly::available_concurrency() *
                   FLAGS_driver_cpu_executor_hw_multiplier,
               std::make_shared<folly::NamedThreadFactory>(
                   "TraceReplayCpuConnector"))),
       ioExecutor_(
           std::make_unique<folly::IOThreadPoolExecutor>(
-              folly::hardware_concurrency() *
+              folly::available_concurrency() *
                   FLAGS_hive_connector_executor_hw_multiplier,
               std::make_shared<folly::NamedThreadFactory>(
                   "TraceReplayIoConnector"))) {}

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -872,10 +872,10 @@ class VectorTestBase {
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::unique_ptr<folly::Executor> executor_{
       std::make_unique<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
   std::shared_ptr<folly::Executor> spillExecutor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
-          folly::hardware_concurrency())};
+          folly::available_concurrency())};
 };
 
 class TestRuntimeStatWriter : public BaseRuntimeStatWriter {


### PR DESCRIPTION
Summary:

The name `hardware_concurrency`, while parallel to `std::thread::hardware_concurrency`, may be misleading. Migrate to the name `available_concurrency`.

Closes: https://github.com/facebookincubator/velox/pull/16393.

Differential Revision: D93263930


