### PR TITLE
Add velox::BufferPool for reusing cached BufferPtr objects (#17041)

### DIFF
--- a/velox/buffer/BufferPool.cpp
+++ b/velox/buffer/BufferPool.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/buffer/BufferPool.h"
+
+namespace facebook::velox {
+
+BufferPtr BufferPool::get(uint64_t minBytes) {
+  for (size_t i = 0; i < buffers_.size(); ++i) {
+    if (buffers_[i]->capacity() >= minBytes) {
+      auto result = std::move(buffers_[i]);
+      buffers_[i] = std::move(buffers_.back());
+      buffers_.pop_back();
+      return result;
+    }
+  }
+  return nullptr;
+}
+
+BufferPtr BufferPool::get() {
+  if (buffers_.empty()) {
+    return nullptr;
+  }
+  auto result = std::move(buffers_.back());
+  buffers_.pop_back();
+  return result;
+}
+
+void BufferPool::release(BufferPtr buffer) {
+  if (buffer != nullptr && buffers_.size() < kMaxCached) {
+    buffers_.push_back(std::move(buffer));
+  }
+}
+
+size_t BufferPool::size() const {
+  return buffers_.size();
+}
+
+} // namespace facebook::velox

--- a/velox/buffer/BufferPool.h
+++ b/velox/buffer/BufferPool.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <vector>
+
+#include "velox/buffer/Buffer.h"
+
+namespace facebook::velox {
+
+/// Caches BufferPtr objects for reuse across encoding lifetimes.
+/// When encoding objects are destroyed, their scratch buffers can be returned
+/// to the pool instead of being freed. New encodings can then grab
+/// pre-allocated buffers from the pool, avoiding MemoryPool allocation
+/// overhead (including mutex contention).
+///
+/// Thread safety: NOT thread-safe. Intended for use within a single
+/// deserialization stream.
+class BufferPool {
+ public:
+  /// Returns a cached buffer with capacity >= minBytes, or nullptr if none
+  /// available.
+  BufferPtr get(uint64_t minBytes);
+
+  /// Returns a cached buffer (any size), or nullptr if none available.
+  BufferPtr get();
+
+  /// Returns a buffer to the pool for future reuse. Drops the buffer if the
+  /// pool is full or if 'buffer' is null.
+  void release(BufferPtr buffer);
+
+  size_t size() const;
+
+ private:
+  static constexpr size_t kMaxCached = 32;
+  std::vector<BufferPtr> buffers_;
+};
+
+} // namespace facebook::velox

--- a/velox/buffer/tests/BufferPoolTest.cpp
+++ b/velox/buffer/tests/BufferPoolTest.cpp
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/buffer/BufferPool.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::velox::test {
+
+class BufferPoolTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ = memory::memoryManager()->addRootPool("BufferPoolTest");
+    pool_ = rootPool_->addLeafChild("leaf");
+  }
+
+  std::shared_ptr<memory::MemoryPool> rootPool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(BufferPoolTest, emptyPool) {
+  BufferPool bufferPool;
+  EXPECT_EQ(bufferPool.size(), 0);
+  EXPECT_EQ(bufferPool.get(), nullptr);
+  EXPECT_EQ(bufferPool.get(100), nullptr);
+}
+
+TEST_F(BufferPoolTest, recycleAndGet) {
+  BufferPool bufferPool;
+  auto buffer = AlignedBuffer::allocate<char>(1'024, pool_.get());
+  auto* rawPtr = buffer.get();
+  const auto capacity = buffer->capacity();
+
+  bufferPool.release(std::move(buffer));
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  auto retrieved = bufferPool.get();
+  EXPECT_NE(retrieved, nullptr);
+  EXPECT_EQ(retrieved.get(), rawPtr);
+  EXPECT_EQ(retrieved->capacity(), capacity);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST_F(BufferPoolTest, getWithMinBytes) {
+  BufferPool bufferPool;
+
+  auto small = AlignedBuffer::allocate<char>(128, pool_.get());
+  auto large = AlignedBuffer::allocate<char>(4'096, pool_.get());
+  auto* largePtr = large.get();
+
+  bufferPool.release(std::move(small));
+  bufferPool.release(std::move(large));
+  EXPECT_EQ(bufferPool.size(), 2);
+
+  // Request minBytes that only the large buffer satisfies.
+  auto retrieved = bufferPool.get(1'024);
+  EXPECT_NE(retrieved, nullptr);
+  EXPECT_EQ(retrieved.get(), largePtr);
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  // The small buffer is still there.
+  auto remaining = bufferPool.get();
+  EXPECT_NE(remaining, nullptr);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST_F(BufferPoolTest, getWithMinBytesNoMatch) {
+  BufferPool bufferPool;
+
+  auto small = AlignedBuffer::allocate<char>(128, pool_.get());
+  bufferPool.release(std::move(small));
+
+  auto retrieved = bufferPool.get(1'000'000);
+  EXPECT_EQ(retrieved, nullptr);
+  EXPECT_EQ(bufferPool.size(), 1);
+}
+
+TEST_F(BufferPoolTest, recycleNullptr) {
+  BufferPool bufferPool;
+  bufferPool.release(nullptr);
+  EXPECT_EQ(bufferPool.size(), 0);
+}
+
+TEST_F(BufferPoolTest, maxCachedLimit) {
+  BufferPool bufferPool;
+
+  // Fill beyond the max cached limit.
+  for (size_t i = 0; i < 40; ++i) {
+    auto buffer = AlignedBuffer::allocate<char>(64, pool_.get());
+    bufferPool.release(std::move(buffer));
+  }
+
+  // Should be capped at 32.
+  EXPECT_EQ(bufferPool.size(), 32);
+}
+
+TEST_F(BufferPoolTest, multipleRecycleAndGet) {
+  BufferPool bufferPool;
+
+  for (int i = 0; i < 5; ++i) {
+    auto buffer = AlignedBuffer::allocate<char>((i + 1) * 256, pool_.get());
+    bufferPool.release(std::move(buffer));
+  }
+  EXPECT_EQ(bufferPool.size(), 5);
+
+  // Get all back out.
+  for (int i = 0; i < 5; ++i) {
+    auto retrieved = bufferPool.get();
+    EXPECT_NE(retrieved, nullptr);
+  }
+  EXPECT_EQ(bufferPool.size(), 0);
+  EXPECT_EQ(bufferPool.get(), nullptr);
+}
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:

Port nimble::BufferPool into velox/buffer/ as a shared utility. BufferPool
caches velox::BufferPtr objects for reuse, avoiding MemoryPool allocation
overhead including mutex contention. Changes from the nimble version:

- Namespace: facebook::velox
- Configurable max pool size via constructor (default 32)
- Added clear() method to release all cached buffers
- Public kDefaultMaxPoolSize constant

Differential Revision: D99721888


