### PR TITLE
fix: Add memory reclaimer to HashTableCache pool (#16963)

### DIFF
--- a/velox/exec/HashTableCache.cpp
+++ b/velox/exec/HashTableCache.cpp
@@ -19,6 +19,7 @@
 #include <fmt/format.h>
 
 #include "velox/core/QueryCtx.h"
+#include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::velox::exec {
 
@@ -44,7 +45,11 @@ std::shared_ptr<HashTableCacheEntry> HashTableCache::get(
     auto entry = std::make_shared<HashTableCacheEntry>(
         key,
         taskId,
-        queryPool->addLeafChild(fmt::format("cached_table_{}", key)));
+        // Add memory reclaimer that is not reclaimable.
+        queryPool->addLeafChild(
+            fmt::format("cached_table_{}", key),
+            /* threadsafe */ true,
+            exec::MemoryReclaimer::create()));
     tables_.insert({key, entry});
 
     // Register callback to clean up this cache entry when QueryCtx is

--- a/velox/exec/tests/HashJoinWithCacheTest.cpp
+++ b/velox/exec/tests/HashJoinWithCacheTest.cpp
@@ -585,5 +585,120 @@ DEBUG_ONLY_TEST_F(HashJoinWithCacheTest, probeOOMWithCachedTable) {
   // Cache should be cleaned up by QueryCtx destructor via release callback.
 }
 
+// Verifies that the hash table cache pool has a memory reclaimer that properly
+// suspends the driver thread during memory arbitration. Without a reclaimer,
+// allocations from the cache pool on a driver thread cause:
+// "Driver thread is not suspended under memory arbitration processing".
+DEBUG_ONLY_TEST_F(HashJoinWithCacheTest, cachePoolArbitration) {
+  const std::string queryId =
+      "cachePoolArbitrationTest_" +
+      std::to_string(
+          std::chrono::steady_clock::now().time_since_epoch().count());
+
+  std::vector<RowVectorPtr> buildVectors = makeBatches(10, [&](int32_t) {
+    return makeRowVector(
+        {"u_k", "u_v"},
+        {
+            makeFlatVector<int32_t>(
+                10'000, [](auto row) { return row % 5'000; }),
+            makeFlatVector<int64_t>(10'000, [](auto row) { return row * 10; }),
+        });
+  });
+
+  std::vector<RowVectorPtr> probeVectors = makeBatches(5, [&](int32_t) {
+    return makeRowVector(
+        {"t_k", "t_v"},
+        {
+            makeFlatVector<int32_t>(100, [](auto row) { return row % 5'000; }),
+            makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+        });
+  });
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto buildPlanNode =
+      PlanBuilder(planNodeIdGenerator).values(buildVectors).planNode();
+  auto probePlanNode =
+      PlanBuilder(planNodeIdGenerator).values(probeVectors).planNode();
+
+  auto outputType = ROW(
+      {"t_k", "t_v", "u_k", "u_v"}, {INTEGER(), BIGINT(), INTEGER(), BIGINT()});
+
+  auto joinNode =
+      core::HashJoinNode::Builder()
+          .id(planNodeIdGenerator->next())
+          .joinType(core::JoinType::kInner)
+          .nullAware(false)
+          .leftKeys(
+              {std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "t_k")})
+          .rightKeys(
+              {std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "u_k")})
+          .left(probePlanNode)
+          .right(buildPlanNode)
+          .outputType(outputType)
+          .useHashTableCache(true)
+          .build();
+  const auto joinNodeId = joinNode->id();
+
+  auto queryCtx = core::QueryCtx::create(
+      driverExecutor_.get(),
+      core::QueryConfig({}),
+      std::unordered_map<std::string, std::shared_ptr<config::ConfigBase>>{},
+      cache::AsyncDataCache::getInstance(),
+      nullptr,
+      nullptr,
+      queryId);
+
+  // Tight pool so the large allocation in the TestValue callback triggers
+  // memory arbitration via growCapacity.
+  constexpr int64_t kPoolCapacity = 20 * 1024 * 1024; // 20MB
+  queryCtx->testingOverrideMemoryPool(
+      memory::memoryManager()->addRootPool(
+          queryCtx->queryId(), kPoolCapacity, exec::MemoryReclaimer::create()));
+
+  const auto cacheKey = fmt::format("{}:{}", queryId, joinNodeId);
+
+  std::atomic_bool injected{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::HashBuild::finishHashBuild",
+      std::function<void(exec::HashBuild*)>(([&](exec::HashBuild* hashBuild) {
+        if (injected.exchange(true)) {
+          return;
+        }
+        // Retrieve the cache entry to access the cache pool. Calling get()
+        // with the builder task's own ID returns the existing entry without
+        // side effects.
+        auto task = hashBuild->operatorCtx()->task();
+        ContinueFuture future;
+        auto entry = HashTableCache::instance()->get(
+            cacheKey, task->taskId(), task->queryCtx().get(), &future);
+
+        // Allocate enough from the cache pool to trigger growCapacity.
+        // growCapacity creates a MemoryPoolArbitrationSection on the
+        // requesting pool, which calls pool->enterArbitration(). The
+        // reclaimer's enterArbitration() must suspend the driver thread;
+        // without a reclaimer the driver is not suspended and the
+        // arbitration state check fails.
+        entry->tablePool->allocate(kPoolCapacity);
+      })));
+
+  // The query throws because the allocation exceeds capacity.
+  // With a proper reclaimer on the cache pool, the error is OOM
+  // ("Exceeded memory pool capacity"), not "Driver thread is not suspended".
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(joinNode, duckDbQueryRunner_)
+          .queryCtx(queryCtx)
+          .maxDrivers(1)
+          .copyResults(pool()),
+      "Exceeded memory pool capacity");
+
+  ASSERT_TRUE(injected) << "TestValue injection was not triggered";
+
+  waitForAllTasksToBeDeleted();
+  queryCtx.reset();
+}
+
 } // namespace
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:

Broadcast join hash table caching (D88284809) creates a leaf memory pool under the query pool without a reclaimer. When HashBuild allocates from this pool on a driver thread and memory arbitration triggers, the driver isn't suspended — causing VeloxRuntimeError: "Driver thread is not suspended under memory arbitration processing". The feature was disabled in production via D94620978 as mitigation.

The fix adds an exec::MemoryReclaimer to the cache pool so enterArbitration() properly suspends the driver thread during arbitration. This is the standard Velox leaf reclaimer pattern used by DWRF Writer, Parquet Writer, HiveDataSink, and Exchange Client pools.

Reviewed By: han-yan01, xiaoxmeng

Differential Revision: D98741623
