### PR TITLE
fix: Fix redundant prefix increment before assignment in StreamArena

### DIFF
--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -62,7 +62,7 @@ void StreamArena::newRange(
   VELOX_DCHECK_LE(currentOffset_, run.numBytes());
   if (currentOffset_ == run.numBytes()) {
     ++currentRun_;
-    ++currentOffset_ = 0;
+    currentOffset_ = 0;
   }
 }
 


### PR DESCRIPTION
In StreamArena::newRange(), `++currentOffset_ = 0` increments
currentOffset_ then immediately overwrites it with 0, making the
increment a no-op. Simplify to `currentOffset_ = 0`.