### PR TITLE
fix(build): Add missing GTest::gmock link to velox_hive_connector_test

### DIFF
--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(
   velox_vector_test_lib
   velox_exec
   velox_exec_test_lib
+  GTest::gmock
   GTest::gtest
   GTest::gtest_main
 )


### PR DESCRIPTION
## Summary
- `TableHandleTest.cpp` includes `<gmock/gmock.h>` but the `velox_hive_connector_test` CMake target did not link to `GTest::gmock`, causing a build failure.
- Adds `GTest::gmock` to `target_link_libraries` in `velox/connectors/hive/tests/CMakeLists.txt`.

Closes #16995