### PR TITLE
Add positional update support for Velox Iceberg connector (#16715)

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -24,6 +24,7 @@ velox_add_library(
   IcebergSplitReader.cpp
   PartitionSpec.cpp
   PositionalDeleteFileReader.cpp
+  PositionalUpdateFileReader.cpp
   TransformEvaluator.cpp
   TransformExprBuilder.cpp
 )

--- a/velox/connectors/hive/iceberg/IcebergDeleteFile.h
+++ b/velox/connectors/hive/iceberg/IcebergDeleteFile.h
@@ -27,6 +27,10 @@ enum class FileContent {
   kData,
   kPositionalDeletes,
   kEqualityDeletes,
+  /// Velox extension (not part of the Iceberg V2 spec). Carries column-level
+  /// updates keyed by (file_path, pos) for merge-on-read without full-row
+  /// rewrites. Standard Iceberg achieves updates via delete + insert.
+  kPositionalUpdates,
 };
 
 struct IcebergDeleteFile {
@@ -65,5 +69,9 @@ struct IcebergDeleteFile {
         lowerBounds(_lowerBounds),
         upperBounds(_upperBounds) {}
 };
+
+/// Type alias for readability. Positional update files reuse the same metadata
+/// structure as delete files; only the content field differs.
+using IcebergUpdateFile = IcebergDeleteFile;
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -69,7 +69,8 @@ HiveIcebergSplit::HiveIcebergSplit(
     bool cacheable,
     std::vector<IcebergDeleteFile> deletes,
     const std::unordered_map<std::string, std::string>& infoColumns,
-    std::optional<FileProperties> properties)
+    std::optional<FileProperties> properties,
+    std::vector<IcebergUpdateFile> updates)
     : HiveConnectorSplit(
           connectorId,
           filePath,
@@ -87,5 +88,6 @@ HiveIcebergSplit::HiveIcebergSplit(
           properties,
           std::nullopt,
           std::nullopt),
-      deleteFiles(std::move(deletes)) {}
+      deleteFiles(std::move(deletes)),
+      updateFiles(std::move(updates)) {}
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -25,6 +25,19 @@ namespace facebook::velox::connector::hive::iceberg {
 struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
   std::vector<IcebergDeleteFile> deleteFiles;
 
+  /// Positional update files attached to this split. Each update file contains
+  /// (file_path, pos, <subset of updated columns>) for merge-on-read column
+  /// updates. Only the columns that were modified are present in the update
+  /// file; unchanged columns are not included and retain their base values.
+  ///
+  /// NOTE: "Positional updates" are a Velox-side merge-on-read extension, not
+  /// part of the Iceberg V2 spec (which achieves updates via delete + insert).
+  ///
+  /// Reuses IcebergDeleteFile because the metadata shape (path, format, record
+  /// count, bounds) is identical; the content field distinguishes the file type
+  /// via FileContent::kPositionalUpdates.
+  std::vector<IcebergUpdateFile> updateFiles;
+
   HiveIcebergSplit(
       const std::string& connectorId,
       const std::string& filePath,
@@ -55,7 +68,8 @@ struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
       bool cacheable = true,
       std::vector<IcebergDeleteFile> deletes = {},
       const std::unordered_map<std::string, std::string>& infoColumns = {},
-      std::optional<FileProperties> fileProperties = std::nullopt);
+      std::optional<FileProperties> fileProperties = std::nullopt,
+      std::vector<IcebergUpdateFile> updates = {});
 };
 
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -115,8 +115,47 @@ void IcebergSplitReader::prepareSplit(
                 splitOffset_,
                 hiveSplit_->connectorId));
       }
+    } else if (deleteFile.content == FileContent::kEqualityDeletes) {
+      VELOX_NYI("Equality deletes are not yet supported.");
     } else {
-      VELOX_NYI();
+      VELOX_NYI(
+          "Unsupported delete file content type: {}",
+          static_cast<int>(deleteFile.content));
+    }
+  }
+
+  positionalUpdateFileReaders_.clear();
+  const auto& updateFiles = icebergSplit->updateFiles;
+  for (const auto& updateFile : updateFiles) {
+    VELOX_CHECK(
+        updateFile.content == FileContent::kPositionalUpdates,
+        "Expected positional update file but got content type: {}",
+        static_cast<int>(updateFile.content));
+    if (updateFile.recordCount > 0) {
+      // Derive update column names and types from the reader output schema,
+      // excluding Iceberg metadata columns (file_path and pos).
+      std::vector<std::string> updateColumnNames;
+      std::vector<TypePtr> updateColumnTypes;
+      for (auto i = 0; i < readerOutputType_->size(); ++i) {
+        updateColumnNames.push_back(readerOutputType_->nameOf(i));
+        updateColumnTypes.push_back(readerOutputType_->childAt(i));
+      }
+
+      positionalUpdateFileReaders_.push_back(
+          std::make_unique<PositionalUpdateFileReader>(
+              updateFile,
+              hiveSplit_->filePath,
+              updateColumnNames,
+              updateColumnTypes,
+              fileHandleFactory_,
+              connectorQueryCtx_,
+              ioExecutor_,
+              hiveConfig_,
+              ioStatistics_,
+              ioStats_,
+              runtimeStats,
+              splitOffset_,
+              hiveSplit_->connectorId));
     }
   }
 }
@@ -159,6 +198,24 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
       : nullptr;
 
   auto rowsScanned = baseRowReader_->next(actualSize, output, &mutation);
