### PR TITLE
feat(hive): Add runtime stats to HiveIndexSource and FileIndexReader (#16926)

### DIFF
--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/FileIndexReader.h"
 
 #include "velox/common/Casts.h"
+#include "velox/common/time/Timer.h"
 #include "velox/connectors/hive/BufferedInputBuilder.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
@@ -311,13 +312,20 @@ void FileIndexReader::startLookup(
   VELOX_CHECK_NOT_NULL(request.input);
   VELOX_CHECK(requestType_->equivalent(*request.input->type()));
 
-  // Use caller-provided maxRowsPerRequest if set, otherwise fall back to
-  // the construction-time default.
-  const auto maxRows = options.maxRowsPerRequest != 0
-      ? options.maxRowsPerRequest
-      : static_cast<vector_size_t>(maxRowsPerRequest_);
-  auto indexBounds = buildRequestIndexBounds(request.input);
-  indexReader_->startLookup(indexBounds, {.maxRowsPerRequest = maxRows});
+  ++numIndexLookupRequests_;
+
+  uint64_t lookupTimeNs{0};
+  {
+    NanosecondTimer timer(&lookupTimeNs);
+    // Use caller-provided maxRowsPerRequest if set, otherwise fall back to
+    // the construction-time default.
+    const auto maxRows = options.maxRowsPerRequest != 0
+        ? options.maxRowsPerRequest
+        : static_cast<vector_size_t>(maxRowsPerRequest_);
+    auto indexBounds = buildRequestIndexBounds(request.input);
+    indexReader_->startLookup(indexBounds, {.maxRowsPerRequest = maxRows});
+  }
+  indexLookupTimeNs_ += lookupTimeNs;
 }
 
 serializer::IndexBounds FileIndexReader::buildRequestIndexBounds(
@@ -406,13 +414,39 @@ bool FileIndexReader::hasNext() {
 
 std::unique_ptr<FileIndexReader::Result> FileIndexReader::next(
     vector_size_t maxOutputRows) {
-  return indexReader_->next(maxOutputRows);
+  uint64_t readTimeNs{0};
+  std::unique_ptr<Result> result;
+  {
+    NanosecondTimer timer(&readTimeNs);
+    result = indexReader_->next(maxOutputRows);
+  }
+  indexReadTimeNs_ += readTimeNs;
+  if (result != nullptr) {
+    numIndexOutputRows_ += result->size();
+  }
+  return result;
 }
 
 std::unordered_map<std::string, RuntimeMetric> FileIndexReader::runtimeStats() {
-  // TODO: Populate with format-specific stats in a follow-up.
-  // File-based IO stats are tracked externally via IoStatistics.
-  return {};
+  std::unordered_map<std::string, RuntimeMetric> stats;
+  if (numIndexLookupRequests_ != 0) {
+    stats[std::string(kNumFileIndexLookupRequests)] = RuntimeMetric(
+        static_cast<int64_t>(numIndexLookupRequests_),
+        RuntimeCounter::Unit::kNone);
+  }
+  if (numIndexOutputRows_ != 0) {
+    stats[std::string(kNumIndexOutputRows)] = RuntimeMetric(
+        static_cast<int64_t>(numIndexOutputRows_), RuntimeCounter::Unit::kNone);
+  }
+  if (indexLookupTimeNs_ != 0) {
+    stats[std::string(kIndexLookupWallNanos)] = RuntimeMetric(
+        static_cast<int64_t>(indexLookupTimeNs_), RuntimeCounter::Unit::kNanos);
+  }
+  if (indexReadTimeNs_ != 0) {
+    stats[std::string(kIndexReadWallNanos)] = RuntimeMetric(
+        static_cast<int64_t>(indexReadTimeNs_), RuntimeCounter::Unit::kNanos);
+  }
+  return stats;
 }
 
 std::string FileIndexReader::toString() const {

--- a/velox/connectors/hive/FileIndexReader.h
+++ b/velox/connectors/hive/FileIndexReader.h
@@ -92,6 +92,18 @@ class FileIndexReader : public SplitIndexReader {
 
   std::string toString() const;
 
+  /// Wall time spent setting up index bounds and initiating lookup.
+  static constexpr std::string_view kIndexLookupWallNanos{
+      "fileIndexLookupWallNanos"};
+  /// Wall time spent reading index results via next().
+  static constexpr std::string_view kIndexReadWallNanos{
+      "fileIndexReadWallNanos"};
+  /// The number of startLookup() calls made to the format-specific IndexReader.
+  static constexpr std::string_view kNumFileIndexLookupRequests{
+      "numFileIndexLookupRequests"};
+  /// The total number of output rows returned across all next() calls.
+  static constexpr std::string_view kNumIndexOutputRows{"numIndexOutputRows"};
+
  private:
   // Creates the file reader for reading file metadata and schema.
   std::unique_ptr<dwio::common::Reader> createFileReader();
@@ -148,6 +160,12 @@ class FileIndexReader : public SplitIndexReader {
   // Reusable column vectors for building index bounds.
   std::vector<VectorPtr> lowerBoundColumns_;
   std::vector<VectorPtr> upperBoundColumns_;
+
+  // Performance counters for runtime stats.
+  uint64_t indexLookupTimeNs_{0};
+  uint64_t indexReadTimeNs_{0};
+  uint64_t numIndexLookupRequests_{0};
+  uint64_t numIndexOutputRows_{0};
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -20,6 +20,7 @@
 #include "velox/connectors/hive/FileIndexReader.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
+#include "velox/exec/IndexLookupJoin.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/vector/LazyVector.h"
@@ -456,17 +457,29 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
       return nullptr;
     }
 
+    IterationStats iterationStats;
+    std::optional<std::unique_ptr<IndexSource::Result>> result;
+
     // Initialize lookup on first call.
     if (state_ == State::kInit) {
-      indexReader_->startLookup(request_, options_);
+      {
+        NanosecondTimer timer(&iterationStats.lookupTimeNs);
+        indexReader_->startLookup(request_, options_);
+      }
       setState(State::kRead);
     }
 
     if (!indexReader_->hasNext()) {
       setState(State::kEnd);
+    } else {
+      result = getOutput(size, iterationStats);
+    }
+
+    indexSource_->recordIterationStats(iterationStats);
+    if (state_ == State::kEnd && !result.has_value()) {
       return nullptr;
     }
-    return getOutput(size);
+    return result;
   }
 
  private:
@@ -523,25 +536,37 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
     }
   }
 
-  std::unique_ptr<IndexSource::Result> getOutput(vector_size_t size) {
-    auto result = indexReader_->next(size);
+  std::unique_ptr<IndexSource::Result> getOutput(
+      vector_size_t size,
+      IterationStats& iterationStats) {
+    std::unique_ptr<IndexSource::Result> result;
+    {
+      NanosecondTimer timer(&iterationStats.nextTimeNs);
+      result = indexReader_->next(size);
+    }
     if (result == nullptr) {
       VELOX_CHECK(!indexReader_->hasNext());
       setState(State::kEnd);
       return nullptr;
     }
     if (indexSource_->remainingFilterExprSet_ == nullptr) {
+      CpuWallTimer timer(iterationStats.outputTiming);
       result->output = indexSource_->projectOutput(
           result->output->size(), nullptr, result->output);
       return result;
     }
-    return evaluateRemainingFilter(std::move(result));
+    return evaluateRemainingFilter(std::move(result), iterationStats);
   }
 
   std::unique_ptr<IndexSource::Result> evaluateRemainingFilter(
-      std::unique_ptr<IndexSource::Result> result) {
+      std::unique_ptr<IndexSource::Result> result,
+      IterationStats& iterationStats) {
     auto& output = result->output;
-    const auto numRemainingRows = indexSource_->evaluateRemainingFilter(output);
+    vector_size_t numRemainingRows;
+    {
+      NanosecondTimer timer(&iterationStats.postFilterTimeNs);
+      numRemainingRows = indexSource_->evaluateRemainingFilter(output);
+    }
 
     if (numRemainingRows == 0) {
       return getEmptyResult();
@@ -556,8 +581,11 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
           result->inputHits,
           indexSource_->pool_);
     }
-    output =
-        indexSource_->projectOutput(numRemainingRows, remainingIndices, output);
+    {
+      CpuWallTimer timer(iterationStats.outputTiming);
+      output = indexSource_->projectOutput(
+          numRemainingRows, remainingIndices, output);
+    }
     return result;
   }
 
@@ -909,11 +937,14 @@ HiveIndexSource::createUnionLookupIterator(
 }
 
 std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
-  std::unordered_map<std::string, RuntimeMetric> stats;
+  // Start with accumulated per-call timing stats.
+  auto stats = runtimeStats_;
+
   if (remainingFilterTimeNs_ != 0) {
     stats[std::string(Connector::kTotalRemainingFilterTime)] =
         RuntimeMetric(remainingFilterTimeNs_, RuntimeCounter::Unit::kNanos);
   }
+
   // Merge stats from all readers.
   for (auto& reader : readers_) {
     for (auto& [key, metric] : reader->runtimeStats()) {
@@ -926,6 +957,28 @@ std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
     }
   }
   return stats;
+}
+
+void HiveIndexSource::recordIterationStats(
+    const IterationStats& iterationStats) {
+  const auto totalTimeNs = iterationStats.lookupTimeNs +
+      iterationStats.nextTimeNs + iterationStats.outputTiming.wallNanos +
+      iterationStats.postFilterTimeNs;
+  if (totalTimeNs != 0) {
+    exec::addOperatorRuntimeStats(
+        exec::IndexLookupJoin::kConnectorLookupWallTime,
+        RuntimeCounter(
+            static_cast<int64_t>(totalTimeNs), RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.outputTiming.cpuNanos != 0) {
+    exec::addOperatorRuntimeStats(
+        exec::IndexLookupJoin::kConnectorResultPrepareTime,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.outputTiming.cpuNanos),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
 }
 
 vector_size_t HiveIndexSource::evaluateRemainingFilter(

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -18,6 +18,7 @@
 #include <folly/Executor.h>
 #include <folly/container/F14Map.h>
 #include "velox/common/io/IoStatistics.h"
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
@@ -32,6 +33,20 @@
 namespace facebook::velox::connector::hive {
 
 class HiveConfig;
+
+/// Captures per-iteration timing breakdown for index lookups.
+struct IterationStats {
+  /// Wall time spent in indexReader_->startLookup() for this iteration.
+  uint64_t lookupTimeNs{0};
+  /// Wall time spent in indexReader_->next() for this iteration.
+  uint64_t nextTimeNs{0};
+  /// Time spent projecting the output columns for this iteration. Uses
+  /// CpuWallTiming to capture both wall and CPU time, since the downstream stat
+  /// (kConnectorResultPrepareTime) reports CPU nanos.
+  CpuWallTiming outputTiming;
+  /// Wall time spent evaluating the remaining filter for this iteration.
+  uint64_t postFilterTimeNs{0};
+};
 
 /// Provides index lookup for Hive-metastore-backed tables.
 ///
@@ -125,6 +140,10 @@ class HiveIndexSource : public IndexSource,
   // Creates a FileIndexReader for a single split.
   void createFileIndexReader(std::shared_ptr<const HiveConnectorSplit> split);
 
+  // Records per-iteration timing breakdown using addOperatorRuntimeStats to
+  // preserve per-call count/min/max granularity.
+  void recordIterationStats(const IterationStats& iterationStats);
+
   FileHandleFactory* const fileHandleFactory_;
   ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<HiveConfig> hiveConfig_;
@@ -183,6 +202,9 @@ class HiveIndexSource : public IndexSource,
 
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
+
+  // Per-call timing stats accumulated via addOperatorRuntimeStats().
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -197,6 +197,9 @@ These stats are reported only by IndexLookupJoin operator
    * - clientNumLazyDecodedResultBatches
      -
      - The number of lazy decoded result batches returned from the storage client.
+   * - numIndexSplits
+     -
+     - The number of index splits provided for index lookup.
 
 Merge
 -----

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -666,6 +666,14 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
     if (!split.hasConnectorSplit()) {
       noMoreIndexSplits_ = true;
       VELOX_CHECK(!indexSplits_.empty());
+      {
+        auto lockedStats = stats_.wlock();
+        lockedStats->addRuntimeStat(
+            kNumIndexSplits,
+            RuntimeCounter(
+                static_cast<int64_t>(indexSplits_.size()),
+                RuntimeCounter::Unit::kNone));
+      }
       indexSource_->addSplits(std::move(indexSplits_));
       return true;
     }

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -81,6 +81,8 @@ class IndexLookupJoin : public Operator {
   /// The number of lookup results received from remote storage with error.
   static constexpr std::string_view kClientNumErrorResults{
       "clientNumErrorResults"};
+  /// The number of index splits provided for index lookup.
+  static constexpr std::string_view kNumIndexSplits{"numIndexSplits"};
 
  private:
   using ResultIterator = connector::IndexSource::ResultIterator;


### PR DESCRIPTION
Summary:

Adds performance metrics to the index lookup pipeline:
- HiveIndexSource reports end-to-end iteration time (kConnectorLookupWallTime) and output projection time (kConnectorResultPrepareTime) using addOperatorRuntimeStats() for per-call granularity
- FileIndexReader reports per-file lookup setup time, read I/O time, request count, and output row count
- Adds kNumIndexSplits to IndexLookupJoin operator for split count tracking
- Stats already tracked by IndexLookupJoin (numLookups, numOutputRows) are not duplicated

Reviewed By: kewang1024

Differential Revision: D98183179


