### PR TITLE
fix: SignatureBinder::tryBindVariablesWithCoercion failure on integer variables

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -344,7 +344,11 @@ bool SignatureBinder::tryBindVariablesWithCoercion(
         typeSignature.parameters().empty(),
         "Variables with parameters are not supported");
     const auto& variable = variableIt->second;
-    VELOX_CHECK(variable.isTypeParameter(), "Not expecting integer variable");
+    if (!variable.isTypeParameter()) {
+      // Integer variables (e.g. decimal precision and scale) are bound
+      // later by tryBind. Skip them here.
+      return true;
+    }
 
     if (!variable.isEligibleType(*actualType)) {
       return false;

--- a/velox/expression/SignatureBinder.h
+++ b/velox/expression/SignatureBinder.h
@@ -192,6 +192,12 @@ class SignatureBinder : private SignatureBinderBase {
  private:
   bool tryBind(bool allowCoercions, std::vector<Coercion>& coercions);
 
+  /// Pre-binds type variables to their least common super type across all
+  /// arguments. Runs before the main binding loop. Only binds type variables,
+  /// not integer variables (e.g. decimal precision/scale) — those are bound
+  /// later by tryBind. Does not check base type name match since coercion may
+  /// change the base type. Returns false if a type variable conflict is found
+  /// that would prevent binding; true otherwise.
   bool tryBindVariablesWithCoercion(
       const exec::TypeSignature& typeSignature,
       const TypePtr& actualType);

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -313,6 +313,16 @@ TEST(SignatureBinderTest, decimals) {
       ASSERT_FALSE(binder1.tryBind());
     }
 
+    // Non-decimal arguments with the same number of type parameters as
+    // DECIMAL (e.g. MAP has 2 type parameters).
+    {
+      const std::vector<TypePtr> argTypes{
+          MAP(VARCHAR(), BIGINT()), MAP(VARCHAR(), BIGINT())};
+      exec::SignatureBinder binder(*signature, argTypes);
+      std::vector<Coercion> coercions;
+      ASSERT_FALSE(binder.tryBindWithCoercions(coercions));
+    }
+
     // Resolving invalid ShortDecimal/LongDecimal arguments returns nullptr.
     {
       // Missing constraints.


### PR DESCRIPTION
Summary:
tryBindVariablesWithCoercion throws when it encounters an integer variable
(e.g. decimal precision/scale) during recursive type parameter matching.
This happens when a decimal function signature like
(DECIMAL(a_precision, a_scale), DECIMAL(a_precision, a_scale)) -> boolean
is tried against argument types that happen to have the same number of
type parameters (e.g. MAP(VARCHAR, BIGINT) also has 2). The method doesn't
check base type names, so it recurses into the parameters and finds
a_precision — an integer variable — triggering a VELOX_CHECK failure.

Fix by skipping integer variables in tryBindVariablesWithCoercion. This
method's purpose is to pre-bind type variables only; integer variables
are bound later by tryBind. Added documentation clarifying the method's
semantics.

Differential Revision: D97078115


