### PR TITLE
refactor(hive): Extract JSON field name constants in HiveDataSink (#16863)

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -869,29 +869,29 @@ std::vector<std::string> HiveDataSink::commitMessage() const {
     const auto& info = writerInfo_.at(i);
     VELOX_CHECK_NOT_NULL(info);
 
-    // Build the fileWriteInfos array from all written files.
     folly::dynamic fileWriteInfosArray = folly::dynamic::array;
     for (const auto& fileInfo : info->writtenFiles) {
       fileWriteInfosArray.push_back(
-          folly::dynamic::object("writeFileName", fileInfo.writeFileName)(
-              "targetFileName", fileInfo.targetFileName)(
-              "fileSize", fileInfo.fileSize));
+          folly::dynamic::object(
+              HiveCommitMessage::kWriteFileName, fileInfo.writeFileName)(
+              HiveCommitMessage::kTargetFileName, fileInfo.targetFileName)(
+              HiveCommitMessage::kFileSize, fileInfo.fileSize));
     }
 
     // clang-format off
       auto partitionUpdateJson = folly::toJson(
        folly::dynamic::object
-          ("name", info->writerParameters.partitionName().value_or(""))
-          ("updateMode",
+          (HiveCommitMessage::kName, info->writerParameters.partitionName().value_or(""))
+          (HiveCommitMessage::kUpdateMode,
             HiveWriterParameters::updateModeToString(
               info->writerParameters.updateMode()))
-          ("writePath", info->writerParameters.writeDirectory())
-          ("targetPath", info->writerParameters.targetDirectory())
-          ("fileWriteInfos", std::move(fileWriteInfosArray))
-          ("rowCount", info->numWrittenRows)
-          ("inMemoryDataSizeInBytes", info->inputSizeInBytes)
-          ("onDiskDataSizeInBytes", ioStats_.at(i)->rawBytesWritten())
-          ("containsNumberedFileNames", true));
+          (HiveCommitMessage::kWritePath, info->writerParameters.writeDirectory())
+          (HiveCommitMessage::kTargetPath, info->writerParameters.targetDirectory())
+          (HiveCommitMessage::kFileWriteInfos, std::move(fileWriteInfosArray))
+          (HiveCommitMessage::kRowCount, info->numWrittenRows)
+          (HiveCommitMessage::kInMemoryDataSizeInBytes, info->inputSizeInBytes)
+          (HiveCommitMessage::kOnDiskDataSizeInBytes, ioStats_.at(i)->rawBytesWritten())
+          (HiveCommitMessage::kContainsNumberedFileNames, true));
     // clang-format on
     partitionUpdates.push_back(partitionUpdateJson);
   }

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -520,6 +520,61 @@ struct HiveWriterIdEq {
   }
 };
 
