### PR TITLE
feat(s3): Add support for hive.s3.min-part-size when writing

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.cpp
@@ -21,6 +21,9 @@
 
 namespace facebook::velox::filesystems {
 
+static constexpr size_t kMinimumMultipartMinPartSize = 5U << 20; // 5MB
+static constexpr size_t kMaximumMultipartMinPartSize = 5U << 30; // 5GB
+
 std::string S3Config::cacheKey(
     std::string_view bucket,
     std::shared_ptr<const config::ConfigBase> config) {
@@ -72,6 +75,15 @@ S3Config::S3Config(
   }
   payloadSigningPolicy_ =
       properties->get<std::string>(kS3PayloadSigningPolicy, "Never");
+
+  VELOX_CHECK_GE(
+      minPartSize(),
+      kMinimumMultipartMinPartSize,
+      "The min-part-size S3 configuration must exceed 5MB.");
+  VELOX_CHECK_LE(
+      minPartSize(),
+      kMaximumMultipartMinPartSize,
+      "The min-part-size S3 configuration must not exceed 5GB.");
 }
 
 std::optional<std::string> S3Config::endpointRegion() const {
@@ -85,6 +97,12 @@ std::optional<std::string> S3Config::endpointRegion() const {
     }
   }
   return region;
+}
+
+size_t S3Config::minPartSize() const {
+  return config::toCapacity(
+      config_.find(Keys::kMultipartMinPartSize)->second.value(),
+      config::CapacityUnit::BYTE);
 }
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Config.h
@@ -77,6 +77,7 @@ class S3Config {
     kUseProxyFromEnv,
     kCredentialsProvider,
     kIMDSEnabled,
+    kMultipartMinPartSize,
     kEnd
   };
 
@@ -116,6 +117,8 @@ class S3Config {
             {Keys::kCredentialsProvider,
              std::make_pair("aws-credentials-provider", std::nullopt)},
             {Keys::kIMDSEnabled, std::make_pair("aws-imds-enabled", "true")},
+            {Keys::kMultipartMinPartSize,
+             std::make_pair("min-part-size", "10MB")},
         };
     return config;
   }
@@ -250,6 +253,8 @@ class S3Config {
     auto value = config_.find(Keys::kIMDSEnabled)->second.value();
     return folly::to<bool>(value);
   }
