### PR TITLE
fix: Support NaN and Inf serialization for Variant

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -201,6 +201,25 @@ std::optional<bool> dispatchDynamicVariantEquality(
       b);
 }
 
+folly::dynamic doubleToDynamic(double val) {
+  if (std::isinf(val) || std::isnan(val)) {
+    return folly::to<std::string>(val);
+  } else {
+    return val;
+  }
+}
+
+double dynamicToDouble(const folly::dynamic& val) {
+  if (val.isString()) {
+    return folly::to<double>(val.asString());
+  } else if (val.isDouble()) {
+    return val.asDouble();
+  } else if (val.isInt()) {
+    return val.asInt();
+  }
+  VELOX_FAIL("Unexpected value type: {}", val.typeName());
+}
+
 } // namespace
 
 std::string encloseWithQuote(std::string str) {
@@ -735,11 +754,11 @@ folly::dynamic Variant::serialize() const {
       break;
     }
     case TypeKind::REAL: {
-      objValue = value<TypeKind::REAL>();
+      objValue = doubleToDynamic(value<TypeKind::REAL>());
       break;
     }
     case TypeKind::DOUBLE: {
-      objValue = value<TypeKind::DOUBLE>();
+      objValue = doubleToDynamic(value<TypeKind::DOUBLE>());
       break;
     }
     case TypeKind::VARCHAR: {
@@ -838,19 +857,9 @@ Variant Variant::create(const folly::dynamic& variantobj) {
       return Variant(obj.asBool());
     }
     case TypeKind::REAL:
-      if (obj.isInt()) {
-        // folly::parseJson() parses eg: "2293699590479675400"
-        // to int64 instead of double, and asDouble() will throw
-        // "folly::ConversionError: Loss of precision", so we do
-        // the check here to make it more robust.
-        return Variant::create<TypeKind::REAL>(obj.asInt());
-      }
-      return Variant::create<TypeKind::REAL>(obj.asDouble());
+      return Variant::create<TypeKind::REAL>(dynamicToDouble(obj));
     case TypeKind::DOUBLE: {
-      if (obj.isInt()) {
-        return Variant::create<TypeKind::DOUBLE>(obj.asInt());
-      }
-      return Variant::create<TypeKind::DOUBLE>(obj.asDouble());
+      return Variant::create<TypeKind::DOUBLE>(dynamicToDouble(obj));
     }
     case TypeKind::OPAQUE: {
       return deserializeOpaque(variantobj);

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -1054,9 +1054,11 @@ TEST(VariantOpaqueTest, opaque) {
 }
 
 void testSerDe(const Variant& value) {
-  auto serialized = value.serialize();
-  auto copy = Variant::create(serialized);
-
+  auto dynamic = value.serialize();
+  auto copy = Variant::create(dynamic);
+  ASSERT_EQ(value, copy);
+  auto json = folly::toJson(value.serialize());
+  copy = Variant::create(folly::parseJson(json));
   ASSERT_EQ(value, copy);
 }
 
@@ -1085,6 +1087,18 @@ TEST(VariantSerializationTest, serialize) {
   testSerDe(Variant(static_cast<int64_t>(1234567)));
   testSerDe(Variant(static_cast<float>(1.2f)));
   testSerDe(Variant(static_cast<double>(1.234)));
+  testSerDe(
+      Variant(static_cast<float>(std::numeric_limits<float>::quiet_NaN())));
+  testSerDe(
+      Variant(static_cast<double>(std::numeric_limits<double>::quiet_NaN())));
+  testSerDe(
+      Variant(static_cast<float>(std::numeric_limits<float>::signaling_NaN())));
+  testSerDe(Variant(
+      static_cast<double>(std::numeric_limits<double>::signaling_NaN())));
+  testSerDe(
+      Variant(static_cast<float>(std::numeric_limits<float>::infinity())));
+  testSerDe(
+      Variant(static_cast<double>(std::numeric_limits<double>::infinity())));
   testSerDe(Variant("This is a test."));
   testSerDe(Variant::binary("This is a test."));
   testSerDe(Variant(Timestamp(1, 2)));
@@ -1128,6 +1142,9 @@ TEST(VariantSerializationTest, serializeArrayTypes) {
           Variant(1.5),
           Variant(2.7),
           Variant(-3.14),
+          Variant(std::numeric_limits<double>::quiet_NaN()),
+          Variant(std::numeric_limits<double>::signaling_NaN()),
+          Variant(std::numeric_limits<double>::infinity()),
       }));
 
   // Array with boolean values.


### PR DESCRIPTION
Summary:
NaN and Inf cannot be represented in JSON natively and must be represented as a
string. Similar is done in toJson methods of Variant.

Differential Revision: D99211299


