### PR TITLE
build: Pre-download gflags source in Ubuntu container image

### DIFF
--- a/scripts/docker/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/docker/ubuntu-22.04-cpp.dockerfile
@@ -47,4 +47,9 @@ RUN apt-get update && \
       apt-get update && apt-get install -y -q --no-install-recommends gh && \
       apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Pre-download gflags source for BUNDLED builds to avoid downloading at build time.
+RUN mkdir -p /velox/deps-sources && \
+    curl -fsSL -o /velox/deps-sources/gflags-v2.2.2.tar.gz \
+      https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz
+
 WORKDIR /velox


### PR DESCRIPTION
## Summary
- Pre-downloads the gflags v2.2.2 source tarball into the Ubuntu Docker image at `/velox/deps-sources/gflags-v2.2.2.tar.gz`
- This allows CI jobs that use `gflags_SOURCE=BUNDLED` to set `VELOX_GFLAGS_URL` to the local copy, avoiding a GitHub download on every run
- Needed by PR #16424 which switches ubuntu-debug to SYSTEM dependencies with BUNDLED gflags

## Test plan
- [ ] Docker image builds successfully (triggered automatically by this PR)
- [ ] Verify the tarball exists at `/velox/deps-sources/gflags-v2.2.2.tar.gz` in the built image