### PR TITLE
fix(ci): Missing symbol ConnectorRegistry::tryGet in velox_exec lib

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -238,6 +238,7 @@ velox_link_libraries(
   velox_common_compression
   velox_core
   velox_connector
+  velox_connector_registry
   velox_expression
   velox_file
   velox_presto_serializer


### PR DESCRIPTION
PR #16977 refactored the connector registry.
The Velox exec library is using the APIs without
explicitly linking it causing build issues with missing symbols if velox_exec is used outside of the mono library
e.g. by PrestoC++.