### PR TITLE
refactor: Propagate CastRule cost through canCoerce (#16821)

### DIFF
--- a/velox/type/CastRegistry.cpp
+++ b/velox/type/CastRegistry.cpp
@@ -60,47 +60,65 @@ void CastRulesRegistry::unregisterCastRules(const std::string& typeName) {
 
 bool CastRulesRegistry::canCast(const TypePtr& fromType, const TypePtr& toType)
     const {
-  return canCastImpl(fromType, toType, /*requireImplicit=*/false);
+  return castCostImpl(fromType, toType, /*requireImplicit=*/false).has_value();
 }
 
-bool CastRulesRegistry::canCoerce(
+std::optional<int32_t> CastRulesRegistry::canCoerce(
     const TypePtr& fromType,
     const TypePtr& toType) const {
-  return canCastImpl(fromType, toType, /*requireImplicit=*/true);
+  return castCostImpl(fromType, toType, /*requireImplicit=*/true);
 }
 
-bool CastRulesRegistry::canCastImpl(
+std::optional<int32_t> CastRulesRegistry::castCostImpl(
     const TypePtr& fromType,
     const TypePtr& toType,
     bool requireImplicit) const {
   VELOX_CHECK_NOT_NULL(fromType, "fromType must not be null");
   VELOX_CHECK_NOT_NULL(toType, "toType must not be null");
 
-  // Cast rules are only registered for non-parametric (leaf) types. Parametric
-  // types (ARRAY, MAP, ROW, and custom types with children like IPPREFIX) are
-  // handled by callers (TypeCoercer::coercible, leastCommonSuperType) which
-  // recurse into children before reaching this method. Return false for
-  // parametric types rather than throwing — this is a query function.
-  if (fromType->size() != 0 || toType->size() != 0) {
-    return false;
-  }
-
-  // Same type is always allowed.
+  // Same type is always allowed with zero cost.
   if (fromType->equivalent(*toType)) {
-    return true;
+    return 0;
   }
 
-  auto rule = findRule(fromType->name(), toType->name());
-  if (!rule) {
-    return false;
+  const auto fromName = fromType->name();
+  const auto toName = toType->name();
+
+  // For leaf types (primitives and custom types), look up rule directly.
+  if (fromType->size() == 0 && toType->size() == 0) {
+    auto rule = findRule(fromName, toName);
+    if (!rule) {
+      return std::nullopt;
+    }
+    if (requireImplicit && !rule->implicitAllowed) {
+      return std::nullopt;
+    }
+    if (rule->validator && !rule->validator(fromType, toType)) {
+      return std::nullopt;
+    }
+    return requireImplicit ? rule->cost : 0;
   }
-  if (requireImplicit && !rule->implicitAllowed) {
-    return false;
+
+  // For container types (ARRAY, MAP, ROW) with the same base type,
+  // recursively check children and sum costs.
+  if (fromName == toName) {
+    if (fromType->size() != toType->size()) {
+      return std::nullopt;
+    }
+    int32_t totalCost = 0;
+    for (auto i = 0; i < fromType->size(); ++i) {
+      auto childCost = castCostImpl(
+          fromType->childAt(i), toType->childAt(i), requireImplicit);
+      if (!childCost) {
+        return std::nullopt;
+      }
+      totalCost += *childCost;
+    }
+    return totalCost;
   }
-  if (rule->validator && !rule->validator(fromType, toType)) {
-    return false;
-  }
-  return true;
+
+  // Different base types with children — not supported.
+  return std::nullopt;
 }
 
 std::optional<CastRule> CastRulesRegistry::findRule(

--- a/velox/type/CastRegistry.h
+++ b/velox/type/CastRegistry.h
@@ -47,15 +47,16 @@ class CastRulesRegistry {
   /// Unregister all rules involving the given type name.
   void unregisterCastRules(const std::string& typeName);
 
-  /// Check if cast is supported (explicit or implicit). Only for
-  /// non-parametric (leaf) types — callers handle container types by recursing
-  /// into children themselves.
+  /// Check if cast is supported (explicit or implicit). Handles container
+  /// types (ARRAY, MAP, ROW) by recursively checking children.
   bool canCast(const TypePtr& fromType, const TypePtr& toType) const;
 
-  /// Check if implicit coercion is allowed. Only for non-parametric (leaf)
-  /// types — callers handle container types by recursing into children
-  /// themselves.
-  bool canCoerce(const TypePtr& fromType, const TypePtr& toType) const;
+  /// Check if implicit coercion is allowed. Returns the coercion cost if
+  /// allowed, or std::nullopt if not. For container types (ARRAY, MAP, ROW),
+  /// returns the sum of children coercion costs.
+  std::optional<int32_t> canCoerce(
+      const TypePtr& fromType,
+      const TypePtr& toType) const;
 
   /// Clear all registered rules. Used for testing.
   void clear();
@@ -63,7 +64,10 @@ class CastRulesRegistry {
  private:
   CastRulesRegistry() = default;
 
-  bool canCastImpl(
+  // Unified implementation. When requireImplicit is true, returns the cost
+  // of implicit coercion. When false, returns 0 for any supported cast.
+  // Returns nullopt if the cast/coercion is not supported.
+  std::optional<int32_t> castCostImpl(
       const TypePtr& fromType,
       const TypePtr& toType,
       bool requireImplicit) const;

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -82,15 +82,14 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
     return it->second;
   }
 
-  // Check custom type coercions from CastRulesRegistry. Built-in coercions
-  // are already handled by kAllowedCoercions above. Use getCustomType (not
-  // getType) because parametric built-in factories (ARRAY, ROW, DECIMAL)
-  // throw when called with empty parameters.
+  // Fall back to CastRulesRegistry for custom type coercions.
   if (fromType->size() == 0) {
     auto toType = getCustomType(toTypeName, {});
-    if (toType != nullptr &&
-        CastRulesRegistry::instance().canCoerce(fromType, toType)) {
-      return Coercion{.type = std::move(toType), .cost = 1};
+    if (toType != nullptr) {
+      if (auto cost =
+              CastRulesRegistry::instance().canCoerce(fromType, toType)) {
+        return Coercion{.type = std::move(toType), .cost = *cost};
+      }
     }
   }
 

--- a/velox/type/tests/CastRegistryTest.cpp
+++ b/velox/type/tests/CastRegistryTest.cpp
@@ -47,6 +47,7 @@ TEST_F(CastRulesRegistryTest, canCastAndCanCoerce) {
       {.fromType = "BIGINT",
        .toType = "DOUBLE",
        .implicitAllowed = true,
+       .cost = 3,
        .validator = {}},
       {.fromType = "DOUBLE",
        .toType = "VARCHAR",
@@ -56,7 +57,7 @@ TEST_F(CastRulesRegistryTest, canCastAndCanCoerce) {
 
   // Same type is always allowed.
   EXPECT_TRUE(CastRulesRegistry::instance().canCast(BIGINT(), BIGINT()));
-  EXPECT_TRUE(CastRulesRegistry::instance().canCoerce(BIGINT(), BIGINT()));
+  EXPECT_EQ(CastRulesRegistry::instance().canCoerce(BIGINT(), BIGINT()), 0);
 
   // Implicit rule: BIGINT -> DOUBLE allows both cast and coerce.
   EXPECT_TRUE(CastRulesRegistry::instance().canCast(BIGINT(), DOUBLE()));
@@ -131,15 +132,169 @@ TEST_F(CastRulesRegistryTest, conflictingRulesThrow) {
       VeloxException);
 }
 
-TEST_F(CastRulesRegistryTest, parametricTypesReturnFalse) {
-  // Parametric types (ARRAY, MAP, ROW, custom types with children like
-  // IPPREFIX) are handled by callers recursing into children. The registry
-  // only stores leaf-to-leaf rules, so parametric types return false.
-  EXPECT_FALSE(
+TEST_F(CastRulesRegistryTest, canCoerceCost) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .cost = 5,
+       .validator = {}},
+  });
+
+  // Primitive coercion returns the rule's cost.
+  EXPECT_EQ(CastRulesRegistry::instance().canCoerce(BIGINT(), DOUBLE()), 5);
+
+  // Container types sum children costs.
+  EXPECT_EQ(
+      CastRulesRegistry::instance().canCoerce(ARRAY(BIGINT()), ARRAY(DOUBLE())),
+      5);
+  EXPECT_EQ(
+      CastRulesRegistry::instance().canCoerce(
+          MAP(BIGINT(), BIGINT()), MAP(DOUBLE(), DOUBLE())),
+      10);
+  EXPECT_EQ(
+      CastRulesRegistry::instance().canCoerce(
+          ROW({BIGINT(), BIGINT(), BIGINT()}),
+          ROW({DOUBLE(), DOUBLE(), DOUBLE()})),
+      15);
+
+  // No coercion returns nullopt.
+  EXPECT_FALSE(CastRulesRegistry::instance().canCoerce(DOUBLE(), BIGINT()));
+
+  // Mixed costs: different rules contribute different costs in the same
+  // container.
+  registerRules({
+      {.fromType = "VARCHAR",
+       .toType = "INTEGER",
+       .implicitAllowed = true,
+       .cost = 3,
+       .validator = {}},
+  });
+  EXPECT_EQ(
+      CastRulesRegistry::instance().canCoerce(
+          ROW({BIGINT(), VARCHAR()}), ROW({DOUBLE(), INTEGER()})),
+      8);
+  EXPECT_EQ(
+      CastRulesRegistry::instance().canCoerce(
+          MAP(VARCHAR(), BIGINT()), MAP(INTEGER(), DOUBLE())),
+      8);
+
+  // Nested containers: cost comes from the leaf rule only.
+  EXPECT_EQ(
+      CastRulesRegistry::instance().canCoerce(
+          ARRAY(ARRAY(BIGINT())), ARRAY(ARRAY(DOUBLE()))),
+      5);
+}
+
+TEST_F(CastRulesRegistryTest, parametricTypeCasting) {
+  // Rule for element types: BIGINT -> DOUBLE.
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // ARRAY<BIGINT> -> ARRAY<DOUBLE> via recursive element check.
+  EXPECT_TRUE(
       CastRulesRegistry::instance().canCast(ARRAY(BIGINT()), ARRAY(DOUBLE())));
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCoerce(
+          ARRAY(BIGINT()), ARRAY(DOUBLE())));
+
+  // Negative: ARRAY<DOUBLE> -> ARRAY<BIGINT> (no reverse rule).
   EXPECT_FALSE(
+      CastRulesRegistry::instance().canCast(ARRAY(DOUBLE()), ARRAY(BIGINT())));
+}
+
+TEST_F(CastRulesRegistryTest, nestedParametricTypes) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // ARRAY<ARRAY<BIGINT>> -> ARRAY<ARRAY<DOUBLE>>.
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCast(
+          ARRAY(ARRAY(BIGINT())), ARRAY(ARRAY(DOUBLE()))));
+}
+
+TEST_F(CastRulesRegistryTest, mapTypeCasting) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // MAP<BIGINT, VARCHAR> -> MAP<DOUBLE, VARCHAR>.
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCast(
+          MAP(BIGINT(), VARCHAR()), MAP(DOUBLE(), VARCHAR())));
+
+  // Negative: MAP<VARCHAR, BIGINT> -> MAP<BIGINT, VARCHAR> (no
+  // VARCHAR->BIGINT rule).
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCast(
+          MAP(VARCHAR(), BIGINT()), MAP(BIGINT(), VARCHAR())));
+}
+
+TEST_F(CastRulesRegistryTest, mismatchedChildCount) {
+  // ROW(BIGINT) vs ROW(BIGINT, VARCHAR) — different child counts.
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCast(
+          ROW({BIGINT()}), ROW({BIGINT(), VARCHAR()})));
+}
+
+TEST_F(CastRulesRegistryTest, differentContainerBaseTypes) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // Different container base types are not supported (e.g. ARRAY -> MAP).
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCast(
+          ARRAY(BIGINT()), MAP(BIGINT(), DOUBLE())));
+}
+
+TEST_F(CastRulesRegistryTest, rowTypeCasting) {
+  registerRules({
+      {.fromType = "BIGINT",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .validator = {}},
+  });
+
+  // ROW({BIGINT}) -> ROW({DOUBLE}) via recursive child check.
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCast(ROW({BIGINT()}), ROW({DOUBLE()})));
+  EXPECT_TRUE(
       CastRulesRegistry::instance().canCoerce(
           ROW({BIGINT()}), ROW({DOUBLE()})));
+}
+
+TEST_F(CastRulesRegistryTest, containerCoercionExplicitOnlyRule) {
+  // Register an explicit-only rule (implicitAllowed=false).
+  registerRules({
+      {.fromType = "VARCHAR",
+       .toType = "BIGINT",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
+
+  // Explicit cast on a container with explicit-only element rule succeeds.
+  EXPECT_TRUE(
+      CastRulesRegistry::instance().canCast(ARRAY(VARCHAR()), ARRAY(BIGINT())));
+
+  // Implicit coercion on a container with explicit-only element rule fails.
+  EXPECT_FALSE(
+      CastRulesRegistry::instance().canCoerce(
+          ARRAY(VARCHAR()), ARRAY(BIGINT())));
 }
 
 TEST_F(CastRulesRegistryTest, clearRemovesAllRules) {

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/type/TypeCoercer.h"
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -216,6 +217,12 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
   ASSERT_TRUE(
       TypeCoercer::leastCommonSuperType(
           MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
+}
+
+TEST(TypeCoercerTest, parametricBuiltinTargetDoesNotThrow) {
+  // Parametric built-in factories throw on empty params. Verify graceful
+  // handling.
+  EXPECT_EQ(TypeCoercer::coerceTypeBase(BIGINT(), "ARRAY"), std::nullopt);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

`TypeCoercer::coerceTypeBase` hardcoded `cost = 1` for all custom type coercions from CastRulesRegistry, ignoring the `cost` field on CastRule. This made overload resolution unable to distinguish between closer and farther coercions (e.g., TIMESTAMP→TSTZ vs DATE→TSTZ).

Changes `canCoerce` from returning `bool` to `std::optional<int32_t>` (the rule's cost, or nullopt). Backward compatible — `std::optional` works in all existing boolean contexts.

Adds private `castCostImpl(from, to, requireImplicit) -> std::optional<int32_t>`. If `requireImplicit=true`, returns the rule cost; otherwise returns `0` for any supported cast. Returns `nullopt` for unsupported casts. Container casts recurse and sum child costs.

Reviewed By: kevinwilfong

Differential Revision: D97155188


