### PR TITLE
fix(operator): Add isFilter() override to MarkDistinct (#16689)

### DIFF
--- a/velox/exec/MarkDistinct.h
+++ b/velox/exec/MarkDistinct.h
@@ -43,6 +43,10 @@ class MarkDistinct : public Operator {
     return false;
   }
 
+  bool isFilter() const override {
+    return true;
+  }
+
   bool needsInput() const override {
     return !noMoreInput_ && !input_;
   }


### PR DESCRIPTION
Summary:

MarkDistinct is a pure annotating passthrough — for every input row, it emits
exactly one output row with an added boolean marker column. It never drops,
duplicates, or reorders rows. This satisfies the isFilter() contract ("never
more output rows than input rows"), matching the pattern used by
AssignUniqueId.

Returning true enables mayPushdownAggregation() in Driver to see through
MarkDistinct, allowing LazyVector pushdown into downstream aggregations.
Previously, the default false return conservatively disabled this optimization.

Reviewed By: Yuhta

Differential Revision: D95845097
