### PR TITLE
fix(build): Disable grouped tests on macOS for individual test discovery

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,6 +33,53 @@ ctest -R ExprTest                # run tests matching a pattern
 
 Test files live in `tests/` subdirectories alongside source.
 
+### Grouped tests
+
+Four test suites use `velox_add_grouped_tests` to reduce link times on Linux CI
+by batching source files into shared binaries:
+- `velox/exec/tests` (`velox_exec_test`, `velox_exec_util_test`)
+- `velox/functions/prestosql/aggregates/tests`
+- `velox/common/caching/tests`
+- `velox/serializers/tests`
+
+All other test suites use individual binaries on all platforms.
+
+On macOS, grouping is off by default (`VELOX_ENABLE_GROUPED_TESTS=OFF`) and each
+test file gets its own binary (e.g., `ValuesTest.cpp` → `velox_exec_test_ValuesTest`).
+On Linux CI, grouping is on (`velox_exec_test_group0` through `_group7`).
+Override with `-DVELOX_ENABLE_GROUPED_TESTS=ON/OFF`.
+
+### Common test workflows
+
+```bash
+# Run all test binaries whose ctest name matches a regex.
+# On Linux this matches velox_exec_test_group0 … _group7.
+# On macOS this matches velox_exec_test_ValuesTest,
+# velox_exec_test_HashJoinTest, etc.
+cd _build/debug && ctest -R velox_exec
+
+# Run a specific test file (macOS — individual binary)
+_build/debug/velox/exec/tests/velox_exec_test_ValuesTest --gtest_filter="ValuesTest.*"
+
+# Run a specific test case (Linux — grouped binary)
+_build/debug/velox/exec/tests/velox_exec_test_group3 --gtest_filter="ValuesTest.empty"
+```
+
+**Re-running a CI failure locally:** CI reports a failure in
+`velox_exec_test_group3` with `ValuesTest.empty`. On Linux, run the grouped
+binary directly. On macOS, the grouped binary does not exist — use the
+per-file binary instead: `velox_exec_test_ValuesTest --gtest_filter="ValuesTest.empty"`.
+
+**Adding a new test to a grouped suite:** Add the source file to the `SOURCES`
+list in the relevant `velox_add_grouped_tests()` call in `CMakeLists.txt`. It
+is automatically assigned to a group on Linux and gets its own binary on macOS.
+
+**Creating a new test suite:** Use `velox_add_grouped_tests` for suites with
+many test files (10+) that link against large libraries like velox core — each
+individual binary pays the full link cost, so grouping them into shared binaries
+significantly reduces total CI build time. For suites with only a few test files
+or lightweight dependencies, use `add_executable` / `add_test`.
+
 ## Formatting
 
 ```bash

--- a/CMake/VeloxUtils.cmake
+++ b/CMake/VeloxUtils.cmake
@@ -269,14 +269,26 @@ function(velox_sources TARGET)
   endif()
 endfunction()
 
+# Group test sources into batched binaries to reduce link target count on CI.
+# On macOS, defaults to OFF so each test source gets its own binary and
+# individual tests are discoverable via 'ctest -R <TestName>'.
+if(APPLE)
+  option(VELOX_ENABLE_GROUPED_TESTS "Group test sources into batched binaries" OFF)
+else()
+  option(VELOX_ENABLE_GROUPED_TESTS "Group test sources into batched binaries" ON)
+endif()
+
 # Number of test source files per grouped test binary. Controls the trade-off
 # between link time (fewer groups = faster linking) and ctest parallelism
-# (more groups = more parallel test processes). Set to 1 for per-file binaries.
+# (more groups = more parallel test processes). Ignored when
+# VELOX_ENABLE_GROUPED_TESTS is OFF.
 set(VELOX_TESTS_PER_GROUP 10 CACHE STRING "Number of test source files per grouped test binary")
 
 # Creates grouped test binaries from a list of test sources. Groups tests into
 # batches of VELOX_TESTS_PER_GROUP to reduce link target count while
-# maintaining ctest parallelism.
+# maintaining ctest parallelism. When VELOX_ENABLE_GROUPED_TESTS is OFF, each
+# source file becomes its own binary named after the source file (without
+# extension), making individual tests discoverable via 'ctest -R <TestName>'.
 #
 # Usage:
 #   velox_add_grouped_tests(
@@ -291,6 +303,18 @@ function(velox_add_grouped_tests)
 
   if(NOT ARG_WORKING_DIRECTORY)
     set(ARG_WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  if(NOT VELOX_ENABLE_GROUPED_TESTS)
+    # Create one binary per source file, named after the source file.
+    foreach(_source IN LISTS ARG_SOURCES)
+      get_filename_component(_name ${_source} NAME_WE)
+      set(_target "${ARG_PREFIX}_${_name}")
+      add_executable(${_target} ${_source} ${ARG_EXTRA_SOURCES})
+      add_test(NAME ${_target} COMMAND ${_target} WORKING_DIRECTORY ${ARG_WORKING_DIRECTORY})
+      target_link_libraries(${_target} ${ARG_DEPS})
+    endforeach()
+    return()
   endif()
 
   list(LENGTH ARG_SOURCES _num_sources)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,47 @@ following best practices:
    your PR. If a component or API does not have a corresponding
    unit test suite, please consider improving the codebase by first adding a
    new unit test suite to ensure the existing behavior is correct.
+   * **Common test workflows**:
+     ```bash
+     # Run all tests in parallel.
+     cd _build/debug && ctest -j 8
+
+     # Run all test binaries whose ctest name matches a regex.
+     # On Linux this matches velox_exec_test_group0 … _group7.
+     # On macOS this matches velox_exec_test_ValuesTest,
+     # velox_exec_test_HashJoinTest, etc.
+     cd _build/debug && ctest -R velox_exec
+
+     # Run a single test binary by name (works on macOS where each
+     # test file produces its own binary).
+     cd _build/debug && ctest -R ValuesTest
+     ```
+   * **Re-running a CI failure locally**: CI reports a failure in
+   `velox_exec_test_group3` with `ValuesTest.empty`. On Linux, run the grouped
+   binary directly. On macOS, the grouped binary does not exist — use the
+   per-file binary instead:
+     ```bash
+     # Linux (grouped binary)
+     _build/debug/velox/exec/tests/velox_exec_test_group3 --gtest_filter="ValuesTest.empty"
+     # macOS (per-file binary)
+     _build/debug/velox/exec/tests/velox_exec_test_ValuesTest --gtest_filter="ValuesTest.empty"
+     ```
+   * **Test binary structure**: Four test suites (`velox/exec/tests`,
+   `velox/functions/prestosql/aggregates/tests`, `velox/common/caching/tests`,
+   `velox/serializers/tests`) use grouped binaries on Linux CI (e.g.,
+   `velox_exec_test_group0` through `_group7`) to reduce link times. All other
+   suites use individual binaries on all platforms. On macOS, grouping is off
+   by default and each test file gets its own binary (e.g.,
+   `velox_exec_test_ValuesTest`). To disable grouping on Linux, pass
+   `-DVELOX_ENABLE_GROUPED_TESTS=OFF` to CMake.
+   * **Adding a test to a grouped suite**: Add the source file to the `SOURCES`
+   list in the relevant `velox_add_grouped_tests()` call in `CMakeLists.txt`.
+   It is automatically assigned to a group on Linux and gets its own binary on
+   macOS. For new test suites, use `velox_add_grouped_tests` when the suite
+   has many test files (10+) that link against large libraries like velox
+   core — each individual binary pays the full link cost, so grouping
+   significantly reduces total CI build time. For suites with only a few
+   test files or lightweight dependencies, use `add_executable` / `add_test`.
 
 4. **Code Comments**: Appropriately add comments to your code and document APIs.
    * As a library, Velox code is optimized for the reader, not the writer.

--- a/README.md
+++ b/README.md
@@ -239,6 +239,13 @@ Run `make` in the root directory to compile the sources. For development, use
 `make debug` to build a non-optimized debug version, or `make release` to build
 an optimized version.  Use `make unittest` to build and run tests.
 
+Four test suites use grouped binaries on Linux CI to reduce link times
+(`velox/exec/tests`, `velox/functions/prestosql/aggregates/tests`,
+`velox/common/caching/tests`, `velox/serializers/tests`). All other suites use
+individual binaries on all platforms. On macOS, grouping is off by default. To
+disable grouping on Linux, pass `-DVELOX_ENABLE_GROUPED_TESTS=OFF` via
+`EXTRA_CMAKE_FLAGS`.
+
 Note that,
 * Velox requires a compiler at the minimum GCC 11.0 or Clang 15.0.
 * Velox requires the CPU to support instruction sets:


### PR DESCRIPTION
## Problem

Fixes #17023.

Before PR #16691, Velox built a single monolithic test binary per test suite (e.g., `velox_exec_test`). Developers could run a specific test locally with:

```bash
_build/debug/velox/exec/tests/velox_exec_test --gtest_filter="*Values*"
```

PR #16691 introduced grouped tests (`velox_add_grouped_tests`) to reduce link times on Linux CI by batching multiple test source files into shared binaries (`velox_exec_test_group0` through `_group7`). This broke the local development workflow on macOS — the familiar `velox_exec_test` binary no longer exists, and there is no way to know which `_groupN` binary contains a given test without grepping the CMake files.

## Solution

- Adds a `VELOX_ENABLE_GROUPED_TESTS` CMake option that defaults to `OFF` on macOS and `ON` on Linux
- When `OFF`, each test source file gets its own binary named after the file (e.g., `ValuesTest.cpp` → `velox_exec_test_ValuesTest`)
- Linux CI continues using grouped binaries for faster linking
- Users can override with `-DVELOX_ENABLE_GROUPED_TESTS=ON/OFF` if needed

## Developer workflow after this change

On macOS (grouped tests OFF), each test file produces its own binary:

```bash
# Run all tests in a specific test file
_build/debug/velox/exec/tests/velox_exec_test_ValuesTest

# Run specific test cases within that binary
_build/debug/velox/exec/tests/velox_exec_test_ValuesTest --gtest_filter="*basic*"

# Discover and run via ctest (now finds individual binaries)
cd _build/debug && ctest -R ValuesTest
```

On Linux CI, nothing changes — grouped binaries (`_group0` through `_group7`) are still used for faster linking.

## Test plan

- [ ] Verify Linux CI passes with grouped tests still enabled (default ON)
- [ ] Verify macOS build creates individual test binaries
- [ ] Verify `ctest -R ValuesTest` discovers individual tests on macOS