### PR TITLE
fix: Remove VELOX_ENABLE_BACKWARD_COMPATIBILITY from Writer::close()

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2181,11 +2181,6 @@ class ExchangeNode : public PlanNode {
   ExchangeNode(const PlanNodeId& id, RowTypePtr type, std::string serdeKind)
       : PlanNode(id), outputType_(type), serdeKind_(std::move(serdeKind)) {}
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  ExchangeNode(const PlanNodeId& id, RowTypePtr type, VectorSerde::Kind kind)
-      : ExchangeNode(id, std::move(type), VectorSerde::kindName(kind)) {}
-#endif
-
   class Builder {
    public:
     Builder() = default;
@@ -2210,13 +2205,6 @@ class ExchangeNode : public PlanNode {
       serdeKind_ = std::move(serdeKind);
       return *this;
     }
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-    Builder& serdeKind(VectorSerde::Kind kind) {
-      serdeKind_ = VectorSerde::kindName(kind);
-      return *this;
-    }
-#endif
 
     std::shared_ptr<ExchangeNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "ExchangeNode id is not set");
@@ -2282,21 +2270,6 @@ class MergeExchangeNode : public ExchangeNode {
       const std::vector<SortOrder>& sortingOrders,
       std::string serdeKind);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  MergeExchangeNode(
-      const PlanNodeId& id,
-      const RowTypePtr& type,
-      const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
-      const std::vector<SortOrder>& sortingOrders,
-      VectorSerde::Kind kind)
-      : MergeExchangeNode(
-            id,
-            type,
-            sortingKeys,
-            sortingOrders,
-            VectorSerde::kindName(kind)) {}
-#endif
-
   class Builder {
    public:
     Builder() = default;
@@ -2333,13 +2306,6 @@ class MergeExchangeNode : public ExchangeNode {
       serdeKind_ = std::move(serdeKind);
       return *this;
     }
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-    Builder& serdeKind(VectorSerde::Kind kind) {
-      serdeKind_ = VectorSerde::kindName(kind);
-      return *this;
-    }
-#endif
 
     std::shared_ptr<MergeExchangeNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "MergeExchangeNode id is not set");
@@ -2761,29 +2727,6 @@ class PartitionedOutputNode : public PlanNode {
       std::string serdeKind,
       PlanNodePtr source);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PartitionedOutputNode(
-      const PlanNodeId& id,
-      Kind kind,
-      const std::vector<TypedExprPtr>& keys,
-      int numPartitions,
-      bool replicateNullsAndAny,
-      PartitionFunctionSpecPtr partitionFunctionSpec,
-      RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
-      PlanNodePtr source)
-      : PartitionedOutputNode(
-            id,
-            kind,
-            keys,
-            numPartitions,
-            replicateNullsAndAny,
-            std::move(partitionFunctionSpec),
-            std::move(outputType),
-            VectorSerde::kindName(serdeKind),
-            std::move(source)) {}
-#endif
-
   static std::shared_ptr<PartitionedOutputNode> broadcast(
       const PlanNodeId& id,
       int numPartitions,
@@ -2791,61 +2734,17 @@ class PartitionedOutputNode : public PlanNode {
       std::string serdeKind,
       PlanNodePtr source);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static std::shared_ptr<PartitionedOutputNode> broadcast(
-      const PlanNodeId& id,
-      int numPartitions,
-      RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
-      PlanNodePtr source) {
-    return broadcast(
-        id,
-        numPartitions,
-        std::move(outputType),
-        VectorSerde::kindName(serdeKind),
-        std::move(source));
-  }
-#endif
-
   static std::shared_ptr<PartitionedOutputNode> arbitrary(
       const PlanNodeId& id,
       RowTypePtr outputType,
       std::string serdeKind,
       PlanNodePtr source);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static std::shared_ptr<PartitionedOutputNode> arbitrary(
-      const PlanNodeId& id,
-      RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
-      PlanNodePtr source) {
-    return arbitrary(
-        id,
-        std::move(outputType),
-        VectorSerde::kindName(serdeKind),
-        std::move(source));
-  }
-#endif
-
   static std::shared_ptr<PartitionedOutputNode> single(
       const PlanNodeId& id,
       RowTypePtr outputType,
       std::string serdeKind,
       PlanNodePtr source);
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static std::shared_ptr<PartitionedOutputNode> single(
-      const PlanNodeId& id,
-      RowTypePtr outputType,
-      VectorSerde::Kind serdeKind,
-      PlanNodePtr source) {
-    return single(
-        id,
-        std::move(outputType),
-        VectorSerde::kindName(serdeKind),
-        std::move(source));
-  }
-#endif
 
   class Builder {
    public:
@@ -2903,13 +2802,6 @@ class PartitionedOutputNode : public PlanNode {
       serdeKind_ = std::move(serdeKind);
       return *this;
     }
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-    Builder& serdeKind(VectorSerde::Kind kind) {
-      serdeKind_ = VectorSerde::kindName(kind);
-      return *this;
-    }
-#endif
 
     Builder& source(PlanNodePtr source) {
       source_ = std::move(source);

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -86,21 +86,12 @@ bool SortingWriter::finish() {
   return true;
 }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-void SortingWriter::close() {
-  VELOX_CHECK(isFinishing());
-  setState(State::kClosed);
-  VELOX_CHECK_NULL(sortBuffer_);
-  outputWriter_->close();
-}
-#else
 std::unique_ptr<FileMetadata> SortingWriter::close() {
   VELOX_CHECK(isFinishing());
   setState(State::kClosed);
   VELOX_CHECK_NULL(sortBuffer_);
   return outputWriter_->close();
 }
-#endif
 
 void SortingWriter::abort() {
   setState(State::kAborted);

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -44,11 +44,7 @@ class SortingWriter : public Writer {
 
   /// Closes the writer. Returns file metadata, or null if no metadata is
   /// available (e.g. for an empty file).
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  void close() override;
-#else
   std::unique_ptr<FileMetadata> close() override;
-#endif
 
   void abort() override;
 

--- a/velox/dwio/common/Writer.h
+++ b/velox/dwio/common/Writer.h
@@ -75,11 +75,7 @@ class Writer {
   /// be null if no metadata is available, such as for an empty data file.
   ///
   /// NOTE: this must be called after the last finish() which returns true.
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  virtual void close() = 0;
-#else
   virtual std::unique_ptr<FileMetadata> close() = 0;
-#endif
 
   /// Aborts the writing by closing the writer and dropping everything.
   /// Data can no longer be written.

--- a/velox/dwio/common/tests/SortingWriterTest.cpp
+++ b/velox/dwio/common/tests/SortingWriterTest.cpp
@@ -43,16 +43,10 @@ class MockWriter : public Writer {
 
   void flush() override {}
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  void close() override {
-    setState(State::kClosed);
-  }
-#else
   std::unique_ptr<FileMetadata> close() override {
     setState(State::kClosed);
     return nullptr;
   }
-#endif
 
   void abort() override {
     setState(State::kAborted);

--- a/velox/dwio/common/tests/WriterTest.cpp
+++ b/velox/dwio/common/tests/WriterTest.cpp
@@ -51,13 +51,9 @@ class MockWriter : public Writer {
 
   void abort() override {}
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  void close() override {}
-#else
   std::unique_ptr<FileMetadata> close() override {
     return nullptr;
   }
-#endif
 };
 
 TEST(WriterTest, stateString) {

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -798,17 +798,6 @@ void Writer::flush() {
   flushInternal(false);
 }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-void Writer::close() {
-  checkRunning();
-  auto exitGuard = folly::makeGuard([this]() {
-    flushPolicy_->onClose();
-    setState(State::kClosed);
-  });
-  flushInternal(true);
-  writerBase_->close();
-}
-#else
 std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
   checkRunning();
   auto exitGuard = folly::makeGuard([this]() {
@@ -819,7 +808,6 @@ std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
   writerBase_->close();
   return std::make_unique<DwrfFileMetadata>();
 }
-#endif
 
 void Writer::abort() {
   checkRunning();

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -90,11 +90,7 @@ class Writer : public dwio::common::Writer {
     return true;
   }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  virtual void close() override;
-#else
   virtual std::unique_ptr<dwio::common::FileMetadata> close() override;
-#endif
 
   virtual void abort() override;
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -552,17 +552,6 @@ void Writer::newRowGroup(int32_t numRows) {
   PARQUET_THROW_NOT_OK(arrowContext_->writer->newRowGroup(numRows));
 }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-void Writer::close() {
-  flush();
-  if (arrowContext_->writer) {
-    PARQUET_THROW_NOT_OK(arrowContext_->writer->close());
-    arrowContext_->writer.reset();
-  }
-  PARQUET_THROW_NOT_OK(stream_->Close());
-  arrowContext_->stagingChunks.clear();
-}
-#else
 std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
   flush();
 
@@ -580,7 +569,6 @@ std::unique_ptr<dwio::common::FileMetadata> Writer::close() {
 
   return parquetFileMetadata;
 }
-#endif
 
 void Writer::abort() {
   stream_->abort();

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -186,18 +186,11 @@ class Writer : public dwio::common::Writer {
     return true;
   }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  // Closes 'this'. After close, data can no longer be added and the completed
-  // Parquet file is flushed into 'sink' provided at construction. 'sink' stays
-  // live until destruction of 'this'.
-  void close() override;
-#else
   // Closes 'this'. After close, data can no longer be added and the completed
   // Parquet file is flushed into 'sink' provided at construction. 'sink' stays
   // live until destruction of 'this'. Returns file metadata, or null if no
   // metadata is available (e.g. for an empty file).
   std::unique_ptr<dwio::common::FileMetadata> close() override;
-#endif
 
   void abort() override;
 

--- a/velox/dwio/text/writer/TextWriter.cpp
+++ b/velox/dwio/text/writer/TextWriter.cpp
@@ -175,16 +175,10 @@ void TextWriter::flush() {
   bufferedWriterSink_->flush();
 }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-void TextWriter::close() {
-  bufferedWriterSink_->close();
-}
-#else
 std::unique_ptr<dwio::common::FileMetadata> TextWriter::close() {
   bufferedWriterSink_->close();
   return std::make_unique<TextFileMetadata>();
 }
-#endif
 
 void TextWriter::abort() {
   bufferedWriterSink_->abort();

--- a/velox/dwio/text/writer/TextWriter.h
+++ b/velox/dwio/text/writer/TextWriter.h
@@ -62,11 +62,7 @@ class TextWriter : public dwio::common::Writer {
     return true;
   }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  void close() override;
-#else
   std::unique_ptr<dwio::common::FileMetadata> close() override;
-#endif
 
   void abort() override;
 

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -324,14 +324,4 @@ std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
     const std::string& kind,
     std::optional<float> minCompressionRatio = std::nullopt);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-inline std::unique_ptr<VectorSerde::Options> getVectorSerdeOptions(
-    common::CompressionKind compressionKind,
-    VectorSerde::Kind kind,
-    std::optional<float> minCompressionRatio = std::nullopt) {
-  return getVectorSerdeOptions(
-      compressionKind, VectorSerde::kindName(kind), minCompressionRatio);
-}
-#endif
-
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -684,12 +684,6 @@ class PlanBuilder {
   /// @param serdekind The kind of seralized data format.
   PlanBuilder& exchange(const RowTypePtr& outputType, std::string serdekind);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& exchange(const RowTypePtr& outputType, VectorSerde::Kind kind) {
-    return exchange(outputType, VectorSerde::kindName(kind));
-  }
-#endif
-
   /// Add a MergeExchangeNode using specified ORDER BY clauses.
   ///
   /// For example,
@@ -702,15 +696,6 @@ class PlanBuilder {
       const RowTypePtr& outputType,
       const std::vector<std::string>& keys,
       std::string serdekind);
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& mergeExchange(
-      const RowTypePtr& outputType,
-      const std::vector<std::string>& keys,
-      VectorSerde::Kind kind) {
-    return mergeExchange(outputType, keys, VectorSerde::kindName(kind));
-  }
-#endif
 
   /// Add a ProjectNode using specified SQL expressions.
   ///
@@ -1203,39 +1188,12 @@ class PlanBuilder {
       const std::vector<std::string>& outputLayout = {},
       std::string serdeKind = "Presto");
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& partitionedOutput(
-      const std::vector<std::string>& keys,
-      int numPartitions,
-      bool replicateNullsAndAny,
-      const std::vector<std::string>& outputLayout,
-      VectorSerde::Kind kind) {
-    return partitionedOutput(
-        keys,
-        numPartitions,
-        replicateNullsAndAny,
-        outputLayout,
-        VectorSerde::kindName(kind));
-  }
-#endif
-
   /// Same as above, but assumes 'replicateNullsAndAny' is false.
   PlanBuilder& partitionedOutput(
       const std::vector<std::string>& keys,
       int numPartitions,
       const std::vector<std::string>& outputLayout = {},
       std::string serdeKind = "Presto");
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& partitionedOutput(
-      const std::vector<std::string>& keys,
-      int numPartitions,
-      const std::vector<std::string>& outputLayout,
-      VectorSerde::Kind kind) {
-    return partitionedOutput(
-        keys, numPartitions, outputLayout, VectorSerde::kindName(kind));
-  }
-#endif
 
   /// Same as above, but allows to provide custom partition function.
   PlanBuilder& partitionedOutput(
@@ -1245,24 +1203,6 @@ class PlanBuilder {
       core::PartitionFunctionSpecPtr partitionFunctionSpec,
       const std::vector<std::string>& outputLayout = {},
       std::string serdeKind = "Presto");
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& partitionedOutput(
-      const std::vector<std::string>& keys,
-      int numPartitions,
-      bool replicateNullsAndAny,
-      core::PartitionFunctionSpecPtr partitionFunctionSpec,
-      const std::vector<std::string>& outputLayout,
-      VectorSerde::Kind kind) {
-    return partitionedOutput(
-        keys,
-        numPartitions,
-        replicateNullsAndAny,
-        std::move(partitionFunctionSpec),
-        outputLayout,
-        VectorSerde::kindName(kind));
-  }
-#endif
 
   /// Adds a PartitionedOutputNode to broadcast the input data.
   ///
@@ -1274,28 +1214,10 @@ class PlanBuilder {
       const std::vector<std::string>& outputLayout = {},
       std::string serdeKind = "Presto");
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& partitionedOutputBroadcast(
-      const std::vector<std::string>& outputLayout,
-      VectorSerde::Kind kind) {
-    return partitionedOutputBroadcast(
-        outputLayout, VectorSerde::kindName(kind));
-  }
-#endif
-
   /// Adds a PartitionedOutputNode to put data into arbitrary buffer.
   PlanBuilder& partitionedOutputArbitrary(
       const std::vector<std::string>& outputLayout = {},
       std::string serdeKind = "Presto");
-
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  PlanBuilder& partitionedOutputArbitrary(
-      const std::vector<std::string>& outputLayout,
-      VectorSerde::Kind kind) {
-    return partitionedOutputArbitrary(
-        outputLayout, VectorSerde::kindName(kind));
-  }
-#endif
 
   /// Adds a LocalPartitionNode to hash-partition the input on the specified
   /// keys using exec::HashPartitionFunction. Number of partitions is determined

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -383,38 +383,6 @@ bool isRegisteredNamedVectorSerde(const std::string& kind);
 /// Get the vector serde identified by `serdeName`. Throws if not found.
 VectorSerde* getNamedVectorSerde(const std::string& kind);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-/// Legacy overloads accepting VectorSerde::Kind for backward compatibility.
-inline void registerNamedVectorSerde(
-    VectorSerde::Kind kind,
-    std::unique_ptr<VectorSerde> serdeToRegister) {
-  registerNamedVectorSerde(
-      VectorSerde::kindName(kind), std::move(serdeToRegister));
-}
-
-inline void deregisterNamedVectorSerde(VectorSerde::Kind kind) {
-  deregisterNamedVectorSerde(VectorSerde::kindName(kind));
-}
-
-inline bool isRegisteredNamedVectorSerde(VectorSerde::Kind kind) {
-  return isRegisteredNamedVectorSerde(VectorSerde::kindName(kind));
-}
-
-inline VectorSerde* getNamedVectorSerde(VectorSerde::Kind kind) {
-  return getNamedVectorSerde(VectorSerde::kindName(kind));
-}
-
-/// Allow comparing std::string with VectorSerde::Kind for backward
-/// compatibility (e.g. serdeKind() == VectorSerde::Kind::kCompactRow).
-inline bool operator==(const std::string& lhs, VectorSerde::Kind rhs) {
-  return lhs == VectorSerde::kindName(rhs);
-}
-
-inline bool operator==(VectorSerde::Kind lhs, const std::string& rhs) {
-  return VectorSerde::kindName(lhs) == rhs;
-}
-#endif
-
 class VectorStreamGroup : public StreamArena {
  public:
   /// If `serde` is not specified, fallback to the default registered.


### PR DESCRIPTION
Summary:
Remove the `VELOX_ENABLE_BACKWARD_COMPATIBILITY` preprocessor flag
and `#ifdef` guards from the `Writer::close()` API in the core DWIO
writer classes. This is the first step in migrating all callers to
the new `std::unique_ptr<FileMetadata> close()` return type introduced
in D93449945.

Previously, `Writer::close()` returned `void` when compiled with
`VELOX_ENABLE_BACKWARD_COMPATIBILITY`, and `std::unique_ptr<FileMetadata>`
without it. Every downstream target needed to add the preprocessor flag
to its BUCK file to avoid ODR violations. This diff removes the flag
from the core writer libraries and their immediate test consumers,
making the new API the only API.

**Writer classes updated:**
- `velox::dwio::common::Writer` (base class) - pure virtual declaration
- `velox::dwio::common::SortingWriter` - declaration and implementation
- `velox::dwrf::Writer` (DWRF writer) - declaration and implementation
- `velox::parquet::Writer` (Parquet writer) - declaration and implementation

**Test mocks updated:**
- `velox/dwio/common/tests/WriterTest.cpp`
- `velox/dwio/common/tests/SortingWriterTest.cpp`

Differential Revision: D96770459


