### PR TITLE
fix: Skip IPADDRESS in containers for expression fuzzer functions

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -23,12 +23,12 @@
 #include "velox/expression/fuzzer/ExpressionFuzzer.h"
 #include "velox/expression/fuzzer/FuzzerRunner.h"
 #include "velox/expression/fuzzer/SpecialFormSignatureGenerator.h"
-#include "velox/functions/prestosql/fuzzer/DistinctFromArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/DivideArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/FloorAndRoundArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/ModulusArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/MultiplyArgTypesGenerator.h"
 #include "velox/functions/prestosql/fuzzer/PlusMinusArgTypesGenerator.h"
+#include "velox/functions/prestosql/fuzzer/SkipIPAddressArgTypesGenerator.h"
 
 #include "velox/functions/prestosql/fuzzer/SortArrayTransformer.h"
 #include "velox/functions/prestosql/fuzzer/TruncateArgTypesGenerator.h"
@@ -80,7 +80,11 @@ std::unordered_map<std::string, std::shared_ptr<ArgTypesGenerator>>
         {"round", std::make_shared<FloorAndRoundArgTypesGenerator>()},
         {"mod", std::make_shared<ModulusArgTypesGenerator>()},
         {"truncate", std::make_shared<TruncateArgTypesGenerator>()},
-        {"distinct_from", std::make_shared<DistinctFromArgTypesGenerator>()}};
+        // Block IPADDRESS in containers for functions whose hash-based
+        // deduplication calls compareTo() on Int128ArrayBlock, which is not
+        // implemented. See: https://github.com/prestodb/presto/issues/26836
+        {"distinct_from", std::make_shared<SkipIPAddressArgTypesGenerator>()},
+        {"array_union", std::make_shared<SkipIPAddressArgTypesGenerator>()}};
 
 std::unordered_map<std::string, std::shared_ptr<ExprTransformer>>
     exprTransformers = {

--- a/velox/functions/prestosql/fuzzer/SkipIPAddressArgTypesGenerator.h
+++ b/velox/functions/prestosql/fuzzer/SkipIPAddressArgTypesGenerator.h
@@ -21,12 +21,12 @@
 
 namespace facebook::velox::exec::test {
 
-/// Custom argument type generator for distinct_from function that blocks
-/// types containing IPADDRESS in container positions (array elements, map
-/// keys, map values) which fail in Presto due to missing compareTo()
-/// implementation in Int128ArrayBlock.
+/// Blocks types containing IPADDRESS in container positions (array elements,
+/// map keys, map values) which fail in Presto due to missing compareTo()
+/// implementation in Int128ArrayBlock. Used for functions that perform
+/// element-level comparison (e.g., array_union, array_sort, contains).
 /// See: https://github.com/prestodb/presto/issues/26836
-class DistinctFromArgTypesGenerator : public fuzzer::ArgTypesGenerator {
+class SkipIPAddressArgTypesGenerator : public fuzzer::ArgTypesGenerator {
  public:
   std::vector<TypePtr> generateArgs(
       const exec::FunctionSignature& signature,


### PR DESCRIPTION
Summary:
Presto's `Int128ArrayBlock.compareTo()` is not implemented and throws
`UnsupportedOperationException` when called during hash-based deduplication
(via TypedSet/BlockSet) on containers with IPADDRESS elements. This causes
the expression fuzzer with Presto SOT to fail on `distinct_from` and
`array_union` when IPADDRESS is nested in containers with duplicate elements.

Rename `DistinctFromArgTypesGenerator` to `SkipIPAddressArgTypesGenerator`
since it now covers multiple functions, and add `array_union` alongside
`distinct_from` in both OSS and internal fuzzer tests.

See: https://github.com/prestodb/presto/issues/26836

Differential Revision: D96264027
