### PR TITLE
refactor: Add name getter to VectorSerde classes

### DIFF
--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -65,6 +65,11 @@ class CompactRowVectorSerde : public VectorSerde {
   /// if not already registered. No-op if a serde with the same name exists.
   static void tryRegisterNamedVectorSerde();
 
+  /// Returns the name of this serde kind.
+  static const std::string& name() {
+    return kSerdeKind;
+  }
+
  private:
   inline static const std::string kSerdeKind{"CompactRow"};
 };

--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -203,6 +203,11 @@ class PrestoVectorSerde : public VectorSerde {
   /// if not already registered. No-op if a serde with the same name exists.
   static void tryRegisterNamedVectorSerde();
 
+  /// Returns the name of this serde kind.
+  static const std::string& name() {
+    return kSerdeKind;
+  }
+
  private:
   inline static const std::string kSerdeKind{"Presto"};
 };

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -65,6 +65,11 @@ class UnsafeRowVectorSerde : public VectorSerde {
   /// if not already registered. No-op if a serde with the same name exists.
   static void tryRegisterNamedVectorSerde();
 
+  /// Returns the name of this serde kind.
+  static const std::string& name() {
+    return kSerdeKind;
+  }
+
  private:
   inline static const std::string kSerdeKind{"UnsafeRow"};
 };


### PR DESCRIPTION
Summary:
Add public static name() method to PrestoVectorSerde, CompactRowVectorSerde,
and UnsafeRowVectorSerde to expose the serde kind string. This allows callers
to get the serde name without hardcoding string literals.

The name() method returns a const reference to the private kSerdeKind constant,
maintaining encapsulation while providing read-only access.

Reviewed By: xiaoxmeng

Differential Revision: D96610213
