### PR TITLE
fix: Add inMaps buffer check at a particular index

### DIFF
--- a/velox/vector/FlatMapVector.h
+++ b/velox/vector/FlatMapVector.h
@@ -276,12 +276,17 @@ class FlatMapVector : public BaseVector {
   }
 
   const uint64_t* rawInMapsAt(column_index_t index) const {
-    return inMaps_.size() > index ? inMaps_[index]->as<uint64_t>() : nullptr;
+    if (inMaps_.size() > index && inMaps_[index]) {
+      return inMaps_[index]->as<uint64_t>();
+    }
+    return nullptr;
   }
 
   uint64_t* mutableRawInMapsAt(column_index_t index) {
-    return inMaps_.size() > index ? inMaps_[index]->asMutable<uint64_t>()
-                                  : nullptr;
+    if (inMaps_.size() > index && inMaps_[index]) {
+      return inMaps_[index]->asMutable<uint64_t>();
+    }
+    return nullptr;
   }
 
   using BaseVector::toString;

--- a/velox/vector/tests/FlatMapVectorTest.cpp
+++ b/velox/vector/tests/FlatMapVectorTest.cpp
@@ -393,6 +393,44 @@ TEST_F(FlatMapVectorTest, nullInMaps) {
   EXPECT_TRUE(flatMap->isInMap(2, 0));
 }
 
+TEST_F(FlatMapVectorTest, copyRangesWithNullInMaps) {
+  auto vectorSize = 2;
+  auto distinctKeys = maker_.flatVector<int32_t>({1, 2, 3});
+
+  std::vector<VectorPtr> sourceMapValues{
+      makeFlatVector<int32_t>({10, 20}),
+      makeFlatVector<int32_t>({30, 40}),
+      makeFlatVector<int32_t>({50, 60}),
+  };
+
+  std::vector<BufferPtr> sourceInMaps(distinctKeys->size());
+  sourceInMaps[1] = AlignedBuffer::allocate<bool>(vectorSize, pool_.get(), 0);
+
+  auto source = std::make_shared<FlatMapVector>(
+      pool_.get(),
+      MAP(INTEGER(), INTEGER()),
+      nullptr,
+      vectorSize,
+      distinctKeys,
+      sourceMapValues,
+      sourceInMaps);
+
+  auto target = std::make_shared<FlatMapVector>(
+      pool_.get(),
+      MAP(INTEGER(), INTEGER()),
+      nullptr,
+      vectorSize,
+      makeFlatVector<int32_t>({4}),
+      std::vector<VectorPtr>{makeFlatVector<int32_t>({0, 0})},
+      std::vector<BufferPtr>{nullptr});
+
+  std::vector<BaseVector::CopyRange> ranges = {BaseVector::CopyRange{0, 0, 2}};
+  target->copyRanges(
+      source.get(), folly::Range<const BaseVector::CopyRange*>{ranges});
+
+  assertEqualVectors(source, target);
+}
+
 TEST_F(FlatMapVectorTest, primitiveKeys) {
   // bigint key.
   auto flatMapVector = maker_.flatMapVector<int64_t, double>({


### PR DESCRIPTION
It's not guaranteed that inMaps is non-null at each index. Let's add a check to verify that it's been defined.

Differential Revision: D98031941


