### PR TITLE
 feat(remote): Serialize only active rows, add null/determinism support, improve errors

### DIFF
--- a/velox/docs/designs/remote-function-enhancements.md
+++ b/velox/docs/designs/remote-function-enhancements.md
@@ -1,0 +1,259 @@
+# Remote Function Execution Enhancements
+
+*2026-03-14*
+
+## Motivation
+
+Velox supports remote function execution ([#5288][issue]) — a framework that
+allows scalar functions to be evaluated in a separate process via Thrift RPC.
+This enables language interoperability (e.g., calling Java SparkSQL functions
+from C++ Velox), process isolation, and resource separation.
+
+The core framework (client, server, Thrift IDL, serialization) was delivered
+in [#4595][pr4595] with subsequent improvements for Unix domain sockets
+([#5482][pr5482]), named serializers ([#5370][pr5370]), and open-source build
+([#5730][pr5730]).
+
+Several items remain open from the original issue:
+
+1. **Active-row serialization** — Currently, all rows in a batch are serialized
+   and sent to the remote server, even when only a subset is selected (e.g.,
+   inside an `IF` or `CASE WHEN`). This wastes network bandwidth and server
+   compute.
+
+2. **Non-deterministic and non-default null behavior** — The metadata fields
+   `deterministic` and `defaultNullBehavior` are inherited but have no test
+   coverage, making it unclear whether they work correctly with remote
+   functions.
+
+3. **Error re-throwing semantics** — Remote errors are deserialized and
+   re-thrown as `std::runtime_error`, losing the `VeloxUserError` type that
+   callers expect. A stale TODO in the Thrift IDL suggests the error format
+   was never finalized.
+
+This design document describes the approach for addressing all three items.
+
+[issue]: https://github.com/facebookincubator/velox/issues/5288
+[pr4595]: https://github.com/facebookincubator/velox/pull/4595
+[pr5482]: https://github.com/facebookincubator/velox/pull/5482
+[pr5370]: https://github.com/facebookincubator/velox/pull/5370
+[pr5730]: https://github.com/facebookincubator/velox/pull/5730
+
+## Background
+
+### Current Architecture
+
+```
+Client (RemoteVectorFunction)           Server (RemoteFunctionServiceHandler)
+─────────────────────────────           ─────────────────────────────────────
+1. Wrap args into RowVector              1. Deserialize RowVector from IOBuf
+2. Serialize RowVector → IOBuf           2. Build ExprSet with CallTypedExpr
+3. Build RemoteFunctionRequest           3. Evaluate expression
+4. Thrift RPC ──────────────────────>    4. Serialize result RowVector → IOBuf
+5. Deserialize result IOBuf          <── 5. Return RemoteFunctionResponse
+6. Extract result vector                 6. (Optional) Serialize error payload
+```
+
+### Key Types
+
+| Type | Location | Purpose |
+|------|----------|---------|
+| `RemoteVectorFunction` | `client/RemoteVectorFunction.h` | Abstract base; serializes input, invokes remote, deserializes output |
+| `RemoteThriftFunction` | `client/Remote.cpp` | Concrete subclass adding Thrift transport |
+| `RemoteVectorFunctionMetadata` | `client/RemoteVectorFunction.h` | Extends `VectorFunctionMetadata` with `serdeFormat`, `preserveEncoding` |
+| `RemoteFunctionServiceHandler` | `server/RemoteFunctionService.h` | Thrift service handler; evaluates functions via `ExprSet` |
+| `PageFormat` | `if/RemoteFunction.thrift` | Enum: `PRESTO_PAGE` or `SPARK_UNSAFE_ROW` |
+
+### Serialization Path
+
+Both `rowVectorToIOBuf()` and `rowVectorToIOBufBatch()` accept an `IndexRange`
+parameter specifying which rows to serialize. Currently, the client always
+passes `{0, rows.end()}` — the full batch.
+
+The serializer APIs (`IterativeVectorSerializer::append()` and
+`BatchVectorSerializer::serialize()`) natively support
+`folly::Range<const IndexRange*>`, allowing non-contiguous row ranges in a
+single call.
+
+## Design
+
+### 1. Active-Row Serialization
+
+**Problem**: When a remote function is called inside a conditional expression
+(e.g., `IF(c0 > 2, remote_fn(c0), c0)`), the expression engine passes a
+`SelectivityVector` indicating which rows are active. The current
+implementation ignores this and serializes all rows.
+
+**Approach**: Convert the `SelectivityVector` into contiguous `IndexRange`
+runs and pass them to the serialization API.
+
+#### Client-Side Changes (`RemoteVectorFunction.cpp`)
+
+**Serialization phase**:
+
+```cpp
+// Convert SelectivityVector to IndexRange runs.
+std::vector<IndexRange> activeRanges = toIndexRanges(rows);
+auto rangesView = folly::Range<const IndexRange*>(
+    activeRanges.data(), activeRanges.size());
+
+// Serialize using the ranges.
+streamGroup->append(remoteRowVector, rangesView, scratch);
+```
+
+The helper `toIndexRanges()` iterates set bits via `bits::forEachSetBit()`
+and merges contiguous positions into `{begin, size}` pairs. For example,
+a `SelectivityVector` with bits `{0, 0, 1, 1, 1}` produces
+`[{begin=2, size=3}]`.
+
+**Row count**: `requestInputs->rowCount()` is set to the number of *selected*
+rows (sum of range sizes), not the full batch size.
+
+**Deserialization phase**: The server returns a compacted result with N' rows
+(where N' <= N). The client must scatter these back to original positions:
+
+```cpp
+if (!allSelected) {
+  auto fullResult = BaseVector::create(outputType, rows.end(), pool);
+  vector_size_t compactIdx = 0;
+  rows.applyToSelected([&](vector_size_t origRow) {
+    fullResult->copy(compactedResult.get(), origRow, compactIdx, 1);
+    ++compactIdx;
+  });
+  result = fullResult;
+}
+```
+
+**Error mapping**: When `throwOnError` is false and the server returns an error
+payload, error indices are similarly mapped from compacted to original
+positions using the same `applyToSelected` iteration.
+
+**Fast path**: When `rows.isAllSelected()`, the existing single-range path is
+used with no scatter overhead.
+
+#### Server-Side Changes
+
+None required. The server receives fewer rows, evaluates them, and returns a
+correspondingly smaller result. The `rowCount` field correctly reflects the
+compacted count.
+
+#### Performance Characteristics
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| All rows selected | Serialize N rows | Same (fast path) |
+| K of N rows selected | Serialize N rows | Serialize K rows |
+| Scatter overhead | None | O(K) copies |
+
+The net effect is positive whenever K < N, which is the common case for
+conditional expressions.
+
+### 2. Non-Deterministic and Non-Default Null Behavior
+
+**Problem**: `RemoteVectorFunctionMetadata` inherits `deterministic` and
+`defaultNullBehavior` from `VectorFunctionMetadata`, and
+`registerRemoteFunction()` passes the metadata through to
+`registerStatefulVectorFunction()`. The plumbing works, but there is no test
+coverage.
+
+**Approach**: No production code changes needed. The fix is purely test
+coverage:
+
+- **`nonDefaultNullBehavior` test**: Register a server-side function
+  (`NullableDoubleFunction`) that uses `callNullable` to handle null inputs
+  explicitly (returns -1 for null, doubles the value otherwise). Register the
+  remote wrapper with `metadata.defaultNullBehavior = false`. Verify that null
+  inputs produce the sentinel value, not null.
+
+- **`nonDeterministic` test**: Register a remote function with
+  `metadata.deterministic = false`. Verify correct execution (smoke test,
+  since determinism is an optimizer hint).
+
+### 3. Error Re-Throwing Semantics
+
+**Problem**: When `throwOnError` is false and the server captures errors,
+they are serialized as VARCHAR strings in `errorPayload`. On the client side,
+these are re-thrown as `std::runtime_error`:
+
+```cpp
+// Before:
+throw std::runtime_error(std::string(errorsVector->valueAt(i)));
+```
+
+This loses the `VeloxUserError` type, which callers (e.g., `TRY()`) may
+depend on for proper error classification.
+
+**Approach**: Use `VELOX_USER_FAIL` instead:
+
+```cpp
+// After:
+VELOX_USER_FAIL("{}", errorsVector->valueAt(i));
+```
+
+This produces a `VeloxUserError` with proper error code and type, consistent
+with how other Velox functions report user-facing errors.
+
+Additionally, the stale TODO comment in `RemoteFunction.thrift` (which
+suggests the error format needs to be defined) is replaced with documentation
+describing the implemented behavior.
+
+**Future work**: For full fidelity, structured error propagation could carry
+the original error code, type, file, and line from the server. This would
+require a new Thrift struct and is deferred as a separate effort. The current
+string-based approach is sufficient for the `TRY()` use case.
+
+## Alternatives Considered
+
+### Active-Row Serialization
+
+**Alternative A: Row-indices-based serialization** — Instead of `IndexRange`
+runs, pass individual row indices via `append(vector, rows, scratch)`. This
+was rejected because the `IterativeVectorSerializer` base class returns
+`VELOX_UNSUPPORTED` for this overload, meaning not all serde implementations
+support it.
+
+**Alternative B: Copy selected rows into a compact vector, then serialize** —
+Create a new RowVector containing only the selected rows, then serialize it
+as a single contiguous range. This was rejected because it requires an
+extra copy step and additional memory allocation, while the `IndexRange`
+approach achieves the same result with zero-copy.
+
+### Error Re-Throwing
+
+**Alternative: Structured error Thrift struct** — Define a new Thrift struct
+carrying error code, type, message, file, and line. This provides full
+error fidelity but adds complexity to the Thrift IDL and both client/server
+implementations. Deferred to a future change since the string-based approach
+works for current use cases.
+
+## Testing
+
+### New Test Cases
+
+| Test | Fixture | Description |
+|------|---------|-------------|
+| `nonDefaultNullBehavior` | `RemoteFunctionTest` (parameterized) | Nullable inputs with `defaultNullBehavior=false` |
+| `nonDeterministic` | `RemoteFunctionTest` (parameterized) | Smoke test with `deterministic=false` |
+| `partialSelection` | `RemoteFunctionTest` (parameterized) | End-to-end with `if(c0 > 2, remote_plus(...), c0)` |
+| `activeRowsSerialization` | `MockRemoteFunctionTest` | Verifies request `rowCount` matches selected rows |
+
+All parameterized tests run with both `PRESTO_PAGE` and `SPARK_UNSAFE_ROW`
+serialization formats.
+
+### Verification
+
+```bash
+cmake -B _build/debug -DCMAKE_BUILD_TYPE=Debug -DVELOX_ENABLE_REMOTE_FUNCTIONS=ON
+cmake --build _build/debug --target velox_functions_remote_test
+cd _build/debug && ctest -R RemoteFunctionTest
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `velox/functions/remote/client/RemoteVectorFunction.cpp` | Active-row serialization, scatter, error re-throw |
+| `velox/functions/remote/client/tests/RemoteFunctionTest.cpp` | 4 new tests, `NullableDoubleFunction` UDF |
+| `velox/functions/remote/if/RemoteFunction.thrift` | Replace stale TODO with accurate docs |
+| `velox/docs/develop/remote-functions.rst` | New developer documentation |
+| `velox/docs/develop.rst` | Toctree entry for new doc |

--- a/velox/docs/develop.rst
+++ b/velox/docs/develop.rst
@@ -10,6 +10,7 @@ This guide is intended for Velox contributors and developers of Velox-based appl
     develop/types
     develop/vectors
     develop/scalar-functions
+    develop/remote-functions
     develop/aggregate-functions
     develop/view-and-writer-types
     develop/lambda-functions

--- a/velox/docs/develop/remote-functions.rst
+++ b/velox/docs/develop/remote-functions.rst
@@ -1,0 +1,203 @@
+================
+Remote Functions
+================
+
+Overview
+--------
+
+Remote functions allow Velox to execute scalar functions in a separate process,
+enabling language interoperability, process isolation, and resource separation.
+A remote function is a :doc:`VectorFunction </develop/scalar-functions>` that
+serializes its input batch, sends it to a remote server via Thrift RPC, and
+deserializes the result.
+
+This is useful when:
+
+- UDFs are written in a different language (e.g., Java SparkSQL functions
+  called from a C++ Velox client).
+- Functions need process isolation for security or resource management.
+- Functions depend on libraries that cannot be linked into the Velox process.
+
+Architecture
+------------
+
+The remote function framework consists of a client-side proxy (registered as a
+regular Velox vector function) and a server-side handler that evaluates the
+actual function.
+
+.. code-block:: text
+
+    Client                              Server
+    ------                              ------
+    registerRemoteFunction()            Functions registered locally
+           |                                  |
+    RemoteVectorFunction.apply()        RemoteFunctionServiceHandler
+           |                                  |
+    RowVector -> serialize -> IOBuf     IOBuf -> deserialize -> RowVector
+           |                                  |
+    Thrift RPC  ---------------------->  ExprSet.eval()
+           |                                  |
+    IOBuf -> deserialize  <-----------  RowVector -> serialize -> IOBuf
+
+**Serialization formats**: Two formats are supported via the ``PageFormat`` enum:
+
+- ``PRESTO_PAGE`` — Uses ``PrestoVectorSerde``. Supports encoding
+  preservation. Recommended for Presto-based systems.
+- ``SPARK_UNSAFE_ROW`` — Uses ``UnsafeRowVectorSerde``. Compatible with
+  Spark's internal row format.
+
+Only active (selected) rows are serialized, reducing network and server
+overhead when the function is called within conditional expressions.
+
+Registering Remote Functions
+----------------------------
+
+Use ``registerRemoteFunction()`` to register a remote function as a standard
+Velox vector function:
+
+.. code-block:: c++
+
+    #include "velox/functions/remote/client/Remote.h"
+
+    RemoteThriftVectorFunctionMetadata metadata;
+    metadata.location = folly::SocketAddress::makeFromPath("/tmp/remote.socket");
+    metadata.serdeFormat = remote::PageFormat::PRESTO_PAGE;
+
+    auto signatures = {exec::FunctionSignatureBuilder()
+                           .returnType("bigint")
+                           .argumentType("bigint")
+                           .argumentType("bigint")
+                           .build()};
+
+    registerRemoteFunction("my_remote_add", signatures, metadata);
+
+After registration, ``my_remote_add`` can be used in expressions just like any
+other Velox function.
+
+Configuration
+~~~~~~~~~~~~~
+
+``RemoteThriftVectorFunctionMetadata`` extends ``RemoteVectorFunctionMetadata``
+(which extends ``VectorFunctionMetadata``) and provides the following options:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field
+     - Default
+     - Description
+   * - ``location``
+     - (none)
+     - ``folly::SocketAddress`` of the remote server. Supports IP:port or Unix
+       domain sockets (via ``SocketAddress::makeFromPath()``).
+   * - ``serdeFormat``
+     - ``PRESTO_PAGE``
+     - Serialization format for input/output data.
+   * - ``preserveEncoding``
+     - ``false``
+     - Whether to preserve vector encodings (e.g., dictionary) during
+       serialization. Only effective with ``PRESTO_PAGE``.
+   * - ``deterministic``
+     - ``true``
+     - Whether the function is deterministic. Set to ``false`` for functions
+       like ``random()`` or ``uuid()``.
+   * - ``defaultNullBehavior``
+     - ``true``
+     - When ``true``, null inputs automatically produce null output without
+       calling the remote function. Set to ``false`` if the remote function
+       needs to handle nulls explicitly.
+   * - ``clientFactory``
+     - (none)
+     - Optional factory for custom ``IRemoteFunctionClient`` implementations.
+       Useful for dependency injection in tests.
+
+Server Implementation
+---------------------
+
+The server-side handler ``RemoteFunctionServiceHandler`` receives Thrift
+requests, deserializes input, evaluates the function using Velox's expression
+engine, and returns serialized results.
+
+.. code-block:: c++
+
+    #include "velox/functions/remote/server/RemoteFunctionService.h"
+
+    // Create handler with an optional function name prefix.
+    auto handler = std::make_shared<RemoteFunctionServiceHandler>(
+        "my_prefix");
+
+    // Set up and start the Thrift server.
+    auto server = std::make_shared<ThriftServer>();
+    server->setInterface(handler);
+    server->setAddress(folly::SocketAddress::makeFromPath("/tmp/remote.socket"));
+    server->serve();
+
+**Function prefix**: The server prepends an optional prefix to the function
+name before looking it up in the local registry. This allows the same process
+to host both the remote proxy and the actual implementation (useful for
+testing). For example, with prefix ``"my_prefix"``, a request for function
+``"add"`` resolves to ``"my_prefix.add"`` on the server.
+
+Error Handling
+--------------
+
+The ``throwOnError`` flag in the request controls error behavior:
+
+- **When true** (default): Exceptions from the remote function propagate
+  directly to the caller.
+- **When false** (e.g., inside a ``TRY()`` expression): The server captures
+  errors per row and serializes them as VARCHAR strings in an error payload.
+  The client deserializes these errors and reports them per-row via
+  ``EvalCtx::setError()``, allowing ``TRY()`` to convert them to nulls.
+
+Testing with Mock Clients
+-------------------------
+
+The ``RemoteFunctionClientFactory`` typedef enables dependency injection for
+testing without a real Thrift server:
+
+.. code-block:: c++
+
+    #include "velox/functions/remote/client/ThriftClient.h"
+
+    // Create a mock client.
+    class MockClient : public IRemoteFunctionClient {
+     public:
+      void invokeFunction(
+          remote::RemoteFunctionResponse& response,
+          const remote::RemoteFunctionRequest& request) override {
+        // Build mock response...
+      }
+    };
+
+    // Register with mock client factory.
+    RemoteThriftVectorFunctionMetadata metadata;
+    metadata.location = folly::SocketAddress("127.0.0.1", 12345);
+    metadata.clientFactory =
+        [](const folly::SocketAddress&, folly::EventBase*) {
+          return std::make_unique<MockClient>();
+        };
+
+    registerRemoteFunction("mock_fn", signatures, metadata);
+
+Build Configuration
+-------------------
+
+Remote functions are gated by the CMake option ``VELOX_ENABLE_REMOTE_FUNCTIONS``
+(default: ``OFF``). Enable it to build the remote function client, server, and
+tests:
+
+.. code-block:: bash
+
+    cmake -DVELOX_ENABLE_REMOTE_FUNCTIONS=ON ...
+
+Custom Transport
+----------------
+
+To use a transport other than Thrift, extend the ``RemoteVectorFunction``
+abstract class and implement:
+
+- ``invokeRemoteFunction()`` — Sends the serialized request and returns the
+  response.
+- ``remoteLocationToString()`` — Returns a human-readable description of the
+  remote endpoint for error messages.

--- a/velox/functions/remote/client/RemoteVectorFunction.cpp
+++ b/velox/functions/remote/client/RemoteVectorFunction.cpp
@@ -171,7 +171,12 @@ void RemoteVectorFunction::applyRemote(
 
   // Invoke function that communicates with the remote host.
   try {
+<<<<<<< HEAD
     remoteResponse = folly::coro::blockingWait(invokeRemoteFunction(request));
+=======
+    remoteResponse =
+        folly::coro::blockingWait(invokeRemoteFunction(request));
+>>>>>>> 84bcc4b97 (fix(remote): Port coroutine-based invokeRemoteFunction to OSS)
   } catch (const std::exception& e) {
     VELOX_FAIL(
         "Error while executing remote function '{}' at '{}': {}",

--- a/velox/functions/remote/client/RemoteVectorFunction.cpp
+++ b/velox/functions/remote/client/RemoteVectorFunction.cpp
@@ -17,7 +17,7 @@
 #include "velox/functions/remote/client/RemoteVectorFunction.h"
 
 #include <folly/coro/BlockingWait.h>
-
+#include "velox/common/base/BitUtil.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/remote/if/GetSerde.h"
 #include "velox/type/fbhive/HiveTypeSerializer.h"
@@ -28,6 +28,42 @@ namespace {
 std::string serializeType(const TypePtr& type) {
   // Use hive type serializer.
   return type::fbhive::HiveTypeSerializer::serialize(type);
+}
+
+/// Convert a SelectivityVector into contiguous IndexRange runs of selected
+/// rows.
+std::vector<IndexRange> toIndexRanges(const SelectivityVector& rows) {
+  std::vector<IndexRange> ranges;
+  vector_size_t rangeStart{-1};
+  vector_size_t rangeSize{0};
+
+  bits::forEachSetBit(
+      rows.allBits(), rows.begin(), rows.end(), [&](vector_size_t row) {
+        if (rangeStart == -1) {
+          rangeStart = row;
+          rangeSize = 1;
+        } else if (row == rangeStart + rangeSize) {
+          ++rangeSize;
+        } else {
+          ranges.push_back({rangeStart, rangeSize});
+          rangeStart = row;
+          rangeSize = 1;
+        }
+      });
+
+  if (rangeStart != -1) {
+    ranges.push_back({rangeStart, rangeSize});
+  }
+  return ranges;
+}
+
+/// Count total rows across all ranges.
+vector_size_t countRows(const std::vector<IndexRange>& ranges) {
+  vector_size_t count{0};
+  for (const auto& range : ranges) {
+    count += range.size;
+  }
+  return count;
 }
 
 } // namespace
@@ -94,20 +130,41 @@ void RemoteVectorFunction::applyRemote(
   functionHandle->argumentTypes() = serializedInputTypes_;
 
   auto requestInputs = request.inputs();
-  requestInputs->rowCount() = remoteRowVector->size();
   requestInputs->pageFormat() = serdeFormat_;
 
-  // TODO: serialize only active rows.
-  if (preserveEncoding_) {
-    requestInputs->payload_ref() = rowVectorToIOBufBatch(
-        remoteRowVector,
-        rows.end(),
-        *context.pool(),
-        serde_.get(),
-        serdeOptions_.get());
+  // Serialize only active rows to reduce network and server overhead.
+  const bool allSelected = rows.isAllSelected();
+  std::vector<IndexRange> activeRanges;
+
+  if (allSelected) {
+    activeRanges.push_back({0, rows.end()});
   } else {
-    requestInputs->payload_ref() = rowVectorToIOBuf(
-        remoteRowVector, rows.end(), *context.pool(), serde_.get());
+    activeRanges = toIndexRanges(rows);
+  }
+
+  const auto numActiveRows =
+      allSelected ? rows.end() : countRows(activeRanges);
+  requestInputs->rowCount() = numActiveRows;
+
+  auto rangesView = folly::Range<const IndexRange*>(
+      activeRanges.data(), activeRanges.size());
+  if (preserveEncoding_) {
+    auto serializer =
+        serde_->createBatchSerializer(context.pool(), serdeOptions_.get());
+    IOBufOutputStream stream(*context.pool());
+    Scratch scratch;
+    serializer->serialize(remoteRowVector, rangesView, scratch, &stream);
+    requestInputs->payload_ref() = std::move(*stream.getIOBuf());
+  } else {
+    auto streamGroup =
+        std::make_unique<VectorStreamGroup>(context.pool(), serde_.get());
+    streamGroup->createStreamTree(
+        asRowType(remoteRowVector->type()), numActiveRows);
+    Scratch scratch;
+    streamGroup->append(remoteRowVector, rangesView, scratch);
+    IOBufOutputStream stream(*context.pool());
+    streamGroup->flush(&stream);
+    requestInputs->payload_ref() = std::move(*stream.getIOBuf());
   }
 
   std::unique_ptr<remote::RemoteFunctionResponse> remoteResponse;
@@ -129,7 +186,19 @@ void RemoteVectorFunction::applyRemote(
       ROW({outputType}),
       *context.pool(),
       serde_.get());
-  result = outputRowVector->childAt(0);
+  auto compactedResult = outputRowVector->childAt(0);
+
+  // Scatter compacted result back to original row positions if needed.
+  if (allSelected) {
+    result = compactedResult;
+  } else {
+    result = BaseVector::create(outputType, rows.end(), context.pool());
+    vector_size_t compactIdx{0};
+    rows.applyToSelected([&](vector_size_t origRow) {
+      result->copy(compactedResult.get(), origRow, compactIdx, 1);
+      ++compactIdx;
+    });
+  }
 
   if (auto errorPayload = remoteResult.errorPayload()) {
     auto errorsRowVector = IOBufToRowVector(
@@ -139,17 +208,33 @@ void RemoteVectorFunction::applyRemote(
         errorsVector,
         "Remote function error payload should be convertible to flat vector.");
 
-    SelectivityVector selectedRows(errorsRowVector->size());
-    selectedRows.applyToSelected([&](vector_size_t i) {
-      if (errorsVector->isNullAt(i)) {
-        return;
-      }
-      try {
-        throw std::runtime_error(std::string(errorsVector->valueAt(i)));
-      } catch (const std::exception&) {
-        context.setError(i, std::current_exception());
-      }
-    });
+    // Map compacted error indices back to original row positions.
+    if (allSelected) {
+      SelectivityVector selectedRows(errorsRowVector->size());
+      selectedRows.applyToSelected([&](vector_size_t i) {
+        if (errorsVector->isNullAt(i)) {
+          return;
+        }
+        try {
+          VELOX_USER_FAIL("{}", errorsVector->valueAt(i));
+        } catch (const std::exception&) {
+          context.setError(i, std::current_exception());
+        }
+      });
+    } else {
+      vector_size_t compactIdx{0};
+      rows.applyToSelected([&](vector_size_t origRow) {
+        if (compactIdx < errorsRowVector->size() &&
+            !errorsVector->isNullAt(compactIdx)) {
+          try {
+            VELOX_USER_FAIL("{}", errorsVector->valueAt(compactIdx));
+          } catch (const std::exception&) {
+            context.setError(origRow, std::current_exception());
+          }
+        }
+        ++compactIdx;
+      });
+    }
   }
 }
 

--- a/velox/functions/remote/client/RemoteVectorFunction.h
+++ b/velox/functions/remote/client/RemoteVectorFunction.h
@@ -53,7 +53,7 @@ class RemoteVectorFunction : public exec::VectorFunction {
  protected:
   // The actual function that communicates with the remote host.
   // Returns a coroutine to allow the worker thread to yield while
-  // waiting for the remote response
+  // waiting for the remote response.
   virtual folly::coro::Task<std::unique_ptr<remote::RemoteFunctionResponse>>
   invokeRemoteFunction(const remote::RemoteFunctionRequest& request) const = 0;
 

--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -71,6 +71,22 @@ struct OpaqueTypeFunction {
   }
 };
 
+/// Returns the input value, or -1 if the input is null. Used to test
+/// non-default null behavior with remote functions.
+template <typename T>
+struct NullableDoubleFunction {
+  FOLLY_ALWAYS_INLINE bool callNullable(
+      int64_t& result,
+      const int64_t* a) {
+    if (a == nullptr) {
+      result = -1;
+    } else {
+      result = (*a) * 2;
+    }
+    return true;
+  }
+};
+
 // Parametrize in the serialization format so we can test both presto page and
 // unsafe row.
 class RemoteFunctionTest
@@ -131,6 +147,22 @@ class RemoteFunctionTest
                                  .build()};
     registerRemoteFunction("remote_opaque", opaqueSignatures, metadata);
 
+    // Register with non-default null behavior.
+    RemoteThriftVectorFunctionMetadata nullableMetadata = metadata;
+    nullableMetadata.defaultNullBehavior = false;
+    auto nullableDoubleSignatures = {exec::FunctionSignatureBuilder()
+                                         .returnType("bigint")
+                                         .argumentType("bigint")
+                                         .build()};
+    registerRemoteFunction(
+        "remote_nullable_double", nullableDoubleSignatures, nullableMetadata);
+
+    // Register with non-deterministic behavior.
+    RemoteThriftVectorFunctionMetadata nonDetMetadata = metadata;
+    nonDetMetadata.deterministic = false;
+    registerRemoteFunction(
+        "remote_plus_nondet", plusSignatures, nonDetMetadata);
+
     // Registers the actual function under a different prefix. This is only
     // needed for tests since the thrift service runs in the same process.
     registerFunction<PlusFunction, int64_t, int64_t, int64_t>(
@@ -143,6 +175,10 @@ class RemoteFunctionTest
         {params.functionPrefix + ".remote_substr"});
     registerFunction<OpaqueTypeFunction, int64_t, std::shared_ptr<Foo>>(
         {params.functionPrefix + ".remote_opaque"});
+    registerFunction<NullableDoubleFunction, int64_t, int64_t>(
+        {params.functionPrefix + ".remote_nullable_double"});
+    registerFunction<PlusFunction, int64_t, int64_t, int64_t>(
+        {params.functionPrefix + ".remote_plus_nondet"});
 
     registerOpaqueType<Foo>("Foo");
     OpaqueType::registerSerialization<Foo>(
@@ -247,6 +283,37 @@ TEST_P(RemoteFunctionTest, opaque) {
       "remote_opaque(c0)", makeRowVector({inputVector}));
 
   auto expected = makeFlatVector<int64_t>({10, 11});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, nonDefaultNullBehavior) {
+  auto inputVector =
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_nullable_double(c0)", makeRowVector({inputVector}));
+
+  // Null inputs should produce -1, non-null inputs should be doubled.
+  auto expected = makeFlatVector<int64_t>({2, -1, 6, -1, 10});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, nonDeterministic) {
+  auto inputVector = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus_nondet(c0, c0)", makeRowVector({inputVector}));
+
+  auto expected = makeFlatVector<int64_t>({2, 4, 6, 8, 10});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, partialSelection) {
+  // Uses if() to create partial selectivity — remote_plus is only called for
+  // rows where c0 > 2.
+  auto inputVector = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "if(c0 > 2, remote_plus(c0, c0), c0)", makeRowVector({inputVector}));
+
+  auto expected = makeFlatVector<int64_t>({1, 2, 6, 8, 10});
   assertEqualVectors(expected, results);
 }
 
@@ -378,6 +445,39 @@ TEST_F(MockRemoteFunctionTest, mockClientIsCalled) {
 
   // Verify the mock returned our expected values.
   auto expected = makeFlatVector<int64_t>({2, 4, 6});
+  assertEqualVectors(expected, results);
+}
+
+TEST_F(MockRemoteFunctionTest, activeRowsSerialization) {
+  // Verify that only active rows are serialized and sent to the remote server.
+  auto signatures = {exec::FunctionSignatureBuilder()
+                         .returnType("bigint")
+                         .argumentType("bigint")
+                         .argumentType("bigint")
+                         .build()};
+  registerMockRemoteFunction("mock_plus_active", signatures);
+
+  EXPECT_CALL(*mockClient_, invokeFunction)
+      .WillOnce([this](
+                    remote::RemoteFunctionResponse& response,
+                    const remote::RemoteFunctionRequest& request) {
+        // Verify the request contains only the active rows (3 out of 5).
+        const auto& inputs = request.inputs().value();
+        EXPECT_EQ(inputs.rowCount().value(), 3);
+
+        // Return the result for those 3 rows.
+        auto resultVector =
+            makeRowVector({makeFlatVector<int64_t>({6, 8, 10})});
+        setMockResponse(response, resultVector);
+      });
+
+  // Use if() so remote function is called only for rows where c0 > 2.
+  auto inputVector = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "if(c0 > 2, mock_plus_active(c0, c0), c0)",
+      makeRowVector({inputVector}));
+
+  auto expected = makeFlatVector<int64_t>({1, 2, 6, 8, 10});
   assertEqualVectors(expected, results);
 }
 

--- a/velox/functions/remote/if/RemoteFunction.thrift
+++ b/velox/functions/remote/if/RemoteFunction.thrift
@@ -69,13 +69,10 @@ struct RemoteFunctionRequest {
   /// The page containing serialized input parameters.
   2: RemoteFunctionPage inputs;
 
-  /// Whether the function is supposed to throw an exception if errors are
-  /// found, or capture exceptions and return back to the user. This is used
-  /// to implement special forms (if the function is inside a try() construct,
-  /// for example).
-  ///
-  /// TODO: the format to return serialized exceptions back to the client needs
-  /// to be defined and implemented.
+  /// Whether the function should throw on error or capture exceptions and
+  /// return them in the errorPayload field of RemoteFunctionPage. When false
+  /// (e.g., inside a try() expression), errors are serialized as VARCHAR
+  /// strings in errorPayload.
   3: bool throwOnError;
 }
 


### PR DESCRIPTION
Implement remaining items from the remote function execution tracking issue:

- Serialize only active rows: convert SelectivityVector to IndexRange runs
  and serialize just the selected rows, scattering results back to original
  positions. Reduces network and server overhead for conditional expressions.
- Add test coverage for non-deterministic functions and non-default null
  behavior (metadata plumbing already existed).
- Use VELOX_USER_FAIL instead of std::runtime_error for error re-throwing,
  producing proper VeloxUserError exceptions.
- Remove stale TODO in Thrift IDL about error format (already implemented).
- Add developer documentation for remote functions.
- Add design document for these enhancements.