### PR TITLE
fix: Remove redundant checks in BufferInputStream

### DIFF
--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -57,9 +57,7 @@ std::string BufferInputStream::toString() const {
 }
 
 bool BufferInputStream::atEnd() const {
-  if (current_ == nullptr) {
-    return false;
-  }
+  VELOX_DCHECK_NOT_NULL(current_);
   if (current_->position < current_->size) {
     return false;
   }
@@ -77,9 +75,7 @@ size_t BufferInputStream::size() const {
 }
 
 size_t BufferInputStream::remainingSize() const {
-  if (ranges_.empty()) {
-    return 0;
-  }
+  VELOX_DCHECK(!ranges_.empty());
   const auto* lastRange = &ranges_.back();
   auto* cur = current_;
   size_t remainingBytes = cur->availableBytes();
@@ -90,10 +86,8 @@ size_t BufferInputStream::remainingSize() const {
 }
 
 std::streampos BufferInputStream::tellp() const {
-  if (ranges_.empty()) {
-    return 0;
-  }
-  assert(current_);
+  VELOX_DCHECK(!ranges_.empty());
+  VELOX_DCHECK_NOT_NULL(current_);
   int64_t size = 0;
   for (auto& range : ranges_) {
     if (&range == current_) {
@@ -105,9 +99,7 @@ std::streampos BufferInputStream::tellp() const {
 }
 
 void BufferInputStream::seekp(std::streampos position) {
-  if (ranges_.empty() && position == 0) {
-    return;
-  }
+  VELOX_DCHECK(!ranges_.empty());
   int64_t toSkip = position;
   for (auto& range : ranges_) {
     if (toSkip <= range.size) {

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -259,6 +259,8 @@ class BufferInputStream : public ByteInputStream {
     return ranges_;
   }
 
+  // The byte ranges backing this stream. Guaranteed to be non-empty after
+  // construction.
   std::vector<ByteRange> ranges_;
 };
 


### PR DESCRIPTION
BufferInputStream's constructor enforces that 'ranges_' is non-empty
(via VELOX_CHECK) and always initializes 'current_' to '&ranges_[0]'.
Since no method ever clears 'ranges_' or sets 'current_' to nullptr,
several defensive checks in member functions are unreachable:

- atEnd(): Remove null check on 'current_'
- remainingSize(): Remove 'ranges_.empty()' check
- tellp(): Remove 'ranges_.empty()' check and 'assert(current_)'
- seekp(): Remove unreachable early return for empty ranges

Replace them with 'VELOX_DCHECK' assertions to document and enforce
the class invariants in debug builds. Also add a comment on 'ranges_'
to clarify the non-empty guarantee.