### PR TITLE
feat(rpc): Add RPC function stubs for sidecar discovery [5/8] (OSS) (#16793)

### DIFF
--- a/velox/exec/rpc/tests/DemoRPCFunctionRegistration.cpp
+++ b/velox/exec/rpc/tests/DemoRPCFunctionRegistration.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Static registration of DemoAsyncRPCFunction with the
+/// AsyncRPCFunctionRegistry.
+
+#include "velox/exec/rpc/tests/DemoRPCFunction.h"
+#include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
+
+using namespace facebook::velox::exec::rpc;
+
+VELOX_REGISTER_RPC_FUNCTION(demo_rpc, DemoAsyncRPCFunction);

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.cpp
@@ -16,6 +16,10 @@
 
 #include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
 
+#include <glog/logging.h>
+
+#include "velox/expression/rpc/RPCFunctionStubs.h"
+
 namespace facebook::velox::exec::rpc {
 
 std::mutex& AsyncRPCFunctionRegistry::mutex() {
@@ -29,18 +33,66 @@ AsyncRPCFunctionRegistry::factories() {
   return instance;
 }
 
+std::unordered_map<std::string, AsyncRPCFunctionRegistry::Signatures>&
+AsyncRPCFunctionRegistry::signatureStore() {
+  static std::unordered_map<std::string, Signatures> instance;
+  return instance;
+}
+
 bool AsyncRPCFunctionRegistry::registerFunction(
     const std::string& name,
     Factory factory) {
   std::lock_guard<std::mutex> lock(mutex());
+  return registerEntryLocked(name, std::move(factory), {});
+}
+
+bool AsyncRPCFunctionRegistry::registerFunction(
+    const std::string& name,
+    Factory factory,
+    Signatures signatures) {
+  std::lock_guard<std::mutex> lock(mutex());
+  return registerEntryLocked(name, std::move(factory), std::move(signatures));
+}
+
+bool AsyncRPCFunctionRegistry::registerEntryLocked(
+    const std::string& name,
+    Factory factory,
+    Signatures signatures) {
   auto& registry = factories();
   if (registry.count(name) > 0) {
     return false; // Already registered
   }
-  // Note: Do NOT use LOG() here as this function may be called during static
-  // initialization, before glog is initialized.
   registry[name] = std::move(factory);
+  if (!signatures.empty()) {
+    signatureStore()[name] = std::move(signatures);
+  }
+  // Note: Do NOT use LOG() here as this function is called during static
+  // initialization, before glog is initialized. Using LOG() would cause
+  // a SIGSEGV crash (Static Initialization Order Fiasco).
   return true;
+}
+
+void AsyncRPCFunctionRegistry::registerStubs(
+    const std::string& namespacePrefix) {
+  std::unordered_map<std::string, Signatures> sigsCopy;
+  {
+    std::lock_guard<std::mutex> lock(mutex());
+    for (const auto& [name, sigs] : signatureStore()) {
+      if (!sigs.empty()) {
+        sigsCopy[name] = sigs;
+      }
+    }
+  }
+  LOG(INFO) << "[RPC] registerStubs: namespacePrefix='" << namespacePrefix
+            << "', found " << sigsCopy.size() << " function(s) with signatures";
+  for (auto& [name, sigs] : sigsCopy) {
+    std::string stubName = namespacePrefix + name;
+    LOG(INFO) << "[RPC] registerStubs: registering stub '" << stubName
+              << "' with " << sigs.size() << " signature(s)";
+    registerRPCFunctionStub(stubName, std::move(sigs));
+  }
+  LOG(INFO) << "[RPC] registerStubs: completed, registered " << sigsCopy.size()
+            << " stub(s)";
 }
 
 std::shared_ptr<AsyncRPCFunction> AsyncRPCFunctionRegistry::create(
@@ -72,6 +124,7 @@ AsyncRPCFunctionRegistry::registeredFunctions() {
 void AsyncRPCFunctionRegistry::testingClear() {
   std::lock_guard<std::mutex> lock(mutex());
   factories().clear();
+  signatureStore().clear();
 }
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/AsyncRPCFunctionRegistry.h
+++ b/velox/expression/rpc/AsyncRPCFunctionRegistry.h
@@ -22,30 +22,58 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
-#include "velox/common/base/Exceptions.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/expression/rpc/AsyncRPCFunction.h"
 
 namespace facebook::velox::exec::rpc {
 
 /// Registry for AsyncRPCFunction implementations.
 ///
-/// This registry allows RPC functions to register themselves by name,
-/// enabling RPCOperator to resolve the function at operator init time
-/// (following the VectorFunction pattern where plan nodes reference
-/// functions by name and the execution layer resolves them).
+/// == Why a separate registry (not the VectorFunction registry)? ==
+///
+/// AsyncRPCFunctions execute via RPCOperator, completely outside the
+/// expression evaluation framework. The Velox VectorFunction registry
+/// (vectorFunctionFactories()) is designed for synchronous, expression-level
+/// functions resolved by ExprCompiler with SignatureBinder type matching.
+/// RPC functions differ in several ways:
+///
+///   1. **Execution model**: VectorFunctions run synchronously inside
+///      Expr::eval(). AsyncRPCFunctions run asynchronously via RPCOperator
+///      with futures, rate limiting, and backpressure — not part of the
+///      expression tree at all.
+///
+///   2. **No type resolution needed**: VectorFunctions need SignatureBinder
+///      because the same name can have multiple overloads (e.g., concat for
+///      varchar vs array). RPC functions have fixed signatures — the Java
+///      planner already resolved types before creating the RPCNode.
+///
+///   3. **Factory signature mismatch**: VectorFunctionFactory takes
+///      (name, inputArgs, config) and returns shared_ptr<VectorFunction>.
+///      Our factory returns shared_ptr<AsyncRPCFunction> with no args;
+///      initialization happens separately via initialize().
+///
+///   4. **Stub bridge for discovery**: We register lightweight stubs in the
+///      VectorFunction registry purely for sidecar /v1/functions discovery.
+///      The stubs throw on direct execution — actual execution goes through
+///      RPCNode → RPCOperator → AsyncRPCFunction.
 ///
 /// Usage (in function's .cpp file):
-///   AsyncRPCFunctionRegistry::registerFunction(
-///       "my_function",
-///       []() { return std::make_shared<MyAsyncRPCFunction>(); });
+///   // For a complete example, see velox/exec/rpc/tests/DemoRPCFunction*.
 ///
-/// Resolution (in RPCOperator::initialize()):
+///   #include "velox/expression/rpc/AsyncRPCFunctionRegistry.h"
+///   VELOX_REGISTER_RPC_FUNCTION(my_function, MyAsyncRPCFunction);
+///
+/// Lookup (in RPCOperator::initialize()):
 ///   auto func = AsyncRPCFunctionRegistry::create("my_function");
 class AsyncRPCFunctionRegistry {
  public:
   /// Factory function type that creates an AsyncRPCFunction instance.
   using Factory = std::function<std::shared_ptr<AsyncRPCFunction>()>;
+
+  /// Signature list type for stub registration.
+  using Signatures = std::vector<std::shared_ptr<exec::FunctionSignature>>;
 
   /// Registers an AsyncRPCFunction factory for the given function name.
   /// Thread-safe. Safe to call during static initialization.
@@ -54,6 +82,26 @@ class AsyncRPCFunctionRegistry {
   /// @param factory Function that creates instances of the AsyncRPCFunction
   /// @return true if registration succeeded, false if name already registered
   static bool registerFunction(const std::string& name, Factory factory);
+
+  /// Registers a function factory AND its signatures for stub registration.
+  /// The factory is registered immediately. The signatures are stored and
+  /// registered as stub Velox functions later via registerStubs().
+  /// Thread-safe. Safe to call during static initialization.
+  static bool registerFunction(
+      const std::string& name,
+      Factory factory,
+      Signatures signatures);
+
+  /// Registers stub Velox functions for all functions that provided signatures.
+  /// Must be called during server startup (after config is available).
+  ///
+  /// For each registered function with signatures, registers a stub using
+  /// the given namespace prefix: namespacePrefix + functionName
+  /// e.g., "presto.default.fb_llm_inference"
+  ///
+  /// @param namespacePrefix The catalog.schema with trailing dot (e.g.,
+  /// "presto.default.")
+  static void registerStubs(const std::string& namespacePrefix);
 
   /// Creates an AsyncRPCFunction instance for the given function name.
   /// Thread-safe.
@@ -83,9 +131,20 @@ class AsyncRPCFunctionRegistry {
  private:
   static std::mutex& mutex();
   static std::unordered_map<std::string, Factory>& factories();
+  static std::unordered_map<std::string, Signatures>& signatureStore();
+
+  /// Registers an entry under the lock. Caller must hold mutex().
+  static bool registerEntryLocked(
+      const std::string& name,
+      Factory factory,
+      Signatures signatures);
 };
 
 /// Helper class for static registration of AsyncRPCFunction implementations.
+///
+/// Two-argument form: registers the factory only (for RPCOperator lookup).
+/// Three-argument form: also stores signatures for deferred stub registration
+/// via registerStubs(), enabling automatic sidecar discovery.
 class AsyncRPCFunctionRegistrar {
  public:
   AsyncRPCFunctionRegistrar(
@@ -93,6 +152,50 @@ class AsyncRPCFunctionRegistrar {
       AsyncRPCFunctionRegistry::Factory factory) {
     AsyncRPCFunctionRegistry::registerFunction(name, std::move(factory));
   }
+
+  AsyncRPCFunctionRegistrar(
+      const std::string& name,
+      AsyncRPCFunctionRegistry::Factory factory,
+      AsyncRPCFunctionRegistry::Signatures signatures) {
+    AsyncRPCFunctionRegistry::registerFunction(
+        name, std::move(factory), std::move(signatures));
+  }
 };
+
+/// Convenience macros for registering AsyncRPCFunction implementations.
+/// Place in the function's .cpp file (at namespace scope).
+///
+/// The ClassName must provide:
+///   - A default constructor (or be constructible via std::make_shared)
+///   - A static signatures() method returning
+///     std::vector<std::shared_ptr<exec::FunctionSignature>>
+///
+/// BUCK target must set link_whole = True to prevent linker stripping.
+
+// Internal helper — generates a unique variable name per line.
+#define _VELOX_RPC_REGISTRAR_VAR(name, line) __velox_rpc_reg_##name##_##line
+#define _VELOX_RPC_REGISTRAR_VAR2(name, line) \
+  _VELOX_RPC_REGISTRAR_VAR(name, line)
+
+/// Register an RPC function with default make_shared factory + signatures().
+/// Usage: VELOX_REGISTER_RPC_FUNCTION(my_rpc, MyAsyncRPCFunction);
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+#define VELOX_REGISTER_RPC_FUNCTION(name, ClassName)                           \
+  static ::facebook::velox::exec::rpc::AsyncRPCFunctionRegistrar               \
+  _VELOX_RPC_REGISTRAR_VAR2(name, __LINE__)(                                   \
+      #name,                                                                   \
+      []()                                                                     \
+          -> std::shared_ptr<::facebook::velox::exec::rpc::AsyncRPCFunction> { \
+            return std::make_shared<ClassName>();                              \
+          },                                                                   \
+      ClassName::signatures())
+
+/// Register an RPC function with a custom factory and explicit signatures.
+/// Usage: VELOX_REGISTER_RPC_FUNCTION_CUSTOM_FACTORY(
+///            my_rpc, myFactoryFn, MyClass::signatures());
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+#define VELOX_REGISTER_RPC_FUNCTION_CUSTOM_FACTORY(name, factory, sigs) \
+  static ::facebook::velox::exec::rpc::AsyncRPCFunctionRegistrar        \
+  _VELOX_RPC_REGISTRAR_VAR2(name, __LINE__)(#name, (factory), (sigs))
 
 } // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/CMakeLists.txt
+++ b/velox/expression/rpc/CMakeLists.txt
@@ -21,6 +21,23 @@ velox_link_libraries(
   INTERFACE velox_rpc_types velox_core velox_type velox_vector Folly::folly
 )
 
+velox_add_library(velox_rpc_function_stubs RPCFunctionStubs.cpp)
+
+velox_link_libraries(
+  velox_rpc_function_stubs
+  velox_expression_functions
+  velox_expression
+  glog::glog
+)
+
 velox_add_library(velox_async_rpc_function_registry AsyncRPCFunctionRegistry.cpp)
 
-velox_link_libraries(velox_async_rpc_function_registry velox_async_rpc_function velox_common_base)
+velox_link_libraries(
+  velox_async_rpc_function_registry
+  velox_async_rpc_function
+  velox_rpc_function_stubs
+  velox_common_base
+  velox_exception
+  velox_expression_functions
+  glog::glog
+)

--- a/velox/expression/rpc/RPCFunctionStubs.cpp
+++ b/velox/expression/rpc/RPCFunctionStubs.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/rpc/RPCFunctionStubs.h"
+
+#include <glog/logging.h>
+
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::exec::rpc {
+namespace {
+
+/// A stub VectorFunction that throws on execution.
+/// This exists only to register the function's signature with the Velox
+/// function registry so the sidecar can discover it via /v1/functions.
+/// The Java planner rewrites RPC function calls to RPCNode before they
+/// reach the executor, so this stub should never actually be invoked.
+class RPCStubFunction : public exec::VectorFunction {
+ public:
+  explicit RPCStubFunction(const std::string& name) : name_(name) {}
+
+  void apply(
+      const SelectivityVector& /*rows*/,
+      std::vector<VectorPtr>& /*args*/,
+      const TypePtr& /*outputType*/,
+      exec::EvalCtx& /*context*/,
+      VectorPtr& /*result*/) const override {
+    VELOX_FAIL(
+        "RPC function '{}' should not be called directly. "
+        "The query plan should have been rewritten by RpcFunctionOptimizer "
+        "to use RPCNode/RPCOperator.",
+        name_);
+  }
+
+ private:
+  std::string name_;
+};
+
+} // namespace
+
+void registerRPCFunctionStub(
+    const std::string& name,
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures) {
+  LOG(INFO) << "[RPC] registerRPCFunctionStub: registering Velox stub '" << name
+            << "' with " << signatures.size() << " signature(s)";
+  exec::registerStatefulVectorFunction(
+      name,
+      std::move(signatures),
+      [name](
+          const std::string& /*name*/,
+          const std::vector<exec::VectorFunctionArg>& /*inputArgs*/,
+          const core::QueryConfig& /*config*/) {
+        return std::make_shared<RPCStubFunction>(name);
+      });
+  LOG(INFO) << "[RPC] registerRPCFunctionStub: successfully registered '"
+            << name << "' in Velox function registry";
+}
+
+} // namespace facebook::velox::exec::rpc

--- a/velox/expression/rpc/RPCFunctionStubs.h
+++ b/velox/expression/rpc/RPCFunctionStubs.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "velox/expression/FunctionSignature.h"
+
+namespace facebook::velox::exec::rpc {
+
+/// Registers a stub Velox vector function for an RPC function.
+/// The stub has the correct signature but throws on direct execution.
+/// This makes the function discoverable via the /v1/functions sidecar endpoint.
+///
+/// @param name Full 3-part Velox name (e.g., "native.rpc.fb_llm_inference")
+/// @param signatures Function signatures (arg types, return type)
+void registerRPCFunctionStub(
+    const std::string& name,
+    std::vector<std::shared_ptr<exec::FunctionSignature>> signatures);
+
+} // namespace facebook::velox::exec::rpc


### PR DESCRIPTION
Summary:

Stub registration and sidecar discovery support.

**RPCFunctionStubs**: Registers lightweight stub VectorFunctions with
correct signatures that throw on direct execution. Enables the sidecar
to report RPC functions to the Java coordinator via GET /v1/functions.

**AsyncRPCFunctionRegistry additions**:
- registerStubs(namespacePrefix): Registers stubs under the Presto
  namespace (e.g., presto.default.fb_llm_inference)
- Deferred stub registration: signatures stored at static init time,
  stubs registered later when the namespace prefix is known

**AsyncRPCFunctionRegistrar**: Static registration helper. Two-arg form
registers factory only; three-arg form also stores signatures for
sidecar discovery.

Reviewed By: Yuhta

Differential Revision: D94996268


