### PR TITLE
fix: Sort function documentation in alphabetical order in array.rst and aggregate.rst (#17001)

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -17,13 +17,13 @@ depending on the order of input values.
 General Aggregate Functions
 ---------------------------
 
-.. function:: arbitrary(x) -> [same as x]
-
-    Returns an arbitrary non-null value of ``x``, if one exists.
-
 .. function:: any_value(x) -> [same as x]
 
     This is an alias for :func:`arbitrary`.
+
+.. function:: arbitrary(x) -> [same as x]
+
+    Returns an arbitrary non-null value of ``x``, if one exists.
 
 .. function:: array_agg(x) -> array<[same as x]>
 
@@ -89,37 +89,17 @@ General Aggregate Functions
 
     This is an alias for :func:`bool_and`.
 
-.. function:: histogram(x)
-
-    Returns a map containing the count of the number of times
-    each input value occurs. Supports integral, floating-point,
-    boolean, timestamp, and date input types.
-
 .. function:: geometric_mean(bigint) -> double
               geometric_mean(double) -> double
               geometric_mean(real) -> real
 
     Returns the `geometric mean <https://en.wikipedia.org/wiki/Geometric_mean>`_ of all input values.
 
-.. function:: max_by(x, y) -> [same as x]
+.. function:: histogram(x)
 
-    Returns the value of ``x`` associated with the maximum value of ``y`` over all input values.
-    ``y`` must be an orderable type.
-
-.. function:: max_by(x, y, n) -> array([same as x])
-    :noindex:
-
-    Returns n values of ``x`` associated with the n largest values of ``y`` in descending order of ``y``.
-
-.. function:: min_by(x, y) -> [same as x]
-
-    Returns the value of ``x`` associated with the minimum value of ``y`` over all input values.
-    ``y`` must be an orderable type.
-
-.. function:: min_by(x, y, n) -> array([same as x])
-    :noindex:
-
-    Returns n values of ``x`` associated with the n smallest values of ``y`` in ascending order of ``y``.
+    Returns a map containing the count of the number of times
+    each input value occurs. Supports integral, floating-point,
+    boolean, timestamp, and date input types.
 
 .. function:: max(x) -> [same as x]
 
@@ -138,6 +118,16 @@ General Aggregate Functions
     Nulls are not included in the output array.
     For REAL and DOUBLE types, NaN is considered greater than Infinity.
 
+.. function:: max_by(x, y) -> [same as x]
+
+    Returns the value of ``x`` associated with the maximum value of ``y`` over all input values.
+    ``y`` must be an orderable type.
+
+.. function:: max_by(x, y, n) -> array([same as x])
+    :noindex:
+
+    Returns n values of ``x`` associated with the n largest values of ``y`` in descending order of ``y``.
+
 .. function:: min(x) -> [same as x]
 
     Returns the minimum value of all input values.
@@ -154,6 +144,16 @@ General Aggregate Functions
     Currently not supported for ARRAY, MAP, and ROW input types.
     Nulls are not included in output array.
     For REAL and DOUBLE types, NaN is considered greater than Infinity.
+
+.. function:: min_by(x, y) -> [same as x]
+
+    Returns the value of ``x`` associated with the minimum value of ``y`` over all input values.
+    ``y`` must be an orderable type.
+
+.. function:: min_by(x, y, n) -> array([same as x])
+    :noindex:
+
+    Returns n values of ``x`` associated with the n smallest values of ``y`` in ascending order of ``y``.
 
 .. function:: multimap_agg(K key, V value) -> map(K,array(V))
 
@@ -764,10 +764,6 @@ Statistical Aggregate Functions
 
     Returns the sample standard deviation of all input values.
 
-.. function:: variance(x) -> double
-
-    This is an alias for :func:`var_samp`.
-
 .. function:: var_pop(x) -> double
 
     Returns the population variance of all input values.
@@ -775,6 +771,10 @@ Statistical Aggregate Functions
 .. function:: var_samp(x) -> double
 
     Returns the sample variance of all input values.
+
+.. function:: variance(x) -> double
+
+    This is an alias for :func:`var_samp`.
 
 Noisy Aggregate Functions
 -------------------------

--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -7,7 +7,7 @@ Array Functions
     Returns whether all elements of an array match the given predicate.
 
         Returns true if all the elements match the predicate (a special case is when the array is empty);
-        Returns false if one or more elements don’t match;
+        Returns false if one or more elements don't match;
         Returns NULL if the predicate function returns NULL for one or more elements and true for all other elements.
         Throws an exception if the predicate fails for one or more elements and returns true or NULL for the rest.
 
@@ -17,15 +17,6 @@ Array Functions
 
         Returns true if one or more elements match the predicate;
         Returns false if none of the elements matches (a special case is when the array is empty);
-        Returns NULL if the predicate function returns NULL for one or more elements and false for all other elements.
-        Throws an exception if the predicate fails for one or more elements and returns false or NULL for the rest.
-
-.. function:: none_match(array(T), function(T, boolean)) → boolean
-
-    Returns whether no elements of an array match the given predicate.
-
-        Returns true if none of the elements matches the predicate (a special case is when the array is empty);
-        Returns false if one or more elements match;
         Returns NULL if the predicate function returns NULL for one or more elements and false for all other elements.
         Throws an exception if the predicate fails for one or more elements and returns false or NULL for the rest.
 
@@ -51,17 +42,6 @@ Array Functions
         SELECT array_distinct(ARRAY [1, 2, 3]); -- [1, 2, 3]
         SELECT array_distinct(ARRAY [1, 2, 1]); -- [1, 2]
         SELECT array_distinct(ARRAY [1, NULL, NULL]); -- [1, NULL]
-
-.. function:: array_split_into_chunks(array(T), sz) -> array(array(T))
-
-    Returns an array of arrays splitting the input array into chunks of given
-    length. The last chunk will be shorter than the chunk length if the array's
-    length is not an integer multiple of the chunk length. Ignores null inputs,
-    but not elements. ::
-
-        SELECT array_split_into_chunks(ARRAY [1, 2, 3, 4, 5], 2); -- [[1, 2], [3, 4], [5]]
-        SELECT array_split_into_chunks(ARRAY [1, 2, 3], 5); -- [[1, 2, 3]]
-        SELECT array_split_into_chunks(ARRAY ['a', 'b', 'c'], 2); -- [['a', 'b'], ['c']]
 
 .. function:: array_duplicates(array(E)) -> array(E)
 
@@ -129,6 +109,13 @@ Array Functions
         SELECT array_max(ARRAY[{-1, -2, -3, nan()]); -- NaN
         SELECT array_max(ARRAY[{infinity(), nan()]); -- NaN
 
+.. function:: array_max_by(array(T), function(T, U)) -> T()
+
+    Applies the provided function to each element, and returns the element that gives the maximum value.
+    ``U`` can be any orderable type. ::
+
+        SELECT array_max_by(ARRAY ['a', 'bbb', 'cc'], x -> LENGTH(x)) -- 'bbb'
+
 .. function:: array_min(array(E)) -> E
 
     Returns the minimum value of input array.
@@ -143,13 +130,6 @@ Array Functions
         SELECT array_min(ARRAY[{-1, -2, -3, nan()]); -- -1
         SELECT array_min(ARRAY[{infinity(), nan()]); -- Infinity
 
-.. function:: array_max_by(array(T), function(T, U)) -> T()
-
-    Applies the provided function to each element, and returns the element that gives the maximum value.
-    ``U`` can be any orderable type. ::
-
-        SELECT array_max_by(ARRAY ['a', 'bbb', 'cc'], x -> LENGTH(x)) -- 'bbb'
-
 .. function:: array_min_by(array(T), function(T, U)) -> T
 
     Applies the provided function to each element, and returns the element that gives the minimum value.
@@ -160,17 +140,6 @@ Array Functions
 .. function:: array_normalize(array(E), E) -> array(E)
 
     Normalizes array ``x`` by dividing each element by the p-norm of the array. It is equivalent to ``TRANSFORM(array, v -> v / REDUCE(array, 0, (a, v) -> a + POW(ABS(v), p), a -> POW(a, 1 / p))``, but the reduce part is only executed once. Returns null if the array is null or there are null array elements. If ``p`` is 0, then the input array is returned. Only REAL and DOUBLE types are supported.
-
-.. function:: arrays_overlap(x, y) -> boolean
-
-    Tests if arrays ``x`` and ``y`` have any non-null elements in common.
-    Returns null if there are no non-null elements in common but either array contains null.
-    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
-
-.. function:: arrays_union(x, y) -> array
-
-    Returns an array of the elements in the union of x and y, without duplicates.
-    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
 
 .. function:: array_position(x, element) -> bigint
 
@@ -245,6 +214,17 @@ Array Functions
 
           SELECT array_sort_desc(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['leopard', 'mouse', 'cat']
 
+.. function:: array_split_into_chunks(array(T), sz) -> array(array(T))
+
+    Returns an array of arrays splitting the input array into chunks of given
+    length. The last chunk will be shorter than the chunk length if the array's
+    length is not an integer multiple of the chunk length. Ignores null inputs,
+    but not elements. ::
+
+        SELECT array_split_into_chunks(ARRAY [1, 2, 3, 4, 5], 2); -- [[1, 2], [3, 4], [5]]
+        SELECT array_split_into_chunks(ARRAY [1, 2, 3], 5); -- [[1, 2, 3]]
+        SELECT array_split_into_chunks(ARRAY ['a', 'b', 'c'], 2); -- [['a', 'b'], ['c']]
+
 .. function:: array_subset(array(T), array(int)) -> array(T)
 
     Returns an array containing elements from the input array at the specified 1-based indices.
@@ -257,31 +237,6 @@ Array Functions
           SELECT array_subset(ARRAY[1, NULL, 3], ARRAY[2]); -- [NULL]
           SELECT array_subset(ARRAY[1, 2, 3], ARRAY[1, 1, 2]); -- [1, 1, 2]
           SELECT array_subset(ARRAY[1, 2, 3], ARRAY[5, 0, -1]); -- []
-
-.. function:: l2_norm(array(T)) -> double
-
-    Returns the Euclidean norm (L2 norm) of an array of numeric values.
-    The L2 norm is calculated as the square root of the sum of squares of all elements: sqrt(sum(x^2)).
-    Returns 0.0 for empty arrays. Null elements are skipped in the calculation.
-    Supports integer and floating point types. ::
-
-          SELECT l2_norm(ARRAY[3, 4]); -- 5.0
-          SELECT l2_norm(ARRAY[1, 2, 2]); -- 3.0
-          SELECT l2_norm(ARRAY[3.0, 4.0]); -- 5.0
-          SELECT l2_norm(ARRAY[]); -- 0.0
-          SELECT l2_norm(ARRAY[3, NULL, 4]); -- 5.0
-
-.. function:: l2_norm(map(K, V)) -> double
-
-    Returns the Euclidean norm (L2 norm) of the values in a map.
-    The L2 norm is calculated as the square root of the sum of squares of all values: sqrt(sum(v^2)).
-    Keys are ignored; only values are used in the calculation.
-    Returns 0.0 for empty maps. Null values are skipped in the calculation.
-    Supports maps with numeric value types (integer or floating point). ::
-
-          SELECT l2_norm(MAP(ARRAY['a', 'b'], ARRAY[3, 4])); -- 5.0
-          SELECT l2_norm(MAP(ARRAY[1, 2], ARRAY[3.0, 4.0])); -- 5.0
-          SELECT l2_norm(MAP(ARRAY[], ARRAY[])); -- 0.0
 
 .. function:: array_sum(array(T)) -> bigint/double
 
@@ -296,6 +251,17 @@ Array Functions
         SELECT array_top_n(ARRAY [1, 100, 2, 5, 3], 3); -- [100, 5, 3]
         SELECT array_top_n(ARRAY [1, 100], 5); -- [100, 1]
         SELECT array_top_n(ARRAY ['a', 'zzz', 'zz', 'b', 'g', 'f'], 3); -- ['zzz', 'zz', 'g']
+
+.. function:: arrays_overlap(x, y) -> boolean
+
+    Tests if arrays ``x`` and ``y`` have any non-null elements in common.
+    Returns null if there are no non-null elements in common but either array contains null.
+    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
+
+.. function:: arrays_union(x, y) -> array
+
+    Returns an array of the elements in the union of x and y, without duplicates.
+    For REAL and DOUBLE, NANs (Not-a-Number) are considered equal.
 
 .. function:: cardinality(x) -> bigint
 
@@ -412,6 +378,31 @@ Array Functions
 
     Flattens an ``array(array(T))`` to an ``array(T)`` by concatenating the contained arrays.
 
+.. function:: l2_norm(array(T)) -> double
+
+    Returns the Euclidean norm (L2 norm) of an array of numeric values.
+    The L2 norm is calculated as the square root of the sum of squares of all elements: sqrt(sum(x^2)).
+    Returns 0.0 for empty arrays. Null elements are skipped in the calculation.
+    Supports integer and floating point types. ::
+
+          SELECT l2_norm(ARRAY[3, 4]); -- 5.0
+          SELECT l2_norm(ARRAY[1, 2, 2]); -- 3.0
+          SELECT l2_norm(ARRAY[3.0, 4.0]); -- 5.0
+          SELECT l2_norm(ARRAY[]); -- 0.0
+          SELECT l2_norm(ARRAY[3, NULL, 4]); -- 5.0
+
+.. function:: l2_norm(map(K, V)) -> double
+
+    Returns the Euclidean norm (L2 norm) of the values in a map.
+    The L2 norm is calculated as the square root of the sum of squares of all values: sqrt(sum(v^2)).
+    Keys are ignored; only values are used in the calculation.
+    Returns 0.0 for empty maps. Null values are skipped in the calculation.
+    Supports maps with numeric value types (integer or floating point). ::
+
+          SELECT l2_norm(MAP(ARRAY['a', 'b'], ARRAY[3, 4])); -- 5.0
+          SELECT l2_norm(MAP(ARRAY[1, 2], ARRAY[3.0, 4.0])); -- 5.0
+          SELECT l2_norm(MAP(ARRAY[], ARRAY[])); -- 0.0
+
 .. function:: ngrams(array(T), n) -> array(array(T))
 
     Returns `n-grams <https://en.wikipedia.org/wiki/N-gram>`_  for the array.
@@ -424,6 +415,15 @@ Array Functions
         SELECT ngrams(ARRAY['foo', 'bar', 'baz', 'foo'], 5); -- [['foo', 'bar', 'baz', 'foo']]
         SELECT ngrams(ARRAY[1, 2, 3, 4], 2); -- [[1, 2], [2, 3], [3, 4]]
         SELECT ngrams(ARRAY["foo", NULL, "bar"], 2); -- [["foo", NULL], [NULL, "bar"]]
+
+.. function:: none_match(array(T), function(T, boolean)) → boolean
+
+    Returns whether no elements of an array match the given predicate.
+
+        Returns true if none of the elements matches the predicate (a special case is when the array is empty);
+        Returns false if one or more elements match;
+        Returns NULL if the predicate function returns NULL for one or more elements and false for all other elements.
+        Throws an exception if the predicate fails for one or more elements and returns false or NULL for the rest.
 
 .. function:: reduce(array(T), initialState S, inputFunction(S,T,S), outputFunction(S,R)) -> R
 
@@ -447,6 +447,14 @@ Array Functions
                       (s, x) -> CAST(ROW(x + s.sum, s.count + 1) AS ROW(sum DOUBLE, count INTEGER)),
                       s -> IF(s.count = 0, NULL, s.sum / s.count));
 
+.. function:: remove_nulls(x) -> array
+
+    Remove null values from an array ``array`` ::
+
+        SELECT remove_nulls(ARRAY[1, NULL, 3, NULL]); -- [1, 3]
+        SELECT remove_nulls(ARRAY[true, false, NULL]); -- [true, false]
+        SELECT remove_nulls(ARRAY[ARRAY[1, 2], NULL, ARRAY[1, NULL, 3]]); -- [[1, 2], [1, null, 3]]
+
 .. function:: repeat(element, count) -> array(E)
 
     Repeat ``element`` for ``count`` times. ``count`` cannot be negative and must be less than or equal to 10000.
@@ -454,6 +462,16 @@ Array Functions
 .. function:: reverse(array(E)) -> array(E)
 
     Returns an array which has the reversed order of the input array.
+
+.. function:: sequence(start, stop) -> array
+
+    Generate a sequence of integers from start to stop, incrementing by 1 if start is less than or equal to stop,
+    otherwise -1.
+
+.. function:: sequence(start, stop, step) -> array
+   :noindex:
+
+    Generate a sequence of integers from start to stop, incrementing by step.
 
 .. function:: shuffle(array(E)) -> array(E)
 
@@ -467,16 +485,6 @@ Array Functions
 
     Returns a subarray starting from index ``start``(or starting from the end
     if ``start`` is negative) with a length of ``length``.
-
-.. function:: sequence(start, stop) -> array
-
-    Generate a sequence of integers from start to stop, incrementing by 1 if start is less than or equal to stop,
-    otherwise -1.
-
-.. function:: sequence(start, stop, step) -> array
-   :noindex:
-
-    Generate a sequence of integers from start to stop, incrementing by step.
 
 .. function:: subscript(array(E), index) -> E
 
@@ -514,14 +522,6 @@ Array Functions
         SELECT trim_array(ARRAY[1, 2, 3, 4], 1); -- [1, 2, 3]
         SELECT trim_array(ARRAY[1, 2, 3, 4], 2); -- [1, 2]
         SELECT trim_array(ARRAY[1, 2, 3, 4], 4); -- []
-
-.. function:: remove_nulls(x) -> array
-
-    Remove null values from an array ``array`` ::
-
-        SELECT remove_nulls(ARRAY[1, NULL, 3, NULL]); -- [1, 3]
-        SELECT remove_nulls(ARRAY[true, false, NULL]); -- [true, false]
-        SELECT remove_nulls(ARRAY[ARRAY[1, 2], NULL, ARRAY[1, NULL, 3]]); -- [[1, 2], [1, null, 3]]
 
 .. function:: zip(array(T), array(U),..) -> array(row(T,U, ...))
 


### PR DESCRIPTION
Summary:

Reordered all function entries in array.rst and aggregate.rst to be in strict alphabetical order, following the approach of D96488148.

array.rst: Moved none_match, array_split_into_chunks, array_max_by, arrays_overlap, arrays_union, array_position, l2_norm, array_sum, sequence, and remove_nulls to their correct alphabetical positions.

aggregate.rst: Fixed ordering within sections:
- General: any_value before arbitrary, geometric_mean before histogram, max/max(n) before max_by, min/min(n) before min_by
- Statistical: var_pop and var_samp before variance

___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: presto_batch

Differential Revision: D99121480


