### PR TITLE
feat: Wire loadClusterIndex/loadChunkIndex through configureOptions

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -746,6 +746,28 @@ class ReaderOptions : public io::ReaderOptions {
     fileMetadataCacheEnabled_ = value;
   }
 
+  /// Whether to load and initialize the cluster index during file open.
+  /// When true, the cluster index section is preloaded and the structured
+  /// ClusterIndex object is created. Default true.
+  bool loadClusterIndex() const {
+    return loadClusterIndex_;
+  }
+
+  void setLoadClusterIndex(bool value) {
+    loadClusterIndex_ = value;
+  }
+
+  /// Whether to load and initialize the chunk index during file open.
+  /// When true, the chunk index section is preloaded and the structured
+  /// ChunkIndex object is created. Default true.
+  bool loadChunkIndex() const {
+    return loadChunkIndex_;
+  }
+
+  void setLoadChunkIndex(bool value) {
+    loadChunkIndex_ = value;
+  }
+
   bool allowEmptyFile() const {
     return allowEmptyFile_;
   }
@@ -772,6 +794,8 @@ class ReaderOptions : public io::ReaderOptions {
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
   bool fileMetadataCacheEnabled_{false};
+  bool loadClusterIndex_{true};
+  bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};
 };
 


### PR DESCRIPTION
Summary:
CONTEXT: As a followup from D95608908, `TabletReader::Options` has
`loadClusterIndex` and `loadChunkIndex` flags but they weren't configurable
through `ReaderOptions` / `configureOptions`. Callers using the selective
reader path (via `ReaderBase::create`) had no way to control index loading.

WHAT:
- Add `loadClusterIndex`/`loadChunkIndex` fields to
  `velox::dwio::common::ReaderOptions` (default `true`) and wire them through
  `TabletReader::configureOptions`, matching the existing pattern for
  `footerSpeculativeIoSize` → `maxFooterIoBytes`.
- Make `configureOptions` the centralized place for deciding which optional
  sections to preload. Index sections are conditionally added to
  `preloadOptionalSections` based on the new flags. Simplify
  `preloadSectionNames` to a passthrough.
- Add `enableChunkIndex` as a Google Test parameter to both `E2EIndexTest`
  and `E2EFilterTest` so all existing test cases run with chunk index on/off.

Differential Revision: D97891697
