### PR TITLE
fix: Incorrect substr length in Tokenizer::matchUnquotedSubscript (#16972)

### DIFF
--- a/velox/type/Tokenizer.cpp
+++ b/velox/type/Tokenizer.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<Subfield::PathElement> Tokenizer::matchUnquotedSubscript() {
   }
   int end = index_;
 
-  std::string token = path_.substr(start, end);
+  std::string token = path_.substr(start, end - start);
 
   // an empty unquoted token is not allowed
   if (token.empty()) {

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -43,7 +43,7 @@ void assertInvalidSubfield(
 }
 
 TEST(SubfieldTest, invalidPaths) {
-  assertInvalidSubfield("a[b]", "Invalid index b]");
+  assertInvalidSubfield("a[b]", "Invalid index b");
   assertInvalidSubfield("a[2", "Invalid subfield path: a[2^");
   assertInvalidSubfield("a.*", "Invalid subfield path: a.^*");
   assertInvalidSubfield("a[2].[3].", "Invalid subfield path: a[2].^[3].");

--- a/velox/type/tests/TokenizerTest.cpp
+++ b/velox/type/tests/TokenizerTest.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/type/Tokenizer.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox::common;
+
+namespace {
+
+std::vector<std::unique_ptr<Subfield::PathElement>> tokenize(
+    const std::string& path) {
+  std::vector<std::unique_ptr<Subfield::PathElement>> elements;
+  Tokenizer tokenizer(path, Separators::get());
+  while (tokenizer.hasNext()) {
+    elements.push_back(tokenizer.next());
+  }
+  return elements;
+}
+
+} // namespace
+
+TEST(TokenizerTest, simpleSubscript) {
+  auto elements = tokenize("a[1]");
+  ASSERT_EQ(elements.size(), 2);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("a"));
+  EXPECT_EQ(*elements[1], Subfield::LongSubscript(1));
+}
+
+TEST(TokenizerTest, subscriptAfterLongPath) {
+  auto elements = tokenize("some.long.path[42]");
+  ASSERT_EQ(elements.size(), 4);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("some"));
+  EXPECT_EQ(*elements[1], Subfield::NestedField("long"));
+  EXPECT_EQ(*elements[2], Subfield::NestedField("path"));
+  EXPECT_EQ(*elements[3], Subfield::LongSubscript(42));
+}
+
+TEST(TokenizerTest, multipleSubscripts) {
+  auto elements = tokenize("a[1][2][3]");
+  ASSERT_EQ(elements.size(), 4);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("a"));
+  EXPECT_EQ(*elements[1], Subfield::LongSubscript(1));
+  EXPECT_EQ(*elements[2], Subfield::LongSubscript(2));
+  EXPECT_EQ(*elements[3], Subfield::LongSubscript(3));
+}
+
+TEST(TokenizerTest, negativeSubscript) {
+  auto elements = tokenize("a[-1]");
+  ASSERT_EQ(elements.size(), 2);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("a"));
+  EXPECT_EQ(*elements[1], Subfield::LongSubscript(-1));
+}
+
+TEST(TokenizerTest, invalidSubscriptErrorMessage) {
+  VELOX_ASSERT_THROW(tokenize("a[b]"), "Invalid index b");
+  VELOX_ASSERT_THROW(tokenize("some.long.path[xyz]"), "Invalid index xyz");
+}
+
+TEST(TokenizerTest, pathSegment) {
+  auto elements = tokenize("a.b.c");
+  ASSERT_EQ(elements.size(), 3);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("a"));
+  EXPECT_EQ(*elements[1], Subfield::NestedField("b"));
+  EXPECT_EQ(*elements[2], Subfield::NestedField("c"));
+}
+
+TEST(TokenizerTest, quotedSubscript) {
+  auto elements = tokenize("a[\"key\"]");
+  ASSERT_EQ(elements.size(), 2);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("a"));
+  EXPECT_EQ(*elements[1], Subfield::StringSubscript("key"));
+}
+
+TEST(TokenizerTest, wildcardSubscript) {
+  auto elements = tokenize("a[*]");
+  ASSERT_EQ(elements.size(), 2);
+  EXPECT_EQ(*elements[0], Subfield::NestedField("a"));
+  EXPECT_EQ(*elements[1], Subfield::AllSubscripts());
+}


### PR DESCRIPTION
Summary:

Fix error in `Tokenizer::matchUnquotedSubscript` that was passing absolute position instead of length to `substr()`, causing `std::stol` to parse extra characters and fail on valid paths.

Add comprehensive `TokenizerTest.cpp` with tests for subscripts, paths, and error messages. The `invalidSubscriptErrorMessage` test confirms the bug: before the fix, error messages included trailing `]` characters because `std::stol` was parsing beyond the intended token boundary.

Differential Revision: D98591270


