### PR TITLE
docs: Document TableWriteNode and TableWriteMergeNode

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -18,6 +18,7 @@
 #include "velox/common/Casts.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/core/PlanNode.h"
+#include "velox/core/TableWriteTraits.h"
 #include "velox/vector/VectorSaver.h"
 
 namespace facebook::velox::core {
@@ -2771,6 +2772,81 @@ PlanNodePtr LocalMergeNode::create(const folly::dynamic& obj, void* context) {
       std::move(sources));
 }
 
+// Validates that grouping keys in 'spec' are present in 'type' and have no
+// duplicates. 'context' is used in error messages (e.g. "written columns",
+// "source output").
+void validateGroupingKeys(
+    const ColumnStatsSpec& spec,
+    const RowType& type,
+    std::string_view context) {
+  folly::F14FastSet<std::string> seenKeys;
+  for (const auto& key : spec.groupingKeys) {
+    VELOX_USER_CHECK(
+        type.containsChild(key->name()),
+        "Grouping key not found in {}: {}",
+        context,
+        key->name());
+    VELOX_USER_CHECK(
+        seenKeys.insert(key->name()).second,
+        "Duplicate grouping key: {}",
+        key->name());
+  }
+}
+
+TableWriteNode::TableWriteNode(
+    const PlanNodeId& id,
+    const RowTypePtr& columns,
+    const std::vector<std::string>& columnNames,
+    std::optional<ColumnStatsSpec> columnStatsSpec,
+    std::shared_ptr<const InsertTableHandle> insertTableHandle,
+    bool hasPartitioningScheme,
+    RowTypePtr outputType,
+    connector::CommitStrategy commitStrategy,
+    const PlanNodePtr& source)
+    : PlanNode(id),
+      sources_{source},
+      columns_{columns},
+      columnNames_{columnNames},
+      columnStatsSpec_(std::move(columnStatsSpec)),
+      insertTableHandle_(std::move(insertTableHandle)),
+      hasPartitioningScheme_(hasPartitioningScheme),
+      outputType_(std::move(outputType)),
+      commitStrategy_(commitStrategy) {
+  VELOX_USER_CHECK_NOT_NULL(sources_[0]);
+  VELOX_USER_CHECK_NOT_NULL(insertTableHandle_);
+  VELOX_USER_CHECK_EQ(columns_->size(), columnNames_.size());
+  for (const auto& column : columns_->names()) {
+    VELOX_USER_CHECK(
+        sources_[0]->outputType()->containsChild(column),
+        "Column not found in TableWrite input: {}",
+        column);
+  }
+  if (columnStatsSpec_.has_value()) {
+    VELOX_USER_CHECK(
+        columnStatsSpec_->aggregationStep == AggregationNode::Step::kSingle ||
+            columnStatsSpec_->aggregationStep ==
+                AggregationNode::Step::kPartial,
+        "TableWriteNode requires aggregation step to be single or partial");
+    validateGroupingKeys(
+        columnStatsSpec_.value(), *columns_, "written columns");
+  }
+  // Single-column BIGINT output with no stats spec. Used by Spark/Gluten
+  // and other non-Prestissimo integrations.
+  if (outputType_->size() == 1 && !columnStatsSpec_.has_value()) {
+    VELOX_USER_CHECK_EQ(
+        outputType_->childAt(0)->kind(),
+        TypeKind::BIGINT,
+        "Single-column outputType must be BIGINT");
+    return;
+  }
+  const auto expectedType = TableWriteTraits::outputType(columnStatsSpec_);
+  VELOX_USER_CHECK(
+      outputType_->equivalent(*expectedType),
+      "TableWriteNode outputType mismatch: {} vs computed {}",
+      outputType_->toString(),
+      expectedType->toString());
+}
+
 void TableWriteNode::addDetails(std::stringstream& stream) const {
   stream << insertTableHandle_->connectorInsertTableHandle()->toString();
 }
@@ -2886,6 +2962,33 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
       outputType,
       commitStrategy,
       deserializeSingleSource(obj, context));
