### PR TITLE
fix: GetTimestampFunction recompiling datetime format on every row

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -435,6 +435,7 @@ struct GetTimestampFunction {
       } else {
         invalidFormat_ = true;
       }
+      isConstantTimeFormat_ = true;
     }
   }
 


### PR DESCRIPTION
Summary:
Fix performance bug where `GetTimestampFunction::initialize` failed to set `isConstantTimeFormat_ = true` after compiling a constant format string. This caused the formatter to be unnecessarily recompiled on every row in `call()`, resulting in orders-of-magnitude slowdown for `to_timestamp(input, format)` calls with constant formats.

Three companion functions (`UnixTimestampParseWithFormatFunction`, `UnixTimestampFunction`, `FromUnixtimeFunction`) correctly set this flag, confirming this was an oversight.

Differential Revision: D99626764


