### PR TITLE
fix: RESPECT NULLS for Spark collect_list function

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -955,15 +955,6 @@ class QueryConfig {
       true,
       "Ignore null fields when generating JSON string.");
 
-  /// If true, collect_list aggregate function will ignore nulls in the input.
-  VELOX_QUERY_CONFIG(
-      kSparkCollectListIgnoreNulls,
-      sparkCollectListIgnoreNulls,
-      "spark.collect_list.ignore_nulls",
-      bool,
-      true,
-      "Ignore nulls in collect_list aggregate function.");
-
   /// The number of local parallel table writer operators per task.
   VELOX_QUERY_CONFIG(
       kTaskWriterCount,

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -54,15 +54,15 @@ General Aggregate Functions
 
     ``hash`` cannot be null.
 
-.. spark:function:: collect_list(x) -> array<[same as x]>
+.. spark:function:: collect_list(x [, ignoreNulls]) -> array<[same as x]>
 
-    Returns an array created from the input ``x`` elements. By default,
-    ignores null inputs and returns an empty array when all inputs are null.
+    Returns an array created from the input ``x`` elements.
+    When ``ignoreNulls`` is ``true`` (default), null inputs are excluded and
+    an empty array is returned when all inputs are null.
 
-    When the configuration property ``spark.collect_list.ignore_nulls`` is set
-    to ``false``, null values are included in the output array (RESPECT NULLS
-    behavior). In this mode, an all-null input produces an array of nulls
-    instead of an empty array.
+    When ``ignoreNulls`` is ``false`` (RESPECT NULLS), null values are included
+    in the output array. In this mode, an all-null input produces an array of
+    nulls instead of an empty array.
 
 .. spark:function:: collect_set(x [, ignoreNulls]) -> array<[same as x]>
 

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -762,10 +762,12 @@ class SimpleAggregateAdapter : public Aggregate {
     }
   }
 
+ protected:
+  std::unique_ptr<FUNC> fn_;
+
+ private:
   std::vector<DecodedVector> inputDecoded_;
   DecodedVector intermediateDecoded_;
-
-  std::unique_ptr<FUNC> fn_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/functions/sparksql/aggregates/CollectListAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectListAggregate.cpp
@@ -18,6 +18,7 @@
 
 #include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/functions/lib/aggregates/ValueList.h"
+#include "velox/vector/ConstantVector.h"
 
 using namespace facebook::velox::aggregate;
 using namespace facebook::velox::exec;