+}
+
+TableWriteMergeNode::TableWriteMergeNode(
+    const PlanNodeId& id,
+    RowTypePtr outputType,
+    std::optional<ColumnStatsSpec> columnStatsSpec,
+    PlanNodePtr source)
+    : PlanNode(id),
+      columnStatsSpec_(std::move(columnStatsSpec)),
+      sources_{std::move(source)},
+      outputType_(std::move(outputType)) {
+  VELOX_USER_CHECK_NOT_NULL(sources_[0]);
+  const auto expectedType = TableWriteTraits::outputType(columnStatsSpec_);
+  VELOX_USER_CHECK(
+      outputType_->equivalent(*expectedType),
+      "TableWriteMergeNode outputType mismatch: {} vs computed {}",
+      outputType_->toString(),
+      expectedType->toString());
+  if (hasColumnStatsSpec()) {
+    VELOX_USER_CHECK(
+        columnStatsSpec_->aggregationStep == AggregationNode::Step::kFinal ||
+            columnStatsSpec_->aggregationStep ==
+                AggregationNode::Step::kIntermediate,
+        "TableWriteMergeNode requires aggregation step to be intermediate or final");
+    validateGroupingKeys(
+        columnStatsSpec_.value(), *sources_[0]->outputType(), "source output");
+  }
 }
 
 void TableWriteMergeNode::addDetails(std::stringstream& /* stream */) const {}

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1474,8 +1474,81 @@ struct ColumnStatsSpec : public ISerializable {
   static ColumnStatsSpec create(const folly::dynamic& obj, void* context);
 };
 
