### PR TITLE
fix: Handle mixed stats/data batches in TableWriteMerge

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1740,18 +1740,19 @@ class TableWriteNode : public PlanNode {
 
 using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;
 
-/// Merges output from multiple TableWrite operators running in parallel
-/// drivers within the same task. Collects fragments, accumulates row counts,
-/// and aggregates column statistics using an embedded ColumnStatsCollector.
+/// Merges output from multiple TableWrite operators. Collects fragments,
+/// accumulates row counts, and aggregates column statistics using an
+/// embedded ColumnStatsCollector.
 ///
-/// Input rows are classified using the same multiplexed format as
-/// TableWriteNode output (see TableWriteTraits):
+/// Input rows are classified per-row using TableWriteTraits::isStatisticsRow
+/// (see TableWriteTraits). Input batches may contain a mix of statistics and
+/// data rows (e.g. when receiving batched output from an exchange):
 ///   - Statistics rows (rows=NULL, fragments=NULL): routed to the stats
 ///     collector for aggregation.
 ///   - Data rows (rows or fragments non-NULL): row counts are accumulated,
 ///     fragments are buffered, and commit context is validated for
-///     consistency (all inputs must share the same taskId and commit
-///     strategy).
+///     consistency (all inputs must share the same commit strategy;
+///     taskId may differ in cross-worker merge).
 ///
 /// Output follows the same three-phase protocol as TableWriteNode:
 ///   1. Fragment rows (emitted first, to free memory).
@@ -1763,10 +1764,8 @@ using TableWriteNodePtr = std::shared_ptr<const TableWriteNode>;
 ///     further merging downstream).
 ///   - kFinal: reads partial state, produces final scalar values.
 ///
-/// Designed for single-task, multi-driver merge. Assumes all input comes
-/// from drivers within the same task (same commit context). Not designed
-/// for cross-task merge (e.g. merging output from multiple workers via an
-/// exchange) — use a separate operator for that.
+/// Supports both single-task multi-driver merge (via LocalGather) and
+/// cross-task merge (via Exchange from multiple workers).
 class TableWriteMergeNode : public PlanNode {
  public:
   /// @param id Plan node ID.

--- a/velox/core/TableWriteTraits.cpp
+++ b/velox/core/TableWriteTraits.cpp
@@ -106,10 +106,12 @@ RowTypePtr TableWriteTraits::outputType(
   return kOutputTypeWithoutStats->unionWith(columnStatsSpec->outputType());
 }
 
-bool TableWriteTraits::isStatisticsRow(const RowVectorPtr& output) {
-  VELOX_CHECK_GT(output->size(), 0);
-  return output->childAt(kRowCountChannel)->isNullAt(0) &&
-      output->childAt(kFragmentChannel)->isNullAt(0);
+bool TableWriteTraits::isStatisticsRow(
+    const RowVectorPtr& output,
+    vector_size_t index) {
+  VELOX_DCHECK_LT(index, output->size());
+  return output->childAt(kRowCountChannel)->isNullAt(index) &&
+      output->childAt(kFragmentChannel)->isNullAt(index);
 }
 
 folly::dynamic TableWriteTraits::getTableCommitContext(
@@ -123,8 +125,8 @@ folly::dynamic TableWriteTraits::getTableCommitContext(
 
 int64_t TableWriteTraits::getRowCount(const RowVectorPtr& output) {
   VELOX_CHECK_GT(output->size(), 0);
-  auto rowCountVector =
-      output->childAt(kRowCountChannel)->asFlatVector<int64_t>();
+  auto* rowCountVector =
+      output->childAt(kRowCountChannel)->as<SimpleVector<int64_t>>();
   VELOX_CHECK_NOT_NULL(rowCountVector);
   int64_t rowCount{0};
   for (int i = 0; i < output->size(); ++i) {

--- a/velox/core/TableWriteTraits.h
+++ b/velox/core/TableWriteTraits.h
@@ -84,10 +84,12 @@ class TableWriteTraits {
   static RowTypePtr outputType(
       const std::optional<core::ColumnStatsSpec>& columnStatsSpec);
 
-  /// Returns true if 'output' is a statistics row (both row count and
-  /// fragment channels are NULL). Statistics rows carry aggregated
+  /// Returns true if row 'index' in 'output' is a statistics row (both row
+  /// count and fragment channels are NULL). Statistics rows carry aggregated
   /// per-column stats; data rows carry row counts and/or file fragments.
-  static bool isStatisticsRow(const RowVectorPtr& output);
+  static bool isStatisticsRow(
+      const RowVectorPtr& output,
+      vector_size_t index = 0);
 
   /// Returns the parsed commit context from table writer 'output'.
   static folly::dynamic getTableCommitContext(const RowVectorPtr& output);

--- a/velox/exec/ColumnStatsCollector.cpp
+++ b/velox/exec/ColumnStatsCollector.cpp
@@ -159,7 +159,6 @@ void ColumnStatsCollector::addInput(RowVectorPtr input) {
     return;
   }
 
-  // Add input to the grouping set
   groupingSet_->addInput(input, /*mayPushdown=*/false);
 }
 

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -357,6 +357,11 @@ uint32_t maxDrivers(
       if (join->isRightSemiProjectJoin() && join->isNullAware()) {
         return 1;
       }
+    } else if (std::dynamic_pointer_cast<const core::TableWriteMergeNode>(
+                   node)) {
+      // TableWriteMerge accumulates state (row counts, fragments, stats)
+      // and produces a single summary row. Must run single-threaded.
+      return 1;
     } else if (
         auto tableWrite =
             std::dynamic_pointer_cast<const core::TableWriteNode>(node)) {

--- a/velox/exec/TableWriteMerge.cpp
+++ b/velox/exec/TableWriteMerge.cpp
@@ -20,21 +20,6 @@
 #include "velox/exec/TableWriter.h"
 
 namespace facebook::velox::exec {
-namespace {
-
-bool containsNonNullRows(const VectorPtr& vector) {
-  if (!vector->mayHaveNulls()) {
-    return true;
-  }
-  for (int i = 0; i < vector->size(); ++i) {
-    if (!vector->isNullAt(i)) {
-      return true;
-    }
-  }
-  return false;
-}
-
-} // namespace
 
 TableWriteMerge::TableWriteMerge(
     int32_t operatorId,
@@ -69,26 +54,69 @@ void TableWriteMerge::initialize() {
   }
 }
 
+namespace {
+// Creates a RowVector containing only the rows at the given indices from
+// 'input'. Each child vector is wrapped in a dictionary to avoid copying.
+RowVectorPtr
+selectRows(const RowVectorPtr& input, BufferPtr indices, vector_size_t size) {
+  std::vector<VectorPtr> children(input->childrenSize());
+  for (auto i = 0; i < input->childrenSize(); ++i) {
+    children[i] =
+        BaseVector::wrapInDictionary(nullptr, indices, size, input->childAt(i));
+  }
+  return std::make_shared<RowVector>(
+      input->pool(), input->type(), nullptr, size, std::move(children));
+}
+} // namespace
+
 void TableWriteMerge::addInput(RowVectorPtr input) {
   VELOX_CHECK(!noMoreInput_);
   VELOX_CHECK_GT(input->size(), 0);
 
-  if (TableWriteTraits::isStatisticsRow(input)) {
-    VELOX_CHECK_NOT_NULL(statsCollector_);
-    statsCollector_->addInput(input);
-    return;
+  // Possibly mixed batch: split into stats and data using dictionary wrapping.
+  auto statsIndices = allocateIndices(input->size(), pool());
+  auto dataIndices = allocateIndices(input->size(), pool());
+  auto* rawStatsIndices = statsIndices->asMutable<vector_size_t>();
+  auto* rawDataIndices = dataIndices->asMutable<vector_size_t>();
+  vector_size_t numStats{0};
+  vector_size_t numData{0};
+  for (vector_size_t i = 0; i < input->size(); ++i) {
+    if (TableWriteTraits::isStatisticsRow(input, i)) {
+      rawStatsIndices[numStats++] = i;
+    } else {
+      rawDataIndices[numData++] = i;
+    }
   }
 
-  // Increments row count.
+  if (numStats > 0) {
+    if (numData == 0) {
+      addStatisticsInput(input);
+    } else {
+      addStatisticsInput(selectRows(input, statsIndices, numStats));
+    }
+  }
+
+  if (numData > 0) {
+    if (numStats == 0) {
+      addDataInput(input);
+    } else {
+      addDataInput(selectRows(input, dataIndices, numData));
+    }
+  }
+}
+
+void TableWriteMerge::addStatisticsInput(const RowVectorPtr& input) {
+  VELOX_CHECK_NOT_NULL(statsCollector_);
+  statsCollector_->addInput(input);
+}
+
+void TableWriteMerge::addDataInput(const RowVectorPtr& input) {
   numRows_ += TableWriteTraits::getRowCount(input);
 
-  // Validate that all inputs share the same task ID and commit strategy.
+  // Validate commit strategy consistency. TaskId may differ in cross-worker
+  // merge (coordinator merging output from multiple workers).
   auto commitContext = TableWriteTraits::getTableCommitContext(input);
   if (lastCommitContext_ != nullptr) {
-    VELOX_CHECK_EQ(
-        lastCommitContext_[TableWriteTraits::kTaskIdContextKey].asString(),
-        commitContext[TableWriteTraits::kTaskIdContextKey].asString(),
-        "Mismatched taskId in commit context");
     VELOX_CHECK_EQ(
         lastCommitContext_[TableWriteTraits::kCommitStrategyContextKey]
             .asString(),
@@ -97,11 +125,27 @@ void TableWriteMerge::addInput(RowVectorPtr input) {
   }
   lastCommitContext_ = commitContext;
 
-  // Adds fragments to the buffer. Fragments will be emitted as soon as possible
-  // to avoid using extra memory.
+  // Buffer non-null fragments for early emission to free memory. The input
+  // may contain a mix of fragment rows (non-null) and summary rows (null
+  // fragment) when the TableWriter produces them in a single multi-row
+  // output.
   auto fragmentVector = input->childAt(TableWriteTraits::kFragmentChannel);
-  if (containsNonNullRows(fragmentVector)) {
+  if (!fragmentVector->mayHaveNulls()) {
     fragmentVectors_.push(fragmentVector);
+  } else {
+    auto indices = allocateIndices(fragmentVector->size(), pool());
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+    vector_size_t numNonNull{0};
+    for (vector_size_t i = 0; i < fragmentVector->size(); ++i) {
+      if (!fragmentVector->isNullAt(i)) {
+        rawIndices[numNonNull++] = i;
+      }
+    }
+    if (numNonNull > 0) {
+      fragmentVectors_.push(
+          BaseVector::wrapInDictionary(
+              nullptr, indices, numNonNull, fragmentVector));
+    }
   }
 }
 

--- a/velox/exec/TableWriteMerge.h
+++ b/velox/exec/TableWriteMerge.h
@@ -55,6 +55,12 @@ class TableWriteMerge : public Operator {
   void close() override;
 
  private:
+  // Processes a batch of statistics rows.
+  void addStatisticsInput(const RowVectorPtr& input);
+
+  // Processes a batch of data rows (row counts, fragments, commit context).
+  void addDataInput(const RowVectorPtr& input);
+
   // Creates non-last output with fragments and last commit context only.
   RowVectorPtr createFragmentsOutput();
 

--- a/velox/exec/tests/TableWriterTest.cpp
+++ b/velox/exec/tests/TableWriterTest.cpp
@@ -19,11 +19,9 @@
 #include "folly/dynamic.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/common/hyperloglog/SparseHll.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/dwio/common/WriterFactory.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/TableWriter.h"
@@ -45,9 +43,9 @@ using namespace facebook::velox::common::testutil;
 
 constexpr uint64_t kQueryMemoryCapacity = 512 * MB;
 
-class BasicTableWriterTestBase : public HiveConnectorTestBase {};
+class BasicTableWriterTest : public HiveConnectorTestBase {};
 
-TEST_F(BasicTableWriterTestBase, roundTrip) {
+TEST_F(BasicTableWriterTest, roundTrip) {
   vector_size_t size = 1'000;
   auto data = makeRowVector({
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
@@ -106,7 +104,7 @@ TEST_F(BasicTableWriterTestBase, roundTrip) {
 
 // Generates a struct (row), write it as a flap map, and check that it is read
 // back as a map.
-TEST_F(BasicTableWriterTestBase, structAsMap) {
+TEST_F(BasicTableWriterTest, structAsMap) {
   // Input struct type.
   vector_size_t size = 1'000;
   auto data = makeRowVector(
@@ -166,7 +164,7 @@ TEST_F(BasicTableWriterTestBase, structAsMap) {
       .assertResults(expected);
 }
 
-TEST_F(BasicTableWriterTestBase, targetFileName) {
+TEST_F(BasicTableWriterTest, targetFileName) {
   constexpr const char* kFileName = "test.dwrf";
   auto data = makeRowVector({makeFlatVector<int64_t>(10, folly::identity)});
   auto directory = TempDirectoryPath::create();
@@ -2293,6 +2291,301 @@ TEST_P(AllTableWriterTest, columnStatsWithTableWriteMerge) {
       ASSERT_TRUE(fragmentVector->isNullAt(i));
       ASSERT_TRUE(columnStatsVector->isNullAt(i));
     }
+  }
+}
+
+// Verifies TableWriteMerge with kFinal step and multiple drivers.
+// Each driver runs TableWrite(kPartial), LocalGather collects, and
+// TableWriteMerge(kFinal) produces final statistics.
+TEST_F(BasicTableWriterTest, columnStatsWithTableWriteMergeFinal) {
+  auto outputDirectory = TempDirectoryPath::create();
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>(100, folly::identity),
+  });
+
+  // Stats columns: min(c0), max(c0) at channels 3 and 4.
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .tableWrite(
+                      outputDirectory->getPath(),
+                      dwio::common::FileFormat::DWRF,
+                      {"min(c0)", "max(c0)"})
+                  .localGather()
+                  .tableWriteMerge(core::AggregationNode::Step::kFinal)
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan).maxDrivers(4).copyResults(pool());
+  ASSERT_GT(result->size(), 0);
+
+  // Verify the output: expect fragment rows, one stats row with values,
+  // and one summary row with the total row count.
+  auto* rowCountVector = result->childAt(TableWriteTraits::kRowCountChannel)
+                             ->as<SimpleVector<int64_t>>();
+  // Stats columns start at kStatsChannel: min(c0) at +0, max(c0) at +1.
+  auto* minVector = result->childAt(TableWriteTraits::kStatsChannel)
+                        ->as<SimpleVector<int32_t>>();
+  auto* maxVector = result->childAt(TableWriteTraits::kStatsChannel + 1)
+                        ->as<SimpleVector<int32_t>>();
+
+  int32_t numFragments = 0;
+  int32_t numStatsWithValues = 0;
+  int32_t numSummary = 0;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    if (!result->childAt(TableWriteTraits::kFragmentChannel)->isNullAt(i)) {
+      ++numFragments;
+    } else if (!minVector->isNullAt(i)) {
+      ++numStatsWithValues;
+      EXPECT_EQ(0, minVector->valueAt(i));
+      EXPECT_EQ(99, maxVector->valueAt(i));
+    } else if (!rowCountVector->isNullAt(i)) {
+      ++numSummary;
+      EXPECT_EQ(100, rowCountVector->valueAt(i));
+    } else {
+      FAIL() << "Unexpected row " << i << ": " << result->toString(i);
+    }
+  }
+
+  EXPECT_EQ(1, numFragments);
+  EXPECT_EQ(1, numStatsWithValues);
+  EXPECT_EQ(1, numSummary);
+}
+
+// Same as above but with a partition key as grouping key for stats.
+TEST_F(BasicTableWriterTest, columnStatsWithTableWriteMergeFinalPartitioned) {
+  auto outputDirectory = TempDirectoryPath::create();
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>(100, folly::identity),
+      makeFlatVector<int32_t>(100, [](auto row) { return row % 3; }),
+  });
+
+  // Partition by c1, collect min/max on c0 grouped by c1.
+  auto plan = PlanBuilder()
+                  .values({input})
+                  .tableWrite(
+                      outputDirectory->getPath(),
+                      {"c1"},
+                      dwio::common::FileFormat::DWRF,
+                      {"min(c0)", "max(c0)"})
+                  .localGather()
+                  .tableWriteMerge(core::AggregationNode::Step::kFinal)
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan).maxDrivers(4).copyResults(pool());
+  ASSERT_GT(result->size(), 0);
+
+  // With 3 partitions, expect 3 stats rows (one per partition key value).
+  auto* rowCountVector = result->childAt(TableWriteTraits::kRowCountChannel)
+                             ->as<SimpleVector<int64_t>>();
+  // Partition key is at kStatsChannel, stats start at kStatsChannel + 1.
+  auto* partKeyVector = result->childAt(TableWriteTraits::kStatsChannel)
+                            ->as<SimpleVector<int32_t>>();
+  auto* minVector = result->childAt(TableWriteTraits::kStatsChannel + 1)
+                        ->as<SimpleVector<int32_t>>();
+  auto* maxVector = result->childAt(TableWriteTraits::kStatsChannel + 2)
+                        ->as<SimpleVector<int32_t>>();
+
+  // Input: c0 = 0..99, c1 = c0 % 3. Per-partition min/max of c0:
+  //   partition 0: min=0, max=99
+  //   partition 1: min=1, max=97
+  //   partition 2: min=2, max=98
+  std::map<int32_t, std::pair<int32_t, int32_t>> expectedStats = {
+      {0, {0, 99}}, {1, {1, 97}}, {2, {2, 98}}};
+
+  int32_t numFragments = 0;
+  int32_t numSummary = 0;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    if (!result->childAt(TableWriteTraits::kFragmentChannel)->isNullAt(i)) {
+      ++numFragments;
+    } else if (!minVector->isNullAt(i)) {
+      ASSERT_FALSE(partKeyVector->isNullAt(i));
+      auto partKey = partKeyVector->valueAt(i);
+      auto it = expectedStats.find(partKey);
+      ASSERT_NE(it, expectedStats.end())
+          << "Unexpected or duplicate stats key: " << partKey;
+      EXPECT_EQ(it->second.first, minVector->valueAt(i));
+      EXPECT_EQ(it->second.second, maxVector->valueAt(i));
+      expectedStats.erase(it);
+    } else if (!rowCountVector->isNullAt(i)) {
+      ++numSummary;
+      EXPECT_EQ(100, rowCountVector->valueAt(i));
+    } else {
+      FAIL() << "Unexpected row " << i << ": " << result->toString(i);
+    }
+  }
+
+  EXPECT_EQ(3, numFragments);
+  EXPECT_TRUE(expectedStats.empty())
+      << "Missing stats: " << expectedStats.size();
+  EXPECT_EQ(1, numSummary);
+}
+
+// Extracts file paths from a fragment JSON object.
+std::vector<std::string> extractFragmentFiles(const folly::dynamic& fragment) {
+  std::vector<std::string> files;
+  auto targetPath = fragment["targetPath"].asString();
+  for (const auto& fileInfo : fragment["fileWriteInfos"]) {
+    files.push_back(
+        fmt::format(
+            "{}/{}", targetPath, fileInfo["targetFileName"].asString()));
+  }
+  return files;
+}
+
+// Builds a kFinal ColumnStatsSpec from a worker plan's kIntermediate spec.
+// The input type is used to resolve aggregate input column references.
+core::ColumnStatsSpec makeFinalStatsSpec(
+    const core::PlanNodePtr& workerPlan,
+    const RowType& inputType) {
+  auto mergeNode =
+      std::dynamic_pointer_cast<const core::TableWriteMergeNode>(workerPlan);
+  VELOX_CHECK_NOT_NULL(mergeNode);
+  VELOX_CHECK(mergeNode->hasColumnStatsSpec());
+
+  auto spec = mergeNode->columnStatsSpec().value();
+  spec.aggregationStep = core::AggregationNode::Step::kFinal;
+  for (size_t i = 0; i < spec.aggregates.size(); ++i) {
+    auto& aggregate = spec.aggregates[i];
+    const auto& name = spec.aggregateNames[i];
+    aggregate.call = std::make_shared<core::CallTypedExpr>(
+        aggregate.call->type(),
+        aggregate.call->name(),
+        std::make_shared<core::FieldAccessTypedExpr>(
+            inputType.findChild(name), name));
+  }
+  return spec;
+}
+
+// Simulates multi-node table write stats merging:
+// 1. Runs worker plan twice on different inputs (simulating 2 workers):
+//    Values → RoundRobinPartition → TableWrite(kPartial) → LocalGather →
+//    TableWriteMerge(kIntermediate)
+// 2. Collects all worker outputs and feeds them to a coordinator plan:
+//    Values(allWorkerOutputs) → TableWriteMerge(kFinal)
+// This tests mixed stats/data batches, cross-worker merge with different
+// taskIds, and dictionary-encoded input handling.
+TEST_F(BasicTableWriterTest, columnStatsWithTwoStageMerge) {
+  // Run worker plan on 2 different inputs (simulating 2 workers).
+  // Worker 1: c0 = 0..49, Worker 2: c0 = 50..99.
+  std::vector<RowVectorPtr> workerInputs = {
+      makeRowVector({makeFlatVector<int32_t>(50, folly::identity)}),
+      makeRowVector(
+          {makeFlatVector<int32_t>(50, [](auto row) { return row + 50; })}),
+  };
+
+  core::PlanNodePtr workerPlan;
+  std::vector<RowVectorPtr> allWorkerOutputs;
+  std::vector<std::shared_ptr<TempDirectoryPath>> outputDirectories;
+  for (const auto& input : workerInputs) {
+    // Each worker writes to a separate directory.
+    auto outputDirectory = TempDirectoryPath::create();
+    outputDirectories.push_back(outputDirectory);
+    workerPlan = PlanBuilder()
+                     .values(split(input, 4))
+                     .localPartitionRoundRobin()
+                     .tableWrite(
+                         outputDirectory->getPath(),
+                         dwio::common::FileFormat::DWRF,
+                         {"min(c0)", "max(c0)"})
+                     .localGather()
+                     .tableWriteMerge()
+                     .planNode();
+
+    auto workerResult =
+        AssertQueryBuilder(workerPlan).maxDrivers(4).copyResults(pool());
+    ASSERT_GT(workerResult->size(), 0);
+    allWorkerOutputs.push_back(workerResult);
+  }
+
+  // Count fragment rows from worker outputs to know expected total.
+  int32_t expectedFragments = 0;
+  for (const auto& output : allWorkerOutputs) {
+    for (vector_size_t i = 0; i < output->size(); ++i) {
+      if (!output->childAt(TableWriteTraits::kFragmentChannel)->isNullAt(i)) {
+        ++expectedFragments;
+      }
+    }
+  }
+  ASSERT_GE(expectedFragments, 2);
+
+  auto verifyCoordinatorResult = [&](const RowVectorPtr& result) {
+    ASSERT_GT(result->size(), 0);
+
+    auto* rowCountVector = result->childAt(TableWriteTraits::kRowCountChannel)
+                               ->as<SimpleVector<int64_t>>();
+    auto* minVector = result->childAt(TableWriteTraits::kStatsChannel)
+                          ->as<SimpleVector<int32_t>>();
+    auto* maxVector = result->childAt(TableWriteTraits::kStatsChannel + 1)
+                          ->as<SimpleVector<int32_t>>();
+
+    auto* fragmentVector = result->childAt(TableWriteTraits::kFragmentChannel)
+                               ->as<SimpleVector<StringView>>();
+
+    int32_t numStatsWithValues = 0;
+    int32_t numSummary = 0;
+    int64_t totalFragmentRows = 0;
+    std::set<std::string> fragmentFiles;
+    for (vector_size_t i = 0; i < result->size(); ++i) {
+      if (!fragmentVector->isNullAt(i)) {
+        auto fragment =
+            folly::parseJson(std::string(fragmentVector->valueAt(i)));
+        totalFragmentRows += fragment["rowCount"].asInt();
+        for (const auto& file : extractFragmentFiles(fragment)) {
+          EXPECT_TRUE(fragmentFiles.insert(file).second)
+              << "Duplicate fragment file: " << file;
+        }
+      } else if (!minVector->isNullAt(i)) {
+        ++numStatsWithValues;
+        EXPECT_EQ(0, minVector->valueAt(i));
+        EXPECT_EQ(99, maxVector->valueAt(i));
+      } else if (!rowCountVector->isNullAt(i)) {
+        ++numSummary;
+        EXPECT_EQ(100, rowCountVector->valueAt(i));
+      } else {
+        FAIL() << "Unexpected row " << i << ": " << result->toString(i);
+      }
+    }
+
+    // Verify fragment files match what's on disk.
+    std::set<std::string> diskFiles;
+    for (const auto& dir : outputDirectories) {
+      for (const auto& entry :
+           std::filesystem::directory_iterator(dir->getPath())) {
+        if (entry.is_regular_file()) {
+          diskFiles.insert(entry.path().string());
+        }
+      }
+    }
+    EXPECT_EQ(fragmentFiles, diskFiles);
+    EXPECT_EQ(100, totalFragmentRows);
+    EXPECT_EQ(1, numStatsWithValues);
+    EXPECT_EQ(1, numSummary);
+  };
+
+  auto spec = makeFinalStatsSpec(workerPlan, *allWorkerOutputs[0]->rowType());
+
+  auto runCoordinator = [&](const std::vector<RowVectorPtr>& input) {
+    auto plan = PlanBuilder().values(input).tableWriteMerge(spec).planNode();
+    verifyCoordinatorResult(
+        AssertQueryBuilder(plan).maxDrivers(1).copyResults(pool()));
+  };
+
+  // Run coordinator on worker outputs in order.
+  runCoordinator(allWorkerOutputs);
+
+  // Run coordinator on reversed worker outputs (worker 2 first).
+  {
+    auto reversed = allWorkerOutputs;
+    std::reverse(reversed.begin(), reversed.end());
+    runCoordinator(reversed);
+  }
+
+  // Run coordinator on split and interleaved worker outputs. Splits each
+  // worker output into 2 vectors, creating mixed batches with both stats
+  // and data rows.
+  {
+    auto parts1 = split(allWorkerOutputs[0], 2);
+    auto parts2 = split(allWorkerOutputs[1], 2);
+    runCoordinator({parts2[0], parts1[0], parts1[1], parts2[1]});
   }
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -839,51 +839,56 @@ const core::TableWriteNodePtr findTableWrite(const core::PlanNodePtr planNode) {
 }
 } // namespace
 
-PlanBuilder& PlanBuilder::tableWriteMerge() {
+PlanBuilder& PlanBuilder::tableWriteMerge(core::AggregationNode::Step step) {
   VELOX_CHECK_NOT_NULL(planNode_, "TableWriteMerge cannot be the source node");
   auto writer = findTableWrite(planNode_);
   VELOX_CHECK_NOT_NULL(
-      writer, "TableWriteMerge can only be added after TableWrite node");
+      writer, "TableWriteMerge requires a TableWrite node in the plan tree");
 
   std::optional<core::ColumnStatsSpec> columnStatsSpec;
   if (writer->hasColumnStatsSpec()) {
-    const auto writerSpec = writer->columnStatsSpec().value();
-    VELOX_CHECK_EQ(
-        writerSpec.aggregationStep, core::AggregationNode::Step::kPartial);
-    std::vector<std::vector<TypePtr>> aggregateRawInputs;
-    const auto numAggregates = writerSpec.aggregates.size();
-    aggregateRawInputs.reserve(numAggregates);
-    for (const auto& aggregate : writerSpec.aggregates) {
-      aggregateRawInputs.push_back(aggregate.rawInputTypes);
-    }
+    const auto& writerSpec = writer->columnStatsSpec().value();
     const auto& inputType = planNode_->outputType();
+    const auto numAggregates = writerSpec.aggregates.size();
 
     std::vector<std::string> aggregateNames;
     aggregateNames.reserve(numAggregates);
     std::vector<core::AggregationNode::Aggregate> aggregates;
     aggregates.reserve(numAggregates);
-    for (int i = 0; i < numAggregates; ++i) {
-      core::AggregationNode::Aggregate aggregate = writerSpec.aggregates[i];
+    for (size_t i = 0; i < numAggregates; ++i) {
+      auto aggregate = writerSpec.aggregates[i];
       aggregate.call = std::make_shared<core::CallTypedExpr>(
           aggregate.call->type(),
           aggregate.call->name(),
           field(inputType, writerSpec.aggregateNames[i]));
       aggregates.push_back(std::move(aggregate));
-      aggregateNames.push_back(fmt::format("a{}", i));
+      aggregateNames.push_back(writerSpec.aggregateNames[i]);
     }
     columnStatsSpec = core::ColumnStatsSpec{
         writerSpec.groupingKeys,
-        core::AggregationNode::Step::kIntermediate,
+        step,
         std::move(aggregateNames),
         std::move(aggregates)};
   }
 
+  auto outputType = TableWriteTraits::outputType(columnStatsSpec);
   planNode_ = std::make_shared<core::TableWriteMergeNode>(
       nextPlanNodeId(),
-      TableWriteTraits::outputType(columnStatsSpec),
-      columnStatsSpec,
+      std::move(outputType),
+      std::move(columnStatsSpec),
       planNode_);
-  VELOX_CHECK(!planNode_->supportsBarrier());
+  return *this;
+}
+
+PlanBuilder& PlanBuilder::tableWriteMerge(
+    core::ColumnStatsSpec columnStatsSpec) {
+  VELOX_CHECK_NOT_NULL(planNode_, "TableWriteMerge cannot be the source node");
+  auto outputType = TableWriteTraits::outputType(columnStatsSpec);
+  planNode_ = std::make_shared<core::TableWriteMergeNode>(
+      nextPlanNodeId(),
+      std::move(outputType),
+      std::move(columnStatsSpec),
+      planNode_);
   return *this;
 }
 
@@ -1547,6 +1552,10 @@ PlanBuilder& PlanBuilder::localPartition(const std::vector<std::string>& keys) {
       pool_);
   VELOX_CHECK(planNode_->supportsBarrier());
   return *this;
+}
+
+PlanBuilder& PlanBuilder::localGather() {
+  return localPartition(std::vector<std::string>{});
 }
 
 PlanBuilder& PlanBuilder::scaleWriterlocalPartition(

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -893,8 +893,18 @@ class PlanBuilder {
           connector::CommitStrategy::kNoCommit,
       std::shared_ptr<core::InsertTableHandle> insertTableHandle = nullptr);
 
-  /// Add a TableWriteMergeNode.
-  PlanBuilder& tableWriteMerge();
+  /// Add a TableWriteMergeNode. Derives the ColumnStatsSpec from the
+  /// TableWriteNode in the plan tree and applies the given step.
+  /// Finds the TableWriteNode through LocalPartitionNode if present.
+  /// @param step Must be kIntermediate or kFinal. Defaults to kIntermediate.
+  PlanBuilder& tableWriteMerge(
+      core::AggregationNode::Step step =
+          core::AggregationNode::Step::kIntermediate);
+
+  /// Add a TableWriteMergeNode with an explicit ColumnStatsSpec. Use for
+  /// coordinator-side merge where the TableWriteNode is in a different
+  /// fragment (e.g. after an Exchange).
+  PlanBuilder& tableWriteMerge(core::ColumnStatsSpec columnStatsSpec);
 
   /// Add an AggregationNode representing partial aggregation with the
   /// specified grouping keys, aggregates and optional masks.
@@ -1301,6 +1311,9 @@ class PlanBuilder {
   /// A convenience method to add a LocalPartitionNode with a single source (the
   /// current plan node).
   PlanBuilder& localPartition(const std::vector<std::string>& keys);
+
+  /// Add a LocalPartitionNode with gather type (N-to-1, empty partition keys).
+  PlanBuilder& localGather();
 
   /// A convenience method to add a LocalPartitionNode with hive partition
   /// function.


### PR DESCRIPTION
Summary:
TableWriteMerge::addInput classified entire batches based on row 0,
which silently dropped data rows when an exchange batched output from
multiple workers into a single vector. Now classifies each row
individually, splitting mixed batches via dictionary wrapping.
Optimized for the common homogeneous case (from LocalGather).

Enforce single-threaded execution for TableWriteMerge in
LocalPlanner.

Builder::tableWriteMerge(step) overload, localGather()
convenience method, and explicit-spec tableWriteMerge overload.

Differential Revision: D96150991


