### PR TITLE
perf: Use SIMD for TIME based comparison operators (#15396)

### DIFF
--- a/velox/functions/prestosql/Comparisons.cpp
+++ b/velox/functions/prestosql/Comparisons.cpp
@@ -179,17 +179,17 @@ class ComparisonSimdFunction : public exec::VectorFunction {
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
 
-    for (const auto& inputType : {
-             "tinyint",
-             "smallint",
-             "integer",
-             "bigint",
-             "real",
-             "double",
-             "date",
-             "interval day to second",
-             "interval year to month",
-         }) {
+    for (const auto& inputType :
+         {"tinyint",
+          "smallint",
+          "integer",
+          "bigint",
+          "real",
+          "double",
+          "date",
+          "interval day to second",
+          "interval year to month",
+          "time"}) {
       signatures.push_back(
           exec::FunctionSignatureBuilder()
               .returnType("boolean")

--- a/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
@@ -32,6 +32,7 @@ void registerVectorFunctions() {
       {"nonsimd_eq"});
   registerFunction<EqFunction, bool, IntervalYearMonth, IntervalYearMonth>(
       {"nonsimd_eq"});
+  registerFunction<EqFunction, bool, Time, Time>({"nonsimd_eq"});
 }
 
 } // namespace facebook::velox::functions
@@ -144,6 +145,14 @@ BENCHMARK(non_simd_interval_year_month_eq) {
 
 BENCHMARK_RELATIVE(simd_interval_year_month_eq) {
   benchmark->run("eq", INTERVAL_YEAR_MONTH());
+}
+
+BENCHMARK(non_simd_time) {
+  benchmark->run("nonsimd_eq", TIME());
+}
+
+BENCHMARK_RELATIVE(simd_time) {
+  benchmark->run("eq", TIME());
 }
 
 } // namespace

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -35,7 +35,6 @@ void registerNonSimdizableScalar(const std::vector<std::string>& aliases) {
   registerFunction<T, TReturn, Timestamp, Timestamp>(aliases);
   registerFunction<T, TReturn, TimestampWithTimezone, TimestampWithTimezone>(
       aliases);
-  registerFunction<T, TReturn, Time, Time>(aliases);
   registerFunction<T, TReturn, TimeWithTimezone, TimeWithTimezone>(aliases);
   registerFunction<T, TReturn, IPAddress, IPAddress>(aliases);
 }


### PR DESCRIPTION
Summary:

Use simd for time based comparison as it is a primitive type  and can be simdized similar to interval_year_month, interval_day_time

Reviewed By: kgpai

Differential Revision: D86261353


