### PR TITLE
feat: Add task barrier support for HashAggregation

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1299,7 +1299,7 @@ class AggregationNode : public PlanNode {
   };
 
   bool supportsBarrier() const override {
-    return isPreGrouped();
+    return true;
   }
 
   const std::vector<PlanNodePtr>& sources() const override {

--- a/velox/docs/develop/task-barrier.rst
+++ b/velox/docs/develop/task-barrier.rst
@@ -408,6 +408,18 @@ hasn't seen a "new" key to trigger the flush.
   ensures that when the task resumes after the barrier with new splits, it
   starts fresh.
 
+Hash Aggregation
+^^^^^^^^^^^^^^^^
+
+* **Function**: Computes grouped or global aggregates using an in-memory hash
+  table instead of relying on sorted input.
+
+**Limitation**: Hash aggregation barrier support is currently intended for
+in-memory aggregation only. It's recommended to keep spill disabled when
+using task barrier with hash aggregation. Otherwise, if the task has
+spilled, ``requestBarrier()`` is not supported and will cause the subsequent
+``next()`` call to throw.
+
 Limitations
 -----------
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -903,9 +903,9 @@ void GroupingSet::resetTable(bool freeTable) {
 }
 
 void GroupingSet::resetGlobalAggregation() {
-  if (!isGlobal_) {
-    return;
-  }
+  VELOX_CHECK(
+      isGlobal_,
+      "resetGlobalAggregation should only be called for global grouping sets");
   destroyGlobalAggregations();
   rows_.clear();
   stringAllocator_.clear();

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -902,6 +902,16 @@ void GroupingSet::resetTable(bool freeTable) {
   }
 }
 
+void GroupingSet::resetGlobalAggregation() {
+  if (!isGlobal_) {
+    return;
+  }
+  destroyGlobalAggregations();
+  rows_.clear();
+  stringAllocator_.clear();
+  globalAggregationInitialized_ = false;
+}
+
 bool GroupingSet::isPartialFull(int64_t maxBytes) {
   VELOX_CHECK(isPartial_);
   if (!table_ || allocatedBytes() <= maxBytes) {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -91,6 +91,10 @@ class GroupingSet {
   /// freed but only table content.
   void resetTable(bool freeTable);
 
+  /// Resets reusable state for global aggregation so it can be initialized
+  /// again for a new processing cycle.
+  void resetGlobalAggregation();
+
   /// Returns true if 'this' should start producing partial
   /// aggregation results. Checks the memory consumption against
   /// 'maxBytes'. If exceeding 'maxBytes', sees if changing hash mode

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -238,6 +238,17 @@ bool HashAggregation::startDrain() {
   return true;
 }
 
+void HashAggregation::finishDrain() {
+  if (!isDraining()) {
+    return;
+  }
+  groupingSet_->resetTable(/*freeTable=*/false);
+  if (isGlobal_) {
+    groupingSet_->resetGlobalAggregation();
+  }
+  Operator::finishDrain();
+}
+
 void HashAggregation::updateRuntimeStats() {
   // Report range sizes and number of distinct values for the group-by keys.
   const auto& hashers = groupingSet_->hashLookup().hashers;
@@ -346,9 +357,7 @@ RowVectorPtr HashAggregation::getOutput() {
       finished_ = true;
     }
     if (!input_) {
-      if (isDraining()) {
-        Operator::finishDrain();
-      }
+      finishDrain();
       return nullptr;
     }
     prepareOutput(input_->size());
@@ -375,10 +384,7 @@ RowVectorPtr HashAggregation::getOutput() {
   if (isDistinct_) {
     auto distinctOutput = getDistinctOutput();
     if (distinctOutput == nullptr) {
-      if (isDraining()) {
-        groupingSet_->resetTable(/*freeTable=*/false);
-        Operator::finishDrain();
-      }
+      finishDrain();
     }
     return distinctOutput;
   }
@@ -396,22 +402,11 @@ RowVectorPtr HashAggregation::getOutput() {
       output_);
   if (!hasData) {
     resultIterator_.reset();
-    if (isDraining()) {
-      if (isPartialOutput_) {
-        resetPartialOutputIfNeed();
-      } else {
-        groupingSet_->resetTable(/*freeTable=*/false);
-        if (isGlobal_) {
-          groupingSet_->resetGlobalAggregation();
-        }
-      }
-      Operator::finishDrain();
-      return nullptr;
-    }
     if (noMoreInput_) {
       finished_ = true;
     }
     resetPartialOutputIfNeed();
+    finishDrain();
     return nullptr;
   }
   numOutputRows_ += output_->size();

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -228,6 +228,16 @@ void HashAggregation::addInput(RowVectorPtr input) {
   }
 }
 
+bool HashAggregation::startDrain() {
+  VELOX_CHECK(isDraining());
+  VELOX_CHECK(!noMoreInput_);
+  VELOX_CHECK(
+      !groupingSet_->hasSpilled(),
+      "Barrier drain is not supported for spilled hash aggregation");
+
+  return true;
+}
+
 void HashAggregation::updateRuntimeStats() {
   // Report range sizes and number of distinct values for the group-by keys.
   const auto& hashers = groupingSet_->hashLookup().hashers;
@@ -336,6 +346,9 @@ RowVectorPtr HashAggregation::getOutput() {
       finished_ = true;
     }
     if (!input_) {
+      if (isDraining()) {
+        Operator::finishDrain();
+      }
       return nullptr;
     }
     prepareOutput(input_->size());
@@ -353,14 +366,21 @@ RowVectorPtr HashAggregation::getOutput() {
   // - partial aggregation reached memory limit;
   // - distinct aggregation has new keys;
   // - running in partial streaming mode and have some output ready.
-  if (!noMoreInput_ && !partialFull_ && !newDistincts_ &&
+  if (!noMoreInput_ && !isDraining() && !partialFull_ && !newDistincts_ &&
       !groupingSet_->hasDrainedNewGroups() && !groupingSet_->hasOutput()) {
     input_ = nullptr;
     return nullptr;
   }
 
   if (isDistinct_) {
-    return getDistinctOutput();
+    auto distinctOutput = getDistinctOutput();
+    if (distinctOutput == nullptr) {
+      if (isDraining()) {
+        groupingSet_->resetTable(/*freeTable=*/false);
+        Operator::finishDrain();
+      }
+    }
+    return distinctOutput;
   }
 
   const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
@@ -376,6 +396,18 @@ RowVectorPtr HashAggregation::getOutput() {
       output_);
   if (!hasData) {
     resultIterator_.reset();
+    if (isDraining()) {
+      if (isPartialOutput_) {
+        resetPartialOutputIfNeed();
+      } else {
+        groupingSet_->resetTable(/*freeTable=*/false);
+        if (isGlobal_) {
+          groupingSet_->resetGlobalAggregation();
+        }
+      }
+      Operator::finishDrain();
+      return nullptr;
+    }
     if (noMoreInput_) {
       finished_ = true;
     }

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -51,6 +51,8 @@ class HashAggregation : public Operator {
     return !noMoreInput_ && !partialFull_;
   }
 
+  bool startDrain() override;
+
   void noMoreInput() override;
 
   BlockingReason isBlocked(ContinueFuture* /* unused */) override {

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -53,6 +53,8 @@ class HashAggregation : public Operator {
 
   bool startDrain() override;
 
+  void finishDrain() override;
+
   void noMoreInput() override;
 
   BlockingReason isBlocked(ContinueFuture* /* unused */) override {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -29,15 +29,19 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregateCompanionSignatures.h"
 #include "velox/exec/GroupingSet.h"
+#include "velox/exec/HashAggregation.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/PrefixSort.h"
+#include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/prefixsort/PrefixSortEncoder.h"
 #include "velox/exec/tests/utils/ArbitratorTestUtil.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/SumNonPODAggregate.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
 #include "velox/type/tests/utils/CustomTypesForTesting.h"
 
 namespace facebook::velox::exec::test {
@@ -153,7 +157,7 @@ void checkSpillStats(PlanNodeStats& stats, bool expectedSpill) {
       stats.customStats[std::string(Operator::kSpillWriteTime)].count);
 }
 
-class AggregationTest : public OperatorTestBase {
+class AggregationTest : public HiveConnectorTestBase {
  protected:
   static void SetUpTestCase() {
     OperatorTestBase::SetUpTestCase();
@@ -161,7 +165,7 @@ class AggregationTest : public OperatorTestBase {
   }
 
   void SetUp() override {
-    OperatorTestBase::SetUp();
+    HiveConnectorTestBase::SetUp();
     filesystems::registerLocalFileSystem();
     registerSumNonPODAggregate("sumnonpod", 64);
   }
@@ -4585,4 +4589,464 @@ DEBUG_ONLY_TEST_F(AggregationTest, aggregationSpillFileCreateConfig) {
   ASSERT_TRUE(aggregationConfigVerified.load());
   ASSERT_TRUE(defaultConfigVerified.load());
 }
+
+TEST_F(AggregationTest, barrierExecutionSingleAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+  createDuckDbTable({data1, data2});
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({"c0"}, {"sum(c1)"})
+                  .planNode();
+
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .serialExecution(true)
+          .barrierExecution(true)
+          .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+          .assertResults("VALUES (1, 30), (2, 70), (1, 50), (3, 130), (4, 80)");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionDistinct) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({"c0"}, {})
+                  .planNode();
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults("VALUES (1), (2), (1), (3), (4)");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionGlobalAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({5, 6, 7, 8}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({}, {"sum(c1)"})
+                  .planNode();
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults("VALUES (100), (260), (NULL)");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionGlobalDistinctAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({}, {"count(DISTINCT c0)"})
+                  .planNode();
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults("VALUES (2), (3), (0)");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionGlobalSortedAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({}, {"array_agg(c1 ORDER BY c1 DESC)"})
+                  .planNode();
+
+  auto expected = makeRowVector({makeNullableArrayVector<int64_t>({
+      std::vector<std::optional<int64_t>>{40, 30, 20, 10},
+      std::vector<std::optional<int64_t>>{80, 70, 60, 50},
+      std::nullopt,
+  })});
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults(expected);
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionPartialAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId partialNodeId;
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .partialAggregation({"c0"}, {"avg(c1)"})
+                  .capturePlanNodeId(partialNodeId)
+                  .finalAggregation()
+                  .planNode();
+
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .serialExecution(true)
+          .barrierExecution(true)
+          .maxDrivers(1)
+          .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+          .assertResults("VALUES (1, 15), (2, 35), (1, 50), (3, 65), (4, 80)");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+  ASSERT_EQ(
+      toPlanStats(task->taskStats())
+          .at(partialNodeId)
+          .customStats.count(
+              std::string(HashAggregation::kAbandonedPartialAggregation)),
+      0);
+}
+
+TEST_F(AggregationTest, barrierExecutionAbandonedPartialAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 70, 80}),
+  });
+  auto data3 = makeRowVector({
+      makeFlatVector<int64_t>({5, 5, 6}),
+      makeFlatVector<int64_t>({90, 100, 110}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+  auto file3 = TempFilePath::create();
+  writeToFile(file3->getPath(), data3);
+
+  core::PlanNodeId partialNodeId;
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .partialAggregation({"c0"}, {"avg(c1)"})
+                  .capturePlanNodeId(partialNodeId)
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 1, 3, 3, 4, 5, 5, 6}),
+      makeRowVector({
+          makeFlatVector<double>({30, 70, 50, 60, 70, 80, 90, 100, 110}),
+          makeFlatVector<int64_t>({2, 2, 1, 1, 1, 1, 1, 1, 1}),
+      }),
+  });
+
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .serialExecution(true)
+          .barrierExecution(true)
+          .maxDrivers(1)
+          .config(QueryConfig::kMaxPartialAggregationMemory, 1)
+          .config(QueryConfig::kAbandonPartialAggregationMinRows, 1)
+          .config(QueryConfig::kAbandonPartialAggregationMinPct, 0)
+          .splits(scanNodeId, makeHiveConnectorSplits({file1, file2, file3}))
+          .assertResults(expected);
+
+  ASSERT_EQ(task->taskStats().numBarriers, 3);
+  ASSERT_GT(
+      toPlanStats(task->taskStats())
+          .at(partialNodeId)
+          .customStats
+          .at(std::string(HashAggregation::kAbandonedPartialAggregation))
+          .sum,
+      0);
+}
+
+TEST_F(AggregationTest, barrierExecutionDistinctAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({10, 10, 30, 40}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 60, 60, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({"c0"}, {"count(DISTINCT c1)"})
+                  .planNode();
+
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .serialExecution(true)
+          .barrierExecution(true)
+          .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+          .assertResults("VALUES (1, 1), (2, 2), (1, 1), (3, 1), (4, 1)");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionSortedAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 2, 2}),
+      makeFlatVector<int64_t>({20, 10, 40, 30}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 3, 3, 4}),
+      makeFlatVector<int64_t>({50, 70, 60, 80}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({"c0"}, {"array_agg(c1 ORDER BY c1)"})
+                  .planNode();
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 1, 3, 4}),
+      makeArrayVector<int64_t>({{10, 20}, {30, 40}, {50}, {60, 70}, {80}}),
+  });
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults(expected);
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionPartiallyPreGroupedAggregation) {
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 1, 2, 2, 2}),
+      makeFlatVector<int64_t>({10, 20, 10, 30, 30, 40}),
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 3, 3, 3, 4}),
+      makeFlatVector<int64_t>({10, 50, 60, 60, 70, 80}),
+      makeFlatVector<int64_t>({7, 8, 9, 10, 11, 12}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .aggregation(
+                      {"c0", "c1"},
+                      {"c0"},
+                      {"array_agg(c2)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults(
+                      "VALUES "
+                      "(1, 10, ARRAY[1, 3]), (1, 20, ARRAY[2]), "
+                      "(2, 30, ARRAY[4, 5]), (2, 40, ARRAY[6]), "
+                      "(1, 10, ARRAY[7]), (1, 50, ARRAY[8]), "
+                      "(3, 60, ARRAY[9, 10]), (3, 70, ARRAY[11]), "
+                      "(4, 80, ARRAY[12])");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionFullyPreGroupedAggregation) {
+  // This test verifies streaming aggregation + task barrier code path.
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 1, 2, 2, 2}),
+      makeFlatVector<int64_t>({10, 10, 20, 30, 30, 40}),
+      makeFlatVector<int64_t>({1, 3, 2, 4, 5, 6}),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>({1, 1, 3, 3, 3, 4}),
+      makeFlatVector<int64_t>({10, 50, 60, 60, 70, 80}),
+      makeFlatVector<int64_t>({7, 8, 9, 10, 11, 12}),
+  });
+
+  auto file1 = TempFilePath::create();
+  writeToFile(file1->getPath(), data1);
+  auto file2 = TempFilePath::create();
+  writeToFile(file2->getPath(), data2);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data1->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .aggregation(
+                      {"c0", "c1"},
+                      {"c0", "c1"},
+                      {"array_agg(c2)"},
+                      {},
+                      core::AggregationNode::Step::kSingle,
+                      false)
+                  .planNode();
+
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .serialExecution(true)
+                  .barrierExecution(true)
+                  .splits(scanNodeId, makeHiveConnectorSplits({file1, file2}))
+                  .assertResults(
+                      "VALUES "
+                      "(1, 10, ARRAY[1, 3]), (1, 20, ARRAY[2]), "
+                      "(2, 30, ARRAY[4, 5]), (2, 40, ARRAY[6]), "
+                      "(1, 10, ARRAY[7]), (1, 50, ARRAY[8]), "
+                      "(3, 60, ARRAY[9, 10]), (3, 70, ARRAY[11]), "
+                      "(4, 80, ARRAY[12])");
+
+  ASSERT_EQ(task->taskStats().numBarriers, 2);
+}
+
+TEST_F(AggregationTest, barrierExecutionSpillEnabledAggregationUnsupported) {
+  rowType_ = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  VectorFuzzer::Options options;
+  options.vectorSize = 2'000;
+  options.stringVariableLength = false;
+  options.stringLength = 128;
+  VectorFuzzer fuzzer(options, pool());
+  auto data = fuzzer.fuzzRow(rowType_);
+
+  auto file = TempFilePath::create();
+  writeToFile(file->getPath(), data);
+  auto spillDirectory = TempDirectoryPath::create();
+  TestScopedSpillInjection scopedSpillInjection(100);
+
+  core::PlanNodeId scanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(asRowType(data->type()))
+                  .capturePlanNodeId(scanNodeId)
+                  .singleAggregation({"c0"}, {"array_agg(c1)"})
+                  .planNode();
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .serialExecution(true)
+          .barrierExecution(true)
+          .spillDirectory(spillDirectory->getPath())
+          .config(QueryConfig::kSpillEnabled, true)
+          .config(QueryConfig::kAggregationSpillEnabled, true)
+          .config(QueryConfig::kMaxOutputBatchRows, 10)
+          .split(
+              scanNodeId,
+              HiveConnectorTestBase::makeHiveConnectorSplit(file->getPath()))
+          .copyResults(pool()),
+      "Barrier drain is not supported for spilled hash aggregation");
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -4791,7 +4791,7 @@ TEST_F(AggregationTest, barrierExecutionPartialAggregation) {
       toPlanStats(task->taskStats())
           .at(partialNodeId)
           .customStats.count(
-              std::string(HashAggregation::kAbandonedPartialAggregation)),
+              std::string(HashAggregation::kAbandonedPartialAggregationRows)),
       0);
 }
 