+
+  if (rowsScanned > 0 && !positionalUpdateFileReaders_.empty()) {
+    auto outputRowVector = std::dynamic_pointer_cast<RowVector>(output);
+    VELOX_CHECK_NOT_NULL(
+        outputRowVector, "Output must be a RowVector for positional updates.");
+
+    for (auto iter = positionalUpdateFileReaders_.begin();
+         iter != positionalUpdateFileReaders_.end();) {
+      (*iter)->applyUpdates(
+          baseReadOffset_, outputRowVector, deleteBitmap_, actualSize);
+
+      if ((*iter)->noMoreData()) {
+        iter = positionalUpdateFileReaders_.erase(iter);
+      } else {
+        ++iter;
+      }
+    }
+  }
 
   return rowsScanned;
 }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -19,6 +19,7 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/SplitReader.h"
 #include "velox/connectors/hive/iceberg/PositionalDeleteFileReader.h"
+#include "velox/connectors/hive/iceberg/PositionalUpdateFileReader.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
@@ -93,13 +94,17 @@ class IcebergSplitReader : public SplitReader {
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
 
-  // The read offset to the beginning of the split in number of rows for the
-  // current batch for the base data file
+  /// Read offset to the beginning of the split in number of rows for the
+  /// current batch for the base data file.
   uint64_t baseReadOffset_;
-  // The file position for the first row in the split
+  /// File position for the first row in the split.
   uint64_t splitOffset_;
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;
   BufferPtr deleteBitmap_;
+
+  /// Readers for positional update files attached to this split.
+  std::list<std::unique_ptr<PositionalUpdateFileReader>>
+      positionalUpdateFileReaders_;
 };
 } // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/PositionalUpdateFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalUpdateFileReader.cpp
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/PositionalUpdateFileReader.h"
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/connectors/hive/BufferedInputBuilder.h"
+#include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
+#include "velox/dwio/common/ReaderFactory.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+PositionalUpdateFileReader::PositionalUpdateFileReader(
+    const IcebergDeleteFile& updateFile,
+    const std::string& baseFilePath,
+    const std::vector<std::string>& updateColumnNames,
+    const std::vector<TypePtr>& updateColumnTypes,
+    FileHandleFactory* fileHandleFactory,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    folly::Executor* executor,
+    const std::shared_ptr<const HiveConfig>& hiveConfig,
+    const std::shared_ptr<io::IoStatistics>& ioStatistics,
+    const std::shared_ptr<IoStats>& ioStats,
+    dwio::common::RuntimeStatistics& runtimeStats,
+    uint64_t splitOffset,
+    const std::string& connectorId)
+    : updateFile_(updateFile),
+      baseFilePath_(baseFilePath),
+      fileHandleFactory_(fileHandleFactory),
+      executor_(executor),
+      connectorQueryCtx_(connectorQueryCtx),
+      hiveConfig_(hiveConfig),
+      ioStatistics_(ioStatistics),
+      ioStats_(ioStats),
+      pool_(connectorQueryCtx->memoryPool()),
+      filePathColumn_(IcebergMetadataColumn::icebergDeleteFilePathColumn()),
+      posColumn_(IcebergMetadataColumn::icebergDeletePosColumn()),
+      splitOffset_(splitOffset),
+      updateColumnNames_(updateColumnNames),
+      updateColumnTypes_(updateColumnTypes) {
+  VELOX_CHECK(updateFile_.content == FileContent::kPositionalUpdates);
+  VELOX_CHECK_GT(updateFile_.recordCount, 0);
+  VELOX_CHECK(
+      !updateColumnNames_.empty(),
+      "Positional update file must specify at least one update column.");
+  VELOX_CHECK_EQ(
+      updateColumnNames_.size(),
+      updateColumnTypes_.size(),
+      "Update column names and types must have the same size.");
+
+  // Build the output row type for readUpdatePositions(): (pos, update_cols...).
+  // Cached to avoid reconstructing on every batch.
+  {
+    std::vector<std::string> outNames{posColumn_->name};
+    std::vector<TypePtr> outTypes{posColumn_->type};
+    outNames.insert(
+        outNames.end(), updateColumnNames_.begin(), updateColumnNames_.end());
+    outTypes.insert(
+        outTypes.end(), updateColumnTypes_.begin(), updateColumnTypes_.end());
+    outputRowType_ = ROW(std::move(outNames), std::move(outTypes));
+  }
+
+  // Build the file schema: (file_path, pos, update_col_1, update_col_2, ...).
+  std::vector<std::string> columnNames;
+  std::vector<TypePtr> columnTypes;
+  columnNames.reserve(2 + updateColumnNames_.size());
+  columnTypes.reserve(2 + updateColumnTypes_.size());
+  columnNames.push_back(filePathColumn_->name);
+  columnTypes.push_back(filePathColumn_->type);
+  columnNames.push_back(posColumn_->name);
+  columnTypes.push_back(posColumn_->type);
+  for (size_t i = 0; i < updateColumnNames_.size(); ++i) {
+    columnNames.push_back(updateColumnNames_[i]);
+    columnTypes.push_back(updateColumnTypes_[i]);
+  }
+  RowTypePtr updateFileSchema =
+      ROW(std::move(columnNames), std::move(columnTypes));
+
+  // Create a ScanSpec that filters on file_path = baseFilePath_ and reads pos
+  // plus the update columns.
+  auto scanSpec = std::make_shared<common::ScanSpec>("<root>");
+  scanSpec->addField(posColumn_->name, 0);
+  for (size_t i = 0; i < updateColumnNames_.size(); ++i) {
+    scanSpec->addField(updateColumnNames_[i], static_cast<int>(i) + 1);
+  }
+  auto* pathSpec = scanSpec->getOrCreateChild(filePathColumn_->name);
+  pathSpec->setFilter(
+      std::make_unique<common::BytesValues>(
+          std::vector<std::string>({baseFilePath_}), false));
+
+  updateSplit_ = std::make_shared<HiveConnectorSplit>(
+      connectorId,
+      updateFile_.filePath,
+      updateFile_.fileFormat,
+      0,
+      updateFile_.fileSizeInBytes);
+
+  dwio::common::ReaderOptions updateReaderOpts(pool_);
+  configureReaderOptions(
+      hiveConfig_,
+      connectorQueryCtx,
+      updateFileSchema,
+      updateSplit_,
+      /*tableParameters=*/{},
+      updateReaderOpts);
+
+  const FileHandleKey fileHandleKey{
+      .filename = updateFile_.filePath,
+      .tokenProvider = connectorQueryCtx_->fsTokenProvider()};
+  auto updateFileHandleCachePtr = fileHandleFactory_->generate(fileHandleKey);
+  auto updateFileInput = BufferedInputBuilder::getInstance()->create(
+      *updateFileHandleCachePtr,
+      updateReaderOpts,
+      connectorQueryCtx,
+      ioStatistics_,
+      ioStats_,
+      executor_);
+
+  auto updateReader =
+      dwio::common::getReaderFactory(updateReaderOpts.fileFormat())
+          ->createReader(std::move(updateFileInput), updateReaderOpts);
+
+  // Filter update columns to only those present in the file. The update file
+  // may carry a subset of the requested columns (e.g., only the columns that
+  // were actually modified). Columns not in the file are left unchanged.
+  const auto& fileRowType = updateReader->rowType();
+  {
+    std::vector<std::string> filteredNames;
+    std::vector<TypePtr> filteredTypes;
+    for (size_t i = 0; i < updateColumnNames_.size(); ++i) {
+      if (fileRowType->containsChild(updateColumnNames_[i])) {
+        filteredNames.push_back(updateColumnNames_[i]);
+        filteredTypes.push_back(updateColumnTypes_[i]);
+      }
+    }
+    VELOX_CHECK(
+        !filteredNames.empty(),
+        "Positional update file contains none of the expected update columns. "
+        "File schema: {}, file: {}",
+        fileRowType->toString(),
+        updateFile_.filePath);
+    updateColumnNames_ = std::move(filteredNames);
+    updateColumnTypes_ = std::move(filteredTypes);
+
+    // Rebuild outputRowType_ and scanSpec after filtering.
+    std::vector<std::string> outNames{posColumn_->name};
+    std::vector<TypePtr> outTypes{posColumn_->type};
+    outNames.insert(
+        outNames.end(), updateColumnNames_.begin(), updateColumnNames_.end());
+    outTypes.insert(
+        outTypes.end(), updateColumnTypes_.begin(), updateColumnTypes_.end());
+    outputRowType_ = ROW(std::move(outNames), std::move(outTypes));
+
+    scanSpec = std::make_shared<common::ScanSpec>("<root>");
+    scanSpec->addField(posColumn_->name, 0);
+    for (size_t i = 0; i < updateColumnNames_.size(); ++i) {
+      scanSpec->addField(updateColumnNames_[i], static_cast<int>(i) + 1);
+    }
+    pathSpec = scanSpec->getOrCreateChild(filePathColumn_->name);
+    pathSpec->setFilter(
+        std::make_unique<common::BytesValues>(
+            std::vector<std::string>({baseFilePath_}), false));
+  }
+
+  if (!testFilters(
+          scanSpec.get(),
+          updateReader.get(),
+          updateSplit_->filePath,
+          updateSplit_->partitionKeys,
+          {},
+          hiveConfig_->readTimestampPartitionValueAsLocalTime(
+              connectorQueryCtx_->sessionProperties()))) {
+    runtimeStats.skippedSplitBytes +=
+        static_cast<int64_t>(updateSplit_->length);
+    updateSplit_.reset();
+    return;
+  }
+
+  dwio::common::RowReaderOptions updateRowReaderOpts;
+  configureRowReaderOptions(
+      {},
+      scanSpec,
+      nullptr,
+      updateFileSchema,
+      updateSplit_,
+      nullptr,
+      nullptr,
+      nullptr,
+      updateRowReaderOpts);
+
+  updateRowReader_ = updateReader->createRowReader(updateRowReaderOpts);
+}
+
+void PositionalUpdateFileReader::readUpdatePositions(
+    uint64_t baseReadOffset,
+    int64_t rowNumberUpperBound) {
+  if (!updateRowReader_ || !updateSplit_) {
+    return;
+  }
+
+  if (!updatePositionsOutput_) {
+    updatePositionsOutput_ = BaseVector::create(outputRowType_, 0, pool_);
+  }
+
+  int64_t rowNumberLowerBound =
+      static_cast<int64_t>(baseReadOffset + splitOffset_);
+
+  // Process any leftover rows from the previous batch.
+  if (updatePositionsOffset_ <
+      static_cast<uint64_t>(updatePositionsOutput_->size())) {
+    auto rowOutput =
+        std::dynamic_pointer_cast<RowVector>(updatePositionsOutput_);
+    auto posVector = rowOutput->childAt(0)->as<FlatVector<int64_t>>();
+
+    while (updatePositionsOffset_ < static_cast<uint64_t>(posVector->size())) {
+      int64_t pos = posVector->valueAt(
+          static_cast<vector_size_t>(updatePositionsOffset_));
+      if (pos >= rowNumberUpperBound) {
+        return;
+      }
+      if (pos >= rowNumberLowerBound) {
+        pendingUpdates_[pos] = {
+            rowOutput, static_cast<vector_size_t>(updatePositionsOffset_)};
+      }
+      ++updatePositionsOffset_;
+    }
+  }
+
+  while (!readFinishedForBatch(rowNumberUpperBound)) {
+    // Allocate a fresh output vector so that next() does not overwrite any
+    // previously stored batch that pendingUpdates_ entries still reference.
+    VectorPtr freshOutput = BaseVector::create(outputRowType_, 0, pool_);
+    auto batchSize = static_cast<uint64_t>(rowNumberUpperBound);
+    auto rowsScanned = updateRowReader_->next(batchSize, freshOutput);
+    updatePositionsOutput_ = freshOutput;
+    totalNumRowsScanned_ += rowsScanned;
+
+    if (rowsScanned > 0) {
+      auto rowOutput =
+          std::dynamic_pointer_cast<RowVector>(updatePositionsOutput_);
+      auto numRows = updatePositionsOutput_->size();
+      if (numRows > 0) {
+        updatePositionsOutput_->loadedVector();
+        auto posVector = rowOutput->childAt(0)->as<FlatVector<int64_t>>();
+        VELOX_CHECK_NOT_NULL(posVector);
+        updatePositionsOffset_ = 0;
+
+        for (vector_size_t i = 0; i < numRows; ++i) {
+          int64_t pos = posVector->valueAt(i);
+          if (pos < rowNumberLowerBound) {
+            ++updatePositionsOffset_;
+            continue;
+          }
+          if (pos >= rowNumberUpperBound) {
+            updatePositionsOffset_ = i;
+            return;
+          }
+          pendingUpdates_[pos] = {rowOutput, i};
+          ++updatePositionsOffset_;
+        }
+      }
+    } else {
+      updateSplit_.reset();
+      break;
+    }
+  }
+}
+
+void PositionalUpdateFileReader::applyUpdates(
+    uint64_t baseReadOffset,
+    const RowVectorPtr& output,
+    const BufferPtr& deleteBitmap,
+    uint64_t batchSize) {
+  int64_t rowNumberUpperBound =
+      static_cast<int64_t>(splitOffset_ + baseReadOffset + batchSize);
+  int64_t rowNumberLowerBound =
+      static_cast<int64_t>(splitOffset_ + baseReadOffset);
+
+  readUpdatePositions(baseReadOffset, rowNumberUpperBound);
+
+  if (pendingUpdates_.empty()) {
+    return;
+  }
+
+  const auto& outputRowType = *output->rowType();
+
+  // Build a mapping from original file position to output row index. When a
+  // delete bitmap is present, deleted rows are removed from the output, so
+  // file positions do not map 1:1 to output indices.
+  const uint64_t* deleteBits =
+      deleteBitmap ? deleteBitmap->as<uint64_t>() : nullptr;
+
+  auto it = pendingUpdates_.lower_bound(rowNumberLowerBound);
+  while (it != pendingUpdates_.end() && it->first < rowNumberUpperBound) {
+    int64_t pos = it->first;
+    auto& [srcBatch, srcIdx] = it->second;
+
+    auto origIndex = static_cast<vector_size_t>(pos - rowNumberLowerBound);
+
+    // If this position was deleted, skip the update.
+    if (deleteBits && origIndex < static_cast<vector_size_t>(batchSize)) {
+      if (bits::isBitSet(deleteBits, origIndex)) {
+        auto nextIt = std::next(it);
+        pendingUpdates_.erase(it);
+        it = nextIt;
+        continue;
+      }
+    }
+
+    // Compute the output row index by counting non-deleted rows before this
+    // position.
+    vector_size_t rowIndex;
+    if (deleteBits) {
+      auto deletedBefore = bits::countBits(deleteBits, 0, origIndex);
+      rowIndex = origIndex - static_cast<vector_size_t>(deletedBefore);
+    } else {
+      rowIndex = origIndex;
+    }
+
+    if (rowIndex >= output->size()) {
+      ++it;
+      continue;
+    }
+
+    for (size_t c = 0; c < updateColumnNames_.size(); ++c) {
+      auto outputColIdx =
+          outputRowType.getChildIdxIfExists(updateColumnNames_[c]);
+      if (!outputColIdx.has_value()) {
+        continue;
+      }
+
+      auto& outputCol = output->childAt(*outputColIdx);
+      // Ensure the output column supports random writes. The base reader may
+      // produce dictionary-encoded or constant vectors which do not allow copy.
+      if (!outputCol->isFlatEncoding()) {
+        BaseVector::flattenVector(outputCol);
+      }
+      // childAt(0) is pos, so update columns start at childAt(1).
+      auto& srcCol = srcBatch->childAt(static_cast<column_index_t>(c + 1));
+      outputCol->copy(srcCol.get(), rowIndex, srcIdx, 1);
+    }
+
+    auto nextIt = std::next(it);
+    pendingUpdates_.erase(it);
+    it = nextIt;
+  }
+}
+
+bool PositionalUpdateFileReader::noMoreData() {
+  if (!pendingUpdates_.empty()) {
+    return false;
+  }
+  // Check for leftover positions that haven't been consumed yet.
+  if (updatePositionsOutput_ &&
+      updatePositionsOffset_ <
+          static_cast<uint64_t>(updatePositionsOutput_->size())) {
+    return false;
+  }
+  return totalNumRowsScanned_ >= updateFile_.recordCount;
+}
+
+bool PositionalUpdateFileReader::readFinishedForBatch(
+    int64_t rowNumberUpperBound) {
+  if (!updatePositionsOutput_) {
+    return true;
+  }
+
+  if (totalNumRowsScanned_ >= updateFile_.recordCount) {
+    return true;
+  }
+
+  auto rowOutput = std::dynamic_pointer_cast<RowVector>(updatePositionsOutput_);
+  if (!rowOutput || rowOutput->size() == 0) {
+    return false;
+  }
+
+  auto posVector = rowOutput->childAt(0)->as<FlatVector<int64_t>>();
+  if (updatePositionsOffset_ < static_cast<uint64_t>(posVector->size()) &&
+      posVector->valueAt(static_cast<vector_size_t>(updatePositionsOffset_)) >=
+          rowNumberUpperBound) {
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/PositionalUpdateFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalUpdateFileReader.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Executor.h>
+#include <map>
+#include <memory>
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/dwio/common/Reader.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+struct IcebergMetadataColumn;
+
+/// Reads a positional update file and applies column-level updates to the base
+/// data during merge-on-read. The update file schema is:
+///   (file_path: VARCHAR, pos: BIGINT, <updated_col_1>, <updated_col_2>, ...)
+///
+/// NOTE: "Positional updates" are a Velox-side merge-on-read extension. The
+/// Iceberg V2 spec does not define a native update file format; standard
+/// Iceberg achieves updates via delete + insert (rewriting the full row into
+/// a new data file). This extension avoids full-row rewrites by carrying only
+/// the changed column values alongside the (file_path, pos) position key.
+///
+/// For each row in the update file matching the base data file path, this
+/// reader records the updated column values indexed by the in-file row
+/// position. During read, updated values are overlaid onto the base data output
+/// vector at the matching positions.
+///
+/// Mirrors PositionalDeleteFileReader but instead of producing a delete bitmap,
+/// builds a sparse map of position → source row index in the read batch, then
+/// copies updated values into the output vector.
+class PositionalUpdateFileReader {
+ public:
+  /// Constructs a reader for a single positional update file.
+  ///
+  /// @param updateFile Metadata about the update file (path, format, bounds).
+  /// @param baseFilePath Path of the base data file being read. Used to filter
+  ///   update records that apply to this specific data file.
+  /// @param updateColumnNames Ordered names of the columns being updated.
+  /// @param updateColumnTypes Ordered types of the columns being updated,
+  ///   matching the update file's schema for those columns.
+  PositionalUpdateFileReader(
+      const IcebergDeleteFile& updateFile,
+      const std::string& baseFilePath,
+      const std::vector<std::string>& updateColumnNames,
+      const std::vector<TypePtr>& updateColumnTypes,
+      FileHandleFactory* fileHandleFactory,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      folly::Executor* executor,
+      const std::shared_ptr<const HiveConfig>& hiveConfig,
+      const std::shared_ptr<io::IoStatistics>& ioStatistics,
+      const std::shared_ptr<IoStats>& ioStats,
+      dwio::common::RuntimeStatistics& runtimeStats,
+      uint64_t splitOffset,
+      const std::string& connectorId);
+
+  /// Applies pending column-level updates to the base data output vector.
+  ///
+  /// The overall flow for each batch is:
+  ///   1. Read update positions and values from the update file for the current
+  ///      batch range via readUpdatePositions().
+  ///   2. For each pending update position:
+  ///      a. If a deleteBitmap is present and the position is marked as
+  ///      deleted,
+  ///         skip the update (deletes take precedence over updates).
+  ///      b. Map the original file position to an output row index, accounting
+  ///         for deleted rows that have been removed from the output.
+  ///      c. Copy updated column values from the update file batch into the
+  ///         output vector at the computed row index.
+  ///
+  /// @param baseReadOffset The read offset from the beginning of the split in
+  ///   number of rows for the current batch.
+  /// @param output The base data output vector. Updated column values are
+  ///   overlaid at matching positions.
+  /// @param deleteBitmap Optional deletion bitmap from positional delete files.
+  ///   When present (i.e., when the split has associated positional delete
+  ///   files), bit i is set if the row at file position i was deleted. Deleted
+  ///   positions are skipped during update application, and the bitmap is used
+  ///   to compute the compacted output row index for surviving rows.
+  /// @param batchSize The pre-deletion batch size (number of rows read from
+  ///   the file before deletions are applied). Used with deleteBitmap to
+  ///   compute the correct output row index.
+  void applyUpdates(
+      uint64_t baseReadOffset,
+      const RowVectorPtr& output,
+      const BufferPtr& deleteBitmap,
+      uint64_t batchSize);
+
+  /// Returns true when there is no more update data to read from this file.
+  bool noMoreData();
+
+ private:
+  // -- Internal helpers (not part of the public contract) --
+
+  /// Reads update records from the file and populates pendingUpdates_ for
+  /// positions within the current batch range.
+  void readUpdatePositions(
+      uint64_t baseReadOffset,
+      int64_t rowNumberUpperBound);
+
+  /// Returns true if we have read enough update positions for the current
+  /// batch.
+  bool readFinishedForBatch(int64_t rowNumberUpperBound);
+
+  const IcebergDeleteFile updateFile_;
+  const std::string baseFilePath_;
+  FileHandleFactory* const fileHandleFactory_;
+  folly::Executor* const executor_;
+  const ConnectorQueryCtx* connectorQueryCtx_;
+  const std::shared_ptr<const HiveConfig> hiveConfig_;
+  const std::shared_ptr<io::IoStatistics> ioStatistics_;
+  const std::shared_ptr<IoStats> ioStats_;
+  memory::MemoryPool* const pool_;
+
+  std::shared_ptr<IcebergMetadataColumn> filePathColumn_;
+  std::shared_ptr<IcebergMetadataColumn> posColumn_;
+  uint64_t splitOffset_;
+
+  /// Cached output row type for readUpdatePositions() to avoid
+  /// reconstructing it on every call. Schema: (pos, update_col_1, ...).
+  RowTypePtr outputRowType_;
+
+  /// Names and types of the columns being updated.
+  std::vector<std::string> updateColumnNames_;
+  std::vector<TypePtr> updateColumnTypes_;
+
+  std::shared_ptr<HiveConnectorSplit> updateSplit_;
+  std::unique_ptr<dwio::common::RowReader> updateRowReader_;
+
+  /// Holds the raw output from reading the update file.
+  VectorPtr updatePositionsOutput_;
+  uint64_t updatePositionsOffset_{0};
+  uint64_t totalNumRowsScanned_{0};
+
+  /// Maps base-file row position → (source batch, index within that batch)
+  /// from which the updated column values should be copied. Each entry keeps
+  /// its own shared_ptr to the source batch so that the underlying data remains
+  /// valid even when the reader advances to subsequent batches.
+  std::map<int64_t, std::pair<RowVectorPtr, vector_size_t>> pendingUpdates_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -1004,4 +1004,935 @@ TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
       0);
 }
 #endif
+
+///////////////////////////////////////////////////////////////////////////////
+// Positional Update Tests
+///////////////////////////////////////////////////////////////////////////////
+
+/// Writes a positional update file with (file_path, pos, updated_columns...)
+/// and returns the temp file path and record count.
+TEST_F(HiveIcebergTest, singleBaseFileSinglePositionalUpdateFile) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  // Write base data file: c0 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  // Write update file: update positions 2, 5, 8 with c0 = 200, 500, 800.
+  auto updateFilePath = TempFilePath::create();
+  auto baseFilePath = dataFilePath->getPath();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  3, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({2, 5, 8}),
+              makeFlatVector<int64_t>({200, 500, 800}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      3,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // Expected: positions 2, 5, 8 have updated values; others unchanged.
+  auto expected = makeRowVector(
+      {makeFlatVector<int64_t>({0, 1, 200, 3, 4, 500, 6, 7, 800, 9})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+TEST_F(HiveIcebergTest, positionalUpdateNoMatchingPositions) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40, 50})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  // Update file targets positions that don't exist in the base file (100, 200).
+  auto updateFilePath = TempFilePath::create();
+  auto baseFilePath = dataFilePath->getPath();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({100, 200}),
+              makeFlatVector<int64_t>({999, 888}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // No positions match, so base data should be returned unchanged.
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>({10, 20, 30, 40, 50})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+TEST_F(HiveIcebergTest, positionalUpdateAllRows) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+
+  // Update all rows to new values.
+  auto updateFilePath = TempFilePath::create();
+  auto baseFilePath = dataFilePath->getPath();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  5, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({0, 1, 2, 3, 4}),
+              makeFlatVector<int64_t>({100, 200, 300, 400, 500}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      5,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>({100, 200, 300, 400, 500})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+TEST_F(HiveIcebergTest, positionalUpdateWithDeletesCombined) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  // Base data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // Delete positions 1 and 3.
+  auto deleteFilePath = TempFilePath::create();
+  writeToFile(
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({1, 3}),
+          })});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      testing::internal::GetFileSize(
+          std::fopen(deleteFilePath->getPath().c_str(), "r")));
+
+  // Update positions 2 and 7.
+  auto updateFilePath = TempFilePath::create();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({2, 7}),
+              makeFlatVector<int64_t>({222, 777}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{deleteFile},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // After deletes: rows 1, 3 removed. Remaining: [0, 2, 4, 5, 6, 7, 8, 9].
+  // After updates: pos 2 gets 222, pos 7 gets 777.
+  // Final: [0, 222, 4, 5, 6, 777, 8, 9].
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>({0, 222, 4, 5, 6, 777, 8, 9})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test that when the same position is both deleted and updated, the delete
+/// wins and the update is skipped. Base data: [0, 1, 2, 3, 4]. Delete pos 2.
+/// Update pos 2 with value 999. Expected: delete wins, output = [0, 1, 3, 4].
+TEST_F(HiveIcebergTest, positionalUpdateAndDeleteSamePosition) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // Delete position 2.
+  auto deleteFilePath = TempFilePath::create();
+  writeToFile(
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  1, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({2}),
+          })});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      testing::internal::GetFileSize(
+          std::fopen(deleteFilePath->getPath().c_str(), "r")));
+
+  // Update position 2 with value 999 — this should be skipped since pos 2 is
+  // deleted.
+  auto updateFilePath = TempFilePath::create();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  1, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({2}),
+              makeFlatVector<int64_t>({999}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{deleteFile},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // Row at position 2 is deleted, update is skipped.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 3, 4})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test two separate update files applied to the same base data file, each
+/// updating different positions.
+TEST_F(HiveIcebergTest, positionalUpdateMultipleUpdateFiles) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // First update file: update positions 1 and 3.
+  auto updateFilePath1 = TempFilePath::create();
+  writeToFile(
+      updateFilePath1->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({1, 3}),
+              makeFlatVector<int64_t>({100, 300}),
+          })});
+
+  IcebergUpdateFile updateFile1(
+      FileContent::kPositionalUpdates,
+      updateFilePath1->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath1->getPath().c_str(), "r")));
+
+  // Second update file: update positions 5 and 7.
+  auto updateFilePath2 = TempFilePath::create();
+  writeToFile(
+      updateFilePath2->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  2, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({5, 7}),
+              makeFlatVector<int64_t>({500, 700}),
+          })});
+
+  IcebergUpdateFile updateFile2(
+      FileContent::kPositionalUpdates,
+      updateFilePath2->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath2->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile1, updateFile2});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {makeFlatVector<int64_t>({0, 100, 2, 300, 4, 500, 6, 700})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test updating only a subset of columns.
+/// The update file only carries c0 — c1 must remain unchanged.
+TEST_F(HiveIcebergTest, positionalUpdatePartialColumns) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+          makeFlatVector<std::string>({"alpha", "beta", "gamma", "delta"}),
+      })};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // Update file only contains c0, not c1. c1 must remain unchanged.
+  auto updateFilePath = TempFilePath::create();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  1, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({1}),
+              makeFlatVector<int64_t>({99}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // c0 at position 1 is updated to 99. c1 remains unchanged because the
+  // update file does not carry c1.
+  auto expected = makeRowVector(
+      {"c0", "c1"},
+      {
+          makeFlatVector<int64_t>({1, 99, 3, 4}),
+          makeFlatVector<std::string>({"alpha", "beta", "gamma", "delta"}),
+      });
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test positional updates with multiple deletes
+/// Deletes at positions 0, 2, 4, 6. Updates at positions 1, 3, 5, 7.
+/// This exercises the delete-aware index mapping with many holes.
+TEST_F(HiveIcebergTest, positionalUpdateHeavyDeletesWithUpdates) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  // Base data: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9].
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // Delete even positions: 0, 2, 4, 6.
+  auto deleteFilePath = TempFilePath::create();
+  writeToFile(
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  4, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({0, 2, 4, 6}),
+          })});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      4,
+      testing::internal::GetFileSize(
+          std::fopen(deleteFilePath->getPath().c_str(), "r")));
+
+  // Update odd positions: 1, 3, 5, 7.
+  auto updateFilePath = TempFilePath::create();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  4, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({1, 3, 5, 7}),
+              makeFlatVector<int64_t>({110, 330, 550, 770}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      4,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{deleteFile},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // After deletes: positions 0,2,4,6 removed. Remaining: [1, 3, 5, 7, 8, 9].
+  // After updates: pos 1→110, 3→330, 5→550, 7→770.
+  // Output indices after deletes: pos1→idx0, pos3→idx1, pos5→idx2, pos7→idx3.
+  // Final: [110, 330, 550, 770, 8, 9].
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>({110, 330, 550, 770, 8, 9})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test that two update files
+
+/// Test that two update files can update the same position. The second update
+/// file should overwrite the first update.
+TEST_F(HiveIcebergTest, positionalUpdateMultipleFilesOverlappingPositions) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  auto dataFilePath = TempFilePath::create();
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>({0, 1, 2, 3, 4})})};
+  writeToFile(dataFilePath->getPath(), dataVectors);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // First update file: update position 2 to 200.
+  auto updateFilePath1 = TempFilePath::create();
+  writeToFile(
+      updateFilePath1->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  1, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({2}),
+              makeFlatVector<int64_t>({200}),
+          })});
+
+  IcebergUpdateFile updateFile1(
+      FileContent::kPositionalUpdates,
+      updateFilePath1->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath1->getPath().c_str(), "r")));
+
+  // Second update file: also update position 2 to 999.
+  auto updateFilePath2 = TempFilePath::create();
+  writeToFile(
+      updateFilePath2->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  1, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({2}),
+              makeFlatVector<int64_t>({999}),
+          })});
+
+  IcebergUpdateFile updateFile2(
+      FileContent::kPositionalUpdates,
+      updateFilePath2->getPath(),
+      dwio::common::FileFormat::DWRF,
+      1,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath2->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile1, updateFile2});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // The second update file overwrites the first. Position 2 should be 999.
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 999, 3, 4})});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test positional updates spanning multiple RowGroups.
+/// contains 2 RowGroups of 10000 rows each (20000 total). Updates target
+/// positions in both RowGroups, verifying cross-batch pagination.
+TEST_F(HiveIcebergTest, positionalUpdateLargeMultiRowGroup) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  // Write base data: 2 RowGroups × 10'000 rows = 20'000 total. c0 = [0..19999].
+  const int64_t rowsPerGroup = 10'000;
+  const int64_t numRows = 2 * rowsPerGroup;
+  auto dataFilePath = TempFilePath::create();
+  auto data1 = makeContinuousIncreasingValues(0, rowsPerGroup);
+  auto data2 = makeContinuousIncreasingValues(rowsPerGroup, 2 * rowsPerGroup);
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>(data1)}),
+      makeRowVector({makeFlatVector<int64_t>(data2)})};
+  writeToFile(
+      dataFilePath->getPath(), dataVectors, config_, flushPolicyFactory_);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // Update positions spanning both RowGroups:
+  //   0       (first row, RowGroup 1)
+  //   9999    (last row, RowGroup 1)
+  //   10000   (first row, RowGroup 2)
+  //   15000   (middle, RowGroup 2)
+  //   19999   (last row, RowGroup 2)
+  std::vector<int64_t> updatePositions = {0, 9999, 10'000, 15'000, 19'999};
+  std::vector<int64_t> updateValues = {-1, -9999, -10'000, -15'000, -19'999};
+
+  auto updateFilePath = TempFilePath::create();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  static_cast<vector_size_t>(updatePositions.size()),
+                  [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>(updatePositions),
+              makeFlatVector<int64_t>(updateValues),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      static_cast<uint64_t>(updatePositions.size()),
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // Build expected: 10000 rows, with 3 positions replaced.
+  std::vector<int64_t> expectedValues;
+  expectedValues.reserve(numRows);
+  std::unordered_map<int64_t, int64_t> updateMap;
+  for (size_t i = 0; i < updatePositions.size(); ++i) {
+    updateMap[updatePositions[i]] = updateValues[i];
+  }
+  for (int64_t i = 0; i < numRows; ++i) {
+    auto it = updateMap.find(i);
+    expectedValues.push_back(it != updateMap.end() ? it->second : i);
+  }
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>(expectedValues)});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+/// Test positional update combined with positional deletes spanning multiple
+/// RowGroups. Exercises delete-aware index mapping at scale with cross-batch
+/// pagination.
+TEST_F(HiveIcebergTest, positionalUpdateWithDeletesLargeDataset) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+  auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+  auto rowType = ROW({"c0"}, {BIGINT()});
+
+  // 2 RowGroups × 10'000 rows = 20'000 total.
+  const int64_t rowsPerGroup = 10'000;
+  const int64_t numRows = 2 * rowsPerGroup;
+  auto dataFilePath = TempFilePath::create();
+  auto data1 = makeContinuousIncreasingValues(0, rowsPerGroup);
+  auto data2 = makeContinuousIncreasingValues(rowsPerGroup, 2 * rowsPerGroup);
+  std::vector<RowVectorPtr> dataVectors = {
+      makeRowVector({makeFlatVector<int64_t>(data1)}),
+      makeRowVector({makeFlatVector<int64_t>(data2)})};
+  writeToFile(
+      dataFilePath->getPath(), dataVectors, config_, flushPolicyFactory_);
+  auto baseFilePath = dataFilePath->getPath();
+
+  // Delete first 100 rows (positions 0-99).
+  std::vector<int64_t> deletePositions;
+  deletePositions.reserve(100);
+  for (int64_t i = 0; i < 100; ++i) {
+    deletePositions.push_back(i);
+  }
+
+  auto deleteFilePath = TempFilePath::create();
+  writeToFile(
+      deleteFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name},
+          {
+              makeFlatVector<std::string>(
+                  static_cast<vector_size_t>(deletePositions.size()),
+                  [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>(deletePositions),
+          })});
+
+  IcebergDeleteFile deleteFile(
+      FileContent::kPositionalDeletes,
+      deleteFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      static_cast<uint64_t>(deletePositions.size()),
+      testing::internal::GetFileSize(
+          std::fopen(deleteFilePath->getPath().c_str(), "r")));
+
+  // Update positions spanning both RowGroups:
+  //   100    (first surviving row after deletes, RowGroup 1)
+  //   9999   (last row of RowGroup 1)
+  //   10000  (first row of RowGroup 2)
+  //   19999  (last row of RowGroup 2)
+  auto updateFilePath = TempFilePath::create();
+  writeToFile(
+      updateFilePath->getPath(),
+      {makeRowVector(
+          {pathColumn->name, posColumn->name, "c0"},
+          {
+              makeFlatVector<std::string>(
+                  4, [&](vector_size_t) { return baseFilePath; }),
+              makeFlatVector<int64_t>({100, 9999, 10'000, 19'999}),
+              makeFlatVector<int64_t>({-100, -9999, -10'000, -19'999}),
+          })});
+
+  IcebergUpdateFile updateFile(
+      FileContent::kPositionalUpdates,
+      updateFilePath->getPath(),
+      dwio::common::FileFormat::DWRF,
+      4,
+      testing::internal::GetFileSize(
+          std::fopen(updateFilePath->getPath().c_str(), "r")));
+
+  auto file = filesystems::getFileSystem(baseFilePath, nullptr)
+                  ->openFileForRead(baseFilePath);
+  auto split = std::make_shared<HiveIcebergSplit>(
+      kIcebergConnectorId,
+      baseFilePath,
+      dwio::common::FileFormat::DWRF,
+      0,
+      file->size(),
+      std::unordered_map<std::string, std::optional<std::string>>{},
+      std::nullopt,
+      std::unordered_map<std::string, std::string>{},
+      nullptr,
+      true,
+      std::vector<IcebergDeleteFile>{deleteFile},
+      std::unordered_map<std::string, std::string>{},
+      std::nullopt,
+      std::vector<IcebergUpdateFile>{updateFile});
+
+  auto plan = PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kIcebergConnectorId)
+                  .outputType(rowType)
+                  .endTableScan()
+                  .planNode();
+
+  // After deletes: positions 0-99 removed. Remaining = [100..19999].
+  // After updates: pos 100→-100, 9999→-9999, 10000→-10000, 19999→-19999.
+  std::vector<int64_t> expectedValues;
+  expectedValues.reserve(numRows - 100);
+  std::unordered_map<int64_t, int64_t> updateMap = {
+      {100, -100}, {9999, -9999}, {10'000, -10'000}, {19'999, -19'999}};
+  for (int64_t i = 100; i < numRows; ++i) {
+    auto it = updateMap.find(i);
+    expectedValues.push_back(it != updateMap.end() ? it->second : i);
+  }
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>(expectedValues)});
+  AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
 } // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:

