### PR TITLE
fix: TempFilePath fd_ member initialization order bug causing flaky test failures (#17020)

### DIFF
--- a/velox/common/testutil/TempFilePath.cpp
+++ b/velox/common/testutil/TempFilePath.cpp
@@ -20,7 +20,9 @@ namespace facebook::velox::common::testutil {
 
 TempFilePath::~TempFilePath() {
   ::unlink(tempPath_.c_str());
-  ::close(fd_);
+  if (fd_ != -1) {
+    ::close(fd_);
+  }
 }
 
 std::shared_ptr<TempFilePath> TempFilePath::create(bool enableFaultInjection) {

--- a/velox/common/testutil/TempFilePath.h
+++ b/velox/common/testutil/TempFilePath.h
@@ -84,10 +84,11 @@ class TempFilePath {
   }
 
   const bool enableFaultInjection_;
+  // initialized to -1 before tempPath_ is initialized,
+  // since members are initialized in declaration order
+  int fd_{-1};
   const std::string tempPath_;
   const std::string path_;
-
-  int fd_{};
 };
 
 std::vector<std::string> toFilePaths(


### PR DESCRIPTION
Summary:

`TempFilePath` has a member initialization order bug that causes flaky test failures (~0.75% rate) with "Received corrupted serialized page" errors during spill deserialization.

Root Cause:

`fd_` is declared after `tempPath_` in the class, but `createTempFile()` sets `fd_` during `tempPath_`'s initialization. Per C++ rules, members initialize in declaration order — so `fd_`'s own default initializer (`int fd_{}`, which is 0) runs *after* `createTempFile()` already wrote the real mkstemp fd into it, overwriting it back to 0.

The destructor then calls `::close(0)`, which closes stdin (fd 0). The real mkstemp fd is leaked. Once fd 0 is freed, glog's `fdopen()` reuses it for WARNING log output. When another `TempFilePath` destructor closes fd 0 again, a subsequent spill file `open()` gets fd 0. glog's stale `FILE*` still points at fd 0, so `FB_LOG_EVERY_MS(WARNING, 1000)` writes ASCII log text (e.g., `W0528 03:14:22.917532 SharedArbitrator.cpp:1421]...`) directly into the binary spill file. The PrestoSerializer then reads these ASCII bytes as a binary Presto wire-format header (21-byte PrestoPage), gets a checksum mismatch, and throws "Received corrupted serialized page."



This also looks like the root cause behind [#16983](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebookincubator%2Fvelox%2Fissues%2F16983&h=AT7DiI-HiMI39bPrp0BocJWx_pTQzIA1_SIIswoCyHr7YXuS_gCqSH8KV7ItPEloF1bxnpUX-ZViXwofxFyk8arw1b5YnqTY0opkRd0kECP97sO9FkiFA02UyKhp-ZyGfueQQ0w6wDwZRIcKmCkJQxnkFUD-) (ModeAggregateTest.groupByString) and [#16901](https://l.facebook.com/l.php?u=https%3A%2F%2Fgithub.com%2Ffacebookincubator%2Fvelox%2Fissues%2F16901&h=AT7DiI-HiMI39bPrp0BocJWx_pTQzIA1_SIIswoCyHr7YXuS_gCqSH8KV7ItPEloF1bxnpUX-ZViXwofxFyk8arw1b5YnqTY0opkRd0kECP97sO9FkiFA02UyKhp-ZyGfueQQ0w6wDwZRIcKmCkJQxnkFUD-) (CountIfAggregationTest), but I couldn't independently reproduce them.
Fix:
1. Move `fd_` before `tempPath_` in declaration order so it initializes first.
2. Change `int fd_{}` (value-initializes to 0) to `int fd_{-1}` (invalid fd).
3. Guard the destructor's `::close(fd_)` with `if (fd_ != -1)`.

Differential Revision: D99366999


