### PR TITLE
refactor: Clean up AllocationTest includes and remove leftover debug log

### DIFF
--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
+#include "velox/common/memory/Allocation.h"
+
 #include <gtest/gtest.h>
 
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/common/memory/Memory.h"
-
-using namespace ::testing;
-using namespace facebook::velox::memory;
 
 namespace facebook::velox::memory {
 
@@ -105,7 +103,6 @@ TEST_F(AllocationTest, maxPageRunLimit) {
       "The number of pages to append 131070 exceeds the PageRun limit 65535");
   ASSERT_EQ(allocation.numPages(), Allocation::PageRun::kMaxPagesInRun);
   ASSERT_EQ(allocation.numRuns(), 1);
-  LOG(ERROR) << "here";
   allocation.clear();
 }
 


### PR DESCRIPTION
- Replace the broad 'Memory.h' include with the specific 'Allocation.h'
  that the test actually tests.
- Remove unused `using namespace` directives (::testing and
  facebook::velox::memory) since the file already wraps its body
  in the velox::memory namespace and fully qualifies testing::Test.
- Remove an accidentally committed `LOG(ERROR) << "here"` that
  appears to be leftover debugging from a prior change.