### PR TITLE
feat(rpc): Add unit tests and reference implementation for RPC framework [4/8] (OSS) (#16792)

### DIFF
--- a/velox/exec/rpc/CMakeLists.txt
+++ b/velox/exec/rpc/CMakeLists.txt
@@ -48,3 +48,16 @@ velox_link_libraries(
 velox_add_library(velox_rpc_plan_node_translator RPCPlanNodeTranslator.cpp)
 
 velox_link_libraries(velox_rpc_plan_node_translator velox_rpc_operator velox_exec)
+
+if(${VELOX_BUILD_TESTING})
+  velox_add_library(velox_demo_rpc_function tests/DemoRPCFunction.cpp)
+
+  velox_link_libraries(
+    velox_demo_rpc_function
+    velox_mock_rpc_client
+    velox_expression_functions
+    velox_async_rpc_function
+  )
+
+  add_subdirectory(tests)
+endif()

--- a/velox/exec/rpc/RPCState.cpp
+++ b/velox/exec/rpc/RPCState.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/exec/rpc/RPCState.h"
 
-#include <folly/executors/GlobalExecutor.h>
+#include <folly/executors/InlineExecutor.h>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -26,24 +26,23 @@
 namespace facebook::velox::exec::rpc {
 
 // ===== Configuration =====
+// These setters are called during RPCOperator construction, before any
+// concurrent access. No lock needed — avoids lock-order-inversion with the
+// Task mutex (TSAN: M0→M1→M0 cycle).
 
 void RPCState::setStreamingMode(RPCStreamingMode mode) {
-  std::lock_guard<std::mutex> l(mutex_);
   streamingMode_ = mode;
 }
 
 RPCStreamingMode RPCState::streamingMode() const {
-  std::lock_guard<std::mutex> l(mutex_);
   return streamingMode_;
 }
 
 void RPCState::setMaxPendingRows(int64_t maxPendingRows) {
-  std::lock_guard<std::mutex> l(mutex_);
   maxPendingRows_ = maxPendingRows;
 }
 
 void RPCState::setMaxPendingBatches(int64_t maxPendingBatches) {
-  std::lock_guard<std::mutex> l(mutex_);
   maxPendingBatches_ = maxPendingBatches;
 }
 
@@ -117,7 +116,7 @@ void RPCState::addPendingRow(
   // We capture selfPtr to keep this RPCState alive until the callback fires.
   auto stateForError = selfPtr;
   folly::futures::detachOn(
-      folly::getGlobalCPUExecutor(),
+      folly::getKeepAliveToken(folly::InlineExecutor::instance()),
       std::move(future)
           .deferValue([state = std::move(selfPtr), rowId, location](
                           RPCResponse response) mutable {
@@ -222,7 +221,7 @@ void RPCState::addPendingBatch(
   // completes. We use .via().thenValue() to run the callback eagerly.
   auto callbackFuture =
       std::move(future)
-          .via(folly::getGlobalCPUExecutor())
+          .via(folly::getKeepAliveToken(folly::InlineExecutor::instance()))
           .thenValue([state = selfPtr](std::vector<RPCResponse> responses) {
             RPC_STATE_VLOG(1)
                 << "Batch completed with " << responses.size() << " responses";

--- a/velox/exec/rpc/tests/CMakeLists.txt
+++ b/velox/exec/rpc/tests/CMakeLists.txt
@@ -1,0 +1,93 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_mock_rpc_client_test MockRPCClientTest.cpp)
+
+target_link_libraries(
+  velox_mock_rpc_client_test
+  velox_mock_rpc_client
+  GTest::gtest
+  GTest::gtest_main
+  Folly::folly
+)
+
+add_test(NAME velox_mock_rpc_client_test COMMAND velox_mock_rpc_client_test)
+
+add_executable(velox_rpc_state_test RPCStateTest.cpp)
+
+target_link_libraries(
+  velox_rpc_state_test
+  velox_rpc_state
+  velox_rpc_types
+  GTest::gtest
+  GTest::gtest_main
+  Folly::folly
+)
+
+add_test(NAME velox_rpc_state_test COMMAND velox_rpc_state_test)
+
+add_executable(velox_rpc_node_test RPCNodeTest.cpp)
+
+target_link_libraries(
+  velox_rpc_node_test
+  velox_mock_rpc_client
+  velox_core
+  velox_memory
+  velox_vector
+  GTest::gtest
+  GTest::gtest_main
+  Folly::folly
+)
+
+add_test(NAME velox_rpc_node_test COMMAND velox_rpc_node_test)
+
+add_executable(velox_demo_rpc_function_test DemoRPCFunctionTest.cpp)
+
+target_link_libraries(
+  velox_demo_rpc_function_test
+  velox_demo_rpc_function
+  velox_core
+  velox_memory
+  velox_vector
+  GTest::gtest
+  GTest::gtest_main
+  Folly::folly
+)
+
+add_test(NAME velox_demo_rpc_function_test COMMAND velox_demo_rpc_function_test)
+
+add_executable(velox_rpc_rate_limiter_test RPCRateLimiterTest.cpp)
+
+target_link_libraries(
+  velox_rpc_rate_limiter_test
+  velox_rpc_rate_limiter
+  GTest::gtest
+  GTest::gtest_main
+)
+
+add_test(NAME velox_rpc_rate_limiter_test COMMAND velox_rpc_rate_limiter_test)
+
+add_executable(velox_rpc_operator_test RPCOperatorTest.cpp Main.cpp)
+
+target_link_libraries(
+  velox_rpc_operator_test
+  velox_demo_rpc_function
+  velox_rpc_plan_node_translator
+  velox_async_rpc_function_registry
+  velox_exec_test_lib
+  GTest::gtest
+  Folly::folly
+)
+
+add_test(NAME velox_rpc_operator_test COMMAND velox_rpc_operator_test)

--- a/velox/exec/rpc/tests/DemoRPCFunction.cpp
+++ b/velox/exec/rpc/tests/DemoRPCFunction.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/rpc/tests/DemoRPCFunction.h"
+
+namespace facebook::velox::exec::rpc {
+
+void DemoAsyncRPCFunction::initialize(
+    const core::QueryConfig& /*queryConfig*/,
+    const std::vector<TypePtr>& /*inputTypes*/,
+    const std::vector<VectorPtr>& /*constantInputs*/) {
+  // Create and cache the mock client during initialization.
+  client_ = std::make_shared<MockRPCClient>(
+      std::chrono::milliseconds(1), // minimal latency
+      0.0); // no errors
+}
+
+std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+DemoAsyncRPCFunction::dispatchPerRow(
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args) {
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>> results;
+
+  if (args.empty()) {
+    return results;
+  }
+
+  auto* promptVector = args[0]->as<SimpleVector<StringView>>();
+  if (!promptVector) {
+    return results;
+  }
+
+  rows.applyToSelected([&](vector_size_t row) {
+    if (promptVector->isNullAt(row)) {
+      // Null input → immediate error response.
+      results.emplace_back(
+          row,
+          folly::makeSemiFuture<RPCResponse>(RPCResponse{
+              .rowId = 0,
+              .result = "",
+              .metadata = {},
+              .error = "null_input"}));
+      return;
+    }
+
+    // Build RPCRequest for MockRPCClient (test utility still uses payload).
+    RPCRequest request;
+    request.payload = promptVector->valueAt(row).str();
+
+    results.emplace_back(row, client_->call(request));
+  });
+
+  return results;
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+DemoAsyncRPCFunction::signatures() {
+  // 1-argument form: demo_rpc(prompt)
+  auto sig = exec::FunctionSignatureBuilder()
+                 .returnType("varchar")
+                 .argumentType("varchar") // prompt
+                 .build();
+
+  return {std::move(sig)};
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/DemoRPCFunction.h
+++ b/velox/exec/rpc/tests/DemoRPCFunction.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "velox/common/rpc/clients/MockRPCClient.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+
+namespace facebook::velox::exec::rpc {
+
+using velox::rpc::MockRPCClient;
+
+/// Demo AsyncRPCFunction that uses MockRPCClient for end-to-end testing.
+///
+/// Demonstrates the full AsyncRPCFunction lifecycle:
+///   1. initialize() — creates and caches the MockRPCClient
+///   2. dispatchPerRow() — dispatches per-row RPCs via MockRPCClient
+///   3. buildOutput() — uses base class default (error→null, result→varchar)
+///
+/// Returns "Response for: <prompt>" for each input row. No external
+/// dependencies — runs entirely in-process with simulated latency.
+///
+/// SQL usage:
+///   SELECT demo_rpc('hello world')
+///   -- Returns: "Response for: hello world"
+class DemoAsyncRPCFunction : public AsyncRPCFunction {
+ public:
+  /// Initialize the mock client. Called by RPCOperator during init.
+  void initialize(
+      const core::QueryConfig& queryConfig,
+      const std::vector<TypePtr>& inputTypes,
+      const std::vector<VectorPtr>& constantInputs) override;
+
+  std::string name() const override {
+    return "demo_rpc";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  /// Dispatch individual RPCs for each active row via MockRPCClient.
+  /// Null-input rows get an immediate RPCResponse with error="null_input".
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override;
+
+  /// SQL function signatures for registration.
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures();
+
+ private:
+  std::shared_ptr<MockRPCClient> client_;
+};
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/DemoRPCFunctionTest.cpp
+++ b/velox/exec/rpc/tests/DemoRPCFunctionTest.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// DemoRPCFunctionTest - End-to-end test for the reference AsyncRPCFunction
+/// implementation.
+///
+/// Exercises the full lifecycle: initialize -> dispatchPerRow -> buildOutput,
+/// verifying that DemoAsyncRPCFunction correctly follows the AsyncRPCFunction
+/// contract.
+
+#include "velox/exec/rpc/tests/DemoRPCFunction.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::exec::rpc {
+namespace {
+
+class DemoRPCFunctionTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    function_ = std::make_shared<DemoAsyncRPCFunction>();
+    pool_ = memory::memoryManager()->addLeafPool();
+
+    // Follow the lifecycle: initialize() before any dispatch.
+    function_->initialize(core::QueryConfig{{}}, {}, {});
+  }
+
+  std::shared_ptr<DemoAsyncRPCFunction> function_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(DemoRPCFunctionTest, endToEnd) {
+  // Build input vector.
+  std::vector<std::string> prompts = {"hello world", "test prompt"};
+  const auto numRows = static_cast<vector_size_t>(prompts.size());
+  auto input = BaseVector::create<FlatVector<StringView>>(
+      VARCHAR(), numRows, pool_.get());
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    input->set(i, StringView(prompts[i]));
+  }
+
+  // Dispatch per-row and collect futures.
+  SelectivityVector rows(numRows);
+  auto futures = function_->dispatchPerRow(rows, {input});
+  ASSERT_EQ(futures.size(), 2);
+  EXPECT_EQ(futures[0].first, 0);
+  EXPECT_EQ(futures[1].first, 1);
+
+  // Resolve futures.
+  std::vector<RPCResponse> responses;
+  responses.reserve(futures.size());
+  for (auto& [rowIdx, future] : futures) {
+    responses.push_back(std::move(future).get());
+  }
+  ASSERT_EQ(responses.size(), 2);
+  for (const auto& resp : responses) {
+    EXPECT_FALSE(resp.hasError());
+  }
+
+  // Build output vector.
+  auto result = function_->buildOutput(responses, pool_.get());
+  ASSERT_EQ(result->size(), 2);
+  auto* flat = result->asFlatVector<StringView>();
+  EXPECT_FALSE(flat->isNullAt(0));
+  EXPECT_FALSE(flat->isNullAt(1));
+  // MockRPCClient returns "Response for: <payload>".
+  EXPECT_EQ(flat->valueAt(0).str(), "Response for: hello world");
+  EXPECT_EQ(flat->valueAt(1).str(), "Response for: test prompt");
+}
+
+TEST_F(DemoRPCFunctionTest, nullInput) {
+  // Build input with a null row.
+  auto input =
+      BaseVector::create<FlatVector<StringView>>(VARCHAR(), 2, pool_.get());
+  input->set(0, StringView("valid prompt"));
+  input->setNull(1, true);
+
+  SelectivityVector rows(2);
+  auto futures = function_->dispatchPerRow(rows, {input});
+
+  // Both rows produce futures (null row gets immediate error response).
+  ASSERT_EQ(futures.size(), 2);
+  EXPECT_EQ(futures[0].first, 0);
+  EXPECT_EQ(futures[1].first, 1);
+
+  // Non-null row should succeed.
+  auto resp0 = std::move(futures[0].second).get();
+  EXPECT_FALSE(resp0.hasError());
+
+  // Null row should get error="null_input".
+  auto resp1 = std::move(futures[1].second).get();
+  EXPECT_TRUE(resp1.hasError());
+  EXPECT_EQ(resp1.error.value(), "null_input");
+}
+
+TEST_F(DemoRPCFunctionTest, errorResponse) {
+  // Build output from a response with an error.
+  std::vector<RPCResponse> responses;
+  RPCResponse ok;
+  ok.rowId = 0;
+  ok.result = "good result";
+  responses.push_back(std::move(ok));
+
+  RPCResponse err;
+  err.rowId = 1;
+  err.error = "RPC failed";
+  responses.push_back(std::move(err));
+
+  auto result = function_->buildOutput(responses, pool_.get());
+  ASSERT_EQ(result->size(), 2);
+  auto* flat = result->asFlatVector<StringView>();
+  EXPECT_FALSE(flat->isNullAt(0));
+  EXPECT_EQ(flat->valueAt(0).str(), "good result");
+  EXPECT_TRUE(flat->isNullAt(1));
+}
+
+TEST_F(DemoRPCFunctionTest, signatures) {
+  auto sigs = DemoAsyncRPCFunction::signatures();
+  ASSERT_EQ(sigs.size(), 1);
+  // demo_rpc(varchar) -> varchar
+  EXPECT_EQ(sigs[0]->argumentTypes().size(), 1);
+}
+
+TEST_F(DemoRPCFunctionTest, metadata) {
+  EXPECT_EQ(function_->name(), "demo_rpc");
+  EXPECT_EQ(function_->resultType()->kind(), TypeKind::VARCHAR);
+  EXPECT_EQ(function_->tierKey(), "");
+}
+
+} // namespace
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/Main.cpp
+++ b/velox/exec/rpc/tests/Main.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/memory/Memory.h"
+#include "velox/common/process/ThreadDebugInfo.h"
+
+#include <folly/Unit.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+// This main is needed for some tests on linux.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  // Signal handler required for ThreadDebugInfoTest
+  facebook::velox::process::addDefaultFatalSignalHandler();
+  folly::Init init(&argc, &argv, false);
+  facebook::velox::memory::MemoryManager::initialize({});
+  return RUN_ALL_TESTS();
+}

--- a/velox/exec/rpc/tests/MockRPCClientTest.cpp
+++ b/velox/exec/rpc/tests/MockRPCClientTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// MockRPCClientTest - Tests the mock RPC backend.
+///
+/// TESTS:
+/// - basicCallAndError: Single call succeeds; error preserves rowId
+/// - batchCallAndError: Batch call returns correct count; errors preserve
+/// rowIds
+
+#include "velox/common/rpc/clients/MockRPCClient.h"
+
+#include <folly/futures/Future.h>
+#include <gtest/gtest.h>
+
+namespace facebook::velox::rpc {
+namespace {
+
+class MockRPCClientTest : public testing::Test {};
+
+TEST_F(MockRPCClientTest, basicCallAndError) {
+  // Success path
+  MockRPCClient client(std::chrono::milliseconds(1), 0.0);
+
+  RPCRequest request;
+  request.rowId = 42;
+  request.payload = "What is the capital of France?";
+  request.options[std::string(rpc::keys::kModel)] = "test-model";
+
+  auto response = client.call(request).get();
+
+  EXPECT_FALSE(response.hasError());
+  EXPECT_FALSE(response.result.empty());
+  EXPECT_EQ(response.rowId, 42);
+  EXPECT_EQ(client.callCount(), 1);
+
+  // Error path: rowId must be preserved
+  MockRPCClient errorClient(std::chrono::milliseconds(1), 1.0);
+
+  RPCRequest errorRequest;
+  errorRequest.rowId = 12345;
+  errorRequest.payload = "Test";
+
+  auto errorResponse = errorClient.call(errorRequest).get();
+
+  EXPECT_TRUE(errorResponse.hasError());
+  EXPECT_EQ(errorResponse.rowId, 12345);
+}
+
+TEST_F(MockRPCClientTest, batchCallAndError) {
+  // Success path
+  MockRPCClient client(std::chrono::milliseconds(1), 0.0);
+
+  std::vector<RPCRequest> requests;
+  for (int i = 0; i < 5; i++) {
+    RPCRequest req;
+    req.rowId = i;
+    req.payload = "Prompt " + std::to_string(i);
+    requests.push_back(std::move(req));
+  }
+
+  auto responses = client.callBatch(requests).get();
+
+  EXPECT_EQ(responses.size(), 5);
+  for (int i = 0; i < 5; i++) {
+    EXPECT_FALSE(responses[i].hasError());
+    EXPECT_EQ(responses[i].rowId, i);
+  }
+  EXPECT_EQ(client.callCount(), 5);
+
+  // Error path: rowIds must be preserved
+  MockRPCClient errorClient(std::chrono::milliseconds(1), 1.0);
+
+  std::vector<RPCRequest> errorRequests;
+  for (int i = 0; i < 5; i++) {
+    RPCRequest req;
+    req.rowId = 100 + i;
+    req.payload = "Test " + std::to_string(i);
+    errorRequests.push_back(std::move(req));
+  }
+
+  auto errorResponses = errorClient.callBatch(errorRequests).get();
+
+  EXPECT_EQ(errorResponses.size(), 5);
+  for (int i = 0; i < 5; i++) {
+    EXPECT_TRUE(errorResponses[i].hasError());
+    EXPECT_EQ(errorResponses[i].rowId, 100 + i);
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::rpc

--- a/velox/exec/rpc/tests/RPCNodeTest.cpp
+++ b/velox/exec/rpc/tests/RPCNodeTest.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// RPCNodeTest - Tests plan node creation and AsyncRPCFunction behavior.
+///
+/// TESTS:
+/// - rpcNodeCreation: RPCNode can be created with correct fields
+/// - rpcNodeWithBatchMode: Batch mode configuration works
+/// - functionDispatchPerRow: AsyncRPCFunction.dispatchPerRow() works
+/// - functionBuildOutput: AsyncRPCFunction.buildOutput() works
+/// - planNodeToString: toString() includes configuration info
+/// - planNodeSingleSource: Plan node has exactly one source
+
+#include "velox/core/PlanNode.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/common/rpc/clients/MockRPCClient.h"
+#include "velox/expression/rpc/AsyncRPCFunction.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::exec::rpc {
+
+using velox::rpc::MockRPCClient;
+
+namespace {
+
+/// Mock implementation of AsyncRPCFunction for testing.
+class MockAsyncRPCFunction : public AsyncRPCFunction {
+ public:
+  explicit MockAsyncRPCFunction(std::shared_ptr<MockRPCClient> client)
+      : client_(std::move(client)) {}
+
+  std::string name() const override {
+    return "mock_rpc_function";
+  }
+
+  TypePtr resultType() const override {
+    return VARCHAR();
+  }
+
+  std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+  dispatchPerRow(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) override {
+    std::vector<std::pair<vector_size_t, folly::SemiFuture<RPCResponse>>>
+        results;
+
+    if (args.empty()) {
+      return results;
+    }
+
+    auto* promptVector = args[0]->as<SimpleVector<StringView>>();
+    if (!promptVector) {
+      return results;
+    }
+
+    rows.applyToSelected([&](vector_size_t row) {
+      if (promptVector->isNullAt(row)) {
+        results.emplace_back(
+            row,
+            folly::makeSemiFuture<RPCResponse>(RPCResponse{
+                .rowId = static_cast<int64_t>(row),
+                .result = "",
+                .metadata = {},
+                .error = "null_input"}));
+        return;
+      }
+      RPCRequest request;
+      request.payload = promptVector->valueAt(row).str();
+      results.emplace_back(row, client_->call(request));
+    });
+
+    return results;
+  }
+
+ private:
+  std::shared_ptr<MockRPCClient> client_;
+};
+
+class RPCNodeTest : public testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    client_ =
+        std::make_shared<MockRPCClient>(std::chrono::milliseconds(10), 0.0);
+    function_ = std::make_shared<MockAsyncRPCFunction>(client_);
+    pool_ = memory::memoryManager()->addLeafPool();
+  }
+
+  std::shared_ptr<MockRPCClient> client_;
+  std::shared_ptr<MockAsyncRPCFunction> function_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(RPCNodeTest, rpcNodeCreation) {
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-1",
+      nullptr,
+      "mock_rpc_function",
+      VARCHAR(),
+      "response",
+      ROW({"response"}, {VARCHAR()}),
+      std::vector<std::string>{},
+      std::vector<TypePtr>{},
+      std::vector<VectorPtr>{});
+
+  EXPECT_EQ(rpcNode->id(), "rpc-1");
+  EXPECT_EQ(rpcNode->name(), "RPC");
+  EXPECT_EQ(rpcNode->functionName(), "mock_rpc_function");
+  EXPECT_EQ(rpcNode->outputColumn(), "response");
+  EXPECT_EQ(rpcNode->streamingMode(), rpc::RPCStreamingMode::kPerRow);
+  EXPECT_EQ(rpcNode->dispatchBatchSize(), 0);
+}
+
+TEST_F(RPCNodeTest, rpcNodeWithBatchMode) {
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-2",
+      nullptr,
+      "mock_rpc_function",
+      VARCHAR(),
+      "result",
+      ROW({"result"}, {VARCHAR()}),
+      std::vector<std::string>{},
+      std::vector<TypePtr>{},
+      std::vector<VectorPtr>{},
+      rpc::RPCStreamingMode::kBatch,
+      100);
+
+  EXPECT_EQ(rpcNode->streamingMode(), rpc::RPCStreamingMode::kBatch);
+  EXPECT_EQ(rpcNode->dispatchBatchSize(), 100);
+}
+
+TEST_F(RPCNodeTest, functionDispatchPerRow) {
+  std::vector<std::string> prompts = {
+      "What is 2+2?",
+      "What is the capital of France?",
+      "Explain quantum computing."};
+
+  const auto numPrompts = static_cast<vector_size_t>(prompts.size());
+  auto promptVector = BaseVector::create<FlatVector<StringView>>(
+      VARCHAR(), numPrompts, pool_.get());
+  for (vector_size_t i = 0; i < numPrompts; ++i) {
+    promptVector->set(i, StringView(prompts[i]));
+  }
+
+  std::vector<VectorPtr> args = {promptVector};
+  SelectivityVector rows(numPrompts);
+
+  auto futures = function_->dispatchPerRow(rows, args);
+
+  // Extract row indices and verify ordering.
+  std::vector<vector_size_t> rowIndices;
+  rowIndices.reserve(futures.size());
+  for (const auto& [idx, _] : futures) {
+    rowIndices.push_back(idx);
+  }
+  EXPECT_THAT(rowIndices, testing::ElementsAre(0, 1, 2));
+
+  // Resolve futures and verify responses.
+  for (auto& [rowIdx, future] : futures) {
+    auto response = std::move(future).get();
+    EXPECT_FALSE(response.hasError());
+    EXPECT_FALSE(response.result.empty());
+  }
+}
+
+TEST_F(RPCNodeTest, functionBuildOutput) {
+  std::vector<RPCResponse> responses;
+  for (int i = 0; i < 3; ++i) {
+    RPCResponse resp;
+    resp.rowId = i;
+    resp.result = "Response for prompt " + std::to_string(i);
+    responses.push_back(std::move(resp));
+  }
+
+  auto result = function_->buildOutput(responses, pool_.get());
+
+  EXPECT_EQ(result->size(), 3);
+  EXPECT_EQ(result->type()->kind(), TypeKind::VARCHAR);
+
+  auto* flatResult = result->asFlatVector<StringView>();
+  EXPECT_EQ(flatResult->valueAt(0).str(), "Response for prompt 0");
+  EXPECT_EQ(flatResult->valueAt(1).str(), "Response for prompt 1");
+  EXPECT_EQ(flatResult->valueAt(2).str(), "Response for prompt 2");
+}
+
+TEST_F(RPCNodeTest, planNodeToString) {
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-1",
+      nullptr,
+      "mock_rpc_function",
+      VARCHAR(),
+      "response",
+      ROW({"response"}, {VARCHAR()}),
+      std::vector<std::string>{},
+      std::vector<TypePtr>{},
+      std::vector<VectorPtr>{});
+
+  std::string str = rpcNode->toString(/*detailed=*/true);
+
+  EXPECT_TRUE(str.find("RPC") != std::string::npos);
+  EXPECT_TRUE(str.find("mock_rpc_function") != std::string::npos);
+}
+
+TEST_F(RPCNodeTest, planNodeSingleSource) {
+  auto rpcNode = std::make_shared<core::RPCNode>(
+      "rpc-1",
+      nullptr,
+      "mock_rpc_function",
+      VARCHAR(),
+      "response",
+      ROW({"response"}, {VARCHAR()}),
+      std::vector<std::string>{},
+      std::vector<TypePtr>{},
+      std::vector<VectorPtr>{});
+
+  ASSERT_EQ(rpcNode->sources().size(), 1);
+  EXPECT_EQ(rpcNode->source().get(), nullptr);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/RPCOperatorTest.cpp
+++ b/velox/exec/rpc/tests/RPCOperatorTest.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// RPCOperatorTest - End-to-end task-level test for RPCOperator.
+///
+/// Runs a full Velox Task/Driver pipeline: Values → RPCNode → output.
+/// Verifies that RPCPlanNodeTranslator, RPCOperator, RPCState, and
+/// AsyncRPCFunction wire together correctly through the execution engine.
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/rpc/RPCPlanNodeTranslator.h"
+#include "velox/exec/rpc/RPCRateLimiter.h"
+#include "velox/exec/rpc/tests/DemoRPCFunction.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
+
+namespace facebook::velox::exec::rpc {
+
+using namespace facebook::velox::exec::test;
+
+class RPCOperatorTest : public OperatorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    OperatorTestBase::SetUpTestCase();
+    registerRPCPlanNodeTranslator();
+    AsyncRPCFunctionRegistry::registerFunction(
+        "demo_rpc", []() { return std::make_shared<DemoAsyncRPCFunction>(); });
+  }
+
+  static void TearDownTestCase() {
+    OperatorTestBase::TearDownTestCase();
+    // Reset MemoryManager to shut down SharedArbitrator executor threads.
+    // Without this, TSAN reports a non-zero exit because the executor
+    // threads are still running at process exit.
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void TearDown() override {
+    RPCRateLimiter::testingResetAllState();
+    OperatorTestBase::TearDown();
+  }
+
+  /// Build an RPCNode on top of a source plan node.
+  /// argumentColumnNames specifies which source columns are RPC arguments.
+  core::PlanNodePtr makeRPCNode(
+      const core::PlanNodePtr& source,
+      const std::vector<std::string>& argumentColumnNames) {
+    auto sourceType = source->outputType();
+
+    std::vector<std::string> argCols;
+    std::vector<TypePtr> argTypes;
+    std::vector<VectorPtr> constantInputs;
+    for (const auto& colName : argumentColumnNames) {
+      argCols.push_back(colName);
+      argTypes.push_back(sourceType->findChild(colName));
+      constantInputs.push_back(nullptr); // Variable, not constant.
+    }
+
+    // Output type = all source columns + RPC result column.
+    auto outputNames = sourceType->names();
+    auto outputTypes = sourceType->children();
+    outputNames.emplace_back("__rpc_result");
+    outputTypes.push_back(VARCHAR());
+    auto outputType = ROW(std::move(outputNames), std::move(outputTypes));
+
+    return std::make_shared<core::RPCNode>(
+        "rpc-0",
+        source,
+        "demo_rpc",
+        VARCHAR(),
+        "__rpc_result",
+        outputType,
+        argCols,
+        argTypes,
+        constantInputs);
+  }
+};
+
+/// Runs Values(3 rows) → RPCNode → verifies passthrough + RPC result.
+TEST_F(RPCOperatorTest, basicPerRow) {
+  auto input = makeRowVector(
+      {"prompt"},
+      {makeFlatVector<StringView>(
+          {"hello world", "test prompt", "third row"})});
+
+  auto plan = makeRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 3);
+  ASSERT_EQ(result->type()->size(), 2); // prompt + __rpc_result
+
+  // Rows may arrive out of order (async dispatch). Collect and sort to verify.
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+
+  std::map<std::string, std::string> rows;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    rows[prompts->valueAt(i).str()] = results->valueAt(i).str();
+  }
+
+  EXPECT_EQ(rows["hello world"], "Response for: hello world");
+  EXPECT_EQ(rows["test prompt"], "Response for: test prompt");
+  EXPECT_EQ(rows["third row"], "Response for: third row");
+}
+
+/// Null input rows should produce null in the RPC result column.
+TEST_F(RPCOperatorTest, nullInput) {
+  auto promptVector =
+      makeNullableFlatVector<StringView>({"valid prompt", std::nullopt});
+  auto input = makeRowVector({"prompt"}, {promptVector});
+
+  auto plan = makeRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 2);
+
+  auto* prompts = result->childAt(0)->asFlatVector<StringView>();
+  auto* results = result->childAt(1)->asFlatVector<StringView>();
+
+  // Find which row is the valid one vs the null one.
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    if (prompts->isNullAt(i)) {
+      // Null input row should produce null result.
+      EXPECT_TRUE(results->isNullAt(i));
+    } else {
+      EXPECT_EQ(prompts->valueAt(i).str(), "valid prompt");
+      EXPECT_FALSE(results->isNullAt(i));
+      EXPECT_EQ(results->valueAt(i).str(), "Response for: valid prompt");
+    }
+  }
+}
+
+/// Multiple source columns — verifies all passthrough columns are preserved.
+TEST_F(RPCOperatorTest, multipleColumns) {
+  auto input = makeRowVector(
+      {"id", "prompt", "extra"},
+      {makeFlatVector<int64_t>({100, 200}),
+       makeFlatVector<StringView>({"question one", "question two"}),
+       makeFlatVector<double>({1.5, 2.5})});
+
+  // Only "prompt" is an RPC argument; "id" and "extra" are passthrough.
+  auto plan = makeRPCNode(PlanBuilder().values({input}).planNode(), {"prompt"});
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  ASSERT_EQ(result->size(), 2);
+  ASSERT_EQ(result->type()->size(), 4); // id, prompt, extra, __rpc_result
+
+  // Rows may arrive out of order. Index by prompt to verify.
+  auto* prompts = result->childAt(1)->asFlatVector<StringView>();
+  auto* ids = result->childAt(0)->asFlatVector<int64_t>();
+  auto* extras = result->childAt(2)->asFlatVector<double>();
+  auto* results = result->childAt(3)->asFlatVector<StringView>();
+
+  std::map<std::string, vector_size_t> rowIndex;
+  for (vector_size_t i = 0; i < result->size(); ++i) {
+    rowIndex[prompts->valueAt(i).str()] = i;
+  }
+
+  auto i1 = rowIndex["question one"];
+  EXPECT_EQ(ids->valueAt(i1), 100);
+  EXPECT_EQ(extras->valueAt(i1), 1.5);
+  EXPECT_EQ(results->valueAt(i1).str(), "Response for: question one");
+
+  auto i2 = rowIndex["question two"];
+  EXPECT_EQ(ids->valueAt(i2), 200);
+  EXPECT_EQ(extras->valueAt(i2), 2.5);
+  EXPECT_EQ(results->valueAt(i2).str(), "Response for: question two");
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/RPCRateLimiterTest.cpp
+++ b/velox/exec/rpc/tests/RPCRateLimiterTest.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// RPCRateLimiterTest - Tests for the per-tier RPC rate limiter.
+///
+/// RPCRateLimiter provides per-tier concurrency limits with FIFO waiter
+/// notification and RAII token-based slot management.
+///
+/// Tests cover:
+/// - acquireAndRelease: Token acquire increments, destruction decrements.
+/// - backpressureWhenAtLimit: checkBackpressure returns future at limit.
+/// - backpressureReliefOnRelease: Waiter notified when token released.
+/// - fifoWaiterNotification: Multiple waiters notified in FIFO order.
+/// - perTierIsolation: Different tiers have independent limits.
+/// - perTierMaxPending: setMaxPending overrides global default.
+/// - defaultMaxPending: setDefaultMaxPending affects tiers without override.
+/// - tokenMoveSemantics: Move constructor/assignment transfer ownership.
+/// - testingResetAllState: Reset clears all tiers and restores defaults.
+
+#include "velox/exec/rpc/RPCRateLimiter.h"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace facebook::velox::exec::rpc {
+namespace {
+
+class RPCRateLimiterTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    RPCRateLimiter::testingResetAllState();
+  }
+
+  void TearDown() override {
+    RPCRateLimiter::testingResetAllState();
+  }
+};
+
+TEST_F(RPCRateLimiterTest, acquireAndRelease) {
+  const std::string tier = "test.tier";
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+
+  {
+    auto token = RPCRateLimiter::acquire(tier);
+    EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 1);
+  }
+  // Token destroyed — count should be back to 0.
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+}
+
+TEST_F(RPCRateLimiterTest, multipleAcquires) {
+  const std::string tier = "test.tier";
+
+  auto token1 = RPCRateLimiter::acquire(tier);
+  auto token2 = RPCRateLimiter::acquire(tier);
+  auto token3 = RPCRateLimiter::acquire(tier);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 3);
+}
+
+TEST_F(RPCRateLimiterTest, backpressureWhenAtLimit) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setMaxPending(tier, 2);
+
+  auto token1 = RPCRateLimiter::acquire(tier);
+  // 1 pending, limit 2 — no backpressure.
+  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
+
+  auto token2 = RPCRateLimiter::acquire(tier);
+  // 2 pending, limit 2 — at limit, should get backpressure.
+  auto future = RPCRateLimiter::checkBackpressure(tier);
+  EXPECT_TRUE(future.has_value());
+}
+
+TEST_F(RPCRateLimiterTest, backpressureReliefOnRelease) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setMaxPending(tier, 1);
+
+  auto token1 = RPCRateLimiter::acquire(tier);
+
+  // At limit — should block.
+  auto future = RPCRateLimiter::checkBackpressure(tier);
+  ASSERT_TRUE(future.has_value());
+  EXPECT_FALSE(future->isReady());
+
+  // Release the token — waiter should be notified.
+  token1 = RPCRateLimiter::Token();
+  EXPECT_TRUE(future->isReady());
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+}
+
+TEST_F(RPCRateLimiterTest, fifoWaiterNotification) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setMaxPending(tier, 1);
+
+  auto token = RPCRateLimiter::acquire(tier);
+
+  // Two waiters enqueue while at limit.
+  auto future1 = RPCRateLimiter::checkBackpressure(tier);
+  auto future2 = RPCRateLimiter::checkBackpressure(tier);
+  ASSERT_TRUE(future1.has_value());
+  ASSERT_TRUE(future2.has_value());
+
+  // Release token — only first waiter should be notified (FIFO).
+  token = RPCRateLimiter::Token();
+  EXPECT_TRUE(future1->isReady());
+  EXPECT_FALSE(future2->isReady());
+
+  // Acquire and release again — second waiter should be notified.
+  {
+    auto token2 = RPCRateLimiter::acquire(tier);
+  }
+  EXPECT_TRUE(future2->isReady());
+}
+
+TEST_F(RPCRateLimiterTest, perTierIsolation) {
+  const std::string tier1 = "tier.one";
+  const std::string tier2 = "tier.two";
+  RPCRateLimiter::setMaxPending(tier1, 1);
+  RPCRateLimiter::setMaxPending(tier2, 1);
+
+  auto tokenA = RPCRateLimiter::acquire(tier1);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier1), 1);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier2), 0);
+
+  // tier1 at limit, tier2 not.
+  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier1).has_value());
+  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier2).has_value());
+}
+
+TEST_F(RPCRateLimiterTest, perTierMaxPending) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setDefaultMaxPending(10);
+  RPCRateLimiter::setMaxPending(tier, 2);
+
+  auto token1 = RPCRateLimiter::acquire(tier);
+  auto token2 = RPCRateLimiter::acquire(tier);
+
+  // Per-tier limit of 2 applies, not global default of 10.
+  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier).has_value());
+}
+
+TEST_F(RPCRateLimiterTest, defaultMaxPending) {
+  RPCRateLimiter::setDefaultMaxPending(2);
+  const std::string tier = "test.default.tier";
+
+  auto token1 = RPCRateLimiter::acquire(tier);
+  EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
+
+  auto token2 = RPCRateLimiter::acquire(tier);
+  // Global default of 2 reached.
+  EXPECT_TRUE(RPCRateLimiter::checkBackpressure(tier).has_value());
+}
+
+TEST_F(RPCRateLimiterTest, tokenMoveConstructor) {
+  const std::string tier = "test.tier";
+
+  auto token1 = RPCRateLimiter::acquire(tier);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 1);
+
+  // Move construct — ownership transfers, count stays 1.
+  auto token2 = std::move(token1);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 1);
+
+  // Destroy moved-from token — no effect.
+  // (token1 is already moved-from, but let it go out of scope naturally)
+}
+
+TEST_F(RPCRateLimiterTest, tokenMoveAssignment) {
+  const std::string tier1 = "tier.one";
+  const std::string tier2 = "tier.two";
+
+  auto token1 = RPCRateLimiter::acquire(tier1);
+  auto token2 = RPCRateLimiter::acquire(tier2);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier1), 1);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier2), 1);
+
+  // Move-assign token2 into token1 — old token1 (tier1) released.
+  token1 = std::move(token2);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier1), 0);
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier2), 1);
+}
+
+TEST_F(RPCRateLimiterTest, testingResetAllState) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setDefaultMaxPending(5);
+  RPCRateLimiter::setMaxPending(tier, 3);
+  auto token = RPCRateLimiter::acquire(tier);
+
+  // Move the token out so it doesn't decrement during reset.
+  // (In practice, testingResetAllState clears the tiers map,
+  // so the token's destructor will create a new empty tier state.)
+
+  RPCRateLimiter::testingResetAllState();
+
+  // Default restored to 20.
+  EXPECT_EQ(RPCRateLimiter::defaultMaxPending(), 20);
+  // Tier state cleared — pending count is 0 for a fresh tier.
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 0);
+}
+
+TEST_F(RPCRateLimiterTest, noBackpressureBelowLimit) {
+  const std::string tier = "test.tier";
+  RPCRateLimiter::setMaxPending(tier, 5);
+
+  std::vector<RPCRateLimiter::Token> tokens;
+  for (int i = 0; i < 4; ++i) {
+    tokens.push_back(RPCRateLimiter::acquire(tier));
+    EXPECT_FALSE(RPCRateLimiter::checkBackpressure(tier).has_value());
+  }
+  EXPECT_EQ(RPCRateLimiter::pendingCount(tier), 4);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::rpc

--- a/velox/exec/rpc/tests/RPCStateTest.cpp
+++ b/velox/exec/rpc/tests/RPCStateTest.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// RPCStateTest - Tests for the RPCState shared state coordination.
+///
+/// RPCState coordinates between the operator's driver thread and async RPC
+/// completion callbacks using a mutex-protected state object.
+///
+/// Tests cover both PER_ROW and BATCH streaming modes:
+///
+/// PER_ROW tests:
+/// - basicAddAndClaim: Add pending row, fulfill, claim via tryClaimOrWait
+/// - claimOrWaitReturnsFinished: After noMoreInput + all claimed
+/// - claimOrWaitMustWait: When no rows ready, returns kMustWait with future
+/// - pendingRowCount: Tracks pending count correctly
+///
+/// BATCH tests:
+/// - basicAddAndPollBatch: Add pending batch, fulfill, poll
+/// - pollBatchOrWaitFinished: After noMoreInput + all polled
+/// - pollBatchOrWaitMustWait: When no batch ready, returns kMustWait
+/// - batchErrorHandling: Exception in batch future handled gracefully
+/// - batchRowLocationsCarriedThrough: Row locations carried from pending to
+///   ready batch
+///
+/// Common tests:
+/// - noMoreInputAndIsFinished: Lifecycle signals
+/// - inputBatchStorageAndRelease: Batch-reference input storage and release
+/// - backpressure: isUnderBackpressure when pending >= max
+/// - drainReadyRows: Batched drain of multiple ready rows
+
+#include "velox/exec/rpc/RPCState.h"
+
+#include <folly/futures/Promise.h>
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <set>
+#include <thread>
+
+namespace facebook::velox::exec::rpc {
+namespace {
+
+class RPCStateTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    state_ = std::make_shared<RPCState>();
+  }
+
+  /// Polls a condition with short waits until it becomes true or timeout.
+  static void waitFor(
+      const std::function<bool()>& condition,
+      std::chrono::milliseconds timeout = std::chrono::milliseconds(5000)) {
+    auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!condition()) {
+      ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+          << "Timed out waiting for condition";
+      /* sleep override */
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }
+
+  std::shared_ptr<RPCState> state_;
+};
+
+// ========== PER_ROW mode tests ==========
+
+TEST_F(RPCStateTest, basicAddAndClaim) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  auto [promise, future] = folly::makePromiseContract<RPCResponse>();
+
+  state_->addPendingRow(
+      state_, 42, RPCState::RowLocation{0, 0}, std::move(future));
+  EXPECT_EQ(state_->numPendingRows(), 1);
+
+  // Fulfill the promise
+  RPCResponse response;
+  response.rowId = 42;
+  response.result = "test result";
+  promise.setValue(std::move(response));
+
+  // Wait for async callback to move response into readyRows_
+  waitFor([&]() { return state_->numPendingRows() == 0; });
+
+  // Now claim
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyRow> claimedRow;
+  auto result = state_->tryClaimOrWait(&waitFuture, &claimedRow);
+
+  ASSERT_EQ(result, RPCState::ClaimResult::kClaimed);
+  ASSERT_TRUE(claimedRow.has_value());
+  EXPECT_EQ(claimedRow->rowId, 42);
+  EXPECT_EQ(claimedRow->response.result, "test result");
+}
+
+TEST_F(RPCStateTest, addAndClaimDirect) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  auto [promise, future] = folly::makePromiseContract<RPCResponse>();
+
+  state_->addPendingRow(
+      state_, 42, RPCState::RowLocation{0, 0}, std::move(future));
+
+  // Fulfill the promise
+  RPCResponse response;
+  response.rowId = 42;
+  response.result = "test result";
+  promise.setValue(std::move(response));
+
+  // Wait for async callback to move response into readyRows_
+  waitFor([&]() { return state_->numPendingRows() == 0; });
+
+  // Now claim
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyRow> claimedRow;
+  auto result = state_->tryClaimOrWait(&waitFuture, &claimedRow);
+
+  ASSERT_EQ(result, RPCState::ClaimResult::kClaimed);
+  ASSERT_TRUE(claimedRow.has_value());
+  EXPECT_EQ(claimedRow->rowId, 42);
+  EXPECT_EQ(claimedRow->response.result, "test result");
+  EXPECT_FALSE(claimedRow->response.hasError());
+}
+
+TEST_F(RPCStateTest, claimOrWaitReturnsFinished) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  // No rows, signal noMoreInput
+  state_->setNoMoreInput();
+
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyRow> claimedRow;
+  auto result = state_->tryClaimOrWait(&waitFuture, &claimedRow);
+
+  EXPECT_EQ(result, RPCState::ClaimResult::kFinished);
+}
+
+TEST_F(RPCStateTest, claimOrWaitMustWait) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  // Add a pending row that hasn't completed yet
+  auto [promise, future] = folly::makePromiseContract<RPCResponse>();
+  state_->addPendingRow(
+      state_, 1, RPCState::RowLocation{0, 0}, std::move(future));
+
+  // Try to claim — should return kMustWait because row isn't ready
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyRow> claimedRow;
+  auto result = state_->tryClaimOrWait(&waitFuture, &claimedRow);
+
+  EXPECT_EQ(result, RPCState::ClaimResult::kMustWait);
+  EXPECT_FALSE(claimedRow.has_value());
+
+  // Fulfill to clean up
+  RPCResponse response;
+  response.rowId = 1;
+  response.result = "done";
+  promise.setValue(std::move(response));
+}
+
+TEST_F(RPCStateTest, pendingRowCount) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  EXPECT_EQ(state_->numPendingRows(), 0);
+
+  auto [promise1, future1] = folly::makePromiseContract<RPCResponse>();
+  auto [promise2, future2] = folly::makePromiseContract<RPCResponse>();
+
+  state_->addPendingRow(
+      state_, 1, RPCState::RowLocation{0, 0}, std::move(future1));
+  EXPECT_EQ(state_->numPendingRows(), 1);
+
+  state_->addPendingRow(
+      state_, 2, RPCState::RowLocation{0, 1}, std::move(future2));
+  EXPECT_EQ(state_->numPendingRows(), 2);
+
+  // Fulfill first
+  RPCResponse r1;
+  r1.rowId = 1;
+  r1.result = "r1";
+  promise1.setValue(std::move(r1));
+
+  waitFor([&]() { return state_->numPendingRows() == 1; });
+  EXPECT_EQ(state_->numPendingRows(), 1);
+
+  // Fulfill second
+  RPCResponse r2;
+  r2.rowId = 2;
+  r2.result = "r2";
+  promise2.setValue(std::move(r2));
+
+  waitFor([&]() { return state_->numPendingRows() == 0; });
+  EXPECT_EQ(state_->numPendingRows(), 0);
+}
+
+// ========== BATCH mode tests ==========
+
+TEST_F(RPCStateTest, basicAddAndPollBatch) {
+  state_->setStreamingMode(RPCStreamingMode::kBatch);
+
+  auto [promise, future] =
+      folly::makePromiseContract<std::vector<RPCResponse>>();
+
+  state_->addPendingBatch(state_, std::move(future), {});
+
+  // Fulfill the promise
+  std::vector<RPCResponse> responses;
+  RPCResponse batchResponse;
+  batchResponse.rowId = 1;
+  batchResponse.result = "test";
+  responses.push_back(std::move(batchResponse));
+  promise.setValue(std::move(responses));
+
+  // Wait for async callback and poll
+  waitFor([&]() {
+    ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+    std::optional<RPCState::ReadyBatch> readyBatch;
+    auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
+    if (result == RPCState::BatchPollResult::kGotBatch) {
+      // Verify row locations are empty (we passed empty).
+      EXPECT_TRUE(readyBatch->rowLocations.empty());
+      return true;
+    }
+    return false;
+  });
+}
+
+TEST_F(RPCStateTest, pollBatchOrWaitFinished) {
+  state_->setStreamingMode(RPCStreamingMode::kBatch);
+
+  // No batches, signal noMoreInput
+  state_->setNoMoreInput();
+
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyBatch> readyBatch;
+  auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
+
+  EXPECT_EQ(result, RPCState::BatchPollResult::kFinished);
+}
+
+TEST_F(RPCStateTest, pollBatchOrWaitMustWait) {
+  state_->setStreamingMode(RPCStreamingMode::kBatch);
+
+  // Add a pending batch that hasn't completed yet
+  auto [promise, future] =
+      folly::makePromiseContract<std::vector<RPCResponse>>();
+  state_->addPendingBatch(state_, std::move(future), {});
+
+  // Try to poll — should return kMustWait
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyBatch> readyBatch;
+  auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
+
+  EXPECT_EQ(result, RPCState::BatchPollResult::kMustWait);
+  EXPECT_FALSE(readyBatch.has_value());
+
+  // Fulfill to clean up
+  promise.setValue(std::vector<RPCResponse>{});
+}
+
+TEST_F(RPCStateTest, batchErrorHandling) {
+  state_->setStreamingMode(RPCStreamingMode::kBatch);
+
+  auto [promise, future] =
+      folly::makePromiseContract<std::vector<RPCResponse>>();
+
+  state_->addPendingBatch(state_, std::move(future), {});
+
+  // Set an exception
+  promise.setException(std::runtime_error("RPC batch failed"));
+
+  // Wait for async callback and poll
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyBatch> readyBatch;
+
+  waitFor([&]() {
+    auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
+    return result == RPCState::BatchPollResult::kGotBatch;
+  });
+
+  ASSERT_TRUE(readyBatch.has_value());
+  ASSERT_TRUE(readyBatch->error.has_value());
+  EXPECT_TRUE(readyBatch->error->find("RPC batch failed") != std::string::npos);
+  EXPECT_TRUE(readyBatch->responses.empty());
+}
+
+// ========== Common tests ==========
+
+TEST_F(RPCStateTest, noMoreInputAndIsFinished) {
+  EXPECT_FALSE(state_->isFinished());
+
+  state_->setNoMoreInput();
+  EXPECT_TRUE(state_->isFinished());
+}
+
+TEST_F(RPCStateTest, isFinishedWithPendingRows) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  auto [promise, future] = folly::makePromiseContract<RPCResponse>();
+  state_->addPendingRow(
+      state_, 1, RPCState::RowLocation{0, 0}, std::move(future));
+
+  state_->setNoMoreInput();
+
+  // Not finished while rows are pending
+  EXPECT_FALSE(state_->isFinished());
+
+  // Fulfill and claim
+  RPCResponse response;
+  response.rowId = 1;
+  response.result = "done";
+  promise.setValue(std::move(response));
+
+  waitFor([&]() { return state_->numPendingRows() == 0; });
+
+  // Claim the ready row
+  ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+  std::optional<RPCState::ReadyRow> claimedRow;
+  state_->tryClaimOrWait(&waitFuture, &claimedRow);
+
+  // Now finished (noMoreInput + no pending + no ready)
+  EXPECT_TRUE(state_->isFinished());
+}
+
+TEST_F(RPCStateTest, inputBatchStorageAndRelease) {
+  // Store two input batches.
+  std::vector<VectorPtr> columns1; // Empty but valid for testing
+  std::vector<VectorPtr> columns2;
+
+  auto batchIdx1 = state_->storeInputBatch(std::move(columns1), 3);
+  auto batchIdx2 = state_->storeInputBatch(std::move(columns2), 2);
+
+  EXPECT_EQ(batchIdx1, 0);
+  EXPECT_EQ(batchIdx2, 1);
+
+  // Verify we can retrieve columns (empty in this test).
+  const auto& cols1 = state_->getInputBatchColumns(batchIdx1);
+  EXPECT_TRUE(cols1.empty());
+
+  const auto& cols2 = state_->getInputBatchColumns(batchIdx2);
+  EXPECT_TRUE(cols2.empty());
+
+  // Release rows incrementally.
+  state_->releaseRows(batchIdx1, 2);
+  // Batch 1 still has 1 active row, columns not released yet.
+  const auto& cols1After = state_->getInputBatchColumns(batchIdx1);
+  // Still accessible (columns empty in this test, but structure is still
+  // valid).
+  (void)cols1After;
+
+  // Release remaining row — batch should be fully released.
+  state_->releaseRows(batchIdx1, 1);
+
+  // Release all rows from batch 2 at once.
+  state_->releaseRows(batchIdx2, 2);
+}
+
+TEST_F(RPCStateTest, batchRowLocationsCarriedThrough) {
+  state_->setStreamingMode(RPCStreamingMode::kBatch);
+
+  auto [promise, future] =
+      folly::makePromiseContract<std::vector<RPCResponse>>();
+
+  // Pass row locations with the batch.
+  std::vector<RPCState::RowLocation> locations = {{0, 5}, {0, 10}, {1, 3}};
+  state_->addPendingBatch(state_, std::move(future), locations);
+
+  // Fulfill the promise.
+  std::vector<RPCResponse> responses;
+  for (int i = 0; i < 3; ++i) {
+    RPCResponse r;
+    r.rowId = i;
+    r.result = "result_" + std::to_string(i);
+    responses.push_back(std::move(r));
+  }
+  promise.setValue(std::move(responses));
+
+  // Poll and verify row locations are carried through.
+  waitFor([&]() {
+    ContinueFuture waitFuture{ContinueFuture::makeEmpty()};
+    std::optional<RPCState::ReadyBatch> readyBatch;
+    auto result = state_->tryPollBatchOrWait(&waitFuture, &readyBatch);
+    if (result == RPCState::BatchPollResult::kGotBatch) {
+      EXPECT_EQ(readyBatch->responses.size(), 3);
+      EXPECT_EQ(readyBatch->rowLocations.size(), 3);
+      EXPECT_EQ(readyBatch->rowLocations[0].batchIndex, 0);
+      EXPECT_EQ(readyBatch->rowLocations[0].rowIndex, 5);
+      EXPECT_EQ(readyBatch->rowLocations[1].batchIndex, 0);
+      EXPECT_EQ(readyBatch->rowLocations[1].rowIndex, 10);
+      EXPECT_EQ(readyBatch->rowLocations[2].batchIndex, 1);
+      EXPECT_EQ(readyBatch->rowLocations[2].rowIndex, 3);
+      return true;
+    }
+    return false;
+  });
+}
+
+TEST_F(RPCStateTest, drainReadyRows) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+
+  // Add 3 pending rows and fulfill them all.
+  std::vector<folly::Promise<RPCResponse>> promises;
+  for (int i = 0; i < 3; ++i) {
+    auto [promise, future] = folly::makePromiseContract<RPCResponse>();
+    state_->addPendingRow(
+        state_,
+        i,
+        RPCState::RowLocation{0, static_cast<vector_size_t>(i)},
+        std::move(future));
+    promises.push_back(std::move(promise));
+  }
+
+  // Fulfill all 3.
+  for (int i = 0; i < 3; ++i) {
+    RPCResponse response;
+    response.rowId = i;
+    response.result = "result_" + std::to_string(i);
+    promises[i].setValue(std::move(response));
+  }
+
+  waitFor([&]() { return state_->numPendingRows() == 0; });
+
+  // Drain up to 10 rows (should get all 3).
+  std::vector<RPCState::ReadyRow> out;
+  state_->drainReadyRows(out, 10);
+
+  ASSERT_EQ(out.size(), 3);
+  // Verify all responses are present (order may vary due to async).
+  std::set<int64_t> rowIds;
+  for (const auto& row : out) {
+    rowIds.insert(row.rowId);
+  }
+  EXPECT_EQ(rowIds.count(0), 1);
+  EXPECT_EQ(rowIds.count(1), 1);
+  EXPECT_EQ(rowIds.count(2), 1);
+
+  // Drain again — should be empty.
+  std::vector<RPCState::ReadyRow> out2;
+  state_->drainReadyRows(out2, 10);
+  EXPECT_TRUE(out2.empty());
+}
+
+TEST_F(RPCStateTest, backpressure) {
+  state_->setStreamingMode(RPCStreamingMode::kPerRow);
+  state_->setMaxPendingRows(2);
+
+  EXPECT_FALSE(state_->isUnderBackpressure());
+
+  auto [promise1, future1] = folly::makePromiseContract<RPCResponse>();
+  state_->addPendingRow(
+      state_, 1, RPCState::RowLocation{0, 0}, std::move(future1));
+  EXPECT_FALSE(state_->isUnderBackpressure());
+
+  auto [promise2, future2] = folly::makePromiseContract<RPCResponse>();
+  state_->addPendingRow(
+      state_, 2, RPCState::RowLocation{0, 1}, std::move(future2));
+  EXPECT_TRUE(state_->isUnderBackpressure());
+
+  // Fulfill one to relieve backpressure
+  RPCResponse r1;
+  r1.rowId = 1;
+  r1.result = "r1";
+  promise1.setValue(std::move(r1));
+
+  waitFor([&]() { return !state_->isUnderBackpressure(); });
+  EXPECT_FALSE(state_->isUnderBackpressure());
+
+  // Clean up
+  RPCResponse r2;
+  r2.rowId = 2;
+  r2.result = "r2";
+  promise2.setValue(std::move(r2));
+}
+
+} // namespace
+} // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
@@ -69,7 +69,7 @@ AsyncRPCFunctionRegistry::registeredFunctions() {
   return result;
 }
 
