### PR TITLE
feat(serializer): Add Arrow IPC format for RemoteFunctionPage (#16981)

### DIFF
--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -36,6 +36,7 @@
 #include "velox/functions/remote/server/RemoteFunctionService.h"
 #include "velox/functions/remote/utils/RemoteFunctionServiceProvider.h"
 #include "velox/serializers/PrestoSerializer.h"
+#include "velox/type/StringView.h"
 #include "velox/vector/VectorStream.h"
 
 using ::apache::thrift::ThriftServer;
@@ -229,10 +230,8 @@ TEST_P(RemoteFunctionTest, tryErrorCode) {
 }
 
 TEST_P(RemoteFunctionTest, opaque) {
-  // TODO: Support opaque type serialization in SPARK_UNSAFE_ROW
-  if (GetParam() == remote::PageFormat::SPARK_UNSAFE_ROW) {
-    LOG(WARNING)
-        << "opaque type serialization not supported in SPARK_UNSAFE_ROW";
+  // Opaque type serialization not supported in SPARK_UNSAFE_ROW or ARROW_IPC.
+  if (GetParam() != remote::PageFormat::PRESTO_PAGE) {
     return;
   }
   auto inputVector = makeFlatVector<std::shared_ptr<void>>(
@@ -265,6 +264,134 @@ TEST_P(RemoteFunctionTest, connectionError) {
   } catch (const VeloxRuntimeError& e) {
     EXPECT_THAT(e.message(), testing::HasSubstr("Channel is !good()"));
   }
+}
+
+// Arrow IPC-specific tests that exercise type coverage and edge cases beyond
+// the parameterized suite. These use TEST_P but skip non-ARROW_IPC formats.
+TEST_P(RemoteFunctionTest, arrowIpcNullsInBigint) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  auto inputVector =
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt, 5});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus(c0, c0)", makeRowVector({inputVector}));
+
+  auto expected =
+      makeNullableFlatVector<int64_t>({2, std::nullopt, 6, std::nullopt, 10});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcNullsInDouble) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  auto numerator =
+      makeNullableFlatVector<double>({1.0, std::nullopt, 9.0, 16.0});
+  auto denominator = makeNullableFlatVector<double>({1.0, 2.0, 3.0, 4.0});
+  auto results = evaluate<SimpleVector<double>>(
+      "remote_divide(c0, c1)", makeRowVector({numerator, denominator}));
+
+  auto expected = makeNullableFlatVector<double>({1.0, std::nullopt, 3.0, 4.0});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcNullsInString) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  auto inputStr = makeNullableFlatVector<StringView>(
+      {"hello"_sv, std::nullopt, "world"_sv, std::nullopt});
+  auto inputPos = makeNullableFlatVector<int32_t>({2, 1, 3, 1});
+  auto results = evaluate<SimpleVector<StringView>>(
+      "remote_substr(c0, c1)", makeRowVector({inputStr, inputPos}));
+
+  auto expected = makeNullableFlatVector<StringView>(
+      {"ello"_sv, std::nullopt, "rld"_sv, std::nullopt});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcLargeBatch) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  constexpr int kSize = 10'000;
+  std::vector<int64_t> values(kSize);
+  std::iota(values.begin(), values.end(), 0);
+
+  auto inputVector = makeFlatVector<int64_t>(values);
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus(c0, c0)", makeRowVector({inputVector}));
+
+  std::vector<int64_t> expectedValues(kSize);
+  for (int i = 0; i < kSize; i++) {
+    expectedValues[i] = values[i] * 2;
+  }
+  auto expected = makeFlatVector<int64_t>(expectedValues);
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcAllNulls) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  auto inputVector = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus(c0, c0)", makeRowVector({inputVector}));
+
+  auto expected = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcMixedNullsAcrossColumns) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  // Column a has nulls at positions 1,3; column b has nulls at positions 0,2.
+  auto colA =
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3, std::nullopt});
+  auto colB =
+      makeNullableFlatVector<int64_t>({std::nullopt, 20, std::nullopt, 40});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus(c0, c1)", makeRowVector({colA, colB}));
+
+  // plus propagates nulls: null if either input is null.
+  auto expected = makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt, std::nullopt});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcLongStrings) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  // Strings longer than 12 bytes (non-inline in Velox StringView).
+  const std::string longStr(256, 'x');
+  const std::string longerStr(4'096, 'y');
+  auto inputStr = makeFlatVector<StringView>(
+      {StringView(longStr), StringView(longerStr), "short"_sv});
+  auto inputPos = makeFlatVector<int32_t>({1, 1, 1});
+  auto results = evaluate<SimpleVector<StringView>>(
+      "remote_substr(c0, c1)", makeRowVector({inputStr, inputPos}));
+
+  // substr(s, 1) returns the full string.
+  auto expected = makeFlatVector<StringView>(
+      {StringView(longStr), StringView(longerStr), "short"_sv});
+  assertEqualVectors(expected, results);
+}
+
+TEST_P(RemoteFunctionTest, arrowIpcSingleRow) {
+  if (GetParam() != remote::PageFormat::ARROW_IPC) {
+    return;
+  }
+  auto inputVector = makeFlatVector<int64_t>({42});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus(c0, c0)", makeRowVector({inputVector}));
+
+  auto expected = makeFlatVector<int64_t>({84});
+  assertEqualVectors(expected, results);
 }
 
 /// Mock implementation of IRemoteFunctionClient for testing without a real
