### PR TITLE
Remove function_scheduler shim from xplat/folly/experimental (#16969)

### DIFF
--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <folly/experimental/FunctionScheduler.h>
+#include <folly/executors/FunctionScheduler.h>
 #include "velox/connectors/Connector.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/fb303/pull/75

X-link: https://github.com/prestodb/presto/pull/27469


Folly/experimental is just shims to the real code, rewriting all these references.

#force_dangling_check

Differential Revision: D97588319
