### PR TITLE
refactor: Refactor RowNumberFuzzerBase to SpillFuzzerBase (#16779)

### DIFF
--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -132,11 +132,11 @@ target_link_libraries(
   velox_test_util
 )
 
-add_library(velox_row_number_fuzzer_base_lib RowNumberFuzzerBase.cpp)
-velox_add_test_headers(velox_row_number_fuzzer_base_lib RowNumberFuzzerBase.h)
+add_library(velox_spill_fuzzer_base_lib SpillFuzzerBase.cpp)
+velox_add_test_headers(velox_spill_fuzzer_base_lib SpillFuzzerBase.h)
 
 target_link_libraries(
-  velox_row_number_fuzzer_base_lib
+  velox_spill_fuzzer_base_lib
   velox_dwio_dwrf_reader
   velox_fuzzer_util
   velox_vector_fuzzer
@@ -148,7 +148,7 @@ velox_add_test_headers(velox_row_number_fuzzer_lib RowNumberFuzzer.h)
 
 target_link_libraries(
   velox_row_number_fuzzer_lib
-  velox_row_number_fuzzer_base_lib
+  velox_spill_fuzzer_base_lib
   velox_type
   velox_expression_test_utility
 )
@@ -163,7 +163,7 @@ velox_add_test_headers(velox_topn_row_number_fuzzer_lib TopNRowNumberFuzzer.h)
 
 target_link_libraries(
   velox_topn_row_number_fuzzer_lib
-  velox_row_number_fuzzer_base_lib
+  velox_spill_fuzzer_base_lib
   velox_type
   velox_expression_test_utility
 )
@@ -178,7 +178,7 @@ velox_add_test_headers(velox_mark_distinct_fuzzer_lib MarkDistinctFuzzer.h)
 
 target_link_libraries(
   velox_mark_distinct_fuzzer_lib
-  velox_row_number_fuzzer_base_lib
+  velox_spill_fuzzer_base_lib
   velox_type
   velox_expression_test_utility
 )

--- a/velox/exec/fuzzer/MarkDistinctFuzzer.cpp
+++ b/velox/exec/fuzzer/MarkDistinctFuzzer.cpp
@@ -20,14 +20,14 @@
 
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
-#include "velox/exec/fuzzer/RowNumberFuzzerBase.h"
+#include "velox/exec/fuzzer/SpillFuzzerBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::exec {
 using namespace facebook::velox::common::testutil;
 namespace {
 
-class MarkDistinctFuzzer : public RowNumberFuzzerBase {
+class MarkDistinctFuzzer : public SpillFuzzerBase {
  public:
   explicit MarkDistinctFuzzer(
       size_t initialSeed,
@@ -68,7 +68,7 @@ class MarkDistinctFuzzer : public RowNumberFuzzerBase {
 MarkDistinctFuzzer::MarkDistinctFuzzer(
     size_t initialSeed,
     std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner)
-    : RowNumberFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {
+    : SpillFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {
   vectorFuzzer_.getMutableOptions().timestampPrecision =
       fuzzer::FuzzerTimestampPrecision::kMilliSeconds;
 }
@@ -109,7 +109,7 @@ std::vector<RowVectorPtr> MarkDistinctFuzzer::generateInput(
   return input;
 }
 
-RowNumberFuzzerBase::PlanWithSplits MarkDistinctFuzzer::makeDefaultPlan(
+PlanWithSplits MarkDistinctFuzzer::makeDefaultPlan(
     const std::string& groupKey,
     const std::string& distinctKey,
     const std::vector<RowVectorPtr>& input) {
@@ -127,7 +127,7 @@ RowNumberFuzzerBase::PlanWithSplits MarkDistinctFuzzer::makeDefaultPlan(
   return PlanWithSplits{std::move(plan)};
 }
 
-RowNumberFuzzerBase::PlanWithSplits MarkDistinctFuzzer::makePlanWithTableScan(
+PlanWithSplits MarkDistinctFuzzer::makePlanWithTableScan(
     const RowTypePtr& type,
     const std::string& groupKey,
     const std::string& distinctKey,
@@ -181,8 +181,7 @@ void MarkDistinctFuzzer::runSingleIteration() {
   const auto& distinctKey = allNames[1];
 
   auto defaultPlan = makeDefaultPlan(groupKey, distinctKey, input);
-  const auto expected =
-      execute(defaultPlan, pool_, /*injectSpill=*/false, false);
+  const auto expected = execute(defaultPlan, /*injectSpill=*/false, false);
 
   // Validate against DuckDB using an equivalent plan without MarkDistinct.
   // DuckDB cannot translate MarkDistinctNode to SQL, so we build a reference

--- a/velox/exec/fuzzer/RowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/RowNumberFuzzer.cpp
@@ -20,14 +20,14 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
-#include "velox/exec/fuzzer/RowNumberFuzzerBase.h"
+#include "velox/exec/fuzzer/SpillFuzzerBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::exec {
 using namespace facebook::velox::common::testutil;
 namespace {
 
-class RowNumberFuzzer : public RowNumberFuzzerBase {
+class RowNumberFuzzer : public SpillFuzzerBase {
  public:
   explicit RowNumberFuzzer(
       size_t initialSeed,
@@ -69,7 +69,7 @@ class RowNumberFuzzer : public RowNumberFuzzerBase {
 RowNumberFuzzer::RowNumberFuzzer(
     size_t initialSeed,
     std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner)
-    : RowNumberFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {
+    : SpillFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {
   // Set timestamp precision as milliseconds, as timestamp may be used as
   // paritition key, and presto doesn't supports nanosecond precision.
   vectorFuzzer_.getMutableOptions().timestampPrecision =
@@ -110,7 +110,7 @@ std::vector<RowVectorPtr> RowNumberFuzzer::generateInput(
   return input;
 }
 
-RowNumberFuzzerBase::PlanWithSplits RowNumberFuzzer::makeDefaultPlan(
+PlanWithSplits RowNumberFuzzer::makeDefaultPlan(
     const std::vector<std::string>& partitionKeys,
     const std::vector<RowVectorPtr>& input) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -124,7 +124,7 @@ RowNumberFuzzerBase::PlanWithSplits RowNumberFuzzer::makeDefaultPlan(
   return PlanWithSplits{std::move(plan)};
 }
 
-RowNumberFuzzerBase::PlanWithSplits RowNumberFuzzer::makePlanWithTableScan(
+PlanWithSplits RowNumberFuzzer::makePlanWithTableScan(
     const RowTypePtr& type,
     const std::vector<std::string>& partitionKeys,
     const std::vector<Split>& splits) {
@@ -165,8 +165,7 @@ void RowNumberFuzzer::runSingleIteration() {
   test::logVectors(input);
 
   auto defaultPlan = makeDefaultPlan(keyNames, input);
-  const auto expected =
-      execute(defaultPlan, pool_, /*injectSpill=*/false, false);
+  const auto expected = execute(defaultPlan, /*injectSpill=*/false, false);
 
   if (expected != nullptr) {
     validateExpectedResults(defaultPlan.plan, input, expected);

--- a/velox/exec/fuzzer/SpillFuzzerBase.cpp
+++ b/velox/exec/fuzzer/SpillFuzzerBase.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/exec/fuzzer/RowNumberFuzzerBase.h"
+#include "velox/exec/fuzzer/SpillFuzzerBase.h"
 
 #include <utility>
 #include "velox/common/testutil/TempDirectoryPath.h"
@@ -69,7 +69,27 @@ namespace facebook::velox::exec {
 
 using namespace facebook::velox::common::testutil;
 
-RowNumberFuzzerBase::RowNumberFuzzerBase(
+namespace {
+void compareResults(const RowVectorPtr& expected, const RowVectorPtr& actual) {
+  if (actual != nullptr && expected != nullptr) {
+    try {
+      VELOX_CHECK(
+          test::assertEqualResults({expected}, {actual}),
+          "Logically equivalent plans produced different results");
+    } catch (const VeloxException&) {
+      LOG(ERROR) << "Expected\n"
+                 << expected->toString(0, expected->size()) << "\nActual\n"
+                 << actual->toString(0, actual->size());
+      throw;
+    }
+  } else {
+    VELOX_CHECK(
+        FLAGS_enable_oom_injection, "Got unexpected nullptr for results");
+  }
+}
+} // namespace
+
+SpillFuzzerBase::SpillFuzzerBase(
     size_t initialSeed,
     std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner)
     : vectorFuzzer_{getFuzzerOptions(), pool_.get()},
@@ -78,18 +98,21 @@ RowNumberFuzzerBase::RowNumberFuzzerBase(
   seed(initialSeed);
 }
 
-void RowNumberFuzzerBase::setupReadWrite() {
+void SpillFuzzerBase::setupReadWrite() {
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();
 
-  if (!isRegisteredNamedVectorSerde("Presto")) {
+  if (!isRegisteredNamedVectorSerde(
+          VectorSerde::kindName(VectorSerde::Kind::kPresto))) {
     serializer::presto::PrestoVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde("CompactRow")) {
+  if (!isRegisteredNamedVectorSerde(
+          VectorSerde::kindName(VectorSerde::Kind::kCompactRow))) {
     serializer::CompactRowVectorSerde::registerNamedVectorSerde();
   }
-  if (!isRegisteredNamedVectorSerde("UnsafeRow")) {
+  if (!isRegisteredNamedVectorSerde(
+          VectorSerde::kindName(VectorSerde::Kind::kUnsafeRow))) {
     serializer::spark::UnsafeRowVectorSerde::registerNamedVectorSerde();
   }
 
@@ -102,20 +125,19 @@ void RowNumberFuzzerBase::setupReadWrite() {
 // Sometimes we generate zero-column input of type ROW({}) or a column of type
 // UNKNOWN(). Such data cannot be written to a file and therefore cannot
 // be tested with TableScan.
-bool RowNumberFuzzerBase::isTableScanSupported(const TypePtr& type) {
-  if (type->kind() == TypeKind::ROW && type->size() == 0) {
-    return false;
-  }
-  if (type->kind() == TypeKind::UNKNOWN) {
-    return false;
-  }
-  if (type->kind() == TypeKind::HUGEINT) {
-    return false;
-  }
-  // Disable testing with TableScan when input contains TIMESTAMP type, due to
-  // the issue #8127.
-  if (type->kind() == TypeKind::TIMESTAMP) {
-    return false;
+bool SpillFuzzerBase::isTableScanSupported(const TypePtr& type) {
+  switch (type->kind()) {
+    case TypeKind::UNKNOWN:
+    case TypeKind::HUGEINT:
+    case TypeKind::TIMESTAMP:
+      return false;
+    case TypeKind::ROW:
+      if (type->size() == 0) {
+        return false;
+      }
+      break;
+    default:
+      break;
   }
 
   for (auto i = 0; i < type->size(); ++i) {
@@ -127,7 +149,7 @@ bool RowNumberFuzzerBase::isTableScanSupported(const TypePtr& type) {
   return true;
 }
 
-void RowNumberFuzzerBase::validateExpectedResults(
+void SpillFuzzerBase::validateExpectedResults(
     const core::PlanNodePtr& plan,
     const std::vector<RowVectorPtr>& input,
     const RowVectorPtr& result) {
@@ -153,7 +175,7 @@ bool isDone(size_t i, T startTime) {
   return i >= FLAGS_steps;
 }
 
-void RowNumberFuzzerBase::run() {
+void SpillFuzzerBase::run() {
   VELOX_USER_CHECK(
       FLAGS_steps > 0 || FLAGS_duration_sec > 0,
       "Either --steps or --duration_sec needs to be greater than zero.");
@@ -174,9 +196,8 @@ void RowNumberFuzzerBase::run() {
   }
 }
 
-RowVectorPtr RowNumberFuzzerBase::execute(
+RowVectorPtr SpillFuzzerBase::execute(
     const PlanWithSplits& plan,
-    const std::shared_ptr<memory::MemoryPool>& pool,
     bool injectSpill,
     bool injectOOM,
     const std::optional<std::string>& spillConfig,
@@ -220,7 +241,7 @@ RowVectorPtr RowNumberFuzzerBase::execute(
   TestScopedSpillInjection scopedSpillInjection(spillPct);
   RowVectorPtr result;
   try {
-    result = builder.copyResults(pool.get());
+    result = builder.copyResults(pool_.get());
   } catch (VeloxRuntimeError& e) {
     if (injectOOM &&
         e.errorCode() == facebook::velox::error_code::kMemCapExceeded &&
@@ -240,50 +261,30 @@ RowVectorPtr RowNumberFuzzerBase::execute(
   return result;
 }
 
-void RowNumberFuzzerBase::testPlan(
+void SpillFuzzerBase::testPlan(
     const PlanWithSplits& plan,
     int32_t testNumber,
     const RowVectorPtr& expected,
     const std::optional<std::string>& spillConfig) {
   LOG(INFO) << "Testing plan #" << testNumber;
 
-  auto actual =
-      execute(plan, pool_, /*injectSpill=*/false, FLAGS_enable_oom_injection);
-  if (actual != nullptr && expected != nullptr) {
-    VELOX_CHECK(
-        test::assertEqualResults({expected}, {actual}),
-        "Logically equivalent plans produced different results");
-  } else {
-    VELOX_CHECK(
-        FLAGS_enable_oom_injection, "Got unexpected nullptr for results");
-  }
+  // Test without spilling first, then with spilling if enabled.
+  const bool testSpill = FLAGS_enable_spill;
+  for (int round = 0; round < (testSpill ? 2 : 1); ++round) {
+    const bool injectSpill = round == 1;
+    if (injectSpill) {
+      LOG(INFO) << "Testing plan #" << testNumber << " with spilling";
+    }
 
-  if (FLAGS_enable_spill) {
-    LOG(INFO) << "Testing plan #" << testNumber << " with spilling";
     const auto fuzzMaxSpillLevel =
         FLAGS_max_spill_level == -1 ? randInt(0, 3) : FLAGS_max_spill_level;
-    actual = execute(
+    auto actual = execute(
         plan,
-        pool_,
-        /*=injectSpill=*/true,
+        injectSpill,
         FLAGS_enable_oom_injection,
-        spillConfig,
-        fuzzMaxSpillLevel);
-    if (actual != nullptr && expected != nullptr) {
-      try {
-        VELOX_CHECK(
-            test::assertEqualResults({expected}, {actual}),
-            "Logically equivalent plans produced different results");
-      } catch (const VeloxException&) {
-        LOG(ERROR) << "Expected\n"
-                   << expected->toString(0, expected->size()) << "\nActual\n"
-                   << actual->toString(0, actual->size());
-        throw;
-      }
-    } else {
-      VELOX_CHECK(
-          FLAGS_enable_oom_injection, "Got unexpected nullptr for results");
-    }
+        injectSpill ? spillConfig : std::nullopt,
+        injectSpill ? fuzzMaxSpillLevel : -1);
+    compareResults(expected, actual);
   }
 }
 

--- a/velox/exec/fuzzer/SpillFuzzerBase.h
+++ b/velox/exec/fuzzer/SpillFuzzerBase.h
@@ -41,21 +41,31 @@ DECLARE_bool(enable_oom_injection);
 
 namespace facebook::velox::exec {
 
-class RowNumberFuzzerBase {
+struct PlanWithSplits {
+  core::PlanNodePtr plan;
+  std::vector<Split> splits;
+
+  explicit PlanWithSplits(
+      core::PlanNodePtr _plan,
+      const std::vector<Split>& _splits = {})
+      : plan(std::move(_plan)), splits(_splits) {}
+};
+
+class SpillFuzzerBase {
  public:
-  explicit RowNumberFuzzerBase(
+  explicit SpillFuzzerBase(
       size_t initialSeed,
       std::unique_ptr<test::ReferenceQueryRunner>);
 
   void run();
 
-  virtual ~RowNumberFuzzerBase() = default;
+  virtual ~SpillFuzzerBase() = default;
 
  protected:
   bool isTableScanSupported(const TypePtr& type);
 
-  // Runs one test iteration from query plans generations, executions and result
-  // verifications.
+  // Runs one test iteration from query plans generations, executions and
+  // result verifications.
   virtual void runSingleIteration() = 0;
 
   // Sets up the Dwrf reader/writer, serializers and Hive connector for the
@@ -91,27 +101,16 @@ class RowNumberFuzzerBase {
       const std::vector<RowVectorPtr>& input,
       const RowVectorPtr& result);
 
-  struct PlanWithSplits {
-    core::PlanNodePtr plan;
-    std::vector<Split> splits;
-
-    explicit PlanWithSplits(
-        core::PlanNodePtr _plan,
-        const std::vector<Split>& _splits = {})
-        : plan(std::move(_plan)), splits(_splits) {}
-  };
-
-  // Executes a plan with spilling and oom injection possibly.
+  // Executes a plan with optional spill and OOM injection.
   RowVectorPtr execute(
       const PlanWithSplits& plan,
-      const std::shared_ptr<memory::MemoryPool>& pool,
       bool injectSpill,
       bool injectOOM,
       const std::optional<std::string>& spillConfig = std::nullopt,
       int maxSpillLevel = -1);
 
-  // Tests a plan by executing it with and without spilling. OOM injection
-  // also might be done based on FLAG_enable_oom_injection.
+  // Tests a plan by executing it with and without spilling. OOM injection is
+  // controlled by FLAGS_enable_oom_injection.
   void testPlan(
       const PlanWithSplits& plan,
       int32_t testNumber,
@@ -123,15 +122,15 @@ class RowNumberFuzzerBase {
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
       memory::memoryManager()->addRootPool(
-          "rowNumberFuzzer",
+          "spillFuzzer",
           memory::kMaxMemory,
           exec::MemoryReclaimer::create())};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild(
-      "rowNumberFuzzerLeaf",
+      "spillFuzzerLeaf",
       true,
       exec::MemoryReclaimer::create())};
   std::shared_ptr<memory::MemoryPool> writerPool_{rootPool_->addAggregateChild(
-      "rowNumberFuzzerWriter",
+      "spillFuzzerWriter",
       exec::MemoryReclaimer::create())};
   VectorFuzzer vectorFuzzer_;
   std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner_;

--- a/velox/exec/fuzzer/TopNRowNumberFuzzer.cpp
+++ b/velox/exec/fuzzer/TopNRowNumberFuzzer.cpp
@@ -20,7 +20,7 @@
 
 #include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/exec/fuzzer/FuzzerUtil.h"
-#include "velox/exec/fuzzer/RowNumberFuzzerBase.h"
+#include "velox/exec/fuzzer/SpillFuzzerBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
@@ -28,7 +28,7 @@ namespace facebook::velox::exec {
 using namespace facebook::velox::common::testutil;
 namespace {
 
-class TopNRowNumberFuzzer : public RowNumberFuzzerBase {
+class TopNRowNumberFuzzer : public SpillFuzzerBase {
  public:
   explicit TopNRowNumberFuzzer(
       size_t initialSeed,
@@ -69,7 +69,7 @@ class TopNRowNumberFuzzer : public RowNumberFuzzerBase {
 TopNRowNumberFuzzer::TopNRowNumberFuzzer(
     size_t initialSeed,
     std::unique_ptr<test::ReferenceQueryRunner> referenceQueryRunner)
-    : RowNumberFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {}
+    : SpillFuzzerBase(initialSeed, std::move(referenceQueryRunner)) {}
 
 std::pair<std::vector<std::string>, std::vector<TypePtr>>
 TopNRowNumberFuzzer::generateKeys(const std::string& prefix) {
@@ -189,8 +189,7 @@ std::vector<RowVectorPtr> TopNRowNumberFuzzer::generateInput(
   return input;
 }
 
-std::pair<RowNumberFuzzerBase::PlanWithSplits, int32_t>
-TopNRowNumberFuzzer::makeDefaultPlan(
+std::pair<PlanWithSplits, int32_t> TopNRowNumberFuzzer::makeDefaultPlan(
     const std::vector<std::string>& partitionKeys,
     const std::vector<std::string>& sortKeys,
     const std::vector<std::string>& allKeys,
@@ -210,7 +209,7 @@ TopNRowNumberFuzzer::makeDefaultPlan(
   return std::make_pair(PlanWithSplits{std::move(plan)}, limit);
 }
 
-RowNumberFuzzerBase::PlanWithSplits TopNRowNumberFuzzer::makePlanWithTableScan(
+PlanWithSplits TopNRowNumberFuzzer::makePlanWithTableScan(
     const std::vector<std::string>& partitionKeys,
     const std::vector<std::string>& sortKeys,
     const std::vector<std::string>& allKeys,
@@ -261,8 +260,7 @@ void TopNRowNumberFuzzer::runSingleIteration() {
   auto [defaultPlan, limit] =
       makeDefaultPlan(partitionKeys, allSortKeys, allKeys, input);
 
-  const auto expected =
-      execute(defaultPlan, pool_, /*injectSpill=*/false, false);
+  const auto expected = execute(defaultPlan, /*injectSpill=*/false, false);
   if (expected != nullptr) {
     validateExpectedResults(defaultPlan.plan, input, expected);
   }


### PR DESCRIPTION
Summary:

per title, simply rename RowNumberFuzzerBase to  SpillFuzzerBase as MarkDistinct with a very trival refroct.**Miscellaneous Refactoring of Spill Fuzzer**

The diff is a refactoring effort that focuses on the Spill Fuzzer. The changes include:

*   Renaming `velox_row_number_fuzzer_base_lib` to `velox_spill_fuzzer_base_lib` to better reflect its purpose.
*   Replacing `RowNumberFuzzerBase` with `SpillFuzzerBase` in multiple files to maintain consistency.
*   Creating a new file `SpillFuzzerBase.cpp` with a corresponding header file `SpillFuzzerBase.h`.
*   Updating the `CMakeLists.txt` file to accommodate the changes.

The overall goal of this diff is to refactor the codebase to make it more organized, maintainable, and efficient. The changes aim to improve the structure and naming conventions of the code, making it easier for developers to understand and work with.

Differential Revision: D94977010


