### PR TITLE
feat: Add custom Parquet read support for Spark TimestampNTZ Type

### DIFF
--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -17,6 +17,8 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveIntegerColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetData.h"
+#include "velox/dwio/parquet/reader/ParquetReaderUtils.h"
 
 namespace facebook::velox::parquet {
 
@@ -45,6 +47,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
     SelectiveIntegerColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
+    formatData_->as<ParquetData>().setRequestedType(requestedType_);
     formatData_->as<ParquetData>().seekToRowGroup(index);
   }
 

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -21,6 +21,7 @@
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/parquet/common/LevelConversion.h"
+#include "velox/dwio/parquet/reader/ParquetReaderUtils.h"
 #include "velox/dwio/parquet/thrift/ThriftTransport.h"
 #include "velox/vector/FlatVector.h"
 
@@ -380,6 +381,18 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
         pageData_,
         pageHeader.compressed_page_size,
         pageHeader.uncompressed_page_size);
+  }
+
+  if (requestedType_ && customTypeExists(requestedType_->name())) {
+    const ParquetDictionaryReadContext readContext{
+        .pageData = pageData_,
+        .inputStream = inputStream_.get(),
+        .bufferStart = &bufferStart_,
+        .bufferEnd = &bufferEnd_,
+        .stats = &stats_};
+    applyParquetDictionaryRead(
+        pool_, readContext, requestedType_, dictionary_, type_);
+    return;
   }
 
   auto parquetType = type_->parquetType_.value();

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -155,6 +155,10 @@ class PageReader {
     return sessionTimezone_;
   }
 
+  void setRequestedType(const TypePtr& requestedType) {
+    requestedType_ = requestedType;
+  }
+
  private:
   // Indicates that we only want the repdefs for the next page. Used when
   // prereading repdefs with seekToPage.
