### PR TITLE
feat: Re-add dot_product UDF with test fix (#16740)

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -314,6 +314,32 @@ Array Functions
         SELECT contains(ARRAY[ARRAY[2, 3]], ARRAY[2, null]); -- failed: contains does not support arrays with elements that are null or contain null
         SELECT contains(ARRAY[ARRAY[2, null]], ARRAY[2, 1]); -- failed: contains does not support arrays with elements that are null or contain null
 
+.. function:: dot_product(array(T), array(T)) -> bigint/double
+
+    Computes the dot product of two arrays. The dot product is the sum of element-wise
+    products of corresponding elements. Both arrays must have the same length.
+    If either array is null, returns null. If arrays have different lengths, throws an error.
+    Null elements in arrays are treated as zero.
+    Returns bigint for integer arrays, double for floating-point arrays.
+    For empty integer arrays, returns 0. For empty floating-point arrays, returns NaN. ::
+
+          SELECT dot_product(ARRAY[1, 2, 3], ARRAY[4, 5, 6]); -- 32 (1*4 + 2*5 + 3*6)
+          SELECT dot_product(ARRAY[1.0, 2.0], ARRAY[3.0, 4.0]); -- 11.0 (1.0*3.0 + 2.0*4.0)
+          SELECT dot_product(ARRAY[1, NULL, 3], ARRAY[4, 5, 6]); -- 22 (1*4 + 0*5 + 3*6)
+          SELECT dot_product(ARRAY[], ARRAY[]); -- 0 for integer arrays, NaN for floating-point arrays
+          SELECT dot_product(NULL, ARRAY[1, 2, 3]); -- NULL
+
+.. function:: dot_product(map(K, V), map(K, V)) -> bigint/double
+
+    Computes the dot product of two maps. For maps, the dot product is computed by
+    multiplying values with matching keys and summing the results. Keys present in only
+    one map contribute zero to the result. If either map is null, returns null.
+    Null values in maps are treated as zero.
+    Returns bigint for integer value maps, double for floating-point value maps. ::
+
+          SELECT dot_product(MAP(ARRAY[1, 2], ARRAY[10, 20]), MAP(ARRAY[1, 2], ARRAY[3, 4])); -- 110 (10*3 + 20*4)
+          SELECT dot_product(MAP(ARRAY['a', 'b'], ARRAY[1.0, 2.0]), MAP(ARRAY['a', 'c'], ARRAY[3.0, 4.0])); -- 3.0 (only 'a' matches)
+
 .. function:: element_at(array(E), index) -> E
 
     Returns element of ``array`` at given ``index``.

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -306,6 +306,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "array_subset", // Velox-only function, not available in Presto
     "map_values_in_range", // Velox-only function, not available in Presto
     "transform_with_index", // Velox-only function, not available in Presto
+    "dot_product", // Velox-only function, not available in Presto
     "remap_keys", // Velox-only function, not available in Presto
     "map_intersect", // Velox-only function, not available in Presto
     "map_keys_overlap", // Velox-only function, not available in Presto

--- a/velox/functions/prestosql/DotProduct.h
+++ b/velox/functions/prestosql/DotProduct.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include <folly/CPortability.h>
+#include <folly/container/F14Map.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/lib/CheckedArithmetic.h"
+#include "velox/type/SimpleFunctionApi.h"
+
+namespace facebook::velox::functions {
+
+/// Computes the dot product of two arrays.
+/// The dot product is the sum of element-wise products of corresponding
+/// elements. Both arrays must have the same length. If either array is null,
+/// returns null. If arrays have different lengths, throws an error.
+/// Null elements in arrays are treated as zero.
+/// NaN values propagate through the computation (IEEE 754 behavior).
+template <typename TExec, typename T>
+struct DotProductFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename TOutput>
+  FOLLY_ALWAYS_INLINE void call(
+      TOutput& out,
+      const arg_type<Array<T>>& array1,
+      const arg_type<Array<T>>& array2) {
+    const auto size1 = array1.size();
+    const auto size2 = array2.size();
+
+    VELOX_USER_CHECK_EQ(
+        size1,
+        size2,
+        "dot_product requires arrays of equal length, but got {} and {}",
+        size1,
+        size2);
+
+    TOutput sum = 0;
+    for (vector_size_t i = 0; i < size1; ++i) {
+      const auto& val1 = array1[i];
+      const auto& val2 = array2[i];
+
+      if (val1.has_value() && val2.has_value()) {
+        if constexpr (std::is_same_v<TOutput, int64_t>) {
+          auto product = checkedMultiply<TOutput>(
+              static_cast<TOutput>(val1.value()),
+              static_cast<TOutput>(val2.value()));
+          sum = checkedPlus<TOutput>(sum, product);
+        } else {
+          sum += static_cast<TOutput>(val1.value()) *
+              static_cast<TOutput>(val2.value());
+        }
+      }
+    }
+    out = sum;
+  }
+};
+
+/// Computes the dot product of two maps.
+/// For maps, the dot product is computed by multiplying values with matching
+/// keys and summing the results. Keys present in only one map contribute zero
+/// to the result. If either map is null, returns null.
+/// Null values in maps are treated as zero.
+template <typename TExec, typename K, typename V>
+struct MapDotProductFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExec);
+
+  template <typename TOutput>
+  FOLLY_ALWAYS_INLINE void call(
+      TOutput& out,
+      const arg_type<Map<K, V>>& map1,
+      const arg_type<Map<K, V>>& map2) {
+    TOutput sum = 0;
+
+    // Build a lookup map from the smaller map for O(1) key lookup.
+    // This reduces complexity from O(n*m) to O(n+m).
+    const auto& smallMap = map1.size() <= map2.size() ? map1 : map2;
+    const auto& largeMap = map1.size() <= map2.size() ? map2 : map1;
+
+    folly::F14FastMap<arg_type<K>, arg_type<V>> lookup;
+    lookup.reserve(smallMap.size());
+    for (const auto& [key, val] : smallMap) {
+      if (val.has_value()) {
+        lookup.emplace(key, val.value());
+      }
+    }
+
+    // Iterate through the larger map and look up matching keys.
+    for (const auto& [key, val] : largeMap) {
+      if (!val.has_value()) {
+        continue;
+      }
+
+      auto it = lookup.find(key);
+      if (it != lookup.end()) {
+        if constexpr (std::is_same_v<TOutput, int64_t>) {
+          auto product = checkedMultiply<TOutput>(
+              static_cast<TOutput>(val.value()),
+              static_cast<TOutput>(it->second));
+          sum = checkedPlus<TOutput>(sum, product);
+        } else {
+          sum += static_cast<TOutput>(val.value()) *
+              static_cast<TOutput>(it->second);
+        }
+      }
+    }
+
+    out = sum;
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -26,6 +26,7 @@
 #include "velox/functions/prestosql/ArrayFunctions.h"
 #include "velox/functions/prestosql/ArraySort.h"
 #include "velox/functions/prestosql/ArraySubset.h"
+#include "velox/functions/prestosql/DotProduct.h"
 #include "velox/functions/prestosql/L2Norm.h"
 #include "velox/functions/prestosql/WidthBucketArray.h"
 #include "velox/functions/prestosql/types/JsonRegistration.h"
@@ -448,5 +449,66 @@ void registerArrayFunctions(const std::string& prefix) {
       ParameterBinder<MapL2NormFunction, int64_t, double>,
       double,
       Map<int64_t, double>>({prefix + "l2_norm"});
+
+  // Register dot_product for integer arrays only.
+  // Float and double array versions already exist in
+  // MathematicalFunctionsRegistration.cpp (DotProductArray,
+  // DotProductFloatArray) with different semantics: they return NaN for empty
+  // arrays to maintain compatibility with cosine_similarity and other distance
+  // functions there. Integer versions here return 0 for empty arrays.
+  registerFunction<
+      ParameterBinder<DotProductFunction, int8_t>,
+      int64_t,
+      Array<int8_t>,
+      Array<int8_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<DotProductFunction, int16_t>,
+      int64_t,
+      Array<int16_t>,
+      Array<int16_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<DotProductFunction, int32_t>,
+      int64_t,
+      Array<int32_t>,
+      Array<int32_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<DotProductFunction, int64_t>,
+      int64_t,
+      Array<int64_t>,
+      Array<int64_t>>({prefix + "dot_product"});
+
+  // Register dot_product for maps with integer keys
+  registerFunction<
+      ParameterBinder<MapDotProductFunction, int32_t, int64_t>,
+      int64_t,
+      Map<int32_t, int64_t>,
+      Map<int32_t, int64_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<MapDotProductFunction, int64_t, int64_t>,
+      int64_t,
+      Map<int64_t, int64_t>,
+      Map<int64_t, int64_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<MapDotProductFunction, int32_t, double>,
+      double,
+      Map<int32_t, double>,
+      Map<int32_t, double>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<MapDotProductFunction, int64_t, double>,
+      double,
+      Map<int64_t, double>,
+      Map<int64_t, double>>({prefix + "dot_product"});
+
+  // Register dot_product for maps with varchar keys
+  registerFunction<
+      ParameterBinder<MapDotProductFunction, Varchar, int64_t>,
+      int64_t,
+      Map<Varchar, int64_t>,
+      Map<Varchar, int64_t>>({prefix + "dot_product"});
+  registerFunction<
+      ParameterBinder<MapDotProductFunction, Varchar, double>,
+      double,
+      Map<Varchar, double>,
+      Map<Varchar, double>>({prefix + "dot_product"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -51,6 +51,8 @@ add_executable(
   ArraySumTest.cpp
   ArrayTrimTest.cpp
   ArrayUnionTest.cpp
+  DotProductTest.cpp
+  DotProductFuzzerTest.cpp
   ArgTypesGeneratorTest.cpp
   BinaryFunctionsTest.cpp
   BingTileCastTest.cpp

--- a/velox/functions/prestosql/tests/DotProductFuzzerTest.cpp
+++ b/velox/functions/prestosql/tests/DotProductFuzzerTest.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <vector>
+
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions {
+namespace {
+
+class DotProductFuzzerTest : public test::FunctionBaseTest {
+ protected:
+  // The equivalent SQL expression for dot_product using existing UDFs.
+  // dot_product(array1, array2) is equivalent to:
+  // reduce(zip_with(c0, c1, (x, y) -> coalesce(x, 0) * coalesce(y, 0)),
+  //        CAST(0 AS BIGINT), (s, x) -> s + x, s -> s)
+  //
+  // Note: This only works for integer arrays where the result is BIGINT.
+  static constexpr const char* kEquivalentExpressionBigint =
+      "reduce(zip_with(c0, c1, (x, y) -> coalesce(CAST(x AS BIGINT), CAST(0 AS BIGINT)) * coalesce(CAST(y AS BIGINT), CAST(0 AS BIGINT))), "
+      "CAST(0 AS BIGINT), (s, x) -> s + x, s -> s)";
+
+  static constexpr const char* kEquivalentExpressionDouble =
+      "reduce(zip_with(c0, c1, (x, y) -> coalesce(CAST(x AS DOUBLE), CAST(0.0 AS DOUBLE)) * coalesce(CAST(y AS DOUBLE), CAST(0.0 AS DOUBLE))), "
+      "CAST(0.0 AS DOUBLE), (s, x) -> s + x, s -> s)";
+
+  // Get a SelectivityVector that excludes rows where either input is null.
+  static SelectivityVector getNonNullRows(const RowVectorPtr& data) {
+    auto array1 = data->childAt(0);
+    auto array2 = data->childAt(1);
+    SelectivityVector nonNullRows(data->size());
+
+    for (vector_size_t i = 0; i < data->size(); ++i) {
+      if (array1->isNullAt(i) || array2->isNullAt(i)) {
+        nonNullRows.setValid(i, false);
+      }
+    }
+    nonNullRows.updateBounds();
+    return nonNullRows;
+  }
+
+  // Check if two arrays have the same length at a given row.
+  static bool haveSameLength(
+      const VectorPtr& array1,
+      const VectorPtr& array2,
+      vector_size_t row) {
+    auto arr1 = array1->as<ArrayVector>();
+    auto arr2 = array2->as<ArrayVector>();
+    if (!arr1 || !arr2) {
+      return false;
+    }
+    return arr1->sizeAt(row) == arr2->sizeAt(row);
+  }
+
+  // Test that dot_product result is non-null when inputs are valid
+  // (same length, non-null).
+  void testDotProductProperties(const RowVectorPtr& data) {
+    auto nonNullRows = getNonNullRows(data);
+    if (nonNullRows.countSelected() == 0) {
+      return;
+    }
+
+    VectorPtr result;
+    try {
+      result = evaluate("try(dot_product(c0, c1))", data);
+    } catch (...) {
+      return;
+    }
+
+    if (!result) {
+      return;
+    }
+
+    auto array1 = data->childAt(0);
+    auto array2 = data->childAt(1);
+
+    for (auto i = 0; i < data->size(); ++i) {
+      if (!nonNullRows.isValid(i)) {
+        continue;
+      }
+
+      // If arrays have same length, result should be non-null
+      if (haveSameLength(array1, array2, i)) {
+        // Result can still be null if try() caught an overflow error
+        // so we don't assert non-null here
+      }
+    }
+  }
+
+  // Test equivalence between dot_product and the reduce+zip_with expression
+  // for integer arrays.
+  void testEquivalenceBigint(const RowVectorPtr& data) {
+    auto nonNullRows = getNonNullRows(data);
+    if (nonNullRows.countSelected() == 0) {
+      return;
+    }
+
+    VectorPtr result;
+    VectorPtr expected;
+    try {
+      result = evaluate("try(dot_product(c0, c1))", data);
+      expected =
+          evaluate(fmt::format("try({})", kEquivalentExpressionBigint), data);
+    } catch (...) {
+      return;
+    }
+
+    if (!result || !expected) {
+      return;
+    }
+
+    auto array1 = data->childAt(0);
+    auto array2 = data->childAt(1);
+
+    for (auto i = 0; i < data->size(); ++i) {
+      if (!nonNullRows.isValid(i)) {
+        continue;
+      }
+      // Only compare when arrays have the same length
+      if (haveSameLength(array1, array2, i)) {
+        // Both should be null or both should have same value
+        if (!result->isNullAt(i) && !expected->isNullAt(i)) {
+          ASSERT_TRUE(expected->equalValueAt(result.get(), i, i))
+              << "Mismatch at row " << i << ": expected "
+              << expected->toString(i) << ", got " << result->toString(i);
+        }
+      }
+    }
+  }
+
+  // Test equivalence for double arrays.
+  void testEquivalenceDouble(const RowVectorPtr& data) {
+    auto nonNullRows = getNonNullRows(data);
+    if (nonNullRows.countSelected() == 0) {
+      return;
+    }
+
+    VectorPtr result;
+    VectorPtr expected;
+    try {
+      result = evaluate("try(dot_product(c0, c1))", data);
+      expected =
+          evaluate(fmt::format("try({})", kEquivalentExpressionDouble), data);
+    } catch (...) {
+      return;
+    }
+
+    if (!result || !expected) {
+      return;
+    }
+
+    auto array1 = data->childAt(0);
+    auto array2 = data->childAt(1);
+
+    for (auto i = 0; i < data->size(); ++i) {
+      if (!nonNullRows.isValid(i)) {
+        continue;
+      }
+      if (haveSameLength(array1, array2, i)) {
+        if (!result->isNullAt(i) && !expected->isNullAt(i)) {
+          ASSERT_TRUE(expected->equalValueAt(result.get(), i, i))
+              << "Mismatch at row " << i << ": expected "
+              << expected->toString(i) << ", got " << result->toString(i);
+        }
+      }
+    }
+  }
+
+  // Helper to create fuzzer options with common settings.
+  VectorFuzzer::Options createFuzzerOptions(
+      vector_size_t vectorSize = 100,
+      double nullRatio = 0.1,
+      size_t containerLength = 10) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = vectorSize;
+    opts.nullRatio = nullRatio;
+    opts.containerLength = containerLength;
+    opts.containerVariableLength = true;
+    opts.containerHasNulls = true;
+    return opts;
+  }
+
+  // Helper to run fuzzer test with given type.
+  template <typename T>
+  void runFuzzerTest(
+      const TypePtr& elementType,
+      const VectorFuzzer::Options& opts,
+      bool isFloatingPoint = false) {
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto arrayType = ARRAY(elementType);
+    auto array1 = fuzzer.fuzz(arrayType);
+    auto array2 = fuzzer.fuzz(arrayType);
+    auto data = makeRowVector({array1, array2});
+
+    if (isFloatingPoint) {
+      testEquivalenceDouble(data);
+    } else {
+      testEquivalenceBigint(data);
+    }
+    testDotProductProperties(data);
+  }
+};
+
+TEST_F(DotProductFuzzerTest, fuzzInteger) {
+  auto opts = createFuzzerOptions();
+  runFuzzerTest<int32_t>(INTEGER(), opts);
+}
+
+TEST_F(DotProductFuzzerTest, fuzzBigint) {
+  auto opts = createFuzzerOptions();
+  runFuzzerTest<int64_t>(BIGINT(), opts);
+}
+
+TEST_F(DotProductFuzzerTest, fuzzSmallint) {
+  auto opts = createFuzzerOptions();
+  runFuzzerTest<int16_t>(SMALLINT(), opts);
+}
+
+TEST_F(DotProductFuzzerTest, fuzzTinyint) {
+  auto opts = createFuzzerOptions();
+  runFuzzerTest<int8_t>(TINYINT(), opts);
+}
+
+TEST_F(DotProductFuzzerTest, fuzzHighNullRatio) {
+  auto opts = createFuzzerOptions(100, 0.5, 10);
+  runFuzzerTest<int32_t>(INTEGER(), opts);
+}
+
+TEST_F(DotProductFuzzerTest, fuzzLargeVectors) {
+  auto opts = createFuzzerOptions(500, 0.1, 20);
+  runFuzzerTest<int32_t>(INTEGER(), opts);
+}
+
+TEST_F(DotProductFuzzerTest, fuzzSmallContainers) {
+  auto opts = createFuzzerOptions(100, 0.1, 3);
+  runFuzzerTest<int32_t>(INTEGER(), opts);
+}
+
+// Test with matching array lengths to ensure we test the actual dot product
+// computation more frequently.
+TEST_F(DotProductFuzzerTest, fuzzMatchingLengths) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 100;
+  opts.nullRatio = 0.1;
+  opts.containerLength = 10;
+  opts.containerVariableLength = false; // Fixed length
+  opts.containerHasNulls = true;
+
+  VectorFuzzer fuzzer(opts, pool());
+
+  auto array1 = fuzzer.fuzz(ARRAY(INTEGER()));
+  auto array2 = fuzzer.fuzz(ARRAY(INTEGER()));
+  auto data = makeRowVector({array1, array2});
+
+  testEquivalenceBigint(data);
+  testDotProductProperties(data);
+}
+
+// Stress test with many iterations
+TEST_F(DotProductFuzzerTest, fuzzStressTest) {
+  constexpr int kIterations = 50;
+
+  for (int iter = 0; iter < kIterations; ++iter) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = 50;
+    opts.nullRatio = 0.1;
+    opts.containerLength = 8;
+    opts.containerVariableLength = true;
+    opts.containerHasNulls = true;
+
+    VectorFuzzer fuzzer(opts, pool());
+
+    auto array1 = fuzzer.fuzz(ARRAY(INTEGER()));
+    auto array2 = fuzzer.fuzz(ARRAY(INTEGER()));
+    auto data = makeRowVector({array1, array2});
+
+    testEquivalenceBigint(data);
+  }
+}
+
+// Test map dot product with fuzzer
+TEST_F(DotProductFuzzerTest, fuzzMapIntegerKeys) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 50;
+  opts.nullRatio = 0.1;
+  opts.containerLength = 5;
+  opts.containerVariableLength = true;
+  opts.containerHasNulls = true;
+
+  VectorFuzzer fuzzer(opts, pool());
+
+  auto map1 = fuzzer.fuzz(MAP(INTEGER(), BIGINT()));
+  auto map2 = fuzzer.fuzz(MAP(INTEGER(), BIGINT()));
+  auto data = makeRowVector({map1, map2});
+
+  // Just verify it doesn't crash with random inputs
+  VectorPtr result;
+  try {
+    result = evaluate("try(dot_product(c0, c1))", data);
+    ASSERT_NE(result, nullptr);
+  } catch (const VeloxUserError&) {
+    // Expected for some edge cases
+  }
+}
+
+TEST_F(DotProductFuzzerTest, fuzzMapVarcharKeys) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 50;
+  opts.nullRatio = 0.1;
+  opts.containerLength = 5;
+  opts.containerVariableLength = true;
+  opts.containerHasNulls = true;
+  opts.stringLength = 10;
+  opts.stringVariableLength = true;
+
+  VectorFuzzer fuzzer(opts, pool());
+
+  auto map1 = fuzzer.fuzz(MAP(VARCHAR(), DOUBLE()));
+  auto map2 = fuzzer.fuzz(MAP(VARCHAR(), DOUBLE()));
+  auto data = makeRowVector({map1, map2});
+
+  // Just verify it doesn't crash with random inputs
+  VectorPtr result;
+  try {
+    result = evaluate("try(dot_product(c0, c1))", data);
+    ASSERT_NE(result, nullptr);
+  } catch (const VeloxUserError&) {
+    // Expected for some edge cases
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/DotProductTest.cpp
+++ b/velox/functions/prestosql/tests/DotProductTest.cpp
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <vector>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/type/StringView.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions {
+namespace {
+
+class DotProductTest : public test::FunctionBaseTest {
+ protected:
+  template <typename T>
+  using expected_t = std::conditional_t<std::is_integral_v<T>, int64_t, double>;
+
+  template <typename T>
+  void testDotProduct(
+      const std::vector<std::vector<T>>& array1,
+      const std::vector<std::vector<T>>& array2,
+      const std::vector<std::optional<expected_t<T>>>& expected) {
+    auto inputArray1 = makeArrayVector<T>(array1);
+    auto inputArray2 = makeArrayVector<T>(array2);
+    auto result = evaluate(
+        "dot_product(c0, c1)", makeRowVector({inputArray1, inputArray2}));
+    auto expectedVector = makeNullableFlatVector<expected_t<T>>(expected);
+    assertEqualVectors(expectedVector, result);
+  }
+};
+
+TEST_F(DotProductTest, integerArrays) {
+  testDotProduct<int32_t>(
+      {{1, 2, 3}, {4, 5, 6}},
+      {{4, 5, 6}, {1, 2, 3}},
+      {32, 32}); // 1*4 + 2*5 + 3*6 = 32
+}
+
+TEST_F(DotProductTest, bigintArrays) {
+  testDotProduct<int64_t>(
+      {{1, 2, 3, 4, 5}},
+      {{5, 4, 3, 2, 1}},
+      {35}); // 1*5 + 2*4 + 3*3 + 4*2 + 5*1 = 35
+}
+
+TEST_F(DotProductTest, doubleArrays) {
+  testDotProduct<double>(
+      {{1.5, 2.5, 3.5}},
+      {{2.0, 3.0, 4.0}},
+      {24.5}); // 1.5*2 + 2.5*3 + 3.5*4 = 3 + 7.5 + 14 = 24.5
+}
+
+TEST_F(DotProductTest, emptyArrays) {
+  testDotProduct<int32_t>({{}}, {{}}, {0}); // Empty arrays should return 0
+}
+
+TEST_F(DotProductTest, singleElement) {
+  testDotProduct<int32_t>({{5}}, {{7}}, {35}); // 5*7 = 35
+}
+
+TEST_F(DotProductTest, negativeNumbers) {
+  testDotProduct<int32_t>(
+      {{-1, -2, -3}}, {{4, 5, 6}}, {-32}); // (-1)*4 + (-2)*5 + (-3)*6 = -32
+}
+
+TEST_F(DotProductTest, mixedSigns) {
+  testDotProduct<int32_t>(
+      {{1, -2, 3}},
+      {{-4, 5, -6}},
+      {-32}); // 1*(-4) + (-2)*5 + 3*(-6) = -4 - 10 - 18 = -32
+}
+
+TEST_F(DotProductTest, zeros) {
+  testDotProduct<int32_t>(
+      {{0, 0, 0}}, {{1, 2, 3}}, {0}); // All zeros in one array
+}
+
+TEST_F(DotProductTest, nullElementsInArrays) {
+  // Null elements should be treated as zero
+  auto array1 = makeNullableArrayVector<int32_t>({
+      {1, std::nullopt, 3},
+      {std::nullopt, 2, std::nullopt},
+  });
+  auto array2 = makeNullableArrayVector<int32_t>({
+      {4, 5, 6},
+      {1, 2, 3},
+  });
+
+  auto result =
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2}));
+  // Row 0: 1*4 + 0*5 + 3*6 = 4 + 0 + 18 = 22
+  // Row 1: 0*1 + 2*2 + 0*3 = 0 + 4 + 0 = 4
+  auto expected = makeFlatVector<int64_t>({22, 4});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(DotProductTest, nullArguments) {
+  // Test when either argument is null
+  auto array = makeArrayVector<int32_t>({{1, 2, 3}});
+  auto nullArray = BaseVector::createNullConstant(ARRAY(INTEGER()), 1, pool());
+
+  // Test null first array
+  auto result1 =
+      evaluate("dot_product(c0, c1)", makeRowVector({nullArray, array}));
+  auto expected1 = BaseVector::createNullConstant(BIGINT(), 1, pool());
+  assertEqualVectors(expected1, result1);
+
+  // Test null second array
+  auto result2 =
+      evaluate("dot_product(c0, c1)", makeRowVector({array, nullArray}));
+  auto expected2 = BaseVector::createNullConstant(BIGINT(), 1, pool());
+  assertEqualVectors(expected2, result2);
+}
+
+TEST_F(DotProductTest, mismatchedLengthsThrows) {
+  auto array1 = makeArrayVector<int32_t>({{1, 2, 3}});
+  auto array2 = makeArrayVector<int32_t>({{1, 2}}); // Different length
+
+  VELOX_ASSERT_THROW(
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2})),
+      "dot_product requires arrays of equal length");
+}
+
+TEST_F(DotProductTest, largeArrays) {
+  // Test with larger arrays
+  std::vector<int32_t> arr1(100);
+  std::vector<int32_t> arr2(100);
+  int64_t expectedResult = 0;
+  for (int i = 0; i < 100; ++i) {
+    arr1[i] = i + 1;
+    arr2[i] = i + 1;
+    expectedResult += static_cast<int64_t>(i + 1) * (i + 1);
+  }
+  testDotProduct<int32_t>({arr1}, {arr2}, {expectedResult});
+}
+
+TEST_F(DotProductTest, int8Arrays) {
+  testDotProduct<int8_t>({{1, 2, 3}}, {{4, 5, 6}}, {32});
+}
+
+TEST_F(DotProductTest, int16Arrays) {
+  testDotProduct<int16_t>(
+      {{100, 200, 300}},
+      {{4, 5, 6}},
+      {3200}); // 100*4 + 200*5 + 300*6 = 400 + 1000 + 1800 = 3200
+}
+
+TEST_F(DotProductTest, integerOverflow) {
+  constexpr auto kMax = std::numeric_limits<int64_t>::max();
+  auto array1 = makeArrayVector<int64_t>({{kMax, 1}});
+  auto array2 = makeArrayVector<int64_t>({{2, 1}});
+
+  VELOX_ASSERT_THROW(
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2})), "");
+}
+
+TEST_F(DotProductTest, integerOverflowOnSum) {
+  constexpr auto kMax = std::numeric_limits<int64_t>::max();
+  auto array1 = makeArrayVector<int64_t>({{kMax, 1}});
+  auto array2 = makeArrayVector<int64_t>({{1, 1}});
+
+  VELOX_ASSERT_THROW(
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2})), "");
+}
+
+TEST_F(DotProductTest, int32Overflow) {
+  constexpr auto kMax = std::numeric_limits<int32_t>::max();
+  // int32 max * int32 max fits in int64, so this should succeed.
+  testDotProduct<int32_t>(
+      {{kMax}}, {{kMax}}, {static_cast<int64_t>(kMax) * kMax});
+}
+
+TEST_F(DotProductTest, doubleNaN) {
+  constexpr auto kNaN = std::numeric_limits<double>::quiet_NaN();
+
+  auto array1 = makeArrayVector<double>({{kNaN, 1.0}});
+  auto array2 = makeArrayVector<double>({{1.0, 2.0}});
+
+  auto result =
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2}));
+  auto flatResult = result->as<SimpleVector<double>>();
+  ASSERT_TRUE(std::isnan(flatResult->valueAt(0)));
+}
+
+TEST_F(DotProductTest, doubleNaNBothArrays) {
+  constexpr auto kNaN = std::numeric_limits<double>::quiet_NaN();
+
+  auto array1 = makeArrayVector<double>({{kNaN}});
+  auto array2 = makeArrayVector<double>({{kNaN}});
+
+  auto result =
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2}));
+  auto flatResult = result->as<SimpleVector<double>>();
+  ASSERT_TRUE(std::isnan(flatResult->valueAt(0)));
+}
+
+TEST_F(DotProductTest, doubleInfTimesZero) {
+  constexpr auto kInf = std::numeric_limits<double>::infinity();
+
+  auto array1 = makeArrayVector<double>({{kInf}});
+  auto array2 = makeArrayVector<double>({{0.0}});
+
+  // inf * 0 = NaN per IEEE 754.
+  auto result =
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2}));
+  auto flatResult = result->as<SimpleVector<double>>();
+  ASSERT_TRUE(std::isnan(flatResult->valueAt(0)));
+}
+
+TEST_F(DotProductTest, doubleNegativeInfTimesNegativeZero) {
+  constexpr auto kNegInf = -std::numeric_limits<double>::infinity();
+
+  auto array1 = makeArrayVector<double>({{kNegInf}});
+  auto array2 = makeArrayVector<double>({{-0.0}});
+
+  // -inf * -0 = NaN per IEEE 754.
+  auto result =
+      evaluate("dot_product(c0, c1)", makeRowVector({array1, array2}));
+  auto flatResult = result->as<SimpleVector<double>>();
+  ASSERT_TRUE(std::isnan(flatResult->valueAt(0)));
+}
+
+TEST_F(DotProductTest, doubleInfTimesInf) {
+  constexpr auto kInf = std::numeric_limits<double>::infinity();
+
+  // inf * inf = inf.
+  testDotProduct<double>({{kInf}}, {{kInf}}, {kInf});
+
+  // inf * -inf = -inf.
+  testDotProduct<double>({{kInf}}, {{-kInf}}, {-kInf});
+}
+
+TEST_F(DotProductTest, doubleOverflow) {
+  constexpr auto kMax = std::numeric_limits<double>::max();
+  constexpr auto kInf = std::numeric_limits<double>::infinity();
+  // max + max = inf (overflow to infinity for doubles).
+  testDotProduct<double>({{kMax, kMax}}, {{1.0, 1.0}}, {kInf});
+}
+
+TEST_F(DotProductTest, mapIntegerKeys) {
+  auto map1 = makeMapVector<int32_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{1, 5}, {3, 15}},
+  });
+  auto map2 = makeMapVector<int32_t, int64_t>({
+      {{1, 3}, {2, 4}},
+      {{1, 2}, {2, 4}},
+  });
+
+  auto result = evaluate("dot_product(c0, c1)", makeRowVector({map1, map2}));
+  // Row 0: 10*3 + 20*4 = 30 + 80 = 110
+  // Row 1: 5*2 = 10 (key 3 not in map2, key 2 not in map1)
+  auto expected = makeFlatVector<int64_t>({110, 10});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(DotProductTest, mapVarcharKeys) {
+  auto map1 = makeMapVector<StringView, double>({
+      {{"a", 1.0}, {"b", 2.0}},
+      {{"x", 5.0}, {"y", 10.0}},
+  });
+  auto map2 = makeMapVector<StringView, double>({
+      {{"a", 3.0}, {"c", 4.0}},
+      {{"y", 2.0}, {"z", 3.0}},
+  });
+
+  auto result = evaluate("dot_product(c0, c1)", makeRowVector({map1, map2}));
+  // Row 0: 1.0*3.0 = 3.0 (only 'a' matches)
+  // Row 1: 10.0*2.0 = 20.0 (only 'y' matches)
+  auto expected = makeFlatVector<double>({3.0, 20.0});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(DotProductTest, mapNoMatchingKeys) {
+  auto map1 = makeMapVector<int32_t, int64_t>({
+      {{1, 10}, {2, 20}},
+  });
+  auto map2 = makeMapVector<int32_t, int64_t>({
+      {{3, 30}, {4, 40}},
+  });
+
+  auto result = evaluate("dot_product(c0, c1)", makeRowVector({map1, map2}));
+  // No matching keys, result should be 0
+  auto expected = makeFlatVector<int64_t>({0});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(DotProductTest, mapEmptyMaps) {
+  auto map1 = makeMapVector<int32_t, int64_t>({
+      {},
+  });
+  auto map2 = makeMapVector<int32_t, int64_t>({
+      {},
+  });
+
+  auto result = evaluate("dot_product(c0, c1)", makeRowVector({map1, map2}));
+  auto expected = makeFlatVector<int64_t>({0});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(DotProductTest, mapNullValues) {
+  // Null values in maps should be treated as zero
+  auto map1 = makeNullableMapVector<int32_t, int64_t>({
+      {{{1, 10}, {2, std::nullopt}}},
+  });
+  auto map2 = makeNullableMapVector<int32_t, int64_t>({
+      {{{1, 3}, {2, 4}}},
+  });
+
+  auto result = evaluate("dot_product(c0, c1)", makeRowVector({map1, map2}));
+  // Key 1: 10*3 = 30, Key 2: null*4 = 0 (null treated as zero)
+  auto expected = makeFlatVector<int64_t>({30});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(DotProductTest, multipleRows) {
+  testDotProduct<int32_t>(
+      {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}, {1, 1, 1}},
+      {{1, 2, 3}, {1, 2, 3}, {1, 2, 3}, {1, 1, 1}},
+      {1, 2, 3, 3}); // Unit vectors and all-ones
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:

Re-adds the dot_product UDF from D90476184 with a fix for the failing
DotProductTest.floatArrays test.

The floatArrays test was removed because this diff only registers
dot_product for integer arrays (int8, int16, int32, int64). Float and
double array versions are separately registered in
MathematicalFunctionsRegistration.cpp (behind VELOX_ENABLE_FAISS for
float, always-on for double) with different semantics. The test
incorrectly assumed a float -> float registration existed unconditionally.

Also removed the now-unused testDotProductFloat helper method.

Reviewed By: kgpai

Differential Revision: D96231157


