### PR TITLE
feat: Add extraction ScanSpec pushdown and HiveDataSource integration (#16968)

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -22,6 +22,8 @@ velox_add_library(
   velox_hive_connector
   OBJECT
   BufferedInputBuilder.cpp
+  ExtractionUtils.cpp
+  ExtractionUtils.h
   FileColumnHandle.cpp
   FileConfig.cpp
   FileConnectorUtil.cpp

--- a/velox/connectors/hive/ExtractionUtils.cpp
+++ b/velox/connectors/hive/ExtractionUtils.cpp
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/ExtractionUtils.h"
+
+#include "velox/type/Filter.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::connector::hive {
+
+namespace {
+
+/// Extract sizes from a MapVector or ArrayVector as a FlatVector<int64_t>.
+VectorPtr extractSizes(const VectorPtr& input, memory::MemoryPool* pool) {
+  auto numRows = input->size();
+  auto sizesBuf = AlignedBuffer::allocate<int64_t>(numRows, pool);
+  auto* sizesData = sizesBuf->asMutable<int64_t>();
+
+  const vector_size_t* rawSizes;
+  if (input->typeKind() == TypeKind::MAP) {
+    rawSizes = input->as<MapVector>()->rawSizes();
+  } else {
+    rawSizes = input->as<ArrayVector>()->rawSizes();
+  }
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    sizesData[i] = rawSizes[i];
+  }
+
+  return std::make_shared<FlatVector<int64_t>>(
+      pool,
+      BIGINT(),
+      input->nulls(),
+      numRows,
+      std::move(sizesBuf),
+      std::vector<BufferPtr>{});
+}
+
+/// Filter a MapVector to only keep entries with matching keys.
+VectorPtr filterMapByKeys(
+    const VectorPtr& input,
+    const ExtractionPathElement& step,
+    memory::MemoryPool* pool) {
+  auto* map = input->as<MapVector>();
+  auto numRows = map->size();
+  auto* rawOffsets = map->rawOffsets();
+  auto* rawSizes = map->rawSizes();
+  auto mapKeys = map->mapKeys();
+  auto mapValues = map->mapValues();
+
+  // Build output offsets and sizes, and a mapping of which key-value pairs
+  // to keep.
+  auto newOffsetsBuf = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  auto newSizesBuf = AlignedBuffer::allocate<vector_size_t>(numRows, pool);
+  auto* newOffsets = newOffsetsBuf->asMutable<vector_size_t>();
+  auto* newSizes = newSizesBuf->asMutable<vector_size_t>();
+
+  // Build keep flags for all key-value pairs across all map entries.
+  std::vector<bool> keepFlags;
+  vector_size_t totalInputElements = 0;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    totalInputElements += rawSizes[i];
+  }
+  keepFlags.resize(totalInputElements, false);
+
+  if (totalInputElements == 0) {
+    // All maps are empty; return the input as-is with zeroed sizes.
+    return std::make_shared<MapVector>(
+        pool,
+        input->type(),
+        map->nulls(),
+        numRows,
+        std::move(newOffsetsBuf),
+        std::move(newSizesBuf),
+        mapKeys,
+        mapValues);
+  }
+
+  auto* stringFilter =
+      dynamic_cast<const StringMapKeyFilterExtractionPathElement*>(&step);
+  if (stringFilter) {
+    std::unordered_set<std::string> keySet(
+        stringFilter->filterKeys().begin(), stringFilter->filterKeys().end());
+    auto* keyVector = mapKeys->as<SimpleVector<StringView>>();
+    for (vector_size_t i = 0; i < totalInputElements; ++i) {
+      VELOX_DCHECK_LT(
+          static_cast<size_t>(i), keepFlags.size(), "Index out of bounds");
+      if (!keyVector->isNullAt(i) &&
+          keySet.count(std::string(keyVector->valueAt(i))) > 0) {
+        keepFlags[i] = true;
+      }
+    }
+  } else {
+    auto& intFilter =
+        static_cast<const IntMapKeyFilterExtractionPathElement&>(step);
+    std::unordered_set<int64_t> keySet(
+        intFilter.filterKeys().begin(), intFilter.filterKeys().end());
+    auto* keyVector = mapKeys->as<SimpleVector<int64_t>>();
+    for (vector_size_t i = 0; i < totalInputElements; ++i) {
+      VELOX_DCHECK_LT(
+          static_cast<size_t>(i), keepFlags.size(), "Index out of bounds");
+      if (!keyVector->isNullAt(i) && keySet.count(keyVector->valueAt(i)) > 0) {
+        keepFlags[i] = true;
+      }
+    }
+  }
+
+  // Count kept entries per map.
+  vector_size_t totalKept = 0;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    newOffsets[i] = totalKept;
+    vector_size_t kept = 0;
+    for (vector_size_t j = 0; j < rawSizes[i]; ++j) {
+      VELOX_DCHECK_LT(
+          static_cast<size_t>(rawOffsets[i] + j),
+          keepFlags.size(),
+          "Index out of bounds");
+      if (keepFlags[rawOffsets[i] + j]) {
+        ++kept;
+      }
+    }
+    newSizes[i] = kept;
+    totalKept += kept;
+  }
+
+  // Build index mapping for kept entries.
+  auto indexBuf = AlignedBuffer::allocate<vector_size_t>(totalKept, pool);
+  auto* indices = indexBuf->asMutable<vector_size_t>();
+  vector_size_t outIdx = 0;
+  for (vector_size_t i = 0; i < numRows; ++i) {
+    for (vector_size_t j = 0; j < rawSizes[i]; ++j) {
+      auto srcIdx = rawOffsets[i] + j;
+      VELOX_DCHECK_LT(
+          static_cast<size_t>(srcIdx), keepFlags.size(), "Index out of bounds");
+      if (keepFlags[srcIdx]) {
+        indices[outIdx++] = srcIdx;
+      }
+    }
+  }
+
+  // Create filtered keys and values using dictionary wrapping.
+  auto filteredKeys =
+      BaseVector::wrapInDictionary(nullptr, indexBuf, totalKept, mapKeys);
+  auto filteredValues =
+      BaseVector::wrapInDictionary(nullptr, indexBuf, totalKept, mapValues);
+
+  return std::make_shared<MapVector>(
+      pool,
+      input->type(),
+      map->nulls(),
+      numRows,
+      std::move(newOffsetsBuf),
+      std::move(newSizesBuf),
+      filteredKeys,
+      filteredValues);
+}
+
+/// Recursive implementation of extraction chain application.
+VectorPtr applyExtractionChainImpl(
+    const VectorPtr& input,
+    const std::vector<ExtractionPathElementPtr>& chain,
+    size_t index,
+    memory::MemoryPool* pool) {
+  if (index >= chain.size()) {
+    return input;
+  }
+
+  const auto& step = chain[index];
+  switch (step->step()) {
+    case ExtractionStep::kStructField: {
+      auto* row = input->as<RowVector>();
+      VELOX_CHECK_NOT_NULL(row);
+      auto& fieldName =
+          static_cast<const StructFieldExtractionPathElement&>(*step)
+              .fieldName();
+      auto childIdx = input->type()->asRow().getChildIdx(fieldName);
+      return applyExtractionChainImpl(
+          row->childAt(childIdx), chain, index + 1, pool);
+    }
+
+    case ExtractionStep::kMapKeys: {
+      auto* map = input->as<MapVector>();
+      VELOX_CHECK_NOT_NULL(map);
+      if (index + 1 >= chain.size()) {
+        return std::make_shared<ArrayVector>(
+            pool,
+            ARRAY(map->mapKeys()->type()),
+            map->nulls(),
+            map->size(),
+            map->offsets(),
+            map->sizes(),
+            map->mapKeys());
+      }
+      VELOX_CHECK_EQ(
+          static_cast<int>(chain[index + 1]->step()),
+          static_cast<int>(ExtractionStep::kArrayElements));
+      auto transformedKeys =
+          applyExtractionChainImpl(map->mapKeys(), chain, index + 2, pool);
+      return std::make_shared<ArrayVector>(
+          pool,
+          ARRAY(transformedKeys->type()),
+          map->nulls(),
+          map->size(),
+          map->offsets(),
+          map->sizes(),
+          transformedKeys);
+    }
+
+    case ExtractionStep::kMapValues: {
+      auto* map = input->as<MapVector>();
+      VELOX_CHECK_NOT_NULL(map);
+      if (index + 1 >= chain.size()) {
+        return std::make_shared<ArrayVector>(
+            pool,
+            ARRAY(map->mapValues()->type()),
+            map->nulls(),
+            map->size(),
+            map->offsets(),
+            map->sizes(),
+            map->mapValues());
+      }
+      VELOX_CHECK_EQ(
+          static_cast<int>(chain[index + 1]->step()),
+          static_cast<int>(ExtractionStep::kArrayElements));
+      auto transformedValues =
+          applyExtractionChainImpl(map->mapValues(), chain, index + 2, pool);
+      return std::make_shared<ArrayVector>(
+          pool,
+          ARRAY(transformedValues->type()),
+          map->nulls(),
+          map->size(),
+          map->offsets(),
+          map->sizes(),
+          transformedValues);
+    }
+
+    case ExtractionStep::kMapKeyFilter: {
+      auto filtered = filterMapByKeys(input, *step, pool);
+      return applyExtractionChainImpl(filtered, chain, index + 1, pool);
+    }
+
+    case ExtractionStep::kArrayElements: {
+      auto* array = input->as<ArrayVector>();
+      VELOX_CHECK_NOT_NULL(array);
+      if (index + 1 >= chain.size()) {
+        return input;
+      }
+      auto transformedElements =
+          applyExtractionChainImpl(array->elements(), chain, index + 1, pool);
+      return std::make_shared<ArrayVector>(
+          pool,
+          ARRAY(transformedElements->type()),
+          array->nulls(),
+          array->size(),
+          array->offsets(),
+          array->sizes(),
+          transformedElements);
+    }
+
+    case ExtractionStep::kSize: {
+      return extractSizes(input, pool);
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+/// Analyze extraction chains on a ROW type to determine which fields are
+/// needed.
+std::unordered_set<std::string> analyzeStructNeeds(
+    const std::vector<NamedExtraction>& extractions) {
+  std::unordered_set<std::string> neededFields;
+  for (const auto& extraction : extractions) {
+    if (extraction.chain.empty()) {
+      // Pass-through: need all fields.
+      return {};
+    }
+    if (extraction.chain[0]->step() == ExtractionStep::kStructField) {
+      neededFields.insert(
+          static_cast<const StructFieldExtractionPathElement&>(
+              *extraction.chain[0])
+              .fieldName());
+    } else {
+      // Non-struct step on a struct: need everything.
+      return {};
+    }
+  }
+  return neededFields;
+}
+
+/// Build sub-chains by stripping the first step from each extraction chain.
+/// For MapKeys/MapValues, also strips the following ArrayElements step.
+/// Only includes extractions whose first step matches 'firstStep'.
+/// For ROW StructField, only includes extractions targeting 'fieldName'.
+std::vector<NamedExtraction> buildSubChains(
+    const std::vector<NamedExtraction>& extractions,
+    ExtractionStep firstStep,
+    const std::string& fieldName = "") {
+  std::vector<NamedExtraction> subChains;
+  for (const auto& extraction : extractions) {
+    if (extraction.chain.empty()) {
+      continue;
+    }
+    if (extraction.chain[0]->step() != firstStep) {
+      continue;
+    }
+    if (firstStep == ExtractionStep::kStructField) {
+      const auto& name = static_cast<const StructFieldExtractionPathElement&>(
+                             *extraction.chain[0])
+                             .fieldName();
+      if (name != fieldName) {
+        continue;
+      }
+    }
+
+    // Determine how many leading steps to skip.
+    size_t skip = 1;
+    if ((firstStep == ExtractionStep::kMapKeys ||
+         firstStep == ExtractionStep::kMapValues) &&
+        skip < extraction.chain.size() &&
+        extraction.chain[skip]->step() == ExtractionStep::kArrayElements) {
+      ++skip;
+    }
+
+    if (skip < extraction.chain.size()) {
+      NamedExtraction sub;
+      sub.outputName = extraction.outputName;
+      sub.chain = std::vector<ExtractionPathElementPtr>(
+          extraction.chain.begin() + static_cast<ptrdiff_t>(skip),
+          extraction.chain.end());
+      sub.dataType = extraction.dataType;
+      subChains.push_back(std::move(sub));
+    }
+  }
+  return subChains;
+}
+
+} // namespace
+
+VectorPtr applyExtractionChain(
+    const VectorPtr& input,
+    const std::vector<ExtractionPathElementPtr>& chain,
+    memory::MemoryPool* pool) {
+  return applyExtractionChainImpl(input, chain, 0, pool);
+}
+
+void configureExtractionScanSpec(
+    const TypePtr& hiveType,
+    const std::vector<NamedExtraction>& extractions,
+    common::ScanSpec& spec,
+    memory::MemoryPool* pool) {
+  if (extractions.empty()) {
+    return;
+  }
+
+  switch (hiveType->kind()) { // NOLINT(clang-diagnostic-switch-enum)
+    case TypeKind::MAP: {
+      // Determine the extraction type from the first step of all chains.
+      bool allKeys = true;
+      bool allValues = true;
+      bool allSize = true;
+      bool allMapKeyFilter = true;
+      for (const auto& extraction : extractions) {
+        if (extraction.chain.empty()) {
+          allKeys = false;
+          allValues = false;
+          allSize = false;
+          allMapKeyFilter = false;
+          break;
+        }
+        auto firstStep = extraction.chain[0]->step();
+        if (firstStep != ExtractionStep::kMapKeys) {
+          allKeys = false;
+        }
+        if (firstStep != ExtractionStep::kMapValues) {
+          allValues = false;
+        }
+        if (firstStep != ExtractionStep::kSize) {
+          allSize = false;
+        }
+        if (firstStep != ExtractionStep::kMapKeyFilter) {
+          allMapKeyFilter = false;
+        }
+      }
+
+      if (allSize) {
+        spec.setExtractionType(common::ScanSpec::ExtractionType::kSize);
+      } else if (allKeys) {
+        spec.setExtractionType(common::ScanSpec::ExtractionType::kKeys);
+        auto subChains = buildSubChains(extractions, ExtractionStep::kMapKeys);
+        if (!subChains.empty()) {
+          auto* keysSpec =
+              spec.childByName(common::ScanSpec::kMapKeysFieldName);
+          if (keysSpec) {
+            configureExtractionScanSpec(
+                hiveType->asMap().keyType(), subChains, *keysSpec, pool);
+          }
+        }
+      } else if (allValues) {
+        spec.setExtractionType(common::ScanSpec::ExtractionType::kValues);
+        auto subChains =
+            buildSubChains(extractions, ExtractionStep::kMapValues);
+        if (!subChains.empty()) {
+          auto* valuesSpec =
+              spec.childByName(common::ScanSpec::kMapValuesFieldName);
+          if (valuesSpec) {
+            configureExtractionScanSpec(
+                hiveType->asMap().valueType(), subChains, *valuesSpec, pool);
+          }
+        }
+      } else if (allMapKeyFilter) {
+        // kMapKeyFilter is type-preserving (MAP -> MAP), so no ExtractionType
+        // is set.  Instead, add an IN filter on the map keys ScanSpec so the
+        // reader can skip non-matching key-value pairs.
+        auto* keysSpec = spec.childByName(common::ScanSpec::kMapKeysFieldName);
+        if (keysSpec) {
+          // Merge filter keys from all extraction chains.
+          std::vector<std::string> mergedStringKeys;
+          std::vector<int64_t> mergedIntKeys;
+          bool useStringKeys = false;
+          for (const auto& extraction : extractions) {
+            if (auto* strFilter = dynamic_cast<
+                    const StringMapKeyFilterExtractionPathElement*>(
+                    extraction.chain[0].get())) {
+              useStringKeys = true;
+              mergedStringKeys.insert(
+                  mergedStringKeys.end(),
+                  strFilter->filterKeys().begin(),
+                  strFilter->filterKeys().end());
+            } else if (
+                auto* intFilter =
+                    dynamic_cast<const IntMapKeyFilterExtractionPathElement*>(
+                        extraction.chain[0].get())) {
+              mergedIntKeys.insert(
+                  mergedIntKeys.end(),
+                  intFilter->filterKeys().begin(),
+                  intFilter->filterKeys().end());
+            }
+          }
+
+          if (useStringKeys) {
+            keysSpec->setFilter(
+                std::make_unique<common::BytesValues>(
+                    mergedStringKeys, /*nullAllowed=*/false));
+          } else {
+            keysSpec->setFilter(
+                common::createBigintValues(
+                    mergedIntKeys, /*nullAllowed=*/false));
+          }
+        }
+
+        // Recurse with remaining chains (strip the kMapKeyFilter step).
+        auto subChains =
+            buildSubChains(extractions, ExtractionStep::kMapKeyFilter);
+        if (!subChains.empty()) {
+          configureExtractionScanSpec(hiveType, subChains, spec, pool);
+        }
+      }
+      break;
+    }
+    case TypeKind::ARRAY: {
+      bool allSize = true;
+      for (const auto& extraction : extractions) {
+        if (extraction.chain.empty() ||
+            extraction.chain[0]->step() != ExtractionStep::kSize) {
+          allSize = false;
+          break;
+        }
+      }
+      if (allSize) {
+        spec.setExtractionType(common::ScanSpec::ExtractionType::kSize);
+      }
+      break;
+    }
+    case TypeKind::ROW: {
+      auto neededFields = analyzeStructNeeds(extractions);
+      if (neededFields.empty()) {
+        // Need all fields: no pruning.
+        break;
+      }
+      const auto& rowType = hiveType->asRow();
+
+      // If exactly one field is needed, set kField extraction so the struct
+      // reader produces the field's vector directly instead of a RowVector.
+      if (neededFields.size() == 1) {
+        auto& onlyFieldName = *neededFields.begin();
+        auto fieldIdx = rowType.getChildIdx(onlyFieldName);
+        spec.setExtractionType(common::ScanSpec::ExtractionType::kField);
+        spec.setExtractionFieldIndex(fieldIdx);
+      }
+
+      for (uint32_t i = 0; i < rowType.size(); ++i) {
+        auto& fieldName = rowType.nameOf(i);
+        if (neededFields.count(fieldName) == 0) {
+          auto* child = spec.childByName(fieldName);
+          if (child) {
+            child->setConstantValue(
+                BaseVector::createNullConstant(rowType.childAt(i), 1, pool));
+          }
+        } else {
+          // Recurse into needed fields with their sub-chains.
+          auto subChains = buildSubChains(
+              extractions, ExtractionStep::kStructField, fieldName);
+          if (!subChains.empty()) {
+            auto* child = spec.childByName(fieldName);
+            if (child) {
+              configureExtractionScanSpec(
+                  rowType.childAt(i), subChains, *child, pool);
+            }
+          }
+        }
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/ExtractionUtils.h
+++ b/velox/connectors/hive/ExtractionUtils.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/ScanSpec.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Apply an extraction chain to a vector, producing the output vector.
+/// The input vector must have a type compatible with the chain's expected
+/// input type.  The output vector has the type derived by the chain.
+///
+/// For multiple named extractions from the same column, call this once
+/// per extraction chain and assemble the results into a RowVector.
+VectorPtr applyExtractionChain(
+    const VectorPtr& input,
+    const std::vector<ExtractionPathElementPtr>& chain,
+    memory::MemoryPool* pool);
+
+/// Configure a ScanSpec for a column that has extraction chains.
+/// Analyzes the extraction chains and marks unneeded sub-streams as
+/// constant null so the reader can skip them (DWRF/Nimble pushdown).
+///
+/// This is an optimization — correctness is guaranteed by the
+/// post-read extraction in applyExtractionChain even without these hints.
+void configureExtractionScanSpec(
+    const TypePtr& hiveType,
+    const std::vector<NamedExtraction>& extractions,
+    common::ScanSpec& spec,
+    memory::MemoryPool* pool);
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileColumnHandle.h
+++ b/velox/connectors/hive/FileColumnHandle.h
@@ -185,8 +185,17 @@ class FileColumnHandle : public ColumnHandle {
 
   virtual ColumnType columnType() const = 0;
 
-  /// The target data type for this column in the output.
-  virtual const TypePtr& dataType() const = 0;
+  /// The type of this column as defined in the table schema (metastore).
+  /// May differ from dataType() when extraction changes the output type.
+  /// Subclasses must provide this.
+  virtual const TypePtr& schemaType() const = 0;
+
+  /// The target data type for this column in the output.  Defaults to
+  /// schemaType() (no extraction or type coercion).  Override when the
+  /// output type differs from the table schema type.
+  virtual const TypePtr& dataType() const {
+    return schemaType();
+  }
 
   /// Subfields required by the query for pruning complex types.
   virtual const std::vector<common::Subfield>& requiredSubfields() const = 0;

--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/Casts.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/connectors/hive/ExtractionUtils.h"
 #include "velox/connectors/hive/FileConfig.h"
 #include "velox/expression/FieldReference.h"
 
@@ -196,8 +197,160 @@ FileDataSource::FileDataSource(
         *scanSpec_, *remainingFilter, expressionEvaluator_);
   }
 
+  // Detect extraction columns and reconfigure scanSpec_ if needed.
+  bool hasExtractions = false;
+  readColumnTypes = readerOutputType_->children();
+  for (int outputIdx = 0; outputIdx < outputType->size(); ++outputIdx) {
+    const auto& outputName = outputType->nameOf(outputIdx);
+    auto it = assignments.find(outputName);
+    if (it == assignments.end()) {
+      continue;
+    }
+    auto* handle = static_cast<const FileColumnHandle*>(it->second.get());
+    if (!handle->extractions().empty()) {
+      // Column has extraction chains.  Read with schemaType from file, then
+      // apply extraction post-read.  Extractions and requiredSubfields are
+      // mutually exclusive (enforced by the column handle constructor).
+      auto readerIdx = readerOutputType_->getChildIdxIfExists(handle->name());
+      if (readerIdx.has_value()) {
+        readColumnTypes[*readerIdx] = handle->schemaType();
+        extractionColumns_[*readerIdx] = handle;
+        hasExtractions = true;
+      }
+    }
+  }
+
+  if (hasExtractions) {
+    // Rebuild readerOutputType_ with schemaType for extraction columns.
+    readerOutputType_ =
+        ROW(std::vector<std::string>(
+                readerOutputType_->names().begin(),
+                readerOutputType_->names().end()),
+            std::move(readColumnTypes));
+    // Rebuild scanSpec_ with the updated readerOutputType_.
+    scanSpec_ = makeScanSpec(
+        readerOutputType_,
+        subfields_,
+        filters_,
+        /*indexColumns=*/{},
+        tableHandle_->dataColumns(),
+        partitionKeys_,
+        infoColumns_,
+        specialColumns_,
+        fileConfig_->readStatsBasedFilterReorderDisabled(
+            connectorQueryCtx->sessionProperties()),
+        pool_);
+    configureExtractionColumns();
+  }
+
   ioStatistics_ = std::make_shared<io::IoStatistics>();
   ioStats_ = std::make_shared<IoStats>();
+}
+
+void FileDataSource::configureExtractionColumns() {
+  // Configure extraction columns on the ScanSpec.  For each column with
+  // extractions, this:
+  // 1. Sets pruning hints so DWRF/Nimble readers skip unneeded sub-streams.
+  // 2. Sets a transform function on the ScanSpec node so the reader applies
+  //    extraction chains and produces the output type directly.
+  for (auto& [colIdx, handle] : extractionColumns_) {
+    auto* fieldSpec = scanSpec_->childByName(readerOutputType_->nameOf(colIdx));
+    if (!fieldSpec) {
+      continue;
+    }
+    const auto& extractions = handle->extractions();
+    auto extractionOutputType = handle->dataType();
+
+    // For multiple extractions, do NOT call configureExtractionScanSpec --
+    // keep ExtractionType as kNone and use full chains in the transform.
+    // This ensures the text reader (which does not handle ExtractionType
+    // natively) produces correct results.
+    if (extractions.size() == 1) {
+      configureExtractionScanSpec(
+          handle->schemaType(), extractions, *fieldSpec, pool_);
+    }
+    if (extractions.size() == 1) {
+      // Store a full-chain transform so hasTransform() returns true.  This
+      // signals to the delta update path that extraction is configured.
+      // The full chain is captured for PrismSplitReader to replace it.
+      fieldSpec->setTransform(
+          [fullChain = extractions[0].chain](
+              const VectorPtr& input, memory::MemoryPool* pool) -> VectorPtr {
+            return applyExtractionChain(input, fullChain, pool);
+          },
+          extractionOutputType);
+    } else {
+      // Multiple extractions: do NOT set ExtractionType on the ScanSpec.
+      // Use full chains in the transform so the text reader (which does
+      // not handle ExtractionType natively) produces correct results.
+      // TODO: Optimization: for agreeing multiple extractions, set
+      // ExtractionType and use remaining chains.  Requires text reader
+      // to handle ExtractionType natively.
+      struct ExtractionInfo {
+        std::string outputName;
+        std::vector<ExtractionPathElementPtr> chain;
+      };
+
+      std::vector<ExtractionInfo> infos;
+      for (const auto& extraction : extractions) {
+        infos.push_back({extraction.outputName, extraction.chain});
+      }
+      // Always need a transform for multiple extractions to assemble ROW.
+      fieldSpec->setTransform(
+          [infos = std::move(infos)](
+              const VectorPtr& input, memory::MemoryPool* pool) -> VectorPtr {
+            std::vector<VectorPtr> children;
+            std::vector<std::string> names;
+            std::vector<TypePtr> types;
+            children.reserve(infos.size());
+            names.reserve(infos.size());
+            types.reserve(infos.size());
+            for (const auto& info : infos) {
+              VectorPtr extracted;
+              if (info.chain.empty()) {
+                extracted = input;
+              } else {
+                extracted = applyExtractionChain(input, info.chain, pool);
+              }
+              names.push_back(info.outputName);
+              types.push_back(extracted->type());
+              children.push_back(std::move(extracted));
+            }
+            return std::make_shared<RowVector>(
+                pool,
+                ROW(std::move(names), std::move(types)),
+                nullptr,
+                input->size(),
+                std::move(children));
+          },
+          extractionOutputType);
+    }
+  }
+
+  // Build readerProducedType_ -- the actual type the reader will produce.
+  // For extraction columns where the reader handles extraction natively
+  // (ExtractionType != kNone), the output type differs from schemaType.
+  {
+    auto names = readerOutputType_->names();
+    auto types = readerOutputType_->children();
+    bool needsSeparateType = false;
+    for (auto& [colIdx, handle] : extractionColumns_) {
+      auto* fieldSpec =
+          scanSpec_->childByName(readerOutputType_->nameOf(colIdx));
+      if (fieldSpec &&
+          fieldSpec->extractionType() !=
+              common::ScanSpec::ExtractionType::kNone) {
+        VELOX_CHECK_LT(static_cast<size_t>(colIdx), types.size());
+        types[colIdx] = handle->dataType();
+        needsSeparateType = true;
+      }
+    }
+    if (needsSeparateType) {
+      readerProducedType_ =
+          ROW(std::vector<std::string>(names.begin(), names.end()),
+              std::move(types));
+    }
+  }
 }
 
 std::unique_ptr<FileSplitReader> FileDataSource::createSplitReader() {
@@ -253,12 +406,14 @@ std::optional<RowVectorPtr> FileDataSource::next(
 
   // Subclass reader may add extra columns to reader output (e.g. for bucket
   // conversion or delta update).
+  auto& outputRowType =
+      readerProducedType_ ? readerProducedType_ : readerOutputType_;
   auto needsExtraColumn = [&] {
     return output_->asUnchecked<RowVector>()->childrenSize() <
-        readerOutputType_->size();
+        outputRowType->size();
   };
   if (!output_ || needsExtraColumn()) {
-    output_ = BaseVector::create(readerOutputType_, 0, pool_);
+    output_ = BaseVector::create(outputRowType, 0, pool_);
   }
 
   const auto rowsScanned = splitReader_->next(size, output_);
@@ -488,6 +643,8 @@ void FileDataSource::setFromDataSource(
   runtimeStats_.processedSplits += source->runtimeStats_.processedSplits;
   runtimeStats_.skippedSplitBytes += source->runtimeStats_.skippedSplitBytes;
   readerOutputType_ = std::move(source->readerOutputType_);
+  readerProducedType_ = std::move(source->readerProducedType_);
+  extractionColumns_ = std::move(source->extractionColumns_);
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);
   scanSpec_ = std::move(source->scanSpec_);
   metadataFilter_ = std::move(source->metadataFilter_);

--- a/velox/connectors/hive/FileDataSource.h
+++ b/velox/connectors/hive/FileDataSource.h
@@ -141,9 +141,24 @@ class FileDataSource : public DataSource {
     return metadataFilter_;
   }
 
+  // Actual type produced by the reader after extraction pushdown.  Differs
+  // from readerOutputType_ when the reader handles extraction natively
+  // (e.g., MapKeys -> ARRAY).  Null if no extraction pushdown is active.
+  RowTypePtr readerProducedType_;
+
+  // Output columns that have extraction chains.  Maps output column index to
+  // the column handle.  These columns are read with schemaType and transformed
+  // post-read using the extraction chains.
+  folly::F14FastMap<column_index_t, const FileColumnHandle*> extractionColumns_;
+
   dwio::common::RuntimeStatistics runtimeStats_;
 
  private:
+  // Configure extraction columns on the ScanSpec and build
+  // readerProducedType_.  Called from the constructor after scanSpec_ is
+  // created.
+  void configureExtractionColumns();
+
   /// Adds the information from column handle to the corresponding fields in
   /// this object.
   void processColumnHandle(const FileColumnHandlePtr& handle);

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -92,6 +92,10 @@ class HiveColumnHandle : public FileColumnHandle {
     return hiveType_;
   }
 
+  const TypePtr& schemaType() const override {
+    return hiveType();
+  }
+
   /// Applies to columns of complex types: arrays, maps and structs.  When a
   /// query uses only some of the subfields, the engine provides the complete
   /// list of required subfields and the connector is free to prune the rest.

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -19,6 +19,7 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/ExtractionUtils.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -953,7 +954,7 @@ TEST_F(HiveConnectorTest, ioStatsOverridesStorageReadBytes) {
            ioStatistics->read().max(),
            RuntimeCounter::Unit::kBytes)});
 
-  // IoStats merge (Step 3 in getRuntimeStats) — override storageReadBytes.
+  // IoStats merge (Step 3 in getRuntimeStats) -- override storageReadBytes.
   const auto ioStatsMap = ioStats.stats();
   for (const auto& [key, value] : ioStatsMap) {
     if (key == FileDataSource::kStorageReadBytes) {
@@ -976,7 +977,7 @@ TEST_F(HiveConnectorTest, storageReadBytesWithoutOverride) {
   auto ioStatistics = std::make_shared<io::IoStatistics>();
   ioStatistics->read().increment(200);
 
-  // IoStats has unrelated counters only — no storageReadBytes.
+  // IoStats has unrelated counters only -- no storageReadBytes.
   IoStats ioStats;
   ioStats.addCounter(
       "wsInRegionReadBytes", RuntimeCounter(300, RuntimeCounter::Unit::kBytes));
@@ -1004,6 +1005,255 @@ TEST_F(HiveConnectorTest, storageReadBytesWithoutOverride) {
   ASSERT_EQ(res.at("storageReadBytes").sum, 200);
   // Unrelated IoStats counters should still be added.
   ASSERT_EQ(res.at("wsInRegionReadBytes").sum, 300);
+}
+
+// --- ScanSpec extraction pushdown tests (file reader layer) ---
+
+TEST_F(HiveConnectorTest, extractionScanSpecMapKeepsBothChildren) {
+  // Map readers read keys and values together, so extraction from maps
+  // does not prune map children.  The extraction is applied post-read.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto rowType = ROW({{"col", hiveType}});
+  auto scanSpec = makeScanSpec(
+      rowType,
+      /*outputSubfields=*/{},
+      /*subfieldFilters=*/{},
+      /*indexColumns=*/{},
+      /*dataColumns=*/nullptr,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_.get());
+
+  // MapKeys extraction -- map children should still be readable.
+  std::vector<NamedExtraction> extractions = {
+      {"keys",
+       {ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       ARRAY(VARCHAR())}};
+
+  auto* colSpec = scanSpec->childByName("col");
+  ASSERT_NE(colSpec, nullptr);
+  configureExtractionScanSpec(hiveType, extractions, *colSpec, pool_.get());
+
+  auto* keysSpec = colSpec->childByName(ScanSpec::kMapKeysFieldName);
+  ASSERT_NE(keysSpec, nullptr);
+  ASSERT_FALSE(keysSpec->isConstant());
+  auto* valuesSpec = colSpec->childByName(ScanSpec::kMapValuesFieldName);
+  ASSERT_NE(valuesSpec, nullptr);
+  ASSERT_FALSE(valuesSpec->isConstant());
+}
+
+TEST_F(HiveConnectorTest, extractionScanSpecSizeKeepsBothChildren) {
+  // Size extraction on a map -- map children should still be readable
+  // (extraction is post-read).
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto rowType = ROW({{"col", hiveType}});
+  auto scanSpec = makeScanSpec(
+      rowType,
+      /*outputSubfields=*/{},
+      /*subfieldFilters=*/{},
+      /*indexColumns=*/{},
+      /*dataColumns=*/nullptr,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_.get());
+
+  std::vector<NamedExtraction> extractions = {
+      {"sz", {ExtractionPathElement::simple(ExtractionStep::kSize)}, BIGINT()}};
+
+  auto* colSpec = scanSpec->childByName("col");
+  configureExtractionScanSpec(hiveType, extractions, *colSpec, pool_.get());
+
+  auto* keysSpec = colSpec->childByName(ScanSpec::kMapKeysFieldName);
+  ASSERT_FALSE(keysSpec->isConstant());
+  auto* valuesSpec = colSpec->childByName(ScanSpec::kMapValuesFieldName);
+  ASSERT_FALSE(valuesSpec->isConstant());
+}
+
+TEST_F(HiveConnectorTest, extractionScanSpecStructFieldPruning) {
+  // Extraction with StructField should prune unneeded fields.
+  auto hiveType = ROW({{"x", INTEGER()}, {"y", DOUBLE()}, {"z", VARCHAR()}});
+  auto rowType = ROW({{"col", hiveType}});
+  auto scanSpec = makeScanSpec(
+      rowType,
+      /*outputSubfields=*/{},
+      /*subfieldFilters=*/{},
+      /*indexColumns=*/{},
+      /*dataColumns=*/nullptr,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_.get());
+
+  std::vector<NamedExtraction> extractions = {
+      {"col_x", {ExtractionPathElement::structField("x")}, INTEGER()}};
+
+  auto* colSpec = scanSpec->childByName("col");
+  configureExtractionScanSpec(hiveType, extractions, *colSpec, pool_.get());
+
+  // x should be readable, y and z should be constant null.
+  ASSERT_FALSE(colSpec->childByName("x")->isConstant());
+  ASSERT_TRUE(colSpec->childByName("y")->isConstant());
+  ASSERT_TRUE(colSpec->childByName("z")->isConstant());
+}
+
+TEST_F(HiveConnectorTest, scanSpecTransformApplied) {
+  // Verify that a transform set on ScanSpec is callable and produces
+  // the correct output type.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto scanSpec = std::make_shared<ScanSpec>("col");
+  scanSpec->addFieldRecursively("col", *hiveType, 0);
+
+  auto* colSpec = scanSpec->childByName("col");
+  ASSERT_NE(colSpec, nullptr);
+  ASSERT_FALSE(colSpec->hasTransform());
+
+  // Set a MapKeys extraction transform.
+  auto chain = std::vector<ExtractionPathElementPtr>{
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  colSpec->setTransform(
+      [chain](const VectorPtr& input, memory::MemoryPool* pool) -> VectorPtr {
+        return applyExtractionChain(input, chain, pool);
+      },
+      ARRAY(VARCHAR()));
+
+  ASSERT_TRUE(colSpec->hasTransform());
+
+  // Create a test MapVector and apply the transform.
+  auto keys = makeFlatVector<StringView>({"a", "b", "c"});
+  auto values = makeFlatVector<int64_t>({1, 2, 3});
+  auto mapVector = makeMapVector({0, 2}, keys, values);
+
+  auto result = colSpec->transform()(mapVector, pool_.get());
+  ASSERT_TRUE(result->type()->isArray());
+  ASSERT_EQ(result->size(), 2);
+  auto* array = result->as<ArrayVector>();
+  ASSERT_EQ(array->sizeAt(0), 2);
+  ASSERT_EQ(array->sizeAt(1), 1);
+}
+
+TEST_F(HiveConnectorTest, extractionScanSpecMapKeyFilterString) {
+  // kMapKeyFilter with string keys should set an IN filter on the keys
+  // ScanSpec.  ExtractionType should remain kNone since kMapKeyFilter is
+  // type-preserving.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto rowType = ROW({{"col", hiveType}});
+  auto scanSpec = makeScanSpec(
+      rowType,
+      /*outputSubfields=*/{},
+      /*subfieldFilters=*/{},
+      /*indexColumns=*/{},
+      /*dataColumns=*/nullptr,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_.get());
+
+  std::vector<NamedExtraction> extractions = {
+      {"filtered",
+       {ExtractionPathElement::mapKeyFilter(
+           std::vector<std::string>{"a", "b"})},
+       hiveType}};
+
+  auto* colSpec = scanSpec->childByName("col");
+  ASSERT_NE(colSpec, nullptr);
+  configureExtractionScanSpec(hiveType, extractions, *colSpec, pool_.get());
+
+  // ExtractionType should remain kNone.
+  ASSERT_EQ(colSpec->extractionType(), ScanSpec::ExtractionType::kNone);
+
+  // Keys ScanSpec should have an IN filter set.
+  auto* keysSpec = colSpec->childByName(ScanSpec::kMapKeysFieldName);
+  ASSERT_NE(keysSpec, nullptr);
+  ASSERT_NE(keysSpec->filter(), nullptr);
+  // Filter should pass "a" and "b" but not "c".
+  ASSERT_TRUE(keysSpec->filter()->testStringView(StringView("a")));
+  ASSERT_TRUE(keysSpec->filter()->testStringView(StringView("b")));
+  ASSERT_FALSE(keysSpec->filter()->testStringView(StringView("c")));
+}
+
+TEST_F(HiveConnectorTest, extractionScanSpecMapKeyFilterInt) {
+  // kMapKeyFilter with integer keys should set an IN filter on the keys
+  // ScanSpec.
+  auto hiveType = MAP(BIGINT(), VARCHAR());
+  auto rowType = ROW({{"col", hiveType}});
+  auto scanSpec = makeScanSpec(
+      rowType,
+      /*outputSubfields=*/{},
+      /*subfieldFilters=*/{},
+      /*indexColumns=*/{},
+      /*dataColumns=*/nullptr,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_.get());
+
+  std::vector<NamedExtraction> extractions = {
+      {"filtered",
+       {ExtractionPathElement::mapKeyFilter(std::vector<int64_t>{10, 20, 30})},
+       hiveType}};
+
+  auto* colSpec = scanSpec->childByName("col");
+  ASSERT_NE(colSpec, nullptr);
+  configureExtractionScanSpec(hiveType, extractions, *colSpec, pool_.get());
+
+  // ExtractionType should remain kNone.
+  ASSERT_EQ(colSpec->extractionType(), ScanSpec::ExtractionType::kNone);
+
+  // Keys ScanSpec should have an IN filter set.
+  auto* keysSpec = colSpec->childByName(ScanSpec::kMapKeysFieldName);
+  ASSERT_NE(keysSpec, nullptr);
+  ASSERT_NE(keysSpec->filter(), nullptr);
+  // Filter should pass 10, 20, 30 but not 5.
+  ASSERT_TRUE(keysSpec->filter()->testInt64(10));
+  ASSERT_TRUE(keysSpec->filter()->testInt64(20));
+  ASSERT_TRUE(keysSpec->filter()->testInt64(30));
+  ASSERT_FALSE(keysSpec->filter()->testInt64(5));
+}
+
+TEST_F(HiveConnectorTest, extractionScanSpecMapKeyFilterThenMapKeys) {
+  // kMapKeyFilter followed by kMapKeys should set a filter on keys and then
+  // configure kKeys extraction on the remaining chain.
+  auto hiveType = MAP(VARCHAR(), BIGINT());
+  auto rowType = ROW({{"col", hiveType}});
+  auto scanSpec = makeScanSpec(
+      rowType,
+      /*outputSubfields=*/{},
+      /*subfieldFilters=*/{},
+      /*indexColumns=*/{},
+      /*dataColumns=*/nullptr,
+      /*partitionKeys=*/{},
+      /*infoColumns=*/{},
+      /*specialColumns=*/{},
+      /*disableStatsBasedFilterReorder=*/false,
+      pool_.get());
+
+  std::vector<NamedExtraction> extractions = {
+      {"keys",
+       {ExtractionPathElement::mapKeyFilter(std::vector<std::string>{"x", "y"}),
+        ExtractionPathElement::simple(ExtractionStep::kMapKeys)},
+       ARRAY(VARCHAR())}};
+
+  auto* colSpec = scanSpec->childByName("col");
+  ASSERT_NE(colSpec, nullptr);
+  configureExtractionScanSpec(hiveType, extractions, *colSpec, pool_.get());
+
+  // Filter should be set on keys.
+  auto* keysSpec = colSpec->childByName(ScanSpec::kMapKeysFieldName);
+  ASSERT_NE(keysSpec, nullptr);
+  ASSERT_NE(keysSpec->filter(), nullptr);
+  ASSERT_TRUE(keysSpec->filter()->testStringView(StringView("x")));
+  ASSERT_FALSE(keysSpec->filter()->testStringView(StringView("z")));
+
+  // After stripping kMapKeyFilter, remaining chain is [kMapKeys], so
+  // kKeys extraction should be set.
+  ASSERT_EQ(colSpec->extractionType(), ScanSpec::ExtractionType::kKeys);
 }
 
 } // namespace

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -19,6 +19,7 @@
 #include <gmock/gmock.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/ExtractionUtils.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
 using namespace facebook::velox;
@@ -633,4 +634,151 @@ TEST(ColumnExtractionTest, threeExtractionsFromSameColumn) {
   ASSERT_TRUE(clone->extractions()[0].dataType->equivalent(*BIGINT()));
   ASSERT_TRUE(clone->extractions()[1].dataType->equivalent(*ARRAY(BIGINT())));
   ASSERT_TRUE(clone->extractions()[2].dataType->equivalent(*ARRAY(VARCHAR())));
+}
+// --- Runtime extraction application tests ---
+
+class ExtractionUtilsTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(ExtractionUtilsTest, mapKeys) {
+  // Apply MapKeys to a MapVector.
+  auto mapVector = makeMapVector<std::string, int64_t>(
+      {{{{"a", 1}, {"b", 2}}}, {{{"c", 3}}}});
+
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapKeys)};
+  auto result = applyExtractionChain(mapVector, chain, pool());
+
+  ASSERT_TRUE(result->type()->isArray());
+  auto* array = result->as<ArrayVector>();
+  ASSERT_EQ(array->size(), 2);
+  // First map has 2 keys, second has 1.
+  ASSERT_EQ(array->sizeAt(0), 2);
+  ASSERT_EQ(array->sizeAt(1), 1);
+}
+
+TEST_F(ExtractionUtilsTest, mapValues) {
+  // Apply MapValues to a MapVector.
+  auto mapVector = makeMapVector<std::string, int64_t>(
+      {{{{"a", 10}, {"b", 20}}}, {{{"c", 30}}}});
+
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues)};
+  auto result = applyExtractionChain(mapVector, chain, pool());
+
+  ASSERT_TRUE(result->type()->isArray());
+  auto* array = result->as<ArrayVector>();
+  ASSERT_EQ(array->size(), 2);
+  ASSERT_EQ(array->sizeAt(0), 2);
+  ASSERT_EQ(array->sizeAt(1), 1);
+  // Check values.
+  auto* elements = array->elements()->as<FlatVector<int64_t>>();
+  ASSERT_EQ(elements->valueAt(0), 10);
+  ASSERT_EQ(elements->valueAt(1), 20);
+  ASSERT_EQ(elements->valueAt(2), 30);
+}
+
+TEST_F(ExtractionUtilsTest, sizeOnMap) {
+  // Apply Size to a MapVector.
+  auto mapVector = makeMapVector<std::string, int64_t>(
+      {{{{"a", 1}, {"b", 2}, {"c", 3}}}, {{{"d", 4}}}});
+
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kSize)};
+  auto result = applyExtractionChain(mapVector, chain, pool());
+
+  ASSERT_TRUE(result->type()->isBigint());
+  auto* sizes = result->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->size(), 2);
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 1);
+}
+
+TEST_F(ExtractionUtilsTest, sizeOnArray) {
+  // Apply Size to an ArrayVector.
+  auto arrayVector = makeArrayVector<int64_t>({{1, 2, 3}, {4, 5}});
+
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kSize)};
+  auto result = applyExtractionChain(arrayVector, chain, pool());
+
+  ASSERT_TRUE(result->type()->isBigint());
+  auto* sizes = result->as<FlatVector<int64_t>>();
+  ASSERT_EQ(sizes->size(), 2);
+  ASSERT_EQ(sizes->valueAt(0), 3);
+  ASSERT_EQ(sizes->valueAt(1), 2);
+}
+
+TEST_F(ExtractionUtilsTest, structField) {
+  // Apply StructField to a RowVector.
+  auto rowVector = makeRowVector(
+      {"x", "y"},
+      {makeFlatVector<int32_t>({10, 20}), makeFlatVector<int32_t>({30, 40})});
+
+  std::vector<EPE> chain = {ExtractionPathElement::structField("x")};
+  auto result = applyExtractionChain(rowVector, chain, pool());
+
+  ASSERT_TRUE(result->type()->isInteger());
+  auto* flat = result->as<FlatVector<int32_t>>();
+  ASSERT_EQ(flat->valueAt(0), 10);
+  ASSERT_EQ(flat->valueAt(1), 20);
+}
+
+TEST_F(ExtractionUtilsTest, mapKeyFilter) {
+  // Apply MapKeyFilter to filter specific keys.
+  auto mapVector = makeMapVector<std::string, int64_t>(
+      {{{{"a", 1}, {"b", 2}, {"c", 3}}}, {{{"a", 10}, {"d", 40}}}});
+
+  std::vector<EPE> chain = {
+      ExtractionPathElement::mapKeyFilter(std::vector<std::string>{"a", "c"})};
+  auto result = applyExtractionChain(mapVector, chain, pool());
+
+  ASSERT_TRUE(result->type()->isMap());
+  auto* filteredMap = result->as<MapVector>();
+  ASSERT_EQ(filteredMap->size(), 2);
+  // First map: "a" and "c" kept (2 out of 3).
+  ASSERT_EQ(filteredMap->sizeAt(0), 2);
+  // Second map: only "a" kept (1 out of 2).
+  ASSERT_EQ(filteredMap->sizeAt(1), 1);
+}
+
+TEST_F(ExtractionUtilsTest, chainMapValuesStructField) {
+  // Chain: [MapValues, ArrayElements, StructField("x")]
+  // on MAP(VARCHAR, ROW(x: INT, y: INT)) -> ARRAY(INT).
+  auto keys = makeFlatVector<StringView>({"k1", "k2", "k3"});
+  auto structValues = makeRowVector(
+      {"x", "y"},
+      {makeFlatVector<int32_t>({10, 20, 30}),
+       makeFlatVector<int32_t>({100, 200, 300})});
+  auto mapVector = makeMapVector({0, 2}, keys, structValues);
+
+  std::vector<EPE> chain = {
+      ExtractionPathElement::simple(ExtractionStep::kMapValues),
+      ExtractionPathElement::simple(ExtractionStep::kArrayElements),
+      ExtractionPathElement::structField("x")};
+  auto result = applyExtractionChain(mapVector, chain, pool());
+
+  // Output should be ARRAY(INT).
+  ASSERT_TRUE(result->type()->isArray());
+  auto* array = result->as<ArrayVector>();
+  ASSERT_EQ(array->size(), 2);
+  // First map had 2 entries, second had 1.
+  ASSERT_EQ(array->sizeAt(0), 2);
+  ASSERT_EQ(array->sizeAt(1), 1);
+  auto* elements = array->elements()->as<FlatVector<int32_t>>();
+  ASSERT_EQ(elements->valueAt(0), 10);
+  ASSERT_EQ(elements->valueAt(1), 20);
+  ASSERT_EQ(elements->valueAt(2), 30);
+}
+
+TEST_F(ExtractionUtilsTest, emptyChain) {
+  // Empty chain should return the input unchanged.
+  auto mapVector = makeMapVector<std::string, int64_t>({{{{"a", 1}}}});
+  std::vector<EPE> chain = {};
+  auto result = applyExtractionChain(mapVector, chain, pool());
+  ASSERT_EQ(result.get(), mapVector.get());
 }

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -380,6 +380,86 @@ class ScanSpec {
     isFlatMapAsStruct_ = value;
   }
 
