### PR TITLE
fix: Copy pattern string in LikeGeneric to prevent use-after-free crash (#16830)

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -943,8 +943,12 @@ class LikeGeneric final : public exec::VectorFunction {
     auto applyRow = [&](const StringView& input,
                         const StringView& pattern,
                         const std::optional<char>& escapeChar) -> bool {
+      // Copy the pattern to a local string to protect against potential
+      // use-after-free if the underlying string buffer is reclaimed by memory
+      // arbitration under memory pressure.
+      std::string patternCopy(pattern.data(), pattern.size());
       PatternMetadata patternMetadata =
-          determinePatternKind(std::string_view(pattern), escapeChar);
+          determinePatternKind(patternCopy, escapeChar);
 
       if (isAscii) {
         switch (patternMetadata.patternKind()) {

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -17,6 +17,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <sys/mman.h>
 #include <velox/type/Type.h>
 #include <functional>
 #include <optional>
@@ -32,6 +33,27 @@
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
+
+// Detect sanitizer builds for guarding death tests.
+#ifdef __has_feature
+#define RE2_BUILDING_WITH_ASAN() __has_feature(address_sanitizer)
+#define RE2_BUILDING_WITH_TSAN() __has_feature(thread_sanitizer)
+#else
+#if defined(__SANITIZE_ADDRESS__) && __SANITIZE_ADDRESS__
+#define RE2_BUILDING_WITH_ASAN() 1
+#else
+#define RE2_BUILDING_WITH_ASAN() 0
+#endif
+#if defined(__SANITIZE_THREAD__) && __SANITIZE_THREAD__
+#define RE2_BUILDING_WITH_TSAN() 1
+#else
+#define RE2_BUILDING_WITH_TSAN() 0
+#endif
+#endif
+
+#if RE2_BUILDING_WITH_TSAN() || RE2_BUILDING_WITH_ASAN()
+#define RE2_BUILDING_WITH_SAN
+#endif
 
 namespace facebook::velox::functions {
 
@@ -520,6 +542,81 @@ TEST_F(Re2FunctionsTest, likePattern) {
 
   testLike("aabbccddeeff", "%aa%bb%", true);
   testLike("aaccddeeff", "%aa%bb%", false);
+}
+
+// Test LikeGeneric with non-constant patterns longer than 12 bytes (non-inline
+// StringView) to exercise the code path where pattern data is stored as a
+// pointer to the vector's string buffer rather than inline in the StringView.
+TEST_F(Re2FunctionsTest, likeGenericWithLongPatterns) {
+  // Patterns >12 bytes to ensure StringView stores a pointer (non-inline).
+  // Fixed pattern.
+  testLike("longfixedpatternvalue", "longfixedpatternvalue", true);
+  testLike("longfixedpatternvalue", "longfixedpatternother", false);
+  // Prefix pattern.
+  testLike("longprefixpatternvalue", "longprefixpattern%", true);
+  testLike("shortvalue", "longprefixpattern%", false);
+  // Suffix pattern.
+  testLike("valuelongsuffixpattern", "%longsuffixpattern", true);
+  testLike("shortvalue", "%longsuffixpattern", false);
+  // Substring pattern.
+  testLike("prefixlongsubstringpatternsuffix", "%longsubstringpattern%", true);
+  testLike("nothinghere", "%longsubstringpattern%", false);
+  // Generic pattern.
+  testLike("a_long_generic_pattern_value", "%long_generic_pattern%", true);
+  testLike("a_short_value", "%long_generic_pattern%", false);
+}
+
+// Verify that copying a pattern string before calling determinePatternKind
+// protects against use-after-free when the underlying StringView buffer is
+// reclaimed. Uses mmap/munmap to simulate the production crash scenario where
+// memory-mapped pages backing pattern data are unmapped under memory pressure,
+// producing a SIGSEGV at a page-aligned address (as seen in T260427308).
+TEST_F(Re2FunctionsTest, likePatternCopyProtectsAgainstDanglingPointer) {
+  // Use a pattern with only literal chars + trailing '%' to get kPrefix kind.
+  // Avoid '_' which is a LIKE single-char wildcard.
+  const std::string pattern = "averylongpatternthatexceedsinlinestorage%";
+  ASSERT_GT(pattern.size(), 12);
+
+  // Allocate a page of memory via mmap (simulates memory-mapped file pages
+  // that back string data in production scans).
+  void* page = mmap(
+      nullptr,
+      4096,
+      PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS,
+      -1,
+      0);
+  ASSERT_NE(page, MAP_FAILED);
+  memcpy(page, pattern.data(), pattern.size());
+
+  // Create a StringView pointing into the mmap'd page (simulates how
+  // FlatVector<StringView> stores pointers to string buffers).
+  StringView patternView(static_cast<const char*>(page), pattern.size());
+
+  // The fix: copy to a local string while the page is still mapped.
+  std::string patternCopy(patternView.data(), patternView.size());
+
+  // Unmap the page (simulates buffer reclamation under memory pressure).
+  // After this, any access to 'page' causes SIGSEGV, exactly matching the
+  // production crash at page-aligned address 0x7fa369c00000.
+  munmap(page, 4096);
+
+  // With the fix (using the copy): works correctly.
+  auto metadata = determinePatternKind(patternCopy, std::nullopt);
+  EXPECT_EQ(metadata.patternKind(), PatternKind::kPrefix);
+  EXPECT_EQ(
+      metadata.fixedPattern(), "averylongpatternthatexceedsinlinestorage");
+
+  // Without the fix (using the unmapped page): SIGSEGV.
+  // Under sanitizers, ASSERT_DEATH may not work reliably (sanitizers
+  // intercept signals and fork() has known issues with ASAN shadow memory).
+#ifndef RE2_BUILDING_WITH_SAN
+  ASSERT_DEATH(
+      determinePatternKind(
+          std::string_view(static_cast<const char*>(page), pattern.size()),
+          std::nullopt),
+      "");
+#endif
 }
 
 TEST_F(Re2FunctionsTest, likeDeterminePatternKind) {


### PR DESCRIPTION
Summary:

## Root Cause Analysis

The production crash was a SIGSEGV at page-aligned address
`0x7fa369c00000` in `PatternStringIterator::charAt()` during
`LikeGeneric::apply()`. The root cause is that `StringView` is a
non-owning pointer — when the backing memory (likely memory-mapped file
pages from a scan operator) was reclaimed/unmapped under memory pressure
(1.96GB peak spill), the pointer became dangling.

This is a known class of bugs in Velox — the DWRF FlatMap writer had an
identical issue (`TestFlatMapDanglingStringViewKeyOnRehash`), where
`StringView` keys in an F14 map dangled after the input vector's buffer
was freed.

**Why the buffer can be freed during `apply()`:**
- Memory arbitration can be triggered by any pool allocation (e.g.,
  `context.ensureWritable()`)
- The arbitrator reclaims from OTHER operators/tasks by spilling them
- The current operator is protected by `NonReclaimableSectionGuard`, but
  operators that produced the input vectors are NOT
- When those operators' memory is reclaimed, the mmap'd pages backing
  string data can be munmap'd
- `DecodedVector` stores raw pointers (NOT shared_ptr) to the base
  vector's data, so it doesn't prevent reclamation

## Fix

Copy the pattern string to a local `std::string` before passing it to
`determinePatternKind()`, eliminating the dependency on the original
buffer's lifetime. The performance cost is minimal: one heap allocation
per row in the already-slow non-constant pattern path.

## Tests

- `likeGenericWithLongPatterns`: Exercises the full `LikeGeneric::apply`
  code path with patterns >12 bytes (non-inline StringView) across all
  optimized pattern kinds (fixed, prefix, suffix, substring, generic).

- `likePatternCopyProtectsAgainstDanglingPointer`: Uses `mmap`/`munmap`
  to precisely reproduce the production crash scenario where
  memory-mapped pages are unmapped. Verifies the defensive copy protects
  against the dangling pointer. Death test guarded with
  `#ifndef RE2_BUILDING_WITH_SAN` following the established Velox pattern
  from `ThreadDebugInfoDeathTest`.

```
W0317 10:45:17.338729   962 [MemoryCheckerTh] PeriodicMemoryChecker.cpp:171] System used memory 98.92GB exceeded limit: 98.00GB
I0317 10:45:17.338799   962 [MemoryCheckerTh] AsyncDataCache.cpp:883] Try to shrink cache to free up 8.92GB  memory
I0317 10:45:18.426632   962 [MemoryCheckerTh] AsyncDataCache.cpp:912] Freed 8.92GB cache memory, spent 1.09s
AsyncDataCache:
Cache size: 47.83GB tinySize: 104.37MB large size: 47.73GB
Cache entries: 631619 read pins: 9 write pins: 0 pinned shared: 3.76MB pinned exclusive: 0B
 num write wait: 2214463 empty entries: 24640747
Cache access miss: 1015380044 hit: 689290647 hit bytes: 297.70TB eviction: 1014733085 savable eviction: 41203463 eviction checks: 210822364904 aged out: 15340 stales: 0
Prefetch entries: 66813 bytes: 299.18MB
Alloc Megaclocks 187071714
Allocated pages: 17191373 cached pages: 12511075
Backing: Memory Allocator[MMAP total capacity 79.00GB free capacity 13.42GB allocated pages 17191373 mapped pages 18370872 external mapped pages 4642968
[size 1: 80775(315MB) allocated 126234 mapped]
[size 2: 81815(639MB) allocated 168151 mapped]
[size 4: 53466(835MB) allocated 85150 mapped]
[size 8: 25931(810MB) allocated 41224 mapped]
[size 16: 23254(1453MB) allocated 31144 mapped]
[size 32: 15357(1919MB) allocated 19535 mapped]
[size 64: 28495(7123MB) allocated 34663 mapped]
[size 128: 10600(5300MB) allocated 10600 mapped]
[size 256: 30620(30620MB) allocated 30845 mapped]
]
SSD: Ssd cache IO: Write 18.22TB read 4.24TB Size 1.44TB Occupied 1.37TB 3745K entries (max 9765K).
GroupStats: <dummy FileGroupStats>
I0317 10:45:18.555488   962 [MemoryCheckerTh] PeriodicMemoryChecker.cpp:228] Memory pushback shrunk 8.92GB Effective bytes shrunk: 9.01GB
I0317 10:45:18.669054  1527 BcAdaptiveTokenManager.cpp:976] BcAdaptiveTokenManager[RX]: AIMD adjustment - UNDERUTILIZED (1.624 GB/s -> 1.65 GB/s)
I0317 10:45:19.350598  1457 BcAdaptiveTokenManager.cpp:974] BcAdaptiveTokenManager[TX]: AIMD adjustment - UNDERUTILIZED (2.619 GB/s -> 2.619 GB/s)
E0317 10:45:23.854575 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=123, timeout=60000ms, path /v1/task/20260317_174241_33921_32fmu.2.0.156.0/results/79
E0317 10:45:23.855425 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=219, timeout=60000ms, path /v1/task/20260317_174241_33921_32fmu.3.0.156.0/results/79
E0317 10:45:27.578008 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=2569, timeout=60000ms, path /v1/task/20260317_174245_33922_32fmu.2.0.29.0/results/7
I0317 10:45:28.113592   954 [clean_old_tasks] TaskManager.cpp:1003] cleanOldTasks: Cleaned 66 old task(s) in 0 ms
E0317 10:45:28.130775   954 [clean_old_tasks] TaskManager.cpp:313] There are 1 zombie Task that satisfy cleanup conditions but could not be cleaned up, because the Task are referenced by more than 1 owners. RUNNING[0] FINISHED[0] CANCELED[0] ABORTED[1] FAILED[0]  Sample task IDs (shows only 20 IDs): 
E0317 10:45:28.130795   954 [clean_old_tasks] TaskManager.cpp:323] Zombie Task [1/1]: Extra Refs: 1, 20260317_172201_33407_32fmu.1.0.16.0
I0317 10:45:32.531476   951 [report_spill_st] PeriodicStatsReporter.cpp:264] Spill memory usage: current[0B] peak[2.24GB]
E0317 10:45:36.031675 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=295, timeout=60000ms, path /v1/task/20260317_174249_33924_32fmu.4.0.15.0/results/30
E0317 10:45:36.049696 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=179, timeout=60000ms, path /v1/task/20260317_174249_33924_32fmu.3.0.15.0/results/30
E0317 10:45:36.054131 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=59, timeout=60000ms, path /v1/task/20260317_174249_33924_32fmu.2.0.15.0/results/30
E0317 10:45:36.055419 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=207, timeout=60000ms, path /v1/task/20260317_174249_33924_32fmu.5.0.15.0/results/30
E0317 10:45:36.084476 843003 [ExchangeCPU3305] PrestoExchangeSource.cpp:550] Abort results failed: proxygen::HTTPException: ingress timeout, streamID=123, timeout=60000ms, path /v1/task/20260317_174249_33924_32fmu.9.0.15.0/results/30
I0317 10:45:36.100535 842798 [HTTPSrvCpu24857] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.20.0.12.0
E0317 10:45:36.100556 842798 [HTTPSrvCpu24857] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.100762 842710 [HTTPSrvCpu24854] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.24.0.94.0
E0317 10:45:36.100787 842710 [HTTPSrvCpu24854] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.100847 842786 [HTTPSrvCpu24855] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.21.0.12.0
E0317 10:45:36.100879 842786 [HTTPSrvCpu24855] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.101078 842800 [HTTPSrvCpu24857] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.23.0.12.0
E0317 10:45:36.101096 842800 [HTTPSrvCpu24857] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.101325 842816 [HTTPSrvCpu24858] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.22.0.12.0
E0317 10:45:36.101351 842816 [HTTPSrvCpu24858] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.101361 842408 [HTTPSrvCpu24850] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.25.0.81.0
E0317 10:45:36.101398 842408 [HTTPSrvCpu24850] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.101961 843007 [HTTPSrvCpu24859] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.27.0.12.0
E0317 10:45:36.101987 843007 [HTTPSrvCpu24859] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.102123 842791 [HTTPSrvCpu24856] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.29.0.94.0
E0317 10:45:36.102156 842791 [HTTPSrvCpu24856] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.102209 843009 [HTTPSrvCpu24859] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.28.0.12.0
E0317 10:45:36.102236 843009 [HTTPSrvCpu24859] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.107154 843015 [HTTPSrvCpu24860] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.16.0.1.0
E0317 10:45:36.107189 843015 [HTTPSrvCpu24860] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.107321 843014 [HTTPSrvCpu24859] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.18.0.12.0
E0317 10:45:36.107344 843014 [HTTPSrvCpu24859] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.108820 842799 [HTTPSrvCpu24857] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.8.0.12.0
E0317 10:45:36.108840 842799 [HTTPSrvCpu24857] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.109087 843036 [HTTPSrvCpu24862] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.10.0.84.0
E0317 10:45:36.109143 843036 [HTTPSrvCpu24862] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.109302 842807 [HTTPSrvCpu24858] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.9.0.94.0
E0317 10:45:36.109320 842807 [HTTPSrvCpu24858] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.109992 843029 [HTTPSrvCpu24861] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.12.0.12.0
E0317 10:45:36.110028 843029 [HTTPSrvCpu24861] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.110075 842709 [HTTPSrvCpu24854] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.13.0.12.0
E0317 10:45:36.110100 842709 [HTTPSrvCpu24854] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.110234 843032 [HTTPSrvCpu24861] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.14.0.94.0
E0317 10:45:36.110255 843032 [HTTPSrvCpu24861] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.271823 843028 [HTTPSrvCpu24861] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.15.0.84.0
I0317 10:45:36.271857 843022 [HTTPSrvCpu24860] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.7.0.12.0
I0317 10:45:36.271853 843027 [HTTPSrvCpu24861] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.2.0.12.0
E0317 10:45:36.271932 843027 [HTTPSrvCpu24861] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
E0317 10:45:36.272019 843022 [HTTPSrvCpu24860] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.271862 843033 [HTTPSrvCpu24861] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.1.0.12.0
I0317 10:45:36.271858 842793 [HTTPSrvCpu24856] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.5.0.12.0
E0317 10:45:36.272382 843033 [HTTPSrvCpu24861] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.271858 843018 [HTTPSrvCpu24860] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.3.0.12.0
E0317 10:45:36.272401 842793 [HTTPSrvCpu24856] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
E0317 10:45:36.271872 843028 [HTTPSrvCpu24861] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
E0317 10:45:36.272423 843018 [HTTPSrvCpu24860] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:36.271854 843019 [HTTPSrvCpu24860] TaskManager.cpp:877] Deleting task 20260317_174453_33962_32fmu.6.0.12.0
E0317 10:45:36.272475 843019 [HTTPSrvCpu24860] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:38.938845   964 [Announcement] PeriodicServiceInventoryManager.cpp:130] Announcement succeeded: HTTP 202. State: active.
I0317 10:45:41.508436 842050 [HTTPSrvCpu24849] TaskManager.cpp:877] Deleting task 20260317_174452_33961_32fmu.3.0.93.0
E0317 10:45:41.508466 842050 [HTTPSrvCpu24849] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
I0317 10:45:41.510092 843020 [HTTPSrvCpu24860] TaskManager.cpp:877] Deleting task 20260317_174452_33961_32fmu.1.0.109.0
E0317 10:45:41.510118 843020 [HTTPSrvCpu24860] Exceptions.h:53] Line: fbcode/velox/exec/Task.cpp:2468, Function:terminate, Expression:  Aborted for external error, Source: RUNTIME, ErrorCode: INVALID_STATE
*** Aborted at 1773769541 (Unix time, try 'date -d 1773769541') ***
*** Signal 11 (SIGSEGV) (0x7facb7e00000) received by PID 113 (pthread TID 0x7faeb1fff000) (linux TID 838941) (code: address not mapped to object), stack trace: ***
    @ 0000000017d3365a folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*) [clone .__uniq.302291754384189453301783370447166124111]
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:552
    @ 0000000017d335c7 folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*) [clone .__uniq.302291754384189453301783370447166124111] [clone .llvm.3532004345868697328]
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:573
    @ 000000000004455f (unknown)
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/libc_sigaction.c:8
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c
    @ 0000000047329fde facebook::velox::functions::determinePatternKind(std::basic_string_view<char, std::char_traits<char> >, std::optional<char>)
                       ./fbcode/velox/functions/lib/Re2Functions.cpp:1988
    @ 0000000047329d4f facebook::velox::functions::(anonymous namespace)::LikeGeneric::apply(facebook::velox::SelectivityVector const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&, std::shared_ptr<facebook::velox::Type const> const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&) const::{lambda(facebook::velox::StringView const&, facebook::velox::StringView const&, std::optional<char> const&)#2}::operator()(facebook::velox::StringView const&, facebook::velox::StringView const&, std::optional<char> const&) const [clone .__uniq.96824254187906811421847846720006205206]
                       ./fbcode/velox/functions/lib/Re2Functions.cpp:947
    @ 0000000015cbed20 _ZNK8facebook5velox17SelectivityVector15applyToSelectedIZNS0_4exec7EvalCtx22applyToSelectedNoThrowIZNKS0_9functions12_GLOBAL__N_111LikeGeneric5applyERKS1_RSt6vectorISt10shared_ptrINS0_10BaseVectorEESaISE_EERKSC_IKNS0_4TypeEERS4_RSE_EUlT_E_ZNS4_22applyToSelectedNoThrowISQ_EEvSA_SP_EUlSP_E_EEvSA_SP_T0_EUlSP_E_EEvSP_.__uniq.96824254187906811421847846720006205206
                       ./fbcode/velox/functions/lib/Re2Functions.cpp:1010
    @ 0000000047102acd facebook::velox::functions::(anonymous namespace)::LikeGeneric::apply(facebook::velox::SelectivityVector const&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&, std::shared_ptr<facebook::velox::Type const> const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&) const [clone .__uniq.96824254187906811421847846720006205206]
                       fbcode/velox/expression/EvalCtx.h:299
    @ 0000000046c466b0 facebook::velox::exec::Expr::applyFunction(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
                       ./fbcode/velox/expression/Expr.cpp:1604
    @ 0000000046c457fa facebook::velox::exec::Expr::evalWithNulls(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
                       ./fbcode/velox/expression/Expr.cpp:1519
    @ 0000000046c8e7d0 facebook::velox::exec::ConjunctExpr::evalSpecialForm(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
                       fbcode/velox/expression/Expr.cpp:1149
    @ 0000000046c4572d facebook::velox::exec::Expr::evalWithNulls(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&)
                       ./fbcode/velox/expression/Expr.cpp:1646
    @ 0000000046c41399 facebook::velox::exec::Expr::eval(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&, facebook::velox::exec::ExprSet const*)
                       ./fbcode/velox/expression/Expr.cpp:1149
    @ 0000000046c40015 facebook::velox::exec::ExprSet::eval(int, int, bool, facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&)
                       ./fbcode/velox/expression/Expr.cpp:2064
    @ 0000000046dda7e2 facebook::velox::exec::FilterProject::getOutput()
                       ./fbcode/velox/exec/FilterProject.cpp:282
    @ 0000000046c5f19d facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
                       ./fbcode/velox/exec/Driver.cpp:486
    @ 0000000046cfed97 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
                       ./fbcode/velox/exec/Driver.cpp:802
    @ 0000000046cfdb98 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
                       fbcode/velox/exec/Driver.cpp:281
    @ 00000000162fd84d void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
                       fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/invoke.h:74
    @ 00000000000df5b4 execute_native_thread_routine
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/src/c++11/../../../.././libstdc++-v3/src/c++11/thread.cc:82
    @ 000000000009abc8 start_thread
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_create.c:434
    @ 000000000012ce4b __clone3
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

Reviewed By: spershin

Differential Revision: D97223914


