### PR TITLE
fix: Resolve null literal in array_split_into_chunks via generic registration

### DIFF
--- a/velox/functions/prestosql/registration/ArraySplitIntoChunksRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArraySplitIntoChunksRegistration.cpp
@@ -30,18 +30,6 @@ inline void registerArraySplitIntoChunksFunctions(const std::string& prefix) {
 
 } // namespace
 void registerArraySplitIntoChunksFunctions(const std::string& prefix) {
-  registerArraySplitIntoChunksFunctions<int8_t>(prefix);
-  registerArraySplitIntoChunksFunctions<int16_t>(prefix);
-  registerArraySplitIntoChunksFunctions<int32_t>(prefix);
-  registerArraySplitIntoChunksFunctions<int64_t>(prefix);
-  registerArraySplitIntoChunksFunctions<int128_t>(prefix);
-  registerArraySplitIntoChunksFunctions<float>(prefix);
-  registerArraySplitIntoChunksFunctions<double>(prefix);
-  registerArraySplitIntoChunksFunctions<bool>(prefix);
-  registerArraySplitIntoChunksFunctions<Timestamp>(prefix);
-  registerArraySplitIntoChunksFunctions<Date>(prefix);
-  registerArraySplitIntoChunksFunctions<Varchar>(prefix);
-  registerArraySplitIntoChunksFunctions<Varbinary>(prefix);
   registerArraySplitIntoChunksFunctions<Generic<T1>>(prefix);
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ArraySplitIntoChunksTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySplitIntoChunksTest.cpp
@@ -136,6 +136,28 @@ TEST_F(ArraySplitIntoChunksTest, tooManyChunks) {
           "array_split_into_chunks(c0, 1::INTEGER)", makeRowVector({input})),
       "Cannot split array of size: 12001 into more than 10000 parts.");
 }
+TEST_F(ArraySplitIntoChunksTest, shortDecimal) {
+  auto input = makeNullableArrayVector<int64_t>(
+      {{100, 200, 300, 400, 500}}, ARRAY(DECIMAL(10, 3)));
+  auto result = evaluate(
+      "array_split_into_chunks(c0, 2::INTEGER)", makeRowVector({input}));
+  auto innerArray = makeNullableArrayVector<int64_t>(
+      {{100, 200}, {300, 400}, {500}}, ARRAY(DECIMAL(10, 3)));
+  auto expected = makeArrayVector({0}, innerArray);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(ArraySplitIntoChunksTest, longDecimal) {
+  auto input = makeNullableArrayVector<int128_t>(
+      {{1, 2, 3, 4, 5}}, ARRAY(DECIMAL(38, 10)));
+  auto result = evaluate(
+      "array_split_into_chunks(c0, 2::INTEGER)", makeRowVector({input}));
+  auto innerArray = makeNullableArrayVector<int128_t>(
+      {{1, 2}, {3, 4}, {5}}, ARRAY(DECIMAL(38, 10)));
+  auto expected = makeArrayVector({0}, innerArray);
+  assertEqualVectors(expected, result);
+}
+
 } // namespace
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Fixes:  https://github.com/prestodb/presto/issues/27429


 ## Summary                                
 Sidecar overload resolution fails on `array_split_into_chunks(null, 2)`:
                                                                                                                                                            
  ```                                                             
  Could not choose a best candidate operator. Explicit type casts must be added.                                                                            
  Candidates are:                                                                                                                                           
    * native.default.array_split_into_chunks(array(double),integer):...                                                                                     
    * native.default.array_split_into_chunks(array(real),integer):...                                                                                       
    ... (12 total)                                                                                                                                          
  ```                                                                                                                                                             
                                                                                                                                  
                                                                  
  - Collapse the 12 per-type registrations into a single                                                                                                    
    `registerArraySplitIntoChunksFunctions<Generic<T1>>(prefix)`. A generic
    registration lets the null literal resolve unambiguously and covers                                                                                     
    all element types.                                                                                                                 
                                                                                                                       
                                                                                                                                                                                                                                                    
  ## Expected CI failures (not blockers)                                                                                                                    
  - **Signature Changes**: flags the 12 removed per-type signatures.                                                                                        
    This is the intended change — `Generic<T1>` replaces them. Please                                                                                       
    acknowledge on the PR.                                                                                                                                  
