### PR TITLE
feat: Support dynamic filter pushdown through LocalPartition / LocalExchange

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -270,7 +270,10 @@ LocalExchange::LocalExchange(
       queue_{operatorCtx_->task()->getLocalExchangeQueue(
           ctx->splitGroupId,
           planNodeId,
-          partition)} {}
+          partition)},
+      dynamicFilters_{operatorCtx_->task()->getLocalExchangeDynamicFilters(
+          ctx->splitGroupId,
+          planNodeId)} {}
 
 BlockingReason LocalExchange::isBlocked(ContinueFuture* future) {
   if (blockingReason_ != BlockingReason::kNotBlocked) {
@@ -324,6 +327,21 @@ void LocalExchange::close() {
   }
 }
 
+void LocalExchange::addDynamicFilterLocked(
+    const core::PlanNodeId& /*producer*/,
+    const PushdownFilters& filters) {
+  dynamicFilters_->withWLock([&](auto& dynamicFilters) {
+    for (auto channel : filters.dynamicFilteredColumns) {
+      auto it = filters.filters.find(channel);
+      VELOX_CHECK(it != filters.filters.end());
+      common::Filter::merge(
+          it->second, dynamicFilters.filters.filters[channel]);
+      dynamicFilters.filters.dynamicFilteredColumns.insert(channel);
+    }
+    ++dynamicFilters.version;
+  });
+}
+
 LocalPartition::LocalPartition(
     int32_t operatorId,
     DriverCtx* ctx,
@@ -338,6 +356,9 @@ LocalPartition::LocalPartition(
       queues_{
           ctx->task->getLocalExchangeQueues(ctx->splitGroupId, planNode->id())},
       numPartitions_{queues_.size()},
+      dynamicFilters_{ctx->task->getLocalExchangeDynamicFilters(
+          ctx->splitGroupId,
+          planNode->id())},
       partitionFunction_(
           numPartitions_ == 1 ? nullptr
                               : planNode->partitionFunctionSpec().create(
@@ -577,11 +598,48 @@ void LocalPartition::populateAndEnqueuePartitions(
   }
 }
 
+void LocalPartition::maybePushdownDynamicFilters() {
+  std::vector<column_index_t> channels;
+  std::vector<common::FilterPtr> filters;
+  uint64_t version;
+
+  {
+    auto lockedFilters = dynamicFilters_->rlock();
+    if (lockedFilters->version == dynamicFiltersVersion_ ||
+        lockedFilters->filters.dynamicFilteredColumns.empty()) {
+      return;
+    }
+
+    channels.reserve(lockedFilters->filters.dynamicFilteredColumns.size());
+    for (auto channel : lockedFilters->filters.dynamicFilteredColumns) {
+      channels.push_back(channel);
+    }
+    std::sort(channels.begin(), channels.end());
+
+    filters.reserve(channels.size());
+    for (auto channel : channels) {
+      auto it = lockedFilters->filters.filters.find(channel);
+      VELOX_CHECK(it != lockedFilters->filters.filters.end());
+      filters.push_back(it->second);
+    }
+    version = lockedFilters->version;
+  }
+
+  operatorCtx_->driver()->pushdownFilters(
+      this, channels, [&](column_index_t index, common::FilterPtr& filter) {
+        filter = filters[index];
+        return true;
+      });
+  dynamicFiltersVersion_ = version;
+}
+
 void LocalPartition::addInput(RowVectorPtr input) {
   prepareForInput(input);
   if (input->size() == 0) {
     return;
   }
+
+  maybePushdownDynamicFilters();
 
   const auto singlePartition = numPartitions_ == 1
       ? 0
@@ -628,6 +686,7 @@ void LocalPartition::prepareForInput(RowVectorPtr& input) {
 }
 
 BlockingReason LocalPartition::isBlocked(ContinueFuture* future) {
+  maybePushdownDynamicFilters();
   if (!futures_.empty()) {
     auto blockingReason = blockingReasons_.front();
     *future = folly::collectAll(futures_.begin(), futures_.end()).unit();

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -20,6 +20,11 @@
 
 namespace facebook::velox::exec {
 
+struct LocalExchangeDynamicFilters {
+  PushdownFilters filters;
+  uint64_t version{0};
+};
+
 /// Keeps track of the total size in bytes of the data buffered in all
 /// LocalExchangeQueues.
 class LocalExchangeMemoryManager {
@@ -193,9 +198,19 @@ class LocalExchange : public SourceOperator {
   /// notifies the producer that no more data is needed.
   void close() override;
 
+  bool canAddDynamicFilter() const override {
+    return true;
+  }
+
+  void addDynamicFilterLocked(
+      const core::PlanNodeId& producer,
+      const PushdownFilters& filters) override;
+
  private:
   const int partition_;
   const std::shared_ptr<LocalExchangeQueue> queue_{nullptr};
+  const std::shared_ptr<folly::Synchronized<LocalExchangeDynamicFilters>>
+      dynamicFilters_{nullptr};
   ContinueFuture future_;
   BlockingReason blockingReason_{BlockingReason::kNotBlocked};
 };
@@ -236,6 +251,8 @@ class LocalPartition : public Operator {
   bool isFinished() override;
 
  protected:
+  void maybePushdownDynamicFilters();
+
   void prepareForInput(RowVectorPtr& input);
 
   void allocateIndexBuffers(const std::vector<vector_size_t>& sizes);
@@ -258,6 +275,8 @@ class LocalPartition : public Operator {
 
   const std::vector<std::shared_ptr<LocalExchangeQueue>> queues_;
   const size_t numPartitions_;
+  const std::shared_ptr<folly::Synchronized<LocalExchangeDynamicFilters>>
+      dynamicFilters_{nullptr};
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
 
   std::vector<BlockingReason> blockingReasons_;
@@ -268,6 +287,7 @@ class LocalPartition : public Operator {
   /// Reusable buffers for input partitioning.
   std::vector<BufferPtr> indexBuffers_;
   std::vector<vector_size_t*> rawIndices_;
+  uint64_t dynamicFiltersVersion_{0};
 
  private:
   // Try getting a reusable vector for 'partition' from the corresponding

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -3342,6 +3342,8 @@ void Task::createLocalExchangeQueuesLocked(
       queryCtx_->queryConfig().maxLocalExchangeBufferSize());
   exchange.vectorPool = std::make_shared<LocalExchangeVectorPool>(
       queryCtx_->queryConfig().maxLocalExchangeBufferSize());
+  exchange.dynamicFilters =
+      std::make_shared<folly::Synchronized<LocalExchangeDynamicFilters>>();
   exchange.queues.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {
     exchange.queues.emplace_back(
@@ -3420,6 +3422,22 @@ Task::getScaleWriterPartitionBalancer(
       splitGroupId,
       taskId());
   return it->second.scaleWriterPartitionBalancer;
+}
+
+const std::shared_ptr<folly::Synchronized<LocalExchangeDynamicFilters>>&
+Task::getLocalExchangeDynamicFilters(
+    uint32_t splitGroupId,
+    const core::PlanNodeId& planNodeId) {
+  auto& splitGroupState = splitGroupStates_[splitGroupId];
+
+  auto it = splitGroupState.localExchanges.find(planNodeId);
+  VELOX_CHECK(
+      it != splitGroupState.localExchanges.end(),
+      "Incorrect local exchange ID {} for group {}, task {}",
+      planNodeId,
+      splitGroupId,
+      taskId());
+  return it->second.dynamicFilters;
 }
 
 const std::shared_ptr<LocalExchangeMemoryManager>&

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -543,6 +543,11 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
+  const std::shared_ptr<folly::Synchronized<LocalExchangeDynamicFilters>>&
+  getLocalExchangeDynamicFilters(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
   /// Returns the shared skewed partition balancer for scale writer local
   /// partitioning with the given split group id and plan node id.
   const std::shared_ptr<common::SkewedPartitionRebalancer>&

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -199,6 +199,8 @@ struct LocalExchangeState {
   std::vector<std::shared_ptr<LocalExchangeQueue>> queues;
   std::shared_ptr<common::SkewedPartitionRebalancer>
       scaleWriterPartitionBalancer;
+  std::shared_ptr<folly::Synchronized<LocalExchangeDynamicFilters>>
+      dynamicFilters;
 };
 
 /// Stores inter-operator state (exchange, bridges) for split groups.

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1793,6 +1793,107 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterEmptyBatch) {
       .run();
 }
 
+TEST_P(MultiThreadedHashJoinTest, dynamicFiltersThroughLocalPartition) {
+  const int32_t numSplits = 5;
+  const int32_t numRowsProbe = 333;
+  const int32_t numRowsBuild = 100;
+
+  std::vector<RowVectorPtr> probeVectors;
+  probeVectors.reserve(numSplits);
+
+  std::vector<std::shared_ptr<TempFilePath>> tempFiles;
+  tempFiles.reserve(numSplits);
+  for (int32_t i = 0; i < numSplits; ++i) {
+    auto rowVector = makeRowVector({
+        makeFlatVector<int32_t>(
+            numRowsProbe, [&](auto row) { return row - i * 10; }),
+        makeFlatVector<int64_t>(numRowsProbe, [](auto row) { return row; }),
+    });
+    probeVectors.push_back(rowVector);
+    tempFiles.push_back(TempFilePath::create());
+    writeToFile(tempFiles.back()->getPath(), rowVector);
+  }
+
+  auto makeInputSplits = [&](const core::PlanNodeId& nodeId) {
+    return [&] {
+      std::vector<exec::Split> probeSplits;
+      probeSplits.reserve(tempFiles.size());
+      for (auto& file : tempFiles) {
+        probeSplits.push_back(
+            exec::Split(makeHiveConnectorSplit(file->getPath())));
+      }
+      SplitInput splits;
+      splits.emplace(nodeId, probeSplits);
+      return splits;
+    };
+  };
+
+  std::vector<RowVectorPtr> buildVectors;
+  buildVectors.reserve(5);
+  for (int32_t i = 0; i < 5; ++i) {
+    buildVectors.push_back(makeRowVector({
+        makeFlatVector<int32_t>(
+            numRowsBuild / 5,
+            [i](auto row) { return 35 + 2 * (row + i * numRowsBuild / 5); }),
+        makeFlatVector<int64_t>(numRowsBuild / 5, [](auto row) { return row; }),
+    }));
+  }
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto probeType = ROW({"c0", "c1"}, {INTEGER(), BIGINT()});
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto buildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
+                       .values(buildVectors)
+                       .project({"c0 AS u_c0", "c1 AS u_c1"})
+                       .planNode();
+
+  for (const auto serialExecution : {false, true}) {
+    SCOPED_TRACE(fmt::format("serialExecution: {}", serialExecution));
+
+    core::PlanNodeId probeScanId;
+    core::PlanNodeId localPartitionId;
+    core::PlanNodeId joinId;
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
+                  .tableScan(probeType)
+                  .capturePlanNodeId(probeScanId)
+                  .localGather()
+                  .capturePlanNodeId(localPartitionId)
+                  .hashJoin(
+                      {"c0"},
+                      {"u_c0"},
+                      buildSide,
+                      "",
+                      {"c0", "c1", "u_c1"},
+                      core::JoinType::kInner)
+                  .capturePlanNodeId(joinId)
+                  .project({"c0", "c1 + 1", "c1 + u_c1"})
+                  .planNode();
+
+    auto task =
+        AssertQueryBuilder(op, duckDbQueryRunner_)
+            .serialExecution(serialExecution)
+            .maxDrivers(serialExecution ? 1 : 3)
+            .config(core::QueryConfig::kMaxLocalExchangeBufferSize, "1")
+            .splits(probeScanId, makeInputSplits(probeScanId)().at(probeScanId))
+            .assertResults(
+                "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0");
+
+    auto planStats = toPlanStats(task->taskStats());
+    auto getStatSum = [&](const core::PlanNodeId& id, const std::string& name) {
+      return planStats.at(id).customStats.at(name).sum;
+    };
+    ASSERT_EQ(1, getStatSum(joinId, "dynamicFiltersProduced"));
+    ASSERT_EQ(
+        serialExecution ? 1 : 3,
+        getStatSum(probeScanId, "dynamicFiltersAccepted"));
+    ASSERT_LT(planStats.at(probeScanId).outputRows, numRowsProbe * numSplits);
+    ASSERT_EQ(
+        planStats.at(probeScanId).dynamicFilterStats.producerNodeIds,
+        std::unordered_set<core::PlanNodeId>({localPartitionId}));
+  }
+}
 VELOX_INSTANTIATE_TEST_SUITE_P(
     MultiThreadedHashJoinTest,
     MultiThreadedHashJoinTest,


### PR DESCRIPTION
This is a minimal patch to support dynamic filter pushdown through LocalPartition.

Pushdown path is: HashJoin -> Driver A -> LocalExchange -> Task (LocalExchangeState) -> LocalPartition -> Driver B -> TableScan (or next  stage of LocalExchange)

A `dynamicFilters` member is adding to  `LocalExchangeState`:

```cpp
struct LocalExchangeState {
  ...
  std::shared_ptr<folly::Synchronized<LocalExchangeDynamicFilters>>
      dynamicFilters;
};

struct LocalExchangeDynamicFilters {
  PushdownFilters filters;
  uint64_t version{0};
};
```

Once a `LocalExchange` node accepts a pushed down filter, it merges the filter to the corresponding `LocalExchangeState`, then update the version:

```cpp
void LocalExchange::addDynamicFilterLocked(
    const core::PlanNodeId& /*producer*/,
    const PushdownFilters& filters) {
  dynamicFilters_->withWLock([&](auto& dynamicFilters) {
    for (auto channel : filters.dynamicFilteredColumns) {
      auto it = filters.filters.find(channel);
      VELOX_CHECK(it != filters.filters.end());
      common::Filter::merge(it->second, dynamicFilters.filters.filters[channel]);
      dynamicFilters.filters.dynamicFilteredColumns.insert(channel); // <- merge
    }
    ++dynamicFilters.version; // <- advances version
  });
}
```

Meanwhile `LocalPartition` keeps tracking the filters and version from `LocalExchangeState`, and pushdown the latest filter when needed:

```cpp
void LocalPartition::maybePushdownDynamicFilters() {
  std::vector<column_index_t> channels;
  std::vector<common::FilterPtr> filters;
  uint64_t version;

  {
    auto lockedFilters = dynamicFilters_->rlock();
    if (lockedFilters->version == dynamicFiltersVersion_ ||
        lockedFilters->filters.dynamicFilteredColumns.empty()) {
      return;
    }
    ... // pushdown
}
```

This feature will remove a blocker on a pending effort to integrate parallel execution mode with Apache Gluten. More specifically, I was testing the following cases:

1. N-to-1 gathered partitioning from scan / shuffle read to the next operator to maximize the IO parallelism.
2. 1-to-N hash partitioning from last operator to hash join / hash agg to maximize the computation parallelism.

