### PR TITLE
fix(rpc): Fix CMake header-only library targets for velox_rpc_types and velox_rpc_client (#16748)

### DIFF
--- a/velox/common/rpc/CMakeLists.txt
+++ b/velox/common/rpc/CMakeLists.txt
@@ -14,11 +14,11 @@
 
 velox_install_library_headers()
 
-velox_add_library(velox_rpc_types RPCTypes.h)
+velox_add_library(velox_rpc_types INTERFACE RPCTypes.h)
 
-velox_add_library(velox_rpc_client IRPCClient.h)
+velox_add_library(velox_rpc_client INTERFACE IRPCClient.h)
 
-velox_link_libraries(velox_rpc_client velox_rpc_types Folly::folly)
+velox_link_libraries(velox_rpc_client INTERFACE velox_rpc_types Folly::folly)
 
 velox_add_library(velox_mock_rpc_client clients/MockRPCClient.cpp)
 

--- a/velox/expression/rpc/CMakeLists.txt
+++ b/velox/expression/rpc/CMakeLists.txt
@@ -14,13 +14,9 @@
 
 velox_install_library_headers()
 
-velox_add_library(velox_async_rpc_function AsyncRPCFunction.h)
+velox_add_library(velox_async_rpc_function INTERFACE AsyncRPCFunction.h)
 
 velox_link_libraries(
   velox_async_rpc_function
-  velox_rpc_client
-  velox_rpc_types
-  velox_core
-  velox_type
-  velox_vector
+  INTERFACE velox_rpc_client velox_rpc_types velox_core velox_type velox_vector
 )


### PR DESCRIPTION
Summary:

https://github.com/facebookincubator/velox/pull/16748

velox_rpc_types and velox_rpc_client are header-only libraries (no .cpp
source files). Without the INTERFACE keyword, CMake cannot determine the
linker language, causing a build failure on macOS:

  CMake Error: CMake can not determine linker language for target: velox_rpc_types

Mark both as INTERFACE libraries and use INTERFACE linkage for
velox_rpc_client dependencies.

Reviewed By: xiaoxmeng

Differential Revision: D96329737


