### PR TITLE
feat(cudf): Support cudf table to velox conversion directly(Part3)

### DIFF
--- a/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveDataSink.cpp
@@ -159,7 +159,7 @@ void CudfHiveDataSink::appendData(RowVectorPtr input) {
   // Convert the input RowVectorPtr to cudf::table
   auto stream = cudfGlobalStreamPool().get_stream();
   auto cudfInput =
-      with_arrow::toCudfTable(input, input->pool(), stream, get_temp_mr());
+      toCudfTable(input, input->pool(), stream, get_temp_mr());
   stream.synchronize();
   VELOX_CHECK_NOT_NULL(
       cudfInput, "Failed to convert input RowVectorPtr to cudf::table");

--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -145,7 +145,7 @@ RowVectorPtr CudfFromVelox::getOutput() {
 
   // Convert RowVector to cudf table
   auto tbl =
-      with_arrow::toCudfTable(input, input->pool(), stream, get_output_mr());
+      toCudfTable(input, input->pool(), stream, get_output_mr());
 
   stream.synchronize();
 

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -33,6 +33,8 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/column/column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -103,22 +105,330 @@ namespace with_arrow {
 
 namespace {
 
+  void setVeloxNulls(
+    const cudf::column_view& col,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    BufferPtr& nulls) {
+  if (!col.has_nulls()) {
+    return nullptr;
+  }
+
+  auto size = col.size();
+
+  auto* dst = nulls->asMutable<uint64_t>(); // Velox uses bitmask (uint64_t aligned)
+
+  const uint8_t* srcMask = nullptr;
+  std::unique_ptr<cudf::column> tempMask;
+
+  // 🔥 Handle offset (same as Arrow code)
+  if (col.offset() > 0) {
+    tempMask = cudf::detail::copy_bitmask(col, stream, mr);
+    srcMask = tempMask->view().null_mask();
+  } else {
+    srcMask = col.null_mask();
+  }
+
+  size_t bytes = ((size + 7) / 8);
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      dst,
+      srcMask,
+      bytes,
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+
+  stream.synchronize();
+}
+
+template <typename T>
+VectorPtr makeFlatVectorFromDevice(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    TypePtr type) {
+  auto size = col.size();
+  auto vec = BaseVector::create(type, size, pool);
+  auto flat = vec->asFlatVector<T>();
+
+  setVeloxNulls(col, stream, mr, flat->mutableNulls(size));
+  char* rawValues = flat->mutableRawValues<char>();
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      rawValues,
+      col.data<T>(),
+      size * sizeof(T),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  return vec;
+}
+
+// CUDA kernel to build StringView array on GPU
+__global__ void build_string_views_kernel(
+    const int32_t* d_offsets,
+    const char* d_chars,
+    StringView* d_stringViews,
+    size_t size)
+{
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= size) return;
+
+    int32_t begin = d_offsets[i];
+    int32_t end   = d_offsets[i + 1];
+    d_stringViews[i] = StringView(d_chars + begin, end - begin);
+}
+
+VectorPtr makeStringFlatVectorFromDevice(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    TypePtr type,
+    rmm::device_async_resource_ref mr) {
+    auto size = scv.size();
+
+    // Allocate device memory for Velox StringView array
+    auto d_stringViews = rmm::device_uvector<StringView>(size, stream);
+
+    // Launch kernel to build StringViews
+    const int threads = 256;
+    const int blocks  = (size + threads - 1) / threads;
+
+    build_string_views_kernel<<<blocks, threads, 0, stream.value()>>>(
+        scv.offsets().data<int32_t>(),
+        scv.chars().data<char>(),
+        d_stringViews.data(),
+        size
+    );
+
+    CUDA_TRY(cudaGetLastError());
+
+    // Allocate Velox FlatVector<StringView> using device memory
+    auto flatVector = BaseVector::create<FlatVector<StringView>>(VARCHAR(), size, pool);
+
+    // Set the device buffer for values directly
+    flatVector->setBuffer(
+        flatVector->mutableRawValues<StringView>(),
+        rmm::device_buffer(d_stringViews.data(), size * sizeof(StringView), stream, rmm::cuda_stream_view{}),
+        size * sizeof(StringView)
+    );
+
+    setVeloxNulls(col, stream, mr, flatVector->mutableNulls(size));
+
+    return vec;
+}
+
+template<>
+VectorPtr makeFlatVectorFromDevice<TypeKind::VARCHAR>(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    TypePtr type) {
+  return makeStringFlatVectorFromDevice(col, pool, stream, type);
+}
+
+template<>
+VectorPtr makeFlatVectorFromDevice<TypeKind::VARBINARY>(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    TypePtr type) {
+  return makeStringFlatVectorFromDevice(col, pool, stream, type);
+}
+
+template<>
+VectorPtr makeFlatVectorFromDevice<TypeKind::BOOLEAN>(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    TypePtr type) {
+  auto size = col.size();
+  auto vec = BaseVector::create(BOOLEAN(), size, pool);
+  auto flat = vec->asFlatVector<bool>();
+
+  // 🔥 GPU: pack bools → bitmask
+  auto [mask, _] =
+      cudf::detail::bools_to_mask(col, stream, mr);
+  // allocate Velox buffer
+  auto raw = flat->mutableRawValues<uint64_t>();
+  size_t bytes = ((size + 7) / 8);
+  // copy packed bits (device → host)
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      raw,
+      mask->data(),
+      bytes,
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+
+  // nulls
+  setVeloxNulls(col, stream, mr, flat->mutableNulls(size));
+
+  return vec;
+
+}
+
+VectorPtr toVeloxColumn(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    const cudf::column_metadata& meta,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref /*mr*/) {
+
+  switch (col.type().id()) {
+
+    case cudf::type_id::INT32:
+      return makeFlatVectorFromDevice<int32_t>(
+          col, pool, stream, INTEGER());
+
+    case cudf::type_id::INT64:
+      return makeFlatVectorFromDevice<int64_t>(
+          col, pool, stream, BIGINT());
+
+    case cudf::type_id::FLOAT32:
+      return makeFlatVectorFromDevice<float>(
+          col, pool, stream, REAL());
+
+    case cudf::type_id::FLOAT64:
+      return makeFlatVectorFromDevice<double>(
+          col, pool, stream, DOUBLE());
+
+    case cudf::type_id::BOOL8:
+      return makeFlatVectorFromDevice<bool>(
+          col, pool, stream, BOOLEAN());
+
+    // ========================
+    // LIST → ArrayVector
+    // ========================
+    case cudf::type_id::LIST: {
+      auto offsetsCol = col.child(0);
+      auto childCol = col.child(1);
+
+      int size = col.size();
+
+      std::vector<int32_t> offsets(size + 1);
+
+      CUDF_CUDA_TRY(cudaMemcpyAsync(
+          offsets.data(),
+          offsetsCol.data<int32_t>(),
+          (size + 1) * sizeof(int32_t),
+          cudaMemcpyDeviceToHost,
+          stream.value()));
+
+      stream.synchronize();
+
+      auto offsetsBuf = AlignedBuffer::allocate<vector_size_t>(size, pool);
+      auto sizesBuf = AlignedBuffer::allocate<vector_size_t>(size, pool);
+
+      auto* rawOffsets = offsetsBuf->asMutable<vector_size_t>();
+      auto* rawSizes = sizesBuf->asMutable<vector_size_t>();
+
+      for (int i = 0; i < size; ++i) {
+        rawOffsets[i] = offsets[i];
+        rawSizes[i] = offsets[i + 1] - offsets[i];
+      }
+
+      auto childVec = toVeloxColumn(
+          childCol,
+          pool,
+          meta.children.empty() ? cudf::column_metadata{} : meta.children[0],
+          stream,
+          nullptr);
+
+      return std::make_shared<ArrayVector>(
+          pool,
+          ARRAY(childVec->type()),
+          nullptr,
+          size,
+          offsetsBuf,
+          sizesBuf,
+          childVec);
+    }
+
+    // ========================
+    // STRUCT → RowVector
+    // ========================
+    case cudf::type_id::STRUCT: {
+      std::vector<VectorPtr> children;
+      std::vector<std::string> names;
+      std::vector<TypePtr> types;
+
+      for (size_t i = 0; i < col.num_children(); ++i) {
+        auto child = toVeloxColumn(
+            col.child(i),
+            pool,
+            meta.children.size() > i ? meta.children[i]
+                                     : cudf::column_metadata{},
+            stream,
+            nullptr);
+
+        children.push_back(child);
+
+        std::string name =
+            (meta.children.size() > i && !meta.children[i].name.empty())
+            ? meta.children[i].name
+            : "c" + std::to_string(i);
+
+        names.push_back(name);
+        types.push_back(child->type());
+      }
+
+      auto rowType = std::make_shared<RowType>(names, types);
+
+      return std::make_shared<RowVector>(
+          pool,
+          rowType,
+          nullptr,
+          col.size(),
+          std::move(children));
+    }
+
+    default:
+      VELOX_FAIL("Unsupported cudf type: {}", static_cast<int>(col.type().id()));
+  }
+}
+
+// ========================
+// Entry point
+// ========================
 RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     memory::MemoryPool* pool,
     const std::vector<cudf::column_metadata>& metadata,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
-  auto arrowDeviceArray = cudf::to_arrow_host(table, stream, mr);
-  auto& arrowArray = arrowDeviceArray->array;
 
-  auto arrowSchema = cudf::to_arrow_schema(table, metadata);
-  auto veloxTable = importFromArrowAsOwner(*arrowSchema, arrowArray, pool);
-  // BaseVector to RowVector
-  auto castedPtr =
-      std::dynamic_pointer_cast<facebook::velox::RowVector>(veloxTable);
-  VELOX_CHECK_NOT_NULL(castedPtr);
-  return castedPtr;
+  std::vector<VectorPtr> children;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  for (size_t i = 0; i < table.num_columns(); ++i) {
+    const auto& col = table.column(i);
+
+    std::string name =
+        (i < metadata.size() && !metadata[i].name.empty())
+        ? metadata[i].name
+        : "c" + std::to_string(i);
+
+    auto vec = toVeloxColumn(
+        col,
+        pool,
+        i < metadata.size() ? metadata[i] : cudf::column_metadata{},
+        stream,
+        mr);
+
+    children.push_back(vec);
+    names.push_back(name);
+    types.push_back(vec->type());
+  }
+  stream.synchronize();
+
+  auto rowType = std::make_shared<RowType>(names, types);
+
+  return std::make_shared<RowVector>(
+      pool,
+      rowType,
+      nullptr,
+      table.num_rows(),
+      std::move(children));
 }
 
 template <typename Iterator>

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -35,6 +35,9 @@
 #include <cudf/utilities/error.hpp>
 #include <cudf/table/table_view.hpp>
 #include <cudf/column/column_view.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/utilities/bit.hpp>
+#include <cudf/strings/strings_column_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -101,30 +104,25 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type) {
   }
 }
 
