### PR TITLE
fix: Fix uninitialized SpillConfig::numMaxMergeFiles causing flaky SpillerTest failure (#16956)

### DIFF
--- a/.github/scripts/detect-build-impact.py
+++ b/.github/scripts/detect-build-impact.py
@@ -298,7 +298,9 @@ def main():
 
     for file_path in changed_files:
         targets, method = resolve_file_to_targets(
-            file_path, file_to_targets, header_to_sources,
+            file_path,
+            file_to_targets,
+            header_to_sources,
         )
         if targets:
             directly_affected.update(targets)

--- a/.github/scripts/generate-dependency-graph.py
+++ b/.github/scripts/generate-dependency-graph.py
@@ -223,9 +223,7 @@ def scan_one_file(
     return source_file, headers
 
 
-def scan_header_deps(
-    build_dir: str, source_dir: str
-) -> dict[str, list[str]]:
+def scan_header_deps(build_dir: str, source_dir: str) -> dict[str, list[str]]:
     """Scan compile_commands.json with g++ -MM to build header_to_sources map."""
     compile_commands_path = os.path.join(build_dir, "compile_commands.json")
     if not os.path.exists(compile_commands_path):

--- a/velox/common/base/SpillConfig.h
+++ b/velox/common/base/SpillConfig.h
@@ -166,7 +166,7 @@ struct SpillConfig {
   /// files to avoid using too much memory and causing OOM. Note that this is
   /// only applicable for ordered spill, is not applicable for spill scenarios
   /// that don't need sorting, e.g. HashJoin.
-  uint32_t numMaxMergeFiles;
+  uint32_t numMaxMergeFiles{0};
 
   /// Prefix sort config when spilling, enable prefix sort when this config is
   /// set, otherwise, fallback to timsort.


### PR DESCRIPTION
Summary:

verifySortedSpillData → createOrderedReader(spillConfig_, ...), where the uninitialized spillConfig_.numMaxMergeFiles happens to be 1, triggering VELOX_CHECK_NE(numMaxMergeFiles, 1).

Differential Revision: D98673049


