### PR TITLE
build: Add new Claude workflow with latest claude-code-action plugin with skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,14 @@
 
 Guidance for Claude Code when working in the Velox repository.
 
+## PR Review
+
+When asked to review a PR (via `/pr-review`), always use the /pr-review skill.
+
+## Queries
+
+When asked a question about the PR or codebase (via `/query`), use the /query skill.
+
 ## Overview
 
 Velox is an open source C++ library for composable data processing and

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,179 @@
+---
+name: pr-review
+description: Review Velox pull requests for code quality, memory safety, performance, and correctness. Use when reviewing PRs, when asked to review code changes, or when the user mentions "/pr-review".
+---
+
+# Velox PR Review Skill
+
+Review Velox pull requests focusing on what CI cannot check: code quality, memory
+safety, concurrency, performance, and correctness. This is performance-critical C++
+code for a database execution engine where bugs can cause data corruption, crashes,
+or security vulnerabilities.
+
+## Usage Modes
+
+### GitHub Actions Mode
+
+When invoked via `/pr-review [additional context]` on a GitHub PR, the action
+pre-fetches PR metadata and injects it into the prompt. Detect this mode by the
+presence of `<formatted_context>`, `<pr_or_issue_body>`, and `<comments>` tags in
+the prompt.
+
+The prompt already contains:
+- PR metadata (title, author, branch names, additions/deletions, file count)
+- PR body/description
+- All comments and review comments (with file/line references)
+- List of changed files with paths and change types
+
+Use git commands to get the diff and commit history. The base branch name is in the prompt context (look for PR Branch: <head> -> <base> or the baseBranch field).
+
+```bash
+# Get the full diff against the base branch
+git diff origin/<baseBranch>...HEAD
+
+# Get diff stats
+git diff --stat origin/<baseBranch>...HEAD
+
+# Get commit history for this PR
+git log origin/<baseBranch>..HEAD --oneline
+
+# If the base branch ref is not available, fetch it first
+git fetch origin <baseBranch> --depth=1
+```
+
+Do NOT use `gh` CLI commands in this mode -- only git commands are available.
+All PR metadata, comments, and reviews are already in the prompt context;
+only the diff and commit log need to be fetched via git.
+
+If the reviewer provided additional context or instructions after the `/pr-review`
+command, incorporate those into your review focus.
+
+### Local CLI Mode
+
+The user provides a PR number or URL:
+
+```
+/pr-review 12345
+/pr-review https://github.com/facebookincubator/velox/pull/12345
+```
+
+Use `gh` CLI to fetch PR data:
+
+```bash
+gh pr view <PR_NUMBER> --json title,body,author,baseRefName,headRefName,files,additions,deletions,commits
+gh pr diff <PR_NUMBER>
+gh pr view <PR_NUMBER> --json comments,reviews
+```
+
+## Review Workflow
+
+### Step 1: Read Project Guidelines
+
+Read CLAUDE.md and CODING_STYLE.md for project-specific standards including:
+- Naming conventions (PascalCase for types, camelCase for functions)
+- Assert/CHECK usage (VELOX_CHECK_* vs VELOX_USER_CHECK_*)
+- Variable conventions (uniform initialization, std::string_view)
+- API design principles
+- Test patterns (gtest matchers)
+
+### Step 2: Analyze Changes
+
+Read through the diff systematically:
+1. Identify the purpose of the change from title/description
+2. Group changes by type (new code, tests, config, docs)
+3. Note the scope of changes (files affected, lines changed)
+
+### Step 3: Deep Review
+
+**Think deeply and carefully about this code.** Take your time to:
+- Trace through the logic step by step
+- Consider what happens at boundary conditions (empty inputs, null values, max sizes)
+- Think about concurrency issues if multiple threads could access this code
+- Consider memory safety: ownership, lifetimes, dangling references
+- Look for off-by-one errors, integer overflow, and other subtle bugs
+- Examine error handling paths - what happens when things fail?
+- Consider how this code interacts with existing code in the codebase
+
+**Be thorough and strict.** It's better to flag a potential issue that turns out
+to be fine than to miss a real bug.
+
+**Explore edge cases exhaustively:**
+- What if the input is empty? Null? Maximum size?
+- What if allocation fails? What if an exception is thrown?
+- What happens on the first iteration? The last iteration?
+- Are there race conditions if called concurrently?
+- What assumptions does this code make? Are they documented and validated?
+
+## Review Areas
+
+Analyze each of these areas thoroughly:
+
+| Area | Focus |
+|------|-------|
+| Correctness & Edge Cases | Logic errors, off-by-one, null/empty handling, boundary conditions, integer overflow, floating point edge cases (NaN, Inf, negative zero) |
+| Memory Safety | Use-after-free, double-free, leaks, dangling pointers/references, buffer overflows, ownership/lifetime issues, exception safety |
+| Concurrency | Race conditions, data races, deadlocks, lock ordering, thread-safety of shared state |
+| Performance | Unnecessary copies (move semantics?), inefficient algorithms, cache-unfriendly access, excessive allocations in hot paths |
+| Error Handling | All error paths handled? Exceptions caught appropriately? Informative error messages? Correct use of VELOX_CHECK_* vs VELOX_USER_CHECK_*? |
+| Code Quality | RAII, const-correctness, smart pointers, naming conventions, clear structure |
+| Testing | Sufficient tests? Edge cases covered? Error paths tested? Using gtest matchers? |
+
+## Output Format
+
+The output should be a markdown-formatted summary and should follow the following markdown format exactly:
+
+```markdown
+### Summary
+Brief overall assessment (1-2 sentences)
+
+### Issues Found
+List any issue, categorized by severity:
+ - 🔴 **Critical**: Must fix before merge
+ - 🟡 **Suggestion**: Should consider
+ - 🟢 **Nitpick**: Minor style issues
+
+Each issue should also include:
+- File and line reference
+- Description of the issue
+- Suggested fix if applicable
+
+### Positive Observations
+Note any particularly good patterns or improvements.
+```
+
+## Inline Comments
+
+Use the `mcp__github_inline_comment__create_inline_comment` tool to post
+comments directly on specific lines in the PR diff. Inline comments should
+be used whenever pointing at the exact line adds clarity beyond the summary
+comment.
+
+**Use inline comments for:**
+- Concrete bugs or incorrect logic
+- Memory safety issues (use-after-free, dangling references, leaks)
+- Off-by-one errors or boundary condition mistakes
+- Incorrect use of VELOX_CHECK_* vs VELOX_USER_CHECK_*
+
+**Do NOT use inline comments for:**
+- Style nitpicks or naming suggestions
+- General architectural feedback
+- Positive observations
+- Anything that applies broadly rather than to a specific line
+
+**Always post a summary comment** with the overall review. Inline comments
+supplement the summary — they do not replace it.
+
+## Key Principles
+
+1. **No repetition** - Each observation appears in exactly one place
+2. **Focus on what CI cannot check** - Don't comment on formatting, linting, or type errors
+3. **Be specific** - Reference file paths and line numbers
+4. **Be actionable** - Provide concrete suggestions, not vague concerns
+5. **Be proportionate** - Minor issues shouldn't block, but note them
+6. **Assume competence** - The author knows C++; explain only non-obvious context
+
+## Files to Reference
+
+When reviewing, consult these project files for context:
+- `CLAUDE.md` - Coding style and project guidelines
+- `CODING_STYLE.md` - Complete coding style guide

