### PR TITLE
fix: Compile RE2 regex once in isColumnNameRequiringEscaping

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -41,8 +41,8 @@ struct hash<facebook::velox::TypeKind> {
 namespace facebook::velox {
 namespace {
 bool isColumnNameRequiringEscaping(const std::string& name) {
-  static const std::string re("^[a-zA-Z_][a-zA-Z0-9_]*$");
-  return !RE2::FullMatch(name, re);
+  static const re2::RE2 pattern("^[a-zA-Z_][a-zA-Z0-9_]*$");
+  return !RE2::FullMatch(name, pattern);
 }
 
 const auto& typeKindNames() {


### PR DESCRIPTION
Summary:
Replace string literal with static RE2 object in `isColumnNameRequiringEscaping` to avoid recompiling the regex pattern on every call.

The function was passing a `std::string` to `RE2::FullMatch`, which constructed a temporary `RE2` object each time. By declaring the pattern as a static `re2::RE2` object instead, the regex is compiled once at initialization and reused across all calls.

Differential Revision: D98845190


