### PR TITLE
(fix) Fix PrestoVectorLexer compilation error with Clang 21

### DIFF
--- a/velox/serializers/PrestoVectorLexer.h
+++ b/velox/serializers/PrestoVectorLexer.h
@@ -96,7 +96,7 @@ class PrestoVectorLexer {
   }
 
   void assertCommitted() const {
-    assert(committedPtr_ == source_.begin());
+    assert(committedPtr_ == source_.data());
   }
 
   void commit(TokenType tokenType);


### PR DESCRIPTION
Fixes a type mismatch error when compiling with Clang 21 by comparing 
committedPtr_ against source_.data() instead of source_.begin(). 
The previous comparison between a raw pointer and an iterator is 
invalid in stricter standard library implementations.