### PR TITLE
test: Add PrintTo for test param structs to improve gtest output (#16796)

### DIFF
--- a/velox/common/memory/tests/RawVectorTest.cpp
+++ b/velox/common/memory/tests/RawVectorTest.cpp
@@ -26,6 +26,10 @@ struct TestParam {
   bool useMemoryPool{false};
 };
 
+inline void PrintTo(const TestParam& param, std::ostream* os) {
+  *os << (param.useMemoryPool ? "withPool" : "noPool");
+}
+
 class RawVectorTest : public testing::WithParamInterface<TestParam>,
                       public testing::Test {
  protected:

--- a/velox/dwio/dwrf/test/ConfigTests.cpp
+++ b/velox/dwio/dwrf/test/ConfigTests.cpp
@@ -78,6 +78,10 @@ struct ConfigTestParams {
   std::vector<uint32_t> expectedCols{}; // do we expect the spec to be valid
 };
 
+inline void PrintTo(const ConfigTestParams& param, std::ostream* os) {
+  *os << "cols:" << param.inputCols;
+}
+
 TEST(ConfigTests, writerOptionsDefaultConfig) {
   WriterOptions options;
   const facebook::velox::config::ConfigBase base({});

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -311,6 +311,10 @@ struct ReaderTestParams {
   }
 };
 
+inline void PrintTo(const ReaderTestParams& param, std::ostream* os) {
+  *os << param.toString();
+}
+
 class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
                          public ColumnReaderTestBase {
  protected:
@@ -370,6 +374,12 @@ struct NonSelectiveReaderTestParams {
   }
 };
 
+inline void PrintTo(
+    const NonSelectiveReaderTestParams& param,
+    std::ostream* os) {
+  *os << param.toString();
+}
+
 // For test cases where SelectiveColumnReader does not have support.
 class TestNonSelectiveColumnReader
     : public testing::TestWithParam<NonSelectiveReaderTestParams>,
@@ -422,6 +432,10 @@ struct SchemaMismatchTestParam {
     return out.str();
   }
 };
+
+inline void PrintTo(const SchemaMismatchTestParam& param, std::ostream* os) {
+  *os << param.toString();
+}
 
 class SchemaMismatchTest : public TestWithParam<SchemaMismatchTestParam>,
                            public ColumnReaderTestBase {

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -50,6 +50,11 @@ struct TestParam {
   int32_t numBuilders{1};
 };
 
+inline void PrintTo(const TestParam& param, std::ostream* os) {
+  *os << fmt::format(
+      "probers:{}_builders:{}", param.numProbers, param.numBuilders);
+}
+
 class HashJoinBridgeTest : public testing::Test,
                            public testing::WithParamInterface<TestParam> {
  public:

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -40,6 +40,10 @@ struct TestParam {
       : outputKind(_outputKind), serdeKind(_serdeKind) {}
 };
 
+inline void PrintTo(const TestParam& param, std::ostream* os) {
+  *os << fmt::format("{}_{}", param.outputKind, param.serdeKind);
+}
+
 class OutputBufferManagerTest : public testing::Test {
  protected:
   OutputBufferManagerTest() : serdeKind_("Presto") {

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -79,6 +79,10 @@ struct TestParam {
   }
 };
 
+inline void PrintTo(const TestParam& param, std::ostream* os) {
+  *os << param.toString();
+}
+
 class SpillTest : public ::testing::TestWithParam<uint32_t>,
                   public facebook::velox::test::VectorTestBase {
  public:

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -119,6 +119,10 @@ struct TestParam {
   }
 };
 
+inline void PrintTo(const TestParam& param, std::ostream* os) {
+  *os << param.toString();
+}
+
 struct TestParamsBuilder {
   std::vector<TestParam> getTestParams() {
     std::vector<TestParam> params;

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -37,6 +37,13 @@ struct TestParam {
   TypeKind comparisonType;
 };
 
+inline void PrintTo(const TestParam& param, std::ostream* os) {
+  *os << fmt::format(
+      "{}_{}",
+      TypeKindName::toName(param.valueType),
+      TypeKindName::toName(param.comparisonType));
+}
+
 const std::vector<TypeKind> kSupportedTypes = {
     TypeKind::BOOLEAN,
     TypeKind::TINYINT,


### PR DESCRIPTION
Summary:

Add `PrintTo` overloads for parameterized test structs that were missing
them. Without these, gtest falls back to dumping raw bytes in diagnostic
output (e.g. `# GetParam() = 16-byte object <01-00 00-00 ...>`), making
CI logs hard to read.

Structs updated:
- SpillerTest::TestParam (delegates to toString())
- HashJoinBridgeTest::TestParam (probers:N_builders:M)
- OutputBufferManagerTest::TestParam (kind_serde)
- SpillTest::TestParam (delegates to toString())
- MinMaxByAggregationTest::TestParam (valueType_comparisonType)
- RawVectorTest::TestParam (withPool/noPool)
- TestColumnReader: ReaderTestParams, NonSelectiveReaderTestParams,
  SchemaMismatchTestParam (all delegate to toString())
- ConfigTests::ConfigTestParams (cols:inputCols)

Differential Revision: D96759255
