### PR TITLE
fix: Fix int32_t truncation of randomSeed in NoisyCountSumAvgAccumulator::deserialize (#16958)

### DIFF
--- a/velox/functions/lib/aggregates/noisy_aggregation/NoisyCountSumAvgAccumulator.h
+++ b/velox/functions/lib/aggregates/noisy_aggregation/NoisyCountSumAvgAccumulator.h
@@ -107,7 +107,7 @@ class NoisyCountSumAvgAccumulator {
   // sizeof(double) for lowerBound_ value
   // sizeof(double) for upperBound_ value
   // sizeof(bool) for randomSeed_ has_value flag
-  // sizeof(int32_t) for randomSeed_ value
+  // sizeof(int64_t) for randomSeed_ value
   static size_t serializedSize() {
     return sizeof(double) + sizeof(uint64_t) + sizeof(double) + sizeof(bool) +
         sizeof(double) + sizeof(double) + sizeof(bool) + sizeof(int64_t);
@@ -137,7 +137,7 @@ class NoisyCountSumAvgAccumulator {
     std::optional<double> lowerBound = stream.read<double>();
     std::optional<double> upperBound = stream.read<double>();
     bool hasRandomSeed = stream.read<bool>();
-    std::optional<int32_t> randomSeed = stream.read<int64_t>();
+    std::optional<int64_t> randomSeed = stream.read<int64_t>();
     return NoisyCountSumAvgAccumulator(
         sum,
         count,


### PR DESCRIPTION
Summary:

per titile, fix a flaky test

```
[ RUN      ] NoisyCountIfGaussianAggregationTest.oneAggregateMultipleGroupsNoNoise
E20260329 22:33:04.161525 43072 Exceptions.h:87] Line: /__w/velox/velox/velox/serializers/PrestoSerializer.cpp:53, Function:computeChecksum, Expression:  Tried to read 959591216 bytes, larger than what's remained in source 2519 bytes. Source details: file (offset 2.48KB/size 2.48KB) current (position 21B/ size 2.48KB), Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Tried to read 959591216 bytes, larger than what's remained in source 2519 bytes. Source details: file (offset 2.48KB/size 2.48KB) current (position 21B/ size 2.48KB)
Retriable: False
Context: Operator: Aggregation[4] 1
Function: computeChecksum
File: /__w/velox/velox/velox/serializers/PrestoSerializer.cpp
Line: 53
Stack trace:
# 0  _ZN8facebook5velox7process10StackTraceC1Ei
# 1  _ZN8facebook5velox14VeloxExceptionC1EPKcmS3_St17basic_string_viewIcSt11char_traitsIcEES7_S7_S7_bNS0_24CompileTimeStringLiteralENS1_4TypeES7_
# 2  _ZN8facebook5velox6detail14veloxCheckFailINS0_17VeloxRuntimeErrorERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEvRKNS1_18VeloxCheckFailArgsET0_NS0_24CompileTimeStringLiteralE
# 3  _ZN8facebook5velox10serializer6presto17PrestoVectorSerde11deserializeEPNS0_15ByteInputStreamEPNS0_6memory10MemoryPoolESt10shared_ptrIKNS0_7RowTypeEEPS9_INS0_9RowVectorEEiPKNS0_11VectorSerde7OptionsE
# 4  _ZN8facebook5velox10serializer6presto17PrestoVectorSerde11deserializeEPNS0_15ByteInputStreamEPNS0_6memory10MemoryPoolESt10shared_ptrIKNS0_7RowTypeEEPS9_INS0_9RowVectorEEPKNS0_11VectorSerde7OptionsE
# 5  _ZN8facebook5velox17VectorStreamGroup4readEPNS0_15ByteInputStreamEPNS0_6memory10MemoryPoolESt10shared_ptrIKNS0_7RowTypeEEPNS0_11VectorSerdeEPS7_INS0_9RowVectorEEPKNSB_7OptionsE
# 6  _ZN8facebook5velox10serializer24SerializedPageFileReader9nextBatchERSt10shared_ptrINS0_9RowVectorEE
# 7  _ZN8facebook5velox4exec20FileSpillMergeStream9nextBatchEv
# 8  _ZN8facebook5velox4exec14SpillPartition27createOrderedReaderInternalEmPNS0_6memory10MemoryPoolEPNS1_10SpillStatsE
# 9  _ZN8facebook5velox4exec14SpillPartition19createOrderedReaderERKNS0_6common11SpillConfigEPNS0_6memory10MemoryPoolEPNS1_10SpillStatsE
# 10 _ZN8facebook5velox4exec11GroupingSet31prepareNextSpillPartitionOutputEv
# 11 _ZN8facebook5velox4exec11GroupingSet18getOutputWithSpillEiiRKSt10shared_ptrINS0_9RowVectorEE
# 12 _ZN8facebook5velox4exec15HashAggregation9getOutputEv
# 13 _ZZN8facebook5velox4exec6Driver11runInternalERSt10shared_ptrIS2_ERS3_INS1_13BlockingStateEERS3_INS0_9RowVectorEEENKUlvE3_clEv
# 14 _ZN8facebook5velox4exec6Driver11runInternalERSt10shared_ptrIS2_ERS3_INS1_13BlockingStateEERS3_INS0_9RowVectorEE
# 15 _ZN8facebook5velox4exec6Driver3runESt10shared_ptrIS2_E
# 16 _ZN5folly6detail8function5call_IZN8facebook5velox4exec6Driver7enqueueESt10shared_ptrIS6_EEUlvE_Lb1ELb0EvJEEET2_DpT3_RNS1_4DataE
# 17 _ZN5folly6detail8function14FunctionTraitsIFvvEEclEv
# 18 _ZN5folly18ThreadPoolExecutor7runTaskERKSt10shared_ptrINS0_6ThreadEEONS0_4TaskE
# 19 _ZN5folly21CPUThreadPoolExecutor9threadRunESt10shared_ptrINS_18ThreadPoolExecutor6ThreadEE
# 20 _ZSt13__invoke_implIvRMN5folly18ThreadPoolExecutorEFvSt10shared_ptrINS1_6ThreadEEERPS1_JRS4_EET_St21__invoke_memfun_derefOT0_OT1_DpOT2_
# 21 _ZSt8__invokeIRMN5folly18ThreadPoolExecutorEFvSt10shared_ptrINS1_6ThreadEEEJRPS1_RS4_EENSt15__invoke_resultIT_JDpT0_EE4typeEOSC_DpOSD_
# 22 _ZNSt5_BindIFMN5folly18ThreadPoolExecutorEFvSt10shared_ptrINS1_6ThreadEEEPS1_S4_EE6__callIvJEJLm0ELm1EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
# 23 _ZNSt5_BindIFMN5folly18ThreadPoolExecutorEFvSt10shared_ptrINS1_6ThreadEEEPS1_S4_EEclIJEvEET0_DpOT_
# 24 _ZN5folly6detail8function5call_ISt5_BindIFMNS_18ThreadPoolExecutorEFvSt10shared_ptrINS4_6ThreadEEEPS4_S7_EELb1ELb0EvJEEET2_DpT3_RNS1_4DataE
# 25 0x00000000000dbae4
# 26 start_thread
# 27 clone
" thrown in the test body.
[  FAILED  ] NoisyCountIfGaussianAggregationTest.oneAggregateMultipleGroupsNoNoise (263 ms)
```

Reviewed By: xiaoxmeng

Differential Revision: D98700209