--- a/.claude/skills/query/SKILL.md
+++ b/.claude/skills/query/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: query
+description: Answer questions about the Velox codebase or pull requests. Use when asked a question via "/query" or when the user wants to understand code, architecture, or implementation details.
+---
+
+# Velox Query Skill
+
+Answer questions about the Velox project codebase or specific pull requests.
+
+## Key Context
+
+- Velox is a C++ execution engine library for analytical data processing
+- Uses C++20 standard with heavy use of templates and SFINAE
+- Custom memory management with MemoryPool
+- Vectorized execution with custom Vector types
+- Follows Google C++ style with some modifications
+
+## Guidelines
+
+- Read CLAUDE.md and CODING_STYLE.md for project-specific conventions
+- Answer thoroughly and accurately
+- If the question is about PR changes, analyze the diff carefully
+- If it's about the codebase, explore relevant files to provide a complete answer
+- Be specific and reference exact file paths and line numbers when relevant

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,137 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Claude — skill-based PR assistant (replaces claude-review.yml)
+#
+# This workflow uses izaitsevfb/claude-code-action (a fork that fixes
+# forked-PR handling) with Claude Skills instead of inline prompts.
+# Review logic lives in .claude/skills/pr-review/SKILL.md.
+#
+# Supported commands (comment on a PR):
+#   @claude /pr-review [context] — thorough code review
+#   @claude /query <question> — ask about the PR or codebase
+#
+# Differences from claude-review.yml (the legacy workflow):
+#   - Uses claude-code-action (higher-level) instead of claude-code-base-action
+#   - Review/query instructions are in Skills, not inline heredocs
+#   - Trigger phrase is @claude (not /claude-review or /claude-query)
+#   - Tag mode handles PR context, diff, and comment posting automatically
+#
+# Security model:
+#   - Hardcoded user allowlist gates workflow execution
+#   - Read-only tools enforced via --allowedTools
+#   - Fork PRs handled securely by the action fork
+
+name: Claude
+
+on:
+  # Tag mode: action detects @claude in comments and responds inline
+  issue_comment:
+    types: [created]
+
+  # Agent mode: manual trigger for testing (log-only unless MCP tools used)
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        required: true
+        type: number
+      model:
+        description: Claude model to use
+        required: false
+        type: choice
+        options:
+          - claude-opus-4-6
+          - claude-opus-4-1-20250805
+          - claude-sonnet-4-20250514
+          - claude-4-0-sonnet-20250805
+        default: claude-opus-4-6
+
+# Restrict default permissions — jobs declare only what they need
+permissions:
+  contents: read
+
+jobs:
+  claude-assistant:
+    name: Claude Assistant
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      actions: read
+      id-token: write
+    # Gate: workflow_dispatch always runs; issue_comment requires PR context,
+    # @claude mention, and an authorized user
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(fromJSON('["kgpai", "mbasmanova", "pedroerp", "yuhta", "kagamiori", "bikramSingh91", "kevinwilfong", "xiaoxmeng", "kKPulla", "juwentus1234", "penescu", "srsuryadev", "jainxrohit", "pratikpugalia"]'), github.event.comment.user.login)
+      )
+
+    steps:
+      # For workflow_dispatch, checkout the PR merge ref so Claude has the
+      # PR code. For issue_comment, default ref is fine — the action handles
+      # diff fetching internally.
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/pull/{0}/merge', inputs.pr_number) || '' }}
+          persist-credentials: false
+
+      - name: Run Claude Code
+        uses: izaitsevfb/claude-code-action@2817c54db8f44f3a0485d57292566bf07d428a25 # forked-pr-fix
+        with:
+          trigger_phrase: "@claude"
+          # prompt is only set for workflow_dispatch (agent mode).
+          # For issue_comment (tag mode), prompt must be empty to avoid
+          # triggering agent mode
+          # CLAUDE.md provides skill routing instructions instead.
+          prompt: ${{ github.event_name == 'workflow_dispatch' && format('Review the PR currently checked out in the Velox project current workspace. Use the /pr-review skill and post the final output as a comment on the original PR {0}', inputs.pr_number) || '' }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Tool access:
+          #   - Skill: invoke /pr-review and /query skills
+          #   - Read,Glob,Grep: codebase exploration (used by skills)
+          #   - mcp__github_inline_comment: post comments on specific PR lines
+          #   - workflow_dispatch adds: MCP comment tool + gh CLI for PR data
+          claude_args: "--model ${{ github.event_name == 'workflow_dispatch' && inputs.model || 'claude-opus-4-6' }} --allowedTools Skill,${{ github.event_name == 'workflow_dispatch' && 'mcp__github_comment__create_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),' || '' }}mcp__github_inline_comment__create_inline_comment,Read,Glob,Grep"
+          settings: '{"alwaysThinkingEnabled": true}'
+
+  # Notify unauthorized users who try to invoke @claude
+  unauthorized-notice:
+    name: Unauthorized Notice
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      !contains(fromJSON('["kgpai", "mbasmanova", "pedroerp", "yuhta", "kagamiori", "bikramSingh91", "kevinwilfong", "xiaoxmeng", "kKPulla", "juwentus1234", "penescu", "srsuryadev", "jainxrohit", "pratikpugalia"]'), github.event.comment.user.login)
+
+    steps:
+      - name: Post unauthorized notice
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `👋 @${context.payload.comment.user.login}, \`@claude\` commands are currently restricted to a small group of users during this initial rollout.\n\nIf you'd like a Claude review, please ask a maintainer to run this command.`
+            });


### PR DESCRIPTION

Add a new claude.yml workflow using izaitsevfb/claude-code-action (a fork that fixes forked-PR handling) with Claude Skills instead of inline prompts. The existing claude-review.yml is kept as a fallback during the transition.

### **Key changes:**

**New workflow (claude.yml)**
- Uses @claude trigger phrase with /pr-review and /query skill commands
- Supports both issue_comment (tag mode) and workflow_dispatch (agent mode with model selection)
- Read-only tools enforced via --allowedTools
- Inline PR review comments via mcp__github_inline_comment__create_inline_comment
- Extended thinking enabled via settings
- Hardcoded user allowlist gates execution, Unauthorized users get a friendly notice

**Claude Skills (.claude/skills/)**
- pr-review/SKILL.md: Structured review covering correctness, memory safety, concurrency, performance, error handling, code quality, and testing. Inline comments used whenever pointing at the exact line adds clarity.
- query/SKILL.md: Answers questions about the PR or codebase.

**Skill routing (.claude/CLAUDE.md)**
- Routes /pr-review and /query commands to their respective skills.

Differential Revision: D95882426


