### PR TITLE
refactor: Pass TypeKind to ColumnMetricsSet::getOrCreate in SelectiveColumnReader

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -61,7 +61,7 @@ SelectiveColumnReader::SelectiveColumnReader(
   // Initialize per-column metrics if collection is enabled.
   if (params.runtimeStatistics().columnMetricsSet) {
     columnMetrics_ = params.runtimeStatistics().columnMetricsSet->getOrCreate(
-        fileType_->id());
+        fileType_->id(), fileType_->type()->kind());
   }
 }
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -250,17 +250,6 @@ const velox::common::ScanSpec* getChildScanSpec(
       : nullptr;
 }
 
-void registerColumnMetrics(
-    const dwio::common::TypeWithId& node,
-    dwio::common::ColumnMetricsSet& metricsSet) {
-  metricsSet.getOrCreate(node.id(), node.type()->kind());
-  for (uint32_t i = 0; i < node.size(); ++i) {
-    if (const auto* child = node.childAt(i).get()) {
-      registerColumnMetrics(*child, metricsSet);
-    }
-  }
-}
-
 } // namespace
 
 DwrfRowReader::DwrfRowReader(
@@ -281,8 +270,6 @@ DwrfRowReader::DwrfRowReader(
       currentUnit_{nullptr} {
   if (options_.collectColumnStats()) {
     columnReaderStats_->columnMetricsSet.emplace();
-    registerColumnMetrics(
-        *getReader().schemaWithId(), *columnReaderStats_->columnMetricsSet);
   }
   const auto& fileFooter = getReader().footer();
   const uint32_t numberOfStripes = fileFooter.stripesSize();


### PR DESCRIPTION
Summary:
Pass TypeKind when creating per-column metrics in the common SelectiveColumnReader
constructor, enabling proper type names in telemetry for all formats (DWRF, Nimble,
Parquet). This removes the need for DWRF's format-specific registerColumnMetrics()
function, simplifying code and using lazy registration instead of eager pre-registration.

Differential Revision: D95835284


