### PR TITLE
fix: Fix owner metadata missing from SimpleFunctionRegistry::getFunctionSignaturesAndMetadata (#16896)

### DIFF
--- a/velox/expression/SimpleFunctionRegistry.cpp
+++ b/velox/expression/SimpleFunctionRegistry.cpp
@@ -129,9 +129,12 @@ SimpleFunctionRegistry::getFunctionSignaturesAndMetadata(
       result.reserve(signatureMap->size());
       for (const auto& [signature, functions] : *signatureMap) {
         VectorFunctionMetadata metadata{
-            false,
-            functions[0]->getMetadata().isDeterministic(),
-            functions[0]->getMetadata().defaultNullBehavior()};
+            .supportsFlattening = false,
+            .deterministic = functions[0]->getMetadata().isDeterministic(),
+            .defaultNullBehavior =
+                functions[0]->getMetadata().defaultNullBehavior(),
+            .companionFunction = false,
+            .owner = functions[0]->getMetadata().owner()};
         result.emplace_back(
             std::pair<VectorFunctionMetadata, const FunctionSignature*>{
                 metadata, &signature});

--- a/velox/functions/tests/FunctionRegistryTest.cpp
+++ b/velox/functions/tests/FunctionRegistryTest.cpp
@@ -693,6 +693,39 @@ TEST_F(FunctionRegistryTest, companionFunction) {
   }
 }
 
+TEST_F(FunctionRegistryTest, getFunctionSignaturesAndMetadata) {
+  registerFunction<MetadataTestFuncAllSet, int32_t, int32_t>(
+      {"metadata_test_all_set"});
+  registerFunction<MetadataTestFuncDefaults, int32_t, int32_t>(
+      {"metadata_test_defaults"});
+
+  const auto& registry = exec::simpleFunctions();
+
+  {
+    auto result =
+        registry.getFunctionSignaturesAndMetadata("metadata_test_all_set");
+    ASSERT_EQ(result.size(), 1);
+    const auto& metadata = result[0].first;
+    EXPECT_FALSE(metadata.supportsFlattening);
+    EXPECT_FALSE(metadata.deterministic);
+    EXPECT_FALSE(metadata.defaultNullBehavior);
+    EXPECT_FALSE(metadata.companionFunction);
+    EXPECT_EQ(metadata.owner, "test-owner-team");
+  }
+
+  {
+    auto result =
+        registry.getFunctionSignaturesAndMetadata("metadata_test_defaults");
+    ASSERT_EQ(result.size(), 1);
+    const auto& metadata = result[0].first;
+    EXPECT_FALSE(metadata.supportsFlattening);
+    EXPECT_TRUE(metadata.deterministic);
+    EXPECT_TRUE(metadata.defaultNullBehavior);
+    EXPECT_FALSE(metadata.companionFunction);
+    EXPECT_TRUE(metadata.owner.empty());
+  }
+}
+
 template <typename T>
 struct TestFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/tests/RegistryTestUtil.h
+++ b/velox/functions/tests/RegistryTestUtil.h
@@ -109,6 +109,29 @@ struct IPPrefixFunc {
   }
 };
 
+// Non-deterministic, uses callNullable (defaultNullBehavior=false), has owner.
+template <typename T>
+struct MetadataTestFuncAllSet {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  static constexpr bool is_deterministic = false;
+  static constexpr std::string_view owner = "test-owner-team";
+
+  FOLLY_ALWAYS_INLINE bool callNullable(int32_t& result, const int32_t* input) {
+    result = input ? *input : 0;
+    return true;
+  }
+};
+
+// Deterministic (default), uses call (defaultNullBehavior=true), no owner.
+template <typename T>
+struct MetadataTestFuncDefaults {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, int32_t input) {
+    result = input;
+  }
+};
+
 class VectorFuncOne : public velox::exec::VectorFunction {
  public:
   void apply(


### PR DESCRIPTION
Summary:

getFunctionSignaturesAndMetadata() constructed VectorFunctionMetadata with only 3 of 5 fields, leaving owner at its default empty string. The inspector then displayed "unknown". Added the missing companionFunction and owner fields to match ResolvedSimpleFunction::metadata(). Added a unit test verifying owner propagation through this code path.

Differential Revision: D97889904


