### PR TITLE
feat: Add MallocAllocator Options struct and malloc-based contiguous allocations

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -21,10 +21,11 @@
 #include <sys/mman.h>
 
 namespace facebook::velox::memory {
-MallocAllocator::MallocAllocator(size_t capacity, uint32_t reservationByteLimit)
+MallocAllocator::MallocAllocator(const Options& options)
     : kind_(MemoryAllocator::Kind::kMalloc),
-      capacity_(capacity),
-      reservationByteLimit_(reservationByteLimit),
+      mallocContiguousEnabled_(options.mallocContiguousEnabled),
+      capacity_(options.capacity),
+      reservationByteLimit_(options.reservationByteLimit),
       reserveFunc_(
           [this](uint32_t& counter, uint32_t increment, std::mutex& lock) {
             return incrementUsageWithReservationFunc(counter, increment, lock);
@@ -145,11 +146,7 @@ bool MallocAllocator::allocateContiguousImpl(
   }
   auto numContiguousCollateralPages = allocation.numPages();
   if (numContiguousCollateralPages > 0) {
-    useHugePages(allocation, false);
-    if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
-      VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno) << "for "
-                           << allocation.data() << ", " << allocation.size();
-    }
+    dispatchFreeContiguous(allocation);
     numMapped_.fetch_sub(numContiguousCollateralPages);
     numAllocated_.fetch_sub(numContiguousCollateralPages);
     numExternalMapped_.fetch_sub(numContiguousCollateralPages);
@@ -175,19 +172,23 @@ bool MallocAllocator::allocateContiguousImpl(
   numAllocated_.fetch_add(numPages);
   numMapped_.fetch_add(numPages);
   numExternalMapped_.fetch_add(numPages);
-  void* data = ::mmap(
-      nullptr,
-      AllocationTraits::pageBytes(maxPages),
-      PROT_READ | PROT_WRITE,
-      MAP_PRIVATE | MAP_ANONYMOUS,
-      -1,
-      0);
-  // TODO: add handling of MAP_FAILED.
-  allocation.set(
-      data,
-      AllocationTraits::pageBytes(numPages),
-      AllocationTraits::pageBytes(maxPages));
-  useHugePages(allocation, true);
+  const auto maxBytes = AllocationTraits::pageBytes(maxPages);
+  void* data = dispatchAllocateContiguous(maxBytes);
+  if (FOLLY_UNLIKELY(data == nullptr)) {
+    numAllocated_.fetch_sub(numPages);
+    numMapped_.fetch_sub(numPages);
+    numExternalMapped_.fetch_sub(numPages);
+    decrementUsage(static_cast<int64_t>(AllocationTraits::pageBytes(numPages)));
+    const auto errorMsg = fmt::format(
+        "Failed to allocate {} of contiguous memory", succinctBytes(maxBytes));
+    VELOX_MEM_LOG(WARNING) << errorMsg;
+    setAllocatorFailureMessage(errorMsg);
+    return false;
+  }
+  allocation.set(data, AllocationTraits::pageBytes(numPages), maxBytes);
+  if (!mallocContiguousEnabled_) {
+    useHugePages(allocation, true);
+  }
   return true;
 }
 
@@ -222,19 +223,44 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   if (allocation.empty()) {
     return;
   }
-  useHugePages(allocation, false);
   const auto bytes = allocation.size();
   const auto numPages = allocation.numPages();
-  if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
-    VELOX_MEM_LOG(ERROR) << "Error for munmap(" << allocation.data() << ", "
-                         << succinctBytes(bytes) << "): '"
-                         << folly::errnoStr(errno) << "'";
-  }
+  dispatchFreeContiguous(allocation);
   numMapped_.fetch_sub(numPages);
   numAllocated_.fetch_sub(numPages);
   numExternalMapped_.fetch_sub(numPages);
   decrementUsage(bytes);
   allocation.clear();
+}
+
+void* MallocAllocator::dispatchAllocateContiguous(size_t maxBytes) {
+  if (testingHasInjectedFailure(InjectedFailure::kAllocate)) {
+    return nullptr;
+  }
+  if (mallocContiguousEnabled_) {
+    return ::aligned_alloc(AllocationTraits::kPageSize, maxBytes);
+  }
+  // TODO: add handling of MAP_FAILED.
+  return ::mmap(
+      nullptr,
+      maxBytes,
+      PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS,
+      -1,
+      0);
+}
+
+void MallocAllocator::dispatchFreeContiguous(ContiguousAllocation& allocation) {
+  if (mallocContiguousEnabled_) {
+    ::free(allocation.data());
+  } else {
+    useHugePages(allocation, false);
+    if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
+      VELOX_MEM_LOG(ERROR) << "Error for munmap(" << allocation.data() << ", "
+                           << succinctBytes(allocation.size()) << "): '"
+                           << folly::errnoStr(errno) << "'";
+    }
+  }
 }
 
 bool MallocAllocator::growContiguousWithoutRetry(

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -26,7 +26,19 @@ namespace facebook::velox::memory {
 /// The implementation of MemoryAllocator using malloc.
 class MallocAllocator : public MemoryAllocator {
  public:
-  MallocAllocator(size_t capacity, uint32_t reservationByteLimit);
+  struct Options {
+    /// Capacity in bytes, default unlimited.
+    size_t capacity{kMaxMemory};
+
+    /// Allocation size threshold below which allocations use sharded local
+    /// counters instead of updating the global counter. Default 1MB.
+    uint32_t reservationByteLimit{1 << 20};
+
+    /// If true, use malloc for contiguous allocations instead of mmap/munmap.
+    bool mallocContiguousEnabled{false};
+  };
+
+  explicit MallocAllocator(const Options& options);
 
   ~MallocAllocator() override;
 
@@ -101,6 +113,15 @@ class MallocAllocator : public MemoryAllocator {
       Allocation* collateral,
       ContiguousAllocation& allocation,
       MachinePageCount maxPages);
+
+  // Allocates 'maxBytes' of contiguous memory using malloc or mmap depending
+  // on 'mallocContiguousEnabled_'. Returns the allocated pointer, or nullptr
+  // on failure.
+  void* dispatchAllocateContiguous(size_t maxBytes);
+
+  // Frees contiguous memory previously allocated by
+  // dispatchAllocateContiguous.
+  void dispatchFreeContiguous(ContiguousAllocation& allocation);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);
 
@@ -216,6 +237,9 @@ class MallocAllocator : public MemoryAllocator {
   }
 
   const Kind kind_;
+
+  // If true, use malloc for contiguous allocations instead of mmap/munmap.
+  const bool mallocContiguousEnabled_;
 
   // Capacity in bytes. Total allocation byte is not allowed to exceed this
   // value.

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -54,9 +54,12 @@ std::shared_ptr<MemoryAllocator> createAllocator(
     mmapOptions.mmapArenaCapacityRatio = options.mmapArenaCapacityRatio;
     return std::make_shared<MmapAllocator>(mmapOptions);
   } else {
-    return std::make_shared<MallocAllocator>(
-        options.allocatorCapacity,
-        options.allocationSizeThresholdWithReservation);
+    MallocAllocator::Options mallocOptions;
+    mallocOptions.capacity = options.allocatorCapacity;
+    mallocOptions.reservationByteLimit =
+        options.allocationSizeThresholdWithReservation;
+    mallocOptions.mallocContiguousEnabled = options.mallocContiguousEnabled;
+    return std::make_shared<MallocAllocator>(mallocOptions);
   }
 }
 

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -139,6 +139,12 @@ class MemoryManager {
     /// NOTE: this only applies for MallocAllocator.
     uint32_t allocationSizeThresholdWithReservation{1 << 20};
 
+    /// If true, MallocAllocator uses malloc for contiguous allocations instead
+    /// of mmap/munmap.
+    ///
+    /// NOTE: this only applies for MallocAllocator.
+    bool mallocContiguousEnabled{false};
+
     /// ================== 'MemoryArbitrator' settings =================
 
     /// Memory capacity available for query/task memory pools. This capacity

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -1993,4 +1993,263 @@ TEST_F(MmapConfigTest, sizeClasses) {
   }
 }
 
+class MallocContiguousTest : public testing::TestWithParam<bool> {
+ protected:
+  static void SetUpTestCase() {
+    FLAGS_velox_memory_leak_check_enabled = true;
+  }
+
+  void SetUp() override {
+    MallocAllocator::Options options;
+    options.capacity = kCapacityBytes;
+    options.reservationByteLimit = 0;
+    options.mallocContiguousEnabled = GetParam();
+    allocator_ = std::make_shared<MallocAllocator>(options);
+  }
+
+  std::shared_ptr<MallocAllocator> allocator_;
+};
+
+TEST_P(MallocContiguousTest, allocateAndFreeContiguous) {
+  constexpr MachinePageCount kNumPages = 16;
+  ContiguousAllocation allocation;
+  ASSERT_TRUE(allocator_->allocateContiguous(kNumPages, nullptr, allocation));
+  ASSERT_FALSE(allocation.empty());
+  ASSERT_EQ(allocation.numPages(), kNumPages);
+  ASSERT_NE(allocation.data(), nullptr);
+
+  // Verify we can write and read from the allocated memory.
+  auto* data = reinterpret_cast<int64_t*>(allocation.data());
+  for (int64_t i = 0; i < kNumPages; ++i) {
+    data[i] = i * 42;
+  }
+  for (int64_t i = 0; i < kNumPages; ++i) {
+    ASSERT_EQ(data[i], i * 42);
+  }
+
+  allocator_->freeContiguous(allocation);
+  ASSERT_TRUE(allocation.empty());
+  ASSERT_EQ(allocator_->numAllocated(), 0);
+  ASSERT_EQ(allocator_->numMapped(), 0);
+}
+
+TEST_P(MallocContiguousTest, allocateContiguousWithMaxPages) {
+  constexpr MachinePageCount kNumPages = 8;
+  constexpr MachinePageCount kMaxPages = 32;
+  ContiguousAllocation allocation;
+  ASSERT_TRUE(allocator_->allocateContiguous(
+      kNumPages, nullptr, allocation, nullptr, kMaxPages));
+  ASSERT_EQ(allocation.numPages(), kNumPages);
+  ASSERT_EQ(allocation.maxSize(), AllocationTraits::pageBytes(kMaxPages));
+
+  allocator_->freeContiguous(allocation);
+  ASSERT_TRUE(allocation.empty());
+}
+
+TEST_P(MallocContiguousTest, growContiguous) {
+  constexpr MachinePageCount kNumPages = 8;
+  constexpr MachinePageCount kMaxPages = 32;
+  ContiguousAllocation allocation;
+  ASSERT_TRUE(allocator_->allocateContiguous(
+      kNumPages, nullptr, allocation, nullptr, kMaxPages));
+
+  // Write data before growing.
+  auto* data = reinterpret_cast<int64_t*>(allocation.data());
+  const auto numWords = static_cast<int64_t>(
+      AllocationTraits::pageBytes(kNumPages) / sizeof(int64_t));
+  for (int64_t i = 0; i < numWords; ++i) {
+    data[i] = i + 1;
+  }
+
+  // Grow within maxPages.
+  constexpr MachinePageCount kIncrement = 8;
+  ASSERT_TRUE(allocator_->growContiguousWithoutRetry(kIncrement, allocation));
+  ASSERT_EQ(allocation.numPages(), kNumPages + kIncrement);
+
+  // Verify original data is intact after grow.
+  data = reinterpret_cast<int64_t*>(allocation.data());
+  for (int64_t i = 0; i < numWords; ++i) {
+    ASSERT_EQ(data[i], i + 1);
+  }
+
+  allocator_->freeContiguous(allocation);
+  ASSERT_TRUE(allocation.empty());
+}
+
+TEST_P(MallocContiguousTest, freeContiguousCollateral) {
+  constexpr MachinePageCount kFirstPages = 16;
+  constexpr MachinePageCount kSecondPages = 8;
+  ContiguousAllocation allocation;
+  ASSERT_TRUE(allocator_->allocateContiguous(kFirstPages, nullptr, allocation));
+  ASSERT_EQ(allocation.numPages(), kFirstPages);
+  ASSERT_EQ(allocator_->numAllocated(), kFirstPages);
+
+  // Allocate again into the same allocation — old allocation is freed as
+  // contiguous collateral.
+  ASSERT_TRUE(
+      allocator_->allocateContiguous(kSecondPages, nullptr, allocation));
+  ASSERT_EQ(allocation.numPages(), kSecondPages);
+  ASSERT_EQ(allocator_->numAllocated(), kSecondPages);
+
+  allocator_->freeContiguous(allocation);
+  ASSERT_EQ(allocator_->numAllocated(), 0);
+}
+
+TEST_P(MallocContiguousTest, allocateContiguousFailure) {
+  constexpr MachinePageCount kNumPages = 16;
+  ContiguousAllocation allocation;
+
+  // Inject allocation failure so dispatchAllocateContiguous returns nullptr.
+  allocator_->testingSetFailureInjection(
+      MemoryAllocator::InjectedFailure::kAllocate, true);
+
+  ASSERT_FALSE(allocator_->allocateContiguous(kNumPages, nullptr, allocation));
+  ASSERT_TRUE(allocation.empty());
+  // Verify all counter increments are properly rolled back.
+  ASSERT_EQ(allocator_->numAllocated(), 0);
+  ASSERT_EQ(allocator_->numMapped(), 0);
+  auto failureMsg = allocator_->getAndClearFailureMessage();
+  EXPECT_THAT(failureMsg, testing::HasSubstr("Failed to allocate"));
+  ASSERT_TRUE(allocator_->checkConsistency());
+}
+
+TEST_P(MallocContiguousTest, allocContiguous) {
+  struct {
+    MachinePageCount nonContiguousPages;
+    MachinePageCount oldContiguousPages;
+    MachinePageCount newContiguousPages;
+  } testSettings[] = {
+      {100, 100, 200},
+      {100, 200, 200},
+      {200, 100, 200},
+      {200, 100, 400},
+      {0, 100, 100},
+      {0, 200, 100},
+      {0, 100, 200},
+      {100, 0, 100},
+      {200, 0, 100},
+      {100, 0, 200}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(
+        fmt::format(
+            "nonContiguousPages:{} oldContiguousPages:{} newContiguousPages:{}",
+            testData.nonContiguousPages,
+            testData.oldContiguousPages,
+            testData.newContiguousPages));
+    SetUp();
+    Allocation allocation;
+    if (testData.nonContiguousPages != 0) {
+      allocator_->allocateNonContiguous(
+          testData.nonContiguousPages, allocation);
+    }
+    ContiguousAllocation contiguousAllocation;
+    if (testData.oldContiguousPages != 0) {
+      allocator_->allocateContiguous(
+          testData.oldContiguousPages, nullptr, contiguousAllocation);
+    }
+    allocator_->allocateContiguous(
+        testData.newContiguousPages, &allocation, contiguousAllocation);
+    ASSERT_EQ(allocator_->numAllocated(), testData.newContiguousPages);
+    ASSERT_EQ(allocator_->numMapped(), testData.newContiguousPages);
+
+    allocator_->freeContiguous(contiguousAllocation);
+    ASSERT_EQ(allocator_->numMapped(), 0);
+    ASSERT_EQ(allocator_->numAllocated(), 0);
+    ASSERT_TRUE(allocator_->checkConsistency());
+  }
+}
+
+TEST_P(MallocContiguousTest, allocContiguousFail) {
+  struct {
+    MachinePageCount nonContiguousPages;
+    MachinePageCount oldContiguousPages;
+    MachinePageCount newContiguousPages;
+  } testSettings[] = {{200, 100, 400}, {0, 100, 200}, {100, 0, 200}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(
+        fmt::format(
+            "nonContiguousPages:{} oldContiguousPages:{} newContiguousPages:{}",
+            testData.nonContiguousPages,
+            testData.oldContiguousPages,
+            testData.newContiguousPages));
+    SetUp();
+    Allocation allocation;
+    if (testData.nonContiguousPages != 0) {
+      allocator_->allocateNonContiguous(
+          testData.nonContiguousPages, allocation);
+    }
+    ContiguousAllocation contiguousAllocation;
+    if (testData.oldContiguousPages != 0) {
+      allocator_->allocateContiguous(
+          testData.oldContiguousPages, nullptr, contiguousAllocation);
+    }
+    ASSERT_EQ(
+        allocator_->numAllocated(),
+        testData.oldContiguousPages + testData.nonContiguousPages);
+
+    allocator_->testingSetFailureInjection(
+        MemoryAllocator::InjectedFailure::kCap, true);
+
+    ASSERT_FALSE(allocator_->allocateContiguous(
+        testData.newContiguousPages, &allocation, contiguousAllocation));
+    auto failureMsg = allocator_->getAndClearFailureMessage();
+    EXPECT_THAT(
+        failureMsg, testing::HasSubstr("Exceeded memory allocator limit"));
+    ASSERT_EQ(allocator_->numAllocated(), 0);
+    ASSERT_EQ(allocator_->numMapped(), 0);
+    ASSERT_TRUE(allocator_->checkConsistency());
+  }
+}
+
+TEST_P(MallocContiguousTest, allocContiguousGrow) {
+  auto largestClass = allocator_->sizeClasses().back();
+  constexpr int32_t kInitialLarge = 1024;
+  constexpr int32_t kMinGrow = 1024;
+  MachinePageCount numPages = 0;
+  std::vector<Allocation> small;
+  auto freeSmall = [&](int32_t toFree) {
+    int32_t freed = 0;
+    while (!small.empty() && freed < toFree) {
+      freed += small.back().numPages();
+      allocator_->freeNonContiguous(small.back());
+      small.pop_back();
+    }
+  };
+
+  for (; numPages < kCapacityPages - kInitialLarge; numPages += largestClass) {
+    Allocation temp;
+    allocator_->allocateNonContiguous(largestClass, temp);
+    small.push_back(std::move(temp));
+  }
+  ContiguousAllocation large;
+  EXPECT_FALSE(allocator_->allocateContiguous(
+      kInitialLarge * 2, nullptr, large, nullptr, kCapacityPages));
+  EXPECT_TRUE(allocator_->allocateContiguous(
+      kInitialLarge, nullptr, large, nullptr, kCapacityPages));
+  EXPECT_FALSE(allocator_->growContiguous(kMinGrow, large));
+  auto failureMsg = allocator_->getAndClearFailureMessage();
+  EXPECT_THAT(
+      failureMsg, testing::HasSubstr("Exceeded memory allocator limit"));
+  freeSmall(kMinGrow);
+  EXPECT_TRUE(allocator_->growContiguous(kMinGrow, large));
+  EXPECT_EQ(allocator_->numAllocated(), kCapacityPages);
+  freeSmall(4 * kMinGrow);
+  EXPECT_TRUE(allocator_->growContiguous(4 * kMinGrow, large));
+  EXPECT_THROW(
+      allocator_->growContiguous(100000 * kMinGrow, large), VeloxException);
+  allocator_->freeContiguous(large);
+  EXPECT_EQ(
+      kCapacityPages - kInitialLarge - 5 * kMinGrow,
+      allocator_->numAllocated());
+  freeSmall(kCapacityPages);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MallocContiguousTests,
+    MallocContiguousTest,
+    testing::Bool(),
+    [](const testing::TestParamInfo<bool>& info) {
+      return info.param ? "mallocContiguous" : "mmapContiguous";
+    });
+
 } // namespace facebook::velox::memory

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -58,8 +58,8 @@ class CachedBufferedInputTest : public testing::Test {
 
   void SetUp() override {
     executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(10);
-    allocator_ = std::make_shared<MallocAllocator>(
-        512 << 20 /*capacity=*/, 0 /*reservationByteLimit=*/);
+    allocator_ = std::make_shared<MallocAllocator>(MallocAllocator::Options{
+        .capacity = 512 << 20, .reservationByteLimit = 0});
     cache_ = AsyncDataCache::create(allocator_.get());
     ioStatistics_ = std::make_shared<IoStatistics>();
     tracker_ = std::make_shared<ScanTracker>(


### PR DESCRIPTION
Summary:
MallocAllocator currently uses mmap/munmap for contiguous allocations despite
its name suggesting it delegates everything to malloc. The mmap/munmap syscall
pair on every contiguous alloc/free cycle adds overhead.

This diff:
1. Adds an `Options` struct to `MallocAllocator` (mirroring `MmapAllocator::Options`)
   for cleaner configuration.
2. Adds a `mallocContiguousEnabled` option that, when true, uses
   `aligned_alloc`/`free` for contiguous allocations instead of `mmap`/`munmap`.
3. Wires the option through `MemoryManager::Options`.
4. Updates `CachedBufferedInputTest` to use the new `Options` struct.

The option defaults to false to preserve existing behavior. When enabled,
contiguous allocations use `aligned_alloc(kPageSize, maxBytes)` which
immediately commits physical memory (vs mmap's lazy page faulting), but this
is acceptable for MallocAllocator's use case.

`growContiguous` requires no changes since both mmap and malloc allocate
`maxPages` upfront, so growth stays within already-allocated memory.

Differential Revision: D95875673