-void AsyncRPCFunctionRegistry::clear() {
+void AsyncRPCFunctionRegistry::testingClear() {
   std::lock_guard<std::mutex> lock(mutex());
   factories().clear();
 }

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.h
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.h
@@ -76,8 +76,9 @@ class AsyncRPCFunctionRegistry {
   static std::unordered_set<std::string> registeredFunctions();
 
   /// Clears all registered functions.
-  /// Primarily for testing.
-  static void clear();
+  /// Intended ONLY for unit tests to avoid test contamination.
+  /// WARNING: Do NOT call this in production code.
+  static void testingClear();
 
  private:
   static std::mutex& mutex();


### PR DESCRIPTION
Summary:

Unit tests and reference implementation for the RPC framework.

**DemoAsyncRPCFunction**: Complete reference implementation of
AsyncRPCFunction, demonstrating the full contract: dispatchPerRow()
(per-row dispatch via MockRPCClient with null handling via immediate
error responses), buildOutput() (default VARCHAR FlatVector from base
class), tierKey() (default ""), and signatures(). Use this as a
template when implementing new RPC functions.

**DemoRPCFunctionTest**: End-to-end test exercising the full pipeline:
initialize -> dispatchPerRow -> resolve futures -> buildOutput.
Also covers null input handling (error="null_input"), error response
mapping, signatures, and tierKey() accessor.

**MockRPCClientTest**: Single-call and batch-call interfaces. Verifies
response generation, error injection, and rowId preservation.

**RPCStateTest**: Both streaming modes (PER_ROW and BATCH):
addPendingRow/tryClaimOrWait, addPendingBatch/tryPollBatchOrWait,
drainReadyRows, error propagation, backpressure, noMoreInput/isFinished
lifecycle, input batch storage with reference-counted release.

**RPCNodeTest**: Tests core::RPCNode with name-based API — construction
with function name + result type, accessors, streaming mode config,
dispatchPerRow via mock, buildOutput, and toString().

Reviewed By: Yuhta

Differential Revision: D94996255


