### PR TITLE
fix: Fix the folly FastSet and FastMap  failure check in MAC

### DIFF
--- a/velox/common/caching/StringIdMap.cpp
+++ b/velox/common/caching/StringIdMap.cpp
@@ -20,7 +20,11 @@ namespace facebook::velox {
 
 uint64_t StringIdMap::id(std::string_view string) {
   std::lock_guard<std::mutex> l(mutex_);
+#ifdef __APPLE__
+  auto it = stringToId_.find(std::string(string));
+#else
   auto it = stringToId_.find(string);
+#endif
   if (it != stringToId_.end()) {
     return it->second;
   }
@@ -56,7 +60,11 @@ void StringIdMap::addReference(uint64_t id) {
 
 uint64_t StringIdMap::makeId(std::string_view string) {
   std::lock_guard<std::mutex> l(mutex_);
+#ifdef __APPLE__
+  auto it = stringToId_.find(std::string(string));
+#else
   auto it = stringToId_.find(string);
+#endif
   if (it != stringToId_.end()) {
     auto entry = idToEntry_.find(it->second);
     VELOX_CHECK(entry != idToEntry_.end());
@@ -79,13 +87,21 @@ uint64_t StringIdMap::makeId(std::string_view string) {
   pinnedSize_ += string.size();
   const auto id = entry.id;
   idToEntry_[id] = std::move(entry);
+#ifdef __APPLE__
+  stringToId_[std::string(string)] = id;
+#else
   stringToId_[string] = id;
+#endif
   return lastId_;
 }
 
 uint64_t StringIdMap::recoverId(uint64_t id, std::string_view string) {
   std::lock_guard<std::mutex> l(mutex_);
+#ifdef __APPLE__
+  auto it = stringToId_.find(std::string(string));
+#else
   auto it = stringToId_.find(string);
+#endif
   if (it != stringToId_.end()) {
     VELOX_CHECK_EQ(
         id, it->second, "Multiple recover ids assigned to {}", string);
@@ -110,7 +126,11 @@ uint64_t StringIdMap::recoverId(uint64_t id, std::string_view string) {
   entry.numInUse = 1;
   pinnedSize_ += string.size();
   idToEntry_[id] = std::move(entry);
+#ifdef __APPLE__
+  stringToId_[std::string(string)] = id;
+#else
   stringToId_[string] = id;
+#endif
   return id;
 }
 } // namespace facebook::velox

--- a/velox/type/tz/TimeZoneMap.cpp
+++ b/velox/type/tz/TimeZoneMap.cpp
@@ -142,9 +142,9 @@ inline bool isTimeZoneOffset(std::string_view str) {
 // The timezone parsing logic follows what is defined here:
 //   https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
 inline bool isUtcEquivalentName(std::string_view zone) {
-  static folly::F14FastSet<std::string> utcSet = {
+  static constexpr std::array<std::string_view, 8> kUtcNames = {
       "utc", "uct", "gmt", "gmt0", "greenwich", "universal", "zulu", "z"};
-  return utcSet.find(zone) != utcSet.end();
+  return std::find(kUtcNames.begin(), kUtcNames.end(), zone) != kUtcNames.end();
 }
 
 // This function tries to apply two normalization rules to time zone offsets:


### PR DESCRIPTION
After upgrade folly version, Gluten unit tests crashed down by seaching string_view in folly FastMap or FastSet in Mac.
The exceptions is 
```
[ RUN      ] ParquetTableScanTest.inFilter
Process 28337 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000010014d0d8 velox_dwio_parquet_table_scan_test`facebook::velox::StringIdMap::release(unsigned long long) + 1064
```
```
- test read v1 iceberg with partition drop *** FAILED ***
  org.apache.gluten.exception.GlutenException: Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: session 'session_timezone' set with invalid value 'GMT'
Retriable: False
Expression: tz::getTimeZoneID(*tz, false) != -1
Function: validateConfig
```
```
Stack: [0x0000000349064000,0x0000000349267000],  sp=0x00000003492650e0,  free space=2052k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [libvelox.dylib+0x258924]  facebook::velox::StringIdMap::release(unsigned long long)+0x3a4
C  [libvelox.dylib+0x150c4]  facebook::velox::dwio::common::DirectBufferedInput::~DirectBufferedInput()+0x13c
C  [libvelox.dylib+0x14d98]  gluten::GlutenDirectBufferedInput::~GlutenDirectBufferedInput()+0x21c
C  [libvelox.dylib+0x14844]  gluten::GlutenDirectBufferedInput::~GlutenDirectBufferedInput()+0xc
C  [libvelox.dylib+0xd60ef0]  facebook::velox::parquet::ReaderBase::~ReaderBase()+0x14c
C  [libvelox.dylib+0xd5be7c]  facebook::velox::parquet::ParquetReader::~ParquetReader()+0x50
C  [libvelox.dylib+0x34d6678]  facebook::velox::connector::hive::SplitReader::~SplitReader()+0xb8
C  [libvelox.dylib+0x34d5710]  facebook::velox::connector::hive::SplitReader::~SplitReader()+0xc
C  [libvelox.dylib+0x34ba458]  facebook::velox::connector::hive::HiveDataSource::~HiveDataSource()+0x594
C  [libvelox.dylib+0x34b96f4]  facebook::velox::connector::hive::HiveDataSource::~HiveDataSource()+0xc
C  [libvelox.dylib+0x36a8640]  facebook::velox::exec::TableScan::~TableScan()+0x88
C  [libvelox.dylib+0x36a812c]  facebook::velox::exec::TableScan::~TableScan()+0xc
C  [libvelox.dylib+0x354c340]  facebook::velox::exec::Driver::~Driver()+0xb0
```
Co-author with https://github.com/rui-mo
Folly issue: https://github.com/facebook/folly/issues/2597
Resolves: https://github.com/facebookincubator/velox/issues/16507
Resolves: https://github.com/apache/gluten/issues/11862