### PR TITLE
fix: Fix Axiom timestamp display format to match Presto (#16929)

### DIFF
--- a/velox/functions/prestosql/types/PrestoTypes.cpp
+++ b/velox/functions/prestosql/types/PrestoTypes.cpp
@@ -226,6 +226,20 @@ std::string PrestoTypes::valueToString(
   return decoded.toString(index);
 }
 
+std::string PrestoTypes::timestampToPrestoString(Timestamp value) {
+  // Uses millisecond precision to match Presto Java's SqlTimestamp.JSON_FORMAT
+  // ("uuuu-MM-dd HH:mm:ss.SSS"). Sub-millisecond nanos are truncated.
+  // This is consistent with PrestoCastHooks (non-legacy mode), which sets the
+  // same options for CAST(timestamp AS varchar).
+  // TODO: Support microsecond precision for TIMESTAMP(6) if needed.
+  static const TimestampToStringOptions kPrestoOptions{
+      .precision = TimestampToStringOptions::Precision::kMilliseconds,
+      .zeroPaddingYear = true,
+      .dateTimeSeparator = ' ',
+  };
+  return value.toString(kPrestoOptions);
+}
+
 std::string PrestoTypes::toHex(StringView value) {
   std::string result;
   result.reserve(value.size() * 3);

--- a/velox/functions/prestosql/types/PrestoTypes.h
+++ b/velox/functions/prestosql/types/PrestoTypes.h
@@ -53,6 +53,11 @@ class PrestoTypes {
       const TypePtr& type);
 
  private:
+  // Formats a Timestamp in Presto format: space separator, millisecond
+  // precision, zero-padded year. Consistent with PrestoCastHooks (non-legacy)
+  // options for CAST(timestamp AS varchar).
+  static std::string timestampToPrestoString(Timestamp value);
+
   // Formats binary data as space-separated hex bytes (e.g., "02 0c 01 00").
   static std::string toHex(StringView value);
 };
@@ -82,6 +87,8 @@ std::string PrestoTypes::valueToString(T value, const TypePtr& type) {
           BingTileType::bingTileY(value),
           BingTileType::bingTileZoom(value));
     }
+  } else if constexpr (std::is_same_v<T, Timestamp>) {
+    return timestampToPrestoString(value);
   } else if constexpr (std::is_same_v<T, StringView>) {
     if (type->isVarbinary()) {
       return toHex(value);

--- a/velox/functions/prestosql/types/tests/PrestoTypesTest.cpp
+++ b/velox/functions/prestosql/types/tests/PrestoTypesTest.cpp
@@ -218,7 +218,16 @@ TEST(PrestoTypeSqlTest, valueToString) {
   EXPECT_EQ(PrestoTypes::valueToString(1.5, DOUBLE()), "1.5");
   EXPECT_EQ(
       PrestoTypes::valueToString(Timestamp(0, 0), TIMESTAMP()),
-      "1970-01-01T00:00:00.000000000");
+      "1970-01-01 00:00:00.000");
+  // Non-zero nanos: verify millisecond truncation.
+  EXPECT_EQ(
+      PrestoTypes::valueToString(
+          Timestamp(1'705'320'000, 123'456'789), TIMESTAMP()),
+      "2024-01-15 12:00:00.123");
+  // Pre-1000 year: verify zero-padded year.
+  EXPECT_EQ(
+      PrestoTypes::valueToString(Timestamp(-62'135'596'800, 0), TIMESTAMP()),
+      "0001-01-01 00:00:00.000");
 }
 
 // Tests PrestoTypes::valueToString(DecodedVector) which handles nulls,


### PR DESCRIPTION
Summary:

[velox] Fix Axiom timestamp display format to match Presto

## Summary

`PrestoTypes::valueToString()` is the shared Velox formatting layer that renders typed values as human-readable strings. Axiom reaches this code via two production paths: the Axiom CLI, where `ResultPrinter` (`axiom/cli/ResultPrinter.cpp:131`) calls `PrestoTypes::valueToString(decodedColumns[col], row, type)` for every cell to render tabular output; and the Axel HTTP server, where `ResponseBuilder` (`axel/server/http/processing/ResponseBuilder.cpp:124`) calls `PrestoTypes::valueToString(timestampVector->valueAt(row), TIMESTAMP())` to serialize timestamps into JSON responses sent to Presto clients. In both paths, `valueToString` had no `Timestamp`-specific handling — it fell through to `Timestamp::toString()` which uses default `TimestampToStringOptions` (`T` separator, nanosecond precision), producing `2024-01-15T12:00:00.000000000` instead of Presto'\''s expected `2024-01-15 12:00:00.000` (space separator, millisecond precision, matching `SqlTimestamp.JSON_FORMAT`). Note that the standard Presto native worker (`presto_cpp/`) is not affected since it uses binary `PrestoVectorSerde` serialization, not string conversion. This format mismatch causes false-positive `COLUMN_MISMATCH` verifier failures when queries cast timestamps to VARCHAR (the string representation becomes the checksummed value), and was found in verifier suite `all_native_coordinator_dataswarm_sql_test` on cluster `pnb1_verifier_bgm_7` — a zero-tolerance correctness gate in the Axiom release Conveyor pipeline. This change adds a `timestampToPrestoString` helper that uses Presto-compatible options (`precision = kMilliseconds`, `zeroPaddingYear = true`, `dateTimeSeparator = '\'' '\''`), consistent with `PrestoCastHooks` (non-legacy mode) which uses the same options for `CAST(timestamp AS varchar)`. The template `valueToString` now delegates to this helper for `Timestamp` values, following the same pattern as `TIMESTAMP_WITH_TIME_ZONE`, `IPADDRESS`, `UUID`, and other custom types.

Reviewed By: natashasehgal

Differential Revision: D98248129


