### PR TITLE
refactor(hive): Add pluggable index reader support (#16803)

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -29,7 +29,7 @@ velox_add_library(
   HiveConnectorSplit.cpp
   HiveDataSink.cpp
   HiveDataSource.cpp
-  HiveIndexReader.cpp
+  FileIndexReader.cpp
   HiveIndexSource.cpp
   HivePartitionName.cpp
   PartitionIdGenerator.cpp

--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/connectors/hive/HiveIndexReader.h"
+#include "velox/connectors/hive/FileIndexReader.h"
 
 #include "velox/common/Casts.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
@@ -35,7 +35,7 @@ std::shared_ptr<const HiveConnectorSplit> getSingleSplit(
   VELOX_CHECK_EQ(
       hiveSplits.size(),
       1,
-      "HiveIndexReader currently only supports a single split");
+      "FileIndexReader currently only supports a single split");
   return hiveSplits[0];
 }
 
@@ -81,7 +81,7 @@ void processBetweenBound(
 
 } // namespace
 
-HiveIndexReader::HiveIndexReader(
+FileIndexReader::FileIndexReader(
     const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits,
     const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
     const ConnectorQueryCtx* connectorQueryCtx,
@@ -93,9 +93,9 @@ HiveIndexReader::HiveIndexReader(
     const std::shared_ptr<io::IoStatistics>& ioStatistics,
     const std::shared_ptr<IoStats>& ioStats,
     FileHandleFactory* fileHandleFactory,
-    folly::Executor* ioExecutor)
-    : hiveSplit_{getSingleSplit(hiveSplits)},
-      tableHandle_{hiveTableHandle},
+    folly::Executor* ioExecutor,
+    uint32_t maxRowsPerRequest)
+    : tableHandle_{hiveTableHandle},
       connectorQueryCtx_{connectorQueryCtx},
       hiveConfig_{hiveConfig},
       fileHandleFactory_{fileHandleFactory},
@@ -106,13 +106,15 @@ HiveIndexReader::HiveIndexReader(
       ioExecutor_{ioExecutor},
       pool_{connectorQueryCtx->memoryPool()},
       scanSpec_{scanSpec},
+      indexLookupConditions_{indexLookupConditions},
+      maxRowsPerRequest_{maxRowsPerRequest},
+      hiveSplit_{getSingleSplit(hiveSplits)},
       fileReader_{createFileReader()},
-      indexReader_{createIndexReader()},
-      indexLookupConditions_{indexLookupConditions} {
+      indexReader_{createIndexReader()} {
   parseIndexLookupConditions();
 }
 
-void HiveIndexReader::parseIndexLookupConditions() {
+void FileIndexReader::parseIndexLookupConditions() {
   VELOX_CHECK(
       !indexLookupConditions_.empty(),
       "Index lookup conditions cannot be empty");
@@ -251,7 +253,7 @@ void HiveIndexReader::parseIndexLookupConditions() {
       ROW(std::move(indexColumnNames), std::move(indexColumnTypes));
 }
 
-std::unique_ptr<dwio::common::Reader> HiveIndexReader::createFileReader() {
+std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
   VELOX_CHECK_NOT_NULL(hiveSplit_);
 
   dwio::common::ReaderOptions readerOpts(connectorQueryCtx_->memoryPool());
@@ -286,12 +288,12 @@ std::unique_ptr<dwio::common::Reader> HiveIndexReader::createFileReader() {
 }
 
 std::unique_ptr<dwio::common::IndexReader>
-HiveIndexReader::createIndexReader() {
+FileIndexReader::createIndexReader() {
   VELOX_CHECK_NOT_NULL(fileReader_);
   VELOX_CHECK_EQ(
       hiveSplit_->fileFormat,
       dwio::common::FileFormat::NIMBLE,
-      "HiveIndexReader only supports Nimble file format");
+      "FileIndexReader only supports Nimble file format");
 
   dwio::common::RowReaderOptions rowReaderOpts;
   configureRowReaderOptions(
@@ -305,13 +307,13 @@ HiveIndexReader::createIndexReader() {
       ioExecutor_,
       rowReaderOpts);
   rowReaderOpts.setIndexEnabled(true);
-  // Disable eager first stripe load since HiveIndexReader loads stripes
+  // Disable eager first stripe load since FileIndexReader loads stripes
   // on-demand based on index lookup results.
   rowReaderOpts.setEagerFirstStripeLoad(false);
   return fileReader_->createIndexReader(rowReaderOpts);
 }
 
-void HiveIndexReader::startLookup(
+void FileIndexReader::startLookup(
     const Request& request,
     const Options& options) {
   VELOX_CHECK(
@@ -320,12 +322,16 @@ void HiveIndexReader::startLookup(
   VELOX_CHECK_NOT_NULL(request.input);
   VELOX_CHECK(requestType_->equivalent(*request.input->type()));
 
-  // Build index bounds from request and pass to the index reader.
+  // Use caller-provided maxRowsPerRequest if set, otherwise fall back to
+  // the construction-time default.
+  const auto maxRows = options.maxRowsPerRequest != 0
+      ? options.maxRowsPerRequest
+      : static_cast<vector_size_t>(maxRowsPerRequest_);
   auto indexBounds = buildRequestIndexBounds(request.input);
-  indexReader_->startLookup(indexBounds, options);
+  indexReader_->startLookup(indexBounds, {.maxRowsPerRequest = maxRows});
 }
 
-serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(
+serializer::IndexBounds FileIndexReader::buildRequestIndexBounds(
     const RowVectorPtr& request) {
   VELOX_CHECK_NOT_NULL(request);
   VELOX_CHECK_NOT_NULL(indexBoundType_);
@@ -405,18 +411,24 @@ serializer::IndexBounds HiveIndexReader::buildRequestIndexBounds(
   return bounds;
 }
 
-bool HiveIndexReader::hasNext() const {
+bool FileIndexReader::hasNext() {
   return indexReader_->hasNext();
 }
 
-std::unique_ptr<HiveIndexReader::Result> HiveIndexReader::next(
+std::unique_ptr<FileIndexReader::Result> FileIndexReader::next(
     vector_size_t maxOutputRows) {
   return indexReader_->next(maxOutputRows);
 }
 
-std::string HiveIndexReader::toString() const {
+std::unordered_map<std::string, RuntimeMetric> FileIndexReader::runtimeStats() {
+  // TODO: Populate with format-specific stats in a follow-up.
+  // File-based IO stats are tracked externally via IoStatistics.
+  return {};
+}
+
+std::string FileIndexReader::toString() const {
   return fmt::format(
-      "HiveIndexReader: hiveSplit_{} scanSpec_{} requestType_{} outputType_{}",
+      "FileIndexReader: split={} scanSpec={} requestType={} outputType={}",
       hiveSplit_->toString(),
       scanSpec_->toString(),
       requestType_->toString(),

--- a/velox/connectors/hive/FileIndexReader.h
+++ b/velox/connectors/hive/FileIndexReader.h
@@ -19,6 +19,7 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/IndexReader.h"
 #include "velox/core/PlanNode.h"
 #include "velox/dwio/common/Reader.h"
 #include "velox/serializers/KeyEncoder.h"
@@ -34,8 +35,7 @@ class HiveTableHandle;
 class HiveColumnHandle;
 class HiveConfig;
 
-/// HiveIndexReader handles index lookups for Hive tables with cluster indexes.
-/// It focuses on:
+/// Handles index lookups for Hive tables with cluster indexes. Focuses on:
 /// - Creating index bounds from index lookup conditions
 /// - Delegating actual index lookups to the format-specific IndexReader
 ///
@@ -43,9 +43,9 @@ class HiveConfig;
 /// - Encoding keys into format-specific representations
 /// - Stripe iteration and row range computation
 /// - Data reading and output assembly
-class HiveIndexReader {
+class FileIndexReader : public SplitIndexReader {
  public:
-  HiveIndexReader(
+  FileIndexReader(
       const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
       const ConnectorQueryCtx* connectorQueryCtx,
@@ -57,13 +57,10 @@ class HiveIndexReader {
       const std::shared_ptr<io::IoStatistics>& ioStats,
       const std::shared_ptr<IoStats>& fsStats,
       FileHandleFactory* fileHandleFactory,
-      folly::Executor* ioExecutor);
+      folly::Executor* ioExecutor,
+      uint32_t maxRowsPerRequest = 0);
 
-  virtual ~HiveIndexReader() = default;
-
-  using Request = IndexSource::Request;
-  using Result = IndexSource::Result;
-  using Options = dwio::common::IndexReader::Options;
+  ~FileIndexReader() override = default;
 
   /// Sets the input for index lookup. Each row in 'input' will be converted
   /// to index bounds and passed to the format-specific IndexReader.
@@ -71,11 +68,12 @@ class HiveIndexReader {
   /// @param request The lookup request containing input row vector with lookup
   /// keys.
   /// @param options Options controlling index reader behavior (e.g.,
-  ///        maxRowsPerRequest). Defaults to no limit.
-  void startLookup(const Request& request, const Options& options = {});
+  /// maxRowsPerRequest). Defaults to no limit.
+  void startLookup(const Request& request, const Options& options = {})
+      override;
 
   /// Returns true if there are more results to fetch from the current lookup.
-  bool hasNext() const;
+  bool hasNext() override;
 
   /// Returns the next batch of matching rows for the current input rows.
   /// The result from a single request row is never split across multiple
@@ -84,7 +82,9 @@ class HiveIndexReader {
   /// @param maxOutputRows Maximum number of output rows to return.
   /// @return Result containing matched rows and input hit indices, or nullptr
   /// if no more results.
-  std::unique_ptr<Result> next(vector_size_t maxOutputRows);
+  std::unique_ptr<Result> next(vector_size_t maxOutputRows) override;
+
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats() override;
 
   std::string toString() const;
 
@@ -102,25 +102,28 @@ class HiveIndexReader {
   // Builds IndexBounds from the request row vector.
   serializer::IndexBounds buildRequestIndexBounds(const RowVectorPtr& request);
 
-  std::shared_ptr<const HiveConnectorSplit> hiveSplit_;
   const std::shared_ptr<const HiveTableHandle> tableHandle_;
   const ConnectorQueryCtx* connectorQueryCtx_;
   const std::shared_ptr<const HiveConfig> hiveConfig_;
   FileHandleFactory* const fileHandleFactory_;
   const RowTypePtr requestType_;
   const RowTypePtr outputType_;
-
   const std::shared_ptr<io::IoStatistics> ioStatistics_;
   const std::shared_ptr<IoStats> ioStats_;
   folly::Executor* const ioExecutor_;
   memory::MemoryPool* const pool_;
-
   const std::shared_ptr<common::ScanSpec> scanSpec_;
-  const std::unique_ptr<dwio::common::Reader> fileReader_;
-  const std::unique_ptr<dwio::common::IndexReader> indexReader_;
   // Index lookup conditions (including equal conditions converted from lookup
   // keys).
   const std::vector<core::IndexLookupConditionPtr> indexLookupConditions_;
+  // Maximum output rows per index request batch. 0 means no limit.
+  const uint32_t maxRowsPerRequest_;
+
+  // Split must be initialized before fileReader_/indexReader_ since they
+  // depend on it during construction.
+  std::shared_ptr<const HiveConnectorSplit> hiveSplit_;
+  const std::unique_ptr<dwio::common::Reader> fileReader_;
+  const std::unique_ptr<dwio::common::IndexReader> indexReader_;
 
   // Request column indices for each index lookup condition (for probe side
   // columns). For EqualIndexLookupCondition, stores {valueIndex}. For

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -17,6 +17,7 @@
 
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/time/Timer.h"
+#include "velox/connectors/hive/FileIndexReader.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
 #include "velox/exec/OperatorUtils.h"
@@ -222,19 +223,20 @@ BufferPtr filterIndices(
 }
 } // namespace
 
+/// Iterates over results from a SplitIndexReader and applies HiveIndexSource's
+/// format-agnostic orchestration: remaining filter evaluation and output
+/// projection.
 class HiveLookupIterator : public IndexSource::ResultIterator {
  public:
   HiveLookupIterator(
       std::shared_ptr<HiveIndexSource> indexSource,
-      HiveIndexReader* indexReader,
+      SplitIndexReader* indexReader,
       IndexSource::Request request,
-      vector_size_t maxRowsPerRequest)
+      SplitIndexReader::Options options)
       : indexSource_(std::move(indexSource)),
         indexReader_(indexReader),
         request_(std::move(request)),
-        maxRowsPerRequest_(maxRowsPerRequest) {}
-
-  ~HiveLookupIterator() override = default;
+        options_(options) {}
 
   bool hasNext() override {
     return state_ != State::kEnd;
@@ -247,10 +249,9 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
       return nullptr;
     }
 
-    // Set the request on first call.
+    // Initialize lookup on first call.
     if (state_ == State::kInit) {
-      indexReader_->startLookup(
-          request_, {.maxRowsPerRequest = maxRowsPerRequest_});
+      indexReader_->startLookup(request_, options_);
       setState(State::kRead);
     }
 
@@ -365,9 +366,9 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
 
   const std::shared_ptr<HiveIndexSource> indexSource_;
   // Raw pointer to index reader for lookup operations.
-  HiveIndexReader* const indexReader_;
+  SplitIndexReader* const indexReader_;
   const IndexSource::Request request_;
-  const vector_size_t maxRowsPerRequest_;
+  const SplitIndexReader::Options options_;
 
   State state_{State::kInit};
   // Cached empty result for reuse when no rows pass the remaining filter.
@@ -643,26 +644,60 @@ void HiveIndexSource::init(
 
 void HiveIndexSource::addSplits(
     std::vector<std::shared_ptr<ConnectorSplit>> splits) {
-  VELOX_CHECK_NULL(
-      indexReader_, "addSplits can only be called once for HiveIndexSource");
-  std::vector<std::shared_ptr<const HiveConnectorSplit>> hiveSplits;
-  hiveSplits.reserve(splits.size());
+  VELOX_CHECK(
+      readers_.empty(),
+      "addSplits can only be called once for HiveIndexSource");
+
+  // Group splits by file format.
+  std::unordered_map<
+      dwio::common::FileFormat,
+      std::vector<std::shared_ptr<const HiveConnectorSplit>>>
+      splitsByFormat;
   for (auto& split : splits) {
     auto hiveSplit = checkedPointerCast<const HiveConnectorSplit>(split);
-    VELOX_CHECK_EQ(
-        hiveSplit->fileFormat,
-        dwio::common::FileFormat::NIMBLE,
-        "HiveIndexSource only supports Nimble file format");
-    hiveSplits.push_back(hiveSplit);
+    auto format = hiveSplit->fileFormat;
+    splitsByFormat[format].push_back(std::move(hiveSplit));
   }
-  createHiveIndexReader(std::move(hiveSplits));
+
+  auto* registry = IndexReaderFactoryRegistry::getInstance();
+  for (auto& [format, formatSplits] : splitsByFormat) {
+    const auto* factory = registry->getFactory(format);
+    if (factory != nullptr) {
+      createCustomIndexReader(*factory, std::move(formatSplits));
+    } else {
+      // Fall back to built-in FileIndexReader.
+      VELOX_CHECK_EQ(
+          format,
+          dwio::common::FileFormat::NIMBLE,
+          "No IndexReaderFactory registered for format: {}",
+          dwio::common::toString(format));
+      // Create one reader per split. FileIndexReader currently supports a
+      // single file.
+      for (auto& nimbleSplit : formatSplits) {
+        createFileIndexReader({std::move(nimbleSplit)});
+      }
+    }
+  }
+
+  VELOX_CHECK(!readers_.empty(), "No index readers created from splits");
 }
 
 std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
     const Request& request) {
-  VELOX_CHECK_NOT_NULL(indexReader_, "No index reader available for lookup");
+  VELOX_CHECK(!readers_.empty(), "No index readers available for lookup");
+  VELOX_CHECK_EQ(
+      readers_.size(),
+      1,
+      "Multi-reader lookup not yet supported. "
+      "Partition routing will be added in a follow-up.");
+
   return std::make_shared<HiveLookupIterator>(
-      shared_from_this(), indexReader_.get(), request, maxRowsPerIndexRequest_);
+      shared_from_this(),
+      readers_[0].get(),
+      request,
+      SplitIndexReader::Options{
+          .maxRowsPerRequest =
+              static_cast<vector_size_t>(maxRowsPerIndexRequest_)});
 }
 
 std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
@@ -670,6 +705,17 @@ std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
   if (remainingFilterTimeNs_ != 0) {
     stats[std::string(Connector::kTotalRemainingFilterTime)] =
         RuntimeMetric(remainingFilterTimeNs_, RuntimeCounter::Unit::kNanos);
+  }
+  // Merge stats from all readers.
+  for (auto& reader : readers_) {
+    for (auto& [key, metric] : reader->runtimeStats()) {
+      auto it = stats.find(key);
+      if (it != stats.end()) {
+        it->second.merge(metric);
+      } else {
+        stats.emplace(key, metric);
+      }
+    }
   }
   return stats;
 }
@@ -729,22 +775,36 @@ RowVectorPtr HiveIndexSource::projectOutput(
       pool_, outputType_, BufferPtr(nullptr), numRows, outputColumns);
 }
 
-void HiveIndexSource::createHiveIndexReader(
+void HiveIndexSource::createCustomIndexReader(
+    const IndexReaderFactory& factory,
     std::vector<std::shared_ptr<const HiveConnectorSplit>> splits) {
   VELOX_CHECK(!splits.empty(), "No splits available");
-  indexReader_ = std::make_unique<HiveIndexReader>(
-      std::move(splits),
-      tableHandle_,
-      connectorQueryCtx_,
-      hiveConfig_,
-      scanSpec_,
-      indexLookupConditions_,
-      requestType_,
-      readerOutputType_,
-      ioStatistics_,
-      ioStats_,
-      fileHandleFactory_,
-      executor_);
+  auto reader = factory(splits, tableHandle_, connectorQueryCtx_);
+  VELOX_CHECK_NOT_NULL(
+      reader,
+      "IndexReaderFactory returned null for format: {}",
+      dwio::common::toString(splits[0]->fileFormat));
+  readers_.push_back(std::move(reader));
+}
+
+void HiveIndexSource::createFileIndexReader(
+    std::vector<std::shared_ptr<const HiveConnectorSplit>> splits) {
+  VELOX_CHECK(!splits.empty(), "No splits available");
+  readers_.push_back(
+      std::make_unique<FileIndexReader>(
+          std::move(splits),
+          tableHandle_,
+          connectorQueryCtx_,
+          hiveConfig_,
+          scanSpec_,
+          indexLookupConditions_,
+          requestType_,
+          readerOutputType_,
+          ioStatistics_,
+          ioStats_,
+          fileHandleFactory_,
+          executor_,
+          maxRowsPerIndexRequest_));
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -21,7 +21,7 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
-#include "velox/connectors/hive/HiveIndexReader.h"
+#include "velox/connectors/hive/IndexReader.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/core/PlanNode.h"
 #include "velox/dwio/common/ScanSpec.h"
@@ -33,12 +33,12 @@ namespace facebook::velox::connector::hive {
 
 class HiveConfig;
 
-/// HiveIndexSource provides index lookup for Hive tables.
-/// Currently supports Nimble file format with TabletIndex for efficient
-/// key-based stripe lookups.
+/// Provides index lookup for Hive-metastore-backed tables.
 ///
-/// NOTE: This is a scaffold implementation that assumes a single Nimble file.
-/// The user may need to optimize and extend this for production use cases.
+/// Owns format-agnostic orchestration: remaining filter evaluation, output
+/// projection, and (in future) partition routing. Delegates format-specific
+/// reads to either the built-in FileIndexReader (for Nimble) or external
+/// SplitIndexReader implementations registered via IndexReaderFactoryRegistry.
 class HiveIndexSource : public IndexSource,
                         public std::enable_shared_from_this<HiveIndexSource> {
  public:
@@ -66,10 +66,6 @@ class HiveIndexSource : public IndexSource,
 
   memory::MemoryPool* pool() const {
     return pool_;
-  }
-
-  uint32_t maxRowsPerIndexRequest() const {
-    return maxRowsPerIndexRequest_;
   }
 
   const RowTypePtr& outputType() const {
@@ -116,8 +112,13 @@ class HiveIndexSource : public IndexSource,
       std::vector<std::string>& readColumnNames,
       std::vector<TypePtr>& readColumnTypes);
 
-  // Creates HiveIndexReader for the splits.
-  void createHiveIndexReader(
+  // Creates a SplitIndexReader using a registered IndexReaderFactory.
+  void createCustomIndexReader(
+      const IndexReaderFactory& factory,
+      std::vector<std::shared_ptr<const HiveConnectorSplit>> splits);
+
+  // Creates FileIndexReader for the splits.
+  void createFileIndexReader(
       std::vector<std::shared_ptr<const HiveConnectorSplit>> splits);
 
   FileHandleFactory* const fileHandleFactory_;
@@ -134,7 +135,7 @@ class HiveIndexSource : public IndexSource,
 
   // All index lookup conditions including equal lookup keys converted to
   // EqualIndexLookupConditions and original non-filter index lookup conditions.
-  // This is passed to HiveIndexReader.
+  // This is passed to FileIndexReader.
   std::vector<core::IndexLookupConditionPtr> indexLookupConditions_;
 
   // Filters for pushdown. Includes subfield filters from table handle and
@@ -168,8 +169,10 @@ class HiveIndexSource : public IndexSource,
   std::shared_ptr<common::ScanSpec> scanSpec_;
   // Output type for the index reader.
   RowTypePtr readerOutputType_;
-  /// Index reader created by addSplits().
-  std::unique_ptr<HiveIndexReader> indexReader_;
+  /// All index readers (both built-in and external). FileIndexReader
+  /// (Nimble) and external readers both implement SplitIndexReader.
+  /// Created by addSplits().
+  std::vector<std::unique_ptr<SplitIndexReader>> readers_;
 
   // Cached empty output vector.
   RowVectorPtr emptyOutput_;

--- a/velox/connectors/hive/IndexReader.h
+++ b/velox/connectors/hive/IndexReader.h
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <mutex>
+#include <unordered_map>
+
+#include <folly/CPortability.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/connectors/Connector.h"
+#include "velox/dwio/common/Reader.h"
+
+namespace facebook::velox::connector::hive {
+
+struct HiveConnectorSplit;
+
+/// Abstract interface for format-specific index readers.
+///
+/// Provides the customization point for storage formats to plug into
+/// HiveIndexSource. Each format implements this interface
+/// with its own I/O and decoding logic. HiveIndexSource owns all
+/// format-agnostic orchestration (partition routing, remaining filter
+/// evaluation, non-index condition filtering, output projection) and delegates
+/// storage-specific reads to SplitIndexReader implementations.
+///
+/// File-based readers (e.g., Nimble) can internally use ScanSpec and filter
+/// pushdown without leaking those concepts through this interface.
+class SplitIndexReader {
+ public:
+  using Request = IndexSource::Request;
+  using Result = IndexSource::Result;
+  using Options = dwio::common::IndexReader::Options;
+
+  virtual ~SplitIndexReader() = default;
+
+  /// Initializes a lookup for the given probe request.
+  ///
+  /// The reader handles format-specific I/O (e.g., file reads for Nimble,
+  /// network RPCs for remote stores). HiveIndexSource handles everything above
+  /// this level (filters, projection, partition routing).
+  ///
+  /// After calling startLookup(), the caller iterates results via hasNext()
+  /// and next().
+  ///
+  /// @param request The probe-side input rows containing lookup keys.
+  /// @param options Lookup options (e.g., max rows per request batch).
+  virtual void startLookup(
+      const Request& request,
+      const Options& options = {}) = 0;
+
+  /// Returns true if there are more result batches to read.
+  virtual bool hasNext() = 0;
+
+  /// Returns the next batch of results, or nullptr if no more results.
+  ///
+  /// @param maxOutputRows Maximum number of rows to return in this batch.
+  virtual std::unique_ptr<Result> next(vector_size_t maxOutputRows) = 0;
+
+  /// Returns runtime statistics collected by this reader.
+  virtual std::unordered_map<std::string, RuntimeMetric> runtimeStats() = 0;
+};
+
+/// Factory function type for creating IndexReader instances.
+///
+/// Called by HiveIndexSource during addSplits() to create a reader for each
+/// split (or group of splits) based on the file format. The factory receives
+/// all the context needed to set up a reader for the given storage format.
+///
+/// @param splits The splits to create the reader for.
+/// @param tableHandle The table handle containing table metadata.
+/// @param connectorQueryCtx Query context (memory pool, session config, etc.).
+/// @return A unique_ptr to the created IndexReader.
+using IndexReaderFactory = std::function<std::unique_ptr<SplitIndexReader>(
+    const std::vector<std::shared_ptr<const HiveConnectorSplit>>& splits,
+    const ConnectorTableHandlePtr& tableHandle,
+    ConnectorQueryCtx* connectorQueryCtx)>;
+
+/// Thread-safe registry for IndexReaderFactory instances keyed by file format.
+///
+/// External storage formats register their reader
+/// factories at application startup. HiveIndexSource consults this registry
+/// during addSplits() to find the appropriate reader for each split's file
+/// format.
+///
+/// Example registration:
+///   IndexReaderFactoryRegistry::getInstance()->registerFactory(
+///       FileFormat::DWRF, myDwrfReaderFactory);
+class IndexReaderFactoryRegistry {
+ public:
+  FOLLY_EXPORT static IndexReaderFactoryRegistry* getInstance() {
+    static IndexReaderFactoryRegistry instance;
+    return &instance;
+  }
+
+  /// Registers a factory for the given file format. Throws if a factory is
+  /// already registered for the format.
+  void registerFactory(
+      dwio::common::FileFormat format,
+      IndexReaderFactory factory) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto [it, inserted] = factories_.emplace(format, std::move(factory));
+    VELOX_CHECK(
+        inserted,
+        "IndexReaderFactory already registered for format: {}",
+        dwio::common::toString(format));
+  }
+
+  /// Unregisters the factory for the given file format. Returns true if a
+  /// factory was removed, false if none was registered.
+  bool unregisterFactory(dwio::common::FileFormat format) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return factories_.erase(format) > 0;
+  }
+
+  /// Returns the registered factory for the given format, or nullptr if none
+  /// is registered.
+  const IndexReaderFactory* getFactory(dwio::common::FileFormat format) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = factories_.find(format);
+    return it != factories_.end() ? &it->second : nullptr;
+  }
+
+ private:
+  IndexReaderFactoryRegistry() = default;
+
+  mutable std::mutex mutex_;
+  std::unordered_map<dwio::common::FileFormat, IndexReaderFactory> factories_;
+};
+
+} // namespace facebook::velox::connector::hive


### PR DESCRIPTION
Summary:

Refactors HiveIndexSource to support pluggable index readers for different
storage formats, decoupling format-specific I/O from format-agnostic
orchestration (remaining filter evaluation, output projection).

**Core idea**: Provide a customization point at the reader level. HiveIndexSource stays as the single orchestrator for all formats. External formats implement a thin `SplitIndexReader` interface (`startLookup()` / `hasNext()` / `next()` + `runtimeStats()`) and register via `IndexReaderFactoryRegistry`.

```
IndexLookupJoin operator
  |
  v
HiveIndexSource (ALL orchestration)
  |-- remaining filter evaluation
  |-- output projection
  |-- runtime stats aggregation
  |-- (TODO) partition routing
  |-- (TODO) non-index condition filtering
  |-- (TODO) partition column synthesis
  |
  +-- SplitIndexReader (interface) -- the ONLY customization point
       |
       +-- FileIndexReader (Nimble)
       |     internally uses ScanSpec, FileHandle, TabletIndex, filter pushdown
       |
       +-- FluxIndexReader (to be converted from FluxIndexSource)
       |     internally uses ZClient, multi-get RPC, JSON/binary decode
       |
       +-- FutureFormatReader
             any new format plugs in here
```

Key changes:
- Extract SplitIndexReader interface (IndexReader.h) with startLookup() /
  hasNext() / next() / runtimeStats() API. This is the extension point for
  external formats. Readers are stateful: startLookup() initializes a lookup,
  then the caller iterates via hasNext()/next().
- Rename HiveFileIndexReader → FileIndexReader (Nimble-specific implementation).
  Reorder members: const members first, non-const second. Place toString()
  after state machine methods for readability.
- Rename IndexReaderFactory.h → IndexReader.h.
- Add IndexReaderFactoryRegistry: thread-safe singleton for external reader
  registration keyed by file format.
- HiveIndexSource::addSplits() now groups splits by format, creates one
  FileIndexReader per Nimble split, and uses registered factories for
  external formats.
- HiveLookupIterator wraps a SplitIndexReader* directly (no intermediate
  iterator adapter). It calls startLookup() on the reader, then iterates
  hasNext()/next() while applying remaining filter + output projection.
- Add new tests: externalReaderFactory, indexReaderFactoryRegistry.

```
  HiveIndexSource::lookup(request)
      │
      ▼
  HiveLookupIterator
      │   calls reader->startLookup(request)
      │   iterates reader->hasNext() / reader->next()
      │   applies remaining filter + projection
      │
      ▼
  Final Result
```

Reviewed By: xiaoxmeng

Differential Revision: D96819229
