### PR TITLE
build: Undefined symbols `registerArraySplitIntoChunksFunctions`

### DIFF
--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   ArrayConcatRegistration.cpp
   ArrayFunctionsRegistration.cpp
   ArrayNGramsRegistration.cpp
+  ArraySplitIntoChunksRegistration.cpp
   BinaryFunctionsRegistration.cpp
   BingTileFunctionsRegistration.cpp
   BitwiseFunctionsRegistration.cpp


### PR DESCRIPTION
Fixes the below undefined symbols compilation error.
```
Undefined symbols for architecture arm64:
  "facebook::velox::functions::registerArraySplitIntoChunksFunctions(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&)", referenced from:
      facebook::velox::functions::registerArrayFunctions(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in libvelox.a[573](ArrayFunctionsRegistration.cpp.o)
```
Follow-up for: https://github.com/facebookincubator/velox/commit/a3770113e2aca39f11824bbe62ec4421217aabd6