### PR TITLE
fix: Fix TSAN data race in SortBuffer output vector reuse

### DIFF
--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -130,10 +130,10 @@ class LocalMergeSource : public MergeSource {
         bool& drained,
         ScopedPromiseNotification& notification) {
       VELOX_CHECK(started_);
+      data.reset();
 
       if (data_.empty()) {
         if (atEnd_) {
-          data.reset();
           return BlockingReason::kNotBlocked;
         }
         if (drained_) {

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -169,7 +169,7 @@ RowVectorPtr SortBuffer::getOutput(vector_size_t maxOutputRows) {
   } else {
     getOutputWithoutSpill();
   }
-  return output_;
+  return std::move(output_);
 }
 
 bool SortBuffer::hasSpilled() const {


### PR DESCRIPTION
Summary:
Fix a data race between the OrderBy (producer) and Merge (consumer) threads
when using LocalMergeSource.

Root cause: `SortBuffer::getOutput()` returned a copy of `output_`, keeping
a reference in `SortBuffer::output_`. When the consumer thread dropped its
reference via `data.reset()` in `LocalMergeSourceQueue::next()`, the refcount
dropped to 1. On the next call, `SortBuffer::prepareOutput()` called
`BaseVector::prepareForReuse()` which saw refcount==1 and reused buffers
in-place (writing to them), while the consumer thread might still be reading
from the same buffers via `SourceStream::copyToOutput()`. There was no
happens-before relationship because `prepareForReuse()` runs before `enqueue()`
which is where the lock is acquired.

The fix changes `return output_` to `return std::move(output_)` so that
`SortBuffer` no longer keeps a reference to the output vector. On the next
call, `prepareOutput()` takes the else branch and creates a fresh vector,
eliminating the cross-thread buffer reuse race.

Also reverts D91402349 which moved `data.reset()` as a workaround but didn't
address the actual root cause.

Differential Revision: D95877235


