### PR TITLE
Improve IcebergSplitReader error handling and fix test file handle leaks

### DIFF
--- a/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.cpp
@@ -18,6 +18,7 @@
 
 #include <folly/lang/Bits.h>
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/common/encode/Base64.h"
 #include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
 #include "velox/connectors/hive/iceberg/IcebergMetadataColumns.h"
@@ -115,8 +116,12 @@ void IcebergSplitReader::prepareSplit(
                 splitOffset_,
                 hiveSplit_->connectorId));
       }
+    } else if (deleteFile.content == FileContent::kEqualityDeletes) {
+      VELOX_NYI("Equality deletes are not yet supported.");
     } else {
-      VELOX_NYI();
+      VELOX_NYI(
+          "Unsupported delete file content type: {}",
+          static_cast<int>(deleteFile.content));
     }
   }
 }

--- a/velox/connectors/hive/iceberg/IcebergSplitReader.h
+++ b/velox/connectors/hive/iceberg/IcebergSplitReader.h
@@ -93,10 +93,10 @@ class IcebergSplitReader : public SplitReader {
       const RowTypePtr& fileType,
       const RowTypePtr& tableSchema) const override;
 
-  // The read offset to the beginning of the split in number of rows for the
-  // current batch for the base data file
+  /// Read offset to the beginning of the split in number of rows for the
+  /// current batch for the base data file.
   uint64_t baseReadOffset_;
-  // The file position for the first row in the split
+  /// File position for the first row in the split.
   uint64_t splitOffset_;
   std::list<std::unique_ptr<PositionalDeleteFileReader>>
       positionalDeleteFileReaders_;

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.cpp
@@ -42,6 +42,15 @@ using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::connector::hive::iceberg {
 
+namespace {
+// Return the file size for the given path using Velox's filesystem API.
+uint64_t getTestFileSize(const std::string& path) {
+  return filesystems::getFileSystem(path, nullptr)
+      ->openFileForRead(path)
+      ->size();
+}
+} // namespace
+
 static const char* kIcebergConnectorId = "test-iceberg";
 
 class HiveIcebergTest : public HiveConnectorTestBase {
@@ -241,8 +250,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
               deleteFilePath,
               fileFomat_,
               deleteFilePaths[deleteFileName].first,
-              testing::internal::GetFileSize(
-                  std::fopen(deleteFilePath.c_str(), "r")));
+              getTestFileSize(deleteFilePath));
           deleteFiles.push_back(icebergDeleteFile);
         }
       }
@@ -354,8 +362,7 @@ class HiveIcebergTest : public HiveConnectorTestBase {
         deleteFilePath->getPath(),
         fileFomat_,
         deletedPositionSize,
-        testing::internal::GetFileSize(
-            std::fopen(deleteFilePath->getPath().c_str(), "r")));
+        getTestFileSize(deleteFilePath->getPath()));
     auto fileSize = filesystems::getFileSystem(path, nullptr)
                         ->openFileForRead(path)
                         ->size();
@@ -934,8 +941,7 @@ TEST_F(HiveIcebergTest, skipDeleteFileByPositionUpperBound) {
       deleteFilePath->getPath(),
       dwio::common::FileFormat::DWRF,
       3,
-      testing::internal::GetFileSize(
-          std::fopen(deleteFilePath->getPath().c_str(), "r")),
+      getTestFileSize(deleteFilePath->getPath()),
       {},
       {},
       {{posColumn->id, encodedUpperBound}});
@@ -1004,4 +1010,5 @@ TEST_F(HiveIcebergTest, positionalDeleteFileWithRowGroupFilter) {
       0);
 }
 #endif
+
 } // namespace facebook::velox::connector::hive::iceberg


### PR DESCRIPTION
Summary:
- Add explicit equality deletes NYI branch in prepareSplit()
- Improve VELOX_NYI error messages with descriptive content type info
- Fix FILE handle leaks in IcebergReadTest by extracting getTestFileSize() helper
- Minor doc comment formatting improvements in IcebergSplitReader.h

Reviewed By: zation99

Differential Revision: D96454844


