### PR TITLE
feat: Add row lineage metadata columns to Iceberg reader

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergMetadataColumns.h
+++ b/velox/connectors/hive/iceberg/IcebergMetadataColumns.h
@@ -28,10 +28,20 @@ struct IcebergMetadataColumn {
   std::shared_ptr<const Type> type;
   std::string doc;
 
-  // Position delete file's metadata column ID, see
-  // https://iceberg.apache.org/spec/#position-delete-files.
+  // Reserved Field IDs for Iceberg tables; see
+  // https://iceberg.apache.org/spec/#reserved-field-ids
   static constexpr int32_t kPosId = 2'147'483'545;
   static constexpr int32_t kFilePathId = 2'147'483'546;
+  static constexpr int32_t kRowId = 2'147'483'540;
+  static constexpr int32_t kLastUpdatedSequenceNumber = 2'147'483'539;
+
+  static constexpr const char* kRowIdColumnName = "_row_id";
+  static constexpr const char* kLastUpdatedSequenceNumberColumnName =
+      "_last_updated_sequence_number";
+  // Info column keys provided in the split's infoColumns map.
+  static constexpr const char* kFirstRowIdInfoColumn = "$first_row_id";
+  static constexpr const char* kDataSequenceNumberInfoColumn =
+      "$data_sequence_number";
 
   IcebergMetadataColumn(
       int _id,

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 
+#include <folly/ScopeGuard.h>
 #include <folly/lang/Bits.h>
 
 #include "velox/common/base/Exceptions.h"
@@ -27,8 +28,52 @@
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/connectors/hive/iceberg/IcebergSplit.h"
 #include "velox/dwio/common/BufferUtil.h"
+#include "velox/vector/DecodedVector.h"
 
 using namespace facebook::velox::dwio::common;
+
+namespace {
+
+// Fills null slots in a BIGINT child vector with values produced by valueAt(i),
+// where i is the output row index. If the whole vector is a null constant,
+// replaces it with a flat vector. If only some slots are null, copies non-null
+// values and fills null slots with valueAt(i). No-op when no nulls are present.
+template <typename F>
+void fillNullsWithInt64(
+    facebook::velox::VectorPtr& child,
+    facebook::velox::memory::MemoryPool* pool,
+    F valueAt) {
+  using namespace facebook::velox;
+  child = BaseVector::loadedVectorShared(child);
+  const auto vectorSize = child->size();
+  if (vectorSize == 0) {
+    return;
+  }
+  if (child->isConstantEncoding() && child->isNullAt(0)) {
+    auto flat =
+        BaseVector::create<FlatVector<int64_t>>(BIGINT(), vectorSize, pool);
+    for (vector_size_t i = 0; i < vectorSize; ++i) {
+      flat->set(i, valueAt(i));
+    }
+    child = std::move(flat);
+  } else if (child->mayHaveNulls()) {
+    const DecodedVector decoded(*child);
+    if (decoded.mayHaveNulls()) {
+      auto flat =
+          BaseVector::create<FlatVector<int64_t>>(BIGINT(), vectorSize, pool);
+      for (vector_size_t i = 0; i < vectorSize; ++i) {
+        if (decoded.isNullAt(i)) {
+          flat->set(i, valueAt(i));
+        } else {
+          flat->set(i, decoded.valueAt<int64_t>(i));
+        }
+      }
+      child = std::move(flat);
+    }
+  }
+}
+
+} // namespace
 
 namespace facebook::velox::connector::hive::iceberg {
 namespace {
@@ -92,18 +137,119 @@ void IcebergSplitReader::prepareSplit(
     std::shared_ptr<common::MetadataFilter> metadataFilter,
     dwio::common::RuntimeStatistics& runtimeStats,
     const folly::F14FastMap<std::string, std::string>& fileReadOps) {
-  createReader();
+  // Temporarily extend the file schema with projected row-lineage columns
+  // (_row_id, _last_updated_sequence_number) so the reader allocates output
+  // slots for them. Scoped to createReader() so getAdaptedRowType() sees the
+  // original schema.
+  {
+    auto originalFileSchema = baseReaderOpts_.fileSchema();
+    auto restorer = folly::makeGuard([&] {
+      if (originalFileSchema) {
+        baseReaderOpts_.setFileSchema(originalFileSchema);
+      }
+    });
+    if (originalFileSchema) {
+      auto names = originalFileSchema->names();
+      auto types = originalFileSchema->children();
+      bool modified = false;
+      for (const auto* colName :
+           {IcebergMetadataColumn::kRowIdColumnName,
+            IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName}) {
+        if (readerOutputType_->containsChild(colName) &&
+            !originalFileSchema->containsChild(colName)) {
+          names.emplace_back(std::string(colName));
+          types.emplace_back(BIGINT());
+          modified = true;
+        }
+      }
+      if (modified) {
+        baseReaderOpts_.setFileSchema(ROW(std::move(names), std::move(types)));
+      }
+    }
+    createReader(fileReadOps);
+  }
+
   if (emptySplit_) {
     return;
   }
 
   configureEqualityDeleteColumns();
 
+  firstRowId_ = std::nullopt;
+  if (auto it = icebergSplit_->infoColumns.find(
+          IcebergMetadataColumn::kFirstRowIdInfoColumn);
+      it != icebergSplit_->infoColumns.end()) {
+    try {
+      firstRowId_ = folly::to<int64_t>(it->second);
+    } catch (const folly::ConversionError&) {
+      VELOX_FAIL(
+          "Invalid $first_row_id value in split info columns: {}", it->second);
+    }
+    VELOX_CHECK_GE(*firstRowId_, 0, "First row ID must be non-negative");
+  }
+
+  dataSequenceNumber_ = std::nullopt;
+  if (auto it = icebergSplit_->infoColumns.find(
+          IcebergMetadataColumn::kDataSequenceNumberInfoColumn);
+      it != icebergSplit_->infoColumns.end()) {
+    try {
+      dataSequenceNumber_ = folly::to<int64_t>(it->second);
+    } catch (const folly::ConversionError&) {
+      VELOX_FAIL(
+          "Invalid $data_sequence_number value in split info columns: {}",
+          it->second);
+    }
+    VELOX_CHECK_GE(
+        *dataSequenceNumber_, 0, "Data sequence number must be non-negative");
+  }
+
+  // getAdaptedRowType() calls adaptColumns(), which may set
+  // _last_updated_sequence_number to a constant. Must run after
+  // dataSequenceNumber_ and firstRowId_ are initialized.
   auto rowType = getAdaptedRowType();
+
+  lastUpdatedSeqNumOutputIndex_ = std::nullopt;
+  if (dataSequenceNumber_.has_value()) {
+    auto* seqNumSpec = scanSpec_->childByName(
+        IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName);
+    if (seqNumSpec && !seqNumSpec->isConstant()) {
+      lastUpdatedSeqNumOutputIndex_ = readerOutputType_->getChildIdxIfExists(
+          IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName);
+    }
+  }
+
+  rowIdOutputIndex_ = std::nullopt;
+  if (firstRowId_.has_value()) {
+    rowIdOutputIndex_ = readerOutputType_->getChildIdxIfExists(
+        IcebergMetadataColumn::kRowIdColumnName);
+  }
 
   if (checkIfSplitIsEmpty(runtimeStats)) {
     VELOX_CHECK(emptySplit_);
     return;
+  }
+
+  // Inject a row-number column when filters, random-skip, or positional
+  // deletes make the output-to-file-position mapping non-contiguous.
+  // Check split metadata rather than positionalDeleteFileReaders_ because
+  // the row reader must be configured before delete files are opened.
+  const bool hasPositionalDeletes = std::any_of(
+      icebergSplit_->deleteFiles.begin(),
+      icebergSplit_->deleteFiles.end(),
+      [](const IcebergDeleteFile& deleteFile) {
+        return deleteFile.content == FileContent::kPositionalDeletes &&
+            deleteFile.recordCount > 0;
+      });
+  useRowNumberColumn_ = rowIdOutputIndex_.has_value() &&
+      (scanSpec_->hasFilter() || baseReaderOpts_.randomSkip() != nullptr ||
+       hasPositionalDeletes);
+  if (useRowNumberColumn_) {
+    dwio::common::RowNumberColumnInfo rowNumInfo;
+    rowNumInfo.insertPosition = readerOutputType_->size();
+    rowNumInfo.name = "";
+    baseRowReaderOpts_.setRowNumberColumnInfo(rowNumInfo);
+  } else {
+    baseRowReaderOpts_.setRowNumberColumnInfo(std::nullopt);
   }
 
   createRowReader(std::move(metadataFilter), std::move(rowType), std::nullopt);
@@ -394,6 +540,59 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
 
   auto rowsScanned = baseRowReader_->next(actualSize, output, &mutation);
 
+  auto* pool = connectorQueryCtx_->memoryPool();
+
+  if (rowsScanned > 0 &&
+      (lastUpdatedSeqNumOutputIndex_.has_value() ||
+       rowIdOutputIndex_.has_value())) {
+    auto* rowOutput = output->as<RowVector>();
+    VELOX_DCHECK_NOT_NULL(
+        rowOutput, "Expected RowVector output from table scan");
+
+    // If lastUpdatedSeqNumOutputIndex_ is present but dataSequenceNumber_ is
+    // not, the output is a constant NULL value vector already populated by the
+    // reader via adaptColumns.
+    if (lastUpdatedSeqNumOutputIndex_.has_value() &&
+        dataSequenceNumber_.has_value()) {
+      auto& seqNumChild = rowOutput->childAt(*lastUpdatedSeqNumOutputIndex_);
+      const int64_t seqNum = static_cast<int64_t>(*dataSequenceNumber_);
+      fillNullsWithInt64(
+          seqNumChild, pool, [seqNum](vector_size_t) { return seqNum; });
+    }
+
+    if (rowIdOutputIndex_.has_value() && firstRowId_.has_value()) {
+      auto& rowIdChild = rowOutput->childAt(*rowIdOutputIndex_);
+      if (useRowNumberColumn_) {
+        // Use the injected row-number column for file-absolute positions.
+        // The row-number column is always appended last (at index
+        // readerOutputType_->size()).
+        const DecodedVector decodedRowNums(
+            *rowOutput->childAt(readerOutputType_->size()));
+        const int64_t firstRowId = static_cast<int64_t>(*firstRowId_);
+        fillNullsWithInt64(rowIdChild, pool, [&](vector_size_t i) {
+          return firstRowId + decodedRowNums.valueAt<int64_t>(i);
+        });
+
+        // Strip the injected row-number column (always last) from the output.
+        auto children = rowOutput->children();
+        children.pop_back();
+        output = std::make_shared<RowVector>(
+            rowOutput->pool(),
+            readerOutputType_,
+            rowOutput->nulls(),
+            rowOutput->size(),
+            std::move(children));
+      } else {
+        // Contiguous output: _row_id = firstRowId_ + file_pos.
+        const int64_t base = static_cast<int64_t>(*firstRowId_) +
+            static_cast<int64_t>(splitOffset_ + baseReadOffset_);
+        fillNullsWithInt64(rowIdChild, pool, [base](vector_size_t i) {
+          return base + static_cast<int64_t>(i);
+        });
+      }
+    }
+  }
+
   // Apply equality deletes after reading base data. Unlike positional deletes
   // (which set bits before reading), equality deletes require the data values
   // to be available for comparison.
@@ -406,8 +605,7 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
 
     // Use a separate bitmap for equality deletes to track which rows to
     // remove from the output.
-    BufferPtr eqDeleteBitmap = AlignedBuffer::allocate<bool>(
-        numRows, connectorQueryCtx_->memoryPool());
+    BufferPtr eqDeleteBitmap = AlignedBuffer::allocate<bool>(numRows, pool);
     std::memset(
         eqDeleteBitmap->asMutable<uint8_t>(), 0, eqDeleteBitmap->size());
 
@@ -432,8 +630,7 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
         // prematurely stop scanning remaining rows in the data file.
         // Instead, set output to an empty vector and return the original
         // scanned count so the caller continues reading.
-        output = BaseVector::create(
-            outputRowVector->type(), 0, connectorQueryCtx_->memoryPool());
+        output = BaseVector::create(outputRowVector->type(), 0, pool);
       } else {
         // Build a list of surviving row ranges and use it to compact.
         std::vector<BaseVector::CopyRange> ranges;
@@ -445,10 +642,8 @@ uint64_t IcebergSplitReader::next(uint64_t size, VectorPtr& output) {
           }
         }
 
-        auto newOutput = BaseVector::create(
-            outputRowVector->type(),
-            numSurviving,
-            connectorQueryCtx_->memoryPool());
+        auto newOutput =
+            BaseVector::create(outputRowVector->type(), numSurviving, pool);
         newOutput->copyRanges(outputRowVector.get(), ranges);
         newOutput->resize(numSurviving);
         output = newOutput;
@@ -502,7 +697,7 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
         auto& outputType = readerOutputType_->childAt(*outputTypeIdx);
         columnTypes[*fileTypeIdx] = outputType;
       } else if (!fileTypeIdx.has_value()) {
-        // Handle columns missing from the data file in three scenarios:
+        // Handle columns missing from the data file in several scenarios:
         // 1. Partition columns from a Hive-migrated table where partition
         //    column values are stored in partition metadata rather than in
         //    the data file itself.
@@ -511,16 +706,45 @@ std::vector<TypePtr> IcebergSplitReader::adaptColumns(
         //    NULL.
         // 3. Schema evolution: Column was added after the data file was
         //    written and doesn't exist in older data files.
-        // 4. Equality-delete partition columns not in the user's projection:
+        // 4. _last_updated_sequence_number: For Iceberg V3 row lineage, if
+        //    the column is not in the file, inherit the data sequence number
+        //    from the file's manifest entry.
+        // 5. _row_id: For Iceberg V3 row lineage, if the column is not in
+        //    the file, set as NULL constant here. When first_row_id is
+        //    available, next() will replace NULL with first_row_id + file
+        //    position.
+        // 6. Equality-delete partition columns not in the user's projection:
         //    'configureEqualityDeleteColumns' has already pre-installed the
         //    partition value as a constant, so this branch leaves it alone.
-        if (childSpec->isConstant()) {
-          // Constant already set (case 4, or set on a previous prepareSplit
+        if (fieldName ==
+            IcebergMetadataColumn::kLastUpdatedSequenceNumberColumnName) {
+          // Column is absent from the data file. If a data sequence number is
+          // available (V3 snapshot), set a constant so every row inherits it.
+          // Otherwise (pre-V3 snapshot where the sequence number chain is
+          // unassigned), return null — analogous to the _row_id null path.
+          if (dataSequenceNumber_.has_value()) {
+            childSpec->setConstantValue(
+                std::make_shared<ConstantVector<int64_t>>(
+                    connectorQueryCtx_->memoryPool(),
+                    1,
+                    false,
+                    BIGINT(),
+                    static_cast<int64_t>(*dataSequenceNumber_)));
+          } else {
+            childSpec->setConstantValue(
+                BaseVector::createNullConstant(
+                    BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+          }
+        } else if (fieldName == IcebergMetadataColumn::kRowIdColumnName) {
+          childSpec->setConstantValue(
+              BaseVector::createNullConstant(
+                  BIGINT(), 1, connectorQueryCtx_->memoryPool()));
+        } else if (childSpec->isConstant()) {
+          // Constant already set (case 6, or set on a previous prepareSplit
           // call for the same scanSpec). Nothing to do.
           continue;
-        }
-        auto partitionIt = fileSplit_->partitionKeys.find(fieldName);
-        if (partitionIt != fileSplit_->partitionKeys.end()) {
+        } else if (auto partitionIt = fileSplit_->partitionKeys.find(fieldName);
+                   partitionIt != fileSplit_->partitionKeys.end()) {
           setPartitionValue(childSpec.get(), fieldName, partitionIt->second);
         } else {
           // Check if column has an initial-default value (Iceberg V3)

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -96,6 +96,17 @@ class IcebergSplitReader : public FileSplitReader {
   ///       Column was added to the table schema after this data file was
   ///       written. Set as NULL constant since the old file doesn't contain
   ///       this column.
+  ///    c) Row lineage (_last_updated_sequence_number):
+  ///       For Iceberg V3 row lineage, if the column is not in the file,
+  ///       inherit the data sequence number from the file's manifest entry
+  ///       (provided via $data_sequence_number info column). Per the spec,
+  ///       null values indicate the value should be inherited.
+  ///    d) Row lineage (_row_id):
+  ///       Per the spec, null _row_id values are assigned as
+  ///       first_row_id + file position. When first_row_id is available from
+  ///       the split info column $first_row_id, the value is computed
+  ///       in next(). When first_row_id is not available (e.g.,
+  ///       pre-V3 tables), NULL is returned.
   std::vector<TypePtr> adaptColumns(
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
@@ -138,9 +149,26 @@ class IcebergSplitReader : public FileSplitReader {
   uint64_t baseReadOffset_;
   /// File position for the first row in the split.
   uint64_t splitOffset_;
+  // Active readers for positional delete files associated with this split.
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;
+  // Bitmap of deleted rows in the current batch; set bits mark deleted rows.
   BufferPtr deleteBitmap_;
+  // Output column index of _last_updated_sequence_number, if projected.
+  std::optional<column_index_t> lastUpdatedSeqNumOutputIndex_;
+  // Data sequence number from the split's manifest entry, used to populate
+  // _last_updated_sequence_number for rows whose stored value is null.
+  std::optional<int64_t> dataSequenceNumber_;
+  // First row ID from the split's $first_row_id info column, used to compute
+  // _row_id as first_row_id + file position for rows whose stored value is
+  // null.
+  std::optional<int64_t> firstRowId_;
+  // Output column index of _row_id, if projected.
+  std::optional<column_index_t> rowIdOutputIndex_;
+  // Whether an implicit row-number column is needed for _row_id computation
+  // (set when filters, random-skip, or positional deletes make output
+  // positions non-contiguous).
+  bool useRowNumberColumn_{false};
 
   /// Readers for Iceberg V3 deletion vectors (Puffin-encoded roaring bitmaps).
   std::list<std::unique_ptr<DeletionVectorReader>> deletionVectorReaders_;

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -251,7 +251,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
           IcebergDeleteFile icebergDeleteFile(
               FileContent::kPositionalDeletes,
               deleteFilePath,
-              fileFomat_,
+              fileFormat_,
               deleteFilePaths[deleteFileName].first,
               getTestFileSize(deleteFilePath));
           deleteFiles.push_back(icebergDeleteFile);
@@ -285,6 +285,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
  protected:
   std::shared_ptr<dwrf::Config> config_;
   std::function<std::unique_ptr<dwrf::DWRFFlushPolicy>()> flushPolicyFactory_;
+  FileFormat fileFormat_{FileFormat::DWRF};
 
   /// Helper to create a standard c0 HiveColumnHandle (BIGINT).
   std::shared_ptr<HiveColumnHandle> makeC0Handle() {
@@ -362,7 +363,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
           std::make_shared<HiveIcebergSplit>(
               kIcebergConnectorId,
               dataFilePath,
-              fileFomat_,
+              fileFormat_,
               i * splitSize,
               splitSize,
               partitionKeys,
@@ -420,7 +421,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     IcebergDeleteFile icebergDeleteFile(
         FileContent::kPositionalDeletes,
         deleteFilePath->getPath(),
-        fileFomat_,
+        fileFormat_,
         deletedPositionSize,
         getTestFileSize(deleteFilePath->getPath()));
     auto fileSize = filesystems::getFileSystem(path, nullptr)
@@ -431,7 +432,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
     return {std::make_shared<HiveIcebergSplit>(
         kIcebergConnectorId,
         path,
-        dwio::common::FileFormat::PARQUET,
+        FileFormat::PARQUET,
         0,
         fileSize,
         partitionKeys,
@@ -442,6 +443,157 @@ class HiveIcebergTest : public HiveConnectorTestBase {
         std::vector<IcebergDeleteFile>{icebergDeleteFile})};
   }
 #endif
+
+  /// Creates a single HiveIcebergSplit from the full data file with info
+  /// columns (e.g. $first_row_id, $data_sequence_number) and optional
+  /// delete files.
+  std::shared_ptr<ConnectorSplit> makeIcebergSplitWithInfoColumns(
+      const std::string& dataFilePath,
+      const std::unordered_map<std::string, std::string>& infoColumns,
+      const std::vector<IcebergDeleteFile>& deleteFiles = {}) {
+    auto file = filesystems::getFileSystem(dataFilePath, nullptr)
+                    ->openFileForRead(dataFilePath);
+    return std::make_shared<HiveIcebergSplit>(
+        kIcebergConnectorId,
+        dataFilePath,
+        fileFormat_,
+        0,
+        file->size(),
+        std::unordered_map<std::string, std::optional<std::string>>{},
+        std::nullopt,
+        std::unordered_map<std::string, std::string>{},
+        nullptr,
+        /*cacheable=*/true,
+        deleteFiles,
+        infoColumns);
+  }
+
+  struct RowLineageTestCase {
+    std::vector<int64_t> values;
+    // Physically stored _row_id values; nullopt entries write a file null.
+    // Absent means no _row_id column in the file; reader derives from
+    // firstRowId. Always paired with storedSequenceNumbers.
+    std::optional<std::vector<std::optional<int64_t>>> storedRowIds;
+    // Physically stored _last_updated_sequence_number values; nullopt entries
+    // write a file null. Absent means no column in the file; reader derives
+    // from dataSequenceNumber. Always paired with storedRowIds.
+    std::optional<std::vector<std::optional<int64_t>>> storedSequenceNumbers;
+    // Passed as first_row_id in the split's info columns.
+    std::optional<int64_t> firstRowId;
+    // Passed as data_sequence_number in the split's info columns.
+    std::optional<int64_t> dataSequenceNumber;
+    // File positions to delete; empty means no delete file is created.
+    std::vector<int64_t> deletePositions;
+    // Subfield filter expression (e.g., "c0 > 20"); empty means no filter.
+    std::string subfieldFilter;
+    // Expected output rows: (c0, _row_id, _last_updated_sequence_number).
+    std::vector<RowVectorPtr> expectedVectors;
+  };
+
+  // Writes tc to a temp data file, executes a table scan over
+  // (c0, _row_id, _last_updated_sequence_number), and asserts the result.
+  void assertRowLineage(const RowLineageTestCase& tc) {
+    VELOX_CHECK_EQ(
+        tc.storedRowIds.has_value(),
+        tc.storedSequenceNumbers.has_value(),
+        "rowIds and sequenceNumbers must both be set or both absent.");
+
+    auto pathColumn = IcebergMetadataColumn::icebergDeleteFilePathColumn();
+    auto posColumn = IcebergMetadataColumn::icebergDeletePosColumn();
+
+    // Build the data file vectors from the explicit column fields.
+    std::vector<RowVectorPtr> inputVectors;
+    if (!tc.storedRowIds.has_value()) {
+      // No physical lineage columns: file contains only c0.
+      inputVectors = {makeRowVector({makeFlatVector<int64_t>(tc.values)})};
+    } else {
+      // Physical lineage columns are present in the file.
+      static const std::vector<std::string> kFileColumns = {
+          "c0", "_row_id", "_last_updated_sequence_number"};
+      inputVectors = {makeRowVector(
+          kFileColumns,
+          {
+              makeFlatVector<int64_t>(tc.values),
+              makeNullableFlatVector<int64_t>(*tc.storedRowIds),
+              makeNullableFlatVector<int64_t>(*tc.storedSequenceNumbers),
+          })};
+    }
+
+    auto dataFilePath = TempFilePath::create();
+    writeToFile(dataFilePath->getPath(), inputVectors);
+
+    std::vector<IcebergDeleteFile> deleteFiles;
+    std::shared_ptr<TempFilePath> deleteFilePath;
+    if (!tc.deletePositions.empty()) {
+      deleteFilePath = TempFilePath::create();
+      writeToFile(
+          deleteFilePath->getPath(),
+          {makeRowVector(
+              {pathColumn->name, posColumn->name},
+              {makeFlatVector<std::string>(
+                   static_cast<vector_size_t>(tc.deletePositions.size()),
+                   [&](auto) { return dataFilePath->getPath(); }),
+               makeFlatVector<int64_t>(tc.deletePositions)})});
+
+      const uint64_t upperBound = static_cast<uint64_t>(*std::max_element(
+          tc.deletePositions.begin(), tc.deletePositions.end()));
+      const auto upperBoundLE = folly::Endian::little(upperBound);
+      const auto encodedUpperBound = encoding::Base64::encode(
+          std::string_view(
+              reinterpret_cast<const char*>(&upperBoundLE),
+              sizeof(upperBoundLE)));
+
+      deleteFiles.push_back(IcebergDeleteFile(
+          FileContent::kPositionalDeletes,
+          deleteFilePath->getPath(),
+          fileFormat_,
+          static_cast<int64_t>(tc.deletePositions.size()),
+          getTestFileSize(deleteFilePath->getPath()),
+          {},
+          {},
+          {{posColumn->id, encodedUpperBound}}));
+    }
+
+    std::unordered_map<std::string, std::string> infoColumns;
+    if (tc.firstRowId.has_value()) {
+      infoColumns[IcebergMetadataColumn::kFirstRowIdInfoColumn] =
+          std::to_string(*tc.firstRowId);
+    }
+    if (tc.dataSequenceNumber.has_value()) {
+      infoColumns[IcebergMetadataColumn::kDataSequenceNumberInfoColumn] =
+          std::to_string(*tc.dataSequenceNumber);
+    }
+
+    auto split = makeIcebergSplitWithInfoColumns(
+        dataFilePath->getPath(), infoColumns, deleteFiles);
+
+    const auto outputType =
+        ROW({"c0", "_row_id", "_last_updated_sequence_number"},
+            {BIGINT(), BIGINT(), BIGINT()});
+    const auto tableDataColumns = ROW({"c0"}, {BIGINT()});
+
+    core::PlanNodePtr plan;
+    if (!tc.subfieldFilter.empty()) {
+      plan = PlanBuilder()
+                 .startTableScan()
+                 .connectorId(kIcebergConnectorId)
+                 .outputType(outputType)
+                 .dataColumns(tableDataColumns)
+                 .subfieldFilter(tc.subfieldFilter)
+                 .endTableScan()
+                 .planNode();
+    } else {
+      plan = PlanBuilder()
+                 .startTableScan()
+                 .connectorId(kIcebergConnectorId)
+                 .outputType(outputType)
+                 .dataColumns(tableDataColumns)
+                 .endTableScan()
+                 .planNode();
+    }
+
+    AssertQueryBuilder(plan).splits({split}).assertResults(tc.expectedVectors);
+  }
 
  private:
   std::map<std::string, std::shared_ptr<TempFilePath>> writeDataFiles(
@@ -644,8 +796,6 @@ class HiveIcebergTest : public HiveConnectorTestBase {
 
     return deletePositionVector;
   }
-
-  dwio::common::FileFormat fileFomat_{dwio::common::FileFormat::DWRF};
 
   std::shared_ptr<IcebergMetadataColumn> pathColumn_ =
       IcebergMetadataColumn::icebergDeleteFilePathColumn();
@@ -1337,7 +1487,7 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
   IcebergDeleteFile deleteFile(
       FileContent::kPositionalDeletes,
       deleteFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
+      FileFormat::DWRF,
       3,
       getTestFileSize(deleteFilePath->getPath()),
       {},
@@ -1361,7 +1511,7 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
   auto split = std::make_shared<HiveIcebergSplit>(
       kIcebergConnectorId,
       dataFilePath->getPath(),
-      dwio::common::FileFormat::DWRF,
+      FileFormat::DWRF,
       static_cast<uint64_t>(fileSize / 2),
       static_cast<uint64_t>(fileSize / 2),
       std::unordered_map<std::string, std::optional<std::string>>{},
@@ -1375,6 +1525,149 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
   createDuckDbTable({makeRowVector(
       {makeFlatVector<int64_t>(makeContinuousIncreasingValues(50, 50))})});
   assertQuery(plan, {split}, "SELECT * FROM tmp", 0);
+}
+
+// Row lineage scenarios for _row_id and _last_updated_sequence_number:
+//   1. Pre-V3: no info columns, no physical columns → both null.
+//   2. V3 new insert: no physical columns; derived from info columns.
+//   3. V3 rewrite: physical values take precedence over info columns.
+//   4. Physical columns all null: falls back to info column derivation.
+//   5. Mixed null/non-null: null slots derived, non-null slots preserved.
+//   6. first_row_id = 0 is a valid value.
+//   7. Positional deletes: _row_id uses file-absolute positions.
+//   8. Subfield filter: _row_id uses file-absolute positions, not output
+//   indices.
+TEST_F(HiveIcebergTest, rowLineage) {
+  folly::SingletonVault::singleton()->registrationComplete();
+
+  static const std::vector<std::string> kOutputNames = {
+      "c0", "_row_id", "_last_updated_sequence_number"};
+
+  // 1. Pre-V3.
+  assertRowLineage({
+      .values = {1, 2, 3},
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({1, 2, 3}),
+              makeNullableFlatVector<int64_t>(
+                  {std::nullopt, std::nullopt, std::nullopt}),
+              makeNullableFlatVector<int64_t>(
+                  {std::nullopt, std::nullopt, std::nullopt}),
+          })},
+  });
+
+  // 2. V3 new insert.
+  assertRowLineage({
+      .values = {10, 20, 30},
+      .firstRowId = 100,
+      .dataSequenceNumber = 7,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({10, 20, 30}),
+              makeFlatVector<int64_t>({100, 101, 102}),
+              makeFlatVector<int64_t>({7, 7, 7}),
+          })},
+  });
+
+  // 3. V3 rewrite: physical values must not be overridden by info columns.
+  assertRowLineage({
+      .values = {1, 2, 3},
+      .storedRowIds = {{500, 501, 502}},
+      .storedSequenceNumbers = {{3, 5, 3}},
+      .firstRowId = 999,
+      .dataSequenceNumber = 99,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({1, 2, 3}),
+              makeFlatVector<int64_t>({500, 501, 502}),
+              makeFlatVector<int64_t>({3, 5, 3}),
+          })},
+  });
+
+  // 4. Physical columns all null: falls back to info column derivation.
+  assertRowLineage({
+      .values = {1, 2, 3},
+      .storedRowIds = {{std::nullopt, std::nullopt, std::nullopt}},
+      .storedSequenceNumbers = {{std::nullopt, std::nullopt, std::nullopt}},
+      .firstRowId = 50,
+      .dataSequenceNumber = 42,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({1, 2, 3}),
+              makeFlatVector<int64_t>({50, 51, 52}),
+              makeFlatVector<int64_t>({42, 42, 42}),
+          })},
+  });
+
+  // 5. Mixed null/non-null: null slots derived from info columns, non-null
+  // preserved.
+  //   pos 0: _row_id=null→10+0=10, seq_num=null→42
+  //   pos 1: _row_id=99,           seq_num=5
+  //   pos 2: _row_id=null→10+2=12, seq_num=null→42
+  //   pos 3: _row_id=77,           seq_num=10
+  assertRowLineage({
+      .values = {10, 20, 30, 40},
+      .storedRowIds = {{std::nullopt, 99, std::nullopt, 77}},
+      .storedSequenceNumbers = {{std::nullopt, 5, std::nullopt, 10}},
+      .firstRowId = 10,
+      .dataSequenceNumber = 42,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({10, 20, 30, 40}),
+              makeFlatVector<int64_t>({10, 99, 12, 77}),
+              makeFlatVector<int64_t>({42, 5, 42, 10}),
+          })},
+  });
+
+  // 6. first_row_id = 0 is a valid value; _row_id starts at zero.
+  assertRowLineage({
+      .values = {5, 6, 7},
+      .firstRowId = 0,
+      .dataSequenceNumber = 5,
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({5, 6, 7}),
+              makeFlatVector<int64_t>({0, 1, 2}),
+              makeFlatVector<int64_t>({5, 5, 5}),
+          })},
+  });
+
+  // 7. Positional deletes: _row_id uses file-absolute positions.
+  assertRowLineage({
+      .values = {10, 20, 30, 40, 50},
+      .firstRowId = 200,
+      .dataSequenceNumber = 42,
+      .deletePositions = {1, 3},
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({10, 30, 50}),
+              makeFlatVector<int64_t>({200, 202, 204}),
+              makeFlatVector<int64_t>({42, 42, 42}),
+          })},
+  });
+
+  // 8. Subfield filter: _row_id uses file-absolute positions, not output
+  // indices.
+  assertRowLineage({
+      .values = {10, 20, 30, 40, 50},
+      .firstRowId = 100,
+      .dataSequenceNumber = 15,
+      .subfieldFilter = "c0 > 20",
+      .expectedVectors = {makeRowVector(
+          kOutputNames,
+          {
+              makeFlatVector<int64_t>({30, 40, 50}),
+              makeFlatVector<int64_t>({102, 103, 104}),
+              makeFlatVector<int64_t>({15, 15, 15}),
+          })},
+  });
 }
 
 #ifdef VELOX_ENABLE_PARQUET

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.cpp
@@ -108,7 +108,7 @@ IcebergSplitReaderBenchmark::makeIcebergSplit(
   return std::make_shared<HiveIcebergSplit>(
       kHiveConnectorId,
       dataFilePath,
-      fileFomat_,
+      fileFormat_,
       0,
       fileSize,
       partitionKeys,
@@ -175,7 +175,7 @@ IcebergSplitReaderBenchmark::createIcebergSplitsWithPositionalDelete(
       IcebergDeleteFile deleteFile(
           FileContent::kPositionalDeletes,
           deleteFilePath,
-          fileFomat_,
+          fileFormat_,
           deleteRowsCount,
           testing::internal::GetFileSize(
               std::fopen(deleteFilePath.c_str(), "r")));

--- a/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergSplitReaderBenchmark.h
@@ -121,7 +121,7 @@ class IcebergSplitReaderBenchmark {
   std::unique_ptr<dwrf::Writer> writer_;
   dwio::common::RuntimeStatistics runtimeStats_;
 
-  dwio::common::FileFormat fileFomat_{dwio::common::FileFormat::DWRF};
+  dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   const std::string kHiveConnectorId = "hive-iceberg";
 };
 


### PR DESCRIPTION
Enhances read support for Iceberg V3 metadata columns in the Iceberg connector. The modifications add support for hidden Iceberg metadata columns `_row_id` and `_last_updated_sequence_number`, enabling handling of row lineage and schema evolution for Iceberg V3 tables.

Part of 
- https://github.com/prestodb/presto/issues/27197

## Changes
### Iceberg Metadata Columns:
- Added `_row_id` and `_last_updated_sequence_number` as hidden metadata columns via `IcebergMetadataColumns.h`.
- Introduced methods to define and instantiate these columns (`icebergRowIdColumn` and `icebergLastUpdatedSequenceNumberColumn`).

### Reader Enhancements:
- Updated `IcebergSplitReader.cpp` to support reading and handling the new metadata columns:
  - `_row_id` is either read directly from the file or dynamically calculated as `first_row_id + _pos`.
  - `_last_updated_sequence_number` is filled with the data sequence number if null values are encountered.
- Refactored processing logic to account for these metadata columns during schema adaptation and data file reading.

### Test Coverage:
- Added multiple unit tests to validate:
- Direct reading and calculation of _row_id.
- Replacement of null values in _last_updated_sequence_number.
- Integration with schema evolution and row deletions.

### Typo Fixes:

- Corrected several instances of the typo `fileFomat_` to `fileFormat_`.