### PR TITLE
feat: Optimize map_intersect performance with early-exit, reserve, and branch hints (#16813)

### DIFF
--- a/velox/functions/prestosql/MapIntersect.h
+++ b/velox/functions/prestosql/MapIntersect.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <algorithm>
+
+#include <folly/Likely.h>
 #include "velox/expression/ComplexViewTypes.h"
 #include "velox/functions/Udf.h"
 #include "velox/type/FloatingPointUtil.h"
@@ -34,26 +37,38 @@ struct MapIntersectPrimitiveFunction {
       const arg_type<Array<Key>>* keys) {
     if (keys != nullptr) {
       constantSearchKeys_ = true;
-      initializeSearchKeys(*keys);
+      searchKeys_.reserve(keys->size());
+      for (const auto& key : keys->skipNulls()) {
+        searchKeys_.emplace(key);
+      }
     }
   }
 
-  void call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Map<Key, Generic<T1>>>& out,
       const arg_type<Map<Key, Generic<T1>>>& inputMap,
       const arg_type<Array<Key>>& keys) {
-    if (keys.empty()) {
+    if (FOLLY_UNLIKELY(keys.empty() || inputMap.empty())) {
       return;
     }
 
     if (!constantSearchKeys_) {
       searchKeys_.clear();
-      initializeSearchKeys(keys);
+      searchKeys_.reserve(keys.size());
+      for (const auto& key : keys.skipNulls()) {
+        searchKeys_.emplace(key);
+      }
     }
 
-    if (searchKeys_.empty()) {
+    if (FOLLY_UNLIKELY(searchKeys_.empty())) {
       return;
     }
+
+    out.reserve(
+        static_cast<vector_size_t>(
+            std::min<size_t>(inputMap.size(), searchKeys_.size())));
+
+    auto toFind = searchKeys_.size();
 
     for (const auto& entry : inputMap) {
       if (!searchKeys_.contains(entry.first)) {
@@ -68,16 +83,15 @@ struct MapIntersectPrimitiveFunction {
         keyWriter = entry.first;
         valueWriter.copy_from(entry.second.value());
       }
+
+      --toFind;
+      if (toFind == 0) {
+        break;
+      }
     }
   }
 
  private:
-  void initializeSearchKeys(const arg_type<Array<Key>>& keys) {
-    for (const auto& key : keys.skipNulls()) {
-      searchKeys_.emplace(key);
-    }
-  }
-
   bool constantSearchKeys_{false};
   util::floating_point::HashSetNaNAware<arg_type<Key>> searchKeys_;
 };
@@ -95,6 +109,7 @@ struct MapIntersectVarcharFunction {
     if (keys != nullptr) {
       constantSearchKeys_ = true;
 
+      searchKeys_.reserve(keys->size());
       searchKeyStrings_.reserve(keys->size());
       for (const auto& key : keys->skipNulls()) {
         if (key.isInline()) {
@@ -107,24 +122,31 @@ struct MapIntersectVarcharFunction {
     }
   }
 
-  void call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Map<Varchar, Generic<T1>>>& out,
       const arg_type<Map<Varchar, Generic<T1>>>& inputMap,
       const arg_type<Array<Varchar>>& keys) {
-    if (keys.empty()) {
+    if (FOLLY_UNLIKELY(keys.empty() || inputMap.empty())) {
       return;
     }
 
     if (!constantSearchKeys_) {
       searchKeys_.clear();
+      searchKeys_.reserve(keys.size());
       for (const auto& key : keys.skipNulls()) {
         searchKeys_.emplace(key);
       }
     }
 
-    if (searchKeys_.empty()) {
+    if (FOLLY_UNLIKELY(searchKeys_.empty())) {
       return;
     }
+
+    out.reserve(
+        static_cast<vector_size_t>(
+            std::min<size_t>(inputMap.size(), searchKeys_.size())));
+
+    auto toFind = searchKeys_.size();
 
     for (const auto& entry : inputMap) {
       if (!searchKeys_.contains(entry.first)) {
@@ -138,6 +160,11 @@ struct MapIntersectVarcharFunction {
         auto [keyWriter, valueWriter] = out.add_item();
         keyWriter.copy_from(entry.first);
         valueWriter.copy_from(entry.second.value());
+      }
+
+      --toFind;
+      if (toFind == 0) {
+        break;
       }
     }
   }
@@ -156,7 +183,7 @@ struct MapIntersectFunctionEqualComparator {
 
     auto result = lhs.compare(rhs, kEqualValueAtFlags);
 
-    // If comparison returns indeterminate (null), treat as not equal
+    // If comparison returns indeterminate (null), treat as not equal.
     if (!result.has_value()) {
       return false;
     }
@@ -171,22 +198,29 @@ template <typename TExec>
 struct MapIntersectFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExec);
 
-  void call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Map<Generic<T1>, Generic<T2>>>& out,
       const arg_type<Map<Generic<T1>, Generic<T2>>>& inputMap,
       const arg_type<Array<Generic<T1>>>& keys) {
-    if (keys.empty()) {
+    if (FOLLY_UNLIKELY(keys.empty() || inputMap.empty())) {
       return;
     }
 
     searchKeys_.clear();
+    searchKeys_.reserve(keys.size());
     for (const auto& key : keys.skipNulls()) {
       searchKeys_.emplace(key);
     }
 
-    if (searchKeys_.empty()) {
+    if (FOLLY_UNLIKELY(searchKeys_.empty())) {
       return;
     }
+
+    out.reserve(
+        static_cast<vector_size_t>(
+            std::min<size_t>(inputMap.size(), searchKeys_.size())));
+
+    auto toFind = searchKeys_.size();
 
     for (const auto& entry : inputMap) {
       if (!searchKeys_.contains(entry.first)) {
@@ -200,6 +234,11 @@ struct MapIntersectFunction {
         auto [keyWriter, valueWriter] = out.add_item();
         keyWriter.copy_from(entry.first);
         valueWriter.copy_from(entry.second.value());
+      }
+
+      --toFind;
+      if (toFind == 0) {
+        break;
       }
     }
   }

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -87,6 +87,9 @@ target_link_libraries(velox_functions_prestosql_benchmarks_map_concat ${BENCHMAR
 add_executable(velox_functions_prestosql_benchmarks_map_input MapInputBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_map_input ${BENCHMARK_DEPENDENCIES})
 
+add_executable(velox_functions_prestosql_benchmarks_map_intersect MapIntersectBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_map_intersect ${BENCHMARK_DEPENDENCIES})
+
 add_executable(velox_functions_benchmarks_url URLBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_url ${BENCHMARK_DEPENDENCIES})
 

--- a/velox/functions/prestosql/benchmarks/MapIntersectBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapIntersectBenchmark.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize({});
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  functions::prestosql::registerAllScalarFunctions();
+
+  auto* pool = benchmarkBuilder.pool();
+  auto& vm = benchmarkBuilder.vectorMaker();
+
+  // ---------------------------------------------------------------------------
+  // Scenario 1: Large map (100 entries), small key array (3 keys).
+  // Tests the early-exit (toFind) optimization — stops after finding 3 matches
+  // instead of scanning all 100 entries.
+  // ---------------------------------------------------------------------------
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.containerLength = 100;
+    options.containerVariableLength = false;
+    options.complexElementsMaxSize = 1'000'000;
+    VectorFuzzer fuzzer(options, pool);
+
+    auto mapVector = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
+
+    // Small constant key array: 3 keys.
+    auto keysVector = vm.arrayVector<int32_t>(
+        std::vector<std::vector<int32_t>>(1'000, {1, 50, 99}));
+
+    benchmarkBuilder
+        .addBenchmarkSet(
+            "large_map_small_keys_int", vm.rowVector({mapVector, keysVector}))
+        .addExpression("map_intersect", "map_intersect(c0, c1)")
+        .addExpression("map_subset", "map_subset(c0, c1)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 2: Small map (5 entries), large key array (50 keys).
+  // Tests the hash set reserve() optimization — pre-allocates for 50 keys.
+  // ---------------------------------------------------------------------------
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.containerLength = 5;
+    options.containerVariableLength = false;
+    options.complexElementsMaxSize = 1'000'000;
+    VectorFuzzer fuzzer(options, pool);
+
+    auto mapVector = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
+
+    std::vector<int32_t> manyKeys(50);
+    std::iota(manyKeys.begin(), manyKeys.end(), 0);
+    auto keysVector = vm.arrayVector<int32_t>(
+        std::vector<std::vector<int32_t>>(1'000, manyKeys));
+
+    benchmarkBuilder
+        .addBenchmarkSet(
+            "small_map_large_keys_int", vm.rowVector({mapVector, keysVector}))
+        .addExpression("map_intersect", "map_intersect(c0, c1)")
+        .addExpression("map_subset", "map_subset(c0, c1)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 3: Medium map (20 entries), medium key array (10 keys).
+  // Balanced workload — tests combined effect of all optimizations.
+  // ---------------------------------------------------------------------------
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.containerLength = 20;
+    options.containerVariableLength = false;
+    options.complexElementsMaxSize = 1'000'000;
+    VectorFuzzer fuzzer(options, pool);
+
+    auto mapVector = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
+
+    std::vector<int32_t> mediumKeys(10);
+    std::iota(mediumKeys.begin(), mediumKeys.end(), 0);
+    auto keysVector = vm.arrayVector<int32_t>(
+        std::vector<std::vector<int32_t>>(1'000, mediumKeys));
+
+    benchmarkBuilder
+        .addBenchmarkSet(
+            "medium_map_medium_keys_int", vm.rowVector({mapVector, keysVector}))
+        .addExpression("map_intersect", "map_intersect(c0, c1)")
+        .addExpression("map_subset", "map_subset(c0, c1)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 4: VARCHAR keys — large map, small key array.
+  // Tests the varchar-specific optimizations (inline string, F14FastSet).
+  // ---------------------------------------------------------------------------
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.containerLength = 50;
+    options.containerVariableLength = false;
+    options.stringLength = 10;
+    options.complexElementsMaxSize = 1'000'000;
+    VectorFuzzer fuzzer(options, pool);
+
+    auto mapVector = fuzzer.fuzz(MAP(VARCHAR(), INTEGER()));
+
+    auto keysVector =
+        vm.arrayVector<StringView>(std::vector<std::vector<StringView>>(
+            1'000, {StringView("abc"), StringView("xyz"), StringView("foo")}));
+
+    benchmarkBuilder
+        .addBenchmarkSet(
+            "large_map_small_keys_varchar",
+            vm.rowVector({mapVector, keysVector}))
+        .addExpression("map_intersect", "map_intersect(c0, c1)")
+        .addExpression("map_subset", "map_subset(c0, c1)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 5: Empty key array — tests the early-exit guard optimization.
+  // ---------------------------------------------------------------------------
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.containerLength = 50;
+    options.containerVariableLength = false;
+    options.complexElementsMaxSize = 1'000'000;
+    VectorFuzzer fuzzer(options, pool);
+
+    auto mapVector = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
+
+    auto keysVector = vm.arrayVector<int32_t>(
+        std::vector<std::vector<int32_t>>(1'000, std::vector<int32_t>{}));
+
+    benchmarkBuilder
+        .addBenchmarkSet(
+            "empty_keys_int", vm.rowVector({mapVector, keysVector}))
+        .addExpression("map_intersect", "map_intersect(c0, c1)")
+        .addExpression("map_subset", "map_subset(c0, c1)");
+  }
+
+  // ---------------------------------------------------------------------------
+  // Scenario 6: Constant keys (compile-time known).
+  // Tests the constant-key caching optimization in initialize().
+  // ---------------------------------------------------------------------------
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1'000;
+    options.containerLength = 50;
+    options.containerVariableLength = false;
+    options.complexElementsMaxSize = 1'000'000;
+    VectorFuzzer fuzzer(options, pool);
+
+    auto mapVector = fuzzer.fuzz(MAP(INTEGER(), INTEGER()));
+
+    benchmarkBuilder
+        .addBenchmarkSet("constant_keys_int", vm.rowVector({mapVector}))
+        .addExpression(
+            "map_intersect",
+            "map_intersect(c0, array_constructor(cast(1 as integer), cast(5 as integer), cast(10 as integer), cast(25 as integer), cast(42 as integer)))")
+        .addExpression(
+            "map_subset",
+            "map_subset(c0, array_constructor(cast(1 as integer), cast(5 as integer), cast(10 as integer), cast(25 as integer), cast(42 as integer)))");
+  }
+
+  benchmarkBuilder.registerBenchmarks();
+  benchmarkBuilder.testBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:

Optimized the map_intersect UDF implementation with 5 performance improvements:
1. Early-exit toFind counter - stops iterating the map once all search keys are found (missing from original but present in map_subset)
2. out.reserve() - pre-allocates MapWriter output capacity to avoid reallocations
3. searchKeys_.reserve() - pre-allocates hash set capacity to avoid rehashing during insertion
4. FOLLY_UNLIKELY branch hints - guides CPU branch predictor for early-return edge cases
5. FOLLY_ALWAYS_INLINE on call() - forces inlining of hot-path per-row evaluation

Also added a comprehensive benchmark (MapIntersectBenchmark.cpp) with 6 scenarios comparing map_intersect vs map_subset head-to-head.

Note: callNullFree was investigated but cannot be used because the Velox framework does not yet support it with Generic type arguments.

Reviewed By: bikramSingh91

Differential Revision: D97016318


