### PR TITLE
test: Extend cast tests in the expression fuzzer test

### DIFF
--- a/velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.cpp
+++ b/velox/expression/fuzzer/SparkSpecialFormSignatureGenerator.cpp
@@ -22,13 +22,20 @@ SparkSpecialFormSignatureGenerator::getSignaturesForCast() const {
   std::vector<exec::FunctionSignaturePtr> signatures =
       getCommonSignaturesForCast();
 
-  // Cast tinyint/smallint/integer/bigint as varbinary is supported in Spark.
+  // Cast integer types as varbinary is supported in Spark.
   for (auto fromType : {"tinyint", "smallint", "integer", "bigint"}) {
     signatures.push_back(makeCastSignature(fromType, "varbinary"));
   }
 
-  // Cast tinyint/smallint/integer/bigint as timestamp is supported in Spark.
-  for (auto fromType : {"tinyint", "smallint", "integer", "bigint"}) {
+  // Cast the below types as timestamp is supported in Spark.
+  for (auto fromType :
+       {"boolean",
+        "tinyint",
+        "smallint",
+        "integer",
+        "bigint",
+        "real",
+        "double"}) {
     signatures.push_back(makeCastSignature(fromType, "timestamp"));
   }
 
@@ -38,6 +45,11 @@ SparkSpecialFormSignatureGenerator::getSignaturesForCast() const {
   for (auto i = 0; i < size; ++i) {
     auto from = signatures[i]->argumentTypes()[0].baseName();
     auto to = signatures[i]->returnType().baseName();
+
+    // Signature parsing of nested decimal type is not supported.
+    if (from == "DECIMAL" || to == "DECIMAL") {
+      continue;
+    }
 
     signatures.push_back(makeCastSignature(
         fmt::format("array({})", from), fmt::format("array({})", to)));
@@ -49,6 +61,12 @@ SparkSpecialFormSignatureGenerator::getSignaturesForCast() const {
     signatures.push_back(makeCastSignature(
         fmt::format("row({})", from), fmt::format("row({})", to)));
   }
+
+  // Cast timestamp as integer types is supported in Spark.
+  for (auto toType : {"tinyint", "smallint", "integer", "bigint"}) {
+    signatures.push_back(makeCastSignature("timestamp", toType));
+  }
+
   return signatures;
 }
 

--- a/velox/expression/fuzzer/SpecialFormSignatureGenerator.h
+++ b/velox/expression/fuzzer/SpecialFormSignatureGenerator.h
@@ -45,8 +45,14 @@ class SpecialFormSignatureGenerator {
       const std::string& toType,
       std::vector<exec::FunctionSignaturePtr>& signatures) const;
 
-  /// Generates signatures for cast from varchar to the given type and adds them
-  /// to signatures.
+  /// Generates signatures for cast from decimal types to the given type
+  /// and adds them to signatures.
+  void addCastFromDecimalSignatures(
+      const std::string& toType,
+      std::vector<exec::FunctionSignaturePtr>& signatures) const;
+
+  /// Generates signatures for cast from varchar to the given type and adds
+  /// them to signatures.
   void addCastFromVarcharSignature(
       const std::string& toType,
       std::vector<exec::FunctionSignaturePtr>& signatures) const;
@@ -110,6 +116,12 @@ class SpecialFormSignatureGenerator {
       "boolean"};
 
   const std::vector<std::string> kFloatingPointTypes_{"real", "double"};
+
+  const std::vector<std::string> kDecimalTypes_{
+      "DECIMAL(6, 0)",
+      "DECIMAL(18, 6)",
+      "DECIMAL(38, 18)",
+      "DECIMAL(38, 38)"};
 };
 
 } // namespace facebook::velox::fuzzer


### PR DESCRIPTION
This PR enables tests for from-decimal and to-decimal conversions in the Presto 
and Spark expression fuzzer. Tests for casting scalar types as timestamp and 
casting timestamp as integer types are enabled for Spark expression fuzzer.

Replace https://github.com/facebookincubator/velox/pull/12492.