@@ -498,7 +625,8 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
     RemoteFunctionTest,
     ::testing::Values(
         remote::PageFormat::PRESTO_PAGE,
-        remote::PageFormat::SPARK_UNSAFE_ROW));
+        remote::PageFormat::SPARK_UNSAFE_ROW,
+        remote::PageFormat::ARROW_IPC));
 
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/remote/if/GetSerde.cpp
+++ b/velox/functions/remote/if/GetSerde.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/remote/if/GetSerde.h"
+#include "velox/serializers/ArrowSerializer.h"
 #include "velox/serializers/PrestoSerializer.h"
 #include "velox/serializers/UnsafeRowSerializer.h"
 
@@ -27,6 +28,9 @@ std::unique_ptr<VectorSerde> getSerde(const remote::PageFormat& format) {
 
     case remote::PageFormat::SPARK_UNSAFE_ROW:
       return std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
+
+    case remote::PageFormat::ARROW_IPC:
+      return std::make_unique<serializer::arrow::ArrowVectorSerde>();
   }
   VELOX_UNREACHABLE();
 }
@@ -42,6 +46,7 @@ std::unique_ptr<VectorSerde::Options> getSerdeOptions(
       return options;
     }
     case remote::PageFormat::SPARK_UNSAFE_ROW:
+    case remote::PageFormat::ARROW_IPC:
       return std::make_unique<VectorSerde::Options>();
   }
   VELOX_UNREACHABLE();

--- a/velox/functions/remote/if/RemoteFunction.thrift
+++ b/velox/functions/remote/if/RemoteFunction.thrift
@@ -32,6 +32,7 @@ typedef binary IOBuf
 enum PageFormat {
   PRESTO_PAGE = 1,
   SPARK_UNSAFE_ROW = 2,
+  ARROW_IPC = 3,
 }
 
 /// Identifies the remote function being called.

