### PR TITLE
misc: Remove unused footer estimated size constant (#16822)

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -556,9 +556,6 @@ class ReaderOptions : public io::ReaderOptions {
  public:
   static constexpr uint64_t kDefaultFooterSpeculativeIoSize =
       1024 * 1024; // 1MB
-  /// @deprecated Use kDefaultFooterSpeculativeIoSize instead.
-  static constexpr uint64_t kDefaultFooterEstimatedSize =
-      kDefaultFooterSpeculativeIoSize;
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
 
@@ -613,11 +610,6 @@ class ReaderOptions : public io::ReaderOptions {
   ReaderOptions& setFooterSpeculativeIoSize(uint64_t size) {
     footerSpeculativeIoSize_ = size;
     return *this;
-  }
-
-  /// @deprecated Use setFooterSpeculativeIoSize instead.
-  ReaderOptions& setFooterEstimatedSize(uint64_t size) {
-    return setFooterSpeculativeIoSize(size);
   }
 
   ReaderOptions& setFilePreloadThreshold(uint64_t threshold) {
@@ -684,11 +676,6 @@ class ReaderOptions : public io::ReaderOptions {
 
   uint64_t footerSpeculativeIoSize() const {
     return footerSpeculativeIoSize_;
-  }
-
-  /// @deprecated Use footerSpeculativeIoSize instead.
-  uint64_t footerEstimatedSize() const {
-    return footerSpeculativeIoSize();
   }
 
   uint64_t filePreloadThreshold() const {


### PR DESCRIPTION
Summary:
Clean up for D95663885

X-link: https://github.com/facebookincubator/nimble/pull/583

Reviewed By: xiaoxmeng

Differential Revision: D97166503


