### PR TITLE
feat: Add extraction protocol types (#16882)

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -39,7 +39,327 @@ std::unordered_map<V, K> invertMap(const std::unordered_map<K, V>& mapping) {
   return inverted;
 }
 
+std::unordered_map<ExtractionStep, std::string> extractionStepNames() {
+  return {
+      {ExtractionStep::kStructField, "STRUCT_FIELD"},
+      {ExtractionStep::kMapKeys, "MAP_KEYS"},
+      {ExtractionStep::kMapValues, "MAP_VALUES"},
+      {ExtractionStep::kMapKeyFilter, "MAP_KEY_FILTER"},
+      {ExtractionStep::kArrayElements, "ARRAY_ELEMENTS"},
+      {ExtractionStep::kSize, "SIZE"},
+  };
+}
+
+/// Validate the extraction chain against the input type for step
+/// compatibility.  Each step's output feeds as input to the next step.
+void validateExtractionChain(
+    const TypePtr& inputType,
+    const std::vector<ExtractionPathElementPtr>& chain) {
+  auto currentType = inputType;
+  for (size_t i = 0; i < chain.size(); ++i) {
+    const auto& element = chain[i];
+    switch (element->step()) {
+      case ExtractionStep::kStructField: {
+        VELOX_USER_CHECK(
+            currentType->isRow(),
+            "Extraction step StructField requires ROW input, got: {}",
+            currentType->toString());
+        const auto& rowType = currentType->asRow();
+        auto& fieldName =
+            static_cast<const StructFieldExtractionPathElement&>(*element)
+                .fieldName();
+        VELOX_USER_CHECK(
+            rowType.containsChild(fieldName),
+            "Extraction step StructField references non-existent field: {}",
+            fieldName);
+        currentType = rowType.findChild(fieldName);
+        break;
+      }
+      case ExtractionStep::kMapKeys: {
+        VELOX_USER_CHECK(
+            currentType->isMap(),
+            "Extraction step MapKeys requires MAP input, got: {}",
+            currentType->toString());
+        currentType = ARRAY(currentType->asMap().keyType());
+        break;
+      }
+      case ExtractionStep::kMapValues: {
+        VELOX_USER_CHECK(
+            currentType->isMap(),
+            "Extraction step MapValues requires MAP input, got: {}",
+            currentType->toString());
+        currentType = ARRAY(currentType->asMap().valueType());
+        break;
+      }
+      case ExtractionStep::kMapKeyFilter: {
+        VELOX_USER_CHECK(
+            currentType->isMap(),
+            "Extraction step MapKeyFilter requires MAP input, got: {}",
+            currentType->toString());
+        // Type-preserving: MAP(K, V) -> MAP(K, V).
+        break;
+      }
+      case ExtractionStep::kArrayElements: {
+        VELOX_USER_CHECK(
+            currentType->isArray(),
+            "Extraction step ArrayElements requires ARRAY input, got: {}",
+            currentType->toString());
+        currentType = currentType->asArray().elementType();
+        break;
+      }
+      case ExtractionStep::kSize: {
+        VELOX_USER_CHECK(
+            currentType->isMap() || currentType->isArray(),
+            "Extraction step Size requires MAP or ARRAY input, got: {}",
+            currentType->toString());
+        VELOX_USER_CHECK_EQ(
+            i,
+            chain.size() - 1,
+            "Extraction step Size must be the last step in the chain.");
+        currentType = BIGINT();
+        break;
+      }
+    }
+  }
+}
+
+/// Recursively derive the output type from the input type and extraction
+/// chain.  This follows the derivation rules in the design document.
+TypePtr deriveOutputTypeImpl(
+    const TypePtr& inputType,
+    const std::vector<ExtractionPathElementPtr>& chain,
+    size_t index) {
+  if (index >= chain.size()) {
+    return inputType;
+  }
+
+  const auto& element = chain[index];
+  switch (element->step()) {
+    case ExtractionStep::kStructField: {
+      VELOX_CHECK(inputType->isRow());
+      auto& fieldName =
+          static_cast<const StructFieldExtractionPathElement&>(*element)
+              .fieldName();
+      auto childType = inputType->asRow().findChild(fieldName);
+      return deriveOutputTypeImpl(childType, chain, index + 1);
+    }
+    case ExtractionStep::kMapKeys: {
+      VELOX_CHECK(inputType->isMap());
+      auto keyType = inputType->asMap().keyType();
+      if (index + 1 >= chain.size()) {
+        return ARRAY(keyType);
+      }
+      VELOX_CHECK_EQ(
+          static_cast<int>(chain[index + 1]->step()),
+          static_cast<int>(ExtractionStep::kArrayElements));
+      return ARRAY(deriveOutputTypeImpl(keyType, chain, index + 2));
+    }
+    case ExtractionStep::kMapValues: {
+      VELOX_CHECK(inputType->isMap());
+      auto valueType = inputType->asMap().valueType();
+      if (index + 1 >= chain.size()) {
+        return ARRAY(valueType);
+      }
+      VELOX_CHECK_EQ(
+          static_cast<int>(chain[index + 1]->step()),
+          static_cast<int>(ExtractionStep::kArrayElements));
+      return ARRAY(deriveOutputTypeImpl(valueType, chain, index + 2));
+    }
+    case ExtractionStep::kMapKeyFilter: {
+      VELOX_CHECK(inputType->isMap());
+      return deriveOutputTypeImpl(inputType, chain, index + 1);
+    }
+    case ExtractionStep::kArrayElements: {
+      VELOX_CHECK(inputType->isArray());
+      auto elementType = inputType->asArray().elementType();
+      return ARRAY(deriveOutputTypeImpl(elementType, chain, index + 1));
+    }
+    case ExtractionStep::kSize: {
+      VELOX_CHECK(inputType->isMap() || inputType->isArray());
+      return BIGINT();
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+folly::dynamic serializeExtractionPathElement(
+    const ExtractionPathElement& element) {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["step"] = extractionStepName(element.step());
+  if (element.step() == ExtractionStep::kStructField) {
+    obj["fieldName"] =
+        static_cast<const StructFieldExtractionPathElement&>(element)
+            .fieldName();
+  }
+  if (element.step() == ExtractionStep::kMapKeyFilter) {
+    if (auto* stringFilter =
+            dynamic_cast<const StringMapKeyFilterExtractionPathElement*>(
+                &element)) {
+      folly::dynamic keys = folly::dynamic::array;
+      for (const auto& key : stringFilter->filterKeys()) {
+        keys.push_back(key);
+      }
+      obj["stringFilterKeys"] = keys;
+    } else if (
+        auto* intFilter =
+            dynamic_cast<const IntMapKeyFilterExtractionPathElement*>(
+                &element)) {
+      folly::dynamic keys = folly::dynamic::array;
+      for (const auto& key : intFilter->filterKeys()) {
+        keys.push_back(key);
+      }
+      obj["intFilterKeys"] = keys;
+    }
+  }
+  return obj;
+}
+
+ExtractionPathElementPtr deserializeExtractionPathElement(
+    const folly::dynamic& obj) {
+  auto step = extractionStepFromName(obj["step"].asString());
+  switch (step) {
+    case ExtractionStep::kStructField:
+      return ExtractionPathElement::structField(obj["fieldName"].asString());
+    case ExtractionStep::kMapKeyFilter: {
+      std::vector<std::string> stringKeys;
+      std::vector<int64_t> intKeys;
+      if (auto it = obj.find("stringFilterKeys"); it != obj.items().end()) {
+        for (const auto& key : it->second) {
+          stringKeys.push_back(key.asString());
+        }
+      }
+      if (auto it = obj.find("intFilterKeys"); it != obj.items().end()) {
+        for (const auto& key : it->second) {
+          intKeys.push_back(key.asInt());
+        }
+      }
+      if (!stringKeys.empty()) {
+        return ExtractionPathElement::mapKeyFilter(std::move(stringKeys));
+      }
+      return ExtractionPathElement::mapKeyFilter(std::move(intKeys));
+    }
+    case ExtractionStep::kMapKeys:
+    case ExtractionStep::kMapValues:
+    case ExtractionStep::kArrayElements:
+    case ExtractionStep::kSize:
+      return ExtractionPathElement::simple(step);
+  }
+  VELOX_UNREACHABLE();
+}
+
+folly::dynamic serializeNamedExtraction(const NamedExtraction& extraction) {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["outputName"] = extraction.outputName;
+  obj["dataType"] = extraction.dataType->serialize();
+  folly::dynamic chain = folly::dynamic::array;
+  for (const auto& element : extraction.chain) {
+    chain.push_back(serializeExtractionPathElement(*element));
+  }
+  obj["chain"] = chain;
+  return obj;
+}
+
+NamedExtraction deserializeNamedExtraction(const folly::dynamic& obj) {
+  NamedExtraction extraction;
+  extraction.outputName = obj["outputName"].asString();
+  extraction.dataType = ISerializable::deserialize<Type>(obj["dataType"]);
+  const auto& chainArr = obj["chain"];
+  extraction.chain.reserve(chainArr.size());
+  for (const auto& element : chainArr) {
+    extraction.chain.push_back(deserializeExtractionPathElement(element));
+  }
+  return extraction;
+}
+
 } // namespace
+
+bool extractionPathElementEquals(
+    const ExtractionPathElement& lhs,
+    const ExtractionPathElement& rhs) {
+  if (lhs.step() != rhs.step()) {
+    return false;
+  }
+  switch (lhs.step()) {
+    case ExtractionStep::kStructField:
+      return static_cast<const StructFieldExtractionPathElement&>(lhs)
+                 .fieldName() ==
+          static_cast<const StructFieldExtractionPathElement&>(rhs).fieldName();
+    case ExtractionStep::kMapKeyFilter: {
+      if (auto* lStr =
+              dynamic_cast<const StringMapKeyFilterExtractionPathElement*>(
+                  &lhs)) {
+        auto* rStr =
+            dynamic_cast<const StringMapKeyFilterExtractionPathElement*>(&rhs);
+        return rStr && lStr->filterKeys() == rStr->filterKeys();
+      }
+      if (auto* lInt =
+              dynamic_cast<const IntMapKeyFilterExtractionPathElement*>(&lhs)) {
+        auto* rInt =
+            dynamic_cast<const IntMapKeyFilterExtractionPathElement*>(&rhs);
+        return rInt && lInt->filterKeys() == rInt->filterKeys();
+      }
+      return false;
+    }
+    case ExtractionStep::kMapKeys:
+    case ExtractionStep::kMapValues:
+    case ExtractionStep::kArrayElements:
+    case ExtractionStep::kSize:
+      return true;
+  }
+  VELOX_UNREACHABLE();
+}
+
+/*static*/ std::shared_ptr<const ExtractionPathElement>
+ExtractionPathElement::simple(ExtractionStep step) {
+  return std::make_shared<SimpleExtractionPathElement>(step);
+}
+
+/*static*/ std::shared_ptr<const ExtractionPathElement>
+ExtractionPathElement::structField(const std::string& name) {
+  return std::make_shared<StructFieldExtractionPathElement>(name);
+}
+
+/*static*/ std::shared_ptr<const ExtractionPathElement>
+ExtractionPathElement::mapKeyFilter(std::vector<std::string> keys) {
+  return std::make_shared<StringMapKeyFilterExtractionPathElement>(
+      std::move(keys));
+}
+
+/*static*/ std::shared_ptr<const ExtractionPathElement>
+ExtractionPathElement::mapKeyFilter(std::vector<int64_t> keys) {
+  return std::make_shared<IntMapKeyFilterExtractionPathElement>(
+      std::move(keys));
+}
+
+bool NamedExtraction::operator==(const NamedExtraction& other) const {
+  if (outputName != other.outputName || chain.size() != other.chain.size() ||
+      !dataType->equivalent(*other.dataType)) {
+    return false;
+  }
+  for (size_t i = 0; i < chain.size(); ++i) {
+    if (!extractionPathElementEquals(*chain[i], *other.chain[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+std::string extractionStepName(ExtractionStep step) {
+  static const auto names = extractionStepNames();
+  return names.at(step);
+}
+
+ExtractionStep extractionStepFromName(const std::string& name) {
+  static const auto nameToStep = invertMap(extractionStepNames());
+  return nameToStep.at(name);
+}
+
+TypePtr deriveExtractionOutputType(
+    const TypePtr& inputType,
+    const std::vector<ExtractionPathElementPtr>& chain) {
+  validateExtractionChain(inputType, chain);
+  return deriveOutputTypeImpl(inputType, chain, 0);
+}
 
 std::string HiveColumnHandle::columnTypeName(
     HiveColumnHandle::ColumnType type) {
@@ -53,6 +373,51 @@ HiveColumnHandle::ColumnType HiveColumnHandle::columnTypeFromName(
   return nameColumnTypes.at(name);
 }
 
+HiveColumnHandle::HiveColumnHandle(
+    const std::string& name,
+    ColumnType columnType,
+    TypePtr dataType,
+    TypePtr hiveType,
+    std::vector<common::Subfield> requiredSubfields,
+    std::vector<NamedExtraction> extractions,
+    ColumnParseParameters columnParseParameters,
+    std::function<void(VectorPtr&)> postProcessor)
+    : name_(name),
+      columnType_(columnType),
+      dataType_(std::move(dataType)),
+      hiveType_(std::move(hiveType)),
+      requiredSubfields_(std::move(requiredSubfields)),
+      extractions_(std::move(extractions)),
+      columnParseParameters_(columnParseParameters),
+      postProcessor_(std::move(postProcessor)) {
+  VELOX_USER_CHECK(
+      extractions_.empty() || requiredSubfields_.empty(),
+      "Extractions and requiredSubfields are mutually exclusive on column: {}",
+      name_);
+
+  if (extractions_.empty()) {
+    // No extractions: dataType and hiveType must match (existing behavior).
+    VELOX_USER_CHECK(
+        dataType_->equivalent(*hiveType_),
+        "data type {} and hive type {} do not match",
+        dataType_->toString(),
+        hiveType_->toString());
+  } else {
+    // Validate each extraction chain against hiveType and verify output types.
+    for (const auto& extraction : extractions_) {
+      auto derivedType =
+          deriveExtractionOutputType(hiveType_, extraction.chain);
+      VELOX_USER_CHECK(
+          derivedType->equivalent(*extraction.dataType),
+          "Extraction '{}' declared output type {} does not match "
+          "derived type: {}",
+          extraction.outputName,
+          extraction.dataType->toString(),
+          derivedType->toString());
+    }
+  }
+}
+
 folly::dynamic HiveColumnHandle::serialize() const {
   folly::dynamic obj = ColumnHandle::serializeBase("HiveColumnHandle");
   obj["hiveColumnHandleName"] = name_;
@@ -64,6 +429,13 @@ folly::dynamic HiveColumnHandle::serialize() const {
     requiredSubfields.push_back(subfield.toString());
   }
   obj["requiredSubfields"] = requiredSubfields;
+  if (!extractions_.empty()) {
+    folly::dynamic extractions = folly::dynamic::array;
+    for (const auto& extraction : extractions_) {
+      extractions.push_back(serializeNamedExtraction(extraction));
+    }
+    obj["extractions"] = extractions;
+  }
   return obj;
 }
 
@@ -78,7 +450,57 @@ std::string HiveColumnHandle::toString() const {
   for (const auto& subfield : requiredSubfields_) {
     out << " " << subfield.toString();
   }
-  out << " ]]";
+  out << " ]";
+  if (!extractions_.empty()) {
+    out << ", extractions: [";
+    for (size_t i = 0; i < extractions_.size(); ++i) {
+      if (i > 0) {
+        out << ", ";
+      }
+      const auto& extraction = extractions_[i];
+      out << "{outputName: " << extraction.outputName << ", chain: [";
+      for (size_t j = 0; j < extraction.chain.size(); ++j) {
+        if (j > 0) {
+          out << ", ";
+        }
+        const auto& elem = *extraction.chain[j];
+        out << extractionStepName(elem.step());
+        if (elem.step() == ExtractionStep::kStructField) {
+          out << "("
+              << static_cast<const StructFieldExtractionPathElement&>(elem)
+                     .fieldName()
+              << ")";
+        }
+        if (elem.step() == ExtractionStep::kMapKeyFilter) {
+          out << "(";
+          if (auto* strFilter =
+                  dynamic_cast<const StringMapKeyFilterExtractionPathElement*>(
+                      &elem)) {
+            for (size_t k = 0; k < strFilter->filterKeys().size(); ++k) {
+              if (k > 0) {
+                out << ", ";
+              }
+              out << "\"" << strFilter->filterKeys()[k] << "\"";
+            }
+          } else if (
+              auto* intFilter =
+                  dynamic_cast<const IntMapKeyFilterExtractionPathElement*>(
+                      &elem)) {
+            for (size_t k = 0; k < intFilter->filterKeys().size(); ++k) {
+              if (k > 0) {
+                out << ", ";
+              }
+              out << intFilter->filterKeys()[k];
+            }
+          }
+          out << ")";
+        }
+      }
+      out << "], dataType: " << extraction.dataType->toString() << "}";
+    }
+    out << "]";
+  }
+  out << "]";
   return out.str();
 }
 
@@ -95,8 +517,20 @@ ColumnHandlePtr HiveColumnHandle::create(const folly::dynamic& obj) {
     requiredSubfields.emplace_back(s.asString());
   }
 
+  std::vector<NamedExtraction> extractions;
+  if (auto it = obj.find("extractions"); it != obj.items().end()) {
+    for (const auto& extraction : it->second) {
+      extractions.push_back(deserializeNamedExtraction(extraction));
+    }
+  }
+
   return std::make_shared<HiveColumnHandle>(
-      name, columnType, dataType, hiveType, std::move(requiredSubfields));
+      name,
+      columnType,
+      dataType,
+      hiveType,
+      std::move(requiredSubfields),
+      std::move(extractions));
 }
 
 void HiveColumnHandle::registerSerDe() {

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -23,6 +23,150 @@
 
 namespace facebook::velox::connector::hive {
 
+/// Type of extraction to apply at one nesting level.
+enum class ExtractionStep : uint8_t {
+  /// Navigate into a struct field.  Input must be ROW.
+  kStructField,
+  /// Extract map keys as ARRAY.  Input must be MAP.
+  kMapKeys,
+  /// Extract map values as ARRAY.  Input must be MAP.
+  kMapValues,
+  /// Filter map to specific keys.  Input must be MAP.  Type-preserving.
+  kMapKeyFilter,
+  /// Navigate into array elements.  Input must be ARRAY.
+  kArrayElements,
+  /// Extract size as BIGINT.  Input must be MAP or ARRAY.  Terminal.
+  kSize,
+};
+
+/// Base class for one step in the extraction chain.
+class ExtractionPathElement {
+ public:
+  virtual ~ExtractionPathElement() = default;
+
+  /// Return the step type.
+  virtual ExtractionStep step() const = 0;
+
+  /// Create a simple step (MapKeys, MapValues, ArrayElements, Size).
+  static std::shared_ptr<const ExtractionPathElement> simple(
+      ExtractionStep step);
+
+  /// Create a StructField step.
+  static std::shared_ptr<const ExtractionPathElement> structField(
+      const std::string& name);
+
+  /// Create a MapKeyFilter step with string keys.
+  static std::shared_ptr<const ExtractionPathElement> mapKeyFilter(
+      std::vector<std::string> keys);
+
+  /// Create a MapKeyFilter step with integer keys.
+  static std::shared_ptr<const ExtractionPathElement> mapKeyFilter(
+      std::vector<int64_t> keys);
+};
+
+using ExtractionPathElementPtr = std::shared_ptr<const ExtractionPathElement>;
+
+/// Simple extraction step without extra data (MapKeys, MapValues,
+/// ArrayElements, Size).
+class SimpleExtractionPathElement : public ExtractionPathElement {
+ public:
+  explicit SimpleExtractionPathElement(ExtractionStep step) : step_(step) {}
+
+  ExtractionStep step() const override {
+    return step_;
+  }
+
+ private:
+  ExtractionStep step_;
+};
+
+/// Struct field extraction step.
+class StructFieldExtractionPathElement : public ExtractionPathElement {
+ public:
+  explicit StructFieldExtractionPathElement(std::string name)
+      : fieldName_(std::move(name)) {}
+
+  ExtractionStep step() const override {
+    return ExtractionStep::kStructField;
+  }
+
+  const std::string& fieldName() const {
+    return fieldName_;
+  }
+
+ private:
+  std::string fieldName_;
+};
+
+/// Map key filter extraction step with string keys.
+class StringMapKeyFilterExtractionPathElement : public ExtractionPathElement {
+ public:
+  explicit StringMapKeyFilterExtractionPathElement(
+      std::vector<std::string> keys)
+      : filterKeys_(std::move(keys)) {}
+
+  ExtractionStep step() const override {
+    return ExtractionStep::kMapKeyFilter;
+  }
+
+  const std::vector<std::string>& filterKeys() const {
+    return filterKeys_;
+  }
+
+ private:
+  std::vector<std::string> filterKeys_;
+};
+
+/// Map key filter extraction step with integer keys.
+class IntMapKeyFilterExtractionPathElement : public ExtractionPathElement {
+ public:
+  explicit IntMapKeyFilterExtractionPathElement(std::vector<int64_t> keys)
+      : filterKeys_(std::move(keys)) {}
+
+  ExtractionStep step() const override {
+    return ExtractionStep::kMapKeyFilter;
+  }
+
+  const std::vector<int64_t>& filterKeys() const {
+    return filterKeys_;
+  }
+
+ private:
+  std::vector<int64_t> filterKeys_;
+};
+
+/// Compare two ExtractionPathElements for equality.  Non-virtual to avoid
+/// slicing hazards with virtual operator==.
+bool extractionPathElementEquals(
+    const ExtractionPathElement& lhs,
+    const ExtractionPathElement& rhs);
+
+/// Named extraction chain producing one output column.
+struct NamedExtraction {
+  /// Output column name in the scan's outputType.
+  std::string outputName;
+
+  /// Extraction chain to apply.  Empty means pass-through (no extraction).
+  std::vector<ExtractionPathElementPtr> chain;
+
+  /// Output type after applying the chain.
+  TypePtr dataType;
+
+  bool operator==(const NamedExtraction& other) const;
+};
+
+/// Return the string name for an ExtractionStep enum value.
+std::string extractionStepName(ExtractionStep step);
+
+/// Parse an ExtractionStep from its string name.
+ExtractionStep extractionStepFromName(const std::string& name);
+
+/// Derive the output type by applying the extraction chain to the input type.
+/// Throws if the chain is invalid for the given input type.
+TypePtr deriveExtractionOutputType(
+    const TypePtr& inputType,
+    const std::vector<ExtractionPathElementPtr>& chain);
+
 class HiveColumnHandle : public ColumnHandle {
  public:
   /// NOTE: Make sure to update the mapping in columnTypeNames() when modifying
@@ -44,32 +188,45 @@ class HiveColumnHandle : public ColumnHandle {
     } partitionDateValueFormat;
   };
 
-  /// NOTE: 'dataType' is the column type in target write table. 'hiveType' is
+  /// NOTE: 'dataType' is the column type in target write table.  'hiveType' is
   /// converted type of the corresponding column in source table which might not
   /// be the same type, and the table scan needs to do data coercion if needs.
   /// The table writer also needs to respect the type difference when processing
   /// input data such as bucket id calculation.
+  ///
+  /// 'extractions' specifies named extraction chains.  When non-empty,
+  /// 'requiredSubfields' must be empty (mutually exclusive).  When a single
+  /// extraction is present, 'dataType' is that extraction's dataType.  When
+  /// multiple extractions are present, 'dataType' is a ROW type whose fields
+  /// are the outputNames with their corresponding dataTypes.
   HiveColumnHandle(
       const std::string& name,
       ColumnType columnType,
       TypePtr dataType,
       TypePtr hiveType,
       std::vector<common::Subfield> requiredSubfields = {},
+      std::vector<NamedExtraction> extractions = {},
       ColumnParseParameters columnParseParameters = {},
+      std::function<void(VectorPtr&)> postProcessor = {});
+
+  /// Legacy constructor without extractions for backward compatibility.
+  HiveColumnHandle(
+      const std::string& name,
+      ColumnType columnType,
+      TypePtr dataType,
+      TypePtr hiveType,
+      std::vector<common::Subfield> requiredSubfields,
+      ColumnParseParameters columnParseParameters,
       std::function<void(VectorPtr&)> postProcessor = {})
-      : name_(name),
-        columnType_(columnType),
-        dataType_(std::move(dataType)),
-        hiveType_(std::move(hiveType)),
-        requiredSubfields_(std::move(requiredSubfields)),
-        columnParseParameters_(columnParseParameters),
-        postProcessor_(std::move(postProcessor)) {
-    VELOX_USER_CHECK(
-        dataType_->equivalent(*hiveType_),
-        "data type {} and hive type {} do not match",
-        dataType_->toString(),
-        hiveType_->toString());
-  }
+      : HiveColumnHandle(
+            name,
+            columnType,
+            std::move(dataType),
+            std::move(hiveType),
+            std::move(requiredSubfields),
+            /*extractions=*/{},
+            columnParseParameters,
+            std::move(postProcessor)) {}
 
   const std::string& name() const override {
     return name_;
@@ -103,6 +260,17 @@ class HiveColumnHandle : public ColumnHandle {
   /// required index.
   const std::vector<common::Subfield>& requiredSubfields() const {
     return requiredSubfields_;
+  }
+
+  /// Named extraction chains.  Empty means no extraction (current behavior).
+  /// When a single entry is present, the column handle's dataType is that
+  /// entry's dataType.  When multiple entries are present, the column
+  /// handle's dataType is a ROW type whose fields are the outputNames with
+  /// their corresponding dataTypes.
+  /// Mutually exclusive with requiredSubfields — if extractions is non-empty,
+  /// requiredSubfields must be empty.
+  const std::vector<NamedExtraction>& extractions() const {
+    return extractions_;
   }
 
   bool isPartitionKey() const {
@@ -150,6 +318,7 @@ class HiveColumnHandle : public ColumnHandle {
   const TypePtr dataType_;
   const TypePtr hiveType_;
   const std::vector<common::Subfield> requiredSubfields_;
+  const std::vector<NamedExtraction> extractions_;
   const ColumnParseParameters columnParseParameters_;
   const std::function<void(VectorPtr&)> postProcessor_;
 };

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -16,11 +16,13 @@
 
 #include "velox/connectors/hive/TableHandle.h"
 
+#include <gmock/gmock.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
 using namespace facebook::velox;
+using namespace facebook::velox::connector::hive;
 
 TEST(FileHandleTest, hiveColumnHandle) {
   Type::registerSerDe();
@@ -128,4 +130,507 @@ TEST(TableHandleTest, hiveTableHandleIndexSupport) {
   ASSERT_EQ(tableHandleWithIndex->indexColumns().size(), 2);
   ASSERT_EQ(tableHandleWithIndex->indexColumns()[0], "col1");
   ASSERT_EQ(tableHandleWithIndex->indexColumns()[1], "col2");
+}
+
+// --- Column extraction pushdown tests ---
+
+using EPE = ExtractionPathElementPtr;
+
+TEST(ExtractionStepTest, nameRoundTrip) {
+  // Verify all extraction steps can be converted to names and back.
+  std::vector<ExtractionStep> steps = {
+      ExtractionStep::kStructField,
+      ExtractionStep::kMapKeys,
+      ExtractionStep::kMapValues,
+      ExtractionStep::kMapKeyFilter,
+      ExtractionStep::kArrayElements,
+      ExtractionStep::kSize,
+  };
+  for (auto step : steps) {
+    auto name = extractionStepName(step);
+    ASSERT_EQ(extractionStepFromName(name), step);
+  }
+}
+
+TEST(ExtractionStepTest, nameValues) {
+  ASSERT_EQ(extractionStepName(ExtractionStep::kStructField), "STRUCT_FIELD");
+  ASSERT_EQ(extractionStepName(ExtractionStep::kMapKeys), "MAP_KEYS");
+  ASSERT_EQ(extractionStepName(ExtractionStep::kMapValues), "MAP_VALUES");
+  ASSERT_EQ(
+      extractionStepName(ExtractionStep::kMapKeyFilter), "MAP_KEY_FILTER");
+  ASSERT_EQ(
+      extractionStepName(ExtractionStep::kArrayElements), "ARRAY_ELEMENTS");
+  ASSERT_EQ(extractionStepName(ExtractionStep::kSize), "SIZE");
+}
+
+TEST(DeriveExtractionOutputTypeTest, mapKeys) {
+  // map_keys(col) where col: MAP(VARCHAR, BIGINT) -> ARRAY(VARCHAR).
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(VARCHAR())));
+}
+
+TEST(DeriveExtractionOutputTypeTest, mapValues) {
+  // map_values(col) where col: MAP(VARCHAR, BIGINT) -> ARRAY(BIGINT).
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues)};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(BIGINT())));
+}
+
+TEST(DeriveExtractionOutputTypeTest, size) {
+  // cardinality(col) where col: MAP(VARCHAR, BIGINT) -> BIGINT.
+  auto mapType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kSize)};
+  auto outputType = deriveExtractionOutputType(mapType, chain);
+  ASSERT_TRUE(outputType->equivalent(*BIGINT()));
+
+  // cardinality(col) where col: ARRAY(BIGINT) -> BIGINT.
+  auto arrayType = ARRAY(BIGINT());
+  outputType = deriveExtractionOutputType(arrayType, chain);
+  ASSERT_TRUE(outputType->equivalent(*BIGINT()));
+}
+
+TEST(DeriveExtractionOutputTypeTest, structFieldMapKeys) {
+  // map_keys(col.a.b) where col: ROW(a: ROW(b: MAP(K, V))) -> ARRAY(K).
+  auto hiveType = ROW({{"a", ROW({{"b", MAP(VARCHAR(), BIGINT())}})}});
+  std::vector<EPE> chain = {
+      ExtractionPathElement::structField("a"),
+      ExtractionPathElement::structField("b"),
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(VARCHAR())));
+}
+
+TEST(DeriveExtractionOutputTypeTest, structFieldSize) {
+  // cardinality(col.features) where col: ROW(features: ARRAY(FLOAT),
+  // label: INT) -> BIGINT.
+  auto hiveType = ROW({{"features", ARRAY(REAL())}, {"label", INTEGER()}});
+  std::vector<EPE> chain = {
+      ExtractionPathElement::structField("features"),
+      ExtractionPathElement::simple(ExtractionStep::kSize)};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*BIGINT()));
+}
+
+TEST(DeriveExtractionOutputTypeTest, mapValuesArrayElementsMapKeys) {
+  // map_keys(map_values(col)) where col: MAP(K1, MAP(K2, V))
+  // -> ARRAY(ARRAY(K2)).
+  auto hiveType = MAP(VARCHAR(), MAP(INTEGER(), DOUBLE()));
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(ARRAY(INTEGER()))));
+}
+
+TEST(DeriveExtractionOutputTypeTest, nestedArrayElements) {
+  // map_keys(array_elements(map_values(col)))
+  // where col: MAP(K1, ARRAY(MAP(K2, V))) -> ARRAY(ARRAY(ARRAY(K2))).
+  auto hiveType = MAP(VARCHAR(), ARRAY(MAP(INTEGER(), DOUBLE())));
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(ARRAY(ARRAY(INTEGER())))));
+}
+
+TEST(DeriveExtractionOutputTypeTest, mapValuesStructField) {
+  // map_values(col).x where col: MAP(K, ROW(x: INT, y: INT))
+  // -> ARRAY(INT).
+  auto hiveType = MAP(VARCHAR(), ROW({{"x", INTEGER()}, {"y", INTEGER()}}));
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::structField("x")};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(INTEGER())));
+}
+
+TEST(DeriveExtractionOutputTypeTest, mapKeyFilter) {
+  // map_subset(col, ARRAY['a', 'b']) where col: MAP(VARCHAR, BIGINT)
+  // -> MAP(VARCHAR, BIGINT).
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::mapKeyFilter(std::vector<std::string>{"a", "b"})};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*MAP(VARCHAR(), BIGINT())));
+}
+
+TEST(DeriveExtractionOutputTypeTest, mapKeyFilterMapValuesStructField) {
+  // element_at(col, 'foo').x via extraction chain:
+  // [MapKeyFilter(["foo"]), MapValues, ArrayElements, StructField("x")]
+  // where col: MAP(VARCHAR, ROW(x: INT, y: INT)) -> ARRAY(INT).
+  auto hiveType = MAP(VARCHAR(), ROW({{"x", INTEGER()}, {"y", INTEGER()}}));
+  std::vector<EPE> chain = {
+      ExtractionPathElement::mapKeyFilter(std::vector<std::string>{"foo"}),
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::structField("x")};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(INTEGER())));
+}
+
+TEST(DeriveExtractionOutputTypeTest, nestedKeyFilter) {
+  // Nested key filter: MAP(K1, MAP(VARCHAR, ROW(x: INT, y: INT)))
+  // Chain: [MapValues, AE, MapKeyFilter(["foo"]), MapValues, AE,
+  // StructField("x")]
+  // -> ARRAY(ARRAY(INT)).
+  auto hiveType =
+      MAP(VARCHAR(), MAP(VARCHAR(), ROW({{"x", INTEGER()}, {"y", DOUBLE()}})));
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::mapKeyFilter(std::vector<std::string>{"foo"}),
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::structField("x")};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*ARRAY(ARRAY(INTEGER()))));
+}
+
+TEST(DeriveExtractionOutputTypeTest, emptyChain) {
+  // Empty chain means pass-through.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {};
+  auto outputType = deriveExtractionOutputType(hiveType, chain);
+  ASSERT_TRUE(outputType->equivalent(*hiveType));
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorMissingArrayElementsAfterMapValues) {
+  // [MapValues, MapKeys] on MAP(K1, ARRAY(MAP(K2, V))) — missing
+  // ArrayElements.
+  auto hiveType = MAP(VARCHAR(), ARRAY(MAP(INTEGER(), DOUBLE())));
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "MapKeys requires MAP input, got: ARRAY");
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorMissingArrayElementsAfterMapKeys) {
+  // [MapKeys, StructField("x")] on MAP(ROW(x: INT, y: INT), V) — missing
+  // ArrayElements.
+  auto hiveType = MAP(ROW({{"x", INTEGER()}, {"y", INTEGER()}}), BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys),
+      ExtractionPathElement::structField("x")};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "StructField requires ROW input, got: ARRAY");
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorSizeNotTerminal) {
+  // Size must be the last step.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kSize),
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "Size must be the last step");
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorStructFieldOnMap) {
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<EPE> chain = {ExtractionPathElement::structField("x")};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "StructField requires ROW input");
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorMapKeysOnArray) {
+  auto hiveType = ARRAY(BIGINT());
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "MapKeys requires MAP input");
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorSizeOnScalar) {
+  auto hiveType = BIGINT();
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kSize)};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "Size requires MAP or ARRAY input");
+}
+
+TEST(DeriveExtractionOutputTypeTest, errorNonExistentField) {
+  auto hiveType = ROW({{"a", INTEGER()}});
+  std::vector<EPE> chain = {ExtractionPathElement::structField("nonexistent")};
+  VELOX_ASSERT_THROW(
+      deriveExtractionOutputType(hiveType, chain),
+      "non-existent field: nonexistent");
+}
+
+TEST(ColumnExtractionTest, singleExtraction) {
+  // Single extraction: map_keys(col) where col: MAP(VARCHAR, BIGINT).
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto outputType = ARRAY(VARCHAR());
+  std::vector<NamedExtraction> extractions = {
+      {"keys",
+       {ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       outputType}};
+
+  auto handle = std::make_shared<HiveColumnHandle>(
+      "col",
+      HiveColumnHandle::ColumnType::kRegular,
+      outputType,
+      hiveType,
+      std::vector<common::Subfield>{},
+      std::move(extractions));
+
+  ASSERT_EQ(handle->name(), "col");
+  ASSERT_TRUE(handle->dataType()->equivalent(*ARRAY(VARCHAR())));
+  ASSERT_TRUE(handle->hiveType()->equivalent(*MAP(VARCHAR(), BIGINT())));
+  ASSERT_TRUE(handle->requiredSubfields().empty());
+  ASSERT_EQ(handle->extractions().size(), 1);
+  ASSERT_EQ(handle->extractions()[0].outputName, "keys");
+  ASSERT_EQ(handle->extractions()[0].chain.size(), 1);
+  ASSERT_EQ(
+      handle->extractions()[0].chain[0]->step(), ExtractionStep::kMapKeys);
+  ASSERT_TRUE(handle->extractions()[0].dataType->equivalent(*ARRAY(VARCHAR())));
+
+  // Serialization round-trip.
+  auto obj = handle->serialize();
+  auto clone = ISerializable::deserialize<HiveColumnHandle>(obj);
+  ASSERT_EQ(clone->toString(), handle->toString());
+  ASSERT_EQ(clone->extractions().size(), 1);
+  ASSERT_EQ(clone->extractions()[0].outputName, "keys");
+  ASSERT_TRUE(clone->extractions()[0].dataType->equivalent(*ARRAY(VARCHAR())));
+}
+
+TEST(ColumnExtractionTest, multipleExtractions) {
+  // Multiple extractions from the same column:
+  // map_keys(col), cardinality(col) where col: MAP(VARCHAR, BIGINT).
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto keysType = ARRAY(VARCHAR());
+  auto sizeType = BIGINT();
+  auto rowOutputType = ROW({{"keys", keysType}, {"size", sizeType}});
+  std::vector<NamedExtraction> extractions = {
+      {"keys",
+       {ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       keysType},
+      {"size",
+       {ExtractionPathElement::simple(ExtractionStep::kSize)},
+       sizeType}};
+
+  auto handle = std::make_shared<HiveColumnHandle>(
+      "col",
+      HiveColumnHandle::ColumnType::kRegular,
+      rowOutputType,
+      hiveType,
+      std::vector<common::Subfield>{},
+      std::move(extractions));
+
+  ASSERT_EQ(handle->extractions().size(), 2);
+  ASSERT_EQ(handle->extractions()[0].outputName, "keys");
+  ASSERT_EQ(handle->extractions()[1].outputName, "size");
+
+  // Serialization round-trip.
+  auto obj = handle->serialize();
+  auto clone = ISerializable::deserialize<HiveColumnHandle>(obj);
+  ASSERT_EQ(clone->extractions().size(), 2);
+  ASSERT_EQ(clone->extractions()[0].outputName, "keys");
+  ASSERT_EQ(clone->extractions()[1].outputName, "size");
+  ASSERT_TRUE(clone->extractions()[0].dataType->equivalent(*ARRAY(VARCHAR())));
+  ASSERT_TRUE(clone->extractions()[1].dataType->equivalent(*BIGINT()));
+}
+
+TEST(ColumnExtractionTest, complexChainWithKeyFilter) {
+  // Chain: [MapKeyFilter(["foo", "bar"]), MapValues, AE, StructField("x")]
+  // on MAP(VARCHAR, ROW(x: INT, y: INT)) -> ARRAY(INT).
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+
+  auto hiveType = MAP(VARCHAR(), ROW({{"x", INTEGER()}, {"y", INTEGER()}}));
+  auto outputType = ARRAY(INTEGER());
+  std::vector<NamedExtraction> extractions = {
+      {"col_x",
+       {ExtractionPathElement::mapKeyFilter(
+            std::vector<std::string>{"foo", "bar"}),
+        ExtractionPathElement::simple(ExtractionStep::kMapValues),
+        ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+        ExtractionPathElement::structField("x")},
+       outputType}};
+
+  auto handle = std::make_shared<HiveColumnHandle>(
+      "col",
+      HiveColumnHandle::ColumnType::kRegular,
+      outputType,
+      hiveType,
+      std::vector<common::Subfield>{},
+      std::move(extractions));
+
+  ASSERT_EQ(handle->extractions().size(), 1);
+  ASSERT_EQ(handle->extractions()[0].chain.size(), 4);
+
+  // Verify key filter keys are preserved.
+  ASSERT_THAT(
+      static_cast<const StringMapKeyFilterExtractionPathElement&>(
+          *handle->extractions()[0].chain[0])
+          .filterKeys(),
+      testing::ElementsAre("foo", "bar"));
+
+  // Serialization round-trip.
+  auto obj = handle->serialize();
+  auto clone = ISerializable::deserialize<HiveColumnHandle>(obj);
+  ASSERT_EQ(clone->extractions().size(), 1);
+  ASSERT_EQ(clone->extractions()[0].chain.size(), 4);
+  ASSERT_THAT(
+      static_cast<const StringMapKeyFilterExtractionPathElement&>(
+          *clone->extractions()[0].chain[0])
+          .filterKeys(),
+      testing::ElementsAre("foo", "bar"));
+}
+
+TEST(ColumnExtractionTest, intFilterKeys) {
+  // MapKeyFilter with integer keys.
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+
+  auto hiveType = MAP(BIGINT(), VARCHAR());
+  auto outputType = MAP(BIGINT(), VARCHAR());
+  std::vector<NamedExtraction> extractions = {
+      {"filtered",
+       {ExtractionPathElement::mapKeyFilter(std::vector<int64_t>{1, 2, 3})},
+       outputType}};
+
+  auto handle = std::make_shared<HiveColumnHandle>(
+      "col",
+      HiveColumnHandle::ColumnType::kRegular,
+      outputType,
+      hiveType,
+      std::vector<common::Subfield>{},
+      std::move(extractions));
+
+  ASSERT_THAT(
+      static_cast<const IntMapKeyFilterExtractionPathElement&>(
+          *handle->extractions()[0].chain[0])
+          .filterKeys(),
+      testing::ElementsAre(1, 2, 3));
+
+  // Serialization round-trip.
+  auto obj = handle->serialize();
+  auto clone = ISerializable::deserialize<HiveColumnHandle>(obj);
+  ASSERT_THAT(
+      static_cast<const IntMapKeyFilterExtractionPathElement&>(
+          *clone->extractions()[0].chain[0])
+          .filterKeys(),
+      testing::ElementsAre(1, 2, 3));
+}
+
+TEST(ColumnExtractionTest, mutualExclusivity) {
+  // Cannot set both extractions and requiredSubfields.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<common::Subfield> requiredSubfields;
+  requiredSubfields.emplace_back("col[\"foo\"]");
+  std::vector<NamedExtraction> extractions = {
+      {"keys",
+       {ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       ARRAY(VARCHAR())}};
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<HiveColumnHandle>(
+          "col",
+          HiveColumnHandle::ColumnType::kRegular,
+          ARRAY(VARCHAR()),
+          hiveType,
+          std::move(requiredSubfields),
+          std::move(extractions)),
+      "mutually exclusive");
+}
+
+TEST(ColumnExtractionTest, extractionOutputTypeMismatch) {
+  // Declared output type doesn't match derived type.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  std::vector<NamedExtraction> extractions = {
+      {"keys",
+       {ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       // Wrong: should be ARRAY(VARCHAR), not ARRAY(BIGINT).
+       ARRAY(BIGINT())}};
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<HiveColumnHandle>(
+          "col",
+          HiveColumnHandle::ColumnType::kRegular,
+          ARRAY(BIGINT()),
+          hiveType,
+          std::vector<common::Subfield>{},
+          std::move(extractions)),
+      "does not match derived type");
+}
+
+TEST(ColumnExtractionTest, noExtractionsBackwardCompatible) {
+  // Empty extractions: existing behavior, dataType must match hiveType.
+  auto type = MAP(VARCHAR(), BIGINT());
+  auto handle = std::make_shared<HiveColumnHandle>(
+      "col", HiveColumnHandle::ColumnType::kRegular, type, type);
+
+  ASSERT_TRUE(handle->extractions().empty());
+  ASSERT_TRUE(handle->requiredSubfields().empty());
+  ASSERT_TRUE(handle->dataType()->equivalent(*type));
+}
+
+TEST(ColumnExtractionTest, threeExtractionsFromSameColumn) {
+  // Three extractions: size, keys, and value subfield.
+  // col: MAP(BIGINT, ROW(a: VARCHAR, b: DOUBLE, c: INT))
+  Type::registerSerDe();
+  HiveColumnHandle::registerSerDe();
+
+  auto hiveType =
+      MAP(BIGINT(), ROW({{"a", VARCHAR()}, {"b", DOUBLE()}, {"c", INTEGER()}}));
+  auto szType = BIGINT();
+  auto keysType = ARRAY(BIGINT());
+  auto valsAType = ARRAY(VARCHAR());
+  auto rowOutputType =
+      ROW({{"sz", szType}, {"keys", keysType}, {"vals_a", valsAType}});
+
+  std::vector<NamedExtraction> extractions = {
+      {"sz", {ExtractionPathElement::simple(ExtractionStep::kSize)}, szType},
+      {"keys",
+       {ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       keysType},
+      {"vals_a",
+       {ExtractionPathElement::simple(ExtractionStep::kMapValues),
+        ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+        ExtractionPathElement::structField("a")},
+       valsAType}};
+
+  auto handle = std::make_shared<HiveColumnHandle>(
+      "col",
+      HiveColumnHandle::ColumnType::kRegular,
+      rowOutputType,
+      hiveType,
+      std::vector<common::Subfield>{},
+      std::move(extractions));
+
+  ASSERT_EQ(handle->extractions().size(), 3);
+
+  // Serialization round-trip.
+  auto obj = handle->serialize();
+  auto clone = ISerializable::deserialize<HiveColumnHandle>(obj);
+  ASSERT_EQ(clone->extractions().size(), 3);
+  ASSERT_EQ(clone->extractions()[0].outputName, "sz");
+  ASSERT_EQ(clone->extractions()[1].outputName, "keys");
+  ASSERT_EQ(clone->extractions()[2].outputName, "vals_a");
+  ASSERT_TRUE(clone->extractions()[0].dataType->equivalent(*BIGINT()));
+  ASSERT_TRUE(clone->extractions()[1].dataType->equivalent(*ARRAY(BIGINT())));
+  ASSERT_TRUE(clone->extractions()[2].dataType->equivalent(*ARRAY(VARCHAR())));
 }


### PR DESCRIPTION
Summary:

Add the protocol layer for column extraction pushdown — a new mechanism
that tells the reader to extract a specific component from a complex type
and produce it as a different output type.  For example, extracting map
keys from MAP(K, V) produces ARRAY(K).

This diff adds:
- ExtractionStep enum (StructField, MapKeys, MapValues, MapKeyFilter,
  ArrayElements, Size)
- ExtractionPathElement abstract base class with 3 concrete subclasses
  (SimpleExtractionPathElement, StructFieldExtractionPathElement,
  MapKeyFilterExtractionPathElement)
- NamedExtraction struct (outputName + chain + dataType)
- Type derivation and validation (deriveExtractionOutputType)
- HiveColumnHandle extended with extractions field (mutually exclusive
  with requiredSubfields)
- Full JSON serialization/deserialization of extraction chains
- Non-virtual equality via extractionPathElementEquals() free function

Reviewed By: maniloya

Differential Revision: D97337138


