### PR TITLE
feat(hive): Add UnionResultIterator for multi-split index lookup (#16812)

### DIFF
--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -27,17 +27,6 @@
 
 namespace facebook::velox::connector::hive {
 namespace {
-// Returns the single split from the vector. Checks that the vector is not empty
-// and has exactly one element.
-// TODO: Support multiple splits.
-std::shared_ptr<const HiveConnectorSplit> getSingleSplit(
-    const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits) {
-  VELOX_CHECK_EQ(
-      hiveSplits.size(),
-      1,
-      "FileIndexReader currently only supports a single split");
-  return hiveSplits[0];
-}
 
 // Gets the index of a column in the request type by name.
 // Throws if the column is not found.
@@ -82,7 +71,7 @@ void processBetweenBound(
 } // namespace
 
 FileIndexReader::FileIndexReader(
-    const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits,
+    std::shared_ptr<const HiveConnectorSplit> hiveSplit,
     const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
     const ConnectorQueryCtx* connectorQueryCtx,
     const std::shared_ptr<const HiveConfig>& hiveConfig,
@@ -108,7 +97,7 @@ FileIndexReader::FileIndexReader(
       scanSpec_{scanSpec},
       indexLookupConditions_{indexLookupConditions},
       maxRowsPerRequest_{maxRowsPerRequest},
-      hiveSplit_{getSingleSplit(hiveSplits)},
+      hiveSplit_{std::move(hiveSplit)},
       fileReader_{createFileReader()},
       indexReader_{createIndexReader()} {
   parseIndexLookupConditions();

--- a/velox/connectors/hive/FileIndexReader.h
+++ b/velox/connectors/hive/FileIndexReader.h
@@ -35,9 +35,13 @@ class HiveTableHandle;
 class HiveColumnHandle;
 class HiveConfig;
 
-/// Handles index lookups for Hive tables with cluster indexes. Focuses on:
+/// Handles index lookups for a single Nimble file with cluster indexes.
+/// Focuses on:
 /// - Creating index bounds from index lookup conditions
 /// - Delegating actual index lookups to the format-specific IndexReader
+///
+/// Each FileIndexReader operates on exactly one file (split). HiveIndexSource
+/// handles multi-split orchestration (union, partition routing) on top.
 ///
 /// The format-specific IndexReader (e.g., SelectiveNimbleIndexReader) handles:
 /// - Encoding keys into format-specific representations
@@ -46,7 +50,7 @@ class HiveConfig;
 class FileIndexReader : public SplitIndexReader {
  public:
   FileIndexReader(
-      const std::vector<std::shared_ptr<const HiveConnectorSplit>>& hiveSplits,
+      std::shared_ptr<const HiveConnectorSplit> hiveSplit,
       const std::shared_ptr<const HiveTableHandle>& hiveTableHandle,
       const ConnectorQueryCtx* connectorQueryCtx,
       const std::shared_ptr<const HiveConfig>& hiveConfig,

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -223,6 +223,213 @@ BufferPtr filterIndices(
 }
 } // namespace
 
+namespace {
+
+// Merges results from multiple split-level ResultIterators in inputHit order.
+// Each split independently produces results with sorted inputHits. This
+// iterator interleaves rows across splits to maintain the global non-decreasing
+// inputHit ordering required by IndexLookupJoin (for left join missed-row
+// detection and the DCHECK in prepareLookupResult).
+//
+// Uses a k-way merge: buffers one Result per split, then repeatedly picks
+// the split with the smallest current request index and copies all its rows
+// for that index before moving on.
+class UnionResultIterator : public IndexSource::ResultIterator {
+ public:
+  UnionResultIterator(
+      std::vector<std::shared_ptr<IndexSource::ResultIterator>> splitIters,
+      const RowTypePtr& outputType,
+      memory::MemoryPool* pool)
+      : outputType_(outputType), pool_(pool) {
+    VELOX_CHECK_GT(
+        splitIters.size(),
+        1,
+        "UnionResultIterator requires at least two iterators");
+    splits_.reserve(splitIters.size());
+    for (auto& iter : splitIters) {
+      splits_.emplace_back(std::move(iter));
+    }
+  }
+
+  bool hasNext() override {
+    for (const auto& split : splits_) {
+      if (split.hasResult() || !split.hasExhausted()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  std::optional<std::unique_ptr<IndexSource::Result>> next(
+      vector_size_t size,
+      ContinueFuture& future) override {
+    // Fetch results for all non-exhausted splits that need data.
+    for (auto& split : splits_) {
+      if (split.needFetchResult()) {
+        if (!split.fetchResult(size, future)) {
+          VELOX_CHECK(future.valid(), "Async return requires a valid future");
+          return std::nullopt;
+        }
+      }
+    }
+
+    // Merge rows from all active splits in inputHit order by repeatedly
+    // picking the split with the smallest current request index and copying
+    // all its rows for that index.
+    auto mergedInputHits = allocateIndices(size, pool_);
+    auto* rawMergedHits = mergedInputHits->asMutable<vector_size_t>();
+    auto mergedOutput = BaseVector::create<RowVector>(outputType_, size, pool_);
+
+    vector_size_t numOutput = 0;
+    while (numOutput < size) {
+      int minSplitIndex = -1;
+      auto minRequestIndex = std::numeric_limits<vector_size_t>::max();
+      for (size_t i = 0; i < splits_.size(); ++i) {
+        if (splits_[i].hasResult() &&
+            splits_[i].currentRequestIndex() < minRequestIndex) {
+          minSplitIndex = static_cast<int>(i);
+          minRequestIndex = splits_[i].currentRequestIndex();
+        }
+      }
+      if (minSplitIndex < 0) {
+        // All splits are exhausted with no buffered data.
+        break;
+      }
+
+      auto& split = splits_[minSplitIndex];
+      VELOX_CHECK_LE(numOutput, size);
+      numOutput += split.fillResult(
+          minRequestIndex,
+          mergedOutput,
+          numOutput,
+          rawMergedHits,
+          size - numOutput);
+
+      // Stop if this split's buffer is consumed but not exhausted. We must
+      // refill it before continuing to avoid emitting larger inputHits from
+      // other splits that would violate non-decreasing order across next()
+      // calls.
+      if (split.needFetchResult()) {
+        break;
+      }
+    }
+
+    if (numOutput == 0) {
+      return nullptr;
+    }
+
+    mergedInputHits->setSize(numOutput * sizeof(vector_size_t));
+    mergedOutput->resize(numOutput);
+    return std::make_unique<IndexSource::Result>(
+        std::move(mergedInputHits), std::move(mergedOutput));
+  }
+
+ private:
+  // Tracks iteration state for a single split's ResultIterator. Buffers
+  // one Result at a time and tracks the current read position within it.
+  struct SplitState {
+    explicit SplitState(std::shared_ptr<IndexSource::ResultIterator> splitIter)
+        : iter(std::move(splitIter)) {}
+
+    const std::shared_ptr<IndexSource::ResultIterator> iter;
+    // Current buffered result from this split, or nullptr if not yet fetched.
+    std::unique_ptr<IndexSource::Result> result;
+    // Next row to read within 'result'.
+    vector_size_t resultOffset{0};
+    // True when the underlying iterator has no more results.
+    bool exhausted{false};
+
+    // Returns true if there are unconsumed rows in the current buffered result.
+    bool hasResult() const {
+      return result != nullptr && resultOffset < result->size();
+    }
+
+    // Returns true if the underlying iterator has no more results.
+    bool hasExhausted() const {
+      return exhausted;
+    }
+
+    // Returns true if the split needs to fetch the next result batch.
+    bool needFetchResult() const {
+      return !hasResult() && !hasExhausted();
+    }
+
+    // Returns the request index (inputHit) of the current row in the buffer.
+    vector_size_t currentRequestIndex() const {
+      VELOX_CHECK(hasResult());
+      return result->inputHits->as<const vector_size_t>()[resultOffset];
+    }
+
+    // Copies buffered rows matching the given request index to the output,
+    // up to maxRows. Returns the number of rows copied.
+    vector_size_t fillResult(
+        vector_size_t requestIndex,
+        const RowVectorPtr& output,
+        vector_size_t outputOffset,
+        vector_size_t* rawHits,
+        vector_size_t maxRows) {
+      VELOX_CHECK(hasResult());
+      // Count contiguous rows with the same request index.
+      const auto* hits = result->inputHits->as<const vector_size_t>();
+      vector_size_t count = 0;
+      while (count < maxRows && resultOffset + count < result->size() &&
+             hits[resultOffset + count] == requestIndex) {
+        ++count;
+      }
+      if (count > 0) {
+        output->copy(result->output.get(), outputOffset, resultOffset, count);
+        std::fill(
+            rawHits + outputOffset,
+            rawHits + outputOffset + count,
+            requestIndex);
+        resultOffset += count;
+      }
+      return count;
+    }
+
+    // Fetches the next non-empty result from the underlying iterator.
+    // Returns true when data is ready (or split is exhausted), false if async.
+    bool fetchResult(vector_size_t size, ContinueFuture& future) {
+      VELOX_CHECK(
+          !hasResult(), "Must consume current result before fetching next");
+      while (!exhausted) {
+        if (!iter->hasNext()) {
+          exhausted = true;
+          return true;
+        }
+        auto resultOpt = iter->next(size, future);
+        if (!resultOpt.has_value()) {
+          return false;
+        }
+        auto fetchedResult = std::move(resultOpt).value();
+        if (fetchedResult == nullptr) {
+          exhausted = true;
+          return true;
+        }
+        // Skip empty results (e.g., when all rows are filtered out by
+        // remaining filter) and continue fetching.
+        if (fetchedResult->size() == 0) {
+          continue;
+        }
+        result = std::move(fetchedResult);
+        resultOffset = 0;
+        return true;
+      }
+      VELOX_UNREACHABLE();
+    }
+  };
+
+  // Output schema used to allocate merged result vectors.
+  const RowTypePtr outputType_;
+  memory::MemoryPool* const pool_;
+  // Per-split state for buffering and tracking iteration progress. Not const
+  // because elements are mutated during iteration (result, resultOffset,
+  // exhausted), and const vector makes elements const via const T& access.
+  std::vector<SplitState> splits_;
+};
+
+} // namespace
+
 /// Iterates over results from a SplitIndexReader and applies HiveIndexSource's
 /// format-agnostic orchestration: remaining filter evaluation and output
 /// projection.
@@ -648,34 +855,19 @@ void HiveIndexSource::addSplits(
       readers_.empty(),
       "addSplits can only be called once for HiveIndexSource");
 
-  // Group splits by file format.
-  std::unordered_map<
-      dwio::common::FileFormat,
-      std::vector<std::shared_ptr<const HiveConnectorSplit>>>
-      splitsByFormat;
+  auto* registry = IndexReaderFactoryRegistry::getInstance();
   for (auto& split : splits) {
     auto hiveSplit = checkedPointerCast<const HiveConnectorSplit>(split);
-    auto format = hiveSplit->fileFormat;
-    splitsByFormat[format].push_back(std::move(hiveSplit));
-  }
-
-  auto* registry = IndexReaderFactoryRegistry::getInstance();
-  for (auto& [format, formatSplits] : splitsByFormat) {
-    const auto* factory = registry->getFactory(format);
+    const auto* factory = registry->getFactory(hiveSplit->fileFormat);
     if (factory != nullptr) {
-      createCustomIndexReader(*factory, std::move(formatSplits));
+      createCustomIndexReader(*factory, std::move(hiveSplit));
     } else {
-      // Fall back to built-in FileIndexReader.
       VELOX_CHECK_EQ(
-          format,
+          hiveSplit->fileFormat,
           dwio::common::FileFormat::NIMBLE,
           "No IndexReaderFactory registered for format: {}",
-          dwio::common::toString(format));
-      // Create one reader per split. FileIndexReader currently supports a
-      // single file.
-      for (auto& nimbleSplit : formatSplits) {
-        createFileIndexReader({std::move(nimbleSplit)});
-      }
+          dwio::common::toString(hiveSplit->fileFormat));
+      createFileIndexReader(std::move(hiveSplit));
     }
   }
 
@@ -685,19 +877,35 @@ void HiveIndexSource::addSplits(
 std::shared_ptr<IndexSource::ResultIterator> HiveIndexSource::lookup(
     const Request& request) {
   VELOX_CHECK(!readers_.empty(), "No index readers available for lookup");
-  VELOX_CHECK_EQ(
-      readers_.size(),
-      1,
-      "Multi-reader lookup not yet supported. "
-      "Partition routing will be added in a follow-up.");
 
-  return std::make_shared<HiveLookupIterator>(
-      shared_from_this(),
-      readers_[0].get(),
-      request,
-      SplitIndexReader::Options{
-          .maxRowsPerRequest =
-              static_cast<vector_size_t>(maxRowsPerIndexRequest_)});
+  auto options = SplitIndexReader::Options{
+      .maxRowsPerRequest = static_cast<vector_size_t>(maxRowsPerIndexRequest_)};
+
+  if (readers_.size() == 1) {
+    return std::make_shared<HiveLookupIterator>(
+        shared_from_this(), readers_[0].get(), request, options);
+  }
+
+  return createUnionLookupIterator(request, options);
+}
+
+std::shared_ptr<IndexSource::ResultIterator>
+HiveIndexSource::createUnionLookupIterator(
+    const Request& request,
+    const SplitIndexReader::Options& options) {
+  // Wraps each reader in a HiveLookupIterator and unions their results
+  // via UnionResultIterator. Each reader searches its own split
+  // independently with the same request.
+  VELOX_CHECK_GT(readers_.size(), 1, "Union requires at least two readers");
+  std::vector<std::shared_ptr<IndexSource::ResultIterator>> splitIters;
+  splitIters.reserve(readers_.size());
+  for (auto& reader : readers_) {
+    splitIters.push_back(
+        std::make_shared<HiveLookupIterator>(
+            shared_from_this(), reader.get(), request, options));
+  }
+  return std::make_shared<UnionResultIterator>(
+      std::move(splitIters), outputType_, pool_);
 }
 
 std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
@@ -777,22 +985,22 @@ RowVectorPtr HiveIndexSource::projectOutput(
 
 void HiveIndexSource::createCustomIndexReader(
     const IndexReaderFactory& factory,
-    std::vector<std::shared_ptr<const HiveConnectorSplit>> splits) {
-  VELOX_CHECK(!splits.empty(), "No splits available");
-  auto reader = factory(splits, tableHandle_, connectorQueryCtx_);
+    std::shared_ptr<const HiveConnectorSplit> split) {
+  VELOX_CHECK_NOT_NULL(split);
+  auto reader = factory(split, tableHandle_, connectorQueryCtx_);
   VELOX_CHECK_NOT_NULL(
       reader,
       "IndexReaderFactory returned null for format: {}",
-      dwio::common::toString(splits[0]->fileFormat));
+      dwio::common::toString(split->fileFormat));
   readers_.push_back(std::move(reader));
 }
 
 void HiveIndexSource::createFileIndexReader(
-    std::vector<std::shared_ptr<const HiveConnectorSplit>> splits) {
-  VELOX_CHECK(!splits.empty(), "No splits available");
+    std::shared_ptr<const HiveConnectorSplit> split) {
+  VELOX_CHECK_NOT_NULL(split);
   readers_.push_back(
       std::make_unique<FileIndexReader>(
-          std::move(splits),
+          std::move(split),
           tableHandle_,
           connectorQueryCtx_,
           hiveConfig_,

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -112,14 +112,18 @@ class HiveIndexSource : public IndexSource,
       std::vector<std::string>& readColumnNames,
       std::vector<TypePtr>& readColumnTypes);
 
+  // Creates a UnionResultIterator that unions results from all readers.
+  std::shared_ptr<ResultIterator> createUnionLookupIterator(
+      const Request& request,
+      const SplitIndexReader::Options& options);
+
   // Creates a SplitIndexReader using a registered IndexReaderFactory.
   void createCustomIndexReader(
       const IndexReaderFactory& factory,
-      std::vector<std::shared_ptr<const HiveConnectorSplit>> splits);
+      std::shared_ptr<const HiveConnectorSplit> split);
 
-  // Creates FileIndexReader for the splits.
-  void createFileIndexReader(
-      std::vector<std::shared_ptr<const HiveConnectorSplit>> splits);
+  // Creates a FileIndexReader for a single split.
+  void createFileIndexReader(std::shared_ptr<const HiveConnectorSplit> split);
 
   FileHandleFactory* const fileHandleFactory_;
   ConnectorQueryCtx* const connectorQueryCtx_;

--- a/velox/connectors/hive/IndexReader.h
+++ b/velox/connectors/hive/IndexReader.h
@@ -76,16 +76,16 @@ class SplitIndexReader {
 
 /// Factory function type for creating IndexReader instances.
 ///
-/// Called by HiveIndexSource during addSplits() to create a reader for each
-/// split (or group of splits) based on the file format. The factory receives
-/// all the context needed to set up a reader for the given storage format.
+/// Creates one IndexReader per split during HiveIndexSource::addSplits().
+/// Receives all the context needed to set up a reader for the given storage
+/// format.
 ///
-/// @param splits The splits to create the reader for.
+/// @param split The split to create the reader for.
 /// @param tableHandle The table handle containing table metadata.
 /// @param connectorQueryCtx Query context (memory pool, session config, etc.).
 /// @return A unique_ptr to the created IndexReader.
 using IndexReaderFactory = std::function<std::unique_ptr<SplitIndexReader>(
-    const std::vector<std::shared_ptr<const HiveConnectorSplit>>& splits,
+    const std::shared_ptr<const HiveConnectorSplit>& split,
     const ConnectorTableHandlePtr& tableHandle,
     ConnectorQueryCtx* connectorQueryCtx)>;
 


### PR DESCRIPTION
Summary:

Adds UnionResultIterator that merges results from multiple split-level
ResultIterators in inputHit order. This enables multi-split index lookup
where a single HiveIndexSource manages multiple files, decoupled from
file format — e.g., two Nimble splits or mixed Nimble + external format.

Each split independently produces results with sorted inputHits.
UnionResultIterator uses a k-way merge to maintain the global
non-decreasing inputHit ordering required by IndexLookupJoin.

Changes:
- Decouple reader creation from file format: addSplits() creates one
  reader per split instead of grouping by format.
- IndexReaderFactory signature: takes a single split instead of a vector.
- FileIndexReader constructor: takes a single split (was already
  single-split internally via getSingleSplit() check).
- UnionResultIterator: k-way merge that buffers one Result per split,
  picks the row with the smallest inputHit, and stops when any
  non-exhausted split's buffer is consumed to preserve ordering across
  next() calls.
- HiveIndexSource::lookup(): single reader takes a fast path; multiple
  readers go through createUnionLookupIterator().

```
HiveIndexSource::lookup(request)
    │
    ├── Single reader (fast path):
    │   HiveLookupIterator(reader) → result
    │
    └── Multiple readers:
        HiveLookupIterator(reader[0]) ─┐
        HiveLookupIterator(reader[1]) ─┤
                                       ▼
                         UnionResultIterator (k-way merge) → result
```

Reviewed By: xiaoxmeng

Differential Revision: D96954019


