### PR TITLE
refactor: Add ConnectorRegistry class with tryGet and unregisterAll (#16977)

### DIFF
--- a/velox/connectors/CMakeLists.txt
+++ b/velox/connectors/CMakeLists.txt
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-velox_add_library(velox_connector Connector.cpp HEADERS Connector.h)
+velox_add_library(velox_connector Connector.cpp HEADERS Connector.h ConnectorRegistryInternal.h)
 
 velox_link_libraries(velox_connector velox_common_config velox_vector)
+
+velox_add_library(velox_connector_registry ConnectorRegistry.cpp HEADERS ConnectorRegistry.h)
+
+velox_link_libraries(velox_connector_registry velox_connector)
 
 add_subdirectory(fuzzer)
 

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -15,47 +15,28 @@
  */
 
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/ConnectorRegistryInternal.h"
 
 namespace facebook::velox::connector {
-namespace {
-
-std::unordered_map<std::string, std::shared_ptr<Connector>>& connectors() {
-  static std::unordered_map<std::string, std::shared_ptr<Connector>> connectors;
-  return connectors;
-}
-} // namespace
-
-bool DataSink::Stats::empty() const {
-  return numWrittenBytes == 0 && numWrittenFiles == 0 && spillStats.empty();
-}
-
-std::string DataSink::Stats::toString() const {
-  return fmt::format(
-      "numWrittenBytes {} numWrittenFiles {} {}",
-      succinctBytes(numWrittenBytes),
-      numWrittenFiles,
-      spillStats.toString());
-}
 
 bool registerConnector(std::shared_ptr<Connector> connector) {
   bool ok = connectors().insert({connector->connectorId(), connector}).second;
   VELOX_CHECK(
       ok,
-      "Connector with ID '{}' is already registered",
+      "Connector with ID is already registered: {}",
       connector->connectorId());
   return true;
 }
 
 bool unregisterConnector(const std::string& connectorId) {
-  auto count = connectors().erase(connectorId);
-  return count == 1;
+  return connectors().erase(connectorId) == 1;
 }
 
 std::shared_ptr<Connector> getConnector(const std::string& connectorId) {
   auto it = connectors().find(connectorId);
   VELOX_CHECK(
       it != connectors().end(),
-      "Connector with ID '{}' not registered",
+      "Connector with ID is not registered: {}",
       connectorId);
   return it->second;
 }
@@ -67,6 +48,18 @@ bool hasConnector(const std::string& connectorId) {
 const std::unordered_map<std::string, std::shared_ptr<Connector>>&
 getAllConnectors() {
   return connectors();
+}
+
+bool DataSink::Stats::empty() const {
+  return numWrittenBytes == 0 && numWrittenFiles == 0 && spillStats.empty();
+}
+
+std::string DataSink::Stats::toString() const {
+  return fmt::format(
+      "numWrittenBytes {} numWrittenFiles {} {}",
+      succinctBytes(numWrittenBytes),
+      numWrittenFiles,
+      spillStats.toString());
 }
 
 folly::Synchronized<

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -787,7 +787,8 @@ std::shared_ptr<Connector> getConnector(const std::string& connectorId);
 
 /// Returns a map of all (connectorId -> connector) pairs currently
 /// registered.
-const std::unordered_map<std::string, std::shared_ptr<Connector>>&
-getAllConnectors();
+[[deprecated("Use ConnectorRegistry methods instead.")]] const std::
+    unordered_map<std::string, std::shared_ptr<Connector>>&
+    getAllConnectors();
 
 } // namespace facebook::velox::connector

--- a/velox/connectors/ConnectorRegistry.cpp
+++ b/velox/connectors/ConnectorRegistry.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/ConnectorRegistryInternal.h"
+
+namespace facebook::velox::connector {
+
+// static
+std::shared_ptr<Connector> ConnectorRegistry::tryGet(
+    const std::string& connectorId) {
+  auto it = connectors().find(connectorId);
+  if (it != connectors().end()) {
+    return it->second;
+  }
+  return nullptr;
+}
+
+// static
+void ConnectorRegistry::unregisterAll() {
+  connectors().clear();
+}
+
+// static
+const std::unordered_map<std::string, std::shared_ptr<Connector>>&
+ConnectorRegistry::all() {
+  return connectors();
+}
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/ConnectorRegistry.h
+++ b/velox/connectors/ConnectorRegistry.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/Connector.h"
+
+namespace facebook::velox::connector {
+
+/// Provides static methods for connector registry operations.
+class ConnectorRegistry {
+ public:
+  /// Return the connector with the specified ID, or nullptr if not registered.
+  static std::shared_ptr<Connector> tryGet(const std::string& connectorId);
+
+  /// Return all connectors whose implementation is of type T.
+  template <typename T>
+  static std::vector<std::shared_ptr<T>> findAll() {
+    std::vector<std::shared_ptr<T>> result;
+    for (const auto& [_, connector] : all()) {
+      if (auto casted = std::dynamic_pointer_cast<T>(connector)) {
+        result.push_back(std::move(casted));
+      }
+    }
+    return result;
+  }
+
+  /// Unregister all connectors.
+  static void unregisterAll();
+
+ private:
+  // Return a reference to the internal connector map.
+  static const std::unordered_map<std::string, std::shared_ptr<Connector>>&
+  all();
+};
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/ConnectorRegistryInternal.h
+++ b/velox/connectors/ConnectorRegistryInternal.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::velox::connector {
+
+class Connector;
+
+// Internal helper shared by Connector.cpp and ConnectorRegistry.cpp.
+// Not part of the public API. Do not include from outside velox/connectors/.
+inline std::unordered_map<std::string, std::shared_ptr<Connector>>&
+connectors() {
+  static std::unordered_map<std::string, std::shared_ptr<Connector>> instance;
+  return instance;
+}
+
+} // namespace facebook::velox::connector

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/common/config/Config.h"
+#include "velox/connectors/ConnectorRegistry.h"
 
 #include <gtest/gtest.h>
 
@@ -43,40 +44,24 @@ class TestConnector : public connector::Connector {
   }
 };
 
-class TestConnectorFactory : public connector::ConnectorFactory {
- public:
-  TestConnectorFactory() : ConnectorFactory("test-factory") {}
-
-  std::shared_ptr<Connector> newConnector(
-      const std::string& id,
-      std::shared_ptr<const config::ConfigBase> /*config*/,
-      folly::Executor* /*ioExecutor*/ = nullptr,
-      folly::Executor* /*cpuExecutor*/ = nullptr) override {
-    return std::make_shared<TestConnector>(id);
-  }
-};
-
-TEST(ConnectorTest, getAllConnectors) {
-  TestConnectorFactory factory;
-
+TEST(ConnectorTest, registryOperations) {
   const int32_t numConnectors = 10;
   for (int32_t i = 0; i < numConnectors; i++) {
-    registerConnector(factory.newConnector(
-        fmt::format("connector-{}", i),
-        std::make_shared<config::ConfigBase>(
-            std::unordered_map<std::string, std::string>())));
-  }
-
-  const auto& connectors = getAllConnectors();
-  EXPECT_EQ(connectors.size(), numConnectors);
-  for (int32_t i = 0; i < numConnectors; i++) {
-    EXPECT_EQ(connectors.count(fmt::format("connector-{}", i)), 1);
+    registerConnector(
+        std::make_shared<TestConnector>(fmt::format("connector-{}", i)));
   }
 
   for (int32_t i = 0; i < numConnectors; i++) {
-    unregisterConnector(fmt::format("connector-{}", i));
+    EXPECT_NE(
+        ConnectorRegistry::tryGet(fmt::format("connector-{}", i)), nullptr);
   }
-  EXPECT_EQ(getAllConnectors().size(), 0);
+  EXPECT_EQ(ConnectorRegistry::tryGet("nonexistent"), nullptr);
+
+  auto allTestConnectors = ConnectorRegistry::findAll<TestConnector>();
+  EXPECT_EQ(allTestConnectors.size(), numConnectors);
+
+  ConnectorRegistry::unregisterAll();
+  EXPECT_EQ(ConnectorRegistry::findAll<TestConnector>().size(), 0);
 }
 
 TEST(ConnectorTest, connectorSplit) {

--- a/velox/tool/trace/TraceReplayRunner.cpp
+++ b/velox/tool/trace/TraceReplayRunner.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/connectors/Connector.h"
+#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
@@ -266,10 +267,7 @@ TraceReplayRunner::~TraceReplayRunner() {
   // This ensures file handles are closed while folly::RequestContext is still
   // valid, preventing use-after-free during program shutdown when the static
   // connector map is destroyed after RequestContext.
-  const auto connectorsCopy = connector::getAllConnectors();
-  for (const auto& [connectorId, connector] : connectorsCopy) {
-    connector::unregisterConnector(connectorId);
-  }
+  connector::ConnectorRegistry::unregisterAll();
 }
 
 void TraceReplayRunner::init() {


### PR DESCRIPTION
Summary:

Add ConnectorRegistry with static methods tryGet() and unregisterAll()
to reduce usage of getAllConnectors() which returns a reference to the
internal map and is incompatible with synchronized access.

Reviewed By: jagill

Differential Revision: D98907426


