### PR TITLE
fix: Back out Avoid redundant outputBuffer clearing (#16829)

### DIFF
--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -28,16 +28,12 @@ namespace facebook::velox::dwio::common {
 template <typename T, typename = std::enable_if_t<std::is_trivial_v<T>>>
 class DataBuffer {
  public:
-  explicit DataBuffer(
-      velox::memory::MemoryPool& pool,
-      uint64_t size = 0,
-      bool zeroFilled = true)
+  explicit DataBuffer(velox::memory::MemoryPool& pool, uint64_t size = 0)
       : pool_(&pool),
-        // Initial allocation uses calloc if zeroFilled, to avoid memset.
+        // Initial allocation uses calloc, to avoid memset.
         buf_(
             reinterpret_cast<T*>(
-                zeroFilled ? pool_->allocateZeroFilled(1, sizeInBytes(size))
-                           : pool_->allocate(sizeInBytes(size)))),
+                pool_->allocateZeroFilled(1, sizeInBytes(size)))),
         size_(size),
         capacity_(size) {
     VELOX_CHECK(buf_ != nullptr || size_ == 0);

--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -22,9 +22,8 @@ namespace facebook::velox::dwio::common::compression {
 
 void PagedInputStream::prepareOutputBuffer(uint64_t uncompressedLength) {
   if (!outputBuffer_ || uncompressedLength > outputBuffer_->capacity()) {
-    // OutputBuffer is intended for writing before reading, not need zeroFilled.
     outputBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
-        pool_, uncompressedLength, false);
+        pool_, uncompressedLength);
   }
 }
 


### PR DESCRIPTION
Summary:

Backing out PR: https://github.com/facebookincubator/velox/pull/15998 because it is causing query failures.
We will investigate and put out a more through fix post backing out.

Original commit changeset: cd2a2c053cc3

Original Phabricator Diff: D94967428

Reviewed By: zation99

Differential Revision: D97194046
