### PR TITLE
fix: Change array_sort comparator lambda return type from bigint to integer (#17030)

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzer.h
+++ b/velox/expression/fuzzer/ExpressionFuzzer.h
@@ -98,7 +98,7 @@ class ExpressionFuzzer {
     // testing. Use function signature to exclude only a specific signature.
     // ex skipFunctions{
     //   "width_bucket",
-    //   "array_sort(array(T),constant function(T,T,bigint)) -> array(T)"}
+    //   "array_sort(array(T),constant function(T,T,integer)) -> array(T)"}
     std::unordered_set<std::string> skipFunctions;
 
     std::unordered_map<std::string, std::shared_ptr<ExprTransformer>>

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -179,7 +179,7 @@ std::unordered_set<std::string> skipFunctions = {
     "uniqueness_distribution(khyperloglog,bigint) -> map(bigint,double)",
     "merge_khll(array(khyperloglog)) -> khyperloglog",
     // Fuzzer cannot generate valid 'comparator' lambda.
-    "array_sort(array(T),constant function(T,T,bigint)) -> array(T)",
+    "array_sort(array(T),constant function(T,T,integer)) -> array(T)",
     "array_sort(array(T),constant function(T,U)) -> array(T)",
     "array_sort_desc(array(T),constant function(T,U)) -> array(T)",
     "split_to_map(varchar,varchar,varchar,function(varchar,varchar,varchar,varchar)) -> map(varchar,varchar)",

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -290,7 +290,7 @@ TEST_F(ExprCompilerTest, customTypeConstant) {
 TEST_F(ExprCompilerTest, rewrites) {
   auto rowType = ROW({"c0", "c1"}, {ARRAY(VARCHAR()), BIGINT()});
   auto arraySortSql =
-      "array_sort(c0, (x, y) -> if(length(x) < length(y), -1, if(length(x) > length(y), 1, 0)))";
+      "array_sort(c0, (x, y) -> if(length(x) < length(y), (-1)::integer, if(length(x) > length(y), 1::integer, 0::integer)))";
 
   ASSERT_NO_THROW(
       std::make_unique<ExprSet>(

--- a/velox/expression/tests/ExprOptimizerTest.cpp
+++ b/velox/expression/tests/ExprOptimizerTest.cpp
@@ -205,11 +205,11 @@ TEST_F(ExprOptimizerTest, lambdas) {
 TEST_F(ExprOptimizerTest, rewritesWithConstantFolding) {
   auto type = ROW({"c0"}, {ARRAY(VARCHAR())});
   testExpression(
-      "array_sort(c0, (x, y) -> if(length(x) < length(y), (-1 * 1), if(length(x) = length(y), abs(0), (2 / 2))))",
+      "array_sort(c0, (x, y) -> if(length(x) < length(y), (-1 * 1)::integer, if(length(x) = length(y), abs(0)::integer, (2 / 2)::integer)))",
       "array_sort(c0, x -> length(x))",
       type);
   testExpression(
-      "array_sort(c0, (x, y) -> if(length(x) < length(y), abs(-1), if(length(x) > length(y), -4 / 3, 0 / 3)))",
+      "array_sort(c0, (x, y) -> if(length(x) < length(y), abs(-1)::integer, if(length(x) > length(y), (-4 / 3)::integer, (0 / 3)::integer)))",
       "array_sort_desc(c0, x -> length(x))",
       type);
 

--- a/velox/functions/lib/ArraySort.cpp
+++ b/velox/functions/lib/ArraySort.cpp
@@ -430,12 +430,12 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
 
   if (withComparator) {
     signatures.push_back(
-        // array(T), function(T,T,bigint) -> array(T)
+        // array(T), function(T,T,integer) -> array(T)
         exec::FunctionSignatureBuilder()
             .typeVariable("T")
             .returnType("array(T)")
             .argumentType("array(T)")
-            .constantArgumentType("function(T,T,bigint)")
+            .constantArgumentType("function(T,T,integer)")
             .build());
   }
   return signatures;

--- a/velox/functions/lib/SimpleComparisonMatcher.cpp
+++ b/velox/functions/lib/SimpleComparisonMatcher.cpp
@@ -97,14 +97,15 @@ bool ComparisonConstantMatcher::match(const core::TypedExprPtr& expr) {
 std::optional<int64_t> ComparisonConstantMatcher::asConstant(
     const core::ITypedExpr* expr) {
   if (auto constant = dynamic_cast<const core::ConstantTypedExpr*>(expr)) {
-    if (constant->hasValueVector()) {
-      auto constantVector =
-          constant->valueVector()->as<SimpleVector<int64_t>>();
-      if (!constantVector->isNullAt(0)) {
-        return constantVector->valueAt(0);
-      }
-    } else {
-      if (!constant->value().isNull()) {
+    if (!constant->isNull()) {
+      if (constant->hasValueVector()) {
+        const auto& vector = constant->valueVector();
+        if (constant->type()->isBigint()) {
+          return vector->as<SimpleVector<int64_t>>()->valueAt(0);
+        } else if (constant->type()->isInteger()) {
+          return vector->as<SimpleVector<int32_t>>()->valueAt(0);
+        }
+      } else {
         if (constant->value().kind() == TypeKind::BIGINT) {
           return constant->value().value<int64_t>();
         }

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -46,7 +46,9 @@ using TestRowType = variant;
 class ArraySortTest : public FunctionBaseTest,
                       public testing::WithParamInterface<TypeKind> {
  protected:
-  ArraySortTest() : numValues_(10), numVectors_(5) {}
+  ArraySortTest() : numValues_(10), numVectors_(5) {
+    options_.parseIntegerAsBigint = false;
+  }
 
   void SetUp() override;
 

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -42,6 +42,7 @@ class SimpleComparisonMatcherTest : public testing::Test,
       const RowTypePtr& rowType) {
     parse::ParseOptions options;
     options.functionPrefix = prefix_;
+    options.parseIntegerAsBigint = false;
     auto untyped = parse::DuckSqlExpressionsParser(options).parseExpr(text);
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
@@ -68,7 +69,7 @@ class TestFunction : public exec::VectorFunction {
                 .typeVariable("T")
                 .returnType("array(T)")
                 .argumentType("array(T)")
-                .argumentType("function(T,T,bigint)")
+                .argumentType("function(T,T,integer)")
                 .build()};
   }
 };
@@ -79,8 +80,7 @@ TEST_F(SimpleComparisonMatcherTest, basic) {
       TestFunction::signatures(),
       std::make_unique<TestFunction>());
 
-  const auto inputType =
-      ROW({"a"}, {ARRAY(ROW({"f", "g"}, {BIGINT(), BIGINT()}))});
+  const auto inputType = ROW({"a"}, {ARRAY(ROW({"f", "g"}, INTEGER()))});
 
   auto checker = std::make_unique<SimpleComparisonChecker>();
 

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -31,6 +31,10 @@ using facebook::velox::functions::test::FunctionBaseTest;
 
 class ArraySortTest : public SparkFunctionBaseTest {
  protected:
+  ArraySortTest() {
+    options_.parseIntegerAsBigint = false;
+  }
+
   void testArraySort(const VectorPtr& input, const VectorPtr& expected) {
     auto result = evaluate("array_sort(c0)", makeRowVector({input}));
     assertEqualVectors(expected, result);

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -24,6 +24,10 @@ namespace facebook::velox::parse {
 struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
+
+  // TODO: Replace or add a new flag with behavior that matches Presto and Spark
+  // where small integer literals are INTEGER and large ones are BIGINT, instead
+  // of this all-or-nothing flag.
   bool parseIntegerAsBigint = true;
   // Controls whether to parse the values in an IN list as separate arguments or
   // as a single array argument.


### PR DESCRIPTION
Summary:

Presto's ArraySortComparatorFunction declares the comparator lambda return type
as int, not bigint. The Velox signature used bigint, causing resolution failures
when the lambda body returned INTEGER.

Also updated SimpleComparisonMatcherTest to use parseIntegerAsBigint = false to
match Presto's integer literal typing behavior.

Differential Revision: D99547164


