### PR TITLE
fix: Handle DST spring-forward gaps in date_parse and parse_datetime

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1590,6 +1590,10 @@ struct FromIso8601Timestamp {
     if (!timeZone) {
       timeZone = sessionTimeZone_;
     }
+    // Adjust for DST gaps (nonexistent local times) before converting to GMT.
+    auto corrected = timeZone->correct_nonexistent_time(
+        std::chrono::seconds(ts.getSeconds()));
+    ts = Timestamp(corrected.count(), ts.getNanos());
     ts.toGMT(*timeZone);
     result = pack(ts, timeZone->id());
     return Status::OK();
@@ -1647,6 +1651,11 @@ struct DateParseFunction {
       return dateTimeResult.error();
     }
 
+    // Adjust for DST gaps (nonexistent local times) before converting to GMT.
+    auto corrected = sessionTimeZone_->correct_nonexistent_time(
+        std::chrono::seconds(dateTimeResult->timestamp.getSeconds()));
+    dateTimeResult->timestamp =
+        Timestamp(corrected.count(), dateTimeResult->timestamp.getNanos());
     dateTimeResult->timestamp.toGMT(*sessionTimeZone_);
     result = dateTimeResult->timestamp;
     return Status::OK();
@@ -1775,6 +1784,11 @@ struct ParseDateTimeFunction {
     // no session timezone, fallback to 0 (GMT).
     const auto* timeZone =
         dateTimeResult->timezone ? dateTimeResult->timezone : sessionTimeZone_;
+    // Adjust for DST gaps (nonexistent local times) before converting to GMT.
+    auto corrected = timeZone->correct_nonexistent_time(
+        std::chrono::seconds(dateTimeResult->timestamp.getSeconds()));
+    dateTimeResult->timestamp =
+        Timestamp(corrected.count(), dateTimeResult->timestamp.getNanos());
     dateTimeResult->timestamp.toGMT(*timeZone);
     result = pack(dateTimeResult->timestamp, timeZone->id());
     return Status::OK();

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -4198,6 +4198,19 @@ TEST_F(DateTimeFunctionsTest, parseDatetime) {
           "yyyy-MM-dd+HH:mm:99 zzzzzzzzzz"),
       "Parsing time zone long names is not supported.");
 
+  // DST gap: 2026-03-08 02:00 does not exist in America/Los_Angeles.
+  // Clocks spring forward from 02:00 PST to 03:00 PDT. parse_datetime should
+  // handle this gracefully by adjusting forward past the gap.
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(
+      parseDatetime("2026-03-08+03:00", "yyyy-MM-dd+HH:mm"),
+      parseDatetime("2026-03-08+02:00", "yyyy-MM-dd+HH:mm"));
+
+  // Mid-gap time: 02:30 is adjusted forward to 03:30 PDT.
+  EXPECT_EQ(
+      parseDatetime("2026-03-08+03:30", "yyyy-MM-dd+HH:mm"),
+      parseDatetime("2026-03-08+02:30", "yyyy-MM-dd+HH:mm"));
+
   // Test overflow in either direction.
   VELOX_ASSERT_THROW(
       parseDatetime(
@@ -5233,6 +5246,15 @@ TEST_F(DateTimeFunctionsTest, fromIso8601Timestamp) {
         fromIso("T11-08:00"));
   }
 
+  // DST gap: 2024-03-10 02:00 does not exist in America/Los_Angeles.
+  // Clocks spring forward from 02:00 PST to 03:00 PDT. from_iso8601_timestamp
+  // should adjust forward past the gap.
+  setQueryTimeZone("America/Los_Angeles");
+  EXPECT_EQ(fromIso("2024-03-10T03:00:00"), fromIso("2024-03-10T02:00:00"));
+
+  // Mid-gap time: 02:30 is adjusted forward to 03:30 PDT.
+  EXPECT_EQ(fromIso("2024-03-10T03:30:00"), fromIso("2024-03-10T02:30:00"));
+
   VELOX_ASSERT_THROW(
       fromIso("1970-01-02 11:38"),
       R"(Unable to parse timestamp value: "1970-01-02 11:38")");
@@ -5379,6 +5401,19 @@ TEST_F(DateTimeFunctionsTest, dateParse) {
   EXPECT_EQ(
       Timestamp(1730707200, 0),
       dateParse("04-Nov-2024 (Mon)", "%d-%b-%Y (%a)"));
+
+  // DST gap: 2026-03-08 02:00 does not exist in America/Los_Angeles.
+  // Clocks spring forward from 02:00 PST to 03:00 PDT. date_parse should
+  // handle this gracefully by adjusting forward past the gap, consistent with
+  // Presto. Both 02:00 (nonexistent) and 03:00 PDT map to the same UTC instant.
+  EXPECT_EQ(
+      dateParse("2026-03-08 03:00", "%Y-%m-%d %H:%i"),
+      dateParse("2026-03-08 02:00", "%Y-%m-%d %H:%i"));
+
+  // Mid-gap time: 02:30 is adjusted forward to 03:30 PDT.
+  EXPECT_EQ(
+      dateParse("2026-03-08 03:30", "%Y-%m-%d %H:%i"),
+      dateParse("2026-03-08 02:30", "%Y-%m-%d %H:%i"));
 
   VELOX_ASSERT_THROW(dateParse("", "%y+"), "Invalid date format: ''");
   VELOX_ASSERT_THROW(dateParse("1", "%y+"), "Invalid date format: '1'");

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -183,6 +183,63 @@ TEST_F(TimestampWithTimeZoneCastTest, fromVarcharWithoutTimezone) {
   testCast(stringVector, expected);
 }
 
+TEST_F(TimestampWithTimeZoneCastTest, fromTimestampDstGap) {
+  // Set session timezone to America/Los_Angeles without
+  // adjustTimestampToTimezone so that TIMESTAMP is treated as wall time and
+  // toGMT is called.
+  queryCtx_->testingOverrideConfigUnsafe({
+      {core::QueryConfig::kSessionTimezone, "America/Los_Angeles"},
+  });
+
+  auto laZoneId = tz::getTimeZoneID("America/Los_Angeles");
+
+  // 2024-03-10 02:30:00 does not exist in America/Los_Angeles (DST gap).
+  // Should be adjusted forward to 03:30:00 PDT = 10:30:00 UTC.
+  auto gapTs = parseTimestamp("2024-03-10 02:30:00");
+  auto expectedUtcMillis = parseTimestamp("2024-03-10 10:30:00").toMillis();
+
+  const auto tsVector = makeNullableFlatVector<Timestamp>({gapTs});
+  auto expected = makeFlatVector<int64_t>(
+      {pack(expectedUtcMillis, laZoneId)}, TIMESTAMP_WITH_TIME_ZONE());
+
+  testCast(tsVector, expected);
+}
+
+TEST_F(TimestampWithTimeZoneCastTest, fromVarcharDstGap) {
+  // Cast a VARCHAR with a DST gap time and explicit timezone.
+  // 2024-03-10 02:30:00 does not exist in America/Los_Angeles.
+  // Should be adjusted forward to 03:30:00 PDT = 10:30:00 UTC.
+  const auto stringVector = makeNullableFlatVector<StringView>(
+      {"2024-03-10 02:30:00 America/Los_Angeles"});
+  auto expectedUtcMillis = parseTimestamp("2024-03-10 10:30:00").toMillis();
+  auto laZoneId = tz::getTimeZoneID("America/Los_Angeles");
+
+  const auto expected = makeFlatVector<int64_t>(
+      {pack(expectedUtcMillis, laZoneId)}, TIMESTAMP_WITH_TIME_ZONE());
+
+  testCast(stringVector, expected);
+}
+
+TEST_F(TimestampWithTimeZoneCastTest, fromVarcharWithoutTimezoneDstGap) {
+  // Cast a VARCHAR without timezone during a DST gap, using session timezone.
+  setQueryTimeZone("America/Los_Angeles");
+
+  const auto stringVector =
+      makeNullableFlatVector<StringView>({"2024-03-10 02:30:00"});
+  auto expectedUtcMillis = parseTimestamp("2024-03-10 10:30:00").toMillis();
+  auto laZoneId = tz::getTimeZoneID("America/Los_Angeles");
+
+  auto timestamps = std::vector<int64_t>{expectedUtcMillis};
+  auto timezones = std::vector<TimeZoneKey>{(int16_t)laZoneId};
+
+  const auto expected = makeTimestampWithTimeZoneVector(
+      timestamps.size(),
+      [&](int32_t index) { return timestamps[index]; },
+      [&](int32_t index) { return timezones[index]; });
+
+  testCast(stringVector, expected);
+}
+
 TEST_F(TimestampWithTimeZoneCastTest, fromVarcharInvalidInput) {
   const auto invalidStringVector1 = makeNullableFlatVector<StringView>(
       {"2012-10-31 01:00:47fooAmerica/Los_Angeles"});

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -80,6 +80,10 @@ void castFromTimestamp(
       // Treat TIMESTAMP as wall time in session time zone. This means that in
       // order to get its UTC representation we need to shift the value by the
       // offset of the time zone.
+      // Adjust for DST gaps (nonexistent local times) before converting to GMT.
+      auto corrected = sessionTimeZone->correct_nonexistent_time(
+          std::chrono::seconds(ts.getSeconds()));
+      ts = Timestamp(corrected.count(), ts.getNanos());
       ts.toGMT(*sessionTimeZone);
     }
     rawResults[row] = pack(ts.toMillis(), sessionTimeZone->id());
@@ -134,6 +138,10 @@ void castFromString(
         const auto& config = context.execCtx()->queryCtx()->queryConfig();
         timeZone = getTimeZoneFromConfig(config);
       }
+      // Adjust for DST gaps (nonexistent local times) before converting to GMT.
+      auto corrected = timeZone->correct_nonexistent_time(
+          std::chrono::seconds(ts.getSeconds()));
+      ts = Timestamp(corrected.count(), ts.getNanos());
       ts.toGMT(*timeZone);
       rawResults[row] = pack(ts.toMillis(), timeZone->id());
     }


### PR DESCRIPTION
Summary:
Engine level (Timestamp::toGMT): Velox fails with 
VELOX_USER_FAIL(e.what()) in the nonexistent_local_time catch block,
so non-Presto callers get an error on DST gap times.
Presto function level: Added correct_nonexistent_time() before each
toGMT() call in 5 Presto functions that accept user-provided local times:
DateParseFunction::call() — date_parse
ParseDateTimeFunction::call() — parse_datetime
FromIso8601Timestamp::call() — from_iso8601_timestamp
castFromTimestamp() — CAST(TIMESTAMP AS TIMESTAMP WITH TIME ZONE)
castFromString() — CAST(VARCHAR AS TIMESTAMP WITH TIME ZONE)
This adjusts nonexistent local times forward past the DST gap before
converting to UTC, matching Presto Java behavior. For example, in
America/Los_Angeles on DST spring-forward day, 02:30 is adjusted
to 03:30 PDT = 10:30 UTC.

Differential Revision: D95824855


