### PR TITLE
feat(parquet): Support config store decimal as integer for write parquet format

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -1011,6 +1011,12 @@ must be specified as raw byte counts.
      - string
      - parquet-cpp-velox version 0.0.0
      - Created-by value used when writing to Parquet.
+   * - hive.parquet.writer.enable-store-decimal-as-integer
+     - hive.parquet.writer.enable_store_decimal_as_integer
+     - bool
+     - true
+     - Whether to store DECIMAL values using integer physical types (INT32/INT64) when precision allows.
+       When false, all DECIMAL values are stored as FIXED_LEN_BYTE_ARRAY regardless of precision.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
+++ b/velox/dwio/parquet/tests/writer/ParquetWriterTest.cpp
@@ -27,6 +27,7 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/parquet/RegisterParquetWriter.h" // @manual
 #include "velox/dwio/parquet/reader/PageReader.h"
+#include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
 #include "velox/dwio/parquet/tests/ParquetTestBase.h"
 #include "velox/dwio/parquet/writer/WriterConfig.h"
 #include "velox/exec/Cursor.h"
@@ -690,6 +691,95 @@ TEST_F(ParquetWriterTest, updateWriterOptionsFromHiveConfig) {
   ASSERT_EQ(
       options.parquetWriteTimestampUnit.value(),
       TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetWriterTest, enableStoreDecimalAsInteger) {
+  const auto rowType = ROW({
+      {"c0", DECIMAL(8, 2)},
+      {"c1", DECIMAL(10, 2)},
+      {"c2", DECIMAL(19, 2)},
+  });
+  // c1 includes an unscaled value exceeding INT32 range (50000000.00).
+  const auto data = makeRowVector({
+      makeFlatVector<int64_t>({100, 99999999}, DECIMAL(8, 2)),
+      makeFlatVector<int64_t>({100, 5000000000LL}, DECIMAL(10, 2)),
+      makeFlatVector<int128_t>({100, 200}, DECIMAL(19, 2)),
+  });
+
+  using PhysicalTypes =
+      std::vector<std::shared_ptr<const ParquetTypeWithId::TypeWithId>>;
+
+  auto expectParquetType = [&](size_t columnIndex,
+                               const PhysicalTypes& types,
+                               thrift::Type::type expectedType,
+                               std::optional<int32_t> expectedTypeLength =
+                                   std::nullopt) {
+    auto col =
+        std::dynamic_pointer_cast<const ParquetTypeWithId>(types[columnIndex]);
+    ASSERT_NE(col, nullptr);
+    ASSERT_TRUE(col->parquetType_.has_value());
+    EXPECT_EQ(col->parquetType_.value(), expectedType);
+    if (expectedTypeLength.has_value()) {
+      EXPECT_EQ(col->typeLength_, expectedTypeLength.value());
+    }
+  };
+
+  const auto verifyStoredAsInteger = [&](const PhysicalTypes& types) {
+    expectParquetType(0, types, thrift::Type::type::INT32);
+    expectParquetType(1, types, thrift::Type::type::INT64);
+    expectParquetType(2, types, thrift::Type::type::FIXED_LEN_BYTE_ARRAY, 9);
+  };
+
+  const auto verifyStoredAsFixedLenByteArray = [&](const PhysicalTypes& types) {
+    expectParquetType(0, types, thrift::Type::type::FIXED_LEN_BYTE_ARRAY, 4);
+    expectParquetType(1, types, thrift::Type::type::FIXED_LEN_BYTE_ARRAY, 5);
+    expectParquetType(2, types, thrift::Type::type::FIXED_LEN_BYTE_ARRAY, 9);
+  };
+
+  const auto writeReadAndVerify =
+      [&](std::unordered_map<std::string, std::string> configFromFile,
+          std::unordered_map<std::string, std::string> sessionProperties,
+          const std::function<void(const PhysicalTypes&)>&
+              verifyPhysicalTypes) {
+        auto* sinkPtr = write(
+            data, std::move(configFromFile), std::move(sessionProperties));
+
+        dwio::common::ReaderOptions readerOptions(leafPool_.get());
+        readerOptions.setDataIoStats(dataIoStats_);
+        readerOptions.setMetadataIoStats(metadataIoStats_);
+        auto reader = createReaderInMemory(*sinkPtr, readerOptions);
+        auto& parquetReader = dynamic_cast<ParquetReader&>(*reader);
+
+        const auto& types = parquetReader.typeWithId()->getChildren();
+        ASSERT_EQ(types.size(), 3);
+        verifyPhysicalTypes(types);
+
+        auto rowReader = createRowReaderWithSchema(std::move(reader), rowType);
+        assertReadWithReaderAndExpected(rowType, *rowReader, data, *leafPool_);
+      };
+
+  const auto configKey = config::ConfigBase::toConfigKey(
+      parquet::WriterConfig::kParquetSessionEnableStoreDecimalAsInteger);
+  const auto sessionKey =
+      parquet::WriterConfig::kParquetSessionEnableStoreDecimalAsInteger;
+
+  // Connector session property.
+  writeReadAndVerify({}, {{sessionKey, "true"}}, verifyStoredAsInteger);
+  writeReadAndVerify(
+      {}, {{sessionKey, "false"}}, verifyStoredAsFixedLenByteArray);
+
+  // Hive config from file.
+  writeReadAndVerify({{configKey, "true"}}, {}, verifyStoredAsInteger);
+  writeReadAndVerify(
+      {{configKey, "false"}}, {}, verifyStoredAsFixedLenByteArray);
+
+  // Session property takes precedence over Hive config from file.
+  writeReadAndVerify(
+      {{configKey, "false"}}, {{sessionKey, "true"}}, verifyStoredAsInteger);
+  writeReadAndVerify(
+      {{configKey, "true"}},
+      {{sessionKey, "false"}},
+      verifyStoredAsFixedLenByteArray);
 }
 
 #ifdef VELOX_ENABLE_PARQUET

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -161,7 +161,11 @@ std::shared_ptr<WriterProperties> getArrowParquetWriterOptions(
   properties = properties->maxRowGroupLength(
       static_cast<int64_t>(flushPolicy->rowsInRowGroup()));
   properties = properties->codecOptions(options.codecOptions);
-  properties = properties->enableStoreDecimalAsInteger();
+  if (options.enableStoreDecimalAsInteger.value_or(true)) {
+    properties = properties->enableStoreDecimalAsInteger();
+  } else {
+    properties = properties->disableStoreDecimalAsInteger();
+  }
   if (options.useParquetDataPageV2.value_or(false)) {
     properties = properties->dataPageVersion(arrow::ParquetDataPageVersion::V2);
   } else {
@@ -324,16 +328,17 @@ std::optional<int64_t> toParquetPageSize(std::optional<std::string> pageSize) {
   return config::toCapacity(*pageSize, config::CapacityUnit::BYTE);
 }
 
-std::optional<bool> toParquetEnableDictionary(
-    std::optional<std::string> enableDictionary) {
-  if (!enableDictionary) {
+std::optional<bool> toBoolConfigValue(
+    std::optional<std::string> value,
+    const char* optionName) {
+  if (!value) {
     return std::nullopt;
   }
   try {
-    return folly::to<bool>(*enableDictionary);
+    return folly::to<bool>(*value);
   } catch (const std::exception& e) {
     VELOX_USER_FAIL(
-        "Invalid parquet writer enable dictionary option: {}", e.what());
+        "Invalid parquet writer {} option: {}", optionName, e.what());
   }
 }
 
@@ -635,9 +640,18 @@ void WriterOptions::processConfigs(
   }
 
   if (!enableDictionary) {
-    enableDictionary =
-        toParquetEnableDictionary(session.getWithFallback<std::string>(
-            WriterConfig::kParquetSessionEnableDictionary, connectorConfig));
+    enableDictionary = toBoolConfigValue(
+        session.getWithFallback<std::string>(
+            WriterConfig::kParquetSessionEnableDictionary, connectorConfig),
+        "enable dictionary");
+  }
+
+  if (!enableStoreDecimalAsInteger) {
+    enableStoreDecimalAsInteger = toBoolConfigValue(
+        session.getWithFallback<std::string>(
+            WriterConfig::kParquetSessionEnableStoreDecimalAsInteger,
+            connectorConfig),
+        "enable store decimal as integer");
   }
 
   if (!dictionaryPageSizeLimit) {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -134,6 +134,13 @@ struct WriterOptions : public dwio::common::WriterOptions {
   std::optional<int64_t> dataPageSize;
   std::optional<int64_t> dictionaryPageSizeLimit;
   std::optional<bool> enableDictionary;
+  /// Controls how DECIMAL values are stored by the Writer.
+  /// - If unset, the Writer defaults to storing as integer (true),
+  /// using INT32/INT64 for short DECIMAL precisions; higher precisions are
+  /// stored as FIXED_LEN_BYTE_ARRAY.
+  /// - If set to false, DECIMAL values are stored as FIXED_LEN_BYTE_ARRAY,
+  /// regardless of precision.
+  std::optional<bool> enableStoreDecimalAsInteger;
   std::optional<bool> useParquetDataPageV2;
   std::optional<std::string> createdBy;
 

--- a/velox/dwio/parquet/writer/WriterConfig.h
+++ b/velox/dwio/parquet/writer/WriterConfig.h
@@ -38,6 +38,11 @@ struct WriterConfig {
       "hive.parquet.writer.enable_dictionary";
   static constexpr const char* kParquetHiveConnectorEnableDictionary =
       "hive.parquet.writer.enable-dictionary";
+  static constexpr const char* kParquetSessionEnableStoreDecimalAsInteger =
+      "hive.parquet.writer.enable_store_decimal_as_integer";
+  static constexpr const char*
+      kParquetHiveConnectorEnableStoreDecimalAsInteger =
+          "hive.parquet.writer.enable-store-decimal-as-integer";
   static constexpr const char* kParquetSessionDictionaryPageSizeLimit =
       "hive.parquet.writer.dictionary_page_size_limit";
   static constexpr const char* kParquetHiveConnectorDictionaryPageSizeLimit =


### PR DESCRIPTION
Spark supports controlling how Parquet decimal fields are written via the parameter spark.sql.parquet.writeLegacyFormat=true.When set to true, it forces decimal columns to be stored as FIXED_LEN_BYTE_ARRAY.

When Spark or Flink reads Hive data using ParquetHiveSerDe in Hive CREATE TABLE statements, especially with older Hive versions such as Hive 2.1, forcing decimal fields to be stored as FIXED_LEN_BYTE_ARRAY can resolve compatibility issues. Otherwise, exceptions will be thrown.

Velox uses different data types based on precision by default. For example, a decimal(8,4) will be stored as an int64.  
This pr depends by gluten https://github.com/apache/gluten/pull/11839