### PR TITLE
feat(parquet): Support DELTA_LENGTH_BYTE_ARRAY encoding in parquet reader

### DIFF
--- a/velox/connectors/hive/paimon/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/CMakeLists.txt
@@ -20,24 +20,11 @@ velox_add_library(
   PaimonRowKind.cpp
 )
 
-velox_link_libraries(
-  velox_hive_paimon_split
-  velox_connector
-  velox_hive_connector
-  fmt::fmt
-)
+velox_link_libraries(velox_hive_paimon_split velox_connector velox_hive_connector fmt::fmt)
 
-velox_add_library(
-  velox_hive_paimon_connector
-  PaimonConnector.cpp
-  PaimonDataSource.cpp
-)
+velox_add_library(velox_hive_paimon_connector PaimonConnector.cpp PaimonDataSource.cpp)
 
-velox_link_libraries(
-  velox_hive_paimon_connector
-  velox_hive_paimon_split
-  velox_hive_connector
-)
+velox_link_libraries(velox_hive_paimon_connector velox_hive_paimon_split velox_hive_connector)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/paimon/tests/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/tests/CMakeLists.txt
@@ -24,11 +24,8 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gmock
   )
 
-  add_executable(
-    velox_hive_paimon_data_file_meta_test PaimonDataFileMetaTest.cpp)
-  add_test(
-    velox_hive_paimon_data_file_meta_test
-    velox_hive_paimon_data_file_meta_test)
+  add_executable(velox_hive_paimon_data_file_meta_test PaimonDataFileMetaTest.cpp)
+  add_test(velox_hive_paimon_data_file_meta_test velox_hive_paimon_data_file_meta_test)
 
   target_link_libraries(
     velox_hive_paimon_data_file_meta_test
@@ -38,11 +35,8 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gmock
   )
 
-  add_executable(
-    velox_hive_paimon_deletion_file_test PaimonDeletionFileTest.cpp)
-  add_test(
-    velox_hive_paimon_deletion_file_test
-    velox_hive_paimon_deletion_file_test)
+  add_executable(velox_hive_paimon_deletion_file_test PaimonDeletionFileTest.cpp)
+  add_test(velox_hive_paimon_deletion_file_test velox_hive_paimon_deletion_file_test)
 
   target_link_libraries(
     velox_hive_paimon_deletion_file_test
@@ -52,11 +46,8 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     GTest::gmock
   )
 
