### PR TITLE
misc: Make `DirectBufferedInput` clone fields protected

### DIFF
--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -239,6 +239,14 @@ class DirectBufferedInput : public BufferedInput {
  protected:
   // Some members are protected to allow custom extended buffered inputs.
   // Regions that are candidates for loading.
+  const StringIdLease fileNum_;
+  const std::shared_ptr<cache::ScanTracker> tracker_;
+  const StringIdLease groupId_;
+  const std::shared_ptr<IoStatistics> ioStatistics_;
+  const std::shared_ptr<velox::IoStats> ioStats_;
+  folly::Executor* const executor_;
+  const uint64_t fileSize_;
+  const io::ReaderOptions options_;
   std::vector<LoadRequest> requests_;
 
   // Distinct coalesced loads in 'coalescedLoads_'.
@@ -300,15 +308,6 @@ class DirectBufferedInput : public BufferedInput {
       pool.reset();
     }
   };
-
-  const StringIdLease fileNum_;
-  const std::shared_ptr<cache::ScanTracker> tracker_;
-  const StringIdLease groupId_;
-  const std::shared_ptr<IoStatistics> ioStatistics_;
-  const std::shared_ptr<velox::IoStats> ioStats_;
-  folly::Executor* const executor_;
-  const uint64_t fileSize_;
-  const io::ReaderOptions options_;
 
   // Coalesced loads spanning multiple streams in one IO.
   folly::Synchronized<folly::F14FastMap<

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -692,12 +692,21 @@ class CustomDirectBufferedInput
             executor,
             readerOptions,
             std::move(fileReadOps)) {
-    // Dummy reserve to ensure the accessibility of protected members in
-    // DirectBufferedInput.
-    requests_.reserve(1);
-    coalescedLoads_.reserve(1);
     VELOX_NYI("Not implemented in CustomBufferedInputBuilder");
   }
+
+ protected:
+  // Expose protected members to verify their accessibility.
+  using facebook::velox::dwio::common::DirectBufferedInput::coalescedLoads_;
+  using facebook::velox::dwio::common::DirectBufferedInput::executor_;
+  using facebook::velox::dwio::common::DirectBufferedInput::fileNum_;
+  using facebook::velox::dwio::common::DirectBufferedInput::fileSize_;
+  using facebook::velox::dwio::common::DirectBufferedInput::groupId_;
+  using facebook::velox::dwio::common::DirectBufferedInput::ioStatistics_;
+  using facebook::velox::dwio::common::DirectBufferedInput::ioStats_;
+  using facebook::velox::dwio::common::DirectBufferedInput::options_;
+  using facebook::velox::dwio::common::DirectBufferedInput::requests_;
+  using facebook::velox::dwio::common::DirectBufferedInput::tracker_;
 };
 
 class CustomBufferedInputBuilder


### PR DESCRIPTION
`StructColumnReader::loadRowGroup` clones the buffered input. To keep using 
custom `DirectBufferedInput` after cloning, we need to override clone, which 
requires changing some fields from private to protected.

https://github.com/facebookincubator/velox/blob/22b90045ef5737c737593fbedde1f6f4f64d6dc5/velox/dwio/parquet/reader/StructColumnReader.cpp#L124