### PR TITLE
perf: Optimize basic numeric upcast

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -107,6 +107,9 @@ target_link_libraries(
 add_executable(velox_cast_benchmark CastBenchmark.cpp)
 target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps} velox_vector_test_lib)
 
+add_executable(velox_numeric_upcast_benchmark NumericUpcastBenchmark.cpp)
+target_link_libraries(velox_numeric_upcast_benchmark ${velox_benchmark_deps} velox_vector_test_lib)
+
 add_executable(velox_benchmark_expr_flat_no_nulls ExprFlatNoNullsBenchmark.cpp)
 target_link_libraries(
   velox_benchmark_expr_flat_no_nulls

--- a/velox/benchmarks/basic/NumericUpcastBenchmark.cpp
+++ b/velox/benchmarks/basic/NumericUpcastBenchmark.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+
+using namespace facebook;
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  const vector_size_t vectorSize = 300'000'000;
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+
+  auto tinyIntInputNullable = vectorMaker.flatVector<int8_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int8_t>::max(); },
+      [](auto j) { return j % 5 == 0; });
+  auto tinyIntInput = vectorMaker.flatVector<int8_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int8_t>::max(); },
+      nullptr);
+
+  auto smallIntInputNullable = vectorMaker.flatVector<int16_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int16_t>::max(); },
+      [](auto j) { return j % 5 == 0; });
+  auto smallIntInput = vectorMaker.flatVector<int16_t>(
+      vectorSize,
+      [](auto j) { return j % std::numeric_limits<int16_t>::max(); },
+      nullptr);
+
+  auto integerInputNullable = vectorMaker.flatVector<int32_t>(
+      vectorSize,
+      [](auto j) { return j * 2 + 1; },
+      [](auto j) { return j % 5 == 0; });
+  auto integerInput = vectorMaker.flatVector<int32_t>(
+      vectorSize, [](auto j) { return j * 2 + 1; }, nullptr);
+
+  auto bigintInputNullable = vectorMaker.flatVector<int64_t>(
+      vectorSize,
+      [](auto j) { return j * 2 + 1; },
+      [](auto j) { return j % 5 == 0; });
+  auto bigintInput = vectorMaker.flatVector<int64_t>(
+      vectorSize, [](auto j) { return j * 2 + 1; }, nullptr);
+
+  auto realInputNullable = vectorMaker.flatVector<float>(
+      vectorSize,
+      [](auto j) { return j * 9.9999; },
+      [](auto j) { return j % 5 == 0; });
+  auto realInput = vectorMaker.flatVector<float>(
+      vectorSize, [](auto j) { return j * 9.9999; }, nullptr);
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "numeric_upcast",
+          vectorMaker.rowVector(
+              {
+                  "tinyint_column_nullable",
+                  "tinyint_column",
+                  "smallint_column_nullable",
+                  "smallint_column",
+                  "integer_column_nullable",
+                  "integer_column",
+                  "bigint_column_nullable",
+                  "bigint_column",
+                  "real_column_nullable",
+                  "real_column",
+              },
+              {
+                  tinyIntInputNullable,
+                  tinyIntInput,
+                  smallIntInputNullable,
+                  smallIntInput,
+                  integerInputNullable,
+                  integerInput,
+                  bigintInputNullable,
+                  bigintInput,
+                  realInputNullable,
+                  realInput,
+              }))
+      // Cast from tinyint.
+      .addExpression(
+          "cast_tinyint_nullable_as_smallint",
+          "cast(tinyint_column_nullable as smallint)")
+      .addExpression(
+          "cast_tinyint_as_smallint", "cast(tinyint_column as smallint)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_integer",
+          "cast(tinyint_column_nullable as integer)")
+      .addExpression(
+          "cast_tinyint_as_integer", "cast(tinyint_column as integer)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_bigint",
+          "cast(tinyint_column_nullable as bigint)")
+      .addExpression("cast_tinyint_as_bigint", "cast(tinyint_column as bigint)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_real",
+          "cast(tinyint_column_nullable as real)")
+      .addExpression("cast_tinyint_as_real", "cast(tinyint_column as real)")
+
+      .addExpression(
+          "cast_tinyint_nullable_as_double",
+          "cast(tinyint_column_nullable as double)")
+      .addExpression("cast_tinyint_as_double", "cast(tinyint_column as double)")
+
+      // Cast from smallint.
+      .addExpression(
+          "cast_smallint_nullable_as_integer",
+          "cast(smallint_column_nullable as integer)")
+      .addExpression(
+          "cast_smallint_as_integer", "cast(smallint_column as integer)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_bigint",
+          "cast(smallint_column_nullable as bigint)")
+      .addExpression(
+          "cast_smallint_as_bigint", "cast(smallint_column as bigint)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_real",
+          "cast(smallint_column_nullable as real)")
+      .addExpression("cast_smallint_as_real", "cast(smallint_column as real)")
+
+      .addExpression(
+          "cast_smallint_nullable_as_double",
+          "cast(smallint_column_nullable as double)")
+      .addExpression(
+          "cast_smallint_as_double", "cast(smallint_column as double)")
+
+      // Cast from integer.
+      .addExpression(
+          "cast_integer_nullable_as_bigint",
+          "cast(integer_column_nullable as bigint)")
+      .addExpression("cast_integer_as_bigint", "cast(integer_column as bigint)")
+
+      .addExpression(
+          "cast_integer_nullable_as_real",
+          "cast(integer_column_nullable as real)")
+      .addExpression("cast_integer_as_real", "cast(integer_column as real)")
+
+      .addExpression(
+          "cast_integer_nullable_as_double",
+          "cast(integer_column_nullable as double)")
+      .addExpression("cast_integer_as_double", "cast(integer_column as double)")
+
+      // Cast from bigint.
+      .addExpression(
+          "cast_bigint_nullable_as_real",
+          "cast(bigint_column_nullable as real)")
+      .addExpression("cast_bigint_as_real", "cast(bigint_column as real)")
+
+      .addExpression(
+          "cast_bigint_nullable_as_double",
+          "cast(bigint_column_nullable as double)")
+      .addExpression("cast_bigint_as_double", "cast(bigint_column as double)")
+
+      // Cast from real.
+      .addExpression(
+          "cast_real_nullable_as_double",
+          "cast(real_column_nullable as double)")
+      .addExpression("cast_real_as_double", "cast(real_column as double)")
+      .withIterations(100)
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -50,6 +50,36 @@ inline std::exception_ptr makeBadCastException(
       false));
 }
 
