### PR TITLE
fix(build): Register /usr/local/lib64 with ldconfig after gflags install on CentOS 9

### DIFF
--- a/scripts/setup-centos9.sh
+++ b/scripts/setup-centos9.sh
@@ -87,6 +87,11 @@ function install_gflags {
   dnf remove -y gflags
   wget_and_untar https://github.com/gflags/gflags/archive/"${GFLAGS_VERSION}".tar.gz gflags
   cmake_install_dir gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON
+  # CentOS 9 does not include ${INSTALL_PREFIX}/lib in the default ldconfig
+  # search paths. Register it so that downstream builds (e.g. fbthrift's
+  # thrift1 compiler) can find libgflags.so at runtime.
+  echo "${INSTALL_PREFIX}/lib" >/etc/ld.so.conf.d/usr-local.conf
+  ldconfig
 }
 
 function install_faiss_deps {


### PR DESCRIPTION
gflags installs to `/usr/local/lib64` which is not in the default `ldconfig` search path on CentOS Stream 9. 
This causes downstream builds (e.g. fbthrift's `thrift1` compiler) to fail at runtime with:

    error while loading shared libraries: libgflags.so.2.2

This moves gflags to `/usr/local/lib` to align with other dependency installation paths and registers that path with `ldconfig`.