### PR TITLE
fix: Allow IoStats to override storageReadBytes in getRuntimeStats

### DIFF
--- a/velox/connectors/hive/FileDataSource.cpp
+++ b/velox/connectors/hive/FileDataSource.cpp
@@ -459,8 +459,15 @@ FileDataSource::getRuntimeStats() {
   }
 
   const auto ioStatsMap = ioStats_->stats();
-  for (const auto& storageStats : ioStatsMap) {
-    res.emplace(storageStats.first, storageStats.second);
+  for (const auto& [key, value] : ioStatsMap) {
+    // IoStats may carry a ReadFile-layer storageReadBytes that reflects the
+    // actual bytes fetched from remote storage. Use it to override the
+    // DWIO-level estimate (IoStatistics).
+    if (key == kStorageReadBytes) {
+      res[std::string(key)] = value;
+    } else {
+      res.emplace(key, value);
+    }
   }
   return res;
 }

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -925,5 +925,86 @@ TEST_F(HiveConnectorTest, fileReadOpsTableIdentityPropagation) {
   ASSERT_EQ(captured.at(std::string(kTableNameKey)), "test_table");
 }
 
+/// Verifies that getRuntimeStats() merge logic allows IoStats (ReadFile-layer)
+/// to override the storageReadBytes value from IoStatistics (DWIO-level).
+TEST_F(HiveConnectorTest, ioStatsOverridesStorageReadBytes) {
+  // Step 1: Simulate DWIO-level IoStatistics with an inaccurate estimate.
+  auto ioStatistics = std::make_shared<io::IoStatistics>();
+  ioStatistics->read().increment(200); // DWIO estimate (undercounts gaps)
+
+  // Step 2: Simulate ReadFile-layer IoStats with ground-truth values.
+  IoStats ioStats;
+  ioStats.addCounter(
+      std::string(FileDataSource::kStorageReadBytes),
+      RuntimeCounter(50, RuntimeCounter::Unit::kBytes));
+  ioStats.addCounter(
+      "extentCacheHitBytes", RuntimeCounter(250, RuntimeCounter::Unit::kBytes));
+
+  // Replicate the merge logic from FileDataSource::getRuntimeStats().
+  std::unordered_map<std::string, RuntimeMetric> res;
+
+  // IoStatistics inserts first (Step 2 in getRuntimeStats).
+  res.insert(
+      {std::string(FileDataSource::kStorageReadBytes),
+       RuntimeMetric(
+           ioStatistics->read().sum(),
+           ioStatistics->read().count(),
+           ioStatistics->read().min(),
+           ioStatistics->read().max(),
+           RuntimeCounter::Unit::kBytes)});
+
+  // IoStats merge (Step 3 in getRuntimeStats) — override storageReadBytes.
+  const auto ioStatsMap = ioStats.stats();
+  for (const auto& [key, value] : ioStatsMap) {
+    if (key == FileDataSource::kStorageReadBytes) {
+      res[std::string(key)] = value;
+    } else {
+      res.emplace(key, value);
+    }
+  }
+
+  // Ground-truth storageReadBytes from IoStats should override DWIO estimate.
+  ASSERT_EQ(res.at("storageReadBytes").sum, 50);
+  ASSERT_EQ(res.at("storageReadBytes").unit, RuntimeCounter::Unit::kBytes);
+  // extentCacheHitBytes should be added as a new diagnostic counter.
+  ASSERT_EQ(res.at("extentCacheHitBytes").sum, 250);
+}
+
+/// Verifies that without IoStats override, storageReadBytes retains the
+/// IoStatistics value.
+TEST_F(HiveConnectorTest, storageReadBytesWithoutOverride) {
+  auto ioStatistics = std::make_shared<io::IoStatistics>();
+  ioStatistics->read().increment(200);
+
+  // IoStats has unrelated counters only — no storageReadBytes.
+  IoStats ioStats;
+  ioStats.addCounter(
+      "wsInRegionReadBytes", RuntimeCounter(300, RuntimeCounter::Unit::kBytes));
+
+  std::unordered_map<std::string, RuntimeMetric> res;
+  res.insert(
+      {std::string(FileDataSource::kStorageReadBytes),
+       RuntimeMetric(
+           ioStatistics->read().sum(),
+           ioStatistics->read().count(),
+           ioStatistics->read().min(),
+           ioStatistics->read().max(),
+           RuntimeCounter::Unit::kBytes)});
+
+  const auto ioStatsMap = ioStats.stats();
+  for (const auto& [key, value] : ioStatsMap) {
+    if (key == FileDataSource::kStorageReadBytes) {
+      res[std::string(key)] = value;
+    } else {
+      res.emplace(key, value);
+    }
+  }
+
+  // storageReadBytes should retain the IoStatistics value.
+  ASSERT_EQ(res.at("storageReadBytes").sum, 200);
+  // Unrelated IoStats counters should still be added.
+  ASSERT_EQ(res.at("wsInRegionReadBytes").sum, 300);
+}
+
 } // namespace
 } // namespace facebook::velox::connector::hive


### PR DESCRIPTION
Summary:
CONTEXT: When ReadFile implementations like Sally report ground-truth I/O
bytes via IoStats (D98526556), these values are more accurate than the DWIO-level
estimates from IoStatistics. The DWIO estimates can undercount bytes
(e.g. CachedBufferedInput excludes coalescing gap bytes). Previously,
IoStats entries could never override IoStatistics entries because
emplace() was used, which silently drops entries on key collision.

https://docs.google.com/document/d/1uhrqOlftXf-ZE5V0m51GhbNmCBBK2EPf1_qtIgi-FuQ/edit?usp=sharing

WHAT: In FileDataSource::getRuntimeStats(), if IoStats contains
storageReadBytes, use operator[] to override the DWIO-level estimate
instead of emplace()

Reviewed By: archang19

Differential Revision: D99694722


