### PR TITLE
fix: Off-by-one boundary bug in Spark make_timestamp validation

### DIFF
--- a/velox/functions/sparksql/MakeTimestamp.cpp
+++ b/velox/functions/sparksql/MakeTimestamp.cpp
@@ -32,12 +32,12 @@ std::optional<Timestamp> makeTimeStampFromDecodedArgs(
     DecodedVector* microsVector) {
   // Check hour.
   auto hour = hourVector->valueAt<int32_t>(row);
-  if (hour < 0 || hour > 24) {
+  if (hour < 0 || hour >= 24) {
     return std::nullopt;
   }
   // Check minute.
   auto minute = minuteVector->valueAt<int32_t>(row);
-  if (minute < 0 || minute > 60) {
+  if (minute < 0 || minute >= 60) {
     return std::nullopt;
   }
   // Check microseconds.

--- a/velox/functions/sparksql/tests/MakeTimestampTest.cpp
+++ b/velox/functions/sparksql/tests/MakeTimestampTest.cpp
@@ -157,13 +157,15 @@ TEST_F(MakeTimestampTest, errors) {
        1,
        1,
        1,
+       1,
+       1,
        1});
-  const auto month = makeFlatVector<int32_t>({1, 1, 0, 13, 1, 1, 1, 1});
-  const auto day = makeFlatVector<int32_t>({1, 1, 1, 1, 0, 32, 1, 1});
-  const auto hour = makeFlatVector<int32_t>({1, 1, 1, 1, 1, 1, 25, 1});
-  const auto minute = makeFlatVector<int32_t>({1, 1, 1, 1, 1, 1, 1, 61});
+  const auto month = makeFlatVector<int32_t>({1, 1, 0, 13, 1, 1, 1, 1, 1, 1});
+  const auto day = makeFlatVector<int32_t>({1, 1, 1, 1, 0, 32, 1, 1, 1, 1});
+  const auto hour = makeFlatVector<int32_t>({1, 1, 1, 1, 1, 1, 25, 1, 24, 1});
+  const auto minute = makeFlatVector<int32_t>({1, 1, 1, 1, 1, 1, 1, 61, 1, 60});
   const auto micros =
-      makeFlatVector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1}, microsType);
+      makeFlatVector<int64_t>({1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, microsType);
   auto data = makeRowVector({year, month, day, hour, minute, micros});
   testInvalidInputs(data);
 


### PR DESCRIPTION
Summary: Fix boundary validation in `make_timestamp` to correctly reject `hour=24` and `minute=60`. The checks were using `>` instead of `>=`, allowing invalid values through and producing incorrect timestamps. Update validation to use `hour >= 24` and `minute >= 60` to match the rest of the codebase. Add test cases for the boundary conditions.

Differential Revision: D98564391