+// Returns true if casting from 'fromType' to 'toType' is a supported fast
+// upcast.
+bool isSupportedFastUpcast(const TypePtr& fromType, const TypePtr& toType) {
+  auto isIntegralType = [](const TypePtr& type) {
+    return type == TINYINT() || type == SMALLINT() || type == INTEGER() ||
+        type == BIGINT();
+  };
+
+  auto isBasicNumericType = [&isIntegralType](const TypePtr& type) {
+    return isIntegralType(type) || type == REAL() || type == DOUBLE();
+  };
+
+  if (isIntegralType(fromType) && isBasicNumericType(toType)) {
+    if (fromType->cppSizeInBytes() < toType->cppSizeInBytes()) {
+      return true;
+    }
+    if (fromType == INTEGER() && toType == REAL()) {
+      return true;
+    }
+    if (fromType == BIGINT() && (toType == REAL() || toType == DOUBLE())) {
+      return true;
+    }
+  }
+
+  if (fromType == REAL() && toType == DOUBLE()) {
+    return true;
+  }
+  return false;
+}
+
 } // namespace
 
 template <typename Func>
@@ -615,6 +645,61 @@ void CastExpr::applyCastPrimitives(
   }
 }
 
+template <TypeKind ToKind, TypeKind FromKind>
+void CastExpr::applyNumericUpcast(
+    const SelectivityVector& rows,
+    const TypePtr& toType,
+    exec::EvalCtx& context,
+    const BaseVector& input,
+    VectorPtr& result) {
+  constexpr auto isNumericTypeKind = [](TypeKind kind) constexpr {
+    return kind == TypeKind::TINYINT || kind == TypeKind::SMALLINT ||
+        kind == TypeKind::INTEGER || kind == TypeKind::BIGINT ||
+        kind == TypeKind::REAL || kind == TypeKind::DOUBLE;
+  };
+
+  if constexpr (isNumericTypeKind(ToKind) && isNumericTypeKind(FromKind)) {
+    using ToNativeType = typename TypeTraits<ToKind>::NativeType;
+    using FromNativeType = typename TypeTraits<FromKind>::NativeType;
+
+    if (input.isConstantEncoding()) {
+      auto constantInput = input.as<ConstantVector<FromNativeType>>();
+      if (constantInput->isNullAt(0)) {
+        result =
+            BaseVector::createNullConstant(toType, rows.end(), context.pool());
+        return;
+      }
+      auto constantValue = static_cast<ToNativeType>(constantInput->valueAt(0));
+      result = std::make_shared<ConstantVector<ToNativeType>>(
+          context.pool(),
+          rows.end(),
+          /*isNull=*/false,
+          toType,
+          std::move(constantValue));
+      return;
+    }
+
+    if (input.isFlatEncoding()) {
+      const auto simpleInput = input.asFlatVector<FromNativeType>();
+      auto flatResult = result->asFlatVector<ToNativeType>();
+
+      const FromNativeType* in =
+          simpleInput->template rawValues<FromNativeType>();
+      ToNativeType* out = flatResult->template mutableRawValues<ToNativeType>();
+
+      rows.applyToSelected([&](auto row) {
+        // Converting large bigint values to float/double directly may lose
+        // precision, but it's consistent with the implementation in
+        // velox/type/Conversions.h.
+        out[row] = static_cast<ToNativeType>(in[row]);
+      });
+      return;
+    }
+  }
+  VELOX_UNSUPPORTED(
+      "Cannot upcast from {} to {}", input.type(), toType->toString());
+}
+
 template <TypeKind ToKind>
 void CastExpr::applyCastPrimitivesDispatch(
     const TypePtr& fromType,
@@ -624,6 +709,19 @@ void CastExpr::applyCastPrimitivesDispatch(
     const BaseVector& input,
     VectorPtr& result) {
   context.ensureWritable(rows, toType, result);
+
+  if (isSupportedFastUpcast(fromType, toType)) {
+    VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+        applyNumericUpcast,
+        ToKind,
+        fromType->kind(),
+        rows,
+        toType,
+        context,
+        input,
+        result);
+    return;
+  }
 
   // This already excludes complex types, hugeint and unknown from type kinds.
   VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -314,6 +314,15 @@ class CastExpr : public SpecialForm {
       exec::EvalCtx& context,
       const BaseVector& input);
 
+  // Casts basic numeric types to wider types.
+  template <TypeKind ToKind, TypeKind FromKind>
+  void applyNumericUpcast(
+      const SelectivityVector& rows,
+      const TypePtr& toType,
+      exec::EvalCtx& context,
+      const BaseVector& input,
+      VectorPtr& result);
+
   bool isTryCast() const {
     return isTryCast_;
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -4070,5 +4070,136 @@ TEST_F(CastExprTest, timestampToTimeCast) {
 
   testCast(TIMESTAMP(), TIME(), realTimestamps, expectedRealTime);
 }
+
+TEST_F(CastExprTest, numericUpcast) {
+  auto testNumericUpcast =
+      [&](std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {
+        auto vectorSize = 1'000;
+        // Cast from TINYINT to SMALLINT.
+        const auto tinyintVector = makeFlatVector<int8_t>(
+            vectorSize,
+            [](auto i) { return i % std::numeric_limits<int8_t>::max(); },
+            isNullAt);
+        testCast(
+            tinyintVector,
+            makeFlatVector<int16_t>(
+                vectorSize,
+                [](auto i) { return i % std::numeric_limits<int8_t>::max(); },
+                isNullAt));
+
+        // Cast from TINYINT to INTEGER.
+        testCast(
+            tinyintVector,
+            makeFlatVector<int32_t>(
+                vectorSize,
+                [](auto i) { return i % std::numeric_limits<int8_t>::max(); },
+                isNullAt));
+
+        // Cast from TINYINT to BIGINT.
+        testCast(
+            tinyintVector,
+            makeFlatVector<int64_t>(
+                vectorSize,
+                [](auto i) { return i % std::numeric_limits<int8_t>::max(); },
+                isNullAt));
+
+        // Cast from TINYINT to REAL.
+        testCast(
+            tinyintVector,
+            makeFlatVector<float>(
+                vectorSize,
+                [](auto i) {
+                  return static_cast<float>(
+                      i % std::numeric_limits<int8_t>::max());
+                },
+                isNullAt));
+
+        // Cast from TINYINT to DOUBLE.
+        testCast(
+            tinyintVector,
+            makeFlatVector<double>(
+                vectorSize,
+                [](auto i) {
+                  return static_cast<double>(
+                      i % std::numeric_limits<int8_t>::max());
+                },
+                isNullAt));
+
+        // Cast from SMALLINT to INTEGER.
+        const auto smallintVector = makeFlatVector<int16_t>(
+            vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt);
+        testCast(
+            smallintVector,
+            makeFlatVector<int32_t>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from SMALLINT to BIGINT.
+        testCast(
+            smallintVector,
+            makeFlatVector<int64_t>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from SMALLINT to REAL.
+        testCast(
+            smallintVector,
+            makeFlatVector<float>(
+                vectorSize,
+                [](auto i) { return static_cast<float>(1 + 2 * i); },
+                isNullAt));
+
+        // Cast from SMALLINT to DOUBLE.
+        testCast(
+            smallintVector,
+            makeFlatVector<double>(
+                vectorSize,
+                [](auto i) { return static_cast<double>(1 + 2 * i); },
+                isNullAt));
+
+        // Cast from INTEGER to BIGINT.
+        const auto integerVector = makeFlatVector<int32_t>(
+            vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt);
+        testCast(
+            integerVector,
+            makeFlatVector<int64_t>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from INTEGER to REAL.
+        testCast(
+            integerVector,
+            makeFlatVector<float>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from INTEGER to DOUBLE.
+        testCast(
+            integerVector,
+            makeFlatVector<double>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from BIGINT to REAL.
+        testCast(
+            makeFlatVector<int64_t>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt),
+            makeFlatVector<float>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from BIGINT to DOUBLE.
+        testCast(
+            makeFlatVector<int64_t>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt),
+            makeFlatVector<double>(
+                vectorSize, [](auto i) { return 1 + 2 * i; }, isNullAt));
+
+        // Cast from REAL to DOUBLE.
+        testCast(
+            makeFlatVector<float>(
+                vectorSize, [](auto i) { return 1.5f + 2 * i; }, isNullAt),
+            makeFlatVector<double>(
+                vectorSize, [](auto i) { return 1.5 + 2 * i; }, isNullAt));
+      };
+
+  testNumericUpcast();
+  testNumericUpcast([](vector_size_t row) { return row % 7 == 0; });
+}
+
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
When the row size is large (e.g., around 300,000,000), casting from a narrower 
integer type to a wider one—such as cast(integer as bigint)—can become time-
consuming.

This PR optimizes the numeric upcast by performing the cast directly on the 
raw values within loops, and drops the try-catch used for potential error handing. 
Since upcasts guarantee that the source value fits within the target type, overflow
handling is unnecessary in this case.

The performance gains are likely attributed to:
1) Eliminating try-catch blocks when error handling is unnecessary.
2) Improved auto-vectorization and lower function call overhead after replacing
`valueAt` and `set` with direct access.
3) Avoiding overflow checks.

Optimized conversions include: 
```
CAST(tinyint AS smallint)
CAST(tinyint AS integer)
CAST(tinyint AS bigint)
CAST(tinyint AS real)
CAST(tinyint AS double)

CAST(smallint AS integer)
CAST(smallint AS bigint)
CAST(smallint AS real)
CAST(smallint AS double)

CAST(integer AS bigint)
CAST(integer AS real)
CAST(integer AS double)

CAST(bigint AS real)
CAST(bigint AS double)

CAST(real AS double)
```

Before:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
numeric_upcast##cast_tinyint_nullable_as_smalli             57.89s    17.27m
numeric_upcast##cast_tinyint_as_smallint                   1.09min    15.32m
numeric_upcast##cast_tinyint_nullable_as_intege             59.07s    16.93m
numeric_upcast##cast_tinyint_as_integer                    1.09min    15.25m
numeric_upcast##cast_tinyint_nullable_as_bigint            1.03min    16.12m
numeric_upcast##cast_tinyint_as_bigint                     1.13min    14.71m
numeric_upcast##cast_tinyint_nullable_as_real              1.87min     8.90m
numeric_upcast##cast_tinyint_as_real                       2.16min     7.71m
numeric_upcast##cast_tinyint_nullable_as_double            1.79min     9.29m
numeric_upcast##cast_tinyint_as_double                     2.06min     8.10m
numeric_upcast##cast_smallint_nullable_as_integ             59.30s    16.86m
numeric_upcast##cast_smallint_as_integer                   1.11min    15.01m
numeric_upcast##cast_smallint_nullable_as_bigin            1.02min    16.29m
numeric_upcast##cast_smallint_as_bigint                    1.14min    14.59m
numeric_upcast##cast_smallint_nullable_as_real             1.99min     8.37m
numeric_upcast##cast_smallint_as_real                      2.29min     7.26m
numeric_upcast##cast_smallint_nullable_as_doubl            1.80min     9.28m
numeric_upcast##cast_smallint_as_double                    2.03min     8.23m
numeric_upcast##cast_integer_nullable_as_bigint            1.03min    16.24m
numeric_upcast##cast_integer_as_bigint                     1.12min    14.89m
numeric_upcast##cast_integer_nullable_as_real              1.40min    11.88m
numeric_upcast##cast_integer_as_real                       1.64min    10.15m
numeric_upcast##cast_integer_nullable_as_double            1.44min    11.56m
numeric_upcast##cast_integer_as_double                     1.65min    10.09m
numeric_upcast##cast_bigint_nullable_as_real               1.41min    11.78m
numeric_upcast##cast_bigint_as_real                        1.65min    10.12m
numeric_upcast##cast_bigint_nullable_as_double             1.46min    11.44m
numeric_upcast##cast_bigint_as_double                      1.65min    10.09m
numeric_upcast##cast_real_nullable_as_double               1.43min    11.64m
numeric_upcast##cast_real_as_double                        1.69min     9.85m
----------------------------------------------------------------------------
```
After:

```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
numeric_upcast##cast_tinyint_nullable_as_smalli             15.12s    66.12m
numeric_upcast##cast_tinyint_as_smallint                  931.11ms      1.07
numeric_upcast##cast_tinyint_nullable_as_intege             16.61s    60.22m
numeric_upcast##cast_tinyint_as_integer                      2.21s   451.83m
numeric_upcast##cast_tinyint_nullable_as_bigint             19.33s    51.73m
numeric_upcast##cast_tinyint_as_bigint                       4.32s   231.37m
numeric_upcast##cast_tinyint_nullable_as_real               16.50s    60.62m
numeric_upcast##cast_tinyint_as_real                         2.83s   353.33m
numeric_upcast##cast_tinyint_nullable_as_double             19.13s    52.26m
numeric_upcast##cast_tinyint_as_double                       8.07s   123.97m
numeric_upcast##cast_smallint_nullable_as_integ             18.96s    52.76m
numeric_upcast##cast_smallint_as_integer                     1.78s   561.26m
numeric_upcast##cast_smallint_nullable_as_bigin             18.72s    53.41m
numeric_upcast##cast_smallint_as_bigint                      4.38s   228.11m
numeric_upcast##cast_smallint_nullable_as_real              16.34s    61.19m
numeric_upcast##cast_smallint_as_real                        1.71s   583.54m
numeric_upcast##cast_smallint_nullable_as_doubl             18.65s    53.62m
numeric_upcast##cast_smallint_as_double                      2.85s   351.36m
numeric_upcast##cast_integer_nullable_as_bigint             18.43s    54.26m
numeric_upcast##cast_integer_as_bigint                       3.47s   288.11m
numeric_upcast##cast_integer_nullable_as_real               16.58s    60.32m
numeric_upcast##cast_integer_as_real                         2.41s   414.34m
numeric_upcast##cast_integer_nullable_as_double             18.53s    53.97m
numeric_upcast##cast_integer_as_double                       3.34s   299.25m
numeric_upcast##cast_bigint_nullable_as_real                16.82s    59.45m
numeric_upcast##cast_bigint_as_real                          4.23s   236.48m
numeric_upcast##cast_bigint_nullable_as_double              19.15s    52.22m
numeric_upcast##cast_bigint_as_double                        4.56s   219.08m
numeric_upcast##cast_real_nullable_as_double                18.35s    54.50m
numeric_upcast##cast_real_as_double                          3.43s   291.53m
----------------------------------------------------------------------------
```

Replace: https://github.com/facebookincubator/velox/pull/15458