### PR TITLE
fix(exec): Fix data race in OutputBuffer::getUtilization and isOverutilized (#17009)

### DIFF
--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -783,10 +783,12 @@ std::string OutputBuffer::toStringLocked() const {
 }
 
 double OutputBuffer::getUtilization() const {
+  std::lock_guard<std::mutex> l(mutex_);
   return bufferedBytes_ / static_cast<double>(maxSize_);
 }
 
 bool OutputBuffer::isOverutilized() const {
+  std::lock_guard<std::mutex> l(mutex_);
   return (bufferedBytes_ > (0.5 * maxSize_)) || atEnd_;
 }
 

--- a/velox/exec/OutputBuffer.h
+++ b/velox/exec/OutputBuffer.h
@@ -403,7 +403,7 @@ class OutputBuffer {
   // after receiving no-more-broadcast-buffers signal.
   std::vector<std::shared_ptr<SerializedPageBase>> dataToBroadcast_;
 
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   // Actual data size in 'buffers_'.
   int64_t bufferedBytes_{0};
   // The number of buffered pages which corresponds to 'bufferedBytes_'.


### PR DESCRIPTION
Summary:

`OutputBuffer::getUtilization()` and `OutputBuffer::isOverutilized()` read
`bufferedBytes_` and `atEnd_` without acquiring `mutex_`, while other methods
such as `updateStatsWithFreedPagesLocked()` write to these fields under the
lock. This causes a data race detected by ThreadSanitizer.

Fix by acquiring `mutex_` in both methods, consistent with how
`OutputBuffer::stats()` already accesses the same fields. Since both methods
are `const`, mark `mutex_` as `mutable`.

Reviewed By: bikramSingh91

Differential Revision: D99238897
