### PR TITLE
build: Add gRPC, gh, and jq to ubuntu-22.04 container image

### DIFF
--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -37,4 +37,14 @@ ARG tz="Etc/UTC"
 ENV TZ=${tz}
 RUN /bin/bash -o pipefail /velox/scripts/setup-ubuntu.sh
 
+# Install tools needed for CI (gh for GitHub Actions stash, jq for JSON parsing)
+RUN apt-get update && \
+      apt-get install -y -q --no-install-recommends jq && \
+      curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+      apt-get update && apt-get install -y -q --no-install-recommends gh && \
+      apt-get clean && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /velox

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -113,6 +113,19 @@ function install_protobuf {
   cmake_install_dir protobuf -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package
 }
 
+function install_grpc {
+  github_checkout grpc/grpc "${GRPC_VERSION}" --depth 1
+  cmake_install_dir grpc \
+    -DgRPC_BUILD_TESTS=OFF \
+    -DgRPC_ABSL_PROVIDER=package \
+    -DgRPC_ZLIB_PROVIDER=package \
+    -DgRPC_CARES_PROVIDER=package \
+    -DgRPC_RE2_PROVIDER=package \
+    -DgRPC_SSL_PROVIDER=package \
+    -DgRPC_PROTOBUF_PROVIDER=package \
+    -DgRPC_INSTALL=ON
+}
+
 function install_double_conversion {
   wget_and_untar https://github.com/google/double-conversion/archive/refs/tags/"${DOUBLE_CONVERSION_VERSION}".tar.gz double-conversion
   cmake_install_dir double-conversion -DBUILD_TESTING=OFF
@@ -310,26 +323,9 @@ function install_gcs_sdk_cpp {
   # Install gcs dependencies
   # https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md#required-libraries
 
-  # abseil-cpp
-  install_abseil
-
-  # protobuf
-  github_checkout protocolbuffers/protobuf v"${PROTOBUF_VERSION}" --depth 1
-  cmake_install_dir protobuf \
-    -Dprotobuf_BUILD_TESTS=OFF \
-    -Dprotobuf_ABSL_PROVIDER=package
-
-  # grpc
-  github_checkout grpc/grpc "${GRPC_VERSION}" --depth 1
-  cmake_install_dir grpc \
-    -DgRPC_BUILD_TESTS=OFF \
-    -DgRPC_ABSL_PROVIDER=package \
-    -DgRPC_ZLIB_PROVIDER=package \
-    -DgRPC_CARES_PROVIDER=package \
-    -DgRPC_RE2_PROVIDER=package \
-    -DgRPC_SSL_PROVIDER=package \
-    -DgRPC_PROTOBUF_PROVIDER=package \
-    -DgRPC_INSTALL=ON
+  # abseil-cpp, protobuf, grpc
+  install_protobuf
+  install_grpc
 
   # crc32
   github_checkout google/crc32c "${CRC32_VERSION}" --depth 1

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -232,6 +232,7 @@ function install_velox_deps {
   run_and_time install_velox_deps_from_apt
   run_and_time install_fmt
   run_and_time install_protobuf
+  run_and_time install_grpc
   run_and_time install_boost
   run_and_time install_fast_float
   run_and_time install_folly


### PR DESCRIPTION
## Summary
- Extract standalone `install_grpc()` function from `install_gcs_sdk_cpp()` in `setup-common.sh` and refactor `install_gcs_sdk_cpp` to reuse it
- Add `install_grpc` to `setup-ubuntu.sh`'s `install_velox_deps` so gRPC is built from source and available as a SYSTEM dependency in the container
- Install `gh` and `jq` in the ubuntu-22.04 Dockerfile, required by `apache/infrastructure-actions/stash` CI action

This enables using `VELOX_DEPENDENCY_SOURCE=SYSTEM` with `VELOX_BUILD_TESTING=ON` in the ubuntu-22.04 container without needing to override `gRPC_SOURCE=BUNDLED` or install CI tools at runtime.

## Test plan
- [ ] Verify the Docker image builds successfully (triggered by the `scripts/` path filter)
- [ ] Verify the `install_gcs_sdk_cpp` refactor doesn't break GCS adapter builds
- [ ] Once image is published, update PR #16424 to remove `gRPC_SOURCE: BUNDLED` override and runtime `gh`/`jq` installation