### PR TITLE
feat: Add valueToString to TimestampWithTimeZoneType (#16840)

### DIFF
--- a/velox/functions/prestosql/types/CMakeLists.txt
+++ b/velox/functions/prestosql/types/CMakeLists.txt
@@ -31,6 +31,7 @@ velox_add_library(
   SfmSketchRegistration.cpp
   TDigestRegistration.cpp
   TimestampWithTimeZoneRegistration.cpp
+  TimestampWithTimeZoneType.cpp
   TimeWithTimezoneRegistration.cpp
   TimeWithTimezoneType.cpp
   SetDigestRegistration.cpp

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox {
+
+std::string TimestampWithTimeZoneType::valueToString(int64_t value) const {
+  static auto kFormatter =
+      functions::buildJodaDateTimeFormatter("yyyy-MM-dd HH:mm:ss.SSS ZZZ")
+          .value();
+
+  auto timestamp = unpackTimestampUtc(value);
+  auto* timeZone = tz::locateZone(tz::getTimeZoneName(unpackZoneKeyId(value)));
+
+  auto maxSize = kFormatter->maxResultSize(timeZone);
+  std::string result(maxSize, '\0');
+  auto size = kFormatter->format(timestamp, timeZone, maxSize, result.data());
+  result.resize(size);
+  return result;
+}
+
+} // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -92,6 +92,9 @@ class TimestampWithTimeZoneType final : public BigintType {
     return name();
   }
 
+  /// Formats a packed value as "YYYY-MM-DD HH:MM:SS.mmm <timezone>".
+  std::string valueToString(int64_t value) const;
+
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
     obj["name"] = "Type";

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -133,4 +133,22 @@ TEST_F(TimestampWithTimeZoneTypeTest, hash) {
   expectHashesNeq(-1639426440000, "+03:00", 1639426440000, "-14:00");
 }
 
+TEST_F(TimestampWithTimeZoneTypeTest, valueToString) {
+  // 1639426440000 ms = 2021-12-13 20:14:00.000 UTC.
+  auto packed = pack(1639426440000, tz::getTimeZoneID("America/Los_Angeles"));
+  ASSERT_EQ(
+      TIMESTAMP_WITH_TIME_ZONE()->valueToString(packed),
+      "2021-12-13 12:14:00.000 America/Los_Angeles");
+
+  packed = pack(1639426440000, tz::getTimeZoneID("+03:00"));
+  ASSERT_EQ(
+      TIMESTAMP_WITH_TIME_ZONE()->valueToString(packed),
+      "2021-12-13 23:14:00.000 +03:00");
+
+  packed = pack(0, tz::getTimeZoneID("UTC"));
+  ASSERT_EQ(
+      TIMESTAMP_WITH_TIME_ZONE()->valueToString(packed),
+      "1970-01-01 00:00:00.000 UTC");
+}
+
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:

Add valueToString(int64_t) to TimestampWithTimeZoneType that formats
a packed timestamp-with-timezone value as
"YYYY-MM-DD HH:MM:SS.mmm <timezone>" to match Presto output.

Uses the same Joda formatter ("yyyy-MM-dd HH:mm:ss.SSS ZZZ") as
CAST(timestamp_with_timezone AS VARCHAR).

Previously, there was no way to get a human-readable string from a
packed TimestampWithTimezone value without going through the full
CAST execution machinery.

Reviewed By: srsuryadev

Differential Revision: D97293095


