### PR TITLE
fix(build): Update new claude-code-action to latest forked-pr-fix branch

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -94,7 +94,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Claude Code
-        uses: izaitsevfb/claude-code-action@2817c54db8f44f3a0485d57292566bf07d428a25 # forked-pr-fix
+        uses: izaitsevfb/claude-code-action@ececd56fb999d06b4dd2477437bc408938295d76 # forked-pr-fix
         with:
           trigger_phrase: "@claude"
           # prompt is only set for workflow_dispatch (agent mode).


### PR DESCRIPTION
Summary:
Update the action reference from the old SHA (2817c54...) to the forked-pr-fix branch head ([hash](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fizaitsevfb%2Fclaude-code-action%2Fcommit%2Fececd56fb999d06b4dd2477437bc408938295d76&h=AT7PbA98v9EAfVo7jEw-16Mx1Xb3PCLrSAEqNHTGedvHzDkTGfYRyYSRyAa9OvZmphyoicFKQ1Zkdz3JgUoRm7Dpgb6xCp9QIM3HP8cVNtvfdUO_ZYCzi6tXZE101k3SxxcQw9otvB8ElhmbkAw1MzWiMC7n)), which is the branch that the includes forked PR support for the Claude Code plugin that PyTorch [uses](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Fpytorch%2Ftest-infra%2Fblob%2Fmain%2F.github%2Fworkflows%2F_claude-code.yml%23L116C15-L116C58&h=AT7PbA98v9EAfVo7jEw-16Mx1Xb3PCLrSAEqNHTGedvHzDkTGfYRyYSRyAa9OvZmphyoicFKQ1Zkdz3JgUoRm7Dpgb6xCp9QIM3HP8cVNtvfdUO_ZYCzi6tXZE101k3SxxcQw9otvB8ElhmbkAw1MzWiMC7n) too.

Tested on a forked PR:
https://github.com/pratikpugalia/velox/pull/2

Differential Revision: D96374984
