### PR TITLE
perf(operator): Batch merge spilled rows in HashAggregation

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1203,9 +1203,12 @@ bool GroupingSet::mergeNextWithAggregates(
   // True if 'merge_' indicates that the next key is the same as the current
   // one.
   bool nextKeyIsEqual{false};
+  bool endOfBatch{false};
+  uint64_t averageRowSize{0};
   for (;;) {
     const auto next = merge_->nextWithEquals();
     if (next.first == nullptr) {
+      initializeAndUpdateRows(maxOutputRows, averageRowSize);
       extractSpillResult(result);
       if (result->size() > 0) {
         return true;
@@ -1219,16 +1222,29 @@ bool GroupingSet::mergeNextWithAggregates(
       continue;
     }
     if (!nextKeyIsEqual) {
+      // This is the first row of a new group.
       mergeState_ = mergeRows_->newRow();
-      initializeRow(*next.first, mergeState_);
+      firstRowStreams_.push_back(next.first);
+      firstRowIndices_.push_back(next.first->currentIndex());
+      firstRowStates_.push_back(mergeState_);
     }
-    updateRow(*next.first, mergeState_);
+    mergeSources_.push_back(&next.first->current());
+    mergeRowIndices_.push_back(next.first->currentIndex(&endOfBatch));
+    mergeStates_.push_back(mergeState_);
     nextKeyIsEqual = next.second;
+    // Merge spilled rows before pop() to avoid dangling pointers into the
+    // stream's internal RowVector.
+    // Also ensures averageRowSize is initialized at the first group boundary,
+    // so the byte-based batch limit check below can take effect early.
+    if (endOfBatch || (!nextKeyIsEqual && averageRowSize == 0)) {
+      initializeAndUpdateRows(maxOutputRows, averageRowSize);
+    }
     next.first->pop();
 
     if (!nextKeyIsEqual &&
         ((mergeRows_->numRows() >= maxOutputRows) ||
-         (mergeRowBytes() >= maxOutputBytes))) {
+         (mergeRows_->numRows() * averageRowSize >= maxOutputBytes))) {
+      initializeAndUpdateRows(maxOutputRows, averageRowSize);
       extractSpillResult(result);
       return true;
     }
@@ -1237,7 +1253,7 @@ bool GroupingSet::mergeNextWithAggregates(
 }
 
 uint64_t GroupingSet::mergeRowBytes() const {
-  auto totalBytes = mergeRows_->allocatedBytes();
+  auto totalBytes = mergeRows_->usedBytes();
   if (sortedAggregations_ != nullptr) {
     totalBytes += sortedAggregations_->inputRowBytes();
 
@@ -1387,27 +1403,49 @@ bool GroupingSet::mergeNextWithoutAggregates(
   return numOutputRows > 0;
 }
 
-void GroupingSet::initializeRow(SpillMergeStream& stream, char* row) {
-  for (auto i = 0; i < keyChannels_.size(); ++i) {
-    mergeRows_->store(stream.decoded(i), stream.currentIndex(), mergeState_, i);
+void GroupingSet::ensureGroupIndices(vector_size_t newSize) {
+  vector_size_t size = groupIndices_.size();
+  if (size < newSize) {
+    groupIndices_.resize(newSize);
+    std::iota(groupIndices_.begin() + size, groupIndices_.end(), size);
   }
-  vector_size_t zero = 0;
+}
+
+void GroupingSet::initializeRows() {
+  VELOX_CHECK_EQ(firstRowStreams_.size(), firstRowIndices_.size());
+  VELOX_CHECK_EQ(firstRowStreams_.size(), firstRowStates_.size());
+  ensureGroupIndices(firstRowStreams_.size());
+  for (auto i = 0; i < keyChannels_.size(); ++i) {
+    for (auto j = 0; j < firstRowStates_.size(); ++j) {
+      mergeRows_->store(
+          firstRowStreams_[j]->decoded(i),
+          firstRowIndices_[j],
+          firstRowStates_[j],
+          i);
+    }
+  }
   for (auto i = 0; i < aggregates_.size(); ++i) {
     if (!aggregates_[i].sortingKeys.empty()) {
       continue;
     }
     if (!aggregates_[i].distinct) {
       aggregates_[i].function->initializeNewGroups(
-          &row, folly::Range<const vector_size_t*>(&zero, 1));
+          firstRowStates_.data(),
+          folly::Range<const vector_size_t*>(
+              groupIndices_.data(), firstRowStates_.size()));
     } else {
       distinctAggregations_[i]->initializeNewGroups(
-          &row, folly::Range<const vector_size_t*>(&zero, 1));
+          firstRowStates_.data(),
+          folly::Range<const vector_size_t*>(
+              groupIndices_.data(), firstRowStates_.size()));
     }
   }
 
   if (sortedAggregations_ != nullptr) {
     sortedAggregations_->initializeNewGroups(
-        &row, folly::Range<const vector_size_t*>(&zero, 1));
+        firstRowStates_.data(),
+        folly::Range<const vector_size_t*>(
+            groupIndices_.data(), firstRowStates_.size()));
   }
 }
 
@@ -1438,38 +1476,72 @@ void GroupingSet::clearMergeRows() {
   }
 }
 
-void GroupingSet::updateRow(SpillMergeStream& input, char* row) {
-  if (input.currentIndex() >= mergeSelection_.size()) {
-    mergeSelection_.resize(bits::roundUp(input.currentIndex() + 1, 64));
-    mergeSelection_.clearAll();
-  }
-  mergeSelection_.setValid(input.currentIndex(), true);
-  mergeSelection_.updateBounds();
+void GroupingSet::updateRows() {
+  VELOX_CHECK_EQ(mergeStates_.size(), intermediateResult_->size());
+  mergeSelection_.resizeFill(intermediateResult_->size(), true);
   for (auto i = 0; i < aggregates_.size(); ++i) {
     if (!aggregates_[i].sortingKeys.empty()) {
       continue;
     }
-    mergeArgs_[0] = input.current().childAt(i + keyChannels_.size());
-    aggregates_[i].function->addSingleGroupIntermediateResults(
-        row, mergeSelection_, mergeArgs_, false);
+    mergeArgs_[0] = intermediateResult_->childAt(i + keyChannels_.size());
+    aggregates_[i].function->addIntermediateResults(
+        mergeStates_.data(), mergeSelection_, mergeArgs_, false);
   }
-  mergeSelection_.setValid(input.currentIndex(), false);
 
   auto sortOrDistinctAggIndex = aggregates_.size() + keyChannels_.size();
   if (sortedAggregations_ != nullptr) {
-    const auto& vector = input.current().childAt(sortOrDistinctAggIndex);
-    sortedAggregations_->addSingleGroupSpillInput(
-        row, vector, input.currentIndex());
+    const auto& vector = intermediateResult_->childAt(sortOrDistinctAggIndex);
+    for (int i = 0; i < mergeStates_.size(); ++i) {
+      sortedAggregations_->addSingleGroupSpillInput(mergeStates_[i], vector, i);
+    }
     ++sortOrDistinctAggIndex;
   }
 
   for (const auto& distinctAgg : distinctAggregations_) {
     if (distinctAgg != nullptr) {
-      distinctAgg->addSingleGroupSpillInput(
-          row,
-          input.current().childAt(sortOrDistinctAggIndex),
-          input.currentIndex());
+      const auto& vector = intermediateResult_->childAt(sortOrDistinctAggIndex);
+      for (int i = 0; i < mergeStates_.size(); ++i) {
+        distinctAgg->addSingleGroupSpillInput(mergeStates_[i], vector, i);
+      }
       ++sortOrDistinctAggIndex;
+    }
+  }
+}
+
+void GroupingSet::initializeAndUpdateRows(
+    int32_t maxOutputRows,
+    uint64_t& averageRowSize) {
+  if (!firstRowStreams_.empty()) {
+    initializeRows();
+    firstRowStreams_.clear();
+    firstRowIndices_.clear();
+    firstRowStates_.clear();
+  }
+
+  if (!mergeStates_.empty()) {
+    if (!intermediateResult_) {
+      intermediateResult_ = BaseVector::create<RowVector>(
+          mergeSources_.back()->type(), maxOutputRows, pool_);
+    }
+    intermediateResult_->prepareForReuse();
+    intermediateResult_->resize(mergeSources_.size());
+    // Only gather copy accumulators.
+    for (auto i = keyChannels_.size(); i < intermediateResult_->childrenSize();
+         i++) {
+      gatherCopy(
+          intermediateResult_->childAt(i).get(),
+          0,
+          mergeSources_.size(),
+          mergeSources_,
+          mergeRowIndices_,
+          i);
+    }
+    updateRows();
+    mergeSources_.clear();
+    mergeRowIndices_.clear();
+    mergeStates_.clear();
+    if (const auto updatedSize = mergeRowBytes() / mergeRows_->numRows()) {
+      averageRowSize = updatedSize;
     }
   }
 }

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -277,22 +277,6 @@ class GroupingSet {
   // Returns the currently accummulated bytes of the unspill merge rows.
   uint64_t mergeRowBytes() const;
 
-  // Initializes a new row in 'mergeRows' with the keys from the
-  // current element from 'stream'. Accumulators are left in the initial
-  // state with no data accumulated. This is called each time a new
-  // key is received from a merge of spilled data. After this
-  // updateRow() is called on the same element and on every subsequent
-  // element read from the stream until a new key is seen, at which
-  // time we again call initializeRow(). When enough rows have been
-  // accumulated and we have a new key, we produce the output and
-  // clear 'mergeRows_' with extractSpillResult() and only then do
-  // initializeRow().
-  void initializeRow(SpillMergeStream& stream, char* row);
-
-  // Updates the accumulators in 'row' with the intermediate type data from
-  // 'keys'. This is called for each row received from a merge of spilled data.
-  void updateRow(SpillMergeStream& keys, char* row);
-
   // Returns a RowType of the spilled data.
   RowTypePtr makeSpillType() const;
 
@@ -310,6 +294,27 @@ class GroupingSet {
   // 'excludeToIntermediate' is true, skip the functions that support
   // 'toIntermediate'.
   std::vector<Accumulator> accumulators(bool excludeToIntermediate);
+
+  // Updates the accumulators in 'mergeStates_' with the intermediate type data
+  // gathered in 'intermediateResult_'. Called in batches during spill merge.
+  void updateRows();
+
+  // Initializes new rows with the keys from 'firstRowStates_' and sets
+  // accumulators to their initial state. Called in batches during spill merge.
+  void initializeRows();
+
+  // Ensures 'groupIndices_' is sized to 'newSize' with identity mapping.This
+  // function only expands the size if 'newSize' is greater than the current
+  // size.
+  void ensureGroupIndices(vector_size_t newSize);
+
+  // Initializes and updates 'mergeRows_' with pending spill merge state by
+  // calling initializeRows() and updateRows() respectively for accumulated
+  // first row of every group and unmerged rows. Updates 'averageRowSize' with
+  // the average row size in 'mergeRows_' only when there are pending merge
+  // states to process, used to estimate the row size of new groups that have
+  // not yet been merged.
+  void initializeAndUpdateRows(int32_t maxOutputRows, uint64_t& averageRowSize);
 
   // A subset of grouping keys on which the input is clustered.
   const std::vector<column_index_t> preGroupedKeyChannels_;
@@ -388,6 +393,18 @@ class GroupingSet {
 
   std::vector<vector_size_t> spillSourceRows_;
 
+  // Records the first rows of all groups of spilled data.
+  std::vector<SpillMergeStream*> firstRowStreams_;
+  std::vector<vector_size_t> firstRowIndices_;
+  std::vector<char*> firstRowStates_;
+
+  // Records the source unmerged rows to update rows by batch.
+  std::vector<const RowVector*> mergeSources_;
+  std::vector<vector_size_t> mergeRowIndices_;
+  std::vector<char*> mergeStates_;
+
+  std::vector<vector_size_t> groupIndices_;
+
   // The value of mayPushdown flag specified in addInput() for the
   // 'remainingInput_'.
   bool remainingMayPushdown_;
@@ -416,6 +433,9 @@ class GroupingSet {
 
   // Intermediate vector for passing arguments to aggregate in merging spill.
   std::vector<VectorPtr> mergeArgs_;
+
+  // Intermediate result from multiple merging streams in merging spill.
+  RowVectorPtr intermediateResult_;
 
   // Indicates the element in mergeArgs_[0] that corresponds to the accumulator
   // to merge.

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -96,33 +96,6 @@ void complexGatherCopy(
   }
 }
 
-void gatherCopy(
-    BaseVector* target,
-    vector_size_t targetIndex,
-    vector_size_t count,
-    const std::vector<const RowVector*>& sources,
-    const std::vector<vector_size_t>& sourceIndices,
-    column_index_t sourceChannel) {
-  const bool flattenSources =
-      std::all_of(sources.begin(), sources.end(), [](const auto& source) {
-        return source->isFlatEncoding();
-      });
-  if (target->isScalar() && flattenSources) {
-    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-        scalarGatherCopy,
-        target->type()->kind(),
-        target,
-        targetIndex,
-        count,
-        sources,
-        sourceIndices,
-        sourceChannel);
-  } else {
-    complexGatherCopy(
-        target, targetIndex, count, sources, sourceIndices, sourceChannel);
-  }
-}
-
 // We want to aggregate some operator runtime metrics per operator rather than
 // per event. This function returns true for such metrics.
 bool shouldAggregateRuntimeMetric(const std::string& name) {
@@ -420,6 +393,33 @@ void loadColumns(const RowVectorPtr& input, core::ExecCtx& execCtx) {
           *decodedHolder.get(),
           *baseRowsHolder.get(input->size()));
     }
+  }
+}
+
+void gatherCopy(
+    BaseVector* target,
+    vector_size_t targetIndex,
+    vector_size_t count,
+    const std::vector<const RowVector*>& sources,
+    const std::vector<vector_size_t>& sourceIndices,
+    column_index_t sourceChannel) {
+  const bool flattenSources =
+      std::all_of(sources.begin(), sources.end(), [](const auto& source) {
+        return source->isFlatEncoding();
+      });
+  if (target->isScalar() && flattenSources) {
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        scalarGatherCopy,
+        target->type()->kind(),
+        target,
+        targetIndex,
+        count,
+        sources,
+        sourceIndices,
+        sourceChannel);
+  } else {
+    complexGatherCopy(
+        target, targetIndex, count, sources, sourceIndices, sourceChannel);
   }
 }
 

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -139,6 +139,21 @@ void gatherCopy(
     const std::vector<vector_size_t>& sourceIndices,
     const std::vector<IdentityProjection>& columnMap = {});
 
+/// Scatter copy from multiple source row vectors into the target base vector.
+/// 'targetIndex' is first row in 'target' to copy to. 'count' specifies how
+/// many rows to copy from the sources. 'sources' and 'sourceIndices' specify
+/// the source rows to copy from. 'sourceChannel' specifies the column channel
+/// in the source row vectors to copy from.
+///
+/// NOTE: all the source row vectors must have the same data type.
+void gatherCopy(
+    BaseVector* target,
+    vector_size_t targetIndex,
+    vector_size_t count,
+    const std::vector<const RowVector*>& sources,
+    const std::vector<vector_size_t>& sourceIndices,
+    column_index_t sourceChannel);
+
 /// Generates the system-wide unique disk spill file path for an operator. It
 /// will be the directory on fs with namespace support or common file prefix if
 /// not. It is assumed that the disk spilling file hierarchy for an operator is

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -1034,15 +1034,17 @@ void RowContainer::extractProbedFlags(
   }
 }
 
+int64_t RowContainer::usedBytes() const {
+  int64_t freeBytes = rows_.freeBytes() + fixedRowSize_ * numFreeRows_;
+  return rows_.allocatedBytes() - freeBytes + stringAllocator_->retainedSize() -
+      stringAllocator_->freeSpace() - rowPointers_.capacity() * sizeof(char*);
+}
+
 std::optional<int64_t> RowContainer::estimateRowSize() const {
   if (numRows_ == 0) {
     return std::nullopt;
   }
-  int64_t freeBytes = rows_.freeBytes() + fixedRowSize_ * numFreeRows_;
-  int64_t usedSize = rows_.allocatedBytes() - freeBytes +
-      stringAllocator_->retainedSize() - stringAllocator_->freeSpace() -
-      rowPointers_.capacity() * sizeof(char*);
-  int64_t rowSize = usedSize / numRows_;
+  int64_t rowSize = usedBytes() / numRows_;
   VELOX_CHECK_GT(
       rowSize, 0, "Estimated row size of the RowContainer must be positive.");
   return rowSize;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -832,6 +832,10 @@ class RowContainer {
         stringAllocator_->freeSpace());
   }
 
+  /// Returns the total bytes used to store rows in this container, excluding
+  /// free space and internal bookkeeping overhead (e.g. row pointer capacity).
+  int64_t usedBytes() const;
+
   /// Returns the average size of rows in bytes stored in this container.
   std::optional<int64_t> estimateRowSize() const;
 

--- a/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
+++ b/velox/exec/tests/ConcatFilesSpillMergeStreamTest.cpp
@@ -146,8 +146,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
               outputRow,
               outputSize,
               spillSources,
-              spillSourceRows,
-              {});
+              spillSourceRows);
           outputRow += outputSize;
           outputSize = 0;
         }
@@ -156,12 +155,7 @@ class ConcatFilesSpillMergeStreamTest : public OperatorTestBase {
       }
       if (FOLLY_LIKELY(outputSize != 0)) {
         gatherCopy(
-            output.get(),
-            outputRow,
-            outputSize,
-            spillSources,
-            spillSourceRows,
-            {});
+            output.get(), outputRow, outputSize, spillSources, spillSourceRows);
       }
       results.push_back(output);
     }


### PR DESCRIPTION
In some of our production cases, Velox spends much more time on decoding vectors and updating the selectivity vector during merging spilled data, because spilled rows are processed one by one. This PR batches the spilled row merging in HashAggregation by collecting rows across multiple streams and processing them together, amortizing the per-row overhead.

