### PR TITLE
feat(rpc): Add RPCNode plan node to core/PlanNode.h [2/8] (OSS) (#16727)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -3896,6 +3896,7 @@ void PlanNode::registerSerDe() {
   registry.Register("WindowNode", WindowNode::create);
   registry.Register("MarkDistinctNode", MarkDistinctNode::create);
   registry.Register("MixedUnionNode", MixedUnionNode::create);
+  registry.Register("RPCNode", RPCNode::create);
   registry.Register(
       "GatherPartitionFunctionSpec", GatherPartitionFunctionSpec::deserialize);
 }
@@ -4161,6 +4162,166 @@ PlanNodePtr MixedUnionNode::create(const folly::dynamic& obj, void* context) {
 
   return std::make_shared<MixedUnionNode>(
       deserializePlanNodeId(obj), std::move(sources));
+}
+
+RPCNode::RPCNode(
+    const PlanNodeId& id,
+    PlanNodePtr source,
+    std::string functionName,
+    TypePtr functionResultType,
+    std::string outputColumn,
+    RowTypePtr outputType,
+    std::vector<std::string> argumentColumns,
+    std::vector<TypePtr> argumentTypes,
+    std::vector<VectorPtr> constantInputs,
+    rpc::RPCStreamingMode streamingMode,
+    int32_t dispatchBatchSize)
+    : PlanNode(id),
+      sources_{std::move(source)},
+      functionName_(std::move(functionName)),
+      resultType_(std::move(functionResultType)),
+      outputColumn_(std::move(outputColumn)),
+      outputType_(std::move(outputType)),
+      argumentColumns_(std::move(argumentColumns)),
+      argumentTypes_(std::move(argumentTypes)),
+      constantInputs_(std::move(constantInputs)),
+      streamingMode_(streamingMode),
+      dispatchBatchSize_(dispatchBatchSize) {
+  VELOX_CHECK_EQ(
+      argumentColumns_.size(),
+      argumentTypes_.size(),
+      "argumentColumns and argumentTypes must have the same size");
+  VELOX_CHECK_EQ(
+      argumentColumns_.size(),
+      constantInputs_.size(),
+      "argumentColumns and constantInputs must have the same size");
+  VELOX_CHECK(
+      outputType_->containsChild(outputColumn_),
+      "RPCNode outputType must contain the RPC result column: {}",
+      outputColumn_);
+}
+
+void RPCNode::addDetails(std::stringstream& stream) const {
+  stream << "function: " << functionName_ << ", outputColumn: " << outputColumn_
+         << ", streamingMode: "
+         << (streamingMode_ == rpc::RPCStreamingMode::kBatch ? "BATCH"
+                                                             : "PER_ROW");
+  if (dispatchBatchSize_ > 0) {
+    stream << ", dispatchBatchSize: " << dispatchBatchSize_;
+  }
+}
+
+folly::dynamic RPCNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["functionName"] = functionName_;
+  obj["resultType"] = resultType_->serialize();
+
+  // Serialize argument columns (string names).
+  auto colsArray = folly::dynamic::array();
+  for (const auto& col : argumentColumns_) {
+    colsArray.push_back(col);
+  }
+  obj["argumentColumns"] = std::move(colsArray);
+
+  // Serialize argument types.
+  obj["argumentTypes"] = ISerializable::serialize(argumentTypes_);
+
+  // Serialize constant inputs as ConstantTypedExpr for round-trip fidelity.
+  auto constArray = folly::dynamic::array();
+  for (size_t i = 0; i < constantInputs_.size(); ++i) {
+    if (constantInputs_[i]) {
+      auto constExpr =
+          std::make_shared<core::ConstantTypedExpr>(constantInputs_[i]);
+      constArray.push_back(constExpr->serialize());
+    } else {
+      constArray.push_back(nullptr);
+    }
+  }
+  obj["constantInputs"] = std::move(constArray);
+
+  obj["outputColumn"] = outputColumn_;
+  obj["outputType"] = outputType_->serialize();
+  obj["streamingMode"] =
+      streamingMode_ == rpc::RPCStreamingMode::kBatch ? "BATCH" : "PER_ROW";
+  obj["dispatchBatchSize"] = dispatchBatchSize_;
+  return obj;
+}
+
+// static
+PlanNodePtr RPCNode::create(const folly::dynamic& obj, void* context) {
+  auto source = deserializeSingleSource(obj, context);
+  auto functionName = obj["functionName"].asString();
+  auto resultType = ISerializable::deserialize<Type>(obj["resultType"]);
+
+  // Deserialize argument columns.
+  std::vector<std::string> argumentColumns;
+  if (obj.count("argumentColumns")) {
+    for (const auto& col : obj["argumentColumns"]) {
+      argumentColumns.push_back(col.asString());
+    }
+  }
+
+  // Deserialize argument types.
+  auto argumentTypes =
+      ISerializable::deserialize<std::vector<Type>>(obj["argumentTypes"]);
+
+  // Deserialize constant inputs from ConstantTypedExpr.
+  std::vector<VectorPtr> constantInputs;
+  if (obj.count("constantInputs")) {
+    for (const auto& item : obj["constantInputs"]) {
+      if (item.isNull()) {
+        constantInputs.push_back(nullptr);
+      } else {
+        auto constExpr = std::dynamic_pointer_cast<const ConstantTypedExpr>(
+            ISerializable::deserialize<ITypedExpr>(item, context));
+        VELOX_CHECK_NOT_NULL(
+            constExpr, "Expected ConstantTypedExpr for constant input");
+        auto* pool = static_cast<memory::MemoryPool*>(context);
+        constantInputs.push_back(constExpr->toConstantVector(pool));
+      }
+    }
+  }
+
+  auto outputColumn = obj["outputColumn"].asString();
+
+  // Deserialize explicit output type.
+  RowTypePtr outputType;
+  if (obj.count("outputType")) {
+    outputType = std::dynamic_pointer_cast<const RowType>(
+        ISerializable::deserialize<Type>(obj["outputType"]));
+  } else {
+    // Backward compat: derive from source + result column.
+    std::vector<std::string> names;
+    std::vector<TypePtr> types;
+    if (source) {
+      auto sourceType = source->outputType();
+      for (int32_t i = 0; i < sourceType->size(); ++i) {
+        names.emplace_back(sourceType->nameOf(i));
+        types.push_back(sourceType->childAt(i));
+      }
+    }
+    names.push_back(outputColumn);
+    types.push_back(resultType);
+    outputType = ROW(std::move(names), std::move(types));
+  }
+
+  auto streamingMode = obj["streamingMode"].asString() == "BATCH"
+      ? rpc::RPCStreamingMode::kBatch
+      : rpc::RPCStreamingMode::kPerRow;
+  auto dispatchBatchSize =
+      static_cast<int32_t>(obj["dispatchBatchSize"].asInt());
+  return std::make_shared<RPCNode>(
+      deserializePlanNodeId(obj),
+      std::move(source),
+      std::move(functionName),
+      std::move(resultType),
+      std::move(outputColumn),
+      std::move(outputType),
+      std::move(argumentColumns),
+      std::move(argumentTypes),
+      std::move(constantInputs),
+      streamingMode,
+      dispatchBatchSize);
 }
 
 } // namespace facebook::velox::core

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "velox/common/Enums.h"
+#include "velox/common/rpc/RPCTypes.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
@@ -6193,6 +6194,126 @@ class PlanNodeVisitor {
     }
   }
 };
