### PR TITLE
docs: Add truncate markers to blog posts for cleaner listing page

### DIFF
--- a/website/blog/2022-07-01-june-2022-updates.mdx
+++ b/website/blog/2022-07-01-june-2022-updates.mdx
@@ -10,6 +10,8 @@ tags: [monthly-updates]
 
 * Add documentation for :ref:`complex types writers<outputs-write>`.
 
+<!-- truncate -->
+
 ## Core Library
 
 * Add support for INTERVAL DAY TO SECOND Presto type.

--- a/website/blog/2022-07-31-public-announcement.mdx
+++ b/website/blog/2022-07-31-public-announcement.mdx
@@ -7,6 +7,8 @@ tags: [public-announcement]
 
 We are extremely excited to introduce Velox as an [open-source project](https://engineering.fb.com/2022/08/31/open-source/velox/), with a mission to define common standards for modular data processing systems. Velox provides reusable, extensible, high-performance, and dialect-agnostic data processing components for building execution engines, and enhancing data management systems. We envision Velox to be the defacto execution engine for [Arrow-compatible](https://www.globenewswire.com/en/news-release/2022/06/23/2468271/0/en/Voltron-Data-Announces-Commitment-to-Improve-Interoperability-Between-Apache-Arrow-and-the-Velox-Open-Source-Project-Created-by-Meta.html) data format powering ML and Analytical workloads.
 
+<!-- truncate -->
+
 The Velox team has been partnering with companies such as [Ahana, Intel, and Voltron Data](https://www.techtarget.com/searchdatamanagement/news/252524446/Meta-and-partners-build-Velox-open-source-execution-engine?amp=1) as well as various academic institutions to accelerate innovation and development in the data management industry.
 
 Looking at the future, we believe Velox’s unified and modular nature has the potential to disrupt the data management industry. It will allow us to deepen our partnership with hardware vendors and proactively adapt our unified software stack as hardware advances. We believe that modularity and reusability are the future of database system development and hope a vibrant open source community will help us in this journey.

--- a/website/blog/2022-10-31-simple-1.mdx
+++ b/website/blog/2022-10-31-simple-1.mdx
@@ -16,6 +16,8 @@ Scalar functions are one of the most used extension points in Velox. Since Velox
 <img src="/img/simple1_1.png"/>
 </figure>
 
+<!-- truncate -->
+
 Writing functions as vector functions directly gives the user `complete` control over the function implementations and optimizations, however it comes with some cost that can be summarized in three points:
 
 - **Complexity** : Requires an understanding of Velox vectorized data representation and encodings, which requires additional work for our customers, specially those without DB background. Moreover, Writing optimized vector functions requires even deeper understanding.

--- a/website/blog/2023-03-15-build-experience.mdx
+++ b/website/blog/2023-03-15-build-experience.mdx
@@ -10,6 +10,8 @@ When Velox was open sourced in August 2021, it was not nearly as easily usable a
 
 To improve the Velox experience for users and community developers, Velox has partnered with Voltron Data to help make Velox more accessible and user-friendly. In this blog post, we will examine the challenges we faced, the improvements that have already been made, and the ones yet to come.
 
+<!-- truncate -->
+
 ## Enhancements & Improvements
 
 Velox was a product of the mono repo and required installation of dependencies on the system via a script. Any change in the state of the host system could cause a build failure and introduce version conflicts of dependencies. Fixing these challenges was a big focus to help the Velox Community and we worked in collaboration with the Voltron Data Team. We wanted to improve the overall Velox user experience by making Velox easy to consume across a wide range of platforms to accelerate its adoption.

--- a/website/blog/2023-05-01-simple-2.mdx
+++ b/website/blog/2023-05-01-simple-2.mdx
@@ -19,6 +19,8 @@ Note that the vector function implementation is minimal without any special opti
 </figure>
 
 
+<!-- truncate -->
+
 ### View types for inputs
 The previous representations of input complex types in the simple function interface were computationally expensive. Data from vectors used to be copied into std containers and passed to simple functions to process it. Arrays, Maps and Structs used to be materialized into std::vectors, folly::F14FastMap and std::tuples.
  The graph below illustrates the previous approach.

--- a/website/blog/2023-07-19-array-sort.mdx
+++ b/website/blog/2023-07-19-array-sort.mdx
@@ -27,6 +27,8 @@ presto> select array_sort_desc(array[2, 5, null, 1, -1]);
 
 Both array_sort and array_sort_desc place nulls at the end of the array.
 
+<!-- truncate -->
+
 There is also a version of <a href="https://prestodb.io/docs/current/functions/array.html#id2">array_sort</a>
 function that takes a comparator lambda function and uses it to sort the array.
 

--- a/website/blog/2023-09-06-optimize-try-cast.mdx
+++ b/website/blog/2023-09-06-optimize-try-cast.mdx
@@ -9,6 +9,8 @@ One of the queries shadowed internally at Meta was much slower in Velox compared
 
 In this blogpost I summarize my learnings from investigating and optimizing try_cast.
 
+<!-- truncate -->
+
 --------------------------------------------------------------------------------------------
 
 ### Start and end results

--- a/website/blog/2023-10-02-reduce-agg.mdx
+++ b/website/blog/2023-10-02-reduce-agg.mdx
@@ -22,6 +22,8 @@ state is returned. Throws an error if initialState is NULL or inputFunction or c
 returns a NULL.
 ```
 
+<!-- truncate -->
+
 Once can think of reduce_agg as using inputFunction to implement partial aggregation and
 combineFunction to implement final aggregation. Partial aggregation processes a list of
 input values and produces an intermediate state:

--- a/website/blog/2024-01-27-like-optimization.mdx
+++ b/website/blog/2024-01-27-like-optimization.mdx
@@ -24,6 +24,8 @@ WHERE name LIKE '%#_%' ESCAPE '#'
 --returns 'a_c' and  '_cd'
 ```
 
+<!-- truncate -->
+
 These examples show the basic usage of LIKE:
 
 - Use `%` to match zero or more characters.

--- a/website/blog/2024-05-31-optimize-try-more.mdx
+++ b/website/blog/2024-05-31-optimize-try-more.mdx
@@ -13,6 +13,8 @@ failure without throwing and introduced a mechanism for scalar functions to do
 the same. Microbenchmark measuring worst case performance of CAST improved
 100x. Samples of production queries show 30x cpu time improvement.
 
+<!-- truncate -->
+
 ## TRY and TRY(CAST)
 
 TRY construct can be applied to any expression to suppress errors and turn them

--- a/website/blog/2024-08-23-ci-migration.mdx
+++ b/website/blog/2024-08-23-ci-migration.mdx
@@ -13,6 +13,8 @@ tags: [tech-blog, packaging]
 
 In late 2023, the Meta OSS (Open Source Software) Team requested all Meta teams to move the CI deployments from CircleCI to Github Actions. [Voltron Data](http://voltrondata.com) and Meta in collaboration migrated all the deployed Velox CI jobs. For the year 2024, Velox CI spend was on track to overshoot the allocated resources by a considerable amount of money. As part of this migration effort, the CI workloads were consolidated and optimized by Q2 2024, bringing down the projected 2024 CI spend by 51%.
 
+<!-- truncate -->
+
 ## Velox’s Continuous Integration Workload
 
 Continuous Integration (CI) is crucial for Velox’s success as an open source project as it helps protect from bugs and errors, reduces likelihood of conflicts and leads to increased community trust in the project. This is to ensure the Velox builds works well on a myriad of system architectures, operating systems and compilers - along with the ones used internally at Meta. The OSS build version of Velox also supports additional features that aren't used internally in Meta (for example, support for Cloud blob stores, etc.).

--- a/website/blog/2024-12-15-tracing-query-tracing.mdx
+++ b/website/blog/2024-12-15-tracing-query-tracing.mdx
@@ -13,6 +13,8 @@ replay of a part of the query plan and dataset in an isolated environment, such 
 This is much more efficient for query performance analysis and issue debugging, as it eliminates the need
 to replay the whole query in a production environment.
 
+<!-- truncate -->
+
 ## How Tracing Works
 
 The tracing process consists of two distinct phases: the tracing phase and the replaying phase. The

--- a/website/blog/2025-02-17-velox-primer-part-1.mdx
+++ b/website/blog/2025-02-17-velox-primer-part-1.mdx
@@ -11,6 +11,8 @@ how distributed queries are executed, how data is shuffled among different
 stages, and present Velox concepts such as Tasks, Splits, Pipelines, Drivers,
 and Operators that enable such functionality.
 
+<!-- truncate -->
+
 ## Distributed Query Execution
 
 Velox is a library that provides the functions that go into a *query fragment* in

--- a/website/blog/2025-03-25-velox-primer-part-2.mdx
+++ b/website/blog/2025-03-25-velox-primer-part-2.mdx
@@ -23,6 +23,8 @@ fragments within a single worker node. Throughout this article, we will present
 which functions are performed by Velox and which by the distributed engine -
 Prestissimo, in this example.
 
+<!-- truncate -->
+
 ## Query Setup
 
 Prestissimo first receives the query through a *coordinator* node, which is

--- a/website/blog/2025-05-12-velox-primer-part-3.mdx
+++ b/website/blog/2025-05-12-velox-primer-part-3.mdx
@@ -21,6 +21,8 @@ producer side of the shuffle.  
 In this article, we will discuss the second query stage, or the consumer side
 of the shuffle.
 
+<!-- truncate -->
+
 ## Shuffle Consumer
 
 As presented in the previous post, on the first query stage each worker reads

--- a/website/blog/2025-07-07-segfault-dependency-update.mdx
+++ b/website/blog/2025-07-07-segfault-dependency-update.mdx
@@ -14,6 +14,8 @@ Updating these dependencies typically involves modifying the Velox code to align
 However, a recent upgrade of Folly and Facebook Thrift to version *v2025.04.28.00* caused a *SEGFAULT* only in one unit test in Velox
 named *velox_functions_remote_client_test*.
 
+<!-- truncate -->
+
 ## Investigation
 We immediately put on our [gdb](https://en.wikipedia.org/wiki/GNU_Debugger) gloves and looked at the stack traces. This issue was also reproducible in a debug build.
 The SEGFAULT occurred in Facebook Thrift's *ThriftServer* Class during it's initialization but the offending call was invoking a destructor of a certain handler.

--- a/website/blog/2025-07-11-extending-velox-with-cudf.mdx
+++ b/website/blog/2025-07-11-extending-velox-with-cudf.mdx
@@ -9,6 +9,8 @@ tags: [tech-blog]
 
 This post describes the design principles and software components for extending Velox with hardware acceleration libraries like NVIDIA's [cuDF](https://github.com/rapidsai/cudf). Velox provides a flexible execution model for hardware accelerators, and cuDF's data structures and algorithms align well with core components in Velox.
 
+<!-- truncate -->
+
 ## How Velox and cuDF Fit Together
 
 Extensibility is a key feature in Velox. The cuDF library integrates with Velox using the [DriverAdapter](https://github.com/facebookincubator/velox/blob/2a9c9043264a60c9a1b01324f8371c64bd095af9/velox/experimental/cudf/exec/ToCudf.cpp#L293) interface to rewrite query plans for GPU execution. The rewriting process allows for operator replacement, operator fusion and operator addition, giving cuDF a lot of freedom when preparing a query plan with GPU operators. Once Velox converts a query plan into executable pipelines, the cuDF DriverAdapter rewrites the plan to use GPU operators:

--- a/website/blog/2025-08-30-cpp20-standard.mdx
+++ b/website/blog/2025-08-30-cpp20-standard.mdx
@@ -10,6 +10,8 @@ The C++ standard used in a project determines what built-in functionality develo
 
 Since its inception in August of 2021 Velox used the C++17 standard.
 
+<!-- truncate -->
+
 ## Benefits
 
 Switching to C++20 contributes to having a modern ecosystem that is attractive in use, to develop in, and to maintain.

--- a/website/blog/2025-11-01-shared-build.mdx
+++ b/website/blog/2025-11-01-shared-build.mdx
@@ -9,6 +9,8 @@ tags: [tech-blog, packaging]
 
 In this post, I’ll share how we unblocked shared library builds in Velox, the challenges we encountered with our large CMake build system, and the creative solution that let us move forward without disrupting contributors or downstream users.
 
+<!-- truncate -->
+
 ## The State of the Velox Build System
 
 Velox’s codebase was started in Meta’s internal monorepo, which still serves as a source of truth. Changes from pull requests in the Github repository are not merged directly via the web UI. Instead, the changes are imported into the internal review and CI tool [Phabricator](https://developers.facebook.com/blog/post/2022/11/15/meta-developers-workflow-exploring-tools-used-to-code/), as a ‘diff’. There, it has to pass an additional set of CI checks before being merged into the monorepo and in turn, exported to Github as a commit on the ‘main’ branch.

--- a/website/blog/2025-11-09-multiround-local-merge.mdx
+++ b/website/blog/2025-11-09-multiround-local-merge.mdx
@@ -24,6 +24,8 @@ sequentially, placing them into the sorter and spilling as needed. Only after al
 does Spark perform a sort-merge of the spilled files. This process produces a large number of small
 spill files, which further degrades efficiency.
 
+<!-- truncate -->
+
 Moreover, Spark’s spill is row-based with a low compression ratio, resulting in approximately 4 times
 amplification compared to the original columnar training data in the data lake. These factors
 significantly degrade task stability and performance. Velox has a `LocalMerge` operator that can be

--- a/website/blog/2025-12-24-why-row-based-sort.mdx
+++ b/website/blog/2025-12-24-why-row-based-sort.mdx
@@ -22,6 +22,8 @@ sort-key columns, reducing the overhead of materializing payload columns. Contra
 end-to-end performance did not improve—in fact, it was even up to **3×** slower. We present the two
 variants and discuss why one is counter-intuitively faster than the other.
 
+<!-- truncate -->
+
 ## Row-based vs. Non-Materialized
 
 ### Row-based Sort

--- a/website/blog/2026-01-06-task-barrier.mdx
+++ b/website/blog/2026-01-06-task-barrier.mdx
@@ -24,6 +24,8 @@ patterns:
 
 See the [Task Barrier Developer Guide](https://facebookincubator.github.io/velox/develop/task-barrier.html) for implementation details.
 
+<!-- truncate -->
+
 ## The Problem
 
 Creating a new Velox task for every data request introduces overhead:

--- a/website/blog/2026-02-10-stringview-api-changes.mdx
+++ b/website/blog/2026-02-10-stringview-api-changes.mdx
@@ -16,6 +16,8 @@ This post describes in more detail how Velox handles columns of strings, the low
 involved and some recent changes made to them, and presents best practices for string usage
 throughout Velox's codebase.
 
+<!-- truncate -->
+
 ## StringView
 
 To efficiently enable string operations, Velox provides a specialized physical C++ type, called

--- a/website/blog/2026-03-07-regex-hidden-traps.mdx
+++ b/website/blog/2026-03-07-regex-hidden-traps.mdx
@@ -24,6 +24,8 @@ when used with column values instead of constants. Understanding why this
 happens helps write faster, more correct queries — and helps engine developers
 make better design choices.
 
+<!-- truncate -->
+
 ## LIKE is not contains
 
 A very common query pattern is to check whether one string contains another:

--- a/website/blog/2026-03-13-simd-capped-unicode-length.mdx
+++ b/website/blog/2026-03-13-simd-capped-unicode-length.mdx
@@ -20,6 +20,8 @@ most configurations, with no regressions on Unicode-heavy inputs. The
 optimization benefits all callers of these helpers, including the Iceberg
 truncate transform and various string functions.
 
+<!-- truncate -->
+
 ## Why SIMD, why here
 
 Velox is a high-performance execution engine, and SIMD is one of the primary

--- a/website/blog/2026-03-29-debugging-flaky-ci.mdx
+++ b/website/blog/2026-03-29-debugging-flaky-ci.mdx
@@ -15,8 +15,6 @@ The root cause turned out to be a bug in
 a Git submodule. This post describes the process of debugging a CI-only failure
 when the bug lives in a different repository.
 
-<!-- truncate -->
-
 ## The problem
 
 [Axiom](https://github.com/facebookincubator/axiom) is a set of open-source


### PR DESCRIPTION
Docusaurus uses `<!-- truncate -->` markers in blog posts to control how much content appears on the blog listing page (`/blog`). Content above the marker is shown as a preview with a "Read more" link; content below is only visible on the full post page. Without the marker, the entire post renders on the listing page.

Previously, only the most recent post had a truncate marker while all older posts lacked one. This meant the newest post was reduced to a few-sentence preview, while older posts dominated the page with their full content — giving less prominence to recent material.

This PR adds `<!-- truncate -->` markers to all older blog posts (after the intro paragraph or TL;DR section) and removes the marker from the most recent post. The result: the newest post shows in full on the listing page, while older posts show a short preview.

Going forward, when adding a new blog post, add `<!-- truncate -->` to the previously-newest post so only the latest one displays in full.