@@ -4849,7 +4849,7 @@ TEST_F(AggregationTest, barrierExecutionAbandonedPartialAggregation) {
       toPlanStats(task->taskStats())
           .at(partialNodeId)
           .customStats
-          .at(std::string(HashAggregation::kAbandonedPartialAggregation))
+          .at(std::string(HashAggregation::kAbandonedPartialAggregationRows))
           .sum,
       0);
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -942,8 +942,7 @@ core::PlanNodePtr PlanBuilder::createIntermediateOrFinalAggregation(
       partialAggNode->ignoreNullKeys(),
       partialAggNode->noGroupsSpanBatches(),
       planNode_);
-  VELOX_CHECK_EQ(
-      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  VELOX_CHECK(aggregationNode->supportsBarrier());
   return aggregationNode;
 }
 
@@ -1153,8 +1152,7 @@ PlanBuilder& PlanBuilder::aggregation(
       ignoreNullKeys,
       /*noGroupsSpanBatches=*/false,
       planNode_);
-  VELOX_CHECK_EQ(
-      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  VELOX_CHECK(aggregationNode->supportsBarrier());
   planNode_ = std::move(aggregationNode);
   return *this;
 }
@@ -1178,8 +1176,7 @@ PlanBuilder& PlanBuilder::streamingAggregation(
       ignoreNullKeys,
       noGroupsSpanBatches,
       planNode_);
-  VELOX_CHECK_EQ(
-      aggregationNode->supportsBarrier(), aggregationNode->isPreGrouped());
+  VELOX_CHECK(aggregationNode->supportsBarrier());
   planNode_ = std::move(aggregationNode);
   return *this;
 }


### PR DESCRIPTION
The PR adds task barrier `Task::requestBarrier` support for HashAggregation. Basic idea is to call `GroupingSet::resetTable` to reset states for grouped aggregation, and to call a new API `GroupingSet::resetGlobalAggregation` to reset states for global aggregation, for finishing a draining request.

Tested aggregation types: 

1. single / final
2. distinct
3. global
4. global + distinct agg
5. global + sorted agg
6. partial / intermediate
7. abandoned partial
8. distinct agg
9. sorted agg
10. partially pre-grouped agg

Limitation:

Spill is not supported yet. It involves many internal states in `GroupingSet` so may need some extra work in the future.

Fixes https://github.com/facebookincubator/velox/issues/16856.