### PR TITLE
feat(joins): Add counting semi-join and anti-join (#16841)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1555,7 +1555,8 @@ void AbstractJoinNode::validate() const {
   // Output of left semi and anti joins cannot include columns from the right
   // side.
   bool outputMayIncludeRightColumns =
-      !(isLeftSemiFilterJoin() || isLeftSemiProjectJoin() || isAntiJoin());
+      !(isLeftSemiFilterJoin() || isLeftSemiProjectJoin() || isAntiJoin() ||
+        isCountingJoin());
 
   for (auto i = 0; i < numOutputColumns; ++i) {
     auto name = outputType_->nameOf(i);
@@ -1616,6 +1617,8 @@ const auto& joinTypeNames() {
       {JoinType::kLeftSemiProject, "LEFT SEMI (PROJECT)"},
       {JoinType::kRightSemiProject, "RIGHT SEMI (PROJECT)"},
       {JoinType::kAnti, "ANTI"},
+      {JoinType::kCountingAnti, "COUNTING ANTI"},
+      {JoinType::kCountingLeftSemiFilter, "COUNTING LEFT SEMI (FILTER)"},
   };
   return kNames;
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2978,6 +2978,12 @@ enum class JoinType {
   // equal to the cardinality of the left side.
   kLeftSemiFilter = 4,
 
+  // Multiset version of kLeftSemiFilter. The build side deduplicates keys and
+  // stores a per-key count. On probe, each match decrements the count; the
+  // probe row is emitted only while the count is greater than zero. Implements
+  // INTERSECT ALL semantics.
+  kCountingLeftSemiFilter = 5,
+
   // Return each row from the left side with a boolean flag indicating whether
   // there exists a match on the right side. For this join type, cardinality
   // of the output equals the cardinality of the left side.
@@ -2986,12 +2992,12 @@ enum class JoinType {
   // 'nullAware' boolean specified separately.
   //
   // Null-aware join follows IN semantic. Regular join follows EXISTS semantic.
-  kLeftSemiProject = 5,
+  kLeftSemiProject = 6,
 
   // Opposite of kLeftSemiFilter. Return a subset of rows from the right side
   // which have a match on the left side. For this join type, cardinality of
   // the output is less than or equal to the cardinality of the right side.
-  kRightSemiFilter = 6,
+  kRightSemiFilter = 7,
 
   // Opposite of kLeftSemiProject. Return each row from the right side with a
   // boolean flag indicating whether there exists a match on the left side.
@@ -3002,7 +3008,7 @@ enum class JoinType {
   // 'nullAware' boolean specified separately.
   //
   // Null-aware join follows IN semantic. Regular join follows EXISTS semantic.
-  kRightSemiProject = 7,
+  kRightSemiProject = 8,
 
   // Return each row from the left side which has no match on the right side.
   // The handling of the rows with nulls in the join key depends on the
@@ -3017,9 +3023,15 @@ enum class JoinType {
   // Regular anti join follows NOT EXISTS semantic:
   // (1) ignore right-side rows with nulls in the join keys;
   // (2) unconditionally return left side rows with nulls in the join keys.
-  kAnti = 8,
+  kAnti = 9,
 
-  kNumJoinTypes = 9,
+  // Multiset version of kAnti. The build side deduplicates keys and stores a
+  // per-key count. On probe, each match decrements the count; the probe row is
+  // emitted only when the count reaches zero or no match is found. Implements
+  // EXCEPT ALL semantics.
+  kCountingAnti = 10,
+
+  kNumJoinTypes = 11,
 };
 
 VELOX_DECLARE_ENUM_NAME(JoinType);
@@ -3060,12 +3072,24 @@ inline bool isAntiJoin(JoinType joinType) {
   return joinType == JoinType::kAnti;
 }
 
+inline bool isCountingAntiJoin(JoinType joinType) {
+  return joinType == JoinType::kCountingAnti;
+}
+
+inline bool isCountingLeftSemiFilterJoin(JoinType joinType) {
+  return joinType == JoinType::kCountingLeftSemiFilter;
+}
+
+inline bool isCountingJoin(JoinType joinType) {
+  return isCountingAntiJoin(joinType) || isCountingLeftSemiFilterJoin(joinType);
+}
+
 /// Returns true if the join type is "probe-only", meaning the output includes
 /// only columns from the probe side (plus possibly a mark column).
-/// These join types are: kLeftSemiFilter, kLeftSemiProject, and kAnti.
 inline bool isProbeOnlyJoin(JoinType joinType) {
   return joinType == JoinType::kLeftSemiFilter ||
-      joinType == JoinType::kLeftSemiProject || joinType == JoinType::kAnti;
+      joinType == JoinType::kLeftSemiProject || joinType == JoinType::kAnti ||
+      isCountingJoin(joinType);
 }
 
 inline bool isNullAwareSupported(JoinType joinType) {
@@ -3206,17 +3230,32 @@ class AbstractJoinNode : public PlanNode {
     return joinType_ == JoinType::kAnti;
   }
 
+  bool isCountingAntiJoin() const {
+    return joinType_ == JoinType::kCountingAnti;
+  }
+
+  bool isCountingLeftSemiFilterJoin() const {
+    return joinType_ == JoinType::kCountingLeftSemiFilter;
+  }
+
+  bool isCountingJoin() const {
+    return core::isCountingJoin(joinType_);
+  }
+
   bool isPreservingProbeOrder() const {
     return isInnerJoin() || isLeftJoin() || isAntiJoin();
   }
 
   /// Indicates if this joinNode can drop duplicate rows with same join key.
   /// For left semi and anti join, it is not necessary to store duplicate rows.
+  /// For counting joins, duplicates are folded into a per-key count.
   bool canDropDuplicates() const {
     // Left semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
-    return !filter() &&
-        (isLeftSemiFilterJoin() || isLeftSemiProjectJoin() || isAntiJoin());
+    // Counting joins always deduplicate and track counts.
+    return isCountingJoin() ||
+        (!filter() &&
+         (isLeftSemiFilterJoin() || isLeftSemiProjectJoin() || isAntiJoin()));
   }
 
   const std::vector<FieldAccessTypedExprPtr>& leftKeys() const {
@@ -3281,6 +3320,12 @@ class HashJoinNode : public AbstractJoinNode {
         nullAware_{nullAware},
         useHashTableCache_{useHashTableCache} {
     validate();
+
+    if (isCountingJoin()) {
+      VELOX_USER_CHECK(
+          !nullAware, "Counting joins do not support null-aware flag");
+      VELOX_USER_CHECK(!filter_, "Counting joins do not support extra filter");
+    }
 
     if (nullAware) {
       VELOX_USER_CHECK(

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -59,6 +59,7 @@ Generic Configuration
      - 0
      - Abandons building a HashTable without duplicates in HashBuild for left semi/anti join if the percentage of
        distinct keys in the HashTable exceeds this threshold. Zero means 'disable this optimization'.
+       Does not apply to counting joins (kCountingAnti, kCountingLeftSemiFilter) which always require deduplication.
    * - session_timezone
      - string
      -

--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -24,11 +24,20 @@ values need to match, and an optional filter to apply to join results.
     :align: center
 
 The join type can be one of kInner, kLeft, kRight, kFull, kLeftSemiFilter,
-kLeftSemiProject, kRightSemiFilter, kRightSemiProject, or kAnti.
+kCountingLeftSemiFilter, kLeftSemiProject, kRightSemiFilter, kRightSemiProject,
+kAnti, or kCountingAnti.
 
 kLeftSemiProject, kRightSemiProject and kAnti joins support an additional
 nullAware flag to distinguish between IN (null aware) and EXISTS (regular)
 semantics.
+
+kCountingAnti and kCountingLeftSemiFilter are multiset variants of kAnti and
+kLeftSemiFilter. The build side deduplicates keys and stores a per-key count.
+On probe, each match decrements the count. kCountingAnti emits a probe row when
+the count reaches zero or no match is found (EXCEPT ALL semantics).
+kCountingLeftSemiFilter emits a probe row while the count is greater than zero
+(INTERSECT ALL semantics). Counting joins do not support extra filter or
+null-aware mode. Spilling is not yet supported.
 
 Filter is optional. If specified it can be any expression over the results of
 the join. This expression will be evaluated using the same expression

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1139,6 +1139,7 @@ bool GroupingSet::getOutputWithSpill(
           false,
           false,
           false,
+          false, // hasCountFlag
           false,
           false,
           pool_);
@@ -1491,6 +1492,7 @@ void GroupingSet::abandonPartialAggregation() {
       false,
       false,
       false,
+      false, // hasCountFlag
       false,
       false,
       pool_);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -242,11 +242,13 @@ void HashBuild::setupTable() {
         dependentTypes,
         true, // allowDuplicates
         true, // hasProbedFlag
+        false, // hasCountFlag
         queryConfig.minTableRowsForParallelJoinBuild(),
         tableMemoryPool());
   } else {
     // Right semi join needs to tag build rows that were probed.
     const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
+    const bool hasCountFlag = joinNode_->isCountingJoin();
     if (isLeftNullAwareJoinWithFilter(joinNode_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // or left semi project join with filter set.
@@ -255,6 +257,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates_, // allowDuplicates
           needProbedFlag, // hasProbedFlag
+          hasCountFlag,
           queryConfig.minTableRowsForParallelJoinBuild(),
           tableMemoryPool());
     } else {
@@ -264,15 +267,16 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates_, // allowDuplicates
           needProbedFlag, // hasProbedFlag
+          hasCountFlag,
           queryConfig.minTableRowsForParallelJoinBuild(),
           tableMemoryPool(),
           queryConfig.hashProbeBloomFilterPushdownMaxSize());
     }
   }
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
-  if (abandonHashBuildDedupMinPct_ == 0) {
+  if (abandonHashBuildDedupMinPct_ == 0 && !joinNode_->isCountingJoin()) {
     // Building a HashTable without duplicates is disabled if
-    // abandonBuildNoDupHashMinPct_ is 0.
+    // abandonBuildNoDupHashMinPct_ is 0. Counting joins always require dedup.
     abandonHashBuildDedup_ = true;
     table_->setAllowDuplicates(true);
     return;
@@ -484,7 +488,9 @@ void HashBuild::addInput(RowVectorPtr input) {
   }
 
   if (dropDuplicates_ && !abandonHashBuildDedup_) {
-    const bool abandonEarly = abandonHashBuildDedupEarly(table_->numDistinct());
+    // Counting joins must not abandon dedup — accurate counts are required.
+    const bool abandonEarly = !joinNode_->isCountingJoin() &&
+        abandonHashBuildDedupEarly(table_->numDistinct());
     if (!abandonEarly) {
       numHashInputRows_ += activeRows_.countSelected();
       table_->prepareForGroupProbe(
@@ -497,6 +503,20 @@ void HashBuild::addInput(RowVectorPtr input) {
       }
       table_->groupProbe(
           *lookup_, BaseHashTable::kNoSpillInputStartPartitionBit);
+
+      // For counting joins, increment the count for duplicate rows.
+      // New rows are initialized with count = 1 by initializeRow.
+      // Increment count for all rows, then decrement for new rows to
+      // correct the over-counting.
+      if (joinNode_->isCountingJoin()) {
+        auto* rows = table_->rows();
+        for (auto row : lookup_->rows) {
+          rows->incrementCount(lookup_->hits[row]);
+        }
+        for (auto newRow : lookup_->newGroups) {
+          rows->decrementCount(lookup_->hits[newRow]);
+        }
+      }
       return;
     }
     abandonHashBuildDedup();
@@ -1241,6 +1261,9 @@ bool HashBuild::canSpill() const {
   // For Cached hash table, we don't support spill either by the
   // task thats building or by the task that is re-using it
   if (useHashTableCache()) {
+    return false;
+  }
+  if (joinNode_->isCountingJoin()) {
     return false;
   }
   if (operatorCtx_->task()->hasMixedExecutionGroupJoin(joinNode_.get())) {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -481,6 +481,7 @@ void HashProbe::asyncWaitForHashTable() {
     }
   } else if (
       (isInnerJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
+       isCountingLeftSemiFilterJoin(joinType_) ||
        isRightSemiFilterJoin(joinType_) ||
        (isRightSemiProjectJoin(joinType_) && !nullAware_) ||
        isRightJoin(joinType_)) &&
@@ -987,8 +988,8 @@ bool HashProbe::needLastProbe() const {
 
 bool HashProbe::skipProbeOnEmptyBuild() const {
   return isInnerJoin(joinType_) || isLeftSemiFilterJoin(joinType_) ||
-      isRightJoin(joinType_) || isRightSemiFilterJoin(joinType_) ||
-      isRightSemiProjectJoin(joinType_);
+      isCountingLeftSemiFilterJoin(joinType_) || isRightJoin(joinType_) ||
+      isRightSemiFilterJoin(joinType_) || isRightSemiProjectJoin(joinType_);
 }
 
 bool HashProbe::canSpill() const {
@@ -1143,7 +1144,7 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
 
   const bool isLeftSemiOrAntiJoinNoFilter = !filter_ &&
       (isLeftSemiFilterJoin(joinType_) || isLeftSemiProjectJoin(joinType_) ||
-       isAntiJoin(joinType_));
+       isAntiJoin(joinType_) || isCountingJoin(joinType_));
 
   const bool emptyBuildSide = (table_->numDistinct() == 0);
 
@@ -1203,6 +1204,31 @@ RowVectorPtr HashProbe::getOutputInternal(bool toSpillOutput) {
             mapping[numOut] = i;
             ++numOut;
           }
+        }
+      }
+    } else if (isCountingAntiJoin(joinType_)) {
+      // Counting anti-join: emit row if no match or count has reached zero.
+      // Decrement count on match.
+      auto* rows = table_->rows();
+      for (auto i = 0; i < inputSize; ++i) {
+        auto* hit = lookup_->hits[i];
+        if (!activeRows_.isValid(i) || !hit || rows->count(hit) == 0) {
+          mapping[numOut] = i;
+          ++numOut;
+        } else {
+          rows->decrementCount(hit);
+        }
+      }
+    } else if (isCountingLeftSemiFilterJoin(joinType_)) {
+      // Counting semi-join: emit row if match and count > 0.
+      // Decrement count on match.
+      auto* rows = table_->rows();
+      for (auto i = 0; i < inputSize; ++i) {
+        auto* hit = lookup_->hits[i];
+        if (activeRows_.isValid(i) && hit && rows->count(hit) > 0) {
+          rows->decrementCount(hit);
+          mapping[numOut] = i;
+          ++numOut;
         }
       }
     } else {
@@ -1718,7 +1744,7 @@ void HashProbe::ensureLoadedIfNotAtEnd(column_index_t channel) {
 void HashProbe::ensureLoaded(column_index_t channel) {
   if (!filter_ &&
       (isLeftSemiFilterJoin(joinType_) || isLeftSemiProjectJoin(joinType_) ||
-       isAntiJoin(joinType_))) {
+       isAntiJoin(joinType_) || isCountingJoin(joinType_))) {
     return;
   }
 

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -119,7 +119,8 @@ class HashProbe : public Operator {
   // output.
   static bool joinIncludesMissesFromLeft(core::JoinType joinType) {
     return isLeftJoin(joinType) || isFullJoin(joinType) ||
-        isAntiJoin(joinType) || isLeftSemiProjectJoin(joinType);
+        isAntiJoin(joinType) || isCountingAntiJoin(joinType) ||
+        isLeftSemiProjectJoin(joinType);
   }
 
   void setState(ProbeOperatorState state);

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -51,6 +51,7 @@ HashTable<ignoreNullKeys>::HashTable(
     bool allowDuplicates,
     bool isJoinBuild,
     bool hasProbedFlag,
+    bool hasCountFlag,
     uint32_t minTableSizeForParallelJoinBuild,
     memory::MemoryPool* pool,
     uint64_t bloomFilterMaxSize)
@@ -78,6 +79,7 @@ HashTable<ignoreNullKeys>::HashTable(
       allowDuplicates,
       isJoinBuild,
       hasProbedFlag,
+      hasCountFlag,
       hashMode_ != HashMode::kHash,
       /*useListRowIndex=*/false,
       pool);

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -544,6 +544,7 @@ class HashTable : public BaseHashTable {
       bool allowDuplicates,
       bool isJoinBuild,
       bool hasProbedFlag,
+      bool hasCountFlag,
       uint32_t minTableSizeForParallelJoinBuild,
       memory::MemoryPool* pool,
       uint64_t bloomFilterMaxSize = 0);
@@ -561,6 +562,7 @@ class HashTable : public BaseHashTable {
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
+        false, // hasCountFlag
         0, // minTableSizeForParallelJoinBuild
         pool);
   }
@@ -570,6 +572,7 @@ class HashTable : public BaseHashTable {
       const std::vector<TypePtr>& dependentTypes,
       bool allowDuplicates,
       bool hasProbedFlag,
+      bool hasCountFlag,
       uint32_t minTableSizeForParallelJoinBuild,
       memory::MemoryPool* pool,
       uint64_t bloomFilterMaxSize = 0) {
@@ -580,6 +583,7 @@ class HashTable : public BaseHashTable {
         allowDuplicates,
         true, // isJoinBuild
         hasProbedFlag,
+        hasCountFlag,
         minTableSizeForParallelJoinBuild,
         pool,
         bloomFilterMaxSize);

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -135,6 +135,7 @@ RowContainer::RowContainer(
     bool hasNext,
     bool isJoinBuild,
     bool hasProbedFlag,
+    bool hasCountFlag,
     bool hasNormalizedKeys,
     bool useListRowIndex,
     memory::MemoryPool* pool)
@@ -247,6 +248,10 @@ RowContainer::RowContainer(
     nextOffset_ = offset;
     offset += sizeof(void*);
   }
+  if (hasCountFlag) {
+    countOffset_ = offset;
+    offset += sizeof(int32_t);
+  }
   fixedRowSize_ = bits::roundUp(offset, alignment_);
   originalNormalizedKeySize_ = hasNormalizedKeys_
       ? bits::roundUp(sizeof(normalized_key_t), alignment_)
@@ -320,6 +325,9 @@ char* RowContainer::initializeRow(char* row, bool reuse) {
     variableRowSize(row) = 0;
   }
   bits::clearBit(row, freeFlagOffset_);
+  if (countOffset_) {
+    countRef(row) = 1;
+  }
   return row;
 }
 

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -302,6 +302,7 @@ class RowContainer {
             false, // hasNext
             false, // isJoinBuild
             false, // hasProbedFlag
+            false, // hasCountFlag
             false, // hasNormalizedKey
             useListRowIndex,
             pool) {}
@@ -334,6 +335,7 @@ class RowContainer {
       bool hasNext,
       bool isJoinBuild,
       bool hasProbedFlag,
+      bool hasCountFlag,
       bool hasNormalizedKey,
       bool useListRowIndex,
       memory::MemoryPool* pool);
@@ -764,6 +766,31 @@ class RowContainer {
   /// 0 if not applicable.
   int32_t probedFlagOffset() const {
     return probedFlagOffset_;
+  }
+
+  /// Byte offset of the per-row count for counting joins. 0 if not applicable.
+  int32_t countOffset() const {
+    return countOffset_;
+  }
+
+  /// Returns the count stored at the given row. Used for counting joins.
+  int32_t count(const char* row) const {
+    VELOX_DCHECK_NE(countOffset_, 0);
+    return countRef(const_cast<char*>(row));
+  }
+
+  /// Increments the count at the given row. Used during hash table build for
+  /// counting joins.
+  void incrementCount(char* row) const {
+    VELOX_DCHECK_NE(countOffset_, 0);
+    ++countRef(row);
+  }
+
+  /// Decrements the count at the given row. Used during hash table probe for
+  /// counting joins.
+  void decrementCount(char* row) const {
+    VELOX_DCHECK_NE(countOffset_, 0);
+    --countRef(row);
   }
 
   /// Returns the offset of a uint32_t row size or 0 if the row has no variable
@@ -1508,6 +1535,10 @@ class RowContainer {
     }
   }
 
+  int32_t& countRef(char* row) const {
+    return *reinterpret_cast<int32_t*>(row + countOffset_);
+  }
+
   const std::vector<TypePtr> keyTypes_;
   const bool nullableKeys_;
   const bool isJoinBuild_;
@@ -1547,6 +1578,9 @@ class RowContainer {
   // Bit offset of the probed flag for a full or right outer join  payload. 0 if
   // not applicable.
   int32_t probedFlagOffset_ = 0;
+
+  // Byte offset of the per-row count for counting joins. 0 if not applicable.
+  int32_t countOffset_ = 0;
 
   // Bit position of free bit.
   int32_t freeFlagOffset_ = 0;

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -47,6 +47,7 @@ RowNumber::RowNumber(
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
+        false, // hasCountFlag
         0, // minTableSizeForParallelJoinBuild
         pool());
     lookup_ = std::make_unique<HashLookup>(table_->hashers(), pool());

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -442,6 +442,7 @@ std::unique_ptr<RowContainer> StreamingAggregation::makeRowContainer(
       false,
       false,
       false,
+      false, // hasCountFlag
       false,
       false,
       pool());

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -189,6 +189,7 @@ TopNRowNumber::TopNRowNumber(
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
+        false, // hasCountFlag
         0, // minTableSizeForParallelJoinBuild
         pool());
     partitionOffset_ = table_->rows()->columnAt(numKeys).offset();

--- a/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinListResultBenchmark.cpp
@@ -378,6 +378,7 @@ class HashTableListJoinResultBenchmark : public VectorTestBase {
           dependentTypes,
           true,
           false,
+          false, // hasCountFlag
           1'000,
           tablePools[i].get());
 

--- a/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashJoinPrepareJoinTableBenchmark.cpp
@@ -221,6 +221,7 @@ class HashJoinPrepareJoinTableBenchmark : public VectorTestBase {
           dependentTypes,
           true,
           false,
+          false, // hasCountFlag
           1'000,
           pool_.get());
 

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -182,6 +182,7 @@ class HashTableBenchmark : public VectorTestBase {
           dependentTypes,
           true,
           false,
+          false, // hasCountFlag
           1'000,
           pool_.get());
 

--- a/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
+++ b/velox/exec/tests/AggregateSpillBenchmarkBase.cpp
@@ -39,6 +39,7 @@ std::unique_ptr<RowContainer> makeRowContainer(
       /*hasNext=*/false,
       /*isJoinBuild=*/false,
       /*hasProbedFlag=*/false,
+      /*hasCountFlag=*/false,
       /*hasNormalizedKey=*/false,
       /*useListRowIndex=*/false,
       pool.get());

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -391,6 +391,7 @@ class AggregationTest : public OperatorTestBase {
         false,
         false,
         true,
+        false, // hasCountFlag
         true,
         false,
         pool_.get());
@@ -4220,6 +4221,7 @@ TEST_F(AggregationTest, destroyAfterPartialInitialization) {
       false, // hasNext
       false, // isJoinBuild
       false, // hasProbedFlag
+      false, // hasCountFlag
       false, // hasNormalizedKeys
       false, // useListRowIndex
       pool());

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(
   FilterToExpressionTest.cpp
   FunctionResolutionTest.cpp
   HashBitRangeTest.cpp
+  CountingJoinTest.cpp
   HashJoinBridgeTest.cpp
   HashJoinTest.cpp
   HashPartitionFunctionTest.cpp

--- a/velox/exec/tests/CountingJoinTest.cpp
+++ b/velox/exec/tests/CountingJoinTest.cpp
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/HashTable.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class CountingJoinTest : public OperatorTestBase {
+ protected:
+  void assertCountingJoin(
+      const std::vector<int32_t>& probe,
+      const std::vector<int32_t>& build,
+      core::JoinType joinType,
+      const std::vector<int32_t>& expected) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .values(makeRowVector({makeFlatVector<int32_t>(probe)}))
+                    .hashJoin(
+                        {"c0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator)
+                            .values(makeRowVector(
+                                {"u0"}, {makeFlatVector<int32_t>(build)}))
+                            .planNode(),
+                        "",
+                        {"c0"},
+                        joinType)
+                    .planNode();
+    assertEqualResults(
+        {makeRowVector({makeFlatVector<int32_t>(expected)})},
+        {AssertQueryBuilder(plan).copyResults(pool())});
+  }
+};
+
+// {A, A, A, B, B} EXCEPT ALL {A, A, C} = {A, B, B}
+TEST_F(CountingJoinTest, countingAnti) {
+  assertCountingJoin(
+      {1, 1, 1, 2, 2}, {1, 1, 3}, core::JoinType::kCountingAnti, {1, 2, 2});
+}
+
+// {A, A, A, B, B} INTERSECT ALL {A, A, C} = {A, A}
+TEST_F(CountingJoinTest, countingSemi) {
+  assertCountingJoin(
+      {1, 1, 1, 2, 2},
+      {1, 1, 3},
+      core::JoinType::kCountingLeftSemiFilter,
+      {1, 1});
+}
+
+// Empty build side: returns all probe rows.
+TEST_F(CountingJoinTest, countingAntiEmptyBuild) {
+  assertCountingJoin({1, 2, 3}, {}, core::JoinType::kCountingAnti, {1, 2, 3});
+}
+
+// Empty build side: returns nothing.
+TEST_F(CountingJoinTest, countingSemiEmptyBuild) {
+  assertCountingJoin(
+      {1, 2, 3}, {}, core::JoinType::kCountingLeftSemiFilter, {});
+}
+
+// Empty probe side: returns nothing.
+TEST_F(CountingJoinTest, emptyProbe) {
+  assertCountingJoin({}, {1, 2, 3}, core::JoinType::kCountingAnti, {});
+  assertCountingJoin(
+      {}, {1, 2, 3}, core::JoinType::kCountingLeftSemiFilter, {});
+}
+
+// No duplicates on build side: degenerates to regular anti/semi.
+TEST_F(CountingJoinTest, noDuplicatesOnBuild) {
+  assertCountingJoin(
+      {1, 2, 3, 4, 5}, {2, 4}, core::JoinType::kCountingAnti, {1, 3, 5});
+  assertCountingJoin(
+      {1, 2, 3, 4, 5}, {2, 4}, core::JoinType::kCountingLeftSemiFilter, {2, 4});
+}
+
+// All duplicates on build side.
+TEST_F(CountingJoinTest, allDuplicatesOnBuild) {
+  // EXCEPT ALL: 5 - 3 = 2
+  assertCountingJoin(
+      {1, 1, 1, 1, 1}, {1, 1, 1}, core::JoinType::kCountingAnti, {1, 1});
+  // INTERSECT ALL: min(5, 3) = 3
+  assertCountingJoin(
+      {1, 1, 1, 1, 1},
+      {1, 1, 1},
+      core::JoinType::kCountingLeftSemiFilter,
+      {1, 1, 1});
+}
+
+// Multiple batches on probe side.
+TEST_F(CountingJoinTest, multipleProbeBatches) {
+  auto probeVectors = {
+      makeRowVector({makeFlatVector<int32_t>({1, 1, 2})}),
+      makeRowVector({makeFlatVector<int32_t>({1, 2, 3})}),
+      makeRowVector({makeFlatVector<int32_t>({2, 3, 3})}),
+  };
+  auto buildVector =
+      makeRowVector({"u0"}, {makeFlatVector<int32_t>({1, 2, 2, 3})});
+
+  auto test = [&](core::JoinType joinType,
+                  const std::vector<int32_t>& expected) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values(probeVectors)
+            .hashJoin(
+                {"c0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values(buildVector).planNode(),
+                "",
+                {"c0"},
+                joinType)
+            .planNode();
+    assertEqualResults(
+        {makeRowVector({makeFlatVector<int32_t>(expected)})},
+        {AssertQueryBuilder(plan).copyResults(pool())});
+  };
+
+  // Probe: {1:3, 2:3, 3:3}, Build: {1:1, 2:2, 3:1}
+  // EXCEPT ALL: {1:2, 2:1, 3:2}
+  test(core::JoinType::kCountingAnti, {1, 1, 2, 3, 3});
+  // INTERSECT ALL: {1:1, 2:2, 3:1}
+  test(core::JoinType::kCountingLeftSemiFilter, {1, 2, 2, 3});
+}
+
+// Multiple columns as join keys.
+TEST_F(CountingJoinTest, multipleKeys) {
+  auto probeVector = makeRowVector(
+      {makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+       makeFlatVector<int32_t>({10, 10, 20, 10, 10})});
+  auto buildVector = makeRowVector(
+      {"u0", "u1"},
+      {makeFlatVector<int32_t>({1, 1, 2}),
+       makeFlatVector<int32_t>({10, 10, 10})});
+
+  // Probe: {(1,10):2, (1,20):1, (2,10):2}, Build: {(1,10):2, (2,10):1}
+  // EXCEPT ALL: {(1,20):1, (2,10):1}
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values(probeVector)
+          .hashJoin(
+              {"c0", "c1"},
+              {"u0", "u1"},
+              PlanBuilder(planNodeIdGenerator).values(buildVector).planNode(),
+              "",
+              {"c0", "c1"},
+              core::JoinType::kCountingAnti)
+          .planNode();
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({1, 2}),
+      makeFlatVector<int32_t>({20, 10}),
+  });
+  assertEqualResults(
+      {expected}, {AssertQueryBuilder(plan).copyResults(pool())});
+}
+
+// Null join keys never match anything (including other nulls).
+TEST_F(CountingJoinTest, nullKeys) {
+  // Probe: {1, null, 1, null, 2}, Build: {1, null, 3}
+  auto probeVector = makeRowVector(
+      {makeNullableFlatVector<int32_t>({1, std::nullopt, 1, std::nullopt, 2})});
+  auto buildVector = makeRowVector(
+      {"u0"}, {makeNullableFlatVector<int32_t>({1, std::nullopt, 3})});
+
+  auto test = [&](core::JoinType joinType,
+                  const std::vector<std::optional<int32_t>>& expected) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan =
+        PlanBuilder(planNodeIdGenerator)
+            .values(probeVector)
+            .hashJoin(
+                {"c0"},
+                {"u0"},
+                PlanBuilder(planNodeIdGenerator).values(buildVector).planNode(),
+                "",
+                {"c0"},
+                joinType)
+            .planNode();
+    assertEqualResults(
+        {makeRowVector({makeNullableFlatVector<int32_t>(expected)})},
+        {AssertQueryBuilder(plan).copyResults(pool())});
+  };
+
+  // EXCEPT ALL: non-null key 1 appears twice on probe and once on build, so one
+  // copy is removed. Key 2 has no build match. Null keys have no match and pass
+  // through.
+  test(core::JoinType::kCountingAnti, {1, std::nullopt, std::nullopt, 2});
+
+  // INTERSECT ALL: non-null key 1 appears twice on probe and once on build, so
+  // one copy is kept. Null keys have no match and are excluded.
+  test(core::JoinType::kCountingLeftSemiFilter, {1});
+}
+
+// Verifies that the build side deduplicates rows and stores only distinct keys.
+TEST_F(CountingJoinTest, buildSideDedup) {
+  // 10 distinct keys repeated 1'000 times each = 10'000 build rows.
+  auto buildVector = makeRowVector(
+      {"u0"}, {makeFlatVector<int32_t>(10, [](auto row) { return row; })});
+
+  // Probe has values 0..14. Build has values 0..9, each repeated 1'000 times.
+  // EXCEPT ALL: values 0..9 each appear once on probe but 1'000 times on build,
+  // so all are consumed. Values 10..14 have no match and are emitted.
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(makeRowVector({makeFlatVector<int32_t>(
+                      15, [](auto row) { return row; })}))
+                  .hashJoin(
+                      {"c0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values({buildVector}, false, 1'000)
+                          .planNode(),
+                      "",
+                      {"c0"},
+                      core::JoinType::kCountingAnti)
+                  .planNode();
+
+  auto expected =
+      makeRowVector({makeFlatVector<int32_t>({10, 11, 12, 13, 14})});
+  auto task = AssertQueryBuilder(plan).assertResults(expected);
+
+  // Verify the build received 10'000 rows but the hash table has only 10
+  // distinct keys.
+  auto planStats = toPlanStats(task->taskStats());
+  const auto& joinStats = planStats.at(plan->id());
+  EXPECT_EQ(10'000, joinStats.operatorStats.at("HashBuild")->inputRows);
+  EXPECT_EQ(
+      10,
+      joinStats.customStats.at(std::string(BaseHashTable::kNumDistinct)).sum);
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -84,7 +84,8 @@ class ExchangeClientTest : public testing::Test,
         executor_.get(), core::QueryConfig{std::move(config)});
     queryCtx->testingOverrideMemoryPool(
         memory::memoryManager()->addRootPool(queryCtx->queryId()));
-    auto plan = test::PlanBuilder().values({}).planNode();
+    auto plan =
+        test::PlanBuilder().values(std::vector<RowVectorPtr>{}).planNode();
     return Task::create(
         taskId,
         core::PlanFragment{plan},

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -102,7 +102,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
     }
     return HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, 1'000, pool_.get());
+        std::move(keyHashers), {}, true, false, false, 1'000, pool_.get());
   }
 
   std::vector<ContinueFuture> createEmptyFutures(int32_t count) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -137,7 +137,13 @@ class HashTableTest : public testing::TestWithParam<bool>,
                 buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, 1'000, pool());
+          std::move(keyHashers),
+          dependentTypes,
+          true,
+          false,
+          false,
+          1'000,
+          pool());
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
@@ -543,7 +549,7 @@ class HashTableTest : public testing::TestWithParam<bool>,
     std::vector<std::unique_ptr<VectorHasher>> hashers;
     hashers.push_back(std::make_unique<VectorHasher>(keys->type(), 0));
     auto table = HashTable<false>::createForJoin(
-        std::move(hashers), {BIGINT()}, true, false, 1'000, pool());
+        std::move(hashers), {BIGINT()}, true, false, false, 1'000, pool());
     copyVectorsToTable({batch}, 0, table.get());
     table->prepareJoinTable(
         {},
@@ -843,7 +849,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, 1'000, pool());
+        std::move(keyHashers), {}, true, false, false, 1'000, pool());
     std::vector<RowVectorPtr> batches;
     makeRows(1 << 12, 1, 0, type, batches);
     copyVectorsToTable(batches, 0, table.get());
@@ -883,6 +889,7 @@ TEST_P(HashTableTest, listJoinResultsSize) {
       std::move(keyHashers),
       {BIGINT(), VARCHAR()},
       true,
+      false,
       false,
       kNumRows,
       pool());
@@ -1038,7 +1045,7 @@ DEBUG_ONLY_TEST_P(HashTableTest, nextBucketOffset) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, 1'000, pool());
+        std::move(keyHashers), {}, true, false, false, 1'000, pool());
     auto testHelper = HashTableTestHelper<true>::create(table.get());
     const uint64_t numDistincts = bits::nextPowerOfTwo(
         2UL * std::numeric_limits<int32_t>::max() / testHelper.tableSlotSize());
@@ -1145,7 +1152,7 @@ DEBUG_ONLY_TEST_P(HashTableTest, failureInCreateRowPartitions) {
     // Set minTableSizeForParallelJoinBuild to be really small so we can trigger
     // a parallel join build without needing a lot of data.
     auto table = HashTable<false>::createForJoin(
-        std::move(hashers), {BIGINT()}, true, false, 1, pool());
+        std::move(hashers), {BIGINT()}, true, false, false, 1, pool());
     copyVectorsToTable({batch}, 0, table.get());
 
     if (topTable == nullptr) {
@@ -1239,6 +1246,7 @@ TEST_P(HashTableTest, toStringSingleKey) {
       {}, /*dependentTypes*/
       true /*allowDuplicates*/,
       false /*hasProbedFlag*/,
+      false /*hasCountFlag*/,
       1 /*minTableSizeForParallelJoinBuild*/,
       pool());
 
@@ -1268,6 +1276,7 @@ TEST_P(HashTableTest, toStringMultipleKeys) {
       {}, /*dependentTypes*/
       true /*allowDuplicates*/,
       false /*hasProbedFlag*/,
+      false /*hasCountFlag*/,
       1 /*minTableSizeForParallelJoinBuild*/,
       pool());
 

--- a/velox/exec/tests/OperatorTraceTest.cpp
+++ b/velox/exec/tests/OperatorTraceTest.cpp
@@ -457,7 +457,8 @@ TEST_F(OperatorTraceTest, task) {
 }
 
 TEST_F(OperatorTraceTest, error) {
-  const auto planNode = PlanBuilder().values({}).planNode();
+  const auto planNode =
+      PlanBuilder().values(std::vector<RowVectorPtr>{}).planNode();
   // No trace dir.
   {
     const auto queryConfigs = std::unordered_map<std::string, std::string>{

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -999,4 +999,27 @@ TEST_F(PlanNodeSerdeTest, columnStatsSpec) {
   }
 }
 
+TEST_F(PlanNodeSerdeTest, countingJoin) {
+  for (auto joinType :
+       {core::JoinType::kCountingAnti,
+        core::JoinType::kCountingLeftSemiFilter}) {
+    SCOPED_TRACE(core::JoinTypeName::toName(joinType));
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .values({data_})
+                    .hashJoin(
+                        {"c0"},
+                        {"u_c0"},
+                        PlanBuilder(planNodeIdGenerator)
+                            .values({data_})
+                            .project({"c0 as u_c0"})
+                            .planNode(),
+                        "",
+                        {"c0", "c1"},
+                        joinType)
+                    .planNode();
+    testSerde(plan);
+  }
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -1058,5 +1058,36 @@ TEST_F(PlanNodeToStringTest, tableWrite) {
   }
 }
 
+TEST_F(PlanNodeToStringTest, countingJoin) {
+  auto makePlan = [&](core::JoinType joinType) {
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    return PlanBuilder(planNodeIdGenerator)
+        .values({data_})
+        .hashJoin(
+            {"c0"},
+            {"u_c0"},
+            PlanBuilder(planNodeIdGenerator)
+                .values({data_})
+                .project({"c0 as u_c0"})
+                .planNode(),
+            "",
+            {"c0", "c1"},
+            joinType)
+        .planNode();
+  };
+
+  auto plan = makePlan(core::JoinType::kCountingAnti);
+  ASSERT_EQ("-- HashJoin[3]\n", plan->toString());
+  ASSERT_EQ(
+      "-- HashJoin[3][COUNTING ANTI c0=u_c0] -> c0:SMALLINT, c1:INTEGER\n",
+      plan->toString(true, false));
+
+  plan = makePlan(core::JoinType::kCountingLeftSemiFilter);
+  ASSERT_EQ("-- HashJoin[3]\n", plan->toString());
+  ASSERT_EQ(
+      "-- HashJoin[3][COUNTING LEFT SEMI (FILTER) c0=u_c0] -> c0:SMALLINT, c1:INTEGER\n",
+      plan->toString(true, false));
+}
+
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1517,6 +1517,7 @@ TEST_F(RowContainerTest, alignment) {
       false,
       false,
       true,
+      false, // hasCountFlag
       true,
       false,
       pool_.get());
@@ -1685,6 +1686,7 @@ TEST_F(RowContainerTest, probedFlag) {
       true, // hasNext
       true, // isJoinBuild
       true, // hasProbedFlag
+      false, // hasCountFlag
       false, // hasNormalizedKey
       false, // useListRowIndex
       pool_.get());
@@ -1788,6 +1790,32 @@ TEST_F(RowContainerTest, probedFlag) {
       makeNullableFlatVector<bool>(
           {true, true, true, true, std::nullopt, true}),
       result);
+}
+
+TEST_F(RowContainerTest, countFlag) {
+  RowContainer rows(
+      {INTEGER()},
+      true, // nullableKeys
+      std::vector<Accumulator>{},
+      {}, // dependentTypes
+      false, // hasNext
+      true, // isJoinBuild
+      false, // hasProbedFlag
+      true, // hasCountFlag
+      false, // hasNormalizedKey
+      false, // useListRowIndex
+      pool_.get());
+
+  ASSERT_NE(rows.countOffset(), 0);
+
+  auto* row = rows.newRow();
+  EXPECT_EQ(rows.count(row), 1);
+  rows.incrementCount(row);
+  EXPECT_EQ(rows.count(row), 2);
+  rows.decrementCount(row);
+  EXPECT_EQ(rows.count(row), 1);
+  rows.decrementCount(row);
+  EXPECT_EQ(rows.count(row), 0);
 }
 
 TEST_F(RowContainerTest, mixedFree) {
@@ -2740,6 +2768,7 @@ TEST_F(RowContainerTest, setAllNull) {
       false,
       true,
       false,
+      false, // hasCountFlag
       false,
       false,
       pool_.get());

--- a/velox/exec/tests/ValuesTest.cpp
+++ b/velox/exec/tests/ValuesTest.cpp
@@ -47,7 +47,9 @@ class ValuesTest : public OperatorTestBase {
 
 TEST_F(ValuesTest, empty) {
   // Base case: no vectors.
-  AssertQueryBuilder(PlanBuilder().values({}).planNode()).assertEmptyResults();
+  AssertQueryBuilder(
+      PlanBuilder().values(std::vector<RowVectorPtr>{}).planNode())
+      .assertEmptyResults();
 
   // Empty input vector.
   auto emptyInput = makeRowVector({});

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -655,6 +655,11 @@ class PlanBuilder {
       bool parallelizable = false,
       size_t repeatTimes = 1);
 
+  /// Convenience overload that wraps a single RowVectorPtr in a vector.
+  PlanBuilder& values(const RowVectorPtr& value) {
+    return values(std::vector<RowVectorPtr>{value});
+  }
+
   PlanBuilder& filtersAsNode(bool filtersAsNode) {
     filtersAsNode_ = filtersAsNode;
     return *this;

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -88,6 +88,7 @@ class RowContainerTestBase : public testing::Test,
         isJoinBuild,
         isJoinBuild,
         true,
+        false, // hasCountFlag
         true,
         useListRowIndex,
         pool_.get());

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -72,6 +72,7 @@ std::shared_ptr<TestIndexTable> TestIndexTable::create(
       /*dependentTypes=*/dependentTypes,
       /*allowDuplicates=*/true,
       /*hasProbedFlag=*/false,
+      /*hasCountFlag=*/false,
       /*minTableSizeForParallelJoinBuild=*/1,
       &pool);
 

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -117,6 +117,7 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
         /*dependentTypes=*/dependentTypes,
         /*allowDuplicates=*/true,
         /*hasProbedFlag=*/false,
+        /*hasCountFlag=*/false,
         /*minTableSizeForParallelJoinBuild=*/1,
         pool_.get());
 


### PR DESCRIPTION
Summary:

Add kCountingLeftSemiFilter and kCountingAnti join types that implement
multiset semantics for INTERSECT ALL and EXCEPT ALL.

The build side deduplicates keys and stores a per-key count in
RowContainer. On probe, each match decrements the count.
kCountingAnti emits a probe row when the count reaches zero or no match
is found. kCountingLeftSemiFilter emits a probe row while the count is
greater than zero.

This achieves O(D) memory on the build side (where D = number of
distinct keys), matching PostgreSQL/DuckDB's dedicated SetOp operators
but reusing the existing hash join infrastructure.

Spilling is not yet supported for counting joins and fails with a clear
error if triggered.

Fixes https://github.com/facebookincubator/velox/issues/16838

Reviewed By: xiaoxmeng

Differential Revision: D97289509