+  /// Extraction type for column extraction pushdown.  When set on a map or
+  /// array ScanSpec, tells the column reader to skip reading unneeded
+  /// streams and produce a different output type.
+  enum class ExtractionType : uint8_t {
+    kNone, ///< No extraction — read normally.
+    kKeys, ///< Extract map keys as ARRAY(K).  Skip reading values.
+    kValues, ///< Extract map values as ARRAY(V).  Skip reading keys.
+    kSize, ///< Extract size as BIGINT.  Skip reading keys and values.
+    kField, ///< Extract a single struct field.  Output is the field's type.
+  };
+
+  void setExtractionType(ExtractionType type) {
+    extractionType_ = type;
+  }
+
+  ExtractionType extractionType() const {
+    return extractionType_;
+  }
+
+  void setExtractionFieldIndex(column_index_t index) {
+    extractionFieldIndex_ = index;
+  }
+
+  column_index_t extractionFieldIndex() const {
+    return extractionFieldIndex_;
+  }
+
+  /// Post-read transform applied to the column's vector after it is read
+  /// from the file.  Used by column extraction pushdown to transform the
+  /// file-type vector (e.g., MAP) into the extraction output type (e.g.,
+  /// ARRAY for MapKeys).  The transform receives the read vector and a
+  /// memory pool, and returns the transformed vector.
+  ///
+  /// The transform is applied in these cases:
+  ///
+  /// 1. Delta update fallback: when a column has both extraction pushdown
+  ///    and a delta update (e.g., MAP_CONCAT), the reader checks
+  ///    deltaUpdate() and bypasses ExtractionType, producing the file
+  ///    type.  After the delta update modifies the vector, the full-chain
+  ///    transform is applied by SelectiveStructColumnReaderBase::getValues().
+  ///    ExtractionType may be set but is ignored by the reader.
+  ///
+  /// 2. Multiple extractions: when multiple extraction chains target the
+  ///    same column, the transform assembles a ROW from the individual
+  ///    extraction results.  ExtractionType is always kNone (not set for
+  ///    multiple extractions to ensure text reader compatibility).
+  ///
+  /// 3. Text reader: RowReader::projectColumns() applies the transform
+  ///    because the text reader does not use the selective reader
+  ///    framework.  ExtractionType is kNone (same as case 2) or set but
+  ///    ignored (single extraction — text reader applies the full-chain
+  ///    transform regardless).
+  ///
+  /// For selective readers (DWRF, Nimble) with a single extraction and
+  /// no delta update, the full chain is handled by ScanSpec pushdown
+  /// (ExtractionType + sub-spec pruning) and the transform is not
+  /// applied at read time.
+  using VectorTransform =
+      std::function<VectorPtr(const VectorPtr&, memory::MemoryPool*)>;
+
+  /// Set the post-read transform and the output type it produces.
+  /// The reader uses outputType to allocate the result vector, reads into
+  /// a temporary vector of the file type, then applies the transform.
+  void setTransform(VectorTransform transform, TypePtr outputType) {
+    transform_ = std::move(transform);
+    transformOutputType_ = std::move(outputType);
+  }
+
+  const VectorTransform& transform() const {
+    return transform_;
+  }
+
+  const TypePtr& transformOutputType() const {
+    return transformOutputType_;
+  }
+
+  bool hasTransform() const {
+    return transform_ != nullptr;
+  }
+
   /// Disable stats based filter reordering.
   void disableStatsBasedFilterReorder() {
     disableStatsBasedFilterReorder_ = true;
@@ -472,6 +552,18 @@ class ScanSpec {
   // This node represents a flat map column that need to be read as struct,
   // i.e. in table schema it is a MAP, but in result vector it is ROW.
   bool isFlatMapAsStruct_ = false;
+
+  // Extraction type for map/array/struct column readers.
+  ExtractionType extractionType_{ExtractionType::kNone};
+
+  // Index of the field to extract when extractionType_ is kField.
+  column_index_t extractionFieldIndex_{0};
+
+  // Post-read transform for column extraction pushdown.
+  VectorTransform transform_;
+
+  // Output type after the transform is applied.
+  TypePtr transformOutputType_;
 };
 
 template <typename F>


### PR DESCRIPTION
Summary:

Add configureExtractionScanSpec() for recursive ScanSpec configuration
(ExtractionType, kField, kMapKeyFilter as IN filter, struct field pruning).
Add applyExtractionChain() for runtime extraction.  Integrate with
HiveDataSource via configureExtractionColumns().  Add ScanSpec
ExtractionType enum (kNone, kKeys, kValues, kSize, kField) with
extractionFieldIndex and VectorTransform.

Reviewed By: maniloya

Differential Revision: D97671731


