### PR TITLE
Break LimitTest to test CI test discovery (#16771)

### DIFF
--- a/CMake/VeloxUtils.cmake
+++ b/CMake/VeloxUtils.cmake
@@ -14,6 +14,7 @@
 include_guard(GLOBAL)
 
 include(CMakePackageConfigHelpers)
+include(GoogleTest)
 
 function(velox_get_rpath_origin VAR)
   if(APPLE)
@@ -264,8 +265,14 @@ function(velox_add_grouped_tests)
     if(_idx GREATER_EQUAL _group_end OR _idx EQUAL _num_sources)
       set(_target "${ARG_PREFIX}_group${_group}")
       add_executable(${_target} ${_current_sources} ${ARG_EXTRA_SOURCES})
-      add_test(NAME ${_target} COMMAND ${_target} WORKING_DIRECTORY ${ARG_WORKING_DIRECTORY})
       target_link_libraries(${_target} ${ARG_DEPS})
+      gtest_discover_tests(${_target}
+        TEST_PREFIX ""
+        WORKING_DIRECTORY ${ARG_WORKING_DIRECTORY}
+        DISCOVERY_MODE PRE_TEST
+        DISCOVERY_TIMEOUT 60
+        TEST_FILTER "-*DISABLED_*"
+      )
       set(_current_sources "")
       math(EXPR _group "${_group} + 1")
     endif()

--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -26,11 +26,36 @@
 #define VELOX_TYPED_TEST_SUITE TYPED_TEST_CASE
 #endif
 
+/// Name generator for parameterized tests that uses the parameter index.
+/// Avoids gtest's default behavior of dumping raw bytes for types without
+/// operator<< or PrintTo.
+struct VeloxTestIndexParamName {
+  template <typename ParamType>
+  std::string operator()(
+      const ::testing::TestParamInfo<ParamType>& info) const {
+    return std::to_string(info.index);
+  }
+};
+
+// Dispatch based on argument count: 3 args = no custom name generator (use
+// index-based default), 4 args = caller-provided name generator.
+#define VELOX_INSTANTIATE_PICK(_1, _2, _3, _4, NAME, ...) NAME
+
 #ifdef INSTANTIATE_TEST_SUITE_P
-#define VELOX_INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_SUITE_P
+#define VELOX_INSTANTIATE_3(prefix, suite, generator) \
+  INSTANTIATE_TEST_SUITE_P(prefix, suite, generator, VeloxTestIndexParamName())
+#define VELOX_INSTANTIATE_4(prefix, suite, generator, nameGen) \
+  INSTANTIATE_TEST_SUITE_P(prefix, suite, generator, nameGen)
 #else
-#define VELOX_INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#define VELOX_INSTANTIATE_3(prefix, suite, generator) \
+  INSTANTIATE_TEST_CASE_P(prefix, suite, generator, VeloxTestIndexParamName())
+#define VELOX_INSTANTIATE_4(prefix, suite, generator, nameGen) \
+  INSTANTIATE_TEST_CASE_P(prefix, suite, generator, nameGen)
 #endif
+
+#define VELOX_INSTANTIATE_TEST_SUITE_P(...) \
+  VELOX_INSTANTIATE_PICK(                   \
+      __VA_ARGS__, VELOX_INSTANTIATE_4, VELOX_INSTANTIATE_3)(__VA_ARGS__)
 
 // The void static cast supresses the "unused expression result" warning in
 // clang.

--- a/velox/exec/tests/LimitTest.cpp
+++ b/velox/exec/tests/LimitTest.cpp
@@ -109,7 +109,7 @@ TEST_F(LimitTest, limitOverLocalExchange) {
   // Do not send no-more-splits message. Expect the task to finish without
   // receiving that message.
 
-  ASSERT_EQ(20, numRead);
+  ASSERT_EQ(21, numRead);
   ASSERT_TRUE(waitForTaskCompletion(cursor->task().get()));
 }
 


### PR DESCRIPTION
Summary:

Intentionally break LimitTest::limitOverLocalExchange by changing the
expected row count from 20 to 21. This is to test gtest_discover_tests()
behavior in GitHub CI — verifying that individual test failures are
properly reported.

DO NOT LAND — this is an experiment.

Differential Revision: D96601845


