### PR TITLE
feat: Trace index splits in IndexLookupJoin for replay (#16950)

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -18,9 +18,12 @@
 #include "velox/buffer/Buffer.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/Connector.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/exec/OperatorTraceWriter.h"
 #include "velox/exec/OperatorType.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
+#include "velox/exec/trace/TraceUtil.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
 
@@ -376,6 +379,40 @@ void IndexLookupJoin::initialize() {
       lookupTableHandle_,
       lookupColumnHandles_,
       connectorQueryCtx_.get());
+
+  createIndexSplitTracer();
+}
+
+void IndexLookupJoin::createIndexSplitTracer() {
+  if (inputTracer_ == nullptr) {
+    return;
+  }
+  const auto& queryConfig = operatorCtx_->driverCtx()->queryConfig();
+  const auto taskTraceDir = exec::trace::getTaskTraceDirectory(
+      queryConfig.queryTraceDir(),
+      operatorCtx_->driverCtx()->task->queryCtx()->queryId(),
+      operatorCtx_->taskId());
+  const auto opTraceDir = exec::trace::getOpTraceDirectory(
+      taskTraceDir,
+      planNodeId(),
+      operatorCtx_->driverCtx()->pipelineId,
+      operatorCtx_->driverCtx()->driverId);
+  indexSplitTracer_ =
+      std::make_unique<trace::OperatorTraceSplitWriter>(this, opTraceDir);
+}
+
+void IndexLookupJoin::traceIndexSplit(const exec::Split& split) {
+  if (FOLLY_UNLIKELY(indexSplitTracer_ != nullptr)) {
+    auto connectorSplit = split.connectorSplit;
+    indexSplitTracer_->write(exec::Split(std::move(connectorSplit)));
+  }
+}
+
+void IndexLookupJoin::closeIndexSplitTracer() {
+  // NOTE: skip calling finish() because the input tracer (via Operator::close)
+  // already wrote the summary file. Both tracers share the same summary path
+  // and finish() would fail with O_EXCL.
+  indexSplitTracer_.reset();
 }
 
 void IndexLookupJoin::ensureInputLoaded(const InputBatchState& batch) {
@@ -633,6 +670,7 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
       return true;
     }
 
+    traceIndexSplit(split);
     indexSplits_.push_back(std::move(split.connectorSplit));
   }
 }
