### PR TITLE
test: Add makeMapVector overload with explicit offsets and sizes

### DIFF
--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -694,6 +694,76 @@ TEST_F(VectorMakerTest, mapVectorUsingKeyValueVectorsUnevenKeysValues) {
   EXPECT_THROW(maker_.mapVector({0, 2, 4}, keys, values), VeloxRuntimeError);
 }
 
+TEST_F(VectorMakerTest, mapVectorWithExplicitSizesNoNulls) {
+  // Keys/values laid out non-contiguously:
+  //   index: 0  1  2  3  4
+  //   key:   1  2  3  4  5
+  //   val:   10 20 30 40 50
+  //
+  // Row 0 -> offset=2, size=3 (indices 2,3,4)
+  // Row 1 -> offset=0, size=2 (indices 0,1)
+  auto keys = maker_.flatVector<int32_t>({1, 2, 3, 4, 5});
+  auto values = maker_.flatVector<int64_t>({10, 20, 30, 40, 50});
+
+  auto mapVector = maker_.mapVector({2, 0}, {3, 2}, keys, values);
+
+  EXPECT_EQ(mapVector->size(), 2);
+  EXPECT_EQ(mapVector->offsetAt(0), 2);
+  EXPECT_EQ(mapVector->sizeAt(0), 3);
+  EXPECT_EQ(mapVector->offsetAt(1), 0);
+  EXPECT_EQ(mapVector->sizeAt(1), 2);
+  EXPECT_FALSE(mapVector->isNullAt(0));
+  EXPECT_FALSE(mapVector->isNullAt(1));
+}
+
+TEST_F(VectorMakerTest, mapVectorWithExplicitSizesWithGaps) {
+  // Rows reference non-adjacent regions, leaving a gap at indices 2-3.
+  //   index: 0  1  2  3  4  5
+  //   key:   1  2  9  9  3  4
+  //   val:   10 20 0  0  30 40
+  //
+  // Row 0 -> offset=0, size=2
+  // Row 1 -> offset=4, size=2
+  auto keys = maker_.flatVector<int32_t>({1, 2, 9, 9, 3, 4});
+  auto values = maker_.flatVector<int64_t>({10, 20, 0, 0, 30, 40});
+
+  auto mapVector = maker_.mapVector({0, 4}, {2, 2}, keys, values);
+
+  EXPECT_EQ(mapVector->size(), 2);
+  EXPECT_EQ(mapVector->offsetAt(0), 0);
+  EXPECT_EQ(mapVector->sizeAt(0), 2);
+  EXPECT_EQ(mapVector->offsetAt(1), 4);
+  EXPECT_EQ(mapVector->sizeAt(1), 2);
+}
+
+TEST_F(VectorMakerTest, mapVectorWithExplicitSizesWithNulls) {
+  auto keys = maker_.flatVector<int32_t>({1, 2, 3, 4});
+  auto values = maker_.flatVector<int64_t>({10, 20, 30, 40});
+
+  // Row 0 -> offset=2, size=2, not null
+  // Row 1 -> null
+  // Row 2 -> offset=0, size=2, not null
+  auto mapVector = maker_.mapVector({2, 0, 0}, {2, 0, 2}, keys, values, {1});
+
+  EXPECT_EQ(mapVector->size(), 3);
+  EXPECT_FALSE(mapVector->isNullAt(0));
+  EXPECT_TRUE(mapVector->isNullAt(1));
+  EXPECT_FALSE(mapVector->isNullAt(2));
+  EXPECT_EQ(mapVector->offsetAt(0), 2);
+  EXPECT_EQ(mapVector->sizeAt(0), 2);
+  EXPECT_EQ(mapVector->sizeAt(1), 0);
+  EXPECT_EQ(mapVector->offsetAt(2), 0);
+  EXPECT_EQ(mapVector->sizeAt(2), 2);
+}
+
+TEST_F(VectorMakerTest, mapVectorWithExplicitSizesMismatch) {
+  auto keys = maker_.flatVector<int32_t>({1, 2});
+  auto values = maker_.flatVector<int64_t>({10, 20});
+
+  // offsets and sizes must have the same length.
+  EXPECT_THROW(maker_.mapVector({0}, {1, 1}, keys, values), VeloxRuntimeError);
+}
+
 TEST_F(VectorMakerTest, mapVectorStringString) {
   auto mapVector = maker_.mapVector<std::string, std::string>({
       {{"a", "1"}, {"b", "2"}},

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -247,26 +247,45 @@ MapVectorPtr VectorMaker::mapVector(
     const std::vector<vector_size_t>& nulls) {
   VELOX_CHECK_EQ(keys->size(), values->size());
 
+  // Derive sizes from consecutive offsets.
   const auto size = offsets.size();
-  BufferPtr offsetsBuffer = allocateOffsets(size, pool_);
-  BufferPtr sizesBuffer = allocateSizes(size, pool_);
-  BufferPtr nullsBuffer = nullptr;
-  auto rawOffsets = offsetsBuffer->asMutable<vector_size_t>();
-  auto rawSizes = sizesBuffer->asMutable<vector_size_t>();
-
-  for (int i = 0; i < size - 1; i++) {
-    rawSizes[i] = offsets[i + 1] - offsets[i];
+  std::vector<vector_size_t> sizes(size);
+  for (size_t i = 0; i + 1 < size; ++i) {
+    sizes[i] = offsets[i + 1] - offsets[i];
   }
-  rawSizes[size - 1] = keys->size() - offsets.back();
+  if (size > 0) {
+    sizes.back() = keys->size() - offsets.back();
+  }
 
-  memcpy(rawOffsets, offsets.data(), size * sizeof(vector_size_t));
+  return mapVector(offsets, sizes, keys, values, nulls);
+}
 
+MapVectorPtr VectorMaker::mapVector(
+    const std::vector<vector_size_t>& offsets,
+    const std::vector<vector_size_t>& sizes,
+    const VectorPtr& keys,
+    const VectorPtr& values,
+    const std::vector<vector_size_t>& nulls) {
+  VELOX_CHECK_EQ(offsets.size(), sizes.size());
+
+  const auto numRows = offsets.size();
+  BufferPtr offsetsBuffer = allocateOffsets(numRows, pool_);
+  BufferPtr sizesBuffer = allocateSizes(numRows, pool_);
+  memcpy(
+      offsetsBuffer->asMutable<vector_size_t>(),
+      offsets.data(),
+      numRows * sizeof(vector_size_t));
+  memcpy(
+      sizesBuffer->asMutable<vector_size_t>(),
+      sizes.data(),
+      numRows * sizeof(vector_size_t));
+
+  BufferPtr nullsBuffer = nullptr;
   if (!nulls.empty()) {
-    nullsBuffer = AlignedBuffer::allocate<bool>(size, pool_, bits::kNotNull);
+    nullsBuffer = allocateNulls(numRows, pool_);
     auto rawNulls = nullsBuffer->asMutable<uint64_t>();
-
-    for (int i = 0; i < nulls.size(); i++) {
-      bits::setNull(rawNulls, nulls[i]);
+    for (const auto idx : nulls) {
+      bits::setNull(rawNulls, idx);
     }
   }
 
@@ -274,7 +293,7 @@ MapVectorPtr VectorMaker::mapVector(
       pool_,
       MAP(keys->type(), values->type()),
       nullsBuffer,
-      size,
+      numRows,
       offsetsBuffer,
       sizesBuffer,
       keys,

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -1050,6 +1050,17 @@ class VectorMaker {
       const VectorPtr& values,
       const std::vector<vector_size_t>& nulls = {});
 
+  /// Create a MapVector from explicit offsets, sizes, and key/value vectors.
+  /// Unlike the offsets-only overload above, this allows non-consecutive or
+  /// out-of-order offsets (e.g. for testing vectors produced by filters or
+  /// slices). An optional nulls vector specifies which row indices are null.
+  MapVectorPtr mapVector(
+      const std::vector<vector_size_t>& offsets,
+      const std::vector<vector_size_t>& sizes,
+      const VectorPtr& keys,
+      const VectorPtr& values,
+      const std::vector<vector_size_t>& nulls = {});
+
  private:
   vector_size_t createOffsetsAndSizes(
       vector_size_t size,

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -664,6 +664,18 @@ class VectorTestBase {
     return vectorMaker_.mapVector(offsets, keyVector, valueVector, nulls);
   }
 
+  // Creates a MapVector with explicit offsets and sizes, allowing
+  // non-consecutive or out-of-order layouts in the underlying key/value arrays.
+  MapVectorPtr makeMapVector(
+      const std::vector<vector_size_t>& offsets,
+      const std::vector<vector_size_t>& sizes,
+      const VectorPtr& keyVector,
+      const VectorPtr& valueVector,
+      const std::vector<vector_size_t>& nulls = {}) {
+    return vectorMaker_.mapVector(
+        offsets, sizes, keyVector, valueVector, nulls);
+  }
+
   MapVectorPtr makeAllNullMapVector(
       vector_size_t size,
       const TypePtr& keyType,


### PR DESCRIPTION
Summary:
Add a new `mapVector(offsets, sizes, keys, values, isNullAt)` overload to
`VectorMaker` and the corresponding `makeMapVector` wrapper in
`VectorTestBase`. Unlike the existing offsets-only overload (which derives
sizes from consecutive offset differences), this variant accepts explicit
sizes, enabling construction of MapVectors with non-consecutive or
out-of-order layouts — useful for testing code that processes vectors
produced by filters, slices, or other transformations.

Differential Revision: D96238549


