### PR TITLE
feat: Migrate built-in coercions from kAllowedCoercions to CastRulesRegistry (#17017)

### DIFF
--- a/velox/type/CastRegistry.cpp
+++ b/velox/type/CastRegistry.cpp
@@ -136,13 +136,17 @@ void CastRulesRegistry::clear() {
 
 void registerCastRules(const std::vector<CastRule>& rules) {
   for (const auto& rule : rules) {
-    // At least one side must be a registered custom type with a CastOperator,
-    // otherwise the cast has no execution path.
+    // Validate that both type names are known. For custom types, at least one
+    // side must have a CastOperator to provide the cast execution path.
+    // Built-in type pairs (e.g. VARCHAR->DOUBLE) are handled by Velox's native
+    // cast machinery in CastExpr, so they don't need a CastOperator.
+    bool hasCustomCast = getCustomTypeCastOperator(rule.fromType) != nullptr ||
+        getCustomTypeCastOperator(rule.toType) != nullptr;
+    bool bothKnown = hasType(rule.fromType) && hasType(rule.toType);
     VELOX_CHECK(
-        getCustomTypeCastOperator(rule.fromType) != nullptr ||
-            getCustomTypeCastOperator(rule.toType) != nullptr,
-        "CastRule {} -> {} requires at least one side to be a registered "
-        "custom type with a CastOperator",
+        hasCustomCast || bothKnown,
+        "CastRule {} -> {} requires either a CastOperator on at least one "
+        "side, or both types to be known built-in types",
         rule.fromType,
         rule.toType);
   }

--- a/velox/type/CastRegistry.h
+++ b/velox/type/CastRegistry.h
@@ -61,6 +61,11 @@ class CastRulesRegistry {
   /// Clear all registered rules. Used for testing.
   void clear();
 
+  /// Find a rule by type name pair. Returns std::nullopt if no rule exists.
+  std::optional<CastRule> findRule(
+      const std::string& fromTypeName,
+      const std::string& toTypeName) const;
+
  private:
   CastRulesRegistry() = default;
 
@@ -71,10 +76,6 @@ class CastRulesRegistry {
       const TypePtr& fromType,
       const TypePtr& toType,
       bool requireImplicit) const;
-
-  std::optional<CastRule> findRule(
-      const std::string& fromTypeName,
-      const std::string& toTypeName) const;
 
   struct PairHash {
     size_t operator()(const std::pair<std::string, std::string>& p) const {
@@ -92,9 +93,10 @@ class CastRulesRegistry {
       rules_;
 };
 
-/// Register cast rules for custom types. Call this after registerCustomType()
-/// in register*Type() functions. Validates that at least one type in each rule
-/// has a registered CastOperator.
+/// Register cast rules. For custom types, call this after
+/// registerCustomType() in register*Type() functions. Validates that either
+/// at least one type has a registered CastOperator, or both types are known
+/// built-in types (handled by Velox's native cast machinery in CastExpr).
 ///
 /// Example:
 ///   registerCastRules({

--- a/velox/type/TypeCoercer.cpp
+++ b/velox/type/TypeCoercer.cpp
@@ -17,6 +17,8 @@
 
 #include "velox/type/CastRegistry.h"
 
+#include <folly/synchronization/CallOnce.h>
+
 namespace facebook::velox {
 
 int64_t Coercion::overallCost(const std::vector<Coercion>& coercions) {
@@ -32,58 +34,61 @@ int64_t Coercion::overallCost(const std::vector<Coercion>& coercions) {
 
 namespace {
 
-std::unordered_map<std::pair<std::string, std::string>, Coercion>
-allowedCoercions() {
-  std::unordered_map<std::pair<std::string, std::string>, Coercion> coercions;
+// Registers implicit coercion rules for built-in types in the
+// CastRulesRegistry. Idempotent — safe to call from multiple overloads.
+// TODO: Migrate as part of phase 3 of Query-Scoped Registries.
+void registerBuiltInCoercions() {
+  static folly::once_flag flag;
+  folly::call_once(flag, [] {
+    auto add = [](const TypePtr& from, const std::vector<TypePtr>& toTypes) {
+      std::vector<CastRule> rules;
+      rules.reserve(toTypes.size());
+      int32_t cost = 0;
+      for (const auto& toType : toTypes) {
+        rules.push_back(
+            {from->name(),
+             toType->name(),
+             /*implicitAllowed=*/true,
+             /*cost=*/++cost,
+             /*validator=*/nullptr});
+      }
+      registerCastRules(rules);
+    };
 
-  auto add = [&](const TypePtr& from, const std::vector<TypePtr>& to) {
-    int32_t cost = 0;
-    for (const auto& toType : to) {
-      coercions.emplace(
-          std::make_pair<std::string, std::string>(
-              from->name(), toType->name()),
-          Coercion{.type = toType, .cost = ++cost});
-    }
-  };
-
-  add(TINYINT(), {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()});
-  add(SMALLINT(), {INTEGER(), BIGINT(), REAL(), DOUBLE()});
-  add(INTEGER(), {BIGINT(), REAL(), DOUBLE()});
-  add(BIGINT(), {DOUBLE()});
-  add(REAL(), {DOUBLE()});
-  add(DECIMAL(1, 0), {REAL(), DOUBLE()});
-  add(DATE(), {TIMESTAMP()});
-  add(UNKNOWN(),
-      {TINYINT(),
-       BOOLEAN(),
-       SMALLINT(),
-       INTEGER(),
-       BIGINT(),
-       REAL(),
-       DOUBLE(),
-       VARCHAR(),
-       VARBINARY()});
-
-  return coercions;
+    add(TINYINT(), {SMALLINT(), INTEGER(), BIGINT(), REAL(), DOUBLE()});
+    add(SMALLINT(), {INTEGER(), BIGINT(), REAL(), DOUBLE()});
+    add(INTEGER(), {BIGINT(), REAL(), DOUBLE()});
+    add(BIGINT(), {DOUBLE()});
+    add(REAL(), {DOUBLE()});
+    add(DECIMAL(1, 0), {REAL(), DOUBLE()});
+    add(DATE(), {TIMESTAMP()});
+    add(UNKNOWN(),
+        {TINYINT(),
+         BOOLEAN(),
+         SMALLINT(),
+         INTEGER(),
+         BIGINT(),
+         REAL(),
+         DOUBLE(),
+         VARCHAR(),
+         VARBINARY()});
+  });
 }
+
 } // namespace
 
 // static
 std::optional<Coercion> TypeCoercer::coerceTypeBase(
     const TypePtr& fromType,
     const TypePtr& toType) {
+  registerBuiltInCoercions();
+
   if (fromType->name() == toType->name()) {
     return Coercion{.type = fromType, .cost = 0};
   }
 
-  // Check built-in coercions first.
-  static const auto kAllowedCoercions = allowedCoercions();
-  auto it = kAllowedCoercions.find({fromType->name(), toType->name()});
-  if (it != kAllowedCoercions.end()) {
-    return it->second;
-  }
-
-  // Check CastRulesRegistry directly — no type reconstruction needed.
+  // CastRulesRegistry is the single source of truth for all coercions
+  // (built-in and custom).
   if (auto cost = CastRulesRegistry::instance().canCoerce(fromType, toType)) {
     return Coercion{.type = toType, .cost = *cost};
   }
@@ -95,31 +100,28 @@ std::optional<Coercion> TypeCoercer::coerceTypeBase(
 std::optional<Coercion> TypeCoercer::coerceTypeBase(
     const TypePtr& fromType,
     const std::string& toTypeName) {
-  static const auto kAllowedCoercions = allowedCoercions();
+  registerBuiltInCoercions();
+
   if (fromType->name() == toTypeName) {
     return Coercion{.type = fromType, .cost = 0};
   }
 
-  // Check built-in coercions first.
-  auto it = kAllowedCoercions.find({fromType->name(), toTypeName});
-  if (it != kAllowedCoercions.end()) {
-    return it->second;
-  }
-
-  // Fall back to CastRulesRegistry for custom type coercions. Skip
-  // parameterized types — we cannot construct the target type without knowing
-  // its type parameters.
-  // getCustomType() returns nullptr for built-in types. Callers must not
-  // pass parametric custom type names (e.g., "BIGINT_ENUM") because their
-  // factories throw when called with empty parameters. SignatureBinder
-  // guards against this by checking typeSignature.parameters().empty().
-  if (fromType->size() == 0 && fromType->parameters().empty()) {
-    if (auto toType = getCustomType(toTypeName, {})) {
-      if (auto cost =
-              CastRulesRegistry::instance().canCoerce(fromType, toType)) {
-        return Coercion{.type = std::move(toType), .cost = *cost};
-      }
+  // Look up by name first to avoid calling getType() for parametric types
+  // whose factories throw with empty parameters (ARRAY, MAP, ROW, BIGINT_ENUM).
+  if (fromType->size() == 0) {
+    auto rule =
+        CastRulesRegistry::instance().findRule(fromType->name(), toTypeName);
+    if (!rule || !rule->implicitAllowed) {
+      return std::nullopt;
     }
+    auto toType = getType(toTypeName, {});
+    if (!toType) {
+      return std::nullopt;
+    }
+    if (rule->validator && !rule->validator(fromType, toType)) {
+      return std::nullopt;
+    }
+    return Coercion{.type = std::move(toType), .cost = rule->cost};
   }
 
   return std::nullopt;

--- a/velox/type/tests/CastRegistryTest.cpp
+++ b/velox/type/tests/CastRegistryTest.cpp
@@ -405,9 +405,9 @@ TEST_F(CastRulesRegistryTest, standaloneRegistration) {
   }));
 }
 
-TEST_F(CastRulesRegistryTest, rejectsRulesWithoutCastOperator) {
-  // The free function registerCastRules() validates that at least one side
-  // has a registered custom type with a CastOperator.
+TEST_F(CastRulesRegistryTest, rejectsRulesWithUnknownTypes) {
+  // Rules where one side is unknown and neither has a CastOperator are
+  // rejected.
   EXPECT_THROW(
       registerCastRules({
           {.fromType = "BIGINT",
@@ -416,6 +416,18 @@ TEST_F(CastRulesRegistryTest, rejectsRulesWithoutCastOperator) {
            .validator = {}},
       }),
       VeloxException);
+}
+
+TEST_F(CastRulesRegistryTest, acceptsBuiltInToBuiltInRules) {
+  // Rules between known built-in types are accepted even without a
+  // CastOperator — Velox's native cast machinery handles them.
+  EXPECT_NO_THROW(registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .cost = 5,
+       .validator = {}},
+  }));
 }
 
 } // namespace

--- a/velox/type/tests/TypeCoercerTest.cpp
+++ b/velox/type/tests/TypeCoercerTest.cpp
@@ -244,10 +244,41 @@ TEST(TypeCoercerTest, leastCommonSuperType) {
           MAP(INTEGER(), REAL()), ROW({INTEGER(), REAL()})) == nullptr);
 }
 
-TEST(TypeCoercerTest, parametricBuiltinTargetDoesNotThrow) {
-  // Parametric built-in factories throw on empty params. Verify graceful
-  // handling.
-  EXPECT_EQ(TypeCoercer::coerceTypeBase(BIGINT(), "ARRAY"), std::nullopt);
+TEST(TypeCoercerTest, customRuleCostPropagation) {
+  // Verify that CastRulesRegistry costs propagate through TypeCoercer.
+  // clear() wipes all rules (including built-in coercions registered once via
+  // function-local static), so only the custom rule below is active.
+  // VARCHAR->DOUBLE is not a built-in coercion, ensuring this tests the
+  // custom-rule path.
+  CastRulesRegistry::instance().clear();
+  registerCastRules({
+      {.fromType = "VARCHAR",
+       .toType = "DOUBLE",
+       .implicitAllowed = true,
+       .cost = 7,
+       .validator = {}},
+  });
+
+  auto coercion = TypeCoercer::coerceTypeBase(VARCHAR(), "DOUBLE");
+  ASSERT_TRUE(coercion.has_value());
+  EXPECT_EQ(coercion->cost, 7);
+  EXPECT_EQ(*coercion->type, *DOUBLE());
+
+  auto cost = TypeCoercer::coercible(VARCHAR(), DOUBLE());
+  ASSERT_TRUE(cost.has_value());
+  EXPECT_EQ(cost.value(), 7);
+
+  CastRulesRegistry::instance().clear();
+}
+
+TEST(TypeCoercerTest, parametricTargetReturnsNullopt) {
+  // Parametric types (ARRAY, MAP, ROW) cannot be constructed without type
+  // parameters. The string overload checks for a coercion rule by name first
+  // and returns nullopt when none exists, avoiding calls to getType() that
+  // would throw.
+  ASSERT_FALSE(TypeCoercer::coerceTypeBase(BIGINT(), "ARRAY").has_value());
+  ASSERT_FALSE(TypeCoercer::coerceTypeBase(BIGINT(), "MAP").has_value());
+  ASSERT_FALSE(TypeCoercer::coerceTypeBase(BIGINT(), "ROW").has_value());
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

`TypeCoercer::coerceTypeBase` maintained a separate static map (`kAllowedCoercions`) for built-in implicit coercions (TINYINT->SMALLINT, INTEGER->BIGINT, etc.) alongside the `CastRulesRegistry` used for custom types. This meant two lookup paths for the same concept — one lock-free static map for built-ins, one registry for custom types.

This diff makes `CastRulesRegistry` the single source of truth for all coercion rules:

1. **Register built-in coercions in the registry.** Replace `kAllowedCoercions` with `registerBuiltInCoercions()`, called once on first use via `folly::call_once`. Same type pairs, same costs — just stored in the registry instead of a separate map. Uses `TypePtr` objects (e.g. `TINYINT()`, `SMALLINT()`) for compile-time safety and extracts names via `.name()`.

2. **Simplify the string-based overload.** The string overload uses `findRule()` to check for a coercion rule by name before calling `getType()`, avoiding throws for parametric types (ARRAY, MAP, ROW, BIGINT_ENUM) whose factories require parameters. When a rule exists, it uses the rule's cost directly — single registry lookup instead of two.

3. **Replace `getCustomType` with `getType` in string overload.** The old code used `getCustomType(toTypeName, {})` which returned nullptr for built-in types, silently dropping registry lookups for built-in->built-in coercions. `getType(toTypeName, {})` resolves both built-in singletons and custom types.

4. **Relax `registerCastRules()` validation.** Previously required a CastOperator on at least one side, blocking built-in->built-in rules. Now also accepts rules where both types are known built-in types, since Velox's native cast machinery in CastExpr handles execution.

Before: `coerceTypeBase` checked `kAllowedCoercions` first, then fell back to `CastRulesRegistry` (which couldn't see built-in types via `getCustomType`).
After: `coerceTypeBase` uses only `CastRulesRegistry` for all coercion lookups — built-in and custom.

Reviewed By: kevinwilfong

Differential Revision: D99197524


