### PR TITLE
feat(rpc): Add RPCOperator, RPCState, RPCRateLimiter, and RPCPlanNodeTranslator [3/8] (OSS) (#16787)

### DIFF
--- a/velox/common/rpc/RPCTypes.h
+++ b/velox/common/rpc/RPCTypes.h
@@ -19,10 +19,28 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <string_view>
 
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::rpc {
+
+/// Well-known option key constants for RPCRequest.options.
+/// Use these instead of raw string literals to prevent typo bugs.
+namespace keys {
+inline constexpr std::string_view kModel = "model";
+inline constexpr std::string_view kTemperature = "temperature";
+inline constexpr std::string_view kMaxTokens = "max_tokens";
+inline constexpr std::string_view kSystemPrompt = "systemPrompt";
+inline constexpr std::string_view kJsonSchema = "json_schema";
+inline constexpr std::string_view kMetagenKey = "metagen_key";
+inline constexpr std::string_view kTierOverride = "tier_override";
+inline constexpr std::string_view kCatToken = "cat_token";
+inline constexpr std::string_view kPollIntervalMs = "poll_interval_ms";
+inline constexpr std::string_view kOwnerUnixname = "owner_unixname";
+inline constexpr std::string_view kIsQuery = "is_query";
+inline constexpr std::string_view kPrefixDim = "prefix_dim";
+} // namespace keys
 
 /// Streaming mode for RPC execution.
 /// Controls how RPC results are emitted to downstream operators.
@@ -62,6 +80,12 @@ struct RPCRequest {
   /// CRITICAL: When prepareRequests() skips null rows, originalRowIndex
   /// tracks the actual input position to avoid slicing mismatch.
   vector_size_t originalRowIndex{0};
+
+  /// Whether this row has a null primary input.
+  /// When true, the transport should short-circuit and return an error
+  /// response so that buildOutput() produces SQL NULL for this row.
+  /// Replaces the former "__null_input" magic string in options.
+  bool isNull{false};
 
   /// The request payload (opaque to the framework).
   std::string payload;

--- a/velox/exec/BlockingReason.cpp
+++ b/velox/exec/BlockingReason.cpp
@@ -35,6 +35,7 @@ const auto& blockingReasonNames() {
       {BlockingReason::kWaitForArbitration, "kWaitForArbitration"},
       {BlockingReason::kWaitForScanScaleUp, "kWaitForScanScaleUp"},
       {BlockingReason::kWaitForIndexLookup, "kWaitForIndexLookup"},
+      {BlockingReason::kWaitForRPC, "kWaitForRPC"},
   };
   return kNames;
 }

--- a/velox/exec/BlockingReason.h
+++ b/velox/exec/BlockingReason.h
@@ -55,6 +55,9 @@ enum class BlockingReason {
   /// Used by IndexLookupJoin operator, indicating that it was blocked by the
   /// async index lookup.
   kWaitForIndexLookup,
+  /// Used by RPC operators, indicating that the operator is blocked waiting
+  /// for an async RPC response (e.g., LLM inference, embedding lookups).
+  kWaitForRPC,
 };
 
 VELOX_DECLARE_ENUM_NAME(BlockingReason);

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -148,4 +148,5 @@ if(${VELOX_ENABLE_BENCHMARKS})
 endif()
 
 add_subdirectory(prefixsort)
+add_subdirectory(rpc)
 add_subdirectory(trace)

--- a/velox/exec/rpc/CMakeLists.txt
+++ b/velox/exec/rpc/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RPCNode is part of velox_core (in core/PlanNode.h)
+
+velox_add_library(velox_rpc_state RPCState.cpp)
+
+velox_link_libraries(
+  velox_rpc_state
+  velox_rpc_types
+  velox_common_base
+  velox_future
+  velox_vector
+  Folly::folly
+)
+
+velox_add_library(velox_rpc_rate_limiter RPCRateLimiter.cpp)
+
+velox_link_libraries(velox_rpc_rate_limiter velox_future)
+
+velox_add_library(velox_rpc_operator RPCOperator.cpp)
+
+velox_link_libraries(
+  velox_rpc_operator
+  velox_rpc_state
+  velox_rpc_rate_limiter
+  velox_async_rpc_function
+  velox_async_rpc_function_registry
+  velox_exec
+  velox_expression
+  velox_vector
+  velox_buffer
+  velox_future
+  Folly::folly
+)
+
+velox_add_library(velox_rpc_plan_node_translator RPCPlanNodeTranslator.cpp)
+
+velox_link_libraries(velox_rpc_plan_node_translator velox_rpc_operator velox_exec)

--- a/velox/exec/rpc/RPCOperator.cpp
+++ b/velox/exec/rpc/RPCOperator.cpp
@@ -1,0 +1,657 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/RPCOperator.h"
+
+#include "velox/common/time/CpuWallTimer.h"
+#include "velox/common/time/Timer.h"
+#include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
+
+#define RPC_OP_LOG(severity) LOG(severity) << "[RPC_OP] "
+#define RPC_OP_VLOG(level) VLOG(level) << "[RPC_OP] "
+
+namespace facebook::velox::exec::rpc {
+
+RPCOperator::RPCOperator(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    std::shared_ptr<const core::RPCNode> rpcNode)
+    : exec::Operator(
+          driverCtx,
+          rpcNode->outputType(),
+          operatorId,
+          rpcNode->id(),
+          "RPC"),
+      rpcNode_(std::move(rpcNode)),
+      state_(std::make_shared<RPCState>()),
+      dispatchBatchSize_(rpcNode_->dispatchBatchSize()) {
+  // Configure RPCState with streaming mode.
+  state_->setStreamingMode(rpcNode_->streamingMode());
+}
+
+void RPCOperator::initialize() {
+  Operator::initialize();
+
+  // Resolve the AsyncRPCFunction by name from the registry.
+  function_ = AsyncRPCFunctionRegistry::create(rpcNode_->functionName());
+  VELOX_CHECK(
+      function_,
+      "Unknown RPC function '{}'. Ensure it is registered via "
+      "AsyncRPCFunctionRegistry::registerFunction() before query execution.",
+      rpcNode_->functionName());
+
+  // Initialize the function with query config, argument types, and constants.
+  // The function creates/caches its own transport and clients internally.
+  function_->initialize(
+      operatorCtx_->driverCtx()->queryConfig(),
+      rpcNode_->argumentTypes(),
+      rpcNode_->constantInputs());
+
+  tierKey_ = function_->tierKey();
+
+  RPC_OP_VLOG(1) << "Created operator for function '"
+                 << rpcNode_->functionName() << "', planNodeId=" << planNodeId()
+                 << ", operatorId=" << operatorId() << ", streamingMode="
+                 << (rpcNode_->streamingMode() == RPCStreamingMode::kBatch
+                         ? "BATCH"
+                         : "PER_ROW");
+
+  // Precompute argument column indices for addInput().
+  const auto& argCols = rpcNode_->argumentColumns();
+  if (!argCols.empty()) {
+    auto sourceType = rpcNode_->source()->outputType();
+    argumentColumnIndices_.reserve(argCols.size());
+    for (const auto& colName : argCols) {
+      auto idx = sourceType->getChildIdx(colName);
+      argumentColumnIndices_.push_back(static_cast<column_index_t>(idx));
+    }
+    RPC_OP_VLOG(1) << "Initialized with " << argCols.size()
+                   << " argument columns";
+  } else {
+    RPC_OP_VLOG(1) << "Initialized with no argument columns "
+                   << "(fallback to all input columns)";
+  }
+
+  // Precompute output column projections to avoid string lookups in
+  // buildOutputVector().
+  initOutputProjections();
+}
+
+bool RPCOperator::needsInput() const {
+  if (noMoreInput_ || isDraining()) {
+    return false;
+  }
+
+  // Don't accept input if we have results ready to output.
+  if (!claimedRows_.empty() || claimedBatch_.has_value()) {
+    return false;
+  }
+
+  // Check per-state backpressure.
+  if (state_->isUnderBackpressure()) {
+    return false;
+  }
+
+  return true;
+}
+
+void RPCOperator::addInput(RowVectorPtr input) {
+  if (!input || input->size() == 0) {
+    RPC_OP_VLOG(2) << "addInput received empty input";
+    return;
+  }
+
+  RPC_OP_VLOG(1) << "addInput received " << input->size() << " rows with "
+                 << input->childrenSize() << " input columns";
+
+  SelectivityVector rows(input->size());
+
+  // Read pre-computed argument columns by precomputed index.
+  std::vector<VectorPtr> args;
+  if (!argumentColumnIndices_.empty()) {
+    args.reserve(argumentColumnIndices_.size());
+    for (auto idx : argumentColumnIndices_) {
+      args.push_back(input->childAt(idx));
+    }
+  } else {
+    // Fallback: use all input columns as arguments.
+    for (auto i = 0; i < input->childrenSize(); ++i) {
+      args.push_back(input->childAt(i));
+    }
+  }
+
+  // Flatten/load all columns upfront to avoid issues with lazy vectors.
+  std::vector<VectorPtr> flattenedColumns;
+  flattenedColumns.reserve(input->childrenSize());
+  for (int32_t j = 0; j < input->childrenSize(); ++j) {
+    auto column = BaseVector::loadedVectorShared(input->childAt(j));
+    BaseVector::flattenVector(column);
+    flattenedColumns.push_back(column);
+  }
+
+  auto streamingMode = state_->streamingMode();
+
+  if (streamingMode == RPCStreamingMode::kPerRow) {
+    // PER_ROW: function dispatches individual RPCs and returns futures.
+    auto futures = function_->dispatchPerRow(rows, args);
+
+    auto batchIndex = state_->storeInputBatch(
+        flattenedColumns, static_cast<int64_t>(futures.size()));
+    numRequestsDispatched_ += static_cast<int64_t>(futures.size());
+
+    for (auto& [originalRowIndex, future] : futures) {
+      auto rowId = globalRowIdCounter_++;
+      auto token = std::make_shared<RPCRateLimiter::Token>(
+          RPCRateLimiter::acquire(tierKey_));
+
+      auto wrapped =
+          std::move(future)
+              .within(kBatchRpcTimeout)
+              .deferValue([rowId, token](RPCResponse resp) {
+                resp.rowId = rowId;
+                return resp;
+              })
+              .deferError([token](folly::exception_wrapper ew) {
+                return folly::makeSemiFuture<RPCResponse>(std::move(ew));
+              });
+
+      state_->addPendingRow(
+          state_,
+          rowId,
+          RPCState::RowLocation{batchIndex, originalRowIndex},
+          std::move(wrapped));
+    }
+  } else {
+    // BATCH: function accumulates typed data internally.
+    auto rowIndices = function_->accumulateBatch(rows, args);
+
+    auto batchIndex = state_->storeInputBatch(
+        flattenedColumns, static_cast<int64_t>(rowIndices.size()));
+    numRequestsDispatched_ += static_cast<int64_t>(rowIndices.size());
+
+    for (auto originalRowIndex : rowIndices) {
+      auto rowId = globalRowIdCounter_++;
+      batchRowLocations_.push_back(
+          RPCState::RowLocation{batchIndex, originalRowIndex});
+      batchRowIds_.push_back(rowId);
+    }
+
+    if (dispatchBatchSize_ > 0 &&
+        function_->pendingBatchSize() >= dispatchBatchSize_) {
+      flushBatchRequests();
+    }
+  }
+}
+
+void RPCOperator::flushBatchRequests() {
+  if (function_->pendingBatchSize() == 0) {
+    VELOX_CHECK(
+        batchRowLocations_.empty(),
+        "Operator has {} accumulated batch rows but function reports "
+        "pendingBatchSize=0. Function must override pendingBatchSize() "
+        "when using BATCH mode.",
+        batchRowLocations_.size());
+    return;
+  }
+
+  RPC_OP_LOG(INFO) << "Flushing batch with " << function_->pendingBatchSize()
+                   << " accumulated rows";
+
+  auto rowLocations = std::move(batchRowLocations_);
+  auto rowIds = std::move(batchRowIds_);
+
+  auto future = function_->flushBatch();
+
+  // Count each flushBatch() as 1 pending unit in the rate limiter.
+  auto token = std::make_shared<RPCRateLimiter::Token>(
+      RPCRateLimiter::acquire(tierKey_));
+
+  // Stamp rowIds onto responses.
+  auto wrapped =
+      std::move(future)
+          .within(kBatchRpcTimeout)
+          .deferValue([rowIds = std::move(rowIds),
+                       token](std::vector<RPCResponse> resps) {
+            VELOX_CHECK_EQ(
+                resps.size(),
+                rowIds.size(),
+                "RPC batch response count ({}) does not match row count ({})",
+                resps.size(),
+                rowIds.size());
+            for (size_t i = 0; i < resps.size(); ++i) {
+              resps[i].rowId = rowIds[i];
+            }
+            return resps;
+          })
+          .deferError([token](folly::exception_wrapper ew) {
+            RPC_OP_LOG(ERROR) << "RPC batch failed: " << ew.what();
+            return folly::makeSemiFuture<std::vector<RPCResponse>>(
+                std::move(ew));
+          });
+
+  state_->addPendingBatch(state_, std::move(wrapped), std::move(rowLocations));
+}
+
+void RPCOperator::noMoreInput() {
+  exec::Operator::noMoreInput();
+
+  RPC_OP_VLOG(1) << "noMoreInput: totalRequestsDispatched="
+                 << numRequestsDispatched_;
+
+  if (state_->streamingMode() == RPCStreamingMode::kBatch) {
+    // Flush any remaining accumulated rows.
+    if (function_->pendingBatchSize() > 0) {
+      flushBatchRequests();
+    }
+  }
+
+  state_->setNoMoreInput();
+}
+
+RowVectorPtr RPCOperator::getOutput() {
+  auto streamingMode = state_->streamingMode();
+
+  if (streamingMode == RPCStreamingMode::kPerRow) {
+    if (claimedRows_.empty()) {
+      // If draining and nothing left to output, check finish.
+      if (isDraining() && state_->isFinished()) {
+        finished_ = true;
+        finishDrain();
+      }
+      return nullptr;
+    }
+
+    // Drain additional ready rows (non-blocking) for batched output.
+    // This amortizes RowVector allocation across multiple completed rows.
+    state_->drainReadyRows(claimedRows_, 1024);
+
+    auto numRows = static_cast<int64_t>(claimedRows_.size());
+    for (const auto& row : claimedRows_) {
+      if (row.response.hasError()) {
+        numErrors_++;
+      }
+    }
+    auto output = buildOutputFromReadyRows(claimedRows_);
+    numResponsesCollected_ += numRows;
+    claimedRows_.clear();
+    return output;
+  } else {
+    if (!claimedBatch_.has_value()) {
+      // If draining and nothing left to output, check finish.
+      if (isDraining() && state_->isFinished()) {
+        finished_ = true;
+        finishDrain();
+      }
+      return nullptr;
+    }
+
+    // Fail loudly on batch errors instead of silently dropping rows.
+    if (claimedBatch_->error.has_value()) {
+      auto error = claimedBatch_->error.value();
+      claimedBatch_.reset();
+      VELOX_FAIL("RPC batch failed: {}", error);
+    }
+
+    auto numRows = static_cast<int64_t>(claimedBatch_->responses.size());
+    for (const auto& response : claimedBatch_->responses) {
+      if (response.hasError()) {
+        numErrors_++;
+      }
+    }
+    auto output = buildOutputFromReadyBatch(*claimedBatch_);
+    numResponsesCollected_ += numRows;
+    claimedBatch_.reset();
+    return output;
+  }
+}
+
+exec::BlockingReason RPCOperator::isBlocked(ContinueFuture* future) {
+  // End any previous block wait measurement.
+  if (blockWaitStartNs_.has_value()) {
+    auto elapsed = getCurrentTimeNano() - blockWaitStartNs_.value();
+    if (blockWaitIsBackpressure_) {
+      totalBackpressureWaitNanos_ += elapsed;
+    } else {
+      totalBlockWaitNanos_ += elapsed;
+    }
+    blockWaitStartNs_ = std::nullopt;
+  }
+
+  // Check per-tier backpressure first.
+  if (auto backpressureFuture = RPCRateLimiter::checkBackpressure(tierKey_)) {
+    RPC_OP_VLOG(1) << "Backpressure applied for tier '" << tierKey_
+                   << "', pending=" << RPCRateLimiter::pendingCount(tierKey_);
+    *future = std::move(*backpressureFuture);
+    blockWaitStartNs_ = getCurrentTimeNano();
+    blockWaitIsBackpressure_ = true;
+    return exec::BlockingReason::kWaitForRPC;
+  }
+
+  // If we already have output ready, don't block.
+  if (!claimedRows_.empty() || claimedBatch_.has_value()) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  // If finished, don't block.
+  if (finished_) {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  auto streamingMode = state_->streamingMode();
+
+  if (streamingMode == RPCStreamingMode::kPerRow) {
+    if (!noMoreInput_ && !isDraining()) {
+      auto claimedRow = state_->tryClaimReady();
+      if (claimedRow) {
+        claimedRows_.push_back(std::move(*claimedRow));
+      }
+      return exec::BlockingReason::kNotBlocked;
+    }
+
+    std::optional<RPCState::ReadyRow> claimedRow;
+    ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+    auto result = state_->tryClaimOrWait(&waitFuture, &claimedRow);
+
+    switch (result) {
+      case RPCState::ClaimResult::kClaimed:
+        claimedRows_.push_back(std::move(*claimedRow));
+        return exec::BlockingReason::kNotBlocked;
+
+      case RPCState::ClaimResult::kFinished:
+        finished_ = true;
+        return exec::BlockingReason::kNotBlocked;
+
+      case RPCState::ClaimResult::kMustWait:
+        *future = std::move(waitFuture);
+        blockWaitStartNs_ = getCurrentTimeNano();
+        blockWaitIsBackpressure_ = false;
+        return exec::BlockingReason::kWaitForRPC;
+    }
+  } else {
+    // BATCH mode
+    if (!noMoreInput_ && !isDraining()) {
+      auto readyBatch = state_->tryPollReady();
+      if (readyBatch) {
+        if (readyBatch->error.has_value()) {
+          RPC_OP_LOG(WARNING)
+              << "Received batch with error: " << readyBatch->error.value();
+        }
+        claimedBatch_ = std::move(*readyBatch);
+      }
+      return exec::BlockingReason::kNotBlocked;
+    }
+
+    std::optional<RPCState::ReadyBatch> readyBatch;
+    ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+    auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
+
+    switch (result) {
+      case RPCState::BatchPollResult::kGotBatch:
+        if (readyBatch->error.has_value()) {
+          RPC_OP_LOG(WARNING)
+              << "Received batch with error: " << readyBatch->error.value();
+        }
+        claimedBatch_ = std::move(*readyBatch);
+        return exec::BlockingReason::kNotBlocked;
+
+      case RPCState::BatchPollResult::kFinished:
+        finished_ = true;
+        return exec::BlockingReason::kNotBlocked;
+
+      case RPCState::BatchPollResult::kMustWait:
+        *future = std::move(waitFuture);
+        blockWaitStartNs_ = getCurrentTimeNano();
+        blockWaitIsBackpressure_ = false;
+        return exec::BlockingReason::kWaitForRPC;
+    }
+  }
+
+  VELOX_UNREACHABLE();
+}
+
+bool RPCOperator::isFinished() {
+  return finished_ && claimedRows_.empty() && !claimedBatch_.has_value();
+}
+
+bool RPCOperator::startDrain() {
+  VELOX_CHECK(isDraining());
+  VELOX_CHECK(!noMoreInput_);
+
+  // Flush any undispatched accumulated rows.
+  if (function_->pendingBatchSize() > 0) {
+    flushBatchRequests();
+  }
+
+  // Signal RPCState that no more rows will be dispatched so it can
+  // detect the finish condition once in-flight RPCs complete.
+  state_->setNoMoreInput();
+
+  // If we have claimed output or pending in-flight RPCs, there is
+  // buffered data to drain.
+  if (!claimedRows_.empty() || claimedBatch_.has_value()) {
+    return true;
+  }
+  if (state_ && !state_->isFinished()) {
+    return true;
+  }
+  return false;
+}
+
+void RPCOperator::close() {
+  recordRuntimeStats();
+
+  // Release resources explicitly. RPCState may be held alive by in-flight
+  // RPC callbacks (via shared_ptr capture), but we release our reference
+  // so that input batch memory can be freed as soon as possible.
+  state_.reset();
+  function_.reset();
+  claimedRows_.clear();
+  claimedBatch_.reset();
+  batchRowLocations_.clear();
+  batchRowIds_.clear();
+  reusableIndices_.reset();
+
+  Operator::close();
+}
+
+void RPCOperator::initOutputProjections() {
+  const auto& outputColumn = rpcNode_->outputColumn();
+  const auto& outputType = rpcNode_->outputType();
+  auto sourceType = rpcNode_->source()->outputType();
+
+  for (int32_t i = 0; i < static_cast<int32_t>(outputType->size()); ++i) {
+    const auto& colName = outputType->nameOf(i);
+    if (colName == outputColumn) {
+      rpcResultOutputChannel_ = static_cast<column_index_t>(i);
+    } else {
+      auto colIdx = sourceType->getChildIdxIfExists(colName);
+      if (colIdx.has_value()) {
+        passthroughProjections_.push_back(
+            OutputProjection{
+                .outputChannel = static_cast<column_index_t>(i),
+                .sourceChannel = static_cast<column_index_t>(colIdx.value())});
+      }
+    }
+  }
+
+  RPC_OP_VLOG(1) << "initOutputProjections: rpcResultChannel="
+                 << rpcResultOutputChannel_ << ", passthroughProjections="
+                 << passthroughProjections_.size();
+}
+
+void RPCOperator::recordRuntimeStats() {
+  auto lockedStats = stats_.wlock();
+  lockedStats->addRuntimeStat(
+      kRpcRequestsDispatched, RuntimeCounter(numRequestsDispatched_));
+  lockedStats->addRuntimeStat(
+      kRpcResponsesReceived, RuntimeCounter(numResponsesCollected_));
+  lockedStats->addRuntimeStat(kRpcErrorCount, RuntimeCounter(numErrors_));
+  if (totalBlockWaitNanos_ > 0) {
+    lockedStats->addRuntimeStat(
+        kRpcWaitWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(totalBlockWaitNanos_),
+            RuntimeCounter::Unit::kNanos));
+  }
+  if (totalBackpressureWaitNanos_ > 0) {
+    lockedStats->addRuntimeStat(
+        kRpcBackpressureWaitNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(totalBackpressureWaitNanos_),
+            RuntimeCounter::Unit::kNanos));
+  }
+
+  if (totalBlockWaitNanos_ > 0 || numResponsesCollected_ > 0) {
+    const CpuWallTiming backgroundTiming{
+        static_cast<uint64_t>(numResponsesCollected_), totalBlockWaitNanos_, 0};
+    lockedStats->backgroundTiming.clear();
+    lockedStats->backgroundTiming.add(backgroundTiming);
+  }
+}
+
+RowVectorPtr RPCOperator::buildOutputFromReadyRows(
+    std::vector<RPCState::ReadyRow>& readyRows) {
+  std::vector<RPCResponse> responses;
+  responses.reserve(readyRows.size());
+
+  std::vector<std::pair<int32_t, vector_size_t>> locations;
+  locations.reserve(readyRows.size());
+
+  for (auto& row : readyRows) {
+    responses.push_back(std::move(row.response));
+    locations.emplace_back(row.location.batchIndex, row.location.rowIndex);
+  }
+
+  return buildOutputVector(responses, locations);
+}
+
+RowVectorPtr RPCOperator::buildOutputFromReadyBatch(
+    RPCState::ReadyBatch& readyBatch) {
+  std::vector<std::pair<int32_t, vector_size_t>> locations;
+  locations.reserve(readyBatch.rowLocations.size());
+  for (const auto& loc : readyBatch.rowLocations) {
+    locations.emplace_back(loc.batchIndex, loc.rowIndex);
+  }
+
+  return buildOutputVector(readyBatch.responses, locations);
+}
+
+RowVectorPtr RPCOperator::buildOutputVector(
+    const std::vector<RPCResponse>& responses,
+    const std::vector<std::pair<int32_t, vector_size_t>>& locations) {
+  const auto numRows = static_cast<vector_size_t>(responses.size());
+  auto* pool = operatorCtx_->pool();
+
+  const auto& outputType = rpcNode_->outputType();
+
+  // Use AsyncRPCFunction to build RPC result column.
+  auto responseVector = function_->buildOutput(responses, pool);
+
+  // Check if all rows come from the same batch (common for BATCH mode).
+  bool singleBatch = true;
+  if (numRows > 0) {
+    int32_t firstBatch = locations[0].first;
+    for (vector_size_t i = 1; i < numRows; ++i) {
+      if (locations[i].first != firstBatch) {
+        singleBatch = false;
+        break;
+      }
+    }
+  }
+
+  std::vector<VectorPtr> outputChildren(outputType->size());
+
+  // Set RPC result column using precomputed index.
+  outputChildren[rpcResultOutputChannel_] = responseVector;
+
+  // Set passthrough columns using precomputed projections.
+  if (numRows == 0) {
+    for (const auto& proj : passthroughProjections_) {
+      outputChildren[proj.outputChannel] =
+          BaseVector::create(outputType->childAt(proj.outputChannel), 0, pool);
+    }
+  } else if (singleBatch) {
+    // All rows from same batch: use dictionary wrapping (zero-copy).
+    const auto indicesByteSize = numRows * sizeof(vector_size_t);
+    if (!reusableIndices_ || !reusableIndices_->unique() ||
+        reusableIndices_->capacity() < indicesByteSize) {
+      reusableIndices_ = allocateIndices(numRows, pool);
+    }
+    reusableIndices_->setSize(indicesByteSize);
+    auto rawIndices = reusableIndices_->asMutable<vector_size_t>();
+    for (vector_size_t rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+      rawIndices[rowIdx] = locations[rowIdx].second;
+    }
+
+    const auto batchCols = state_->getInputBatchColumns(locations[0].first);
+    for (const auto& proj : passthroughProjections_) {
+      if (proj.sourceChannel < static_cast<column_index_t>(batchCols.size())) {
+        outputChildren[proj.outputChannel] = BaseVector::wrapInDictionary(
+            nullptr, reusableIndices_, numRows, batchCols[proj.sourceChannel]);
+      } else {
+        outputChildren[proj.outputChannel] = BaseVector::createNullConstant(
+            outputType->childAt(proj.outputChannel), numRows, pool);
+      }
+    }
+  } else {
+    // Rows from multiple batches: fetch columns once per batch.
+    std::unordered_map<int32_t, std::vector<VectorPtr>> batchColsCache;
+    for (const auto& proj : passthroughProjections_) {
+      auto combined = BaseVector::create(
+          outputType->childAt(proj.outputChannel), numRows, pool);
+      for (vector_size_t rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+        const auto& [batchIdx, rowInBatch] = locations[rowIdx];
+        auto it = batchColsCache.find(batchIdx);
+        if (it == batchColsCache.end()) {
+          it = batchColsCache
+                   .emplace(batchIdx, state_->getInputBatchColumns(batchIdx))
+                   .first;
+        }
+        const auto& batchCols = it->second;
+        if (proj.sourceChannel <
+            static_cast<column_index_t>(batchCols.size())) {
+          combined->copy(
+              batchCols[proj.sourceChannel].get(), rowIdx, rowInBatch, 1);
+        } else {
+          combined->setNull(rowIdx, true);
+        }
+      }
+      outputChildren[proj.outputChannel] = combined;
+    }
+  }
+
+  // Fill any remaining nullptr entries with null constants.
+  for (int32_t i = 0; i < static_cast<int32_t>(outputChildren.size()); ++i) {
+    if (!outputChildren[i]) {
+      outputChildren[i] =
+          BaseVector::createNullConstant(outputType->childAt(i), numRows, pool);
+    }
+  }
+
+  // Release rows from their input batches.
+  std::unordered_map<int32_t, int64_t> batchReleaseCounts;
+  for (const auto& loc : locations) {
+    batchReleaseCounts[loc.first]++;
+  }
+  for (const auto& [batchIdx, count] : batchReleaseCounts) {
+    state_->releaseRows(batchIdx, count);
+  }
+
+  return std::make_shared<RowVector>(
+      pool, outputType, nullptr, numRows, std::move(outputChildren));
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCOperator.h
+++ b/velox/exec/rpc/RPCOperator.h
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "velox/buffer/Buffer.h"
+#include "velox/common/future/VeloxPromise.h"
+#include "velox/exec/Operator.h"
+#include "velox/exec/rpc/RPCRateLimiter.h"
+#include "velox/exec/rpc/RPCState.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Single-operator implementation for async RPC execution in Velox.
+///
+/// Handles both dispatch (send RPCs in addInput()) and join (receive results
+/// in isBlocked()/getOutput()) within the same operator.
+///
+/// Architecture:
+///   TableScan -> RPCOperator -> downstream
+///
+/// The operator lifecycle:
+/// 1. addInput(): Reads pre-computed argument columns, dispatches RPCs via
+///    the function's dispatchPerRow() or accumulateBatch()+flushBatch().
+/// 2. needsInput(): Returns false when under backpressure or when there are
+///    ready results to output (prioritizes outputting over accepting input).
+/// 3. isBlocked(): Checks RPCState for completed responses. Returns
+///    kWaitForRPC when no results are ready yet.
+/// 4. getOutput(): Builds output RowVector from completed RPC responses
+///    combined with preserved input (passthrough) columns.
+/// 5. noMoreInput(): In BATCH mode, flushes remaining accumulated rows.
+///    Signals RPCState that no more rows will be dispatched.
+///
+/// Supports two streaming modes:
+/// - PER_ROW: Rows emitted as individual RPCs complete (out-of-order).
+///   Lower tail latency for high-variance workloads (e.g., LLM inference).
+/// - BATCH: All rows in a batch complete before emitting. Lower overhead
+///   for uniform-latency workloads. Supports pipelined dispatch via
+///   dispatchBatchSize.
+///
+/// State is derived from data presence (no explicit state machine enum):
+/// - Has output: claimedRows_ non-empty or claimedBatch_ has value
+/// - Finished: noMoreInput_ && state_->isFinished() && no claimed data
+///
+/// Thread safety model:
+/// - addInput(), getOutput(), needsInput(), isBlocked() are called from
+///   a single driver thread (Velox guarantee). No synchronization needed
+///   for operator-local state (e.g., globalRowIdCounter_, claimedRows_).
+/// - Async RPC callbacks may run on any thread (transport executor pool).
+///   All cross-thread coordination goes through RPCState, which is fully
+///   mutex-protected (see RPCState.h for per-method annotations).
+/// - RPCRateLimiter tokens use RAII: destruction (including from cancelled
+///   futures) automatically decrements the pending count and notifies
+///   waiters.
+///
+class RPCOperator : public exec::Operator {
+ public:
+  RPCOperator(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const core::RPCNode> rpcNode);
+
+  void initialize() override;
+
+  void close() override;
+
+  bool needsInput() const override;
+
+  void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
+
+  RowVectorPtr getOutput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) override;
+
+  bool isFinished() override;
+
+  bool startDrain() override;
+
+  /// Runtime stat names.
+  static inline const std::string kRpcRequestsDispatched{
+      "rpcRequestsDispatched"};
+  static inline const std::string kRpcResponsesReceived{"rpcResponsesReceived"};
+  static inline const std::string kRpcErrorCount{"rpcErrorCount"};
+  static inline const std::string kRpcWaitWallNanos{"rpcWaitWallNanos"};
+  static inline const std::string kRpcBackpressureWaitNanos{
+      "rpcBackpressureWaitNanos"};
+
+ private:
+  /// Flush accumulated batch rows via function_->flushBatch().
+  /// Called when threshold is reached or at noMoreInput/drain time.
+  void flushBatchRequests();
+
+  /// Build output RowVector from ready rows (PER_ROW mode).
+  /// Supports multiple rows via batched drain for pipeline efficiency.
+  RowVectorPtr buildOutputFromReadyRows(
+      std::vector<RPCState::ReadyRow>& readyRows);
+
+  /// Build output RowVector from a ready batch (BATCH mode).
+  RowVectorPtr buildOutputFromReadyBatch(RPCState::ReadyBatch& readyBatch);
+
+  /// Common helper: build output vector from responses + input data lookup.
+  RowVectorPtr buildOutputVector(
+      const std::vector<RPCResponse>& responses,
+      const std::vector<std::pair<int32_t, vector_size_t>>& locations);
+
+  /// Precompute output column projections from source type to output type.
+  /// Called once in initialize() to avoid repeated string lookups in
+  /// buildOutputVector().
+  void initOutputProjections();
+
+  /// Record runtime stats into operator stats. Called from close().
+  void recordRuntimeStats();
+
+  std::shared_ptr<const core::RPCNode> rpcNode_;
+  std::shared_ptr<RPCState> state_;
+  std::shared_ptr<AsyncRPCFunction> function_;
+
+  // Tier key for per-tier rate limiting (from function_->tierKey()).
+  std::string tierKey_;
+
+  // Precomputed argument column indices for reading from input in addInput().
+  // Initialized in initialize() by looking up argumentColumns in source type.
+  std::vector<column_index_t> argumentColumnIndices_;
+
+  // Collected row locations for current batch (BATCH mode).
+  // Passed to addPendingBatch() when the batch is flushed.
+  std::vector<RPCState::RowLocation> batchRowLocations_;
+
+  // Collected row IDs for current batch (BATCH mode).
+  // Used to stamp rowIds onto responses at flush time.
+  std::vector<int64_t> batchRowIds_;
+
+  int64_t numRequestsDispatched_{0};
+  int64_t numResponsesCollected_{0};
+  int64_t numErrors_{0};
+
+  // Global row ID counter for unique IDs across all input batches.
+  int64_t globalRowIdCounter_{0};
+
+  // Dispatch batch size for pipelined BATCH mode.
+  // 0 = collect all rows, fire once in noMoreInput().
+  // > 0 = fire flushBatch() every N rows during addInput().
+  int32_t dispatchBatchSize_{0};
+
+  // Claimed rows/batch from isBlocked() for use in getOutput().
+  // State is derived from these: if non-empty, we have output ready.
+  std::vector<RPCState::ReadyRow> claimedRows_;
+  std::optional<RPCState::ReadyBatch> claimedBatch_;
+
+  // Whether we've detected the finish condition.
+  bool finished_{false};
+
+  // Timeout for batch RPC calls (30 minutes).
+  // This is a ceiling — the operator returns as soon as results are ready.
+  // Batch LLM inference can take many minutes due to MetaGen queuing
+  // and GPU scheduling, so the timeout needs generous headroom.
+  static constexpr auto kBatchRpcTimeout = std::chrono::milliseconds(1'800'000);
+
+  // Block wait time tracking for runtime stats.
+  std::optional<uint64_t> blockWaitStartNs_;
+  bool blockWaitIsBackpressure_{false};
+  uint64_t totalBlockWaitNanos_{0};
+  uint64_t totalBackpressureWaitNanos_{0};
+
+  // Reusable indices buffer for dictionary wrapping in single-batch output
+  // path.
+  BufferPtr reusableIndices_;
+
+  // Precomputed output column projections (initialized in initialize()).
+  // Maps output column index to source column index for passthrough columns.
+  // Avoids repeated string-based column lookups in buildOutputVector().
+  struct OutputProjection {
+    column_index_t outputChannel;
+    column_index_t sourceChannel;
+  };
+  std::vector<OutputProjection> passthroughProjections_;
+  column_index_t rpcResultOutputChannel_{0};
+};
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCPlanNodeTranslator.cpp
+++ b/velox/exec/rpc/RPCPlanNodeTranslator.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/RPCPlanNodeTranslator.h"
+
+#include <algorithm>
+
+#include "velox/exec/rpc/RPCOperator.h"
+
+namespace facebook::velox::exec::rpc {
+
+std::unique_ptr<exec::Operator> RPCPlanNodeTranslator::toOperator(
+    exec::DriverCtx* ctx,
+    int32_t id,
+    const core::PlanNodePtr& node) {
+  if (auto rpcNode = std::dynamic_pointer_cast<const core::RPCNode>(node)) {
+    VLOG(1) << "[RPC_TRANSLATOR] Creating RPCOperator for node id="
+            << node->id();
+    return std::make_unique<RPCOperator>(id, ctx, rpcNode);
+  }
+  return nullptr;
+}
+
+std::optional<uint32_t> RPCPlanNodeTranslator::maxDrivers(
+    const core::PlanNodePtr& node) {
+  if (auto rpcNode = std::dynamic_pointer_cast<const core::RPCNode>(node)) {
+    if (rpcNode->streamingMode() == rpc::RPCStreamingMode::kBatch) {
+      // BATCH mode: Force single-driver execution. Multiple drivers would
+      // race for batch results, with only one getting data and others
+      // finishing empty.
+      return 1;
+    }
+
+    // When all arguments are constants and no real data columns flow from the
+    // source, the upstream is a synthetic single-row ValuesNode. The Java
+    // AddLocalExchanges optimizer inserts a ROUND_ROBIN LocalExchange that
+    // distributes this single row across N drivers, causing N-1 drivers to
+    // finish empty and the result to be lost. Force single-driver execution.
+    const auto& constantInputs = rpcNode->constantInputs();
+    const auto& argumentColumns = rpcNode->argumentColumns();
+    bool allConstant = !constantInputs.empty() &&
+        std::all_of(
+            constantInputs.begin(), constantInputs.end(), [](const auto& v) {
+              return v != nullptr;
+            });
+    if (allConstant) {
+      auto sourceType = rpcNode->source()->outputType();
+      if (sourceType->size() <= argumentColumns.size()) {
+        return 1;
+      }
+    }
+
+    // PER_ROW mode: Allow parallel execution. Each driver claims individual
+    // rows atomically via RPCState::tryClaimOrWait().
+    return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+void registerRPCPlanNodeTranslator() {
+  exec::Operator::registerOperator(std::make_unique<RPCPlanNodeTranslator>());
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCPlanNodeTranslator.h
+++ b/velox/exec/rpc/RPCPlanNodeTranslator.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// PlanNodeTranslator for RPCNode.
+///
+/// Creates RPCOperator from RPCNode plan nodes.
+///
+/// maxDrivers() returns 1 for BATCH mode to prevent multiple drivers from
+/// competing for batch results. PER_ROW mode allows parallel execution
+/// since each driver claims individual rows atomically.
+class RPCPlanNodeTranslator : public exec::Operator::PlanNodeTranslator {
+ public:
+  std::unique_ptr<exec::Operator> toOperator(
+      exec::DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override;
+
+  /// Returns 1 for BATCH mode (single-driver), nullopt for PER_ROW mode.
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override;
+};
+
+/// Register the RPCPlanNodeTranslator with Velox.
+void registerRPCPlanNodeTranslator();
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCRateLimiter.cpp
+++ b/velox/exec/rpc/RPCRateLimiter.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/RPCRateLimiter.h"
+
+#define RPC_RATE_LIMITER_LOG(severity) LOG(severity) << "[RPC_RATE_LIMITER] "
+#define RPC_RATE_LIMITER_VLOG(level) VLOG(level) << "[RPC_RATE_LIMITER] "
+
+namespace facebook::velox::exec::rpc {
+
+// --- Token implementation ---
+
+RPCRateLimiter::Token::Token(const std::string& tierKey)
+    : tierKey_(tierKey), valid_(true) {}
+
+RPCRateLimiter::Token& RPCRateLimiter::Token::operator=(
+    Token&& other) noexcept {
+  if (this != &other) {
+    if (valid_) {
+      decrementPending(tierKey_);
+    }
+    tierKey_ = std::move(other.tierKey_);
+    valid_ = other.valid_;
+    other.valid_ = false;
+  }
+  return *this;
+}
+
+RPCRateLimiter::Token::~Token() {
+  if (valid_) {
+    decrementPending(tierKey_);
+  }
+}
+
+// --- Function-local statics ---
+
+std::mutex& RPCRateLimiter::mapMutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::atomic<int64_t>& RPCRateLimiter::defaultMaxPendingRef() {
+  // Default: 20 concurrent RPCs per process per tier.
+  static std::atomic<int64_t> maxPending{20};
+  return maxPending;
+}
+
+std::unordered_map<std::string, std::unique_ptr<RPCRateLimiter::TierState>>&
+RPCRateLimiter::tiers() {
+  static std::unordered_map<std::string, std::unique_ptr<TierState>> tierMap;
+  return tierMap;
+}
+
+// --- TierState lookup ---
+
+RPCRateLimiter::TierState& RPCRateLimiter::getOrCreateTierState(
+    const std::string& tierKey) {
+  std::lock_guard<std::mutex> l(mapMutex());
+  auto& tierMap = tiers();
+  auto it = tierMap.find(tierKey);
+  if (it != tierMap.end()) {
+    return *it->second;
+  }
+  auto [newIt, _] = tierMap.emplace(tierKey, std::make_unique<TierState>());
+  return *newIt->second;
+}
+
+// --- Public API ---
+
+RPCRateLimiter::Token RPCRateLimiter::acquire(const std::string& tierKey) {
+  incrementPending(tierKey);
+  return Token(tierKey);
+}
+
+std::optional<ContinueFuture> RPCRateLimiter::checkBackpressure(
+    const std::string& tierKey) {
+  auto& state = getOrCreateTierState(tierKey);
+
+  std::lock_guard<std::mutex> l(state.mutex);
+
+  int64_t pending = state.pendingCount.load();
+  int64_t maxPending =
+      state.maxPending > 0 ? state.maxPending : defaultMaxPendingRef().load();
+
+  if (pending < maxPending) {
+    RPC_RATE_LIMITER_VLOG(2)
+        << "checkBackpressure[" << tierKey << "]: OK (pending=" << pending
+        << ", max=" << maxPending << ")";
+    return std::nullopt;
+  }
+
+  RPC_RATE_LIMITER_VLOG(1) << "checkBackpressure[" << tierKey
+                           << "]: BLOCKED (pending=" << pending
+                           << ", max=" << maxPending
+                           << "), creating wait promise #"
+                           << state.waiters.size();
+  state.waiters.emplace_back("RPCRateLimiter::checkBackpressure");
+  return state.waiters.back().getSemiFuture();
+}
+
+int64_t RPCRateLimiter::pendingCount(const std::string& tierKey) {
+  auto& state = getOrCreateTierState(tierKey);
+  return state.pendingCount.load();
+}
+
+void RPCRateLimiter::setMaxPending(const std::string& tierKey, int64_t limit) {
+  auto& state = getOrCreateTierState(tierKey);
+  std::lock_guard<std::mutex> l(state.mutex);
+  state.maxPending = limit;
+  RPC_RATE_LIMITER_VLOG(1) << "setMaxPending[" << tierKey << "]: set to "
+                           << limit;
+}
+
+void RPCRateLimiter::setDefaultMaxPending(int64_t limit) {
+  defaultMaxPendingRef().store(limit);
+  RPC_RATE_LIMITER_VLOG(1) << "setDefaultMaxPending: set to " << limit;
+}
+
+int64_t RPCRateLimiter::defaultMaxPending() {
+  return defaultMaxPendingRef().load();
+}
+
+void RPCRateLimiter::testingResetAllState() {
+  std::lock_guard<std::mutex> l(mapMutex());
+  defaultMaxPendingRef().store(20);
+  tiers().clear();
+}
+
+// --- Internal helpers ---
+
+void RPCRateLimiter::incrementPending(const std::string& tierKey) {
+  auto& state = getOrCreateTierState(tierKey);
+  int64_t newCount = ++state.pendingCount;
+  RPC_RATE_LIMITER_VLOG(2) << "incrementPending[" << tierKey
+                           << "]: pending=" << newCount;
+}
+
+void RPCRateLimiter::decrementPending(const std::string& tierKey) {
+  auto& state = getOrCreateTierState(tierKey);
+  int64_t newCount = --state.pendingCount;
+  RPC_RATE_LIMITER_VLOG(2) << "decrementPending[" << tierKey
+                           << "]: pending=" << newCount;
+
+  // CRITICAL: Hold the per-tier mutex when checking whether to notify waiters.
+  // This prevents a TOCTOU race where:
+  // 1. We read newCount < maxPending (should notify)
+  // 2. A new waiter is added in checkBackpressure() between read and notify
+  //
+  // By holding the lock during check-and-notify, any waiter added in
+  // checkBackpressure() will either:
+  // - Be in state.waiters before we check (and we'll notify it)
+  // - See the updated count and not need to wait at all
+  //
+  // We notify only one waiter per decrement (FIFO) to avoid thundering herd.
+  std::optional<ContinuePromise> waiterToNotify;
+  {
+    std::lock_guard<std::mutex> l(state.mutex);
+    int64_t maxPending =
+        state.maxPending > 0 ? state.maxPending : defaultMaxPendingRef().load();
+    if (newCount < maxPending && !state.waiters.empty()) {
+      RPC_RATE_LIMITER_VLOG(1)
+          << "decrementPending[" << tierKey << "]: notifying 1 of "
+          << state.waiters.size() << " waiters";
+      waiterToNotify = std::move(state.waiters.front());
+      state.waiters.pop_front();
+    }
+  }
+  if (waiterToNotify) {
+    waiterToNotify->setValue();
+  }
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCRateLimiter.h
+++ b/velox/exec/rpc/RPCRateLimiter.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "velox/common/future/VeloxPromise.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Per-tier (per-process) rate limiter for RPC dispatch.
+///
+/// Each backend service tier (e.g., "service.backend.prod") gets its own
+/// independent concurrency limit and waiter queue. This allows different
+/// backends to have different concurrency budgets.
+///
+/// The rate limiter is per-process. Each Presto worker is a separate process
+/// with its own ServiceRouter connections. Cross-worker coordination is
+/// handled by the backend's own admission control.
+///
+/// The tier key comes from IRPCClient::tierKey(). Empty string means
+/// "no tier configured" and falls back to the global default limit.
+class RPCRateLimiter {
+ public:
+  /// RAII token representing one in-flight request slot.
+  /// Decrements the pending count on destruction, guaranteeing cleanup
+  /// even if the RPC future is abandoned (e.g., query cancellation).
+  class Token {
+   public:
+    Token() = default;
+
+    Token(Token&& other) noexcept
+        : tierKey_(std::move(other.tierKey_)), valid_(other.valid_) {
+      other.valid_ = false;
+    }
+
+    Token& operator=(Token&& other) noexcept;
+
+    ~Token();
+
+    // Non-copyable.
+    Token(const Token&) = delete;
+    Token& operator=(const Token&) = delete;
+
+   private:
+    friend class RPCRateLimiter;
+    explicit Token(const std::string& tierKey);
+
+    std::string tierKey_;
+    bool valid_{false};
+  };
+
+  /// Acquire a slot for the given tier. Increments pending count and
+  /// returns a Token that will decrement on destruction.
+  static Token acquire(const std::string& tierKey);
+
+  /// Check backpressure for a specific tier.
+  /// Returns a future to wait on if that tier's limit is reached.
+  /// @return Future to wait on if blocked, nullopt if can proceed.
+  static std::optional<ContinueFuture> checkBackpressure(
+      const std::string& tierKey);
+
+  /// Get current pending count for a specific tier.
+  static int64_t pendingCount(const std::string& tierKey);
+
+  /// Configure the max pending limit for a specific tier.
+  /// If not configured, falls back to the global default.
+  static void setMaxPending(const std::string& tierKey, int64_t limit);
+
+  /// Set the global default max pending (used when no per-tier config).
+  static void setDefaultMaxPending(int64_t limit);
+
+  /// Get the global default max pending.
+  static int64_t defaultMaxPending();
+
+  /// Reset all state. Intended ONLY for unit tests
+  /// to avoid test contamination across test cases.
+  /// WARNING: Do NOT call this in production code.
+  static void testingResetAllState();
+
+ private:
+  /// Per-tier state. Allocated via unique_ptr for pointer stability across
+  /// map inserts (std::unordered_map does not invalidate existing entries).
+  struct TierState {
+    std::mutex mutex;
+    std::atomic<int64_t> pendingCount{0};
+    int64_t maxPending{0}; // 0 = use global default
+    std::deque<ContinuePromise> waiters;
+  };
+
+  static void incrementPending(const std::string& tierKey);
+  static void decrementPending(const std::string& tierKey);
+
+  static TierState& getOrCreateTierState(const std::string& tierKey);
+
+  // Global mutex protects only the tier map for inserts/lookups.
+  static std::mutex& mapMutex();
+  static std::atomic<int64_t>& defaultMaxPendingRef();
+  static std::unordered_map<std::string, std::unique_ptr<TierState>>& tiers();
+};
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -1,0 +1,358 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/RPCState.h"
+
+#include <folly/executors/GlobalExecutor.h>
+
+#include "velox/common/base/Exceptions.h"
+
+#define RPC_STATE_LOG(severity) LOG(severity) << "[RPC_STATE] "
+#define RPC_STATE_VLOG(level) VLOG(level) << "[RPC_STATE] "
+
+namespace facebook::velox::exec::rpc {
+
+// ===== Configuration =====
+
+void RPCState::setStreamingMode(RPCStreamingMode mode) {
+  std::lock_guard<std::mutex> l(mutex_);
+  streamingMode_ = mode;
+}
+
+RPCStreamingMode RPCState::streamingMode() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  return streamingMode_;
+}
+
+void RPCState::setMaxPendingRows(int64_t maxPendingRows) {
+  std::lock_guard<std::mutex> l(mutex_);
+  maxPendingRows_ = maxPendingRows;
+}
+
+void RPCState::setMaxPendingBatches(int64_t maxPendingBatches) {
+  std::lock_guard<std::mutex> l(mutex_);
+  maxPendingBatches_ = maxPendingBatches;
+}
+
+// ===== Input batch storage =====
+
+int32_t RPCState::storeInputBatch(
+    std::vector<VectorPtr> flatColumns,
+    int64_t rowCount) {
+  std::lock_guard<std::mutex> l(mutex_);
+  auto batchIndex = static_cast<int32_t>(inputBatches_.size());
+  inputBatches_.push_back(
+      InputBatchRef{
+          .flatColumns = std::move(flatColumns), .activeRowCount = rowCount});
+  RPC_STATE_VLOG(2) << "storeInputBatch: batchIndex=" << batchIndex
+                    << ", rowCount=" << rowCount;
+  return batchIndex;
+}
+
+std::vector<VectorPtr> RPCState::getInputBatchColumns(
+    int32_t batchIndex) const {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_LT(
+      batchIndex,
+      static_cast<int32_t>(inputBatches_.size()),
+      "Invalid batchIndex {} for inputBatches_ of size {}",
+      batchIndex,
+      inputBatches_.size());
+  return inputBatches_[batchIndex].flatColumns;
+}
+
+void RPCState::releaseRows(int32_t batchIndex, int64_t count) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK_LT(
+      batchIndex,
+      static_cast<int32_t>(inputBatches_.size()),
+      "Invalid batchIndex {} for inputBatches_ of size {}",
+      batchIndex,
+      inputBatches_.size());
+  auto& batch = inputBatches_[batchIndex];
+  VELOX_CHECK_GE(
+      batch.activeRowCount,
+      count,
+      "Cannot release {} rows from batch {} with only {} active rows",
+      count,
+      batchIndex,
+      batch.activeRowCount);
+  batch.activeRowCount -= count;
+  if (batch.activeRowCount == 0) {
+    // Release the column vectors to free memory.
+    batch.flatColumns.clear();
+    RPC_STATE_VLOG(2) << "releaseRows: batch " << batchIndex
+                      << " fully released";
+  }
+}
+
+// ===== PER_ROW mode API =====
+
+void RPCState::addPendingRow(
+    std::shared_ptr<RPCState> selfPtr,
+    int64_t rowId,
+    RowLocation location,
+    folly::SemiFuture<RPCResponse> future) {
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    numPendingRows_++;
+    RPC_STATE_VLOG(2) << "addPendingRow: rowId=" << rowId
+                      << ", pendingCount=" << numPendingRows_;
+  }
+
+  // Attach completion callbacks that delegate to completeRow().
+  // We capture selfPtr to keep this RPCState alive until the callback fires.
+  auto stateForError = selfPtr;
+  folly::futures::detachOn(
+      folly::getGlobalCPUExecutor(),
+      std::move(future)
+          .deferValue([state = std::move(selfPtr), rowId, location](
+                          RPCResponse response) mutable {
+            state->completeRow(rowId, location, std::move(response));
+          })
+          .deferError([state = std::move(stateForError), rowId, location](
+                          const folly::exception_wrapper& ew) mutable {
+            RPC_STATE_LOG(ERROR)
+                << "RPC failed for rowId=" << rowId << ": " << ew.what();
+            RPCResponse errorResponse;
+            errorResponse.rowId = rowId;
+            errorResponse.error = ew.what().toStdString();
+            state->completeRow(rowId, location, std::move(errorResponse));
+          }));
+}
+
+void RPCState::completeRow(
+    int64_t rowId,
+    RowLocation location,
+    RPCResponse response) {
+  std::lock_guard<std::mutex> l(mutex_);
+  readyRows_.push_back(
+      ReadyRow{
+          .rowId = rowId,
+          .location = location,
+          .response = std::move(response)});
+  numPendingRows_--;
+
+  RPC_STATE_VLOG(2) << "Row completed: rowId=" << rowId
+                    << ", readyRows=" << readyRows_.size()
+                    << ", pendingCount=" << numPendingRows_;
+
+  notifyWaitersLocked();
+}
+
+RPCState::ClaimResult RPCState::tryClaimOrWait(
+    ContinueFuture* future,
+    std::optional<ReadyRow>* claimedRow) {
+  std::lock_guard<std::mutex> l(mutex_);
+
+  // Step 1: Try to claim a ready row.
+  if (!readyRows_.empty()) {
+    *claimedRow = std::move(readyRows_.front());
+    readyRows_.pop_front();
+    RPC_STATE_VLOG(1) << "tryClaimOrWait: claimed rowId="
+                      << (*claimedRow)->rowId
+                      << ", remaining ready=" << readyRows_.size();
+    return ClaimResult::kClaimed;
+  }
+
+  // Step 2: Check finish condition.
+  if (noMoreInput_ && numPendingRows_ == 0) {
+    RPC_STATE_VLOG(1) << "tryClaimOrWait: finish condition met";
+    return ClaimResult::kFinished;
+  }
+
+  // Step 3: Must wait — create a promise under the same lock to prevent
+  // TOCTOU races (no completion can slip between the check and wait).
+  RPC_STATE_VLOG(2) << "tryClaimOrWait: must wait (pending=" << numPendingRows_
+                    << ")";
+  promises_.emplace_back("RPCState::tryClaimOrWait");
+  *future = promises_.back().getSemiFuture();
+  return ClaimResult::kMustWait;
+}
+
+std::optional<RPCState::ReadyRow> RPCState::tryClaimReady() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (!readyRows_.empty()) {
+    auto row = std::move(readyRows_.front());
+    readyRows_.pop_front();
+    RPC_STATE_VLOG(1) << "tryClaimReady: claimed rowId=" << row.rowId
+                      << ", remaining ready=" << readyRows_.size();
+    return row;
+  }
+  return std::nullopt;
+}
+
+void RPCState::drainReadyRows(std::vector<ReadyRow>& out, int32_t maxRows) {
+  std::lock_guard<std::mutex> l(mutex_);
+  while (!readyRows_.empty() && static_cast<int32_t>(out.size()) < maxRows) {
+    out.push_back(std::move(readyRows_.front()));
+    readyRows_.pop_front();
+  }
+}
+
+int64_t RPCState::numPendingRows() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return numPendingRows_;
+}
+
+// ===== BATCH mode API =====
+
+void RPCState::addPendingBatch(
+    std::shared_ptr<RPCState> selfPtr,
+    folly::SemiFuture<std::vector<RPCResponse>> future,
+    std::vector<RowLocation> rowLocations) {
+  std::lock_guard<std::mutex> l(mutex_);
+
+  int64_t batchId = nextBatchId_++;
+
+  // Attach a completion callback that notifies waiters when the batch
+  // completes. We use .via().thenValue() to run the callback eagerly.
+  auto callbackFuture =
+      std::move(future)
+          .via(folly::getGlobalCPUExecutor())
+          .thenValue([state = selfPtr](std::vector<RPCResponse> responses) {
+            RPC_STATE_VLOG(1)
+                << "Batch completed with " << responses.size() << " responses";
+            {
+              std::lock_guard<std::mutex> l(state->mutex_);
+              state->notifyWaitersLocked();
+            }
+            return responses;
+          })
+          .thenError([state = selfPtr](folly::exception_wrapper ew) {
+            RPC_STATE_LOG(ERROR) << "Batch failed: " << ew.what();
+            {
+              std::lock_guard<std::mutex> l(state->mutex_);
+              state->notifyWaitersLocked();
+            }
+            return folly::makeSemiFuture<std::vector<RPCResponse>>(
+                std::move(ew));
+          })
+          .semi();
+
+  pendingBatches_.push_back(
+      PendingBatch{
+          .batchId = batchId,
+          .future = std::move(callbackFuture),
+          .rowLocations = std::move(rowLocations)});
+
+  RPC_STATE_VLOG(1) << "addPendingBatch: batchId=" << batchId
+                    << ", totalPending=" << pendingBatches_.size();
+}
+
+RPCState::BatchPollResult RPCState::tryPollBatchOrWait(
+    ContinueFuture* future,
+    std::optional<ReadyBatch>* readyBatch) {
+  std::lock_guard<std::mutex> l(mutex_);
+
+  // Step 1: Check for a ready batch (out-of-order: first ready wins).
+  for (auto it = pendingBatches_.begin(); it != pendingBatches_.end(); ++it) {
+    if (it->future.isReady()) {
+      ReadyBatch result;
+      result.batchId = it->batchId;
+      result.rowLocations = std::move(it->rowLocations);
+
+      try {
+        result.responses = std::move(it->future).get();
+        RPC_STATE_VLOG(1) << "tryPollBatchOrWait: batchId=" << result.batchId
+                          << " ready with " << result.responses.size()
+                          << " responses";
+      } catch (const std::exception& e) {
+        result.error = e.what();
+        result.responses = {};
+        RPC_STATE_LOG(ERROR) << "tryPollBatchOrWait: batchId=" << result.batchId
+                             << " failed: " << e.what();
+      }
+
+      pendingBatches_.erase(it);
+      *readyBatch = std::move(result);
+      return BatchPollResult::kGotBatch;
+    }
+  }
+
+  // Step 2: Check finish condition.
+  if (noMoreInput_ && pendingBatches_.empty()) {
+    RPC_STATE_VLOG(1) << "tryPollBatchOrWait: finish condition met";
+    return BatchPollResult::kFinished;
+  }
+
+  // Step 3: Must wait.
+  RPC_STATE_VLOG(2) << "tryPollBatchOrWait: must wait";
+  promises_.emplace_back("RPCState::tryPollBatchOrWait");
+  *future = promises_.back().getSemiFuture();
+  return BatchPollResult::kMustWait;
+}
+
+std::optional<RPCState::ReadyBatch> RPCState::tryPollReady() {
+  std::lock_guard<std::mutex> l(mutex_);
+  for (auto it = pendingBatches_.begin(); it != pendingBatches_.end(); ++it) {
+    if (it->future.isReady()) {
+      ReadyBatch result;
+      result.batchId = it->batchId;
+      result.rowLocations = std::move(it->rowLocations);
+      try {
+        result.responses = std::move(it->future).get();
+        RPC_STATE_VLOG(1) << "tryPollReady: batchId=" << result.batchId
+                          << " ready with " << result.responses.size()
+                          << " responses";
+      } catch (const std::exception& e) {
+        result.error = e.what();
+        result.responses = {};
+        RPC_STATE_LOG(ERROR) << "tryPollReady: batchId=" << result.batchId
+                             << " failed: " << e.what();
+      }
+      pendingBatches_.erase(it);
+      return result;
+    }
+  }
+  return std::nullopt;
+}
+
+// ===== Common =====
+
+void RPCState::setNoMoreInput() {
+  std::lock_guard<std::mutex> l(mutex_);
+  noMoreInput_ = true;
+  RPC_STATE_VLOG(1) << "setNoMoreInput: pendingRows=" << numPendingRows_
+                    << ", pendingBatches=" << pendingBatches_.size()
+                    << ", readyRows=" << readyRows_.size();
+  notifyWaitersLocked();
+}
+
+bool RPCState::isFinished() {
+  std::lock_guard<std::mutex> l(mutex_);
+  return noMoreInput_ && numPendingRows_ == 0 && readyRows_.empty() &&
+      pendingBatches_.empty();
+}
+
+bool RPCState::isUnderBackpressure() {
+  std::lock_guard<std::mutex> l(mutex_);
+  if (streamingMode_ == RPCStreamingMode::kBatch) {
+    return static_cast<int64_t>(pendingBatches_.size()) >= maxPendingBatches_;
+  }
+  return numPendingRows_ >= maxPendingRows_;
+}
+
+void RPCState::notifyWaitersLocked() {
+  // Fulfill all promises to wake up blocked drivers.
+  // Called while mutex_ is held.
+  for (auto& promise : promises_) {
+    promise.setValue();
+  }
+  promises_.clear();
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/RPCState.h
+++ b/velox/exec/rpc/RPCState.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <vector>
+
+#include <folly/futures/Future.h>
+
+#include "velox/common/future/VeloxPromise.h"
+#include "velox/common/rpc/RPCTypes.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::exec::rpc {
+
+// Import RPC types from velox/common/rpc into this namespace.
+using velox::rpc::RPCResponse;
+using velox::rpc::RPCStreamingMode;
+
+/// A stored input batch with its rows referenced by index.
+/// Instead of slicing individual rows, we keep the entire batch and
+/// use row indices to look up passthrough columns at output time.
+struct InputBatchRef {
+  /// Flattened columns from the input batch (shared across all rows).
+  std::vector<VectorPtr> flatColumns;
+
+  /// Number of rows from this batch that are still in-flight or pending output.
+  /// When this reaches 0, the batch can be released.
+  int64_t activeRowCount{0};
+};
+
+/// Shared state between RPCOperator's driver thread and RPC completion
+/// callbacks.
+///
+/// A mutex-protected state object owned by RPCOperator. It coordinates
+/// async RPC dispatch (addPendingRow/addPendingBatch) with result
+/// consumption (tryClaimOrWait/tryPollBatchOrWait) across the driver
+/// thread and RPC client executor threads.
+///
+/// Thread safety: All public methods are thread-safe. The mutex_ protects
+/// all mutable state. Completion callbacks from the RPC client's executor
+/// threads call notifyWaitersLocked() to wake the driver thread.
+///
+/// Two streaming modes:
+/// - PER_ROW: Rows are emitted as they complete individually (out-of-order).
+///   Lower tail latency for high-variance workloads (e.g., LLM inference).
+/// - BATCH: All rows in a batch complete before emitting. Lower overhead
+///   for uniform-latency workloads.
+class RPCState {
+ public:
+  // ===== Data structures =====
+
+  /// Location of a row within an input batch.
+  struct RowLocation {
+    int32_t batchIndex{0};
+    vector_size_t rowIndex{0};
+  };
+
+  /// A completed row with its RPC response and location in the input batch.
+  struct ReadyRow {
+    int64_t rowId{0};
+    RowLocation location;
+    RPCResponse response;
+  };
+
+  /// A batch of rows waiting for RPC response.
+  struct PendingBatch {
+    int64_t batchId;
+    folly::SemiFuture<std::vector<RPCResponse>> future;
+    /// Row locations for mapping responses back to input batch positions.
+    /// Stored at batch level instead of per-row in a map, since callBatch()
+    /// returns responses in the same order as requests.
+    std::vector<RowLocation> rowLocations;
+  };
+
+  /// A batch with completed RPC responses.
+  struct ReadyBatch {
+    int64_t batchId{0};
+    std::vector<RPCResponse> responses;
+    std::optional<std::string> error;
+    /// Row locations carried from PendingBatch for response-to-input mapping.
+    std::vector<RowLocation> rowLocations;
+  };
+
+  RPCState() = default;
+
+  // ===== Configuration =====
+  // These must be called before any dispatch (single-threaded init phase).
+
+  /// Set the streaming mode. Must be called before any dispatch.
+  void setStreamingMode(RPCStreamingMode mode);
+
+  /// Get the current streaming mode.
+  RPCStreamingMode streamingMode() const;
+
+  /// Set the maximum number of pending rows before backpressure.
+  void setMaxPendingRows(int64_t maxPendingRows);
+
+  /// Set the maximum number of pending batches before backpressure (BATCH
+  /// mode).
+  void setMaxPendingBatches(int64_t maxPendingBatches);
+
+  // ===== Input batch storage =====
+  // Called from the driver thread (addInput/getOutput). Thread-safe.
+
+  /// Store an input batch and return its index. Thread-safe.
+  /// The batch is reference-counted; call releaseRows() when rows are output.
+  int32_t storeInputBatch(std::vector<VectorPtr> flatColumns, int64_t rowCount);
+
+  /// Get the flattened columns for a stored input batch. Thread-safe.
+  /// Returns by value to avoid returning a reference that outlives the lock.
+  std::vector<VectorPtr> getInputBatchColumns(int32_t batchIndex) const;
+
+  /// Release rows from an input batch. Thread-safe.
+  /// When all rows are released, the batch columns are freed.
+  void releaseRows(int32_t batchIndex, int64_t count);
+
+  // ===== PER_ROW mode API =====
+
+  /// Add a pending row with its RPC future and location in the input batch.
+  /// Thread-safe. Called from the driver thread in addInput().
+  ///
+  /// Attaches a completion callback to the future that moves the response
+  /// into readyRows_ and notifies waiting drivers. The callback runs on
+  /// the RPC client's executor thread, acquiring mutex_ internally.
+  ///
+  /// @param selfPtr Shared pointer to this RPCState, captured by the callback
+  ///        to prevent premature destruction.
+  /// @param rowId Globally unique row ID for correlation.
+  /// @param location Row's location in the stored input batch.
+  /// @param future The SemiFuture from client->call().
+  void addPendingRow(
+      std::shared_ptr<RPCState> selfPtr,
+      int64_t rowId,
+      RowLocation location,
+      folly::SemiFuture<RPCResponse> future);
+
+  /// Atomically try to claim a ready row, check finish, or wait. Thread-safe.
+  /// Called from the driver thread in isBlocked().
+  ///
+  /// All three checks happen under a single lock to prevent TOCTOU races.
+  ///
+  /// @param[out] future Set to a wait future if kMustWait.
+  /// @param[out] claimedRow Set to the claimed row if kClaimed.
+  /// @return kClaimed, kFinished, or kMustWait.
+  enum class ClaimResult { kClaimed, kFinished, kMustWait };
+  ClaimResult tryClaimOrWait(
+      ContinueFuture* future,
+      std::optional<ReadyRow>* claimedRow);
+
+  /// Non-blocking claim of a ready row. Thread-safe.
+  /// Returns nullopt if no ready rows.
+  /// Unlike tryClaimOrWait(), does NOT create a promise on miss.
+  /// Use this pre-noMoreInput to avoid accumulating orphaned promises.
+  std::optional<ReadyRow> tryClaimReady();
+
+  /// Drain all currently ready rows (non-blocking, up to maxRows). Thread-safe.
+  /// Used for batched PER_ROW output to amortize RowVector allocation.
+  void drainReadyRows(std::vector<ReadyRow>& out, int32_t maxRows);
+
+  /// Returns the number of pending (in-flight) rows. Thread-safe.
+  int64_t numPendingRows();
+
+  // ===== BATCH mode API =====
+
+  /// Add a pending batch future with row locations for response-to-input
+  /// mapping. Thread-safe. Called from the driver thread in
+  /// flushBatchRequests().
+  ///
+  /// Attaches a completion callback that notifies waiters on completion.
+  /// The callback runs on the RPC client's executor thread, acquiring
+  /// mutex_ internally.
+  ///
+  /// @param selfPtr Shared pointer to this RPCState (prevent destruction).
+  /// @param future The SemiFuture from client->callBatch().
+  /// @param rowLocations Locations mapping each request to its input batch
+  ///        position. Stored on the PendingBatch and carried through to
+  ///        ReadyBatch, eliminating per-row rowLocations_ map overhead.
+  void addPendingBatch(
+      std::shared_ptr<RPCState> selfPtr,
+      folly::SemiFuture<std::vector<RPCResponse>> future,
+      std::vector<RowLocation> rowLocations);
+
+  /// Atomically try to poll a ready batch, check finish, or wait. Thread-safe.
+  /// Called from the driver thread in isBlocked().
+  ///
+  /// @param[out] future Set to a wait future if kMustWait.
+  /// @param[out] readyBatch Set to the ready batch if kGotBatch.
+  /// @return kGotBatch, kFinished, or kMustWait.
+  enum class BatchPollResult { kGotBatch, kFinished, kMustWait };
+  BatchPollResult tryPollBatchOrWait(
+      ContinueFuture* future,
+      std::optional<ReadyBatch>* readyBatch);
+
+  /// Non-blocking poll of a ready batch. Thread-safe.
+  /// Returns nullopt if no batch ready.
+  /// Unlike tryPollBatchOrWait(), does NOT create a promise on miss.
+  /// Use this pre-noMoreInput to avoid accumulating orphaned promises.
+  std::optional<ReadyBatch> tryPollReady();
+
+  // ===== Common =====
+
+  /// Signal that no more rows will be dispatched. Thread-safe.
+  void setNoMoreInput();
+
+  /// Returns true when all work is complete. Thread-safe.
+  bool isFinished();
+
+  /// Returns true if backpressure should be applied. Thread-safe.
+  /// PER_ROW mode: pending rows >= maxPendingRows.
+  /// BATCH mode: pending batches >= maxPendingBatches.
+  bool isUnderBackpressure();
+
+ private:
+  /// Move a completed row into readyRows_ and notify waiters.
+  /// Called from the RPC completion callback (runs on executor thread).
+  void completeRow(int64_t rowId, RowLocation location, RPCResponse response);
+
+  /// Fulfill all waiting promises and clear. Called under lock.
+  void notifyWaitersLocked();
+
+  mutable std::mutex mutex_;
+  std::vector<ContinuePromise> promises_;
+
+  // Input batch storage (shared across PER_ROW and BATCH modes)
+  std::vector<InputBatchRef> inputBatches_;
+
+  // PER_ROW state
+  std::deque<ReadyRow> readyRows_;
+  int64_t numPendingRows_{0};
+
+  // BATCH state
+  int64_t nextBatchId_{0};
+  std::deque<PendingBatch> pendingBatches_;
+
+  // Common
+  bool noMoreInput_{false};
+  RPCStreamingMode streamingMode_{RPCStreamingMode::kPerRow};
+  int64_t maxPendingRows_{100};
+  int64_t maxPendingBatches_{10};
+};
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/AsyncRPCFunction.h
+++ b/velox/expression/rpc/AsyncRPCFunction.h
@@ -18,20 +18,22 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
-#include "velox/common/rpc/IRPCClient.h"
+#include <folly/futures/Future.h>
+
 #include "velox/common/rpc/RPCTypes.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/SelectivityVector.h"
 
 namespace facebook::velox::exec::rpc {
 
 // Import core RPC types from velox/common/rpc into this namespace so that
 // existing code in velox/expression/rpc can use them unqualified.
-using velox::rpc::IRPCClient;
 using velox::rpc::RPCRequest;
 using velox::rpc::RPCResponse;
 using velox::rpc::RPCStreamingMode;
@@ -39,30 +41,30 @@ using velox::rpc::RPCStreamingMode;
 /// Base interface for async RPC functions (business logic layer).
 ///
 /// Lives in velox/expression/rpc/ because it is a function interface — it
-/// defines what an RPC function is (signature, request/response format),
+/// defines what an RPC function is (signature, dispatch, response format),
 /// analogous to VectorFunction in velox/expression/. Transport-layer types
 /// (IRPCClient, RPCRequest, RPCResponse) live in velox/common/rpc/.
 /// The execution operator (RPCOperator) that drives async dispatch lives
 /// in velox/exec/rpc/.
 ///
-/// AsyncRPCFunction owns the domain-specific logic: how to convert input rows
-/// into RPC requests (prepareRequests) and how to interpret responses back into
-/// Velox vectors (buildOutput). It is decoupled from the transport layer —
-/// IRPCClient (in velox/common/rpc/) handles the actual network communication.
+/// AsyncRPCFunction owns the domain-specific logic: how to dispatch RPCs
+/// from input rows (dispatchPerRow / accumulateBatch+flushBatch) and how
+/// to interpret responses back into Velox vectors (buildOutput). The
+/// function creates and holds its own transport/client internally.
 ///
-/// Subclasses implement domain-specific request/response handling (e.g., LLM
-/// inference, embedding calls). The RPCOperator handles async execution,
-/// batching, and result collection.
+/// Subclasses implement domain-specific dispatch and response handling
+/// (e.g., LLM inference, embedding calls). The RPCOperator handles async
+/// coordination: rate limiting, timeout wrapping, rowId assignment,
+/// RPCState wiring, and passthrough columns.
 ///
 /// Lifecycle (called by RPCOperator):
-///   1. initialize(queryConfig, inputTypes, constantInputs) — create/cache RPC
-///      clients, inspect argument types and constant values (called once during
-///      operator init). constantInputs[i] is non-null when argument i is a
-///      constant expression (e.g., a literal model name or JSON options
-///      string).
-///   2. prepareRequests() — convert input rows to RPC requests
-///   3. getClient()->call() or getBatchClient()->callBatch() — dispatch RPCs
-///   4. buildOutput() — convert RPC responses to output vectors
+///   1. initialize(queryConfig, inputTypes, constantInputs) — create/cache
+///      transport and RPC clients, inspect constant values (called once
+///      during operator init).
+///   2. dispatchPerRow(rows, args) — dispatch individual RPCs per row
+///      OR accumulateBatch(rows, args) + flushBatch() — accumulate and
+///      dispatch as a batch.
+///   3. buildOutput() — convert RPC responses to output vectors.
 class AsyncRPCFunction {
  public:
   virtual ~AsyncRPCFunction() = default;
@@ -73,16 +75,11 @@ class AsyncRPCFunction {
   /// Use this to create/cache RPC clients, read session properties, and
   /// inspect constant argument values (e.g., model name, options JSON).
   ///
-  /// Follows the same pattern as SimpleFunction::initialize() and the stateful
-  /// VectorFunction factory, which receive argument types and constant values
-  /// at init time.
-  ///
   /// @param queryConfig Query configuration with session properties.
   /// @param inputTypes Types of each argument expression.
   /// @param constantInputs Constant values aligned with inputTypes.
-  /// Non-constant
-  ///        arguments are nullptr. Constant arguments are single-element
-  ///        ConstantVectors. Matches the VectorFunctionArg convention.
+  ///        Non-constant arguments are nullptr. Constant arguments are
+  ///        single-element ConstantVectors.
   virtual void initialize(
       const core::QueryConfig& /*queryConfig*/,
       const std::vector<TypePtr>& /*inputTypes*/,
@@ -94,33 +91,91 @@ class AsyncRPCFunction {
   /// Return the Velox type of the result column.
   virtual TypePtr resultType() const = 0;
 
-  /// Prepare RPC requests from input rows.
-  ///
-  /// @param rows Active rows in the input batch.
-  /// @param args Evaluated argument columns (e.g., prompt, model name).
-  /// @return One RPCRequest per active non-null row. Each request's
-  ///         originalRowIndex is set to the row's position in the input batch.
-  virtual std::vector<RPCRequest> prepareRequests(
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args) const = 0;
+  /// Return the service tier key for rate limiting.
+  /// Empty string means "no tier configured — uses global default limit."
+  virtual std::string tierKey() const {
+    return "";
+  }
 
-  /// Build output vector from RPC responses.
+  // ── PER_ROW mode ──────────────────────────────────────────────
+
+  /// Dispatch individual RPCs for each active row.
+  /// Returns one future per active row, keyed by originalRowIndex.
   ///
-  /// @param responses Completed RPC responses (may include errors).
-  /// @param pool Memory pool for allocating the output vector.
-  /// @return Vector matching resultType(), one element per response.
+  /// The function:
+  ///   1. Unpacks argument vectors (typed)
+  ///   2. Builds typed requests directly
+  ///   3. Dispatches via transport
+  ///   4. Returns the futures
+  ///
+  /// Null-input rows: return an immediate RPCResponse with
+  /// error="null_input".
+  virtual std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) = 0;
+
+  // ── BATCH mode ────────────────────────────────────────────────
+
+  /// Accumulate rows for batch dispatch.
+  /// Called by the operator on each addInput(). The function unpacks typed
+  /// data from (rows, args) and stores it internally.
+  ///
+  /// Returns the original row indices for ALL processed rows (null and
+  /// non-null). For null rows, the function stores a null marker
+  /// internally. For non-null rows, the function stores typed data.
+  ///
+  /// The operator uses these indices for:
+  /// 1. storeInputBatch(flattenedColumns, rowCount)
+  /// 2. batchRowLocations_ — one entry per accumulated row
+  /// 3. batchRowIds_ — assign one rowId per accumulated row
+  virtual std::vector<vector_size_t> accumulateBatch(
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/) {
+    VELOX_UNSUPPORTED(
+        "accumulateBatch() not implemented for function '{}'", name());
+  }
+
+  /// Dispatch accumulated batch.
+  /// Called by the operator at flush time (noMoreInput or threshold).
+  /// The function builds the typed batch request from its internal
+  /// accumulated state and dispatches it.
+  ///
+  /// Returns responses for ALL accumulated rows. Null rows get
+  /// RPCResponse{.error = "null_input"}. This keeps the operator
+  /// completely agnostic to null handling in batch mode.
+  virtual folly::SemiFuture<std::vector<RPCResponse>> flushBatch() {
+    VELOX_UNSUPPORTED("flushBatch() not implemented for function '{}'", name());
+  }
+
+  /// Number of rows accumulated so far (for threshold checks).
+  /// Batch-capable functions MUST override this; the operator uses
+  /// function_->pendingBatchSize() >= dispatchBatchSize_ to decide
+  /// when to flush.
+  virtual int32_t pendingBatchSize() const {
+    return 0;
+  }
+
+  // ── Output ────────────────────────────────────────────────────
+
+  /// Build output vector from completed responses.
+  /// Default: VARCHAR FlatVector (errors → SQL NULL, success → string
+  /// value). Override for non-VARCHAR return types (e.g., ARRAY(REAL)
+  /// for embeddings) or custom result processing.
   virtual VectorPtr buildOutput(
       const std::vector<RPCResponse>& responses,
-      memory::MemoryPool* pool) const = 0;
-
-  /// Get the RPC client for individual call() dispatch.
-  virtual std::shared_ptr<IRPCClient> getClient() const = 0;
-
-  /// Get the RPC client for callBatch() dispatch.
-  /// Default returns getClient(). Override for backends with separate
-  /// batch endpoints.
-  virtual std::shared_ptr<IRPCClient> getBatchClient() const {
-    return getClient();
+      memory::MemoryPool* pool) const {
+    const auto numRows = static_cast<vector_size_t>(responses.size());
+    auto result =
+        BaseVector::create<FlatVector<StringView>>(VARCHAR(), numRows, pool);
+    for (vector_size_t i = 0; i < numRows; ++i) {
+      if (responses[i].hasError()) {
+        result->setNull(i, true);
+      } else {
+        result->set(i, StringView(responses[i].result));
+      }
+    }
+    return result;
   }
 };
 

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
+
+namespace facebook::velox::exec::rpc {
+
+std::mutex& AsyncRPCFunctionRegistry::mutex() {
+  static std::mutex instance;
+  return instance;
+}
+
+std::unordered_map<std::string, AsyncRPCFunctionRegistry::Factory>&
+AsyncRPCFunctionRegistry::factories() {
+  static std::unordered_map<std::string, Factory> instance;
+  return instance;
+}
+
+bool AsyncRPCFunctionRegistry::registerFunction(
+    const std::string& name,
+    Factory factory) {
+  std::lock_guard<std::mutex> lock(mutex());
+  auto& registry = factories();
+  if (registry.count(name) > 0) {
+    return false; // Already registered
+  }
+  // Note: Do NOT use LOG() here as this function may be called during static
+  // initialization, before glog is initialized.
+  registry[name] = std::move(factory);
+  return true;
+}
+
+std::shared_ptr<AsyncRPCFunction> AsyncRPCFunctionRegistry::create(
+    const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex());
+  auto& registry = factories();
+  auto it = registry.find(name);
+  if (it == registry.end()) {
+    return nullptr;
+  }
+  return it->second();
+}
+
+bool AsyncRPCFunctionRegistry::isRegistered(const std::string& name) {
+  std::lock_guard<std::mutex> lock(mutex());
+  return factories().count(name) > 0;
+}
+
+std::unordered_set<std::string>
+AsyncRPCFunctionRegistry::registeredFunctions() {
+  std::lock_guard<std::mutex> lock(mutex());
+  std::unordered_set<std::string> result;
+  for (const auto& [name, _] : factories()) {
+    result.insert(name);
+  }
+  return result;
+}
+
+void AsyncRPCFunctionRegistry::clear() {
+  std::lock_guard<std::mutex> lock(mutex());
+  factories().clear();
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.h
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Registry for AsyncRPCFunction implementations.
+///
+/// This registry allows RPC functions to register themselves by name,
+/// enabling RPCOperator to resolve the function at operator init time
+/// (following the VectorFunction pattern where plan nodes reference
+/// functions by name and the execution layer resolves them).
+///
+/// Usage (in function's .cpp file):
+///   AsyncRPCFunctionRegistry::registerFunction(
+///       "my_function",
+///       []() { return std::make_shared<MyAsyncRPCFunction>(); });
+///
+/// Resolution (in RPCOperator::initialize()):
+///   auto func = AsyncRPCFunctionRegistry::create("my_function");
+class AsyncRPCFunctionRegistry {
+ public:
+  /// Factory function type that creates an AsyncRPCFunction instance.
+  using Factory = std::function<std::shared_ptr<AsyncRPCFunction>()>;
+
+  /// Registers an AsyncRPCFunction factory for the given function name.
+  /// Thread-safe. Safe to call during static initialization.
+  ///
+  /// @param name Function name (e.g., "my_rpc_function")
+  /// @param factory Function that creates instances of the AsyncRPCFunction
+  /// @return true if registration succeeded, false if name already registered
+  static bool registerFunction(const std::string& name, Factory factory);
+
+  /// Creates an AsyncRPCFunction instance for the given function name.
+  /// Thread-safe.
+  ///
+  /// @param name Function name to look up
+  /// @return AsyncRPCFunction instance, or nullptr if not registered
+  static std::shared_ptr<AsyncRPCFunction> create(const std::string& name);
+
+  /// Checks if a function name is registered.
+  /// Thread-safe.
+  ///
+  /// @param name Function name to check
+  /// @return true if the function is registered
+  static bool isRegistered(const std::string& name);
+
+  /// Returns all registered function names.
+  /// Thread-safe.
+  ///
+  /// @return Set of registered function names
+  static std::unordered_set<std::string> registeredFunctions();
+
+  /// Clears all registered functions.
+  /// Primarily for testing.
+  static void clear();
+
+ private:
+  static std::mutex& mutex();
+  static std::unordered_map<std::string, Factory>& factories();
+};
+
+/// Helper class for static registration of AsyncRPCFunction implementations.
+class AsyncRPCFunctionRegistrar {
+ public:
+  AsyncRPCFunctionRegistrar(
+      const std::string& name,
+      AsyncRPCFunctionRegistry::Factory factory) {
+    AsyncRPCFunctionRegistry::registerFunction(name, std::move(factory));
+  }
+};
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/CMakeLists.txt
+++ b/velox/expression/rpc/CMakeLists.txt
@@ -18,5 +18,9 @@ velox_add_library(velox_async_rpc_function INTERFACE AsyncRPCFunction.h)
 
 velox_link_libraries(
   velox_async_rpc_function
-  INTERFACE velox_rpc_client velox_rpc_types velox_core velox_type velox_vector
+  INTERFACE velox_rpc_types velox_core velox_type velox_vector Folly::folly
 )
+
+velox_add_library(velox_async_rpc_function_registry AsyncRPCFunctionRegistry.cpp)
+
+velox_link_libraries(velox_async_rpc_function_registry velox_async_rpc_function velox_common_base)


### PR DESCRIPTION
Summary:

Execution layer: operator, shared state, rate limiter, plan translator,
and function registry.

**AsyncRPCFunction interface** (in velox/expression/rpc/):
Defines the dispatch contract between RPCOperator and RPC functions.
Functions implement dispatchPerRow() for individual RPCs and optionally
accumulateBatch()/flushBatch() for batch dispatch. The function owns
its transport and clients internally — the operator never holds client
references. tierKey() provides the service tier for rate limiting.

**RPCOperator**: Single Velox operator handling both RPC dispatch and
response collection. Pipeline: Source -> RPCOperator -> downstream.
Resolves AsyncRPCFunction by name via AsyncRPCFunctionRegistry at
initialize() time. In PER_ROW mode, calls function->dispatchPerRow()
which returns per-row futures; operator wraps each with rate limiter
tokens and timeouts. In BATCH mode, calls function->accumulateBatch()
to accumulate rows, then function->flushBatch() to dispatch. Builds
output using dictionary-wrapped passthrough columns (zero-copy).

**RPCState**: Thread-safe coordination between driver thread and async
RPC callbacks. Single mutex with VeloxPromise/ContinueFuture. Two
streaming modes: PER_ROW (out-of-order emission, low tail latency) and
BATCH (first-ready-wins polling, lower overhead). Backpressure via
configurable maxPendingRows/maxPendingBatches.

**RPCRateLimiter**: Per-process, per-tier concurrency limiter with RAII
Token for cleanup on cancellation.

**RPCPlanNodeTranslator**: Converts RPCNode -> RPCOperator. Forces
single-driver for BATCH mode.

**AsyncRPCFunctionRegistry**: Static registry mapping function names to
factories.

## Reading Guide

1. **RPCState.h** — Core data model: InputBatchRef, RowLocation,
   ReadyRow, ReadyBatch, and the two streaming mode APIs.

2. **RPCOperator.h/cpp** — Operator lifecycle: initialize() resolves
   function, addInput() dispatches via dispatchPerRow/accumulateBatch,
   isBlocked() claims results, getOutput() builds output vectors.

3. **AsyncRPCFunction.h** — The function interface: dispatchPerRow(),
   accumulateBatch()/flushBatch(), tierKey(), buildOutput().

4. **RPCRateLimiter.h/cpp** — RAII Token pattern, per-tier limits.

5. **AsyncRPCFunctionRegistry.h/cpp** — Name->factory registry.

6. **RPCPlanNodeTranslator.h/cpp** — Plan node to operator glue.

Reviewed By: Yuhta

Differential Revision: D94996241