+
+/// Plan node for async RPC execution (e.g., LLM inference, embeddings).
+///
+/// Stores the function name, result type, argument columns, and streaming
+/// mode. The RPCNode does NOT evaluate argument expressions — a ProjectNode
+/// inserted before this node by the plan rewriter computes argument columns.
+///
+/// Architecture:
+///   SQL: SELECT rpc_function(col1, 'model_name') FROM table
+///            |
+///            v (Plan Rewriter)
+///     ProjectNode (__rpc_arg_0 = col1, __rpc_arg_1 = 'model_name')
+///           |
+///        RPCNode (argumentColumns = [__rpc_arg_0, __rpc_arg_1])
+///           |
+///       source[0]
+///           |
+///       TableScan
+class RPCNode : public PlanNode {
+ public:
+  /// @param id Unique identifier for this plan node.
+  /// @param source Data source (the only source).
+  /// @param functionName Name of the registered AsyncRPCFunction.
+  /// @param functionResultType Velox type of the RPC result column.
+  /// @param outputColumn Name of the output column for RPC responses.
+  /// @param outputType Explicit output type. Must contain outputColumn
+  ///        and any passthrough source columns needed by downstream.
+  ///        Specified explicitly (like AbstractJoinNode) to support column
+  ///        pruning.
+  /// @param argumentColumns Names of input columns containing pre-evaluated
+  ///        argument values. RPCOperator reads these columns in addInput().
+  /// @param argumentTypes Types of each argument (aligned with
+  ///        argumentColumns). Passed to AsyncRPCFunction::initialize().
+  /// @param constantInputs Constant argument values (aligned with
+  ///        argumentColumns). nullptr for non-constant args, single-element
+  ///        ConstantVectors for constant args. Passed to initialize().
+  /// @param streamingMode The streaming mode for RPC execution.
+  /// @param dispatchBatchSize For BATCH mode pipelining: fire callBatch()
+  ///        every N rows during addInput() instead of collecting all rows.
+  RPCNode(
+      const PlanNodeId& id,
+      PlanNodePtr source,
+      std::string functionName,
+      TypePtr functionResultType,
+      std::string outputColumn,
+      RowTypePtr outputType,
+      std::vector<std::string> argumentColumns,
+      std::vector<TypePtr> argumentTypes,
+      std::vector<VectorPtr> constantInputs,
+      rpc::RPCStreamingMode streamingMode = rpc::RPCStreamingMode::kPerRow,
+      int32_t dispatchBatchSize = 0);
+
+  const PlanNodePtr& source() const {
+    return sources_[0];
+  }
+
+  const std::string& functionName() const {
+    return functionName_;
+  }
+
+  const TypePtr& rpcResultType() const {
+    return resultType_;
+  }
+
+  const std::string& outputColumn() const {
+    return outputColumn_;
+  }
+
+  const std::vector<std::string>& argumentColumns() const {
+    return argumentColumns_;
+  }
+
+  const std::vector<TypePtr>& argumentTypes() const {
+    return argumentTypes_;
+  }
+
+  const std::vector<VectorPtr>& constantInputs() const {
+    return constantInputs_;
+  }
+
+  rpc::RPCStreamingMode streamingMode() const {
+    return streamingMode_;
+  }
+
+  int32_t dispatchBatchSize() const {
+    return dispatchBatchSize_;
+  }
+
+  std::string_view name() const override {
+    return "RPC";
+  }
+
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  const std::vector<PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  std::vector<PlanNodePtr> sources_;
+  std::string functionName_;
+  TypePtr resultType_;
+  std::string outputColumn_;
+  RowTypePtr outputType_;
+  std::vector<std::string> argumentColumns_;
+  std::vector<TypePtr> argumentTypes_;
+  std::vector<VectorPtr> constantInputs_;
+  rpc::RPCStreamingMode streamingMode_;
+  int32_t dispatchBatchSize_{0};
+};
+
+using RPCNodePtr = std::shared_ptr<RPCNode>;
 
 } // namespace facebook::velox::core
 

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -16,6 +16,7 @@
 #include "velox/core/PlanNode.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
 #include "velox/parse/PlanNodeIdGenerator.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
