### PR TITLE
docs: Add Meng Duan as maintainer for Core Library, Memory Management, and Fuzzers

### DIFF
--- a/website/docs/community/03-components-and-maintainers.md
+++ b/website/docs/community/03-components-and-maintainers.md
@@ -52,6 +52,7 @@ maintainers of that component.
 * Jimmy Lu - [Yuhta](https://github.com/Yuhta) / jimmylu@meta.com
 * Masha Basmanova - [mbasmanova](https://github.com/mbasmanova) / mbasmanova@meta.com
 * Xiaoxuan Meng - [xiaoxmeng](https://github.com/xiaoxmeng) / xiaoxmeng@meta.com
+* Meng Duan - [duanmeng](https://github.com/duanmeng) / meng.duan@bytedance.com
 
 ### Presto Functions
 
@@ -67,6 +68,7 @@ maintainers of that component.
 ### Memory Management
 
 * Xiaoxuan Meng - [xiaoxmeng](https://github.com/xiaoxmeng) / xiaoxmeng@meta.com
+* Meng Duan - [duanmeng](https://github.com/duanmeng) / meng.duan@bytedance.com
 
 ### IO, Cache, Hive connector, and File reader/writers
 
@@ -101,3 +103,4 @@ maintainers of that component.
 
 * Masha Basmanova - [mbasmanova](https://github.com/mbasmanova) / mbasmanova@meta.com
 * Pedro Pedreira - [pedroerp](https://github.com/pedroerp) / pedroerp@meta.com
+* Meng Duan - [duanmeng](https://github.com/duanmeng) / meng.duan@bytedance.com


### PR DESCRIPTION
Summary:
Add Meng Duan (duanmeng) as a maintainer for:
- Core Library
- Memory Management
- Fuzzers and Test Frameworks

Differential Revision: D95972273


