### PR TITLE
fix(build): IcebergParquetStatsCollector requires ParquetWriter

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -43,6 +43,10 @@ velox_link_libraries(
   Folly::folly
 )
 
+if(VELOX_ENABLE_PARQUET)
+  velox_link_libraries(velox_hive_iceberg_splitreader velox_dwio_arrow_parquet_writer)
+endif()
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()

--- a/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.cpp
@@ -25,6 +25,7 @@
 #include "velox/dwio/parquet/writer/Writer.h"
 #include "velox/dwio/parquet/writer/arrow/Metadata.h"
 #include "velox/dwio/parquet/writer/arrow/Statistics.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 

--- a/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h
+++ b/velox/connectors/hive/iceberg/IcebergParquetStatsCollector.h
@@ -17,12 +17,10 @@
 
 #include <unordered_set>
 
-#include "velox/connectors/hive/TableHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergColumnHandle.h"
 #include "velox/connectors/hive/iceberg/IcebergDataFileStatistics.h"
 #include "velox/dwio/common/FileMetadata.h"
 #include "velox/dwio/parquet/ParquetFieldId.h"
-#include "velox/type/Type.h"
 
 namespace facebook::velox::connector::hive::iceberg {
 


### PR DESCRIPTION
Also cleaned up some of the headers where duplicate inclusion was made and moved some from the header file to the cpp file.