### PR TITLE
feat: Optimize Nimble metadata IO with MetadataCache and pinned caching (#16948)

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -281,6 +281,11 @@ bool HiveConfig::fileMetadataCacheEnabled(
       config_->get<bool>(kFileMetadataCacheEnabled, false));
 }
 
+bool HiveConfig::pinFileMetadata(const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kPinFileMetadataSession, config_->get<bool>(kPinFileMetadata, false));
+}
+
 uint64_t HiveConfig::orcFooterSpeculativeIoSize(
     const config::ConfigBase* session) const {
   return session->get<uint64_t>(

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -233,6 +233,14 @@ class HiveConfig {
   static constexpr const char* kFileMetadataCacheEnabledSession =
       "file_metadata_cache_enabled";
 
+  /// Whether to pin parsed metadata objects (e.g., StripeGroup, IndexGroup)
+  /// in the reader's metadata cache with strong references so they are never
+  /// evicted. This avoids re-reading and re-parsing metadata on every stripe
+  /// access when weak-pointer cache entries would otherwise expire.
+  /// Currently only supported by Nimble format.
+  static constexpr const char* kPinFileMetadata = "pin-file-metadata";
+  static constexpr const char* kPinFileMetadataSession = "pin_file_metadata";
+
   /// Speculative tail-read size in bytes when opening files. Controls how many
   /// bytes are read from the end of the file to load the footer and nearby
   /// metadata in a single IO operation. Format-specific configs with different
@@ -346,6 +354,9 @@ class HiveConfig {
 
   /// Whether to cache file metadata in the process-wide AsyncDataCache.
   bool fileMetadataCacheEnabled(const config::ConfigBase* session) const;
+
+  /// Whether to pin parsed metadata objects in the reader's metadata cache.
+  bool pinFileMetadata(const config::ConfigBase* session) const;
 
   /// Returns the speculative tail read size in bytes for footer.
   /// ORC/Parquet default to 256KB, Nimble defaults to 8MB. 0 means adaptive.

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -639,6 +639,8 @@ void configureReaderOptions(
       connectorQueryCtx->selectiveNimbleReaderEnabled());
   readerOptions.setFileMetadataCacheEnabled(
       hiveConfig->fileMetadataCacheEnabled(sessionProperties));
+  readerOptions.setPinFileMetadata(
+      hiveConfig->pinFileMetadata(sessionProperties));
 
   // Set footer speculative IO size based on file format.
   switch (hiveSplit->fileFormat) {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -835,6 +835,14 @@ Each query can override the config by setting corresponding query session proper
      - Whether to cache file metadata (footer, stripes, index) in the process-wide AsyncDataCache. When enabled,
        the first reader performs a speculative tail read and populates the cache; subsequent readers on the same file
        serve metadata from cache with zero file IO. Currently only supported by Nimble format.
+   * - pin-file-metadata
+     - pin_file_metadata
+     - bool
+     - false
+     - Whether to pin parsed metadata objects (e.g., StripeGroup, IndexGroup) in the reader's metadata cache with
+       strong references so they are never evicted. This avoids re-reading and re-parsing metadata on every stripe
+       access when weak-pointer cache entries would otherwise expire. Can be used independently of
+       file-metadata-cache-enabled. Currently only supported by Nimble format.
    * - hive.reader.collect-column-stats
      - hive.reader.collect_column_stats
      - bool

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -167,6 +167,25 @@ class CachedBufferedInput : public BufferedInput {
         options_);
   }
 
+  /// Creates a clone that reads through the cache but marks entries as
+  /// immediately evictable on destruction (cacheable=false). Use when the
+  /// caller has its own caching layer (e.g., MetadataCache) and does not need
+  /// AsyncDataCache to retain the raw bytes.
+  std::unique_ptr<CachedBufferedInput> cloneNonCacheable() const {
+    auto nonCacheableOptions = options_;
+    nonCacheableOptions.setCacheable(false);
+    return std::make_unique<CachedBufferedInput>(
+        input_,
+        fileNum_,
+        cache_,
+        tracker_,
+        groupId_,
+        ioStatistics_,
+        ioStats_,
+        executor_,
+        nonCacheableOptions);
+  }
+
   cache::AsyncDataCache* cache() const {
     return cache_;
   }

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -746,6 +746,18 @@ class ReaderOptions : public io::ReaderOptions {
     fileMetadataCacheEnabled_ = value;
   }
 
+  /// If true, pins parsed metadata objects (e.g., StripeGroup, IndexGroup) in
+  /// the reader's metadata cache with strong references so they are never
+  /// evicted. This avoids re-reading and re-parsing metadata on every stripe
+  /// access when weak-pointer cache entries would otherwise expire.
+  bool pinFileMetadata() const {
+    return pinFileMetadata_;
+  }
+
+  void setPinFileMetadata(bool value) {
+    pinFileMetadata_ = value;
+  }
+
   /// Whether to load and initialize the cluster index during file open.
   /// When true, the cluster index section is preloaded and the structured
   /// ClusterIndex object is created. Default true.
@@ -794,6 +806,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
   bool fileMetadataCacheEnabled_{false};
+  bool pinFileMetadata_{false};
   bool loadClusterIndex_{true};
   bool loadChunkIndex_{true};
   bool allowEmptyFile_{false};

--- a/velox/dwio/common/tests/CachedBufferedInputTest.cpp
+++ b/velox/dwio/common/tests/CachedBufferedInputTest.cpp
@@ -1588,4 +1588,95 @@ TEST_F(CachedBufferedInputTest, prefetchScope) {
 
   EXPECT_EQ(ioStatistics_->prefetch().sum(), kNumRequests * kRequestSize);
 }
+
+TEST_F(CachedBufferedInputTest, cloneNonCacheable) {
+  constexpr int32_t kContentSize = 1 << 20; // 1MB
+  std::string content(kContentSize, 'x');
+  auto readFile = std::make_shared<InMemoryReadFile>(content);
+
+  io::ReaderOptions readerOptions(pool_.get());
+  readerOptions.setLoadQuantum(1 << 20);
+
+  auto& ids = fileIds();
+  StringIdLease fileId(ids, "testFile");
+  StringIdLease groupId(ids, "testGroup");
+
+  const auto fileNum = fileId.id();
+  CachedBufferedInput input(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId),
+      cache_.get(),
+      tracker_,
+      std::move(groupId),
+      ioStatistics_,
+      /*ioStats=*/nullptr,
+      executor_.get(),
+      readerOptions);
+
+  ASSERT_TRUE(input.hasCache());
+
+  auto nonCacheable = input.cloneNonCacheable();
+  ASSERT_TRUE(nonCacheable->hasCache());
+
+  // Read through the non-cacheable clone.
+  constexpr uint64_t kOffset = 0;
+  constexpr uint64_t kLength = 1'024;
+  StreamIdentifier sid(0);
+  auto stream = nonCacheable->enqueue({kOffset, kLength}, &sid);
+  nonCacheable->load(LogType::FILE);
+
+  auto result = getNext(*stream);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->size(), kLength);
+
+  // The cache should have an entry from the non-cacheable read.
+  auto statsAfterLoad = cache_->refreshStats();
+  EXPECT_GT(statsAfterLoad.numEntries, 0);
+
+  // The entry should not be evictable while the non-cacheable clone is alive.
+  const cache::RawFileCacheKey cacheKey{fileNum, kOffset};
+  EXPECT_FALSE(cache_->testingIsEvictable(cacheKey));
+
+  // Release the stream and destroy the non-cacheable input. Because
+  // cacheable=false, the destructor marks preloaded entries as immediately
+  // evictable (lastUse=0, numUses=0).
+  stream.reset();
+  nonCacheable.reset();
+
+  // The entry is still in cache but now marked as immediately evictable.
+  auto statsAfterDestroy = cache_->refreshStats();
+  EXPECT_EQ(statsAfterDestroy.numEntries, statsAfterLoad.numEntries);
+  EXPECT_TRUE(cache_->testingIsEvictable(cacheKey));
+
+  // Read the same region through a cacheable input — should still work.
+  StringIdLease fileId2(ids, "testFile2");
+  StringIdLease groupId2(ids, "testGroup2");
+  const auto fileNum2 = fileId2.id();
+  CachedBufferedInput cacheableInput(
+      readFile,
+      MetricsLog::voidLog(),
+      std::move(fileId2),
+      cache_.get(),
+      tracker_,
+      std::move(groupId2),
+      ioStatistics_,
+      /*ioStats=*/nullptr,
+      executor_.get(),
+      readerOptions);
+
+  auto stream2 = cacheableInput.enqueue({kOffset, kLength}, &sid);
+  cacheableInput.load(LogType::FILE);
+  auto result2 = getNext(*stream2);
+  ASSERT_TRUE(result2.has_value());
+  EXPECT_EQ(result2->size(), kLength);
+
+  // The cacheable input's entry should persist and not be marked evictable.
+  stream2.reset();
+  const cache::RawFileCacheKey cacheKey2{fileNum2, kOffset};
+  auto statsAfterCacheable = cache_->refreshStats();
+  EXPECT_GT(statsAfterCacheable.numEntries, 0);
+  EXPECT_FALSE(cache_->testingIsEvictable(cacheKey2));
+}
+
 } // namespace


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/nimble/pull/616

CONTEXT: Nimble's metadata IO (stripe groups, cluster index, chunk index) uses a weak-pointer cache (ReferenceCountedCache) that expires entries as soon as the last reference is dropped. For workloads that access multiple stripes, metadata gets re-read and re-parsed on every stripe access. Additionally, when AsyncDataCache is enabled, both metadata and data are cached indiscriminately — metadata is small and hot while data is large and often cold, leading to cache pollution.

WHAT:
1. **MetadataCache**: New thread-safe template cache (MetadataCache.h) replacing ReferenceCountedCache with three entry types:
   - Preloaded: strong refs moved to weak cache after first access
   - Pinned: strong refs when `pinEntries_=true`, never evicted
   - Cached: weak refs (existing behavior)
   Uses read-lock fast path (shared_mutex) with builder called outside both locks.

2. **TabletReader**: Migrated stripeGroupCache_, clusterIndexCache_, chunkIndexCache_ from ReferenceCountedCache to MetadataCache. Added `pinMetadataInCache` option to pin parsed metadata objects with strong references.

3. **ReaderOptions**: Added `pinMetadataInCache()` getter/setter to velox::dwio::common::ReaderOptions. When enabled, pins metadata in the reader's MetadataCache so it survives across stripe accesses.

4. **ReaderBase**: Replaced `prevStripeIdentifier_` class member with local variable in `setStripe()` — only needs to stay alive during the call.

5. **Test coverage**:
   - MetadataCacheTest: 9 tests including preload, customBuilder, preloadDoesNotOverwrite (parameterized over pin/non-pin mode), and concurrent fuzzer test with 8 threads.
   - E2EFilterTest: Extended parameterization with pinMetadataInCache.
   - E2EIndexTest: Extended parameterization with pinMetadataInCache + test loop over enableCache.
   - SelectiveNimbleReaderTest: Added pinMetadataInCache test with enableCache loop.

6. **Benchmark tuning**: Changed chunk_index_min_avg_chunks default to 1.0, commented out custom sizeClassSizes, removed setIOExecutor in cluster index benchmark.

Reviewed By: tanjialiang, HuamengJiang, kewang1024

Differential Revision: D98260058
