### PR TITLE
docs: Add HashTableCaching doc to index

### DIFF
--- a/velox/docs/develop.rst
+++ b/velox/docs/develop.rst
@@ -34,3 +34,4 @@ This guide is intended for Velox contributors and developers of Velox-based appl
     develop/TpchBenchmark
     develop/window
     develop/dynamic-loading
+    develop/hash-table-caching


### PR DESCRIPTION
Summary: Add missing index entry for hash table caching docs

Differential Revision: D95992622