-  add_executable(
-    velox_hive_paimon_row_kind_test PaimonRowKindTest.cpp)
-  add_test(
-    velox_hive_paimon_row_kind_test
-    velox_hive_paimon_row_kind_test)
+  add_executable(velox_hive_paimon_row_kind_test PaimonRowKindTest.cpp)
+  add_test(velox_hive_paimon_row_kind_test velox_hive_paimon_row_kind_test)
 
   target_link_libraries(
     velox_hive_paimon_row_kind_test

--- a/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
@@ -38,6 +38,55 @@ class DeltaLengthByteArrayDecoder {
     return std::string_view(bufferStart_ - length, length);
   }
 
+  void skip(uint64_t numValues) {
+    skip<false>(numValues, 0, nullptr);
+  }
+
+  template <bool hasNulls>
+  inline void skip(int32_t numValues, int32_t current, const uint64_t* nulls) {
+    if (hasNulls) {
+      numValues = bits::countNonNulls(nulls, current, current + numValues);
+    }
+    for (int32_t i = 0; i < numValues; ++i) {
+      readString();
+    }
+  }
+
+  template <bool hasNulls, typename Visitor>
+  void readWithVisitor(const uint64_t* nulls, Visitor visitor) {
+    int32_t current = visitor.start();
+    skip<hasNulls>(current, 0, nulls);
+    int32_t toSkip;
+    bool atEnd = false;
+    const bool allowNulls = hasNulls && visitor.allowNulls();
+    for (;;) {
+      if (hasNulls && allowNulls && bits::isBitNull(nulls, current)) {
+        toSkip = visitor.processNull(atEnd);
+      } else {
+        if (hasNulls && !allowNulls) {
+          toSkip = visitor.checkAndSkipNulls(nulls, current, atEnd);
+          if (!Visitor::dense) {
+            skip<false>(toSkip, current, nullptr);
+          }
+          if (atEnd) {
+            return;
+          }
+        }
+
+        // We are at a non-null value on a row to visit.
+        toSkip = visitor.process(readString(), atEnd);
+      }
+      ++current;
+      if (toSkip) {
+        skip<hasNulls>(toSkip, current, nulls);
+        current += toSkip;
+      }
+      if (atEnd) {
+        return;
+      }
+    }
+  }
+
  private:
   void decodeLengths() {
     int64_t numLength = lengthDecoder_->validValuesCount();

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -782,6 +782,13 @@ void PageReader::makeDecoder() {
         break;
       }
       [[fallthrough]];
+    case Encoding::DELTA_LENGTH_BYTE_ARRAY:
+      if (parquetType == thrift::Type::BYTE_ARRAY) {
+        deltaLengthByteArrDecoder_ =
+            std::make_unique<DeltaLengthByteArrayDecoder>(pageData_);
+        break;
+      }
+      [[fallthrough]];
     default:
       VELOX_UNSUPPORTED("Encoding not supported yet: {}", encoding_);
   }
@@ -824,6 +831,8 @@ void PageReader::skip(int64_t numRows) {
     deltaBpDecoder_->skip(toSkip);
   } else if (deltaByteArrDecoder_) {
     deltaByteArrDecoder_->skip(toSkip);
+  } else if (deltaLengthByteArrDecoder_) {
+    deltaLengthByteArrDecoder_->skip(toSkip);
   } else if (rleBooleanDecoder_) {
     rleBooleanDecoder_->skip(toSkip);
   } else {

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -316,6 +316,9 @@ class PageReader {
       } else if (encoding_ == thrift::Encoding::DELTA_BYTE_ARRAY) {
         nullsFromFastPath = false;
         deltaByteArrDecoder_->readWithVisitor<true>(nulls, visitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+        nullsFromFastPath = false;
+        deltaLengthByteArrDecoder_->readWithVisitor<true>(nulls, visitor);
       } else {
         nullsFromFastPath = false;
         stringDecoder_->readWithVisitor<true>(nulls, visitor);
@@ -326,6 +329,8 @@ class PageReader {
         dictionaryIdDecoder_->readWithVisitor<false>(nullptr, dictVisitor);
       } else if (encoding_ == thrift::Encoding::DELTA_BYTE_ARRAY) {
         deltaByteArrDecoder_->readWithVisitor<false>(nulls, visitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+        deltaLengthByteArrDecoder_->readWithVisitor<false>(nulls, visitor);
       } else {
         stringDecoder_->readWithVisitor<false>(nulls, visitor);
       }
@@ -520,6 +525,7 @@ class PageReader {
   std::unique_ptr<BooleanDecoder> booleanDecoder_;
   std::unique_ptr<DeltaBpDecoder> deltaBpDecoder_;
   std::unique_ptr<DeltaByteArrayDecoder> deltaByteArrDecoder_;
+  std::unique_ptr<DeltaLengthByteArrayDecoder> deltaLengthByteArrDecoder_;
   std::unique_ptr<RleBpDataDecoder> rleBooleanDecoder_;
   // Add decoders for other encodings here.
 };

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -541,6 +541,23 @@ TEST_F(E2EFilterTest, stringDeltaByteArray) {
       20);
 }
 
+TEST_F(E2EFilterTest, stringDeltaLengthByteArray) {
+  options_.enableDictionary = false;
+  options_.encoding =
+      facebook::velox::parquet::arrow::Encoding::kDeltaLengthByteArray;
+
+  testWithTypes(
+      "string_val:string,"
+      "string_val_2:string",
+      [&]() {
+        makeStringUnique("string_val");
+        makeStringUnique("string_val_2");
+      },
+      true,
+      {"string_val", "string_val_2"},
+      20);
+}
+
 TEST_F(E2EFilterTest, dedictionarize) {
   rowsInRowGroup_ = 10'000;
   options_.dictionaryPageSizeLimit = 20'000;


### PR DESCRIPTION
Parquet writer already supports DELTA_LENGTH_BYTE_ARRAY encoding, but the reader threw "Encoding not supported yet" when encountering it. This PR closes the gap.

Add skip() and readWithVisitor() methods to `DeltaLengthByteArrayDecoder` so it can function as a standalone page-level decoder, not just as an internal helper for `DeltaByteArrayDecoder`.
