### PR TITLE
fix(dwrf): Fix dangling StringView keys in FlatMapColumnWriter (#16800)

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -1507,6 +1507,93 @@ void testFlatMapWriter(
   }
 }
 
+// Regression test for dangling StringView keys in FlatMapColumnWriter.
+//
+// FlatMapColumnWriter stores StringView keys in an F14NodeMap (valueWriters_).
+// StringView is non-owning — it holds a pointer to external string data.
+// When the input batch is released between writes, the stored StringViews
+// become dangling. On a subsequent write that triggers F14 rehash,
+// F14Table::rehashImpl recomputes hashes from the dangling pointers and
+// hits assertion: hp.second == srcChunk->tag(srcI).
+//
+// This test reproduces the crash by:
+// 1. Writing a batch with long string keys (>12 chars → external pointer)
+// 2. Corrupting the backing buffer to simulate freed memory
+// 3. Writing a second batch with enough new keys to trigger F14 rehash
+//
+// With the bug: crashes with SIGABRT in F14Table::rehashImpl.
+// With the fix: passes (keys are properly owned).
+TEST_F(ColumnWriterTest, TestFlatMapDanglingStringViewKeyOnRehash) {
+  const auto rowType = CppToType<Row<Map<StringView, int32_t>>>::create();
+  const auto writerSchema = TypeWithId::create(rowType);
+  const auto writerDataTypeWithId = writerSchema->childAt(0);
+
+  const auto config = std::make_shared<Config>();
+  config->set(Config::FLATTEN_MAP, true);
+  config->set(Config::MAP_FLAT_COLS, {writerDataTypeWithId->column()});
+  config->set(Config::MAP_FLAT_DISABLE_DICT_ENCODING, true);
+  config->set<uint32_t>(Config::MAP_FLAT_MAX_KEYS, 100);
+
+  WriterContext context{config, memory::memoryManager()->addRootPool()};
+  context.initBuffer();
+  const auto writer = BaseColumnWriter::create(context, *writerDataTypeWithId);
+
+  using b = MapBuilder<StringView, int32_t>;
+
+  // Batch 1: 10 rows, each with one key-value pair.
+  // Keys are >12 chars so StringView uses an external data pointer
+  // (not inline storage). We control the backing buffer so we can
+  // corrupt it after writing to reliably simulate use-after-free.
+  constexpr int kBatch1Size = 10;
+  constexpr int kKeySlotSize = 32;
+  auto keyDataBuf = std::make_unique<char[]>(kBatch1Size * kKeySlotSize);
+
+  {
+    b::rows rows;
+    for (int i = 0; i < kBatch1Size; ++i) {
+      auto key = fmt::format("very_long_string_key_{:04d}", i);
+      ASSERT_GT(key.size(), 12u);
+      memcpy(keyDataBuf.get() + i * kKeySlotSize, key.data(), key.size());
+      StringView sv(
+          keyDataBuf.get() + i * kKeySlotSize,
+          static_cast<int32_t>(key.size()));
+      rows.emplace_back(b::row{b::pair{sv, static_cast<int32_t>(i)}});
+    }
+    auto batch = b::create(*pool_, rows);
+    writer->write(batch, common::Ranges::of(0, batch->size()));
+  }
+
+  // Corrupt batch 1's key data to simulate the input vector's string
+  // buffer being freed and reused. The writer's F14NodeMap still holds
+  // StringView keys pointing into this buffer.
+  memset(keyDataBuf.get(), 0xFF, kBatch1Size * kKeySlotSize);
+
+  // Batch 2: 15 rows with new keys. Combined with batch 1's 10 keys,
+  // the total of 25 unique keys exceeds the F14NodeMap's initial
+  // capacity, triggering rehashImpl. During rehash, F14 recomputes
+  // hashes for batch 1's stored StringView keys — which now point to
+  // corrupted memory — producing different hashes and hitting the
+  // assertion: hp.second == srcChunk->tag(srcI).
+  {
+    std::vector<std::string> keyStrings;
+    keyStrings.reserve(15);
+    for (int i = 0; i < 15; ++i) {
+      keyStrings.push_back(fmt::format("different_long_key_b2_{:04d}", i));
+    }
+    b::rows rows;
+    for (int i = 0; i < 15; ++i) {
+      rows.emplace_back(
+          b::row{b::pair{
+              StringView(keyStrings[i]),
+              static_cast<int32_t>(i + kBatch1Size)}});
+    }
+    auto batch = b::create(*pool_, rows);
+    writer->write(batch, common::Ranges::of(0, batch->size()));
+  }
+
+  writer->createIndexEntry();
+}
+
 TEST_F(ColumnWriterTest, TestFlatMapKeyNotInAllBatches) {
   VectorMaker maker(pool_.get());
   // Test the case where not all keys appear in all batches.

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -61,6 +61,9 @@ FlatMapColumnWriter<K>::FlatMapColumnWriter(
       valueType_{*type.childAt(1)},
       maxKeyCount_{context_.getConfig(Config::MAP_FLAT_MAX_KEYS)},
       collectMapStats_{context.getConfig(Config::MAP_STATISTICS)} {
+  if constexpr (std::is_same_v<KeyType, StringView>) {
+    stringKeys_.reserve(maxKeyCount_);
+  }
   auto options = StatisticsBuilder::optionsFromConfig(context.getConfigs());
   keyFileStatsBuilder_ =
       std::unique_ptr<typename TypeInfo<K>::StatisticsBuilder>(
@@ -174,6 +177,7 @@ void FlatMapColumnWriter<K>::reset() {
   BaseColumnWriter::reset();
   clearNodes();
   valueWriters_.clear();
+  stringKeys_.clear();
   rowsInStrides_.clear();
   rowsInCurrentStride_ = 0;
   totalRows_ = 0;
@@ -210,6 +214,16 @@ ValueWriter& FlatMapColumnWriter<K>::getValueWriter(
   }
 
   auto keyInfo = getKeyInfo(key);
+
+  // For non-inline StringView keys (>12 chars), store an owned copy of the
+  // string data to prevent dangling pointers when input batches are released
+  // between writes. Inline StringViews are self-contained and safe as-is.
+  if constexpr (std::is_same_v<KeyType, StringView>) {
+    if (!key.isInline()) {
+      stringKeys_.emplace_back(key.data(), key.size());
+      key = StringView(stringKeys_.back());
+    }
+  }
 
   it = valueWriters_
            .emplace(


### PR DESCRIPTION
Summary:

FlatMapColumnWriter stores StringView keys in an F14NodeMap. StringView
is non-owning — for strings >12 chars it stores a pointer to external
data. When input batches are released between writes, these pointers
dangle. During F14Table::rehashImpl, recomputing hashes from freed
memory produces wrong values, triggering assertion
`hp.second == srcChunk->tag(srcI)` (SIGABRT).

Fix: store owned copies of string key data in the existing
`stringKeys_` vector (pre-reserved to `maxKeyCount_` to prevent
reallocation) before inserting into the F14NodeMap. This ensures
StringView keys always point to stable memory.

Includes a regression test that reproduces the crash by:
1. Writing a batch with long string keys (>12 chars)
2. Corrupting the key memory buffer
3. Writing a second batch with enough new keys to trigger rehash

Differential Revision: D96812892


