### PR TITLE
fix(rpc): Remove gmock dependency from RPCNodeTest to fix OSS GCC-14 build (#16848)

### DIFF
--- a/velox/exec/rpc/tests/RPCNodeTest.cpp
+++ b/velox/exec/rpc/tests/RPCNodeTest.cpp
@@ -26,7 +26,6 @@
 
 #include "velox/core/PlanNode.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include "velox/common/memory/Memory.h"
@@ -173,7 +172,10 @@ TEST_F(RPCNodeTest, functionDispatchPerRow) {
   for (const auto& [idx, _] : futures) {
     rowIndices.push_back(idx);
   }
-  EXPECT_THAT(rowIndices, testing::ElementsAre(0, 1, 2));
+  ASSERT_EQ(rowIndices.size(), 3);
+  EXPECT_EQ(rowIndices[0], 0);
+  EXPECT_EQ(rowIndices[1], 1);
+  EXPECT_EQ(rowIndices[2], 2);
 
   // Resolve futures and verify responses.
   for (auto& [rowIdx, future] : futures) {


### PR DESCRIPTION
Summary:

The Velox OSS Docker CI uses gcc-toolset-14 which is incompatible with
the system-installed gmock headers. RPCNodeTest only used gmock for a
single `EXPECT_THAT(rowIndices, testing::ElementsAre(0, 1, 2))` call.
Replace with explicit ASSERT_EQ/EXPECT_EQ and remove the gmock include
and BUCK dep.

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: presto_batch

Differential Revision: D97341033


