### PR TITLE
fix(build): Improve CI dependency download reliability

### DIFF
--- a/CMake/resolve_dependency_modules/geos.cmake
+++ b/CMake/resolve_dependency_modules/geos.cmake
@@ -19,13 +19,13 @@ block()
   set(VELOX_GEOS_BUILD_VERSION 3.10.7)
   set(
     VELOX_GEOS_BUILD_SHA256_CHECKSUM
-    8b2ab4d04d660e27f2006550798f49dd11748c3767455cae9f71967dc437da1f
+    fcde02913159711fd3188afccf9ba78008ecced089d7e6cb6ff9a4bc1eed10a1
   )
   string(
     CONCAT
     VELOX_GEOS_SOURCE_URL
-    "https://download.osgeo.org/geos/"
-    "geos-${VELOX_GEOS_BUILD_VERSION}.tar.bz2"
+    "https://github.com/libgeos/geos/archive/refs/tags/"
+    "${VELOX_GEOS_BUILD_VERSION}.tar.gz"
   )
 
   velox_resolve_dependency_url(GEOS)

--- a/scripts/setup-common.sh
+++ b/scripts/setup-common.sh
@@ -167,7 +167,7 @@ function install_glog {
 }
 
 function install_lzo {
-  wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-"${LZO_VERSION}".tar.gz lzo
+  wget_and_untar https://www.oberhumer.com/opensource/lzo/download/lzo-"${LZO_VERSION}".tar.gz lzo
   (
     cd "${DEPENDENCY_DIR}"/lzo || exit
     ./configure --prefix="${INSTALL_PREFIX}" --enable-shared --disable-static --docdir=/usr/share/doc/lzo-"${LZO_VERSION}"


### PR DESCRIPTION
Summary:
- Switch GEOS download from download.osgeo.org to GitHub mirror.
  The OSGeo host is community-run with no SLA and is currently down,
  breaking the ubuntu-debug CI job which uses BUNDLED dependency
  resolution. The GitHub URL matches what setup-common.sh already uses.
- Fix LZO download URL to use HTTPS instead of HTTP to prevent potential MITM attacks during dependency fetching.

Differential Revision: D96171610


