### PR TITLE
feat: Add simdFill utility to SimdUtil

### DIFF
--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
+#include <type_traits>
+
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 
@@ -530,6 +533,43 @@ inline void memcpy(void* to, const void* from, int64_t bytes, const A& = {});
 // constant values of 'bytes'.
 template <typename A = xsimd::default_arch>
 void memset(void* to, char data, int32_t bytes, const A& = {});
+
+// Fills 'count' elements of 'output' with 'value' using SIMD broadcast+store
+// for types that support it (int32_t, uint32_t, int64_t, uint64_t, float,
+// double), and falls back to std::fill for other types.
+//
+// Uses a simpler structure than std::fill's auto-vectorized code — broadcast +
+// tight store loop + overlapping tail — that performs better for repeated calls
+// with small variable-length fills.
+template <typename T>
+inline void simdFill(T* output, T value, uint32_t count) {
+  if constexpr (
+      std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t> ||
+      std::is_same_v<T, int64_t> || std::is_same_v<T, uint64_t> ||
+      std::is_same_v<T, float> || std::is_same_v<T, double>) {
+    constexpr auto kBatchSize = xsimd::batch<T>::size;
+    if (count >= kBatchSize) {
+      auto batch = xsimd::broadcast<T>(value);
+      uint32_t i = 0;
+      for (; i + kBatchSize <= count; i += kBatchSize) {
+        batch.store_unaligned(output + i);
+      }
+      // Handle tail with an overlapping store. Safe because we're filling
+      // with a constant value, so re-writing already-written positions is
+      // harmless. The outer 'count >= kBatchSize' guard ensures
+      // 'count - kBatchSize' never underflows.
+      if (i < count) {
+        batch.store_unaligned(output + count - kBatchSize);
+      }
+    } else {
+      for (uint32_t i = 0; i < count; ++i) {
+        output[i] = value;
+      }
+    }
+  } else {
+    std::fill(output, output + count, value);
+  }
+}
 
 // Calls a different instantiation of a template function according to
 // 'numBytes'.

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -656,4 +656,76 @@ TEST_F(SimdUtilTest, randomStringStrStr) {
   }
 }
 
+TEST_F(SimdUtilTest, simdFill) {
+  // Test supported types: SIMD path (int32_t, uint32_t, int64_t, uint64_t,
+  // float, double).
+  auto testFill = [](auto value) {
+    using T = decltype(value);
+    struct TestParam {
+      uint32_t count;
+      std::string debugString() const {
+        return fmt::format("count {}", count);
+      }
+    };
+    std::vector<TestParam> testSettings = {
+        {0},
+        {1},
+        {3},
+        {7},
+        {8},
+        {9},
+        {15},
+        {16},
+        {17},
+        {31},
+        {32},
+        {33},
+        {63},
+        {64},
+        {100},
+        {255},
+        {256},
+        {1'000},
+        {10'000}};
+    for (const auto& testData : testSettings) {
+      SCOPED_TRACE(testData.debugString());
+      std::vector<T> output(testData.count, T{});
+      simd::simdFill(output.data(), value, testData.count);
+      for (uint32_t i = 0; i < testData.count; ++i) {
+        ASSERT_EQ(output[i], value) << "at index " << i;
+      }
+    }
+  };
+
+  testFill(static_cast<int32_t>(42));
+  testFill(static_cast<uint32_t>(42));
+  testFill(static_cast<int64_t>(123'456'789));
+  testFill(static_cast<uint64_t>(123'456'789));
+  testFill(3.14f);
+  testFill(2.718281828);
+
+  // Test unsupported types: fallback to std::fill (int8_t, int16_t, bool).
+  {
+    std::vector<int8_t> output(100, 0);
+    simd::simdFill(output.data(), static_cast<int8_t>(7), 100u);
+    for (auto v : output) {
+      ASSERT_EQ(v, 7);
+    }
+  }
+  {
+    std::vector<int16_t> output(100, 0);
+    simd::simdFill(output.data(), static_cast<int16_t>(1'234), 100u);
+    for (auto v : output) {
+      ASSERT_EQ(v, 1'234);
+    }
+  }
+  {
+    bool output[100] = {};
+    simd::simdFill(output, true, 100u);
+    for (int i = 0; i < 100; ++i) {
+      ASSERT_EQ(output[i], true);
+    }
+  }
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
CONTEXT: The nimble RLE encoding has a SIMD-optimized fill function (simdFill)
that outperforms std::fill for repeated short variable-length fills by 1.3-2.1x.
This pattern is useful beyond nimble encodings.

WHAT: Move simdFill to velox's SimdUtil.h as a reusable SIMD utility. The function
uses xsimd broadcast + tight store loop + overlapping tail store, which has lower
per-call overhead than std::fill's auto-vectorized multi-path code for small
variable-length fills.

Supported types: int32_t, uint32_t, int64_t, uint64_t, float, double.
Falls back to std::fill for other types.

Differential Revision: D97313499


