### PR TITLE
refactor: Make StreamArena::allocationQuantum_ a static constexpr

### DIFF
--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -43,11 +43,12 @@ void StreamArena::newRange(
   const int32_t numRuns = allocation_.numRuns();
   if (currentRun_ >= numRuns) {
     if (numRuns > 0) {
+      // No need to push an empty Allocation into 'allocations_'.
       allocations_.push_back(
           std::make_unique<memory::Allocation>(std::move(allocation_)));
     }
     pool_->allocateNonContiguous(
-        std::max(allocationQuantum_, numPages), allocation_);
+        std::max(kAllocationQuantum, numPages), allocation_);
     currentRun_ = 0;
     currentOffset_ = 0;
     size_ += allocation_.byteSize();

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <memory>
+#include <vector>
+
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox {
@@ -30,20 +34,18 @@ class StreamArena {
 
   virtual ~StreamArena() = default;
 
-  /// Sets range to the request 'bytes' of writable memory owned by
-  /// 'this'.  We allocate non-contiguous memory to store range bytes
-  /// if requested 'bytes' is equal or less than the largest class
-  /// page size. Otherwise, we allocate from contiguous
-  /// memory. 'range' is set to point to the allocated memory. If
-  /// 'lastRange' is non-nullptr, it is the last range of the stream
-  /// to which we are adding the new range. 'lastRange' is nullptr if
-  /// adding the first range to a stream. The memory is stays owned by
-  /// 'this' in all cases. Used by HashStringAllocator when extending
-  /// a multipart entry. The previously last part has its last 8 bytes
-  /// moved to the next part and gets a pointer to the next part as
-  /// its last 8 bytes. When extending, we need to update the entry so
-  /// that the next pointer is not seen when reading the content and
-  /// is also not counted in the payload size of the multipart entry.
+  /// Sets range to the request 'bytes' of writable memory owned by 'this'. We
+  /// allocate non-contiguous memory to store range bytes if requested 'bytes'
+  /// is equal or less than the largest class page size. Otherwise, we allocate
+  /// from contiguous memory. 'range' is set to point to the allocated memory.
+  /// If 'lastRange' is non-nullptr, it is the last range of the stream to which
+  /// we are adding the new range. 'lastRange' is nullptr if adding the first
+  /// range to a stream. The memory is stays owned by 'this' in all cases. Used
+  /// by HashStringAllocator when extending a multipart entry. The previously
+  /// last part has its last 8 bytes moved to the next part and gets a pointer
+  /// to the next part as its last 8 bytes. When extending, we need to update
+  /// the entry so that the next pointer is not seen when reading the content
+  /// and is also not counted in the payload size of the multipart entry.
   ///
   /// NOTE: The method does not guarantee returned 'range' has size of 'bytes',
   /// it is caller's responsibility to check.
@@ -63,13 +65,13 @@ class StreamArena {
   virtual void clear();
 
   memory::MachinePageCount testingAllocationQuantum() const {
-    return allocationQuantum_;
+    return kAllocationQuantum;
   }
 
  private:
-  memory::MemoryPool* const pool_;
+  static constexpr memory::MachinePageCount kAllocationQuantum{2};
 
-  const memory::MachinePageCount allocationQuantum_{2};
+  memory::MemoryPool* const pool_;
 
   // All non-contiguous allocations.
   std::vector<std::unique_ptr<memory::Allocation>> allocations_;


### PR DESCRIPTION
`StreamArena::allocationQuantum_` is a compile-time constant (always 2)
that is never configured per-object. Rename it to `kAllocationQuantum`
and make it static constexpr to better express intent and follow the
codebase naming convention.

Also:
- Add missing direct includes (<memory>, <vector>) following IWYU.
- Reflow the newRange() doc comment for consistent line width.