@@ -459,6 +463,7 @@ class PageReader {
   // Dictionary contents.
   dwio::common::DictionaryValues dictionary_;
   thrift::Encoding::type dictionaryEncoding_;
+  TypePtr requestedType_;
 
   // Offset of current page's header from start of ColumnChunk.
   uint64_t pageStart_{0};

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -40,7 +40,9 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
     common::ScanSpec& scanSpec) {
-  auto colName = scanSpec.fieldName();
+  if (customTypeExists(requestedType->name())) {
+    return getParquetColumnReader(requestedType, fileType, params, scanSpec);
+  }
 
   if (fileType->type()->isTime()) {
     VELOX_CHECK(fileType->type()->equivalent(*TIME()));

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -18,24 +18,9 @@
 
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/parquet/reader/ParquetData.h"
+#include "velox/dwio/parquet/reader/ParquetReaderUtils.h"
 
 namespace facebook::velox::parquet {
-
-/// Parquet stores integers of 8, 16, 32 bits with 32 bits and 64 as 64 bits.
-inline int32_t parquetSizeOfIntKind(TypeKind kind) {
-  switch (kind) {
-    case TypeKind::TINYINT:
-    case TypeKind::SMALLINT:
-    case TypeKind::INTEGER:
-      return 4;
-    case TypeKind::BIGINT:
-      return 8;
-    case TypeKind::HUGEINT:
-      return 16;
-    default:
-      VELOX_FAIL("Not an integer TypeKind");
-  }
-}
 
 /// Wrapper for static functions for Parquet columns.
 class ParquetColumnReader {

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -130,6 +130,9 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(int64_t index) {
       metadata.totalCompressedSize(),
       stats_,
       sessionTimezone_);
+  if (requestedType_) {
+    reader_->setRequestedType(requestedType_);
+  }
   return dwio::common::PositionProvider(empty);
 }
 

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -200,6 +200,13 @@ class ParquetData : public dwio::common::FormatData {
     return reader_->isDeltaByteArray();
   }
 
+  void setRequestedType(const TypePtr& requestedType) {
+    requestedType_ = requestedType;
+    if (reader_) {
+      reader_->setRequestedType(requestedType_);
+    }
+  }
+
   bool parentNullsInLeaves() const override {
     return true;
   }
@@ -226,6 +233,7 @@ class ParquetData : public dwio::common::FormatData {
   dwio::common::ColumnReaderStatistics& stats_;
   const tz::TimeZone* sessionTimezone_;
   std::unique_ptr<PageReader> reader_;
+  TypePtr requestedType_;
 
   // Nulls derived from leaf repdefs for non-leaf readers.
   BufferPtr presetNulls_;

--- a/velox/dwio/parquet/reader/ParquetReaderUtils.h
+++ b/velox/dwio/parquet/reader/ParquetReaderUtils.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+// Forward declarations.
+namespace facebook::velox::dwio::common {
+struct ColumnReaderStatistics;
+class SeekableInputStream;
+} // namespace facebook::velox::dwio::common
+
+namespace facebook::velox::parquet {
+
+struct ParquetDictionaryReadContext {
+  const char* pageData{nullptr};
+  dwio::common::SeekableInputStream* inputStream{nullptr};
+  const char** bufferStart{nullptr};
+  const char** bufferEnd{nullptr};
+  dwio::common::ColumnReaderStatistics* stats{nullptr};
+};
+
+/// Parquet stores integers of 8, 16, 32 bits with 32 bits and 64 as 64 bits.
+inline int32_t parquetSizeOfIntKind(TypeKind kind) {
+  switch (kind) {
+    case TypeKind::TINYINT:
+    case TypeKind::SMALLINT:
+    case TypeKind::INTEGER:
+      return 4;
+    case TypeKind::BIGINT:
+      return 8;
+    case TypeKind::HUGEINT:
+      return 16;
+    default:
+      VELOX_FAIL("Not an integer TypeKind");
+  }
+}
+
+} // namespace facebook::velox::parquet

--- a/velox/functions/sparksql/types/TimestampNTZColumnReader.h
+++ b/velox/functions/sparksql/types/TimestampNTZColumnReader.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/parquet/reader/IntegerColumnReader.h"
+#include "velox/type/Timestamp.h"
+
+namespace facebook::velox::functions::sparksql {
+
+class TimestampNTZColumnReader : public parquet::IntegerColumnReader {
+ public:
+  TimestampNTZColumnReader(
+      const TypePtr& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> fileType,
+      parquet::ParquetParams& params,
+      common::ScanSpec& scanSpec)
+      : parquet::IntegerColumnReader(
+            requestedType,
+            fileType,
+            params,
+            scanSpec) {
+    const auto typeWithId =
+        std::static_pointer_cast<const parquet::ParquetTypeWithId>(fileType_);
+    if (auto logicalType = typeWithId->logicalType_) {
+      VELOX_CHECK(logicalType->__isset.TIMESTAMP);
+      const auto unit = logicalType->TIMESTAMP.unit;
+      if (unit.__isset.MILLIS) {
+        filePrecision_ = TimestampPrecision::kMilliseconds;
+      } else if (unit.__isset.MICROS) {
+        filePrecision_ = TimestampPrecision::kMicroseconds;
+      } else {
+        VELOX_UNREACHABLE();
+      }
+    } else if (auto convertedType = typeWithId->convertedType_) {
+      if (convertedType ==
+          ::facebook::velox::parquet::thrift::ConvertedType::type::
+              TIMESTAMP_MILLIS) {
+        filePrecision_ = TimestampPrecision::kMilliseconds;
+      } else if (
+          convertedType ==
+          ::facebook::velox::parquet::thrift::ConvertedType::type::
+              TIMESTAMP_MICROS) {
+        filePrecision_ = TimestampPrecision::kMicroseconds;
+      } else {
+        VELOX_UNREACHABLE();
+      }
+    } else {
+      VELOX_NYI("Logical type and converted type are not provided.");
+    }
+  }
+
+  bool hasBulkPath() const override {
+    return false;
+  }
+
+  void getValues(const RowSet& rows, VectorPtr* result) override {
+    getIntValues(rows, BIGINT(), result);
+
+    VectorPtr resultVector = *result;
+    auto rawValues =
+        resultVector->asUnchecked<FlatVector<int64_t>>()->mutableRawValues();
+    for (auto i = 0; i < numValues_; ++i) {
+      if (resultVector->isNullAt(i)) {
+        continue;
+      }
+      if (filePrecision_ == TimestampPrecision::kMilliseconds) {
+        rawValues[i] = rawValues[i] * 1'000;
+      }
+    }
+  }
+
+  void read(
+      int64_t offset,
+      const RowSet& rows,
+      const uint64_t* /*incomingNulls*/) override {
+    // The 'fileType_' is 'TIMESTAMP' and needs to be read as 'BIGINT' and
+    // converted to 'TIMESTAMP_NTZ'.
+    VELOX_WIDTH_DISPATCH(sizeof(int64_t), prepareRead, offset, rows, nullptr);
+    readCommon<parquet::IntegerColumnReader, true>(rows);
+    readOffset_ += rows.back() + 1;
+  }
+
+ private:
+  // The precision of int64_t timestamp in Parquet.
+  TimestampPrecision filePrecision_;
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/types/TimestampNTZRegistration.cpp
+++ b/velox/functions/sparksql/types/TimestampNTZRegistration.cpp
@@ -16,8 +16,10 @@
 
 #include "velox/functions/sparksql/types/TimestampNTZRegistration.h"
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
+#include "velox/dwio/parquet/reader/ParquetReaderUtils.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/sparksql/types/TimestampNTZCastUtil.h"
+#include "velox/functions/sparksql/types/TimestampNTZColumnReader.h"
 #include "velox/functions/sparksql/types/TimestampNTZType.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -98,6 +100,57 @@ class TimestampNTZTypeFactory : public CustomTypeFactory {
       const InputGeneratorConfig& config) const override {
     return std::make_shared<fuzzer::RandomInputGenerator<int64_t>>(
         config.seed_, TIMESTAMP_NTZ(), config.nullRatio_);
+  }
+
+  std::unique_ptr<dwio::common::SelectiveColumnReader> getParquetColumnReader(
+      const TypePtr& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+      parquet::ParquetParams& params,
+      common::ScanSpec& scanSpec) const override {
+    return std::make_unique<TimestampNTZColumnReader>(
+        requestedType, fileType, params, scanSpec);
+  }
+
+  void applyParquetDictionaryRead(
+      memory::MemoryPool& pool,
+      const parquet::ParquetDictionaryReadContext& readContext,
+      dwio::common::DictionaryValues& dictionary,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType)
+      const override {
+    if (dictionary.numValues == 0) {
+      return;
+    }
+
+    const auto parquetTypeWithId =
+        std::static_pointer_cast<const parquet::ParquetTypeWithId>(fileType);
+    VELOX_USER_CHECK_EQ(
+        parquetTypeWithId->parquetType_.value(), parquet::thrift::Type::INT64);
+    const auto numBytes = dictionary.numValues * sizeof(int64_t);
+
+    auto values = AlignedBuffer::allocate<int64_t>(dictionary.numValues, &pool);
+    auto* rawValues = values->asMutable<int64_t>();
+
+    if (readContext.pageData) {
+      memcpy(rawValues, readContext.pageData, numBytes);
+    } else {
+      VELOX_DCHECK_NOT_NULL(readContext.inputStream);
+      VELOX_DCHECK_NOT_NULL(readContext.bufferStart);
+      VELOX_DCHECK_NOT_NULL(readContext.bufferEnd);
+      VELOX_DCHECK_NOT_NULL(readContext.stats);
+      uint64_t readUs{0};
+      {
+        MicrosecondTimer timer(&readUs);
+        dwio::common::readBytes(
+            numBytes,
+            readContext.inputStream,
+            reinterpret_cast<char*>(rawValues),
+            *readContext.bufferStart,
+            *readContext.bufferEnd);
+      }
+      readContext.stats->pageLoadTimeNs.increment(readUs * 1'000);
+    }
+
+    dictionary.values = std::move(values);
   }
 };
 

--- a/velox/functions/sparksql/types/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/types/tests/CMakeLists.txt
@@ -20,3 +20,20 @@ target_link_libraries(
   velox_vector_test_lib
   GTest::gtest_main
 )
+
+add_executable(velox_custom_parquet_table_scan_test CustomParquetTableScanTest.cpp)
+add_test(
+  NAME velox_custom_parquet_table_scan_test
+  COMMAND velox_custom_parquet_table_scan_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(
+  velox_custom_parquet_table_scan_test
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
+  velox_spark_types
+  velox_exec_test_lib
+  velox_exec
+  velox_hive_connector
+  ${TEST_LINK_LIBS}
+)

--- a/velox/functions/sparksql/types/tests/CustomParquetTableScanTest.cpp
+++ b/velox/functions/sparksql/types/tests/CustomParquetTableScanTest.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+
+#include "velox/common/testutil/TempDirectoryPath.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h" // @manual
+#include "velox/dwio/parquet/writer/Writer.h" // @manual
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h" // @manual
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/sparksql/types/TimestampNTZRegistration.h"
+#include "velox/functions/sparksql/types/TimestampNTZType.h"
+
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class CustomParquetTableScanTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    parquet::registerParquetReaderFactory();
+    registerTimestampNTZType();
+  }
+
+  void loadData(RowVectorPtr data) {
+    createDuckDbTable({data});
+  }
+
+  std::shared_ptr<connector::hive::HiveConnectorSplit> makeSplit(
+      const std::string& filePath,
+      const std::optional<
+          std::unordered_map<std::string, std::optional<std::string>>>&
+          partitionKeys = std::nullopt,
+      const std::optional<std::unordered_map<std::string, std::string>>&
+          infoColumns = std::nullopt) {
+    return makeHiveConnectorSplits(
+        filePath,
+        1,
+        dwio::common::FileFormat::PARQUET,
+        partitionKeys,
+        infoColumns)[0];
+  }
+
+  // Write data to a parquet file on specified path.
+  void writeToParquetFile(
+      const std::string& path,
+      const std::vector<RowVectorPtr>& data,
+      parquet::WriterOptions options) {
+    VELOX_CHECK_GT(data.size(), 0);
+
+    auto writeFile = std::make_unique<LocalWriteFile>(path, true, false);
+    auto sink = std::make_unique<dwio::common::WriteFileSink>(
+        std::move(writeFile), path);
+    auto childPool =
+        rootPool_->addAggregateChild("ParquetTableScanTest.Writer");
+    options.memoryPool = childPool.get();
+
+    auto writer = std::make_unique<parquet::Writer>(
+        std::move(sink), options, asRowType(data[0]->type()));
+
+    for (const auto& vector : data) {
+      writer->write(vector);
+    }
+    writer->close();
+  }
+
+  void testTimestampNTZRead(const parquet::WriterOptions& options) {
+    auto stringToTimestamp = [](std::string_view view) {
+      return util::fromTimestampString(
+                 view.data(),
+                 view.size(),
+                 util::TimestampParseMode::kPrestoCast)
+          .thenOrThrow(folly::identity, [&](const Status& status) {
+            VELOX_USER_FAIL("{}", status.message());
+          });
+    };
+    std::vector<std::string_view> views = {
+        "2015-06-01 19:34:56.007",
+        "2015-06-02 19:34:56.12306",
+        "2001-02-03 03:34:06.056",
+        "1998-03-01 08:01:06.996669",
+        "2022-12-23 03:56:01",
+        "1980-01-24 00:23:07",
+        "1999-12-08 13:39:26.123456",
+        "2023-04-21 09:09:34.5",
+        "2000-09-12 22:36:29",
+        "2007-12-12 04:27:56.999",
+    };
+
+    std::vector<Timestamp> values;
+    std::vector<int64_t> bigints;
+    values.reserve(views.size());
+    bigints.reserve(views.size());
+    for (auto view : views) {
+      auto timestamp = stringToTimestamp(view);
+      values.emplace_back(timestamp);
+      bigints.push_back(
+          options.parquetWriteTimestampUnit == TimestampPrecision::kMicroseconds
+              ? timestamp.toMicros()
+              : timestamp.toMillis() * 1'000);
+    }
+
+    auto vector = makeRowVector({"t"}, {makeFlatVector<Timestamp>(values)});
+    auto file = common::testutil::TempFilePath::create();
+    writeToParquetFile(file->getPath(), {vector}, options);
+    loadData(makeRowVector({"t"}, {makeFlatVector<int64_t>(bigints)}));
+
+    // The values are stored as TIMESTAMPs in Parquet, and the reader will
+    // convert them to TIMESTAMP_NTZ type.
+    const auto plan = PlanBuilder()
+                          .tableScan(
+                              ROW({"t"}, {TIMESTAMP_NTZ()}),
+                              {},
+                              "",
+                              ROW({"t"}, {TIMESTAMP()}))
+                          .planNode();
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .split(makeSplit(file->getPath()))
+        .assertResults("SELECT t from tmp");
+  }
+};
+
+TEST_F(CustomParquetTableScanTest, timestampNTZPlainMicro) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = false;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
+  testTimestampNTZRead(options);
+}
+
+TEST_F(CustomParquetTableScanTest, timestampNTZDictionaryMicro) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = true;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
+  testTimestampNTZRead(options);
+}
+
+TEST_F(CustomParquetTableScanTest, timestampNTZPlainMilli) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = false;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampNTZRead(options);
+}
+
+TEST_F(CustomParquetTableScanTest, timestampNTZDictionaryMilli) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = true;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampNTZRead(options);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::Init init{&argc, &argv, false};
+  return RUN_ALL_TESTS();
+}

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -24,6 +24,8 @@
 #include <sstream>
 #include <typeindex>
 
+#include "velox/dwio/common/SelectiveColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetReaderUtils.h"
 #include "velox/external/tzdb/exception.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/Time.h"
@@ -1204,7 +1206,42 @@ exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name) {
   return nullptr;
 }
 
