### PR TITLE
build(ci): Grant pull-requests write permission to Linux build workflow

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -45,6 +45,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}


### PR DESCRIPTION
## Summary

- Add `pull-requests: write` to the `permissions` block in `linux-build.yml`

## Why

The `GITHUB_TOKEN` in `linux-build.yml` currently only has `contents: read`. Since `linux-build-base.yml` is a reusable workflow invoked via `workflow_call`, it inherits the caller's token permissions. This means any job in the reusable workflow that tries to post PR comments via `gh pr comment` fails with:

```
GraphQL: Resource not accessible by integration (addComment)
```

GitHub evaluates workflow permissions from the **base branch** (`main`), not from the PR branch. So this permission change must be merged to `main` before any PR can use it.

## Context

This is a prerequisite for [#17015](https://github.com/facebookincubator/velox/pull/17015), which adds automated CI failure reporting — posting PR comments when builds or tests fail, listing specific failed tests and linking to logs.

The `pull-requests: write` permission only grants the ability to comment on, review, and label PRs. It does **not** grant any code push or commit access (that's `contents: write`).

## Test plan

- [x] `zizmor` security linter passes
- [x] GitHub Actions workflow validation passes
- [ ] After merge, PR #17015's comment steps will succeed