### PR TITLE
fix: Fix flaky PrintPlanWithStatsTest by marking blockedWaitForSplit stats as optional (#16957)

### DIFF
--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -213,6 +213,12 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"        runningIsBlockedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"    -- TableScan\\[2\\]\\[table: hive_table\\] -> c0:INTEGER, c1:BIGINT"},
        {"       Input: 2000 rows \\(.+\\), Raw Input: 20480 rows \\(.+\\), Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 20, DynamicFilter producer plan nodes: 3, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
+       // These lines may or may not appear depending on whether the operator
+       // gets blocked waiting for a split during a run.
+       {"          blockedWaitForSplitTimes\\s+sum: .+, count: .+, min: 1, max: 1, avg: 1",
+        true},
+       {"          blockedWaitForSplitWallNanos\\s+sum: .+, count: .+, min: .+, max: .+",
+        true},
        {"          cacheWaitWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
         true},
        {"          coalescedSsdLoadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
@@ -332,6 +338,10 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
     std::vector<ExpectedLine> scanDisablePrefetchMetrics = {
         {"  -- TableScan\\[0\\]\\[table: hive_table\\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR"},
         {"     Input: 10000 rows \\(.+\\), Output: 10000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
+        {"        blockedWaitForSplitTimes\\s+sum: 1, count: 1, min: 1, max: 1, avg: 1",
+         true},
+        {"        blockedWaitForSplitWallNanos\\s+sum: .+, count: 1, min: .+, max: .+",
+         true},
         {"        cacheWaitWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
          true},
         {"        coalescedSsdLoadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
@@ -380,6 +390,10 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
     std::vector<ExpectedLine> scanPrefetchMetrics = {
         {"  -- TableScan\\[0\\]\\[table: hive_table\\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR"},
         {"     Input: 10000 rows \\(.+\\), Output: 10000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+)"},
+        {"        blockedWaitForSplitTimes\\s+sum: 1, count: 1, min: 1, max: 1, avg: 1",
+         true},
+        {"        blockedWaitForSplitWallNanos\\s+sum: .+, count: 1, min: .+, max: .+",
+         true},
         {"        cacheWaitWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
          true},
         {"        coalescedSsdLoadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
@@ -485,6 +499,12 @@ TEST_F(PrintPlanWithStatsTest, tableWriterWithTableScan) {
           {"      writeIOWallNanos\\s+sum: .+, count: 1, min: .+, max: .+, avg: .+"},
           {R"(  -- TableScan\[0\]\[table: hive_table\] -> c0:BIGINT, c1:INTEGER, c2:SMALLINT, c3:REAL, c4:DOUBLE, c5:VARCHAR)"},
           {R"(     Input: 100 rows \(.+\), Output: 100 rows \(.+\), Cpu time: .+, Blocked wall time: .+, Peak memory: .+, Memory allocations: .+, Threads: 1, Splits: 1, CPU breakdown: B/I/O/F (.+/.+/.+/.+))"},
+          // These lines may or may not appear depending on whether the operator
+          // gets blocked waiting for a split during a run.
+          {"        blockedWaitForSplitTimes\\s+sum: 1, count: 1, min: 1, max: 1, avg: 1",
+           true},
+          {"        blockedWaitForSplitWallNanos\\s+sum: .+, count: 1, min: .+, max: .+",
+           true},
           {"        cacheWaitWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",
            true},
           {"        coalescedSsdLoadWallNanos[ ]* sum: .+, count: .+, min: .+, max: .+",


### PR DESCRIPTION
Summary:

Fix flakness: 
```
readCursorAsync(...) {
  cursor->start();  // driver thread starts
  auto future = ContinueFuture::makeEmpty();
  while (!cursor->noMoreSplits()) {
    if (future.valid()) {
      future.wait();
    }
    future = addSplits(cursor.get()); // main thread add split
```
1. cursor->start() spawns driver thread
2. Driver thread: TableScan::isBlocked() → Task::getSplitOrFuture() → kWaitForSplit (no splits yet)
3. Main thread: hasn't reached addSplits(cursor.get()) yet
4. The driver blocks, and when it unblocks, recordBlockingTime writes blockedWaitForSplitTimes. 

That stat then appears in the output but the test doesn't expect it.

Fix: Mark these as optional, same pattern as blockedWaitForJoinBuildTimes

Reviewed By: xiaoxmeng

Differential Revision: D98678512