+/// JSON field names for the partition update object produced by each writer
+/// and consumed by the Presto coordinator to finalize files and update the
+/// metastore.
+///
+/// JSON structure:
+/// {
+///   "name":                        "<partition key, e.g. ds=2024-01-01>",
+///   "updateMode":                  "NEW" | "APPEND" | "OVERWRITE",
+///   "writePath":                   "<staging directory>",
+///   "targetPath":                  "<final directory>",
+///   "fileWriteInfos": [
+///     {
+///       "writeFileName":           "<temp filename in writePath>",
+///       "targetFileName":          "<final filename in targetPath>",
+///       "fileSize":                <bytes>
+///     }
+///   ],
+///   "rowCount":                    <total rows>,
+///   "inMemoryDataSizeInBytes":     <uncompressed bytes>,
+///   "onDiskDataSizeInBytes":       <compressed bytes on disk>,
+///   "containsNumberedFileNames":   true | false
+/// }
+struct HiveCommitMessage {
+  /// Partition directory name in Hive format (e.g., "ds=2024-01-01/region=us").
+  /// Empty string for unpartitioned tables.
+  static constexpr const char* kName = "name";
+  /// Write mode: "NEW", "APPEND", or "OVERWRITE". Controls how the committer
+  /// handles metastore updates and existing file conflicts.
+  static constexpr const char* kUpdateMode = "updateMode";
+  /// Staging directory where files were written during execution.
+  static constexpr const char* kWritePath = "writePath";
+  /// Final destination directory. Files are renamed from writePath to
+  /// targetPath during commit.
+  static constexpr const char* kTargetPath = "targetPath";
+  /// Array of per-file metadata objects. One entry per file written, including
+  /// rotated files.
+  static constexpr const char* kFileWriteInfos = "fileWriteInfos";
+  /// Temporary filename used during writing (in the staging directory).
+  static constexpr const char* kWriteFileName = "writeFileName";
+  /// Final filename after commit (in the target directory).
+  static constexpr const char* kTargetFileName = "targetFileName";
+  /// Size of individual file in bytes.
+  static constexpr const char* kFileSize = "fileSize";
+  /// Total rows written to this partition across all files.
+  static constexpr const char* kRowCount = "rowCount";
+  /// Uncompressed input data size in bytes.
+  static constexpr const char* kInMemoryDataSizeInBytes =
+      "inMemoryDataSizeInBytes";
+  /// Compressed bytes written to disk.
+  static constexpr const char* kOnDiskDataSizeInBytes = "onDiskDataSizeInBytes";
+  /// Whether filenames follow a numbered sequence from file rotation.
+  static constexpr const char* kContainsNumberedFileNames =
+      "containsNumberedFileNames";
+};
+
 class HiveDataSink : public DataSink {
  public:
   /// The list of runtime stats reported by hive data sink

--- a/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
+++ b/velox/connectors/hive/storage_adapters/test_common/InsertTest.h
@@ -19,6 +19,7 @@
 
 #include "velox/common/memory/Memory.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/TableWriter.h"
@@ -90,17 +91,19 @@ class InsertTest : public velox::test::VectorTestBase {
     folly::dynamic obj =
         folly::parseJson(std::string_view(details->valueAt(1)));
 
-    ASSERT_EQ(numRows, obj["rowCount"].asInt());
-    auto fileWriteInfos = obj["fileWriteInfos"];
+    ASSERT_EQ(numRows, obj[HiveCommitMessage::kRowCount].asInt());
+    auto fileWriteInfos = obj[HiveCommitMessage::kFileWriteInfos];
     ASSERT_EQ(1, fileWriteInfos.size());
 
-    auto writeFileName = fileWriteInfos[0]["writeFileName"].asString();
+    auto writeFileName =
+        fileWriteInfos[0][HiveCommitMessage::kWriteFileName].asString();
 
     // Read from 'writeFileName' and verify the data matches the original.
     plan = exec::test::PlanBuilder().tableScan(rowType).planNode();
 
     auto filePath = fmt::format("{}{}", outputDirectory, writeFileName);
-    const int64_t fileSize = fileWriteInfos[0]["fileSize"].asInt();
+    const int64_t fileSize =
+        fileWriteInfos[0][HiveCommitMessage::kFileSize].asInt();
     auto split = exec::test::HiveConnectorSplitBuilder(filePath)
                      .fileFormat(dwio::common::FileFormat::PARQUET)
                      .length(fileSize)

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -25,6 +25,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
@@ -1344,15 +1345,17 @@ TEST_F(HiveDataSinkTest, fileRotationBasic) {
   ASSERT_EQ(partitions.size(), 1);
 
   const auto partitionJson = folly::parseJson(partitions[0]);
-  ASSERT_TRUE(partitionJson.count("fileWriteInfos") > 0);
-  const auto& fileWriteInfos = partitionJson["fileWriteInfos"];
+  ASSERT_TRUE(partitionJson.count(HiveCommitMessage::kFileWriteInfos) > 0);
+  const auto& fileWriteInfos =
+      partitionJson[HiveCommitMessage::kFileWriteInfos];
   ASSERT_GT(fileWriteInfos.size(), 1);
 
   for (size_t i = 0; i < fileWriteInfos.size(); ++i) {
-    ASSERT_TRUE(fileWriteInfos[i].count("writeFileName") > 0);
-    ASSERT_TRUE(fileWriteInfos[i].count("targetFileName") > 0);
-    ASSERT_TRUE(fileWriteInfos[i].count("fileSize") > 0);
-    ASSERT_GT(fileWriteInfos[i]["fileSize"].asInt(), 0);
+    ASSERT_TRUE(fileWriteInfos[i].count(HiveCommitMessage::kWriteFileName) > 0);
+    ASSERT_TRUE(
+        fileWriteInfos[i].count(HiveCommitMessage::kTargetFileName) > 0);
+    ASSERT_TRUE(fileWriteInfos[i].count(HiveCommitMessage::kFileSize) > 0);
+    ASSERT_GT(fileWriteInfos[i][HiveCommitMessage::kFileSize].asInt(), 0);
   }
   createDuckDbTable(vectors);
   verifyWrittenData(outputDirectory->getPath(), stats.numWrittenFiles);
@@ -1380,8 +1383,9 @@ TEST_F(HiveDataSinkTest, fileRotationNoEmptyTrailingFile) {
 
   ASSERT_EQ(partitions.size(), 1);
   const auto partitionJson = folly::parseJson(partitions[0]);
-  ASSERT_TRUE(partitionJson.count("fileWriteInfos") > 0);
-  const auto& fileWriteInfos = partitionJson["fileWriteInfos"];
+  ASSERT_TRUE(partitionJson.count(HiveCommitMessage::kFileWriteInfos) > 0);
+  const auto& fileWriteInfos =
+      partitionJson[HiveCommitMessage::kFileWriteInfos];
   ASSERT_EQ(fileWriteInfos.size(), 5);
 
   const auto filePaths = listFiles(outputDirectory->getPath());
@@ -1429,8 +1433,9 @@ TEST_F(HiveDataSinkTest, fileRotationDisabledForBucketedTables) {
 
   for (const auto& partition : partitions) {
     const auto partitionJson = folly::parseJson(partition);
-    ASSERT_TRUE(partitionJson.count("fileWriteInfos") > 0);
-    const auto& fileWriteInfos = partitionJson["fileWriteInfos"];
+    ASSERT_TRUE(partitionJson.count(HiveCommitMessage::kFileWriteInfos) > 0);
+    const auto& fileWriteInfos =
+        partitionJson[HiveCommitMessage::kFileWriteInfos];
     ASSERT_EQ(fileWriteInfos.size(), 1);
   }
 
@@ -1463,29 +1468,30 @@ TEST_F(HiveDataSinkTest, fileRotationDisabledByDefault) {
 
   // Verify partition update has correct file info
   const auto partitionJson = folly::parseJson(partitions[0]);
-  ASSERT_TRUE(partitionJson.count("fileWriteInfos") > 0);
-  const auto& fileWriteInfos = partitionJson["fileWriteInfos"];
+  ASSERT_TRUE(partitionJson.count(HiveCommitMessage::kFileWriteInfos) > 0);
+  const auto& fileWriteInfos =
+      partitionJson[HiveCommitMessage::kFileWriteInfos];
   ASSERT_EQ(fileWriteInfos.size(), 1)
       << "Should have exactly 1 file entry when rotation disabled";
 
   // Verify file info fields
   const auto& fileInfo = fileWriteInfos[0];
-  ASSERT_TRUE(fileInfo.count("writeFileName") > 0);
-  ASSERT_TRUE(fileInfo.count("targetFileName") > 0);
-  ASSERT_TRUE(fileInfo.count("fileSize") > 0);
-  ASSERT_FALSE(fileInfo["writeFileName"].asString().empty());
-  ASSERT_FALSE(fileInfo["targetFileName"].asString().empty());
+  ASSERT_TRUE(fileInfo.count(HiveCommitMessage::kWriteFileName) > 0);
+  ASSERT_TRUE(fileInfo.count(HiveCommitMessage::kTargetFileName) > 0);
+  ASSERT_TRUE(fileInfo.count(HiveCommitMessage::kFileSize) > 0);
+  ASSERT_FALSE(fileInfo[HiveCommitMessage::kWriteFileName].asString().empty());
+  ASSERT_FALSE(fileInfo[HiveCommitMessage::kTargetFileName].asString().empty());
 
   const auto reportedFileSize =
-      static_cast<uint64_t>(fileInfo["fileSize"].asInt());
+      static_cast<uint64_t>(fileInfo[HiveCommitMessage::kFileSize].asInt());
   ASSERT_GT(reportedFileSize, 0);
 
   // File size in fileWriteInfos should match stats.numWrittenBytes
   ASSERT_EQ(reportedFileSize, stats.numWrittenBytes);
 
   // onDiskDataSizeInBytes should also match
-  const auto onDiskBytes =
-      static_cast<uint64_t>(partitionJson["onDiskDataSizeInBytes"].asInt());
+  const auto onDiskBytes = static_cast<uint64_t>(
+      partitionJson[HiveCommitMessage::kOnDiskDataSizeInBytes].asInt());
   ASSERT_EQ(onDiskBytes, stats.numWrittenBytes);
 
   // Verify actual file on disk matches reported size
@@ -1541,8 +1547,8 @@ TEST_F(HiveDataSinkTest, fileRotationIoStatsAccumulation) {
 
   ASSERT_EQ(partitions.size(), 1);
   const auto partitionJson = folly::parseJson(partitions[0]);
-  const auto onDiskBytes =
-      static_cast<uint64_t>(partitionJson["onDiskDataSizeInBytes"].asInt());
+  const auto onDiskBytes = static_cast<uint64_t>(
+      partitionJson[HiveCommitMessage::kOnDiskDataSizeInBytes].asInt());
   ASSERT_EQ(onDiskBytes, statsAfterClose.numWrittenBytes);
 
   createDuckDbTable(vectors);
@@ -1577,7 +1583,8 @@ TEST_F(HiveDataSinkTest, fileRotationFileInfoConsistency) {
   ASSERT_EQ(partitions.size(), 1);
 
   const auto partitionJson = folly::parseJson(partitions[0]);
-  const auto& fileWriteInfos = partitionJson["fileWriteInfos"];
+  const auto& fileWriteInfos =
+      partitionJson[HiveCommitMessage::kFileWriteInfos];
 
   // Verify file count matches
   ASSERT_EQ(fileWriteInfos.size(), stats.numWrittenFiles);
@@ -1591,8 +1598,9 @@ TEST_F(HiveDataSinkTest, fileRotationFileInfoConsistency) {
   uint64_t totalReportedSize = 0;
   for (size_t i = 0; i < fileWriteInfos.size(); ++i) {
     const auto& info = fileWriteInfos[i];
-    const auto fileName = info["writeFileName"].asString();
-    const auto fileSize = static_cast<uint64_t>(info["fileSize"].asInt());
+    const auto fileName = info[HiveCommitMessage::kWriteFileName].asString();
+    const auto fileSize =
+        static_cast<uint64_t>(info[HiveCommitMessage::kFileSize].asInt());
     reportedFiles[fileName] = fileSize;
     totalReportedSize += fileSize;
 
@@ -1602,8 +1610,8 @@ TEST_F(HiveDataSinkTest, fileRotationFileInfoConsistency) {
   }
 
   // Verify onDiskDataSizeInBytes matches sum of file sizes
-  const auto onDiskBytes =
-      static_cast<uint64_t>(partitionJson["onDiskDataSizeInBytes"].asInt());
+  const auto onDiskBytes = static_cast<uint64_t>(
+      partitionJson[HiveCommitMessage::kOnDiskDataSizeInBytes].asInt());
   ASSERT_EQ(onDiskBytes, totalReportedSize);
   ASSERT_EQ(onDiskBytes, stats.numWrittenBytes);
 
@@ -1716,17 +1724,18 @@ TEST_F(HiveDataSinkTest, fileRotationWithPartitionedTable) {
   uint32_t totalFilesFromPartitions = 0;
   for (const auto& partition : partitions) {
     const auto partitionJson = folly::parseJson(partition);
-    ASSERT_TRUE(partitionJson.count("fileWriteInfos") > 0);
-    const auto& fileWriteInfos = partitionJson["fileWriteInfos"];
+    ASSERT_TRUE(partitionJson.count(HiveCommitMessage::kFileWriteInfos) > 0);
+    const auto& fileWriteInfos =
+        partitionJson[HiveCommitMessage::kFileWriteInfos];
     ASSERT_GT(fileWriteInfos.size(), 0);
     totalFilesFromPartitions += fileWriteInfos.size();
 
     // Verify each file has valid info
     for (const auto& fileInfo : fileWriteInfos) {
-      ASSERT_TRUE(fileInfo.count("writeFileName") > 0);
-      ASSERT_TRUE(fileInfo.count("targetFileName") > 0);
-      ASSERT_TRUE(fileInfo.count("fileSize") > 0);
-      ASSERT_GT(fileInfo["fileSize"].asInt(), 0);
+      ASSERT_TRUE(fileInfo.count(HiveCommitMessage::kWriteFileName) > 0);
+      ASSERT_TRUE(fileInfo.count(HiveCommitMessage::kTargetFileName) > 0);
+      ASSERT_TRUE(fileInfo.count(HiveCommitMessage::kFileSize) > 0);
+      ASSERT_GT(fileInfo[HiveCommitMessage::kFileSize].asInt(), 0);
     }
   }
 


### PR DESCRIPTION
Summary:

These were hardcoded string constants, designed to mirror the Presto Java implementation. In this change, I am pulling out the definition of JSON fields to HiveDataSink-scoped constants

Reviewed By: mbasmanova

Differential Revision: D97401572
