### PR TITLE
fix(build): Guard fuzzer examples subdirectory with VELOX_BUILD_TESTING

### DIFF
--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -45,8 +45,7 @@ target_link_libraries(
   velox_vector_fuzzer_util
 )
 
-add_subdirectory(examples)
-
 if(${VELOX_BUILD_TESTING})
+  add_subdirectory(examples)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
## Summary

The unconditional `add_subdirectory(examples)` in `velox/vector/fuzzer/CMakeLists.txt` (added in #16897) breaks builds with `VELOX_BUILD_TESTING=OFF`, such as the Presto GPU CI build. Guard it with `VELOX_BUILD_TESTING` like the `tests` subdirectory below it.

## Test plan

- Presto GPU CI build passes with this fix