### PR TITLE
fix: Support constant arguments in Presto window functions (#16915)

### DIFF
--- a/velox/functions/lib/window/NthValue.cpp
+++ b/velox/functions/lib/window/NthValue.cpp
@@ -31,13 +31,16 @@ class NthValueFunction : public exec::WindowFunction {
       velox::memory::MemoryPool* pool)
       : WindowFunction(resultType, pool, nullptr), ignoreNulls_(ignoreNulls) {
     VELOX_CHECK_EQ(args.size(), 2);
-    VELOX_CHECK_NULL(args[0].constantValue);
     auto offsetType = args[1].type;
     VELOX_USER_CHECK(
         (offsetType->isInteger() || offsetType->isBigint()),
         "Invalid offset type: {}",
         offsetType->toString());
-    valueIndex_ = args[0].index.value();
+    if (args[0].constantValue) {
+      constantValue_ = args[0].constantValue;
+    } else {
+      valueIndex_ = args[0].index.value();
+    }
     if (args[1].constantValue) {
       if (args[1].constantValue->isNullAt(0)) {
         isConstantOffsetNull_ = true;
@@ -82,6 +85,17 @@ class NthValueFunction : public exec::WindowFunction {
       int32_t resultOffset,
       const VectorPtr& result) override {
     auto numRows = frameStarts->size() / sizeof(vector_size_t);
+
+    // When value is a constant null and IGNORE NULLS is set, the result is
+    // always null.
+    if (constantValue_ && ignoreNulls_ && constantValue_->isNullAt(0)) {
+      for (auto i = 0; i < numRows; ++i) {
+        result->setNull(resultOffset + i, true);
+      }
+      partitionOffset_ += numRows;
+      return;
+    }
+
     rowNumbers_.resize(numRows);
 
     if (isConstantOffsetNull_) {
@@ -94,9 +108,13 @@ class NthValueFunction : public exec::WindowFunction {
 
     setRowNumbersForEmptyFrames(validRows);
 
-    auto rowNumbersRange = folly::Range(rowNumbers_.data(), numRows);
-    partition_->extractColumn(
-        valueIndex_, rowNumbersRange, resultOffset, result);
+    if (constantValue_) {
+      setConstantResult(numRows, resultOffset, result);
+    } else {
+      auto rowNumbersRange = folly::Range(rowNumbers_.data(), numRows);
+      partition_->extractColumn(
+          valueIndex_, rowNumbersRange, resultOffset, result);
+    }
 
     partitionOffset_ += numRows;
   }
@@ -116,7 +134,9 @@ class NthValueFunction : public exec::WindowFunction {
     auto rawFrameEnds = frameEnds->as<vector_size_t>();
     bool ignoreNullsForBlock = false;
     vector_size_t leastFrame = 0;
-    if (ignoreNulls_) {
+    // When the value is a constant (non-null, since null+ignoreNulls is
+    // handled earlier), there are no nulls to ignore.
+    if (ignoreNulls_ && !constantValue_) {
       auto extractNullsResult = partition_->extractNulls(
           valueIndex_, validRows, frameStarts, frameEnds, &nulls_);
       // Perform ignoreNulls processing only if there are null values in the
@@ -223,6 +243,21 @@ class NthValueFunction : public exec::WindowFunction {
     }
   }
 
+  // Write the constant value for rows with valid rowNumbers and null
+  // otherwise.
+  void setConstantResult(
+      vector_size_t numRows,
+      int32_t resultOffset,
+      const VectorPtr& result) {
+    for (auto i = 0; i < numRows; ++i) {
+      if (rowNumbers_[i] == kNullRow) {
+        result->setNull(resultOffset + i, true);
+      } else {
+        result->copy(constantValue_.get(), resultOffset + i, 0, 1);
+      }
+    }
+  }
+
   void setRowNumbersForEmptyFrames(const SelectivityVector& validRows) {
     if (validRows.isAllSelected()) {
       return;
@@ -270,6 +305,9 @@ class NthValueFunction : public exec::WindowFunction {
   }
 
   const bool ignoreNulls_;
+
+  // Non-null when the value argument is a constant expression.
+  VectorPtr constantValue_;
 
   // These are the argument indices of the nth_value value and offset columns
   // in the input row vector. These are needed to retrieve column values

--- a/velox/functions/prestosql/window/FirstLastValue.cpp
+++ b/velox/functions/prestosql/window/FirstLastValue.cpp
@@ -37,8 +37,11 @@ class FirstLastValueFunction : public exec::WindowFunction {
       bool ignoreNulls,
       velox::memory::MemoryPool* pool)
       : WindowFunction(resultType, pool, nullptr), ignoreNulls_(ignoreNulls) {
-    VELOX_CHECK_NULL(args[0].constantValue);
-    valueIndex_ = args[0].index.value();
+    if (args[0].constantValue) {
+      constantValue_ = args[0].constantValue;
+    } else {
+      valueIndex_ = args[0].index.value();
+    }
 
     nulls_ = allocateNulls(0, pool_);
   }
@@ -56,6 +59,24 @@ class FirstLastValueFunction : public exec::WindowFunction {
       int32_t resultOffset,
       const VectorPtr& result) override {
     auto numRows = frameStarts->size() / sizeof(vector_size_t);
+
+    if (constantValue_) {
+      // Rows with empty frames should return null.
+      if (validRows.isAllSelected()) {
+        result->copy(constantValue_.get(), resultOffset, 0, numRows);
+      } else {
+        // Set constant for valid rows, null for invalid rows.
+        for (auto i = 0; i < numRows; ++i) {
+          if (validRows.isValid(i)) {
+            result->copy(constantValue_.get(), resultOffset + i, 0, 1);
+          } else {
+            result->setNull(resultOffset + i, true);
+          }
+        }
+      }
+      return;
+    }
+
     rowNumbers_.resize(numRows);
     if (validRows.hasSelections()) {
       if (ignoreNulls_) {
@@ -139,6 +160,9 @@ class FirstLastValueFunction : public exec::WindowFunction {
   }
 
   const bool ignoreNulls_;
+
+  // Non-null when the argument is a constant expression.
+  VectorPtr constantValue_;
 
   // Index of the first_value / last_value argument column in the input row
   // vector. This is used to retrieve column values from the partition data.

--- a/velox/functions/prestosql/window/LeadLag.cpp
+++ b/velox/functions/prestosql/window/LeadLag.cpp
@@ -30,7 +30,11 @@ class LeadLagFunction : public exec::WindowFunction {
       bool ignoreNulls,
       velox::memory::MemoryPool* pool)
       : WindowFunction(resultType, pool, nullptr), ignoreNulls_(ignoreNulls) {
-    valueIndex_ = args[0].index.value();
+    if (args[0].constantValue) {
+      constantValue_ = args[0].constantValue;
+    } else {
+      valueIndex_ = args[0].index.value();
+    }
 
     initializeOffset(args);
     initializeDefaultValue(args);
@@ -43,7 +47,9 @@ class LeadLagFunction : public exec::WindowFunction {
     partitionOffset_ = 0;
     ignoreNullsForPartition_ = false;
 
-    if (ignoreNulls_) {
+    // When the value is a constant, there are no per-row nulls to extract
+    // from the partition.
+    if (ignoreNulls_ && !constantValue_) {
       auto partitionSize = partition_->numRows();
       AlignedBuffer::reallocate<bool>(&nulls_, partitionSize);
 
@@ -67,6 +73,19 @@ class LeadLagFunction : public exec::WindowFunction {
 
     rowNumbers_.resize(numRows);
 
+    // When the value is a constant null and IGNORE NULLS is set, every row
+    // is null so lead/lag can never find a non-null value. Return the default
+    // value for all rows (or null if no default).
+    if (constantValue_ && ignoreNulls_ && constantValue_->isNullAt(0)) {
+      std::fill(rowNumbers_.begin(), rowNumbers_.end(), kDefaultValueRow);
+      for (auto i = 0; i < numRows; ++i) {
+        result->setNull(resultOffset + i, true);
+      }
+      setDefaultValue(result, resultOffset);
+      partitionOffset_ += numRows;
+      return;
+    }
+
     if (constantOffset_.has_value() || isConstantOffsetNull_) {
       setRowNumbersForConstantOffset();
     } else {
@@ -77,9 +96,25 @@ class LeadLagFunction : public exec::WindowFunction {
       }
     }
 
-    auto rowNumbersRange = folly::Range(rowNumbers_.data(), numRows);
-    partition_->extractColumn(
-        valueIndex_, rowNumbersRange, resultOffset, result);
+    if (constantValue_) {
+      // For constant value, write the constant for valid rows, null for
+      // kNullRow, and leave kDefaultValueRow for setDefaultValue to handle.
+      for (auto i = 0; i < numRows; ++i) {
+        if (rowNumbers_[i] == kNullRow) {
+          result->setNull(resultOffset + i, true);
+        } else if (rowNumbers_[i] == kDefaultValueRow) {
+          // Set null here; setDefaultValue will overwrite with actual default
+          // if one is specified.
+          result->setNull(resultOffset + i, true);
+        } else {
+          result->copy(constantValue_.get(), resultOffset + i, 0, 1);
+        }
+      }
+    } else {
+      auto rowNumbersRange = folly::Range(rowNumbers_.data(), numRows);
+      partition_->extractColumn(
+          valueIndex_, rowNumbersRange, resultOffset, result);
+    }
 
     setDefaultValue(result, resultOffset);
 
@@ -286,6 +321,9 @@ class LeadLagFunction : public exec::WindowFunction {
   // Certain partitions may not have null values. So ignore nulls processing can
   // be skipped for them. Used for tracking this at the partition level.
   bool ignoreNullsForPartition_;
+
+  // Non-null when the value argument is a constant expression.
+  VectorPtr constantValue_;
 
   // Index of the 'value' argument.
   column_index_t valueIndex_;

--- a/velox/functions/prestosql/window/tests/LeadLagTest.cpp
+++ b/velox/functions/prestosql/window/tests/LeadLagTest.cpp
@@ -433,6 +433,55 @@ TEST_P(LeadLagTest, emptyFrames) {
   }
 }
 
+// Verify that lead and lag handle constant value arguments. This can happen
+// when the optimizer constant-folds a column that is always the same value
+// within the window partition context.
+TEST_F(LeadLagTest, constantArgument) {
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+  });
+
+  auto assertResults = [&](const std::string& function,
+                           const VectorPtr& expectedWindow) {
+    auto expected = makeRowVector({
+        input->childAt(0),
+        input->childAt(1),
+        expectedWindow,
+    });
+    WindowTestBase::testWindowFunction(
+        {input},
+        function,
+        "partition by c0 order by c1",
+        "rows between unbounded preceding and current row",
+        expected);
+  };
+
+  // Constant value: returns the constant, null when offset goes out of
+  // partition.
+  assertResults(
+      "lag('foo', 1)",
+      makeNullableFlatVector<StringView>(
+          {std::nullopt, "foo", "foo", std::nullopt, "foo"}));
+  assertResults(
+      "lead('foo', 1)",
+      makeNullableFlatVector<StringView>(
+          {"foo", "foo", std::nullopt, "foo", std::nullopt}));
+
+  // Null constant value returns null for all rows.
+  auto allNulls = makeAllNullFlatVector<StringView>(5);
+
+  assertResults("lag(null::varchar, 1)", allNulls);
+  assertResults("lead(null::varchar, 1)", allNulls);
+
+  // Constant null value with IGNORE NULLS and a default value. Every row is
+  // null so lead/lag can never find a non-null value. All rows should get the
+  // default value.
+  assertResults(
+      "lag(null::varchar, 1, 'default' IGNORE NULLS)",
+      makeConstant<StringView>("default", 5));
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(LagTest, LeadLagTest, ::testing::Values("lag"));
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -346,6 +346,57 @@ TEST_F(NthValueTest, ignoreNulls) {
   }
 }
 
+// Verify that first_value, last_value, and nth_value handle constant value
+// arguments. This can happen when the optimizer constant-folds a column that
+// is always the same value within the window partition context.
+TEST_F(NthValueTest, constantArgument) {
+  auto input = makeRowVector({
+      makeFlatVector<int32_t>({1, 1, 1, 2, 2}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+  });
+
+  // Use a frame clause that produces empty frames for the first row in each
+  // partition: "rows between 2 preceding and 1 preceding" is empty when
+  // there are fewer than 2 preceding rows.
+  auto assertResults = [&](const std::string& function,
+                           const VectorPtr& expectedWindow) {
+    auto expected = makeRowVector({
+        input->childAt(0),
+        input->childAt(1),
+        expectedWindow,
+    });
+    WindowTestBase::testWindowFunction(
+        {input},
+        function,
+        "partition by c0 order by c1",
+        "rows between 2 preceding and 1 preceding",
+        expected);
+  };
+
+  // Constant for valid frames, null for empty.
+  auto expected = makeNullableFlatVector<StringView>(
+      {std::nullopt, "foo", "foo", std::nullopt, "foo"});
+
+  assertResults("first_value('foo')", expected);
+  assertResults("last_value('foo')", expected);
+  assertResults("nth_value('foo', 1)", expected);
+
+  // Null constant value returns null for all rows.
+  auto allNulls = makeAllNullFlatVector<StringView>(5);
+
+  assertResults("first_value(null::varchar)", allNulls);
+  assertResults("last_value(null::varchar)", allNulls);
+  assertResults("nth_value(null::varchar, 1)", allNulls);
+
+  // nth_value with offset beyond frame returns null.
+  WindowTestBase::testWindowFunction(
+      {input},
+      "nth_value('foo', 100)",
+      "partition by c0 order by c1",
+      "rows between unbounded preceding and current row",
+      makeRowVector({input->childAt(0), input->childAt(1), allNulls}));
+}
+
 TEST_F(NthValueTest, frameStartsFromFollowing) {
   auto input = makeRowVector({
       makeNullableFlatVector<int64_t>({1, std::nullopt, 2}),


### PR DESCRIPTION
Summary:

Axiom's optimizer may pass constant expressions directly as arguments to window
functions (e.g. first_value('foo')) instead of projecting them into a column
first. Previously, first_value, last_value, nth_value, lead, and lag all
assumed the value argument is always a column reference and crashed with an
assertion failure or bad_optional_access when receiving a constant.

Handle constant value arguments in all five functions by storing the constant
and writing it directly to the result vector, bypassing partition column
extraction. Empty frames and out-of-range offsets still correctly produce null.
IGNORE NULLS with a constant null value returns null for all rows.

Note: Even with constant arguments, the window function cannot be constant-folded
away entirely because the result depends on frame boundaries — empty frames and
out-of-range offsets produce null regardless of the constant value.

Differential Revision: D98096044


