### PR TITLE
fix(build): Run single exchange fuzzer instance to avoid OOM

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -917,9 +917,9 @@ jobs:
           cat /proc/sys/vm/max_map_count
           export LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH
           chmod +x velox_exchange_fuzzer run-fuzzer-parallel.sh
-          # Exchange fuzzer is multi-threaded and memory-heavy; run 2 instances
-          # on ubuntu-latest (more RAM) with a longer duration per instance.
-          ./run-fuzzer-parallel.sh 2 /tmp/exchange_fuzzer_repro \
+          # Exchange fuzzer is multi-threaded and memory-heavy; run 1 instance
+          # on ubuntu-latest with an extended duration.
+          ./run-fuzzer-parallel.sh 1 /tmp/exchange_fuzzer_repro \
             ./velox_exchange_fuzzer \
                 --seed __SEED__ \
                 --duration_sec 480 \


### PR DESCRIPTION
## Summary

- Reduces exchange fuzzer from 2 parallel instances to 1 on `ubuntu-latest`
- The exchange fuzzer is multi-threaded and memory-heavy; 2 instances cause OOM kills (observed in CI run [23207325437](https://github.com/facebookincubator/velox/actions/runs/23207325437))
- Keeps the full 480s duration for adequate coverage

This was intended to be part of #16797 but the final merged version had 2 instances.

## Test plan

- CI scheduled fuzzer run validates exchange fuzzer passes with 1 instance