### PR TITLE
test: Split join tests out of monolithic exec test target

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -56,24 +56,19 @@ set(
   FilterToExpressionTest.cpp
   FunctionResolutionTest.cpp
   HashBitRangeTest.cpp
-  HashJoinBridgeTest.cpp
-  HashJoinTest.cpp
   HashPartitionFunctionTest.cpp
   HashTableTest.cpp
-  IndexLookupJoinTest.cpp
   LimitTest.cpp
   LocalPartitionTest.cpp
   MarkDistinctTest.cpp
   MarkSortedTest.cpp
   EnforceDistinctTest.cpp
   MemoryReclaimerTest.cpp
-  MergeJoinTest.cpp
   MergeTest.cpp
   MergerTest.cpp
   MixedUnionTest.cpp
   MixedUnionWithTableScanTest.cpp
   MultiFragmentTest.cpp
-  NestedLoopJoinTest.cpp
   OrderByTest.cpp
   OperatorTraceTest.cpp
   OutputBufferManagerTest.cpp
@@ -165,6 +160,40 @@ velox_add_grouped_tests(
   PREFIX velox_exec_test
   SOURCES ${VELOX_EXEC_TEST_SOURCES}
   DEPS ${VELOX_EXEC_TEST_DEPS}
+  EXTRA_SOURCES Main.cpp
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+set(
+  VELOX_EXEC_JOIN_TEST_SOURCES
+  HashJoinBridgeTest.cpp
+  HashJoinTest.cpp
+  IndexLookupJoinTest.cpp
+  MergeJoinTest.cpp
+  NestedLoopJoinTest.cpp
+)
+
+set(
+  VELOX_EXEC_JOIN_TEST_DEPS
+  velox_dwio_common_test_utils
+  velox_exec
+  velox_exec_test_lib
+  velox_memory
+  velox_test_util
+  velox_type_test_lib
+  velox_vector_fuzzer
+  Folly::folly
+  GTest::gtest
+  GTest::gtest_main
+  GTest::gmock
+  fmt::fmt
+  re2::re2
+)
+
+velox_add_grouped_tests(
+  PREFIX velox_exec_join_test
+  SOURCES ${VELOX_EXEC_JOIN_TEST_SOURCES}
+  DEPS ${VELOX_EXEC_JOIN_TEST_DEPS}
   EXTRA_SOURCES Main.cpp
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )


### PR DESCRIPTION
Summary:
The `velox/exec/tests:test` target bundles 78 source files (~72K lines)
into a single binary with 70 dependencies. This makes build and link
times unnecessarily long, especially for developers iterating on
specific operator tests.

This diff extracts the 5 join test files (HashJoinTest, HashJoinBridgeTest,
MergeJoinTest, NestedLoopJoinTest, IndexLookupJoinTest) into a dedicated
`join_test` target with only 17 dependencies. The resulting binary is ~34MB
vs the monolith's ~130MB+, significantly reducing link times for incremental
builds and enabling better CI parallelism.

Changes:
- BUCK: Added `join_test` cpp_unittest target, removed join files from `test`
- CMakeLists.txt: Added `VELOX_EXEC_JOIN_TEST_SOURCES/DEPS` and
  `velox_add_grouped_tests` section, removed join files from
  `VELOX_EXEC_TEST_SOURCES`

Differential Revision: D97182249


