### PR TITLE
fix: Remove per-query timeout in TableEvolutionFuzzer

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzer.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzer.cpp
@@ -271,10 +271,9 @@ std::vector<std::vector<RowVectorPtr>> runTaskCursors(
     });
   }
   std::vector<std::vector<RowVectorPtr>> results;
-  constexpr std::chrono::seconds kTaskTimeout(10);
   results.reserve(futures.size());
   for (auto& future : futures) {
-    results.push_back(std::move(future).get(kTaskTimeout));
+    results.push_back(std::move(future).get());
   }
   return results;
 }


### PR DESCRIPTION
Summary:
`runTaskCursors()` had a hardcoded 10-second timeout (`kTaskTimeout`) on
`folly::SemiFuture::get()`. Under CI resource contention (4 parallel
instances on a 4-core runner), queries routinely exceeded this threshold,
causing `FutureTimeout` ("Timed out") followed by a "pure virtual method
called" crash during abnormal teardown.

No other Velox fuzzer uses a per-query timeout — they all block
indefinitely on cursor reads, relying on `--duration_sec` and CI job
timeouts as safety nets. For example:
- `ExchangeFuzzer.cpp:209`: `while (cursor->moveNext())` — no timeout
- `WriterFuzzer.cpp:873`: `.copyResults(pool_.get())` — no timeout
- `JoinFuzzer.cpp:417`: `.copyResults(pool_.get())` — no timeout

This aligns the Table Evolution Fuzzer with the standard pattern.

Fixes https://github.com/facebookincubator/velox/issues/17044

Differential Revision: D99753937


