### PR TITLE
fix: BetweenFunction to handle NaN with correct Spark semantics

### DIFF
--- a/velox/functions/sparksql/Comparisons.h
+++ b/velox/functions/sparksql/Comparisons.h
@@ -166,7 +166,9 @@ struct BetweenFunction {
       const TInput& value,
       const TInput& low,
       const TInput& high) {
-    result = value >= low && value <= high;
+    GreaterOrEqual<TInput> gte;
+    LessOrEqual<TInput> lte;
+    result = gte(value, low) && lte(value, high);
   }
 };
 

--- a/velox/functions/sparksql/tests/ComparisonsTest.cpp
+++ b/velox/functions/sparksql/tests/ComparisonsTest.cpp
@@ -25,6 +25,7 @@ namespace {
 static constexpr double kInf = std::numeric_limits<double>::infinity();
 static constexpr float kInfF = std::numeric_limits<float>::infinity();
 static constexpr auto kNaN = std::numeric_limits<double>::quiet_NaN();
+static constexpr auto kNaNF = std::numeric_limits<float>::quiet_NaN();
 
 class ComparisonsTest : public SparkFunctionBaseTest {
  protected:
@@ -355,8 +356,6 @@ TEST_F(ComparisonsTest, between) {
   EXPECT_EQ(between<double>(1, std::nullopt, 3), std::nullopt);
   EXPECT_EQ(between<double>(kNaN, std::nullopt, 4), std::nullopt);
   EXPECT_EQ(between<double>(kNaN, 1, 5), false);
-  EXPECT_EQ(between<double>(0, -1, kNaN), false);
-  EXPECT_EQ(between<double>(kNaN, 0, kNaN), false);
   EXPECT_EQ(between<double>(kInf, 0, kInf), true);
   EXPECT_EQ(between<float>(kInfF, 0, kInfF), true);
   EXPECT_EQ(between<double>(kInf, 2.0, 5.0), false);
@@ -364,7 +363,15 @@ TEST_F(ComparisonsTest, between) {
   EXPECT_EQ(between<float>(kInfF, 1.0, 6.0), false);
   EXPECT_EQ(between<float>(-kInfF, 1.0, 6.0), false);
   EXPECT_EQ(between<float>(kInfF, -kInfF, kInfF), true);
-  EXPECT_EQ(between<double>(kInf, -kInf, kNaN), false);
+
+  // Spark NaN semantics: NaN == NaN and NaN > everything.
+  EXPECT_EQ(between<double>(0, -1, kNaN), true);
+  EXPECT_EQ(between<double>(kNaN, 0, kNaN), true);
+  EXPECT_EQ(between<double>(kInf, -kInf, kNaN), true);
+  EXPECT_EQ(between<double>(kNaN, kNaN, kNaN), true);
+  EXPECT_EQ(between<float>(kNaNF, kNaNF, kNaNF), true);
+  EXPECT_EQ(between<float>(0.0f, -1.0f, kNaNF), true);
+  EXPECT_EQ(between<float>(kNaNF, 0.0f, kNaNF), true);
 }
 
 TEST_F(ComparisonsTest, decimal) {


### PR DESCRIPTION
Summary: Fix incorrect NaN comparison behavior in Spark's BETWEEN function. The function was using raw IEEE 754 operators where NaN comparisons always return false, instead of [Spark's NaN semantics](https://spark.apache.org/docs/latest/sql-ref-datatypes.html#nan-semantics) where `NaN == NaN` and `NaN > everything`. This can cause silent wrong results for queries like `NaN BETWEEN NaN AND NaN` (returned false instead of true). Updates the implementation to use the existing NaN-aware comparators (`GreaterOrEqual` and `LessOrEqual`) that handle Spark semantics correctly, consistent with all other comparison operators in the same file.

Differential Revision: D99480959