-namespace with_arrow {
-
 namespace {
 
-  void setVeloxNulls(
+void setVeloxNulls(
     const cudf::column_view& col,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr,
     BufferPtr& nulls) {
-  if (!col.has_nulls()) {
-    return nullptr;
-  }
 
   auto size = col.size();
 
   auto* dst = nulls->asMutable<uint64_t>(); // Velox uses bitmask (uint64_t aligned)
 
-  const uint8_t* srcMask = nullptr;
-  std::unique_ptr<cudf::column> tempMask;
+  const cudf::bitmask_type* srcMask = nullptr;
+  rmm::device_buffer tempMask;
 
   // 🔥 Handle offset (same as Arrow code)
   if (col.offset() > 0) {
-    tempMask = cudf::detail::copy_bitmask(col, stream, mr);
-    srcMask = tempMask->view().null_mask();
+    tempMask = cudf::copy_bitmask(col, stream, mr);
+    srcMask = reinterpret_cast<const cudf::bitmask_type*>(tempMask.data());
   } else {
     srcMask = col.null_mask();
   }
@@ -133,114 +131,150 @@ namespace {
 
   CUDF_CUDA_TRY(cudaMemcpyAsync(
       dst,
-      srcMask,
+      reinterpret_cast<const uint8_t*>(srcMask),
       bytes,
       cudaMemcpyDeviceToHost,
       stream.value()));
+}
 
-  stream.synchronize();
+void setVeloxNulls(
+    const cudf::column_view& col,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr,
+    VectorPtr& flat) {
+  if (!col.has_nulls()) {
+    return;
+  }
+  setVeloxNulls(col, stream, mr, flat->mutableNulls(col.size()));
 }
 
 template <typename T>
 VectorPtr makeFlatVectorFromDevice(
     const cudf::column_view& col,
     memory::MemoryPool* pool,
+    const TypePtr& type,
     rmm::cuda_stream_view stream,
-    TypePtr type) {
+    rmm::device_async_resource_ref mr) {
   auto size = col.size();
   auto vec = BaseVector::create(type, size, pool);
   auto flat = vec->asFlatVector<T>();
 
-  setVeloxNulls(col, stream, mr, flat->mutableNulls(size));
-  char* rawValues = flat->mutableRawValues<char>();
+  setVeloxNulls(col, stream, mr, vec);
+  T* rawValues = flat->template mutableRawValues<T>();
 
   CUDF_CUDA_TRY(cudaMemcpyAsync(
-      rawValues,
-      col.data<T>(),
-      size * sizeof(T),
-      cudaMemcpyDeviceToHost,
-      stream.value()));
+    rawValues,
+    col.data<T>(),
+    size * sizeof(T),
+    cudaMemcpyDeviceToHost,
+    stream.value()));
   return vec;
-}
-
-// CUDA kernel to build StringView array on GPU
-__global__ void build_string_views_kernel(
-    const int32_t* d_offsets,
-    const char* d_chars,
-    StringView* d_stringViews,
-    size_t size)
-{
-    int i = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i >= size) return;
-
-    int32_t begin = d_offsets[i];
-    int32_t end   = d_offsets[i + 1];
-    d_stringViews[i] = StringView(d_chars + begin, end - begin);
 }
 
 VectorPtr makeStringFlatVectorFromDevice(
     const cudf::column_view& col,
     memory::MemoryPool* pool,
     rmm::cuda_stream_view stream,
-    TypePtr type,
-    rmm::device_async_resource_ref mr) {
+    rmm::device_async_resource_ref mr,
+    const TypePtr& type) {
+    cudf::strings_column_view scv(col);
     auto size = scv.size();
 
-    // Allocate device memory for Velox StringView array
-    auto d_stringViews = rmm::device_uvector<StringView>(size, stream);
+    auto vec = BaseVector::create(VARCHAR(), size, pool);
+    auto flat = vec->template asFlatVector<StringView>();
 
-    // Launch kernel to build StringViews
-    const int threads = 256;
-    const int blocks  = (size + threads - 1) / threads;
+    setVeloxNulls(col, stream, mr, vec);
 
-    build_string_views_kernel<<<blocks, threads, 0, stream.value()>>>(
-        scv.offsets().data<int32_t>(),
-        scv.chars().data<char>(),
-        d_stringViews.data(),
-        size
-    );
+    // Copy offsets and chars from device to host
+    std::vector<int32_t> offsets(size + 1);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+      offsets.data(),
+      scv.offsets().data<int32_t>(),
+      (size + 1) * sizeof(int32_t),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+    CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+    auto bufferSize = offsets[size];
+    auto rawBuffer = flat->getRawStringBufferWithSpace(bufferSize, true);
+    auto charsCount = scv.chars_size(stream);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+      rawBuffer,
+      scv.chars_begin(stream),
+      bufferSize,
+      cudaMemcpyDeviceToHost,
+      stream.value()));
 
-    CUDA_TRY(cudaGetLastError());
 
-    // Allocate Velox FlatVector<StringView> using device memory
-    auto flatVector = BaseVector::create<FlatVector<StringView>>(VARCHAR(), size, pool);
-
-    // Set the device buffer for values directly
-    flatVector->setBuffer(
-        flatVector->mutableRawValues<StringView>(),
-        rmm::device_buffer(d_stringViews.data(), size * sizeof(StringView), stream, rmm::cuda_stream_view{}),
-        size * sizeof(StringView)
-    );
-
-    setVeloxNulls(col, stream, mr, flatVector->mutableNulls(size));
+    // Fill StringView values
+    for (auto i = 0; i < size; ++i) {
+      if (!flat->isNullAt(i)) {
+        flat->setNoCopy(i, StringView(rawBuffer + offsets[i], offsets[i + 1] - offsets[i]));
+      }
+    }
 
     return vec;
 }
 
