### PR TITLE
fix: Handle non-decimal HUGEINT types in Variant::toString and toJson

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -251,8 +251,10 @@ std::string Variant::toString(const TypePtr& type) const {
       return str;
     }
     case TypeKind::HUGEINT: {
-      VELOX_CHECK(type->isLongDecimal());
-      return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      if (type->isLongDecimal()) {
+        return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      }
+      return folly::to<std::string>(value<TypeKind::HUGEINT>());
     }
     case TypeKind::TINYINT:
       [[fallthrough]];
@@ -465,8 +467,10 @@ std::string Variant::toJson(const Type& type) const {
       return target;
     }
     case TypeKind::HUGEINT: {
-      VELOX_CHECK(type.isLongDecimal());
-      return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      if (type.isLongDecimal()) {
+        return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      }
+      return folly::to<std::string>(value<TypeKind::HUGEINT>());
     }
     case TypeKind::TINYINT:
       [[fallthrough]];
@@ -497,7 +501,7 @@ std::string Variant::toJson(const Type& type) const {
       return stringifyFloatingPointerValue<double>(value<TypeKind::DOUBLE>());
     }
     case TypeKind::TIMESTAMP: {
-      auto& timestamp = value<TypeKind::TIMESTAMP>();
+      const auto& timestamp = value<TypeKind::TIMESTAMP>();
       return '"' + timestamp.toString() + '"';
     }
     case TypeKind::OPAQUE: {
@@ -592,8 +596,10 @@ std::string Variant::toJsonUnsafe(const TypePtr& type) const {
       return target;
     }
     case TypeKind::HUGEINT: {
-      VELOX_CHECK(type && type->isLongDecimal());
-      return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      if (type && type->isLongDecimal()) {
+        return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      }
+      return folly::to<std::string>(value<TypeKind::HUGEINT>());
     }
     case TypeKind::TINYINT:
       [[fallthrough]];

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -1688,6 +1688,30 @@ TEST(VariantTest, toString) {
   EXPECT_EQ(
       Variant::row({1, 2, 3}).toString(ROW({INTEGER(), INTEGER(), INTEGER()})),
       "[1,2,3]");
+
+  // Non-decimal HUGEINT types (e.g., IPADDRESS, UUID).
+  auto hugeintType = HugeintType::create();
+  EXPECT_EQ(
+      Variant::create<TypeKind::HUGEINT>(int128_t(42)).toString(hugeintType),
+      "42");
+  EXPECT_EQ(
+      Variant::create<TypeKind::HUGEINT>(
+          HugeInt::build(0x0123456789ABCDEF, 0xFEDCBA9876543210))
+          .toString(hugeintType),
+      "1512366075204170947332355369683137040");
+}
+
+TEST(VariantTest, toJsonHugeint) {
+  auto hugeintType = HugeintType::create();
+  auto small = Variant::create<TypeKind::HUGEINT>(int128_t(42));
+  auto large = Variant::create<TypeKind::HUGEINT>(
+      HugeInt::build(0x0123456789ABCDEF, 0xFEDCBA9876543210));
+
+  EXPECT_EQ(small.toJson(hugeintType), "42");
+  EXPECT_EQ(large.toJson(hugeintType), "1512366075204170947332355369683137040");
+
+  EXPECT_EQ(small.toJsonUnsafe(), "42");
+  EXPECT_EQ(large.toJsonUnsafe(), "1512366075204170947332355369683137040");
 }
 
 template <typename T>


### PR DESCRIPTION
Summary:
Variant::toString, toJson, and toJsonUnsafe assumed HUGEINT is always
LongDecimal, crashing with VELOX_CHECK when encountering custom HUGEINT
types like IPADDRESS or UUID.

Fix: for non-decimal HUGEINT, fall back to printing the raw int128
value as a string.

Differential Revision: D97863751


