### PR TITLE
(feat): MixedUnion operator takes row ratio from split per barrier cycle

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -5889,15 +5889,7 @@ using TopNRowNumberNodePtr = std::shared_ptr<const TopNRowNumberNode>;
 class MixedUnionNode : public PlanNode {
  public:
   MixedUnionNode(const PlanNodeId& id, std::vector<PlanNodePtr> sources)
-      : MixedUnionNode(id, std::move(sources), {}) {}
-
-  MixedUnionNode(
-      const PlanNodeId& id,
-      std::vector<PlanNodePtr> sources,
-      std::vector<int64_t> batchSizesPerSource)
-      : PlanNode(id),
-        sources_(std::move(sources)),
-        batchSizesPerSource_(std::move(batchSizesPerSource)) {
+      : PlanNode(id), sources_(std::move(sources)) {
     VELOX_USER_CHECK(
         !sources_.empty(), "Union node must have at least one source");
 
@@ -5921,7 +5913,6 @@ class MixedUnionNode : public PlanNode {
     explicit Builder(const MixedUnionNode& other) {
       id_ = other.id();
       sources_ = other.sources();
-      batchSizesPerSource_ = other.batchSizesPerSource();
     }
 
     Builder& id(PlanNodeId id) {
@@ -5942,38 +5933,18 @@ class MixedUnionNode : public PlanNode {
       return *this;
     }
 
-    Builder& batchSizesPerSource(std::vector<int64_t> batchSizes) {
-      batchSizesPerSource_ = std::move(batchSizes);
-      return *this;
-    }
-
-    Builder& batchSizeForSource(int32_t sourceIndex, int64_t batchSize) {
-      if (!batchSizesPerSource_.has_value()) {
-        batchSizesPerSource_ = std::vector<int64_t>{};
-      }
-      if (sourceIndex >= batchSizesPerSource_->size()) {
-        batchSizesPerSource_->resize(sourceIndex + 1, 0);
-      }
-      (*batchSizesPerSource_)[sourceIndex] = batchSize;
-      return *this;
-    }
-
     std::shared_ptr<MixedUnionNode> build() const {
       VELOX_USER_CHECK(id_.has_value(), "MixedUnionNode id is not set");
       VELOX_USER_CHECK(
           sources_.has_value() && !sources_->empty(),
           "MixedUnionNode sources is not set or empty");
 
-      return std::make_shared<MixedUnionNode>(
-          id_.value(),
-          sources_.value(),
-          batchSizesPerSource_.value_or(std::vector<int64_t>{}));
+      return std::make_shared<MixedUnionNode>(id_.value(), sources_.value());
     }
 
    private:
     std::optional<PlanNodeId> id_;
     std::optional<std::vector<PlanNodePtr>> sources_;
-    std::optional<std::vector<int64_t>> batchSizesPerSource_;
   };
 
   const std::vector<PlanNodePtr>& sources() const override {
@@ -5982,20 +5953,6 @@ class MixedUnionNode : public PlanNode {
 
   const RowTypePtr& outputType() const override {
     return outputType_;
-  }
-
-  /// Returns the batch sizes per source index.
-  /// This controls how many rows are taken from each source when mixing.
-  const std::vector<int64_t>& batchSizesPerSource() const {
-    return batchSizesPerSource_;
-  }
-
-  /// Get batch size for a specific source index (returns 0 if not set).
-  int64_t getBatchSizeForSource(int32_t sourceIndex) const {
-    if (sourceIndex < 0 || sourceIndex >= batchSizesPerSource_.size()) {
-      return 0;
-    }
-    return batchSizesPerSource_[sourceIndex];
   }
 
   bool requiresSingleThread() const override {
@@ -6021,7 +5978,6 @@ class MixedUnionNode : public PlanNode {
   void addDetails(std::stringstream& /* stream */) const override {}
   const std::vector<PlanNodePtr> sources_;
   RowTypePtr outputType_;
-  std::vector<int64_t> batchSizesPerSource_;
 };
 
 using MixedUnionNodePtr = std::shared_ptr<const MixedUnionNode>;

--- a/velox/exec/MixedUnion.cpp
+++ b/velox/exec/MixedUnion.cpp
@@ -31,7 +31,6 @@ MixedUnion::MixedUnion(
           operatorId,
           unionNode->id(),
           OperatorType::kMixedUnion),
-      unionNode_(unionNode),
       maxOutputBatchRows_(outputBatchRows()),
       maxOutputBatchBytes_(
           driverCtx->queryConfig().preferredOutputBatchBytes()) {}
@@ -47,6 +46,8 @@ BlockingReason MixedUnion::addMergeSources(ContinueFuture* /* future */) {
     pendingData_.resize(numSources);
     sourcesFinished_.resize(numSources, false);
     sourcesDrained_.resize(numSources, false);
+
+    updateSourceFractions();
   }
   return BlockingReason::kNotBlocked;
 }
@@ -183,12 +184,60 @@ void MixedUnion::finishDrain() {
 }
 
 RowVectorPtr MixedUnion::getOutputMixed() {
+  // Re-read split counts in case they were updated for a new barrier cycle.
+  updateSourceFractions();
+
   // Drain pendingData_ populated by isBlocked() in both normal and drain modes.
+  vector_size_t numSourcesWithData = 0;
+  for (const auto& data : pendingData_) {
+    if (data) {
+      ++numSourcesWithData;
+    }
+  }
+
   std::vector<RowVectorPtr> validInputs;
-  for (size_t i = 0; i < pendingData_.size(); ++i) {
-    if (pendingData_[i]) {
-      validInputs.push_back(std::move(pendingData_[i]));
-      pendingData_[i] = nullptr;
+  if (numSourcesWithData > 0) {
+    // When fractions are configured and multiple sources have data, apply
+    // proportional mixing so the output reflects the split ratio. Otherwise
+    // each source gets an equal share of maxOutputBatchRows_.
+    const bool useFractions =
+        !sourceFractions_.empty() && numSourcesWithData > 1;
+
+    for (size_t i = 0; i < pendingData_.size(); ++i) {
+      if (!pendingData_[i]) {
+        continue;
+      }
+      const auto available = pendingData_[i]->size();
+      auto rowsToTake = available;
+
+      if (useFractions && i < sourceFractions_.size()) {
+        if (sourceFractions_[i] < 1.0) {
+          rowsToTake = std::max<vector_size_t>(
+              1,
+              static_cast<vector_size_t>(
+                  std::round(available * sourceFractions_[i])));
+          rowsToTake = std::min(rowsToTake, available);
+        }
+        // fraction == 1.0: take all rows.
+      } else if (numSourcesWithData > 1) {
+        // Equal-share fallback.
+        const auto perSourceShare = maxOutputBatchRows_ / numSourcesWithData;
+        if (perSourceShare > 0 &&
+            available > static_cast<vector_size_t>(perSourceShare)) {
+          rowsToTake = static_cast<vector_size_t>(perSourceShare);
+        }
+      }
+
+      if (rowsToTake < available) {
+        validInputs.push_back(
+            std::dynamic_pointer_cast<RowVector>(
+                pendingData_[i]->slice(0, rowsToTake)));
+        pendingData_[i] = std::dynamic_pointer_cast<RowVector>(
+            pendingData_[i]->slice(rowsToTake, available - rowsToTake));
+      } else {
+        validInputs.push_back(std::move(pendingData_[i]));
+        pendingData_[i] = nullptr;
+      }
     }
   }
 
@@ -290,6 +339,28 @@ bool MixedUnion::hasDataFromAllSources() const {
     }
   }
   return true;
+}
+
+void MixedUnion::updateSourceFractions() {
+  const auto& splitCounts =
+      operatorCtx_->task()->getSourceSplitCounts(planNodeId());
+  if (splitCounts.empty()) {
+    sourceFractions_.clear();
+    return;
+  }
+  const auto maxCount =
+      *std::max_element(splitCounts.begin(), splitCounts.end());
+  if (maxCount <= 0) {
+    sourceFractions_.clear();
+    return;
+  }
+  sourceFractions_.resize(sources_.size(), 1.0);
+  for (size_t i = 0;
+       i < std::min(splitCounts.size(), static_cast<size_t>(sources_.size()));
+       ++i) {
+    sourceFractions_[i] =
+        static_cast<double>(splitCounts[i]) / static_cast<double>(maxCount);
+  }
 }
 
 void MixedUnion::close() {

--- a/velox/exec/MixedUnion.h
+++ b/velox/exec/MixedUnion.h
@@ -74,8 +74,6 @@ class MixedUnion : public SourceOperator {
   /// Check if we have data from all active sources for mixed mode
   bool hasDataFromAllSources() const;
 
-  const std::shared_ptr<const core::MixedUnionNode> unionNode_;
-
   /// MergeSource objects representing each input pipeline
   std::vector<std::shared_ptr<MergeSource>> sources_;
 
@@ -97,6 +95,18 @@ class MixedUnion : public SourceOperator {
   /// Maximum output batch size
   const vector_size_t maxOutputBatchRows_;
   const uint64_t maxOutputBatchBytes_;
+
+  /// Re-read per-source split counts from the Task and recompute
+  /// sourceFractions_. Called on each barrier cycle so that per-UnionedSplit
+  /// ratios are applied, matching the Koski path behavior.
+  void updateSourceFractions();
+
+  // Per-source mixing fractions derived from split counts set on the Task.
+  // fraction[i] = splitCount[i] / max(splitCounts). The source with the most
+  // splits has fraction 1.0 and takes all rows; smaller sources take a
+  // proportional fraction, retaining the rest for subsequent output batches.
+  // Empty when no ratios are configured (equal-share mixing).
+  std::vector<double> sourceFractions_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3018,6 +3018,25 @@ const std::vector<std::shared_ptr<MergeSource>>& Task::getLocalMergeSources(
   return splitGroupStates_[splitGroupId].localMergeSources[planNodeId];
 }
 
+void Task::setSourceSplitCounts(
+    const core::PlanNodeId& planNodeId,
+    std::vector<int64_t> counts) {
+  // Store in split group 0 (ungrouped execution).
+  splitGroupStates_[0].sourceSplitCounts[planNodeId] = std::move(counts);
+}
+
+static const std::vector<int64_t> kEmptySplitCounts;
+
+const std::vector<int64_t>& Task::getSourceSplitCounts(
+    const core::PlanNodeId& planNodeId) {
+  auto& state = splitGroupStates_[0];
+  auto it = state.sourceSplitCounts.find(planNodeId);
+  if (it != state.sourceSplitCounts.end()) {
+    return it->second;
+  }
+  return kEmptySplitCounts;
+}
+
 void Task::createMergeJoinSource(
     uint32_t splitGroupId,
     const core::PlanNodeId& planNodeId) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -472,6 +472,17 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
+  /// Sets per-source split counts for a MixedUnion node. Used to compute
+  /// mixing fractions from the split ratio.
+  void setSourceSplitCounts(
+      const core::PlanNodeId& planNodeId,
+      std::vector<int64_t> counts);
+
+  /// Returns per-source split counts for a MixedUnion node, or empty if not
+  /// set.
+  const std::vector<int64_t>& getSourceSplitCounts(
+      const core::PlanNodeId& planNodeId);
+
   void createMergeJoinSource(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -228,6 +228,10 @@ struct SplitGroupState {
   std::unordered_map<core::PlanNodeId, std::shared_ptr<ScaledScanController>>
       scaledScanControllers;
 
+  /// Per-source split counts for MixedUnion nodes, keyed on MixedUnion plan
+  /// node ID. Used to compute mixing fractions from the split ratio.
+  std::unordered_map<core::PlanNodeId, std::vector<int64_t>> sourceSplitCounts;
+
   /// Drivers created and still running for this split group.
   /// The split group is finished when this numbers reaches zero.
   uint32_t numRunningDrivers{0};

--- a/velox/exec/tests/MixedUnionTest.cpp
+++ b/velox/exec/tests/MixedUnionTest.cpp
@@ -1519,3 +1519,311 @@ TEST_F(MixedUnionBarrierTest, barrierWithAggregation) {
   // 10 distinct groups
   ASSERT_EQ(result->size(), 10);
 }
+
+// ============================================================================
+// Execution tests verifying equal-share mixing.
+// The operator takes an equal share from each source per output batch,
+// so both sides make proportional progress and finish together.
+// ============================================================================
+
+TEST_F(MixedUnionTest, equalShareAllRowsPresent) {
+  // Verify all rows from both sources appear in the output when the operator
+  // uses equal-share mixing.
+  constexpr int kRows1 = 100;
+  constexpr int kRows2 = 80;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows1, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows2, [](auto row) { return row + 1'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto result = AssertQueryBuilder(mixedUnionNode)
+                    .serialExecution(true)
+                    .copyResults(pool());
+  ASSERT_EQ(result->size(), kRows1 + kRows2);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  std::set<int64_t> values;
+  for (int i = 0; i < result->size(); ++i) {
+    values.insert(col->valueAt(i));
+  }
+  EXPECT_EQ(values.size(), kRows1 + kRows2);
+  for (int i = 0; i < kRows1; ++i) {
+    EXPECT_TRUE(values.count(i)) << "Missing value " << i << " from source 0";
+  }
+  for (int i = 0; i < kRows2; ++i) {
+    EXPECT_TRUE(values.count(i + 1'000))
+        << "Missing value " << (i + 1'000) << " from source 1";
+  }
+}
+
+TEST_F(MixedUnionTest, equalShareMixingInterleaved) {
+  // Verify that rows from different sources appear interleaved, not all
+  // source-0 rows followed by all source-1 rows.
+  constexpr int kRows = 20;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row + 1'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto result = AssertQueryBuilder(mixedUnionNode)
+                    .serialExecution(true)
+                    .copyResults(pool());
+  ASSERT_EQ(result->size(), kRows * 2);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  bool seenSource0 = false;
+  bool seenSource1 = false;
+  int transitions = 0;
+  bool lastWasSource0 = false;
+
+  for (int i = 0; i < result->size(); ++i) {
+    bool isSource0 = col->valueAt(i) < 1'000;
+    if (i > 0 && isSource0 != lastWasSource0) {
+      transitions++;
+    }
+    if (isSource0) {
+      seenSource0 = true;
+    } else {
+      seenSource1 = true;
+    }
+    lastWasSource0 = isSource0;
+  }
+  EXPECT_TRUE(seenSource0);
+  EXPECT_TRUE(seenSource1);
+  // Equal-share mixing should produce at least 1 transition (source-0 block
+  // followed by source-1 block within the combined output).
+  EXPECT_GE(transitions, 1) << "Expected interleaved output, not sequential";
+}
+
+TEST_F(MixedUnionTest, equalShareAsymmetricData) {
+  // With asymmetric data sizes (4:1), equal-share mixing ensures both sides
+  // are present and no rows are lost.
+  constexpr int kRows1 = 160;
+  constexpr int kRows2 = 40;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows1, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows2, [](auto row) { return row + 1'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto result = AssertQueryBuilder(mixedUnionNode)
+                    .serialExecution(true)
+                    .copyResults(pool());
+  ASSERT_EQ(result->size(), kRows1 + kRows2);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  int source0Count = 0;
+  int source1Count = 0;
+  for (int i = 0; i < result->size(); ++i) {
+    if (col->valueAt(i) < 1'000) {
+      source0Count++;
+    } else {
+      source1Count++;
+    }
+  }
+  EXPECT_EQ(source0Count, kRows1);
+  EXPECT_EQ(source1Count, kRows2);
+}
+
+TEST_F(MixedUnionTest, equalShareThreeSources) {
+  constexpr int kRows1 = 30;
+  constexpr int kRows2 = 60;
+  constexpr int kRows3 = 90;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows1, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows2, [](auto row) { return row + 1'000; }),
+  });
+  auto data3 = makeRowVector({
+      makeFlatVector<int64_t>(kRows3, [](auto row) { return row + 2'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data3}).planNode()});
+
+  auto result = AssertQueryBuilder(mixedUnionNode)
+                    .serialExecution(true)
+                    .copyResults(pool());
+  ASSERT_EQ(result->size(), kRows1 + kRows2 + kRows3);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  std::set<int64_t> values;
+  for (int i = 0; i < result->size(); ++i) {
+    values.insert(col->valueAt(i));
+  }
+  EXPECT_EQ(values.size(), kRows1 + kRows2 + kRows3);
+}
+
+TEST_F(MixedUnionTest, equalShareWithDownstreamFilter) {
+  constexpr int kRows = 50;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row + 1'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .addNode([&](auto, auto) { return mixedUnionNode; })
+                  .filter("c0 >= 25")
+                  .planNode();
+
+  auto result =
+      AssertQueryBuilder(plan).serialExecution(true).copyResults(pool());
+
+  // Source 0: values 25..49 = 25 rows.
+  // Source 1: values 1000..1049 = 50 rows (all >= 25).
+  ASSERT_EQ(result->size(), 75);
+}
+
+TEST_F(MixedUnionTest, equalShareWithDownstreamProjection) {
+  constexpr int kRows = 20;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row * 10; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row + 100; }),
+      makeFlatVector<int64_t>(kRows, [](auto row) { return (row + 100) * 10; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .addNode([&](auto, auto) { return mixedUnionNode; })
+                  .project({"c0 + c1 as sum"})
+                  .planNode();
+
+  auto result =
+      AssertQueryBuilder(plan).serialExecution(true).copyResults(pool());
+  ASSERT_EQ(result->size(), kRows * 2);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  std::set<int64_t> sums;
+  for (int i = 0; i < result->size(); ++i) {
+    sums.insert(col->valueAt(i));
+  }
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_TRUE(sums.count(i * 11)) << "Missing sum " << i * 11;
+  }
+  for (int i = 0; i < kRows; ++i) {
+    EXPECT_TRUE(sums.count((i + 100) * 11)) << "Missing sum " << (i + 100) * 11;
+  }
+}
+
+// ============================================================================
+// Split-ratio proportional mixing tests.
+// Split ratios are set on the Task via setSourceSplitCounts(), and the
+// MixedUnion operator reads them to compute mixing fractions.
+// ============================================================================
+
+TEST_F(MixedUnionTest, splitRatioAllRowsPresent) {
+  // 2:5 ratio. Verify no rows are lost with asymmetric data sizes.
+  constexpr int kRows1 = 80;
+  constexpr int kRows2 = 200;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows1, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows2, [](auto row) { return row + 1'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto result = AssertQueryBuilder(mixedUnionNode)
+                    .serialExecution(true)
+                    .copyResults(pool());
+  ASSERT_EQ(result->size(), kRows1 + kRows2);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  std::set<int64_t> values;
+  for (int i = 0; i < result->size(); ++i) {
+    values.insert(col->valueAt(i));
+  }
+  EXPECT_EQ(values.size(), kRows1 + kRows2);
+}
+
+TEST_F(MixedUnionTest, splitRatioEqualCountsNoThrottling) {
+  // Equal data from both sources — same as equal-share.
+  constexpr int kRows = 50;
+  auto data1 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row; }),
+  });
+  auto data2 = makeRowVector({
+      makeFlatVector<int64_t>(kRows, [](auto row) { return row + 1'000; }),
+  });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto mixedUnionNode = std::make_shared<core::MixedUnionNode>(
+      planNodeIdGenerator->next(),
+      std::vector<core::PlanNodePtr>{
+          PlanBuilder(planNodeIdGenerator).values({data1}).planNode(),
+          PlanBuilder(planNodeIdGenerator).values({data2}).planNode()});
+
+  auto result = AssertQueryBuilder(mixedUnionNode)
+                    .serialExecution(true)
+                    .copyResults(pool());
+  ASSERT_EQ(result->size(), kRows * 2);
+
+  auto* col = result->childAt(0)->asFlatVector<int64_t>();
+  int source0 = 0;
+  int source1 = 0;
+  for (int i = 0; i < result->size(); ++i) {
+    if (col->valueAt(i) < 1'000) {
+      ++source0;
+    } else {
+      ++source1;
+    }
+  }
+  EXPECT_EQ(source0, kRows);
+  EXPECT_EQ(source1, kRows);
+}


### PR DESCRIPTION
Summary:
Add support for dynamically updating MixedUnion mixing fractions per barrier
cycle, enabling proportional row mixing in distributed barriered execution.

Previously, mixing ratios were baked into the MixedUnionNode plan node at
plan creation time via batchSizesPerSource. This doesn't work for distributed
execution where each UnionedSplit can have different per-source split counts.

This diff:
- Removes batchSizesPerSource from MixedUnionNode (reverts the static plan
  node approach from D91948457/D91948529)
- Adds setSourceSplitCounts()/getSourceSplitCounts() on Task to allow the
  cursor to communicate per-barrier-cycle split counts to the operator
- Adds MixedUnion::updateSourceFractions() which re-reads split counts from
  the Task on each getOutputMixed() call, computing fraction[i] =
  splitCount[i] / max(splitCounts) for proportional mixing
- Updates MixedUnionTest with splitRatio tests exercising the new fraction-
  based mixing

Differential Revision: D98589188