@@ -1416,6 +1454,8 @@ void IndexLookupJoin::close() {
   lookupOutputNulls_ = nullptr;
 
   Operator::close();
+
+  closeIndexSplitTracer();
 }
 
 bool IndexLookupJoin::applyFilterOnLookupResult(InputBatchState& batch) {

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -391,5 +391,18 @@ class IndexLookupJoin : public Operator {
   // after the no-more-splits signal is received (i.e., 'noMoreIndexSplits_' is
   // true).
   std::vector<std::shared_ptr<connector::ConnectorSplit>> indexSplits_;
+
+  // Traces the index splits received by this operator for replay. Set when
+  // tracing is enabled for this operator.
+  std::unique_ptr<trace::TraceSplitWriter> indexSplitTracer_;
+
+  // Creates the index split tracer if input tracing is enabled.
+  void createIndexSplitTracer();
+
+  // Traces the given index split for replay.
+  void traceIndexSplit(const exec::Split& split);
+
+  // Closes and resets the index split tracer.
+  void closeIndexSplitTracer();
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -143,6 +143,26 @@ class TestIndexConnectorSplit : public connector::ConnectorSplit {
   std::string toString() const override {
     return "TestIndexConnectorSplit";
   }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = "TestIndexConnectorSplit";
+    obj["connectorId"] = connectorId;
+    return obj;
+  }
+
+  static std::shared_ptr<TestIndexConnectorSplit> create(
+      const folly::dynamic& obj) {
+    return std::make_shared<TestIndexConnectorSplit>(
+        obj["connectorId"].getString());
+  }
+
+  static void registerSerDe() {
+    auto& registry = DeserializationWithContextRegistryForSharedPtr();
+    registry.Register(
+        "TestIndexConnectorSplit",
+        [](const folly::dynamic& obj, void*) { return create(obj); });
+  }
 };
 
 class TestIndexColumnHandle : public connector::ColumnHandle {

--- a/velox/tool/trace/IndexLookupJoinReplayer.cpp
+++ b/velox/tool/trace/IndexLookupJoinReplayer.cpp
@@ -15,21 +15,36 @@
  */
 
 #include "velox/tool/trace/IndexLookupJoinReplayer.h"
+#include "velox/common/Casts.h"
+#include "velox/connectors/Connector.h"
+#include "velox/exec/OperatorTraceReader.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/trace/TraceUtil.h"
+#include "velox/tool/trace/TraceReplayTaskRunner.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::tool::trace {
+
 core::PlanNodePtr IndexLookupJoinReplayer::createPlanNode(
     const core::PlanNode* node,
     const core::PlanNodeId& nodeId,
     const core::PlanNodePtr& source) const {
   const auto* indexLookupJoinNode =
-      dynamic_cast<const core::IndexLookupJoinNode*>(node);
-  VELOX_CHECK_NOT_NULL(indexLookupJoinNode);
+      checkedPointerCast<const core::IndexLookupJoinNode>(node);
+
+  // Re-create the lookup source node with a unique node ID to avoid conflicts
+  // with the replay plan's generated node IDs (e.g., TraceScanNode).
+  const auto* lookupSource = checkedPointerCast<const core::TableScanNode>(
+      indexLookupJoinNode->lookupSource().get());
+  auto replayLookupSource = std::make_shared<core::TableScanNode>(
+      planNodeIdGenerator_->next(),
+      lookupSource->outputType(),
+      lookupSource->tableHandle(),
+      lookupSource->assignments());
+
   return std::make_shared<core::IndexLookupJoinNode>(
       nodeId,
       indexLookupJoinNode->joinType(),
@@ -38,8 +53,64 @@ core::PlanNodePtr IndexLookupJoinReplayer::createPlanNode(
       indexLookupJoinNode->joinConditions(),
       indexLookupJoinNode->filter(),
       indexLookupJoinNode->hasMarker(),
-      source, // Probe side
-      indexLookupJoinNode->lookupSource(), // Index side
+      source,
+      replayLookupSource,
       indexLookupJoinNode->outputType());
 }
+
+RowVectorPtr IndexLookupJoinReplayer::run(
+    bool copyResults,
+    bool cursorCopyResult) {
+  auto queryCtx = createQueryCtx();
+  const auto plan = createPlan();
+
+  // Find the IndexLookupJoinNode to get the index source node ID.
+  const auto* replayNode =
+      core::PlanNode::findNodeById(plan.get(), replayPlanNodeId_);
+  VELOX_CHECK_NOT_NULL(replayNode);
+  const auto* indexLookupJoinNode =
+      checkedPointerCast<const core::IndexLookupJoinNode>(replayNode);
+  const auto indexSourceNodeId = indexLookupJoinNode->lookupSource()->id();
+
+  TraceReplayTaskRunner traceTaskRunner(plan, std::move(queryCtx));
+  traceTaskRunner.maxDrivers(static_cast<int32_t>(driverIds_.size()))
+      .cursorCopyResult(cursorCopyResult);
+
+  // Provide the traced index splits if the lookup source needs them.
+  const auto indexSplits = getIndexSplits();
+  if (!indexSplits.empty()) {
+    traceTaskRunner.splits(
+        indexSourceNodeId,
+        std::vector<exec::Split>(indexSplits.begin(), indexSplits.end()));
+  }
+
+  auto [task, result] = traceTaskRunner.run(copyResults);
+  printStats(task);
+  return result;
+}
+
+std::vector<exec::Split> IndexLookupJoinReplayer::getIndexSplits() const {
+  std::vector<std::string> splitInfoDirs;
+  splitInfoDirs.reserve(driverIds_.size());
+  for (const auto driverId : driverIds_) {
+    splitInfoDirs.push_back(
+        exec::trace::getOpTraceDirectory(
+            nodeTraceDir_, pipelineIds_.front(), driverId));
+  }
+  const auto serializedSplits =
+      exec::trace::OperatorTraceSplitReader(
+          splitInfoDirs, memory::MemoryManager::getInstance()->tracePool())
+          .read();
+
+  std::vector<exec::Split> splits;
+  for (const auto& serializedSplit : serializedSplits) {
+    folly::dynamic splitInfoObject{folly::parseJson(serializedSplit)};
+    const auto split =
+        ISerializable::deserialize<connector::ConnectorSplit>(splitInfoObject);
+    splits.emplace_back(
+        std::const_pointer_cast<connector::ConnectorSplit>(split));
+  }
+  return splits;
+}
+
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/IndexLookupJoinReplayer.h
+++ b/velox/tool/trace/IndexLookupJoinReplayer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanNode.h"
+#include "velox/exec/Split.h"
 #include "velox/tool/trace/OperatorReplayerBase.h"
 
 namespace facebook::velox::tool::trace {
@@ -43,10 +44,17 @@ class IndexLookupJoinReplayer : public OperatorReplayerBase {
             queryCapacity,
             executor) {}
 
+  /// Overrides to provide index splits to the task during replay.
+  RowVectorPtr run(bool copyResults = true, bool cursorCopyResult = false)
+      override;
+
  private:
   core::PlanNodePtr createPlanNode(
       const core::PlanNode* node,
       const core::PlanNodeId& nodeId,
       const core::PlanNodePtr& source) const override;
+
+  // Reads traced index splits from the trace directory.
+  std::vector<exec::Split> getIndexSplits() const;
 };
 } // namespace facebook::velox::tool::trace

--- a/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
+++ b/velox/tool/trace/tests/IndexLookupJoinReplayerTest.cpp
@@ -62,11 +62,14 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
     velox::exec::trace::registerDummySourceSerDe();
     core::ITypedExpr::registerSerDe();
     registerPartitionFunctionSerDe();
-    auto connectorCpuExecutor =
-        std::make_unique<folly::CPUThreadPoolExecutor>(128);
-    TestIndexConnectorFactory::registerConnector(connectorCpuExecutor.get());
     TestIndexTableHandle::registerSerDe();
     TestIndexColumnHandle::registerSerDe();
+    TestIndexConnectorSplit::registerSerDe();
+  }
+
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    TestIndexConnectorFactory::registerConnector(connectorCpuExecutor_.get());
   }
 
   void TearDown() override {
@@ -149,9 +152,13 @@ class IndexLookupJoinReplayerTest : public HiveConnectorTestBase {
   // Makes index table handle with the specified index table and async lookup
   // flag.
   static std::shared_ptr<TestIndexTableHandle> makeIndexTableHandle(
-      const std::shared_ptr<TestIndexTable>& indexTable) {
+      const std::shared_ptr<TestIndexTable>& indexTable,
+      bool needsIndexSplit = false) {
     return std::make_shared<TestIndexTableHandle>(
-        kTestIndexConnectorName, indexTable, /*asyncLookup*/ false);
+        kTestIndexConnectorName,
+        indexTable,
+        /*asyncLookup=*/false,
+        needsIndexSplit);
   }
 
   struct PlanWithSplits {
@@ -294,6 +301,93 @@ TEST_F(IndexLookupJoinReplayerTest, test) {
           .copyResults(pool(), task);
 
   // Run the replayer
+  const auto replayingResult = IndexLookupJoinReplayer(
+                                   traceRoot,
+                                   task->queryCtx()->queryId(),
+                                   task->taskId(),
+                                   traceNodeId_,
+                                   "IndexLookupJoin",
+                                   "",
+                                   0,
+                                   executor_.get())
+                                   .run();
+  assertEqualResults({results}, {replayingResult});
+}
+
+TEST_F(IndexLookupJoinReplayerTest, testWithIndexSplits) {
+  // Test that index splits are traced and replayed correctly when
+  // needsIndexSplit is true.
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId probeScanId;
+
+  const auto indexTable = createIndexTable(
+      /*numEqualJoinKeys=*/1,
+      makeRowVector(
+          indexType_->names(),
+          {makeFlatVector<int64_t>({1, 2, 3}),
+           makeFlatVector<int32_t>({10, 20, 30}),
+           makeFlatVector<int16_t>({100, 200, 300}),
+           makeFlatVector<StringView>({"a", "b", "c"})}),
+      makeRowVector(
+          {"u4", "u5"},
+          {makeFlatVector<int64_t>({1000, 2000, 3000}),
+           makeFlatVector<StringView>({"x", "y", "z"})}));
+
+  // Create handle with needsIndexSplit=true.
+  auto indexTableHandle =
+      makeIndexTableHandle(indexTable, /*needsIndexSplit=*/true);
+
+  connector::ColumnHandleMap columnHandles;
+  for (const auto& name : indexType_->names()) {
+    columnHandles[name] = std::make_shared<TestIndexColumnHandle>(name);
+  }
+
+  auto indexScan = std::make_shared<core::TableScanNode>(
+      planNodeIdGenerator->next(), indexType_, indexTableHandle, columnHandles);
+  const auto indexScanId = indexScan->id();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(probeType_)
+          .capturePlanNodeId(probeScanId)
+          .indexLookupJoin(
+              leftKeys,
+              rightKeys,
+              std::dynamic_pointer_cast<const core::TableScanNode>(indexScan),
+              /*joinConditions=*/{},
+              /*filter=*/"",
+              /*hasMarker=*/false,
+              concat(probeType_, indexType_)->names(),
+              core::JoinType::kInner)
+          .capturePlanNodeId(traceNodeId_)
+          .planNode();
+
+  const auto testDir = TempDirectoryPath::create();
+  const auto traceRoot = fmt::format("{}/{}", testDir->getPath(), "traceRoot");
+  std::shared_ptr<Task> task;
+
+  const auto sourceFilePath = TempFilePath::create();
+  writeToFile(sourceFilePath->getPath(), probeInput_);
+
+  // Provide index splits to the original query.
+  auto results =
+      AssertQueryBuilder(plan)
+          .config(core::QueryConfig::kQueryTraceEnabled, true)
+          .config(core::QueryConfig::kQueryTraceDir, traceRoot)
+          .config(core::QueryConfig::kQueryTraceMaxBytes, 100UL << 30)
+          .config(core::QueryConfig::kQueryTraceTaskRegExp, ".*")
+          .config(core::QueryConfig::kQueryTraceNodeId, traceNodeId_)
+          .splits(
+              probeScanId,
+              {Split(makeHiveConnectorSplit(sourceFilePath->getPath()))})
+          .splits(
+              indexScanId,
+              {Split(
+                  std::make_shared<TestIndexConnectorSplit>(
+                      kTestIndexConnectorName))})
+          .copyResults(pool(), task);
+
+  // Replay and verify the results match.
   const auto replayingResult = IndexLookupJoinReplayer(
                                    traceRoot,
                                    task->queryCtx()->queryId(),


### PR DESCRIPTION
Summary:

Adds index split tracing to the IndexLookupJoin operator and a corresponding
replayer. During tracing, the operator records the ConnectorSplit objects
received for the index (lookup) side using an OperatorTraceSplitWriter.
During replay, IndexLookupJoinReplayer deserializes the traced splits and
provides them to a live TableScanNode so the lookup side performs actual
index lookups against the original table.

Key changes:
- IndexLookupJoin::initialize() creates an indexSplitTracer_ when input
  tracing is enabled.
- IndexLookupJoin::addIndexSplits() writes each split (without group ID) to
  the tracer.
- IndexLookupJoinReplayer overrides run() to read the traced splits via
  OperatorTraceSplitReader and route them to the lookup source node by
  plan node ID.
- IndexLookupJoinReplayer::createPlanNode() re-creates the lookup source
  TableScanNode with a fresh plan node ID to avoid ID collision with the
  TraceScanNode generated for the probe side.
- TestIndexConnectorSplit gains serialize/deserialize/registerSerDe support
  for the round-trip test.
- Registers the prism connector in TraceReplayerMain for production replay.

Reviewed By: xiaoxmeng

Differential Revision: D98623165


