### PR TITLE
feat: Add coercion rules for TIMESTAMP WITH TIME ZONE (#16823)

### DIFF
--- a/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
 #include "velox/functions/prestosql/types/fuzzer_utils/TimeWithTimezoneInputGenerator.h"
+#include "velox/type/CastRegistry.h"
 #include "velox/type/Time.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -290,6 +291,24 @@ void registerTimeWithTimezoneType() {
   registerCustomType(
       "time with time zone",
       std::make_unique<const TimeWithTimezoneTypeFactory>());
+  registerCastRules({
+      {.fromType = "TIME",
+       .toType = "TIME WITH TIME ZONE",
+       .implicitAllowed = true,
+       .validator = {}},
+      {.fromType = "VARCHAR",
+       .toType = "TIME WITH TIME ZONE",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIME WITH TIME ZONE",
+       .toType = "TIME",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIME WITH TIME ZONE",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/functions/prestosql/types/fuzzer_utils/TimestampWithTimeZoneInputGenerator.h"
+#include "velox/type/CastRegistry.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
@@ -386,7 +387,6 @@ class TimestampWithTimeZoneTypeFactory : public CustomTypeFactory {
     return TIMESTAMP_WITH_TIME_ZONE();
   }
 
-  // Type casting from and to TimestampWithTimezone is not supported yet.
   exec::CastOperatorPtr getCastOperator() const override {
     return TimestampWithTimeZoneCastOperator::get();
   }
@@ -403,5 +403,43 @@ void registerTimestampWithTimeZoneType() {
   registerCustomType(
       "timestamp with time zone",
       std::make_unique<const TimestampWithTimeZoneTypeFactory>());
+  // Lower cost = preferred during overload resolution. TIMESTAMP is closer
+  // to TIMESTAMP WITH TIME ZONE than DATE.
+  registerCastRules({
+      {.fromType = "TIMESTAMP",
+       .toType = "TIMESTAMP WITH TIME ZONE",
+       .implicitAllowed = true,
+       .cost = 1,
+       .validator = {}},
+      {.fromType = "VARCHAR",
+       .toType = "TIMESTAMP WITH TIME ZONE",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "DATE",
+       .toType = "TIMESTAMP WITH TIME ZONE",
+       .implicitAllowed = true,
+       .cost = 2,
+       .validator = {}},
+      {.fromType = "TIME",
+       .toType = "TIMESTAMP WITH TIME ZONE",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIMESTAMP WITH TIME ZONE",
+       .toType = "TIMESTAMP",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIMESTAMP WITH TIME ZONE",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIMESTAMP WITH TIME ZONE",
+       .toType = "DATE",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIMESTAMP WITH TIME ZONE",
+       .toType = "TIME",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   velox_presto_types_test
   BingTileTypeTest.cpp
+  CustomTypeCoercionTest.cpp
   HyperLogLogTypeTest.cpp
   JsonTypeTest.cpp
   KHyperLogLogTypeTest.cpp

--- a/velox/functions/prestosql/types/tests/CustomTypeCoercionTest.cpp
+++ b/velox/functions/prestosql/types/tests/CustomTypeCoercionTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneRegistration.h"
+#include "velox/functions/prestosql/types/TimeWithTimezoneType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/TypeCoercer.h"
+
+namespace facebook::velox {
+namespace {
+
+// Verifies implicit coercion rules registered by Presto custom types.
+class CustomTypeCoercionTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    registerTimestampWithTimeZoneType();
+    registerTimeWithTimezoneType();
+  }
+};
+
+TEST_F(CustomTypeCoercionTest, timestampWithTimeZone) {
+  auto coercion = TypeCoercer::coerceTypeBase(
+      TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE()->name());
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, TIMESTAMP_WITH_TIME_ZONE());
+  EXPECT_EQ(coercion->cost, 1);
+
+  coercion =
+      TypeCoercer::coerceTypeBase(DATE(), TIMESTAMP_WITH_TIME_ZONE()->name());
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, TIMESTAMP_WITH_TIME_ZONE());
+  EXPECT_EQ(coercion->cost, 2);
+
+  // Reverse directions are explicit-only, not coercible.
+  ASSERT_FALSE(
+      TypeCoercer::coerceTypeBase(
+          TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP()->name()));
+  ASSERT_FALSE(
+      TypeCoercer::coerceTypeBase(TIMESTAMP_WITH_TIME_ZONE(), DATE()->name()));
+}
+
+TEST_F(CustomTypeCoercionTest, timeWithTimeZone) {
+  auto coercion =
+      TypeCoercer::coerceTypeBase(TIME(), TIME_WITH_TIME_ZONE()->name());
+  ASSERT_TRUE(coercion.has_value());
+  VELOX_EXPECT_EQ_TYPES(coercion->type, TIME_WITH_TIME_ZONE());
+
+  // Reverse directions are explicit-only, not coercible.
+  ASSERT_FALSE(
+      TypeCoercer::coerceTypeBase(TIME_WITH_TIME_ZONE(), TIME()->name()));
+  ASSERT_FALSE(
+      TypeCoercer::coerceTypeBase(TIME_WITH_TIME_ZONE(), DATE()->name()));
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:

Add cast rules for Presto custom types using the new CastRegistry for TIMESTAMP WITH TIME ZONE:
- TIMESTAMP -> TIMESTAMP WITH TIME ZONE (implicit)
- DATE -> TIMESTAMP WITH TIME ZONE (implicit)
- VARCHAR -> TIMESTAMP WITH TIME ZONE (explicit)
- TIME -> TIMESTAMP WITH TIME ZONE (explicit)

Reviewed By: kevinwilfong

Differential Revision: D93797021


