### PR TITLE
feat: Register custom type cast rules and fix coerceTypeBase for parametric types (#17006)

### DIFF
--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -410,7 +410,7 @@ bool SignatureBinderBase::tryBind(
   const auto& baseName = typeSignature.baseName();
   auto typeName = boost::algorithm::to_upper_copy(baseName);
   if (!boost::algorithm::iequals(typeName, actualType->name())) {
-    if (allowCoercion) {
+    if (allowCoercion && typeSignature.parameters().empty()) {
       if (auto availableCoercion =
               TypeCoercer::coerceTypeBase(actualType, typeName)) {
         coercion = availableCoercion.value();

--- a/velox/functions/prestosql/types/BigintEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/BigintEnumRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/BigintEnumRegistration.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -132,6 +133,13 @@ class BigintEnumTypeFactory : public CustomTypeFactory {
 
 void registerBigintEnumType() {
   registerCustomType(
-      "bigint_enum", std::make_unique<const BigintEnumTypeFactory>());
+      "BIGINT_ENUM", std::make_unique<const BigintEnumTypeFactory>());
+  registerCastRules({
+      {.fromType = "TINYINT", .toType = "BIGINT_ENUM"},
+      {.fromType = "SMALLINT", .toType = "BIGINT_ENUM"},
+      {.fromType = "INTEGER", .toType = "BIGINT_ENUM"},
+      {.fromType = "BIGINT", .toType = "BIGINT_ENUM"},
+      {.fromType = "BIGINT_ENUM", .toType = "BIGINT"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 
@@ -137,7 +138,11 @@ class BingTileTypeFactory : public CustomTypeFactory {
 } // namespace
 
 void registerBingTileType() {
-  registerCustomType("bingtile", std::make_unique<const BingTileTypeFactory>());
+  registerCustomType("BINGTILE", std::make_unique<const BingTileTypeFactory>());
+  registerCastRules({
+      {.fromType = "BIGINT", .toType = "BINGTILE"},
+      {.fromType = "BINGTILE", .toType = "BIGINT"},
+  });
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -22,6 +22,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -273,6 +274,14 @@ class IPAddressTypeFactory : public CustomTypeFactory {
 
 void registerIPAddressType() {
   registerCustomType(
-      "ipaddress", std::make_unique<const IPAddressTypeFactory>());
+      "IPADDRESS", std::make_unique<const IPAddressTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR", .toType = "IPADDRESS"},
+      {.fromType = "VARBINARY", .toType = "IPADDRESS"},
+      {.fromType = "IPPREFIX", .toType = "IPADDRESS"},
+      {.fromType = "IPADDRESS", .toType = "VARCHAR"},
+      {.fromType = "IPADDRESS", .toType = "VARBINARY"},
+      {.fromType = "IPADDRESS", .toType = "IPPREFIX"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -191,6 +192,12 @@ class IPPrefixTypeFactory : public CustomTypeFactory {
 } // namespace
 
 void registerIPPrefixType() {
-  registerCustomType("ipprefix", std::make_unique<const IPPrefixTypeFactory>());
+  registerCustomType("IPPREFIX", std::make_unique<const IPPrefixTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR", .toType = "IPPREFIX"},
+      {.fromType = "IPADDRESS", .toType = "IPPREFIX"},
+      {.fromType = "IPPREFIX", .toType = "VARCHAR"},
+      {.fromType = "IPPREFIX", .toType = "IPADDRESS"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/JsonRegistration.cpp
+++ b/velox/functions/prestosql/types/JsonRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/functions/prestosql/types/JsonCastOperator.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/type/CastRegistry.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -63,6 +64,33 @@ class JsonTypeFactory : public CustomTypeFactory {
 } // namespace
 
 void registerJsonType() {
-  registerCustomType("json", std::make_unique<const JsonTypeFactory>());
+  registerCustomType("JSON", std::make_unique<const JsonTypeFactory>());
+  // Register primitive cast rules only. Container types (ARRAY, MAP, ROW)
+  // are cross-type casts (e.g. ARRAY -> JSON), which the registry cannot
+  // resolve via its same-base-type recursive logic. These are handled at
+  // runtime by JsonCastOperator::isSupportedFromType/isSupportedToType.
+  registerCastRules({
+      // TO JSON (from primitive types).
+      {.fromType = "UNKNOWN", .toType = "JSON"},
+      {.fromType = "BOOLEAN", .toType = "JSON"},
+      {.fromType = "TINYINT", .toType = "JSON"},
+      {.fromType = "SMALLINT", .toType = "JSON"},
+      {.fromType = "INTEGER", .toType = "JSON"},
+      {.fromType = "BIGINT", .toType = "JSON"},
+      {.fromType = "REAL", .toType = "JSON"},
+      {.fromType = "DOUBLE", .toType = "JSON"},
+      {.fromType = "VARCHAR", .toType = "JSON"},
+      {.fromType = "TIMESTAMP", .toType = "JSON"},
+      // FROM JSON (to primitive types).
+      // Note: JSON -> TIMESTAMP is not supported in Presto.
+      {.fromType = "JSON", .toType = "BOOLEAN"},
+      {.fromType = "JSON", .toType = "TINYINT"},
+      {.fromType = "JSON", .toType = "SMALLINT"},
+      {.fromType = "JSON", .toType = "INTEGER"},
+      {.fromType = "JSON", .toType = "BIGINT"},
+      {.fromType = "JSON", .toType = "REAL"},
+      {.fromType = "JSON", .toType = "DOUBLE"},
+      {.fromType = "JSON", .toType = "VARCHAR"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/P4HyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/P4HyperLogLogRegistration.cpp
@@ -22,6 +22,7 @@
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/P4HyperLogLogType.h"
 #include "velox/functions/prestosql/types/fuzzer_utils/P4HyperLogLogInputGenerator.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -160,6 +161,10 @@ class P4HyperLogLogTypeFactory : public CustomTypeFactory {
 } // namespace
 void registerP4HyperLogLogType() {
   registerCustomType(
-      "p4hyperloglog", std::make_unique<const P4HyperLogLogTypeFactory>());
+      "P4HYPERLOGLOG", std::make_unique<const P4HyperLogLogTypeFactory>());
+  registerCastRules({
+      {.fromType = "HYPERLOGLOG", .toType = "P4HYPERLOGLOG"},
+      {.fromType = "P4HYPERLOGLOG", .toType = "HYPERLOGLOG"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimeWithTimezoneRegistration.cpp
@@ -289,25 +289,15 @@ class TimeWithTimezoneTypeFactory : public CustomTypeFactory {
 
 void registerTimeWithTimezoneType() {
   registerCustomType(
-      "time with time zone",
+      "TIME WITH TIME ZONE",
       std::make_unique<const TimeWithTimezoneTypeFactory>());
   registerCastRules({
       {.fromType = "TIME",
        .toType = "TIME WITH TIME ZONE",
-       .implicitAllowed = true,
-       .validator = {}},
-      {.fromType = "VARCHAR",
-       .toType = "TIME WITH TIME ZONE",
-       .implicitAllowed = false,
-       .validator = {}},
-      {.fromType = "TIME WITH TIME ZONE",
-       .toType = "TIME",
-       .implicitAllowed = false,
-       .validator = {}},
-      {.fromType = "TIME WITH TIME ZONE",
-       .toType = "VARCHAR",
-       .implicitAllowed = false,
-       .validator = {}},
+       .implicitAllowed = true},
+      {.fromType = "VARCHAR", .toType = "TIME WITH TIME ZONE"},
+      {.fromType = "TIME WITH TIME ZONE", .toType = "TIME"},
+      {.fromType = "TIME WITH TIME ZONE", .toType = "VARCHAR"},
   });
 }
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -401,7 +401,7 @@ class TimestampWithTimeZoneTypeFactory : public CustomTypeFactory {
 
 void registerTimestampWithTimeZoneType() {
   registerCustomType(
-      "timestamp with time zone",
+      "TIMESTAMP WITH TIME ZONE",
       std::make_unique<const TimestampWithTimeZoneTypeFactory>());
   // Lower cost = preferred during overload resolution. TIMESTAMP is closer
   // to TIMESTAMP WITH TIME ZONE than DATE.
@@ -409,37 +409,17 @@ void registerTimestampWithTimeZoneType() {
       {.fromType = "TIMESTAMP",
        .toType = "TIMESTAMP WITH TIME ZONE",
        .implicitAllowed = true,
-       .cost = 1,
-       .validator = {}},
-      {.fromType = "VARCHAR",
-       .toType = "TIMESTAMP WITH TIME ZONE",
-       .implicitAllowed = false,
-       .validator = {}},
+       .cost = 1},
+      {.fromType = "VARCHAR", .toType = "TIMESTAMP WITH TIME ZONE"},
       {.fromType = "DATE",
        .toType = "TIMESTAMP WITH TIME ZONE",
        .implicitAllowed = true,
-       .cost = 2,
-       .validator = {}},
-      {.fromType = "TIME",
-       .toType = "TIMESTAMP WITH TIME ZONE",
-       .implicitAllowed = false,
-       .validator = {}},
-      {.fromType = "TIMESTAMP WITH TIME ZONE",
-       .toType = "TIMESTAMP",
-       .implicitAllowed = false,
-       .validator = {}},
-      {.fromType = "TIMESTAMP WITH TIME ZONE",
-       .toType = "VARCHAR",
-       .implicitAllowed = false,
-       .validator = {}},
-      {.fromType = "TIMESTAMP WITH TIME ZONE",
-       .toType = "DATE",
-       .implicitAllowed = false,
-       .validator = {}},
-      {.fromType = "TIMESTAMP WITH TIME ZONE",
-       .toType = "TIME",
-       .implicitAllowed = false,
-       .validator = {}},
+       .cost = 2},
+      {.fromType = "TIME", .toType = "TIMESTAMP WITH TIME ZONE"},
+      {.fromType = "TIMESTAMP WITH TIME ZONE", .toType = "TIMESTAMP"},
+      {.fromType = "TIMESTAMP WITH TIME ZONE", .toType = "VARCHAR"},
+      {.fromType = "TIMESTAMP WITH TIME ZONE", .toType = "DATE"},
+      {.fromType = "TIMESTAMP WITH TIME ZONE", .toType = "TIME"},
   });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -160,6 +161,12 @@ class UuidTypeFactory : public CustomTypeFactory {
 } // namespace
 
 void registerUuidType() {
-  registerCustomType("uuid", std::make_unique<const UuidTypeFactory>());
+  registerCustomType("UUID", std::make_unique<const UuidTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR", .toType = "UUID"},
+      {.fromType = "VARBINARY", .toType = "UUID"},
+      {.fromType = "UUID", .toType = "VARCHAR"},
+      {.fromType = "UUID", .toType = "VARBINARY"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/VarcharEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/VarcharEnumRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -102,6 +103,10 @@ class VarcharEnumTypeFactory : public CustomTypeFactory {
 
 void registerVarcharEnumType() {
   registerCustomType(
-      "varchar_enum", std::make_unique<const VarcharEnumTypeFactory>());
+      "VARCHAR_ENUM", std::make_unique<const VarcharEnumTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR", .toType = "VARCHAR_ENUM"},
+      {.fromType = "VARCHAR_ENUM", .toType = "VARCHAR"},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/IPPrefixTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPPrefixTypeTest.cpp
@@ -29,7 +29,6 @@ class IPPrefixTypeTest : public testing::Test, public TypeTestBase {
 TEST_F(IPPrefixTypeTest, basic) {
   ASSERT_STREQ(IPPREFIX()->name(), "IPPREFIX");
   ASSERT_STREQ(IPPREFIX()->kindName(), "ROW");
-  ASSERT_EQ(IPPREFIX()->name(), "IPPREFIX");
   ASSERT_TRUE(IPPREFIX()->parameters().empty());
 
   ASSERT_TRUE(hasType("IPPREFIX"));

--- a/velox/functions/sparksql/types/TimestampNTZRegistration.cpp
+++ b/velox/functions/sparksql/types/TimestampNTZRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/sparksql/types/TimestampNTZCastUtil.h"
 #include "velox/functions/sparksql/types/TimestampNTZType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {
@@ -105,7 +106,10 @@ class TimestampNTZTypeFactory : public CustomTypeFactory {
 
 void registerTimestampNTZType() {
   registerCustomType(
-      "timestamp_ntz", std::make_unique<const TimestampNTZTypeFactory>());
+      "TIMESTAMP_NTZ", std::make_unique<const TimestampNTZTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR", .toType = "TIMESTAMP_NTZ"},
+  });
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/type/CastRegistry.cpp
+++ b/velox/type/CastRegistry.cpp
@@ -84,12 +84,10 @@ std::optional<int32_t> CastRulesRegistry::castCostImpl(
   const auto fromName = fromType->name();
   const auto toName = toType->name();
 
-  // For leaf types (primitives and custom types), look up rule directly.
-  if (fromType->size() == 0 && toType->size() == 0) {
-    auto rule = findRule(fromName, toName);
-    if (!rule) {
-      return std::nullopt;
-    }
+  // Try direct rule lookup first. This handles primitives and custom types
+  // including those with children like IPPREFIX (which extends RowType).
+  auto rule = findRule(fromName, toName);
+  if (rule) {
     if (requireImplicit && !rule->implicitAllowed) {
       return std::nullopt;
     }
@@ -99,9 +97,9 @@ std::optional<int32_t> CastRulesRegistry::castCostImpl(
     return requireImplicit ? rule->cost : 0;
   }
 
-  // For container types (ARRAY, MAP, ROW) with the same base type,
-  // recursively check children and sum costs.
-  if (fromName == toName) {
+  // No explicit rule. For container types (ARRAY, MAP, ROW) with the same
+  // base type, recursively check children and sum costs.
+  if (fromName == toName && fromType->size() > 0) {
     if (fromType->size() != toType->size()) {
       return std::nullopt;
     }

--- a/velox/type/CastRule.h
+++ b/velox/type/CastRule.h
@@ -49,7 +49,7 @@ struct CastRule {
   int32_t cost{1};
 
   /// Optional validator for parameter-aware type checks.
-  CastValidator validator;
+  CastValidator validator{};
 
   /// Compare rules by type names, implicitAllowed, and cost. Excludes
   /// 'validator' because std::function has no meaningful equality semantics.

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -70,6 +70,29 @@ allowedCoercions() {
 // static
 std::optional<Coercion> TypeCoercer::coerceTypeBase(
     const TypePtr& fromType,
+    const TypePtr& toType) {
+  if (fromType->name() == toType->name()) {
+    return Coercion{.type = fromType, .cost = 0};
+  }
+
+  // Check built-in coercions first.
+  static const auto kAllowedCoercions = allowedCoercions();
+  auto it = kAllowedCoercions.find({fromType->name(), toType->name()});
+  if (it != kAllowedCoercions.end()) {
+    return it->second;
+  }
+
+  // Check CastRulesRegistry directly — no type reconstruction needed.
+  if (auto cost = CastRulesRegistry::instance().canCoerce(fromType, toType)) {
+    return Coercion{.type = toType, .cost = *cost};
+  }
+
+  return std::nullopt;
+}
+
+// static
+std::optional<Coercion> TypeCoercer::coerceTypeBase(
+    const TypePtr& fromType,
     const std::string& toTypeName) {
   static const auto kAllowedCoercions = allowedCoercions();
   if (fromType->name() == toTypeName) {
@@ -85,9 +108,12 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
   // Fall back to CastRulesRegistry for custom type coercions. Skip
   // parameterized types — we cannot construct the target type without knowing
   // its type parameters.
+  // getCustomType() returns nullptr for built-in types. Callers must not
+  // pass parametric custom type names (e.g., "BIGINT_ENUM") because their
+  // factories throw when called with empty parameters. SignatureBinder
+  // guards against this by checking typeSignature.parameters().empty().
   if (fromType->size() == 0 && fromType->parameters().empty()) {
-    auto toType = getCustomType(toTypeName, {});
-    if (toType != nullptr) {
+    if (auto toType = getCustomType(toTypeName, {})) {
       if (auto cost =
               CastRulesRegistry::instance().canCoerce(fromType, toType)) {
         return Coercion{.type = std::move(toType), .cost = *cost};
@@ -110,7 +136,7 @@ std::optional<int32_t> TypeCoercer::coercible(
   }
 
   if (fromType->size() == 0) {
-    if (auto coercion = TypeCoercer::coerceTypeBase(fromType, toType->name())) {
+    if (auto coercion = TypeCoercer::coerceTypeBase(fromType, toType)) {
       return coercion->cost;
     }
 
@@ -181,11 +207,11 @@ TypePtr TypeCoercer::leastCommonSuperType(const TypePtr& a, const TypePtr& b) {
   }
 
   if (a->size() == 0) {
-    if (TypeCoercer::coerceTypeBase(a, b->name())) {
+    if (TypeCoercer::coerceTypeBase(a, b)) {
       return b;
     }
 
-    if (TypeCoercer::coerceTypeBase(b, a->name())) {
+    if (TypeCoercer::coerceTypeBase(b, a)) {
       return a;
     }
 

--- a/velox/type/TypeCoercer.h
+++ b/velox/type/TypeCoercer.h
@@ -73,8 +73,19 @@ struct Coercion {
 
 class TypeCoercer {
  public:
+  /// Checks if 'fromType' can be implicitly converted to 'toType'.
+  ///
+  /// Prefer this over the string overload when the target type is available,
+  /// as it avoids reconstructing the type from a name (which can throw for
+  /// parametric custom types like BigintEnum).
+  ///
+  /// @return "to" type and cost if conversion is possible.
+  static std::optional<Coercion> coerceTypeBase(
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
   /// Checks if the base of 'fromType' can be implicitly converted to a type
-  /// with the given name.
+  /// with the given name. Used by SignatureBinder which only has a type name.
   ///
   /// @return "to" type and cost if conversion is possible.
   static std::optional<Coercion> coerceTypeBase(


### PR DESCRIPTION
Summary:

Register CastRulesRegistry rules for all Presto custom types that support casts: BigintEnum, VarcharEnum, BingTile, IPAddress, IPPrefix, Uuid, Json, P4HyperLogLog, and Spark TimestampNTZ.

Add a `coerceTypeBase(TypePtr, TypePtr)` overload that checks the CastRulesRegistry directly without reconstructing the type from a name. The existing string overload calls `getCustomType(name, {})` which throws for parametric custom types like BigintEnum whose factories require parameters. Internal call sites in `coercible()` and `leastCommonSuperType()` now use the safe TypePtr overload. The string overload is retained for SignatureBinder (which only has a type name), with a `typeSignature.parameters().empty()` guard to prevent parametric type names from reaching `getCustomType`.

Also fix CastRegistry.cpp to try rule lookup before checking for custom cast existence (enabling cast rules for custom types that extend RowType like IPPREFIX), and remove a duplicate assertion in IPPrefixTypeTest.

Normalize `registerCustomType` calls to uppercase for consistency with `registerCastRules` (both subsystems store type names in uppercase internally). Remove redundant default field values (`.implicitAllowed = false`, `.validator = {}`) from cast rule registrations.

Differential Revision: D99173066


