### PR TITLE
feat(cudf): Support velox to cudf table conversion directly(Part2)

### DIFF
--- a/velox/experimental/cudf/benchmarks/CMakeLists.txt
+++ b/velox/experimental/cudf/benchmarks/CMakeLists.txt
@@ -20,3 +20,15 @@ target_link_libraries(
   velox_cudf_exec_test_lib
   velox_tpch_benchmark_lib
 )
+
+add_executable(velox_cudf_interop_benchmark CudfInteropBenchmark.cpp)
+
+target_link_libraries(
+  velox_cudf_interop_benchmark
+  velox_cudf_exec
+  velox_vector
+  velox_memory
+  Folly::folly
+  Folly::follybenchmark
+  velox_vector_fuzzer
+)

--- a/velox/experimental/cudf/benchmarks/CudfInteropBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfInteropBenchmark.cpp
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+#include <cudf/utilities/default_stream.hpp>
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+namespace facebook::velox::cudf_velox {
+namespace {
+
+class CudfInteropBenchmark {
+ public:
+  CudfInteropBenchmark() {
+    pool_ = memory::memoryManager()->addLeafPool();
+  }
+
+  std::unique_ptr<cudf::table> veloxToCudf(const RowVectorPtr& data) {
+    // Ensure the vector is flat before exporting.
+    VectorPtr flatData = data;
+    BaseVector::flattenVector(flatData);
+    auto cudfTable = with_arrow::toCudfTable(
+        std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
+    stream.synchronize();
+    VELOX_CHECK_NOT_NULL(cudfTable);
+    VELOX_CHECK_EQ(cudfTable->num_rows(), flatData->size());
+    return cudfTable;
+  }
+
+  void cudfToVelox(
+      std::unique_ptr<cudf::table>& cudfTable,
+      const RowTypePtr& rowType) {
+    auto veloxData = with_arrow::toVeloxColumn(
+        cudfTable->view(), pool_.get(), rowType, stream, mr);
+    stream.synchronize();
+    VELOX_CHECK_NOT_NULL(veloxData);
+    VELOX_CHECK_EQ(veloxData->size(), cudfTable->num_rows());
+  }
+
+  std::unique_ptr<cudf::table> veloxToCudfLarge(
+      const RowTypePtr& rowType,
+      size_t numRows) {
+    folly::BenchmarkSuspender suspender;
+    auto data = makeLargeData(rowType, numRows);
+    // Ensure the vector is flat before exporting.
+    VectorPtr flatData = data;
+    BaseVector::flattenVector(flatData);
+    suspender.dismiss();
+
+    auto stream = cudf::get_default_stream();
+    auto mr = cudf::get_current_device_resource_ref();
+    auto cudfTable = with_arrow::toCudfTable(
+        std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
+    stream.synchronize();
+    VELOX_CHECK_NOT_NULL(cudfTable);
+    VELOX_CHECK_EQ(cudfTable->num_rows(), flatData->size());
+    return cudfTable;
+  }
+
+  void cudfToVeloxLarge(
+      std::unique_ptr<cudf::table>& cudfTable,
+      const RowTypePtr& rowType) {
+    auto veloxData = with_arrow::toVeloxColumn(
+        cudfTable->view(), pool_.get(), rowType, stream, mr);
+    stream.synchronize();
+    VELOX_CHECK_NOT_NULL(veloxData);
+    VELOX_CHECK_EQ(veloxData->size(), cudfTable->num_rows());
+  }
+
+  RowVectorPtr makeLargeData(const RowTypePtr& rowType, size_t maxRows) {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.nullRatio = 0.25;
+    options.allowDictionaryVector = false;
+
+    const auto seed = 1; // For reproducibility.
+    VectorFuzzer fuzzer(options, pool_.get(), seed);
+
+    // Create initial batch
+    auto result = fuzzer.fuzzInputRow(rowType);
+
+    // Use exponential growth: append result to itself to double the size
+    // Check if doubling would exceed maxRows before appending
+    size_t currentSize = result->size();
+    while (currentSize * 2 < maxRows) {
+      // Append result to itself for exponential growth
+      result->append(result.get());
+      currentSize = result->size();
+    }
+
+    return result;
+  }
+
+  RowVectorPtr makeData(const RowTypePtr& rowType, double nullRatio = 0.25) {
+    folly::BenchmarkSuspender suspender;
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.nullRatio = nullRatio;
+    options.allowDictionaryVector = false;
+
+    const auto seed = 1; // For reproducibility.
+    VectorFuzzer fuzzer(options, pool_.get(), seed);
+    auto vector = fuzzer.fuzzInputRow(rowType);
+    suspender.dismiss();
+    return vector;
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  rmm::cuda_stream_view stream = cudf::get_default_stream();
+  rmm::device_async_resource_ref mr = cudf::get_current_device_resource_ref();
+};
+
+size_t iters = 2000;
+
+#define INTEROP_BENCHMARKS(name, rowType)         \
+  BENCHMARK(velox_to_cudf_##name) {               \
+    CudfInteropBenchmark benchmark;               \
+                                                  \
+    folly::BenchmarkSuspender suspender;          \
+    auto data = benchmark.makeData(rowType);      \
+    suspender.dismiss();                          \
+                                                  \
+    for (auto i = 0; i < iters; ++i) {            \
+      benchmark.veloxToCudf(data);                \
+    }                                             \
+  }                                               \
+                                                  \
+  BENCHMARK(cudf_to_velox_##name) {               \
+    CudfInteropBenchmark benchmark;               \
+                                                  \
+    folly::BenchmarkSuspender suspender;          \
+    auto data = benchmark.makeData(rowType);      \
+    auto cudfTable = benchmark.veloxToCudf(data); \
+    suspender.dismiss();                          \
+                                                  \
+    for (auto i = 0; i < iters; ++i) {            \
+      benchmark.cudfToVelox(cudfTable, rowType);  \
+    }                                             \
+  }                                               \
+                                                  \
+  BENCHMARK(velox_to_cudf_non_null_##name) {      \
+    CudfInteropBenchmark benchmark;               \
+                                                  \
+    folly::BenchmarkSuspender suspender;          \
+    auto data = benchmark.makeData(rowType, 0);   \
+    suspender.dismiss();                          \
+                                                  \
+    for (auto i = 0; i < iters; ++i) {            \
+      benchmark.veloxToCudf(data);                \
+    }                                             \
+  }                                               \
+                                                  \
+  BENCHMARK(cudf_to_velox_non_null_##name) {      \
+    CudfInteropBenchmark benchmark;               \
+                                                  \
+    folly::BenchmarkSuspender suspender;          \
+    auto data = benchmark.makeData(rowType, 0);   \
+    auto cudfTable = benchmark.veloxToCudf(data); \
+    suspender.dismiss();                          \
+                                                  \
+    for (auto i = 0; i < iters; ++i) {            \
+      benchmark.cudfToVelox(cudfTable, rowType);  \
+    }                                             \
+  }
+
+// Fixed-width type benchmarks with non-null variants (1000 rows)
+INTEROP_BENCHMARKS(
+    fixedWidth5,
+    ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()}));
+
+INTEROP_BENCHMARKS(
+    fixedWidth10,
+    ROW({
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        DOUBLE(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+    }));
+
+INTEROP_BENCHMARKS(
+    fixedWidth20,
+    ROW({
+        BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT(),
+        BIGINT(), BIGINT(), BIGINT(), DOUBLE(), DOUBLE(), DOUBLE(), DOUBLE(),
+        DOUBLE(), DOUBLE(), DOUBLE(), DOUBLE(), BIGINT(), BIGINT(),
+    }));
+
+// Decimal benchmarks
+INTEROP_BENCHMARKS(decimals, ROW({BIGINT(), DECIMAL(12, 2), DECIMAL(38, 18)}));
+
+// String benchmarks with non-null variants (1000 rows)
+INTEROP_BENCHMARKS(strings1, ROW({BIGINT(), VARCHAR()}));
+
+INTEROP_BENCHMARKS(
+    strings5,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+    }));
+
+// Array benchmarks with non-null variants (1000 rows)
+INTEROP_BENCHMARKS(arrays, ROW({BIGINT(), ARRAY(BIGINT())}));
+
+INTEROP_BENCHMARKS(nestedArrays, ROW({BIGINT(), ARRAY(ARRAY(BIGINT()))}));
+
+// Struct benchmarks with non-null variants (1000 rows)
+INTEROP_BENCHMARKS(
+    structs,
+    ROW({BIGINT(), ROW({BIGINT(), DOUBLE(), BOOLEAN(), TINYINT(), REAL()})}));
+
+// Mixed type benchmarks with non-null variants (1000 rows)
+INTEROP_BENCHMARKS(
+    mixed,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        DOUBLE(),
+        ARRAY(BIGINT()),
+        ROW({BIGINT(), VARCHAR()}),
+    }));
+
+// Date and timestamp benchmarks with non-null variants (1000 rows)
+INTEROP_BENCHMARKS(dates, ROW({BIGINT(), DATE()}));
+
+INTEROP_BENCHMARKS(timestamps, ROW({BIGINT(), TIMESTAMP()}));
+
+INTEROP_BENCHMARKS(
+    dateTimeMixed,
+    ROW({BIGINT(), DATE(), TIMESTAMP(), VARCHAR()}));
+
+// Large vector benchmarks with different row counts
+#define LARGE_INTEROP_BENCHMARKS(name, rowType, numRows)   \
+  BENCHMARK(velox_to_cudf_large_##name##_##numRows) {      \
+    CudfInteropBenchmark benchmark;                        \
+                                                           \
+    folly::BenchmarkSuspender suspender;                   \
+    auto data = benchmark.makeLargeData(rowType, numRows); \
+    suspender.dismiss();                                   \
+                                                           \
+    for (auto i = 0; i < iters; ++i) {                     \
+      benchmark.veloxToCudf(data);                         \
+    }                                                      \
+  }                                                        \
+                                                           \
+  BENCHMARK(cudf_to_velox_large_##name##_##numRows) {      \
+    CudfInteropBenchmark benchmark;                        \
+                                                           \
+    folly::BenchmarkSuspender suspender;                   \
+    auto data = benchmark.makeLargeData(rowType, numRows); \
+    auto cudfTable = benchmark.veloxToCudf(data);          \
+    suspender.dismiss();                                   \
+                                                           \
+    for (auto i = 0; i < iters; ++i) {                     \
+      benchmark.cudfToVeloxLarge(cudfTable, rowType);      \
+    }                                                      \
+  }
+
+// Test with 10,000 rows
+LARGE_INTEROP_BENCHMARKS(
+    fixedWidth10,
+    ROW({
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        DOUBLE(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+    }),
+    10000);
+
+LARGE_INTEROP_BENCHMARKS(
+    strings5,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+    }),
+    10000);
+
+LARGE_INTEROP_BENCHMARKS(
+    mixed,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        DOUBLE(),
+        ARRAY(BIGINT()),
+        ROW({BIGINT(), VARCHAR()}),
+    }),
+    10000);
+
+LARGE_INTEROP_BENCHMARKS(timestamps, ROW({BIGINT(), TIMESTAMP()}), 10000);
+
+LARGE_INTEROP_BENCHMARKS(booleans, ROW({BIGINT(), BOOLEAN()}), 10000);
+
+LARGE_INTEROP_BENCHMARKS(arrays, ROW({ARRAY(BIGINT())}), 10000);
+
+// Test with 40,000 rows
+LARGE_INTEROP_BENCHMARKS(
+    fixedWidth10,
+    ROW({
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        DOUBLE(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+    }),
+    40000);
+
+LARGE_INTEROP_BENCHMARKS(
+    strings5,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+    }),
+    40000);
+
+LARGE_INTEROP_BENCHMARKS(
+    mixed,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        DOUBLE(),
+        ARRAY(BIGINT()),
+        ROW({BIGINT(), VARCHAR()}),
+    }),
+    40000);
+
+// Test with 80,000 rows
+LARGE_INTEROP_BENCHMARKS(
+    fixedWidth10,
+    ROW({
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+        DOUBLE(),
+        BIGINT(),
+        BIGINT(),
+        BIGINT(),
+    }),
+    80000);
+
+LARGE_INTEROP_BENCHMARKS(
+    strings5,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+        VARCHAR(),
+    }),
+    80000);
+
+LARGE_INTEROP_BENCHMARKS(
+    mixed,
+    ROW({
+        BIGINT(),
+        VARCHAR(),
+        DOUBLE(),
+        ARRAY(BIGINT()),
+        ROW({BIGINT(), VARCHAR()}),
+    }),
+    80000);
+
+} // namespace
+} // namespace facebook::velox::cudf_velox
+
+int main(int argc, char** argv) {
+  folly::Init init{&argc, &argv};
+  facebook::velox::memory::MemoryManager::initialize(
+      facebook::velox::memory::MemoryManager::Options{});
+  folly::runBenchmarks();
+  return 0;
+}
+
+// Made with Bob