-template<>
-VectorPtr makeFlatVectorFromDevice<TypeKind::VARCHAR>(
+template <>
+VectorPtr makeFlatVectorFromDevice<Timestamp>(
     const cudf::column_view& col,
     memory::MemoryPool* pool,
+    const TypePtr& type,
     rmm::cuda_stream_view stream,
-    TypePtr type) {
-  return makeStringFlatVectorFromDevice(col, pool, stream, type);
+    rmm::device_async_resource_ref mr) {
+  auto size = col.size();
+  auto vec = BaseVector::create(type, size, pool);
+  auto flat = vec->asFlatVector<Timestamp>();
+
+  setVeloxNulls(col, stream, mr, vec);
+  Timestamp* rawValues = flat->template mutableRawValues<Timestamp>();
+  // Get device data (int64 nanoseconds)
+  auto dData = col.data<int64_t>();
+    // Copy to host (simplest version; optimize to GPU execution later if needed)
+  std::vector<int64_t> hData(size);
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      hData.data(),
+      dData,
+      sizeof(int64_t) * size,
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+
+  // Convert ns → (seconds, nanos)
+  for (size_t i = 0; i < size; ++i) {
+    int64_t ns = hData[i];
+
+    int64_t seconds = ns / 1'000'000'000;
+    int64_t nanos = ns % 1'000'000'000;
+
+    // Handle negative timestamps correctly
+    if (nanos < 0) {
+      nanos += 1'000'000'000;
+      --seconds;
+    }
+
+    rawValues[i] = Timestamp(seconds, nanos);
+  }
+  
+  return vec;
 }
 
 template<>
-VectorPtr makeFlatVectorFromDevice<TypeKind::VARBINARY>(
+VectorPtr makeFlatVectorFromDevice<StringView>(
     const cudf::column_view& col,
     memory::MemoryPool* pool,
+    const TypePtr& type,
     rmm::cuda_stream_view stream,
-    TypePtr type) {
-  return makeStringFlatVectorFromDevice(col, pool, stream, type);
+    rmm::device_async_resource_ref mr) {
+  return makeStringFlatVectorFromDevice(col, pool, stream, mr, type);
 }
 
 template<>
-VectorPtr makeFlatVectorFromDevice<TypeKind::BOOLEAN>(
+VectorPtr makeFlatVectorFromDevice<bool>(
     const cudf::column_view& col,
     memory::MemoryPool* pool,
+    const TypePtr& type,
     rmm::cuda_stream_view stream,
-    TypePtr type) {
+    rmm::device_async_resource_ref mr) {
   auto size = col.size();
   auto vec = BaseVector::create(BOOLEAN(), size, pool);
   auto flat = vec->asFlatVector<bool>();
@@ -260,10 +294,8 @@ VectorPtr makeFlatVectorFromDevice<TypeKind::BOOLEAN>(
       stream.value()));
 
   // nulls
-  setVeloxNulls(col, stream, mr, flat->mutableNulls(size));
-
+  setVeloxNulls(col, stream, mr, vec);
   return vec;
-
 }
 
 VectorPtr toVeloxColumn(
@@ -271,115 +303,162 @@ VectorPtr toVeloxColumn(
     memory::MemoryPool* pool,
     const cudf::column_metadata& meta,
     rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref /*mr*/) {
+    rmm::device_async_resource_ref mr);
 
+VectorPtr makeRowVectorFromDevice(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    const cudf::column_metadata& meta,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::vector<VectorPtr> children;
+  std::vector<std::string> names;
+  std::vector<TypePtr> types;
+
+  for (size_t i = 0; i < col.num_children(); ++i) {
+    auto child = toVeloxColumn(
+        col.child(i),
+        pool,
+        meta.children_meta.size() > i ? meta.children_meta[i]
+                                  : cudf::column_metadata{},
+        stream,
+        mr);
+
+    children.push_back(child);
+
+    std::string name =
+        (meta.children_meta.size() > i && !meta.children_meta[i].name.empty())
+        ? meta.children_meta[i].name
+        : "c" + std::to_string(i);
+
+    names.push_back(name);
+    types.push_back(child->type());
+  }
+  BufferPtr nulls;
+  if (col.has_nulls()) {
+    nulls = AlignedBuffer::allocate<uint64_t>(
+          bits::nwords(col.size()),
+          pool);;
+    setVeloxNulls(col, stream, mr, nulls);
+  }
+
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
+
+  return std::make_shared<RowVector>(
+    pool,
+    rowType,
+    nulls,
+    col.size(),
+    std::move(children));
+}
+
+VectorPtr makeArrayVectorFromDevice(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    const cudf::column_metadata& meta,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto offsetsCol = col.child(0);
+  auto childCol = col.child(1);
+
+  int size = col.size();
+  BufferPtr nulls;
+  if (col.has_nulls()) {
+    nulls = AlignedBuffer::allocate<uint64_t>(
+          bits::nwords(col.size()),
+          pool);;
+    setVeloxNulls(col, stream, mr, nulls);  
+  }
+
+  std::vector<int32_t> offsets(size + 1);
+
+  CUDF_CUDA_TRY(cudaMemcpyAsync(
+      offsets.data(),
+      offsetsCol.data<int32_t>(),
+      (size + 1) * sizeof(int32_t),
+      cudaMemcpyDeviceToHost,
+      stream.value()));
+  CUDF_CUDA_TRY(cudaStreamSynchronize(stream.value()));
+  auto offsetsBuf = AlignedBuffer::allocate<vector_size_t>(size, pool);
+  auto sizesBuf = AlignedBuffer::allocate<vector_size_t>(size, pool);
+
+  auto* rawOffsets = offsetsBuf->asMutable<vector_size_t>();
+  auto* rawSizes = sizesBuf->asMutable<vector_size_t>();
+
+  for (int i = 0; i < size; ++i) {
+    rawOffsets[i] = offsets[i];
+    rawSizes[i] = offsets[i + 1] - offsets[i];
+  }
+
+  auto childVec = toVeloxColumn(
+      childCol,
+      pool,
+      meta.children_meta.empty() ? cudf::column_metadata{} : meta.children_meta[0],
+      stream,
+      mr);
+
+  return std::make_shared<ArrayVector>(
+      pool,
+      ARRAY(childVec->type()),
+      nulls,
+      size,
+      offsetsBuf,
+      sizesBuf,
+      childVec);
+}
+
+VectorPtr toVeloxColumn(
+    const cudf::column_view& col,
+    memory::MemoryPool* pool,
+    const cudf::column_metadata& meta,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
   switch (col.type().id()) {
+    case cudf::type_id::INT8:
+      return makeFlatVectorFromDevice<int8_t>(
+          col, pool, TINYINT(), stream, mr);
+    case cudf::type_id::INT16:
+      return makeFlatVectorFromDevice<int16_t>(
+          col, pool, SMALLINT(), stream, mr);
 
     case cudf::type_id::INT32:
       return makeFlatVectorFromDevice<int32_t>(
-          col, pool, stream, INTEGER());
+          col, pool, INTEGER(), stream, mr);
 
     case cudf::type_id::INT64:
       return makeFlatVectorFromDevice<int64_t>(
-          col, pool, stream, BIGINT());
+          col, pool, BIGINT(), stream, mr);
 
     case cudf::type_id::FLOAT32:
       return makeFlatVectorFromDevice<float>(
-          col, pool, stream, REAL());
+          col, pool, REAL(), stream, mr);
 
     case cudf::type_id::FLOAT64:
       return makeFlatVectorFromDevice<double>(
-          col, pool, stream, DOUBLE());
+          col, pool, DOUBLE(), stream, mr);
 
     case cudf::type_id::BOOL8:
       return makeFlatVectorFromDevice<bool>(
-          col, pool, stream, BOOLEAN());
-
+          col, pool, BOOLEAN(), stream, mr);
+    case cudf::type_id::STRING:
+      return makeFlatVectorFromDevice<StringView>(
+          col, pool, VARCHAR(), stream, mr);
+    case cudf::type_id::TIMESTAMP_DAYS:
+      return makeFlatVectorFromDevice<int32_t>(
+          col, pool, DATE(), stream, mr);
+    case cudf::type_id::TIMESTAMP_NANOSECONDS:
+      return makeFlatVectorFromDevice<Timestamp>(
+          col, pool, TIMESTAMP(), stream, mr);
     // ========================
     // LIST → ArrayVector
     // ========================
-    case cudf::type_id::LIST: {
-      auto offsetsCol = col.child(0);
-      auto childCol = col.child(1);
-
-      int size = col.size();
-
-      std::vector<int32_t> offsets(size + 1);
-
-      CUDF_CUDA_TRY(cudaMemcpyAsync(
-          offsets.data(),
-          offsetsCol.data<int32_t>(),
-          (size + 1) * sizeof(int32_t),
-          cudaMemcpyDeviceToHost,
-          stream.value()));
-
-      stream.synchronize();
-
-      auto offsetsBuf = AlignedBuffer::allocate<vector_size_t>(size, pool);
-      auto sizesBuf = AlignedBuffer::allocate<vector_size_t>(size, pool);
-
-      auto* rawOffsets = offsetsBuf->asMutable<vector_size_t>();
-      auto* rawSizes = sizesBuf->asMutable<vector_size_t>();
-
-      for (int i = 0; i < size; ++i) {
-        rawOffsets[i] = offsets[i];
-        rawSizes[i] = offsets[i + 1] - offsets[i];
-      }
-
-      auto childVec = toVeloxColumn(
-          childCol,
-          pool,
-          meta.children.empty() ? cudf::column_metadata{} : meta.children[0],
-          stream,
-          nullptr);
-
-      return std::make_shared<ArrayVector>(
-          pool,
-          ARRAY(childVec->type()),
-          nullptr,
-          size,
-          offsetsBuf,
-          sizesBuf,
-          childVec);
-    }
-
+    case cudf::type_id::LIST:
+      return makeArrayVectorFromDevice(col, pool, meta, stream, mr);
     // ========================
     // STRUCT → RowVector
     // ========================
-    case cudf::type_id::STRUCT: {
-      std::vector<VectorPtr> children;
-      std::vector<std::string> names;
-      std::vector<TypePtr> types;
-
-      for (size_t i = 0; i < col.num_children(); ++i) {
-        auto child = toVeloxColumn(
-            col.child(i),
-            pool,
-            meta.children.size() > i ? meta.children[i]
-                                     : cudf::column_metadata{},
-            stream,
-            nullptr);
-
-        children.push_back(child);
-
-        std::string name =
-            (meta.children.size() > i && !meta.children[i].name.empty())
-            ? meta.children[i].name
-            : "c" + std::to_string(i);
-
-        names.push_back(name);
-        types.push_back(child->type());
-      }
-
-      auto rowType = std::make_shared<RowType>(names, types);
-
-      return std::make_shared<RowVector>(
-          pool,
-          rowType,
-          nullptr,
-          col.size(),
-          std::move(children));
-    }
+    case cudf::type_id::STRUCT:
+      return makeRowVectorFromDevice(col, pool, meta, stream, mr);
 
     default:
       VELOX_FAIL("Unsupported cudf type: {}", static_cast<int>(col.type().id()));
