### PR TITLE
refactor: Improve the OOM debuging logs (#16997)

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -544,10 +544,14 @@ ScopedReclaimedBytesRecorder::~ScopedReclaimedBytesRecorder() {
   const int64_t reservedBytesAfterReclaim = pool_->reservedBytes();
   if (reservedBytesAfterReclaim > reservedBytesBeforeReclaim_) {
     LOG(ERROR) << "Unexpected reserved bytes growth from " << pool_->name()
+               << ", root pool: " << pool_->root()->name()
                << " after memory reclaim from "
                << succinctBytes(reservedBytesBeforeReclaim_) << " to "
-               << succinctBytes(reservedBytesAfterReclaim) << ", current usage "
-               << succinctBytes(pool_->usedBytes());
+               << succinctBytes(reservedBytesAfterReclaim)
+               << ", used: " << succinctBytes(pool_->usedBytes())
+               << ", reservation: " << succinctBytes(pool_->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool_->root()->reservedBytes());
   }
   *reclaimedBytes_ = reservedBytesBeforeReclaim_ - reservedBytesAfterReclaim;
 }

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -1539,7 +1539,10 @@ uint64_t HiveDataSink::WriterReclaimer::reclaim(
                  << " which is under non-reclaimable section, root pool: "
                  << pool->root()->name()
                  << ", state: " << stateString(dataSink_->state_)
-                 << ", reservation: " << succinctBytes(pool->reservedBytes());
+                 << ", used: " << succinctBytes(pool->usedBytes())
+                 << ", reservation: " << succinctBytes(pool->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool->root()->reservedBytes());
     ++stats.numNonReclaimableAttempts;
     return 0;
   }

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -114,10 +114,14 @@ uint64_t SortingWriter::reclaim(
 
   if (!isRunning() && !isFinishing()) {
     LOG(WARNING) << "Can't reclaim from a not running hive sort writer pool: "
-                 << sortPool_->name() << ", state: " << state()
-                 << "used memory: " << succinctBytes(sortPool_->usedBytes())
-                 << ", reserved memory: "
-                 << succinctBytes(sortPool_->reservedBytes());
+                 << sortPool_->name()
+                 << ", root pool: " << sortPool_->root()->name()
+                 << ", state: " << state()
+                 << ", used: " << succinctBytes(sortPool_->usedBytes())
+                 << ", reservation: "
+                 << succinctBytes(sortPool_->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(sortPool_->root()->reservedBytes());
     ++stats.numNonReclaimableAttempts;
     return 0;
   }

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -860,13 +860,22 @@ uint64_t Writer::MemoryReclaimer::reclaim(
     LOG(WARNING)
         << "Can't reclaim from dwrf writer which is under non-reclaimable "
            "section: "
-        << pool->name();
+        << pool->name() << ", root pool: " << pool->root()->name()
+        << ", used: " << succinctBytes(pool->usedBytes())
+        << ", reservation: " << succinctBytes(pool->reservedBytes())
+        << ", root pool reservation: "
+        << succinctBytes(pool->root()->reservedBytes());
     ++stats.numNonReclaimableAttempts;
     return 0;
   }
   if (!writer_->isRunning()) {
     LOG(WARNING) << "Can't reclaim from a not running dwrf writer: "
-                 << pool->name() << ", state: " << writer_->state();
+                 << pool->name() << ", root pool: " << pool->root()->name()
+                 << ", state: " << writer_->state()
+                 << ", used: " << succinctBytes(pool->usedBytes())
+                 << ", reservation: " << succinctBytes(pool->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool->root()->reservedBytes());
     ++stats.numNonReclaimableAttempts;
     return 0;
   }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -970,8 +970,11 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool_->name()
-               << ", usage: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes());
+               << ", root pool: " << pool_->root()->name()
+               << ", used: " << succinctBytes(pool_->usedBytes())
+               << ", reservation: " << succinctBytes(pool_->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool_->root()->reservedBytes());
 }
 
 void GroupingSet::ensureOutputFits() {
@@ -1010,8 +1013,11 @@ void GroupingSet::ensureOutputFits() {
   LOG(WARNING) << "Failed to reserve "
                << succinctBytes(outputBufferSizeToReserve)
                << " for memory pool " << pool_->name()
-               << ", usage: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes());
+               << ", root pool: " << pool_->root()->name()
+               << ", used: " << succinctBytes(pool_->usedBytes())
+               << ", reservation: " << succinctBytes(pool_->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool_->root()->reservedBytes());
 }
 
 RowTypePtr GroupingSet::makeSpillType() const {

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -495,9 +495,11 @@ void HashAggregation::reclaim(
     if (groupingSet_->hasSpilled()) {
       LOG(WARNING)
           << "Can't reclaim from aggregation operator which has spilled and is under output processing, pool "
-          << pool()->name()
-          << ", memory usage: " << succinctBytes(pool()->usedBytes())
-          << ", reservation: " << succinctBytes(pool()->reservedBytes());
+          << pool()->name() << ", root pool: " << pool()->root()->name()
+          << ", used: " << succinctBytes(pool()->usedBytes())
+          << ", reservation: " << succinctBytes(pool()->reservedBytes())
+          << ", root pool reservation: "
+          << succinctBytes(pool()->root()->reservedBytes());
       return;
     }
     if (isDistinct_) {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -318,11 +318,17 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
         numPartitionBits;
     // Disable spilling if exceeding the max spill level and the query might run
     // out of memory if the restored partition still can't fit in memory.
-    if (config->exceedSpillLevelLimit(startPartitionBit)) {
+    if (FOLLY_UNLIKELY(config->exceedSpillLevelLimit(startPartitionBit))) {
       RECORD_METRIC_VALUE(kMetricMaxSpillLevelExceededCount);
       LOG(WARNING) << "Exceeded spill level limit: " << config->maxSpillLevel
                    << ", and disable spilling for memory pool: "
-                   << pool()->name();
+                   << pool()->name()
+                   << ", root pool: " << pool()->root()->name()
+                   << ", used: " << succinctBytes(pool()->usedBytes())
+                   << ", reservation: "
+                   << succinctBytes(pool()->reservedBytes())
+                   << ", root pool reservation: "
+                   << succinctBytes(pool()->root()->reservedBytes());
       spillStats_->spillMaxLevelExceededCount.fetch_add(
           1, std::memory_order_relaxed);
       exceededMaxSpillLevelLimit_ = true;
@@ -651,8 +657,11 @@ void HashBuild::ensureInputFits(RowVectorPtr& input) {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 void HashBuild::spillInput(const RowVectorPtr& input) {
@@ -990,9 +999,11 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(memoryBytesToReserve)
                << " for join table build from last hash build operator "
-               << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << pool()->name() << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 void HashBuild::postHashBuildProcess() {
@@ -1288,8 +1299,12 @@ void HashBuild::reclaim(
     LOG(WARNING)
         << "Can't reclaim from hash build operator, exceeded maximum spill "
            "level of "
-        << config->maxSpillLevel << ", " << pool()->name() << ", usage "
-        << succinctBytes(pool()->usedBytes());
+        << config->maxSpillLevel << ", " << pool()->name()
+        << ", root pool: " << pool()->root()->name()
+        << ", used: " << succinctBytes(pool()->usedBytes())
+        << ", reservation: " << succinctBytes(pool()->reservedBytes())
+        << ", root pool reservation: "
+        << succinctBytes(pool()->root()->reservedBytes());
     return;
   }
 
@@ -1302,11 +1317,16 @@ void HashBuild::reclaim(
     LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                  << stateName(state_) << "], nonReclaimableSection_["
                  << nonReclaimableSection_ << "], spiller_["
-                 << (stateCleared_ ? "cleared"
-                                   : (spiller_->finalized() ? "finalized"
-                                                            : "non-finalized"))
+                 << (stateCleared_               ? "cleared"
+                         : spiller_ == nullptr   ? "null"
+                         : spiller_->finalized() ? "finalized"
+                                                 : "non-finalized")
                  << "] " << pool()->name()
-                 << ", usage: " << succinctBytes(pool()->usedBytes());
+                 << ", root pool: " << pool()->root()->name()
+                 << ", used: " << succinctBytes(pool()->usedBytes())
+                 << ", reservation: " << succinctBytes(pool()->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool()->root()->reservedBytes());
     return;
   }
 
@@ -1325,9 +1345,18 @@ void HashBuild::reclaim(
       ++stats.numNonReclaimableAttempts;
       LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                    << stateName(buildOp->state_) << "], nonReclaimableSection_["
-                   << buildOp->nonReclaimableSection_ << "], "
-                   << buildOp->pool()->name() << ", usage: "
-                   << succinctBytes(buildOp->pool()->usedBytes());
+                   << buildOp->nonReclaimableSection_ << "], spiller_["
+                   << (buildOp->stateCleared_               ? "cleared"
+                           : buildOp->spiller_ == nullptr   ? "null"
+                           : buildOp->spiller_->finalized() ? "finalized"
+                                                            : "non-finalized")
+                   << "], " << buildOp->pool()->name()
+                   << ", root pool: " << buildOp->pool()->root()->name()
+                   << ", used: " << succinctBytes(buildOp->pool()->usedBytes())
+                   << ", reservation: "
+                   << succinctBytes(buildOp->pool()->reservedBytes())
+                   << ", root pool reservation: "
+                   << succinctBytes(buildOp->pool()->root()->reservedBytes());
       return;
     }
   }

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1942,8 +1942,11 @@ void HashProbe::ensureOutputFits() {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(bytesToReserve)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 bool HashProbe::needLazyLoadProbeInput() const {
@@ -2060,8 +2063,12 @@ void HashProbe::reclaim(
     LOG(WARNING)
         << "Can't reclaim from hash probe operator, exceeded maximum spill "
            "level of "
-        << config->maxSpillLevel << ", " << pool()->name() << ", usage "
-        << succinctBytes(pool()->usedBytes());
+        << config->maxSpillLevel << ", " << pool()->name()
+        << ", root pool: " << pool()->root()->name()
+        << ", used: " << succinctBytes(pool()->usedBytes())
+        << ", reservation: " << succinctBytes(pool()->reservedBytes())
+        << ", root pool reservation: "
+        << succinctBytes(pool()->root()->reservedBytes());
     return;
   }
 
@@ -2078,9 +2085,13 @@ void HashProbe::reclaim(
                  << (table_ == nullptr ? "nullptr"
                                        : std::to_string(table_->numDistinct()))
                  << "], " << pool()->name()
-                 << ", usage: " << succinctBytes(pool()->usedBytes())
+                 << ", root pool: " << pool()->root()->name()
+                 << ", used: " << succinctBytes(pool()->usedBytes())
+                 << ", reservation: " << succinctBytes(pool()->reservedBytes())
                  << ", node pool reservation: "
-                 << succinctBytes(pool()->parent()->reservedBytes());
+                 << succinctBytes(pool()->parent()->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool()->root()->reservedBytes());
     return;
   }
 
@@ -2108,9 +2119,14 @@ void HashProbe::reclaim(
                            ? "nullptr"
                            : std::to_string(probeOp->table_->numDistinct()))
                    << "], " << peerPool->name()
-                   << ", usage: " << succinctBytes(peerPool->usedBytes())
+                   << ", root pool: " << peerPool->root()->name()
+                   << ", used: " << succinctBytes(peerPool->usedBytes())
+                   << ", reservation: "
+                   << succinctBytes(peerPool->reservedBytes())
                    << ", node pool reservation: "
-                   << succinctBytes(peerPool->parent()->reservedBytes());
+                   << succinctBytes(peerPool->parent()->reservedBytes())
+                   << ", root pool reservation: "
+                   << succinctBytes(peerPool->root()->reservedBytes());
       return;
     }
     hasMoreProbeInput |= !probeOp->noMoreSpillInput_;

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -288,8 +288,11 @@ void MarkDistinct::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 void MarkDistinct::reclaim(
@@ -302,11 +305,15 @@ void MarkDistinct::reclaim(
     return;
   }
 
-  if (exceededMaxSpillLevelLimit_) {
+  if (FOLLY_UNLIKELY(exceededMaxSpillLevelLimit_)) {
     LOG(WARNING) << "Exceeded mark distinct spill level limit: "
                  << spillConfig_->maxSpillLevel
-                 << ", and abandon spilling for memory pool: "
-                 << pool()->name();
+                 << ", and abandon spilling for memory pool: " << pool()->name()
+                 << ", root pool: " << pool()->root()->name()
+                 << ", used: " << succinctBytes(pool()->usedBytes())
+                 << ", reservation: " << succinctBytes(pool()->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool()->root()->reservedBytes());
     spillStats_->spillMaxLevelExceededCount.fetch_add(
         1, std::memory_order_relaxed);
     return;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -757,9 +757,12 @@ uint64_t Operator::MemoryReclaimer::reclaim(
     ++stats.numNonReclaimableAttempts;
     RECORD_METRIC_VALUE(kMetricMemoryNonReclaimableCount);
     LOG(WARNING) << "Can't reclaim from memory pool " << pool->name()
-                 << " which is under non-reclaimable section, memory usage: "
-                 << succinctBytes(pool->usedBytes())
-                 << ", reservation: " << succinctBytes(pool->reservedBytes());
+                 << " which is under non-reclaimable section"
+                 << ", root pool: " << pool->root()->name()
+                 << ", used: " << succinctBytes(pool->usedBytes())
+                 << ", reservation: " << succinctBytes(pool->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool->root()->reservedBytes());
     return 0;
   }
 

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -241,8 +241,11 @@ void RowNumber::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 FlatVector<int64_t>& RowNumber::getOrCreateRowNumberVector(vector_size_t size) {
@@ -385,11 +388,15 @@ void RowNumber::reclaim(
     return;
   }
 
-  if (exceededMaxSpillLevelLimit_) {
+  if (FOLLY_UNLIKELY(exceededMaxSpillLevelLimit_)) {
     LOG(WARNING) << "Exceeded row spill level limit: "
                  << spillConfig_->maxSpillLevel
-                 << ", and abandon spilling for memory pool: "
-                 << pool()->name();
+                 << ", and abandon spilling for memory pool: " << pool()->name()
+                 << ", root pool: " << pool()->root()->name()
+                 << ", used: " << succinctBytes(pool()->usedBytes())
+                 << ", reservation: " << succinctBytes(pool()->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool()->root()->reservedBytes());
     spillStats_->spillMaxLevelExceededCount.fetch_add(
         1, std::memory_order_relaxed);
     return;

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -258,8 +258,11 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
   }
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 void SortBuffer::ensureOutputFits(vector_size_t batchSize) {
@@ -290,8 +293,11 @@ void SortBuffer::ensureOutputFits(vector_size_t batchSize) {
   LOG(WARNING) << "Failed to reserve "
                << succinctBytes(outputBufferSizeToReserve)
                << " for memory pool " << pool_->name()
-               << ", usage: " << succinctBytes(pool_->usedBytes())
-               << ", reservation: " << succinctBytes(pool_->reservedBytes());
+               << ", root pool: " << pool_->root()->name()
+               << ", used: " << succinctBytes(pool_->usedBytes())
+               << ", reservation: " << succinctBytes(pool_->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool_->root()->reservedBytes());
 }
 
 void SortBuffer::ensureSortFits() {

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -146,9 +146,12 @@ void SortWindowBuild::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << data_->pool()->name()
-               << ", usage: " << succinctBytes(data_->pool()->usedBytes())
+               << ", root pool: " << data_->pool()->root()->name()
+               << ", used: " << succinctBytes(data_->pool()->usedBytes())
                << ", reservation: "
-               << succinctBytes(data_->pool()->reservedBytes());
+               << succinctBytes(data_->pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(data_->pool()->root()->reservedBytes());
 }
 
 void SortWindowBuild::ensureSortFits() {

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -392,8 +392,11 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
     // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING) << "Can't reclaim from a closed writer connector pool: "
-                 << pool->name()
-                 << ", memory usage: " << succinctBytes(pool->reservedBytes());
+                 << pool->name() << ", root pool: " << pool->root()->name()
+                 << ", used: " << succinctBytes(pool->usedBytes())
+                 << ", reservation: " << succinctBytes(pool->reservedBytes())
+                 << ", root pool reservation: "
+                 << succinctBytes(pool->root()->reservedBytes());
     return 0;
   }
 
@@ -402,8 +405,11 @@ uint64_t TableWriter::ConnectorReclaimer::reclaim(
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING)
         << "Can't reclaim from a writer connector pool which hasn't initialized yet: "
-        << pool->name()
-        << ", memory usage: " << succinctBytes(pool->reservedBytes());
+        << pool->name() << ", root pool: " << pool->root()->name()
+        << ", used: " << succinctBytes(pool->usedBytes())
+        << ", reservation: " << succinctBytes(pool->reservedBytes())
+        << ", root pool reservation: "
+        << succinctBytes(pool->root()->reservedBytes());
     return 0;
   }
   RuntimeStatWriterScopeGuard opStatsGuard(op_);

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -981,8 +981,11 @@ void TopNRowNumber::reclaim(
     // TODO Add support for spilling after noMoreInput().
     LOG(WARNING)
         << "Can't reclaim from topNRowNumber operator which has started producing output: "
-        << pool()->name() << ", usage: " << succinctBytes(pool()->usedBytes())
-        << ", reservation: " << succinctBytes(pool()->reservedBytes());
+        << pool()->name() << ", root pool: " << pool()->root()->name()
+        << ", used: " << succinctBytes(pool()->usedBytes())
+        << ", reservation: " << succinctBytes(pool()->reservedBytes())
+        << ", root pool reservation: "
+        << succinctBytes(pool()->root()->reservedBytes());
     return;
   }
 
@@ -1051,8 +1054,11 @@ void TopNRowNumber::ensureInputFits(const RowVectorPtr& input) {
 
   LOG(WARNING) << "Failed to reserve " << succinctBytes(targetIncrementBytes)
                << " for memory pool " << pool()->name()
-               << ", usage: " << succinctBytes(pool()->usedBytes())
-               << ", reservation: " << succinctBytes(pool()->reservedBytes());
+               << ", root pool: " << pool()->root()->name()
+               << ", used: " << succinctBytes(pool()->usedBytes())
+               << ", reservation: " << succinctBytes(pool()->reservedBytes())
+               << ", root pool reservation: "
+               << succinctBytes(pool()->root()->reservedBytes());
 }
 
 void TopNRowNumber::spill() {

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -279,8 +279,11 @@ void Window::reclaim(
     // TODO Add support for spilling after noMoreInput().
     LOG(WARNING)
         << "Can't reclaim from window operator which has started producing output: "
-        << pool()->name() << ", usage: " << succinctBytes(pool()->usedBytes())
-        << ", reservation: " << succinctBytes(pool()->reservedBytes());
+        << pool()->name() << ", root pool: " << pool()->root()->name()
+        << ", used: " << succinctBytes(pool()->usedBytes())
+        << ", reservation: " << succinctBytes(pool()->reservedBytes())
+        << ", root pool reservation: "
+        << succinctBytes(pool()->root()->reservedBytes());
     return;
   }
 


### PR DESCRIPTION
Summary:

Unify and improve OOM debugging logs across all Velox memory reclaim paths.

1: Unified field naming across all log sites: used: for usedBytes(), reservation: for reservedBytes(), root pool: for root pool name, root pool reservation: for root()->reservedBytes().
2: Added missing root pool and root pool reservation to 12 log sites that previously only logged local pool info                       
3: Added missing usedBytes() to log sites that only logged reservedBytes

Reviewed By: tanjialiang

Differential Revision: D96401272


