### PR TITLE
feat(cudf): Add GPU-accelerated Window operator

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   CudfOrderBy.cpp
   CudfReduce.cpp
   CudfTopN.cpp
+  CudfWindow.cpp
   DebugUtil.cpp
   DecimalAggregationDevice.cu
   DecimalAggregationHostOps.cpp

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -196,8 +196,15 @@ cudf::column_view makeCountStarInputColumn(
   if (sortedView.num_columns() > 0) {
     return sortedView.column(0);
   }
-  auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
-  owner = cudf::make_column_from_scalar(oneScalar, logicalRowCount, stream, mr);
+  // Reuse a single materialized ones-column across all zero-column count(*)
+  // calls in this batch. Overwriting `owner` on every call would invalidate
+  // column_views already captured by earlier calls (e.g. deferred requests
+  // held in PendingRangeRolling::inputCol).
+  if (!std::holds_alternative<std::unique_ptr<cudf::column>>(owner)) {
+    auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
+    owner =
+        cudf::make_column_from_scalar(oneScalar, logicalRowCount, stream, mr);
+  }
   return asView(owner);
 }
 
@@ -603,7 +610,10 @@ bool CudfWindow::canRunOnGPU(
                                       const core::TypedExprPtr& value) {
         if (type == core::WindowNode::BoundType::kPreceding ||
             type == core::WindowNode::BoundType::kFollowing) {
-          return !value ||
+          // A PRECEDING/FOLLOWING bound requires a constant offset; a null
+          // value here would throw at execution time (see
+          // constantRowsBoundValue) instead of falling back to CPU cleanly.
+          return value != nullptr &&
               std::dynamic_pointer_cast<const core::ConstantTypedExpr>(value) !=
               nullptr;
         }
@@ -744,7 +754,7 @@ void CudfWindow::computeRankColumnsBatch(
     return;
   }
 
-  const auto n = logicalRowCount_;
+  const auto numRows = logicalRowCount_;
   // Single-column ORDER BY only (multi-column rejected in canRunOnGPU).
   auto colOrder =
       sortKeyIndices_.empty() ? cudf::order::ASCENDING : sortOrders_[0];
@@ -754,13 +764,14 @@ void CudfWindow::computeRankColumnsBatch(
   if (partitionKeyIndices_.empty()) {
     for (const auto& [funcIndex, baseName] : pendingRanks) {
       if (sortKeyIndices_.empty() && baseName != "row_number") {
-        windowResultCols[funcIndex] = makeConstantOnesColumn(n, stream, mr);
+        windowResultCols[funcIndex] =
+            makeConstantOnesColumn(numRows, stream, mr);
         continue;
       }
       if (baseName == "row_number") {
         auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
         windowResultCols[funcIndex] =
-            cudf::sequence(n, oneScalar, oneScalar, stream, mr);
+            cudf::sequence(numRows, oneScalar, oneScalar, stream, mr);
         continue;
       }
       auto valuesCol = sortedInput.column(sortKeyIndices_[0]);
@@ -786,7 +797,8 @@ void CudfWindow::computeRankColumnsBatch(
   for (size_t i = 0; i < pendingRanks.size(); ++i) {
     const auto& [funcIndex, baseName] = pendingRanks[i];
     if (sortKeyIndices_.empty() && baseName != "row_number") {
-      windowResultCols[funcIndex] = makeConstantOnesColumn(n, stream, mr);
+      windowResultCols[funcIndex] =
+          makeConstantOnesColumn(numRows, stream, mr);
       continue;
     }
 
@@ -933,31 +945,18 @@ std::unique_ptr<cudf::column> CudfWindow::computeNthValueColumn(
 
 std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
     const cudf::table_view& partKeys,
-    const cudf::table_view& sortedView,
     cudf::column_view inputCol,
     const core::WindowNode::Function& func,
     const std::string& baseName,
     bool isCountStar,
     rmm::cuda_stream_view stream,
     rmm::device_async_resource_ref mr) const {
-  std::unique_ptr<cudf::rolling_aggregation> agg;
-  agg = makeRollingAggregation(baseName, isCountStar);
-
+  // The unpartitioned, sort-key-less full-partition case is already
+  // dispatched to computeGlobalAggregate() directly from doGetOutput(), so
+  // this is always reached with a non-trivial partition/rolling window.
+  auto agg = makeRollingAggregation(baseName, isCountStar);
   const bool isFullPartition =
       isFullPartitionFrame(func, !sortKeyIndices_.empty());
-
-  if (isFullPartition && sortKeyIndices_.empty() &&
-      partKeys.num_columns() == 0) {
-    return computeGlobalAggregate(
-        inputCol,
-        baseName,
-        isCountStar,
-        veloxToCudfDataType(func.functionCall->type()),
-        sortedView.num_rows(),
-        stream,
-        mr);
-  }
-
   return invokeGroupedRollingWindow(
       partKeys, inputCol, func, std::move(agg), isFullPartition, stream, mr);
 }
@@ -1164,14 +1163,7 @@ RowVectorPtr CudfWindow::doGetOutput() {
                 makeRollingAggregation(baseName, isCountStar)});
       } else {
         windowResultCols[funcIndex] = computeAggregateColumn(
-            partKeys,
-            sortedView,
-            inputCol,
-            func,
-            baseName,
-            isCountStar,
-            stream_,
-            mr);
+            partKeys, inputCol, func, baseName, isCountStar, stream_, mr);
       }
     } else {
       VELOX_FAIL("Unsupported window function for cudf: {}", baseName);
@@ -1235,22 +1227,24 @@ RowVectorPtr CudfWindow::doGetOutput() {
   sortedData_.reset();
   const auto numInputCols = inputRowType_->size();
   for (size_t i = 0; i < windowResultCols.size(); ++i) {
-    auto& wc = windowResultCols[i];
-    VELOX_CHECK_NOT_NULL(wc);
+    auto& resultColumn = windowResultCols[i];
+    VELOX_CHECK_NOT_NULL(resultColumn);
     auto expectedType =
         veloxToCudfDataType(outputType_->childAt(numInputCols + i));
-    if (wc->type() != expectedType) {
-      wc = cudf::cast(wc->view(), expectedType, stream_, mr);
+    if (resultColumn->type() != expectedType) {
+      resultColumn =
+          cudf::cast(resultColumn->view(), expectedType, stream_, mr);
     }
 
     const auto baseName = stripFunctionPrefix(
         windowNode_->windowFunctions()[i].functionCall->name(), prefix);
-    if (baseName == "count" && wc->null_count() > 0) {
+    if (baseName == "count" && resultColumn->null_count() > 0) {
       cudf::numeric_scalar<int64_t> zero(0, true, stream_, mr);
-      wc = cudf::replace_nulls(wc->view(), zero, stream_, mr);
+      resultColumn =
+          cudf::replace_nulls(resultColumn->view(), zero, stream_, mr);
     }
 
-    sortedCols.push_back(std::move(wc));
+    sortedCols.push_back(std::move(resultColumn));
   }
   auto resultTable = std::make_unique<cudf::table>(std::move(sortedCols));
   auto resultSize = resultTable->num_rows();

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -797,8 +797,7 @@ void CudfWindow::computeRankColumnsBatch(
   for (size_t i = 0; i < pendingRanks.size(); ++i) {
     const auto& [funcIndex, baseName] = pendingRanks[i];
     if (sortKeyIndices_.empty() && baseName != "row_number") {
-      windowResultCols[funcIndex] =
-          makeConstantOnesColumn(numRows, stream, mr);
+      windowResultCols[funcIndex] = makeConstantOnesColumn(numRows, stream, mr);
       continue;
     }
 

--- a/velox/experimental/cudf/exec/CudfWindow.cpp
+++ b/velox/experimental/cudf/exec/CudfWindow.cpp
@@ -1,0 +1,1276 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfWindow.h"
+#include "velox/experimental/cudf/exec/DecimalAggregationHostOps.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/Utilities.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/Expressions.h"
+#include "velox/exec/Operator.h"
+#include "velox/type/Type.h"
+
+#include <cudf/aggregation.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/filling.hpp>
+#include <cudf/groupby.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/replace.hpp>
+#include <cudf/rolling.hpp>
+#include <cudf/rolling/range_window_bounds.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/scalar/scalar_factories.hpp>
+#include <cudf/sorting.hpp>
+#include <cudf/table/table_view.hpp>
+#include <cudf/types.hpp>
+#include <cudf/unary.hpp>
+
+#include <nvtx3/nvtx3.hpp>
+
+#include <fmt/format.h>
+
+#include <limits>
+#include <optional>
+#include <unordered_set>
+#include <utility>
+
+namespace facebook::velox::cudf_velox {
+
+namespace {
+
+// Returns true when the window function's value argument is a cast expression.
+// The CPU Window operator only accepts field-access or constant arguments
+// (exec::exprToChannel throws on anything else), so casts on window arguments
+// are normally materialized in a projection below the WindowNode. We reject
+// them here rather than silently reading the un-cast column, which would
+// evaluate f(x) instead of f(cast(x)).
+bool windowArgIsCast(const core::WindowNode::Function& func) {
+  const auto& inputs = func.functionCall->inputs();
+  return !inputs.empty() &&
+      std::dynamic_pointer_cast<const core::CastTypedExpr>(inputs[0]) !=
+      nullptr;
+}
+
+std::optional<column_index_t> resolveInputChannel(
+    const core::WindowNode::Function& func,
+    const RowTypePtr& inputType) {
+  const auto& inputs = func.functionCall->inputs();
+  if (inputs.empty()) {
+    return std::nullopt;
+  }
+  // Match the CPU Window operator: the argument must be a field access or
+  // constant. canRunOnGPU rejects cast arguments (windowArgIsCast) before we
+  // reach here, so we never strip a cast and reinterpret its semantics.
+  return exec::exprToChannel(inputs[0].get(), inputType);
+}
+
+bool isFullPartitionFrame(
+    const core::WindowNode::Function& func,
+    bool hasSortKeys) {
+  const bool isUnboundedPreceding =
+      func.frame.startType == core::WindowNode::BoundType::kUnboundedPreceding;
+  const bool isUnboundedFollowing =
+      func.frame.endType == core::WindowNode::BoundType::kUnboundedFollowing;
+  const bool isCurrentRowFollowing =
+      func.frame.endType == core::WindowNode::BoundType::kCurrentRow;
+  const bool isRange = func.frame.type == core::WindowNode::WindowType::kRange;
+  return isUnboundedPreceding &&
+      (isUnboundedFollowing ||
+       (isRange && isCurrentRowFollowing && !hasSortKeys));
+}
+
+std::optional<std::pair<cudf::range_window_type, cudf::range_window_type>>
+toBatchRangeWindowTypes(
+    const core::WindowNode::Function& func,
+    bool isFullPartition) {
+  if (func.frame.type != core::WindowNode::WindowType::kRange) {
+    return std::nullopt;
+  }
+  if (isFullPartition) {
+    return std::make_pair(
+        cudf::range_window_type{cudf::unbounded{}},
+        cudf::range_window_type{cudf::unbounded{}});
+  }
+  cudf::range_window_type following;
+  if (func.frame.endType == core::WindowNode::BoundType::kCurrentRow) {
+    following = cudf::current_row{};
+  } else if (
+      func.frame.endType == core::WindowNode::BoundType::kUnboundedFollowing) {
+    following = cudf::unbounded{};
+  } else {
+    return std::nullopt;
+  }
+  return std::make_pair(cudf::range_window_type{cudf::unbounded{}}, following);
+}
+
+struct PendingRangeRolling {
+  size_t funcIndex;
+  cudf::column_view inputCol;
+  std::unique_ptr<cudf::rolling_aggregation> agg;
+};
+
+struct RangeRollingBatch {
+  cudf::range_window_type preceding;
+  cudf::range_window_type following;
+  std::vector<PendingRangeRolling> requests;
+};
+
+bool rangeWindowTypesEqual(
+    const cudf::range_window_type& left,
+    const cudf::range_window_type& right) {
+  // Batch gating only uses unbounded/current_row; index distinguishes kinds.
+  return left.index() == right.index();
+}
+
+RangeRollingBatch* findRangeRollingBatch(
+    std::vector<RangeRollingBatch>& batches,
+    const std::pair<cudf::range_window_type, cudf::range_window_type>&
+        rangeTypes) {
+  for (auto& batch : batches) {
+    if (rangeWindowTypesEqual(batch.preceding, rangeTypes.first) &&
+        rangeWindowTypesEqual(batch.following, rangeTypes.second)) {
+      return &batch;
+    }
+  }
+  return nullptr;
+}
+
+void addRangeRollingRequest(
+    std::vector<RangeRollingBatch>& batches,
+    const std::pair<cudf::range_window_type, cudf::range_window_type>&
+        rangeTypes,
+    PendingRangeRolling pending) {
+  if (auto* batch = findRangeRollingBatch(batches, rangeTypes)) {
+    batch->requests.push_back(std::move(pending));
+    return;
+  }
+  RangeRollingBatch batch{rangeTypes.first, rangeTypes.second, {}};
+  batch.requests.push_back(std::move(pending));
+  batches.push_back(std::move(batch));
+}
+
+cudf::rank_method toRankMethod(const std::string& name) {
+  if (name == "row_number") {
+    return cudf::rank_method::FIRST;
+  }
+  if (name == "rank") {
+    return cudf::rank_method::MIN;
+  }
+  if (name == "dense_rank") {
+    return cudf::rank_method::DENSE;
+  }
+  VELOX_FAIL("Unsupported rank window function: {}", name);
+}
+
+std::unique_ptr<cudf::column> makeConstantOnesColumn(
+    cudf::size_type numRows,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
+  return cudf::make_column_from_scalar(oneScalar, numRows, stream, mr);
+}
+
+cudf::column_view makeCountStarInputColumn(
+    const cudf::table_view& sortedView,
+    cudf::size_type logicalRowCount,
+    ColumnOrView& owner,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  if (sortedView.num_columns() > 0) {
+    return sortedView.column(0);
+  }
+  auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
+  owner = cudf::make_column_from_scalar(oneScalar, logicalRowCount, stream, mr);
+  return asView(owner);
+}
+
+std::unique_ptr<cudf::column> computeGlobalAggregate(
+    cudf::column_view inputCol,
+    const std::string& baseName,
+    bool isCountStar,
+    cudf::data_type resultType,
+    cudf::size_type numRows,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) {
+  std::unique_ptr<cudf::scalar> resultScalar;
+  if (baseName == "sum") {
+    auto agg = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+    resultScalar = cudf::reduce(inputCol, *agg, resultType, stream, mr);
+  } else if (baseName == "min") {
+    auto agg = cudf::make_min_aggregation<cudf::reduce_aggregation>();
+    resultScalar = cudf::reduce(inputCol, *agg, inputCol.type(), stream, mr);
+  } else if (baseName == "max") {
+    auto agg = cudf::make_max_aggregation<cudf::reduce_aggregation>();
+    resultScalar = cudf::reduce(inputCol, *agg, inputCol.type(), stream, mr);
+  } else if (baseName == "count") {
+    auto agg = cudf::make_count_aggregation<cudf::reduce_aggregation>(
+        isCountStar ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE);
+    resultScalar = cudf::reduce(
+        inputCol, *agg, cudf::data_type(cudf::type_id::INT64), stream, mr);
+  } else if (baseName == "avg") {
+    auto agg = cudf::make_mean_aggregation<cudf::reduce_aggregation>();
+    resultScalar = cudf::reduce(
+        inputCol, *agg, cudf::data_type(cudf::type_id::FLOAT64), stream, mr);
+  } else {
+    VELOX_FAIL("Unsupported global aggregate window function: {}", baseName);
+  }
+  return cudf::make_column_from_scalar(*resultScalar, numRows, stream, mr);
+}
+
+bool containsCustomComparison(const TypePtr& type) {
+  if (type->providesCustomComparison()) {
+    return true;
+  }
+  for (uint32_t i = 0; i < type->size(); ++i) {
+    if (containsCustomComparison(type->childAt(i))) {
+      return true;
+    }
+  }
+  return false;
+}
+
+cudf::size_type constantRowsBoundValue(const core::TypedExprPtr& value) {
+  VELOX_USER_CHECK_NOT_NULL(value, "ROWS frame offset must be specified");
+
+  auto constExpr =
+      std::dynamic_pointer_cast<const core::ConstantTypedExpr>(value);
+  VELOX_USER_CHECK_NOT_NULL(
+      constExpr, "ROWS frame offset must be a constant expression");
+  VELOX_USER_CHECK(!constExpr->isNull(), "ROWS frame offset must not be null");
+  VELOX_USER_CHECK(
+      constExpr->type()->isInteger() || constExpr->type()->isBigint(),
+      "ROWS frame offset must be INTEGER or BIGINT type, got {}",
+      constExpr->type()->toString());
+
+  int64_t offset;
+  if (constExpr->hasValueVector()) {
+    auto vec = constExpr->valueVector();
+    if (vec->type()->kind() == TypeKind::INTEGER) {
+      offset = vec->as<SimpleVector<int32_t>>()->valueAt(0);
+    } else {
+      offset = vec->as<SimpleVector<int64_t>>()->valueAt(0);
+    }
+  } else if (constExpr->type()->kind() == TypeKind::INTEGER) {
+    offset = constExpr->value().value<int32_t>();
+  } else {
+    offset = constExpr->value().value<int64_t>();
+  }
+
+  VELOX_USER_CHECK_GE(
+      offset, 0, "ROWS frame offset must not be negative: {}", offset);
+  VELOX_USER_CHECK_LE(
+      offset,
+      std::numeric_limits<cudf::size_type>::max(),
+      "ROWS frame offset {} exceeds cudf size_type limit",
+      offset);
+
+  return static_cast<cudf::size_type>(offset);
+}
+
+cudf::window_bounds toRowsPrecedingBound(
+    core::WindowNode::BoundType type,
+    const core::TypedExprPtr& value) {
+  switch (type) {
+    case core::WindowNode::BoundType::kUnboundedPreceding:
+      return cudf::window_bounds::unbounded();
+    case core::WindowNode::BoundType::kCurrentRow:
+      return cudf::window_bounds::get(1);
+    case core::WindowNode::BoundType::kPreceding: {
+      const auto offset = constantRowsBoundValue(value);
+      VELOX_USER_CHECK_LT(
+          offset,
+          std::numeric_limits<cudf::size_type>::max(),
+          "ROWS PRECEDING offset {} exceeds cudf preceding bound limit",
+          offset);
+      return cudf::window_bounds::get(offset + 1);
+    }
+    case core::WindowNode::BoundType::kFollowing: {
+      const auto offset = constantRowsBoundValue(value);
+      return cudf::window_bounds::get(1 - offset);
+    }
+    default:
+      VELOX_UNREACHABLE(
+          "Invalid ROWS start bound type: {}", static_cast<int>(type));
+  }
+}
+
+cudf::window_bounds toRowsFollowingBound(
+    core::WindowNode::BoundType type,
+    const core::TypedExprPtr& value) {
+  switch (type) {
+    case core::WindowNode::BoundType::kUnboundedFollowing:
+      return cudf::window_bounds::unbounded();
+    case core::WindowNode::BoundType::kCurrentRow:
+      return cudf::window_bounds::get(0);
+    case core::WindowNode::BoundType::kFollowing:
+      return cudf::window_bounds::get(constantRowsBoundValue(value));
+    case core::WindowNode::BoundType::kPreceding:
+      return cudf::window_bounds::get(-constantRowsBoundValue(value));
+    default:
+      VELOX_UNREACHABLE(
+          "Invalid ROWS end bound type: {}", static_cast<int>(type));
+  }
+}
+
+// Convert Velox RANGE frame bounds to cudf range_window_bounds.
+int64_t constantIntegerOrBigintValue(const core::ConstantTypedExpr& constExpr) {
+  VELOX_USER_CHECK(!constExpr.isNull(), "Constant offset must not be null");
+  VELOX_USER_CHECK(
+      constExpr.type()->isInteger() || constExpr.type()->isBigint(),
+      "Constant must be INTEGER or BIGINT type, got {}",
+      constExpr.type()->toString());
+  if (constExpr.hasValueVector()) {
+    auto vec = constExpr.valueVector();
+    if (vec->type()->kind() == TypeKind::INTEGER) {
+      return vec->as<SimpleVector<int32_t>>()->valueAt(0);
+    }
+    return vec->as<SimpleVector<int64_t>>()->valueAt(0);
+  }
+  if (constExpr.type()->kind() == TypeKind::INTEGER) {
+    return constExpr.value().value<int32_t>();
+  }
+  return constExpr.value().value<int64_t>();
+}
+
+std::unique_ptr<cudf::rolling_aggregation> makeRollingAggregation(
+    const std::string& baseName,
+    bool isCountStar) {
+  if (baseName == "sum") {
+    return cudf::make_sum_aggregation<cudf::rolling_aggregation>();
+  }
+  if (baseName == "min") {
+    return cudf::make_min_aggregation<cudf::rolling_aggregation>();
+  }
+  if (baseName == "max") {
+    return cudf::make_max_aggregation<cudf::rolling_aggregation>();
+  }
+  if (baseName == "count") {
+    auto nullPolicy =
+        isCountStar ? cudf::null_policy::INCLUDE : cudf::null_policy::EXCLUDE;
+    return cudf::make_count_aggregation<cudf::rolling_aggregation>(nullPolicy);
+  }
+  if (baseName == "avg") {
+    return cudf::make_mean_aggregation<cudf::rolling_aggregation>();
+  }
+  VELOX_FAIL("Unsupported rolling window function: {}", baseName);
+}
+
+} // namespace
+
+bool CudfWindow::isSupportedWindowFunction(
+    const std::string& baseName,
+    size_t numArgs) {
+  static const std::unordered_set<std::string> kSupportedFunctions = {
+      "lag",
+      "lead",
+      "row_number",
+      "rank",
+      "dense_rank",
+      "first_value",
+      "last_value",
+      "sum",
+      "min",
+      "max",
+      "count",
+      "avg"};
+  if (!kSupportedFunctions.contains(baseName)) {
+    return false;
+  }
+  // lag/lead only support up to 2 arguments (value, offset)
+  if ((baseName == "lag" || baseName == "lead") && numArgs > 2) {
+    return false;
+  }
+  return true;
+}
+
+bool CudfWindow::canRunOnGPU(const core::WindowNode& windowNode) {
+  return canRunOnGPU(windowNode, nullptr);
+}
+
+bool CudfWindow::canRunOnGPU(
+    const core::WindowNode& windowNode,
+    std::string* reason) {
+  if (windowNode.sortingKeys().size() > 1) {
+    if (reason) {
+      *reason = "Multi-column ORDER BY requires a cuDF upgrade (follow-on PR)";
+    }
+    return false;
+  }
+
+  for (const auto& key : windowNode.partitionKeys()) {
+    if (containsCustomComparison(key->type())) {
+      if (reason) {
+        *reason = fmt::format(
+            "PARTITION BY key {} uses custom comparison type {}",
+            key->name(),
+            key->type()->toString());
+      }
+      return false;
+    }
+  }
+
+  for (const auto& key : windowNode.sortingKeys()) {
+    if (containsCustomComparison(key->type())) {
+      if (reason) {
+        *reason = fmt::format(
+            "ORDER BY key {} uses custom comparison type {}",
+            key->name(),
+            key->type()->toString());
+      }
+      return false;
+    }
+  }
+
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+  const auto inputType = asRowType(windowNode.inputType());
+  for (const auto& func : windowNode.windowFunctions()) {
+    const auto baseName =
+        stripFunctionPrefix(func.functionCall->name(), prefix);
+    if (!isSupportedWindowFunction(
+            baseName, func.functionCall->inputs().size())) {
+      if (reason) {
+        *reason = fmt::format(
+            "Unsupported window function: {}", func.functionCall->name());
+      }
+      return false;
+    }
+
+    if (windowArgIsCast(func)) {
+      if (reason) {
+        *reason = fmt::format(
+            "Cast expression in {} argument is not supported", baseName);
+      }
+      return false;
+    }
+
+    // Reject NULL constant frame offsets so we fall back to the CPU operator
+    // instead of reinterpreting a null as a garbage integer offset at runtime.
+    const auto isNullConstantBound = [](core::WindowNode::BoundType type,
+                                        const core::TypedExprPtr& value) {
+      if (type != core::WindowNode::BoundType::kPreceding &&
+          type != core::WindowNode::BoundType::kFollowing) {
+        return false;
+      }
+      auto constExpr =
+          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(value);
+      return constExpr != nullptr && constExpr->isNull();
+    };
+    if (isNullConstantBound(func.frame.startType, func.frame.startValue) ||
+        isNullConstantBound(func.frame.endType, func.frame.endValue)) {
+      if (reason) {
+        *reason = "NULL frame offset is not supported";
+      }
+      return false;
+    }
+
+    if (baseName == "lag" || baseName == "lead") {
+      if (func.ignoreNulls) {
+        if (reason) {
+          *reason = fmt::format("{} IGNORE NULLS is not supported", baseName);
+        }
+        return false;
+      }
+
+      const auto inputChannel = resolveInputChannel(func, inputType);
+      if (!inputChannel.has_value() || *inputChannel == kConstantChannel) {
+        if (reason) {
+          *reason = fmt::format(
+              "Constant value argument for {} is not supported", baseName);
+        }
+        return false;
+      }
+
+      if (func.functionCall->inputs().size() >= 2) {
+        const auto offsetExpr =
+            std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+                func.functionCall->inputs()[1]);
+        if (!offsetExpr) {
+          if (reason) {
+            *reason = fmt::format(
+                "Non-constant offset for {} is not supported", baseName);
+          }
+          return false;
+        }
+
+        if (offsetExpr->isNull()) {
+          if (reason) {
+            *reason =
+                fmt::format("Null offset for {} is not supported", baseName);
+          }
+          return false;
+        }
+
+        const int64_t offset = constantIntegerOrBigintValue(*offsetExpr);
+        constexpr int64_t kMaxCudfLeadLagOffset =
+            std::numeric_limits<cudf::size_type>::max() - 1LL;
+        if (offset < 0 || offset > kMaxCudfLeadLagOffset) {
+          if (reason) {
+            *reason = fmt::format(
+                "{} offset {} is outside cuDF's supported range [0, {}]",
+                baseName,
+                offset,
+                kMaxCudfLeadLagOffset);
+          }
+          return false;
+        }
+      }
+    }
+
+    if (!func.functionCall->inputs().empty()) {
+      const auto& argumentType = func.functionCall->inputs()[0]->type();
+
+      const bool unsupportedRealSum =
+          baseName == "sum" && argumentType->isReal();
+      const bool unsupportedDecimalAverage =
+          baseName == "avg" && argumentType->isDecimal();
+      const bool unsupportedNestedMinMax =
+          (baseName == "min" || baseName == "max") &&
+          (argumentType->isArray() || argumentType->isMap() ||
+           argumentType->isRow());
+
+      if (unsupportedRealSum || unsupportedDecimalAverage ||
+          unsupportedNestedMinMax) {
+        if (reason) {
+          *reason = fmt::format(
+              "{} does not support input type {} on cuDF",
+              baseName,
+              argumentType->toString());
+        }
+        return false;
+      }
+    }
+
+    const bool isFullPartition =
+        isFullPartitionFrame(func, !windowNode.sortingKeys().empty());
+    const bool usesRollingFullPartitionPath =
+        !windowNode.partitionKeys().empty() ||
+        !windowNode.sortingKeys().empty();
+
+    if (baseName == "avg" && isFullPartition && usesRollingFullPartitionPath) {
+      if (reason) {
+        *reason = "Full-partition AVG requires optimized cuDF MEAN support";
+      }
+      return false;
+    }
+
+    const bool usesFrame = baseName == "first_value" ||
+        baseName == "last_value" || baseName == "sum" || baseName == "min" ||
+        baseName == "max" || baseName == "count" || baseName == "avg";
+
+    if (usesFrame) {
+      if (auto channel = resolveInputChannel(func, inputType)) {
+        if (*channel == kConstantChannel) {
+          if (reason) {
+            *reason = "Constant window aggregate input not supported";
+          }
+          return false;
+        }
+      }
+
+      if (func.frame.type == core::WindowNode::WindowType::kRange) {
+        const bool startOk = func.frame.startType ==
+            core::WindowNode::BoundType::kUnboundedPreceding;
+        const bool endOk = func.frame.endType ==
+                core::WindowNode::BoundType::kUnboundedFollowing ||
+            func.frame.endType == core::WindowNode::BoundType::kCurrentRow;
+        if (!startOk || !endOk) {
+          if (reason) {
+            *reason =
+                "RANGE frame with non-unbounded/current bounds not supported";
+          }
+          return false;
+        }
+      }
+
+      const auto isConstantBound = [](core::WindowNode::BoundType type,
+                                      const core::TypedExprPtr& value) {
+        if (type == core::WindowNode::BoundType::kPreceding ||
+            type == core::WindowNode::BoundType::kFollowing) {
+          return !value ||
+              std::dynamic_pointer_cast<const core::ConstantTypedExpr>(value) !=
+              nullptr;
+        }
+        return true;
+      };
+      if (!isConstantBound(func.frame.startType, func.frame.startValue) ||
+          !isConstantBound(func.frame.endType, func.frame.endValue)) {
+        if (reason) {
+          *reason = "Non-constant frame bound not supported";
+        }
+        return false;
+      }
+    }
+
+    const auto isNonNegativeConstantBound =
+        [](core::WindowNode::BoundType type,
+           const core::TypedExprPtr& value) -> std::optional<int64_t> {
+      if (type != core::WindowNode::BoundType::kPreceding &&
+          type != core::WindowNode::BoundType::kFollowing) {
+        return std::nullopt;
+      }
+      if (!value) {
+        return std::nullopt;
+      }
+      auto constExpr =
+          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(value);
+      if (!constExpr) {
+        return std::nullopt;
+      }
+      if (constExpr->hasValueVector()) {
+        auto vec = constExpr->valueVector();
+        if (vec->type()->kind() == TypeKind::INTEGER) {
+          return vec->as<SimpleVector<int32_t>>()->valueAt(0);
+        }
+        return vec->as<SimpleVector<int64_t>>()->valueAt(0);
+      }
+      if (constExpr->type()->kind() == TypeKind::INTEGER) {
+        return constExpr->value().value<int32_t>();
+      }
+      return constExpr->value().value<int64_t>();
+    };
+    const auto validateRowsBound = [&](core::WindowNode::BoundType type,
+                                       const core::TypedExprPtr& value,
+                                       bool isStartBound) {
+      const auto constant = isNonNegativeConstantBound(type, value);
+      if (!constant.has_value()) {
+        return true;
+      }
+
+      if (*constant < 0) {
+        if (reason) {
+          *reason = fmt::format(
+              "Window frame {} offset must not be negative", *constant);
+        }
+        return false;
+      }
+
+      const int64_t maxOffset =
+          static_cast<int64_t>(std::numeric_limits<cudf::size_type>::max()) -
+          (isStartBound && type == core::WindowNode::BoundType::kPreceding ? 1
+                                                                           : 0);
+
+      if (*constant > maxOffset) {
+        if (reason) {
+          *reason = fmt::format(
+              "Window frame offset {} exceeds cuDF limit {}",
+              *constant,
+              maxOffset);
+        }
+        return false;
+      }
+
+      return true;
+    };
+
+    if (func.frame.type == core::WindowNode::WindowType::kRows &&
+        (!validateRowsBound(
+             func.frame.startType, func.frame.startValue, true) ||
+         !validateRowsBound(func.frame.endType, func.frame.endValue, false))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+CudfWindow::CudfWindow(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::WindowNode>& windowNode)
+    : CudfOperatorBase(
+          operatorId,
+          driverCtx,
+          windowNode->outputType(),
+          windowNode->id(),
+          "CudfWindow",
+          nvtx3::rgb{255, 165, 0},
+          NvtxMethodFlag::kAddInput | NvtxMethodFlag::kGetOutput),
+      windowNode_(windowNode),
+      inputRowType_(asRowType(windowNode->inputType())) {
+  const auto& inputType = windowNode->inputType();
+
+  for (const auto& key : windowNode->partitionKeys()) {
+    partitionKeyIndices_.push_back(inputType->getChildIdx(key->name()));
+  }
+
+  for (size_t i = 0; i < windowNode->sortingKeys().size(); ++i) {
+    sortKeyIndices_.push_back(
+        inputType->getChildIdx(windowNode->sortingKeys()[i]->name()));
+    const auto& order = windowNode->sortingOrders()[i];
+    sortOrders_.push_back(
+        order.isAscending() ? cudf::order::ASCENDING : cudf::order::DESCENDING);
+    // Velox isNullsFirst() is absolute; cuDF null_order is relative to sort
+    // direction. BEFORE means nulls precede values in that direction.
+    bool nullsBefore = (order.isNullsFirst() && order.isAscending()) ||
+        (!order.isNullsFirst() && !order.isAscending());
+    nullOrders_.push_back(
+        nullsBefore ? cudf::null_order::BEFORE : cudf::null_order::AFTER);
+  }
+}
+
+void CudfWindow::doAddInput(RowVectorPtr input) {
+  // Queue inputs, process all at once.
+  if (input->size() > 0) {
+    auto cudfInput = std::dynamic_pointer_cast<CudfVector>(input);
+    VELOX_CHECK_NOT_NULL(cudfInput, "CudfWindow expects CudfVector input");
+    inputBatches_.push_back(std::move(cudfInput));
+  }
+}
+
+void CudfWindow::computeRankColumnsBatch(
+    const cudf::table_view& sortedInput,
+    const std::vector<std::pair<size_t, std::string>>& pendingRanks,
+    cudf::groupby::groupby* rankGrouper,
+    std::vector<std::unique_ptr<cudf::column>>& windowResultCols,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  if (pendingRanks.empty()) {
+    return;
+  }
+
+  const auto n = logicalRowCount_;
+  // Single-column ORDER BY only (multi-column rejected in canRunOnGPU).
+  auto colOrder =
+      sortKeyIndices_.empty() ? cudf::order::ASCENDING : sortOrders_[0];
+  auto nullOrd =
+      sortKeyIndices_.empty() ? cudf::null_order::BEFORE : nullOrders_[0];
+
+  if (partitionKeyIndices_.empty()) {
+    for (const auto& [funcIndex, baseName] : pendingRanks) {
+      if (sortKeyIndices_.empty() && baseName != "row_number") {
+        windowResultCols[funcIndex] = makeConstantOnesColumn(n, stream, mr);
+        continue;
+      }
+      if (baseName == "row_number") {
+        auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream, mr);
+        windowResultCols[funcIndex] =
+            cudf::sequence(n, oneScalar, oneScalar, stream, mr);
+        continue;
+      }
+      auto valuesCol = sortedInput.column(sortKeyIndices_[0]);
+      auto method = toRankMethod(baseName);
+      auto agg = cudf::make_rank_aggregation<cudf::scan_aggregation>(
+          method, colOrder, cudf::null_policy::INCLUDE, nullOrd);
+      windowResultCols[funcIndex] = cudf::scan(
+          valuesCol,
+          *agg,
+          cudf::scan_type::INCLUSIVE,
+          cudf::null_policy::INCLUDE,
+          stream,
+          mr);
+    }
+    return;
+  }
+
+  std::vector<cudf::groupby::scan_request> scanRequests;
+  scanRequests.reserve(pendingRanks.size());
+  std::vector<size_t> batchedFuncIndices;
+  batchedFuncIndices.reserve(pendingRanks.size());
+
+  for (size_t i = 0; i < pendingRanks.size(); ++i) {
+    const auto& [funcIndex, baseName] = pendingRanks[i];
+    if (sortKeyIndices_.empty() && baseName != "row_number") {
+      windowResultCols[funcIndex] = makeConstantOnesColumn(n, stream, mr);
+      continue;
+    }
+
+    cudf::groupby::scan_request request;
+    if (!sortKeyIndices_.empty()) {
+      request.values = sortedInput.column(sortKeyIndices_[0]);
+    } else {
+      // row_number without ORDER BY: values column is unused for tie detection.
+      request.values = sortedInput.column(partitionKeyIndices_[0]);
+    }
+    request.aggregations.push_back(
+        cudf::make_rank_aggregation<cudf::groupby_scan_aggregation>(
+            toRankMethod(baseName),
+            colOrder,
+            cudf::null_policy::INCLUDE,
+            nullOrd));
+    scanRequests.push_back(std::move(request));
+    batchedFuncIndices.push_back(funcIndex);
+  }
+
+  if (scanRequests.empty()) {
+    return;
+  }
+
+  VELOX_CHECK_NOT_NULL(rankGrouper);
+  auto scanResult = rankGrouper->scan(scanRequests, stream, mr);
+  auto& aggResults = scanResult.second;
+  VELOX_CHECK_EQ(aggResults.size(), scanRequests.size());
+  for (size_t i = 0; i < scanRequests.size(); ++i) {
+    VELOX_CHECK_EQ(aggResults[i].results.size(), 1);
+    windowResultCols[batchedFuncIndices[i]] =
+        std::move(aggResults[i].results[0]);
+  }
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeLeadLagColumn(
+    const cudf::table_view& partKeys,
+    cudf::column_view inputCol,
+    const core::WindowNode::Function& func,
+    const std::string& baseName,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  VELOX_CHECK_LE(
+      func.functionCall->inputs().size(),
+      2,
+      "cudf {} does not support default value (3rd argument)",
+      baseName);
+
+  // Extract offset from the second argument, defaulting to 1.
+  auto getOffset = [&]() -> cudf::size_type {
+    const auto& args = func.functionCall->inputs();
+    if (args.size() < 2) {
+      return 1;
+    }
+    auto constExpr =
+        std::dynamic_pointer_cast<const core::ConstantTypedExpr>(args[1]);
+    VELOX_USER_CHECK_NOT_NULL(
+        constExpr,
+        "cudf {} requires constant offset, non-constant offset not supported",
+        baseName);
+    const int64_t offset = constantIntegerOrBigintValue(*constExpr);
+    VELOX_USER_CHECK_GE(
+        offset, 0, "cudf {} offset must not be negative: {}", baseName, offset);
+    // We pass offset + 1 as the cudf window size below, so cap one below the
+    // size_type max to avoid overflowing cudf::size_type.
+    VELOX_USER_CHECK_LE(
+        offset,
+        std::numeric_limits<cudf::size_type>::max() - 1,
+        "cudf {} offset {} exceeds cudf size_type limit",
+        baseName,
+        offset);
+    return static_cast<cudf::size_type>(offset);
+  };
+  auto offset = getOffset();
+
+  if (baseName == "lag") {
+    auto agg = cudf::make_lag_aggregation<cudf::rolling_aggregation>(offset);
+    return cudf::grouped_rolling_window(
+        partKeys, inputCol, offset + 1, 0, offset + 1, *agg, stream, mr);
+  }
+  auto agg = cudf::make_lead_aggregation<cudf::rolling_aggregation>(offset);
+  return cudf::grouped_rolling_window(
+      partKeys, inputCol, 0, offset + 1, offset + 1, *agg, stream, mr);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::invokeGroupedRollingWindow(
+    const cudf::table_view& partKeys,
+    cudf::column_view inputCol,
+    const core::WindowNode::Function& func,
+    std::unique_ptr<cudf::rolling_aggregation> agg,
+    bool isFullPartition,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  // RANGE frames are handled by the batched grouped_range_rolling_window path
+  // in doGetOutput (see toBatchRangeWindowTypes). canRunOnGPU only accepts
+  // RANGE frames that path can express, so RANGE never reaches here.
+  VELOX_CHECK(
+      func.frame.type != core::WindowNode::WindowType::kRange,
+      "RANGE window frames must be handled by the batched range rolling path");
+
+  if (isFullPartition) {
+    return cudf::grouped_rolling_window(
+        partKeys,
+        inputCol,
+        cudf::window_bounds::unbounded(),
+        cudf::window_bounds::unbounded(),
+        1,
+        *agg,
+        stream,
+        mr);
+  }
+
+  auto preceding =
+      toRowsPrecedingBound(func.frame.startType, func.frame.startValue);
+  auto following =
+      toRowsFollowingBound(func.frame.endType, func.frame.endValue);
+  return cudf::grouped_rolling_window(
+      partKeys, inputCol, preceding, following, 1, *agg, stream, mr);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeNthValueColumn(
+    const cudf::table_view& partKeys,
+    cudf::column_view inputCol,
+    const core::WindowNode::Function& func,
+    const std::string& baseName,
+    bool isFullPartition,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  auto nullPolicy = func.ignoreNulls ? cudf::null_policy::EXCLUDE
+                                     : cudf::null_policy::INCLUDE;
+
+  if (baseName == "first_value") {
+    auto agg = cudf::make_nth_element_aggregation<cudf::rolling_aggregation>(
+        0, nullPolicy);
+    return invokeGroupedRollingWindow(
+        partKeys, inputCol, func, std::move(agg), isFullPartition, stream, mr);
+  }
+  // last_value: use -1 to get the last element in the frame.
+  auto agg = cudf::make_nth_element_aggregation<cudf::rolling_aggregation>(
+      -1, nullPolicy);
+  return invokeGroupedRollingWindow(
+      partKeys, inputCol, func, std::move(agg), isFullPartition, stream, mr);
+}
+
+std::unique_ptr<cudf::column> CudfWindow::computeAggregateColumn(
+    const cudf::table_view& partKeys,
+    const cudf::table_view& sortedView,
+    cudf::column_view inputCol,
+    const core::WindowNode::Function& func,
+    const std::string& baseName,
+    bool isCountStar,
+    rmm::cuda_stream_view stream,
+    rmm::device_async_resource_ref mr) const {
+  std::unique_ptr<cudf::rolling_aggregation> agg;
+  agg = makeRollingAggregation(baseName, isCountStar);
+
+  const bool isFullPartition =
+      isFullPartitionFrame(func, !sortKeyIndices_.empty());
+
+  if (isFullPartition && sortKeyIndices_.empty() &&
+      partKeys.num_columns() == 0) {
+    return computeGlobalAggregate(
+        inputCol,
+        baseName,
+        isCountStar,
+        veloxToCudfDataType(func.functionCall->type()),
+        sortedView.num_rows(),
+        stream,
+        mr);
+  }
+
+  return invokeGroupedRollingWindow(
+      partKeys, inputCol, func, std::move(agg), isFullPartition, stream, mr);
+}
+
+void CudfWindow::doNoMoreInput() {
+  Operator::noMoreInput();
+  if (inputBatches_.empty()) {
+    finished_ = true;
+    stream_ = cudfGlobalStreamPool().get_stream();
+    streamAcquired_ = true;
+    return;
+  }
+
+  // Verify total row count doesn't exceed cudf's int32 limit.
+  int64_t totalRows = 0;
+  for (const auto& batch : inputBatches_) {
+    totalRows += batch->size();
+  }
+  VELOX_CHECK_LE(
+      totalRows,
+      std::numeric_limits<cudf::size_type>::max(),
+      "Total row count {} exceeds cudf size_type limit",
+      totalRows);
+  logicalRowCount_ = static_cast<cudf::size_type>(totalRows);
+
+  stream_ = cudfGlobalStreamPool().get_stream();
+  streamAcquired_ = true;
+  auto mr = get_output_mr();
+
+  // Concatenate all input batches into one table with proper stream sync.
+  auto allData = getConcatenatedTable(
+      std::exchange(inputBatches_, {}), inputRowType_, stream_, mr);
+
+  // Sort by partition keys + sort keys if the plan is not already sorted.
+  if (!windowNode_->inputsSorted()) {
+    std::vector<cudf::size_type> allSortKeys;
+    std::vector<cudf::order> allOrders;
+    std::vector<cudf::null_order> allNullOrders;
+
+    for (auto idx : partitionKeyIndices_) {
+      allSortKeys.push_back(idx);
+      allOrders.push_back(cudf::order::ASCENDING);
+      allNullOrders.push_back(cudf::null_order::BEFORE);
+    }
+    for (size_t i = 0; i < sortKeyIndices_.size(); ++i) {
+      allSortKeys.push_back(sortKeyIndices_[i]);
+      allOrders.push_back(sortOrders_[i]);
+      allNullOrders.push_back(nullOrders_[i]);
+    }
+
+    // Skip sorting if there are no sort keys (global window without ORDER BY).
+    if (allSortKeys.empty()) {
+      sortedData_ = std::move(allData);
+    } else {
+      auto allView = allData->view();
+      auto keyTable = allView.select(allSortKeys);
+      sortedData_ = cudf::stable_sort_by_key(
+          allView, keyTable, allOrders, allNullOrders, stream_, mr);
+    }
+  } else {
+    sortedData_ = std::move(allData);
+  }
+}
+
+bool CudfWindow::isFinished() {
+  return finished_;
+}
+
+RowVectorPtr CudfWindow::doGetOutput() {
+  if (finished_ || !noMoreInput_) {
+    return nullptr;
+  }
+  if (!sortedData_) {
+    finished_ = true;
+    return nullptr;
+  }
+
+  auto mr = get_output_mr();
+  auto sortedView = sortedData_->view();
+  ColumnOrView countStarColOwner;
+
+  // Build partition key table for grouped_rolling_window.
+  auto partKeys = sortedView.select(partitionKeyIndices_);
+
+  std::unique_ptr<cudf::groupby::groupby> rankGrouper;
+  if (!partitionKeyIndices_.empty()) {
+    bool needsRankGrouper = false;
+    const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+    for (const auto& func : windowNode_->windowFunctions()) {
+      const auto baseName =
+          stripFunctionPrefix(func.functionCall->name(), prefix);
+      if (baseName == "row_number" || baseName == "rank" ||
+          baseName == "dense_rank") {
+        needsRankGrouper = true;
+        break;
+      }
+    }
+    if (needsRankGrouper) {
+      rankGrouper = std::make_unique<cudf::groupby::groupby>(
+          sortedView.select(partitionKeyIndices_),
+          cudf::null_policy::INCLUDE,
+          cudf::sorted::YES,
+          std::vector<cudf::order>(
+              partitionKeyIndices_.size(), cudf::order::ASCENDING),
+          std::vector<cudf::null_order>(
+              partitionKeyIndices_.size(), cudf::null_order::BEFORE));
+    }
+  }
+
+  std::vector<std::unique_ptr<cudf::column>> windowResultCols(
+      windowNode_->windowFunctions().size());
+  std::vector<std::unique_ptr<cudf::column>> decimalSumInputOwners(
+      windowNode_->windowFunctions().size());
+  std::vector<RangeRollingBatch> rangeRollingBatches;
+  std::vector<std::pair<size_t, std::string>> pendingRanks;
+  const auto& prefix = CudfConfig::getInstance().functionNamePrefix;
+
+  for (size_t funcIndex = 0; funcIndex < windowNode_->windowFunctions().size();
+       ++funcIndex) {
+    const auto& func = windowNode_->windowFunctions()[funcIndex];
+    const auto baseName =
+        stripFunctionPrefix(func.functionCall->name(), prefix);
+
+    if (baseName == "row_number" || baseName == "rank" ||
+        baseName == "dense_rank") {
+      pendingRanks.emplace_back(funcIndex, baseName);
+    } else if (baseName == "lag" || baseName == "lead") {
+      auto inputColIdx = resolveInputChannel(func, inputRowType_);
+      VELOX_CHECK(
+          inputColIdx.has_value(),
+          "Window function {} requires an input column",
+          baseName);
+      auto inputCol = sortedView.column(*inputColIdx);
+      windowResultCols[funcIndex] =
+          computeLeadLagColumn(partKeys, inputCol, func, baseName, stream_, mr);
+    } else if (baseName == "first_value" || baseName == "last_value") {
+      auto inputColIdx = resolveInputChannel(func, inputRowType_);
+      VELOX_CHECK(
+          inputColIdx.has_value(),
+          "Window function {} requires an input column",
+          baseName);
+      auto inputCol = sortedView.column(*inputColIdx);
+      const bool isFullPartition =
+          isFullPartitionFrame(func, !sortKeyIndices_.empty());
+      if (auto rangeTypes = toBatchRangeWindowTypes(func, isFullPartition)) {
+        auto nullPolicy = func.ignoreNulls ? cudf::null_policy::EXCLUDE
+                                           : cudf::null_policy::INCLUDE;
+        std::unique_ptr<cudf::rolling_aggregation> agg;
+        if (baseName == "first_value") {
+          agg = cudf::make_nth_element_aggregation<cudf::rolling_aggregation>(
+              0, nullPolicy);
+        } else {
+          agg = cudf::make_nth_element_aggregation<cudf::rolling_aggregation>(
+              -1, nullPolicy);
+        }
+        addRangeRollingRequest(
+            rangeRollingBatches,
+            rangeTypes.value(),
+            PendingRangeRolling{funcIndex, inputCol, std::move(agg)});
+      } else {
+        windowResultCols[funcIndex] = computeNthValueColumn(
+            partKeys, inputCol, func, baseName, isFullPartition, stream_, mr);
+      }
+    } else if (
+        baseName == "sum" || baseName == "min" || baseName == "max" ||
+        baseName == "count" || baseName == "avg") {
+      auto inputColIdx = resolveInputChannel(func, inputRowType_);
+      const bool isCountStar = baseName == "count" && !inputColIdx.has_value();
+      if (!isCountStar) {
+        VELOX_CHECK(
+            inputColIdx.has_value(),
+            "Window function {} requires an input column",
+            baseName);
+      }
+      cudf::column_view inputCol = isCountStar
+          ? makeCountStarInputColumn(
+                sortedView, logicalRowCount_, countStarColOwner, stream_, mr)
+          : sortedView.column(*inputColIdx);
+      if (baseName == "sum" &&
+          func.functionCall->inputs()[0]->type()->isDecimal()) {
+        inputCol = castDecimal64InputToDecimal128(
+            inputCol, decimalSumInputOwners[funcIndex], stream_);
+      }
+      const bool isFullPartition =
+          isFullPartitionFrame(func, !sortKeyIndices_.empty());
+      if (isFullPartition && sortKeyIndices_.empty() &&
+          partKeys.num_columns() == 0) {
+        windowResultCols[funcIndex] = computeGlobalAggregate(
+            inputCol,
+            baseName,
+            isCountStar,
+            veloxToCudfDataType(func.functionCall->type()),
+            logicalRowCount_,
+            stream_,
+            mr);
+      } else if (
+          auto rangeTypes = toBatchRangeWindowTypes(func, isFullPartition)) {
+        addRangeRollingRequest(
+            rangeRollingBatches,
+            rangeTypes.value(),
+            PendingRangeRolling{
+                funcIndex,
+                inputCol,
+                makeRollingAggregation(baseName, isCountStar)});
+      } else {
+        windowResultCols[funcIndex] = computeAggregateColumn(
+            partKeys,
+            sortedView,
+            inputCol,
+            func,
+            baseName,
+            isCountStar,
+            stream_,
+            mr);
+      }
+    } else {
+      VELOX_FAIL("Unsupported window function for cudf: {}", baseName);
+    }
+  }
+
+  computeRankColumnsBatch(
+      sortedView,
+      pendingRanks,
+      rankGrouper.get(),
+      windowResultCols,
+      stream_,
+      mr);
+
+  if (!rangeRollingBatches.empty()) {
+    ColumnOrView orderbyColHolder{cudf::column_view{}};
+    cudf::column_view orderbyCol;
+    cudf::order order = cudf::order::ASCENDING;
+    cudf::null_order nullOrder = cudf::null_order::BEFORE;
+    if (sortKeyIndices_.empty()) {
+      auto oneScalar = cudf::numeric_scalar<int64_t>(1, true, stream_, mr);
+      orderbyColHolder =
+          cudf::sequence(logicalRowCount_, oneScalar, oneScalar, stream_, mr);
+      orderbyCol = asView(orderbyColHolder);
+    } else {
+      orderbyCol = sortedView.column(sortKeyIndices_[0]);
+      order = sortOrders_[0];
+      nullOrder = nullOrders_[0];
+    }
+    for (auto& batch : rangeRollingBatches) {
+      auto& pendingRequests = batch.requests;
+      std::vector<cudf::rolling_request> rollingRequests;
+      rollingRequests.reserve(pendingRequests.size());
+      for (auto& pending : pendingRequests) {
+        rollingRequests.push_back(
+            cudf::rolling_request{pending.inputCol, 1, std::move(pending.agg)});
+      }
+      auto batchResult = cudf::grouped_range_rolling_window(
+          partKeys,
+          orderbyCol,
+          order,
+          nullOrder,
+          batch.preceding,
+          batch.following,
+          cudf::host_span<cudf::rolling_request const>(
+              rollingRequests.data(), rollingRequests.size()),
+          stream_,
+          mr);
+      auto resultCols = batchResult->release();
+      VELOX_CHECK_EQ(resultCols.size(), pendingRequests.size());
+      for (size_t i = 0; i < pendingRequests.size(); ++i) {
+        windowResultCols[pendingRequests[i].funcIndex] =
+            std::move(resultCols[i]);
+      }
+    }
+  }
+
+  // Build the output table: input columns + window result columns.
+  // Cast window result columns to expected output types if needed.
+  auto sortedCols = sortedData_->release();
+  sortedData_.reset();
+  const auto numInputCols = inputRowType_->size();
+  for (size_t i = 0; i < windowResultCols.size(); ++i) {
+    auto& wc = windowResultCols[i];
+    VELOX_CHECK_NOT_NULL(wc);
+    auto expectedType =
+        veloxToCudfDataType(outputType_->childAt(numInputCols + i));
+    if (wc->type() != expectedType) {
+      wc = cudf::cast(wc->view(), expectedType, stream_, mr);
+    }
+
+    const auto baseName = stripFunctionPrefix(
+        windowNode_->windowFunctions()[i].functionCall->name(), prefix);
+    if (baseName == "count" && wc->null_count() > 0) {
+      cudf::numeric_scalar<int64_t> zero(0, true, stream_, mr);
+      wc = cudf::replace_nulls(wc->view(), zero, stream_, mr);
+    }
+
+    sortedCols.push_back(std::move(wc));
+  }
+  auto resultTable = std::make_unique<cudf::table>(std::move(sortedCols));
+  auto resultSize = resultTable->num_rows();
+  if (resultSize == 0 && logicalRowCount_ > 0) {
+    resultSize = logicalRowCount_;
+  }
+
+  finished_ = true;
+  return std::make_shared<CudfVector>(
+      pool(), outputType_, resultSize, std::move(resultTable), stream_);
+}
+
+void CudfWindow::doClose() {
+  Operator::close();
+  // Release GPU allocations only after pending work on stream_ completes.
+  if (streamAcquired_) {
+    stream_.synchronize();
+  }
+  inputBatches_.clear();
+  sortedData_.reset();
+}
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/cudf/exec/CudfOperator.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
+#include "velox/type/Type.h"
+
+#include <cudf/groupby.hpp>
+#include <cudf/rolling.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::cudf_velox {
+
+/// GPU-accelerated Window operator using cuDF.
+///
+/// Incoming GPU batches are stored in addInput(). When noMoreInput() is called,
+/// batches are concatenated and sorted. getOutput() then evaluates window
+/// functions and returns one output batch.
+///
+/// inputsSorted fast path: when WindowNode::inputsSorted() is true, this
+/// operator skips stable_sorted_order and the full-table gather (see
+/// WindowNode::inputsSorted() for the ordering contract). The flag is taken
+/// from the plan as-is; Velox does not infer it here. Connectors / optimizers
+/// must only set it when a Sort or ordered exchange actually guarantees
+/// globally sorted input across concatenated batches with partition keys
+/// ASCENDING / nulls-first, followed by the window ORDER BY keys (matching
+/// sortOrders_/nullOrders_). Rank grouping with partition keys also assumes
+/// that partition-key ordering when constructing the groupby grouper.
+///
+/// Memory: the sorted path peaks at roughly concat output plus gather copy plus
+/// window result columns. Batch-wise / streaming evaluation would require a
+/// larger redesign.
+///
+/// Rank-like functions (row_number, rank, dense_rank) use
+/// cudf::groupby::scan with cudf::make_rank_aggregation.
+/// Aggregate windows and lag/lead use cudf::grouped_rolling_window.
+class CudfWindow : public CudfOperatorBase {
+ public:
+  CudfWindow(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::WindowNode>& windowNode);
+
+  /// Returns true if every window function and frame in the plan node is
+  /// supported by CudfWindow. On failure, @p reason is populated with a
+  /// human-readable explanation when a non-null pointer is provided.
+  static bool canRunOnGPU(const core::WindowNode& windowNode);
+
+  static bool canRunOnGPU(
+      const core::WindowNode& windowNode,
+      std::string* reason);
+
+  /// Returns true if the window function is supported by CudfWindow.
+  static bool isSupportedWindowFunction(
+      const std::string& baseName,
+      size_t numArgs);
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ protected:
+  void doAddInput(RowVectorPtr input) override;
+
+  RowVectorPtr doGetOutput() override;
+
+  void doNoMoreInput() override;
+
+  void doClose() override;
+
+ private:
+  // Compute row_number/rank/dense_rank via cudf::groupby::scan or cudf::scan.
+  void computeRankColumnsBatch(
+      const cudf::table_view& sortedInput,
+      const std::vector<std::pair<size_t, std::string>>& pendingRanks,
+      cudf::groupby::groupby* rankGrouper,
+      std::vector<std::unique_ptr<cudf::column>>& windowResultCols,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::unique_ptr<cudf::column> computeLeadLagColumn(
+      const cudf::table_view& partKeys,
+      cudf::column_view inputCol,
+      const core::WindowNode::Function& func,
+      const std::string& baseName,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  // Compute first_value or last_value via cudf rolling window APIs.
+  std::unique_ptr<cudf::column> computeNthValueColumn(
+      const cudf::table_view& partKeys,
+      cudf::column_view inputCol,
+      const core::WindowNode::Function& func,
+      const std::string& baseName,
+      bool isFullPartition,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  // Compute aggregate window functions (sum, min, max, count, avg)
+  // with frame bounds from the WindowNode.
+  std::unique_ptr<cudf::column> computeAggregateColumn(
+      const cudf::table_view& partKeys,
+      const cudf::table_view& sortedView,
+      cudf::column_view inputCol,
+      const core::WindowNode::Function& func,
+      const std::string& baseName,
+      bool isCountStar,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  // Dispatch ROWS window frames to grouped_rolling_window. RANGE frames are
+  // handled separately by the batched grouped_range_rolling_window path.
+  std::unique_ptr<cudf::column> invokeGroupedRollingWindow(
+      const cudf::table_view& partKeys,
+      cudf::column_view inputCol,
+      const core::WindowNode::Function& func,
+      std::unique_ptr<cudf::rolling_aggregation> agg,
+      bool isFullPartition,
+      rmm::cuda_stream_view stream,
+      rmm::device_async_resource_ref mr) const;
+
+  std::shared_ptr<const core::WindowNode> windowNode_;
+  const RowTypePtr inputRowType_;
+
+  std::vector<cudf::size_type> partitionKeyIndices_;
+  std::vector<cudf::size_type> sortKeyIndices_;
+  std::vector<cudf::order> sortOrders_;
+  std::vector<cudf::null_order> nullOrders_;
+
+  std::vector<CudfVectorPtr> inputBatches_;
+
+  // Sorted and concatenated input data, prepared in doNoMoreInput().
+  std::unique_ptr<cudf::table> sortedData_;
+  cudf::size_type logicalRowCount_{0};
+  rmm::cuda_stream_view stream_{};
+  bool streamAcquired_{false};
+
+  bool finished_ = false;
+};
+
+} // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/CudfWindow.h
+++ b/velox/experimental/cudf/exec/CudfWindow.h
@@ -131,7 +131,6 @@ class CudfWindow : public CudfOperatorBase {
   // with frame bounds from the WindowNode.
   std::unique_ptr<cudf::column> computeAggregateColumn(
       const cudf::table_view& partKeys,
-      const cudf::table_view& sortedView,
       cudf::column_view inputCol,
       const core::WindowNode::Function& func,
       const std::string& baseName,

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -33,6 +33,7 @@
 #include "velox/experimental/cudf/exec/CudfOrderBy.h"
 #include "velox/experimental/cudf/exec/CudfReduce.h"
 #include "velox/experimental/cudf/exec/CudfTopN.h"
+#include "velox/experimental/cudf/exec/CudfWindow.h"
 #include "velox/experimental/cudf/exec/OperatorAdapters.h"
 #include "velox/experimental/cudf/exec/Utilities.h"
 #include "velox/experimental/cudf/exec/Validation.h"
@@ -58,6 +59,7 @@
 #include "velox/exec/Task.h"
 #include "velox/exec/TopN.h"
 #include "velox/exec/Values.h"
+#include "velox/exec/Window.h"
 
 namespace facebook::velox::cudf_velox {
 
@@ -969,6 +971,58 @@ class CallbackSinkAdapter : public OperatorAdapter {
   }
 };
 
+// WindowAdapter - Replaces with CudfWindow
+class WindowAdapter : public OperatorAdapter {
+ public:
+  WindowAdapter() : OperatorAdapter("Window") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::Window*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* /*ctx*/) const override {
+    auto windowNode =
+        std::dynamic_pointer_cast<const core::WindowNode>(planNode);
+    if (!windowNode) {
+      return false;
+    }
+    std::string reason;
+    if (!CudfWindow::canRunOnGPU(*windowNode, &reason)) {
+      LOG_FALLBACK(
+          "{}, PlanNode id: {}",
+          reason.empty() ? "unknown" : reason,
+          planNode->id());
+      return false;
+    }
+    return true;
+  }
+
+  bool acceptsGpuInput() const override {
+    return true;
+  }
+
+  bool producesGpuOutput() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto windowPlanNode =
+        std::dynamic_pointer_cast<const core::WindowNode>(planNode);
+
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfWindow>(operatorId, ctx, windowPlanNode));
+    return result;
+  }
+};
+
 /// GroupIdAdapter - Replaces with CudfGroupId
 class GroupIdAdapter : public OperatorAdapter {
  public:
@@ -1036,6 +1090,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<GroupIdAdapter>());
   registry.registerAdapter(std::make_unique<ValuesAdapter>());
   registry.registerAdapter(std::make_unique<CallbackSinkAdapter>());
+  registry.registerAdapter(std::make_unique<WindowAdapter>());
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/Utilities.cpp
+++ b/velox/experimental/cudf/exec/Utilities.cpp
@@ -309,6 +309,21 @@ const CudaEvent& CudaEvent::waitOn(rmm::cuda_stream_view stream) const {
   return *this;
 }
 
+std::string getBaseFunctionName(const std::string& fullName) {
+  auto pos = fullName.rfind('.');
+  return pos == std::string::npos ? fullName : fullName.substr(pos + 1);
+}
+
+std::string stripFunctionPrefix(
+    const std::string& name,
+    const std::string& prefix) {
+  auto base = getBaseFunctionName(name);
+  if (!prefix.empty() && base.find(prefix) == 0) {
+    return base.substr(prefix.size());
+  }
+  return base;
+}
+
 void orderCudfVectorDeallocationsAfterStream(
     std::span<const CudfVectorPtr> vectors,
     std::span<const rmm::cuda_stream_view> inputStreams,

--- a/velox/experimental/cudf/exec/Utilities.h
+++ b/velox/experimental/cudf/exec/Utilities.h
@@ -208,4 +208,14 @@ void orderCudfVectorDeallocationsAfterStream(
     std::span<const CudfVectorPtr> vectors,
     std::span<const rmm::cuda_stream_view> inputStreams,
     rmm::cuda_stream_view stream);
+
+/// Extract the base function name from a possibly-prefixed name.
+/// Handles both Presto-style "presto.default.lag" and simple "lag".
+std::string getBaseFunctionName(const std::string& fullName);
+
+/// Also strip any registered function name prefix (e.g. "spark_" for Spark).
+std::string stripFunctionPrefix(
+    const std::string& name,
+    const std::string& prefix);
+
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -269,6 +269,12 @@ velox_add_cudf_test(
   LIBS ${CUDF_TEST_DEFAULT_LIBS} fmt::fmt
 )
 
+velox_add_cudf_test(
+  NAME velox_cudf_window_test
+  SOURCES Main.cpp WindowTest.cpp
+  LIBS ${CUDF_TEST_DEFAULT_LIBS} velox_window
+)
+
 add_subdirectory(iceberg)
 add_subdirectory(utils)
 

--- a/velox/experimental/cudf/tests/WindowTest.cpp
+++ b/velox/experimental/cudf/tests/WindowTest.cpp
@@ -1,0 +1,2201 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/CudfConversion.h"
+#include "velox/experimental/cudf/exec/CudfWindow.h"
+#include "velox/experimental/cudf/exec/OperatorAdapters.h"
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/core/Expressions.h"
+#include "velox/core/PlanNode.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/exec/Driver.h"
+#include "velox/exec/Task.h"
+#include "velox/exec/Window.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <fmt/format.h>
+#include <folly/String.h>
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <sstream>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+namespace {
+
+class CudfWindowTest : public testing::Test,
+                       public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    if (!isRegisteredVectorSerde()) {
+      serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    }
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+    facebook::velox::window::prestosql::registerAllWindowFunctions();
+    parse::registerTypeResolver();
+    cudf_velox::CudfConfig::getInstance().allowCpuFallback = false;
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+  }
+};
+
+TEST_F(CudfWindowTest, rowNumberPartitionOrder) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 15, 25, 35}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"row_number() over (partition by id order by val)"})
+                  .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "w0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 15, 25, 35}),
+          makeFlatVector<int64_t>({1, 2, 3, 1, 2, 3}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, lagLead) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({100, 200, 300, 10, 20}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "lag(val, 1) over (partition by id order by val) as lag_val",
+              "lead(val, 1) over (partition by id order by val) as lead_val",
+          })
+          .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto lagValues = makeNullableFlatVector<int64_t>(
+      {std::nullopt, 100, 200, std::nullopt, 10});
+  auto leadValues = makeNullableFlatVector<int64_t>(
+      {200, 300, std::nullopt, 20, std::nullopt});
+  auto expected = makeRowVector(
+      {"id", "val", "lag_val", "lead_val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({100, 200, 300, 10, 20}),
+          lagValues,
+          leadValues,
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rankPartitionOrder) {
+  // Ties: partition 1 has two rows with val=20.
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 20, 30, 5, 5, 15}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"rank() over (partition by id order by val)"})
+                  .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // rank(): tied rows get the same rank, next rank skips.
+  // Partition 1 (10,20,20,30): 1,2,2,4
+  // Partition 2 (5,5,15): 1,1,3
+  auto expected = makeRowVector(
+      {"id", "val", "w0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 20, 30, 5, 5, 15}),
+          makeFlatVector<int64_t>({1, 2, 2, 4, 1, 1, 3}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, denseRankPartitionOrder) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 20, 30, 5, 5, 15}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"dense_rank() over (partition by id order by val)"})
+                  .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // dense_rank(): tied rows get the same rank, no gaps.
+  // Partition 1 (10,20,20,30): 1,2,2,3
+  // Partition 2 (5,5,15): 1,1,2
+  auto expected = makeRowVector(
+      {"id", "val", "w0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 20, 30, 5, 5, 15}),
+          makeFlatVector<int64_t>({1, 2, 2, 3, 1, 1, 2}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, firstValueLastValue) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "first_value(val) over (partition by id order by val) as fv",
+              "last_value(val) over (partition by id order by val "
+              "rows between unbounded preceding and unbounded following) as lv",
+          })
+          .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "fv", "lv"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({10, 10, 10, 100, 100}),
+          makeFlatVector<int64_t>({30, 30, 30, 200, 200}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, sumWindow) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "sum(val) over (partition by id "
+                      "rows between unbounded preceding and "
+                      "unbounded following) as total",
+                  })
+                  .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "total"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({60, 60, 60, 300, 300}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, minMaxWindow) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "min(val) over (partition by id "
+              "rows between unbounded preceding and unbounded following) as mn",
+              "max(val) over (partition by id "
+              "rows between unbounded preceding and unbounded following) as mx",
+          })
+          .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "mn", "mx"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({10, 10, 10, 100, 100}),
+          makeFlatVector<int64_t>({30, 30, 30, 200, 200}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, countWindow) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "count(val) over (partition by id "
+              "rows between unbounded preceding and unbounded following) as cnt",
+          })
+          .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "cnt"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({3, 3, 3, 2, 2}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, avgWindow) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<double>({10.0, 20.0, 30.0, 100.0, 200.0}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "avg(val) over (partition by id order by val "
+              "rows between unbounded preceding and current row) as average",
+          })
+          .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "average"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<double>({10.0, 20.0, 30.0, 100.0, 200.0}),
+          makeFlatVector<double>({10.0, 15.0, 20.0, 100.0, 150.0}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Ports of checks from velox/exec/tests/WindowTest.cpp (CPU window tests).
+
+TEST_F(CudfWindowTest, duplicateOrOverlappingKeys) {
+  auto data = makeRowVector(
+      ROW({"a", "b", "c", "d", "e"},
+          {
+              BIGINT(),
+              BIGINT(),
+              BIGINT(),
+              BIGINT(),
+              BIGINT(),
+          }),
+      10);
+
+  auto buildPlan = [&](const std::vector<std::string>& partitionKeys,
+                       const std::vector<std::string>& sortingKeys) {
+    std::ostringstream sql;
+    sql << "row_number() over (";
+    if (!partitionKeys.empty()) {
+      sql << " partition by ";
+      sql << folly::join(", ", partitionKeys);
+    }
+    if (!sortingKeys.empty()) {
+      sql << " order by ";
+      sql << folly::join(", ", sortingKeys);
+    }
+    sql << ")";
+
+    PlanBuilder().values({data}).window({sql.str()}).planNode();
+  };
+
+  VELOX_ASSERT_THROW(
+      buildPlan({"a", "a"}, {"b"}),
+      "Partitioning keys must be unique. Found duplicate key: a");
+
+  VELOX_ASSERT_THROW(
+      buildPlan({"a", "b"}, {"c", "d", "c"}),
+      "Sorting keys must be unique and not overlap with partitioning keys. Found duplicate key: c");
+
+  VELOX_ASSERT_THROW(
+      buildPlan({"a", "b"}, {"c", "b"}),
+      "Sorting keys must be unique and not overlap with partitioning keys. Found duplicate key: b");
+}
+
+TEST_F(CudfWindowTest, rowNumberGlobalOrderBy) {
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4}),
+          makeFlatVector<int16_t>({1, 1, 2, 2, 2}),
+          makeFlatVector<int32_t>({30, 10, 20, 5, 15}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"row_number() over (order by s)"})
+                  .orderBy({"s ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"d", "p", "s", "w0"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2, 3, 4}),
+          makeFlatVector<int16_t>({1, 1, 2, 2, 2}),
+          makeFlatVector<int32_t>({30, 10, 20, 5, 15}),
+          makeFlatVector<int64_t>({5, 2, 4, 1, 3}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rankGlobalOrderBy) {
+  auto data = makeRowVector({"c1"}, {makeFlatVector<int64_t>({1, 1, 1, 2, 2})});
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({"rank() over (order by c1 rows unbounded preceding)"})
+          .orderBy({"c1 ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"c1", "w0"},
+      {
+          makeFlatVector<int64_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({1, 1, 1, 4, 4}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rowNumberMultiBatch) {
+  auto data = makeRowVector(
+      {"id", "val"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 15, 25, 35}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 3))
+                  .window({"row_number() over (partition by id order by val)"})
+                  .orderBy({"id ASC NULLS LAST", "val ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"id", "val", "w0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 15, 25, 35}),
+          makeFlatVector<int64_t>({1, 2, 3, 1, 2, 3}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Multi-column ORDER BY covered in follow-on PR (requires cuDF upgrade).
+TEST_F(CudfWindowTest, DISABLED_multiFunctionPartitionOrder) {
+  // Same shape as valuesRowsStreamingWindowBuild (CPU) but non-streaming window
+  // and explicit expected vectors (no DuckDB runner).
+  auto data = makeRowVector(
+      {"c0", "c1", "c2", "c3", "c4"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int32_t>({1, 2, 3, 1, 2}),
+          makeFlatVector<int64_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int32_t>({0, 1, 2, 0, 1}),
+          makeFlatVector<int32_t>({10, 20, 30, 100, 200}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "rank() over (partition by c0, c2 order by c1, c3)",
+                      "dense_rank() over (partition by c0, c2 order by c1, c3)",
+                      "row_number() over (partition by c0, c2 order by c1, c3)",
+                      "sum(c4) over (partition by c0, c2 order by c1, c3)",
+                  })
+                  .orderBy(
+                      {"c0 ASC NULLS LAST",
+                       "c2 ASC NULLS LAST",
+                       "c1 ASC NULLS LAST",
+                       "c3 ASC NULLS LAST"},
+                      false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"c0", "c1", "c2", "c3", "c4", "w0", "w1", "w2", "w3"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int32_t>({1, 2, 3, 1, 2}),
+          makeFlatVector<int64_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int32_t>({0, 1, 2, 0, 1}),
+          makeFlatVector<int32_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({1, 2, 3, 1, 2}),
+          makeFlatVector<int64_t>({1, 2, 3, 1, 2}),
+          makeFlatVector<int64_t>({1, 2, 3, 1, 2}),
+          makeFlatVector<int64_t>({10, 30, 60, 100, 300}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rankNaNRangeFrameBounds) {
+  // rank() ignores RANGE frame bounds; port of the rank() loop from
+  // WindowTest.NaNFrameBound (sum+RANGE is not mirrored here).
+  const auto kNan = std::numeric_limits<double>::quiet_NaN();
+  auto data = makeRowVector(
+      {"c0", "s0", "off0", "off1"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+          makeFlatVector<double>({1.0, 2.0, 3.0, kNan}),
+          makeFlatVector<double>({0.1, 2.0, 1.9, kNan}),
+          makeFlatVector<double>({kNan, 2.0, kNan, kNan}),
+      });
+
+  const auto makeFrames = [](const std::string& call) {
+    std::vector<std::string> frames;
+
+    std::vector<std::string> orders{"asc", "desc"};
+    std::vector<std::string> bounds{"preceding", "following"};
+    for (const std::string& order : orders) {
+      for (const std::string& startBound : bounds) {
+        for (const std::string& endBound : bounds) {
+          if (startBound == "following" && endBound == "preceding") {
+            continue;
+          }
+          frames.push_back(
+              fmt::format(
+                  "{} over (order by s0 {} range between off0 {} and off1 {})",
+                  call,
+                  order,
+                  startBound,
+                  endBound));
+          frames.push_back(
+              fmt::format(
+                  "{} over (order by s0 {} range between off1 {} and off0 {})",
+                  call,
+                  order,
+                  startBound,
+                  endBound));
+        }
+      }
+    }
+    return frames;
+  };
+
+  auto expected =
+      makeRowVector({"w0"}, {makeFlatVector<int64_t>({1, 2, 3, 4})});
+  for (const auto& frame : makeFrames("rank()")) {
+    auto plan =
+        PlanBuilder().values({data}).window({frame}).project({"w0"}).planNode();
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+}
+
+// =============================================================================
+// Tests ported from velox/exec/tests/WindowTest.cpp
+// =============================================================================
+
+namespace {
+
+int64_t rowNumberWithinPartitionAsc(
+    vector_size_t row,
+    vector_size_t size,
+    int numPartitions) {
+  return row / numPartitions + 1;
+}
+
+int64_t rowNumberWithinPartitionDesc(
+    vector_size_t row,
+    vector_size_t size,
+    int numPartitions) {
+  const auto partition = row % numPartitions;
+  int64_t rowNumber = 0;
+  for (int64_t r = partition; r < size; r += numPartitions) {
+    if (r >= row) {
+      ++rowNumber;
+    }
+  }
+  return rowNumber;
+}
+
+} // namespace
+
+// CudfWindow buffers all input; spill configs are ignored but results must
+// match CPU window semantics under the same split/batch settings.
+TEST_F(CudfWindowTest, spill) {
+  const vector_size_t size = 1'000;
+  const int numPartitions = 11;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 10))
+                  .window({"row_number() over (partition by p order by s)"})
+                  .orderBy({"p ASC NULLS LAST", "s ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"d", "p", "s", "w0"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(
+              size,
+              [size, numPartitions](auto row) {
+                return rowNumberWithinPartitionAsc(row, size, numPartitions);
+              }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillEnabled, "true")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, spillBatchReadTinyPartitions) {
+  const vector_size_t size = 1'000;
+  const uint32_t partitionRows = 1;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row / partitionRows; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 10))
+                  .window({"row_number() over (partition by p order by s)"})
+                  .orderBy({"p ASC NULLS LAST", "s ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"d", "p", "s", "w0"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row / partitionRows; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(size, [](auto) { return 1; }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillMinReadBatchRows, "100")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, spillBatchReadHugePartitions) {
+  const vector_size_t size = 1'000;
+  const uint32_t partitionRows = 200;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row / partitionRows; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 10))
+                  .window({"row_number() over (partition by p order by s)"})
+                  .orderBy({"p ASC NULLS LAST", "s ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"d", "p", "s", "w0"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row / partitionRows; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(
+              size, [](auto row) { return row % partitionRows + 1; }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillMinReadBatchRows, "100")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, spillUnsupported) {
+  const vector_size_t size = 1'000;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(size, [](auto row) { return row % 11; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 10))
+                  .window({"row_number() over (order by s)"})
+                  .orderBy({"s ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"d", "p", "s", "w0"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(size, [](auto row) { return row % 11; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row + 1; }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillEnabled, "true")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rowBasedStreamingWindowOOM) {
+  const vector_size_t size = 10'000;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 10))
+                  .window({"row_number() over (partition by p order by s)"})
+                  .project({"d"})
+                  .singleAggregation({}, {"sum(d)"})
+                  .planNode();
+
+  auto expected =
+      makeRowVector({makeConstant<int64_t>(size * (size - 1) / 2, 1)});
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, prePartitionedSortBuild) {
+  const vector_size_t size = 1'000;
+  const int numPartitions = 37;
+  auto data = makeRowVector(
+      {"p", "s"},
+      {
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values(split(data, 10))
+          .window({"row_number() over (partition by p order by s desc)"})
+          .orderBy({"p ASC NULLS LAST", "s DESC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"p", "s", "w0"},
+      {
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(
+              size,
+              [size, numPartitions](auto row) {
+                return rowNumberWithinPartitionDesc(row, size, numPartitions);
+              }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kWindowNumSubPartitions, "4")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, prePartitionedSortBuildSkewed) {
+  const vector_size_t size = 1'000;
+  const int numPartitions = 4;
+  auto data = makeRowVector(
+      {"p", "s"},
+      {
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values(split(data, 10))
+          .window({"row_number() over (partition by p order by s desc)"})
+          .orderBy({"p ASC NULLS LAST", "s DESC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"p", "s", "w0"},
+      {
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(
+              size,
+              [size, numPartitions](auto row) {
+                return rowNumberWithinPartitionDesc(row, size, numPartitions);
+              }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kWindowNumSubPartitions, "16")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, prePartitionedBuildWithSpill) {
+  const vector_size_t size = 1'000;
+  const int numPartitions = 37;
+  auto data = makeRowVector(
+      {"d", "p", "s"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values(split(data, 10))
+          .window({"row_number() over (partition by p order by s desc)"})
+          .orderBy({"p ASC NULLS LAST", "s DESC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"d", "p", "s", "w0"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int16_t>(
+              size, [](auto row) { return row % numPartitions; }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(
+              size,
+              [size, numPartitions](auto row) {
+                return rowNumberWithinPartitionDesc(row, size, numPartitions);
+              }),
+      });
+
+  AssertQueryBuilder(plan)
+      .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
+      .config(core::QueryConfig::kWindowNumSubPartitions, "4")
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kWindowSpillEnabled, "true")
+      .assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, negativeFrameArg) {
+  const vector_size_t size = 1'000;
+
+  auto sizeAt = [](vector_size_t row) { return row % 5; };
+  auto keyAt = [](vector_size_t row) { return row % 11; };
+  auto keys = makeArrayVector<float>(size, sizeAt, keyAt);
+  auto data = makeRowVector(
+      {"c0", "c1", "p0", "p1", "k0", "row_number"},
+      {
+          makeFlatVector<float>(size, [](auto row) { return row; }),
+          makeFlatVector<float>(size, [](auto row) { return row; }),
+          keys,
+          makeFlatVector<std::string>(
+              size, [](auto row) { return fmt::format("{}", row + 20); }),
+          makeFlatVector<int32_t>(size, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+      });
+
+  struct {
+    std::string fragmentStart;
+    std::string fragmentEnd;
+  } testSettings[] = {
+      {"k0", "-1"},
+      {"-1", "k0"},
+      {"-1", "-3"},
+  };
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(
+        fmt::format("{} / {}", testData.fragmentStart, testData.fragmentEnd));
+    auto plan =
+        PlanBuilder()
+            .values({data})
+            .window({fmt::format(
+                "sum(c0) over (partition by p0, p1 order by row_number ROWS between {} PRECEDING and {} FOLLOWING)",
+                testData.fragmentStart,
+                testData.fragmentEnd)})
+            .planNode();
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+}
+
+TEST_F(CudfWindowTest, NaNFrameBound) {
+  const auto kNan = std::numeric_limits<double>::quiet_NaN();
+  auto data = makeRowVector(
+      {"c0", "s0", "off0", "off1"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+          makeFlatVector<double>({1.0, 2.0, 3.0, kNan}),
+          makeFlatVector<double>({0.1, 2.0, 1.9, kNan}),
+          makeFlatVector<double>({kNan, 2.0, kNan, kNan}),
+      });
+
+  const auto makeFrames = [](const std::string& call) {
+    std::vector<std::string> frames;
+
+    std::vector<std::string> orders{"asc", "desc"};
+    std::vector<std::string> bounds{"preceding", "following"};
+    for (const std::string& order : orders) {
+      for (const std::string& startBound : bounds) {
+        for (const std::string& endBound : bounds) {
+          if (startBound == "following" && endBound == "preceding") {
+            continue;
+          }
+          frames.push_back(
+              fmt::format(
+                  "{} over (order by s0 {} range between off0 {} and off1 {})",
+                  call,
+                  order,
+                  startBound,
+                  endBound));
+          frames.push_back(
+              fmt::format(
+                  "{} over (order by s0 {} range between off1 {} and off0 {})",
+                  call,
+                  order,
+                  startBound,
+                  endBound));
+        }
+      }
+    }
+    return frames;
+  };
+
+  for (const auto& frame : makeFrames("sum(c0)")) {
+    auto plan =
+        PlanBuilder().values({data}).window({frame}).project({"w0"}).planNode();
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4})});
+  for (const auto& frame : makeFrames("rank()")) {
+    auto plan =
+        PlanBuilder().values({data}).window({frame}).project({"w0"}).planNode();
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+}
+
+// =============================================================================
+// Tests ported from velox/functions/prestosql/window/tests/RankTest.cpp
+// =============================================================================
+
+// Tests rank functions with all rows in a single partition.
+TEST_F(CudfWindowTest, rankSinglePartition) {
+  // All rows have the same partition key.
+  auto data = makeRowVector(
+      {"p", "s"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 20, 30, 40}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "row_number() over (partition by p order by s) as rn",
+                      "rank() over (partition by p order by s) as r",
+                      "dense_rank() over (partition by p order by s) as dr",
+                  })
+                  .orderBy({"s ASC NULLS LAST"}, false)
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"p", "s", "rn", "r", "dr"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({1, 2, 2, 4, 5}),
+          makeFlatVector<int64_t>({1, 2, 2, 3, 4}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Tests rank functions with single-row partitions.
+TEST_F(CudfWindowTest, rankSingleRowPartitions) {
+  // Each row is its own partition.
+  auto data = makeRowVector(
+      {"p", "s"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({100, 200, 300, 400, 500}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "row_number() over (partition by p order by s) as rn",
+                      "rank() over (partition by p order by s) as r",
+                      "dense_rank() over (partition by p order by s) as dr",
+                  })
+                  .orderBy({"p ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // Each partition has only one row, so all ranks are 1.
+  auto expected = makeRowVector(
+      {"p", "s", "rn", "r", "dr"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({100, 200, 300, 400, 500}),
+          makeFlatVector<int64_t>({1, 1, 1, 1, 1}),
+          makeFlatVector<int64_t>({1, 1, 1, 1, 1}),
+          makeFlatVector<int64_t>({1, 1, 1, 1, 1}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Tests rank functions with nulls in sort key.
+TEST_F(CudfWindowTest, rankWithNulls) {
+  auto data = makeRowVector(
+      {"p", "s"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 2, 2, 2}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, 10, 20, 20, std::nullopt, std::nullopt, 30}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "row_number() over (partition by p order by s NULLS FIRST) as rn",
+              "rank() over (partition by p order by s NULLS FIRST) as r",
+              "dense_rank() over (partition by p order by s NULLS FIRST) as dr",
+          })
+          .orderBy({"p ASC NULLS LAST", "s ASC NULLS FIRST"}, false)
+          .planNode();
+
+  // With NULLS FIRST, null values come before non-null values.
+  // Partition 1: null, 10, 20, 20 -> row_number: 1,2,3,4; rank: 1,2,3,3;
+  //   dense_rank: 1,2,3,3
+  // Partition 2: null, null, 30 -> row_number: 1,2,3; rank: 1,1,3;
+  //   dense_rank: 1,1,2
+  auto expected = makeRowVector(
+      {"p", "s", "rn", "r", "dr"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 2, 2, 2}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, 10, 20, 20, std::nullopt, std::nullopt, 30}),
+          makeFlatVector<int64_t>({1, 2, 3, 4, 1, 2, 3}),
+          makeFlatVector<int64_t>({1, 2, 3, 3, 1, 1, 3}),
+          makeFlatVector<int64_t>({1, 2, 3, 3, 1, 1, 2}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// =============================================================================
+// Tests ported from velox/functions/prestosql/window/tests/LeadLagTest.cpp
+// =============================================================================
+
+// Tests lag/lead with zero offset.
+TEST_F(CudfWindowTest, lagLeadZeroOffset) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "lag(v, 0) over (partition by p order by v) as lag0",
+                      "lead(v, 0) over (partition by p order by v) as lead0",
+                  })
+                  .orderBy({"p ASC NULLS LAST", "v ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // Zero offset means the current row's value.
+  auto expected = makeRowVector(
+      {"p", "v", "lag0", "lead0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+          makeFlatVector<int64_t>({10, 20, 30, 100, 200}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Tests lag/lead with larger offset.
+TEST_F(CudfWindowTest, lagLeadLargeOffset) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "lag(v, 3) over (partition by p order by v) as lag3",
+                      "lead(v, 3) over (partition by p order by v) as lead3",
+                  })
+                  .orderBy({"v ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // lag(3): first 3 rows are null, then 10, 20
+  // lead(3): last 3 rows are null, first 2 are 40, 50
+  auto expected = makeRowVector(
+      {"p", "v", "lag3", "lead3"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, std::nullopt, std::nullopt, 10, 20}),
+          makeNullableFlatVector<int64_t>(
+              {40, 50, std::nullopt, std::nullopt, std::nullopt}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Tests lag/lead with nulls in the value column.
+TEST_F(CudfWindowTest, lagLeadWithNullValues) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+          makeNullableFlatVector<int64_t>(
+              {10, std::nullopt, 30, std::nullopt, 50}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "lag(v, 1) over (partition by p order by v NULLS FIRST) as lag1",
+              "lead(v, 1) over (partition by p order by v NULLS FIRST) as lead1",
+          })
+          .orderBy({"v ASC NULLS FIRST"}, false)
+          .planNode();
+
+  // With NULLS FIRST, order is: null, null, 10, 30, 50
+  // lag(1): null, null, null, 10, 30
+  // lead(1): null, 10, 30, 50, null
+  auto expected = makeRowVector(
+      {"p", "v", "lag1", "lead1"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1, 1}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, std::nullopt, 10, 30, 50}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, std::nullopt, std::nullopt, 10, 30}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, 10, 30, 50, std::nullopt}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Tests lag/lead with single-row partitions.
+TEST_F(CudfWindowTest, lagLeadSingleRowPartitions) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "lag(v, 1) over (partition by p order by v) as lag1",
+                      "lead(v, 1) over (partition by p order by v) as lead1",
+                  })
+                  .orderBy({"p ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // Each partition has only one row, so lag and lead are always null.
+  auto expected = makeRowVector(
+      {"p", "v", "lag1", "lead1"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt,
+               std::nullopt,
+               std::nullopt,
+               std::nullopt,
+               std::nullopt}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt,
+               std::nullopt,
+               std::nullopt,
+               std::nullopt,
+               std::nullopt}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Tests lag/lead with small partitions (5 rows each).
+TEST_F(CudfWindowTest, lagLeadSmallPartitions) {
+  // Create data with small partitions.
+  std::vector<int32_t> partitions;
+  std::vector<int64_t> values;
+  for (int i = 0; i < 100; ++i) {
+    partitions.push_back(i / 5); // 5 rows per partition
+    values.push_back(i);
+  }
+
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>(partitions),
+          makeFlatVector<int64_t>(values),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "lag(v, 2) over (partition by p order by v) as lag2",
+                      "lead(v, 2) over (partition by p order by v) as lead2",
+                  })
+                  .orderBy({"p ASC NULLS LAST", "v ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // Compute expected results.
+  std::vector<std::optional<int64_t>> expectedLag;
+  std::vector<std::optional<int64_t>> expectedLead;
+  for (int i = 0; i < 100; ++i) {
+    int posInPartition = i % 5;
+    int partitionStart = (i / 5) * 5;
+    if (posInPartition < 2) {
+      expectedLag.push_back(std::nullopt);
+    } else {
+      expectedLag.push_back(values[i - 2]);
+    }
+    if (posInPartition >= 3) {
+      expectedLead.push_back(std::nullopt);
+    } else {
+      expectedLead.push_back(values[i + 2]);
+    }
+  }
+
+  auto expected = makeRowVector(
+      {"p", "v", "lag2", "lead2"},
+      {
+          makeFlatVector<int32_t>(partitions),
+          makeFlatVector<int64_t>(values),
+          makeNullableFlatVector<int64_t>(expectedLag),
+          makeNullableFlatVector<int64_t>(expectedLead),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test count(*) counts all rows including those with nulls.
+// Previously count(*) incorrectly used null_policy::EXCLUDE which would skip
+// nulls in the arbitrary column used for counting.
+TEST_F(CudfWindowTest, countStarWithNulls) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeNullableFlatVector<int64_t>(
+              {10, std::nullopt, 30, std::nullopt, 50}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"count(*) over (partition by p) as cnt"})
+                  .orderBy({"p ASC NULLS LAST", "v ASC NULLS FIRST"}, false)
+                  .planNode();
+
+  // count(*) should count all rows, including those where v is null.
+  // Partition 1 has 3 rows, partition 2 has 2 rows.
+  auto expected = makeRowVector(
+      {"p", "v", "cnt"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, 10, 30, std::nullopt, 50}),
+          makeFlatVector<int64_t>({3, 3, 3, 2, 2}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test count(col) excludes nulls.
+TEST_F(CudfWindowTest, countColumnExcludesNulls) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeNullableFlatVector<int64_t>(
+              {10, std::nullopt, 30, std::nullopt, 50}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"count(v) over (partition by p) as cnt"})
+                  .orderBy({"p ASC NULLS LAST", "v ASC NULLS FIRST"}, false)
+                  .planNode();
+
+  // count(v) should exclude nulls.
+  // Partition 1 has 2 non-null values, partition 2 has 1 non-null value.
+  auto expected = makeRowVector(
+      {"p", "v", "cnt"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeNullableFlatVector<int64_t>(
+              {std::nullopt, 10, 30, std::nullopt, 50}),
+          makeFlatVector<int64_t>({2, 2, 2, 1, 1}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test rank()/dense_rank() without ORDER BY returns 1 for all rows.
+// Previously used column 0 for tie detection which was incorrect.
+TEST_F(CudfWindowTest, rankWithoutOrderBy) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int64_t>({30, 10, 20, 50, 40}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "row_number() over (partition by p) as rn",
+                      "rank() over (partition by p) as r",
+                      "dense_rank() over (partition by p) as dr",
+                  })
+                  .orderBy({"p ASC NULLS LAST", "v ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // Without ORDER BY:
+  // - row_number() still assigns unique sequential numbers within partition
+  // - rank() and dense_rank() return 1 for all rows (all tied)
+  // Note: row_number order is non-deterministic without ORDER BY, so we just
+  // check rank/dense_rank are all 1s.
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  // Verify rank and dense_rank are all 1s
+  auto rankCol = result->childAt(3)->asFlatVector<int64_t>();
+  auto denseRankCol = result->childAt(4)->asFlatVector<int64_t>();
+  for (int i = 0; i < result->size(); ++i) {
+    EXPECT_EQ(rankCol->valueAt(i), 1) << "rank should be 1 at row " << i;
+    EXPECT_EQ(denseRankCol->valueAt(i), 1)
+        << "dense_rank should be 1 at row " << i;
+  }
+}
+
+// Test rank() OVER () - global window without partition or order by.
+// This addresses mattgara's comment: rank should return 1 for all rows.
+TEST_F(CudfWindowTest, rankGlobalWithoutOrderBy) {
+  auto data = makeRowVector(
+      {"x"},
+      {
+          makeFlatVector<int32_t>({2, 1}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({
+                      "rank() over () as r",
+                      "dense_rank() over () as dr",
+                  })
+                  .planNode();
+
+  // Without ORDER BY, all rows are considered tied, so rank and dense_rank
+  // should both return 1 for all rows.
+  auto expected = makeRowVector(
+      {"x", "r", "dr"},
+      {
+          makeFlatVector<int32_t>({2, 1}),
+          makeFlatVector<int64_t>({1, 1}),
+          makeFlatVector<int64_t>({1, 1}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// RANGE frames peer-group by ORDER BY key value. With duplicate sort keys, rows
+// in the same peer group share the same frame. Addresses mattgara's review
+// comment on PR #16892:
+//   sum(v) OVER (ORDER BY k RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)
+//   FROM (VALUES (1, 10), (1, 20), (2, 30)) AS t(k, v)
+// Expected: s = {30, 30, 60}, not {10, 30, 60} from ROWS semantics.
+TEST_F(CudfWindowTest, sumRangeWithDuplicateSortKeys) {
+  auto data = makeRowVector(
+      {"k", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({"sum(v) over (order by k "
+                   "range between unbounded preceding and current row) as s"})
+          .orderBy({"k ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"k", "v", "s"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<int64_t>({30, 30, 60}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test last_value respects the actual frame bounds.
+// Default frame with ORDER BY is RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT
+// ROW, which for last_value means returning the current row's value.
+// Previously hardcoded UNBOUNDED FOLLOWING which was incorrect.
+// Addresses mattgara's comment: with the bug, this would return {3,3,3}.
+TEST_F(CudfWindowTest, lastValueWithDefaultFrame) {
+  auto data = makeRowVector(
+      {"x"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"last_value(x) over (order by x) as lv"})
+                  .orderBy({"x ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // With default frame (RANGE UNBOUNDED PRECEDING TO CURRENT ROW):
+  // Row 1 (x=1): frame is [1], last_value = 1
+  // Row 2 (x=2): frame is [1,2], last_value = 2
+  // Row 3 (x=3): frame is [1,2,3], last_value = 3
+  // The bug would have returned {3, 3, 3} by using UNBOUNDED FOLLOWING.
+  auto expected = makeRowVector(
+      {"x", "lv"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test first_value respects the actual frame bounds.
+TEST_F(CudfWindowTest, firstValueWithDefaultFrame) {
+  auto data = makeRowVector(
+      {"v"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .window({"first_value(v) over (order by v) as fv"})
+                  .orderBy({"v ASC NULLS LAST"}, false)
+                  .planNode();
+
+  // With default frame (RANGE UNBOUNDED PRECEDING TO CURRENT ROW):
+  // All rows have first_value = 1 (the first value in the frame)
+  auto expected = makeRowVector(
+      {"v", "fv"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({1, 1, 1}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test last_value with explicit ROWS UNBOUNDED frame.
+TEST_F(CudfWindowTest, lastValueWithUnboundedFrame) {
+  auto data = makeRowVector(
+      {"v"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window(
+              {"last_value(v) over (order by v rows between unbounded preceding and unbounded following) as lv"})
+          .orderBy({"v ASC NULLS LAST"}, false)
+          .planNode();
+
+  // With UNBOUNDED PRECEDING TO UNBOUNDED FOLLOWING:
+  // All rows see the entire partition, so last_value = 3 for all.
+  auto expected = makeRowVector(
+      {"v", "lv"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({3, 3, 3}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+// Test WindowAdapter::canRunOnGPU gating checks. This verifies that the
+// adapter correctly rejects unsupported window configurations and accepts
+// supported ones. With allowCpuFallback=false (set in SetUp), unsupported
+// configurations throw.
+TEST_F(CudfWindowTest, windowAdapterGatingChecks) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  // Unsupported: nth_value function
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .window({"nth_value(v, 2) over (partition by p order by v)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+
+  // Unsupported: lag/lead with 3 arguments (default value)
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .window({"lag(v, 1, 0) over (partition by p order by v)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+
+  // Unsupported: lag/lead with non-constant offset
+  auto dataWithOffset = makeRowVector(
+      {"p", "v", "off"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<int64_t>({1, 2, 1}),
+      });
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({dataWithOffset})
+              .window({"lag(v, off) over (partition by p order by v)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+
+  // Unsupported: RANGE frame with k PRECEDING
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .window({"sum(v) over (partition by p order by v "
+                       "range between 5 preceding and current row)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+
+  // Unsupported: RANGE frame with k FOLLOWING
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .window({"sum(v) over (partition by p order by v "
+                       "range between current row and 5 following)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+
+  // Unsupported: Non-constant frame bound (column reference)
+  auto dataWithBound = makeRowVector(
+      {"p", "v", "bound"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({dataWithBound})
+              .window({"sum(v) over (partition by p order by v "
+                       "rows between bound preceding and current row)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+
+  // Supported: RANGE UNBOUNDED PRECEDING to CURRENT ROW (peer groups by sort
+  // key)
+  auto plan1 =
+      PlanBuilder()
+          .values({data})
+          .window({"sum(v) over (partition by p order by v "
+                   "range between unbounded preceding and current row)"})
+          .orderBy({"p ASC NULLS LAST", "v ASC NULLS LAST"}, false)
+          .planNode();
+  auto expected1 = makeRowVector(
+      {"p", "v", "w0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<int64_t>({10, 30, 60}),
+      });
+  AssertQueryBuilder(plan1).assertResults(expected1);
+
+  // Supported: RANGE UNBOUNDED PRECEDING to UNBOUNDED FOLLOWING
+  auto plan2 =
+      PlanBuilder()
+          .values({data})
+          .window(
+              {"sum(v) over (partition by p order by v "
+               "range between unbounded preceding and unbounded following)"})
+          .orderBy({"p ASC NULLS LAST", "v ASC NULLS LAST"}, false)
+          .planNode();
+  auto expected2 = makeRowVector(
+      {"p", "v", "w0"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<int64_t>({60, 60, 60}),
+      });
+  AssertQueryBuilder(plan2).assertResults(expected2);
+
+  // Unsupported: RANGE CURRENT ROW to UNBOUNDED FOLLOWING
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .window({"sum(v) over (partition by p order by v "
+                       "range between current row and unbounded following)"})
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+}
+
+TEST_F(CudfWindowTest, explicitRowsCurrentRowWithoutOrderByIsNotFullPartition) {
+  auto data = makeRowVector(
+      {"p", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({"sum(v) over (partition by p "
+                   "rows between unbounded preceding and current row) as s"})
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"p", "v", "s"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<int64_t>({10, 30, 60}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rowsFrameBoundsUseCudfWindowSizes) {
+  auto data = makeRowVector(
+      {"v"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3}),
+      });
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({"sum(v) over (order by v "
+                             "rows between current row and current row) as s"})
+                    .orderBy({"v ASC NULLS LAST"}, false)
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"v", "s"},
+        {
+            makeFlatVector<int64_t>({1, 2, 3}),
+            makeFlatVector<int64_t>({1, 2, 3}),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({"sum(v) over (order by v "
+                             "rows between 1 preceding and current row) as s"})
+                    .orderBy({"v ASC NULLS LAST"}, false)
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"v", "s"},
+        {
+            makeFlatVector<int64_t>({1, 2, 3}),
+            makeFlatVector<int64_t>({1, 3, 5}),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({"sum(v) over (order by v "
+                             "rows between 1 following and 1 following) as s"})
+                    .orderBy({"v ASC NULLS LAST"}, false)
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"v", "s"},
+        {
+            makeFlatVector<int64_t>({1, 2, 3}),
+            makeNullableFlatVector<int64_t>({2, 3, std::nullopt}),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({"sum(v) over (order by v "
+                             "rows between 2 preceding and 1 preceding) as s"})
+                    .orderBy({"v ASC NULLS LAST"}, false)
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"v", "s"},
+        {
+            makeFlatVector<int64_t>({1, 2, 3}),
+            makeNullableFlatVector<int64_t>({std::nullopt, 1, 3}),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+}
+
+TEST_F(CudfWindowTest, inputsSortedStreamingWindow) {
+  auto data = makeRowVector(
+      {"p", "ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2, 2}),
+          makeFlatVector<int32_t>({1, 2, 1, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values(split(data, 2))
+                  .streamingWindow({
+                      "row_number() over (partition by p order by ord) as rn",
+                      "sum(v) over (partition by p order by ord "
+                      "rows between unbounded preceding and current row) as s",
+                  })
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"p", "ord", "v", "rn", "s"},
+      {
+          makeFlatVector<int32_t>({1, 1, 2, 2}),
+          makeFlatVector<int32_t>({1, 2, 1, 2}),
+          makeFlatVector<int64_t>({10, 20, 30, 40}),
+          makeFlatVector<int64_t>({1, 2, 1, 2}),
+          makeFlatVector<int64_t>({10, 30, 30, 70}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, lagLeadIgnoreNullsFallsBack) {
+  auto data = makeRowVector(
+      {"p", "ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 1}),
+          makeFlatVector<int32_t>({1, 2, 3, 4}),
+          makeNullableFlatVector<int64_t>({10, std::nullopt, 20, 30}),
+      });
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(
+          PlanBuilder()
+              .values({data})
+              .window({
+                  "lag(v, 1 IGNORE NULLS) over "
+                  "(partition by p order by ord) as lag_v",
+                  "lead(v, 1 IGNORE NULLS) over "
+                  "(partition by p order by ord) as lead_v",
+              })
+              .planNode())
+          .copyResults(pool()),
+      "Replacement with cuDF operator failed");
+}
+
+TEST_F(CudfWindowTest, countStarOverZeroColumnInputPreservesLogicalRows) {
+  auto data = makeRowVector(
+      {"v"},
+      {
+          makeFlatVector<int64_t>({1, 2, 3, 4}),
+      });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .project({})
+                  .window({
+                      "count(*) over (rows between unbounded preceding "
+                      "and unbounded following) as cnt",
+                  })
+                  .planNode();
+
+  auto expected = makeRowVector(
+      {"cnt"},
+      {
+          makeFlatVector<int64_t>({4, 4, 4, 4}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, rangeWithoutOrderByDoesNotDependOnFunctionCount) {
+  auto data = makeRowVector(
+      {"v"},
+      {
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({"sum(v) over (range between unbounded preceding "
+                             "and current row) as s"})
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"v", "s"},
+        {
+            makeFlatVector<int64_t>({10, 20, 30}),
+            makeFlatVector<int64_t>({60, 60, 60}),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({
+                        "sum(v) over (range between unbounded preceding "
+                        "and current row) as s",
+                        "count(v) over (range between unbounded preceding "
+                        "and current row) as c",
+                    })
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"v", "s", "c"},
+        {
+            makeFlatVector<int64_t>({10, 20, 30}),
+            makeFlatVector<int64_t>({60, 60, 60}),
+            makeFlatVector<int64_t>({3, 3, 3}),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  }
+}
+
+TEST_F(CudfWindowTest, emptyFrameCountReturnsZero) {
+  auto data = makeRowVector(
+      {"ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeNullableFlatVector<int64_t>({10, std::nullopt, 30}),
+      });
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .window({
+              "count(*) over (order by ord rows between 1 following and "
+              "1 following) as count_all",
+              "count(v) over (order by ord rows between 1 following and "
+              "1 following) as count_v",
+          })
+          .orderBy({"ord ASC NULLS LAST"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {"ord", "v", "count_all", "count_v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeNullableFlatVector<int64_t>({10, std::nullopt, 30}),
+          makeFlatVector<int64_t>({1, 1, 0}),
+          makeFlatVector<int64_t>({0, 1, 0}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, globalIntegerSumUsesBigintAccumulator) {
+  auto data = makeRowVector(
+      {"v"},
+      {makeFlatVector<int32_t>({std::numeric_limits<int32_t>::max(), 1})});
+
+  auto plan =
+      PlanBuilder().values({data}).window({"sum(v) over () as s"}).planNode();
+
+  auto expected = makeRowVector(
+      {"v", "s"},
+      {
+          makeFlatVector<int32_t>({std::numeric_limits<int32_t>::max(), 1}),
+          makeFlatVector<int64_t>({2'147'483'648LL, 2'147'483'648LL}),
+      });
+
+  AssertQueryBuilder(plan).assertResults(expected);
+}
+
+TEST_F(CudfWindowTest, unsupportedLeadLagArgumentsFallback) {
+  auto data = makeRowVector(
+      {"ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  const std::vector<std::string> expressions = {
+      "lag('foo', 1) over (order by ord) as w",
+      "lead('foo', 1) over (order by ord) as w",
+      "lag(v, null::bigint) over (order by ord) as w",
+      "lead(v, null::bigint) over (order by ord) as w",
+      "lag(v, 4294967294) over (order by ord) as w",
+      "lead(v, 4294967294) over (order by ord) as w",
+  };
+
+  for (const auto& expression : expressions) {
+    SCOPED_TRACE(expression);
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(
+            PlanBuilder().values({data}).window({expression}).planNode())
+            .copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+}
+
+TEST_F(CudfWindowTest, oversizedRowsBoundsFallback) {
+  auto data = makeRowVector(
+      {"ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+      });
+
+  const std::vector<std::string> expressions = {
+      "count(v) over (order by ord rows between "
+      "2147483647 preceding and current row) as c",
+      "count(v) over (order by ord rows between "
+      "current row and 2147483648 following) as c",
+  };
+
+  for (const auto& expression : expressions) {
+    SCOPED_TRACE(expression);
+    auto plan = PlanBuilder().values({data}).window({expression}).planNode();
+
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+}
+
+TEST_F(CudfWindowTest, unsupportedAggregateInputTypesFallback) {
+  const auto assertFallback = [&](const RowVectorPtr& data,
+                                  const std::string& expression) {
+    SCOPED_TRACE(expression);
+    auto plan = PlanBuilder().values({data}).window({expression}).planNode();
+
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  };
+
+  auto realData = makeRowVector(
+      {"ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<float>({16'777'216.0F, 1.0F, -16'777'216.0F}),
+      });
+  assertFallback(
+      realData,
+      "sum(v) over (order by ord rows between unbounded preceding "
+      "and current row) as s");
+
+  auto decimalData = makeRowVector(
+      {"ord", "d"},
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<int64_t>({100, 101}, DECIMAL(3, 2)),
+      });
+  assertFallback(
+      decimalData,
+      "avg(d) over (order by ord rows between unbounded preceding "
+      "and current row) as a");
+
+  auto arrayData = makeRowVector(
+      {"ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeArrayVector<int64_t>({{2}, {1, 3}, {1, 2}}),
+      });
+  assertFallback(
+      arrayData,
+      "min(v) over (order by ord rows between unbounded preceding "
+      "and current row) as v_min");
+  assertFallback(
+      arrayData,
+      "max(v) over (order by ord rows between unbounded preceding "
+      "and current row) as v_max");
+}
+
+TEST_F(CudfWindowTest, customComparisonWindowKeysFallback) {
+  const auto first = pack(12'345, 1);
+  const auto second = pack(12'345, 2);
+  auto data = makeRowVector(
+      {"id", "ts"},
+      {
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<int64_t>({first, second}, TIMESTAMP_WITH_TIME_ZONE()),
+      });
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({
+                        "rank() over (order by ts) as r",
+                        "dense_rank() over (order by ts) as dr",
+                    })
+                    .planNode();
+
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+
+  {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({
+                        "count(*) over (partition by ts) as c",
+                    })
+                    .planNode();
+
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+}
+
+TEST_F(CudfWindowTest, fullPartitionAverageFallsBackUntilOptimized) {
+  auto data = makeRowVector(
+      {"p", "ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+          makeFlatVector<int32_t>({1, 2, 3, 1, 2}),
+          makeNullableFlatVector<double>({10.0, std::nullopt, 30.0, 5.0, 15.0}),
+      });
+
+  const std::vector<std::string> expressions = {
+      "avg(v) over (partition by p) as a",
+      "avg(v) over (partition by p order by ord "
+      "rows between unbounded preceding and unbounded following) as a",
+  };
+
+  for (const auto& expression : expressions) {
+    SCOPED_TRACE(expression);
+    auto plan = PlanBuilder().values({data}).window({expression}).planNode();
+
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+}
+
+TEST_F(CudfWindowTest, decimalSumWidensBeforeWindowAggregation) {
+  constexpr int32_t kNumRows = 12;
+  constexpr int64_t kBig = 900'000'000'000'000'000;
+
+  std::vector<int32_t> partitions(kNumRows, 1);
+  std::vector<int64_t> values(kNumRows, kBig);
+  std::vector<int128_t> fullSums(
+      kNumRows, static_cast<int128_t>(kBig) * kNumRows);
+  std::vector<int128_t> runningSums;
+  runningSums.reserve(kNumRows);
+  for (int32_t i = 0; i < kNumRows; ++i) {
+    runningSums.push_back(static_cast<int128_t>(kBig) * (i + 1));
+  }
+
+  auto data = makeRowVector(
+      {"p", "ord", "d"},
+      {
+          makeFlatVector<int32_t>(partitions),
+          makeFlatVector<int32_t>(kNumRows, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(values, DECIMAL(18, 0)),
+      });
+
+  const auto assertSum = [&](const std::string& expression,
+                             const std::vector<int128_t>& expectedSums) {
+    auto plan = PlanBuilder()
+                    .values({data})
+                    .window({expression})
+                    .orderBy({"ord ASC NULLS LAST"}, false)
+                    .planNode();
+
+    auto expected = makeRowVector(
+        {"p", "ord", "d", "s"},
+        {
+            makeFlatVector<int32_t>(partitions),
+            makeFlatVector<int32_t>(kNumRows, [](auto row) { return row; }),
+            makeFlatVector<int64_t>(values, DECIMAL(18, 0)),
+            makeFlatVector<int128_t>(expectedSums, DECIMAL(38, 0)),
+        });
+
+    AssertQueryBuilder(plan).assertResults(expected);
+  };
+
+  assertSum("sum(d) over () as s", fullSums);
+  assertSum("sum(d) over (partition by p) as s", fullSums);
+  assertSum(
+      "sum(d) over (partition by p order by ord "
+      "rows between unbounded preceding and current row) as s",
+      runningSums);
+}
+
+// A cast on a window function argument (e.g. sum(cast(v as bigint))) reaches
+// the WindowNode as a CastTypedExpr. The CPU Window operator rejects such
+// arguments outright, so CudfWindow must fall back instead of silently reading
+// the un-cast column and evaluating f(x) instead of f(cast(x)).
+TEST_F(CudfWindowTest, castInWindowArgFallsBack) {
+  auto data = makeRowVector(
+      {"ord", "v"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int32_t>({10, 20, 30}),
+      });
+
+  const std::vector<std::string> expressions = {
+      "sum(cast(v as bigint)) over (order by ord "
+      "rows between unbounded preceding and current row) as w",
+      "max(cast(v as bigint)) over (order by ord "
+      "rows between unbounded preceding and current row) as w",
+      "lag(cast(v as bigint), 1) over (order by ord) as w",
+      "first_value(cast(v as bigint)) over (order by ord) as w",
+  };
+
+  for (const auto& expression : expressions) {
+    SCOPED_TRACE(expression);
+    auto plan = PlanBuilder().values({data}).window({expression}).planNode();
+
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "Replacement with cuDF operator failed");
+  }
+}
+
+} // namespace


### PR DESCRIPTION
Add a GPU-accelerated Window operator (`CudfWindow`) that replaces the Velox `Window` operator when `canRunOnGPU()` succeeds. Incoming batches are buffered in `addInput()`, concatenated and sorted by partition/order keys in `getOutput()`, and evaluated via cuDF `groupby::scan` (rank-like functions) and `grouped_rolling_window` / `grouped_range_rolling_window` (positional and aggregate windows).

Unsupported shapes fall back to the CPU `Window` operator with a logged reason from `WindowAdapter`.

## Supported window functions

**Rank-like** (via `cudf::groupby::scan`):
- `row_number()` — `rank_method::FIRST`
- `rank()` — `rank_method::MIN`
- `dense_rank()` — `rank_method::DENSE`

**Positional** (via `cudf::grouped_rolling_window`):
- `lag(col [, offset])` — constant offset only
- `lead(col [, offset])` — constant offset only
- `first_value(col)` — supports `IGNORE NULLS`
- `last_value(col)` — supports `IGNORE NULLS`

**Aggregate windows** (via `grouped_rolling_window` / `grouped_range_rolling_window`):
- `sum(col)`, `min(col)`, `max(col)`, `count(col)`, `avg(col)`

## Frame support

**ROWS**
- Constant `PRECEDING` / `FOLLOWING` bounds with side-aware conversion to cuDF window sizes (`[i - preceding + 1, i + following]`)
- `UNBOUNDED PRECEDING`, `CURRENT ROW`, and `UNBOUNDED FOLLOWING`
- Explicit `ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW` is **not** treated as a full-partition aggregate

**RANGE**
- `UNBOUNDED PRECEDING` to `CURRENT ROW` or `UNBOUNDED FOLLOWING`
- Constant numeric `PRECEDING` / `FOLLOWING` bounds on the ORDER BY column
- Batched `grouped_range_rolling_window` for multiple RANGE aggregates sharing the same frame (including single-function plans)
- Synthesized ORDER BY column when there is no sort key (all rows are peers)

**Full-partition fast path**
- Global aggregates (`SUM`, `MIN`, `MAX`, `COUNT`) with no partition/order keys use `cudf::reduce`
- `SUM` uses the Velox function result type as the cuDF accumulator type (e.g. `INTEGER` → `BIGINT`)
- Empty-frame `COUNT` results are normalized to `0` after cuDF evaluation (`min_periods = 1` otherwise leaves nulls)

## Architecture

- `CudfWindow` — main operator; buffers input, sorts, dispatches window functions
- `resolveInputChannel()` — resolves function argument columns (including through casts)
- `computeRankColumnsBatch()` — batched rank-like evaluation via `groupby::scan`
- `computeLeadLagColumn()` — lag/lead via physical row shift
- `computeNthValueColumn()` — first_value/last_value
- `computeAggregateColumn()` — rolling / global aggregates
- `invokeGroupedRollingWindow()` — ROWS and single-request RANGE rolling
- `toRowsPrecedingBound()` / `toRowsFollowingBound()` — side-aware ROWS frame translation
- `toRangeWindowBound()` / `toBatchRangeWindowTypes()` — RANGE frame translation and batching
- `containsCustomComparison()` — rejects keys with Velox custom comparison semantics
- `stripFunctionPrefix()` — strips Presto dotted names and `CudfConfig::functionNamePrefix`
- `WindowAdapter` — GPU gating and operator replacement in `OperatorAdapters.cpp`

## CPU fallback (`canRunOnGPU`)

The GPU operator is selected only when all window functions and frames are supported. Notable fallback cases:

- Unsupported functions: `ntile`, `percent_rank`, `cume_dist`, `nth_value`, etc.
- Multi-column `ORDER BY` (deferred to follow-on PR after cuDF upgrade)
- Partition / order keys with custom comparison types (e.g. `TIMESTAMP WITH TIME ZONE`)
- `lag` / `lead`:
  - `IGNORE NULLS`
  - default value (3rd argument)
  - constant value argument (e.g. `lag('foo', 1)`)
  - non-constant, null, negative, or oversized offset
- Aggregate input types:
  - `sum(REAL)` (FLOAT32 accumulation precision)
  - `avg(DECIMAL)` (decimal rounding semantics)
  - `min` / `max` over nested `ARRAY` / `MAP` / `ROW`
- Full-partition `avg` over partitioned or ordered windows (generic rolling `MEAN` is quadratic; falls back until cuDF fully-unbounded `MEAN` is available)
- `ROWS` bounds that exceed cuDF representable limits (side-aware: start `N PRECEDING` → cuDF preceding size `N + 1`)
- Non-constant frame bounds
- `RANGE` frames outside supported bound combinations

## Testing

`CudfWindowTest` contains **53 active GPU tests** (1 disabled: `multiFunctionPartitionOrder`). All 53 pass on GH200:

- Native host build (`CUDA_VISIBLE_DEVICES=0`)
- `presto-native-worker-gpu-6` container (`CUDA_VISIBLE_DEVICES=0`)

Coverage includes rank/lag/lead/aggregate windows, ROWS and RANGE frames, spill paths, adapter gating, zero-column `count(*)`, empty-frame COUNT normalization, integer SUM BIGINT accumulation, unsupported-shape fallbacks, and review-driven edge cases.

Tests use hardcoded expected results (no DuckDB dependency; works on aarch64 64K-page kernels).