--- a/velox/serializers/ArrowSerializer.cpp
+++ b/velox/serializers/ArrowSerializer.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/ArrowSerializer.h"
+
+#include <cstdint>
+
+#include <arrow/buffer.h>
+#include <arrow/c/bridge.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <folly/Range.h>
+
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/arrow/Bridge.h"
+
+namespace facebook::velox::serializer::arrow {
+
+namespace {
+
+// Adapts a Velox OutputStream to an arrow::io::OutputStream so that Arrow IPC
+// writes flow directly into the Velox output without an intermediate buffer.
+class VeloxArrowOutputStream : public ::arrow::io::OutputStream {
+ public:
+  explicit VeloxArrowOutputStream(velox::OutputStream* sink) : sink_(sink) {}
+
+  ::arrow::Status Write(const void* data, int64_t nbytes) override {
+    sink_->write(reinterpret_cast<const char*>(data), nbytes);
+    position_ += nbytes;
+    return ::arrow::Status::OK();
+  }
+
+  ::arrow::Result<int64_t> Tell() const override {
+    return position_;
+  }
+
+  ::arrow::Status Close() override {
+    closed_ = true;
+    return ::arrow::Status::OK();
+  }
+
+  bool closed() const override {
+    return closed_;
+  }
+
+ private:
+  velox::OutputStream* sink_;
+  int64_t position_{0};
+  bool closed_{false};
+};
+
+// Extracts the specified row ranges from a RowVector into a new contiguous
+// RowVector. Returns the input directly when ranges cover the full vector.
+RowVectorPtr extractRanges(
+    const RowVectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges,
+    memory::MemoryPool* pool) {
+  if (ranges.size() == 1 && ranges[0].begin == 0 &&
+      ranges[0].size == vector->size()) {
+    return vector;
+  }
+
+  vector_size_t totalRows = 0;
+  for (const auto& range : ranges) {
+    totalRows += range.size;
+  }
+
+  auto rowType = asRowType(vector->type());
+  const auto numChildren = vector->childrenSize();
+  std::vector<VectorPtr> children;
+  children.reserve(numChildren);
+  for (int32_t i = 0; i < numChildren; ++i) {
+    auto child = vector->childAt(i);
+    auto newChild = BaseVector::create(child->type(), totalRows, pool);
+    vector_size_t outIdx = 0;
+    for (const auto& range : ranges) {
+      newChild->copy(child.get(), outIdx, range.begin, range.size);
+      outIdx += range.size;
+    }
+    children.push_back(std::move(newChild));
+  }
+
+  BufferPtr nulls;
+  if (vector->mayHaveNulls()) {
+    nulls = AlignedBuffer::allocate<bool>(totalRows, pool);
+    auto rawNulls = nulls->asMutable<uint64_t>();
+    vector_size_t outIdx = 0;
+    for (const auto& range : ranges) {
+      for (vector_size_t j = 0; j < range.size; ++j) {
+        bits::setBit(rawNulls, outIdx++, !vector->isNullAt(range.begin + j));
+      }
+    }
+  }
+
+  return std::make_shared<RowVector>(
+      pool, rowType, nulls, totalRows, std::move(children));
+}
+
+void serializeToArrowIpc(
+    const RowVectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges,
+    memory::MemoryPool* pool,
+    OutputStream* stream) {
+  auto toSerialize = extractRanges(vector, ranges, pool);
+
+  // Export Velox vector to Arrow C Data Interface (zero-copy for fixed-width).
+  ArrowArray arrowArray{};
+  ArrowSchema arrowSchema{};
+  exportToArrow(toSerialize, arrowArray, pool);
+  exportToArrow(toSerialize, arrowSchema);
+
+  // Import into Arrow C++ RecordBatch (zero-copy wrapper).
+  // ImportRecordBatch takes ownership on success. On failure, we must release.
+  auto batch = ::arrow::ImportRecordBatch(&arrowArray, &arrowSchema);
+  if (!batch.ok()) {
+    if (arrowArray.release) {
+      arrowArray.release(&arrowArray);
+    }
+    if (arrowSchema.release) {
+      arrowSchema.release(&arrowSchema);
+    }
+    VELOX_FAIL("Arrow ImportRecordBatch failed: {}", batch.status().ToString());
+  }
+
+  // Write IPC stream directly to the Velox output stream.
+  auto sink = std::make_shared<VeloxArrowOutputStream>(stream);
+  auto writer = ::arrow::ipc::MakeStreamWriter(sink, (*batch)->schema());
+  VELOX_CHECK(
+      writer.ok(),
+      "Arrow MakeStreamWriter failed: {}",
+      writer.status().ToString());
+  auto writeStatus = (*writer)->WriteRecordBatch(**batch);
+  VELOX_CHECK(
+      writeStatus.ok(),
+      "Arrow WriteRecordBatch failed: {}",
+      writeStatus.ToString());
+  auto closeStatus = (*writer)->Close();
+  VELOX_CHECK(
+      closeStatus.ok(),
+      "Arrow writer Close failed: {}",
+      closeStatus.ToString());
+}
+
+// Batch serializer: single-shot serialize of a RowVector subset.
+class ArrowBatchVectorSerializer : public BatchVectorSerializer {
+ public:
+  explicit ArrowBatchVectorSerializer(memory::MemoryPool* pool) : pool_(pool) {}
+
+  void serialize(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      Scratch& /*scratch*/,
+      OutputStream* stream) override {
+    serializeToArrowIpc(vector, ranges, pool_, stream);
+  }
+
+  void estimateSerializedSize(
+      VectorPtr /*vector*/,
+      const folly::Range<const IndexRange*>& ranges,
+      vector_size_t** sizes,
+      Scratch& /*scratch*/) override {
+    for (int32_t i = 0; i < static_cast<int32_t>(ranges.size()); ++i) {
+      *sizes[i] += static_cast<vector_size_t>(ranges[i].size * sizeof(int64_t));
+    }
+  }
+
+ private:
+  memory::MemoryPool* pool_;
+};
+
+// Iterative serializer: accumulates rows across multiple append() calls,
+// materializes into a single RowVector on flush().
+class ArrowIterativeVectorSerializer : public IterativeVectorSerializer {
+ public:
+  ArrowIterativeVectorSerializer(
+      RowTypePtr type,
+      int32_t /*numRows*/,
+      StreamArena* streamArena)
+      : type_(std::move(type)), pool_(streamArena->pool()) {}
+
+  void append(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      Scratch& /*scratch*/) override {
+    for (const auto& range : ranges) {
+      accumulated_.emplace_back(vector, range);
+      numRows_ += range.size;
+    }
+  }
+
+  size_t maxSerializedSize() const override {
+    // Rough upper-bound estimate.
+    return numRows_ * type_->size() * sizeof(int64_t) + 1'024;
+  }
+
+  void flush(OutputStream* stream) override {
+    if (numRows_ == 0) {
+      return;
+    }
+
+    auto& sourceVector = accumulated_.at(0).first;
+    const auto numChildren = sourceVector->childrenSize();
+    std::vector<VectorPtr> children;
+    children.reserve(numChildren);
+    for (int32_t col = 0; col < numChildren; ++col) {
+      auto child = BaseVector::create(
+          sourceVector->childAt(col)->type(), numRows_, pool_);
+      vector_size_t outIdx = 0;
+      for (const auto& [accVector, range] : accumulated_) {
+        child->copy(
+            accVector->childAt(col).get(), outIdx, range.begin, range.size);
+        outIdx += range.size;
+      }
+      children.push_back(std::move(child));
+    }
+
+    auto merged = std::make_shared<RowVector>(
+        pool_, type_, BufferPtr{}, numRows_, std::move(children));
+
+    IndexRange fullRange{0, numRows_};
+    serializeToArrowIpc(merged, folly::Range(&fullRange, 1), pool_, stream);
+
+    accumulated_.clear();
+    numRows_ = 0;
+  }
+
+ private:
+  RowTypePtr type_;
+  memory::MemoryPool* pool_;
+  std::vector<std::pair<RowVectorPtr, IndexRange>> accumulated_;
+  vector_size_t numRows_{0};
+};
+
+} // namespace
+
+std::unique_ptr<IterativeVectorSerializer>
+ArrowVectorSerde::createIterativeSerializer(
+    RowTypePtr type,
+    int32_t numRows,
+    StreamArena* streamArena,
+    const Options* /*options*/) {
+  return std::make_unique<ArrowIterativeVectorSerializer>(
+      std::move(type), numRows, streamArena);
+}
+
+std::unique_ptr<BatchVectorSerializer> ArrowVectorSerde::createBatchSerializer(
+    memory::MemoryPool* pool,
+    const Options* /*options*/) {
+  return std::make_unique<ArrowBatchVectorSerializer>(pool);
+}
+
+namespace {
+
+// Parses an Arrow IPC stream from an arrow::Buffer and produces a Velox
+// RowVector. The buffer's data stays alive via the Arrow ownership chain:
+// arrow::Buffer → RecordBatch (SliceBuffer) → ArrowArray → BufferView.
+RowVectorPtr deserializeFromArrowBuffer(
+    const std::shared_ptr<::arrow::Buffer>& arrowBuffer,
+    velox::memory::MemoryPool* pool,
+    const RowTypePtr& type) {
+  auto bufferReader = std::make_shared<::arrow::io::BufferReader>(arrowBuffer);
+
+  auto reader = ::arrow::ipc::RecordBatchStreamReader::Open(bufferReader);
+  VELOX_CHECK(
+      reader.ok(),
+      "Arrow IPC reader open failed: {}",
+      reader.status().ToString());
+
+  std::shared_ptr<::arrow::RecordBatch> batch;
+  auto readStatus = (*reader)->ReadNext(&batch);
+  VELOX_CHECK(
+      readStatus.ok(), "Arrow IPC ReadNext failed: {}", readStatus.ToString());
+  VELOX_CHECK_NOT_NULL(batch, "Arrow IPC stream contained no record batches.");
+
+  ArrowArray arrowArray{};
+  ArrowSchema arrowSchema{};
+  auto exportStatus =
+      ::arrow::ExportRecordBatch(*batch, &arrowArray, &arrowSchema);
+  if (!exportStatus.ok()) {
+    if (arrowArray.release) {
+      arrowArray.release(&arrowArray);
+    }
+    if (arrowSchema.release) {
+      arrowSchema.release(&arrowSchema);
+    }
+    VELOX_FAIL("Arrow ExportRecordBatch failed: {}", exportStatus.ToString());
+  }
+
+  // importFromArrowAsOwner takes ownership of arrowArray and arrowSchema.
+  auto imported = importFromArrowAsOwner(arrowSchema, arrowArray, pool);
+  auto importedRow = std::dynamic_pointer_cast<RowVector>(imported);
+  VELOX_CHECK_NOT_NULL(
+      importedRow, "Arrow IPC deserialized data is not a RowVector.");
+
+  return std::make_shared<RowVector>(
+      pool,
+      type,
+      importedRow->nulls(),
+      importedRow->size(),
+      importedRow->children());
+}
+
+// Wraps a folly::IOBuf as an arrow::Buffer. Coalesces if fragmented (zero-copy
+// if already contiguous). Captures the IOBuf to keep the memory alive.
+// The exposed data_/size_ pointers are valid for the lifetime of this object.
+// Thread safety: not thread-safe; callers must not access the buffer
+// concurrently with destruction.
+class IOBufArrowBuffer : public ::arrow::Buffer {
+ public:
+  explicit IOBufArrowBuffer(const folly::IOBuf& iobuf)
+      : ::arrow::Buffer(nullptr, 0),
+        ownedBuf_(iobuf.cloneCoalescedAsValueWithHeadroomTailroom(0, 0)) {
+    data_ = ownedBuf_.data();
+    size_ = static_cast<int64_t>(ownedBuf_.length());
+    capacity_ = size_;
+  }
+
+ private:
+  folly::IOBuf ownedBuf_;
+};
+
+std::shared_ptr<::arrow::Buffer> wrapIOBufAsArrowBuffer(
+    const folly::IOBuf& iobuf) {
+  return std::make_shared<IOBufArrowBuffer>(iobuf);
+}
+
+} // namespace
+
+void ArrowVectorSerde::deserialize(
+    ByteInputStream* source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* /*options*/) {
+  const auto totalSize = source->remainingSize();
+  VELOX_CHECK_GT(totalSize, 0, "Empty input to Arrow IPC deserializer.");
+  // Guard against corrupted input causing excessive allocation.
+  constexpr size_t kMaxArrowIpcPayloadSize = 1ULL << 32; // 4 GB
+  VELOX_CHECK_LE(
+      totalSize,
+      kMaxArrowIpcPayloadSize,
+      "Arrow IPC payload too large: {} bytes.",
+      totalSize);
+
+  std::string data;
+  data.resize(totalSize);
+  source->readBytes(
+      reinterpret_cast<uint8_t*>(data.data()), static_cast<int32_t>(totalSize));
+
+  auto arrowBuffer = ::arrow::Buffer::FromString(std::move(data));
+  *result = deserializeFromArrowBuffer(arrowBuffer, pool, type);
+}
+
+void ArrowVectorSerde::deserialize(
+    const folly::IOBuf& source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* /*options*/) {
+  VELOX_CHECK_GT(
+      source.computeChainDataLength(),
+      0,
+      "Empty input to Arrow IPC deserializer.");
+
+  // Wrap IOBuf as arrow::Buffer (zero-copy for contiguous IOBufs).
+  auto arrowBuffer = wrapIOBufAsArrowBuffer(source);
+  *result = deserializeFromArrowBuffer(arrowBuffer, pool, type);
+}
+
+void ArrowVectorSerde::registerVectorSerde() {
+  velox::registerVectorSerde(std::make_unique<ArrowVectorSerde>());
+}
+
+void ArrowVectorSerde::registerNamedVectorSerde() {
+  velox::registerNamedVectorSerde(
+      kSerdeKind, std::make_unique<ArrowVectorSerde>());
+}
+
+void ArrowVectorSerde::tryRegisterNamedVectorSerde() {
+  if (!velox::isRegisteredNamedVectorSerde(kSerdeKind)) {
+    registerNamedVectorSerde();
+  }
+}
+
+} // namespace facebook::velox::serializer::arrow