@@ -395,7 +474,6 @@ RowVectorPtr toVeloxColumn(
     const std::vector<cudf::column_metadata>& metadata,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
-
   std::vector<VectorPtr> children;
   std::vector<std::string> names;
   std::vector<TypePtr> types;
@@ -421,7 +499,7 @@ RowVectorPtr toVeloxColumn(
   }
   stream.synchronize();
 
-  auto rowType = std::make_shared<RowType>(names, types);
+  auto rowType = std::make_shared<RowType>(std::move(names), std::move(types));
 
   return std::make_shared<RowVector>(
       pool,
@@ -519,8 +597,6 @@ RowVectorPtr toVeloxColumn(
   auto metadata = getMetadataWithName(rowType);
   return toVeloxColumn(table, pool, metadata, stream, mr);
 }
-
-} // namespace with_arrow
 
 namespace {
 std::unique_ptr<cudf::table> toCudfTableArrow(

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -17,13 +17,19 @@
 #include "velox/experimental/cudf/CudfNoDefaults.h"
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Nulls.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
+#include "velox/vector/FlatVector.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/arrow/Bridge.h"
 
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
 #include <cudf/interop.hpp>
+#include <cudf/null_mask.hpp>
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <cudf/utilities/error.hpp>
@@ -76,7 +82,9 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type) {
     // case TypeKind::LONG_DECIMAL: return cudf::type_id::DECIMAL128;
     case TypeKind::ARRAY:
       return cudf::type_id::LIST;
-    // case TypeKind::MAP: return cudf::type_id::EMPTY;
+    case TypeKind::MAP:
+      // MAP is represented as LIST<STRUCT<key, value>> in cudf.
+      return cudf::type_id::LIST;
     case TypeKind::ROW:
       return cudf::type_id::STRUCT;
     // case TypeKind::UNKNOWN: return cudf::type_id::EMPTY;
@@ -92,37 +100,6 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type) {
 }
 
 namespace with_arrow {
-
-std::unique_ptr<cudf::table> toCudfTable(
-    const facebook::velox::RowVectorPtr& veloxTable,
-    facebook::velox::memory::MemoryPool* pool,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr) {
-  // Need to flattenDictionary and flattenConstant, otherwise we observe issues
-  // in the null mask.
-  ArrowOptions arrowOptions{true, true};
-  ArrowArray arrowArray;
-  exportToArrow(
-      std::dynamic_pointer_cast<facebook::velox::BaseVector>(veloxTable),
-      arrowArray,
-      pool,
-      arrowOptions);
-  ArrowSchema arrowSchema;
-  exportToArrow(
-      std::dynamic_pointer_cast<facebook::velox::BaseVector>(veloxTable),
-      arrowSchema,
-      arrowOptions);
-  auto tbl = cudf::from_arrow(&arrowSchema, &arrowArray, stream, mr);
-
-  // Release Arrow resources
-  if (arrowArray.release) {
-    arrowArray.release(&arrowArray);
-  }
-  if (arrowSchema.release) {
-    arrowSchema.release(&arrowSchema);
-  }
-  return tbl;
-}
 
 namespace {
 
@@ -153,7 +130,43 @@ getMetadata(Iterator begin, Iterator end, const std::string& namePrefix) {
     metadata.push_back(cudf::column_metadata(namePrefix + std::to_string(i)));
     metadata.back().children_meta = getMetadata(
         c->child_begin(), c->child_end(), namePrefix + std::to_string(i));
+    std::cout <<"The child metadata size is " << metadata.back().children_meta.size() << std::endl;
     i++;
+  }
+  return metadata;
+}
+
+// Recursively generate metadata using exact names from Velox RowType.
+cudf::column_metadata getMetadataWithName(
+    const facebook::velox::TypePtr& type,
+    const std::string& name) {
+  cudf::column_metadata meta(name);
+  if (type->kind() == facebook::velox::TypeKind::ROW) {
+    auto rowType = std::dynamic_pointer_cast<const facebook::velox::RowType>(type);
+    for (size_t i = 0; i < rowType->size(); ++i) {
+      meta.children_meta.push_back(getMetadataWithName(rowType->childAt(i), rowType->nameOf(i)));
+    }
+  } else if (type->kind() == facebook::velox::TypeKind::MAP) {
+    // MAP is represented as LIST<STRUCT<key, value>> in cudf.
+    // STRUCT child inside LIST
+    cudf::column_metadata structMeta;
+    // key / value names
+    structMeta.children_meta.push_back(getMetadataWithName(type->childAt(0), "key"));
+    structMeta.children_meta.push_back(getMetadataWithName(type->childAt(1), "value"));
+    meta.children_meta.emplace_back(structMeta);
+  } else if (type->kind() == facebook::velox::TypeKind::ARRAY) {
+      // cudf::lists_column_view::child_column_index is 1, the first metadata is offsets
+    meta.children_meta.emplace_back(cudf::column_metadata(name + "_offsets"));
+    meta.children_meta.push_back(getMetadataWithName(type->childAt(0), "element"));
+  }
+  return meta;
+}
+
+std::vector<cudf::column_metadata> getMetadataWithName(
+    const RowTypePtr& rowType) {
+  std::vector<cudf::column_metadata> metadata;
+  for (size_t i = 0; i < rowType->size(); ++i) {
+    metadata.push_back(getMetadataWithName(rowType->childAt(i), rowType->nameOf(i)));
   }
   return metadata;
 }
@@ -167,6 +180,7 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
   auto metadata = getMetadata(table.begin(), table.end(), namePrefix);
+  std::cout <<"The input table metadata size " << metadata.size() << std::endl;
   return toVeloxColumn(table, pool, metadata, stream, mr);
 }
 
@@ -183,5 +197,513 @@ RowVectorPtr toVeloxColumn(
   return toVeloxColumn(table, pool, metadata, stream, mr);
 }
 
+// New overload: Accepts a Velox TypePtr for recursive metadata construction.
+RowVectorPtr toVeloxColumn(
+    const cudf::table_view& table,
+    memory::MemoryPool* pool,
+    const TypePtr& type,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Recursively generate metadata using Velox type names for all columns.
+  // This assumes 'type' is a RowType and its children match the cudf table columns.
+  auto rowType = std::dynamic_pointer_cast<const facebook::velox::RowType>(type);
+  VELOX_CHECK_NOT_NULL(rowType);
+  auto metadata = getMetadataWithName(rowType);
+  return toVeloxColumn(table, pool, metadata, stream, mr);
+}
+
 } // namespace with_arrow
+
+namespace {
+std::unique_ptr<cudf::table> toCudfTableArrow(
+    const VectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  // Need to flattenDictionary and flattenConstant, otherwise we observe issues
+  // in the null mask.
+  ArrowOptions arrowOptions{true, true};
+  ArrowArray arrowArray;
+  exportToArrow(
+      veloxTable,
+      arrowArray,
+      pool,
+      arrowOptions);
+  ArrowSchema arrowSchema;
+  exportToArrow(
+      veloxTable,
+      arrowSchema,
+      arrowOptions);
+  auto tbl = cudf::from_arrow(&arrowSchema, &arrowArray, stream, mr);
+
+  // Release Arrow resources
+  if (arrowArray.release) {
+    arrowArray.release(&arrowArray);
+  }
+  if (arrowSchema.release) {
+    arrowSchema.release(&arrowSchema);
+  }
+  return tbl;
+}
+
+/// Holds the CUDA stream and memory resource used throughout the Velox-to-cudf
+/// direct conversion, avoiding repetitive parameter passing.
+struct DispatchColumn {
+  rmm::cuda_stream_view stream;
+  rmm::device_async_resource_ref mr;
+
+  /// Copies the Velox null bitmask to a GPU device buffer. Velox and cudf both
+  /// use a validity bitmask where bit=1 means valid (not null), so no
+  /// conversion is needed. Returns an empty buffer if there are no nulls.
+  std::unique_ptr<rmm::device_buffer> copyNullMask(
+      const BaseVector& vector) const {
+    const auto* rawNulls = vector.rawNulls();
+    if (rawNulls == nullptr) {
+      return std::make_unique<rmm::device_buffer>(0, stream, mr);
+    }
+    // Velox stores null bits as uint64_t words; compute byte size needed.
+    auto numBytes = bits::nbytes(vector.size());
+    auto mask = std::make_unique<rmm::device_buffer>(numBytes, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        mask->data(),
+        rawNulls,
+        numBytes,
+        cudaMemcpyHostToDevice,
+        stream.value()));
+    return mask;
+  }
+
+  /// Returns the null count for a Velox vector. Uses Velox's cached value if
+  /// available, otherwise counts from the raw bitmap.
+  static cudf::size_type getNullCount(const BaseVector& vector) {
+    auto nullCount = vector.getNullCount();
+    if (nullCount.has_value()) {
+      return static_cast<cudf::size_type>(nullCount.value());
+    }
+    const auto* rawNulls = vector.rawNulls();
+    if (rawNulls == nullptr) {
+      return 0;
+    }
+    return static_cast<cudf::size_type>(
+        bits::countNulls(rawNulls, 0, vector.size()));
+  }
+
+  /// Copies a host vector of int32_t offsets to a GPU column.
+  /// This is the common building block for strings, lists, and maps which all
+  /// need an offsets column of shape [numRows + 1] on the device.
+  std::unique_ptr<cudf::column> makeOffsetsColumn(
+      const std::vector<int32_t>& offsets) const {
+    rmm::device_buffer offsetBuf(
+        offsets.size() * sizeof(int32_t), stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        offsetBuf.data(),
+        offsets.data(),
+        offsets.size() * sizeof(int32_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+    return std::make_unique<cudf::column>(
+        cudf::data_type{cudf::type_id::INT32},
+        static_cast<cudf::size_type>(offsets.size()),
+        std::move(offsetBuf),
+        rmm::device_buffer{0, stream, mr},
+        0);
+  }
+
+  /// Builds a cudf INT32 offsets column from Velox's (offset, size) pairs.
+  /// Velox stores separate rawOffsets and rawSizes arrays while cudf uses
+  /// Arrow-style cumulative offsets [0, size0, size0+size1, ...]. The returned
+  /// pair contains the offsets column and the total element count.
+  std::pair<std::unique_ptr<cudf::column>, int32_t> makeOffsetsColumnFromSizes(
+      const vector_size_t* rawSizes,
+      vector_size_t numRows) const {
+    std::vector<int32_t> cudfOffsets(numRows + 1);
+    int32_t runningOffset = 0;
+    for (int32_t i = 0; i < numRows; ++i) {
+      cudfOffsets[i] = runningOffset;
+      runningOffset += rawSizes[i];
+    }
+    cudfOffsets[numRows] = runningOffset;
+    return {makeOffsetsColumn(cudfOffsets), runningOffset};
+  }
+
+  /// Reads a flat scalar column from a Velox FlatVector and creates a cudf
+  /// column by copying the data buffers to GPU. This mirrors the pattern from
+  /// GpuBufferBatchResizer::DispatchColumn::readFlatColumn.
+  template <TypeKind Kind>
+  std::unique_ptr<cudf::column> readColumn(
+      const BaseVector& vector,
+      const TypePtr& type) const {
+    using T = typename TypeTraits<Kind>::NativeType;
+    const auto numRows = vector.size();
+
+    auto* flatVector = vector.as<FlatVector<T>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector for direct conversion");
+
+    // Copy values buffer to GPU.
+    const auto* rawValues = flatVector->rawValues();
+    const size_t valueBytes = numRows * sizeof(T);
+    rmm::device_buffer dataBuf(valueBytes, stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        dataBuf.data(),
+        rawValues,
+        valueBytes,
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    // Copy null mask to GPU.
+    auto nullBuf = copyNullMask(vector);
+    auto nullCount = getNullCount(vector);
+
+    cudf::data_type cudfType{veloxToCudfTypeId(type)};
+    return std::make_unique<cudf::column>(
+        cudfType, numRows, std::move(dataBuf), std::move(*nullBuf), nullCount);
+  }
+
+  /// Converts a Velox FlatVector<StringView> to a cudf STRING column. Builds
+  /// offsets and chars buffers on CPU from the StringView array, then copies
+  /// them to GPU. This mirrors GpuBufferBatchResizer's string handling.
+  std::unique_ptr<cudf::column> readStringColumn(
+      const BaseVector& vector) const {
+    const auto numRows = vector.size();
+
+    auto* flatVector = vector.as<FlatVector<StringView>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector<StringView> for direct conversion");
+
+    // Build offsets (int32_t[numRows+1]) and concatenated chars on CPU.
+    std::vector<int32_t> offsets(numRows + 1);
+    int32_t totalChars = 0;
+    for (int32_t i = 0; i < numRows; ++i) {
+      offsets[i] = totalChars;
+      if (!vector.isNullAt(i)) {
+        totalChars += static_cast<int32_t>(flatVector->valueAt(i).size());
+      }
+    }
+    offsets[numRows] = totalChars;
+
+    // Build contiguous chars buffer.
+    std::vector<char> chars(totalChars);
+    for (int32_t i = 0; i < numRows; ++i) {
+      if (!vector.isNullAt(i)) {
+        auto sv = flatVector->valueAt(i);
+        std::memcpy(chars.data() + offsets[i], sv.data(), sv.size());
+      }
+    }
+
+    auto offsetsColumn = makeOffsetsColumn(offsets);
+
+    // Copy chars to GPU.
+    rmm::device_buffer charsBuf(totalChars, stream, mr);
+    if (totalChars > 0) {
+      CUDF_CUDA_TRY(cudaMemcpyAsync(
+          charsBuf.data(),
+          chars.data(),
+          totalChars,
+          cudaMemcpyHostToDevice,
+          stream.value()));
+    }
+
+    // Copy null mask and get null count.
+    auto nullBuf = copyNullMask(vector);
+    auto nullCount = getNullCount(vector);
+
+    return cudf::make_strings_column(
+        numRows,
+        std::move(offsetsColumn),
+        std::move(charsBuf),
+        nullCount,
+        std::move(*nullBuf));
+  }
+
+  template <typename Vector>
+  bool isCompact(const Vector& vec) const {
+    for (vector_size_t i = 1; i < vec.size(); ++i) {
+      if (vec.offsetAt(i - 1) + vec.sizeAt(i - 1) != vec.offsetAt(i)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Converts a Velox ArrayVector to a cudf LIST column.
+  /// Velox stores lists with separate offsets and sizes arrays, while cudf uses
+  /// Arrow-style cumulative offsets (length = num_rows + 1). We compute the
+  /// cumulative offsets from Velox's (offset, size) pairs and recursively
+  /// convert the elements child vector.
+  std::unique_ptr<cudf::column> readArrayColumn(
+      const VectorPtr& vector,
+      const TypePtr& type,
+      memory::MemoryPool* pool) const {
+    const auto numRows = vector->size();
+    auto* arrayVector = vector->as<ArrayVector>();
+    VELOX_CHECK_NOT_NULL(arrayVector, "Expected ArrayVector for direct conversion");
+    if (!isCompact(*arrayVector) && arrayVector->elements()->type()->isPrimitiveType()) {
+      std::cout <<"array is not compact and primitive type"<< std::endl;
+      auto* rawOffsets = arrayVector->rawOffsets();
+      auto* rawSizes = arrayVector->rawSizes();
+      int32_t totalElements = 0;
+      std::vector<int32_t> offsets(numRows + 1);
+      offsets[0] = 0;
+      // Step 1: build compact offsets
+      for (int i = 0; i < numRows; ++i) {
+        std::cout <<"offsets at index " << i << " " <<rawOffsets[i] << std::endl;
+        std::cout <<"sizes at index " << i << " " <<rawSizes[i] << std::endl;
+        totalElements += rawSizes[i];
+        offsets[i + 1] = totalElements; 
+      }
+      // Step 2: gather elements into contiguous buffer
+      auto elements = BaseVector::loadedVectorShared(arrayVector->elements());
+      // Create indices for gather
+      std::vector<vector_size_t> gatherIndices;
+      gatherIndices.reserve(totalElements);
+      for (int i = 0; i < numRows; ++i) {
+        auto offset = rawOffsets[i];
+        auto size = rawSizes[i];
+        std::cout <<"offsets at index " << i << " " <<offset << std::endl;
+        std::cout <<"sizes at index " << i << " " <<size << std::endl;
+        for (int j = 0; j < size; ++j) {
+           gatherIndices.push_back(offset + j);
+        }
+      }
+      // Wrap indices into a Velox buffer/vector
+      auto indexBuffer = AlignedBuffer::allocate<vector_size_t>( gatherIndices.size(), pool);
+      std::memcpy( indexBuffer->asMutable<vector_size_t>(), gatherIndices.data(), gatherIndices.size() * sizeof(vector_size_t));
+      // Use Velox dictionary to compact
+      auto compactElements = BaseVector::wrapInDictionary( BufferPtr(nullptr), indexBuffer, gatherIndices.size(), elements);
+      std::cout <<"compactElements is " << compactElements->toString()<< std::endl;
+      // Now convert compacted child
+      BaseVector::flattenVector(compactElements);
+      auto childColumn = convertColumn(compactElements, type->childAt(0), pool);
+      auto nullBuf = copyNullMask(*vector);
+      auto nullCount = getNullCount(*vector);
+      auto offsetsColumn = makeOffsetsColumn(offsets);
+      return cudf::make_lists_column(
+        numRows,
+        std::move(offsetsColumn),
+        std::move(childColumn),
+        nullCount,
+        std::move(*nullBuf),
+        stream,
+        mr);   
+    }
+
+    if (!isCompact(*arrayVector)) {
+      std::cout <<"array is not compact"<< std::endl;
+      // Non-compact: accumulate only for non-null rows, always set offset for each row.
+      // Need to reorder all the row, fallback to with arrow conversion
+      // Wrap the vector in a RowVector for Arrow conversion
+      auto rowType = ROW({type});
+      std::vector<VectorPtr> children = {vector};
+      auto rowVector = std::make_shared<RowVector>(
+          pool,
+          rowType,
+          nullptr,
+          vector->size(),
+          children);
+      auto columns = toCudfTableArrow(rowVector, pool, stream, mr)->release();
+      return std::move(columns[0]);
+    }
+    std::vector<int32_t> offsets(numRows + 1);
+    offsets[0] = 0;
+    // If compact, copy offsets directly and compute the last offset.
+    std::memcpy(offsets.data(), arrayVector->rawOffsets(), sizeof(int32_t) * numRows);
+    offsets[numRows] = arrayVector->offsetAt(numRows - 1) + arrayVector->sizeAt(numRows - 1);
+
+    auto offsetsColumn = makeOffsetsColumn(offsets);
+    auto elements = arrayVector->elements();
+    auto childColumn = convertColumn(elements, type->childAt(0), pool);
+
+    auto nullBuf = copyNullMask(*vector);
+    auto nullCount = getNullCount(*vector);
+
+    return cudf::make_lists_column(
+        numRows,
+        std::move(offsetsColumn),
+        std::move(childColumn),
+        nullCount,
+        std::move(*nullBuf),
+        stream,
+        mr);
+  }
+
+  /// Converts a Velox RowVector to a cudf STRUCT column.
+  /// Recursively converts each child column and assembles them into a struct.
+  std::unique_ptr<cudf::column> readStructColumn(
+      const BaseVector& vector,
+      const TypePtr& type,
+      memory::MemoryPool* pool) const {
+    const auto numRows = vector.size();
+
+    auto* rowVector = vector.as<RowVector>();
+    VELOX_CHECK_NOT_NULL(
+        rowVector, "Expected RowVector for direct struct conversion");
+
+    const auto numChildren = rowVector->childrenSize();
+    std::vector<std::unique_ptr<cudf::column>> childColumns;
+    childColumns.reserve(numChildren);
+
+    for (auto i = 0; i < numChildren; ++i) {
+      const auto& child = rowVector->childAt(i);
+      auto childType = type->childAt(i);
+      childColumns.push_back(convertColumn(child, childType, pool));
+    }
+
+    std::cout << "childColumns size " << childColumns.size() << std::endl;
+
+    auto nullBuf = copyNullMask(vector);
+    auto nullCount = getNullCount(vector);
+
+    return cudf::make_structs_column(
+      numRows,
+      std::move(childColumns),
+      nullCount,
+      std::move(*nullBuf),
+      stream,
+      mr);
+  }
+
+  /// Converts any Velox vector to a cudf column by dispatching on TypeKind.
+  std::unique_ptr<cudf::column> convertColumn(
+      const VectorPtr& vector,
+      const TypePtr& type,
+      memory::MemoryPool* pool) const {
+    switch (type->kind()) {
+      case TypeKind::BOOLEAN:
+        return readBooleanColumn(*vector, type);
+      case TypeKind::TINYINT:
+        return readColumn<TypeKind::TINYINT>(*vector, type);
+      case TypeKind::SMALLINT:
+        return readColumn<TypeKind::SMALLINT>(*vector, type);
+      case TypeKind::INTEGER:
+        return readColumn<TypeKind::INTEGER>(*vector, type);
+      case TypeKind::BIGINT:
+        return readColumn<TypeKind::BIGINT>(*vector, type);
+      case TypeKind::REAL:
+        return readColumn<TypeKind::REAL>(*vector, type);
+      case TypeKind::DOUBLE:
+        return readColumn<TypeKind::DOUBLE>(*vector, type);
+      case TypeKind::TIMESTAMP:
+        return readTimestampColumn(*vector, type);
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+        return readStringColumn(*vector);
+      case TypeKind::ARRAY:
+        return readArrayColumn(vector, type, pool);
+      case TypeKind::ROW:
+        return readStructColumn(*vector, type, pool);
+      default:
+        VELOX_FAIL(
+            "Unsupported Velox type for direct cudf conversion: {}",
+            type->toString());
+    }
+  }
+
+ private:
+  /// Specialization for BOOLEAN: Velox stores booleans as bit-packed uint64_t
+  /// arrays, and cudf BOOL8 stores them as one byte per value (int8_t). We
+  /// need to expand the bit-packed representation.
+  std::unique_ptr<cudf::column> readBooleanColumn(
+      const BaseVector& vector,
+      const TypePtr& type) const {
+    const auto numRows = vector.size();
+    auto* flatVector = vector.as<FlatVector<bool>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector<bool> for direct conversion");
+
+    // Velox stores booleans bit-packed. cudf BOOL8 uses int8_t per value.
+    // Expand bits to bytes on CPU, then copy to GPU.
+    const auto* rawBits = flatVector->template rawValues<uint64_t>();
+    std::vector<int8_t> expanded(numRows);
+    for (int32_t i = 0; i < numRows; ++i) {
+      expanded[i] = bits::isBitSet(rawBits, i) ? 1 : 0;
+    }
+
+    rmm::device_buffer dataBuf(numRows * sizeof(int8_t), stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        dataBuf.data(),
+        expanded.data(),
+        numRows * sizeof(int8_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    auto nullBuf = copyNullMask(vector);
+    auto nullCount = getNullCount(vector);
+
+    cudf::data_type cudfType{veloxToCudfTypeId(type)};
+    return std::make_unique<cudf::column>(
+        cudfType, numRows, std::move(dataBuf), std::move(*nullBuf), nullCount);
+  }
+
+  /// Specialization for TIMESTAMP: Velox uses a Timestamp struct (seconds +
+  /// nanos, 16 bytes) while cudf TIMESTAMP_NANOSECONDS uses a single int64_t.
+  /// We convert each Timestamp to nanoseconds since epoch via toNanos().
+  std::unique_ptr<cudf::column> readTimestampColumn(
+      const BaseVector& vector,
+      const TypePtr& type) const {
+    const auto numRows = vector.size();
+    auto* flatVector = vector.as<FlatVector<Timestamp>>();
+    VELOX_CHECK_NOT_NULL(
+        flatVector, "Expected FlatVector<Timestamp> for direct conversion");
+
+    // Convert Velox Timestamp (seconds + nanos) to int64_t nanoseconds.
+    const auto* rawTimestamps = flatVector->rawValues();
+    std::vector<int64_t> nanosValues(numRows);
+    for (int32_t i = 0; i < numRows; ++i) {
+      if (!vector.isNullAt(i)) {
+        nanosValues[i] = rawTimestamps[i].toNanos();
+      } else {
+        nanosValues[i] = 0;
+      }
+    }
+
+    rmm::device_buffer dataBuf(numRows * sizeof(int64_t), stream, mr);
+    CUDF_CUDA_TRY(cudaMemcpyAsync(
+        dataBuf.data(),
+        nanosValues.data(),
+        numRows * sizeof(int64_t),
+        cudaMemcpyHostToDevice,
+        stream.value()));
+
+    auto nullBuf = copyNullMask(vector);
+    auto nullCount = getNullCount(vector);
+
+    cudf::data_type cudfType{veloxToCudfTypeId(type)};
+    return std::make_unique<cudf::column>(
+        cudfType, numRows, std::move(dataBuf), std::move(*nullBuf), nullCount);
+  }
+};
+
+} // namespace
+
+std::unique_ptr<cudf::table> toCudfTable(
+    const facebook::velox::RowVectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  const auto numColumns = veloxTable->childrenSize();
+
+  // Flatten dictionary and constant encodings to get flat vectors.
+  // This matches what the Arrow path does with ArrowOptions{true, true}.
+  VectorPtr flattenTarget = veloxTable;
+  BaseVector::flattenVector(flattenTarget);
+  auto flatRow = std::dynamic_pointer_cast<RowVector>(flattenTarget);
+
+  const auto& rowType = flatRow->type()->as<TypeKind::ROW>();
+
+  DispatchColumn dispatcher{stream, mr};
+
+  std::vector<std::unique_ptr<cudf::column>> cudfColumns;
+  cudfColumns.reserve(numColumns);
+
+  for (auto i = 0; i < numColumns; ++i) {
+    auto child = flatRow->childAt(i);
+    const auto& colType = rowType.childAt(i);
+    auto column = dispatcher.convertColumn(child, colType, pool);
+    cudfColumns.push_back(std::move(column));
+  }
+
+  return std::make_unique<cudf::table>(std::move(cudfColumns));
+}
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -130,7 +130,6 @@ getMetadata(Iterator begin, Iterator end, const std::string& namePrefix) {
     metadata.push_back(cudf::column_metadata(namePrefix + std::to_string(i)));
     metadata.back().children_meta = getMetadata(
         c->child_begin(), c->child_end(), namePrefix + std::to_string(i));
-    std::cout <<"The child metadata size is " << metadata.back().children_meta.size() << std::endl;
     i++;
   }
   return metadata;
@@ -180,7 +179,6 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) {
   auto metadata = getMetadata(table.begin(), table.end(), namePrefix);
-  std::cout <<"The input table metadata size " << metadata.size() << std::endl;
   return toVeloxColumn(table, pool, metadata, stream, mr);
 }
 
@@ -439,7 +437,6 @@ struct DispatchColumn {
     auto* arrayVector = vector->as<ArrayVector>();
     VELOX_CHECK_NOT_NULL(arrayVector, "Expected ArrayVector for direct conversion");
     if (!isCompact(*arrayVector) && arrayVector->elements()->type()->isPrimitiveType()) {
-      std::cout <<"array is not compact and primitive type"<< std::endl;
       auto* rawOffsets = arrayVector->rawOffsets();
       auto* rawSizes = arrayVector->rawSizes();
       int32_t totalElements = 0;
@@ -447,8 +444,6 @@ struct DispatchColumn {
       offsets[0] = 0;
       // Step 1: build compact offsets
       for (int i = 0; i < numRows; ++i) {
-        std::cout <<"offsets at index " << i << " " <<rawOffsets[i] << std::endl;
-        std::cout <<"sizes at index " << i << " " <<rawSizes[i] << std::endl;
         totalElements += rawSizes[i];
         offsets[i + 1] = totalElements; 
       }
@@ -460,8 +455,6 @@ struct DispatchColumn {
       for (int i = 0; i < numRows; ++i) {
         auto offset = rawOffsets[i];
         auto size = rawSizes[i];
-        std::cout <<"offsets at index " << i << " " <<offset << std::endl;
-        std::cout <<"sizes at index " << i << " " <<size << std::endl;
         for (int j = 0; j < size; ++j) {
            gatherIndices.push_back(offset + j);
         }
@@ -471,7 +464,6 @@ struct DispatchColumn {
       std::memcpy( indexBuffer->asMutable<vector_size_t>(), gatherIndices.data(), gatherIndices.size() * sizeof(vector_size_t));
       // Use Velox dictionary to compact
       auto compactElements = BaseVector::wrapInDictionary( BufferPtr(nullptr), indexBuffer, gatherIndices.size(), elements);
-      std::cout <<"compactElements is " << compactElements->toString()<< std::endl;
       // Now convert compacted child
       BaseVector::flattenVector(compactElements);
       auto childColumn = convertColumn(compactElements, type->childAt(0), pool);
@@ -489,7 +481,6 @@ struct DispatchColumn {
     }
 
     if (!isCompact(*arrayVector)) {
-      std::cout <<"array is not compact"<< std::endl;
       // Non-compact: accumulate only for non-null rows, always set offset for each row.
       // Need to reorder all the row, fallback to with arrow conversion
       // Wrap the vector in a RowVector for Arrow conversion
@@ -548,8 +539,6 @@ struct DispatchColumn {
       auto childType = type->childAt(i);
       childColumns.push_back(convertColumn(child, childType, pool));
     }
-
-    std::cout << "childColumns size " << childColumns.size() << std::endl;
 
     auto nullBuf = copyNullMask(vector);
     auto nullCount = getNullCount(vector);

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.h
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.h
@@ -30,12 +30,6 @@ cudf::type_id veloxToCudfTypeId(const TypePtr& type);
 
 namespace with_arrow {
 
-std::unique_ptr<cudf::table> toCudfTable(
-    const facebook::velox::RowVectorPtr& veloxTable,
-    facebook::velox::memory::MemoryPool* pool,
-    rmm::cuda_stream_view stream,
-    rmm::device_async_resource_ref mr);
-
 facebook::velox::RowVectorPtr toVeloxColumn(
     const cudf::table_view& table,
     facebook::velox::memory::MemoryPool* pool,
@@ -50,6 +44,25 @@ facebook::velox::RowVectorPtr toVeloxColumn(
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr);
 
+// New overload: Accepts a Velox TypePtr for recursive metadata construction.
+facebook::velox::RowVectorPtr toVeloxColumn(
+    const cudf::table_view& table,
+    facebook::velox::memory::MemoryPool* pool,
+    const TypePtr& type,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
+
 } // namespace with_arrow
+
+/// Converts a Velox RowVector to a cudf table by directly reading from
+/// Velox vector buffers and copying to GPU. This avoids the overhead of
+/// Arrow serialization/deserialization. Supports flat scalar types, strings,
+/// and complex/nested types (ARRAY as LIST, ROW as STRUCT, MAP as
+/// LIST<STRUCT<key, value>>).
+std::unique_ptr<cudf::table> toCudfTable(
+    const facebook::velox::RowVectorPtr& veloxTable,
+    facebook::velox::memory::MemoryPool* pool,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr);
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(
 # add_executable(velox_cudf_table_write_test Main.cpp TableWriteTest.cpp)
 add_executable(velox_cudf_topn_test Main.cpp TopNTest.cpp)
 add_executable(velox_cudf_batch_concat_test Main.cpp BatchConcatTest.cpp)
+add_executable(velox_cudf_interop_test Main.cpp InteropTest.cpp)
 
 add_test(
   NAME velox_cudf_aggregation_test
@@ -131,6 +132,12 @@ add_test(
 )
 
 add_test(
+  NAME velox_cudf_interop_test
+  COMMAND velox_cudf_interop_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_test(
   NAME velox_cudf_aggregation_selection_test
   COMMAND velox_cudf_aggregation_selection_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
@@ -179,6 +186,7 @@ set_tests_properties(
   PROPERTIES LABELS cuda_driver TIMEOUT 3000
 )
 set_tests_properties(velox_cudf_batch_concat_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_interop_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 
 target_link_libraries(
   velox_cudf_aggregation_test
@@ -374,6 +382,16 @@ target_link_libraries(
   gtest_main
   fmt::fmt
   velox_cudf_exec
+)
+
+target_link_libraries(
+  velox_cudf_interop_test
+  velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
 )
 
 add_subdirectory(utils)

--- a/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
+++ b/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
@@ -32,7 +32,7 @@ class CudfFunctionBaseTest : public velox::functions::test::FunctionBaseTest {
 
     VELOX_CHECK(!rows.has_value());
     auto stream = cudf::get_default_stream();
-    auto cudfTable = velox::cudf_velox::with_arrow::toCudfTable(
+    auto cudfTable = velox::cudf_velox::toCudfTable(
         input, pool_.get(), stream, cudf::get_current_device_resource_ref());
     auto filterEvaluator =
         createCudfExpression({exprSet.exprs()[0]}, input->rowType());

--- a/velox/experimental/cudf/tests/InteropTest.cpp
+++ b/velox/experimental/cudf/tests/InteropTest.cpp
@@ -1,0 +1,510 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::cudf_velox;
+
+namespace {
+
+/// Tests the direct toCudfTable conversion (bypassing Arrow) by round-tripping
+/// Velox RowVector -> cudf table (direct) -> Velox RowVector (via Arrow) and
+/// verifying the result matches the original.
+class InteropTest : public ::testing::Test,
+                         public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  /// Round-trips a RowVector through the direct toCudfTable and back via
+  /// with_arrow::toVeloxColumn, then asserts equality with the original.
+  void roundTrip(const RowVectorPtr& input) {
+    auto stream = cudf::get_default_stream();
+    auto mr = cudf::get_current_device_resource_ref();
+
+    // Log input vector.
+    std::cout << "[roundTrip] Input vector: " << input->toString() << std::endl;
+
+    // Convert Velox -> cudf using the new direct path.
+    auto cudfTable = cudf_velox::toCudfTable(input, pool_.get(), stream, mr);
+    std::cout << "[roundTrip] cudfTable num_columns: " << cudfTable->num_columns() << std::endl;
+
+    std::cout << "[roundTrip] toCudfTable successfully: " << input->toString() << std::endl;
+    ASSERT_NE(cudfTable, nullptr);
+    ASSERT_EQ(cudfTable->num_rows(), input->size());
+    ASSERT_EQ(
+        cudfTable->num_columns(),
+        static_cast<cudf::size_type>(input->childrenSize()));
+
+    // Convert cudf -> Velox using the existing Arrow path.
+    auto result = cudf_velox::with_arrow::toVeloxColumn(
+        cudfTable->view(), pool_.get(), input->type(), stream, mr);
+    stream.synchronize();
+
+    // Log output vector.
+    std::cout << "[roundTrip] Output vector: " << result->toString() << std::endl;
+
+    // Verify.
+    test::assertEqualVectors(input, result);
+  }
+};
+
+// ========== Integer types ==========
+
+TEST_F(InteropTest, tinyint) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int8_t>({1, -2, 3, 0, 127, -128})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, smallint) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int16_t>({1, -2, 300, 0, 32767, -32768})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, integer) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int32_t>({1, -2, 300, 0, 2147483647, -2147483648})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, bigint) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<int64_t>({1, -2, 300, 0, 9223372036854775807LL})});
+  roundTrip(input);
+}
+
+// ========== Floating point types ==========
+
+TEST_F(InteropTest, real) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<float>({1.5f, -2.5f, 0.0f, 3.14f})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, double_type) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<double>({1.5, -2.5, 0.0, 3.14159265358979})});
+  roundTrip(input);
+}
+
+// ========== Boolean ==========
+
+TEST_F(InteropTest, boolean) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<bool>({true, false, true, true, false})});
+  roundTrip(input);
+}
+
+// ========== String types ==========
+
+TEST_F(InteropTest, varchar) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<StringView>(
+          {"hello", "world", "", "a longer string value", "x"})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, varbinary) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<StringView>(
+          {"binary\x00data"_sv, "more"_sv, ""_sv})});
+  roundTrip(input);
+}
+
+// ========== With nulls ==========
+
+TEST_F(InteropTest, integerWithNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<int32_t>(
+          {1, std::nullopt, 3, std::nullopt, 5})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, booleanWithNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<bool>(
+          {true, std::nullopt, false, std::nullopt, true})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, varcharWithNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<StringView>(
+          {"hello"_sv, std::nullopt, "world"_sv, std::nullopt})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, doubleWithNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<double>(
+          {1.1, std::nullopt, 3.3, std::nullopt, 5.5})});
+  roundTrip(input);
+}
+
+// ========== Timestamp ==========
+
+TEST_F(InteropTest, timestamp) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<Timestamp>(
+          {Timestamp(0, 0),
+           Timestamp(1, 500000000),
+           Timestamp(100, 0),
+           Timestamp(1000000, 999999999)})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, timestampWithNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<Timestamp>(
+          {Timestamp(0, 0),
+           std::nullopt,
+           Timestamp(100, 0),
+           std::nullopt})});
+  roundTrip(input);
+}
+
+// ========== Multiple columns ==========
+
+TEST_F(InteropTest, multipleColumns) {
+  auto input = makeRowVector(
+      {"c0", "c1", "c2", "c3"},
+      {makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<double>({1.1, 2.2, 3.3, 4.4, 5.5}),
+       makeFlatVector<bool>({true, false, true, false, true}),
+       makeFlatVector<StringView>(
+           {"a", "bb", "ccc", "dddd", "eeeee"})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, multipleColumnsWithNulls) {
+  auto input = makeRowVector(
+      {"c0", "c1", "c2"},
+      {makeNullableFlatVector<int64_t>(
+           {1, std::nullopt, 3, std::nullopt, 5}),
+       makeNullableFlatVector<StringView>(
+           {"a"_sv, "b"_sv, std::nullopt, "d"_sv, std::nullopt}),
+       makeNullableFlatVector<bool>(
+           {true, std::nullopt, false, std::nullopt, true})});
+  roundTrip(input);
+}
+
+// ========== Empty input ==========
+
+TEST_F(InteropTest, emptyInput) {
+  auto input = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<int32_t>({}),
+       makeFlatVector<StringView>({})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyBoolean) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<bool>({})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyDouble) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<double>({})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyTimestamp) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeFlatVector<Timestamp>({})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyArray) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeArrayVector<int32_t>({})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyStruct) {
+  auto structVector = makeRowVector(
+      {makeFlatVector<int32_t>({}),
+       makeFlatVector<StringView>({})});
+  auto input = makeRowVector({"c0"}, {structVector});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, DISABLED_emptyMap) {
+  auto mapVector = makeMapVector<int32_t, StringView>({});
+  auto input = makeRowVector({"c0"}, {mapVector});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, emptyMultipleColumns) {
+  auto input = makeRowVector(
+      {"c0", "c1", "c2", "c3"},
+      {makeFlatVector<int64_t>({}),
+       makeFlatVector<bool>({}),
+       makeFlatVector<StringView>({}),
+       makeArrayVector<int32_t>({})});
+  roundTrip(input);
+}
+
+// ========== All nulls ==========
+
+TEST_F(InteropTest, allNulls) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<int32_t>(
+          {std::nullopt, std::nullopt, std::nullopt})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, allNullsString) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeNullableFlatVector<StringView>(
+          {std::nullopt, std::nullopt, std::nullopt})});
+  roundTrip(input);
+}
+
+// ========== ARRAY (LIST) types ==========
+
+TEST_F(InteropTest, arrayOfIntegers) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeArrayVector<int32_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6},
+          {},
+          {7, 8, 9, 10},
+      })});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, arrayOfStrings) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeArrayVector<StringView>({
+          {"hello"_sv, "world"_sv},
+          {},
+          {"foo"_sv, "bar"_sv, "baz"_sv},
+      })});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, arrayOfDoubles) {
+  auto input = makeRowVector(
+      {"c0"},
+      {makeArrayVector<double>({
+          {1.1, 2.2, 3.3},
+          {},
+          {4.4},
+      })});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, arrayWithNulls) {
+  // Array column with some null array entries.
+  auto elements = makeNullableFlatVector<int32_t>(
+      {1, 2, std::nullopt, 4, 5, std::nullopt});
+  auto offsets = makeIndices({0, 3, 3, 3});
+  auto sizes = makeIndices({3, 0, 3, 0});
+  auto arrayVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(INTEGER()),
+      makeNulls({false, true, false, true}),
+      4,
+      offsets,
+      sizes,
+      elements);
+
+  auto input = makeRowVector({"c0"}, {arrayVector});
+  roundTrip(input);
+}
+
+// ========== ROW (STRUCT) types ==========
+
+TEST_F(InteropTest, structSimple) {
+  auto structVector = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4}),
+       makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv, "d"_sv})});
+  auto input = makeRowVector({"c0"}, {structVector});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, structWithNulls) {
+  auto structVector = makeRowVector(
+      {makeNullableFlatVector<int32_t>({1, std::nullopt, 3, std::nullopt}),
+       makeNullableFlatVector<double>({1.1, 2.2, std::nullopt, 4.4})},
+      // Null the struct itself at row 1.
+      [](auto row) { return row == 1; });
+  auto input = makeRowVector({"c0"}, {structVector});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, structMultipleFields) {
+  auto structVector = makeRowVector(
+      {makeFlatVector<int64_t>({10, 20, 30}),
+       makeFlatVector<bool>({true, false, true}),
+       makeFlatVector<StringView>({"x"_sv, "y"_sv, "z"_sv})});
+  auto input = makeRowVector({"c0"}, {structVector});
+  roundTrip(input);
+}
+
+// ========== Nested complex types ==========
+
+TEST_F(InteropTest, arrayOfArrays) {
+  // Build ARRAY(ARRAY(INTEGER)).
+  auto innerArray = makeArrayVector<int32_t>({
+      {1, 2},
+      {3},
+      {4, 5, 6},
+      {},
+      {7},
+  });
+  auto outerOffsets = makeIndices({0, 2, 2, 3});
+  auto outerSizes = makeIndices({2, 0, 2, 1});
+  auto outerArray = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(ARRAY(INTEGER())),
+      nullptr,
+      4,
+      outerOffsets,
+      outerSizes,
+      innerArray);
+
+  auto input = makeRowVector({"c0"}, {outerArray});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, structWithArray) {
+  auto arrayChild = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+      {6},
+  });
+  auto intChild = makeFlatVector<int64_t>({10, 20, 30});
+  auto structVector = makeRowVector({intChild, arrayChild});
+  auto input = makeRowVector({"c0"}, {structVector});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, arrayOfStructs) {
+  auto structElements = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+       makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv, "d"_sv, "e"_sv})});
+  auto offsets = makeIndices({0, 2, 2});
+  auto sizes = makeIndices({2, 0, 3});
+  auto arrayVector = std::make_shared<ArrayVector>(
+      pool_.get(),
+      ARRAY(ROW({INTEGER(), VARCHAR()})),
+      nullptr,
+      3,
+      offsets,
+      sizes,
+      structElements);
+
+  auto input = makeRowVector({"c0"}, {arrayVector});
+  roundTrip(input);
+}
+
+// ========== MAP types ==========
+// MAP is represented as LIST<STRUCT<key, value>> in cudf. The round-trip
+// through cudf->Arrow->Velox won't produce a MAP type. Instead, we compare
+// the direct path against the Arrow-based path to ensure both produce
+// identical cudf tables.
+
+TEST_F(InteropTest, DISABLED_mapIntToString) {
+    auto mapVector = makeMapVector<int32_t, StringView>({
+      {{1, "a"_sv}, {2, "b"_sv}, {3, "c"_sv}},
+      {},
+      {{4, "d"_sv}},
+    });
+    auto input = makeRowVector({"c0"}, {mapVector});
+    roundTrip(input);
+}
+
+TEST_F(InteropTest, DISABLED_mapStringToInt) {
+    auto mapVector = makeMapVector<StringView, int64_t>({
+      {{"x"_sv, 10}, {"y"_sv, 20}},
+      {{"z"_sv, 30}},
+      {},
+    });
+    auto input = makeRowVector({"c0"}, {mapVector});
+    roundTrip(input);
+}
+
+TEST_F(InteropTest, DISABLED_mapWithNullValues) {
+    auto mapVector = makeMapVector<int32_t, StringView>({
+      {{1, "a"_sv}, {2, std::nullopt}},
+      {{3, "c"_sv}},
+    });
+    auto input = makeRowVector({"c0"}, {mapVector});
+    roundTrip(input);
+}
+
+// ========== Mixed complex and scalar columns ==========
+
+TEST_F(InteropTest, mixedScalarAndArray) {
+  auto input = makeRowVector(
+      {"c0", "c1", "c2"},
+      {makeFlatVector<int32_t>({1, 2, 3}),
+       makeArrayVector<int64_t>({
+           {10, 20},
+           {30},
+           {40, 50, 60},
+       }),
+       makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv})});
+  roundTrip(input);
+}
+
+TEST_F(InteropTest, mixedScalarAndStruct) {
+  auto structChild = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3}),
+       makeFlatVector<double>({1.1, 2.2, 3.3})});
+  auto input = makeRowVector(
+      {"c0", "c1"},
+      {makeFlatVector<StringView>({"x"_sv, "y"_sv, "z"_sv}),
+       structChild});
+  roundTrip(input);
+}
+
+} // namespace