--- a/velox/experimental/cudf/benchmarks/CudfInteropBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfInteropBenchmark.cpp
@@ -35,8 +35,24 @@ class CudfInteropBenchmark {
 
   std::unique_ptr<cudf::table> veloxToCudf(const RowVectorPtr& data) {
     // Ensure the vector is flat before exporting.
+    folly::BenchmarkSuspender suspender;
     VectorPtr flatData = data;
     BaseVector::flattenVector(flatData);
+    suspender.dismiss();
+    auto cudfTable = toCudfTable(
+        std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
+    stream.synchronize();
+    VELOX_CHECK_NOT_NULL(cudfTable);
+    VELOX_CHECK_EQ(cudfTable->num_rows(), flatData->size());
+    return cudfTable;
+  }
+
+  std::unique_ptr<cudf::table> veloxToCudfArrow(const RowVectorPtr& data) {
+    // Ensure the vector is flat before exporting.
+    folly::BenchmarkSuspender suspender;
+    VectorPtr flatData = data;
+    BaseVector::flattenVector(flatData);
+    suspender.dismiss();
     auto cudfTable = with_arrow::toCudfTable(
         std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
     stream.synchronize();
@@ -65,9 +81,7 @@ class CudfInteropBenchmark {
     BaseVector::flattenVector(flatData);
     suspender.dismiss();
 
-    auto stream = cudf::get_default_stream();
-    auto mr = cudf::get_current_device_resource_ref();
-    auto cudfTable = with_arrow::toCudfTable(
+    auto cudfTable = toCudfTable(
         std::static_pointer_cast<RowVector>(flatData), pool_.get(), stream, mr);
     stream.synchronize();
     VELOX_CHECK_NOT_NULL(cudfTable);
@@ -142,6 +156,18 @@ size_t iters = 2000;
       benchmark.veloxToCudf(data);                \
     }                                             \
   }                                               \
+                                                \
+  BENCHMARK_RELATIVE(velox_to_cudf_arrow_##name) {               \
+    CudfInteropBenchmark benchmark;               \
+                                                  \
+    folly::BenchmarkSuspender suspender;          \
+    auto data = benchmark.makeData(rowType);      \
+    suspender.dismiss();                          \
+                                                  \
+    for (auto i = 0; i < iters; ++i) {            \
+      benchmark.veloxToCudfArrow(data);                \
+    }                                             \
+  }                                               \
                                                   \
   BENCHMARK(cudf_to_velox_##name) {               \
     CudfInteropBenchmark benchmark;               \
@@ -165,6 +191,18 @@ size_t iters = 2000;
                                                   \
     for (auto i = 0; i < iters; ++i) {            \
       benchmark.veloxToCudf(data);                \
+    }                                             \
+  }                                               \
+                                                  \
+  BENCHMARK_RELATIVE(velox_to_cudf_non_null_arrow_##name) {      \
+    CudfInteropBenchmark benchmark;               \
+                                                  \
+    folly::BenchmarkSuspender suspender;          \
+    auto data = benchmark.makeData(rowType, 0);   \
+    suspender.dismiss();                          \
+                                                  \
+    for (auto i = 0; i < iters; ++i) {            \
+      benchmark.veloxToCudfArrow(data);                \
     }                                             \
   }                                               \
                                                   \

--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
@@ -158,8 +158,7 @@ void CudfHiveDataSink::appendData(RowVectorPtr input) {
 
   // Convert the input RowVectorPtr to cudf::table
   auto stream = cudfGlobalStreamPool().get_stream();
-  auto cudfInput =
-      with_arrow::toCudfTable(input, input->pool(), stream, get_temp_mr());
+  auto cudfInput = toCudfTable(input, input->pool(), stream, get_temp_mr());
   stream.synchronize();
   VELOX_CHECK_NOT_NULL(
       cudfInput, "Failed to convert input RowVectorPtr to cudf::table");

--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -49,6 +49,9 @@ target_link_libraries(
     velox_exec
     velox_cudf_hive_connector
     velox_cudf_expression
+    velox_cudf_exec_util
 )
 
 target_compile_options(velox_cudf_exec PRIVATE -Wno-missing-field-initializers)
+
+add_subdirectory(util)

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -146,7 +146,7 @@ RowVectorPtr CudfFromVelox::doGetOutput() {
   // Convert RowVector to cudf table.  toCudfTable synchronizes the stream
   // internally before releasing Arrow host buffers, so no additional sync
   // is needed here.
-  auto tbl = with_arrow::toCudfTable(
+  auto tbl = toCudfTable(
       input, input->pool(), stream, get_output_mr(), timestampTimeZone_);
 
   VELOX_CHECK_NOT_NULL(tbl);
@@ -211,7 +211,7 @@ RowVectorPtr CudfToVelox::convertFrontToVelox() {
   auto stream = cudfVector->stream();
   auto tableView = cudfVector->getTableView();
   auto output = with_arrow::toVeloxColumn(
-      tableView, pool(), outputType_, "", stream, get_temp_mr());
+      tableView, pool(), outputType_, stream, get_temp_mr());
   stream.synchronize();
   output->setType(outputType_);
   return output;
@@ -309,7 +309,7 @@ RowVectorPtr CudfToVelox::doGetOutput() {
           std::move(toConcat), outputType_, stream, get_temp_mr());
       auto tableView = concatTable->view();
       veloxBuffer_ = with_arrow::toVeloxColumn(
-          tableView, pool(), outputType_, "", stream, get_temp_mr());
+          tableView, pool(), outputType_, stream, get_temp_mr());
       stream.synchronize();
       veloxBuffer_->setType(outputType_);
       veloxOffset_ = 0;

--- a/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
+++ b/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
@@ -77,8 +77,7 @@ void CudfEnforceSingleRow::doNoMoreInput() {
 
     // Convert to CudfVector
     auto stream = cudf::get_default_stream(cudf::allow_default_stream);
-    auto cudfTable =
-        with_arrow::toCudfTable(nullRow, pool(), stream, get_output_mr());
+    auto cudfTable = toCudfTable(nullRow, pool(), stream, get_output_mr());
     stream.synchronize();
     input_ = std::make_shared<CudfVector>(
         pool(), outputType_, 1, std::move(cudfTable), stream);

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -17,16 +17,28 @@
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/exec/util/InteropUtil.h"
 
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Nulls.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/arrow/Bridge.h"
 
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_view.hpp>
 #include <cudf/interop.hpp>
+#include <cudf/null_mask.hpp>
+#include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/transform.hpp>
 #include <cudf/types.hpp>
+#include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/error.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -119,70 +131,6 @@ cudf::data_type veloxToCudfDataType(const TypePtr& type) {
 }
 
 namespace with_arrow {
-
-std::unique_ptr<cudf::table> toCudfTable(
-    const facebook::velox::RowVectorPtr& veloxTable,
-    facebook::velox::memory::MemoryPool* pool,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
-    std::optional<std::string> timestampTimeZone) {
-  TimestampUnit unit;
-  switch (CudfConfig::getInstance().timestampUnit) {
-    case cudf::type_id::TIMESTAMP_NANOSECONDS:
-      unit = TimestampUnit::kNano;
-      break;
-    case cudf::type_id::TIMESTAMP_MICROSECONDS:
-      unit = TimestampUnit::kMicro;
-      break;
-    case cudf::type_id::TIMESTAMP_MILLISECONDS:
-      unit = TimestampUnit::kMilli;
-      break;
-    case cudf::type_id::TIMESTAMP_SECONDS:
-      unit = TimestampUnit::kSecond;
-      break;
-    default:
-      VELOX_UNSUPPORTED();
-  }
-  // Need to flattenDictionary and flattenConstant, otherwise we observe issues
-  // in the null mask. Also, libcudf does not support Arrow binary, so we export
-  // VARBINARY as UTF-8.
-  ArrowOptions arrowOptions{
-      .flattenDictionary = true,
-      .flattenConstant = true,
-      .timestampUnit = unit,
-      .timestampTimeZone = timestampTimeZone,
-      .exportVarbinaryAsString = true,
-      .useDecimalTypeWidth = true};
-  ArrowArray arrowArray;
-  exportToArrow(
-      std::dynamic_pointer_cast<facebook::velox::BaseVector>(veloxTable),
-      arrowArray,
-      pool,
-      arrowOptions);
-  ArrowSchema arrowSchema;
-  exportToArrow(
-      std::dynamic_pointer_cast<facebook::velox::BaseVector>(veloxTable),
-      arrowSchema,
-      arrowOptions);
-  auto tbl = cudf::from_arrow(&arrowSchema, &arrowArray, stream, mr);
-
-  // Synchronize before releasing Arrow resources.  cudf::from_arrow uses
-  // cudaMemcpyBatchAsync (CUDA 13.0+) with cudaMemcpySrcAccessOrderStream,
-  // which defers reading the host source buffers until the stream reaches
-  // each copy.  The Arrow arrays must therefore stay alive until the stream
-  // has executed those copies.
-  stream.synchronize();
-
-  // Release Arrow resources
-  if (arrowArray.release) {
-    arrowArray.release(&arrowArray);
-  }
-  if (arrowSchema.release) {
-    arrowSchema.release(&arrowSchema);
-  }
-  return tbl;
-}
-
 namespace {
 
 void setArrowFormatBackToVarbinary(ArrowSchema* schema, const TypePtr& type) {
@@ -252,7 +200,6 @@ RowVectorPtr toVeloxColumn(
   }
 
   auto veloxTable = importFromArrowAsOwner(schemaCopy, arrayCopy, pool);
-
   // BaseVector to RowVector
   auto castedPtr =
       std::dynamic_pointer_cast<facebook::velox::RowVector>(veloxTable);
@@ -318,17 +265,6 @@ facebook::velox::RowVectorPtr toVeloxColumn(
   return toVeloxColumn(table, pool, metadata, nullptr, stream, mr);
 }
 
-facebook::velox::RowVectorPtr toVeloxColumn(
-    const cudf::table_view& table,
-    facebook::velox::memory::MemoryPool* pool,
-    const facebook::velox::RowTypePtr& outputType,
-    std::string namePrefix,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  auto metadata = getMetadata(table.begin(), table.end(), namePrefix);
-  return toVeloxColumn(table, pool, metadata, &outputType, stream, mr);
-}
-
 // New overload: Accepts a Velox TypePtr for recursive metadata construction.
 RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
@@ -347,5 +283,540 @@ RowVectorPtr toVeloxColumn(
 }
 
 } // namespace with_arrow
+
+namespace {
+std::unique_ptr<cudf::table> toCudfTableArrow(
+    const VectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    std::optional<std::string> timestampTimeZone) {
+  TimestampUnit unit;
+  switch (CudfConfig::getInstance().timestampUnit) {
+    case cudf::type_id::TIMESTAMP_NANOSECONDS:
+      unit = TimestampUnit::kNano;
+      break;
+    case cudf::type_id::TIMESTAMP_MICROSECONDS:
+      unit = TimestampUnit::kMicro;
+      break;
+    case cudf::type_id::TIMESTAMP_MILLISECONDS:
+      unit = TimestampUnit::kMilli;
+      break;
+    case cudf::type_id::TIMESTAMP_SECONDS:
+      unit = TimestampUnit::kSecond;
+      break;
+    default:
+      VELOX_UNSUPPORTED();
+  }
+  // Need to flattenDictionary and flattenConstant, otherwise we observe issues
+  // in the null mask. Also, libcudf does not support Arrow binary, so we export
+  // VARBINARY as UTF-8.
+  ArrowOptions arrowOptions{
+      .flattenDictionary = true,
+      .flattenConstant = true,
+      .timestampUnit = unit,
+      .timestampTimeZone = timestampTimeZone,
+      .exportVarbinaryAsString = true,
+      .useDecimalTypeWidth = true};
+  ArrowArray arrowArray;
+  exportToArrow(veloxTable, arrowArray, pool, arrowOptions);
+  ArrowSchema arrowSchema;
+  exportToArrow(veloxTable, arrowSchema, arrowOptions);
+  auto tbl = cudf::from_arrow(&arrowSchema, &arrowArray, stream, mr);
+
+  // Synchronize before releasing Arrow resources.  cudf::from_arrow uses
+  // cudaMemcpyBatchAsync (CUDA 13.0+) with cudaMemcpySrcAccessOrderStream,
+  // which defers reading the host source buffers until the stream reaches
+  // each copy.  The Arrow arrays must therefore stay alive until the stream
+  // has executed those copies.
+  stream.synchronize();
+
+  // Release Arrow resources
+  if (arrowArray.release) {
+    arrowArray.release(&arrowArray);
+  }
+  if (arrowSchema.release) {
+    arrowSchema.release(&arrowSchema);
+  }
+  return tbl;
+}
+
+/// Holds the CUDA stream and memory resource used throughout the Velox-to-cudf
+/// direct conversion, avoiding repetitive parameter passing.
+struct DispatchColumn {
+  rmm::cuda_stream_view stream;
+  rmm::device_async_resource_ref mr;
+  std::optional<std::string> timestampTimeZone;
+
+  /// Copies the Velox null bitmask to a GPU device buffer. Velox and cudf both
+  /// use a validity bitmask where bit=1 means valid (not null), so no
+  /// conversion is needed. Returns an empty buffer if there are no nulls.
+  std::unique_ptr<rmm::device_buffer> copyNullMask(
+      const BaseVector& input,
+      int32_t nullCount) const {
+    if (nullCount == 0) {
+      return std::make_unique<rmm::device_buffer>(0, stream, mr);
+    }
+    // Velox stores null bits as uint64_t words; compute byte size needed.
+    const auto* rawNulls = input.rawNulls();
+
+    auto const numRows = static_cast<cudf::size_type>(input.size());
+    auto const paddedWords = cudf::bitmask_allocation_size_bytes(numRows) /
+        sizeof(cudf::bitmask_type);
+    auto const copySize = bits::nbytes(numRows);
+
+    auto mask =
+        rmm::device_uvector<cudf::bitmask_type>(paddedWords, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        mask.data(), rawNulls, copySize, cudaMemcpyDefault, stream.value()));
+    return std::make_unique<rmm::device_buffer>(mask.release());
+  }
+
+  /// Returns the null count for a Velox vector. Uses Velox's cached value if
+  /// available, otherwise counts from the raw bitmap.
+  static cudf::size_type getNullCount(const BaseVector& vector) {
+    auto nullCount = vector.getNullCount();
+    if (nullCount.has_value()) {
+      return static_cast<cudf::size_type>(nullCount.value());
+    }
+    const auto* rawNulls = vector.rawNulls();
+    if (rawNulls == nullptr) {
+      return 0;
+    }
+    return static_cast<cudf::size_type>(
+        bits::countNulls(rawNulls, 0, vector.size()));
+  }
+
+  /// GPU-accelerated version: builds offsets column directly on device from
+  /// sizes array using Thrust inclusive_scan (prefix sum).
+  std::unique_ptr<cudf::column> makeOffsetsColumnFromSizes(
+      const int32_t* rawSizes,
+      cudf::size_type numRows) const {
+    // Copy sizes to device
+    auto dSizes = rmm::device_uvector<int32_t>(numRows, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        dSizes.data(),
+        rawSizes,
+        numRows * sizeof(int32_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    // Use utility function to compute offsets on GPU
+    return util::computeOffsetsFromSizes(dSizes.data(), numRows, stream, mr);
+  }
+
+  /// Reads a flat scalar column from a Velox FlatVector and creates a cudf
+  /// column by copying the data buffers to GPU. This mirrors the pattern from
+  /// GpuBufferBatchResizer::DispatchColumn::readFlatColumn.
+  template <TypeKind Kind>
+  std::unique_ptr<cudf::column> readColumn(
+      const BaseVector& vector,
+      const TypePtr& type) const {
+    using T = typename TypeTraits<Kind>::NativeType;
+    const auto numRows = vector.size();
+
+    auto* flatVector = vector.as<FlatVector<T>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector for direct conversion");
+
+    // Copy values buffer to GPU.
+    const auto* rawValues = flatVector->rawValues();
+    const size_t valueBytes = numRows * sizeof(T);
+    rmm::device_buffer dataBuf(valueBytes, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        dataBuf.data(),
+        rawValues,
+        valueBytes,
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    // Copy null mask to GPU.
+    auto nullCount = getNullCount(vector);
+    auto nullBuf = copyNullMask(vector, nullCount);
+
+    auto cudfType = veloxToCudfDataType(type);
+    return std::make_unique<cudf::column>(
+        cudfType, numRows, std::move(dataBuf), std::move(*nullBuf), nullCount);
+  }
+
+  // Converts a Velox FlatVector<StringView> to a cudf STRING column.
+  // Because we don't know the StringView is in which stringBuffers, so we
+  // cannot implement as Arrow to no copy. Velox must copy all the CPU buffers
+  // to GPU buffers, and then make string column.
+  std::unique_ptr<cudf::column> readStringColumn(
+      const BaseVector& vector) const {
+    const auto numRows = vector.size();
+
+    auto* flatVector = vector.as<FlatVector<StringView>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector<StringView> for direct conversion");
+
+    // Build offsets (int32_t[numRows+1]) and concatenated chars on CPU.
+    // Use shared_ptr for automatic lifetime management with CUDA stream.
+    auto offsets = std::make_shared<std::vector<int32_t>>(numRows + 1);
+    int64_t totalChars = 0;
+    for (int32_t i = 0; i < numRows; ++i) {
+      (*offsets)[i] = static_cast<int32_t>(totalChars);
+      if (!vector.isNullAt(i)) {
+        totalChars += flatVector->valueAt(i).size();
+      }
+    }
+    VELOX_CHECK_LE(
+        totalChars,
+        std::numeric_limits<int32_t>::max(),
+        "Total string length exceeds int32 max");
+    (*offsets)[numRows] = totalChars;
+
+    // Build contiguous chars buffer.
+    auto chars = std::make_shared<std::vector<char>>(totalChars);
+    for (int32_t i = 0; i < numRows; ++i) {
+      if (!vector.isNullAt(i)) {
+        auto sv = flatVector->valueAt(i);
+        std::memcpy(chars->data() + (*offsets)[i], sv.data(), sv.size());
+      }
+    }
+
+    rmm::device_buffer offsetBuf(offsets->size() * sizeof(int32_t), stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        offsetBuf.data(),
+        offsets->data(),
+        offsets->size() * sizeof(int32_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    // Schedule cleanup of offsets buffer after copy completes
+    CUDF_CUDA_TRY(cudaLaunchHostFunc(
+        stream.value(),
+        [](void* p) {
+          auto sp = static_cast<std::shared_ptr<void>*>(p);
+          delete sp; // refcount drops here
+        },
+        new std::shared_ptr<void>(offsets)));
+
+    auto offsetsColumn = std::make_unique<cudf::column>(
+        cudf::data_type{cudf::type_id::INT32},
+        static_cast<cudf::size_type>(offsets->size()),
+        std::move(offsetBuf),
+        rmm::device_buffer{0, stream, mr},
+        0);
+
+    // Copy chars to GPU.
+    rmm::device_buffer charsBuf(totalChars, stream, mr);
+    if (totalChars > 0) {
+      CUDF_CUDA_TRY(cudaMemcpyAsync(
+          charsBuf.data(),
+          chars->data(),
+          totalChars,
+          cudaMemcpyHostToDevice,
+          stream.value()));
+
+      // Schedule cleanup of chars buffer after copy completes
+      CUDF_CUDA_TRY(cudaLaunchHostFunc(
+          stream.value(),
+          [](void* p) {
+            auto sp = static_cast<std::shared_ptr<void>*>(p);
+            delete sp; // refcount drops here
+          },
+          new std::shared_ptr<void>(chars)));
+    }
+
+    // No need to synchronize - cudaLaunchHostFunc ensures buffers stay alive
+
+    // Copy null mask and get null count.
+    auto nullCount = getNullCount(vector);
+    auto nullBuf = copyNullMask(vector, nullCount);
+
+    return cudf::make_strings_column(
+        numRows,
+        std::move(offsetsColumn),
+        std::move(charsBuf),
+        nullCount,
+        std::move(*nullBuf));
+  }
+
+  template <typename Vector>
+  bool isCompact(const Vector& vec) const {
+    for (vector_size_t i = 1; i < vec.size(); ++i) {
+      if (vec.offsetAt(i - 1) + vec.sizeAt(i - 1) != vec.offsetAt(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Converts a Velox ArrayVector to a cudf LIST column.
+  /// Velox stores lists with separate offsets and sizes arrays, while cudf uses
+  /// Arrow-style cumulative offsets (length = numRows + 1). We compute the
+  /// cumulative offsets from Velox's (offset, size) pairs and recursively
+  /// convert the elements child vector.
+  std::unique_ptr<cudf::column> readArrayColumn(
+      const VectorPtr& vector,
+      const TypePtr& type,
+      memory::MemoryPool* pool) const {
+    const auto numRows = vector->size();
+    auto* arrayVector = vector->as<ArrayVector>();
+    VELOX_CHECK_NOT_NULL(
+        arrayVector, "Expected ArrayVector for direct conversion");
+    if (!isCompact(*arrayVector) &&
+        arrayVector->elements()->type()->isPrimitiveType()) {
+      auto* rawOffsets = arrayVector->rawOffsets();
+      auto* rawSizes = arrayVector->rawSizes();
+
+      // Step 1: build compact offsets using GPU-accelerated prefix sum
+      auto offsetsColumn = makeOffsetsColumnFromSizes(rawSizes, numRows);
+
+      // Compute total elements for gather indices
+      int32_t totalElements = 0;
+      for (int i = 0; i < numRows; ++i) {
+        totalElements += rawSizes[i];
+      }
+      // Step 2: gather elements into contiguous buffer
+      auto elements = BaseVector::loadedVectorShared(arrayVector->elements());
+      // Create indices for gather
+      std::vector<vector_size_t> gatherIndices;
+      gatherIndices.reserve(totalElements);
+      for (int i = 0; i < numRows; ++i) {
+        auto offset = rawOffsets[i];
+        auto size = rawSizes[i];
+        for (int j = 0; j < size; ++j) {
+          gatherIndices.push_back(offset + j);
+        }
+      }
+      // Wrap indices into a Velox buffer/vector
+      auto indexBuffer =
+          AlignedBuffer::allocate<vector_size_t>(gatherIndices.size(), pool);
+      std::memcpy(
+          indexBuffer->asMutable<vector_size_t>(),
+          gatherIndices.data(),
+          gatherIndices.size() * sizeof(vector_size_t));
+      // Use Velox dictionary to compact
+      auto compactElements = BaseVector::wrapInDictionary(
+          BufferPtr(nullptr), indexBuffer, gatherIndices.size(), elements);
+      // Now convert compacted child
+      BaseVector::flattenVector(compactElements);
+      auto childColumn = convertColumn(compactElements, type->childAt(0), pool);
+      auto nullCount = getNullCount(*vector);
+      auto nullBuf = copyNullMask(*vector, nullCount);
+      return cudf::make_lists_column(
+          numRows,
+          std::move(offsetsColumn),
+          std::move(childColumn),
+          nullCount,
+          std::move(*nullBuf));
+    }
+
+    if (!isCompact(*arrayVector)) {
+      // Non-compact: accumulate only for non-null rows, always set offset for
+      // each row. Need to reorder all the row, fallback to with arrow
+      // conversion Wrap the vector in a RowVector for Arrow conversion
+      auto rowType = ROW({type});
+      std::vector<VectorPtr> children = {vector};
+      auto rowVector = std::make_shared<RowVector>(
+          pool, rowType, nullptr, vector->size(), children);
+      auto columns =
+          toCudfTableArrow(rowVector, pool, stream, mr, timestampTimeZone)
+              ->release();
+      return std::move(columns[0]);
+    }
+    // If compact, use GPU-accelerated offsets generation from sizes
+    auto offsetsColumn =
+        makeOffsetsColumnFromSizes(arrayVector->rawSizes(), numRows);
+    auto elements = arrayVector->elements();
+    auto childColumn = convertColumn(elements, type->childAt(0), pool);
+
+    auto nullCount = getNullCount(*vector);
+    auto nullBuf = copyNullMask(*vector, nullCount);
+    return cudf::make_lists_column(
+        numRows,
+        std::move(offsetsColumn),
+        std::move(childColumn),
+        nullCount,
+        std::move(*nullBuf));
+  }
+
+  /// Converts a Velox RowVector to a cudf STRUCT column.
+  /// Recursively converts each child column and assembles them into a struct.
+  std::unique_ptr<cudf::column> readStructColumn(
+      const BaseVector& vector,
+      const TypePtr& type,
+      memory::MemoryPool* pool) const {
+    const auto numRows = vector.size();
+
+    auto* rowVector = vector.as<RowVector>();
+    VELOX_CHECK_NOT_NULL(
+        rowVector, "Expected RowVector for direct struct conversion");
+
+    const auto numChildren = rowVector->childrenSize();
+    std::vector<std::unique_ptr<cudf::column>> childColumns;
+    childColumns.reserve(numChildren);
+
+    for (auto i = 0; i < numChildren; ++i) {
+      const auto& child = rowVector->childAt(i);
+      auto childType = type->childAt(i);
+      childColumns.push_back(convertColumn(child, childType, pool));
+    }
+
+    auto nullCount = getNullCount(vector);
+    auto nullBuf = copyNullMask(vector, nullCount);
+
+    return cudf::make_structs_column(
+        numRows,
+        std::move(childColumns),
+        nullCount,
+        std::move(*nullBuf),
+        stream,
+        mr);
+  }
+
+  /// Converts any Velox vector to a cudf column by dispatching on TypeKind.
+  std::unique_ptr<cudf::column> convertColumn(
+      const VectorPtr& vector,
+      const TypePtr& type,
+      memory::MemoryPool* pool) const {
+    switch (type->kind()) {
+      case TypeKind::BOOLEAN:
+        return readBooleanColumn(*vector, type);
+      case TypeKind::TINYINT:
+        return readColumn<TypeKind::TINYINT>(*vector, type);
+      case TypeKind::SMALLINT:
+        return readColumn<TypeKind::SMALLINT>(*vector, type);
+      case TypeKind::INTEGER:
+        return readColumn<TypeKind::INTEGER>(*vector, type);
+      case TypeKind::BIGINT:
+        return readColumn<TypeKind::BIGINT>(*vector, type);
+      case TypeKind::HUGEINT:
+        return readColumn<TypeKind::HUGEINT>(*vector, type);
+      case TypeKind::REAL:
+        return readColumn<TypeKind::REAL>(*vector, type);
+      case TypeKind::DOUBLE:
+        return readColumn<TypeKind::DOUBLE>(*vector, type);
+      case TypeKind::TIMESTAMP:
+        return readTimestampColumn(*vector, type);
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+        return readStringColumn(*vector);
+      case TypeKind::ARRAY:
+        return readArrayColumn(vector, type, pool);
+      case TypeKind::ROW:
+        return readStructColumn(*vector, type, pool);
+      default:
+        VELOX_FAIL(
+            "Unsupported Velox type for direct cudf conversion: {}",
+            type->toString());
+    }
+  }
+
+ private:
+  /// Specialization for BOOLEAN: Velox stores booleans as bit-packed uint64_t
+  /// arrays, and cudf BOOL8 stores them as one byte per value (int8_t).
+  /// Optimized GPU-accelerated version using cuDF's mask_to_bools to expand
+  /// bit-packed representation directly on GPU.
+  std::unique_ptr<cudf::column> readBooleanColumn(
+      const BaseVector& vector,
+      const TypePtr& type) const {
+    const auto numRows = vector.size();
+    auto* flatVector = vector.as<FlatVector<bool>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector<bool> for direct conversion");
+    // Copy null mask to device (bit-packed boolean data)
+    auto nullCount = getNullCount(vector);
+    auto nullBuf = copyNullMask(vector, nullCount);
+    auto dataBuffer = flatVector->rawValues<uint8_t>();
+    auto const dataWords = cudf::num_bitmask_words(numRows);
+    auto const copySize = bits::nbytes(numRows);
+
+    auto data = rmm::device_uvector<cudf::bitmask_type>(dataWords, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        data.data(), dataBuffer, copySize, cudaMemcpyDefault, stream.value()));
+
+    // Use cudf::mask_to_bools to expand bit-packed mask to BOOL8 column
+    auto boolColumn = cudf::mask_to_bools(
+        static_cast<cudf::bitmask_type*>(data.data()),
+        0,
+        static_cast<cudf::size_type>(numRows),
+        stream,
+        mr);
+
+    // Set null mask for nulls in the original vector
+    boolColumn->set_null_mask(std::move(*nullBuf), nullCount);
+    return boolColumn;
+  }
+
+  /// Fully GPU-accelerated version: copies Timestamp array to GPU and uses
+  /// Thrust transform to convert to nanoseconds directly on device.
+  std::unique_ptr<cudf::column> readTimestampColumn(
+      const BaseVector& vector,
+      const TypePtr& type) const {
+    const auto numRows = vector.size();
+    auto* flatVector = vector.as<FlatVector<Timestamp>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector<Timestamp> for direct conversion");
+
+    // Copy Timestamp array to device
+    const auto* rawTimestamps = flatVector->rawValues();
+    auto dTimestamps = rmm::device_uvector<Timestamp>(numRows, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        dTimestamps.data(),
+        rawTimestamps,
+        numRows * sizeof(Timestamp),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    // Copy null mask to device
+    auto nullCount = getNullCount(vector);
+    auto nullBuf = copyNullMask(vector, nullCount);
+    auto dMask = static_cast<cudf::bitmask_type*>(nullBuf->data());
+
+    auto dValues = rmm::device_uvector<int64_t>(numRows, stream, mr);
+
+    util::convertTimestamps(
+        dTimestamps.data(),
+        dMask,
+        dValues.data(),
+        numRows,
+        CudfConfig::getInstance().timestampUnit,
+        timestampTimeZone ? std::optional<std::string_view>(*timestampTimeZone)
+                          : std::nullopt,
+        stream);
+
+    auto cudfType = veloxToCudfDataType(type);
+    return std::make_unique<cudf::column>(
+        cudfType, numRows, dValues.release(), std::move(*nullBuf), nullCount);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<cudf::table> toCudfTable(
+    const facebook::velox::RowVectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    std::optional<std::string> timestampTimeZone) {
+  const auto numColumns = veloxTable->childrenSize();
+
+  // Flatten dictionary and constant encodings to get flat vectors.
+  // This matches what the Arrow path does with ArrowOptions{true, true}.
+  VectorPtr flattenTarget = veloxTable;
+  BaseVector::flattenVector(flattenTarget);
+  auto flatRow = std::dynamic_pointer_cast<RowVector>(flattenTarget);
+
+  const auto& rowType = flatRow->type()->as<TypeKind::ROW>();
+
+  DispatchColumn dispatcher{stream, mr, std::move(timestampTimeZone)};
+
+  std::vector<std::unique_ptr<cudf::column>> cudfColumns;
+  cudfColumns.reserve(numColumns);
+
+  for (auto i = 0; i < numColumns; ++i) {
+    auto child = flatRow->childAt(i);
+    const auto& colType = rowType.childAt(i);
+    auto column = dispatcher.convertColumn(child, colType, pool);
+    cudfColumns.push_back(std::move(column));
+  }
+  stream.synchronize();
+
+  return std::make_unique<cudf::table>(std::move(cudfColumns));
+}
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -26,6 +26,7 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/LazyVector.h"
 #include "velox/vector/arrow/Bridge.h"
 
 #include <cudf/column/column.hpp>
@@ -351,7 +352,7 @@ struct DispatchColumn {
   /// Copies the Velox null bitmask to a GPU device buffer. Velox and cudf both
   /// use a validity bitmask where bit=1 means valid (not null), so no
   /// conversion is needed. Returns an empty buffer if there are no nulls.
-  std::unique_ptr<rmm::device_buffer> copyNullMask(
+  inline std::unique_ptr<rmm::device_buffer> copyNullMask(
       const BaseVector& input,
       int32_t nullCount) const {
     if (nullCount == 0) {
@@ -375,34 +376,13 @@ struct DispatchColumn {
   /// Returns the null count for a Velox vector. Uses Velox's cached value if
   /// available, otherwise counts from the raw bitmap.
   static cudf::size_type getNullCount(const BaseVector& vector) {
-    auto nullCount = vector.getNullCount();
-    if (nullCount.has_value()) {
-      return static_cast<cudf::size_type>(nullCount.value());
-    }
-    const auto* rawNulls = vector.rawNulls();
-    if (rawNulls == nullptr) {
+    if (vector.nulls()) {
       return 0;
     }
-    return static_cast<cudf::size_type>(
-        bits::countNulls(rawNulls, 0, vector.size()));
-  }
-
-  /// GPU-accelerated version: builds offsets column directly on device from
-  /// sizes array using Thrust inclusive_scan (prefix sum).
-  std::unique_ptr<cudf::column> makeOffsetsColumnFromSizes(
-      const int32_t* rawSizes,
-      cudf::size_type numRows) const {
-    // Copy sizes to device
-    auto dSizes = rmm::device_uvector<int32_t>(numRows, stream, mr);
-    CUDF_CUDA_TRY(cudaMemcpyAsync(
-        dSizes.data(),
-        rawSizes,
-        numRows * sizeof(int32_t),
-        cudaMemcpyHostToDevice,
-        stream.value()));
-
-    // Use utility function to compute offsets on GPU
-    return util::computeOffsetsFromSizes(dSizes.data(), numRows, stream, mr);
+    if (auto nullCount = vector.getNullCount()) {
+      return *nullCount;
+    }
+    return BaseVector::countNulls(vector.nulls(), vector.size()); 
   }
 
   /// Reads a flat scalar column from a Velox FlatVector and creates a cudf
@@ -563,13 +543,8 @@ struct DispatchColumn {
       auto* rawSizes = arrayVector->rawSizes();
 
       // Step 1: build compact offsets using GPU-accelerated prefix sum
-      auto offsetsColumn = makeOffsetsColumnFromSizes(rawSizes, numRows);
+      auto [offsetsColumn, totalElements] = makeOffsetsColumnFromSizes(rawSizes, numRows, stream, mr);
 
-      // Compute total elements for gather indices
-      int32_t totalElements = 0;
-      for (int i = 0; i < numRows; ++i) {
-        totalElements += rawSizes[i];
-      }
       // Step 2: gather elements into contiguous buffer
       auto elements = BaseVector::loadedVectorShared(arrayVector->elements());
       // Create indices for gather
@@ -620,7 +595,7 @@ struct DispatchColumn {
     }
     // If compact, use GPU-accelerated offsets generation from sizes
     auto offsetsColumn =
-        makeOffsetsColumnFromSizes(arrayVector->rawSizes(), numRows);
+        makeOffsetsColumnFromSizes(arrayVector->rawSizes(), numRows, stream, mr).first;
     auto elements = arrayVector->elements();
     auto childColumn = convertColumn(elements, type->childAt(0), pool);
 
@@ -769,7 +744,7 @@ struct DispatchColumn {
 
     auto dValues = rmm::device_uvector<int64_t>(numRows, stream, mr);
 
-    util::convertTimestamps(
+    convertTimestamps(
         dTimestamps.data(),
         dMask,
         dValues.data(),
@@ -794,14 +769,23 @@ std::unique_ptr<cudf::table> toCudfTable(
     rmm::device_async_resource_ref mr,
     std::optional<std::string> timestampTimeZone) {
   const auto numColumns = veloxTable->childrenSize();
+  const auto numRows = veloxTable->size();
 
   // Flatten dictionary and constant encodings to get flat vectors.
   // This matches what the Arrow path does with ArrowOptions{true, true}.
-  VectorPtr flattenTarget = veloxTable;
-  BaseVector::flattenVector(flattenTarget);
-  auto flatRow = std::dynamic_pointer_cast<RowVector>(flattenTarget);
+  for (auto& child : veloxTable->children()) {
+    facebook::velox::BaseVector::flattenVector(child);
+    if (child->isLazy()) {
+      child = child->as<facebook::velox::LazyVector>()->loadedVectorShared();
+      VELOX_DCHECK_NOT_NULL(child);
+    }
+    // In case of output from Limit, RowVector size can be smaller than its children size.
+    if (child->size() > numRows) {
+      child = child->slice(0, numRows);
+    }
+  }
 
-  const auto& rowType = flatRow->type()->as<TypeKind::ROW>();
+  const auto& rowType = veloxTable->type()->as<TypeKind::ROW>();
 
   DispatchColumn dispatcher{stream, mr, std::move(timestampTimeZone)};
 
@@ -809,7 +793,7 @@ std::unique_ptr<cudf::table> toCudfTable(
   cudfColumns.reserve(numColumns);
 
   for (auto i = 0; i < numColumns; ++i) {
-    auto child = flatRow->childAt(i);
+    auto child = veloxTable->childAt(i);
     const auto& colType = rowType.childAt(i);
     auto column = dispatcher.convertColumn(child, colType, pool);
     cudfColumns.push_back(std::move(column));
@@ -817,6 +801,17 @@ std::unique_ptr<cudf::table> toCudfTable(
   stream.synchronize();
 
   return std::make_unique<cudf::table>(std::move(cudfColumns));
+}
+
+namespace with_arrow {
+std::unique_ptr<cudf::table> toCudfTable(
+    const facebook::velox::RowVectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    std::optional<std::string> timestampTimeZone) {
+  return toCudfTableArrow(veloxTable, pool, stream, mr, timestampTimeZone);
+  }
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.h
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.h
@@ -31,6 +31,14 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type);
 cudf::data_type veloxToCudfDataType(const TypePtr& type);
 
 namespace with_arrow {
+
+    std::unique_ptr<cudf::table> toCudfTable(
+    const facebook::velox::RowVectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    std::optional<std::string> timestampTimeZone = std::nullopt);
+    
 // String types are converted to varchar. Use the overload with outputType if
 // you want to convert to varbinary instead.
 facebook::velox::RowVectorPtr toVeloxColumn(

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.h
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.h
@@ -31,14 +31,8 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type);
 cudf::data_type veloxToCudfDataType(const TypePtr& type);
 
 namespace with_arrow {
-
-std::unique_ptr<cudf::table> toCudfTable(
-    const facebook::velox::RowVectorPtr& veloxTable,
-    facebook::velox::memory::MemoryPool* pool,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr,
-    std::optional<std::string> timestampTimeZone = std::nullopt);
-
+// String types are converted to varchar. Use the overload with outputType if
+// you want to convert to varbinary instead.
 facebook::velox::RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     facebook::velox::memory::MemoryPool* pool,
@@ -46,22 +40,26 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
 
-// Accepts a Velox TypePtr for recursive metadata construction.
-facebook::velox::RowVectorPtr toVeloxColumn(
-    const cudf::table_view& table,
-    facebook::velox::memory::MemoryPool* pool,
-    const facebook::velox::RowTypePtr& outputType,
-    std::string namePrefix,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr);
-
+/// Accepts a Velox TypePtr for recursive metadata construction.
+/// The outputType decides if the cudf string type converts to varbinary or
+/// varchar.
 facebook::velox::RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     facebook::velox::memory::MemoryPool* pool,
     const TypePtr& type,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
-
 } // namespace with_arrow
+
+/// Converts a Velox RowVector to a cudf table by directly reading from
+/// Velox vector buffers and copying to GPU. This avoids the overhead of
+/// Arrow serialization/deserialization. Supports flat scalar types, strings,
+/// and complex/nested types (ARRAY as LIST, ROW as STRUCT.
+std::unique_ptr<cudf::table> toCudfTable(
+    const facebook::velox::RowVectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    std::optional<std::string> timestampTimeZone = std::nullopt);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/util/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/util/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(velox_cudf_exec_util InteropUtil.cu)
+
+target_link_libraries(velox_cudf_exec_util PRIVATE cudf::cudf)
+
+target_compile_options(
+  velox_cudf_exec_util
+  PRIVATE -Wno-missing-field-initializers --extended-lambda
+)

--- a/velox/experimental/cudf/exec/util/InteropUtil.cu
+++ b/velox/experimental/cudf/exec/util/InteropUtil.cu
@@ -20,17 +20,20 @@
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/utilities/bit.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/detail/sizes_to_offsets_iterator.cuh>
+
+#include <cuda/iterator>
 
 #include <rmm/exec_policy.hpp>
 
-#include <thrust/iterator/counting_iterator.h>
+
 #include <thrust/scan.h>
 #include <thrust/transform.h>
 
 #include <optional>
 #include <string_view>
 
-namespace facebook::velox::cudf_velox::util {
+namespace facebook::velox::cudf_velox {
 
 // DeviceTimestamp matches Velox Timestamp layout for device code
 // Avoids including velox/type/Timestamp.h which may conflict with folly
@@ -77,59 +80,58 @@ void convertTimestamps(
           rmm::exec_policy_nosync(stream),
           cuda::counting_iterator<cudf::size_type>(0),
           cuda::counting_iterator<cudf::size_type>(numRows),
-          thrust::counting_iterator<cudf::size_type>(numRows),
           dOutput,
           [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
             if (dMask && !cudf::bit_is_set(dMask, idx)) {
               return int64_t{};
             }
             auto const& ts = dTimestampsTyped[idx];
-            return ts.getSeconds() * kNanosPerSecond +
-                static_cast<int64_t>(ts.getNanos());
+            return ts.seconds() * kNanosPerSecond +
+                static_cast<int64_t>(ts.nanos());
           });
       break;
     case cudf::type_id::TIMESTAMP_MICROSECONDS:
       thrust::transform(
           rmm::exec_policy_nosync(stream),
-          thrust::counting_iterator<cudf::size_type>(0),
-          thrust::counting_iterator<cudf::size_type>(numRows),
+          cuda::counting_iterator<cudf::size_type>(0),
+          cuda::counting_iterator<cudf::size_type>(numRows),
           dOutput,
           [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
             if (dMask && !cudf::bit_is_set(dMask, idx)) {
               return int64_t{};
             }
             auto const& ts = dTimestampsTyped[idx];
-            return ts.getSeconds() * kMicrosPerSecond +
-                static_cast<int64_t>(ts.getNanos() / 1000);
+            return ts.seconds() * kMicrosPerSecond +
+                static_cast<int64_t>(ts.nanos() / 1000);
           });
       break;
     case cudf::type_id::TIMESTAMP_MILLISECONDS:
       thrust::transform(
           rmm::exec_policy_nosync(stream),
-          thrust::counting_iterator<cudf::size_type>(0),
-          thrust::counting_iterator<cudf::size_type>(numRows),
+          cuda::counting_iterator<cudf::size_type>(0),
+          cuda::counting_iterator<cudf::size_type>(numRows),
           dOutput,
           [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
             if (dMask && !cudf::bit_is_set(dMask, idx)) {
               return int64_t{};
             }
             auto const& ts = dTimestampsTyped[idx];
-            return ts.getSeconds() * kMillisPerSecond +
-                static_cast<int64_t>(ts.getNanos() / 1000000);
+            return ts.seconds() * kMillisPerSecond +
+                static_cast<int64_t>(ts.nanos() / 1000000);
           });
       break;
     case cudf::type_id::TIMESTAMP_SECONDS:
       thrust::transform(
           rmm::exec_policy_nosync(stream),
-          thrust::counting_iterator<cudf::size_type>(0),
-          thrust::counting_iterator<cudf::size_type>(numRows),
+          cuda::counting_iterator<cudf::size_type>(0),
+          cuda::counting_iterator<cudf::size_type>(numRows),
           dOutput,
           [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
             if (dMask && !cudf::bit_is_set(dMask, idx)) {
               return int64_t{};
             }
             auto const& ts = dTimestampsTyped[idx];
-            return ts.getSeconds();
+            return ts.seconds();
           });
       break;
     default:
@@ -137,34 +139,47 @@ void convertTimestamps(
   }
 }
 
-std::unique_ptr<cudf::column> computeOffsetsFromSizes(
-    const int32_t* dSizes,
+std::pair<std::unique_ptr<cudf::column>, cudf::size_type>
+makeOffsetsColumnFromSizes(
+    const int32_t* rawSizes,
     cudf::size_type numRows,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
-  // Allocate offsets buffer (numRows + 1)
-  auto dOffsets = rmm::device_uvector<int32_t>(numRows + 1, stream, mr);
 
-  // Set first offset to 0
-  CUDF_CUDA_TRY(
-      cudaMemsetAsync(dOffsets.data(), 0, sizeof(int32_t), stream.value()));
+    if (numRows == 0)
+    {
+        return {
+            cudf::make_empty_column(cudf::type_id::INT32),
+            cudf::size_type{0}
+        };
+    }
 
-  // Use Thrust inclusive_scan to compute prefix sum: offsets[i+1] =
-  // sum(sizes[0..i])
-  thrust::inclusive_scan(
-      rmm::exec_policy_nosync(stream),
-      dSizes,
-      dSizes + numRows,
-      dOffsets.data() + 1);
+    // 1. host → device
+    rmm::device_uvector<int32_t> d_sizes(numRows, stream);
 
-  return std::make_unique<cudf::column>(
-      cudf::data_type{cudf::type_id::INT32},
-      numRows + 1,
-      dOffsets.release(),
-      rmm::device_buffer{0, stream, mr},
-      0);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        d_sizes.data(),
+        rawSizes,
+        numRows * sizeof(int32_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    auto sizes_itr = thrust::make_counting_iterator(0);
+
+    auto transform_itr =
+        cuda::proclaim_return_type<cudf::size_type>(
+            [d_sizes = d_sizes.data()] __device__ (cudf::size_type i) {
+                return static_cast<cudf::size_type>(d_sizes[i]);
+            });
+
+    auto begin = thrust::make_transform_iterator(sizes_itr, transform_itr);
+    auto end   = begin + numRows;
+
+    auto [offsets_column, bytes] =
+        cudf::detail::make_offsets_child_column(
+            begin, end, stream, mr);
+
+    return {std::move(offsets_column), bytes};
 }
 
-} // namespace facebook::velox::cudf_velox::util
-
-// Made with Bob
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/util/InteropUtil.cu
+++ b/velox/experimental/cudf/exec/util/InteropUtil.cu
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/util/InteropUtil.h"
+
+#include <cudf/column/column_factories.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <cudf/utilities/error.hpp>
+
+#include <rmm/exec_policy.hpp>
+
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/scan.h>
+#include <thrust/transform.h>
+
+#include <optional>
+#include <string_view>
+
+namespace facebook::velox::cudf_velox::util {
+
+// DeviceTimestamp matches Velox Timestamp layout for device code
+// Avoids including velox/type/Timestamp.h which may conflict with folly
+struct DeviceTimestamp {
+  int64_t seconds_;
+  uint64_t nanos_;
+
+  __device__ int64_t seconds() const {
+    return seconds_;
+  }
+  __device__ uint64_t nanos() const {
+    return nanos_;
+  }
+};
+
+namespace {
+constexpr int64_t kNanosPerSecond = 10'000'000'00LL;
+constexpr int64_t kMicrosPerSecond = 1'000'000LL;
+constexpr int64_t kMillisPerSecond = 1'000LL;
+} // namespace
+
+void convertTimestamps(
+    const void* dTimestamps,
+    const cudf::bitmask_type* dMask,
+    int64_t* dOutput,
+    cudf::size_type numRows,
+    cudf::type_id timestampUnit,
+    std::optional<std::string_view> timestampTimeZone,
+    rmm::cuda_stream_view stream) {
+  CUDF_EXPECTS(
+      !timestampTimeZone.has_value() || timestampTimeZone->empty() ||
+          *timestampTimeZone == "UTC",
+      "Direct GPU timestamp conversion supports only UTC or empty timezone. Got: " +
+          std::string(timestampTimeZone.value_or("")));
+
+  // Use reinterpret_cast to access Timestamp data with matching layout
+  auto dTimestampsTyped = reinterpret_cast<const DeviceTimestamp*>(dTimestamps);
+
+  // Specialize the device lambda for each timestamp unit to avoid per-row
+  // branching
+  switch (timestampUnit) {
+    case cudf::type_id::TIMESTAMP_NANOSECONDS:
+      thrust::transform(
+          rmm::exec_policy_nosync(stream),
+          cuda::counting_iterator<cudf::size_type>(0),
+          cuda::counting_iterator<cudf::size_type>(numRows),
+          thrust::counting_iterator<cudf::size_type>(numRows),
+          dOutput,
+          [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
+            if (dMask && !cudf::bit_is_set(dMask, idx)) {
+              return int64_t{};
+            }
+            auto const& ts = dTimestampsTyped[idx];
+            return ts.getSeconds() * kNanosPerSecond +
+                static_cast<int64_t>(ts.getNanos());
+          });
+      break;
+    case cudf::type_id::TIMESTAMP_MICROSECONDS:
+      thrust::transform(
+          rmm::exec_policy_nosync(stream),
+          thrust::counting_iterator<cudf::size_type>(0),
+          thrust::counting_iterator<cudf::size_type>(numRows),
+          dOutput,
+          [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
+            if (dMask && !cudf::bit_is_set(dMask, idx)) {
+              return int64_t{};
+            }
+            auto const& ts = dTimestampsTyped[idx];
+            return ts.getSeconds() * kMicrosPerSecond +
+                static_cast<int64_t>(ts.getNanos() / 1000);
+          });
+      break;
+    case cudf::type_id::TIMESTAMP_MILLISECONDS:
+      thrust::transform(
+          rmm::exec_policy_nosync(stream),
+          thrust::counting_iterator<cudf::size_type>(0),
+          thrust::counting_iterator<cudf::size_type>(numRows),
+          dOutput,
+          [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
+            if (dMask && !cudf::bit_is_set(dMask, idx)) {
+              return int64_t{};
+            }
+            auto const& ts = dTimestampsTyped[idx];
+            return ts.getSeconds() * kMillisPerSecond +
+                static_cast<int64_t>(ts.getNanos() / 1000000);
+          });
+      break;
+    case cudf::type_id::TIMESTAMP_SECONDS:
+      thrust::transform(
+          rmm::exec_policy_nosync(stream),
+          thrust::counting_iterator<cudf::size_type>(0),
+          thrust::counting_iterator<cudf::size_type>(numRows),
+          dOutput,
+          [dTimestampsTyped, dMask] __device__(auto idx) -> int64_t {
+            if (dMask && !cudf::bit_is_set(dMask, idx)) {
+              return int64_t{};
+            }
+            auto const& ts = dTimestampsTyped[idx];
+            return ts.getSeconds();
+          });
+      break;
+    default:
+      CUDF_FAIL("Unsupported timestamp unit for direct GPU conversion");
+  }
+}
+
+std::unique_ptr<cudf::column> computeOffsetsFromSizes(
+    const int32_t* dSizes,
+    cudf::size_type numRows,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Allocate offsets buffer (numRows + 1)
+  auto dOffsets = rmm::device_uvector<int32_t>(numRows + 1, stream, mr);
+
+  // Set first offset to 0
+  CUDF_CUDA_TRY(
+      cudaMemsetAsync(dOffsets.data(), 0, sizeof(int32_t), stream.value()));
+
+  // Use Thrust inclusive_scan to compute prefix sum: offsets[i+1] =
+  // sum(sizes[0..i])
+  thrust::inclusive_scan(
+      rmm::exec_policy_nosync(stream),
+      dSizes,
+      dSizes + numRows,
+      dOffsets.data() + 1);
+
+  return std::make_unique<cudf::column>(
+      cudf::data_type{cudf::type_id::INT32},
+      numRows + 1,
+      dOffsets.release(),
+      rmm::device_buffer{0, stream, mr},
+      0);
+}
+
+} // namespace facebook::velox::cudf_velox::util
+
+// Made with Bob

--- a/velox/experimental/cudf/exec/util/InteropUtil.h
+++ b/velox/experimental/cudf/exec/util/InteropUtil.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cudf/column/column.hpp>
+#include <cudf/strings/strings_column_view.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_uvector.hpp>
+
+#include <memory>
+
+namespace facebook::velox::cudf_velox::util {
+
+/// Convert Timestamp array to the configured cuDF timestamp representation on
+/// GPU.
+void convertTimestamps(
+    const void* dTimestamps,
+    const cudf::bitmask_type* dMask,
+    int64_t* dOutput,
+    cudf::size_type numRows,
+    cudf::type_id timestampUnit,
+    std::optional<std::string_view> timestampTimeZone,
+    rmm::cuda_stream_view stream);
+
+/// Compute prefix sum (inclusive scan) on GPU using CUB
+std::unique_ptr<cudf::column> computeOffsetsFromSizes(
+    const int32_t* dSizes,
+    cudf::size_type numRows,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
+} // namespace facebook::velox::cudf_velox::util
+
+// Made with Bob

--- a/velox/experimental/cudf/exec/util/InteropUtil.h
+++ b/velox/experimental/cudf/exec/util/InteropUtil.h
@@ -25,7 +25,7 @@
 
 #include <memory>
 
-namespace facebook::velox::cudf_velox::util {
+namespace facebook::velox::cudf_velox {
 
 /// Convert Timestamp array to the configured cuDF timestamp representation on
 /// GPU.
@@ -38,13 +38,13 @@ void convertTimestamps(
     std::optional<std::string_view> timestampTimeZone,
     rmm::cuda_stream_view stream);
 
-/// Compute prefix sum (inclusive scan) on GPU using CUB
-std::unique_ptr<cudf::column> computeOffsetsFromSizes(
-    const int32_t* dSizes,
+std::pair<std::unique_ptr<cudf::column>, cudf::size_type>
+makeOffsetsColumnFromSizes(
+    const int32_t* rawSizes,
     cudf::size_type numRows,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
 
-} // namespace facebook::velox::cudf_velox::util
+} // namespace facebook::velox::cudf_velox
 
 // Made with Bob

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -41,6 +41,25 @@ add_executable(velox_cudf_mark_distinct_test Main.cpp MarkDistinctTest.cpp)
 add_executable(velox_cudf_topn_test Main.cpp TopNTest.cpp)
 add_executable(velox_cudf_batch_concat_test Main.cpp BatchConcatTest.cpp)
 
+add_executable(velox_cudf_interop_test Main.cpp InteropTest.cpp)
+add_test(
+  NAME velox_cudf_interop_test
+  COMMAND velox_cudf_interop_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(
+  velox_cudf_interop_test
+  velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  velox_vector_fuzzer
+  gtest
+  gtest_main
+  fmt::fmt
+)
+set_tests_properties(velox_cudf_interop_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+
 add_test(
   NAME velox_cudf_aggregation_test
   COMMAND velox_cudf_aggregation_test

--- a/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
+++ b/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
@@ -32,7 +32,7 @@ class CudfFunctionBaseTest : public velox::functions::test::FunctionBaseTest {
 
     VELOX_CHECK(!rows.has_value());
     auto stream = cudf::get_default_stream();
-    auto cudfTable = velox::cudf_velox::with_arrow::toCudfTable(
+    auto cudfTable = velox::cudf_velox::toCudfTable(
         input, pool_.get(), stream, cudf::get_current_device_resource_ref());
     auto filterEvaluator =
         createCudfExpression({exprSet.exprs()[0]}, input->rowType());

--- a/velox/experimental/cudf/tests/InteropTest.cpp
+++ b/velox/experimental/cudf/tests/InteropTest.cpp
@@ -33,16 +33,14 @@ class InteropTest : public ::testing::Test, public VectorTestBase {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
   }
 
-  /// Round-trips a RowVector through the direct toCudfTable and back via
-  /// with_arrow::toVeloxColumn, then asserts equality with the original.
+  // Round-trips a RowVector through the direct toCudfTable and back via
+  // with_arrow::toVeloxColumn, then asserts equality with the original.
   void roundTrip(const RowVectorPtr& input) {
     auto stream = cudf::get_default_stream();
     auto mr = cudf::get_current_device_resource_ref();
 
     // Convert Velox -> cudf using the new direct path.
-    // auto cudfTable = cudf_velox::toCudfTable(input, pool_.get(), stream, mr);
-    auto cudfTable =
-        cudf_velox::with_arrow::toCudfTable(input, pool_.get(), stream, mr);
+    auto cudfTable = cudf_velox::toCudfTable(input, pool_.get(), stream, mr);
     ASSERT_NE(cudfTable, nullptr);
     ASSERT_EQ(cudfTable->num_rows(), input->size());
     ASSERT_EQ(
@@ -53,7 +51,12 @@ class InteropTest : public ::testing::Test, public VectorTestBase {
     auto result = cudf_velox::with_arrow::toVeloxColumn(
         cudfTable->view(), pool_.get(), input->type(), stream, mr);
     stream.synchronize();
-
+    // Decimal type lost precision in the conversion, after toVeloxColumn, it
+    // always set the short decimal precision to 18 and long decimal precision
+    // to 38, will resolve it in cudf::table to RowVector directly.
+    if (input->childAt(0)->type()->isDecimal()) {
+      result->setType(input->type());
+    }
     // Verify.
     test::assertEqualVectors(input, result);
   }
@@ -406,6 +409,25 @@ TEST_F(InteropTest, arrayOfStructs) {
       structElements);
 
   auto input = makeRowVector({"c0"}, {arrayVector});
+  roundTrip(input);
+}
+
+// ========== Decimal types ==========
+
+TEST_F(InteropTest, decimalShort) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int64_t>(
+          {12345, -67890, 0, 99999999, -1}, DECIMAL(10, 2))});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, decimalLong) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int128_t>(
+          {1234567890123456, -9876543210987654, 0, 999999999999999999, -1},
+          DECIMAL(20, 6))});
   roundTrip(input);
 }
 

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -67,7 +67,7 @@ class SubfieldFilterAstTest : public OperatorTestBase {
     auto mr = cudf::get_current_device_resource_ref();
 
     {
-      auto cudfTable = cudf_velox::with_arrow::toCudfTable(
+      auto cudfTable = cudf_velox::toCudfTable(
           vector, pool_.get(), stream, cudf::get_current_device_resource_ref());
       ASSERT_NE(cudfTable, nullptr);
 
@@ -601,7 +601,7 @@ TEST_F(SubfieldFilterAstTest, MultipleSubfieldFilters) {
   auto stream = cudf::get_default_stream();
   auto mr = cudf::get_current_device_resource_ref();
 
-  auto cudfTable = cudf_velox::with_arrow::toCudfTable(
+  auto cudfTable = cudf_velox::toCudfTable(
       vec, pool_.get(), stream, cudf::get_current_device_resource_ref());
   ASSERT_NE(cudfTable, nullptr);
   auto cudfResult =

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
@@ -162,7 +162,7 @@ void CudfHiveConnectorTestBase::writeToFile(
   for (const auto& vector : vectors) {
     VELOX_CHECK_NOT_NULL(vector);
     if (vector->size()) {
-      auto cudfTable = with_arrow::toCudfTable(
+      auto cudfTable = toCudfTable(
           vector,
           vector->pool(),
           stream,
@@ -203,7 +203,7 @@ void CudfHiveConnectorTestBase::writeToFile(
   auto rowType = asRowType(vector->type());
   auto const sinkInfo = cudf::io::sink_info(filePath);
   auto stream = cudf::get_default_stream();
-  auto cudfTable = with_arrow::toCudfTable(
+  auto cudfTable = toCudfTable(
       vector, vector->pool(), stream, cudf::get_current_device_resource_ref());
   stream.synchronize();
   auto tableInputMetadata = cudf::io::table_input_metadata(cudfTable->view());


### PR DESCRIPTION
Support all the data type.
Notes: The timestamp now converts to nano seconds align with Presto behavior.
Map type is not supported in this PR, because cudf does not have a native MapType, converts a Velox MapVector to a cudf LIST<STRUCT<key, value>> column, but we cannot convert back LIST<STRUCT<key, value>> to map.
May use cudaMemPrefetchAsync to prefetch all the CPU memory to GPU before construct the cudf columns