### PR TITLE
fix: Premature return in readColumns skips remaining columns after all-null column (#16951)

### DIFF
--- a/velox/serializers/PrestoSerializerDeserializationUtils.cpp
+++ b/velox/serializers/PrestoSerializerDeserializationUtils.cpp
@@ -1349,7 +1349,7 @@ void readColumns(
                 pool,
                 opts,
                 columnResult)) {
-          return;
+          continue;
         }
       }
       checkTypeEncoding(encoding, columnType);

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -1092,6 +1092,39 @@ TEST_P(PrestoSerializerTest, unknown) {
   testAllNullSerializedAsUnknown(flatVector, BIGINT());
 }
 
+TEST_P(PrestoSerializerTest, multiColumnWithUnknown) {
+  const vector_size_t size = 50;
+
+  // Create a RowVector with 2 columns. Column 0 is UNKNOWN with all nulls.
+  auto unknownCol =
+      BaseVector::createNullConstant(UNKNOWN(), size, pool_.get());
+  auto intCol = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto rowVector = makeRowVector({unknownCol, intCol});
+
+  // Serialize two pages into a single stream.
+  std::ostringstream out;
+  serialize(rowVector, &out, nullptr);
+  serialize(rowVector, &out, nullptr);
+
+  auto bytes = out.str();
+
+  // Deserialize expecting (BIGINT, INTEGER).
+  auto outputType = ROW({"c0", "c1"}, {BIGINT(), INTEGER()});
+  auto byteStream = toByteStream(bytes);
+  auto paramOptions = getParamSerdeOptions(nullptr);
+
+  RowVectorPtr result;
+  serde_->deserialize(
+      byteStream.get(), pool_.get(), outputType, &result, 0, &paramOptions);
+  ASSERT_EQ(result->size(), size);
+
+  ASSERT_FALSE(byteStream->atEnd());
+  serde_->deserialize(
+      byteStream.get(), pool_.get(), outputType, &result, 0, &paramOptions);
+  ASSERT_EQ(result->size(), size);
+  ASSERT_TRUE(byteStream->atEnd());
+}
+
 TEST_P(PrestoSerializerTest, multiPage) {
   std::ostringstream out;
   std::vector<RowVectorPtr> testVectors;


### PR DESCRIPTION
Summary:

When deserializing a multi-column page where a non-last column has `BYTE_ARRAY` encoding (UNKNOWN type) but the output expects a different type, `tryReadNullColumn` successfully reads that column's all-null data. However, return exits the entire column-reading loop, leaving subsequent columns' bytes unconsumed in the stream. This misaligns the stream position, causing the next page read to interpret data bytes as header fields.

Differential Revision: D98644255
