### PR TITLE
feat: Track CPU time consumed on spill executor background threads

### DIFF
--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -525,7 +525,7 @@ TEST_F(HiveDataSinkTest, basic) {
       "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillExtractVectorTime[0ns] spillSerializationTimeNanos[0ns] "
       "spillWrites[0] spillFlushTimeNanos[0ns] spillWriteTimeNanos[0ns] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
-      "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]");
+      "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns] spillCpuTimeNanos[0ns]");
 
   const int numBatches = 10;
   const auto vectors = createVectors(500, numBatches);
@@ -576,7 +576,7 @@ TEST_F(HiveDataSinkTest, basicBucket) {
       "spillFillTimeNanos[0ns] spillSortTimeNanos[0ns] spillExtractVectorTime[0ns] spillSerializationTimeNanos[0ns] "
       "spillWrites[0] spillFlushTimeNanos[0ns] spillWriteTimeNanos[0ns] "
       "maxSpillExceededLimitCount[0] spillReadBytes[0B] spillReads[0] "
-      "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns]");
+      "spillReadTimeNanos[0ns] spillReadDeserializationTimeNanos[0ns] spillCpuTimeNanos[0ns]");
 
   const int numBatches = 10;
   const auto vectors = createVectors(500, numBatches);

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -380,6 +380,13 @@ class QueryConfig {
   static constexpr const char* kLocalMergeSpillEnabled =
       "local_merge_spill_enabled";
 
+  /// If true, track and report CPU time consumed on spill executor background
+  /// threads. When enabled, the time is recorded as a runtime stat
+  /// (`spillBackgroundCpuTimeNanos`) and included in task-level CPU accounting
+  /// (which affects billing). True by default.
+  static constexpr const char* kTrackSpillBackgroundCpuTime =
+      "track_spill_background_cpu_time";
+
   /// Specify the max number of local sources to merge at a time.
   static constexpr const char* kLocalMergeMaxNumMergeSources =
       "local_merge_max_num_merge_sources";
@@ -1287,6 +1294,10 @@ class QueryConfig {
   int32_t spillableReservationGrowthPct() const {
     constexpr int32_t kDefaultPct = 10;
     return get<int32_t>(kSpillableReservationGrowthPct, kDefaultPct);
+  }
+
+  bool trackSpillBackgroundCpuTime() const {
+    return get<bool>(kTrackSpillBackgroundCpuTime, false);
   }
 
   bool queryTraceEnabled() const {

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -701,7 +701,8 @@ void SpillMerger::readFromSpillFileStream(
 void SpillMerger::scheduleAsyncSpillFileStreamReads() {
   VELOX_CHECK_EQ(batchStreams_.size(), sources_.size());
   for (auto i = 0; i < batchStreams_.size(); ++i) {
-    executor_->add([&, streamIdx = i]() {
+    executor_->add([&, streamIdx = i, stats = spillStats_]() {
+      SpillBackgroundCpuTimer timer(stats.get());
       readFromSpillFileStream(std::weak_ptr(shared_from_this()), streamIdx);
     });
   }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -476,6 +476,25 @@ void Operator::recordSpillStats() {
         statName, RuntimeCounter(statValue.sum, statValue.unit));
   }
 
+  // Record spill background CPU time as a runtime stat only when the config
+  // is enabled. This is NOT added to backgroundTiming to avoid inflating
+  // per-operator finishCpu and per-driver kDriverCpuTime. Instead,
+  // PrestoTask.cpp extracts this stat and adds it to totalCpuTimeInNanos.
+  if (operatorCtx_->task()
+          ->queryCtx()
+          ->queryConfig()
+          .trackSpillBackgroundCpuTime()) {
+    const auto spillCpuTime =
+        spillStats_->spillCpuTimeNanos.load(std::memory_order_relaxed);
+    if (spillCpuTime != 0) {
+      lockedStats->addRuntimeStat(
+          kSpillBackgroundCpuTime,
+          RuntimeCounter{
+              static_cast<int64_t>(spillCpuTime),
+              RuntimeCounter::Unit::kNanos});
+    }
+  }
+
   spillStats_->reset();
 }
 

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -185,6 +185,9 @@ class Operator : public BaseRuntimeStatWriter {
   static constexpr std::string_view kSpillReadTime{"spillReadWallNanos"};
   static constexpr std::string_view kSpillDeserializationTime{
       "spillDeserializationWallNanos"};
+  /// CPU time consumed on spill executor threads (background, non-driver).
+  static constexpr std::string_view kSpillBackgroundCpuTime{
+      "spillBackgroundCpuTimeNanos"};
 
   /// The vector serde kind used by an operator for shuffle. The recorded
   /// runtime stats value is the corresponding enum value.

--- a/velox/exec/SpillStats.cpp
+++ b/velox/exec/SpillStats.cpp
@@ -53,7 +53,8 @@ SpillStats::SpillStats(
     uint64_t _spillReadBytes,
     uint64_t _spillReads,
     uint64_t _spillReadTimeNanos,
-    uint64_t _spillDeserializationTimeNanos) {
+    uint64_t _spillDeserializationTimeNanos,
+    uint64_t _spillCpuTimeNanos) {
   spillRuns.store(_spillRuns, std::memory_order_relaxed);
   spilledInputBytes.store(_spilledInputBytes, std::memory_order_relaxed);
   spilledBytes.store(_spilledBytes, std::memory_order_relaxed);
@@ -76,6 +77,7 @@ SpillStats::SpillStats(
   spillReadTimeNanos.store(_spillReadTimeNanos, std::memory_order_relaxed);
   spillDeserializationTimeNanos.store(
       _spillDeserializationTimeNanos, std::memory_order_relaxed);
+  spillCpuTimeNanos.store(_spillCpuTimeNanos, std::memory_order_relaxed);
 }
 
 SpillStats::SpillStats(const SpillStats& other) {
@@ -144,6 +146,9 @@ SpillStats& SpillStats::operator+=(const SpillStats& other) {
   spillDeserializationTimeNanos.fetch_add(
       other.spillDeserializationTimeNanos.load(std::memory_order_relaxed),
       std::memory_order_relaxed);
+  spillCpuTimeNanos.fetch_add(
+      other.spillCpuTimeNanos.load(std::memory_order_relaxed),
+      std::memory_order_relaxed);
   ioStats.merge(other.ioStats);
   return *this;
 }
@@ -206,6 +211,9 @@ void SpillStats::copyFrom(const SpillStats& other) {
       std::memory_order_relaxed);
   spillDeserializationTimeNanos.store(
       other.spillDeserializationTimeNanos.load(std::memory_order_relaxed),
+      std::memory_order_relaxed);
+  spillCpuTimeNanos.store(
+      other.spillCpuTimeNanos.load(std::memory_order_relaxed),
       std::memory_order_relaxed);
   ioStats.merge(other.ioStats);
 }
@@ -284,6 +292,10 @@ SpillStats SpillStats::operator-(const SpillStats& other) const {
       spillDeserializationTimeNanos.load(std::memory_order_relaxed) -
           other.spillDeserializationTimeNanos.load(std::memory_order_relaxed),
       std::memory_order_relaxed);
+  result.spillCpuTimeNanos.store(
+      spillCpuTimeNanos.load(std::memory_order_relaxed) -
+          other.spillCpuTimeNanos.load(std::memory_order_relaxed),
+      std::memory_order_relaxed);
   return result;
 }
 
@@ -323,7 +335,9 @@ bool SpillStats::operator==(const SpillStats& other) const {
       spillReadTimeNanos.load(std::memory_order_relaxed) ==
       other.spillReadTimeNanos.load(std::memory_order_relaxed) &&
       spillDeserializationTimeNanos.load(std::memory_order_relaxed) ==
-      other.spillDeserializationTimeNanos.load(std::memory_order_relaxed);
+      other.spillDeserializationTimeNanos.load(std::memory_order_relaxed) &&
+      spillCpuTimeNanos.load(std::memory_order_relaxed) ==
+      other.spillCpuTimeNanos.load(std::memory_order_relaxed);
 }
 
 void SpillStats::reset() {
@@ -345,6 +359,7 @@ void SpillStats::reset() {
   spillReads.store(0, std::memory_order_relaxed);
   spillReadTimeNanos.store(0, std::memory_order_relaxed);
   spillDeserializationTimeNanos.store(0, std::memory_order_relaxed);
+  spillCpuTimeNanos.store(0, std::memory_order_relaxed);
   ioStats = IoStats();
 }
 
@@ -391,7 +406,9 @@ std::string SpillStats::toString() const {
      << "spillReadDeserializationTimeNanos["
      << succinctNanos(
             spillDeserializationTimeNanos.load(std::memory_order_relaxed))
-     << "]";
+     << "] "
+     << "spillCpuTimeNanos["
+     << succinctNanos(spillCpuTimeNanos.load(std::memory_order_relaxed)) << "]";
 
   const auto ioStatsMap = ioStats.stats();
   if (!ioStatsMap.empty()) {

--- a/velox/exec/SpillStats.h
+++ b/velox/exec/SpillStats.h
@@ -20,6 +20,7 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/file/File.h"
+#include "velox/common/process/ProcessBase.h"
 
 namespace facebook::velox::exec {
 
@@ -67,6 +68,9 @@ struct SpillStats {
   std::atomic_uint64_t spillReadTimeNanos{0};
   /// The time spent on deserializing rows read from spilled files.
   std::atomic_uint64_t spillDeserializationTimeNanos{0};
+  /// The CPU time spent on spill operations running on background (non-driver)
+  /// threads.
+  std::atomic_uint64_t spillCpuTimeNanos{0};
   /// Filesystem I/O stats for spill operations.
   IoStats ioStats;
 
@@ -90,7 +94,8 @@ struct SpillStats {
       uint64_t _spillReadBytes,
       uint64_t _spillReads,
       uint64_t _spillReadTimeNanos,
-      uint64_t _spillDeserializationTimeNanos);
+      uint64_t _spillDeserializationTimeNanos,
+      uint64_t _spillCpuTimeNanos);
 
   SpillStats(const SpillStats& other);
 
@@ -110,6 +115,29 @@ struct SpillStats {
 
  private:
   void copyFrom(const SpillStats& other);
+};
+
+class SpillBackgroundCpuTimer {
+ public:
+  explicit SpillBackgroundCpuTimer(SpillStats* stats)
+      : stats_(stats),
+        cpuTimeStart_(stats_ != nullptr ? process::threadCpuNanos() : 0) {}
+
+  ~SpillBackgroundCpuTimer() {
+    if (stats_ != nullptr) {
+      stats_->spillCpuTimeNanos.fetch_add(
+          process::threadCpuNanos() - cpuTimeStart_, std::memory_order_relaxed);
+    }
+  }
+
+  SpillBackgroundCpuTimer(const SpillBackgroundCpuTimer&) = delete;
+  SpillBackgroundCpuTimer& operator=(const SpillBackgroundCpuTimer&) = delete;
+  SpillBackgroundCpuTimer(SpillBackgroundCpuTimer&&) = delete;
+  SpillBackgroundCpuTimer& operator=(SpillBackgroundCpuTimer&&) = delete;
+
+ private:
+  SpillStats* const stats_;
+  const uint64_t cpuTimeStart_;
 };
 
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -49,6 +49,11 @@ class SpillerBase {
 
   exec::SpillStats stats() const;
 
+  /// Returns the raw pointer to the spill stats for direct atomic updates.
+  exec::SpillStats* spillStatsPtr() const {
+    return spillStats_;
+  }
+
   std::string toString() const;
 
  protected:
@@ -134,7 +139,9 @@ class SpillerBase {
         SpillPartitionId _partitionId,
         int32_t _numWritten,
         std::exception_ptr _error)
-        : partitionId(_partitionId), rowsWritten(_numWritten), error(_error) {}
+        : partitionId(_partitionId),
+          rowsWritten(_numWritten),
+          error(std::move(_error)) {}
   };
 
   RowContainer* const container_{nullptr};

--- a/velox/exec/tests/SpillStatsTest.cpp
+++ b/velox/exec/tests/SpillStatsTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/exec/SpillStats.h"
+#include <folly/Benchmark.h>
 #include <gtest/gtest.h>
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -42,6 +43,7 @@ TEST(SpillStatsTest, spillStats) {
   stats1.spillReads = 10;
   stats1.spillReadTimeNanos = 100;
   stats1.spillDeserializationTimeNanos = 100;
+  stats1.spillCpuTimeNanos = 100;
   ASSERT_FALSE(stats1.empty());
   SpillStats stats2;
   stats2.spillRuns = 100;
@@ -62,6 +64,7 @@ TEST(SpillStatsTest, spillStats) {
   stats2.spillReads = 10;
   stats2.spillReadTimeNanos = 100;
   stats2.spillDeserializationTimeNanos = 100;
+  stats2.spillCpuTimeNanos = 100;
   ASSERT_TRUE(stats1 != stats2);
   ASSERT_FALSE(stats1 == stats2);
 
@@ -85,6 +88,7 @@ TEST(SpillStatsTest, spillStats) {
   ASSERT_EQ(delta.spillReads, 0);
   ASSERT_EQ(delta.spillReadTimeNanos, 0);
   ASSERT_EQ(delta.spillDeserializationTimeNanos, 0);
+  ASSERT_EQ(delta.spillCpuTimeNanos, 0);
   delta = stats1 - stats2;
   ASSERT_EQ(delta.spilledInputBytes, 0);
   ASSERT_EQ(delta.spilledBytes, 0);
@@ -103,6 +107,7 @@ TEST(SpillStatsTest, spillStats) {
   ASSERT_EQ(delta.spillReads, 0);
   ASSERT_EQ(delta.spillReadTimeNanos, 0);
   ASSERT_EQ(delta.spillDeserializationTimeNanos, 0);
+  ASSERT_EQ(delta.spillCpuTimeNanos, 0);
   stats1.spilledInputBytes = 2060;
   stats1.spilledBytes = 1030;
   stats1.spillReadBytes = 4096;
@@ -119,7 +124,7 @@ TEST(SpillStatsTest, spillStats) {
       "spillSerializationTimeNanos[1.03us] spillWrites[1028] spillFlushTimeNanos[1.03us] "
       "spillWriteTimeNanos[1.03us] maxSpillExceededLimitCount[4] "
       "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
-      "spillReadDeserializationTimeNanos[100ns]");
+      "spillReadDeserializationTimeNanos[100ns] spillCpuTimeNanos[100ns]");
   ASSERT_EQ(
       fmt::format("{}", stats2),
       "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] "
@@ -129,5 +134,33 @@ TEST(SpillStatsTest, spillStats) {
       "spillFlushTimeNanos[1.03us] spillWriteTimeNanos[1.03us] "
       "maxSpillExceededLimitCount[4] "
       "spillReadBytes[2.00KB] spillReads[10] spillReadTimeNanos[100ns] "
-      "spillReadDeserializationTimeNanos[100ns]");
+      "spillReadDeserializationTimeNanos[100ns] spillCpuTimeNanos[100ns]");
+}
+
+TEST(SpillStatsTest, backgroundCpuTimer) {
+  SpillStats stats;
+  ASSERT_EQ(stats.spillCpuTimeNanos.load(), 0);
+
+  // Burn some CPU inside the timer scope.
+  {
+    SpillBackgroundCpuTimer timer(&stats);
+    uint64_t sum = 0;
+    for (int i = 0; i < 1'000'000; ++i) {
+      sum += i;
+    }
+    folly::doNotOptimizeAway(sum);
+  }
+
+  ASSERT_GT(stats.spillCpuTimeNanos.load(), 0);
+
+  const auto firstMeasurement = stats.spillCpuTimeNanos.load();
+  {
+    SpillBackgroundCpuTimer timer(&stats);
+    uint64_t sum = 0;
+    for (int i = 0; i < 1'000'000; ++i) {
+      sum += i;
+    }
+    folly::doNotOptimizeAway(sum);
+  }
+  ASSERT_GT(stats.spillCpuTimeNanos.load(), firstMeasurement);
 }


### PR DESCRIPTION
Summary:
per title
now 
operatorCpuNanoscpu = isBlocked + addInput + getOutput + finish + backgroundTiming.cpuNanos
         prestoTaskStats.totalCpuTimeInNanos += cpuNanos

Differential Revision: D96229831


