### PR TITLE
docs: Add comments to PositionalDeleteFileReader

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergDataSink.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.h
@@ -32,35 +32,6 @@
 
 namespace facebook::velox::connector::hive::iceberg {
 
-namespace {
-
-IcebergColumnHandlePtr convertToIcebergColumnHandle(
-    const HiveColumnHandlePtr& hiveColumn) {
-  static int32_t fieldIdCounter = 1;
-
-  std::function<parquet::ParquetFieldId(const TypePtr&, int32_t&)> makeField =
-      [&makeField](
-          const TypePtr& type, int32_t& fieldId) -> parquet::ParquetFieldId {
-    const int32_t currentId = fieldId++;
-    std::vector<parquet::ParquetFieldId> children;
-    children.reserve(type->size());
-    for (auto i = 0; i < type->size(); ++i) {
-      children.push_back(makeField(type->childAt(i), fieldId));
-    }
-    return parquet::ParquetFieldId{currentId, children};
-  };
-
-  auto field = makeField(hiveColumn->dataType(), fieldIdCounter);
-
-  return std::make_shared<const IcebergColumnHandle>(
-      hiveColumn->name(),
-      hiveColumn->columnType(),
-      hiveColumn->dataType(),
-      field);
-}
-
-} // namespace
-
 /// Represents a request for Iceberg write.
 class IcebergInsertTableHandle final : public HiveInsertTableHandle {
  public:

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.h
@@ -23,15 +23,52 @@
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
 #include "velox/dwio/common/Reader.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 
-struct IcebergDeleteFile;
-struct IcebergMetadataColumn;
-
+/// Reads a positional delete file and produces a deletion bitmap for the base
+/// data during merge-on-read. The delete file schema per the Iceberg V2 spec
+/// is:
+///   (file_path: VARCHAR, pos: BIGINT)
+///
+/// For each row in the delete file matching the base data file path, this
+/// reader records the deleted row position. During read, these positions are
+/// converted into a bitmap where set bits indicate rows that should be excluded
+/// from the output.
+///
+/// The reader processes delete positions incrementally, batch by batch.
+/// Positions from the delete file that fall within the current batch range are
+/// converted to bitmap bits. Leftover positions beyond the current batch are
+/// preserved and carried over to the next readDeletePositions() call.
 class PositionalDeleteFileReader {
  public:
+  /// Constructs a reader for a single positional delete file.
+  ///
+  /// Opens the delete file, sets up a filter on file_path = baseFilePath to
+  /// read only delete positions relevant to the current base data file, and
+  /// applies testFilters() to skip the entire delete file when possible (e.g.,
+  /// when the delete file contains no entries for this base file).
+  ///
+  /// @param deleteFile Metadata about the delete file (path, format, bounds,
+  ///   record count).
+  /// @param baseFilePath Path of the base data file being read. Used to filter
+  ///   delete records that apply to this specific data file.
+  /// @param fileHandleFactory Factory for creating file handles.
+  /// @param connectorQueryCtx Query context providing memory pool, session
+  ///   properties, and filesystem token.
+  /// @param executor Executor for async I/O operations.
+  /// @param hiveConfig Hive connector configuration.
+  /// @param ioStatistics Shared I/O statistics counters.
+  /// @param ioStats Shared I/O stats tracker.
+  /// @param runtimeStats Runtime statistics to record skipped bytes when the
+  ///   delete file is filtered out entirely.
+  /// @param splitOffset Row number offset of the current split within the base
+  ///   data file. Delete positions are absolute within the file, so this offset
+  ///   is used to translate them to split-relative positions.
+  /// @param connectorId Connector ID for constructing the internal split.
   PositionalDeleteFileReader(
       const IcebergDeleteFile& deleteFile,
       const std::string& baseFilePath,
@@ -45,24 +82,46 @@ class PositionalDeleteFileReader {
       uint64_t splitOffset,
       const std::string& connectorId);
 
+  /// Reads delete positions for the current batch and sets corresponding bits
+  /// in the deletion bitmap.
+  ///
+  /// Processes delete positions in the range
+  /// [splitOffset + baseReadOffset, splitOffset + baseReadOffset + size).
+  /// Positions from the delete file that fall within this range have their
+  /// corresponding bits set in deleteBitmap. Positions beyond the range are
+  /// buffered for subsequent calls.
+  ///
+  /// @param baseReadOffset The read offset from the beginning of the split in
+  ///   number of rows for the current batch.
+  /// @param size The number of rows in the current batch, before deletion.
+  /// @param deleteBitmap Output bitmap buffer where set bits mark rows to
+  ///   delete. Bit positions are relative to baseReadOffset within the split.
   void readDeletePositions(
       uint64_t baseReadOffset,
       uint64_t size,
       BufferPtr deleteBitmap);
 
+  /// Returns true when all delete positions have been read and consumed from
+  /// this file.
   bool noMoreData();
 
  private:
+  // Converts delete positions from deletePositionsVector into set bits in the
+  // deleteBitmapBuffer for positions within
+  // [splitOffset + baseReadOffset, rowNumberUpperBound).
   void updateDeleteBitmap(
       VectorPtr deletePositionsVector,
       uint64_t baseReadOffset,
       int64_t rowNumberUpperBound,
       BufferPtr deleteBitmapBuffer);
 
+  // Returns true if enough delete positions have been read for the current
+  // batch, either because EOF or the next unprocessed position >=
+  // rowNumberUpperBound.
   bool readFinishedForBatch(int64_t rowNumberUpperBound);
 
-  const IcebergDeleteFile& deleteFile_;
-  const std::string& baseFilePath_;
+  const IcebergDeleteFile deleteFile_;
+  const std::string baseFilePath_;
   FileHandleFactory* const fileHandleFactory_;
   folly::Executor* const executor_;
   const ConnectorQueryCtx* connectorQueryCtx_;
@@ -71,22 +130,29 @@ class PositionalDeleteFileReader {
   const std::shared_ptr<IoStats> ioStats_;
   memory::MemoryPool* const pool_;
 
+  // Iceberg metadata column descriptors for the delete file schema.
   std::shared_ptr<IcebergMetadataColumn> filePathColumn_;
   std::shared_ptr<IcebergMetadataColumn> posColumn_;
+
+  // Row number offset of the current split within the base data file.
   uint64_t splitOffset_;
 
+  // Internal split and row reader for the delete file. Reset to nullptr when
+  // the delete file is fully consumed or skipped by testFilters().
   std::shared_ptr<HiveConnectorSplit> deleteSplit_;
   std::unique_ptr<dwio::common::RowReader> deleteRowReader_;
-  // The vector to hold the delete positions read from the positional delete
-  // file. These positions are relative to the start of the whole base data
-  // file.
+
+  // Holds the raw output from reading the delete file. Contains a RowVector
+  // with a single pos column. Positions are absolute row numbers within the
+  // base data file.
   VectorPtr deletePositionsOutput_;
-  // The index of deletePositionsOutput_ that indicates up to where the delete
-  // positions have been converted into the bitmap
+
+  // Index into deletePositionsOutput_ indicating how far delete positions
+  // have been consumed and converted into bitmap bits.
   uint64_t deletePositionsOffset_;
-  // Total number of rows read from this positional delete file reader,
-  // including the rows filtered out from filters on both filePathColumn_ and
-  // posColumn_.
+
+  // Total number of rows read from this delete file, including rows filtered
+  // out by the file_path filter. Used to detect end-of-file.
   uint64_t totalNumRowsScanned_;
 };
 


### PR DESCRIPTION
Add missing comments to PositionalDeleteFileReader.h.
Include correct header file instead of declare dummy struct.
Address dangling reference risk.
Remove unused free function.