### PR TITLE
TorchWave fused PyTorch nativert executor (#16878)

### DIFF
--- a/velox/experimental/torchwave/Builtins.cpp
+++ b/velox/experimental/torchwave/Builtins.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/Registry.h"
+
+namespace torch::wave {
+
+void registerBuiltins() {
+  // Binary arithmetic.
+  Registry::registerElementwise("torch.ops.aten.add.Tensor", {"alpha"});
+  Registry::registerElementwise("torch.ops.aten.sub.Tensor", {"alpha"});
+  Registry::registerElementwise("torch.ops.aten.mul.Tensor");
+  Registry::registerElementwise("torch.ops.aten.div.Tensor");
+  Registry::registerElementwise("torch.ops.aten.remainder.Tensor");
+  Registry::registerElementwise("torch.ops.aten.fmod.Tensor");
+  Registry::registerElementwise("torch.ops.aten.pow.Tensor_Tensor");
+
+  // Comparison.
+  Registry::registerElementwise("torch.ops.aten.eq.Tensor");
+  Registry::registerElementwise("torch.ops.aten.ne.Tensor");
+  Registry::registerElementwise("torch.ops.aten.lt.Tensor");
+  Registry::registerElementwise("torch.ops.aten.le.Tensor");
+  Registry::registerElementwise("torch.ops.aten.gt.Tensor");
+  Registry::registerElementwise("torch.ops.aten.ge.Tensor");
+
+  // Bitwise.
+  Registry::registerElementwise("torch.ops.aten.bitwise_and.Tensor");
+  Registry::registerElementwise("torch.ops.aten.bitwise_or.Tensor");
+  Registry::registerElementwise("torch.ops.aten.bitwise_xor.Tensor");
+  Registry::registerElementwise("torch.ops.aten.bitwise_not.default");
+
+  // Logical.
+  Registry::registerElementwise("torch.ops.aten.logical_and.default");
+  Registry::registerElementwise("torch.ops.aten.logical_or.default");
+  Registry::registerElementwise("torch.ops.aten.logical_xor.default");
+  Registry::registerElementwise("torch.ops.aten.logical_not.default");
+
+  // Unary math.
+  Registry::registerElementwise("torch.ops.aten.abs.default");
+  Registry::registerElementwise("torch.ops.aten.neg.default");
+  Registry::registerElementwise("torch.ops.aten.ceil.default");
+  Registry::registerElementwise("torch.ops.aten.floor.default");
+  Registry::registerElementwise("torch.ops.aten.round.default");
+  Registry::registerElementwise("torch.ops.aten.trunc.default");
+  Registry::registerElementwise("torch.ops.aten.sign.default");
+  Registry::registerElementwise("torch.ops.aten.sqrt.default");
+  Registry::registerElementwise("torch.ops.aten.rsqrt.default");
+  Registry::registerElementwise("torch.ops.aten.reciprocal.default");
+  Registry::registerElementwise("torch.ops.aten.exp.default");
+  Registry::registerElementwise("torch.ops.aten.log.default");
+  Registry::registerElementwise("torch.ops.aten.log2.default");
+  Registry::registerElementwise("torch.ops.aten.log10.default");
+  Registry::registerElementwise("torch.ops.aten.log1p.default");
+
+  // Trigonometric.
+  Registry::registerElementwise("torch.ops.aten.sin.default");
+  Registry::registerElementwise("torch.ops.aten.cos.default");
+  Registry::registerElementwise("torch.ops.aten.tan.default");
+  Registry::registerElementwise("torch.ops.aten.asin.default");
+  Registry::registerElementwise("torch.ops.aten.acos.default");
+  Registry::registerElementwise("torch.ops.aten.atan.default");
+  Registry::registerElementwise("torch.ops.aten.atan2.default");
+  Registry::registerElementwise("torch.ops.aten.sinh.default");
+  Registry::registerElementwise("torch.ops.aten.cosh.default");
+  Registry::registerElementwise("torch.ops.aten.tanh.default");
+
+  // Activation functions.
+  Registry::registerElementwise("torch.ops.aten.relu.default");
+  Registry::registerElementwise("torch.ops.aten.sigmoid.default");
+  Registry::registerElementwise("torch.ops.aten.clamp.default", {"min", "max"});
+
+  // Min/max.
+  Registry::registerElementwise("torch.ops.aten.minimum.default");
+  Registry::registerElementwise("torch.ops.aten.maximum.default");
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/CMakeLists.txt
+++ b/velox/experimental/torchwave/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(
+  torch_wave
+  Builtins.cpp
+  Compile.cpp
+  Execute.cpp
+  Executor.cpp
+  NativertSerialization.cpp
+  ParallelExpr.cpp
+  Project.cpp
+  Pt2Load.cpp
+  Registry.cpp
+  Utils.cpp
+)
+
+target_link_libraries(
+  torch_wave
+  velox_wave_common
+  torch
+  torch_cpu
+  c10
+  fmt::fmt
+  nlohmann_json::nlohmann_json
+  Folly::folly
+  CUDA::cudart
+)
+
+add_library(
+  torch_wave_graph_view
+  GraphView.cpp
+)
+
+target_link_libraries(
+  torch_wave_graph_view
+  torch_wave
+)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/experimental/torchwave/Compile.cpp
+++ b/velox/experimental/torchwave/Compile.cpp
@@ -1,0 +1,1448 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/Compile.h"
+#include "velox/experimental/torchwave/Executor.h"
+
+#include <ATen/ATen.h>
+#include <algorithm>
+#include <deque>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+namespace torch::wave {
+
+std::atomic<int32_t> CompileCtx::kernelCounter_{0};
+
+int32_t CompileCtx::nextKernelId() {
+  return kernelCounter_++;
+}
+
+CompositeKernel::CompositeKernel(
+    std::vector<std::unique_ptr<KernelOperation>>&& ops)
+    : ops_(std::move(ops)) {
+  auto kernelId = CompileCtx::nextKernelId();
+  auto entryPoint = "torchwave" + std::to_string(kernelId);
+
+  std::stringstream ss;
+  ss << "#include \"velox/experimental/torchwave/Core.cuh\"\n\n"
+     << "namespace torch::wave {\n\n"
+     << "__global__ void " << entryPoint << "(TorchWaveParams params) {\n"
+     << "  ENTRY;\n"
+     << "  switch (blockInfo.op) {\n";
+  for (const auto& op : ops_) {
+    for (auto opCode : op->opCodes()) {
+      ss << "    case " << opCode << ": {\n"
+         << op->code() << "      break;\n"
+         << "    }\n";
+    }
+  }
+  ss << "  }\n"
+     << "  __syncthreads();\n"
+     << "}\n\n"
+     << "} // namespace torch::wave\n";
+
+  auto code = ss.str();
+
+  // Save to /tmp for debugging.
+  auto filePath = "/tmp/kernel" + std::to_string(kernelId) + ".cu";
+  {
+    std::ofstream out(filePath);
+    out << code;
+  }
+
+  // Only compile the kernel if a GPU is available.
+  if (facebook::velox::wave::currentDevice()) {
+    kernel_ = facebook::velox::wave::CompiledKernel::getKernel(
+        entryPoint,
+        [code = std::move(code),
+         entryPoint,
+         filePath]() -> facebook::velox::wave::KernelSpec {
+          facebook::velox::wave::KernelSpec spec;
+          spec.code = code;
+          spec.entryPoints = {entryPoint};
+          spec.filePath = filePath;
+          spec.numHeaders = 0;
+          spec.headers = nullptr;
+          return spec;
+        });
+  }
+}
+
+template <typename Func>
+bool CompileCtx::allReachable(
+    const nativert::Node& node,
+    const NodeSet& placed,
+    Func&& predicate,
+    NodeSet& visited) const {
+  if (!visited.insert(&node).second) {
+    return true;
+  }
+  auto* meta = Registry::metadata(node.target());
+  if (!meta || !predicate(*meta)) {
+    return false;
+  }
+  for (auto& input : node.inputs()) {
+    auto* producer = input.value->producer();
+    if (!producer || (inputs_ && inputs_->count(producer)) ||
+        placed.count(producer)) {
+      continue;
+    }
+    if (!allReachable(*producer, placed, predicate, visited)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename Func>
+bool CompileCtx::anyReachable(
+    const nativert::Node& node,
+    const NodeSet& placed,
+    Func&& predicate,
+    NodeSet& visited) const {
+  if (!visited.insert(&node).second) {
+    return false;
+  }
+  auto* meta = Registry::metadata(node.target());
+  if (meta && predicate(*meta)) {
+    return true;
+  }
+  for (auto& input : node.inputs()) {
+    auto* producer = input.value->producer();
+    if (!producer || (inputs_ && inputs_->count(producer)) ||
+        placed.count(producer)) {
+      continue;
+    }
+    if (anyReachable(*producer, placed, predicate, visited)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+namespace {
+
+void extractSubgraphInputs(
+    const nativert::Node* node,
+    const CompileCtx::NodeSet& inputs,
+    const CompileCtx::NodeSet& placed,
+    std::unordered_set<const nativert::Value*>& seen,
+    std::vector<const nativert::Value*>& result) {
+  for (auto& input : node->inputs()) {
+    auto* value = input.value;
+    auto* producer = value->producer();
+    if (!producer || inputs.count(producer) || placed.count(producer)) {
+      if (seen.insert(value).second) {
+        result.push_back(value);
+      }
+    } else {
+      extractSubgraphInputs(producer, inputs, placed, seen, result);
+    }
+  }
+}
+
+void listConstantsImpl(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& inputs,
+    std::unordered_set<const nativert::Node*>& visited,
+    std::deque<c10::IValue>& storage) {
+  if (!visited.insert(node).second) {
+    return;
+  }
+  for (const auto& input : node->inputs()) {
+    if (inputs.count(input.value)) {
+      continue;
+    }
+    auto* producer = input.value->producer();
+    if (producer) {
+      listConstantsImpl(producer, inputs, visited, storage);
+    }
+  }
+  const auto& attrs = node->attributes();
+  if (attrs.empty()) {
+    return;
+  }
+  std::vector<const nativert::Attribute*> sorted;
+  sorted.reserve(attrs.size());
+  for (const auto& attr : attrs) {
+    sorted.push_back(&attr);
+  }
+  std::sort(sorted.begin(), sorted.end(), [](const auto* a, const auto* b) {
+    return a->name < b->name;
+  });
+  for (const auto* attr : sorted) {
+    storage.push_back(nativert::constantToIValue(attr->value));
+  }
+}
+
+void collectAttrOffsets(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& inputs,
+    std::unordered_set<const nativert::Node*>& visited,
+    int32_t& offset,
+    std::unordered_map<
+        std::pair<const nativert::Node*, std::string>,
+        int32_t,
+        KernelOperation::NodeAttrHash>& attrOffsets) {
+  if (!visited.insert(node).second) {
+    return;
+  }
+  for (const auto& input : node->inputs()) {
+    if (inputs.count(input.value)) {
+      continue;
+    }
+    auto* producer = input.value->producer();
+    if (producer) {
+      collectAttrOffsets(producer, inputs, visited, offset, attrOffsets);
+    }
+  }
+  const auto& attrs = node->attributes();
+  if (attrs.empty()) {
+    return;
+  }
+  std::vector<const nativert::Attribute*> sorted;
+  sorted.reserve(attrs.size());
+  for (const auto& attr : attrs) {
+    sorted.push_back(&attr);
+  }
+  std::sort(sorted.begin(), sorted.end(), [](const auto* a, const auto* b) {
+    return a->name < b->name;
+  });
+  for (const auto* attr : sorted) {
+    attrOffsets[{node, attr->name}] = offset;
+    offset += 8;
+  }
+}
+
+std::vector<const c10::IValue*> listConstants(
+    const Subgraph& sg,
+    std::deque<c10::IValue>& storage) {
+  std::unordered_set<const nativert::Value*> inputSet(
+      sg.inputs.begin(), sg.inputs.end());
+  std::unordered_set<const nativert::Node*> visited;
+  auto startSize = storage.size();
+  listConstantsImpl(sg.root, inputSet, visited, storage);
+  std::vector<const c10::IValue*> result;
+  for (auto it = storage.begin() + startSize; it != storage.end(); ++it) {
+    result.push_back(&*it);
+  }
+  return result;
+}
+
+bool subgraphNodesMatch(
+    const nativert::Node* left,
+    const nativert::Node* right,
+    const std::unordered_set<const nativert::Value*>& leftInputs,
+    const std::unordered_set<const nativert::Value*>& rightInputs,
+    const Subgraph& leftSg,
+    const Subgraph& rightSg) {
+  if (left->target() != right->target()) {
+    return false;
+  }
+  auto& li = left->inputs();
+  auto& ri = right->inputs();
+  if (li.size() != ri.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < li.size(); ++i) {
+    bool leftIsInput = leftInputs.count(li[i].value);
+    bool rightIsInput = rightInputs.count(ri[i].value);
+    if (leftIsInput != rightIsInput) {
+      return false;
+    }
+    if (leftIsInput) {
+      // Both are subgraph inputs. Must be at the same position and same type.
+      auto leftIt =
+          std::find(leftSg.inputs.begin(), leftSg.inputs.end(), li[i].value);
+      auto rightIt =
+          std::find(rightSg.inputs.begin(), rightSg.inputs.end(), ri[i].value);
+      auto leftPos = leftIt - leftSg.inputs.begin();
+      auto rightPos = rightIt - rightSg.inputs.begin();
+      if (leftPos != rightPos) {
+        return false;
+      }
+      if (leftSg.inputTypes[leftPos] != rightSg.inputTypes[rightPos]) {
+        return false;
+      }
+    } else {
+      auto* lp = li[i].value->producer();
+      auto* rp = ri[i].value->producer();
+      if (!lp || !rp) {
+        if (lp != rp) {
+          return false;
+        }
+        continue;
+      }
+      if (!subgraphNodesMatch(
+              lp, rp, leftInputs, rightInputs, leftSg, rightSg)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+void hashSubgraphNode(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& inputs,
+    size_t& hash) {
+  auto h = std::hash<std::string_view>{}(node->target());
+  hash ^= h + 0x9e3779b9 + (hash << 6) + (hash >> 2);
+  for (auto& input : node->inputs()) {
+    if (inputs.count(input.value)) {
+      continue;
+    }
+    auto* producer = input.value->producer();
+    if (producer) {
+      hashSubgraphNode(producer, inputs, hash);
+    }
+  }
+}
+
+int32_t fillParamOffsets(
+    const std::vector<const nativert::Value*>& values,
+    const std::vector<const c10::IValue*>& constants,
+    int32_t startOffset,
+    std::vector<int32_t>& offsets) {
+  offsets.reserve(values.size() + constants.size());
+  int32_t offset = startOffset;
+  for (const auto* value : values) {
+    offsets.push_back(offset);
+    if (value->type().kind() == nativert::Type::Kind::Tensor) {
+      offset += sizeof(Tensor);
+    } else {
+      offset += 8;
+    }
+  }
+  for (size_t i = 0; i < constants.size(); ++i) {
+    offsets.push_back(offset);
+    offset += 8;
+  }
+  return offset - startOffset;
+}
+
+} // namespace
+
+int32_t KernelOperation::paramOffset(const nativert::Value* value) const {
+  auto it = paramOffsets_.find(value);
+  TORCH_CHECK(it != paramOffsets_.end(), "Value not found in paramOffsets");
+  return it->second;
+}
+
+int32_t KernelOperation::attrOffset(
+    const nativert::Node* node,
+    std::string_view attr) const {
+  auto it = attrOffsets_.find({node, std::string(attr)});
+  TORCH_CHECK(
+      it != attrOffsets_.end(),
+      "Attribute '",
+      attr,
+      "' not found for node ",
+      node->target());
+  return it->second;
+}
+
+int64_t KernelOperation::numElements(
+    nativert::ExecutionFrame& frame,
+    const FormalToActual& map) const {
+  TORCH_CHECK(
+      numElements_ != nullptr, "numElements_ not set for KernelOperation");
+  return numElements_(frame, map);
+}
+
+void KernelOperation::addSharedDeclaration(const std::string& decl) {
+  if (std::find(sharedDeclarations_.begin(), sharedDeclarations_.end(), decl) ==
+      sharedDeclarations_.end()) {
+    sharedDeclarations_.push_back(decl);
+  }
+}
+
+void KernelOperation::setCode(std::stringstream& code) {
+  text_ = code.str();
+  code.str("");
+  code.clear();
+}
+
+namespace {
+
+bool isAllElementwise(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& subgraphInputs,
+    std::unordered_set<const nativert::Node*>& visited) {
+  if (!visited.insert(node).second) {
+    return true;
+  }
+  auto* meta = Registry::metadata(node->target());
+  if (!meta || !meta->elementWise) {
+    return false;
+  }
+  for (auto& input : node->inputs()) {
+    auto* value = input.value;
+    if (subgraphInputs.count(value)) {
+      continue;
+    }
+    auto* producer = value->producer();
+    if (!producer) {
+      continue;
+    }
+    if (!isAllElementwise(producer, subgraphInputs, visited)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void collectDeduppedInputs(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& subgraphInputs,
+    std::unordered_set<const nativert::Value*>& seen,
+    std::vector<const nativert::Value*>& result) {
+  for (auto& input : node->inputs()) {
+    auto* value = input.value;
+    if (subgraphInputs.count(value) || !value->producer()) {
+      if (seen.insert(value).second) {
+        result.push_back(value);
+      }
+    } else {
+      collectDeduppedInputs(value->producer(), subgraphInputs, seen, result);
+    }
+  }
+}
+
+} // namespace
+
+void KernelOperation::setOutputs(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& subgraphInputs,
+    std::vector<const nativert::Value*>& outputValues,
+    std::vector<OutputReserveFunc>& outputReserves) {
+  std::unordered_set<const nativert::Node*> visited;
+  if (isAllElementwise(node, subgraphInputs, visited)) {
+    outputValues.push_back(node->outputs()[0]);
+    std::unordered_set<const nativert::Value*> seen;
+    std::vector<const nativert::Value*> deduppedInputs;
+    collectDeduppedInputs(node, subgraphInputs, seen, deduppedInputs);
+    outputReserves.push_back([deduppedInputs = std::move(deduppedInputs)](
+                                 const nativert::Node* n,
+                                 nativert::ExecutionFrame& frame,
+                                 FormalToActual map) {
+      return elementwiseOutputShape(deduppedInputs, n, frame, map);
+    });
+    return;
+  }
+
+  for (auto& input : node->inputs()) {
+    auto* value = input.value;
+    if (subgraphInputs.count(value)) {
+      continue;
+    }
+    auto* producer = value->producer();
+    if (producer) {
+      setOutputs(producer, subgraphInputs, outputValues, outputReserves);
+    }
+  }
+
+  auto* meta = Registry::metadata(node->target());
+  if (!meta) {
+    return;
+  }
+  const auto& outputs = node->outputs();
+  for (size_t i = 0; i < meta->returnMeta.size() && i < outputs.size(); ++i) {
+    if (!meta->returnMeta[i].isRegister) {
+      outputValues.push_back(outputs[i]);
+      auto reserveShape = meta->returnMeta[i].reserveShape;
+      outputReserves.push_back(
+          [node, reserveShape](
+              const nativert::Node* /*unused*/,
+              nativert::ExecutionFrame& frame,
+              FormalToActual map) { return reserveShape(node, frame, map); });
+    }
+  }
+}
+
+namespace {
+
+/// Prints the expression rooted at 'node'. Inputs in 'inputSet' and values
+/// without a producer print as %v<id>. Nodes with outputs in 'outputSet' also
+/// print as %v<id> (they get their own assignment line).
+void kernelExprImpl(
+    std::stringstream& ss,
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& inputSet,
+    const std::unordered_set<const nativert::Value*>& outputSet) {
+  if (node->inputs().empty() && node->attributes().empty()) {
+    ss << node->target();
+    return;
+  }
+  ss << node->target() << "(";
+  bool first = true;
+  for (const auto& input : node->inputs()) {
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+    auto* value = input.value;
+    auto* producer = value->producer();
+    if (producer == nullptr || inputSet.count(value) ||
+        outputSet.count(value)) {
+      ss << "%v" << value->id();
+    } else {
+      kernelExprImpl(ss, producer, inputSet, outputSet);
+    }
+  }
+  for (const auto& attr : node->attributes()) {
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+    ss << attr.name << "=" << constantToString(attr.value);
+  }
+  ss << ")";
+}
+
+} // namespace
+
+std::string KernelOperation::toString() const {
+  std::stringstream ss;
+  std::unordered_set<const nativert::Value*> inputSet(
+      orderedInputs_.begin(), orderedInputs_.begin() + numInputs_);
+  std::unordered_set<const nativert::Value*> outputSet(
+      orderedInputs_.begin() + numInputs_, orderedInputs_.end());
+
+  // Print output-producing nodes as separate assignment lines, dependencies
+  // first.
+  std::unordered_set<const nativert::Node*> printed;
+  std::function<void(const nativert::Node*)> printNode =
+      [&](const nativert::Node* node) {
+        if (!printed.insert(node).second) {
+          return;
+        }
+        // Recurse into producers that themselves have outputs in outputSet.
+        for (const auto& input : node->inputs()) {
+          auto* producer = input.value->producer();
+          if (producer && !inputSet.count(input.value) &&
+              outputSet.count(input.value)) {
+            printNode(producer);
+          }
+        }
+
+        // Collect this node's outputs that are in the output set.
+        std::vector<const nativert::Value*> nodeOutputs;
+        for (const auto* v : node->outputs()) {
+          if (outputSet.count(v)) {
+            nodeOutputs.push_back(v);
+          }
+        }
+        if (!nodeOutputs.empty()) {
+          ss << "(";
+          for (size_t i = 0; i < nodeOutputs.size(); ++i) {
+            if (i > 0) {
+              ss << ", ";
+            }
+            ss << "%v" << nodeOutputs[i]->id();
+          }
+          ss << ") = ";
+        }
+        kernelExprImpl(ss, node, inputSet, outputSet);
+        ss << "\n";
+      };
+
+  printNode(expr_);
+
+  for (auto code : opCode_) {
+    ss << "opCode = " << code << ":\n";
+  }
+  ss << text_ << "\n";
+
+  return ss.str();
+}
+
+namespace {
+
+std::string ivalueToString(const c10::IValue& value) {
+  if (value.isInt()) {
+    return std::to_string(value.toInt());
+  }
+  if (value.isDouble()) {
+    return std::to_string(value.toDouble());
+  }
+  if (value.isBool()) {
+    return value.toBool() ? "true" : "false";
+  }
+  if (value.isString()) {
+    return "\"" + value.toStringRef() + "\"";
+  }
+  if (value.isNone()) {
+    return "None";
+  }
+  return "<IValue>";
+}
+
+} // namespace
+
+std::string OpInvocation::toString() const {
+  std::stringstream ss;
+  for (auto code : op_->opCodes()) {
+    ss << "opCode=" << code;
+  }
+  ss << " inputs=(";
+  for (size_t i = 0; i < values_.size(); ++i) {
+    if (i > 0) {
+      ss << ", ";
+    }
+    ss << "%v" << values_[i]->id();
+  }
+  ss << ")";
+  // Print outputs from bindings.
+  const auto& orderedInputs = op_->orderedInputs();
+  auto numInputs = op_->numInputs();
+  if (static_cast<size_t>(numInputs) < orderedInputs.size()) {
+    ss << " outputs=(";
+    bool first = true;
+    for (size_t i = numInputs; i < orderedInputs.size(); ++i) {
+      if (!first) {
+        ss << ", ";
+      }
+      first = false;
+      auto it = bindings_.find(orderedInputs[i]->id());
+      if (it != bindings_.end()) {
+        ss << "%v" << it->second;
+      } else {
+        ss << "%v" << orderedInputs[i]->id();
+      }
+    }
+    ss << ")";
+  }
+  if (!constants_.empty()) {
+    ss << " constants=(";
+    for (size_t i = 0; i < constants_.size(); ++i) {
+      if (i > 0) {
+        ss << ", ";
+      }
+      ss << ivalueToString(*constants_[i]);
+    }
+    ss << ")";
+  }
+  ss << "\n";
+  return ss.str();
+}
+
+int64_t OpInvocation::allocateOutput(
+    nativert::ExecutionFrame& frame,
+    const ValueTypes& types) {
+  const auto& reserves = op_->outputReserves();
+  const auto& orderedInputs = op_->orderedInputs();
+  auto numInputs = op_->numInputs();
+  for (size_t i = 0; i < reserves.size(); ++i) {
+    auto* formalValue = orderedInputs[numInputs + i];
+    auto shapes = reserves[i](nullptr, frame, bindings_);
+    TORCH_CHECK(
+        !shapes.empty(),
+        "OutputReserveFunc returned empty shapes for output ",
+        i);
+    auto* meta = types.types[formalValue->id()];
+    TORCH_CHECK(
+        meta != nullptr,
+        "No TensorMeta for output value %v",
+        formalValue->id());
+    auto dtype = meta->dtype();
+    auto it = bindings_.find(formalValue->id());
+    TORCH_CHECK(
+        it != bindings_.end(),
+        "Output value %v",
+        formalValue->id(),
+        " not found in bindings");
+    auto actualId = it->second;
+    std::vector<int64_t> dims(shapes[0].begin(), shapes[0].end());
+    auto tensor =
+        at::empty(dims, at::TensorOptions().dtype(dtype).device(at::kCUDA));
+    frame.setIValue(actualId, std::move(tensor));
+  }
+  return op_->numElements(frame, bindings_);
+}
+
+std::string CompositeKernel::toString() const {
+  std::stringstream ss;
+  for (const auto& op : ops_) {
+    ss << op->toString();
+  }
+  return ss.str();
+}
+
+void CompositeKernel::launch(
+    int32_t numBlocks,
+    int32_t numThreads,
+    int32_t sharedMemory,
+    facebook::velox::wave::Stream* stream,
+    void** args) {
+  kernel_->launch(0, numBlocks, numThreads, sharedMemory, stream, args);
+}
+
+std::string CompositeInvocation::toString() const {
+  std::stringstream ss;
+  ss << "CompositeKernel:\n" << kernel->toString();
+  ss << "Invocations:\n";
+  for (const auto& op : ops) {
+    ss << "  " << op.toString();
+  }
+  return ss.str();
+}
+
+namespace {
+
+float sumNodeCosts(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& inputs,
+    std::unordered_set<const nativert::Node*>& visited) {
+  if (!visited.insert(node).second) {
+    return 0;
+  }
+  float cost = 0;
+  auto* meta = Registry::metadata(node->target());
+  if (meta) {
+    cost += meta->cost;
+  }
+  for (const auto& input : node->inputs()) {
+    if (inputs.count(input.value)) {
+      continue;
+    }
+    auto* producer = input.value->producer();
+    if (producer) {
+      cost += sumNodeCosts(producer, inputs, visited);
+    }
+  }
+  return cost;
+}
+
+} // namespace
+
+KernelOperation::KernelOperation(
+    const Subgraph& sg,
+    int32_t opCode,
+    bool useSingleBlock)
+    : opCode_{opCode},
+      expr_{sg.root},
+      inputs_{sg.inputs.begin(), sg.inputs.end()},
+      orderedInputs_{sg.inputs},
+      numInputs_(sg.inputs.size()),
+      isSingleBlock_{useSingleBlock} {
+  int32_t offset = 0;
+  for (const auto* value : orderedInputs_) {
+    paramOffsets_[value] = offset;
+    if (value->type().kind() == nativert::Type::Kind::Tensor) {
+      offset += sizeof(Tensor);
+    } else {
+      offset += 8;
+    }
+  }
+  std::unordered_set<const nativert::Node*> visited;
+  collectAttrOffsets(sg.root, inputs_, visited, offset, attrOffsets_);
+
+  std::vector<const nativert::Value*> outputValues;
+  setOutputs(sg.root, inputs_, outputValues, outputReserve_);
+
+  // For all-elementwise kernel ops, set numElements_ to get the numel of the
+  // output tensor.
+  std::unordered_set<const nativert::Node*> ewVisited;
+  if (!outputValues.empty() && isAllElementwise(sg.root, inputs_, ewVisited)) {
+    auto outputId = outputValues[0]->id();
+    numElements_ = [outputId](
+                       nativert::ExecutionFrame& frame,
+                       const FormalToActual& map) -> int64_t {
+      auto it = map.find(outputId);
+      TORCH_CHECK(
+          it != map.end(),
+          "Output value %v",
+          outputId,
+          " not found in FormalToActual map");
+      return frame.getTensor(it->second).numel();
+    };
+  }
+
+  // Compute unit cost before adding outputs to inputs_: 10 per input/output +
+  // sum of node costs from registry.
+  std::unordered_set<const nativert::Node*> costVisited;
+  unitCost_ = 10.0f * (numInputs_ + outputValues.size());
+  unitCost_ += sumNodeCosts(sg.root, inputs_, costVisited);
+
+  for (auto* value : outputValues) {
+    inputs_.insert(value);
+    orderedInputs_.push_back(value);
+    paramOffsets_[value] = offset;
+    if (value->type().kind() == nativert::Type::Kind::Tensor) {
+      offset += sizeof(Tensor);
+    } else {
+      offset += 8;
+    }
+  }
+}
+
+OpInvocation::OpInvocation(
+    KernelOperation* op,
+    const Subgraph& sg,
+    std::vector<const c10::IValue*> constants,
+    int32_t startOffset)
+    : op_{op},
+      values_{sg.inputs},
+      constants_{std::move(constants)},
+      paramOffset_{startOffset} {
+  paramSize_ = fillParamOffsets(values_, constants_, startOffset, offsets_);
+  Subgraph formalSg;
+  formalSg.root = op->expr();
+  formalSg.inputs = op->orderedInputs();
+  formalSg.inputs.resize(op->numInputs());
+  makeBindings(formalSg, sg);
+}
+
+namespace {
+
+void makeBindingsImpl(
+    const nativert::Node* formalNode,
+    const nativert::Node* actualNode,
+    const std::unordered_set<const nativert::Value*>& formalInputs,
+    const std::unordered_set<const nativert::Value*>& outputValues,
+    std::unordered_set<const nativert::Node*>& visited,
+    FormalToActual& bindings) {
+  if (!visited.insert(formalNode).second) {
+    return;
+  }
+  const auto& formalIns = formalNode->inputs();
+  const auto& actualIns = actualNode->inputs();
+  for (size_t i = 0; i < formalIns.size() && i < actualIns.size(); ++i) {
+    auto* formalValue = formalIns[i].value;
+    if (formalInputs.count(formalValue)) {
+      continue;
+    }
+    auto* formalProducer = formalValue->producer();
+    auto* actualProducer = actualIns[i].value->producer();
+    if (formalProducer && actualProducer) {
+      makeBindingsImpl(
+          formalProducer,
+          actualProducer,
+          formalInputs,
+          outputValues,
+          visited,
+          bindings);
+    }
+  }
+  const auto& formalOutputs = formalNode->outputs();
+  const auto& actualOutputs = actualNode->outputs();
+  for (size_t i = 0; i < formalOutputs.size() && i < actualOutputs.size();
+       ++i) {
+    if (outputValues.count(formalOutputs[i])) {
+      bindings[formalOutputs[i]->id()] = actualOutputs[i]->id();
+    }
+  }
+}
+
+} // namespace
+
+void OpInvocation::makeBindings(
+    const Subgraph& formalSg,
+    const Subgraph& actualSg) {
+  const auto& orderedInputs = op_->orderedInputs();
+  auto numInputs = op_->numInputs();
+  std::unordered_set<const nativert::Value*> formalInputs(
+      formalSg.inputs.begin(), formalSg.inputs.end());
+  // Map formal input values to actual input values.
+  for (size_t i = 0; i < formalSg.inputs.size() && i < actualSg.inputs.size();
+       ++i) {
+    bindings_[formalSg.inputs[i]->id()] = actualSg.inputs[i]->id();
+  }
+  std::unordered_set<const nativert::Value*> outputValues(
+      orderedInputs.begin() + numInputs, orderedInputs.end());
+  if (outputValues.empty()) {
+    return;
+  }
+  std::unordered_set<const nativert::Node*> visited;
+  makeBindingsImpl(
+      formalSg.root,
+      actualSg.root,
+      formalInputs,
+      outputValues,
+      visited,
+      bindings_);
+}
+
+Subgraph CompileCtx::extractSubgraph(
+    const nativert::Node* node,
+    const NodeSet& inputs,
+    const NodeSet& placed) {
+  Subgraph sg;
+  sg.root = node;
+  std::unordered_set<const nativert::Value*> seen;
+  extractSubgraphInputs(node, inputs, placed, seen, sg.inputs);
+  sg.inputTypes.reserve(sg.inputs.size());
+  for (auto* value : sg.inputs) {
+    sg.inputTypes.push_back(types_.types[value->id()]);
+  }
+  return sg;
+}
+
+bool subgraphsMatch(const Subgraph& left, const Subgraph& right) {
+  if (left.inputs.size() != right.inputs.size()) {
+    return false;
+  }
+  if (left.root->outputs().size() != right.root->outputs().size()) {
+    return false;
+  }
+  std::unordered_set<const nativert::Value*> leftInputs(
+      left.inputs.begin(), left.inputs.end());
+  std::unordered_set<const nativert::Value*> rightInputs(
+      right.inputs.begin(), right.inputs.end());
+  return subgraphNodesMatch(
+      left.root, right.root, leftInputs, rightInputs, left, right);
+}
+
+size_t SubgraphHash::operator()(const Subgraph& sg) const {
+  std::unordered_set<const nativert::Value*> inputSet(
+      sg.inputs.begin(), sg.inputs.end());
+  size_t hash = 0;
+  hashSubgraphNode(sg.root, inputSet, hash);
+  return hash;
+}
+
+bool CompileCtx::isElementWise(
+    const nativert::Node& node,
+    const NodeSet& placed) const {
+  NodeSet visited;
+  return allReachable(
+      node,
+      placed,
+      [](const Metadata& m) { return m.elementWise != nullptr; },
+      visited);
+}
+
+bool CompileCtx::hasBarrier(const nativert::Node& node, const NodeSet& placed)
+    const {
+  NodeSet visited;
+  return anyReachable(
+      node, placed, [](const Metadata& m) { return m.hasBarrier; }, visited);
+}
+
+bool CompileCtx::isSingleBlock(
+    const nativert::Node& node,
+    const NodeSet& placed) const {
+  NodeSet visited;
+  return allReachable(
+      node,
+      placed,
+      [](const Metadata& m) {
+        return m.elementWise != nullptr || m.singleBlockVariant != nullptr;
+      },
+      visited);
+}
+
+bool CompileCtx::hasStandalone(
+    const nativert::Node& node,
+    const NodeSet& placed) const {
+  NodeSet visited;
+  return anyReachable(
+      node, placed, [](const Metadata& m) { return m.isStandalone; }, visited);
+}
+
+bool CompileCtx::isMultikernel(
+    const nativert::Node& node,
+    const NodeSet& placed) const {
+  NodeSet visited;
+  return anyReachable(
+      node,
+      placed,
+      [](const Metadata& m) { return m.nextKernel != nullptr; },
+      visited);
+}
+
+KernelOperation* CompileCtx::makeKernelOperation(const Subgraph& sg) {
+  auto opCode = nextOpCode_++;
+  opStorage_.push_back(std::make_unique<KernelOperation>(sg, opCode));
+  auto* op = opStorage_.back().get();
+  if (isElementWise(*sg.root, placed_)) {
+    ResultSpec resultSpec;
+    resultSpec.value = sg.root->outputs()[0];
+    generateElementwise(sg, resultSpec);
+    std::stringstream combined;
+    combined << declarations_.str() << code_.str();
+    declarations_.str("");
+    declarations_.clear();
+    op->setCode(combined);
+    code_.str("");
+    code_.clear();
+    return op;
+  }
+  return nullptr;
+}
+
+void CompileCtx::generateElementwise(
+    const Subgraph& sg,
+    const ResultSpec& resultSpec) {
+  auto inputs = sg.inputs;
+  auto* root = sg.root;
+  if (resultSpec.value) {
+    inputs.push_back(resultSpec.value);
+    auto tp = cudaType(resultSpec.value);
+    auto id = inputs.size() - 1;
+    elementWiseBody(
+        root,
+        *opStorage_.back(),
+        inputs,
+        tp + " result",
+        "r" + std::to_string(id) + "[idx] = result;",
+        false);
+  } else {
+    auto tp = cudaType(inputs[0]);
+    elementWiseBody(
+        root,
+        *opStorage_.back(),
+        inputs,
+        tp + " result",
+        " " + resultSpec.variable + " = result;",
+        false);
+  }
+}
+
+std::vector<const nativert::Value*> CompileCtx::elementwiseHead(
+    const nativert::Node* node,
+    KernelOperation* op) {
+  std::unordered_set<const nativert::Value*> seen;
+  std::vector<const nativert::Value*> leafInputs;
+  extractSubgraphInputs(node, *inputs_, placed_, seen, leafInputs);
+
+  op->addSharedDeclaration("  __shared__ uint32_t size;\n");
+  auto numFastPathVars = (leafInputs.size() + 31) / 32;
+  for (size_t i = 0; i < numFastPathVars; ++i) {
+    op->addSharedDeclaration(
+        "  __shared__ uint32_t isFastPath" + std::to_string(i) + ";\n");
+  }
+
+  code_ << "  if (threadIdx.x == 0) {\n";
+  for (size_t i = 0; i < numFastPathVars; ++i) {
+    code_ << "    isFastPath" << i << " = 0;\n";
+  }
+  code_ << "    Tensor* temp = param(blockInfo, "
+        << op->paramOffset(leafInputs[0]) << ");  size = numEl(temp);\n"
+        << "    isFastPath0 |= isFastPath(temp);\n";
+  if (leafInputs.size() > 1) {
+    code_ << "    uint32_t size2;\n";
+  }
+  for (size_t valueIdx = 1; valueIdx < leafInputs.size(); ++valueIdx) {
+    auto W = valueIdx / 32;
+    auto B = valueIdx % 32;
+    code_ << "    temp = param<tensor>(blockInfo, "
+          << op->paramOffset(leafInputs[valueIdx]) << ");\n"
+          << "    size2 = numEl(temp);\n"
+          << "    isFastPath" << W << " |= isFastPath(temp) << " << B << ";\n"
+          << "    if (size2 != size) {\n"
+          << "      if (size2 > size) {\n";
+    for (size_t I = 0; (I + 1) * 32 <= valueIdx; ++I) {
+      code_ << "        isFastPath" << I << " = 0;\n";
+    }
+    code_ << "        isFastPath" << W << " &= ~((1 << " << B << ") - 1);\n"
+          << "      size = size2;\n"
+          << "      } else {\n"
+          << "    fastPath" << W << " &= ~(1 << " << B << ");\n"
+          << "}"
+          << "    }\n";
+  }
+  code_ << "  }\n"
+        << "  __syncthreads();\n";
+  return leafInputs;
+}
+
+namespace {
+
+std::string cudaAttrType(const nativert::Constant& c) {
+  return std::visit(
+      [](const auto& v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, bool>) {
+          return "bool";
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+          return "int64_t";
+        } else if constexpr (std::is_same_v<T, double>) {
+          return "double";
+        } else {
+          TORCH_CHECK(false, "Unsupported attribute type for CUDA");
+        }
+      },
+      c);
+}
+
+void declareAttributesImpl(
+    const nativert::Node* node,
+    const KernelOperation& op,
+    const std::unordered_set<const nativert::Value*>& inputs,
+    std::unordered_set<const nativert::Node*>& visited,
+    std::stringstream& ss) {
+  if (!visited.insert(node).second) {
+    return;
+  }
+  for (const auto& input : node->inputs()) {
+    if (inputs.count(input.value)) {
+      continue;
+    }
+    auto* producer = input.value->producer();
+    if (producer) {
+      declareAttributesImpl(producer, op, inputs, visited, ss);
+    }
+  }
+  const auto& attrs = node->attributes();
+  if (attrs.empty()) {
+    return;
+  }
+  std::vector<const nativert::Attribute*> sorted;
+  sorted.reserve(attrs.size());
+  for (const auto& attr : attrs) {
+    sorted.push_back(&attr);
+  }
+  std::sort(sorted.begin(), sorted.end(), [](const auto* a, const auto* b) {
+    return a->name < b->name;
+  });
+  for (const auto* attr : sorted) {
+    auto off = op.attrOffset(node, attr->name);
+    auto tp = cudaAttrType(attr->value);
+    ss << "  " << tp << " attr" << off << " = getAttr<" << tp << ">(blockInfo, "
+       << off << ");\n";
+  }
+}
+
+} // namespace
+
+std::string CompileCtx::declareAttributes(
+    const nativert::Node* node,
+    const KernelOperation& op,
+    const std::vector<const nativert::Value*>& inputs) {
+  std::unordered_set<const nativert::Value*> inputSet(
+      inputs.begin(), inputs.end());
+  std::unordered_set<const nativert::Node*> visited;
+  std::stringstream ss;
+  declareAttributesImpl(node, op, inputSet, visited, ss);
+  return ss.str();
+}
+
+void CompileCtx::elementWiseBody(
+    const nativert::Node* node,
+    const KernelOperation& op,
+    const std::vector<const nativert::Value*>& inputs,
+    std::string resultName,
+    std::string resultStmt,
+    bool fullBlockResult) {
+  // Assign tensor storage for each input to a register.
+  for (size_t valueIdx = 0; valueIdx < inputs.size(); ++valueIdx) {
+    auto tp = cudaType(inputs[valueIdx]);
+    code_ << "  " << tp << " b" << valueIdx << " = storage<" << tp
+          << ">(param(blockInfo, " << op.paramOffset(inputs[valueIdx])
+          << "));\n";
+  }
+
+  // Declare attribute variables.
+  code_ << declareAttributes(node, op, inputs);
+
+  // Generate fastPath test for all inputs.
+  auto numFastPathVars = (inputs.size() + 31) / 32;
+  code_ << "  if (";
+  for (size_t i = 0; i < numFastPathVars; ++i) {
+    if (i > 0) {
+      code_ << " && ";
+    }
+    uint32_t mask;
+    if (i < numFastPathVars - 1) {
+      mask = 0xffffffff;
+    } else {
+      auto bitsInLast = inputs.size() - i * 32;
+      if (bitsInLast >= 32) {
+        mask = 0xffffffff;
+      } else {
+        mask = (1u << bitsInLast) - 1;
+      }
+    }
+    code_ << "isFastPath" << i << " == 0x" << std::hex << mask << std::dec;
+  }
+  code_ << ") {\n";
+
+  auto expr = elementWiseExpr(node, op, inputs);
+
+  // Fast path body.
+  if (fullBlockResult) {
+    code_
+        << "    uint32_t rounded = roundUp(size, blockDim.x);\n"
+        << "    for (uint32_t idx = blockInfo.blockInOp * blockDim.x + threadIdx.x; idx < rounded; idx += blockInfo.numBlocksInOp * blockDim.x) {\n"
+        << "      " << resultName << ";\n"
+        << "      if (idx < size) {\n"
+        << "        result = " << expr << ";\n"
+        << "      }\n"
+        << "      " << resultStmt << "\n"
+        << "    }\n";
+  } else {
+    code_
+        << "    for (uint32_t idx = blockInfo.blockInOp * blockDim.x + threadIdx.x; idx < size; idx += blockInfo.numBlocksInOp * blockDim.x) {\n"
+        << "      " << resultName << " = " << expr << ";\n"
+        << "      " << resultStmt << "\n"
+        << "    }\n";
+  }
+
+  code_ << "  } else {\n";
+
+  // Slow path body (same structure, but would handle broadcast etc.).
+  if (fullBlockResult) {
+    code_
+        << "    uint32_t rounded = roundUp(size, blockDim.x);\n"
+        << "    for (uint32_t idx = blockInfo.blockInOp * blockDim.x + threadIdx.x; idx < rounded; idx += blockInfo.numBlocksInOp * blockDim.x) {\n"
+        << "      " << resultName << ";\n"
+        << "      if (idx < size) {\n"
+        << "        result = " << expr << ";\n"
+        << "      }\n"
+        << "      " << resultStmt << "\n"
+        << "    }\n";
+  } else {
+    code_
+        << "    for (uint32_t idx = blockInfo.blockInOp * blockDim.x + threadIdx.x; idx < size; idx += blockInfo.numBlocksInOp * blockDim.x) {\n"
+        << "      " << resultName << " = " << expr << ";\n"
+        << "      " << resultStmt << "\n"
+        << "    }\n";
+  }
+
+  code_ << "  }\n";
+}
+
+void CompileCtx::addInclude(std::string_view header) {
+  includes_.insert(std::string(header));
+}
+
+namespace {
+
+void elementWiseExprImpl(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Value*>& inputSet,
+    const std::vector<const nativert::Value*>& inputs,
+    const KernelOperation& op,
+    std::stringstream& ss) {
+  auto* meta = Registry::metadata(node->target());
+  TORCH_CHECK(
+      meta && meta->elementWise, "Not an elementwise op: ", node->target());
+  const auto& ew = *meta->elementWise;
+  // Convert "--func" to "__func".
+  std::string funcName = ew.functionName;
+  TORCH_CHECK(
+      funcName.size() >= 3 && funcName[0] == '-' && funcName[1] == '-',
+      "Invalid elementwise function name: ",
+      funcName);
+  funcName[0] = '_';
+  funcName[1] = '_';
+  ss << funcName << "(";
+  bool first = true;
+  for (const auto& input : node->inputs()) {
+    auto* value = input.value;
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+    if (inputSet.count(value)) {
+      auto it = std::find(inputs.begin(), inputs.end(), value);
+      TORCH_CHECK(it != inputs.end(), "Input value not found in inputs vector");
+      auto valueIdx = it - inputs.begin();
+      ss << "b" << valueIdx << "[idx]";
+    } else {
+      auto* producer = value->producer();
+      TORCH_CHECK(producer, "Non-input value has no producer");
+      elementWiseExprImpl(producer, inputSet, inputs, op, ss);
+    }
+  }
+  for (const auto& attrName : ew.attributeArgs) {
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+    auto off = op.attrOffset(node, attrName);
+    ss << "attr" << off;
+  }
+  ss << ")";
+}
+
+} // namespace
+
+std::string CompileCtx::elementWiseExpr(
+    const nativert::Node* node,
+    const KernelOperation& op,
+    const std::vector<const nativert::Value*>& inputs) {
+  addInclude("Elementwise.cuh");
+  std::unordered_set<const nativert::Value*> inputSet(
+      inputs.begin(), inputs.end());
+  std::stringstream ss;
+  elementWiseExprImpl(node, inputSet, inputs, op, ss);
+  return ss.str();
+}
+
+std::string CompileCtx::cudaType(const nativert::Value* value) const {
+  TORCH_CHECK(
+      value->id() < types_.types.size() && types_.types[value->id()],
+      "No TensorMeta for value ",
+      value->name());
+  auto dtype = types_.types[value->id()]->dtype();
+  switch (dtype) {
+    case c10::ScalarType::Float:
+      return "float";
+    case c10::ScalarType::Double:
+      return "double";
+    case c10::ScalarType::Half:
+      return "__half";
+    case c10::ScalarType::BFloat16:
+      return "__nv_bfloat16";
+    case c10::ScalarType::Int:
+      return "int32_t";
+    case c10::ScalarType::Long:
+      return "int64_t";
+    case c10::ScalarType::Short:
+      return "int16_t";
+    case c10::ScalarType::Char:
+      return "int8_t";
+    case c10::ScalarType::Byte:
+      return "uint8_t";
+    case c10::ScalarType::Bool:
+      return "bool";
+    default:
+      TORCH_CHECK(false, "Unsupported dtype ", c10::toString(dtype));
+  }
+}
+
+namespace {
+std::string cudaTypeString(c10::ScalarType dtype) {
+  switch (dtype) {
+    case c10::ScalarType::Float:
+      return "float";
+    case c10::ScalarType::Double:
+      return "double";
+    case c10::ScalarType::Half:
+      return "__half";
+    case c10::ScalarType::BFloat16:
+      return "__nv_bfloat16";
+    case c10::ScalarType::Int:
+      return "int32_t";
+    case c10::ScalarType::Long:
+      return "int64_t";
+    case c10::ScalarType::Short:
+      return "int16_t";
+    case c10::ScalarType::Char:
+      return "int8_t";
+    case c10::ScalarType::Byte:
+      return "uint8_t";
+    case c10::ScalarType::Bool:
+      return "bool";
+    default:
+      TORCH_CHECK(false, "Unsupported dtype ", c10::toString(dtype));
+  }
+}
+} // namespace
+
+std::string CompileCtx::declare(c10::ScalarType scalarType) {
+  auto tp = cudaTypeString(scalarType);
+  auto name = "temp" + std::to_string(declareCounter_++);
+  declarations_ << "  " << tp << " " << name << ";\n";
+  return name;
+}
+
+std::unique_ptr<CompiledNode> CompileCtx::compileNode(ProjectNode& project) {
+  inputs_ = &project.inputs();
+  auto& nodes = project.nodes();
+  for (size_t i = 0; i < nodes.size(); ++i) {
+    auto* node = nodes[i];
+    auto sg = extractSubgraph(node, project.inputs(), placed_);
+    auto it = kernelOps_.find(sg);
+    if (it != kernelOps_.end()) {
+      auto constants = listConstants(sg, ivalueStorage_);
+      ops_.emplace_back(it->second, sg, std::move(constants), paramOffset_);
+      paramOffset_ += ops_.back().paramSize();
+    } else {
+      auto* op = makeKernelOperation(sg);
+      if (op) {
+        kernelOps_[sg] = op;
+        auto constants = listConstants(sg, ivalueStorage_);
+        ops_.emplace_back(op, sg, std::move(constants), paramOffset_);
+        paramOffset_ += ops_.back().paramSize();
+      }
+    }
+  }
+  auto compositeKernel =
+      std::make_unique<CompositeKernel>(std::move(opStorage_));
+  auto invocation = std::make_unique<CompositeInvocation>();
+  invocation->kernel = std::move(compositeKernel);
+  invocation->ops = std::move(ops_);
+
+  std::vector<std::unique_ptr<CompositeInvocation>> inner;
+  inner.push_back(std::move(invocation));
+  std::vector<std::vector<std::unique_ptr<CompositeInvocation>>> outer;
+  outer.push_back(std::move(inner));
+
+  return std::make_unique<CompiledNode>(std::move(outer));
+}
+std::string CompiledNode::toString() const {
+  std::stringstream ss;
+  // Find the length of the longest inner vector.
+  size_t maxWaves = 0;
+  for (const auto& inner : kernels_) {
+    maxWaves = std::max(maxWaves, inner.size());
+  }
+
+  for (size_t wave = 0; wave < maxWaves; ++wave) {
+    if (wave > 0) {
+      ss << "\n";
+    }
+    ss << "Wave " << wave << ":\n";
+    for (size_t g = 0; g < kernels_.size(); ++g) {
+      if (wave < kernels_[g].size()) {
+        if (g > 0) {
+          ss << "\n";
+        }
+        ss << "Group " << g << ":\n";
+        ss << kernels_[g][wave]->toString();
+      }
+    }
+  }
+  return ss.str();
+}
+
+std::string WaveGraph::toString() const {
+  std::stringstream ss;
+  for (size_t i = 0; i < nodes_.size(); ++i) {
+    if (i > 0) {
+      ss << "\n";
+    }
+    ss << "Node " << i << ":\n";
+    ss << nodes_[i]->toString();
+  }
+  return ss.str();
+}
+
+WaveGraph::WaveGraph(const nativert::Graph& graph, const ValueTypes& types) {
+  ParallelNodes parallelNodes;
+  auto* lastProjectNode = parallelNodes.makeParallelNodes(graph);
+
+  CompileCtx ctx(types);
+
+  // Collect nodes from last to first, then reverse to get leafmost first.
+  std::vector<ProjectNode*> ordered;
+  for (auto* pn = lastProjectNode; pn != nullptr; pn = pn->input()) {
+    ordered.push_back(pn);
+  }
+  std::reverse(ordered.begin(), ordered.end());
+
+  for (auto* pn : ordered) {
+    nodes_.push_back(ctx.compileNode(*pn));
+  }
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Compile.h
+++ b/velox/experimental/torchwave/Compile.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <deque>
+
+#include <ATen/core/ivalue.h>
+#include <torch/nativert/graph/TensorMeta.h>
+#include "velox/experimental/torchwave/CompiledOp.h"
+#include "velox/experimental/torchwave/ParallelExpr.h"
+#include "velox/experimental/torchwave/Registry.h"
+
+namespace torch::wave {
+
+struct ValueTypes {
+  /// Tensor metadata for tensor type values, indexed by Value id().
+  std::vector<const nativert::TensorMeta*> types;
+};
+
+struct ResultSpec {
+  const nativert::Value* value{nullptr};
+  std::string variable;
+};
+
+struct Subgraph {
+  const nativert::Node* root;
+  std::vector<const nativert::Value*> inputs;
+  std::vector<const nativert::TensorMeta*> inputTypes;
+};
+
+bool subgraphsMatch(const Subgraph& left, const Subgraph& right);
+
+struct SubgraphHash {
+  size_t operator()(const Subgraph& sg) const;
+};
+
+struct SubgraphEqual {
+  bool operator()(const Subgraph& left, const Subgraph& right) const {
+    return subgraphsMatch(left, right);
+  }
+};
+
+using SubgraphMap =
+    std::unordered_map<Subgraph, KernelOperation*, SubgraphHash, SubgraphEqual>;
+
+class CompileCtx {
+ public:
+  using NodeSet = std::unordered_set<const nativert::Node*>;
+
+  explicit CompileCtx(const ValueTypes& types) : types_{types} {}
+
+  std::unique_ptr<CompiledNode> compileNode(ProjectNode& node);
+
+  KernelOperation* makeKernelOperation(const Subgraph& sg);
+
+  void generateElementwise(const Subgraph& sg, const ResultSpec& resultSpec);
+
+  std::vector<const nativert::Value*> elementwiseHead(
+      const nativert::Node* node,
+      KernelOperation* op);
+
+  void elementWiseBody(
+      const nativert::Node* node,
+      const KernelOperation& op,
+      const std::vector<const nativert::Value*>& inputs,
+      std::string resultName,
+      std::string resultStmt,
+      bool fullBlockResult);
+
+  std::string elementWiseExpr(
+      const nativert::Node* node,
+      const KernelOperation& op,
+      const std::vector<const nativert::Value*>& inputs);
+
+  void addInclude(std::string_view header);
+
+  std::string declareAttributes(
+      const nativert::Node* node,
+      const KernelOperation& op,
+      const std::vector<const nativert::Value*>& inputs);
+
+  std::string cudaType(const nativert::Value* value) const;
+
+  /// Declares a temporary variable of the CUDA type for 'scalarType'. Appends a
+  /// declaration line to declarations_ and returns the variable name.
+  std::string declare(c10::ScalarType scalarType);
+
+  Subgraph extractSubgraph(
+      const nativert::Node* node,
+      const NodeSet& inputs,
+      const NodeSet& placed);
+
+  bool isElementWise(const nativert::Node& node, const NodeSet& placed = {})
+      const;
+
+  bool hasBarrier(const nativert::Node& node, const NodeSet& placed = {}) const;
+
+  bool isSingleBlock(const nativert::Node& node, const NodeSet& placed = {})
+      const;
+
+  bool hasStandalone(const nativert::Node& node, const NodeSet& placed = {})
+      const;
+
+  bool isMultikernel(const nativert::Node& node, const NodeSet& placed = {})
+      const;
+
+  static int32_t nextKernelId();
+
+ private:
+  static std::atomic<int32_t> kernelCounter_;
+
+  template <typename Func>
+  bool allReachable(
+      const nativert::Node& node,
+      const NodeSet& placed,
+      Func&& predicate,
+      NodeSet& visited) const;
+
+  template <typename Func>
+  bool anyReachable(
+      const nativert::Node& node,
+      const NodeSet& placed,
+      Func&& predicate,
+      NodeSet& visited) const;
+
+  const ValueTypes& types_;
+  int32_t nextOpCode_{0};
+  std::unordered_set<std::string> includes_;
+  std::stringstream code_;
+  std::stringstream declarations_;
+  int32_t declareCounter_{0};
+  const std::unordered_set<const nativert::Node*>* inputs_;
+  NodeSet placed_;
+
+  // Offset of param corresponding to Value in the kernel's BlockInfo::params.
+  std::unordered_map<const nativert::Value*, int32_t> valueParamOffset_;
+
+  bool singleBlockTarget_{false};
+
+  std::vector<OpInvocation> ops_;
+  // Start of params for the op being produced.
+  int32_t paramOffset_{0};
+  SubgraphMap kernelOps_;
+  // Stable storage for KernelOperations so pointers remain valid.
+  std::vector<std::unique_ptr<KernelOperation>> opStorage_;
+  // Stable storage for IValues so OpInvocation can hold const pointers.
+  std::deque<c10::IValue> ivalueStorage_;
+};
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/CompiledOp.h
+++ b/velox/experimental/torchwave/CompiledOp.h
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+#include <torch/nativert/graph/Graph.h>
+#include "velox/experimental/torchwave/KernelParams.h"
+#include "velox/experimental/torchwave/Registry.h"
+#include "velox/experimental/wave/common/Cuda.h"
+#include "velox/experimental/wave/common/ResultStaging.h"
+
+namespace torch::wave {
+
+struct ExecutionState;
+class OpInvocation;
+
+class HostControlPoint {
+ public:
+  virtual ~HostControlPoint() = default;
+
+  /// Entry point. This is called after the return data from the previous launch
+  /// has arrived. A typical application has this allocating device memory with
+  /// sizes dependent on results from device.
+  virtual void baction() = 0;
+};
+
+/// Represents an operation offered by   a composite kernel. For example a fused
+/// expression like a + b * c + scalar. At run time the operation may span a
+/// variable number of blocks in an invocation of a composite kernel.
+struct Subgraph;
+
+class KernelOperation {
+ public:
+  KernelOperation(
+      const Subgraph& sg,
+      int32_t opCode,
+      bool useSingleBlock = false);
+
+  int32_t paramOffset(const nativert::Value* value) const;
+
+  int32_t attrOffset(const nativert::Node* node, std::string_view attr) const;
+
+  void addSharedDeclaration(const std::string& decl);
+
+  /// Sets the CUDA code text from the given stream and clears the stream.
+  void setCode(std::stringstream& code);
+
+  const std::string& code() const {
+    return text_;
+  }
+
+  const std::vector<int32_t>& opCodes() const {
+    return opCode_;
+  }
+
+  // Count of lanes on which this should be launched given the actual
+  // parameters.
+  int32_t laneCount(const OpInvocation& call);
+
+  /// Returns the number of elements for this operation given the frame and
+  /// bindings. Errors if numElements_ is not set.
+  int64_t numElements(
+      nativert::ExecutionFrame& frame,
+      const FormalToActual& map) const;
+
+  void fillLaunch(
+      const OpInvocation& call,
+      std::vector<std::vector<BlockInfo>>& blocks,
+      std::vector<facebook::velox::wave::ResultStaging>& paramStaging,
+      std::vector<facebook::velox::wave::ResultStaging>& returnStaging,
+      std::vector<std::unique_ptr<HostControlPoint>> hostSyncs);
+
+  /// Recurses through the subgraph. For elementwise subtrees, adds the output
+  /// value and an OutputReserveFunc that calls elementwiseOutputShape. For
+  /// non-elementwise nodes, adds outputs where returnMeta has isRegister false.
+  void setOutputs(
+      const nativert::Node* node,
+      const std::unordered_set<const nativert::Value*>& subgraphInputs,
+      std::vector<const nativert::Value*>& outputValues,
+      std::vector<OutputReserveFunc>& outputReserves);
+
+  std::string toString() const;
+
+  const nativert::Node* expr() const {
+    return expr_;
+  }
+
+  int32_t numInputs() const {
+    return numInputs_;
+  }
+
+  const std::vector<const nativert::Value*>& orderedInputs() const {
+    return orderedInputs_;
+  }
+
+  const std::vector<OutputReserveFunc>& outputReserves() const {
+    return outputReserve_;
+  }
+
+  float unitCost() const {
+    return unitCost_;
+  }
+
+  // Hash for (Node*, attrName) pairs used as keys in attrOffsets_.
+  struct NodeAttrHash {
+    size_t operator()(
+        const std::pair<const nativert::Node*, std::string>& key) const {
+      auto h1 = std::hash<const void*>{}(key.first);
+      auto h2 = std::hash<std::string>{}(key.second);
+      return h1 ^ (h2 + 0x9e3779b9 + (h1 << 6) + (h1 >> 2));
+    }
+  };
+
+ private:
+  /// Op code, unique within a CompositeKernel. A follow up in a multi-kernel
+  /// computation can have more than one opcode.
+  std::vector<int32_t> opCode_;
+
+  // The represented computation. 'expr' is the top level result. This graph is
+  // a tre, except that it may have multiple occurrences of the same Value in
+  // 'inputs'. Not filled in in follow ups or single block variant.
+  const nativert::Node* expr_;
+
+  // The Values this takes as input. All these are reachable from
+  // 'expr'. This operation is usable for any expr that has the same
+  // 'expr' with the structure bounded by the save Values. The
+  // graphs, including repeated use of the same values in many
+  // places must be strictly isomorphic. a+a does not match a+b even
+  // if a and b are of the same type as the a in a+a.
+  std::unordered_set<const nativert::Value*> inputs_;
+
+  // Operations to run host side before launch. These need d to H transfers to
+  // be complete and sync the stream to do host side decisions, for example
+  // allocating memory when size depends on device side results.
+  std::vector<std::unique_ptr<HostControlPoint>> hostSyncs_;
+
+  // If multiple launches are needed, as in multiblock compaction, then this is
+  // the next launch.
+  std::unique_ptr<KernelOperation> followUp_;
+
+  std::unique_ptr<KernelOperation> singleBlockVariant_;
+
+  // shared memory locals. These are unioned with the shared memory locals of
+  // other KernelOperations in the composite kernel and declared in front.
+  std::vector<std::string> sharedLocals_;
+
+  // Cuda program text, to be inserted into the opCode case of the composite
+  // kernel.
+  std::string text_;
+
+  std::vector<const nativert::Value*> orderedInputs_;
+
+  // Offset of each input Value in the kernel's BlockInfo::params, starting at
+  // 0.
+  std::unordered_map<const nativert::Value*, int32_t> paramOffsets_;
+
+  // Offset of each node attribute in BlockInfo::params, following the input
+  // param offsets at intervals of 8.
+  std::unordered_map<
+      std::pair<const nativert::Node*, std::string>,
+      int32_t,
+      NodeAttrHash>
+      attrOffsets_;
+
+  // Shared memory declarations for the kernel.
+  std::vector<std::string> sharedDeclarations_;
+
+  std::vector<OutputReserveFunc> outputReserve_;
+
+  using NumElementsFunc =
+      std::function<int64_t(nativert::ExecutionFrame&, const FormalToActual&)>;
+  NumElementsFunc numElements_;
+
+  float unitCost_{0};
+
+  int32_t numInputs_{0};
+
+  bool isSingleBlock_{false};
+};
+
+struct ValueTypes;
+
+struct ActualParameter {
+  const nativert::Value* value;
+  std::optional<c10::IValue> constant;
+};
+
+class OpInvocation {
+ public:
+  /// Allocates output tensors on device using the kernel op's reserve functions
+  /// and places them in the frame at the bound actual value IDs. Returns the
+  /// numElements for the kernel op.
+  int64_t allocateOutput(
+      nativert::ExecutionFrame& frame,
+      const ValueTypes& types);
+
+  std::string toString() const;
+
+  OpInvocation(
+      KernelOperation* op,
+      const Subgraph& sg,
+      std::vector<const c10::IValue*> constants,
+      int32_t startOffset = 0);
+
+  KernelOperation* op() const {
+    return op_;
+  }
+
+  const std::vector<const nativert::Value*>& values() const {
+    return values_;
+  }
+
+  const std::vector<const c10::IValue*>& constants() const {
+    return constants_;
+  }
+
+  int32_t paramOffset() const {
+    return paramOffset_;
+  }
+
+  int32_t paramSize() const {
+    return paramSize_;
+  }
+
+  const std::vector<int32_t>& offsets() const {
+    return offsets_;
+  }
+
+  const OpInvocation* followUp() const {
+    return followUp_.get();
+  }
+
+  const FormalToActual& bindings() const {
+    return bindings_;
+  }
+
+ private:
+  /// Recurses through formalSg and actualSg in parallel. Stops at inputs of
+  /// formalSg. When a node in formalSg has an output that is in the
+  /// KernelOperation's outputs, adds a mapping from the formal value id to the
+  /// actual value id.
+  void makeBindings(const Subgraph& formalSg, const Subgraph& actualSg);
+  KernelOperation* op_;
+  std::vector<const nativert::Value*> values_;
+  std::vector<const c10::IValue*> constants_;
+  std::vector<int32_t> offsets_;
+  int32_t paramOffset_{0};
+  int32_t paramSize_{0};
+  std::unique_ptr<OpInvocation> followUp_;
+  FormalToActual bindings_;
+};
+
+class CompositeKernel {
+ public:
+  explicit CompositeKernel(std::vector<std::unique_ptr<KernelOperation>>&& ops);
+
+  std::string toString() const;
+
+  /// Launches the kernel on the given stream.
+  void launch(
+      int32_t numBlocks,
+      int32_t numThreads,
+      int32_t sharedMemory,
+      facebook::velox::wave::Stream* stream,
+      void** args);
+
+ private:
+  std::unique_ptr<facebook::velox::wave::CompiledKernel> kernel_;
+  std::vector<std::unique_ptr<KernelOperation>> ops_;
+};
+
+struct CompositeInvocation {
+  std::string toString() const;
+
+  /// Executes this composite invocation: allocates outputs, builds the grid,
+  /// copies params to pinned+device memory, and enqueues the H2D transfer.
+  void execute(ExecutionState& state);
+
+  std::unique_ptr<CompositeKernel> kernel;
+  std::vector<OpInvocation> ops;
+};
+
+/// Represents a single ProjectNode in a stack of ProjectNodes. Contains a graph
+/// of CompositeKernels and a binding of their parameters to slots in the
+/// execution state.
+class CompiledNode {
+ public:
+  explicit CompiledNode(
+      std::vector<std::vector<std::unique_ptr<CompositeInvocation>>>&& kernels)
+      : kernels_(std::move(kernels)) {}
+
+  std::string toString() const;
+
+  /// Executes this node using the given execution state.
+  void execute(ExecutionState& state);
+
+ private:
+  // The outer array represents parallel launchable sequences kernels. The inner
+  // array is a sequence of consecutive kernels.
+  std::vector<std::vector<std::unique_ptr<CompositeInvocation>>> kernels_;
+};
+
+struct ValueTypes;
+
+/// Top level container for result of compiling a FX Graph to torch::wave.
+/// Multiple Executors can share the same WaveGraph.
+class WaveGraph {
+ public:
+  /// Analyzes 'graph' and creates an execution plan and fused kernels. The
+  /// actual tensor content types and ranks come from 'weights'.
+  WaveGraph(const nativert::Graph& graph, const ValueTypes& types);
+
+  std::string toString() const;
+
+  const std::vector<std::unique_ptr<CompiledNode>>& nodes() const {
+    return nodes_;
+  }
+
+ private:
+  // The executable graph. the nodes are executed sequentially. Each node has
+  // internal prallelism.
+  std::vector<std::unique_ptr<CompiledNode>> nodes_;
+};
+
+using WaveGraphPtr = std::shared_ptr<const WaveGraph>;
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Core.cuh
+++ b/velox/experimental/torchwave/Core.cuh
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include "velox/experimental/torchwave/KernelParams.h"
+
+namespace torch::wave {
+
+template <typename T>
+__device__ inline param(const BlockInfo& block, offset) {
+  return reinterpret_cast<T*>(reinterpret_cast<char*>(block->params) + offset);
+}
+
+__device__ uint32_t numEl(Tensor& tensor) {
+  uint32_t size = 1;
+  for (auto i = 0; i < tensor.rank; ++i) {
+    size = size * tensor.dims[i];
+  }
+  return size;
+}
+
+__device__ bool isFastPathTensor(Tensor& tensor) {
+  return tensor.rank == 1 && tensor.stride[0] == 1;
+}
+
+#define ENTRY                                                                  \
+  __shared__ BlockInfo* blockInfo = reinterpret_cast<WaveShared*>(sharedChar); \
+  if (threadIdx.x == 0) {                                                      \
+    blockInfo =                                                                \
+        params.info ? params.info[blockIdx.x] : params.inlineInfo[blockIdx.x]; \
+  }                                                                            \
+  __syncthreads();
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Elementwise.cuh
+++ b/velox/experimental/torchwave/Elementwise.cuh
@@ -1,0 +1,395 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace torch::wave {
+
+// Binary arithmetic.
+
+template <typename T>
+__device__ inline T __add(T a1, T a2, T alpha) {
+  return a1 + a2 * alpha;
+}
+
+template <typename T>
+__device__ inline T __sub(T a1, T a2, T alpha) {
+  return a1 - a2 * alpha;
+}
+
+template <typename T>
+__device__ inline T __mul(T a1, T a2) {
+  return a1 * a2;
+}
+
+template <typename T>
+__device__ inline T __div(T a1, T a2) {
+  return a1 / a2;
+}
+
+template <typename T>
+__device__ inline T __remainder(T a1, T a2) {
+  return a1 % a2;
+}
+
+__device__ inline float __remainder(float a1, float a2) {
+  return remainderf(a1, a2);
+}
+
+__device__ inline double __remainder(double a1, double a2) {
+  return ::remainder(a1, a2);
+}
+
+template <typename T>
+__device__ inline T __fmod(T a1, T a2) {
+  return a1 % a2;
+}
+
+__device__ inline float __fmod(float a1, float a2) {
+  return fmodf(a1, a2);
+}
+
+__device__ inline double __fmod(double a1, double a2) {
+  return fmod(a1, a2);
+}
+
+template <typename T>
+__device__ inline T __pow(T a1, T a2) {
+  return powf(static_cast<float>(a1), static_cast<float>(a2));
+}
+
+__device__ inline float __pow(float a1, float a2) {
+  return powf(a1, a2);
+}
+
+__device__ inline double __pow(double a1, double a2) {
+  return pow(a1, a2);
+}
+
+// Comparison.
+
+template <typename T>
+__device__ inline bool __eq(T a1, T a2) {
+  return a1 == a2;
+}
+
+template <typename T>
+__device__ inline bool __ne(T a1, T a2) {
+  return a1 != a2;
+}
+
+template <typename T>
+__device__ inline bool __lt(T a1, T a2) {
+  return a1 < a2;
+}
+
+template <typename T>
+__device__ inline bool __le(T a1, T a2) {
+  return a1 <= a2;
+}
+
+template <typename T>
+__device__ inline bool __gt(T a1, T a2) {
+  return a1 > a2;
+}
+
+template <typename T>
+__device__ inline bool __ge(T a1, T a2) {
+  return a1 >= a2;
+}
+
+// Bitwise.
+
+template <typename T>
+__device__ inline T __bitwise_and(T a1, T a2) {
+  return a1 & a2;
+}
+
+template <typename T>
+__device__ inline T __bitwise_or(T a1, T a2) {
+  return a1 | a2;
+}
+
+template <typename T>
+__device__ inline T __bitwise_xor(T a1, T a2) {
+  return a1 ^ a2;
+}
+
+template <typename T>
+__device__ inline T __bitwise_not(T a1) {
+  return ~a1;
+}
+
+// Logical.
+
+template <typename T>
+__device__ inline bool __logical_and(T a1, T a2) {
+  return static_cast<bool>(a1) && static_cast<bool>(a2);
+}
+
+template <typename T>
+__device__ inline bool __logical_or(T a1, T a2) {
+  return static_cast<bool>(a1) || static_cast<bool>(a2);
+}
+
+template <typename T>
+__device__ inline bool __logical_xor(T a1, T a2) {
+  return static_cast<bool>(a1) != static_cast<bool>(a2);
+}
+
+template <typename T>
+__device__ inline bool __logical_not(T a1) {
+  return !static_cast<bool>(a1);
+}
+
+// Unary math.
+
+template <typename T>
+__device__ inline T __abs(T a1) {
+  return abs(a1);
+}
+
+__device__ inline float __abs(float a1) {
+  return fabsf(a1);
+}
+
+__device__ inline double __abs(double a1) {
+  return fabs(a1);
+}
+
+template <typename T>
+__device__ inline T __neg(T a1) {
+  return -a1;
+}
+
+__device__ inline float __ceil(float a1) {
+  return ceilf(a1);
+}
+
+__device__ inline double __ceil(double a1) {
+  return ceil(a1);
+}
+
+__device__ inline float __floor(float a1) {
+  return floorf(a1);
+}
+
+__device__ inline double __floor(double a1) {
+  return floor(a1);
+}
+
+__device__ inline float __round(float a1) {
+  return roundf(a1);
+}
+
+__device__ inline double __round(double a1) {
+  return round(a1);
+}
+
+__device__ inline float __trunc(float a1) {
+  return truncf(a1);
+}
+
+__device__ inline double __trunc(double a1) {
+  return trunc(a1);
+}
+
+template <typename T>
+__device__ inline T __sign(T a1) {
+  return (a1 > T(0)) - (a1 < T(0));
+}
+
+__device__ inline float __sqrt(float a1) {
+  return sqrtf(a1);
+}
+
+__device__ inline double __sqrt(double a1) {
+  return sqrt(a1);
+}
+
+__device__ inline float __rsqrt(float a1) {
+  return rsqrtf(a1);
+}
+
+__device__ inline double __rsqrt(double a1) {
+  return 1.0 / sqrt(a1);
+}
+
+__device__ inline float __reciprocal(float a1) {
+  return 1.0f / a1;
+}
+
+__device__ inline double __reciprocal(double a1) {
+  return 1.0 / a1;
+}
+
+__device__ inline float __exp(float a1) {
+  return expf(a1);
+}
+
+__device__ inline double __exp(double a1) {
+  return exp(a1);
+}
+
+__device__ inline float __log(float a1) {
+  return logf(a1);
+}
+
+__device__ inline double __log(double a1) {
+  return log(a1);
+}
+
+__device__ inline float __log2(float a1) {
+  return log2f(a1);
+}
+
+__device__ inline double __log2(double a1) {
+  return log2(a1);
+}
+
+__device__ inline float __log10(float a1) {
+  return log10f(a1);
+}
+
+__device__ inline double __log10(double a1) {
+  return log10(a1);
+}
+
+__device__ inline float __log1p(float a1) {
+  return log1pf(a1);
+}
+
+__device__ inline double __log1p(double a1) {
+  return log1p(a1);
+}
+
+// Trigonometric.
+
+__device__ inline float __sin(float a1) {
+  return sinf(a1);
+}
+
+__device__ inline double __sin(double a1) {
+  return sin(a1);
+}
+
+__device__ inline float __cos(float a1) {
+  return cosf(a1);
+}
+
+__device__ inline double __cos(double a1) {
+  return cos(a1);
+}
+
+__device__ inline float __tan(float a1) {
+  return tanf(a1);
+}
+
+__device__ inline double __tan(double a1) {
+  return tan(a1);
+}
+
+__device__ inline float __asin(float a1) {
+  return asinf(a1);
+}
+
+__device__ inline double __asin(double a1) {
+  return asin(a1);
+}
+
+__device__ inline float __acos(float a1) {
+  return acosf(a1);
+}
+
+__device__ inline double __acos(double a1) {
+  return acos(a1);
+}
+
+__device__ inline float __atan(float a1) {
+  return atanf(a1);
+}
+
+__device__ inline double __atan(double a1) {
+  return atan(a1);
+}
+
+__device__ inline float __atan2(float a1, float a2) {
+  return atan2f(a1, a2);
+}
+
+__device__ inline double __atan2(double a1, double a2) {
+  return atan2(a1, a2);
+}
+
+__device__ inline float __sinh(float a1) {
+  return sinhf(a1);
+}
+
+__device__ inline double __sinh(double a1) {
+  return sinh(a1);
+}
+
+__device__ inline float __cosh(float a1) {
+  return coshf(a1);
+}
+
+__device__ inline double __cosh(double a1) {
+  return cosh(a1);
+}
+
+__device__ inline float __tanh(float a1) {
+  return tanhf(a1);
+}
+
+__device__ inline double __tanh(double a1) {
+  return tanh(a1);
+}
+
+// Activation functions.
+
+template <typename T>
+__device__ inline T __relu(T a1) {
+  return a1 > T(0) ? a1 : T(0);
+}
+
+__device__ inline float __sigmoid(float a1) {
+  return 1.0f / (1.0f + expf(-a1));
+}
+
+__device__ inline double __sigmoid(double a1) {
+  return 1.0 / (1.0 + exp(-a1));
+}
+
+template <typename T>
+__device__ inline T __clamp(T a1, T lo, T hi) {
+  return a1 < lo ? lo : (a1 > hi ? hi : a1);
+}
+
+// Min/max.
+
+template <typename T>
+__device__ inline T __minimum(T a1, T a2) {
+  return a1 < a2 ? a1 : a2;
+}
+
+template <typename T>
+__device__ inline T __maximum(T a1, T a2) {
+  return a1 > a2 ? a1 : a2;
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Execute.cpp
+++ b/velox/experimental/torchwave/Execute.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <ATen/ATen.h>
+#include <torch/csrc/export/pt2_archive_constants.h>
+#include <torch/csrc/jit/serialization/pickle.h>
+#include <torch/nativert/executor/ExecutionFrame.h>
+#include <torch/nativert/executor/Weights.h>
+#include <torch/nativert/kernels/KernelFactory.h>
+
+#include "velox/experimental/torchwave/Execute.h"
+
+namespace torch::wave {
+
+std::unique_ptr<torch::nativert::ExecutionFrame> executeGraph(
+    const LoadedModel& model) {
+  const auto& graph = *model.graph;
+  const auto& reader = model.reader;
+  const auto& modelName = model.modelName;
+
+  // Create Weights from the archive.
+  auto weights = std::make_shared<torch::nativert::Weights>(
+      &graph,
+      reader,
+      model.tensorPaths,
+      torch::_export::archive_spec::WEIGHTS_DIR,
+      model.constantPaths,
+      torch::_export::archive_spec::CONSTANTS_DIR);
+
+  std::cout << "Weights loaded\n";
+
+  // Initialize kernels for every node in the graph.
+  torch::nativert::ExecutorConfig config;
+  torch::nativert::KernelFactory factory;
+  auto execKernels =
+      factory.initializeNodeKernels(graph, weights, config, reader);
+  auto& nodeKernels = execKernels.nodeKernels;
+
+  std::cout << "Initialized " << nodeKernels.size() << " kernels\n";
+
+  // Create the execution frame (pre-populates weight/constant values).
+  auto frame = std::make_unique<torch::nativert::ExecutionFrame>(
+      graph, *weights, config);
+
+  // Try to load sample inputs from the package.
+  const auto& userInputs = graph.signature().userInputs();
+  std::string sampleInputsPath = fmt::format(
+      torch::_export::archive_spec::SAMPLE_INPUTS_FILENAME_FORMAT, modelName);
+  bool loadedFromPackage = false;
+  if (reader->hasRecord(sampleInputsPath)) {
+    auto size = reader->getRecordSize(sampleInputsPath);
+    std::vector<char> buffers(size);
+    reader->getRecord(sampleInputsPath, buffers.data(), size);
+    auto value = torch::jit::pickle_load(buffers);
+    if (value.isTuple() && value.toTupleRef().elements().size() == 2) {
+      const auto& argsVal = value.toTupleRef().elements().at(0);
+      const auto& kwargsVal = value.toTupleRef().elements().at(1);
+      // Collect flat inputs: args then kwargs values.
+      std::vector<c10::IValue> flatInputs;
+      if (argsVal.isTuple()) {
+        for (const auto& arg : argsVal.toTupleRef().elements()) {
+          flatInputs.push_back(arg);
+        }
+      }
+      if (kwargsVal.isTuple()) {
+        for (const auto& kwarg : kwargsVal.toTupleRef().elements()) {
+          flatInputs.push_back(kwarg);
+        }
+      } else if (kwargsVal.isGenericDict()) {
+        for (const auto& entry : kwargsVal.toGenericDict()) {
+          flatInputs.push_back(entry.value());
+        }
+      }
+      auto count = std::min(flatInputs.size(), userInputs.size());
+      for (size_t i = 0; i < count; ++i) {
+        auto* val = graph.tryGetValue(userInputs[i]);
+        if (val) {
+          frame->setIValue(val->id(), flatInputs[i]);
+        }
+      }
+      std::cout << "Loaded " << count << " sample inputs from package\n";
+      loadedFromPackage = true;
+    }
+  }
+
+  // Fall back to zero tensors for any inputs not loaded.
+  if (!loadedFromPackage) {
+    const auto& tensorValuesMeta = graph.tensorValuesMeta();
+    for (const auto& name : userInputs) {
+      auto it = tensorValuesMeta.find(name);
+      if (it != tensorValuesMeta.end()) {
+        const auto& tm = it->second;
+        auto* value = graph.tryGetValue(name);
+        if (value && !tm.hasSymbolicShape()) {
+          auto tensor =
+              at::zeros(tm.sizes(), at::TensorOptions().dtype(tm.dtype()));
+          frame->setIValue(value->id(), std::move(tensor));
+        }
+      }
+    }
+    std::cout
+        << "User inputs populated with zeros (no sample inputs in package)\n";
+  }
+
+  // Execute all nodes except prim.Input (0) and prim.Output (last).
+  for (size_t i = 1; i + 1 < nodeKernels.size(); ++i) {
+    const auto* node = nodeKernels[i]->node();
+    std::cout << "Executing node " << i << ": " << node->target() << "\n";
+    nodeKernels[i]->compute(*frame);
+  }
+
+  std::cout << "Execution complete\n";
+  return frame;
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Execute.h
+++ b/velox/experimental/torchwave/Execute.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <caffe2/serialize/inline_container.h>
+#include <torch/nativert/executor/ExecutionFrame.h>
+#include <torch/nativert/graph/Graph.h>
+
+namespace torch::wave {
+
+/// Format-agnostic representation of a loaded model.  Produced by
+/// loadSigmoidPackage() or loadPt2File() and consumed by executeGraph()
+/// and the compile path so that neither needs to know the file format.
+struct LoadedModel {
+  std::shared_ptr<caffe2::serialize::PyTorchStreamReader> reader;
+  std::unique_ptr<torch::nativert::Graph> graph;
+  std::string modelName;
+  std::unordered_map<std::string, std::string> tensorPaths;
+  std::unordered_map<std::string, std::string> constantPaths;
+};
+
+// Builds an ExecutionFrame from the graph and the package weights,
+// then executes all nodes via nativert kernel dispatch.
+// Returns the frame after execution.
+std::unique_ptr<torch::nativert::ExecutionFrame> executeGraph(
+    const LoadedModel& model);
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Executor.cpp
+++ b/velox/experimental/torchwave/Executor.cpp
@@ -1,0 +1,579 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/Executor.h"
+
+#include <ATen/ATen.h>
+#include "velox/experimental/wave/common/GpuArena.h"
+
+namespace torch::wave {
+
+namespace {
+
+struct GlobalResources {
+  std::unique_ptr<facebook::velox::wave::GpuArena> deviceArena;
+  std::unique_ptr<facebook::velox::wave::GpuArena> pinnedArena;
+  std::unique_ptr<facebook::velox::wave::GpuArena> managedArena;
+  std::unique_ptr<StreamPool> streamPool;
+  std::unique_ptr<EventPool> eventPool;
+};
+
+GlobalResources* globals() {
+  static GlobalResources instance;
+  return &instance;
+}
+
+bool initialized = false;
+
+} // namespace
+
+void initialize() {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+  registerBuiltins();
+  facebook::velox::wave::Device* device = nullptr;
+  try {
+    device = facebook::velox::wave::getDevice();
+  } catch (...) {
+    return;
+  }
+  if (!device) {
+    return;
+  }
+  facebook::velox::wave::setDevice(device);
+  auto* g = globals();
+  g->deviceArena = std::make_unique<facebook::velox::wave::GpuArena>(
+      100'000'000,
+      facebook::velox::wave::getDeviceAllocator(device),
+      400'000'000);
+  g->pinnedArena = std::make_unique<facebook::velox::wave::GpuArena>(
+      100'000'000, facebook::velox::wave::getHostAllocator(device));
+  g->managedArena = std::make_unique<facebook::velox::wave::GpuArena>(
+      100'000'000, facebook::velox::wave::getAllocator(device));
+  g->streamPool = std::make_unique<StreamPool>(
+      []() { return std::make_unique<facebook::velox::wave::Stream>(); });
+  g->eventPool = std::make_unique<EventPool>(
+      []() { return std::make_unique<facebook::velox::wave::Event>(); });
+}
+
+facebook::velox::wave::WaveBufferPtr tensorsToDevice(
+    const std::vector<at::Tensor>& in,
+    std::vector<at::Tensor>& out,
+    facebook::velox::wave::Stream& stream) {
+  // Compute total bytes needed across all tensors.
+  int64_t totalBytes = 0;
+  std::vector<int64_t> sizes(in.size());
+  for (size_t i = 0; i < in.size(); ++i) {
+    sizes[i] = in[i].nbytes();
+    totalBytes += sizes[i];
+  }
+
+  auto* g = globals();
+
+  // Allocate contiguous pinned host buffer and copy tensor data into it.
+  auto pinnedBuffer = g->pinnedArena->allocateBytes(totalBytes);
+  auto* pinnedBase = pinnedBuffer->as<uint8_t>();
+  int64_t offset = 0;
+  for (size_t i = 0; i < in.size(); ++i) {
+    memcpy(pinnedBase + offset, in[i].data_ptr(), sizes[i]);
+    offset += sizes[i];
+  }
+
+  // Allocate contiguous device buffer.
+  auto deviceBuffer = g->deviceArena->allocateBytes(totalBytes);
+  auto* deviceBase = deviceBuffer->as<uint8_t>();
+
+  // Async H2D copy.
+  stream.hostToDeviceAsync(deviceBase, pinnedBase, totalBytes);
+
+  // Build output tensors pointing into the device buffer. Each tensor's
+  // storage holds a copy of the WaveBufferPtr to keep the device memory alive.
+  out.resize(in.size());
+  offset = 0;
+  for (size_t i = 0; i < in.size(); ++i) {
+    auto ref = new facebook::velox::wave::WaveBufferPtr(deviceBuffer);
+    auto storage = c10::Storage(
+        c10::Storage::use_byte_size_t(),
+        sizes[i],
+        at::DataPtr(
+            deviceBase + offset,
+            ref,
+            [](void* ctx) {
+              delete static_cast<facebook::velox::wave::WaveBufferPtr*>(ctx);
+            },
+            c10::Device(c10::kCUDA)));
+    out[i] = at::empty({0}, in[i].options())
+                 .set_(std::move(storage), 0, in[i].sizes(), in[i].strides());
+    offset += sizes[i];
+  }
+
+  return deviceBuffer;
+}
+
+void tensorsToHost(
+    const std::vector<at::Tensor>& in,
+    std::vector<at::Tensor>& out,
+    facebook::velox::wave::Stream& stream) {
+  int64_t totalBytes = 0;
+  std::vector<int64_t> sizes(in.size());
+  for (size_t i = 0; i < in.size(); ++i) {
+    sizes[i] = in[i].nbytes();
+    totalBytes += sizes[i];
+  }
+
+  auto* g = globals();
+
+  // Allocate contiguous pinned host buffer.
+  auto pinnedBuffer = g->pinnedArena->allocateBytes(totalBytes);
+  auto* pinnedBase = pinnedBuffer->as<uint8_t>();
+
+  // Gather device pointers for a single D2H copy.
+  // All input tensors are assumed contiguous in device memory only if they came
+  // from tensorsToDevice. In general, copy each tensor individually.
+  int64_t offset = 0;
+  for (size_t i = 0; i < in.size(); ++i) {
+    stream.deviceToHostAsync(pinnedBase + offset, in[i].data_ptr(), sizes[i]);
+    offset += sizes[i];
+  }
+
+  // Build output tensors backed by the pinned buffer.
+  out.resize(in.size());
+  offset = 0;
+  for (size_t i = 0; i < in.size(); ++i) {
+    auto ref = new facebook::velox::wave::WaveBufferPtr(pinnedBuffer);
+    auto storage = c10::Storage(
+        c10::Storage::use_byte_size_t(),
+        sizes[i],
+        at::DataPtr(
+            pinnedBase + offset,
+            ref,
+            [](void* ctx) {
+              delete static_cast<facebook::velox::wave::WaveBufferPtr*>(ctx);
+            },
+            c10::Device(c10::kCPU)));
+    out[i] = at::empty({0}, in[i].options().device(c10::kCPU))
+                 .set_(std::move(storage), 0, in[i].sizes(), in[i].strides());
+    offset += sizes[i];
+  }
+}
+
+WaveGraphExecutor::WaveGraphExecutor(
+    const nativert::Graph& graph,
+    std::vector<std::unique_ptr<nativert::OpKernel>> nodeKernels,
+    const nativert::ExecutorConfig& executorConfig,
+    std::shared_ptr<nativert::Weights> weights)
+    : GraphExecutorBase(graph, std::move(nodeKernels), executorConfig),
+      weights_(std::move(weights)) {
+  initValueTypes();
+  waveGraph_ = std::make_unique<WaveGraph>(graph_, valueTypes_);
+  framePool_ = std::make_unique<Pool<nativert::ExecutionFrame>>(
+      [this]() { return makeDeviceFrame(); });
+}
+
+void WaveGraphExecutor::initValueTypes() {
+  const auto& tensorValuesMeta = graph_.tensorValuesMeta();
+  valueTypes_.types.resize(graph_.values().size(), nullptr);
+  for (const auto* value : graph_.values()) {
+    auto it = tensorValuesMeta.find(std::string{value->name()});
+    if (it != tensorValuesMeta.end()) {
+      auto meta = std::make_unique<nativert::TensorMeta>(it->second);
+      valueTypes_.types[value->id()] = meta.get();
+      metaStore_.push_back(std::move(meta));
+    }
+  }
+}
+
+std::unique_ptr<nativert::ExecutionFrame> WaveGraphExecutor::makeFrame() {
+  return std::make_unique<nativert::ExecutionFrame>(
+      graph_, *weights_, executorConfig_);
+}
+
+std::unique_ptr<nativert::ExecutionFrame> WaveGraphExecutor::makeDeviceFrame() {
+  auto frame = makeFrame();
+
+  // Collect all persistent tensor values and their ids.
+  auto persistentValues =
+      nativert::ExecutionFrame::getPersistentValues(graph_, weights_.get());
+  std::vector<nativert::ValueId> tensorIds;
+  std::vector<at::Tensor> hostTensors;
+  for (auto& [id, iv] : persistentValues) {
+    if (iv.isTensor()) {
+      tensorIds.push_back(id);
+      hostTensors.push_back(iv.toTensor());
+    }
+  }
+
+  if (!hostTensors.empty()) {
+    auto stream = globals()->streamPool->get();
+    std::vector<at::Tensor> deviceTensors;
+    tensorsToDevice(hostTensors, deviceTensors, *stream);
+    stream->wait();
+    globals()->streamPool->put(std::move(stream));
+
+    for (size_t i = 0; i < tensorIds.size(); ++i) {
+      frame->setIValue(tensorIds[i], c10::IValue(std::move(deviceTensors[i])));
+    }
+  }
+
+  return frame;
+}
+
+std::unique_ptr<nativert::ExecutionFrame> WaveGraphExecutor::getFrame() {
+  return framePool_->get();
+}
+
+void WaveGraphExecutor::returnFrame(
+    std::unique_ptr<nativert::ExecutionFrame> frame) {
+  frame->clearNonPersistentValues();
+  framePool_->put(std::move(frame));
+}
+
+std::vector<c10::IValue> WaveGraphExecutor::execute(
+    nativert::ExecutionFrame& /*frame*/,
+    std::vector<c10::IValue> inputs) {
+  auto pooledFrame = getFrame();
+  fillUserInputs(*pooledFrame, std::move(inputs));
+  auto outputs = executeWithPrefilledFrame(*pooledFrame);
+  returnFrame(std::move(pooledFrame));
+  return outputs;
+}
+
+std::vector<c10::IValue> WaveGraphExecutor::executeWithPrefilledFrame(
+    nativert::ExecutionFrame& frame) {
+  // Move any user input tensors that are not on device to device.
+  const auto& userInputs = graph_.signature().userInputs();
+  std::vector<nativert::ValueId> tensorIds;
+  std::vector<at::Tensor> hostTensors;
+  for (const auto& name : userInputs) {
+    auto* value = graph_.tryGetValue(name);
+    if (!value) {
+      continue;
+    }
+    const auto& ivalue = frame.getIValue(value->id());
+    if (ivalue.isTensor() && !ivalue.toTensor().is_cuda()) {
+      tensorIds.push_back(value->id());
+      hostTensors.push_back(ivalue.toTensor());
+    }
+  }
+
+  if (!hostTensors.empty()) {
+    auto stream = globals()->streamPool->get();
+    std::vector<at::Tensor> deviceTensors;
+    tensorsToDevice(hostTensors, deviceTensors, *stream);
+    stream->wait();
+    globals()->streamPool->put(std::move(stream));
+
+    for (size_t i = 0; i < tensorIds.size(); ++i) {
+      frame.setIValue(tensorIds[i], c10::IValue(std::move(deviceTensors[i])));
+    }
+  }
+
+  executeWave(frame, *waveGraph_);
+  // tryMoveUserOutputs moves the output IValues out of the frame, decoupling
+  // them so the frame can be safely returned to the pool.
+  return frame.tryMoveUserOutputs();
+}
+
+void WaveGraphExecutor::executeWave(
+    nativert::ExecutionFrame& frame,
+    const WaveGraph& waveGraph) {
+  auto* g = globals();
+  ExecutionState state{
+      .frame = frame,
+      .valueTypes = &valueTypes_,
+      .deviceArena = g->deviceArena.get(),
+      .pinnedArena = g->pinnedArena.get(),
+      .managedArena = g->managedArena.get(),
+      .streamPool = g->streamPool.get(),
+      .eventPool = g->eventPool.get()};
+  for (const auto& node : waveGraph.nodes()) {
+    node->execute(state);
+  }
+}
+
+void makeGrid(
+    const std::vector<OpInvocation>& ops,
+    const std::vector<int64_t>& numElements,
+    std::vector<BlockInfo>& blocks,
+    std::vector<int32_t>& opIndices,
+    std::vector<OpInvocation*>& nextOps) {
+  const int32_t blockSize = 256;
+
+  // Compute cost per op: numElements * unitCost.
+  std::vector<float> costs(ops.size());
+  float totalCost = 0;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    costs[i] = static_cast<float>(numElements[i]) * ops[i].op()->unitCost();
+    totalCost += costs[i];
+  }
+
+  // Max blocks each op could use.
+  std::vector<int32_t> maxBlocks(ops.size());
+  for (size_t i = 0; i < ops.size(); ++i) {
+    maxBlocks[i] =
+        static_cast<int32_t>((numElements[i] + blockSize - 1) / blockSize);
+    if (maxBlocks[i] < 1) {
+      maxBlocks[i] = 1;
+    }
+  }
+
+  // Target blocks from device SM count.
+  int32_t numSMs = 100;
+  auto* device = facebook::velox::wave::currentDevice();
+  if (device) {
+    numSMs = device->numSM;
+  }
+  int32_t targetBlocks = numSMs * 4;
+
+  // Assign blocks pro rata by cost, at least 1 per op, capped by maxBlocks.
+  std::vector<int32_t> numBlocksPerOp(ops.size());
+  int32_t totalAssigned = 0;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    float fraction = (totalCost > 0) ? costs[i] / totalCost : 1.0f / ops.size();
+    int32_t assigned =
+        std::max(1, static_cast<int32_t>(fraction * targetBlocks + 0.5f));
+    assigned = std::min(assigned, maxBlocks[i]);
+    numBlocksPerOp[i] = assigned;
+    totalAssigned += assigned;
+  }
+
+  // Fill blocks and opIndices.
+  blocks.resize(totalAssigned);
+  opIndices.resize(totalAssigned);
+  int32_t blockIdx = 0;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    auto opCode = ops[i].op()->opCodes()[0];
+    auto nBlocks = numBlocksPerOp[i];
+    auto elements = numElements[i];
+    for (int32_t b = 0; b < nBlocks; ++b) {
+      auto& info = blocks[blockIdx];
+      info.op = opCode;
+      info.blockInOp = b;
+      info.numBlocksInOp = nBlocks;
+      // Distribute elements across blocks.
+      auto elemsPerBlock = (elements + nBlocks - 1) / nBlocks;
+      auto startRow = static_cast<int64_t>(b) * elemsPerBlock;
+      auto endRow = std::min(startRow + elemsPerBlock, elements);
+      info.rowsForBlock = static_cast<int32_t>(endRow - startRow);
+      info.rowIdx = 0;
+      info.params = nullptr;
+      info.returnData = nullptr;
+      info.debug = nullptr;
+      opIndices[blockIdx] = static_cast<int32_t>(i);
+      ++blockIdx;
+    }
+  }
+
+  nextOps.clear();
+}
+
+namespace {
+
+void fillTensorParam(const at::Tensor& tensor, void* dest) {
+  TORCH_CHECK(
+      tensor.dim() <= 3,
+      "Tensors with more than 3 dims not supported, got ",
+      tensor.dim());
+  auto* t = reinterpret_cast<Tensor*>(dest);
+  t->storage = tensor.data_ptr();
+  t->rank = tensor.dim();
+  for (int i = 0; i < 3; ++i) {
+    t->dims[i] = i < tensor.dim() ? tensor.size(i) : 0;
+    t->strides[i] = i < tensor.dim() ? tensor.stride(i) : 0;
+  }
+}
+
+} // namespace
+
+void CompositeInvocation::execute(ExecutionState& state) {
+  auto& frame = state.frame;
+  const auto& types = *state.valueTypes;
+
+  // 1. Allocate outputs and collect numElements per op.
+  std::vector<int64_t> numElements;
+  numElements.reserve(ops.size());
+  for (auto& op : ops) {
+    numElements.push_back(op.allocateOutput(frame, types));
+  }
+
+  // 2. Build the grid.
+  std::vector<BlockInfo> blocks;
+  std::vector<int32_t> opIndices;
+  std::vector<OpInvocation*> nextOps;
+  makeGrid(ops, numElements, blocks, opIndices, nextOps);
+
+  // 3. Compute total param bytes and track per-op param offsets relative to
+  //    the start of the pinned buffer.
+  auto numBlocks = blocks.size();
+  auto blockInfoBytes = static_cast<int64_t>(numBlocks) * sizeof(BlockInfo);
+  std::vector<int64_t> opParamOffsets(ops.size());
+  int64_t paramCursor = blockInfoBytes;
+  for (size_t i = 0; i < ops.size(); ++i) {
+    opParamOffsets[i] = paramCursor;
+    paramCursor += ops[i].paramSize();
+  }
+  auto totalPinnedBytes = paramCursor;
+
+  // 4. Allocate pinned host buffer: BlockInfos + params.
+  auto pinnedBuffer = state.pinnedArena->allocateBytes(totalPinnedBytes);
+  auto* pinnedBase = pinnedBuffer->as<uint8_t>();
+
+  // 5. Copy BlockInfos to beginning of pinned buffer.
+  if (!blocks.empty()) {
+    memcpy(pinnedBase, blocks.data(), blockInfoBytes);
+  }
+
+  // 6. Fill params from frame values after the BlockInfos.
+  for (size_t opIdx = 0; opIdx < ops.size(); ++opIdx) {
+    auto& op = ops[opIdx];
+    auto* paramBase = pinnedBase + opParamOffsets[opIdx];
+    const auto& values = op.values();
+    const auto& offsets = op.offsets();
+    const auto& constants = op.constants();
+    auto numInputValues = values.size();
+
+    const auto& orderedInputs = op.op()->orderedInputs();
+    auto numInputs = op.op()->numInputs();
+
+    // Fill input value params.
+    for (size_t i = 0; i < numInputValues; ++i) {
+      auto* value = values[i];
+      auto offset = offsets[i];
+      auto* dest = paramBase + offset;
+      auto it = op.bindings().find(value->id());
+      auto actualId = it != op.bindings().end() ? it->second : value->id();
+      const auto& ivalue = frame.getIValue(actualId);
+      if (ivalue.isTensor()) {
+        fillTensorParam(ivalue.toTensor(), dest);
+      } else if (ivalue.isInt()) {
+        *reinterpret_cast<int64_t*>(dest) = ivalue.toInt();
+      } else if (ivalue.isDouble()) {
+        *reinterpret_cast<double*>(dest) = ivalue.toDouble();
+      } else if (ivalue.isBool()) {
+        *reinterpret_cast<int64_t*>(dest) = ivalue.toBool() ? 1 : 0;
+      } else {
+        TORCH_CHECK(false, "Unsupported IValue type for kernel param");
+      }
+    }
+
+    // Fill output params via bindings.
+    for (size_t i = numInputs; i < orderedInputs.size() &&
+         (numInputValues + (i - numInputs)) < offsets.size();
+         ++i) {
+      auto formalId = orderedInputs[i]->id();
+      auto bindIt = op.bindings().find(formalId);
+      if (bindIt == op.bindings().end()) {
+        continue;
+      }
+      auto actualId = bindIt->second;
+      auto offsetIdx = numInputValues + (i - numInputs);
+      auto offset = offsets[offsetIdx];
+      auto* dest = paramBase + offset;
+      const auto& ivalue = frame.getIValue(actualId);
+      if (ivalue.isTensor()) {
+        fillTensorParam(ivalue.toTensor(), dest);
+      } else {
+        TORCH_CHECK(false, "Expected tensor for output param");
+      }
+    }
+
+    // Fill constant params.
+    for (size_t i = 0; i < constants.size(); ++i) {
+      auto offsetIdx = numInputValues + i;
+      if (offsetIdx >= offsets.size()) {
+        break;
+      }
+      auto offset = offsets[offsetIdx];
+      auto* dest = paramBase + offset;
+      const auto* c = constants[i];
+      if (c->isInt()) {
+        *reinterpret_cast<int64_t*>(dest) = c->toInt();
+      } else if (c->isDouble()) {
+        *reinterpret_cast<double*>(dest) = c->toDouble();
+      } else if (c->isBool()) {
+        *reinterpret_cast<int64_t*>(dest) = c->toBool() ? 1 : 0;
+      } else {
+        TORCH_CHECK(false, "Unsupported constant type for kernel param");
+      }
+    }
+  }
+
+  // 7. Allocate device memory.
+  auto deviceBuffer = state.deviceArena->allocateBytes(totalPinnedBytes);
+  auto* deviceBase = deviceBuffer->as<uint8_t>();
+
+  // 8. Patch BlockInfo params pointers to point to the device-side param
+  //    area for the corresponding op (will be valid after H2D copy).
+  auto* pinnedBlocks = reinterpret_cast<BlockInfo*>(pinnedBase);
+  for (size_t b = 0; b < numBlocks; ++b) {
+    auto opIdx = opIndices[b];
+    pinnedBlocks[b].params = deviceBase + opParamOffsets[opIdx];
+  }
+
+  // 9. Get a stream and enqueue H2D transfer.
+  auto stream = state.streamPool->get();
+  stream->hostToDeviceAsync(deviceBase, pinnedBase, totalPinnedBytes);
+
+  // 10. Launch the composite kernel on the same stream.
+  const int32_t blockSize = 256;
+  TorchWaveParams params;
+  params.info = reinterpret_cast<BlockInfo*>(deviceBase);
+  void* args[] = {&params};
+  kernel->launch(
+      static_cast<int32_t>(numBlocks), blockSize, 0, stream.get(), args);
+
+  // 11. Wait for the kernel to complete and return the stream to the pool.
+  stream->wait();
+  state.streamPool->put(std::move(stream));
+}
+
+void CompiledNode::execute(ExecutionState& state) {
+  for (auto& group : kernels_) {
+    for (auto& invocation : group) {
+      invocation->execute(state);
+    }
+  }
+}
+
+std::vector<std::vector<Dim>> elementwiseOutputShape(
+    const std::vector<const nativert::Value*>& inputs,
+    const nativert::Node* /*node*/,
+    nativert::ExecutionFrame& frame,
+    FormalToActual map) {
+  int64_t maxNumel = -1;
+  std::vector<Dim> bestShape;
+  for (const auto* input : inputs) {
+    auto it = map.find(input->id());
+    TORCH_CHECK(
+        it != map.end(),
+        "Input value %v",
+        input->id(),
+        " not found in FormalToActual map");
+    auto actualId = it->second;
+    auto tensor = frame.getTensor(actualId);
+    auto numel = tensor.numel();
+    if (numel > maxNumel) {
+      maxNumel = numel;
+      auto sizes = tensor.sizes();
+      bestShape.assign(sizes.begin(), sizes.end());
+    }
+  }
+  return {bestShape};
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Executor.h
+++ b/velox/experimental/torchwave/Executor.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <torch/nativert/executor/GraphExecutorBase.h>
+#include <torch/nativert/executor/Weights.h>
+#include "velox/experimental/torchwave/Compile.h"
+#include "velox/experimental/torchwave/CompiledOp.h"
+#include "velox/experimental/torchwave/Registry.h"
+#include "velox/experimental/torchwave/Utils.h"
+#include "velox/experimental/wave/common/Buffer.h"
+
+namespace facebook::velox::wave {
+class GpuArena;
+} // namespace facebook::velox::wave
+
+namespace torch::wave {
+
+/// Initializes process-wide GPU resources (arenas, stream/event pools).
+/// Does nothing if no GPU is available. Safe to call multiple times.
+void initialize();
+
+/// Copies tensors from host to device. Allocates a contiguous pinned buffer,
+/// copies tensor storage into it, allocates a matching device buffer, and
+/// enqueues an async H2D transfer on 'stream'. The output tensors in 'out'
+/// share the device buffer and point into the appropriate offsets. The returned
+/// WaveBufferPtr keeps the device memory alive as long as any output tensor
+/// references it.
+facebook::velox::wave::WaveBufferPtr tensorsToDevice(
+    const std::vector<at::Tensor>& in,
+    std::vector<at::Tensor>& out,
+    facebook::velox::wave::Stream& stream);
+
+/// Copies tensors from device to host. Allocates a contiguous pinned buffer,
+/// enqueues an async D2H transfer on 'stream', and builds output tensors
+/// backed by the pinned buffer. The caller must wait on 'stream' before
+/// accessing the output data.
+void tensorsToHost(
+    const std::vector<at::Tensor>& in,
+    std::vector<at::Tensor>& out,
+    facebook::velox::wave::Stream& stream);
+
+/// Holds runtime state for executing a WaveGraph.
+struct ExecutionState {
+  nativert::ExecutionFrame& frame;
+  const ValueTypes* valueTypes{nullptr};
+  facebook::velox::wave::GpuArena* deviceArena{nullptr};
+  facebook::velox::wave::GpuArena* pinnedArena{nullptr};
+  facebook::velox::wave::GpuArena* managedArena{nullptr};
+  StreamPool* streamPool{nullptr};
+  EventPool* eventPool{nullptr};
+};
+
+/// Builds BlockInfo grid for a set of OpInvocations given their numElements.
+/// Populates 'blocks' with the BlockInfo array, 'opIndices' with the op index
+/// for each block, and clears 'nextOps'.
+void makeGrid(
+    const std::vector<OpInvocation>& ops,
+    const std::vector<int64_t>& numElements,
+    std::vector<BlockInfo>& blocks,
+    std::vector<int32_t>& opIndices,
+    std::vector<OpInvocation*>& nextOps);
+
+/// Computes output shapes for elementwise operations given the dedupped input
+/// values' shapes.
+std::vector<std::vector<Dim>> elementwiseOutputShape(
+    const std::vector<const nativert::Value*>& inputs,
+    const nativert::Node* node,
+    nativert::ExecutionFrame& frame,
+    FormalToActual map);
+
+/// Executes a WaveGraph as a GraphExecutorBase subclass, allowing it to
+/// be used wherever the standard nativert executors are used.
+class WaveGraphExecutor : public nativert::GraphExecutorBase {
+ public:
+  WaveGraphExecutor(
+      const nativert::Graph& graph,
+      std::vector<std::unique_ptr<nativert::OpKernel>> nodeKernels,
+      const nativert::ExecutorConfig& executorConfig,
+      std::shared_ptr<nativert::Weights> weights);
+
+  /// Creates an ExecutionFrame on CPU with all constants and weights
+  /// pre-filled.
+  std::unique_ptr<nativert::ExecutionFrame> makeFrame();
+
+  /// Creates an ExecutionFrame whose persistent tensors have been copied to
+  /// device.
+  std::unique_ptr<nativert::ExecutionFrame> makeDeviceFrame();
+
+  /// Executes with a pooled device frame. The frame is obtained from the pool,
+  /// inputs are filled, the wave graph runs, outputs are extracted and
+  /// decoupled from the frame, and the frame is returned to the pool.
+  std::vector<c10::IValue> execute(
+      nativert::ExecutionFrame& frame,
+      std::vector<c10::IValue> inputs) override;
+
+  std::vector<c10::IValue> executeWithPrefilledFrame(
+      nativert::ExecutionFrame& frame) override;
+
+  /// Returns a frame from the pool, creating one if needed.
+  std::unique_ptr<nativert::ExecutionFrame> getFrame();
+
+  /// Returns 'frame' to the pool after clearing non-persistent values.
+  void returnFrame(std::unique_ptr<nativert::ExecutionFrame> frame);
+
+ private:
+  /// Runs the WaveGraph on the given frame.
+  void executeWave(nativert::ExecutionFrame& frame, const WaveGraph& waveGraph);
+
+  /// Builds ValueTypes from the graph's tensor metadata.
+  void initValueTypes();
+
+  std::shared_ptr<nativert::Weights> weights_;
+
+  /// Stable storage for TensorMeta objects referenced by valueTypes_.
+  std::vector<std::unique_ptr<nativert::TensorMeta>> metaStore_;
+
+  ValueTypes valueTypes_;
+
+  std::unique_ptr<WaveGraph> waveGraph_;
+
+  /// Pool of device-side ExecutionFrames with persistent tensors on GPU.
+  std::unique_ptr<Pool<nativert::ExecutionFrame>> framePool_;
+};
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/GraphView.cpp
+++ b/velox/experimental/torchwave/GraphView.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/GraphView.h"
+
+#include <algorithm>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <torch/nativert/graph/Graph.h>
+#include <torch/nativert/graph/TensorMeta.h>
+
+#include "velox/experimental/torchwave/Executor.h"
+#include "velox/experimental/torchwave/ParallelExpr.h"
+
+namespace torch::wave {
+
+void printTensorMeta(
+    std::string_view name,
+    const torch::nativert::TensorMeta& tm) {
+  std::cout << "  path: " << name << "  shape: [";
+  if (!tm.hasSymbolicShape()) {
+    const auto sizes = tm.sizes();
+    for (int64_t i = 0; i < static_cast<int64_t>(sizes.size()); ++i) {
+      if (i > 0) {
+        std::cout << ", ";
+      }
+      std::cout << sizes[i];
+    }
+    std::cout << "]  dtype: " << c10::toString(tm.dtype())
+              << "  numel: " << tm.numel() << "\n";
+  } else {
+    std::cout << "symbolic]  dtype: " << c10::toString(tm.dtype()) << "\n";
+  }
+}
+
+void printModelParams(const torch::nativert::Graph& graph) {
+  const auto& sig = graph.signature();
+  const auto& weightsMeta = graph.weightsMeta();
+  const auto& tensorValuesMeta = graph.tensorValuesMeta();
+
+  std::cout << "\nParameters:\n";
+  for (const auto& [inputName, fqn] : sig.inputsToParameters()) {
+    const std::string fqnStr(fqn);
+    if (auto it = weightsMeta.find(fqnStr); it != weightsMeta.end()) {
+      printTensorMeta(fqn, it->second);
+    }
+  }
+
+  std::cout << "\nBuffers:\n";
+  for (const auto& [inputName, fqn] : sig.inputsToBuffers()) {
+    const std::string fqnStr(fqn);
+    if (auto it = weightsMeta.find(fqnStr); it != weightsMeta.end()) {
+      printTensorMeta(fqn, it->second);
+    }
+  }
+
+  std::cout << "\nSample Inputs:\n";
+  for (const auto& name : sig.userInputs()) {
+    if (auto it = tensorValuesMeta.find(name); it != tensorValuesMeta.end()) {
+      printTensorMeta(name, it->second);
+    }
+  }
+}
+
+void printGraphView(const torch::nativert::Graph& graph) {
+  initialize();
+  std::cout << "\nGraph Signature:\n";
+  std::cout << graph.signature() << "\n";
+  std::cout << "\nOutput Node:\n";
+  std::cout << graph.outputNode()->toString() << "\n";
+
+  std::cout << "\nAll Nodes:\n";
+  int nodeIdx = 0;
+  for (const auto& node : graph.nodes()) {
+    std::cout << nodeIdx++ << ": " << node.toString() << "\n";
+  }
+
+  std::cout << "\nProject Nodes:\n";
+  torch::wave::ParallelNodes parallelNodes;
+  auto* lastProjectNode = parallelNodes.makeParallelNodes(graph);
+  std::vector<const torch::wave::ProjectNode*> projectNodeList;
+  for (auto* pn = lastProjectNode; pn != nullptr; pn = pn->input()) {
+    projectNodeList.push_back(pn);
+  }
+  std::reverse(projectNodeList.begin(), projectNodeList.end());
+  torch::wave::PlanObjectSet border;
+  for (const auto* pn : projectNodeList) {
+    std::cout << pn->toString(graph, border);
+    border.insert(pn->nodes().begin(), pn->nodes().end());
+  }
+
+  std::unordered_map<std::string, int32_t> functionCounts;
+  for (const auto* pn : projectNodeList) {
+    pn->distinctFunctions(functionCounts);
+  }
+  std::vector<std::pair<std::string, int32_t>> sorted(
+      functionCounts.begin(), functionCounts.end());
+  std::sort(sorted.begin(), sorted.end(), [](const auto& a, const auto& b) {
+    return a.second > b.second;
+  });
+  std::cout << "\nDistinct Functions:\n";
+  for (const auto& [name, count] : sorted) {
+    std::cout << count << ": " << name << "\n";
+  }
+
+  std::unordered_map<std::string, int32_t> nameCounts;
+  for (const auto& [key, count] : functionCounts) {
+    auto pos = key.find(' ');
+    auto name = (pos != std::string::npos) ? key.substr(0, pos) : key;
+    nameCounts[name] += count;
+  }
+  std::vector<std::pair<std::string, int32_t>> sortedNames(
+      nameCounts.begin(), nameCounts.end());
+  std::sort(
+      sortedNames.begin(), sortedNames.end(), [](const auto& a, const auto& b) {
+        return a.second > b.second;
+      });
+  std::cout << "\nDistinct Function Names:\n";
+  for (const auto& [name, count] : sortedNames) {
+    std::cout << count << ": " << name << "\n";
+  }
+
+  const auto& tensorValuesMeta = graph.tensorValuesMeta();
+  std::cout << "\nValue Tensor Metadata:\n";
+  for (const auto* value : graph.values()) {
+    auto it = tensorValuesMeta.find(std::string{value->name()});
+    if (it == tensorValuesMeta.end()) {
+      continue;
+    }
+    const auto& tm = it->second;
+    std::cout << value->id() << " : ";
+    if (!tm.hasSymbolicShape()) {
+      const auto sizes = tm.sizes();
+      std::cout << "dtype=" << c10::toString(tm.dtype()) << " shape=[";
+      for (int64_t i = 0; i < static_cast<int64_t>(sizes.size()); ++i) {
+        if (i > 0) {
+          std::cout << ", ";
+        }
+        std::cout << sizes[i];
+      }
+      std::cout << "] device=" << tm.device() << " numel=" << tm.numel()
+                << "\n";
+    } else {
+      std::cout << "dtype=" << c10::toString(tm.dtype())
+                << " shape=[symbolic] device=" << tm.device() << "\n";
+    }
+  }
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/GraphView.h
+++ b/velox/experimental/torchwave/GraphView.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string_view>
+
+#include <torch/nativert/graph/Graph.h>
+#include <torch/nativert/graph/TensorMeta.h>
+
+namespace torch::wave {
+
+void printTensorMeta(
+    std::string_view name,
+    const torch::nativert::TensorMeta& tm);
+
+void printModelParams(const torch::nativert::Graph& graph);
+
+void printGraphView(const torch::nativert::Graph& graph);
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/KernelParams.h
+++ b/velox/experimental/torchwave/KernelParams.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace torch::wave {
+/// Header for host to torch::wave kernel communication. Includeed in both host
+/// and device code.
+
+struct Tensor {
+  void* storage;
+  int8_t rank;
+  int32_t dims[3];
+  int32_t strides[3];
+};
+
+/// Struct for returning errors to host. Each block has one. These may be
+/// checked at a delay, so return status that requires action on host side must
+/// be sent in returnStatus, not here.
+struct DebugInfo {
+  int32_t code;
+  int32_t line;
+  char message[80];
+  int64_t extra[2];
+};
+
+/// Each TB fetches its instructions from BlockInfo at blockIdx.x. Copied at
+/// offset 0 in dynamic shared memory of the block.
+struct BlockInfo {
+  /// kernel dependent op code for this block.
+  int32_t op;
+
+  /// Index of this block within the blocks with for the same op.
+  int32_t blockInOp;
+
+  /// Number of blocks for this op.
+  int32_t numBlocksInOp;
+
+  /// Number of data items to process in this block. Suppose 2 blocks of 256
+  /// with 600 elements to process, the first would have 512 and the next would
+  /// have 88.
+  int32_t rowsForBlock;
+
+  /// Index of row processed by lane 0 of this block. The block increments this
+  /// by blockDim.x on each iteration until this is >= rowsForBlock.
+  int32_t rowIdx{0};
+  /// Pointer to per-op params, format depends on 'op'.
+  void* params;
+
+  // Pointer to per block return status. If not nullptr, the block must write a
+  // per-block status to pass to host here. For example, for stream compaction,
+  // the result length for data processed by this block. Consolidated with
+  // return data of other blocks for single D to H transfer.
+  void* returnData;
+
+  DebugInfo* debug;
+};
+
+struct TorchWaveParams {
+  // Pointer to BlockInfo for blockIdx.x 0. gridDim.x consecutive BlockInfos. If
+  // nullptr the BlockInfos are in inlineInfo.
+  BlockInfo* info;
+  BlockInfo inlineInfo[100];
+};
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/NativertSerialization.cpp
+++ b/velox/experimental/torchwave/NativertSerialization.cpp
@@ -1,0 +1,776 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Local copy of caffe2/torch/nativert/graph/Serialization.cpp.
+// Copied because the nativert graph code has no standalone Buck target;
+// it is normally compiled directly into binaries that need it (e.g.
+// ModelRunner).  We need jsonToGraph() to load open-source .pt2 files.
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <torch/nativert/graph/Serialization.h>
+#include <limits>
+namespace torch::nativert {
+
+namespace {
+
+std::unique_ptr<Graph> jsonToSubgraph(
+    const torch::_export::Graph& jsonGraph,
+    const torch::_export::GraphSignature* signature,
+    bool loadNodeMetadata);
+
+Value* symbolicToValue(
+    const torch::_export::Argument& arg,
+    Graph& graph,
+    Node* insertBefore) {
+  switch (arg.tag()) {
+    case torch::_export::Argument::Tag::AS_TENSOR:
+      return graph.getValue(arg.get_as_tensor().get_name());
+    case torch::_export::Argument::Tag::AS_TENSORS: {
+      // Need to insert a list pack node
+      std::vector<Value*> listValue;
+      for (const auto& listEl : arg.get_as_tensors()) {
+        listValue.push_back(graph.getValue(listEl.get_name()));
+      }
+      auto listPack =
+          graph.createListPack(std::move(listValue), Type::Kind::Tensor);
+      return graph.insertBefore(listPack, insertBefore)->outputs()[0];
+    }
+    case torch::_export::Argument::Tag::AS_NESTED_TENSORS: {
+      // Handle nested tensor lists (List[List[Tensor]])
+      // Create inner ListPack nodes for each inner list, then pack them
+      // together
+      std::vector<Value*> outerListValues;
+      for (const auto& innerList : arg.get_as_nested_tensors()) {
+        std::vector<Value*> innerListValues;
+        for (const auto& tensorArg : innerList) {
+          innerListValues.push_back(graph.getValue(tensorArg.get_name()));
+        }
+        auto innerListPack = graph.createListPack(
+            std::move(innerListValues), Type::Kind::Tensor);
+        outerListValues.push_back(
+            graph.insertBefore(innerListPack, insertBefore)->outputs()[0]);
+      }
+      auto outerListPack = graph.createListPack(
+          std::move(outerListValues), Type::Kind::TensorList);
+      return graph.insertBefore(outerListPack, insertBefore)->outputs()[0];
+    }
+    case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS: {
+      // Need to insert a list pack node
+      std::vector<Value*> listValue;
+      for (const auto& listEl : arg.get_as_optional_tensors()) {
+        switch (listEl.tag()) {
+          case torch::_export::OptionalTensorArgument::Tag::AS_TENSOR: {
+            listValue.push_back(
+                graph.getValue(listEl.get_as_tensor().get_name()));
+            break;
+          }
+          case torch::_export::OptionalTensorArgument::Tag::AS_NONE: {
+            listValue.push_back(
+                graph.addValue(std::nullopt, Type::Kind::None, nullptr));
+            break;
+          }
+          default:
+            TORCH_CHECK(
+                false,
+                fmt::format(
+                    "Unknown OptionalTensorArgument type: {}",
+                    torch::_export::printEnum(listEl.tag())));
+        }
+      }
+      auto listPack = graph.createOptionalListPack(std::move(listValue));
+      return graph.insertBefore(listPack, insertBefore)->outputs()[0];
+    }
+    case torch::_export::Argument::Tag::AS_SYM_INT: {
+      return graph.getValue(arg.get_as_sym_int().get_as_name());
+    }
+    case torch::_export::Argument::Tag::AS_SYM_INTS: {
+      // Need to insert a list pack node
+      std::vector<Value*> listValue;
+      for (const auto& listEl : arg.get_as_sym_ints()) {
+        switch (listEl.tag()) {
+          case torch::_export::SymIntArgument::Tag::AS_NAME: {
+            listValue.push_back(graph.getValue(listEl.get_as_name()));
+            break;
+          }
+          case torch::_export::SymIntArgument::Tag::AS_INT: {
+            // These are concrete int values in the SymIntList, e.g [s0, 8]
+            // We convert them into a constant Value in graph. These value
+            // doesn't have producer node
+            int64_t value = listEl.get_as_int();
+            TORCH_CHECK(
+                value >= std::numeric_limits<int>::min() &&
+                value <= std::numeric_limits<int>::max());
+            Value* symintValue =
+                graph.createConstantSymIntValue(static_cast<int>(value));
+            listValue.push_back(symintValue);
+            break;
+          }
+          default:
+            TORCH_CHECK(
+                false,
+                fmt::format(
+                    "Unknown SymIntArgument type: {}",
+                    torch::_export::printEnum(listEl.tag())));
+        }
+      }
+      auto listPack =
+          graph.createListPack(std::move(listValue), Type::Kind::SymInt);
+      return graph.insertBefore(listPack, insertBefore)->outputs()[0];
+    }
+    case torch::_export::Argument::Tag::AS_CUSTOM_OBJ: {
+      return graph.getValue(arg.get_as_custom_obj().get_name());
+    }
+    case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+      return graph.getValue(arg.get_as_sym_bool().get_as_name());
+    }
+    case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+      return graph.getValue(arg.get_as_sym_float().get_as_name());
+    }
+    case torch::_export::Argument::Tag::AS_STRING_TO_ARGUMENT: {
+      TORCH_CHECK(
+          false,
+          "String to argument mapping is not yet supported in symbolic context");
+    }
+    default:
+      TORCH_CHECK(
+          false,
+          fmt::format(
+              "This function should only be called with symbolic arguments, got {} instead",
+              torch::_export::printEnum(arg.tag())));
+  }
+}
+
+std::pair<
+    std::vector<torch::_export::InputSpec>,
+    std::vector<torch::_export::Argument>>
+enforceInputOrder(
+    const std::vector<torch::_export::InputSpec>& inputSpecs,
+    const std::vector<torch::_export::Argument>& graphInputs) {
+  // Enforce the order of inputSpecs and graphInputs to be the following:
+  // 1. token
+  // 2. parameter
+  // 3. persistent buffer, non-persistent buffer
+  // 4. tensor_constant
+  // 5. custom_obj
+  // 6. user_input/constant_input
+  std::vector<torch::_export::InputSpec> reorderedInputSpecs;
+  std::vector<torch::_export::Argument> reorderedGraphInputs;
+  std::vector<torch::_export::InputSpec::Tag> desiredOrder = {
+      torch::_export::InputSpec::Tag::TOKEN,
+      torch::_export::InputSpec::Tag::PARAMETER,
+      torch::_export::InputSpec::Tag::BUFFER,
+      torch::_export::InputSpec::Tag::TENSOR_CONSTANT,
+      torch::_export::InputSpec::Tag::CUSTOM_OBJ};
+
+  auto reorder = [&](auto condition) {
+    for (size_t i = 0; i < inputSpecs.size(); ++i) {
+      if (condition(inputSpecs[i])) {
+        reorderedInputSpecs.push_back(inputSpecs[i]);
+        reorderedGraphInputs.push_back(graphInputs[i]);
+      }
+    }
+  };
+
+  for (const auto& tag : desiredOrder) {
+    if (tag == torch::_export::InputSpec::Tag::BUFFER) {
+      // Add persistent buffers first, then non-persistent
+      reorder([&](const auto& spec) {
+        return spec.tag() == tag && spec.get_buffer().get_persistent();
+      });
+      reorder([&](const auto& spec) {
+        return spec.tag() == tag && !spec.get_buffer().get_persistent();
+      });
+    } else {
+      reorder([&](const auto& spec) { return spec.tag() == tag; });
+    }
+  }
+
+  // Append USER_INPUT and CONSTANT_INPUT without reordering
+  for (size_t i = 0; i < inputSpecs.size(); ++i) {
+    auto tag = inputSpecs[i].tag();
+    if (tag == torch::_export::InputSpec::Tag::USER_INPUT ||
+        tag == torch::_export::InputSpec::Tag::CONSTANT_INPUT) {
+      reorderedInputSpecs.push_back(inputSpecs[i]);
+      reorderedGraphInputs.push_back(graphInputs[i]);
+    }
+  }
+  return {std::move(reorderedInputSpecs), std::move(reorderedGraphInputs)};
+}
+
+std::unique_ptr<Graph> jsonToSubgraph(
+    const torch::_export::Graph& jsonGraph,
+    const torch::_export::GraphSignature* signature,
+    bool loadNodeMetadata) {
+  auto graphInputs = jsonGraph.get_inputs();
+  auto graph = Graph::createGraph();
+
+  if (signature) {
+    // enforcing the order signature inputspecs and graph inputs
+    const auto& inputSpecs = signature->get_input_specs();
+
+    auto [reorderedInputSpecs, reorderedGraphInputs] =
+        enforceInputOrder(inputSpecs, graphInputs);
+
+    graphInputs = std::move(reorderedGraphInputs);
+    auto reorderedSignature = *signature;
+    reorderedSignature.set_input_specs(reorderedInputSpecs);
+    graph->setSignature(GraphSignature{reorderedSignature});
+  }
+
+  for (const auto& input : graphInputs) {
+    if (isSymbolic(input)) {
+      switch (input.tag()) {
+        case torch::_export::Argument::Tag::AS_TENSOR: {
+          const auto& asTensor = input.get_as_tensor();
+          const auto& name = asTensor.get_name();
+          graph->addInput(name, Type::Kind::Tensor);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_TENSORS: {
+          // Handle list of tensors - each tensor becomes a separate input
+          for (const auto& tensor : input.get_as_tensors()) {
+            graph->addInput(tensor.get_name(), Type::Kind::Tensor);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR: {
+          // Handle single optional tensor
+          const auto& optTensor = input.get_as_optional_tensor();
+          if (optTensor.tag() ==
+              torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+            graph->addInput(
+                optTensor.get_as_tensor().get_name(), Type::Kind::Tensor);
+          }
+          // Skip if None
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS: {
+          // Handle list of optional tensors
+          for (const auto& optTensor : input.get_as_optional_tensors()) {
+            if (optTensor.tag() ==
+                torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+              graph->addInput(
+                  optTensor.get_as_tensor().get_name(), Type::Kind::Tensor);
+            }
+            // Skip None tensors
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INT: {
+          const auto& symInt = input.get_as_sym_int();
+          if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+            graph->addInput(symInt.get_as_name(), Type::Kind::SymInt);
+          }
+          // Skip constant symints
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INTS: {
+          for (const auto& symInt : input.get_as_sym_ints()) {
+            if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+              graph->addInput(symInt.get_as_name(), Type::Kind::SymInt);
+            }
+            // Skip constant symints
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+          const auto& symBool = input.get_as_sym_bool();
+          if (symBool.tag() == torch::_export::SymBoolArgument::Tag::AS_NAME) {
+            graph->addInput(symBool.get_as_name(), Type::Kind::SymBool);
+          }
+          // Skip constant symbools
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOLS: {
+          for (const auto& symBool : input.get_as_sym_bools()) {
+            if (symBool.tag() ==
+                torch::_export::SymBoolArgument::Tag::AS_NAME) {
+              graph->addInput(symBool.get_as_name(), Type::Kind::SymBool);
+            }
+            // Skip constant symbools
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+          // SymFloat inputs - add as SymFloat type
+          graph->addInput(
+              fmt::format("sym_float_{}", graph->numValues()),
+              Type::Kind::SymFloat);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+          for (size_t i = 0; i < input.get_as_sym_floats().size(); ++i) {
+            graph->addInput(
+                fmt::format("sym_float_{}_{}", graph->numValues(), i),
+                Type::Kind::SymFloat);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_CUSTOM_OBJ: {
+          const auto& asCustomObj = input.get_as_custom_obj();
+          const std::string& name = asCustomObj.get_name();
+          const std::string& classFqn = asCustomObj.get_class_fqn();
+          graph->addInput(name, Type(Type::Kind::CustomObj, classFqn));
+          break;
+        }
+        default:
+          TORCH_CHECK(
+              false,
+              fmt::format(
+                  "Unsupported symbolic graph input type: {}",
+                  torch::_export::printEnum(input.tag())));
+      }
+    } else {
+      switch (input.tag()) {
+        case torch::_export::Argument::Tag::AS_INT:
+        case torch::_export::Argument::Tag::AS_FLOAT:
+        case torch::_export::Argument::Tag::AS_STRING:
+        case torch::_export::Argument::Tag::AS_BOOL:
+        case torch::_export::Argument::Tag::AS_NONE: {
+          // Constant graph inputs are specialized in the graph, here we simply
+          // add a nullptr of Value to the graph input node.
+          graph->addInput();
+          break;
+        }
+        default:
+          TORCH_CHECK(
+              false,
+              fmt::format(
+                  "Unsupported constant graph input type: {}",
+                  torch::_export::printEnum(input.tag())));
+      }
+    }
+  }
+
+  for (const auto& jsonNode : jsonGraph.get_nodes()) {
+    auto node = graph->insertNode(
+        jsonNode.get_target(),
+        {},
+        loadNodeMetadata ? jsonNode.get_metadata()
+                         : std::unordered_map<std::string, std::string>());
+
+    std::vector<NamedArgument> args;
+    std::vector<Attribute> attributes;
+    for (const auto& input : jsonNode.get_inputs()) {
+      // We handle constants and symbolic inputs differently.
+      const auto& arg = input.get_arg();
+      if (isSymbolic(arg)) {
+        // Symbolic values are made part of the inputs to the node
+        node->addInput(
+            NamedArgument{
+                input.get_name(),
+                symbolicToValue(input.get_arg(), *graph, node)});
+      } else if (arg.tag() == torch::_export::Argument::Tag::AS_NONE) {
+        node->addInput(
+            NamedArgument{
+                input.get_name(),
+                graph->addValue(std::nullopt, Type::Kind::None, node)});
+      } else {
+        node->addAttribute(
+            Attribute{
+                input.get_name(),
+                constantToValue(input.get_arg(), loadNodeMetadata)});
+        // Constant values are added as "attributes" to the node.
+      }
+    }
+
+    std::vector<Value*> outputs;
+    std::vector<Value*> listUnpacksToCreate;
+    for (const auto& output : jsonNode.get_outputs()) {
+      switch (output.tag()) {
+        case torch::_export::Argument::Tag::AS_NONE: {
+          node->addOutput(Type::Kind::None);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_TENSOR: {
+          const auto name = output.get_as_tensor().get_name();
+          node->addOutput(name, Type::Kind::Tensor);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_TENSORS: {
+          auto outputValue = node->addOutput(
+              graph->getUniqueValueName(), Type::Kind::TensorList);
+
+          Node* listUnpack =
+              graph->insertNode("prim.ListUnpack", {{"input", outputValue}});
+          for (const auto& arg : output.get_as_tensors()) {
+            listUnpack->addOutput(arg.get_name(), Type::Kind::Tensor);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INT: {
+          const auto name = output.get_as_sym_int().get_as_name();
+          node->addOutput(name, Type::Kind::SymInt);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INTS: {
+          TORCH_CHECK(
+              false,
+              "SymInts NYI. We currently don't have ops that produce SymInts as output");
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+          const auto name = output.get_as_sym_bool().get_as_name();
+          node->addOutput(name, Type::Kind::SymBool);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOLS: {
+          TORCH_CHECK(
+              false,
+              "SymBools NYI. We currently don't have ops that produce SymBools as output");
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+          const auto name = output.get_as_sym_float().get_as_name();
+          node->addOutput(name, Type::Kind::SymFloat);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+          TORCH_CHECK(
+              false,
+              "SymFloats NYI. We currently doesn't have op that produces SymFloats as output");
+        }
+        default:
+          TORCH_CHECK(
+              false,
+              fmt::format(
+                  "Unsupported graph output type: {}",
+                  torch::_export::printEnum(output.tag())));
+      }
+    }
+  }
+
+  for (const auto& output : jsonGraph.get_outputs()) {
+    // handle symbolic outputs and constant outputs differently
+    if (isSymbolic(output)) {
+      switch (output.tag()) {
+        case torch::_export::Argument::Tag::AS_TENSOR: {
+          const auto& asTensor = output.get_as_tensor();
+          const auto& name = asTensor.get_name();
+          Value* outputValue = graph->getValue(name);
+          graph->addOutput(outputValue);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_TENSORS: {
+          // Handle list of tensors - each tensor becomes a separate output
+          for (const auto& tensor : output.get_as_tensors()) {
+            Value* outputValue = graph->getValue(tensor.get_name());
+            graph->addOutput(outputValue);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR: {
+          // Handle single optional tensor
+          const auto& optTensor = output.get_as_optional_tensor();
+          if (optTensor.tag() ==
+              torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+            Value* outputValue =
+                graph->getValue(optTensor.get_as_tensor().get_name());
+            graph->addOutput(outputValue);
+          }
+          // Skip None tensors
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS: {
+          // Handle list of optional tensors
+          for (const auto& optTensor : output.get_as_optional_tensors()) {
+            if (optTensor.tag() ==
+                torch::_export::OptionalTensorArgument::Tag::AS_TENSOR) {
+              Value* outputValue =
+                  graph->getValue(optTensor.get_as_tensor().get_name());
+              graph->addOutput(outputValue);
+            }
+            // Skip None tensors
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INT: {
+          const auto& asSymInt = output.get_as_sym_int();
+          TORCH_CHECK(
+              asSymInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME);
+          const auto& name = asSymInt.get_as_name();
+          Value* outputValue = graph->getValue(name);
+          graph->addOutput(outputValue);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_INTS: {
+          for (const auto& symInt : output.get_as_sym_ints()) {
+            if (symInt.tag() == torch::_export::SymIntArgument::Tag::AS_NAME) {
+              Value* outputValue = graph->getValue(symInt.get_as_name());
+              graph->addOutput(outputValue);
+            }
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOL: {
+          const auto& symBool = output.get_as_sym_bool();
+          if (symBool.tag() == torch::_export::SymBoolArgument::Tag::AS_NAME) {
+            Value* outputValue = graph->getValue(symBool.get_as_name());
+            graph->addOutput(outputValue);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_BOOLS: {
+          for (const auto& symBool : output.get_as_sym_bools()) {
+            if (symBool.tag() ==
+                torch::_export::SymBoolArgument::Tag::AS_NAME) {
+              Value* outputValue = graph->getValue(symBool.get_as_name());
+              graph->addOutput(outputValue);
+            }
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+          const auto& symFloat = output.get_as_sym_float();
+          Value* outputValue = graph->getValue(symFloat.get_as_name());
+          graph->addOutput(outputValue);
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+          for (const auto& symFloat : output.get_as_sym_floats()) {
+            Value* outputValue = graph->getValue(symFloat.get_as_name());
+            graph->addOutput(outputValue);
+          }
+          break;
+        }
+        case torch::_export::Argument::Tag::AS_CUSTOM_OBJ: {
+          const auto& asCustomObj = output.get_as_custom_obj();
+          Value* outputValue = graph->getValue(asCustomObj.get_name());
+          graph->addOutput(outputValue);
+          break;
+        }
+        default:
+          TORCH_CHECK(
+              false,
+              fmt::format(
+                  "Unsupported graph output type: {}",
+                  torch::_export::printEnum(output.tag())));
+      }
+    } else {
+      Constant constValue = constantToValue(output, loadNodeMetadata);
+      graph->addConstantOutput(std::move(constValue));
+    }
+  }
+
+  auto jsonTensorValue = jsonGraph.get_tensor_values();
+
+  if (!signature) {
+    // For subgraphs we just need to derive a graph signature that only
+    // contains user inputs and outputs, because we don't need to handle any
+    // special semantics for them, e.g. mutation or gradients.
+    torch::_export::GraphSignature sig;
+    std::vector<torch::_export::InputSpec> inputSpecs;
+    for (const auto& input : graph->inputs()) {
+      torch::_export::Argument arg;
+      if (input->type().kind() == Type::Kind::Tensor) {
+        torch::_export::TensorArgument targ;
+        targ.set_name(std::string{input->name()});
+        arg.set_as_tensor(std::move(targ));
+      } else {
+        TORCH_CHECK(
+            false,
+            fmt::format(
+                "Unsupported subgraph input type {}",
+                fmt::streamed(input->type())));
+      }
+      torch::_export::UserInputSpec userInputSpec;
+      userInputSpec.set_arg(std::move(arg));
+      torch::_export::InputSpec inputSpec;
+      inputSpec.set_user_input(std::move(userInputSpec));
+      inputSpecs.push_back(std::move(inputSpec));
+    }
+    sig.set_input_specs(std::move(inputSpecs));
+
+    std::vector<torch::_export::OutputSpec> outputSpecs;
+    for (const auto& output : graph->outputs()) {
+      torch::_export::Argument arg;
+      if (output->type().kind() == Type::Kind::Tensor) {
+        torch::_export::TensorArgument targ;
+        targ.set_name(std::string{output->name()});
+        arg.set_as_tensor(std::move(targ));
+      } else {
+        TORCH_CHECK(
+            false,
+            fmt::format(
+                "Unsupported subgraph output type {}",
+                fmt::streamed(output->type())));
+      }
+      torch::_export::UserOutputSpec userOutputSpec;
+      userOutputSpec.set_arg(std::move(arg));
+      torch::_export::OutputSpec outputSpec;
+      outputSpec.set_user_output(std::move(userOutputSpec));
+      outputSpecs.push_back(std::move(outputSpec));
+    }
+    sig.set_output_specs(std::move(outputSpecs));
+
+    graph->setSignature(GraphSignature{sig});
+  }
+
+  // weightsTensorMeta are indexed by weight's name, not graph input's name
+  std::unordered_map<std::string, torch::_export::TensorMeta> weightsTensorMeta;
+  for (const auto& [inputName, weightName] :
+       graph->signature().inputsToWeights()) {
+    auto value = graph->getValue(inputName);
+    if (value->type().kind() == Type::Kind::CustomObj) {
+      // skip setting meta for non-tensor inputs
+      continue;
+    }
+
+    auto it = jsonTensorValue.find(inputName);
+    TORCH_CHECK(
+        it != jsonTensorValue.end(),
+        "Missing tensor metadata for ",
+        inputName,
+        "in thriftGraph.tensorValue");
+    weightsTensorMeta[weightName] = it->second;
+  }
+  graph->setWeightsMeta(weightsTensorMeta);
+
+  graph->setTensorValuesMeta(jsonTensorValue);
+
+  graph->finalize();
+
+  graph->lint();
+  return graph;
+}
+
+} // namespace
+
+bool isSymbolic(const torch::_export::Argument& arg) {
+  switch (arg.tag()) {
+    case torch::_export::Argument::Tag::AS_TENSOR:
+    case torch::_export::Argument::Tag::AS_TENSORS:
+    case torch::_export::Argument::Tag::AS_NESTED_TENSORS:
+    case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS:
+    case torch::_export::Argument::Tag::AS_SYM_INT:
+    case torch::_export::Argument::Tag::AS_SYM_INTS:
+    case torch::_export::Argument::Tag::AS_SYM_BOOL:
+    case torch::_export::Argument::Tag::AS_SYM_BOOLS:
+    case torch::_export::Argument::Tag::AS_SYM_FLOAT:
+    case torch::_export::Argument::Tag::AS_SYM_FLOATS:
+    case torch::_export::Argument::Tag::AS_CUSTOM_OBJ:
+    case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR:
+      return true;
+    default:
+      return false;
+  }
+}
+
+Constant constantToValue(
+    const torch::_export::Argument& jsonArg,
+    bool loadNodeMetadata) {
+  switch (jsonArg.tag()) {
+    case torch::_export::Argument::Tag::AS_NONE:
+      return None();
+    case torch::_export::Argument::Tag::AS_INT:
+      return jsonArg.get_as_int();
+    case torch::_export::Argument::Tag::AS_INTS: {
+      std::vector<int64_t> ret;
+      for (const auto& arg : jsonArg.get_as_ints()) {
+        ret.push_back(arg);
+      }
+      return ret;
+    }
+    case torch::_export::Argument::Tag::AS_FLOAT:
+      return jsonArg.get_as_float().get();
+    case torch::_export::Argument::Tag::AS_FLOATS: {
+      std::vector<double> ret;
+      for (const auto& arg : jsonArg.get_as_floats()) {
+        ret.push_back(arg.get());
+      }
+      return ret;
+    }
+    case torch::_export::Argument::Tag::AS_STRING:
+      return jsonArg.get_as_string();
+    case torch::_export::Argument::Tag::AS_STRINGS: {
+      std::vector<std::string> ret;
+      for (const auto& arg : jsonArg.get_as_strings()) {
+        ret.push_back(arg);
+      }
+      return ret;
+    }
+    case torch::_export::Argument::Tag::AS_SCALAR_TYPE:
+      return convertJsonScalarType(jsonArg.get_as_scalar_type());
+    case torch::_export::Argument::Tag::AS_MEMORY_FORMAT:
+      return convertJsonMemoryFormat(jsonArg.get_as_memory_format());
+    case torch::_export::Argument::Tag::AS_LAYOUT:
+      return convertJsonLayout(jsonArg.get_as_layout());
+    case torch::_export::Argument::Tag::AS_DEVICE:
+      return convertJsonDevice(jsonArg.get_as_device());
+    case torch::_export::Argument::Tag::AS_BOOL:
+      return jsonArg.get_as_bool();
+    case torch::_export::Argument::Tag::AS_BOOLS: {
+      std::vector<bool> ret;
+      for (const auto& arg : jsonArg.get_as_bools()) {
+        ret.push_back(arg);
+      }
+      return ret;
+    }
+    case torch::_export::Argument::Tag::AS_GRAPH: {
+      return jsonToSubgraph(
+          *jsonArg.get_as_graph().get_graph(), nullptr, loadNodeMetadata);
+    }
+    case torch::_export::Argument::Tag::AS_TENSOR:
+    case torch::_export::Argument::Tag::AS_TENSORS:
+    case torch::_export::Argument::Tag::AS_OPTIONAL_TENSORS:
+      TORCH_CHECK(false, "Tensor values are symbolic, not constant.");
+    case torch::_export::Argument::Tag::AS_SYM_INT:
+    case torch::_export::Argument::Tag::AS_SYM_INTS:
+    case torch::_export::Argument::Tag::AS_SYM_BOOL:
+    case torch::_export::Argument::Tag::AS_SYM_BOOLS:
+      TORCH_CHECK(false, "Symint/Symbool Values are symbolic, not constant.");
+    case torch::_export::Argument::Tag::AS_CUSTOM_OBJ:
+      TORCH_CHECK(false, "custom obj is symbolic, not constant");
+    case torch::_export::Argument::Tag::AS_OPERATOR:
+      return jsonArg.get_as_operator();
+    case torch::_export::Argument::Tag::AS_SYM_FLOAT: {
+      TORCH_CHECK(false, "SymFloat is not yet implemented");
+    }
+    case torch::_export::Argument::Tag::AS_SYM_FLOATS: {
+      TORCH_CHECK(false, "SymFloats is not yet implemented");
+    }
+    case torch::_export::Argument::Tag::AS_OPTIONAL_TENSOR:
+      TORCH_CHECK(false, "Optional tensor is symbolic, not constant");
+    case torch::_export::Argument::Tag::AS_COMPLEX:
+      TORCH_CHECK(false, "Complex values are not yet supported as constants");
+    case torch::_export::Argument::Tag::AS_INT_LISTS: {
+      std::vector<std::vector<int64_t>> ret;
+      for (const auto& inner_list : jsonArg.get_as_int_lists()) {
+        std::vector<int64_t> inner_ret;
+        for (const auto& val : inner_list) {
+          inner_ret.push_back(val);
+        }
+        ret.push_back(inner_ret);
+      }
+      return ret;
+    }
+    case torch::_export::Argument::Tag::AS_STRING_TO_ARGUMENT:
+      return None();
+    default:
+      TORCH_CHECK(false, "Got unknown json argument");
+  }
+}
+
+std::unique_ptr<Graph> jsonToGraph(
+    const torch::_export::GraphModule& jsonGraphModule,
+    bool loadNodeMetadata) {
+  auto graph = jsonToSubgraph(
+      jsonGraphModule.get_graph(),
+      &jsonGraphModule.get_signature(),
+      loadNodeMetadata);
+  return graph;
+}
+
+} // namespace torch::nativert

--- a/velox/experimental/torchwave/ParallelExpr.cpp
+++ b/velox/experimental/torchwave/ParallelExpr.cpp
@@ -1,0 +1,620 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <ranges>
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <fmt/format.h>
+
+#include "velox/experimental/torchwave/ParallelExpr.h"
+
+namespace torch::wave {
+
+namespace {
+
+// Returns the input nodes of 'expr'. Loops over inputs() of the node and adds
+// the producer of the Value of each NamedArgument if not null.
+std::vector<ExprCP> args(ExprCP expr) {
+  std::vector<ExprCP> result;
+  for (const auto& input : expr->inputs()) {
+    auto* producer = input.value->producer();
+    if (producer != nullptr && producer != expr) {
+      result.push_back(producer);
+    }
+  }
+  return result;
+}
+
+// Returns true if 'expr' is a call-like expression (has arguments).
+bool isCallExpr(ExprCP expr) {
+  return !args(expr).empty();
+}
+
+// Adds 'expr' and all its transitive subexpressions to 'result'.
+void subexpressionsInner(ExprCP expr, PlanObjectSet& result) {
+  for (auto arg : args(expr)) {
+    if (result.count(arg)) {
+      continue;
+    }
+    result.insert(arg);
+    subexpressionsInner(arg, result);
+  }
+}
+
+// Returns all transitive subexpressions of 'expr'.
+PlanObjectSet subexpressions(ExprCP expr) {
+  PlanObjectSet result;
+  subexpressionsInner(expr, result);
+  return result;
+}
+
+// Returns a unit cost for a node.
+float selfCost(ExprCP /*expr*/) {
+  return 1.0f;
+}
+
+struct LevelData {
+  PlanObjectSet exprs;
+};
+
+size_t levelOf(std::vector<LevelData>& levels, ExprCP expr) {
+  for (size_t i = 0; i < levels.size(); ++i) {
+    if (levels[i].exprs.count(expr)) {
+      return i;
+    }
+  }
+  __builtin_unreachable();
+}
+
+void pushdownExpr(
+    ExprCP expr,
+    int32_t level,
+    std::vector<LevelData>& levelData) {
+  const auto defined = levelOf(levelData, expr);
+  if (defined >= static_cast<size_t>(level)) {
+    return;
+  }
+
+  if (level >= static_cast<int32_t>(levelData.size())) {
+    levelData.resize(level + 1);
+  }
+  levelData[defined].exprs.erase(expr);
+  levelData[level].exprs.insert(expr);
+
+  for (auto input : args(expr)) {
+    pushdownExpr(input, level + 1, levelData);
+  }
+}
+
+void makeLevelsInner(
+    ExprCP expr,
+    int32_t level,
+    std::vector<LevelData>& levelData,
+    std::unordered_map<ExprCP, int32_t>& refCount,
+    PlanObjectSet& counted) {
+  if (counted.count(expr)) {
+    ++refCount[expr];
+    pushdownExpr(expr, level, levelData);
+    return;
+  }
+
+  if (level >= static_cast<int32_t>(levelData.size())) {
+    levelData.resize(level + 1);
+  }
+
+  counted.insert(expr);
+  ++refCount[expr];
+  levelData[level].exprs.insert(expr);
+  for (auto input : args(expr)) {
+    makeLevelsInner(input, level + 1, levelData, refCount, counted);
+  }
+}
+
+void makeExprLevels(
+    const PlanObjectSet& exprs,
+    std::vector<LevelData>& levelData,
+    std::unordered_map<ExprCP, int32_t>& refCount) {
+  PlanObjectSet counted;
+  for (auto expr : exprs) {
+    makeLevelsInner(expr, 0, levelData, refCount, counted);
+  }
+}
+
+PlanObjectSet makeCseBorder(
+    const std::vector<LevelData>& levelData,
+    const PlanObjectSet& placed,
+    std::unordered_map<ExprCP, int32_t>& refCount) {
+  PlanObjectSet border;
+  for (const auto& data : levelData | std::views::reverse) {
+    for (auto expr : data.exprs) {
+      if (placed.count(expr)) {
+        continue;
+      }
+      if (refCount[expr] > 1) {
+        auto subs = subexpressions(expr);
+        bool overlaps = false;
+        for (auto sub : subs) {
+          if (border.count(sub)) {
+            overlaps = true;
+            break;
+          }
+        }
+        if (overlaps) {
+          continue;
+        }
+        border.insert(expr);
+      }
+    }
+  }
+  return border;
+}
+
+float parallelBorder(
+    ExprCP expr,
+    const PlanObjectSet& placed,
+    PlanObjectSet& result) {
+  constexpr float kSplit = -1;
+  constexpr float kTargetCost = 50;
+  if (placed.count(expr)) {
+    return 0;
+  }
+
+  if (!isCallExpr(expr)) {
+    return selfCost(expr);
+  }
+
+  const float cost = selfCost(expr);
+  auto exprArgs = args(expr);
+  std::unordered_set<int32_t> splitArgs;
+  float allArgsCost = 0;
+  float highestArgCost = 0;
+  for (int32_t i = 0; i < static_cast<int32_t>(exprArgs.size()); ++i) {
+    auto argCost = parallelBorder(exprArgs[i], placed, result);
+    highestArgCost = std::max(highestArgCost, argCost);
+    if (argCost == kSplit) {
+      splitArgs.insert(i);
+    }
+    allArgsCost += argCost;
+  }
+
+  if (!splitArgs.empty()) {
+    for (int32_t i = 0; i < static_cast<int32_t>(exprArgs.size()); ++i) {
+      if (!splitArgs.count(i) && isCallExpr(exprArgs[i])) {
+        result.insert(exprArgs[i]);
+      }
+    }
+    return kSplit;
+  }
+
+  if (allArgsCost > kTargetCost && highestArgCost < allArgsCost / 2) {
+    for (auto arg : exprArgs) {
+      if (isCallExpr(arg)) {
+        result.insert(arg);
+      }
+    }
+    return kSplit;
+  }
+  return cost + allArgsCost;
+}
+
+// Helper to format a leaf value using tensor metadata from the graph.
+std::string leafValueString(
+    std::string_view valueName,
+    const nativert::Graph& graph) {
+  const nativert::TensorMeta* tm = nullptr;
+  std::string name(valueName);
+  auto it = graph.tensorValuesMeta().find(name);
+  if (it != graph.tensorValuesMeta().end()) {
+    tm = &it->second;
+  } else {
+    auto wit = graph.weightsMeta().find(name);
+    if (wit != graph.weightsMeta().end()) {
+      tm = &wit->second;
+    }
+  }
+  if (tm != nullptr && !tm->hasSymbolicShape()) {
+    auto sizes = tm->sizes();
+    if (sizes.empty()) {
+      return name; // scalar
+    }
+    std::string result = "<literal [";
+    for (int64_t i = 0; i < static_cast<int64_t>(sizes.size()); ++i) {
+      if (i > 0) {
+        result += ", ";
+      }
+      result += std::to_string(sizes[i]);
+    }
+    result += "]>";
+    return result;
+  }
+  return name;
+}
+
+} // namespace
+
+// ---------- nodeExprString ----------
+
+std::string constantToString(const nativert::Constant& c) {
+  return std::visit(
+      [](const auto& v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, nativert::None>) {
+          return "None";
+        } else if constexpr (std::is_same_v<T, bool>) {
+          return v ? "True" : "False";
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+          return std::to_string(v);
+        } else if constexpr (std::is_same_v<T, double>) {
+          return fmt::format("{}", v);
+        } else if constexpr (std::is_same_v<T, std::string>) {
+          return fmt::format("\"{}\"", v);
+        } else if constexpr (std::is_same_v<T, c10::ScalarType>) {
+          return c10::toString(v);
+        } else if constexpr (std::is_same_v<T, c10::MemoryFormat>) {
+          return c10::toString(v);
+        } else if constexpr (std::is_same_v<T, c10::Layout>) {
+          return c10::toString(v);
+        } else if constexpr (std::is_same_v<T, c10::Device>) {
+          return v.str();
+        } else if constexpr (std::is_same_v<T, std::vector<int64_t>>) {
+          std::string r = "[";
+          for (size_t i = 0; i < v.size(); ++i) {
+            if (i > 0) {
+              r += ", ";
+            }
+            r += std::to_string(v[i]);
+          }
+          return r + "]";
+        } else if constexpr (std::is_same_v<T, std::vector<double>>) {
+          std::string r = "[";
+          for (size_t i = 0; i < v.size(); ++i) {
+            if (i > 0) {
+              r += ", ";
+            }
+            r += fmt::format("{}", v[i]);
+          }
+          return r + "]";
+        } else if constexpr (std::is_same_v<T, std::vector<bool>>) {
+          std::string r = "[";
+          for (size_t i = 0; i < v.size(); ++i) {
+            if (i > 0) {
+              r += ", ";
+            }
+            r += v[i] ? "True" : "False";
+          }
+          return r + "]";
+        } else if constexpr (std::is_same_v<T, std::vector<std::string>>) {
+          std::string r = "[";
+          for (size_t i = 0; i < v.size(); ++i) {
+            if (i > 0) {
+              r += ", ";
+            }
+            r += fmt::format("\"{}\"", v[i]);
+          }
+          return r + "]";
+        } else if constexpr (std::is_same_v<
+                                 T,
+                                 std::vector<std::vector<int64_t>>>) {
+          std::string r = "[";
+          for (size_t i = 0; i < v.size(); ++i) {
+            if (i > 0) {
+              r += ", ";
+            }
+            r += "[";
+            for (size_t j = 0; j < v[i].size(); ++j) {
+              if (j > 0) {
+                r += ", ";
+              }
+              r += std::to_string(v[i][j]);
+            }
+            r += "]";
+          }
+          return r + "]";
+        } else if constexpr (std::is_same_v<
+                                 T,
+                                 std::unique_ptr<nativert::Graph>>) {
+          return "<subgraph>";
+        } else {
+          return "<unknown>";
+        }
+      },
+      c);
+}
+
+namespace {
+
+void nodeExprStringImpl(
+    std::stringstream& ss,
+    const nativert::Node* node,
+    const nativert::Graph& graph,
+    PlanObjectSet& border) {
+  if (!isCallExpr(node)) {
+    ss << node->target();
+    return;
+  }
+
+  ss << node->target() << "(";
+  bool first = true;
+  for (const auto& input : node->inputs()) {
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+
+    auto* value = input.value;
+    auto* producer = value->producer();
+
+    if (producer == nullptr || producer == node) {
+      ss << leafValueString(value->name(), graph);
+    } else if (border.count(producer)) {
+      ss << "%" << value->id();
+    } else {
+      nodeExprStringImpl(ss, producer, graph, border);
+    }
+  }
+  for (const auto& attr : node->attributes()) {
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+    ss << attr.name << "=" << constantToString(attr.value);
+  }
+  ss << ")";
+}
+
+} // namespace
+
+std::string nodeExprString(
+    const nativert::Node* node,
+    const nativert::Graph& graph,
+    PlanObjectSet& border) {
+  std::stringstream ss;
+  nodeExprStringImpl(ss, node, graph, border);
+  return ss.str();
+}
+
+// ---------- ProjectNode::toString ----------
+
+namespace {
+
+void formatOutputIds(std::stringstream& ss, const nativert::Node* node) {
+  const auto& outputs = node->outputs();
+  if (outputs.empty()) {
+    return;
+  }
+  std::vector<int> ids;
+  ids.reserve(outputs.size());
+  for (const auto* v : outputs) {
+    if (v != nullptr) {
+      ids.push_back(v->id());
+    }
+  }
+  if (ids.empty()) {
+    return;
+  }
+  if (ids.size() == 1) {
+    ss << "%" << ids[0];
+    return;
+  }
+  std::sort(ids.begin(), ids.end());
+
+  bool first = true;
+  size_t i = 0;
+  while (i < ids.size()) {
+    size_t j = i;
+    while (j + 1 < ids.size() && ids[j + 1] == ids[j] + 1) {
+      ++j;
+    }
+    if (!first) {
+      ss << ", ";
+    }
+    first = false;
+    if (j > i) {
+      ss << "[%" << ids[i] << ", %" << ids[j] << "]";
+    } else {
+      ss << "%" << ids[i];
+    }
+    i = j + 1;
+  }
+}
+
+} // namespace
+
+std::string ProjectNode::toString(
+    const nativert::Graph& graph,
+    PlanObjectSet& border) const {
+  std::stringstream ss;
+  PlanObjectSet localBorder(inputs_.begin(), inputs_.end());
+  localBorder.insert(border.begin(), border.end());
+  ss << fmt::format("ProjectNode {}:\n", id_);
+  for (int32_t i = 0; i < static_cast<int32_t>(nodes_.size()); ++i) {
+    ss << fmt::format("  {}.{}: ", id_, i);
+    formatOutputIds(ss, nodes_[i]);
+    ss << " = " << nodeExprString(nodes_[i], graph, localBorder) << "\n";
+  }
+  if (input_ != nullptr) {
+    ss << fmt::format("  input: ProjectNode {}\n", input_->id());
+  }
+  return ss.str();
+}
+
+// ---------- ParallelNodes ----------
+
+namespace {
+
+// Collects all top-level exprs from a ProjectNode and all its transitive
+// inputs.
+PlanObjectSet collectAllInputExprs(const ProjectNode* node) {
+  PlanObjectSet allExprs;
+  for (auto* cur = node; cur != nullptr; cur = cur->input()) {
+    allExprs.insert(cur->nodes().begin(), cur->nodes().end());
+  }
+  return allExprs;
+}
+
+// Traverses the subgraph reachable from 'expr', collecting nodes that are in
+// 'inputExprs' into 'reachable' and nodes with no inputs that are not in
+// 'inputExprs' into 'leafInputs'. Stops recursing into a branch once it hits a
+// node in 'inputExprs'.
+void collectReachableAndLeaves(
+    ExprCP expr,
+    const PlanObjectSet& inputExprs,
+    PlanObjectSet& visited,
+    PlanObjectSet& reachable,
+    PlanObjectSet& leafInputs) {
+  if (!visited.insert(expr).second) {
+    return;
+  }
+  if (inputExprs.count(expr)) {
+    reachable.insert(expr);
+    return;
+  }
+  auto inputs = args(expr);
+  if (inputs.empty()) {
+    leafInputs.insert(expr);
+    return;
+  }
+  for (auto* child : inputs) {
+    collectReachableAndLeaves(
+        child, inputExprs, visited, reachable, leafInputs);
+  }
+}
+
+} // namespace
+
+ProjectNode* ParallelNodes::makeParallelProject(
+    ProjectNode* input,
+    const PlanObjectSet& topExprs,
+    std::vector<ExprCP> orderedExprs) {
+  if (orderedExprs.empty()) {
+    orderedExprs.assign(topExprs.begin(), topExprs.end());
+  }
+  std::vector<const nativert::Node*> nodes;
+  PlanObjectSet seen;
+  for (auto* expr : orderedExprs) {
+    if (seen.insert(expr).second) {
+      nodes.push_back(expr);
+    }
+  }
+  std::unordered_set<const nativert::Node*> inputs;
+  std::unordered_set<const nativert::Node*> leafInputs;
+
+  if (input != nullptr) {
+    auto allInputExprs = collectAllInputExprs(input);
+
+    PlanObjectSet visited;
+    PlanObjectSet reachable;
+    PlanObjectSet leaves;
+    for (auto* expr : topExprs) {
+      collectReachableAndLeaves(
+          expr, allInputExprs, visited, reachable, leaves);
+    }
+    inputs = std::move(reachable);
+    leafInputs = std::move(leaves);
+  }
+
+  auto projectNode = std::make_unique<ProjectNode>(
+      std::move(nodes),
+      std::move(inputs),
+      std::move(leafInputs),
+      input,
+      nextId_++);
+  auto* result = projectNode.get();
+  projectNodes_.push_back(std::move(projectNode));
+  return result;
+}
+
+ProjectNode* ParallelNodes::makeParallelNodes(const nativert::Graph& graph) {
+  ExprCP root = graph.outputNode();
+  auto topExprs = args(root);
+  PlanObjectSet top(topExprs.begin(), topExprs.end());
+
+  std::vector<LevelData> levelData;
+  std::unordered_map<ExprCP, int32_t> refCount;
+  makeExprLevels(top, levelData, refCount);
+
+  PlanObjectSet placed;
+  ProjectNode* current = nullptr;
+
+  for (;;) {
+    auto cses = makeCseBorder(levelData, placed, refCount);
+    if (cses.empty()) {
+      break;
+    }
+
+    for (auto expr : cses) {
+      auto subs = subexpressions(expr);
+      placed.insert(subs.begin(), subs.end());
+    }
+    placed.insert(cses.begin(), cses.end());
+
+    current = makeParallelProject(current, cses);
+  }
+
+  PlanObjectSet parallel;
+  for (auto expr : top) {
+    parallelBorder(expr, placed, parallel);
+  }
+
+  if (!parallel.empty()) {
+    for (auto expr : parallel) {
+      auto subs = subexpressions(expr);
+      placed.insert(subs.begin(), subs.end());
+    }
+    placed.insert(parallel.begin(), parallel.end());
+
+    current = makeParallelProject(current, parallel);
+  }
+
+  if (nextId_ > 1000) {
+    printSet(placed);
+    std::unordered_map<ExprCP, int32_t> refs;
+    printRefcount(refs, 0);
+  }
+  current = makeParallelProject(current, top, topExprs);
+
+  return current;
+}
+
+__attribute__((used)) void printSet(PlanObjectSet& set) {
+  fmt::print("{}\n", set.size());
+  for (const auto* node : set) {
+    auto ptr = reinterpret_cast<int64_t>(node);
+    fmt::print("{:x} {}\n", (ptr >> 3) & 0xffff, std::string(node->target()));
+  }
+}
+
+__attribute__((used)) void printRefcount(
+    std::unordered_map<ExprCP, int32_t>& refCount,
+    int32_t min) {
+  fmt::print("{}\n", refCount.size());
+  for (const auto& [expr, count] : refCount) {
+    if (count >= min) {
+      auto ptr = reinterpret_cast<int64_t>(expr);
+      fmt::print("{} {:x} {}\n", count, (ptr >> 3) & 0xffff, expr->toString());
+    }
+  }
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/ParallelExpr.h
+++ b/velox/experimental/torchwave/ParallelExpr.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "velox/experimental/torchwave/Project.h"
+
+namespace torch::wave {
+
+using ExprCP = const nativert::Node*;
+
+using PlanObjectSet = std::unordered_set<const nativert::Node*>;
+
+class ParallelNodes {
+ public:
+  ProjectNode* makeParallelProject(
+      ProjectNode* input,
+      const PlanObjectSet& topExprs,
+      std::vector<ExprCP> orderedExprs = {});
+
+  ProjectNode* makeParallelNodes(const nativert::Graph& graph);
+
+ private:
+  std::vector<std::unique_ptr<ProjectNode>> projectNodes_;
+  int32_t nextId_{0};
+};
+
+// Produce a human-readable expression string for a node.
+// For a non-function node, returns the target. For a function node, prints
+// target(arg1, arg2, ...) where each arg is either a literal shape, a border
+// node target, or a recursive expression.
+std::string nodeExprString(
+    const nativert::Node* node,
+    const nativert::Graph& graph,
+    PlanObjectSet& border);
+
+std::string constantToString(const nativert::Constant& c);
+
+void printSet(PlanObjectSet& set);
+
+void printRefcount(std::unordered_map<ExprCP, int32_t>& refCount, int32_t min);
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Project.cpp
+++ b/velox/experimental/torchwave/Project.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "velox/experimental/torchwave/ParallelExpr.h"
+#include "velox/experimental/torchwave/Project.h"
+
+namespace torch::wave {
+
+namespace {
+
+void distinctFunctionsInner(
+    const nativert::Node* node,
+    const std::unordered_set<const nativert::Node*>& inputs,
+    std::unordered_set<const nativert::Node*>& visited,
+    std::unordered_map<std::string, int32_t>& counts) {
+  if (!visited.insert(node).second) {
+    return;
+  }
+  if (inputs.count(node)) {
+    return;
+  }
+
+  // Check if this node represents a function (has inputs from other nodes).
+  bool isFunction = false;
+  for (const auto& input : node->inputs()) {
+    auto* producer = input.value->producer();
+    if (producer != nullptr && producer != node) {
+      isFunction = true;
+      break;
+    }
+  }
+
+  if (isFunction) {
+    // Build key: target followed by sorted literal attributes.
+    std::string key(node->target());
+    const auto& attrs = node->attributes();
+    if (!attrs.empty()) {
+      std::vector<std::pair<std::string, std::string>> sorted;
+      sorted.reserve(attrs.size());
+      for (const auto& attr : attrs) {
+        sorted.emplace_back(attr.name, constantToString(attr.value));
+      }
+      std::sort(sorted.begin(), sorted.end());
+      for (const auto& [name, value] : sorted) {
+        key += " ";
+        key += name;
+        key += "=";
+        key += value;
+      }
+    }
+    ++counts[key];
+  }
+
+  // Recurse into inputs.
+  for (const auto& input : node->inputs()) {
+    auto* producer = input.value->producer();
+    if (producer != nullptr && producer != node) {
+      distinctFunctionsInner(producer, inputs, visited, counts);
+    }
+  }
+}
+
+} // namespace
+
+void ProjectNode::distinctFunctions(
+    std::unordered_map<std::string, int32_t>& counts) const {
+  std::unordered_set<const nativert::Node*> visited;
+  for (const auto* node : nodes_) {
+    distinctFunctionsInner(node, inputs_, visited, counts);
+  }
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Project.h
+++ b/velox/experimental/torchwave/Project.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <torch/nativert/graph/Graph.h>
+
+namespace torch::wave {
+
+class ProjectNode {
+ public:
+  ProjectNode(
+      std::vector<const nativert::Node*> nodes,
+      std::unordered_set<const nativert::Node*> inputs,
+      std::unordered_set<const nativert::Node*> leafInputs,
+      ProjectNode* input,
+      int32_t id)
+      : nodes_{std::move(nodes)},
+        inputs_{std::move(inputs)},
+        leafInputs_{std::move(leafInputs)},
+        input_{input},
+        id_{id} {}
+
+  int32_t id() const {
+    return id_;
+  }
+
+  std::string toString(
+      const nativert::Graph& graph,
+      std::unordered_set<const nativert::Node*>& border) const;
+
+  const std::vector<const nativert::Node*>& nodes() const {
+    return nodes_;
+  }
+
+  const std::unordered_set<const nativert::Node*>& inputs() const {
+    return inputs_;
+  }
+
+  const std::unordered_set<const nativert::Node*>& leafInputs() const {
+    return leafInputs_;
+  }
+
+  ProjectNode* input() const {
+    return input_;
+  }
+
+  void distinctFunctions(
+      std::unordered_map<std::string, int32_t>& counts) const;
+
+ private:
+  std::vector<const nativert::Node*> nodes_;
+  std::unordered_set<const nativert::Node*> inputs_;
+  std::unordered_set<const nativert::Node*> leafInputs_;
+  ProjectNode* input_;
+  int32_t id_;
+};
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Pt2Load.cpp
+++ b/velox/experimental/torchwave/Pt2Load.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/Pt2Load.h"
+
+#include <string>
+#include <vector>
+
+#include <fmt/format.h>
+#include <nlohmann/json.hpp>
+
+#include <caffe2/caffe2/serialize/file_adapter.h>
+#include <caffe2/serialize/inline_container.h> // @manual=//caffe2/caffe2/serialize:inline_container
+#include <torch/csrc/export/pt2_archive_constants.h> // @manual
+#include <torch/csrc/utils/generated_serialization_types.h>
+#include <torch/nativert/graph/Serialization.h>
+
+namespace torch::wave {
+
+namespace {
+
+constexpr std::string_view kModelsDir =
+    torch::_export::archive_spec::MODELS_DIR;
+constexpr std::string_view kJsonSuffix = ".json";
+
+/// Read a PayloadConfig JSON from the archive and return the name-to-path map.
+std::unordered_map<std::string, std::string> getPayloadConfig(
+    caffe2::serialize::PyTorchStreamReader& reader,
+    std::string_view configFormat,
+    const std::string& modelName) {
+  std::string configPath = fmt::format(fmt::runtime(configFormat), modelName);
+  if (!reader.hasRecord(configPath)) {
+    return {};
+  }
+  const auto& [data, size] = reader.getRecord(configPath);
+  std::string serialized{reinterpret_cast<char*>(data.get()), size};
+  auto configJson = nlohmann::json::parse(serialized)
+                        .template get<torch::_export::PayloadConfig>();
+  std::unordered_map<std::string, std::string> paths;
+  for (const auto& entry : configJson.get_config()) {
+    paths[entry.first] = entry.second.get_path_name();
+  }
+  return paths;
+}
+
+} // namespace
+
+std::vector<std::string> getModelNames(
+    caffe2::serialize::PyTorchStreamReader& reader) {
+  std::vector<std::string> names;
+  for (const auto& record : reader.getAllRecords()) {
+    if (record.size() > kModelsDir.size() + kJsonSuffix.size() &&
+        record.compare(0, kModelsDir.size(), kModelsDir) == 0 &&
+        record.compare(
+            record.size() - kJsonSuffix.size(),
+            kJsonSuffix.size(),
+            kJsonSuffix) == 0) {
+      names.push_back(record.substr(
+          kModelsDir.size(),
+          record.size() - kModelsDir.size() - kJsonSuffix.size()));
+    }
+  }
+  return names;
+}
+
+LoadedModel loadPt2Model(
+    std::shared_ptr<caffe2::serialize::PyTorchStreamReader> reader,
+    const std::string& modelName) {
+  std::string modelFilePath = fmt::format(
+      torch::_export::archive_spec::MODELS_FILENAME_FORMAT, modelName);
+
+  const auto& [modelData, modelSize] = reader->getRecord(modelFilePath);
+  std::string modelSerialized{
+      reinterpret_cast<char*>(modelData.get()), modelSize};
+
+  auto exportedProgram = nlohmann::json::parse(modelSerialized)
+                             .template get<torch::_export::ExportedProgram>();
+
+  auto graph = torch::nativert::jsonToGraph(exportedProgram.get_graph_module());
+
+  auto tensorPaths = getPayloadConfig(
+      *reader,
+      torch::_export::archive_spec::WEIGHTS_CONFIG_FILENAME_FORMAT,
+      modelName);
+  auto constantPaths = getPayloadConfig(
+      *reader,
+      torch::_export::archive_spec::CONSTANTS_CONFIG_FILENAME_FORMAT,
+      modelName);
+
+  LoadedModel loaded;
+  loaded.reader = std::move(reader);
+  loaded.graph = std::move(graph);
+  loaded.modelName = modelName;
+  loaded.tensorPaths = std::move(tensorPaths);
+  loaded.constantPaths = std::move(constantPaths);
+  return loaded;
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Pt2Load.h
+++ b/velox/experimental/torchwave/Pt2Load.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <caffe2/serialize/inline_container.h> // @manual=//caffe2/caffe2/serialize:inline_container
+#include "velox/experimental/torchwave/Execute.h"
+
+namespace torch::wave {
+
+std::vector<std::string> getModelNames(
+    caffe2::serialize::PyTorchStreamReader& reader);
+
+LoadedModel loadPt2Model(
+    std::shared_ptr<caffe2::serialize::PyTorchStreamReader> reader,
+    const std::string& modelName);
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Registry.cpp
+++ b/velox/experimental/torchwave/Registry.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/Registry.h"
+
+#include <ATen/core/dispatch/Dispatcher.h>
+#include <c10/util/StringUtil.h>
+
+namespace torch::wave {
+
+std::unordered_map<std::string, Metadata>& Registry::registry() {
+  static std::unordered_map<std::string, Metadata> map;
+  return map;
+}
+
+void Registry::registerMetadata(std::string_view op, Metadata metadata) {
+  registry()[std::string(op)] = std::move(metadata);
+}
+
+const Metadata* Registry::metadata(std::string_view op) {
+  auto& map = registry();
+  auto it = map.find(std::string(op));
+  if (it == map.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+void Registry::registerElementwise(
+    std::string_view qualifiedName,
+    std::vector<std::string> attributeArgs) {
+  auto atoms = c10::split(qualifiedName, '.');
+  TORCH_CHECK(atoms.size() >= 3, "Invalid qualified op name: ", qualifiedName);
+
+  auto numAtoms = atoms.size();
+  auto ns = atoms[numAtoms - 3];
+  auto opName = atoms[numAtoms - 2];
+  auto overloadName = atoms[numAtoms - 1];
+
+  auto operatorName = fmt::format("{}::{}", ns, opName);
+  std::string normalizedOverload =
+      (overloadName == "default") ? "" : std::string(overloadName);
+
+  auto handle = c10::Dispatcher::singleton().findSchemaOrThrow(
+      operatorName.c_str(), normalizedOverload.c_str());
+  const auto& schema = handle.schema();
+
+  Metadata md;
+  md.kind = Metadata::kMetadata;
+  md.functionSchema = &schema;
+  md.sizeArgs = {0};
+  md.inPlaceIfLastUse = true;
+  md.argumentMeta.resize(
+      schema.arguments().size(), ArgumentMeta{.isRegister = true});
+  md.returnMeta = {ArgumentMeta{.isRegister = true}};
+  md.elementWise = std::make_unique<ElementwiseOp>();
+  md.elementWise->functionName = fmt::format("--{}", opName);
+  md.elementWise->attributeArgs = std::move(attributeArgs);
+
+  registerMetadata(qualifiedName, std::move(md));
+}
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Registry.h
+++ b/velox/experimental/torchwave/Registry.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+#include <aten/src/ATen/core/function_schema.h>
+#include <torch/nativert/executor/OpKernel.h>
+#include <torch/nativert/graph/Graph.h>
+
+namespace torch::wave {
+
+/// Describes element-wise operations like binary and unary arithmetic.
+struct ElementwiseOp {
+  std::string functionName;
+
+  /// addition can have alpha
+  int32_t numArgs{2};
+
+  /// Attribute names that map to extra args in the CUDA function, e.g.
+  /// {"alpha"} for add/sub, {"min", "max"} for clamp.
+  std::vector<std::string> attributeArgs;
+};
+
+enum class ArgumentMode { kRegister, kMemory, kMemoryBarrier };
+
+class CompileCtx;
+
+struct Intermediate {
+  c10::ScalarType scalarType;
+  bool isTensor{false};
+  std::string variable;
+  std::optional<int32_t> paramOffset;
+};
+
+struct Metadata;
+
+using CodeGenFunc = std::function<void(
+    CompileCtx& ctx,
+    const Metadata& metadata,
+    const nativert::Node& node,
+    const std::vector<Intermediate>& args,
+    std::vector<Intermediate>& results)>;
+
+using Dim = uint32_t;
+
+/// A map from value ids in a lambda matching OutputReserveFunc and
+/// the value ids in the frame passed to OutputReserveFunc. The same
+/// kernel operation can be invoked with many different sets of
+/// inputs to produce sizes for each.
+using FormalToActual = std::unordered_map<int32_t, int32_t>;
+
+// Returns shapes to reserve for outputs given inputs. Can return multiple
+// shapes for output params that are tuples of tensors.
+using OutputReserveFunc = std::function<std::vector<std::vector<Dim>>(
+    const nativert::Node* node,
+    nativert::ExecutionFrame&,
+    FormalToActual map)>;
+
+struct ArgumentMeta {
+  // If can be passed / returned in a register. Caller must read from / assign
+  // to tensor if needed.
+  bool isRegister{false};
+
+  /// For outputs that are materialized tensors, function that determines the
+  /// size to allocate based on inputs and execution state.
+  OutputReserveFunc reserveShape{nullptr};
+
+  /// True if actual size is determined on device, e.g. stream compaction.
+  bool shapeSetOnDevice{false};
+};
+
+struct Metadata {
+  enum Kind {
+    kMetadata,
+    kMapKernel,
+    kMapAndBarrier,
+  };
+
+  Kind kind;
+
+  const c10::FunctionSchema* functionSchema;
+
+  /// The ordinal in arguments for the argument that determines the number of
+  /// elements the kernel runs on. If many, the number of lanes to process y the
+  /// kernel is the sum of the sizes of the args. If arg is a tensor, we get the
+  /// number of elements. If it is a number or zero dim tensor, we use the
+  /// number.
+  std::vector<int32_t> sizeArgs;
+
+  std::vector<ArgumentMeta> argumentMeta;
+
+  std::vector<ArgumentMeta> returnMeta;
+
+  /// True if requires a D to H transfer for return status, for example a length
+  /// after stream compaction.
+  bool hasReturn{false};
+
+  /// If inputs are small, has a single block variant that is
+  /// embeddable between __synthreads() and needs no kernel
+  /// boundary. For example, stream compaction for under 10K elements
+  /// is better as a single block than as 3 consecutive multiblock
+  /// kernels.
+  Metadata* singleBlockVariant{nullptr};
+
+  /// True if all values to be computed by a block must be ready before calling.
+  /// True for example for single block stream compaction or first stage of
+  /// multi-kernel stream compaction.
+  bool hasBarrier{false};
+
+  /// If this represents a multiple kernel launch operation, e.g. a multiblock
+  /// stream compaction, then each launch has its own Metadata Ops with dynamic
+  /// number of launches will be standalone.
+  std::unique_ptr<Metadata> nextKernel;
+
+  /// The input can be overwritten and used as output if there are no concurrent
+  /// or subsequent uses of input. True for example of elementwise arithmetic.
+  bool inPlaceIfLastUse{false};
+
+  /// True if must be launched as its own kernel sequence  with no fusion.
+  bool isStandalone{false};
+
+  std::string header;
+
+  std::unique_ptr<ElementwiseOp> elementWise;
+
+  float cost{1};
+
+  CodeGenFunc codegen;
+};
+
+class Registry {
+ public:
+  static void registerMetadata(std::string_view op, Metadata metadata);
+  static const Metadata* metadata(std::string_view op);
+
+  /// Registers an elementwise op by its qualified aten name (e.g.
+  /// "torch.ops.aten.add.Tensor"). Looks up the FunctionSchema from the
+  /// dispatcher, then creates a Metadata entry with sizeArgs={0},
+  /// inPlaceIfLastUse=true, and an ElementwiseOp whose functionName is "--"
+  /// followed by the op name part (e.g. "--add").
+  static void registerElementwise(
+      std::string_view qualifiedName,
+      std::vector<std::string> attributeArgs = {});
+
+ private:
+  static std::unordered_map<std::string, Metadata>& registry();
+};
+
+void registerBuiltins();
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Utils.cpp
+++ b/velox/experimental/torchwave/Utils.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/torchwave/Utils.h"
+
+namespace torch::wave {
+
+// Pool is header-only (template). This file exists for future non-template
+// utilities.
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/Utils.h
+++ b/velox/experimental/torchwave/Utils.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+#include "velox/experimental/wave/common/Cuda.h"
+
+namespace torch::wave {
+
+/// Reusable pool of unique_ptr<T>. Thread-safe. Returns an existing item if
+/// available, otherwise creates one via the make function passed at
+/// construction.
+template <typename T>
+class Pool {
+ public:
+  using MakeFunc = std::function<std::unique_ptr<T>()>;
+
+  explicit Pool(MakeFunc make) : make_(std::move(make)) {}
+
+  std::unique_ptr<T> get() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!items_.empty()) {
+      auto item = std::move(items_.back());
+      items_.pop_back();
+      return item;
+    }
+    return make_();
+  }
+
+  void put(std::unique_ptr<T> item) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    items_.push_back(std::move(item));
+  }
+
+ private:
+  std::mutex mutex_;
+  std::vector<std::unique_ptr<T>> items_;
+  MakeFunc make_;
+};
+
+using StreamPool = Pool<facebook::velox::wave::Stream>;
+using EventPool = Pool<facebook::velox::wave::Event>;
+
+} // namespace torch::wave

--- a/velox/experimental/torchwave/tests/CMakeLists.txt
+++ b/velox/experimental/torchwave/tests/CMakeLists.txt
@@ -1,0 +1,76 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+set(TORCHWAVE_TEST_DATA_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_data)
+
+# Generate element_test.pt2 and element_test_results.pt at build time.
+add_custom_command(
+  OUTPUT
+    ${TORCHWAVE_TEST_DATA_DIR}/element_test.pt2
+    ${TORCHWAVE_TEST_DATA_DIR}/element_test_results.pt
+  COMMAND ${Python3_EXECUTABLE}
+    ${CMAKE_CURRENT_SOURCE_DIR}/element_test_run_pt2.py
+    --output_dir ${TORCHWAVE_TEST_DATA_DIR}
+  DEPENDS
+    ${CMAKE_CURRENT_SOURCE_DIR}/element_test_run_pt2.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/element_test.py
+  COMMENT "Generating element_test.pt2 and reference results"
+)
+
+add_custom_target(
+  element_test_data
+  DEPENDS
+    ${TORCHWAVE_TEST_DATA_DIR}/element_test.pt2
+    ${TORCHWAVE_TEST_DATA_DIR}/element_test_results.pt
+)
+
+add_executable(
+  torchwave_executor_test
+  ExecutorTest.cpp
+)
+
+add_dependencies(torchwave_executor_test element_test_data)
+
+target_compile_definitions(
+  torchwave_executor_test
+  PRIVATE
+    ELEMENT_TEST_PT2_PATH="${TORCHWAVE_TEST_DATA_DIR}/element_test.pt2"
+    ELEMENT_TEST_RESULTS_PATH="${TORCHWAVE_TEST_DATA_DIR}/element_test_results.pt"
+)
+
+target_link_libraries(
+  torchwave_executor_test
+  torch_wave
+  GTest::gtest
+  GTest::gtest_main
+  Folly::folly
+  CUDA::cudart
+)
+
+add_test(torchwave_executor_test torchwave_executor_test)
+set_tests_properties(torchwave_executor_test PROPERTIES LABELS cuda_driver)
+
+add_executable(
+  torchwave_graph_tool
+  GraphTool.cpp
+)
+
+target_link_libraries(
+  torchwave_graph_tool
+  torch_wave
+  torch_wave_graph_view
+  Folly::folly
+)

--- a/velox/experimental/torchwave/tests/ExecutorTest.cpp
+++ b/velox/experimental/torchwave/tests/ExecutorTest.cpp
@@ -1,0 +1,383 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+
+#include <ATen/ATen.h>
+#include <glog/logging.h>
+#include <torch/csrc/export/pt2_archive_constants.h>
+#include <torch/csrc/jit/serialization/pickle.h>
+#include <torch/nativert/executor/ExecutionFrame.h>
+#include <torch/nativert/executor/SerialGraphExecutor.h>
+#include <torch/nativert/executor/Weights.h>
+#include <torch/nativert/kernels/KernelFactory.h>
+
+#include <caffe2/caffe2/serialize/file_adapter.h>
+#include <caffe2/serialize/inline_container.h> // @manual=//caffe2/caffe2/serialize:inline_container
+
+#include "velox/experimental/torchwave/Executor.h"
+#include "velox/experimental/torchwave/Pt2Load.h"
+#include "velox/experimental/torchwave/Registry.h"
+
+#ifndef ELEMENT_TEST_PT2_PATH
+#define ELEMENT_TEST_PT2_PATH "/tmp/element_test.pt2"
+#endif
+
+#ifndef ELEMENT_TEST_RESULTS_PATH
+#define ELEMENT_TEST_RESULTS_PATH "/tmp/element_test_results.pt"
+#endif
+
+namespace torch::wave {
+namespace {
+
+using Clock = std::chrono::high_resolution_clock;
+
+/// Timing results from running a model through an executor.
+struct RunTiming {
+  /// Time to transfer inputs to device (0 for CPU executors).
+  int64_t dataTransferUs{0};
+  /// Execution time excluding data transfer.
+  int64_t executeUs{0};
+};
+
+/// Reads a file into a vector of chars.
+std::vector<char> readFile(const std::string& path) {
+  std::ifstream file(path, std::ios::binary | std::ios::ate);
+  EXPECT_TRUE(file.good()) << "Cannot open " << path;
+  auto size = file.tellg();
+  file.seekg(0);
+  std::vector<char> data(size);
+  file.read(data.data(), size);
+  return data;
+}
+
+/// Loads reference tensors saved by Python via torch.save([t1, t2, ...], path).
+std::vector<at::Tensor> loadReferenceTensors(const std::string& path) {
+  auto data = readFile(path);
+  auto ivalue = torch::jit::pickle_load(data);
+  EXPECT_TRUE(ivalue.isList()) << "Expected a list of tensors";
+  std::vector<at::Tensor> tensors;
+  for (const auto& item : ivalue.toListRef()) {
+    EXPECT_TRUE(item.isTensor());
+    tensors.push_back(item.toTensor());
+  }
+  return tensors;
+}
+
+/// Holds the loaded model and weights shared across test methods.
+struct ModelFixture {
+  std::string pt2Path;
+  std::shared_ptr<caffe2::serialize::PyTorchStreamReader> reader;
+  LoadedModel model;
+  std::shared_ptr<nativert::Weights> weights;
+  nativert::ExecutorConfig config;
+
+  static std::unique_ptr<ModelFixture> load(const std::string& pt2Path) {
+    auto fixture = std::make_unique<ModelFixture>();
+    fixture->pt2Path = pt2Path;
+
+    fixture->reader = std::make_shared<caffe2::serialize::PyTorchStreamReader>(
+        std::make_unique<caffe2::serialize::FileAdapter>(pt2Path));
+
+    auto modelNames = getModelNames(*fixture->reader);
+    EXPECT_FALSE(modelNames.empty()) << "No models found in " << pt2Path;
+    if (modelNames.empty()) {
+      return nullptr;
+    }
+
+    fixture->model = loadPt2Model(fixture->reader, modelNames[0]);
+    const auto& graph = *fixture->model.graph;
+
+    fixture->weights = std::make_shared<nativert::Weights>(
+        &graph,
+        fixture->reader,
+        fixture->model.tensorPaths,
+        torch::_export::archive_spec::WEIGHTS_DIR,
+        fixture->model.constantPaths,
+        torch::_export::archive_spec::CONSTANTS_DIR);
+
+    return fixture;
+  }
+
+  /// Creates fresh node kernels (each executor consumes them).
+  std::vector<std::unique_ptr<nativert::OpKernel>> makeKernels() const {
+    nativert::KernelFactory factory;
+    auto execKernels =
+        factory.initializeNodeKernels(*model.graph, weights, config, reader);
+    return std::move(execKernels.nodeKernels);
+  }
+};
+
+class ExecutorTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    initialize();
+  }
+
+  /// Runs a .pt2 model through the nativert SerialGraphExecutor on CPU.
+  /// Verifies outputs match 'expected' and returns timing.
+  RunTiming runSerial(
+      ModelFixture& fixture,
+      const std::vector<at::Tensor>& expected) {
+    const auto& graph = *fixture.model.graph;
+
+    auto kernels = fixture.makeKernels();
+    nativert::SerialGraphExecutor executor(
+        graph, std::move(kernels), fixture.config);
+
+    auto frame = std::make_unique<nativert::ExecutionFrame>(
+        graph, *fixture.weights, fixture.config);
+
+    auto inputs = loadSampleInputs(fixture);
+
+    auto start = Clock::now();
+    auto outputs = executor.execute(*frame, std::move(inputs));
+    auto executeUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                         Clock::now() - start)
+                         .count();
+
+    verifyOutputs(outputs, expected, "serial");
+    return {0, executeUs};
+  }
+
+  /// Runs a .pt2 model through the nativert SerialGraphExecutor on device.
+  /// ATen kernels dispatch to CUDA when given device tensors.
+  /// Verifies outputs match 'expected' and returns timing.
+  RunTiming runSerialOnDevice(
+      ModelFixture& fixture,
+      const std::vector<at::Tensor>& expected) {
+    const auto& graph = *fixture.model.graph;
+
+    auto kernels = fixture.makeKernels();
+    nativert::SerialGraphExecutor executor(
+        graph, std::move(kernels), fixture.config);
+
+    auto frame = std::make_unique<nativert::ExecutionFrame>(
+        graph, *fixture.weights, fixture.config);
+
+    // Load sample inputs and move to device.
+    auto inputs = loadSampleInputs(fixture);
+    std::vector<at::Tensor> inputTensors;
+    for (auto& iv : inputs) {
+      if (iv.isTensor()) {
+        inputTensors.push_back(iv.toTensor());
+      }
+    }
+
+    facebook::velox::wave::Stream stream;
+    std::vector<at::Tensor> deviceInputs;
+
+    auto dataMovStart = Clock::now();
+    tensorsToDevice(inputTensors, deviceInputs, stream);
+    stream.wait();
+    auto dataMovUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                         Clock::now() - dataMovStart)
+                         .count();
+
+    // Build IValue inputs from device tensors.
+    std::vector<c10::IValue> deviceIvalues;
+    deviceIvalues.reserve(deviceInputs.size());
+    for (auto& t : deviceInputs) {
+      deviceIvalues.emplace_back(std::move(t));
+    }
+
+    auto start = Clock::now();
+    auto outputs = executor.execute(*frame, std::move(deviceIvalues));
+    auto executeUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                         Clock::now() - start)
+                         .count();
+
+    // Copy outputs to host for comparison.
+    std::vector<at::Tensor> deviceOutputTensors;
+    for (auto& iv : outputs) {
+      EXPECT_TRUE(iv.isTensor()) << "Serial GPU output is not a tensor";
+      if (iv.isTensor()) {
+        deviceOutputTensors.push_back(iv.toTensor());
+      }
+    }
+
+    facebook::velox::wave::Stream hostStream;
+    std::vector<at::Tensor> hostOutputs;
+    tensorsToHost(deviceOutputTensors, hostOutputs, hostStream);
+    hostStream.wait();
+
+    verifyOutputs(hostOutputs, expected, "serial-gpu");
+    return {dataMovUs, executeUs};
+  }
+
+  /// Runs a .pt2 model through the WaveGraphExecutor on device.
+  /// Verifies outputs match 'expected' and returns timing.
+  RunTiming runWave(
+      ModelFixture& fixture,
+      const std::vector<at::Tensor>& expected) {
+    const auto& graph = *fixture.model.graph;
+
+    WaveGraphExecutor waveExec(
+        graph, fixture.makeKernels(), fixture.config, fixture.weights);
+
+    // Get a device frame (not timed).
+    auto pooledFrame = waveExec.getFrame();
+    EXPECT_NE(pooledFrame, nullptr);
+
+    // Load sample inputs and move to device (timed).
+    auto inputs = loadSampleInputs(fixture);
+    std::vector<at::Tensor> inputTensors;
+    for (auto& iv : inputs) {
+      if (iv.isTensor()) {
+        inputTensors.push_back(iv.toTensor());
+      }
+    }
+
+    facebook::velox::wave::Stream stream;
+    std::vector<at::Tensor> deviceInputs;
+
+    auto dataMovStart = Clock::now();
+    tensorsToDevice(inputTensors, deviceInputs, stream);
+    stream.wait();
+    auto dataMovUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                         Clock::now() - dataMovStart)
+                         .count();
+
+    // Fill device inputs into the frame.
+    const auto& userInputNames = graph.signature().userInputs();
+    size_t tensorIdx = 0;
+    for (const auto& name : userInputNames) {
+      auto* value = graph.tryGetValue(name);
+      EXPECT_NE(value, nullptr) << "No value for input " << name;
+      if (value && tensorIdx < deviceInputs.size()) {
+        pooledFrame->setIValue(
+            value->id(), c10::IValue(std::move(deviceInputs[tensorIdx++])));
+      }
+    }
+
+    // Time wave executor (excluding frame acquisition and data transfer).
+    auto waveStart = Clock::now();
+    auto waveOutputs = waveExec.executeWithPrefilledFrame(*pooledFrame);
+    auto waveUs = std::chrono::duration_cast<std::chrono::microseconds>(
+                      Clock::now() - waveStart)
+                      .count();
+
+    waveExec.returnFrame(std::move(pooledFrame));
+
+    // Copy outputs to host for comparison.
+    std::vector<at::Tensor> deviceOutputTensors;
+    for (auto& iv : waveOutputs) {
+      EXPECT_TRUE(iv.isTensor()) << "Wave output is not a tensor";
+      if (iv.isTensor()) {
+        deviceOutputTensors.push_back(iv.toTensor());
+      }
+    }
+
+    facebook::velox::wave::Stream hostStream;
+    std::vector<at::Tensor> hostOutputs;
+    tensorsToHost(deviceOutputTensors, hostOutputs, hostStream);
+    hostStream.wait();
+
+    verifyOutputs(hostOutputs, expected, "wave");
+    return {dataMovUs, waveUs};
+  }
+
+ private:
+  /// Loads sample inputs from the .pt2 package.
+  std::vector<c10::IValue> loadSampleInputs(ModelFixture& fixture) {
+    auto modelName = getModelNames(*fixture.reader)[0];
+    std::string sampleInputsPath = fmt::format(
+        torch::_export::archive_spec::SAMPLE_INPUTS_FILENAME_FORMAT, modelName);
+
+    std::vector<c10::IValue> inputs;
+    if (fixture.reader->hasRecord(sampleInputsPath)) {
+      auto size = fixture.reader->getRecordSize(sampleInputsPath);
+      std::vector<char> buffers(size);
+      fixture.reader->getRecord(sampleInputsPath, buffers.data(), size);
+      auto value = torch::jit::pickle_load(buffers);
+      if (value.isTuple() && value.toTupleRef().elements().size() == 2) {
+        const auto& argsVal = value.toTupleRef().elements().at(0);
+        if (argsVal.isTuple()) {
+          for (const auto& arg : argsVal.toTupleRef().elements()) {
+            inputs.push_back(arg);
+          }
+        }
+        const auto& kwargsVal = value.toTupleRef().elements().at(1);
+        if (kwargsVal.isTuple()) {
+          for (const auto& kwarg : kwargsVal.toTupleRef().elements()) {
+            inputs.push_back(kwarg);
+          }
+        } else if (kwargsVal.isGenericDict()) {
+          for (const auto& entry : kwargsVal.toGenericDict()) {
+            inputs.push_back(entry.value());
+          }
+        }
+      }
+    }
+    EXPECT_FALSE(inputs.empty()) << "No sample inputs found in package";
+    return inputs;
+  }
+
+  /// Verifies that IValue outputs match expected tensors.
+  void verifyOutputs(
+      const std::vector<c10::IValue>& outputs,
+      const std::vector<at::Tensor>& expected,
+      const std::string& label) {
+    ASSERT_EQ(outputs.size(), expected.size())
+        << label << ": output count mismatch";
+    for (size_t i = 0; i < expected.size(); ++i) {
+      ASSERT_TRUE(outputs[i].isTensor())
+          << label << " output " << i << " is not a tensor";
+      EXPECT_TRUE(outputs[i].toTensor().equal(expected[i]))
+          << label << " output " << i << " differs from expected";
+    }
+  }
+
+  /// Verifies that tensor outputs match expected tensors.
+  void verifyOutputs(
+      const std::vector<at::Tensor>& outputs,
+      const std::vector<at::Tensor>& expected,
+      const std::string& label) {
+    ASSERT_EQ(outputs.size(), expected.size())
+        << label << ": output count mismatch";
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_TRUE(outputs[i].equal(expected[i]))
+          << label << " output " << i << " differs from expected";
+    }
+  }
+};
+
+TEST_F(ExecutorTest, elementTest) {
+  auto fixture = ModelFixture::load(ELEMENT_TEST_PT2_PATH);
+  ASSERT_NE(fixture, nullptr);
+
+  auto expected = loadReferenceTensors(ELEMENT_TEST_RESULTS_PATH);
+  ASSERT_FALSE(expected.empty());
+
+  auto serialTiming = runSerial(*fixture, expected);
+  auto serialGpuTiming = runSerialOnDevice(*fixture, expected);
+  auto waveTiming = runWave(*fixture, expected);
+
+  LOG(INFO) << "element_test serial CPU: " << serialTiming.executeUs << " us";
+  LOG(INFO) << "element_test serial GPU data transfer (H2D): "
+            << serialGpuTiming.dataTransferUs << " us";
+  LOG(INFO) << "element_test serial GPU executor: " << serialGpuTiming.executeUs
+            << " us";
+  LOG(INFO) << "element_test wave data transfer (H2D): "
+            << waveTiming.dataTransferUs << " us";
+  LOG(INFO) << "element_test wave executor: " << waveTiming.executeUs << " us";
+}
+
+} // namespace
+} // namespace torch::wave

--- a/velox/experimental/torchwave/tests/GraphTool.cpp
+++ b/velox/experimental/torchwave/tests/GraphTool.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include <caffe2/caffe2/serialize/file_adapter.h>
+#include <caffe2/serialize/inline_container.h> // @manual=//caffe2/caffe2/serialize:inline_container
+
+#include "common/init/light.h"
+#include "velox/experimental/torchwave/Compile.h"
+#include "velox/experimental/torchwave/Execute.h"
+#include "velox/experimental/torchwave/Executor.h"
+#include "velox/experimental/torchwave/GraphView.h"
+#include "velox/experimental/torchwave/Pt2Load.h"
+
+DEFINE_string(pt2, "", "Path to a .pt2 file (open source torch.export format)");
+DEFINE_string(
+    model_name,
+    "",
+    "Substring filter for model names (empty matches all)");
+DEFINE_bool(
+    print_params,
+    false,
+    "Print model parameters and sample input metadata");
+DEFINE_bool(print_graph, false, "Print graph signature and output node");
+DEFINE_bool(
+    list_models,
+    false,
+    "List model names found in the package and exit");
+DEFINE_bool(execute, false, "Execute the graph using nativert kernel dispatch");
+DEFINE_bool(compile, false, "Compile the graph");
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::init::InitFacebookLight guard(&argc, &argv);
+
+  torch::wave::initialize();
+
+  if (FLAGS_pt2.empty()) {
+    std::cerr << "Error: --pt2 is required\n";
+    return 1;
+  }
+
+  std::cout << "Loading pt2: " << FLAGS_pt2 << "\n";
+
+  auto reader = std::make_shared<caffe2::serialize::PyTorchStreamReader>(
+      std::make_unique<caffe2::serialize::FileAdapter>(FLAGS_pt2));
+
+  const auto allModelNames = torch::wave::getModelNames(*reader);
+
+  if (FLAGS_list_models) {
+    for (const auto& name : allModelNames) {
+      std::cout << name << "\n";
+    }
+    return 0;
+  }
+
+  for (const auto& modelName : allModelNames) {
+    if (!FLAGS_model_name.empty() &&
+        modelName.find(FLAGS_model_name) == std::string::npos) {
+      continue;
+    }
+
+    std::cout << "\n=== Model: " << modelName << " ===\n";
+
+    auto loaded = torch::wave::loadPt2Model(reader, modelName);
+    const auto& graph = *loaded.graph;
+
+    std::cout << "Number of nodes: " << graph.nodes().size() << "\n";
+
+    if (FLAGS_print_params) {
+      torch::wave::printModelParams(graph);
+    }
+
+    if (FLAGS_print_graph) {
+      torch::wave::printGraphView(graph);
+    }
+
+    if (FLAGS_execute) {
+      std::cout << "\nExecuting graph...\n";
+      auto frame = torch::wave::executeGraph(loaded);
+      std::cout << "Execution returned frame\n";
+    }
+
+    if (FLAGS_compile) {
+      const auto& tensorValuesMeta = graph.tensorValuesMeta();
+      torch::wave::ValueTypes types;
+      types.types.resize(graph.values().size(), nullptr);
+      std::vector<std::unique_ptr<torch::nativert::TensorMeta>> metaStore;
+      for (const auto* value : graph.values()) {
+        auto it = tensorValuesMeta.find(std::string{value->name()});
+        if (it != tensorValuesMeta.end()) {
+          auto meta = std::make_unique<torch::nativert::TensorMeta>(it->second);
+          types.types[value->id()] = meta.get();
+          metaStore.push_back(std::move(meta));
+        }
+      }
+      torch::wave::WaveGraph waveGraph(graph, types);
+      std::cout << waveGraph.toString() << "\n";
+      return 0;
+    }
+  }
+
+  return 0;
+}

--- a/velox/experimental/torchwave/tests/element_test.py
+++ b/velox/experimental/torchwave/tests/element_test.py
@@ -1,0 +1,27 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import torch
+from torch import nn, Tensor
+
+
+class ElementTestPreproc(nn.Module):
+    """Simple element-wise preproc for testing sigmoid packaging.
+
+    Inputs: a, b, c (10000 longs each), d, e, f (100000 longs each)
+    Outputs: o1 = a + b - c, o2 = c - a, o3 = d + e + 100, o4 = f - e + d
+    """
+
+    def forward(
+        self,
+        a: Tensor,
+        b: Tensor,
+        c: Tensor,
+        d: Tensor,
+        e: Tensor,
+        f: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        o1 = a + b - c
+        o2 = c - a
+        o3 = torch.add(d, e, alpha=2)
+        o4 = f - e + d
+        return o1, o2, o3, o4

--- a/velox/experimental/torchwave/tests/element_test_run_pt2.py
+++ b/velox/experimental/torchwave/tests/element_test_run_pt2.py
@@ -1,0 +1,61 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import argparse
+import os
+
+import torch
+from velox.experimental.torchwave.tests.element_test import (
+    ElementTestPreproc,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output_dir",
+        default="/tmp",
+        help="Directory to write element_test.pt2 and element_test_results.pt",
+    )
+    args = parser.parse_args()
+    output_dir = args.output_dir
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Generate test inputs: sequential 1, 2, 3, ...
+    a = torch.arange(1, 10001, dtype=torch.long)
+    b = torch.arange(1, 10001, dtype=torch.long)
+    c = torch.arange(1, 10001, dtype=torch.long)
+    d = torch.arange(1, 100001, dtype=torch.long)
+    e = torch.arange(1, 100001, dtype=torch.long)
+    f = torch.arange(1, 100001, dtype=torch.long)
+
+    # Run in eager mode
+    module = ElementTestPreproc()
+    o1, o2, o3, o4 = module(a, b, c, d, e, f)
+    print(f"Eager results: o1={o1[:5]}, o2={o2[:5]}, o3={o3[:5]}, o4={o4[:5]}")
+
+    # Save eager results as a list of tensors (easy to load in C++).
+    results_path = os.path.join(output_dir, "element_test_results.pt")
+    torch.save([o1, o2, o3, o4], results_path)
+    print(f"Saved results to {results_path}")
+
+    # Export via torch.export
+    print("Exporting via torch.export...")
+    with torch.no_grad():
+        exported_program = torch.export.export(
+            module,
+            (a, b, c, d, e, f),
+            strict=False,
+        )
+    print(f"Export successful, graph has {len(exported_program.graph.nodes)} nodes")
+
+    # Save as open source PyTorch .pt2 file with sample inputs embedded.
+    pt2_path = os.path.join(output_dir, "element_test.pt2")
+    print(f"Saving exported program to {pt2_path}")
+    sample_inputs = ((a, b, c, d, e, f), {})
+    torch.export.save(exported_program, pt2_path, sample_inputs=sample_inputs)
+    print(f"Successfully saved .pt2 to {pt2_path}")
+    print(f"File size: {os.path.getsize(pt2_path)} bytes")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

TorchWave is a GPU kernel fusion and execution framework that compiles nativert FX graphs into fused CUDA kernels. It analyzes the dataflow graph, groups operations into composite kernels, generates CUDA code, and executes them with efficient GPU resource management.

**Core files:**

- **Registry.h/.cpp, Builtins.cpp** — Operation registry mapping nativert op names to metadata (elementwise traits, cost, code generation functions). Builtins registers standard aten ops (add, sub, mul, div, etc.).

- **ParallelExpr.h/.cpp** — Analyzes the nativert graph to identify independent subgraphs (ProjectNodes) that can execute in parallel, partitioning the graph into sequential stages with internal parallelism.

- **Compile.h/.cpp** — The compilation pipeline. Extracts subgraphs from ProjectNodes, matches isomorphic subgraphs to reuse compiled kernels, generates fused CUDA code for elementwise expression trees, and assembles CompositeKernels from multiple KernelOperations.

- **CompiledOp.h** — Data structures for the compiled representation: KernelOperation (a single fused op with CUDA code), OpInvocation (runtime binding of a KernelOperation to actual values), CompositeKernel (groups KernelOperations into one compiled CUDA kernel), CompositeInvocation (runtime invocation with grid building and param filling), CompiledNode (parallel/sequential kernel groups), and WaveGraph (top-level compiled graph).

- **Executor.h/.cpp** — The executor that ties compilation to execution. WaveGraphExecutor extends nativert's GraphExecutorBase. Contains process-wide GPU resource initialization (arenas, stream/event pools), ExecutionState management, grid construction (makeGrid), and the full execution path: output allocation, BlockInfo grid building, pinned buffer param filling, H2D transfer, and kernel launch.

- **KernelParams.h** — Shared host/device structs: Tensor (storage pointer + dims/strides for up to 3D), BlockInfo (per-thread-block dispatch info with op code, element count, param pointer), TorchWaveParams (kernel entry point parameter).

- **Core.cuh, Elementwise.cuh** — CUDA device code. Core.cuh provides the kernel entry macro (ENTRY) and BlockInfo loading. Elementwise.cuh implements the fused elementwise kernel body with fast-path detection for contiguous tensors and broadcast support.

- **Utils.h/.cpp** — Thread-safe Pool<T> template for reusing GPU Streams and Events.

- **Pt2Load.h/.cpp** — Loading .pt2 archives: deserializes the nativert graph, tensor metadata, and weight paths from PyTorchStreamReader.

- **GraphView.h/.cpp** — Diagnostic printing of the nativert graph and compiled WaveGraph structure.

- **NativertSerialization.cpp** — Deserialization of nativert graph IR from JSON format within .pt2 archives.

- **Execute.h/.cpp** — Standalone entry point for loading and running a .pt2 model through the WaveGraph executor.

- **Project.h/.cpp** — ProjectNode representation for the parallelism analysis stage.

- **tests/ExecutorTest.cpp** — End-to-end test: loads a .pt2 model, runs it through both nativert SerialGraphExecutor and WaveGraphExecutor, verifies outputs match eager-mode expectations.

- **tests/GraphTool.cpp** — CLI tool for inspecting .pt2 graph structure and compiled WaveGraph.

- **tests/element_test.py, element_test_run_pt2.py** — Python test model (elementwise arithmetic on int64 tensors) and script to export it as a .pt2 archive for the C++ tests.

Differential Revision: D95696931


