### PR TITLE
fix(fuzzer): Expression Fuzzer crash: block TIME type in DistinctFromArgTypesGenerator

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -327,7 +327,7 @@ bool PrestoQueryRunner::isConstantExprSupported(
     // same timezone as Velox. Interval type cannot be used as the type of
     // constant literals in Presto SQL.
     auto& type = expr->type();
-    return type->isPrimitiveType() && !type->isTimestamp() &&
+    return type->isPrimitiveType() && !type->isTimestamp() && !type->isTime() &&
         !isJsonType(type) && !type->isIntervalDayTime() &&
         !isIPAddressType(type) && !isIPPrefixType(type) && !isUuidType(type) &&
         !isTimestampWithTimeZoneType(type) && !isHyperLogLogType(type) &&


### PR DESCRIPTION
Summary:
The Expression Fuzzer with Presto SOT crashes when `DistinctFromArgTypesGenerator`
generates `IS DISTINCT FROM` with a TIME type argument. Since `distinct_from` uses
`Generic<T1>` in its signature, the signature-level type filter in
`PrestoQueryRunner::isSupported()` doesn't catch TIME. The fuzzer resolves
`Generic<T1>` to TIME (available in the type pool via `localtime` registration),
producing expressions like `73597840 IS DISTINCT FROM cast(c0 as TIME)`. Presto
rejects this with "'IS DISTINCT FROM' cannot be applied to integer, time", while
Velox evaluates it successfully (TIME is int64 internally), causing a verification
failure abort.

Filter out TIME type in `DistinctFromArgTypesGenerator::generateArgs()`, matching
the existing IPADDRESS filter pattern. TIME WITH TIMEZONE is not filtered because
`IntermediateTypeTransform` handles it gracefully by casting to VARCHAR.

GitHub Issue: https://github.com/facebookincubator/velox/issues/16663

Differential Revision: D95842007


