### PR TITLE
fix(hive): allow FileIndexReader for Flux

### DIFF
--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -279,10 +279,10 @@ std::unique_ptr<dwio::common::Reader> FileIndexReader::createFileReader() {
 std::unique_ptr<dwio::common::IndexReader>
 FileIndexReader::createIndexReader() {
   VELOX_CHECK_NOT_NULL(fileReader_);
-  VELOX_CHECK_EQ(
-      hiveSplit_->fileFormat,
-      dwio::common::FileFormat::NIMBLE,
-      "FileIndexReader only supports Nimble file format");
+  VELOX_CHECK(
+      hiveSplit_->fileFormat == dwio::common::FileFormat::NIMBLE ||
+          hiveSplit_->fileFormat == dwio::common::FileFormat::FLUX,
+      "FileIndexReader only supports Nimble and Flux file formats");
 
   dwio::common::RowReaderOptions rowReaderOpts;
   configureRowReaderOptions(


### PR DESCRIPTION
Summary:
FileIndexReader already delegates format-specific index reader creation to the
dwio reader implementation. Relax the Hive-side file format check so it accepts
Flux alongside Nimble when creating index readers.

Reviewed By: xiaoxmeng

Differential Revision: D97234249