--- a/velox/serializers/ArrowSerializer.h
+++ b/velox/serializers/ArrowSerializer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::serializer::arrow {
+
+/// Serializes Velox vectors using Arrow IPC stream format. Uses the Arrow C
+/// Data Interface bridge for zero-copy conversion where possible, then the
+/// Arrow C++ IPC writer/reader for wire format serialization.
+class ArrowVectorSerde : public VectorSerde {
+ public:
+  ArrowVectorSerde() : VectorSerde(kSerdeKind) {}
+
+  std::unique_ptr<IterativeVectorSerializer> createIterativeSerializer(
+      RowTypePtr type,
+      int32_t numRows,
+      StreamArena* streamArena,
+      const Options* options) override;
+
+  std::unique_ptr<BatchVectorSerializer> createBatchSerializer(
+      memory::MemoryPool* pool,
+      const Options* options) override;
+
+  void deserialize(
+      ByteInputStream* source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options) override;
+
+  /// Zero-copy deserialize from IOBuf. Wraps the IOBuf memory directly as an
+  /// Arrow buffer, avoiding the coalesce copy in the ByteInputStream path.
+  void deserialize(
+      const folly::IOBuf& source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options) override;
+
+  /// Registers as the global default vector serde.
+  static void registerVectorSerde();
+
+  /// Registers in the named serde registry under kSerdeKind.
+  static void registerNamedVectorSerde();
+
+  /// Registers in the named serde registry only if not already registered.
+  static void tryRegisterNamedVectorSerde();
+
+  static const std::string& name() {
+    return kSerdeKind;
+  }
+
+ private:
+  inline static const std::string kSerdeKind{"ArrowIpc"};
+};
+
+} // namespace facebook::velox::serializer::arrow

