### PR TITLE
misc: Add option to UnnestNode to enable/disable splitting of output (#16762)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1363,12 +1363,32 @@ UnnestNode::UnnestNode(
     std::optional<std::string> ordinalityName,
     std::optional<std::string> markerName,
     const PlanNodePtr& source)
+    : UnnestNode(
+          id,
+          std::move(replicateVariables),
+          std::move(unnestVariables),
+          std::move(unnestNames),
+          std::move(ordinalityName),
+          std::move(markerName),
+          std::nullopt,
+          source) {}
+
+UnnestNode::UnnestNode(
+    const PlanNodeId& id,
+    std::vector<FieldAccessTypedExprPtr> replicateVariables,
+    std::vector<FieldAccessTypedExprPtr> unnestVariables,
+    std::vector<std::string> unnestNames,
+    std::optional<std::string> ordinalityName,
+    std::optional<std::string> markerName,
+    std::optional<bool> splitOutput,
+    const PlanNodePtr& source)
     : PlanNode(id),
       replicateVariables_{std::move(replicateVariables)},
       unnestVariables_{std::move(unnestVariables)},
       unnestNames_{std::move(unnestNames)},
       ordinalityName_{std::move(ordinalityName)},
       markerName_(std::move(markerName)),
+      splitOutput_(splitOutput),
       sources_{source} {
   // Calculate output type. First come "replicate" columns, followed by
   // "unnest" columns, followed by an optional ordinality column.
@@ -1429,6 +1449,9 @@ folly::dynamic UnnestNode::serialize() const {
   if (markerName_.has_value()) {
     obj["markerName"] = markerName_.value();
   }
+  if (splitOutput_.has_value()) {
+    obj["splitOutput"] = splitOutput_.value();
+  }
   return obj;
 }
 
@@ -1453,6 +1476,10 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
   if (obj.count("markerName")) {
     markerName = obj["markerName"].asString();
   }
+  std::optional<bool> splitOutput = std::nullopt;
+  if (obj.count("splitOutput")) {
+    splitOutput = obj["splitOutput"].asBool();
+  }
   return std::make_shared<UnnestNode>(
       deserializePlanNodeId(obj),
       std::move(replicateVariables),
@@ -1460,6 +1487,7 @@ PlanNodePtr UnnestNode::create(const folly::dynamic& obj, void* context) {
       std::move(unnestNames),
       std::move(ordinalityName),
       std::move(markerName),
+      splitOutput,
       std::move(source));
 }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -4667,6 +4667,12 @@ class UnnestNode : public PlanNode {
   /// output row has non-empty unnested value. If not present, marker column is
   /// not provided and the unnest operator also skips producing output rows
   /// with empty unnest value.
+  /// @param splitOutput Optional flag to control whether it should output 1
+  /// batch for each input batch, or split output batches if they are too large.
+  /// If true, output is split into batches according to Operator's
+  /// outputBatchRows logic. If false, output is not split and output batches
+  /// match input batches 1:1. If not set, defaults to the value of the
+  /// unnest_split_output config in the QueryConfig.
   UnnestNode(
       const PlanNodeId& id,
       std::vector<FieldAccessTypedExprPtr> replicateVariables,
@@ -4674,6 +4680,16 @@ class UnnestNode : public PlanNode {
       std::vector<std::string> unnestNames,
       std::optional<std::string> ordinalityName,
       std::optional<std::string> markerName,
+      const PlanNodePtr& source);
+
+  UnnestNode(
+      const PlanNodeId& id,
+      std::vector<FieldAccessTypedExprPtr> replicateVariables,
+      std::vector<FieldAccessTypedExprPtr> unnestVariables,
+      std::vector<std::string> unnestNames,
+      std::optional<std::string> ordinalityName,
+      std::optional<std::string> markerName,
+      std::optional<bool> splitOutput,
       const PlanNodePtr& source);
 
   class Builder {
@@ -4686,6 +4702,7 @@ class UnnestNode : public PlanNode {
       unnestVariables_ = other.unnestVariables();
       unnestNames_ = other.unnestNames_;
       ordinalityName_ = other.ordinalityName_;
+      splitOutput_ = other.splitOutput_;
       VELOX_CHECK_EQ(other.sources().size(), 1);
       source_ = other.sources()[0];
     }
@@ -4727,6 +4744,11 @@ class UnnestNode : public PlanNode {
       return *this;
     }
 
+    Builder& splitOutput(std::optional<bool> splitOutput) {
+      splitOutput_ = splitOutput;
+      return *this;
+    }
+
     std::shared_ptr<UnnestNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "UnnestNode id is not set");
       VELOX_USER_CHECK(
@@ -4746,6 +4768,7 @@ class UnnestNode : public PlanNode {
           unnestNames_.value(),
           ordinalityName_,
           markerName_,
+          splitOutput_,
           source_.value());
     }
 
@@ -4757,6 +4780,7 @@ class UnnestNode : public PlanNode {
     std::optional<std::string> ordinalityName_;
     std::optional<std::string> markerName_;
     std::optional<PlanNodePtr> source_;
+    std::optional<bool> splitOutput_;
   };
 
   bool supportsBarrier() const override {
@@ -4805,6 +4829,10 @@ class UnnestNode : public PlanNode {
     return markerName_.has_value();
   }
 
+  const std::optional<bool>& splitOutput() const {
+    return splitOutput_;
+  }
+
   std::string_view name() const override {
     return "Unnest";
   }
@@ -4821,6 +4849,7 @@ class UnnestNode : public PlanNode {
   const std::vector<std::string> unnestNames_;
   const std::optional<std::string> ordinalityName_;
   const std::optional<std::string> markerName_;
+  const std::optional<bool> splitOutput_;
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;
 };

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -846,7 +846,8 @@ class QueryConfig {
 
   /// If this is true, then the unnest operator might split output for each
   /// input batch based on the output batch size control. Otherwise, it produces
-  /// a single output for each input batch.
+  /// a single output for each input batch. This can be overridden on a per
+  /// operator basis by the splitOutput parameter in the UnnestPlanNode.
   static constexpr const char* kUnnestSplitOutput = "unnest_split_output";
 
   /// Priority of the query in the memory pool reclaimer. Lower value means

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -1002,6 +1002,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
   std::vector<std::string> unnestNames{"b"};
   std::optional<std::string> ordinalityName =
       std::make_optional<std::string>("ord");
+  std::optional<bool> splitOutput = false;
 
   const auto verify = [&](const std::shared_ptr<const UnnestNode>& node) {
     EXPECT_EQ(node->id(), id);
@@ -1009,6 +1010,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
     EXPECT_EQ(node->unnestVariables(), unnestVariables);
     EXPECT_TRUE(node->hasOrdinality());
     EXPECT_EQ(node->sources()[0], source_);
+    EXPECT_EQ(node->splitOutput(), splitOutput);
 
     for (int i = 0; i < node->outputType()->size(); ++i) {
       if (i < replicateVariables.size()) {
@@ -1031,6 +1033,7 @@ TEST_F(PlanNodeBuilderTest, unnestNode) {
                         .unnestNames(unnestNames)
                         .ordinalityName(ordinalityName)
                         .source(source_)
+                        .splitOutput(splitOutput)
                         .build();
   verify(node);
 

--- a/velox/exec/Unnest.cpp
+++ b/velox/exec/Unnest.cpp
@@ -45,7 +45,12 @@ Unnest::Unnest(
       withOrdinality_(unnestNode->hasOrdinality()),
       withMarker_(unnestNode->hasMarker()),
       maxOutputSize_(
-          driverCtx->queryConfig().unnestSplitOutput()
+          // If splitOutput is set to true in the UnnestNode or it's not set at
+          // all and it's enabled in the QueryConfig.
+          ((unnestNode->splitOutput().has_value() &&
+            unnestNode->splitOutput().value()) ||
+           (!unnestNode->splitOutput().has_value() &&
+            driverCtx->queryConfig().unnestSplitOutput()))
               ? outputBatchRows()
               : std::numeric_limits<vector_size_t>::max()) {
   const auto& inputType = unnestNode->sources()[0]->outputType();

--- a/velox/exec/tests/UnnestTest.cpp
+++ b/velox/exec/tests/UnnestTest.cpp
@@ -974,6 +974,99 @@ TEST_P(UnnestTest, spiltOutput) {
   }
 }
 
+// Test that UnnestNode::splitOutput overrides query config.
+TEST_P(UnnestTest, splitOutputNodeOverride) {
+  const auto numBatches = 3;
+  const auto inputBatchSize = 256;
+  std::vector<RowVectorPtr> vectors;
+  vectors.reserve(numBatches);
+  for (int32_t i = 0; i < numBatches; ++i) {
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int64_t>(inputBatchSize, [](auto row) { return row; }),
+    }));
+  }
+
+  const auto expectedResult = makeRowVector({
+      makeFlatVector<int64_t>(
+          numBatches * 3 * inputBatchSize,
+          [](auto row) { return 1 + row % 3; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  // Create a plan with project node to generate the sequence.
+  auto projectPlan = PlanBuilder(planNodeIdGenerator)
+                         .values(vectors)
+                         .project({"sequence(1, 3) as s"})
+                         .planNode();
+
+  // Get the output type from the project node.
+  auto projectOutput = projectPlan->outputType();
+  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> unnestFields;
+  unnestFields.emplace_back(
+      std::make_shared<core::FieldAccessTypedExpr>(
+          projectOutput->childAt(0), "s"));
+
+  struct {
+    std::optional<bool> nodeSplitOutput;
+    bool configSplitOutput{};
+    bool expectSplit{};
+
+    std::string toString() const {
+      return fmt::format(
+          "nodeSplitOutput: {}, configSplitOutput: {}, expectSplit: {}",
+          nodeSplitOutput.has_value()
+              ? (nodeSplitOutput.value() ? "true" : "false")
+              : "nullopt",
+          configSplitOutput,
+          expectSplit);
+    }
+  } testSettings[] = {
+      // Node splitOutput not set, use config.
+      {std::nullopt, true, true},
+      {std::nullopt, false, false},
+      // Node splitOutput=true overrides config.
+      {true, true, true},
+      {true, false, true},
+      // Node splitOutput=false overrides config.
+      {false, true, false},
+      {false, false, false},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.toString());
+
+    core::PlanNodeId unnestPlanNodeId;
+    auto unnestNode = std::make_shared<core::UnnestNode>(
+        planNodeIdGenerator->next(),
+        std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>{},
+        unnestFields,
+        std::vector<std::string>{"s_e"},
+        std::nullopt,
+        std::nullopt,
+        testData.nodeSplitOutput,
+        projectPlan);
+    unnestPlanNodeId = unnestNode->id();
+
+    const int expectedNumOutputVectors = testData.expectSplit
+        ? bits::divRoundUp(inputBatchSize * 3, GetParam()) * numBatches
+        : numBatches;
+
+    auto task = AssertQueryBuilder(unnestNode)
+                    .config(
+                        core::QueryConfig::kPreferredOutputBatchRows,
+                        std::to_string(GetParam()))
+                    .config(
+                        core::QueryConfig::kUnnestSplitOutput,
+                        testData.configSplitOutput ? "true" : "false")
+                    .assertResults(expectedResult);
+    const auto taskStats = task->taskStats();
+    ASSERT_EQ(
+        exec::toPlanStats(taskStats).at(unnestPlanNodeId).outputVectors,
+        expectedNumOutputVectors);
+  }
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     UnnestTest,
     UnnestTest,


### PR DESCRIPTION
Summary:

In the past year an option was added to the QueryConfig, unnest_split_output, which dictates
whether all Unnest operators in the plan should split they're output based on Operator's
outputBatchRows() or guarantee that for each batch Unnest receives as input, it returns a
single batch with all resulting rows as output. This config was added as an optimization, for
cases where we know the plan would be more efficient if we didn't break up the batches.

This optimization decision is based on the downstream operators, so a QueryConfig that
applies to all Unnest operators has too broad of an effect, this is a decision that typically
needs to be made on a per-operator basis.

To enable this, I've added a new parameter to the UnnestPlanNode, splitOutput, which is
an optional flag. When it is set, the Unnest operator ignores the QueryConfig and makes the
decision to split based on the value of this flag.  When it is unset it defaults to the current
behavior, respecting the value of the QueryConfig.

To preserve the existing behavior it defaults to unset, but it gives us the option to make this
decision on a per operator basis going forward.

Reviewed By: xiaoxmeng, breeze1990

Differential Revision: D96498326


