### PR TITLE
fix: Pre-load lazy probe input vectors before the non-reclaimable probe loop (#16774)

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/HashProbe.h"
+#include <folly/ScopeGuard.h>
 #include "velox/common/base/Counters.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/testutil/TestValue.h"
@@ -866,6 +867,7 @@ void HashProbe::fillLeftSemiProjectMatchColumn(vector_size_t size) {
 }
 
 void HashProbe::fillOutput(vector_size_t size) {
+  TestValue::adjust("facebook::velox::exec::HashProbe::fillOutput", this);
   prepareOutput(size);
 
   for (auto [in, out] : projectedInputColumns_) {
@@ -1077,7 +1079,7 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
 
   clearProjectedOutput();
 
-  if (!input_) {
+  if (input_ == nullptr) {
     if (hasMoreInput()) {
       return nullptr;
     }
@@ -1248,6 +1250,20 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
       return nullptr;
     }
     VELOX_CHECK_LE(numOut, outputBatchSize);
+
+    // Pre-load lazy input vectors within a reclaimable section so that the
+    // subsequent non-reclaimable evalFilter/fillOutput does not trigger OOM.
+    // If memory reclaim spills the hash table during lazy loading,
+    // ensureLazyInputLoaded() spills the current input and sets input_ to
+    // nullptr. We must bail out because resultIter_ now references freed
+    // hash table rows.
+    if (!toSpillOutput) {
+      ensureLazyInputLoaded();
+      if (input_ == nullptr) {
+        return nullptr;
+      }
+      VELOX_CHECK_NOT_NULL(table_);
+    }
 
     numOut = evalFilter(numOut);
 
@@ -1889,9 +1905,11 @@ void HashProbe::ensureOutputFits() {
     memory::testingRunArbitration(pool());
   }
 
-  const uint64_t bytesToReserve =
-      operatorCtx_->driverCtx()->queryConfig().preferredOutputBatchBytes() *
-      1.2;
+  const uint64_t bytesToReserve = static_cast<uint64_t>(
+      static_cast<double>(operatorCtx_->driverCtx()
+                              ->queryConfig()
+                              .preferredOutputBatchBytes()) *
+      1.2);
   if (pool()->availableReservation() >= bytesToReserve) {
     return;
   }
@@ -1905,6 +1923,97 @@ void HashProbe::ensureOutputFits() {
                << " for memory pool " << pool()->name()
                << ", usage: " << succinctBytes(pool()->usedBytes())
                << ", reservation: " << succinctBytes(pool()->reservedBytes());
+}
+
+bool HashProbe::needLazyLoadProbeInput() const {
+  if (!canReclaim() || input_ == nullptr || replacedWithDynamicFilter_) {
+    return false;
+  }
+
+  // For left semi filter/project and anti joins without a filter,
+  // ensureLoaded() is a no-op — lazy vectors are passed through zero-copy
+  // via wrapChild() in fillOutput() and never loaded during probe.
+  // Preloading is unnecessary because no loading happens.
+  if (!filter_ &&
+      (isLeftSemiFilterJoin(joinType_) || isLeftSemiProjectJoin(joinType_) ||
+       isAntiJoin(joinType_))) {
+    return false;
+  }
+  return true;
+}
+
+void HashProbe::ensureLazyInputLoaded() {
+  if (!needLazyLoadProbeInput()) {
+    return;
+  }
+
+  VELOX_CHECK_NOT_NULL(input_);
+
+  // When atEnd (single output batch), fillOutput() skips loading via
+  // ensureLoadedIfNotAtEnd() and wraps lazy vectors zero-copy.
+  // However, createFilterInput() unconditionally loads filter+projected
+  // columns, so those still need preloading when a filter is present.
+  const bool atEnd{resultIter_->atEnd()};
+  if (atEnd && !filter_) {
+    return;
+  }
+
+  std::vector<column_index_t> lazyChannels;
+  if (!atEnd) {
+    for (const auto& [in, _] : projectedInputColumns_) {
+      if (isLazyNotLoaded(*input_->childAt(in))) {
+        lazyChannels.push_back(in);
+      }
+    }
+  }
+  if (filter_) {
+    for (const auto& projection : filterInputProjections_) {
+      if (atEnd &&
+          projectedInputColumns_.find(projection.inputChannel) ==
+              projectedInputColumns_.end()) {
+        continue;
+      }
+      if (isLazyNotLoaded(*input_->childAt(projection.inputChannel))) {
+        lazyChannels.push_back(projection.inputChannel);
+      }
+    }
+  }
+  if (lazyChannels.empty()) {
+    return;
+  }
+
+  const bool tableWasNonEmpty{table_->numDistinct() > 0};
+  {
+    loadingLazyInput_ = true;
+    SCOPE_EXIT {
+      loadingLazyInput_ = false;
+    };
+    Operator::ReclaimableSectionGuard guard(this);
+    if (testingTriggerSpill(pool()->name())) {
+      memory::testingRunArbitration(pool());
+    }
+    for (const auto channel : lazyChannels) {
+      ensureLoaded(channel);
+    }
+  }
+
+  // If the hash table was spilled during lazy loading (it was non-empty
+  // before but is now empty), spill the current input so it can be re-probed
+  // during the restore pass. After spilling, resultIter_ references freed
+  // hash table rows, so we must abandon the current iteration by setting
+  // input_ to nullptr.
+  VELOX_CHECK_NOT_NULL(input_);
+  if (tableWasNonEmpty && table_->numDistinct() == 0) {
+    VELOX_CHECK_NOT_NULL(inputSpiller_);
+    spillInput(input_);
+    if (input_ != nullptr) {
+      // Non-spilled rows remain. For join types that skip probe on empty
+      // build side (inner, right, semi filter), dropping them is correct.
+      // For left/anti/full joins this would be data loss — fail loudly.
+      VELOX_CHECK(skipProbeOnEmptyBuild());
+    }
+    input_ = nullptr;
+  }
 }
 
 bool HashProbe::canReclaim() const {
@@ -2036,6 +2145,13 @@ void HashProbe::spillOutput(const std::vector<HashProbe*>& operators) {
   auto* spillExecutor = spillConfig()->executor;
   for (auto* op : operators) {
     HashProbe* probeOp = static_cast<HashProbe*>(op);
+    // Skip operators that are in the middle of loading lazy input vectors.
+    // Their reclaim path re-enters getOutputInternal()->fillOutput(), or
+    // evalFilter()->createFilterInput() which loads the same lazy vectors,
+    // deadlocking on the column reader's folly::basic_once_flag.
+    if (probeOp->loadingLazyInput_) {
+      continue;
+    }
     spillTasks.push_back(
         memory::createAsyncMemoryReclaimTask<SpillResult>([probeOp]() {
           try {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -279,6 +279,17 @@ class HashProbe : public Operator {
   // operator is set to reclaimable at this stage.
   void ensureOutputFits();
 
+  // Returns true if the current input batch requires lazy preloading before
+  // the non-reclaimable probe output loop. Checks canReclaim(), input state,
+  // and join type to determine if preloading is needed.
+  bool needLazyLoadProbeInput() const;
+
+  // Pre-loads lazy input vectors in a reclaimable section so that the
+  // subsequent non-reclaimable evalFilter/fillOutput does not trigger OOM.
+  // Called after listJoinResults() so that atEnd() is known and preloading
+  // can be skipped for columns that fillOutput/createFilterInput won't load.
+  void ensureLazyInputLoaded();
+
   // Setups spilled output reader if 'spillOutputPartitionSet_' is not empty.
   void maybeSetupSpillOutputReader();
 
@@ -683,6 +694,11 @@ class HashProbe : public Operator {
   // cases where there is more than one batch of output or join filter
   // input.
   SelectivityVector passingInputRows_;
+
+  // Set while loading lazy input vectors inside a ReclaimableSectionGuard.
+  // Tells reclaim() to skip spillOutput() for this operator to avoid
+  // re-entering the column reader (which would deadlock on call_once).
+  tsan_atomic<bool> loadingLazyInput_{false};
 
   // Indicates if this hash probe has exceeded max spill limit which is not
   // allowed to spill. This is reset when hash probe operator starts to probe

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/exec/Cursor.h"
 #include "velox/exec/HashBuild.h"
 #include "velox/exec/HashJoinBridge.h"
+#include "velox/exec/HashProbe.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -3742,6 +3743,253 @@ TEST_P(HashJoinTest, lazyVectorPartiallyLoadedInFilterLeftSemiFilter) {
       "not (c1 < 15 and c2 >= 0)",
       {"c1", "c2"},
       "SELECT t.c1, t.c2 FROM t WHERE c0 IN (SELECT u.c0 FROM u WHERE t.c0 = u.c0 AND NOT (t.c1 < 15 AND t.c2 >= 0))");
+}
+
+// Verifies that lazy probe-side vectors are loaded in ensureLazyInputLoaded()
+// (inside a reclaimable section) BEFORE the non-reclaimable probe output loop
+// in getOutputInternal(). Tests fuzzed data with partial/all lazy columns and
+// deterministic low-selectivity data. When spill is injected via
+// HashJoinBuilder, verifies spill actually occurs and results remain correct.
+DEBUG_ONLY_TEST_P(HashJoinTest, hashProbeEnsureLazyInputLoaded) {
+  struct {
+    bool useDeterministicData;
+    std::vector<int> lazyColumnIndices;
+    bool useHashJoinBuilder;
+
+    std::string debugString() const {
+      return fmt::format(
+          "useDeterministicData: {}, lazyColumns: {}, useHashJoinBuilder: {}",
+          useDeterministicData,
+          lazyColumnIndices.empty() ? "all"
+                                    : folly::join(",", lazyColumnIndices),
+          useHashJoinBuilder);
+    }
+  } testSettings[] = {
+      // Fuzzed data, non-key columns lazy.
+      {false, {1, 2}, false},
+      // Deterministic low selectivity (~1% match rate), non-key columns lazy.
+      {true, {1, 2}, false},
+      // Fuzzed data, all columns lazy, with spill injection.
+      {false, {}, true},
+  };
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    std::vector<RowVectorPtr> probeVectors;
+    std::vector<RowVectorPtr> buildInput;
+
+    if (testData.useDeterministicData) {
+      auto probe = makeRowVector(
+          {"t_k1", "t_k2", "t_v1"},
+          {makeFlatVector<int32_t>(1'000, [](auto row) { return row; }),
+           makeFlatVector<StringView>(
+               1'000,
+               [](auto /*row*/) { return StringView::makeInline("probe"); }),
+           makeFlatVector<StringView>(1'000, [](auto /*row*/) {
+             return StringView::makeInline("val");
+           })});
+      probeVectors.push_back(
+          VectorFuzzer({.vectorSize = 1'000}, pool())
+              .fuzzRowChildrenToLazy(probe, testData.lazyColumnIndices));
+      createDuckDbTable(
+          "t",
+          {std::dynamic_pointer_cast<RowVector>(
+              probe->testingCopyPreserveEncodings())});
+
+      // Build data only has keys 0-9, so only ~1% of probe rows match.
+      // Use enough duplicates (200 per key) so the output exceeds
+      // outputBatchSize (default 1024) and spans multiple batches, ensuring
+      // the ensureLoadedIfNotAtEnd at-end optimization does not bypass the
+      // preloading path we are testing.
+      auto build = makeRowVector(
+          {"u_k1", "u_k2", "u_v1"},
+          {makeFlatVector<int32_t>(2'000, [](auto row) { return row % 10; }),
+           makeFlatVector<StringView>(
+               2'000,
+               [](auto /*row*/) { return StringView::makeInline("build"); }),
+           makeFlatVector<int32_t>(2'000, [](auto row) { return row * 100; })});
+      buildInput.push_back(build);
+      createDuckDbTable("u", {build});
+    } else {
+      VectorFuzzer::Options opts;
+      opts.vectorSize = 1'000;
+      VectorFuzzer fuzzer(opts, pool());
+
+      auto nonLazy = fuzzer.fuzzRow(probeType_);
+      // Overwrite the join key column (index 0) with values from a small
+      // range to guarantee probe-build matches. Without this, random int32
+      // keys across 1'000 rows have near-zero probability of overlapping.
+      nonLazy->childAt(0) =
+          makeFlatVector<int32_t>(1'000, [](auto row) { return row % 100; });
+      createDuckDbTable(
+          "t",
+          {std::dynamic_pointer_cast<RowVector>(
+              nonLazy->testingCopyPreserveEncodings())});
+      probeVectors.push_back(
+          testData.lazyColumnIndices.empty()
+              ? VectorFuzzer(opts, pool()).fuzzRowChildrenToLazy(nonLazy)
+              : VectorFuzzer(opts, pool())
+                    .fuzzRowChildrenToLazy(
+                        nonLazy, testData.lazyColumnIndices));
+
+      auto buildRow = fuzzer.fuzzRow(buildType_);
+      buildRow->childAt(0) =
+          makeFlatVector<int32_t>(1'000, [](auto row) { return row % 100; });
+      buildInput.push_back(buildRow);
+      createDuckDbTable("u", buildInput);
+    }
+
+    // Track whether fillOutput (the non-reclaimable probe output loop) has
+    // been entered. Lazy loading should happen BEFORE this point.
+    std::atomic_bool fillOutputEntered{false};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::HashProbe::fillOutput",
+        std::function<void(HashProbe*)>(
+            [&](HashProbe*) { fillOutputEntered = true; }));
+
+    std::atomic_int lazyLoadsBeforeFillOutput{0};
+    std::atomic_int lazyLoadsDuringFillOutput{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::{}::VectorLoaderWrap::loadInternal",
+        std::function<void(void*)>([&](void*) {
+          if (fillOutputEntered) {
+            ++lazyLoadsDuringFillOutput;
+          } else {
+            ++lazyLoadsBeforeFillOutput;
+          }
+        }));
+
+    const std::string referenceQuery =
+        "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1";
+
+    if (testData.useHashJoinBuilder) {
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .numDrivers(numDrivers_)
+          .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
+          .probeKeys({"t_k1"})
+          .probeVectors(std::move(probeVectors))
+          .buildKeys({"u_k1"})
+          .buildVectors(std::move(buildInput))
+          .referenceQuery(referenceQuery)
+          .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+            if (hasSpill) {
+              const auto statsPair = taskSpilledStats(*task);
+              ASSERT_GT(statsPair.first.spilledBytes, 0);
+            }
+          })
+          .run();
+    } else {
+      const auto spillDirectory = TempDirectoryPath::create();
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto plan = PlanBuilder(planNodeIdGenerator)
+                      .values(probeVectors, false)
+                      .hashJoin(
+                          {"t_k1"},
+                          {"u_k1"},
+                          PlanBuilder(planNodeIdGenerator)
+                              .values(buildInput, false)
+                              .planNode(),
+                          "",
+                          concat(probeType_->names(), buildType_->names()))
+                      .planNode();
+
+      AssertQueryBuilder(duckDbQueryRunner_)
+          .spillDirectory(spillDirectory->getPath())
+          .config(core::QueryConfig::kSpillEnabled, true)
+          .config(core::QueryConfig::kJoinSpillEnabled, true)
+          .plan(plan)
+          .assertResults(referenceQuery);
+    }
+
+    // HashJoinBuilder runs the query twice (without and with spill).  On the
+    // first (non-spill) run canReclaim() is false, so ensureLazyInputLoaded()
+    // is a no-op and lazy vectors are loaded inside fillOutput().  The atomic
+    // counters accumulate across both runs, so only assert loading order for
+    // the single-run non-builder case where spill is explicitly configured.
+    if (!testData.useHashJoinBuilder) {
+      ASSERT_GT(lazyLoadsBeforeFillOutput, 0);
+      ASSERT_EQ(lazyLoadsDuringFillOutput, 0);
+    }
+  }
+}
+
+// Verifies that hash join with lazy probe input produces correct results
+// across multiple join types, with automatic spill injection via
+// HashJoinBuilder.
+TEST_P(MultiThreadedHashJoinTest, hashJoinWithLazyProbeInputAndSpill) {
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 1'000;
+  VectorFuzzer fuzzer(opts, pool());
+
+  const int32_t numProbeVectors = 3;
+  std::vector<RowVectorPtr> probeVectors;
+  std::vector<RowVectorPtr> probeReference;
+  probeVectors.reserve(numProbeVectors);
+  probeReference.reserve(numProbeVectors);
+  for (int32_t i = 0; i < numProbeVectors; ++i) {
+    auto nonLazy = fuzzer.fuzzRow(probeType_);
+    probeReference.push_back(
+        std::dynamic_pointer_cast<RowVector>(
+            nonLazy->testingCopyPreserveEncodings()));
+    probeVectors.push_back(
+        VectorFuzzer(opts, pool()).fuzzRowChildrenToLazy(nonLazy));
+  }
+  createDuckDbTable("t", probeReference);
+
+  const int32_t numBuildVectors = 3;
+  std::vector<RowVectorPtr> buildVectors;
+  buildVectors.reserve(numBuildVectors);
+  for (int32_t i = 0; i < numBuildVectors; ++i) {
+    buildVectors.push_back(fuzzer.fuzzRow(buildType_));
+  }
+  createDuckDbTable("u", buildVectors);
+
+  struct {
+    core::JoinType joinType;
+    std::string filter;
+    std::vector<std::string> outputColumns;
+    std::string referenceQuery;
+  } testCases[] = {
+      {core::JoinType::kInner,
+       "",
+       concat(probeType_->names(), buildType_->names()),
+       "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1"},
+      {core::JoinType::kLeft,
+       "",
+       concat(probeType_->names(), buildType_->names()),
+       "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t LEFT JOIN u ON t.t_k1 = u.u_k1"},
+      {core::JoinType::kFull,
+       "",
+       concat(probeType_->names(), buildType_->names()),
+       "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t FULL OUTER JOIN u ON t.t_k1 = u.u_k1"},
+      {core::JoinType::kAnti,
+       "t_k2 <> u_k2",
+       probeType_->names(),
+       "SELECT t_k1, t_k2, t_v1 FROM t WHERE NOT EXISTS (SELECT 1 FROM u WHERE t.t_k1 = u.u_k1 AND t.t_k2 <> u.u_k2)"},
+      {core::JoinType::kLeftSemiProject,
+       "",
+       concat(probeType_->names(), {"match"}),
+       "SELECT t_k1, t_k2, t_v1, EXISTS (SELECT 1 FROM u WHERE t.t_k1 = u.u_k1) FROM t"},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(
+        fmt::format("joinType: {}", static_cast<int>(testCase.joinType)));
+
+    HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+        .numDrivers(numDrivers_)
+        .parallelizeJoinBuildRows(parallelBuildSideRowsEnabled_)
+        .probeKeys({"t_k1"})
+        .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+        .buildKeys({"u_k1"})
+        .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+        .joinType(testCase.joinType)
+        .joinFilter(testCase.filter)
+        .joinOutputLayout(std::vector<std::string>(testCase.outputColumns))
+        .referenceQuery(testCase.referenceQuery)
+        .run();
+  }
 }
 
 TEST_P(HashJoinTest, dynamicFilters) {


### PR DESCRIPTION
Summary:

The fix ensures all lazy loading happens in one burst before the main loop, not scattered across iterations. And the maybeReserve with ReclaimableSectionGuard gives the arbitrator a chance to reclaim RIGHT BEFORE that burst.

fix the error call stack like
```
 Split [Hive: ws://ws.dw.ncg0dw0/namespace/ad_metrics/warehouse/1abdd19b6f304ecfb1245a3f5ce722de/c719cc14089642f69f8d91269df819c7/ds=2026-03-11/hr=13/ts=2026-03-11+20%3A45%3A99/metric=fast/category=impressions/attributed_ds=2026-03-11/is_rollup_eligible=true/20260311_232547_71841_xqvw8.1.0.138.0_3_51_067503ec-c2b5-4da3-9903-09eee0b699d6 67108864 - 67108864] Task 20260313_123155_44608_h3bbf.1.0.113.0 Operator: HashProbe[5093] 2
	at Unknown.# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >) [clone .cold](Unknown Source)
	at Unknown.# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)(Unknown Source)
	at Unknown.# 2  facebook::velox::memory::SharedArbitrator::growCapacity(facebook::velox::memory::ArbitrationOperation&)(Unknown Source)
	at Unknown.# 3  facebook::velox::memory::SharedArbitrator::growCapacity(facebook::velox::memory::MemoryPool*, unsigned long)(Unknown Source)
	at Unknown.# 4  facebook::velox::memory::MemoryPoolImpl::growCapacity(facebook::velox::memory::MemoryPool*, unsigned long)(Unknown Source)
	at Unknown.# 5  facebook::velox::memory::MemoryPoolImpl::incrementReservationThreadSafe(facebook::velox::memory::MemoryPool*, unsigned long)(Unknown Source)
	at Unknown.# 6  facebook::velox::memory::MemoryPoolImpl::incrementReservationThreadSafe(facebook::velox::memory::MemoryPool*, unsigned long)(Unknown Source)
	at Unknown.# 7  facebook::velox::memory::MemoryPoolImpl::incrementReservationThreadSafe(facebook::velox::memory::MemoryPool*, unsigned long)(Unknown Source)
	at Unknown.# 8  facebook::velox::memory::MemoryPoolImpl::allocate(long, std::optional<unsigned int>)(Unknown Source)
	at Unknown.# 9  boost::intrusive_ptr<facebook::velox::Buffer> facebook::velox::AlignedBuffer::allocate<short>(unsigned long, facebook::velox::memory::MemoryPool*, std::optional<short> const&, bool)(Unknown Source)
	at Unknown.# 10 boost::intrusive_ptr<facebook::velox::Buffer> facebook::velox::dwrf::(anonymous namespace)::readDict<short>(facebook::velox::dwio::common::IntDecoder<true>*, long, facebook::velox::memory::MemoryPool*) [clone .__uniq.116763424515567834310455430928237730121] [clone .llvm.2414237226279268614](Unknown Source)
	at Unknown.# 11 boost::intrusive_ptr<facebook::velox::Buffer> folly::detail::function::call_<facebook::velox::dwrf::StripeStreamsBase::getIntDictionaryInitializerForNode(facebook::velox::dwrf::EncodingKey const&, unsigned long, facebook::velox::dwrf::StreamLabels const&, unsigned long)::$_0, true, false, boost::intrusive_ptr<facebook::velox::Buffer>, facebook::velox::memory::MemoryPool*>(facebook::velox::memory::MemoryPool*, folly::detail::function::Data&) [clone .__uniq.116763424515567834310455430928237730121] [clone .llvm.2414237226279268614] [clone .cold](Unknown Source)
	at Unknown.# 12 void folly::basic_once_flag<folly::SharedMutexImpl<false, void, std::atomic, folly::SharedMutexPolicyDefault>, std::atomic>::call_once_slow<facebook::velox::dwrf::StripeDictionaryCache::DictionaryEntry::getDictionaryBuffer(facebook::velox::memory::MemoryPool*)::$_0>(facebook::velox::dwrf::StripeDictionaryCache::DictionaryEntry::getDictionaryBuffer(facebook::velox::memory::MemoryPool*)::$_0&&) [clone .__uniq.318532636856512363936001090669623975081] [clone .llvm.8752444219899589160](Unknown Source)
	at Unknown.# 13 facebook::velox::dwrf::StripeDictionaryCache::getIntDictionary(facebook::velox::dwrf::EncodingKey const&)(Unknown Source)
	at Unknown.# 14 std::_Function_handler<boost::intrusive_ptr<facebook::velox::Buffer> (), facebook::velox::dwrf::StripeStreamsBase::getIntDictionaryInitializerForNode(facebook::velox::dwrf::EncodingKey const&, unsigned long, facebook::velox::dwrf::StreamLabels const&, unsigned long)::$_1>::_M_invoke(std::_Any_data const&) [clone .__uniq.116763424515567834310455430928237730121] [clone .llvm.2414237226279268614](Unknown Source)
	at Unknown.# 15 facebook::velox::dwrf::SelectiveIntegerDictionaryColumnReader::read(long, folly::Range<int const*> const&, unsigned long const*) [clone .warm](Unknown Source)
	at Unknown.# 16 facebook::velox::dwio::common::ColumnLoader::loadInternal(folly::Range<int const*>, facebook::velox::ValueHook*, int, std::shared_ptr<facebook::velox::BaseVector>*)(Unknown Source)
	at Unknown.# 17 facebook::velox::LazyVector::ensureLoadedRowsImpl(std::shared_ptr<facebook::velox::BaseVector> const&, facebook::velox::DecodedVector&, facebook::velox::SelectivityVector const&, facebook::velox::SelectivityVector&)(Unknown Source)
	at Unknown.# 18 facebook::velox::exec::HashProbe::getOutputInternal(bool)(Unknown Source)
	at Unknown.# 19 facebook::velox::exec::HashProbe::getOutput()(Unknown Source)
	at Unknown.# 20 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)(Unknown Source)
	at Unknown.# 21 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)(Unknown Source)
	at Unknown.# 22 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)(Unknown Source)
	at Unknown.# 23 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)(Unknown Source)
	at Unknown.# 24 execute_native_thread_routine(Unknown Source)
	at Unknown.# 25 start_thread(Unknown Source)
	at Unknown.# 26 __clone3(Unknown Source)
```

Reviewed By: tanjialiang

Differential Revision: D96558322