+
+  size_t minPartSize() const;
 
  private:
   std::unordered_map<Keys, std::optional<std::string>> config_;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -455,8 +455,8 @@ S3FileSystem::S3FileSystem(
     std::string_view bucketName,
     const std::shared_ptr<const config::ConfigBase> config)
     : FileSystem(config) {
-  S3Config s3Config(bucketName, config);
-  impl_ = std::make_shared<Impl>(s3Config);
+  s3Config_ = std::make_shared<S3Config>(bucketName, config);
+  impl_ = std::make_shared<Impl>(*s3Config_);
 }
 
 std::string S3FileSystem::getLogLevelName() const {
@@ -480,8 +480,8 @@ std::unique_ptr<WriteFile> S3FileSystem::openFileForWrite(
     std::string_view s3Path,
     const FileOptions& options) {
   const auto path = getPath(s3Path);
-  auto s3file =
-      std::make_unique<S3WriteFile>(path, impl_->s3Client(), options.pool);
+  auto s3file = std::make_unique<S3WriteFile>(
+      path, impl_->s3Client(), options.pool, s3Config_->minPartSize());
   return s3file;
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -90,6 +90,7 @@ class S3FileSystem : public FileSystem {
  protected:
   class Impl;
   std::shared_ptr<Impl> impl_;
+  std::shared_ptr<S3Config> s3Config_;
 };
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.cpp
@@ -29,6 +29,7 @@
 #include <aws/s3/model/CreateMultipartUploadRequest.h>
 #include <aws/s3/model/HeadBucketRequest.h>
 #include <aws/s3/model/HeadObjectRequest.h>
+#include <aws/s3/model/PutObjectRequest.h>
 #include <aws/s3/model/UploadPartRequest.h>
 
 namespace facebook::velox::filesystems {
@@ -38,13 +39,14 @@ class S3WriteFile::Impl {
   explicit Impl(
       std::string_view path,
       Aws::S3::S3Client* client,
-      memory::MemoryPool* pool)
-      : client_(client), pool_(pool) {
+      memory::MemoryPool* pool,
+      size_t minPartSize)
+      : client_(client), pool_(pool), minPartSize_(minPartSize) {
     VELOX_CHECK_NOT_NULL(client);
     VELOX_CHECK_NOT_NULL(pool);
     getBucketAndKeyFromPath(path, bucket_, key_);
     currentPart_ = std::make_unique<dwio::common::DataBuffer<char>>(*pool_);
-    currentPart_->reserve(kPartUploadSize);
+    currentPart_->reserve(minPartSize_);
     // Check that the object doesn't exist, if it does throw an error.
     {
       Aws::S3::Model::HeadObjectRequest request;
@@ -77,31 +79,60 @@ class S3WriteFile::Impl {
             outcome, "Failed to create S3 bucket", bucket_, "");
       }
     }
-
-    // Initiate the multi-part upload.
-    {
-      Aws::S3::Model::CreateMultipartUploadRequest request;
-      request.SetBucket(awsString(bucket_));
-      request.SetKey(awsString(key_));
-
-      /// If we do not set anything then the SDK will default to application/xml
-      /// which confuses some tools
-      /// (https://github.com/apache/arrow/issues/11934). So we instead default
-      /// to application/octet-stream which is less misleading.
-      request.SetContentType(kApplicationOctetStream);
-      auto outcome = client_->CreateMultipartUpload(request);
-      VELOX_CHECK_AWS_OUTCOME(
-          outcome, "Failed initiating multiple part upload", bucket_, key_);
-      uploadState_.id = outcome.GetResult().GetUploadId();
-    }
-
     fileSize_ = 0;
+  }
+
+  void createMultipartUploadRequest() {
+    Aws::S3::Model::CreateMultipartUploadRequest request;
+    request.SetBucket(awsString(bucket_));
+    request.SetKey(awsString(key_));
+
+    /// If we do not set anything then the SDK will default to application/xml
+    /// which confuses some tools
+    /// (https://github.com/apache/arrow/issues/11934). So we instead default
+    /// to application/octet-stream which is less misleading.
+    request.SetContentType(kApplicationOctetStream);
+    auto outcome = client_->CreateMultipartUpload(request);
+    VELOX_CHECK_AWS_OUTCOME(
+        outcome, "Failed initiating multiple part upload", bucket_, key_);
+    uploadState_.id = outcome.GetResult().GetUploadId();
+  }
+
+  // This uploads the buffer as a single object. This is used if we deal with
+  // buffers smaller than min-part-size.
+
+  void putObjectRequest() {
+    Aws::S3::Model::PutObjectRequest request;
+    request.SetBucket(awsString(bucket_));
+    request.SetKey(awsString(key_));
+
+    /// If we do not set anything then the SDK will default to application/xml
+    /// which confuses some tools
+    /// (https://github.com/apache/arrow/issues/11934). So we instead default
+    /// to application/octet-stream which is less misleading.
+    request.SetContentType(kApplicationOctetStream);
+    request.SetContentLength(currentPart_->size());
+    request.SetBody(
+        std::make_shared<StringViewStream>(
+            currentPart_->data(), currentPart_->size()));
+    RECORD_METRIC_VALUE(kMetricS3StartedUploads);
+    auto outcome = client_->PutObject(request);
+    VELOX_CHECK_AWS_OUTCOME(
+        outcome, "Failed single object upload", bucket_, key_);
+    if (outcome.IsSuccess()) {
+      RECORD_METRIC_VALUE(kMetricS3SuccessfulUploads);
+    } else {
+      RECORD_METRIC_VALUE(kMetricS3FailedUploads);
+    }
   }
 
   // Appends data to the end of the file.
   void append(std::string_view data) {
     VELOX_CHECK(!closed(), "File is closed");
-    if (data.size() + currentPart_->size() >= kPartUploadSize) {
+    if (data.size() + currentPart_->size() > minPartSize_) {
+      if (uploadState_.partNumber == 0) {
+        createMultipartUploadRequest();
+      }
       upload(data);
     } else {
       // Append to current part.
@@ -113,16 +144,26 @@ class S3WriteFile::Impl {
   // No-op.
   void flush() {
     VELOX_CHECK(!closed(), "File is closed");
-    /// currentPartSize must be less than kPartUploadSize since
-    /// append() would have already flushed after reaching kUploadPartSize.
-    VELOX_CHECK_LT(currentPart_->size(), kPartUploadSize);
+    /// currentPartSize must be less than minPartSize_ since
+    /// append() would have already flushed after reaching minPartSize_.
+    VELOX_CHECK_LT(currentPart_->size(), minPartSize_);
   }
 
-  // Complete the multipart upload and close the file.
+  // Send the buffer in a single request or complete the multipart upload.
+  // Then close the file.
   void close() {
     if (closed()) {
       return;
     }
+    // If we haven't sent anything yet, that is the file is less then
+    // minFileSize_. lets put the object that is in the buffer.
+    if (uploadState_.partNumber == 0) {
+      // Send single request.
+      putObjectRequest();
+      currentPart_->clear();
+      return;
+    }
+
     RECORD_METRIC_VALUE(kMetricS3StartedUploads);
     uploadPart({currentPart_->data(), currentPart_->size()}, true);
     VELOX_CHECK_EQ(uploadState_.partNumber, uploadState_.completedParts.size());
@@ -158,7 +199,6 @@ class S3WriteFile::Impl {
   }
 
  private:
-  static constexpr int64_t kPartUploadSize = 10 * 1024 * 1024;
   static constexpr const char* kApplicationOctetStream =
       "application/octet-stream";
 
@@ -174,8 +214,8 @@ class S3WriteFile::Impl {
   };
   UploadState uploadState_;
 
-  // Data can be smaller or larger than the kPartUploadSize.
-  // Complete the currentPart_ and upload kPartUploadSize chunks of data.
+  // Data can be smaller or larger than the minPartSize_.
+  // Complete the currentPart_ and upload minPartSize_ chunks of data.
   // Save the remaining into currentPart_.
   void upload(const std::string_view data) {
     auto dataPtr = data.data();
@@ -186,18 +226,18 @@ class S3WriteFile::Impl {
     uploadPart({currentPart_->data(), currentPart_->size()});
     dataPtr += remainingBufferSize;
     dataSize -= remainingBufferSize;
-    while (dataSize > kPartUploadSize) {
-      uploadPart({dataPtr, kPartUploadSize});
-      dataPtr += kPartUploadSize;
-      dataSize -= kPartUploadSize;
+    while (dataSize > minPartSize_) {
+      uploadPart({dataPtr, minPartSize_});
+      dataPtr += minPartSize_;
+      dataSize -= minPartSize_;
     }
     // Stash the remaining at the beginning of currentPart.
     currentPart_->unsafeAppend(0, dataPtr, dataSize);
   }
 
   void uploadPart(const std::string_view part, bool isLast = false) {
-    // Only the last part can be less than kPartUploadSize.
-    VELOX_CHECK(isLast || (!isLast && (part.size() == kPartUploadSize)));
+    // Only the last part can be less than minPartSize_.
+    VELOX_CHECK(isLast || (!isLast && (part.size() == minPartSize_)));
     // Upload the part.
     {
       Aws::S3::Model::UploadPartRequest request;
@@ -232,13 +272,15 @@ class S3WriteFile::Impl {
   std::string bucket_;
   std::string key_;
   size_t fileSize_ = -1;
+  size_t minPartSize_;
 };
 
 S3WriteFile::S3WriteFile(
     std::string_view path,
     Aws::S3::S3Client* client,
-    memory::MemoryPool* pool) {
-  impl_ = std::make_shared<Impl>(path, client, pool);
+    memory::MemoryPool* pool,
+    size_t minPartSize) {
+  impl_ = std::make_shared<Impl>(path, client, pool, minPartSize);
 }
 
 void S3WriteFile::append(std::string_view data) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -30,15 +30,18 @@ namespace facebook::velox::filesystems {
 /// Multipart upload allows you to upload a single object as a set of parts.
 /// Each part is a contiguous portion of the object's data.
 /// While AWS and Minio support different sizes for each
-/// part (only requiring a minimum of 5MB), Cloudflare R2 requires that every
-/// part be exactly equal (except for the last part). We set this to 10 MiB, so
-/// that in combination with the maximum number of parts of 10,000, this gives a
-/// file limit of 100k MiB (or about 98 GiB).
-/// (see https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html)
-/// (for rational, see: https://github.com/apache/arrow/issues/34363)
-/// You can upload these object parts independently and in any order.
-/// After all parts of your object are uploaded, Amazon S3 assembles these parts
-/// and creates the object.
+/// part (only requiring a minimum of 5MB - but not enforced), Apache Ozone
+/// enforces the minimum 5MB (smaller parts are ignored), and Cloudflare R2
+/// requires that every part be exactly equal (except for the last part). We set
+/// this to minPartSize (default 10MB), so that in combination with the maximum
+/// number of parts of 10,000, this gives a file limit of 100k MiB (or about 98
+/// GiB).
+/// (for rationale, see: https://github.com/apache/arrow/issues/34363)
+/// For AWS limits see
+/// https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html). You can
+/// upload these object parts independently and in any order. After all parts of
+/// your object are uploaded, Amazon S3 assembles these parts and creates the
+/// object.
 /// https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html
 /// https://github.com/apache/arrow/blob/main/cpp/src/arrow/filesystem/s3fs.cc
 /// S3WriteFile is not thread-safe.
@@ -50,7 +53,8 @@ class S3WriteFile : public WriteFile {
   S3WriteFile(
       std::string_view path,
       Aws::S3::S3Client* client,
-      memory::MemoryPool* pool);
+      memory::MemoryPool* pool,
+      size_t minPartSize);
 
   /// Appends data to the end of the file.
   /// Uploads a part on reaching part size limit.
@@ -69,6 +73,8 @@ class S3WriteFile : public WriteFile {
   int numPartsUploaded() const;
 
  protected:
+  void createMultipartUploadRequest();
+
   class Impl;
   std::shared_ptr<Impl> impl_;
 };

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3ConfigTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/s3fs/S3Config.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/config/Config.h"
 
 #include <gtest/gtest.h>
@@ -38,6 +39,7 @@ TEST(S3ConfigTest, defaultConfig) {
   ASSERT_EQ(s3Config.cacheKey("foo", config), "foo");
   ASSERT_EQ(s3Config.bucket(), "");
   ASSERT_EQ(s3Config.useIMDS(), true);
+  ASSERT_EQ(s3Config.minPartSize(), 10485760);
 }
 
 TEST(S3ConfigTest, overrideConfig) {
@@ -55,7 +57,8 @@ TEST(S3ConfigTest, overrideConfig) {
       {S3Config::baseConfigKey(S3Config::Keys::kIamRoleSessionName), "velox"},
       {S3Config::baseConfigKey(S3Config::Keys::kCredentialsProvider),
        "my-credentials-provider"},
-      {S3Config::baseConfigKey(S3Config::Keys::kIMDSEnabled), "false"}};
+      {S3Config::baseConfigKey(S3Config::Keys::kIMDSEnabled), "false"},
+      {S3Config::baseConfigKey(S3Config::Keys::kMultipartMinPartSize), "20MB"}};
   auto configBase =
       std::make_shared<config::ConfigBase>(std::move(configFromFile));
   auto s3Config = S3Config("bucket", configBase);
@@ -74,6 +77,7 @@ TEST(S3ConfigTest, overrideConfig) {
   ASSERT_EQ(s3Config.bucket(), "bucket");
   ASSERT_EQ(s3Config.credentialsProvider(), "my-credentials-provider");
   ASSERT_EQ(s3Config.useIMDS(), false);
+  ASSERT_EQ(s3Config.minPartSize(), 20971520);
 }
 
 TEST(S3ConfigTest, overrideBucketConfig) {
@@ -99,7 +103,8 @@ TEST(S3ConfigTest, overrideBucketConfig) {
        "my-credentials-provider"},
       {S3Config::bucketConfigKey(S3Config::Keys::kCredentialsProvider, bucket),
        "override-credentials-provider"},
-      {S3Config::baseConfigKey(S3Config::Keys::kIMDSEnabled), "false"}};
+      {S3Config::baseConfigKey(S3Config::Keys::kIMDSEnabled), "false"},
+      {S3Config::baseConfigKey(S3Config::Keys::kMultipartMinPartSize), "20MB"}};
   auto configBase =
       std::make_shared<config::ConfigBase>(std::move(bucketConfigFromFile));
   auto s3Config = S3Config(bucket, configBase);
@@ -120,6 +125,49 @@ TEST(S3ConfigTest, overrideBucketConfig) {
   ASSERT_EQ(s3Config.cacheKey("foo", configBase), "endpoint-foo");
   ASSERT_EQ(s3Config.credentialsProvider(), "override-credentials-provider");
   ASSERT_EQ(s3Config.useIMDS(), false);
+  ASSERT_EQ(s3Config.minPartSize(), 20971520);
+}
+
+TEST(S3ConfigTest, minPartSizeValidation) {
+  // Test that setting min-part-size below 5MB throws an error.
+  std::unordered_map<std::string, std::string> configFromFile = {
+      {S3Config::baseConfigKey(S3Config::Keys::kMultipartMinPartSize), "4MB"}};
+  auto configBase =
+      std::make_shared<config::ConfigBase>(std::move(configFromFile));
+
+  VELOX_ASSERT_THROW(
+      S3Config("bucket", configBase),
+      "The min-part-size S3 configuration must exceed 5MB");
+
+  configFromFile = {
+      {S3Config::baseConfigKey(S3Config::Keys::kMultipartMinPartSize), "10GB"}};
+  configBase = std::make_shared<config::ConfigBase>(std::move(configFromFile));
+  VELOX_ASSERT_THROW(
+      S3Config("bucket", configBase),
+      "The min-part-size S3 configuration must not exceed 5GB");
+}
+
+TEST(S3ConfigTest, minPartSizeValidationBucketConfig) {
+  // Test that setting bucket-specific min-part-size below 5MB throws an error.
+  std::string_view bucket = "testbucket";
+  std::unordered_map<std::string, std::string> configFromFile = {
+      {S3Config::bucketConfigKey(S3Config::Keys::kMultipartMinPartSize, bucket),
+       "3MB"}};
+  auto configBase =
+      std::make_shared<config::ConfigBase>(std::move(configFromFile));
+
+  VELOX_ASSERT_THROW(
+      S3Config(bucket, configBase),
+      "The min-part-size S3 configuration must exceed 5MB");
+
+  configFromFile = {
+      {S3Config::bucketConfigKey(S3Config::Keys::kMultipartMinPartSize, bucket),
+       "10GB"}};
+  configBase = std::make_shared<config::ConfigBase>(std::move(configFromFile));
+
+  VELOX_ASSERT_THROW(
+      S3Config(bucket, configBase),
+      "The min-part-size S3 configuration must not exceed 5GB");
 }
 
 } // namespace

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3InsertTest.cpp
@@ -28,18 +28,21 @@ class S3InsertTest : public S3Test, public test::InsertTest {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+    filesystems::registerS3FileSystem();
+  }
+
+  static void TearDownTestCase() {
+    filesystems::finalizeS3FileSystem();
   }
 
   void SetUp() override {
     S3Test::SetUp();
-    filesystems::registerS3FileSystem();
     InsertTest::SetUp(minioServer_->hiveConfig(), ioExecutor_.get());
   }
 
   void TearDown() override {
     S3Test::TearDown();
     InsertTest::TearDown();
-    filesystems::finalizeS3FileSystem();
   }
 };
 } // namespace
@@ -48,6 +51,22 @@ TEST_F(S3InsertTest, s3InsertTest) {
   const int64_t kExpectedRows = 1'000;
   const std::string_view kOutputDirectory{"s3://writedata/"};
   minioServer_->addBucket("writedata");
+
+  runInsertTest(kOutputDirectory, kExpectedRows, pool());
+}
+
+// Test with data exceeding the default 5MB minPartSize to trigger multipart
+// upload. This test generates enough data to exceed 5MB, which should trigger
+// at least one multipart upload part and a remainder.
+TEST_F(S3InsertTest, s3MultipartUploadTest) {
+  // Generate enough rows to exceed 5MB.
+  // Each row has 4 columns: BIGINT (8 bytes), INTEGER (4 bytes),
+  // SMALLINT (2 bytes), DOUBLE (8 bytes) = 22 bytes per row minimum.
+  // To exceed 5MB (5 * 1024 * 1024 = 5,242,880 bytes), we need at least
+  // 5,242,880 / 22 ≈ 238,313 rows. Let's use 300,000 rows to be safe.
+  const int64_t kExpectedRows = 300'000;
+  const std::string_view kOutputDirectory{"s3://multipartdata/"};
+  minioServer_->addBucket("multipartdata");
 
   runInsertTest(kOutputDirectory, kExpectedRows, pool());
 }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1086,6 +1086,14 @@ Each query can override the config by setting corresponding query session proper
      - true
      - AWS Instance Metadata Service (IMDS) is an AWS EC2 instance component used by applications to securely access metadata.
        We must disable it on other instances to avoid high first-time read latency from S3 compatible object storages.
+   * - hive.s3.min-part-size
+     - string
+     - 10MB
+     - Minimum multi-part upload part size. The smallest allowed value is 5MB. The largest allowed value is 5GB.
+       If a file is less than this size, the file is sent as a single put request.
+       Otherwise, the file is split into multiple equal sized chunks of this part size excluding the last chunk.
+       The `AWS specification <https://docs.aws.amazon.com/AmazonS3/latest/userguide/qfacts.html> `_ limits the part size between 5MB and 5GB.
+       Some S3 backend providers enforce these limits strictly.
 
 Bucket Level Configuration
 """"""""""""""""""""""""""


### PR DESCRIPTION
This PR introduces the hive.s3.min-part-size option available in Presto Java. It defines the minimum size of a buffer before multipart uploads are used. As a result files less than the min-part-size are sent in a single PUT request. Previously, even smaller files were sent through the multi-part upload. However, AWS limits the minimum size of a part to 5MB.
As a result, some S3 backends such as Apache Ozone ignored uploads of parts with less than 5MB leading to errors when finishing the multi-part upload.

The default part size is 10MB to match the existing hard coded value. Every part is of size min-part-size to conform to other S3 backends where each part size must be exactly the same size except the last part. As a result min-part-size is also the effective part size. Therefore, this change may affect performance with the default configuration.