### PR TITLE
Use mold linker for ubuntu-debug GitHub builds (#16836)

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -406,6 +406,10 @@ jobs:
         run: |
           ccache -sz
 
+      - name: Install Mold Linker
+        run: |
+          apt-get update && apt-get install -y mold
+
       - name: Make Debug Build
         env:
           VELOX_DEPENDENCY_SOURCE: SYSTEM
@@ -423,6 +427,8 @@ jobs:
         run: |
           EXTRA_CMAKE_FLAGS=(
             "-DCMAKE_LINK_LIBRARIES_STRATEGY=REORDER_FREELY"
+            "-DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold"
+            "-DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold"
             "-DVELOX_BUILD_SHARED=ON"
             "-DVELOX_ENABLE_BENCHMARKS=ON"
             "-DVELOX_ENABLE_EXAMPLES=ON"
@@ -511,6 +517,10 @@ jobs:
         run: |
           ccache -sz
 
+      - name: Install Mold Linker
+        run: |
+          dnf install -y -q --setopt=install_weak_deps=False mold
+
       - name: Make Debug Build
         env:
           VELOX_DEPENDENCY_SOURCE: SYSTEM
@@ -523,6 +533,8 @@ jobs:
             -DVELOX_ENABLE_PARQUET=ON
             -DARROW_THRIFT_USE_SHARED=ON
             -DVELOX_ENABLE_EXAMPLES=ON
+            -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold
+            -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold
         run: |
           uv tool install --force cmake@3.31.1
           dnf install -y -q --setopt=install_weak_deps=False grpc-devel grpc-plugins


### PR DESCRIPTION
Summary:

The ubuntu-debug CI job currently uses the default GNU ld (bfd) linker,
which is single-threaded and memory-hungry. This forces MAX_LINK_JOBS
down to 6 on a 32-core runner to avoid OOM.

Switch to the mold linker which is highly parallel and uses significantly
less memory per link. This allows bumping MAX_LINK_JOBS from 6 to 16,
which combined with mold's faster per-link performance should
substantially reduce link phase wall-clock time.

Changes:
- Add a step to install mold in the ubuntu-22.04 container
- Pass -fuse-ld=mold via CMAKE_EXE_LINKER_FLAGS and CMAKE_SHARED_LINKER_FLAGS
- Bump MAX_LINK_JOBS from 6 to 16

Differential Revision: D97251829