--- a/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
+++ b/velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
@@ -67,7 +67,7 @@ class SubfieldFilterAstTest : public OperatorTestBase {
     auto mr = cudf::get_current_device_resource_ref();
 
     {
-      auto cudfTable = cudf_velox::with_arrow::toCudfTable(
+      auto cudfTable = cudf_velox::toCudfTable(
           vector, pool_.get(), stream, cudf::get_current_device_resource_ref());
       ASSERT_NE(cudfTable, nullptr);
 
@@ -601,7 +601,7 @@ TEST_F(SubfieldFilterAstTest, MultipleSubfieldFilters) {
   auto stream = cudf::get_default_stream();
   auto mr = cudf::get_current_device_resource_ref();
 
-  auto cudfTable = cudf_velox::with_arrow::toCudfTable(
+  auto cudfTable = cudf_velox::toCudfTable(
       vec, pool_.get(), stream, cudf::get_current_device_resource_ref());
   ASSERT_NE(cudfTable, nullptr);
   auto cudfResult =

--- a/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
+++ b/velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
@@ -169,7 +169,7 @@ void CudfHiveConnectorTestBase::writeToFile(
     VELOX_CHECK_NOT_NULL(vector);
     if (vector->size()) {
       auto stream = cudf::get_default_stream();
-      auto cudfTable = with_arrow::toCudfTable(
+      auto cudfTable = toCudfTable(
           vector,
           vector->pool(),
           stream,
@@ -210,7 +210,7 @@ void CudfHiveConnectorTestBase::writeToFile(
   auto const sinkInfo = cudf::io::sink_info(filePath);
   VELOX_CHECK_NOT_NULL(vector);
   auto stream = cudf::get_default_stream();
-  auto cudfTable = with_arrow::toCudfTable(
+  auto cudfTable = toCudfTable(
       vector, vector->pool(), stream, cudf::get_current_device_resource_ref());
   stream.synchronize();
   auto tableInputMetadata = cudf::io::table_input_metadata(cudfTable->view());


### PR DESCRIPTION
The velox to cudf conversion directly not only reduces function call, memory copy, and we can also update some conversion path to run with CUDA, such as generate StringView, convert Timestamp from int64_t nanos to velox Timestamp