Implements merge-on-read column-level positional update support for the Velox
Iceberg connector. This is analogous to the existing positional deletes
support, enabling the reader to overlay updated column values onto base data
during read without rewriting data files.

Positional update files follow the schema:
  (file_path: VARCHAR, pos: BIGINT, <updated_col_1>, <updated_col_2>, ...)

The reader builds a sparse map of position to source row index from each update
file, then during next() applies the updated values to the output vector at
matching positions. The implementation correctly handles the interaction between
positional deletes and updates - when rows are deleted from the output, the
update application accounts for shifted indices by computing the correct output
row position relative to the delete bitmap.

Key design decisions:
- Mirrors PositionalDeleteFileReader architecture for consistency.
- Uses a std::map<int64_t, vector_size_t> to track pending updates, enabling
  efficient lookup and range-based iteration by batch.
- Flattens dictionary-encoded output vectors before copy operations, since
  BaseVector::copy() requires flat or complex vector targets.
- Delete-aware update application: skips deleted positions and computes correct
  output row indices by counting non-deleted rows before each target position.

New files:
- PositionalUpdateFileReader.h/cpp: Reader class for positional update files.

Modified files:
- IcebergDeleteFile.h: Extended FileContent enum with kPositionalUpdates.
- IcebergSplit.h/cpp: Added updateFiles vector for update file metadata.
- IcebergSplitReader.h/cpp: Integrated update readers in prepareSplit()/next().
- BUCK files: Added new sources to build targets.
- IcebergReadTest.cpp: 5 comprehensive test cases covering single updates,
  no-match, all-rows, combined deletes+updates, and multi-column updates.

Reviewed By: xiaoxmeng

Differential Revision: D95595341