@@ -585,4 +586,152 @@ TEST_F(PlanNodeTest, aggregationNodeNoGroupsSpanBatches) {
         "-- Aggregation[agg][SINGLE [c0] sum := sum()] -> c0:BIGINT, sum:BIGINT\n");
   }
 }
+TEST_F(PlanNodeTest, rpcNodeSerdePerRowMode) {
+  Type::registerSerDe();
+  core::PlanNode::registerSerDe();
+  core::ITypedExpr::registerSerDe();
+
+  // Create a ValuesNode as the source with a "prompt" column.
+  auto sourceData =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"hello"})});
+  auto valuesNode = std::make_shared<core::ValuesNode>(
+      "values-1", std::vector<RowVectorPtr>{sourceData});
+
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-1",
+      valuesNode,
+      "test_function",
+      VARCHAR(),
+      "response",
+      ROW({"prompt", "response"}, {VARCHAR(), VARCHAR()}),
+      std::vector<std::string>{"prompt"},
+      std::vector<TypePtr>{VARCHAR()},
+      std::vector<VectorPtr>{nullptr},
+      rpc::RPCStreamingMode::kPerRow,
+      0);
+
+  // Serialize and deserialize.
+  const auto serialized = rpcNode->serialize();
+  auto copy =
+      ISerializable::deserialize<core::PlanNode>(serialized, pool_.get());
+
+  // Compare detailed string representation.
+  ASSERT_EQ(rpcNode->toString(true, true), copy->toString(true, true));
+
+  // Verify deserialized fields.
+  auto* copyRpc = dynamic_cast<const core::RPCNode*>(copy.get());
+  ASSERT_NE(copyRpc, nullptr);
+  EXPECT_EQ(copyRpc->functionName(), "test_function");
+  EXPECT_EQ(copyRpc->outputColumn(), "response");
+  EXPECT_EQ(copyRpc->streamingMode(), rpc::RPCStreamingMode::kPerRow);
+  EXPECT_EQ(copyRpc->dispatchBatchSize(), 0);
+  EXPECT_EQ(*copyRpc->rpcResultType(), *VARCHAR());
+  EXPECT_EQ(copyRpc->argumentColumns().size(), 1);
+  EXPECT_EQ(copyRpc->argumentColumns()[0], "prompt");
+  EXPECT_EQ(copyRpc->argumentTypes().size(), 1);
+  EXPECT_EQ(*copyRpc->argumentTypes()[0], *VARCHAR());
+}
+
+TEST_F(PlanNodeTest, rpcNodeSerdeBatchMode) {
+  Type::registerSerDe();
+  core::PlanNode::registerSerDe();
+  core::ITypedExpr::registerSerDe();
+
+  auto sourceData = makeRowVector(
+      {"prompt", "model"},
+      {makeFlatVector<StringView>({"hello"}),
+       makeFlatVector<StringView>({"llama"})});
+  auto valuesNode = std::make_shared<core::ValuesNode>(
+      "values-1", std::vector<RowVectorPtr>{sourceData});
+
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-2",
+      valuesNode,
+      "batch_function",
+      VARCHAR(),
+      "result",
+      ROW({"prompt", "model", "result"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
+      std::vector<std::string>{"prompt", "model"},
+      std::vector<TypePtr>{VARCHAR(), VARCHAR()},
+      std::vector<VectorPtr>{nullptr, nullptr},
+      rpc::RPCStreamingMode::kBatch,
+      50);
+
+  const auto serialized = rpcNode->serialize();
+  auto copy =
+      ISerializable::deserialize<core::PlanNode>(serialized, pool_.get());
+
+  ASSERT_EQ(rpcNode->toString(true, true), copy->toString(true, true));
+
+  auto* copyRpc = dynamic_cast<const core::RPCNode*>(copy.get());
+  ASSERT_NE(copyRpc, nullptr);
+  EXPECT_EQ(copyRpc->functionName(), "batch_function");
+  EXPECT_EQ(copyRpc->outputColumn(), "result");
+  EXPECT_EQ(copyRpc->streamingMode(), rpc::RPCStreamingMode::kBatch);
+  EXPECT_EQ(copyRpc->dispatchBatchSize(), 50);
+  EXPECT_EQ(copyRpc->argumentColumns().size(), 2);
+  EXPECT_EQ(copyRpc->argumentColumns()[0], "prompt");
+  EXPECT_EQ(copyRpc->argumentColumns()[1], "model");
+}
+
+TEST_F(PlanNodeTest, rpcNodeSerdeWithConstants) {
+  Type::registerSerDe();
+  core::PlanNode::registerSerDe();
+  core::ITypedExpr::registerSerDe();
+
+  auto sourceData =
+      makeRowVector({"prompt"}, {makeFlatVector<StringView>({"hello"})});
+  auto valuesNode = std::make_shared<core::ValuesNode>(
+      "values-1", std::vector<RowVectorPtr>{sourceData});
+
+  // Create constant vectors for model and system_prompt arguments.
+  auto modelConstant = makeConstant("llama3", 1);
+  auto systemPromptConstant = makeConstant("You are helpful.", 1);
+
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-3",
+      valuesNode,
+      "test_function",
+      VARCHAR(),
+      "response",
+      ROW({"prompt", "response"}, {VARCHAR(), VARCHAR()}),
+      std::vector<std::string>{"prompt", "model", "system_prompt"},
+      std::vector<TypePtr>{VARCHAR(), VARCHAR(), VARCHAR()},
+      std::vector<VectorPtr>{nullptr, modelConstant, systemPromptConstant});
+
+  // Verify constants before serde.
+  ASSERT_EQ(rpcNode->constantInputs().size(), 3);
+  EXPECT_EQ(rpcNode->constantInputs()[0], nullptr);
+  EXPECT_NE(rpcNode->constantInputs()[1], nullptr);
+  EXPECT_NE(rpcNode->constantInputs()[2], nullptr);
+
+  // Serialize and deserialize.
+  const auto serialized = rpcNode->serialize();
+  auto copy =
+      ISerializable::deserialize<core::PlanNode>(serialized, pool_.get());
+
+  auto* copyRpc = dynamic_cast<const core::RPCNode*>(copy.get());
+  ASSERT_NE(copyRpc, nullptr);
+  EXPECT_EQ(copyRpc->functionName(), "test_function");
+  EXPECT_EQ(copyRpc->argumentColumns().size(), 3);
+
+  // Verify constants survive the round-trip.
+  ASSERT_EQ(copyRpc->constantInputs().size(), 3);
+  EXPECT_EQ(copyRpc->constantInputs()[0], nullptr);
+  ASSERT_NE(copyRpc->constantInputs()[1], nullptr);
+  ASSERT_NE(copyRpc->constantInputs()[2], nullptr);
+
+  // Verify constant values.
+  auto modelVec = copyRpc->constantInputs()[1];
+  EXPECT_TRUE(modelVec->isConstantEncoding());
+  EXPECT_EQ(
+      modelVec->as<ConstantVector<StringView>>()->valueAt(0).str(), "llama3");
+
+  auto promptVec = copyRpc->constantInputs()[2];
+  EXPECT_TRUE(promptVec->isConstantEncoding());
+  EXPECT_EQ(
+      promptVec->as<ConstantVector<StringView>>()->valueAt(0).str(),
+      "You are helpful.");
+}
+
 } // namespace


### PR DESCRIPTION
Summary:

RPCNode plan node for async RPC execution, living in core/PlanNode.h
alongside other Velox plan nodes.

RPCNode uses name-based function references — storing the function name
and result type rather than a pointer to an AsyncRPCFunction instance.
Function instantiation is deferred to RPCOperator::initialize(),
following Velox's convention where plan nodes are declarative and
operators are imperative.

RPCNode stores: function name, result type, argument expressions,
output column name, streaming mode, and dispatch batch size.
Output type = source columns + one RPC result column.
Single source node (this is a map operation, not a join).

Reviewed By: xiaoxmeng

Differential Revision: D95489253


