### PR TITLE
fix: CURL resource leak in PrestoQueryRunner on timeout

### DIFF
--- a/velox/exec/fuzzer/PrestoQueryRunner.cpp
+++ b/velox/exec/fuzzer/PrestoQueryRunner.cpp
@@ -542,16 +542,18 @@ std::string PrestoQueryRunner::startQuery(
 
   // Perform the request
   CURLcode res = curl_easy_perform(curl);
+
+  // Clean up CURL resources before checking the result to avoid leaks on
+  // error.
+  curl_slist_free_all(headers);
+  curl_easy_cleanup(curl);
+
   VELOX_CHECK_EQ(
       CURLE_OK,
       res,
       "POST to {} failed: {}",
       coordinatorUri_,
       curl_easy_strerror(res));
-
-  // Cleanup
-  curl_slist_free_all(headers);
-  curl_easy_cleanup(curl);
 
   return response;
 }
@@ -577,12 +579,14 @@ std::string PrestoQueryRunner::fetchNext(const std::string& nextUri) {
 
   // Perform GET request
   CURLcode res = curl_easy_perform(curl);
-  VELOX_CHECK_EQ(
-      CURLE_OK, res, "Get request failed: {}", curl_easy_strerror(res));
 
-  // Cleanup
+  // Clean up CURL resources before checking the result to avoid leaks on
+  // error.
   curl_slist_free_all(headers);
   curl_easy_cleanup(curl);
+
+  VELOX_CHECK_EQ(
+      CURLE_OK, res, "Get request failed: {}", curl_easy_strerror(res));
 
   return response;
 }


### PR DESCRIPTION
Summary:
Both startQuery() and fetchNext() in PrestoQueryRunner leak CURL handles
and header lists when a request fails. The cleanup calls (curl_slist_free_all
and curl_easy_cleanup) are placed after the VELOX_CHECK_EQ that throws on
error, so they are never reached on failure.

Move CURL resource cleanup before the error check so resources are always
freed regardless of whether the request succeeded or failed.

Differential Revision: D98130632


