### PR TITLE
fix: SIGSEGV in AggregationFuzzer when reference query returns empty result vector

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -1079,7 +1079,7 @@ bool AggregationFuzzer::compareEquivalentPlanResults(
               firstPlan, referenceQueryRunner_.get());
           stats_.updateReferenceQueryStats(referenceResult.second);
 
-          if (referenceResult.first) {
+          if (referenceResult.first && !referenceResult.first.value().empty()) {
             velox::fuzzer::ResultOrError expected;
             expected.result = fuzzer::mergeRowVectors(
                 referenceResult.first.value(), pool_.get());


### PR DESCRIPTION
Summary:
`compareEquivalentPlanResults` calls `mergeRowVectors` on the reference query result without checking if the result vector is empty. When the reference query runner (e.g. SparkQueryRunner) returns a valid `optional` containing an empty `vector<RowVectorPtr>` (query succeeded but produced zero result batches), `mergeRowVectors` crashes accessing `results[0]` on an empty vector.

This was the root cause of recurring Spark Aggregate Fuzzer SIGSEGV crashes in the scheduled CI (e.g. seed 13256).

The fix adds an emptiness check on the result vector before calling
`mergeRowVectors`.

Fixes Pattern 3 mentioned in #16327 

Differential Revision: D99347601