+std::unique_ptr<dwio::common::SelectiveColumnReader> getParquetColumnReader(
+    const TypePtr& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+    parquet::ParquetParams& params,
+    common::ScanSpec& scanSpec) {
+  auto factory = getTypeFactory(requestedType->name());
+  if (factory) {
+    return factory->getParquetColumnReader(
+        requestedType, fileType, params, scanSpec);
+  }
+  return nullptr;
+}
+
+void applyParquetDictionaryRead(
+    memory::MemoryPool& pool,
+    const parquet::ParquetDictionaryReadContext& readContext,
+    const TypePtr& requestedType,
+    dwio::common::DictionaryValues& dictionary,
+    const std::shared_ptr<const dwio::common::TypeWithId>& fileType) {
+  auto factory = getTypeFactory(requestedType->name());
+  if (factory) {
+    factory->applyParquetDictionaryRead(
+        pool, readContext, dictionary, fileType);
+  }
+}
+
 CustomTypeFactory::~CustomTypeFactory() = default;
+
+std::unique_ptr<dwio::common::SelectiveColumnReader>
+CustomTypeFactory::getParquetColumnReader(
+    const TypePtr& /*requestedType*/,
+    const std::shared_ptr<const dwio::common::TypeWithId>& /*fileType*/,
+    parquet::ParquetParams& /*params*/,
+    common::ScanSpec& /*scanSpec*/) const {
+  return nullptr;
+}
 
 AbstractInputGenerator::~AbstractInputGenerator() = default;
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2362,6 +2362,23 @@ class CastOperator;
 using CastOperatorPtr = std::shared_ptr<const CastOperator>;
 } // namespace exec
 
