### PR TITLE
refactor: Migrate folly symbolizer references from folly/experimental to folly/debugging in velox (#17040)

### DIFF
--- a/velox/common/process/StackTrace.cpp
+++ b/velox/common/process/StackTrace.cpp
@@ -30,12 +30,12 @@
 #include <fmt/format.h>
 #include <folly/Indestructible.h>
 #include <folly/String.h>
-#include <folly/experimental/symbolizer/StackTrace.h>
+#include <folly/debugging/symbolizer/StackTrace.h>
 
 #include "velox/common/process/ProcessBase.h"
 
 #ifdef __linux__
-#include <folly/experimental/symbolizer/Symbolizer.h> // @manual
+#include <folly/debugging/symbolizer/Symbolizer.h> // @manual
 #include <folly/fibers/FiberManager.h> // @manual
 #endif
 

--- a/velox/common/process/ThreadDebugInfo.cpp
+++ b/velox/common/process/ThreadDebugInfo.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/common/process/ThreadDebugInfo.h"
 
-#include <folly/experimental/symbolizer/SignalHandler.h>
+#include <folly/debugging/symbolizer/SignalHandler.h>
 #include <glog/logging.h>
 
 namespace facebook::velox::process {

--- a/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxExchangeTest.cpp
@@ -22,7 +22,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <folly/Executor.h>
-#include <folly/experimental/EventCount.h>
+#include <folly/synchronization/EventCount.h>
 #include <gtest/gtest-param-test.h>
 #include <gtest/gtest.h>
 #include <rmm/device_buffer.hpp>

--- a/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
+++ b/velox/experimental/ucx-exchange/tests/UcxOutputQueueManagerTest.cpp
@@ -19,7 +19,7 @@
 #include <cudf/table/table.hpp>
 #include <cudf/types.hpp>
 #include <folly/Executor.h>
-#include <folly/experimental/EventCount.h>
+#include <folly/synchronization/EventCount.h>
 #include <gtest/gtest.h>
 #include <rmm/device_buffer.hpp>
 #include <memory>


### PR DESCRIPTION
Summary:

Migrating symbolizer references from /experimental, because experimental headers are just shims to the standard headers.

Reviewed By: rexzhang123

Differential Revision: D99718627


