### PR TITLE
fix(remote): Use VELOX_USER_FAIL for remote error re-throwing (#16903)

### DIFF
--- a/velox/functions/remote/client/RemoteVectorFunction.cpp
+++ b/velox/functions/remote/client/RemoteVectorFunction.cpp
@@ -145,7 +145,7 @@ void RemoteVectorFunction::applyRemote(
         return;
       }
       try {
-        throw std::runtime_error(std::string(errorsVector->valueAt(i)));
+        VELOX_USER_FAIL("{}", errorsVector->valueAt(i));
       } catch (const std::exception&) {
         context.setError(i, std::current_exception());
       }


### PR DESCRIPTION
Summary:
Remote errors were re-thrown as std::runtime_error, losing the VeloxUserError type that callers (e.g., TRY()) depend on for proper error classification. Use VELOX_USER_FAIL instead to produce proper VeloxUserError exceptions.


Reviewed By: kgpai

Differential Revision: D98217349

Pulled By: nookcreed


