### PR TITLE
fix: Skip filter evaluation in HashProbe when no rows are selected (#16868)

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1334,7 +1334,7 @@ RowVectorPtr HashProbe::createFilterInput(vector_size_t size) {
 }
 
 void HashProbe::prepareFilterRowsForNullAwareJoin(
-    RowVectorPtr& filterInput,
+    const RowVector* filterInput,
     vector_size_t numRows,
     bool filterPropagateNulls) {
   VELOX_CHECK_LE(numRows, kBatchSize);
@@ -1343,6 +1343,18 @@ void HashProbe::prepareFilterRowsForNullAwareJoin(
         BaseVector::create<RowVector>(filterInputType_, kBatchSize, pool());
   }
 
+  // When no rows are selected, filterInput must be nullptr since
+  // createFilterInput() cannot be called when outputRowMapping_ has been
+  // overwritten. When rows are selected, filterInput must be valid.
+  if (FOLLY_UNLIKELY(!filterInputRows_.hasSelections())) {
+    VELOX_CHECK_NULL(filterInput);
+    if (filterPropagateNulls) {
+      nullFilterInputRows_.resizeFill(numRows, false);
+    }
+    return;
+  }
+
+  VELOX_CHECK_NOT_NULL(filterInput);
   if (filterPropagateNulls) {
     nullFilterInputRows_.resizeFill(numRows, false);
     auto* rawNullRows = nullFilterInputRows_.asMutableRange().bits();
@@ -1573,17 +1585,26 @@ int32_t HashProbe::evalFilter(int32_t numRows) {
     filterInputRows_.updateBounds();
   }
 
-  RowVectorPtr filterInput = createFilterInput(numRows);
+  // Skip filter evaluation when no rows are selected. filterPassed()
+  // short-circuits on filterInputRows_, so the result is never read.
+  // We cannot call createFilterInput() here because it wraps probe columns
+  // in a dictionary over outputRowMapping_, which listJoinResults() may have
+  // already overwritten in the previous iteration — the dictionary would fail
+  // validation in debug builds.
+  if (FOLLY_LIKELY(filterInputRows_.hasSelections())) {
+    RowVectorPtr filterInput = createFilterInput(numRows);
+    if (nullAware_) {
+      prepareFilterRowsForNullAwareJoin(
+          filterInput.get(), numRows, filterPropagateNulls);
+    }
 
-  if (nullAware_) {
-    prepareFilterRowsForNullAwareJoin(
-        filterInput, numRows, filterPropagateNulls);
+    EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput.get());
+    filter_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult_);
+
+    decodedFilterResult_.decode(*filterResult_[0], filterInputRows_);
+  } else if (nullAware_) {
+    prepareFilterRowsForNullAwareJoin(nullptr, numRows, filterPropagateNulls);
   }
-
-  EvalCtx evalCtx(operatorCtx_->execCtx(), filter_.get(), filterInput.get());
-  filter_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult_);
-
-  decodedFilterResult_.decode(*filterResult_[0], filterInputRows_);
 
   int32_t numPassed = 0;
   if (isLeftJoin(joinType_) || isFullJoin(joinType_)) {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -200,7 +200,7 @@ class HashProbe : public Operator {
   // 'filterPropagateNulls' is true, the probe input row which has null in any
   // probe filter column can't pass the filter.
   void prepareFilterRowsForNullAwareJoin(
-      RowVectorPtr& filterInput,
+      const RowVector* filterInput,
       vector_size_t numRows,
       bool filterPropagateNulls);
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -308,6 +308,99 @@ TEST_P(MultiThreadedHashJoinTest, filter) {
       .run();
 }
 
+// Regression test for a JoinFuzzer-found bug where HashProbe::evalFilter
+// produces a DictionaryVector<bool> with indices pointing past the base
+// vector's size. The issue involves the filter "t_N = true" on a
+// dictionary-encoded probe boolean column combined with expression
+// memoization across multiple output batches from the same probe input.
+// In debug builds, this triggers a validation failure in
+// DictionaryVector::validate().
+//
+// This test exercises the same code path: hash join with boolean filter on
+// a probe column that is also a join key, using dictionary-encoded probe
+// input (matching the fuzzer's ENCODED input type) and small output batch
+// sizes to force multiple output batches from the same probe input.
+TEST_P(HashJoinTest, booleanJoinFilterDictionaryValidation) {
+  VectorFuzzer::Options opts;
+  opts.nullRatio = 0.1;
+
+  for (int seed = 0; seed < 20; ++seed) {
+    SCOPED_TRACE(fmt::format("seed: {}", seed));
+    opts.vectorSize = 10 + (seed % 20);
+    VectorFuzzer fuzzer(opts, pool_.get(), seed);
+
+    auto probeType = ROW({"t0", "t1"}, {INTEGER(), BOOLEAN()});
+    auto buildType = ROW({"u0", "u1"}, {INTEGER(), BOOLEAN()});
+
+    // Use fuzzRow which wraps columns in dictionary/constant encoding,
+    // matching the JoinFuzzer's ENCODED input type.
+    std::vector<RowVectorPtr> probeVectors = {fuzzer.fuzzRow(probeType)};
+    std::vector<RowVectorPtr> buildVectors = {fuzzer.fuzzRow(buildType)};
+
+    for (int batchSize : {3, 5}) {
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .numDrivers(1)
+          .probeKeys({"t0", "t1"})
+          .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+          .buildKeys({"u0", "u1"})
+          .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+          .joinFilter("t1 = true")
+          .joinOutputLayout({"t0", "t1", "u0", "u1"})
+          .config(
+              core::QueryConfig::kPreferredOutputBatchRows,
+              std::to_string(batchSize))
+          .config(
+              core::QueryConfig::kMaxOutputBatchRows, std::to_string(batchSize))
+          .injectSpill(false)
+          .referenceQuery(
+              "SELECT t.t0, t.t1, u.u0, u.u1 FROM t, u "
+              "WHERE t.t0 = u.u0 AND t.t1 = u.u1 AND t.t1 = true")
+          .run();
+    }
+  }
+}
+
+// Same as above but with the boolean filter column as a non-key payload
+// column, exercising a slightly different code path where only integer
+// keys are used for join matching.
+TEST_P(HashJoinTest, booleanPayloadFilterDictionaryValidation) {
+  VectorFuzzer::Options opts;
+  opts.nullRatio = 0.1;
+
+  for (int seed = 0; seed < 20; ++seed) {
+    SCOPED_TRACE(fmt::format("seed: {}", seed));
+    opts.vectorSize = 10 + (seed % 20);
+    VectorFuzzer fuzzer(opts, pool_.get(), seed);
+
+    auto probeType = ROW({"t0", "t1"}, {INTEGER(), BOOLEAN()});
+    auto buildType = ROW({"u0", "u1"}, {INTEGER(), BOOLEAN()});
+
+    std::vector<RowVectorPtr> probeVectors = {fuzzer.fuzzRow(probeType)};
+    std::vector<RowVectorPtr> buildVectors = {fuzzer.fuzzRow(buildType)};
+
+    for (int batchSize : {3, 5}) {
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .numDrivers(1)
+          .probeKeys({"t0"})
+          .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+          .buildKeys({"u0"})
+          .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+          .joinFilter("t1 = true")
+          .joinOutputLayout({"t0", "t1", "u0", "u1"})
+          .config(
+              core::QueryConfig::kPreferredOutputBatchRows,
+              std::to_string(batchSize))
+          .config(
+              core::QueryConfig::kMaxOutputBatchRows, std::to_string(batchSize))
+          .injectSpill(false)
+          .referenceQuery(
+              "SELECT t.t0, t.t1, u.u0, u.u1 FROM t, u "
+              "WHERE t.t0 = u.u0 AND t.t1 = true")
+          .run();
+    }
+  }
+}
+
 DEBUG_ONLY_TEST_P(MultiThreadedHashJoinTest, filterSpillOnFirstProbeInput) {
   auto spillDirectory = TempDirectoryPath::create();
   std::atomic_bool injectProbeSpillOnce{true};
@@ -1746,6 +1839,51 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
         })
         .run();
   }
+}
+
+// Reproduces a debug-mode crash in evalFilter for ANTI join with filter.
+// A batch of all matched rows followed by a batch of all non-matching rows
+// triggers DictionaryVector::validate on a stale filterResult_ whose shared
+// outputRowMapping_ buffer has been overwritten by listJoinResults.
+TEST_P(MultiThreadedHashJoinTest, antiJoinWithBooleanKeysAndFilter) {
+  // 5 build rows with key (true, true).
+  auto buildVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {
+            makeFlatVector<bool>(5, [](auto /*row*/) { return true; }),
+            makeFlatVector<bool>(5, [](auto /*row*/) { return true; }),
+        });
+  });
+
+  // 10 probe rows: rows 0-1 match (2 * 5 = 10 output entries),
+  // rows 2-9 don't match (8 miss entries).
+  auto probeVectors = makeBatches(1, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"t0", "t1"},
+        {
+            makeFlatVector<bool>(10, [](auto row) { return row < 2; }),
+            makeFlatVector<bool>(10, [](auto row) { return row < 2; }),
+        });
+  });
+
+  // outputBatchSize=10 forces the split: 10 matches in batch 1,
+  // 8 misses in batch 2.
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(1)
+      .probeKeys({"t0", "t1"})
+      .probeVectors(std::move(probeVectors))
+      .buildKeys({"u0", "u1"})
+      .buildVectors(std::move(buildVectors))
+      .joinType(core::JoinType::kAnti)
+      .joinFilter("t1 = true")
+      .joinOutputLayout({"t0", "t1"})
+      .referenceQuery(
+          "SELECT t.* FROM t WHERE NOT EXISTS "
+          "(SELECT * FROM u WHERE t.t0 = u.u0 AND t.t1 = u.u1 AND t.t1 = true)")
+      .config(core::QueryConfig::kPreferredOutputBatchRows, std::to_string(10))
+      .checkSpillStats(false)
+      .run();
 }
 
 TEST_P(MultiThreadedHashJoinTest, leftJoin) {


### PR DESCRIPTION
Summary:

fix debug-only sanity check failure crash in DictionaryVector::validate during HashProbe::evalFilter for ANTI joins with a filter that references a probe-side join key.
for query like `ANTI JOIN ON t0=u0 AND t1=u1, FILTER: eq(t1, true)`

When the crash happens at
1:     filter_->eval(0, 1, true, filterInputRows_, evalCtx, filterResult_);
2:    exprs_[i]->eval(rows, context, result[i], this);
3:     checkResultInternalState(result);
4:      result->validate() -->  DictionaryVector<T>::validate

```
    VELOX_CHECK_LT(
        rawIndices_[i],
        dictionaryValues_->size(),
        "Dictionary index must be less than base vector's size. Index: {}.",
        i);
```
rawIndices_[0]                       ← from outputRowMapping_, written by batch 2
dictionaryValues_->size()    ← from peeledResult, created by batch 1
The filterResult_[0] is essentially currputed.

**Why it's not a prod issue**
1. The corrupted dictionary from the previous batch only survives if nothing overwrites it. Any batch with at least one selected row goes through evalEncodings → moveOrCopyResult → replaces it.
2. For FilterInputRows_ has zero selections. the only place to read the the currupted dict is filterPassed(i), and filterPassed(i) never reads the dictionary as  filterInputRows_.isValid(i)  = false;

The Crash CallStack

```

I0320 11:08:08.671550 493014 JoinFuzzer.cpp:363] Executing query plan with UNGROUPED strategy[0 groups]:
-- HashJoin[4][ANTI t0=u0 AND t1=u1, filter: eq(ROW["t1"],true)] -> t1:BOOLEAN, tp2:ARRAY<BOOLEAN>
  -- Project[1][expressions: (t0:BOOLEAN, ROW["t0"]), (t1:BOOLEAN, ROW["t1"]), (tp2:ARRAY<BOOLEAN>, ROW["tp2"])] -> t0:BOOLEAN, t1:BOOLEAN, tp2:ARRAY<BOOLEAN>
    -- Values[0][200 rows in 20 vectors] -> t0:BOOLEAN, t1:BOOLEAN, tp2:ARRAY<BOOLEAN>
  -- Project[3][expressions: (u0:BOOLEAN, ROW["u0"]), (u1:BOOLEAN, ROW["u1"]), (bp2:DATE, ROW["bp2"])] -> u0:BOOLEAN, u1:BOOLEAN, bp2:DATE
    -- Values[2][40 rows in 20 vectors] -> u0:BOOLEAN, u1:BOOLEAN, bp2:DATE
E0320 11:08:08.688031 493307 Exceptions.h:87] Line: buck-out/v2/art/fbcode/velox/vector/__velox_vector__/19e83d3ce9051793/buck-headers/velox/vector/DictionaryVector-inl.h:214, Function:validate, Expression: rawIndices_[i] < dictionaryValues_->size() (8 vs. 8) Dictionary index must be less than base vector's size. Index: 7., Source: RUNTIME, ErrorCode: INVALID_STATE
V0320 11:08:08.689075 493307 Task.cpp:2478] Terminating task test_cursor_1 with state Failed after running for 16ms
V0320 11:08:08.690125 493307 Task.cpp:1449] All drivers (2) finished for task test_cursor_1 after running for 17ms
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: (8 vs. 8) Dictionary index must be less than base vector's size. Index: 7.
Retriable: False
Expression: rawIndices_[i] < dictionaryValues_->size()
Context: Top-level Expression: eq(t1, true:BOOLEAN)
Additional Context: Operator: HashProbe[4] 2
Function: validate
File: buck-out/v2/art/fbcode/velox/vector/__velox_vector__/19e83d3ce9051793/buck-headers/velox/vector/DictionaryVector-inl.h
Line: 214
Stack trace:
# 0  std::shared_ptr<facebook::velox::VeloxException::State const> facebook::velox::VeloxException::State::make<facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::CompileTimeStringLiteral, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::$_0>(facebook::velox::VeloxException::Type, facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::CompileTimeStringLiteral, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::$_0)
# 1  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::CompileTimeStringLiteral, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)
# 2  facebook::velox::VeloxRuntimeError::VeloxRuntimeError(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::CompileTimeStringLiteral, std::basic_string_view<char, std::char_traits<char> >)
# 3  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, facebook::velox::CompileTimeStringLiteral)
# 4  facebook::velox::DictionaryVector<bool>::validate(facebook::velox::VectorValidateOptions const&) const
# 5  facebook::velox::exec::(anonymous namespace)::checkResultInternalState(std::shared_ptr<facebook::velox::BaseVector>&)
# 6  facebook::velox::exec::Expr::eval(facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::shared_ptr<facebook::velox::BaseVector>&, facebook::velox::exec::ExprSet const*)
# 7  facebook::velox::exec::ExprSet::eval(int, int, bool, facebook::velox::SelectivityVector const&, facebook::velox::exec::EvalCtx&, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&)
# 8  facebook::velox::exec::HashProbe::evalFilter(int)
# 9  facebook::velox::exec::HashProbe::getOutputInternal(bool)
# 10 facebook::velox::exec::HashProbe::getOutput()
# 11 facebook::velox::exec::(anonymous namespace)::getOutput(facebook::velox::exec::Operator*, std::shared_ptr<facebook::velox::RowVector>&)
# 12 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_5::operator()() const
# 13 void facebook::velox::exec::Driver::withDeltaCpuWallTimer<facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_5>(facebook::velox::exec::Operator*, facebook::velox::CpuWallTiming facebook::velox::exec::OperatorStats::*, facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)::$_5&&)
# 14 facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 15 facebook::velox::exec::Driver::run(std::shared_ptr<facebook::velox::exec::Driver>)
# 16 facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0::operator()() const
# 17 void folly::detail::function::call_<facebook::velox::exec::Driver::enqueue(std::shared_ptr<facebook::velox::exec::Driver>)::$_0, true, false, void>(, folly::detail::function::Data&)
# 18 folly::detail::function::FunctionTraits<void ()>::operator()()
# 19 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
# 20 folly::CPUThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
# 21 void std::__invoke_impl<void, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(std::__invoke_memfun_deref, void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 22 std::__invoke_result<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>::type std::__invoke<void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&>(void (folly::ThreadPoolExecutor::*&)(std::shared_ptr<folly::ThreadPoolExecutor::Thread>), folly::ThreadPoolExecutor*&, std::shared_ptr<folly::ThreadPoolExecutor::Thread>&)
# 23 void std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::__call<void, , 0ul, 1ul>(std::tuple<>&&, std::_Index_tuple<0ul, 1ul>)
# 24 void std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>::operator()<, void>()
# 25 void folly::detail::function::call_<std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)>, true, false, void>(, folly::detail::function::Data&)
# 26 folly::detail::function::FunctionTraits<void ()>::operator()()
# 27 folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}::operator()()
# 28 void std::__invoke_impl<void, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}>(std::__invoke_other, folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}&&)
# 29 std::__invoke_result<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}>::type std::__invoke<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}>(folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}&&)
# 30 void std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}> >::_M_invoke<0ul>(std::_Index_tuple<0ul>)
# 31 std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}> >::operator()()
# 32 std::thread::_State_impl<std::thread::_Invoker<std::tuple<folly::NamedThreadFactory::newThread(folly::Function<void ()>&&)::{lambda()#1}> > >::_M_run()
# 33 execute_native_thread_routine
# 34 asan_thread_start(void*)
# 35 start_thread
# 36 __clone3

 *** Aborted at 1774030088 (Unix time, try 'date -d 1774030088') ***
 *** Signal 6 (SIGABRT) (0x5888000785d6) received by PID 493014 (pthread TID 0x7fe1d236f100) (linux TID 493014) (maybe from PID 493014, UID 22664) (code: sent by tkill or tgkill), stack trace: ***
==493014==WARNING: ASan doesn't fully support makecontext/swapcontext functions and may produce false positives in some cases!
    @ 0000000000040bd3 folly::symbolizer::(anonymous namespace)::innerSignalHandler(int, siginfo_t*, void*)
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:551
    @ 000000000003f5db folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*)
                       ./fbcode/folly/debugging/symbolizer/SignalHandler.cpp:572
    @ 000000000004455f (unknown)
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/libc_sigaction.c:8
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/unix/sysv/linux/x86_64/libc_sigaction.c
    @ 000000000009c993 pthread_kill
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/nptl/pthread_kill.c:46
    @ 00000000000444ac raise
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/signal/../sysdeps/posix/raise.c:26
    @ 000000000002c432 abort
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/stdlib/abort.c:79
    @ 00000000000a3fc4 __gnu_cxx::__verbose_terminate_handler()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/vterminate.cc:95
    @ 00000000000a1b29 __cxxabiv1::__terminate(void (*)())
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:48
    @ 00000000000a1b94 std::terminate()
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_terminate.cc:58
    @ 00000000000a1e5f __cxa_throw
                       /home/engshare/third-party2/libgcc/11.x/src/gcc-11.x/x86_64-facebook-linux/libstdc++-v3/libsupc++/../../.././libstdc++-v3/libsupc++/eh_throw.cc:95
    @ 000000000036a5af facebook::velox::exec::(anonymous namespace)::JoinFuzzer::execute(facebook::velox::exec::JoinMaker::PlanWithSplits const&, bool)
                       ./fbcode/velox/exec/fuzzer/JoinFuzzer.cpp:425
    @ 000000000035912d facebook::velox::exec::(anonymous namespace)::JoinFuzzer::verify(facebook::velox::core::JoinType)
                       ./fbcode/velox/exec/fuzzer/JoinFuzzer.cpp:731
    @ 00000000003456a2 facebook::velox::exec::(anonymous namespace)::JoinFuzzer::go()
                       ./fbcode/velox/exec/fuzzer/JoinFuzzer.cpp:868
    @ 0000000000343fba facebook::velox::exec::joinFuzzer(unsigned long, std::unique_ptr<facebook::velox::exec::test::ReferenceQueryRunner, std::default_delete<facebook::velox::exec::test::ReferenceQueryRunner> >)
                       ./fbcode/velox/exec/fuzzer/JoinFuzzer.cpp:884
    @ 00000000003d7de4 main
                       ./fbcode/velox/exec/fuzzer/JoinFuzzerRunner.cpp:116
    @ 000000000002c656 __libc_start_call_main
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/nptl/libc_start_call_main.h:58
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86/libc-start.c
    @ 000000000002c717 __libc_start_main
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../csu/libc-start.c:409
                       -> /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86/libc-start.c
    @ 00000000003405c0 _start
                       /home/engshare/third-party2/glibc/2.34/src/glibc-2.34/csu/../sysdeps/x86_64/start.S:116

```

Reviewed By: tanjialiang

Differential Revision: D97574083