+/// Writes input rows to a table via a connector-specific DataSink and
+/// optionally collects per-column statistics (count, min, max,
+/// approx_distinct) using an embedded ColumnStatsCollector.
+///
+/// Two output modes depending on outputType:
+///
+/// 1. Single-column BIGINT (Spark/Gluten): output is a single row count.
+///    No stats, no fragments, no commit context. Used when columnStatsSpec
+///    is not set.
+///
+/// 2. Multiplexed format (Prestissimo, see TableWriteTraits):
+///   Channel 0 (rows):      row count or NULL
+///   Channel 1 (fragments): file fragment data or NULL
+///   Channel 2 (context):   commit context JSON (always present)
+///   Channel 3+ (stats):    aggregated statistics columns (if configured)
+///
+///   Each operator instance (one per driver) produces three kinds of rows:
+///     - Statistics rows: rows=NULL, fragments=NULL, stats populated.
+///       One row per partition (or one row for unpartitioned tables).
+///     - Fragment rows:   rows=NULL, fragments=non-NULL, stats=NULL.
+///       One row per output file.
+///     - Summary row:     rows=totalCount, fragments=NULL, stats=NULL.
+///       One per driver, emitted last.
+///
+///   The context column (channel 2) is a JSON object. See
+///   TableWriteTraits for field names (taskId, lifespan,
+///   pageSinkCommitStrategy, lastPage). All rows carry context; the
+///   summary row has lastPage=true.
+///
+///   When columnStatsSpec is set, the aggregation step controls output types:
+///     - kSingle:  produces final statistics values (single-driver, no merge).
+///     - kPartial: produces intermediate aggregation state (requires a
+///                 downstream TableWriteMergeNode to finalize).
+///
+/// Typical plan topologies (data flows left to right):
+///
+///   Single-node, single-driver:
+///     Input → TableWrite(kSingle)
+///
+///   Single-node, multi-driver:
+///     Input → TableWrite(kPartial) → LocalGather → TableWriteMerge(kFinal)
+///
+///   Multi-node, multi-driver:
+///     Worker:      Input → TableWrite(kPartial) → LocalGather
+///                    → TableWriteMerge(kIntermediate) → PartitionedOutput
+///     Coordinator: Exchange → TableWriteMerge(kFinal)
+///     In Prestissimo, the coordinator uses Presto's Java
+///     TableFinishOperator instead of TableWriteMerge.
 class TableWriteNode : public PlanNode {
  public:
+  /// @param id Plan node ID.
+  /// @param columns Subset of source output columns to write, potentially
+  /// reordered. The names in this type must match columns in the source
+  /// output (used to build the input-to-output column mapping).
+  /// @param columnNames Target table column names for the written data.
+  /// Aligned 1:1 with 'columns'. May differ from 'columns' names when the
+  /// query renames columns (e.g. source has "expr_0" but table column is
+  /// "key"). The DataSink receives data using these names.
+  /// @param columnStatsSpec Optional specification for column statistics
+  /// collection. When set, the operator collects per-column aggregates
+  /// (count, min, max, approx_distinct) alongside the write. Restrictions:
+  ///   - aggregation step must be kSingle or kPartial.
+  ///   - grouping keys must be a subset of 'columns' (partition columns).
+  ///   - grouping keys must not contain duplicates.
+  /// @param insertTableHandle Connector-specific handle identifying the
+  /// target table and write operation.
+  /// @param hasPartitioningScheme Whether a partitioning scheme is configured
+  /// for shuffles. Controls which query config determines the number of
+  /// writer operator instances: 'task_partitioned_writer_count' if true,
+  /// 'task_writer_count' if false.
+  /// @param outputType Output row type. For Prestissimo, must match
+  /// TableWriteTraits::outputType(columnStatsSpec). For Spark/Gluten, a
+  /// single-column BIGINT type with no columnStatsSpec.
+  /// @param commitStrategy Commit strategy for the write operation.
+  /// @param source Input plan node providing rows to write.
   TableWriteNode(
       const PlanNodeId& id,
       const RowTypePtr& columns,
@@ -1485,25 +1558,7 @@ class TableWriteNode : public PlanNode {
       bool hasPartitioningScheme,
       RowTypePtr outputType,
       connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source)
-      : PlanNode(id),
-        sources_{source},
-        columns_{columns},
-        columnNames_{columnNames},
-        columnStatsSpec_(std::move(columnStatsSpec)),
-        insertTableHandle_(std::move(insertTableHandle)),
-        hasPartitioningScheme_(hasPartitioningScheme),
-        outputType_(std::move(outputType)),
-        commitStrategy_(commitStrategy) {
-    VELOX_USER_CHECK_EQ(columns_->size(), columnNames_.size());
-    for (const auto& column : columns_->names()) {
-      VELOX_USER_CHECK(
-          source->outputType()->containsChild(column),
-          "Column {} not found in TableWriter input: {}",
-          column,
-          source->outputType()->toString());
-    }
-  }
+      const PlanNodePtr& source);
 
   class Builder {
    public:
@@ -1641,8 +1696,7 @@ class TableWriteNode : public PlanNode {
   /// Indicates if this table write plan node has specified partitioning
   /// scheme for remote and local shuffles. If true, the task creates a
   /// number of table write operators based on the query config
-  /// 'task_partitioned_writer_count', otherwise based on
-  /// x'task_writer_count'.
+  /// 'task_partitioned_writer_count', otherwise based on 'task_writer_count'.
   bool hasPartitioningScheme() const {
     return hasPartitioningScheme_;
   }
@@ -1651,13 +1705,10 @@ class TableWriteNode : public PlanNode {
     return commitStrategy_;
   }
 
-  /// Returns true of this table write plan node has configured column
-  /// statistics collection.
   bool hasColumnStatsSpec() const {
     return columnStatsSpec_.has_value();
   }
 
-  /// Optional spec for column statistics collection.
   const std::optional<ColumnStatsSpec>& columnStatsSpec() const {
     return columnStatsSpec_;
   }
@@ -1689,29 +1740,51 @@ class TableWriteNode : public PlanNode {
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;
 
+/// Merges output from multiple TableWrite operators running in parallel
+/// drivers within the same task. Collects fragments, accumulates row counts,
+/// and aggregates column statistics using an embedded ColumnStatsCollector.
+///
+/// Input rows are classified using the same multiplexed format as
+/// TableWriteNode output (see TableWriteTraits):
+///   - Statistics rows (rows=NULL, fragments=NULL): routed to the stats
+///     collector for aggregation.
+///   - Data rows (rows or fragments non-NULL): row counts are accumulated,
+///     fragments are buffered, and commit context is validated for
+///     consistency (all inputs must share the same taskId and commit
+///     strategy).
+///
+/// Output follows the same three-phase protocol as TableWriteNode:
+///   1. Fragment rows (emitted first, to free memory).
+///   2. Aggregated statistics rows from the stats collector.
+///   3. Summary row with total row count and lastPage=true.
+///
+/// The aggregation step in ColumnStatsSpec must be kIntermediate or kFinal:
+///   - kIntermediate: reads partial state, produces partial state (for
+///     further merging downstream).
+///   - kFinal: reads partial state, produces final scalar values.
+///
+/// Designed for single-task, multi-driver merge. Assumes all input comes
+/// from drivers within the same task (same commit context). Not designed
+/// for cross-task merge (e.g. merging output from multiple workers via an
+/// exchange) — use a separate operator for that.
 class TableWriteMergeNode : public PlanNode {
  public:
-  /// 'outputType' specifies the type to store the metadata of table write
-  /// output which contains the following columns: 'numWrittenRows',
-  /// 'fragment' and 'tableCommitContext'.
+  /// @param id Plan node ID.
+  /// @param columnStatsSpec Optional specification for column statistics
+  /// aggregation. Restrictions:
+  ///   - aggregation step must be kIntermediate or kFinal.
+  ///   - grouping keys must be present in source output type.
+  ///   - grouping keys must not contain duplicates.
+  /// @param outputType Output row type. Column names may differ from
+  /// TableWriteTraits defaults (e.g. Prestissimo appends node ID suffixes).
+  /// Types must match TableWriteTraits::outputType(columnStatsSpec).
+  /// @param source Input plan node, typically a LocalGather over
+  /// TableWriteNode(s).
   TableWriteMergeNode(
       const PlanNodeId& id,
       RowTypePtr outputType,
       std::optional<ColumnStatsSpec> columnStatsSpec,
-      PlanNodePtr source)
-      : PlanNode(id),
-        columnStatsSpec_(std::move(columnStatsSpec)),
-        sources_{std::move(source)},
-        outputType_(std::move(outputType)) {
-    if (hasColumnStatsSpec()) {
-      VELOX_USER_CHECK(
-          columnStatsSpec_->aggregationStep ==
-                  core::AggregationNode::Step::kFinal ||
-              columnStatsSpec_->aggregationStep ==
-                  core::AggregationNode::Step::kIntermediate,
-          "TableWriteMergeNode requires aggregation step to be intermediate or final");
-    }
-  }
+      PlanNodePtr source);
 
   class Builder {
    public:

--- a/velox/core/TableWriteTraits.cpp
+++ b/velox/core/TableWriteTraits.cpp
@@ -106,6 +106,12 @@ RowTypePtr TableWriteTraits::outputType(
   return kOutputTypeWithoutStats->unionWith(columnStatsSpec->outputType());
 }
 
+bool TableWriteTraits::isStatisticsRow(const RowVectorPtr& output) {
+  VELOX_CHECK_GT(output->size(), 0);
+  return output->childAt(kRowCountChannel)->isNullAt(0) &&
+      output->childAt(kFragmentChannel)->isNullAt(0);
+}
+
 folly::dynamic TableWriteTraits::getTableCommitContext(
     const RowVectorPtr& input) {
   VELOX_CHECK_GT(input->size(), 0);

--- a/velox/core/TableWriteTraits.h
+++ b/velox/core/TableWriteTraits.h
@@ -51,6 +51,8 @@ class TableWriteTraits {
   ///
   /// [row_count_channel] - contains number of rows processed by a TableWriter
   /// [fragment_channel] - contains data provided by the DataSink#finish
+  /// [context_channel] - JSON-serialized commit context (VARBINARY).
+  ///   Present on every row. See k*ContextKey constants below.
   /// [statistic_channel_1] ...[statistic_channel_N] -
   /// contain aggregated statistics computed by the statistics aggregation
   /// within the TableWriter
@@ -69,7 +71,10 @@ class TableWriteTraits {
   static constexpr int32_t kContextChannel = 2;
   static constexpr int32_t kStatsChannel = 3;
 
-  /// Defines the names of metadata in commit context in table writer output.
+  /// Field names in the commit context JSON object (context_channel).
+  /// The context is a JSON object serialized as VARBINARY, e.g.:
+  ///   {"taskId":"...", "lifespan":"TaskWide",
+  ///    "pageSinkCommitStrategy":"NO_COMMIT", "lastPage":true}
   static constexpr std::string_view kLifeSpanContextKey = "lifespan";
   static constexpr std::string_view kTaskIdContextKey = "taskId";
   static constexpr std::string_view kCommitStrategyContextKey =
@@ -78,6 +83,11 @@ class TableWriteTraits {
 
   static RowTypePtr outputType(
       const std::optional<core::ColumnStatsSpec>& columnStatsSpec);
+
+  /// Returns true if 'output' is a statistics row (both row count and
+  /// fragment channels are NULL). Statistics rows carry aggregated
+  /// per-column stats; data rows carry row counts and/or file fragments.
+  static bool isStatisticsRow(const RowVectorPtr& output);
 
   /// Returns the parsed commit context from table writer 'output'.
   static folly::dynamic getTableCommitContext(const RowVectorPtr& output);

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -17,6 +17,7 @@
 
 #include "velox/common/memory/Memory.h"
 #include "velox/core/PlanNode.h"
+#include "velox/core/TableWriteTraits.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/tests/utils/AggregationResolver.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
@@ -358,7 +359,6 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
   const PlanNodeId id = "table_write_node_id";
   const RowTypePtr columns = ROW({"c0"}, {INTEGER()});
   const std::vector<std::string> columnNames{"c0"};
-  const RowTypePtr outputType = ROW({"c1"}, {BIGINT()});
   const bool hasPartitioningScheme = true;
   const auto commitStrategy = connector::CommitStrategy::kNoCommit;
 
@@ -367,6 +367,7 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
       std::vector<std::string>{},
       AggregationNode::Step::kPartial,
       std::vector<std::string>{"sum(c0)"});
+  const auto outputType = TableWriteTraits::outputType(statsSpec);
 
   const auto insertTableHandle =
       std::make_shared<InsertTableHandle>("connector_id", nullptr);
@@ -378,7 +379,7 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
     EXPECT_EQ(node->insertTableHandle(), insertTableHandle);
     EXPECT_TRUE(node->hasColumnStatsSpec());
     EXPECT_EQ(node->hasPartitioningScheme(), hasPartitioningScheme);
-    EXPECT_EQ(node->outputType(), outputType);
+    EXPECT_TRUE(node->outputType()->equivalent(*outputType));
     EXPECT_EQ(node->commitStrategy(), commitStrategy);
     EXPECT_EQ(node->sources(), std::vector<PlanNodePtr>{source_});
   };
@@ -402,19 +403,19 @@ TEST_F(PlanNodeBuilderTest, tableWriteNode) {
 
 TEST_F(PlanNodeBuilderTest, tableWriteMergeNode) {
   const PlanNodeId id = "table_write_merge_node_id";
-  const RowTypePtr outputType = ROW({"c0"}, {BIGINT()});
 
   const auto statsSpec = createStatsSpec(
-      outputType,
+      source_->outputType(),
       std::vector<std::string>{},
       AggregationNode::Step::kIntermediate,
       std::vector<std::string>{"sum(c0)"},
       {{BIGINT()}});
+  const auto outputType = TableWriteTraits::outputType(statsSpec);
 
   const auto verify =
       [&](const std::shared_ptr<const TableWriteMergeNode>& node) {
         EXPECT_EQ(node->id(), id);
-        EXPECT_EQ(node->outputType(), outputType);
+        EXPECT_TRUE(node->outputType()->equivalent(*outputType));
         EXPECT_TRUE(node->hasColumnStatsSpec());
         EXPECT_EQ(node->sources()[0], source_);
       };

--- a/velox/exec/TableWriteMerge.cpp
+++ b/velox/exec/TableWriteMerge.cpp
@@ -16,24 +16,11 @@
 
 #include "velox/exec/TableWriteMerge.h"
 
-#include "HashAggregation.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/TableWriter.h"
-#include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
 namespace {
-
-bool isSameCommitContext(
-    const folly::dynamic& first,
-    const folly::dynamic& second) {
-  return std::tie(
-             first[TableWriteTraits::kTaskIdContextKey],
-             first[TableWriteTraits::kCommitStrategyContextKey]) ==
-      std::tie(
-             second[TableWriteTraits::kTaskIdContextKey],
-             second[TableWriteTraits::kCommitStrategyContextKey]);
-}
 
 bool containsNonNullRows(const VectorPtr& vector) {
   if (!vector->mayHaveNulls()) {
@@ -86,7 +73,7 @@ void TableWriteMerge::addInput(RowVectorPtr input) {
   VELOX_CHECK(!noMoreInput_);
   VELOX_CHECK_GT(input->size(), 0);
 
-  if (isStatistics(input)) {
+  if (TableWriteTraits::isStatisticsRow(input)) {
     VELOX_CHECK_NOT_NULL(statsCollector_);
     statsCollector_->addInput(input);
     return;
@@ -95,14 +82,18 @@ void TableWriteMerge::addInput(RowVectorPtr input) {
   // Increments row count.
   numRows_ += TableWriteTraits::getRowCount(input);
 
-  // Makes sure the lifespan is the same.
+  // Validate that all inputs share the same task ID and commit strategy.
   auto commitContext = TableWriteTraits::getTableCommitContext(input);
   if (lastCommitContext_ != nullptr) {
-    VELOX_CHECK(
-        isSameCommitContext(lastCommitContext_, commitContext),
-        "incompatible table commit context: {} is not compatible with {}",
-        lastCommitContext_.asString(),
-        commitContext.asString());
+    VELOX_CHECK_EQ(
+        lastCommitContext_[TableWriteTraits::kTaskIdContextKey].asString(),
+        commitContext[TableWriteTraits::kTaskIdContextKey].asString(),
+        "Mismatched taskId in commit context");
+    VELOX_CHECK_EQ(
+        lastCommitContext_[TableWriteTraits::kCommitStrategyContextKey]
+            .asString(),
+        commitContext[TableWriteTraits::kCommitStrategyContextKey].asString(),
+        "Mismatched commit strategy in commit context");
   }
   lastCommitContext_ = commitContext;
 
@@ -216,8 +207,4 @@ RowVectorPtr TableWriteMerge::createLastOutput() {
   return output;
 }
 
-bool TableWriteMerge::isStatistics(RowVectorPtr input) {
-  return input->childAt(TableWriteTraits::kRowCountChannel)->isNullAt(0) &&
-      input->childAt(TableWriteTraits::kFragmentChannel)->isNullAt(0);
-}
 } // namespace facebook::velox::exec

--- a/velox/exec/TableWriteMerge.h
+++ b/velox/exec/TableWriteMerge.h
@@ -65,9 +65,6 @@ class TableWriteMerge : public Operator {
   // Creates the last output and fragment columns must be null.
   RowVectorPtr createLastOutput();
 
-  // Check if the input is statistics input.
-  bool isStatistics(RowVectorPtr input);
-
   std::unique_ptr<ColumnStatsCollector> statsCollector_;
   bool finished_{false};
   // The sum of written rows.


### PR DESCRIPTION
Summary:
Add class-level documentation for TableWriteNode and TableWriteMergeNode
describing the multiplexed output format, row classification protocol,
aggregation step semantics, and plan topologies (single-node single-driver,
single-node multi-driver, multi-node Prestissimo).

Document that TableWriteMergeNode is designed for single-task multi-driver
merge and is not suitable for cross-worker merge via exchange (Prestissimo
uses Presto's Java TableFinishOperator for that).

Add new constructors that compute outputType from columnStatsSpec, making the
redundant outputType parameter optional. Mark old constructors as legacy.

Add sanity checks:
- TableWriteNode: aggregation step must be kSingle or kPartial; grouping
  keys must be a subset of written columns with no duplicates;
  insertTableHandle must not be null.
- TableWriteMergeNode: grouping keys must be present in source output
  with no duplicates; source must not be null.
- Both: outputType must match TableWriteTraits::outputType(columnStatsSpec).

Move isStatistics() from TableWriteMerge (private) to
TableWriteTraits::isStatisticsRow() (public static) so consumers don't
need to reimplement the row classificat

Document commit context JSON format in TableWriteTraits.

Differential Revision: D96145728