+namespace common {
+class ScanSpec;
+} // namespace common
+
+namespace dwio {
+namespace common {
+struct DictionaryValues;
+class SelectiveColumnReader;
+class TypeWithId;
+} // namespace common
+} // namespace dwio
+
+namespace parquet {
+class ParquetParams;
+struct ParquetDictionaryReadContext;
+} // namespace parquet
+
 /// Forward declaration.
 class Variant;
 class AbstractInputGenerator;
@@ -2399,6 +2416,22 @@ class CustomTypeFactory {
 
   virtual AbstractInputGeneratorPtr getInputGenerator(
       const InputGeneratorConfig& config) const = 0;
+
+  /// Returns a Parquet column reader for this custom type if it has a custom
+  /// implementation. Returns nullptr otherwise.
+  virtual std::unique_ptr<dwio::common::SelectiveColumnReader>
+  getParquetColumnReader(
+      const TypePtr& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+      parquet::ParquetParams& params,
+      common::ScanSpec& scanSpec) const;
+
+  // Applies custom Parquet dictionary read operation for this custom type.
+  virtual void applyParquetDictionaryRead(
+      memory::MemoryPool& pool,
+      const parquet::ParquetDictionaryReadContext& readContext,
+      dwio::common::DictionaryValues& dictionary,
+      const std::shared_ptr<const dwio::common::TypeWithId>& fileType) const {}
 };
 
 class AbstractInputGenerator {
@@ -2488,8 +2521,21 @@ TypePtr getCustomType(
     const std::string& name,
     const std::vector<TypeParameter>& parameters);
 
-/// Removes custom type from the registry if exists. Returns true if type was
-/// removed, false if type didn't exist.
+std::unique_ptr<dwio::common::SelectiveColumnReader> getParquetColumnReader(
+    const TypePtr& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
+    parquet::ParquetParams& params,
+    common::ScanSpec& scanSpec);
+
+void applyParquetDictionaryRead(
+    memory::MemoryPool& pool,
+    const parquet::ParquetDictionaryReadContext& readContext,
+    const TypePtr& requestedType,
+    dwio::common::DictionaryValues& dictionary,
+    const std::shared_ptr<const dwio::common::TypeWithId>& fileType);
+
+/// Removes custom type from the registry if exists. Returns true if type
+/// was removed, false if type didn't exist.
 bool unregisterCustomType(const std::string& name);
 
 /// Returns the custom cast operator for the custom type with the specified
@@ -2516,12 +2562,12 @@ void toTypeSql(const TypePtr& type, std::ostream& out);
 /// Cache of serialized RowType instances. Useful to reduce the size of
 /// serialized expressions and plans. Disabled by default. Not thread safe.
 ///
-/// To enable, call 'serializedTypeCache().enable()'. This enables the cache for
-/// the current thread. To disable, call 'serializedTypeCache().disable()'.
-/// While enables, type serialization will use the cache and serialize the types
-/// using IDs stored in the cache. The caller is responsible for saving
-/// serialized types from the cache and using these to hidrate
-/// 'deserializedTypeCache()' before deserializing the types.
+/// To enable, call 'serializedTypeCache().enable()'. This enables the cache
+/// for the current thread. To disable, call
+/// 'serializedTypeCache().disable()'. While enables, type serialization will
+/// use the cache and serialize the types using IDs stored in the cache. The
+/// caller is responsible for saving serialized types from the cache and using
+/// these to hidrate 'deserializedTypeCache()' before deserializing the types.
 class SerializedTypeCache {
  public:
   struct Options {
@@ -2554,16 +2600,16 @@ class SerializedTypeCache {
     cache_.clear();
   }
 
-  /// Returns the ID of the type if it is in the cache. Returns std::nullopt if
-  /// type is not found in the cache. Cache key is type instance pointer. Hence,
-  /// equal but different instances are stored separately.
+  /// Returns the ID of the type if it is in the cache. Returns std::nullopt
+  /// if type is not found in the cache. Cache key is type instance pointer.
+  /// Hence, equal but different instances are stored separately.
   std::optional<int32_t> get(const Type& type) const;
 
-  /// Stores the type in the cache. Returns the ID of the type. Reports an error
-  /// if type is already present in the cache. IDs are monotonically increasing.
-  /// Serialized type may refer to types stored previously in the cache. When
-  /// deserializing type cache, make sure to deserialize types in the order of
-  /// cache IDs.
+  /// Stores the type in the cache. Returns the ID of the type. Reports an
+  /// error if type is already present in the cache. IDs are monotonically
+  /// increasing. Serialized type may refer to types stored previously in the
+  /// cache. When deserializing type cache, make sure to deserialize types in
+  /// the order of cache IDs.
   int32_t put(const Type& type, folly::dynamic serialized);
 
   /// Serialized the types stored in the cache. Use


### PR DESCRIPTION
TimestampNTZ is a custom type of Spark, and its values are stored as 
`TIMESTAMP(MICROS, /*isAdjustedToUTC=*/false)` in Parquet.
This PR adds a custom Parquet read path for Spark TimestampNTZ, including 
plain and dictionary encodings support. Hooked `ParquetColumnReader::build` 
and `PageReader::prepareDictionary` for TimestampNTZ into a custom column 
reader dispatch. Introduced custom Parquet read operations through a custom 
type factory while keeping the default Parquet type behavior unchanged.