### PR TITLE
refactor: Refactor iotaData initialization to use IIFE

### DIFF
--- a/velox/common/memory/RawVector.cpp
+++ b/velox/common/memory/RawVector.cpp
@@ -15,32 +15,32 @@
  */
 
 #include "velox/common/memory/RawVector.h"
-#include <folly/Preprocessor.h>
+
 #include <numeric>
 
 namespace facebook::velox {
 
 namespace {
-raw_vector<int32_t> iotaData;
 
-bool initializeIota() {
-  iotaData.resize(1'000'000);
-  iotaData.resize(iotaData.capacity());
-  std::iota(iotaData.begin(), iotaData.end(), 0);
-  return true;
-}
+const raw_vector<int32_t> kIotaData = [] {
+  raw_vector<int32_t> v;
+  v.resize(1'000'000);
+  v.resize(v.capacity());
+  std::iota(v.begin(), v.end(), 0);
+  return v;
+}();
+
 } // namespace
 
 const int32_t*
 iota(int32_t size, raw_vector<int32_t>& storage, int32_t offset) {
-  if (iotaData.size() < offset + size) {
+  if (kIotaData.size() < offset + size) {
     storage.resize(size);
     std::iota(storage.begin(), storage.end(), offset);
     return storage.data();
   }
-  return iotaData.data() + offset;
-}
 
-static bool FB_ANONYMOUS_VARIABLE(g_iotaConstants) = initializeIota();
+  return kIotaData.data() + offset;
+}
 
 } // namespace facebook::velox

--- a/velox/common/memory/RawVector.h
+++ b/velox/common/memory/RawVector.h
@@ -282,12 +282,11 @@ class raw_vector {
   int64_t capacity_{0};
 };
 
-// Returns a pointer to 'size' int32_t's with consecutive values
-// starting at 0. There are at least kPadding / sizeof(int32_t) values
-// past 'size', so that it is safe to access the returned pointer at maximum
-// SIMD width. Typically returns preallocated memory but if this is
-// not large enough,resizes and initializes 'storage' to the requested
-// size and returns storage.data().
+/// Returns a pointer to 'size' int32_t's with consecutive values starting at
+/// 'offset'. There are at least kPadding / sizeof(int32_t) values past 'size',
+/// so that it is safe to access the returned pointer at maximum SIMD width.
+/// Returns pre-allocated memory if it is large enough, otherwise resizes and
+/// initializes 'storage' to the requested size and 'returns storage.data()'.
 const int32_t*
 iota(int32_t size, raw_vector<int32_t>& storage, int32_t offset = 0);
 


### PR DESCRIPTION
Replace the two-phase initialization pattern (default-constructed
global + initializeIota() helper + FB_ANONYMOUS_VARIABLE trigger)
with an immediately-invoked lambda expression (IIFE), as recommended
by C++ Core Guidelines ES.28 [1].

This enables declaring iotaData as const (renamed to kIotaData),
making immutability explicit and preventing accidental modification.
It also removes the folly/Preprocessor.h dependency, the helper
function, and the throwaway bool variable.

Also update the iota() comment in RawVector.h to reflect the offset
parameter and simplify wording.

[1] https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Res-lambda-init