### PR TITLE
feat: Add ConcatExpr to IExpr hierarchy (#16927)

### DIFF
--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -159,4 +159,34 @@ std::string LambdaExpr::toString() const {
   return out.str();
 }
 
+std::string ConcatExpr::toString() const {
+  std::ostringstream out;
+  out << "row(";
+  for (size_t i = 0; i < inputs().size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << inputs()[i]->toString() << " as " << fieldNames_[i];
+  }
+  out << ")";
+  return appendAliasIfExists(out.str());
+}
+
+bool ConcatExpr::operator==(const IExpr& other) const {
+  if (!other.is(Kind::kConcat)) {
+    return false;
+  }
+  auto* otherConcat = other.as<ConcatExpr>();
+  return fieldNames_ == otherConcat->fieldNames_ &&
+      compareAliasAndInputs(other);
+}
+
+size_t ConcatExpr::localHash() const {
+  size_t hash = 0;
+  for (const auto& name : fieldNames_) {
+    hash = bits::hashMix(hash, std::hash<std::string>{}(name));
+  }
+  return hash;
+}
+
 } // namespace facebook::velox::core

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -271,4 +271,36 @@ class LambdaExpr : public IExpr,
   const ExprPtr body_;
 };
 
+/// Named ROW constructor. Carries field names alongside child expressions
+/// through the unresolved expression tree.
+class ConcatExpr : public IExpr {
+ public:
+  ConcatExpr(std::vector<std::string> fieldNames, std::vector<ExprPtr> inputs)
+      : IExpr(IExpr::Kind::kConcat, std::move(inputs)),
+        fieldNames_(std::move(fieldNames)) {
+    VELOX_CHECK_EQ(fieldNames_.size(), this->inputs().size());
+  }
+
+  const std::vector<std::string>& fieldNames() const {
+    return fieldNames_;
+  }
+
+  std::string toString() const override;
+
+  ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const override {
+    return std::make_shared<ConcatExpr>(fieldNames_, std::move(newInputs));
+  }
+
+  ExprPtr dropAlias() const override {
+    return std::make_shared<ConcatExpr>(fieldNames_, inputs());
+  }
+
+  bool operator==(const IExpr& other) const override;
+
+  size_t localHash() const override;
+
+ private:
+  const std::vector<std::string> fieldNames_;
+};
+
 } // namespace facebook::velox::core

--- a/velox/parse/IExpr.h
+++ b/velox/parse/IExpr.h
@@ -42,6 +42,7 @@ class IExpr {
     kConstant = 4,
     kLambda = 5,
     kSubquery = 6,
+    kConcat = 7,
   };
 
   VELOX_DECLARE_EMBEDDED_ENUM_NAME(Kind)


### PR DESCRIPTION
Summary:

Add ConcatExpr, a named ROW constructor expression that carries field
names alongside child expressions. Also add kConcat to IExpr::Kind.

This enables SQL dialects to represent ROW(expr AS name, ...) syntax
in the unresolved expression tree before type resolution.

Differential Revision: D98227805
