### PR TITLE
[draft] Fix missing parquet writer link in iceberg splitreader CMake

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -43,6 +43,13 @@ velox_link_libraries(
   Folly::folly
 )
 
+if(VELOX_ENABLE_PARQUET)
+  velox_link_libraries(
+    velox_hive_iceberg_splitreader
+    velox_dwio_parquet_writer
+  )
+endif()
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Summary:
The `velox_hive_iceberg_splitreader` library conditionally compiles
`IcebergParquetStatsCollector.cpp` when `VELOX_ENABLE_PARQUET` is ON,
and `IcebergDataSink.cpp` uses `parquet::WriterOptions`. However, the
CMakeLists.txt only linked `velox_dwio_parquet_field_id` (a header-only
interface library), not the actual `velox_dwio_parquet_writer` that
provides the parquet writer and arrow metadata symbols.

This caused undefined reference linker errors when building
`presto_to_velox_connector_test` (and other targets linking
`velox_hive_iceberg_splitreader`) in presto-native-execution:
- `typeinfo for facebook::velox::parquet::WriterOptions`
- `facebook::velox::parquet::arrow::FileMetaData::numRows()`
- `facebook::velox::parquet::arrow::RowGroupMetaData::numColumns()`
- and several other parquet arrow metadata symbols

Fix: conditionally link `velox_dwio_parquet_writer` when
`VELOX_ENABLE_PARQUET` is enabled, following the same pattern used in
`velox/connectors/hive/tests/CMakeLists.txt`.

Differential Revision: D97626196