@@ -43,14 +44,6 @@ class CollectListAggregate {
   // cannot access the runtime ignoreNulls_ config. Without it, partial
   // aggregation uses the accumulator path, which correctly respects the config.
   bool ignoreNulls_{true};
-
-  void initialize(
-      core::AggregationNode::Step /*step*/,
-      const std::vector<TypePtr>& /*argTypes*/,
-      const TypePtr& /*resultType*/,
-      const core::QueryConfig& config) {
-    ignoreNulls_ = config.sparkCollectListIgnoreNulls();
-  }
 
   struct AccumulatorType {
     ValueList elements_;
@@ -114,16 +107,40 @@ class CollectListAggregate {
   };
 };
 
+// Adapter that overrides setConstantInputs to read the ignoreNulls flag.
+class CollectListAdapter : public SimpleAggregateAdapter<CollectListAggregate> {
+ public:
+  using SimpleAggregateAdapter<CollectListAggregate>::SimpleAggregateAdapter;
+
+  void setConstantInputs(
+      const std::vector<VectorPtr>& constantInputs) override {
+    if (constantInputs.size() >= 2 && constantInputs[1] != nullptr &&
+        !constantInputs[1]->isNullAt(0)) {
+      fn_->ignoreNulls_ =
+          constantInputs[1]->as<ConstantVector<bool>>()->valueAt(0);
+    }
+  }
+};
+
 AggregateRegistrationResult registerCollectList(
     const std::string& name,
     bool withCompanionFunctions,
     bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      // collect_list(E) -> array(E): default ignoreNulls=true.
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("E")
           .returnType("array(E)")
           .intermediateType("array(E)")
           .argumentType("E")
+          .build(),
+      // collect_list(E, ignoreNulls) -> array(E): explicit flag.
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("E")
+          .returnType("array(E)")
+          .intermediateType("array(E)")
+          .argumentType("E")
+          .constantArgumentType("boolean")
           .build()};
   return exec::registerAggregateFunction(
       name,
@@ -133,9 +150,7 @@ AggregateRegistrationResult registerCollectList(
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
-        VELOX_CHECK_EQ(
-            argTypes.size(), 1, "{} takes at most one argument", name);
-        return std::make_unique<SimpleAggregateAdapter<CollectListAggregate>>(
+        return std::make_unique<CollectListAdapter>(
             step, argTypes, resultType, &config);
       },
       withCompanionFunctions,

--- a/velox/functions/sparksql/aggregates/tests/CollectListAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CollectListAggregateTest.cpp
@@ -124,24 +124,28 @@ TEST_F(CollectListAggregateTest, allNullsInput) {
       {});
 }
 
-std::unordered_map<std::string, std::string> makeConfig(bool ignoreNulls) {
-  return {{"spark.collect_list.ignore_nulls", ignoreNulls ? "true" : "false"}};
+TEST_F(CollectListAggregateTest, explicitIgnoreNullsTrue) {
+  // 2-arg form with ignoreNulls=true should behave same as 1-arg.
+  auto input = makeRowVector({makeNullableFlatVector<int32_t>(
+      {1, 2, std::nullopt, 4, std::nullopt, 6})});
+  auto expected =
+      makeRowVector({makeArrayVectorFromJson<int32_t>({"[1, 2, 4, 6]"})});
+  testAggregations(
+      {input},
+      {},
+      {"spark_collect_list(c0, true)"},
+      {"array_sort(a0)"},
+      {expected});
 }
 
 TEST_F(CollectListAggregateTest, respectNulls) {
-  // When ignoreNulls is false (RESPECT NULLS), nulls should be included.
+  // 2-arg form with ignoreNulls=false (RESPECT NULLS).
   auto input = makeRowVector({makeNullableFlatVector<int32_t>(
       {1, 2, std::nullopt, 4, std::nullopt, 6})});
   auto expected = makeRowVector({makeNullableArrayVector<int32_t>(
       std::vector<std::vector<std::optional<int32_t>>>{
           {1, 2, std::nullopt, 4, std::nullopt, 6}})});
-  std::vector<RowVectorPtr> expectedResult{expected};
-  testAggregations(
-      {input},
-      {},
-      {"spark_collect_list(c0)"},
-      expectedResult,
-      makeConfig(false));
+  testAggregations({input}, {}, {"spark_collect_list(c0, false)"}, {expected});
 }
 
 TEST_F(CollectListAggregateTest, respectNullsGroupBy) {
@@ -153,30 +157,20 @@ TEST_F(CollectListAggregateTest, respectNullsGroupBy) {
        makeNullableArrayVector<int64_t>(
            std::vector<std::vector<std::optional<int64_t>>>{
                {std::nullopt, 1}, {2, std::nullopt, 3}})});
-  std::vector<RowVectorPtr> expectedResult{expected};
   testAggregations(
       {data},
       {"c0"},
-      {"spark_collect_list(c1)"},
+      {"spark_collect_list(c1, false)"},
       {"c0", "a0"},
-      expectedResult,
-      makeConfig(false));
+      {expected});
 }
 
 TEST_F(CollectListAggregateTest, respectNullsAllNulls) {
-  // When all inputs are null and ignoreNulls is false, output should be an
-  // array of nulls (not an empty array).
   auto input = makeRowVector({makeAllNullFlatVector<int32_t>(3)});
   auto expected = makeRowVector({makeNullableArrayVector<int32_t>(
       std::vector<std::vector<std::optional<int32_t>>>{
           {std::nullopt, std::nullopt, std::nullopt}})});
-  std::vector<RowVectorPtr> expectedResult{expected};
-  testAggregations(
-      {input},
-      {},
-      {"spark_collect_list(c0)"},
-      expectedResult,
-      makeConfig(false));
+  testAggregations({input}, {}, {"spark_collect_list(c0, false)"}, {expected});
 }
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -87,6 +87,8 @@ int main(int argc, char** argv) {
       // Velox registers a 2-arg collect_set(T, boolean) signature that Spark
       // doesn't support. The fuzzer may pick this signature and fail.
       "collect_set",
+      // Same as collect_set — 2-arg signature not supported by Spark.
+      "collect_list",
       "first_ignore_null",
       "last_ignore_null",
       "regr_replacement",


### PR DESCRIPTION
## Summary

Follow-up to #16416 (collect_set RESPECT NULLS). Applies the same pattern to `collect_list`:

- Remove `kSparkCollectListIgnoreNulls` QueryConfig
- Add 2-arg `collect_list(x [, ignoreNulls])` signature with constant boolean
- Use `setConstantInputs` via `CollectListAdapter` subclass of `SimpleAggregateAdapter`
- Make `fn_` protected in `SimpleAggregateAdapter` to enable subclass access

### Changes
- `CollectListAggregate.cpp`: Replace config-based with constant-arg approach
- `QueryConfig.h`: Remove `kSparkCollectListIgnoreNulls`
- `SimpleAggregateAdapter.h`: Make `fn_` protected
- `aggregate.rst`: Update doc format
- `SparkAggregationFuzzerTest.cpp`: Add to skipFunctions
- Tests updated to use 2-arg form

### Testing
All 8 CollectList tests pass.

Closes #16839