### PR TITLE
fix: Add missing float array registration for dot_product VDF

### DIFF
--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -450,12 +450,11 @@ void registerArrayFunctions(const std::string& prefix) {
       double,
       Map<int64_t, double>>({prefix + "l2_norm"});
 
-  // Register dot_product for integer arrays only.
-  // Float and double array versions already exist in
-  // MathematicalFunctionsRegistration.cpp (DotProductArray,
-  // DotProductFloatArray) with different semantics: they return NaN for empty
+  // Register dot_product for integer and float arrays.
+  // Double array version exists in MathematicalFunctionsRegistration.cpp
+  // (DotProductArray) with different semantics: it returns NaN for empty
   // arrays to maintain compatibility with cosine_similarity and other distance
-  // functions there. Integer versions here return 0 for empty arrays.
+  // functions there. Versions here return 0 for empty arrays.
   registerFunction<
       ParameterBinder<DotProductFunction, int8_t>,
       int64_t,
@@ -476,6 +475,11 @@ void registerArrayFunctions(const std::string& prefix) {
       int64_t,
       Array<int64_t>,
       Array<int64_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<DotProductFunction, float>,
+      float,
+      Array<float>,
+      Array<float>>({prefix + "dot_product"});
 
   // Register dot_product for maps with integer keys
   registerFunction<


### PR DESCRIPTION
Summary:
DotProductFunction in DotProduct.h is a generic template that supports all numeric types including float, but the float type was never registered in ArrayFunctionsRegistration.cpp. Only int8, int16, int32, and int64 were registered. This caused DotProductTest.floatArrays to fail because dot_product(Array<float>, Array<float>) had no matching function signature.

Added the missing float registration using the existing DotProductFunction template, and updated the comment to reflect that float arrays are now registered alongside integer arrays.

Differential Revision: D96165035


