### PR TITLE
refactor: Remove VectorSerde::kind() method, use static serializer names (#16710)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3277,6 +3277,10 @@ PartitionedOutputNode::PartitionedOutputNode(
       partitionFunctionSpec_(std::move(partitionFunctionSpec)),
       serdeKind_(std::move(serdeKind)),
       outputType_(std::move(outputType)) {
+  VELOX_CHECK(
+      isRegisteredNamedVectorSerde(serdeKind_),
+      "Serde is not registered: {}",
+      serdeKind_);
   VELOX_USER_CHECK_GT(numPartitions_, 0);
   if (numPartitions_ == 1) {
     VELOX_USER_CHECK(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2179,7 +2179,12 @@ using GroupIdNodePtr = std::shared_ptr<const GroupIdNode>;
 class ExchangeNode : public PlanNode {
  public:
   ExchangeNode(const PlanNodeId& id, RowTypePtr type, std::string serdeKind)
-      : PlanNode(id), outputType_(type), serdeKind_(std::move(serdeKind)) {}
+      : PlanNode(id), outputType_(type), serdeKind_(std::move(serdeKind)) {
+    VELOX_CHECK(
+        isRegisteredNamedVectorSerde(serdeKind_),
+        "Serde is not registered: {}",
+        serdeKind_);
+  }
 
   class Builder {
    public:

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/tests/utils/AggregationResolver.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/serializers/RegisterAllVectorSerdes.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace ::facebook::velox;
@@ -36,6 +37,7 @@ class PlanNodeBuilderTest : public testing::Test, public test::VectorTestBase {
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
     aggregate::prestosql::registerAllAggregateFunctions();
+    registerAllNamedVectorSerdes();
   }
 
   core::ColumnStatsSpec createStatsSpec(

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/core/Expressions.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
+#include "velox/serializers/RegisterAllVectorSerdes.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -29,6 +30,7 @@ class PlanNodeTest : public testing::Test, public test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    registerAllNamedVectorSerdes();
   }
 
   PlanNodeTest() {

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -751,6 +751,8 @@ distribution fields.
      - Factory to make partition functions to use when calculating partitions for input rows.
    * - outputType
      - A list of output columns. This is a subset of input columns possibly in a different order.
+   * - serdeKind
+     - Name of the serialization format to use for shuffling data. Built-in formats: 'Presto', 'CompactRow', 'UnsafeRow'.
 
 ValuesNode
 ~~~~~~~~~~
@@ -786,6 +788,8 @@ streams are coming from remote exchange or shuffle.
      - Description
    * - type
      - A list of columns in the input streams.
+   * - serdeKind
+     - Name of the serialization format used by the upstream shuffle. Built-in formats: 'Presto', 'CompactRow', 'UnsafeRow'.
 
 MergeExchangeNode
 ~~~~~~~~~~~~~~~~~
@@ -806,6 +810,8 @@ orderedness. Input streams are coming from remote exchange or shuffle.
      - List of one of more input columns to sort by.
    * - sortingOrders
      - Sorting order for each of the soring keys. See OrderBy for the list of supported orders.
+   * - serdeKind
+     - Name of the serialization format used by the upstream shuffle. Built-in formats: 'Presto', 'CompactRow', 'UnsafeRow'.
 
 LocalMergeNode
 ~~~~~~~~~~~~~~

--- a/velox/docs/develop/serde.rst
+++ b/velox/docs/develop/serde.rst
@@ -27,3 +27,20 @@ The details of UnsafeRow and CompactRow formats can be found in the following ar
 
 Velox also uses another row-wise serialization format, ContainerRowSerde, for storing
 data in aggregation and join operators. This format is similar to CompactRow.
+
+Serde Registration API
+======================
+
+Velox uses a named registry for serialization formats. Each serde is registered
+under a unique string name via ``registerNamedVectorSerde(name, serde)`` and
+retrieved with ``getNamedVectorSerde(name)``. Use
+``isRegisteredNamedVectorSerde(name)`` to check whether a name has been
+registered. Names must be non-empty; passing an empty string throws.
+
+Built-in format names are available via the ``name()`` static method on each serde class:
+
+* ``serializer::presto::PrestoVectorSerde::name()`` — ``"Presto"``
+* ``serializer::CompactRowVectorSerde::name()`` — ``"CompactRow"``
+* ``serializer::spark::UnsafeRowVectorSerde::name()`` — ``"UnsafeRow"``
+
+Custom formats can be registered under any non-empty name.

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -351,8 +351,7 @@ void Exchange::close() {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
         Operator::kShuffleSerdeKind,
-        RuntimeCounter(
-            static_cast<int64_t>(VectorSerde::kindByName(serdeKind_))));
+        RuntimeCounter(Operator::shuffleSerdeStatsValue(serdeKind_)));
     lockedStats->addRuntimeStat(
         Operator::kShuffleCompressionKind,
         RuntimeCounter(static_cast<int64_t>(serdeOptions_->compressionKind)));

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -780,11 +780,12 @@ MergeExchange::MergeExchange(
           mergeExchangeNode->sortingOrders(),
           mergeExchangeNode->id(),
           OperatorType::kMergeExchange),
-      serde_(getNamedVectorSerde(mergeExchangeNode->serdeKind())),
+      serdeKind_(mergeExchangeNode->serdeKind()),
+      serde_(getNamedVectorSerde(serdeKind_)),
       serdeOptions_(getVectorSerdeOptions(
           common::stringToCompressionKind(
               driverCtx->queryConfig().shuffleCompressionKind()),
-          mergeExchangeNode->serdeKind())) {}
+          serdeKind_)) {}
 
 BlockingReason MergeExchange::addMergeSources(ContinueFuture* future) {
   if (operatorCtx_->driverCtx()->driverId != 0) {
@@ -861,8 +862,7 @@ void MergeExchange::close() {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
         Operator::kShuffleSerdeKind,
-        RuntimeCounter(
-            static_cast<int64_t>(VectorSerde::kindByName(serde_->kind()))));
+        RuntimeCounter(Operator::shuffleSerdeStatsValue(serdeKind_)));
     lockedStats->addRuntimeStat(
         Operator::kShuffleCompressionKind,
         RuntimeCounter(static_cast<int64_t>(serdeOptions_->compressionKind)));

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -396,6 +396,7 @@ class MergeExchange : public Merge {
   BlockingReason addMergeSources(ContinueFuture* future) override;
 
  private:
+  const std::string serdeKind_;
   VectorSerde* const serde_;
   const std::unique_ptr<VectorSerde::Options> serdeOptions_;
   bool noMoreSplits_ = false;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -23,6 +23,9 @@
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
+#include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -76,6 +79,20 @@ OperatorCtx::createConnectorQueryCtx(
   connectorQueryCtx->setRowSizeTrackingMode(
       driverCtx_->queryConfig().rowSizeTrackingMode());
   return connectorQueryCtx;
+}
+
+// static
+int64_t Operator::shuffleSerdeStatsValue(std::string_view name) {
+  if (name == serializer::presto::PrestoVectorSerde::name()) {
+    return 0;
+  }
+  if (name == serializer::CompactRowVectorSerde::name()) {
+    return 1;
+  }
+  if (name == serializer::spark::UnsafeRowVectorSerde::name()) {
+    return 2;
+  }
+  return -1;
 }
 
 Operator::Operator(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -187,8 +187,13 @@ class Operator : public BaseRuntimeStatWriter {
       "spillDeserializationWallNanos"};
 
   /// The vector serde kind used by an operator for shuffle. The recorded
-  /// runtime stats value is the corresponding enum value.
+  /// runtime stats value is the int64_t returned by shuffleSerdeStatsValue().
   static constexpr std::string_view kShuffleSerdeKind{"shuffleSerdeKind"};
+
+  /// Maps a serde name to an int64_t for stat reporting.
+  /// Returns 0 for "Presto", 1 for "CompactRow", 2 for "UnsafeRow", -1
+  /// otherwise.
+  static int64_t shuffleSerdeStatsValue(std::string_view name);
 
   /// The compression kind used by an operator for shuffle. The recorded
   /// runtime stats value is the corresponding enum value.

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -19,6 +19,9 @@
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
+#include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
 
 namespace facebook::velox::exec {
 
@@ -27,6 +30,7 @@ Destination::Destination(
     const std::string& taskId,
     int destination,
     VectorSerde* serde,
+    const std::string& serdeKind,
     VectorSerde::Options* serdeOptions,
     memory::MemoryPool* pool,
     bool eagerFlush,
@@ -34,6 +38,7 @@ Destination::Destination(
     : taskId_(taskId),
       destination_(destination),
       serde_(serde),
+      serdeKind_(serdeKind),
       serdeOptions_(serdeOptions),
       pool_(pool),
       eagerFlush_(eagerFlush),
@@ -79,14 +84,14 @@ BlockingReason Destination::advance(
   createVectorStreamGroup(output);
 
   const auto rows = folly::Range(&rows_[firstRow], rowIdx_ - firstRow);
-  if (serde_->kind() == "CompactRow") {
+  if (serdeKind_ == serializer::CompactRowVectorSerde::name()) {
     VELOX_CHECK_NOT_NULL(outputCompactRow);
     current_->append(*outputCompactRow, rows, sizes);
-  } else if (serde_->kind() == "UnsafeRow") {
+  } else if (serdeKind_ == serializer::spark::UnsafeRowVectorSerde::name()) {
     VELOX_CHECK_NOT_NULL(outputUnsafeRow);
     current_->append(*outputUnsafeRow, rows, sizes);
   } else {
-    VELOX_CHECK_EQ(serde_->kind(), "Presto");
+    VELOX_CHECK_EQ(serdeKind_, serializer::presto::PrestoVectorSerde::name());
     current_->append(output, rows, scratch);
   }
 
@@ -228,6 +233,7 @@ PartitionedOutput::PartitionedOutput(
           eagerFlush ||
           ctx->task->queryCtx()->queryConfig().partitionedOutputEagerFlush()),
       serde_(getNamedVectorSerde(planNode->serdeKind())),
+      serdeKind_(planNode->serdeKind()),
       serdeOptions_(getVectorSerdeOptions(
           common::stringToCompressionKind(operatorCtx_->driverCtx()
                                               ->queryConfig()
@@ -274,9 +280,9 @@ void PartitionedOutput::initializeInput(RowVectorPtr input) {
     output_->childAt(i)->loadedVector();
   }
 
-  if (serde_->kind() == "CompactRow") {
+  if (serdeKind_ == serializer::CompactRowVectorSerde::name()) {
     outputCompactRow_ = std::make_unique<row::CompactRow>(output_);
-  } else if (serde_->kind() == "UnsafeRow") {
+  } else if (serdeKind_ == serializer::spark::UnsafeRowVectorSerde::name()) {
     outputUnsafeRow_ = std::make_unique<row::UnsafeRowFast>(output_);
   }
 }
@@ -290,6 +296,7 @@ void PartitionedOutput::initializeDestinations() {
               taskId,
               i,
               serde_,
+              serdeKind_,
               serdeOptions_.get(),
               pool(),
               eagerFlush_,
@@ -319,16 +326,16 @@ void PartitionedOutput::estimateRowSizes() {
   raw_vector<vector_size_t> storage(pool());
   const auto numbers = iota(numInput, storage);
   const auto rows = folly::Range(numbers, numInput);
-  if (serde_->kind() == "CompactRow") {
+  if (serdeKind_ == serializer::CompactRowVectorSerde::name()) {
     VELOX_CHECK_NOT_NULL(outputCompactRow_);
     serde_->estimateSerializedSize(
         outputCompactRow_.get(), rows, sizePointers_.data());
-  } else if (serde_->kind() == "UnsafeRow") {
+  } else if (serdeKind_ == serializer::spark::UnsafeRowVectorSerde::name()) {
     VELOX_CHECK_NOT_NULL(outputUnsafeRow_);
     serde_->estimateSerializedSize(
         outputUnsafeRow_.get(), rows, sizePointers_.data());
   } else {
-    VELOX_CHECK_EQ(serde_->kind(), "Presto");
+    VELOX_CHECK_EQ(serdeKind_, serializer::presto::PrestoVectorSerde::name());
     serde_->estimateSerializedSize(
         output_.get(), rows, sizePointers_.data(), scratch_);
   }
@@ -511,8 +518,7 @@ void PartitionedOutput::close() {
     auto lockedStats = stats_.wlock();
     lockedStats->addRuntimeStat(
         Operator::kShuffleSerdeKind,
-        RuntimeCounter(
-            static_cast<int64_t>(VectorSerde::kindByName(serde_->kind()))));
+        RuntimeCounter(Operator::shuffleSerdeStatsValue(serdeKind_)));
     lockedStats->addRuntimeStat(
         Operator::kShuffleCompressionKind,
         RuntimeCounter(static_cast<int64_t>(serdeOptions_->compressionKind)));

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -33,6 +33,7 @@ class Destination {
       const std::string& taskId,
       int destination,
       VectorSerde* serde,
+      const std::string& serdeKind,
       VectorSerde::Options* options,
       memory::MemoryPool* pool,
       bool eagerFlush,
@@ -114,6 +115,7 @@ class Destination {
   const std::string taskId_;
   const int destination_;
   VectorSerde* const serde_;
+  const std::string serdeKind_;
   VectorSerde::Options* const serdeOptions_;
   memory::MemoryPool* const pool_;
   const bool eagerFlush_;
@@ -239,6 +241,7 @@ class PartitionedOutput : public Operator {
   const int64_t maxBufferedBytes_;
   const bool eagerFlush_;
   VectorSerde* const serde_;
+  const std::string serdeKind_;
   const std::unique_ptr<VectorSerde::Options> serdeOptions_;
 
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -379,10 +379,10 @@ TEST_P(MultiFragmentTest, aggregationSingleKey) {
   ASSERT_EQ(serdeKindRuntimsStats.count, 4);
   ASSERT_EQ(
       serdeKindRuntimsStats.min,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
   ASSERT_EQ(
       serdeKindRuntimsStats.max,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
 
   for (const auto& finalTask : finalTasks) {
     auto finalPlanStats = toPlanStats(finalTask->taskStats());
@@ -392,10 +392,12 @@ TEST_P(MultiFragmentTest, aggregationSingleKey) {
     ASSERT_EQ(serdeKindRuntimsStats.count, 1);
     ASSERT_EQ(
         serdeKindRuntimsStats.min,
-        static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+        static_cast<int64_t>(
+            Operator::shuffleSerdeStatsValue(GetParam().serdeKind)));
     ASSERT_EQ(
         serdeKindRuntimsStats.max,
-        static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+        static_cast<int64_t>(
+            Operator::shuffleSerdeStatsValue(GetParam().serdeKind)));
   }
 }
 
@@ -683,10 +685,10 @@ TEST_P(MultiFragmentTest, mergeExchange) {
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
       serdeKindRuntimsStats.min,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
   ASSERT_EQ(
       serdeKindRuntimsStats.max,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
 }
 
 // Test reordering and dropping columns in PartitionedOutput operator.
@@ -1002,10 +1004,10 @@ TEST_P(MultiFragmentTest, mergeExchangeWithSpill) {
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
       serdeKindRuntimsStats.min,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
   ASSERT_EQ(
       serdeKindRuntimsStats.max,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
 }
 
 TEST_P(MultiFragmentTest, noHashPartitionSkew) {
@@ -2222,10 +2224,10 @@ TEST_P(MultiFragmentTest, customPlanNodeWithExchangeClient) {
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
       serdeKindRuntimsStats.min,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
   ASSERT_EQ(
       serdeKindRuntimsStats.max,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam().serdeKind)));
+      Operator::shuffleSerdeStatsValue(GetParam().serdeKind));
 }
 
 // This test is to reproduce the race condition between task terminate and no

--- a/velox/exec/tests/PartitionedOutputTest.cpp
+++ b/velox/exec/tests/PartitionedOutputTest.cpp
@@ -159,11 +159,9 @@ TEST_P(PartitionedOutputTest, flush) {
           .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
-      serdeKindRuntimsStats.min,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
+      serdeKindRuntimsStats.min, Operator::shuffleSerdeStatsValue(GetParam()));
   ASSERT_EQ(
-      serdeKindRuntimsStats.max,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
+      serdeKindRuntimsStats.max, Operator::shuffleSerdeStatsValue(GetParam()));
 }
 
 TEST_P(PartitionedOutputTest, keyChannelNotAtBeginningWithNulls) {
@@ -275,11 +273,9 @@ TEST_P(PartitionedOutputTest, multipleFlushCycles) {
           .customStats.at(std::string(Operator::kShuffleSerdeKind));
   ASSERT_EQ(serdeKindRuntimsStats.count, 1);
   ASSERT_EQ(
-      serdeKindRuntimsStats.min,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
+      serdeKindRuntimsStats.min, Operator::shuffleSerdeStatsValue(GetParam()));
   ASSERT_EQ(
-      serdeKindRuntimsStats.max,
-      static_cast<int64_t>(VectorSerde::kindByName(GetParam())));
+      serdeKindRuntimsStats.max, Operator::shuffleSerdeStatsValue(GetParam()));
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/serializers/RegisterAllVectorSerdes.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -38,6 +39,7 @@ class PlanNodeSerdeTest : public testing::Test,
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
     parse::registerTypeResolver();
+    registerAllNamedVectorSerdes();
 
     Type::registerSerDe();
     common::Filter::registerSerDe();

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/parse/TypeResolver.h"
+#include "velox/serializers/RegisterAllVectorSerdes.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <gtest/gtest.h>
@@ -37,6 +38,7 @@ class PlanNodeToStringTest : public testing::Test,
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
     parse::registerTypeResolver();
+    registerAllNamedVectorSerdes();
     data_ = makeRowVector(
         {makeFlatVector<int16_t>({0, 1, 2, 3, 4}),
          makeFlatVector<int32_t>({0, 1, 2, 3, 4}),

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -22,7 +22,7 @@ namespace facebook::velox::serializer {
 
 class CompactRowVectorSerde : public VectorSerde {
  public:
-  CompactRowVectorSerde() : VectorSerde(kSerdeKind) {}
+  CompactRowVectorSerde() = default;
 
   void estimateSerializedSize(
       const row::CompactRow* compactRow,
@@ -57,8 +57,9 @@ class CompactRowVectorSerde : public VectorSerde {
   /// default serde is already registered.
   static void registerVectorSerde();
 
-  /// Registers this serde in the named serde registry under kSerdeKind.
-  /// Throws if a serde with the same name is already registered.
+  /// Registers this serde in the named serde registry under kSerdeKind
+  /// (same name returned by name()). Throws if a serde with the same name
+  /// is already registered.
   static void registerNamedVectorSerde();
 
   /// Registers this serde in the named serde registry under kSerdeKind only

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -88,7 +88,7 @@ class PrestoVectorSerde : public VectorSerde {
     bool preserveEncodings{false};
   };
 
-  PrestoVectorSerde() : VectorSerde(kSerdeKind) {}
+  PrestoVectorSerde() = default;
 
   /// Adds the serialized sizes of the rows of 'vector' in 'ranges[i]' to
   /// '*sizes[i]'.
@@ -195,8 +195,9 @@ class PrestoVectorSerde : public VectorSerde {
   /// default serde is already registered.
   static void registerVectorSerde();
 
-  /// Registers this serde in the named serde registry under kSerdeKind.
-  /// Throws if a serde with the same name is already registered.
+  /// Registers this serde in the named serde registry under kSerdeKind
+  /// (same name returned by name()). Throws if a serde with the same name
+  /// is already registered.
   static void registerNamedVectorSerde();
 
   /// Registers this serde in the named serde registry under kSerdeKind only

--- a/velox/serializers/RegisterAllVectorSerdes.h
+++ b/velox/serializers/RegisterAllVectorSerdes.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/serializers/CompactRowSerializer.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox {
+
+/// Registers all built-in named vector serdes (Presto, CompactRow, UnsafeRow).
+/// Safe to call multiple times; skips already-registered serdes.
+inline void registerAllNamedVectorSerdes() {
+  if (!isRegisteredNamedVectorSerde(
+          serializer::presto::PrestoVectorSerde::name())) {
+    serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(
+          serializer::CompactRowVectorSerde::name())) {
+    serializer::CompactRowVectorSerde::registerNamedVectorSerde();
+  }
+  if (!isRegisteredNamedVectorSerde(
+          serializer::spark::UnsafeRowVectorSerde::name())) {
+    serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
+  }
+}
+
+} // namespace facebook::velox

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -21,7 +21,7 @@ namespace facebook::velox::serializer::spark {
 
 class UnsafeRowVectorSerde : public VectorSerde {
  public:
-  UnsafeRowVectorSerde() : VectorSerde(kSerdeKind) {}
+  UnsafeRowVectorSerde() = default;
 
   void estimateSerializedSize(
       const row::UnsafeRowFast* unsafeRow,
@@ -57,8 +57,9 @@ class UnsafeRowVectorSerde : public VectorSerde {
   /// default serde is already registered.
   static void registerVectorSerde();
 
-  /// Registers this serde in the named serde registry under kSerdeKind.
-  /// Throws if a serde with the same name is already registered.
+  /// Registers this serde in the named serde registry under kSerdeKind
+  /// (same name returned by name()). Throws if a serde with the same name
+  /// is already registered.
   static void registerNamedVectorSerde();
 
   /// Registers this serde in the named serde registry under kSerdeKind only

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -70,8 +70,6 @@ class CompactRowSerializerTest : public ::testing::Test,
     deregisterNamedVectorSerde("CompactRow");
     serializer::CompactRowVectorSerde::registerVectorSerde();
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
-    ASSERT_EQ(getVectorSerde()->kind(), "CompactRow");
-    ASSERT_EQ(getNamedVectorSerde("CompactRow")->kind(), "CompactRow");
     appendRow_ = GetParam().appendRow;
     compressionKind_ = GetParam().compressionKind;
     microBatchDeserialize_ = GetParam().microBatchDeserialize;

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1971,11 +1971,9 @@ class PrestoSerializerBatchEstimateSizeTest : public testing::Test,
     if (!isRegisteredVectorSerde()) {
       serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }
-    ASSERT_EQ(getVectorSerde()->kind(), "Presto");
     if (!isRegisteredNamedVectorSerde("Presto")) {
       serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
     }
-    ASSERT_EQ(getNamedVectorSerde("Presto")->kind(), "Presto");
 
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -69,8 +69,6 @@ class UnsafeRowSerializerTest : public ::testing::Test,
     deregisterNamedVectorSerde("CompactRow");
     serializer::spark::UnsafeRowVectorSerde::registerVectorSerde();
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
-    ASSERT_EQ(getVectorSerde()->kind(), "UnsafeRow");
-    ASSERT_EQ(getNamedVectorSerde("UnsafeRow")->kind(), "UnsafeRow");
     appendRow_ = GetParam().appendRow;
     compressionKind_ = GetParam().compressionKind;
     microBatchDeserialize_ = GetParam().microBatchDeserialize;

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -94,35 +94,6 @@ std::unique_ptr<BatchVectorSerializer> VectorSerde::createBatchSerializer(
   return std::make_unique<DefaultBatchVectorSerializer>(pool, this, options);
 }
 
-std::string VectorSerde::kindName(Kind kind) {
-  switch (kind) {
-    case Kind::kPresto:
-      return "Presto";
-    case Kind::kCompactRow:
-      return "CompactRow";
-    case Kind::kUnsafeRow:
-      return "UnsafeRow";
-  }
-  VELOX_UNREACHABLE(
-      fmt::format("Unknown vector serde kind: {}", static_cast<int32_t>(kind)));
-}
-
-VectorSerde::Kind VectorSerde::kindByName(const std::string& kindName) {
-  static const std::unordered_map<std::string, Kind> kNameToKind = {
-      {"Presto", Kind::kPresto},
-      {"CompactRow", Kind::kCompactRow},
-      {"UnsafeRow", Kind::kUnsafeRow}};
-  const auto it = kNameToKind.find(kindName);
-  VELOX_CHECK(
-      it != kNameToKind.end(), "Unknown vector serde kind: {}", kindName);
-  return it->second;
-}
-
-std::ostream& operator<<(std::ostream& out, VectorSerde::Kind kind) {
-  out << VectorSerde::kindName(kind);
-  return out;
-}
-
 VectorSerde* getVectorSerde() {
   auto serde = getVectorSerdeImpl().get();
   VELOX_CHECK_NOT_NULL(serde, "Vector serde is not registered.");
@@ -149,6 +120,7 @@ bool isRegisteredVectorSerde() {
 void registerNamedVectorSerde(
     const std::string& kind,
     std::unique_ptr<VectorSerde> serdeToRegister) {
+  VELOX_CHECK(!kind.empty(), "Serde name must not be empty.");
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   VELOX_CHECK(
       namedSerdeMap.find(kind) == namedSerdeMap.end(),
@@ -163,11 +135,13 @@ void deregisterNamedVectorSerde(const std::string& kind) {
 }
 
 bool isRegisteredNamedVectorSerde(const std::string& kind) {
+  VELOX_CHECK(!kind.empty(), "Serde name must not be empty.");
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   return namedSerdeMap.find(kind) != namedSerdeMap.end();
 }
 
 VectorSerde* getNamedVectorSerde(const std::string& kind) {
+  VELOX_CHECK(!kind.empty(), "Serde name must not be empty.");
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   auto it = namedSerdeMap.find(kind);
   VELOX_CHECK(

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -206,16 +206,6 @@ class RowIterator {
 
 class VectorSerde {
  public:
-  enum class Kind {
-    kPresto,
-    kCompactRow,
-    kUnsafeRow,
-  };
-
-  static std::string kindName(Kind type);
-
-  static Kind kindByName(const std::string& name);
-
   virtual ~VectorSerde() = default;
 
   // Lets the caller pass options to the Serde. This can be extended to add
@@ -238,10 +228,6 @@ class VectorSerde {
     /// times compression misses the target the less frequently it is tried.
     float minCompressionRatio{0.8};
   };
-
-  const std::string& kind() const {
-    return kind_;
-  }
 
   virtual void estimateSerializedSize(
       const BaseVector* /*vector*/,
@@ -350,14 +336,7 @@ class VectorSerde {
       const Options* options = nullptr) {
     VELOX_NYI();
   }
-
- protected:
-  explicit VectorSerde(std::string kind) : kind_(std::move(kind)) {}
-
-  const std::string kind_;
 };
-
-std::ostream& operator<<(std::ostream& out, VectorSerde::Kind kind);
 
 /// Register/deregister the "default" vector serde.
 void registerVectorSerde(std::unique_ptr<VectorSerde> serdeToRegister);
@@ -532,12 +511,3 @@ RowVectorPtr IOBufToRowVector(
     VectorSerde* serde = nullptr);
 
 } // namespace facebook::velox
-
-template <>
-struct fmt::formatter<facebook::velox::VectorSerde::Kind>
-    : formatter<std::string> {
-  auto format(facebook::velox::VectorSerde::Kind s, format_context& ctx) const {
-    return formatter<std::string>::format(
-        facebook::velox::VectorSerde::kindName(s), ctx);
-  }
-};

--- a/velox/vector/tests/VectorStreamTest.cpp
+++ b/velox/vector/tests/VectorStreamTest.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::test {
 
 class MockVectorSerde : public VectorSerde {
  public:
-  MockVectorSerde() : VectorSerde("Presto") {}
+  MockVectorSerde() = default;
 
   void estimateSerializedSize(
       const BaseVector* /*vector*/,


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/facebookincubator/velox/pull/16710

Reviewed By: xiaoxmeng

Differential Revision: D96046667


