### PR TITLE
refactor: CastExpr queries CastRulesRegistry before operator methods (#17012)

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -26,6 +26,7 @@
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/external/tzdb/time_zone.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
+#include "velox/type/CastRegistry.h"
 #include "velox/type/Type.h"
 #include "velox/type/tz/TimeZoneMap.h"
 #include "velox/vector/ComplexVector.h"
@@ -782,15 +783,19 @@ void CastExpr::applyPeeled(
     const TypePtr& toType,
     VectorPtr& result) {
   auto castFromOperator = getCastOperator(fromType);
-  if (castFromOperator && !castFromOperator->isSupportedToType(toType)) {
-    VELOX_USER_FAIL(
-        "Cannot cast {} to {}.", fromType->toString(), toType->toString());
-  }
-
   auto castToOperator = getCastOperator(toType);
-  if (castToOperator && !castToOperator->isSupportedFromType(fromType)) {
-    VELOX_USER_FAIL(
-        "Cannot cast {} to {}.", fromType->toString(), toType->toString());
+
+  // Check CastRulesRegistry first — it has all registered cast rules.
+  // If no rule exists (e.g., JSON container types), fall back to operator.
+  if (!CastRulesRegistry::instance().canCast(fromType, toType)) {
+    if (castFromOperator && !castFromOperator->isSupportedToType(toType)) {
+      VELOX_USER_FAIL(
+          "Cannot cast {} to {}.", fromType->toString(), toType->toString());
+    }
+    if (castToOperator && !castToOperator->isSupportedFromType(fromType)) {
+      VELOX_USER_FAIL(
+          "Cannot cast {} to {}.", fromType->toString(), toType->toString());
+    }
   }
 
   if (castFromOperator || castToOperator) {

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -29,11 +29,13 @@ class CastOperator {
   virtual ~CastOperator() = default;
 
   /// Determines whether the cast operator supports casting to the custom type
-  /// from the other type.
+  /// from the other type. CastRulesRegistry is checked first; this method is
+  /// only called as a fallback when no registry rule exists.
   virtual bool isSupportedFromType(const TypePtr& other) const = 0;
 
   /// Determines whether the cast operator supports casting from the custom type
-  /// to the other type.
+  /// to the other type. CastRulesRegistry is checked first; this method is
+  /// only called as a fallback when no registry rule exists.
   virtual bool isSupportedToType(const TypePtr& other) const = 0;
 
   /// Casts an input vector to the custom type. This function should not throw

--- a/velox/functions/prestosql/types/BigintEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/BigintEnumRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/BigintEnumRegistration.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -133,5 +134,27 @@ class BigintEnumTypeFactory : public CustomTypeFactory {
 void registerBigintEnumType() {
   registerCustomType(
       "bigint_enum", std::make_unique<const BigintEnumTypeFactory>());
+  registerCastRules({
+      {.fromType = "TINYINT",
+       .toType = "BIGINT_ENUM",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "SMALLINT",
+       .toType = "BIGINT_ENUM",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "INTEGER",
+       .toType = "BIGINT_ENUM",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "BIGINT",
+       .toType = "BIGINT_ENUM",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "BIGINT_ENUM",
+       .toType = "BIGINT",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/BingTileRegistration.cpp
+++ b/velox/functions/prestosql/types/BingTileRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/BingTileType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 
@@ -138,6 +139,16 @@ class BingTileTypeFactory : public CustomTypeFactory {
 
 void registerBingTileType() {
   registerCustomType("bingtile", std::make_unique<const BingTileTypeFactory>());
+  registerCastRules({
+      {.fromType = "BIGINT",
+       .toType = "BINGTILE",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "BINGTILE",
+       .toType = "BIGINT",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPAddressRegistration.cpp
+++ b/velox/functions/prestosql/types/IPAddressRegistration.cpp
@@ -22,6 +22,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/IPAddressType.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -274,5 +275,31 @@ class IPAddressTypeFactory : public CustomTypeFactory {
 void registerIPAddressType() {
   registerCustomType(
       "ipaddress", std::make_unique<const IPAddressTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "IPADDRESS",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "VARBINARY",
+       .toType = "IPADDRESS",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPPREFIX",
+       .toType = "IPADDRESS",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPADDRESS",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPADDRESS",
+       .toType = "VARBINARY",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPADDRESS",
+       .toType = "IPPREFIX",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/IPPrefixRegistration.cpp
+++ b/velox/functions/prestosql/types/IPPrefixRegistration.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/IPPrefixType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -192,5 +193,23 @@ class IPPrefixTypeFactory : public CustomTypeFactory {
 
 void registerIPPrefixType() {
   registerCustomType("ipprefix", std::make_unique<const IPPrefixTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "IPPREFIX",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPADDRESS",
+       .toType = "IPPREFIX",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPPREFIX",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "IPPREFIX",
+       .toType = "IPADDRESS",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/JsonRegistration.cpp
+++ b/velox/functions/prestosql/types/JsonRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/common/fuzzer/ConstrainedGenerators.h"
 #include "velox/functions/prestosql/types/JsonCastOperator.h"
 #include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/type/CastRegistry.h"
 #include "velox/type/Type.h"
 
 namespace facebook::velox {
@@ -64,5 +65,86 @@ class JsonTypeFactory : public CustomTypeFactory {
 
 void registerJsonType() {
   registerCustomType("json", std::make_unique<const JsonTypeFactory>());
+  // Register primitive cast rules only. Container types (ARRAY, MAP, ROW)
+  // are cross-type casts (e.g. ARRAY -> JSON), which the registry cannot
+  // resolve via its same-base-type recursive logic. These are handled at
+  // runtime by JsonCastOperator::isSupportedFromType/isSupportedToType.
+  registerCastRules({
+      // TO JSON (from primitive types).
+      {.fromType = "UNKNOWN",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "BOOLEAN",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TINYINT",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "SMALLINT",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "INTEGER",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "BIGINT",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "REAL",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "DOUBLE",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "VARCHAR",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "TIMESTAMP",
+       .toType = "JSON",
+       .implicitAllowed = false,
+       .validator = {}},
+      // FROM JSON (to primitive types).
+      // Note: JSON -> TIMESTAMP is not supported in Presto.
+      {.fromType = "JSON",
+       .toType = "BOOLEAN",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "TINYINT",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "SMALLINT",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "INTEGER",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "BIGINT",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "REAL",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "DOUBLE",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "JSON",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/P4HyperLogLogRegistration.cpp
+++ b/velox/functions/prestosql/types/P4HyperLogLogRegistration.cpp
@@ -22,6 +22,7 @@
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/functions/prestosql/types/P4HyperLogLogType.h"
 #include "velox/functions/prestosql/types/fuzzer_utils/P4HyperLogLogInputGenerator.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -161,5 +162,15 @@ class P4HyperLogLogTypeFactory : public CustomTypeFactory {
 void registerP4HyperLogLogType() {
   registerCustomType(
       "p4hyperloglog", std::make_unique<const P4HyperLogLogTypeFactory>());
+  registerCastRules({
+      {.fromType = "HYPERLOGLOG",
+       .toType = "P4HYPERLOGLOG",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "P4HYPERLOGLOG",
+       .toType = "HYPERLOGLOG",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/UuidRegistration.cpp
+++ b/velox/functions/prestosql/types/UuidRegistration.cpp
@@ -22,6 +22,7 @@
 
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/UuidType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -161,5 +162,23 @@ class UuidTypeFactory : public CustomTypeFactory {
 
 void registerUuidType() {
   registerCustomType("uuid", std::make_unique<const UuidTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "UUID",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "VARBINARY",
+       .toType = "UUID",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "UUID",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "UUID",
+       .toType = "VARBINARY",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/VarcharEnumRegistration.cpp
+++ b/velox/functions/prestosql/types/VarcharEnumRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/prestosql/types/VarcharEnumRegistration.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/prestosql/types/VarcharEnumType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox {
 namespace {
@@ -103,5 +104,15 @@ class VarcharEnumTypeFactory : public CustomTypeFactory {
 void registerVarcharEnumType() {
   registerCustomType(
       "varchar_enum", std::make_unique<const VarcharEnumTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "VARCHAR_ENUM",
+       .implicitAllowed = false,
+       .validator = {}},
+      {.fromType = "VARCHAR_ENUM",
+       .toType = "VARCHAR",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/tests/IPPrefixTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/IPPrefixTypeTest.cpp
@@ -29,7 +29,7 @@ class IPPrefixTypeTest : public testing::Test, public TypeTestBase {
 TEST_F(IPPrefixTypeTest, basic) {
   ASSERT_STREQ(IPPREFIX()->name(), "IPPREFIX");
   ASSERT_STREQ(IPPREFIX()->kindName(), "ROW");
-  ASSERT_EQ(IPPREFIX()->name(), "IPPREFIX");
+  ASSERT_STREQ(IPPREFIX()->name(), "IPPREFIX");
   ASSERT_TRUE(IPPREFIX()->parameters().empty());
 
   ASSERT_TRUE(hasType("IPPREFIX"));

--- a/velox/functions/sparksql/types/TimestampNTZRegistration.cpp
+++ b/velox/functions/sparksql/types/TimestampNTZRegistration.cpp
@@ -19,6 +19,7 @@
 #include "velox/expression/CastExpr.h"
 #include "velox/functions/sparksql/types/TimestampNTZCastUtil.h"
 #include "velox/functions/sparksql/types/TimestampNTZType.h"
+#include "velox/type/CastRegistry.h"
 
 namespace facebook::velox::functions::sparksql {
 namespace {
@@ -106,6 +107,12 @@ class TimestampNTZTypeFactory : public CustomTypeFactory {
 void registerTimestampNTZType() {
   registerCustomType(
       "timestamp_ntz", std::make_unique<const TimestampNTZTypeFactory>());
+  registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "TIMESTAMP_NTZ",
+       .implicitAllowed = false,
+       .validator = {}},
+  });
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/type/CastRegistry.cpp
+++ b/velox/type/CastRegistry.cpp
@@ -84,12 +84,10 @@ std::optional<int32_t> CastRulesRegistry::castCostImpl(
   const auto fromName = fromType->name();
   const auto toName = toType->name();
 
-  // For leaf types (primitives and custom types), look up rule directly.
-  if (fromType->size() == 0 && toType->size() == 0) {
-    auto rule = findRule(fromName, toName);
-    if (!rule) {
-      return std::nullopt;
-    }
+  // Try direct rule lookup first. This handles primitives and custom types
+  // including those with children like IPPREFIX (which extends RowType).
+  auto rule = findRule(fromName, toName);
+  if (rule) {
     if (requireImplicit && !rule->implicitAllowed) {
       return std::nullopt;
     }
@@ -99,9 +97,9 @@ std::optional<int32_t> CastRulesRegistry::castCostImpl(
     return requireImplicit ? rule->cost : 0;
   }
 
-  // For container types (ARRAY, MAP, ROW) with the same base type,
-  // recursively check children and sum costs.
-  if (fromName == toName) {
+  // No explicit rule. For container types (ARRAY, MAP, ROW) with the same
+  // base type, recursively check children and sum costs.
+  if (fromName == toName && fromType->size() > 0) {
     if (fromType->size() != toType->size()) {
       return std::nullopt;
     }

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -83,6 +83,11 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
   }
 
   // Fall back to CastRulesRegistry for custom type coercions.
+  // TODO: getCustomType() returns nullptr for built-in types (e.g., DOUBLE,
+  // VARCHAR), so registry rules between built-in pairs are invisible here.
+  // Switching to getType() would fix this, but getType("ARRAY", {}) and
+  // getType("ROW", {}) throw because parametric factories require params.
+  // Requires a try/catch guard or a non-throwing getType variant.
   if (fromType->size() == 0) {
     auto toType = getCustomType(toTypeName, {});
     if (toType != nullptr) {


### PR DESCRIPTION
Summary:

CastExpr::applyPeeled() now checks CastRulesRegistry::canCast() before falling back to the per-operator isSupportedFromType()/isSupportedToType() methods. This makes the registry the primary source of truth for cast validation, with operator methods as a fallback for types not yet fully migrated to the registry (e.g., JSON container types like ARRAY<X>→JSON that require recursive type checking).

This is a no-op behavioral change: the registry answers match what operators would answer for all registered types. The fallback path ensures JSON container casts and any future types with complex validation continue to work.

Differential Revision: D99232107


