### PR TITLE
feat: Add pmod (positive modulo) function to Presto SQL (#17008)

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -482,6 +482,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "uniqueness_distribution(khyperloglog) -> map(bigint,double)",
     "uniqueness_distribution(khyperloglog,bigint) -> map(bigint,double)",
     "merge_khll(array(khyperloglog)) -> khyperloglog",
+    "pmod", // Not available in Presto
 };
 
 int main(int argc, char** argv) {

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -191,6 +191,45 @@ struct ModulusFunction {
   }
 };
 
+// Positive modulo for integral types. Returns NULL for division by zero.
+template <typename T>
+struct PModIntFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput a, const TInput n)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
+    if (UNLIKELY(n == 0)) {
+      return false;
+    }
+    if (UNLIKELY(n == 1 || n == -1)) {
+      result = 0;
+      return true;
+    }
+    TInput r = a % n;
+    result = (r > 0) ? r : (r + n) % n;
+    return true;
+  }
+};
+
+// Positive modulo for floating-point types. Returns NULL for division by zero.
+template <typename T>
+struct PModFloatFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == static_cast<TInput>(0))) {
+      return false;
+    }
+    TInput r = std::fmod(a, n);
+    result = (r > 0) ? r : std::fmod(r + n, n);
+    return true;
+  }
+};
+
 template <typename T>
 struct CeilFunction {
   template <typename TOutput, typename TInput = TOutput>

--- a/velox/functions/prestosql/registration/MathematicalOperatorsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MathematicalOperatorsRegistration.cpp
@@ -91,6 +91,8 @@ void registerMathOperators(const std::string& prefix = "") {
       IntervalYearMonth,
       double>({prefix + "divide"});
   registerBinaryFloatingPoint<ModulusFunction>({prefix + "mod"});
+  registerBinaryIntegral<PModIntFunction>({prefix + "pmod"});
+  registerBinaryFloatingPoint<PModFloatFunction>({prefix + "pmod"});
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -272,6 +272,49 @@ TEST_F(ArithmeticTest, modInt) {
   assertError<int64_t>("mod(c0, c1)", {10}, {0}, "Cannot divide by 0");
 }
 
+TEST_F(ArithmeticTest, pmod) {
+  // Positive modulo returns non-negative results for positive divisors.
+  std::vector<double> numerDouble = {0, 6, -7, 10, -10};
+  std::vector<double> denomDouble = {1, 2, 3, 3, 3};
+  std::vector<double> expectedDouble = {0, 0, 2, 1, 2};
+
+  assertExpression<double>(
+      "pmod(c0, c1)", numerDouble, denomDouble, expectedDouble);
+
+  // Division by zero returns NULL.
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<double>(
+          "pmod(c0, c1)",
+          std::optional<double>(5.0),
+          std::optional<double>(0.0)));
+}
+
+TEST_F(ArithmeticTest, pmodInt) {
+  std::vector<int64_t> numerInt = {9, 10, -7, 0, -9};
+  std::vector<int64_t> denomInt = {3, 3, 3, 3, 3};
+  std::vector<int64_t> expectedInt = {0, 1, 2, 0, 0};
+
+  assertExpression<int64_t, int64_t>(
+      "pmod(c0, c1)", numerInt, denomInt, expectedInt);
+
+  // INT64_MIN % -1 edge case.
+  EXPECT_EQ(
+      0,
+      evaluateOnce<int64_t>(
+          "pmod(c0, c1)",
+          std::optional<int64_t>(std::numeric_limits<int64_t>::min()),
+          std::optional<int64_t>(-1)));
+
+  // Division by zero returns NULL.
+  EXPECT_EQ(
+      std::nullopt,
+      evaluateOnce<int64_t>(
+          "pmod(c0, c1)",
+          std::optional<int64_t>(10),
+          std::optional<int64_t>(0)));
+}
+
 TEST_F(ArithmeticTest, power) {
   std::vector<double> baseDouble = {
       0, 0, 0, -1, -1, -1, -9, 9.1, 10.1, 11.1, -11.1};


### PR DESCRIPTION
Summary:

Add `pmod` function to Velox's Presto SQL function set, matching Spark/Hive semantics. `pmod(a, n)` returns the positive remainder of `a` divided by `n`, ensuring non-negative results for positive divisors. Returns NULL when the divisor is zero.

Two implementation structs: `PModIntFunction` for integral types (with ASAN overflow suppression and INT64_MIN edge case handling) and `PModFloatFunction` for floating-point types using `std::fmod`.

Enables expressions like `PMOD(HASH(group_key), 1000)` for deterministic bucket assignment.

Reviewed By: kaikalur

Differential Revision: D99229614