--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -22,6 +22,10 @@ velox_link_libraries(
   velox_vector
 )
 
+velox_add_library(velox_arrow_serializer ArrowSerializer.cpp HEADERS ArrowSerializer.h)
+
+velox_link_libraries(velox_arrow_serializer velox_vector velox_arrow_bridge arrow)
+
 velox_add_library(
   velox_presto_serializer
   CompactRowSerializer.cpp

--- a/velox/serializers/tests/ArrowSerializerTest.cpp
+++ b/velox/serializers/tests/ArrowSerializerTest.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/ArrowSerializer.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::serializer::arrow {
+namespace {
+
+class ArrowSerializerTest : public testing::Test,
+                            public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    ArrowVectorSerde::registerNamedVectorSerde();
+    serde_ = std::make_unique<ArrowVectorSerde>();
+  }
+
+  void TearDown() override {
+    deregisterNamedVectorSerde("ArrowIpc");
+    deregisterVectorSerde();
+  }
+
+  // Serialize and deserialize a RowVector via the batch path.
+  RowVectorPtr roundTrip(const RowVectorPtr& input) {
+    auto iobuf = rowVectorToIOBufBatch(input, *pool_, serde_.get());
+    return IOBufToRowVector(
+        iobuf, asRowType(input->type()), *pool_, serde_.get());
+  }
+
+  std::unique_ptr<ArrowVectorSerde> serde_;
+};
+
+TEST_F(ArrowSerializerTest, integers) {
+  auto input = makeRowVector({
+      makeFlatVector<int8_t>({1, -2, 3}),
+      makeFlatVector<int16_t>({100, -200, 300}),
+      makeFlatVector<int32_t>({1'000, -2'000, 3'000}),
+      makeFlatVector<int64_t>({10'000, -20'000, 30'000}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, floats) {
+  auto input = makeRowVector({
+      makeFlatVector<float>({1.5f, -2.5f, 3.5f}),
+      makeFlatVector<double>({1.1, -2.2, 3.3}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, booleans) {
+  auto input = makeRowVector({
+      makeFlatVector<bool>({true, false, true, false, true}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, strings) {
+  auto input = makeRowVector({
+      makeFlatVector<StringView>({"short", "", "a longer string value here"}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, nulls) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+      makeNullableFlatVector<StringView>(
+          {std::nullopt, "hello"_sv, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, allNulls) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, emptyBatch) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({}),
+  });
+  auto result = roundTrip(input);
+  ASSERT_EQ(result->size(), 0);
+}
+
+TEST_F(ArrowSerializerTest, arrayType) {
+  auto input = makeRowVector({
+      makeArrayVector<int32_t>({{1, 2, 3}, {4, 5}, {}}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, mapType) {
+  auto input = makeRowVector({
+      makeMapVector<int32_t, StringView>(
+          {{{1, "a"_sv}, {2, "b"_sv}}, {{3, "c"_sv}}}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, rowType) {
+  auto input = makeRowVector({
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<StringView>({"x"_sv, "y"_sv}),
+      }),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, iterativeSerializer) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+  });
+
+  auto iobuf = rowVectorToIOBuf(input, *pool_, serde_.get());
+  auto result =
+      IOBufToRowVector(iobuf, asRowType(input->type()), *pool_, serde_.get());
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, namedSerdeRegistration) {
+  ASSERT_TRUE(isRegisteredNamedVectorSerde("ArrowIpc"));
+  auto* serde = getNamedVectorSerde("ArrowIpc");
+  ASSERT_NE(serde, nullptr);
+  ASSERT_EQ(serde->kind(), "ArrowIpc");
+}
+
+} // namespace
+} // namespace facebook::velox::serializer::arrow

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -102,6 +102,8 @@ std::string VectorSerde::kindName(Kind kind) {
       return "CompactRow";
     case Kind::kUnsafeRow:
       return "UnsafeRow";
+    case Kind::kArrowIpc:
+      return "ArrowIpc";
   }
   VELOX_UNREACHABLE(
       fmt::format("Unknown vector serde kind: {}", static_cast<int32_t>(kind)));
@@ -111,7 +113,8 @@ VectorSerde::Kind VectorSerde::kindByName(const std::string& kindName) {
   static const std::unordered_map<std::string, Kind> kNameToKind = {
       {"Presto", Kind::kPresto},
       {"CompactRow", Kind::kCompactRow},
-      {"UnsafeRow", Kind::kUnsafeRow}};
+      {"UnsafeRow", Kind::kUnsafeRow},
+      {"ArrowIpc", Kind::kArrowIpc}};
   const auto it = kNameToKind.find(kindName);
   VELOX_CHECK(
       it != kNameToKind.end(), "Unknown vector serde kind: {}", kindName);
@@ -175,6 +178,25 @@ VectorSerde* getNamedVectorSerde(const std::string& kind) {
       "Named vector serde '{}' is not registered.",
       kind);
   return it->second.get();
+}
+
+void VectorSerde::deserialize(
+    const folly::IOBuf& source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* options) {
+  std::vector<ByteRange> ranges;
+  ranges.reserve(4);
+  for (const auto& range : source) {
+    ranges.emplace_back(
+        ByteRange{
+            const_cast<uint8_t*>(range.data()),
+            static_cast<int32_t>(range.size()),
+            0});
+  }
+  auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
+  deserialize(byteStream.get(), pool, type, result, options);
 }
 
 void VectorStreamGroup::createStreamTree(
@@ -318,26 +340,12 @@ RowVectorPtr IOBufToRowVector(
     const RowTypePtr& outputType,
     memory::MemoryPool& pool,
     VectorSerde* serde) {
-  std::vector<ByteRange> ranges;
-  ranges.reserve(4);
-
-  for (const auto& range : ioBuf) {
-    ranges.emplace_back(
-        ByteRange{
-            const_cast<uint8_t*>(range.data()),
-            static_cast<int32_t>(range.size()),
-            0});
-  }
-
-  auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
-  RowVectorPtr outputVector;
-
-  // If not supplied, use the default one.
   if (serde == nullptr) {
     serde = getVectorSerde();
   }
-  serde->deserialize(
-      byteStream.get(), &pool, outputType, &outputVector, nullptr);
+
+  RowVectorPtr outputVector;
+  serde->deserialize(ioBuf, &pool, outputType, &outputVector, nullptr);
   return outputVector;
 }
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -210,6 +210,7 @@ class VectorSerde {
     kPresto,
     kCompactRow,
     kUnsafeRow,
+    kArrowIpc,
   };
 
   static std::string kindName(Kind type);
@@ -350,6 +351,17 @@ class VectorSerde {
       const Options* options = nullptr) {
     VELOX_NYI();
   }
+
+  /// Deserializes data directly from an IOBuf, enabling zero-copy paths for
+  /// formats like Arrow IPC that can wrap IOBuf memory without copying. The
+  /// default implementation converts to a ByteInputStream and calls the
+  /// regular deserialize().
+  virtual void deserialize(
+      const folly::IOBuf& source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options = nullptr);
 
  protected:
   explicit VectorSerde(std::string kind) : kind_(std::move(kind)) {}


### PR DESCRIPTION
Summary:

Add ArrowVectorSerde implementing Arrow IPC stream format for the
remote function framework. Adds ARROW_IPC as a third PageFormat
alongside PRESTO_PAGE and SPARK_UNSAFE_ROW.

Serialize: Velox Bridge export (zero-copy) -> Arrow C++ RecordBatch
-> IPC stream write via VeloxArrowOutputStream adapter (~2x bandwidth
vs PrestoPage ~5x). No CRC, no null bitmap inversion.

Deserialize: IOBufArrowBuffer wraps thrift IOBuf directly as
arrow::Buffer (zero-copy for contiguous IOBufs) -> IPC parse with
SliceBuffer (zero-copy) -> importFromArrowAsOwner (zero-copy for
fixed-width). ~0x bandwidth for fixed-width vs PrestoPage ~3x.

Adds VectorSerde::deserialize(const folly::IOBuf&, ...) virtual
method so IOBufToRowVector() bypasses ByteInputStream conversion.

Differential Revision: D98584648


