### PR TITLE
refactor: Add initColumnStatsCollection to ColumnReaderStatistics

### DIFF
--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -23,6 +23,8 @@
 #include <type_traits>
 #include <utility>
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/UnitLoader.h"
 
 #include "velox/common/base/Exceptions.h"
@@ -676,6 +678,18 @@ struct ColumnReaderStatistics {
   // collection is enabled.
   std::optional<ColumnMetricsSet> columnMetricsSet;
 
+  /// Initializes column stats collection for the given schema if enabled in
+  /// options. Recursively registers metrics for all columns in the type tree.
+  void initColumnStatsCollection(
+      const TypeWithId& schema,
+      const RowReaderOptions& options) {
+    if (!options.collectColumnStats()) {
+      return;
+    }
+    columnMetricsSet.emplace();
+    registerColumnMetricsImpl(schema);
+  }
+
   /// Merges all stats from another ColumnReaderStatistics instance.
   void mergeFrom(const ColumnReaderStatistics& other) {
     flattenStringDictionaryValues += other.flattenStringDictionaryValues;
@@ -708,6 +722,16 @@ struct ColumnReaderStatistics {
     }
     if (columnMetricsSet) {
       columnMetricsSet->toRuntimeMetrics(result);
+    }
+  }
+
+ private:
+  void registerColumnMetricsImpl(const TypeWithId& node) {
+    columnMetricsSet->getOrCreate(node.id(), node.type()->kind());
+    for (uint32_t i = 0; i < node.size(); ++i) {
+      if (const auto* child = node.childAt(i).get()) {
+        registerColumnMetricsImpl(*child);
+      }
     }
   }
 };

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -250,17 +250,6 @@ const velox::common::ScanSpec* getChildScanSpec(
       : nullptr;
 }
 
-void registerColumnMetrics(
-    const dwio::common::TypeWithId& node,
-    dwio::common::ColumnMetricsSet& metricsSet) {
-  metricsSet.getOrCreate(node.id(), node.type()->kind());
-  for (uint32_t i = 0; i < node.size(); ++i) {
-    if (const auto* child = node.childAt(i).get()) {
-      registerColumnMetrics(*child, metricsSet);
-    }
-  }
-}
-
 } // namespace
 
 DwrfRowReader::DwrfRowReader(
@@ -279,11 +268,8 @@ DwrfRowReader::DwrfRowReader(
       columnReaderStats_(
           std::make_shared<dwio::common::ColumnReaderStatistics>()),
       currentUnit_{nullptr} {
-  if (options_.collectColumnStats()) {
-    columnReaderStats_->columnMetricsSet.emplace();
-    registerColumnMetrics(
-        *getReader().schemaWithId(), *columnReaderStats_->columnMetricsSet);
-  }
+  columnReaderStats_->initColumnStatsCollection(
+      *getReader().schemaWithId(), options_);
   const auto& fileFooter = getReader().footer();
   const uint32_t numberOfStripes = fileFooter.stripesSize();
   currentStripe_ = numberOfStripes;


### PR DESCRIPTION
Summary:
Add `initColumnStatsCollection()` method to `ColumnReaderStatistics` that
encapsulates column metrics initialization. The method checks the
`collectColumnStats()` option internally and recursively registers metrics
for all columns.

Reviewed By: xiaoxmeng

Differential Revision: D95745946


