### PR TITLE
feat(hive): Add runtime metrics to index lookup join pipeline

### DIFF
--- a/velox/connectors/hive/FileIndexReader.cpp
+++ b/velox/connectors/hive/FileIndexReader.cpp
@@ -317,6 +317,8 @@ void FileIndexReader::startLookup(
   VELOX_CHECK_NOT_NULL(request.input);
   VELOX_CHECK(requestType_->equivalent(*request.input->type()));
 
+  ++numIndexLookupRequests_;
+
   // Use caller-provided maxRowsPerRequest if set, otherwise fall back to
   // the construction-time default.
   const auto maxRows = options.maxRowsPerRequest != 0
@@ -412,13 +414,25 @@ bool FileIndexReader::hasNext() {
 
 std::unique_ptr<FileIndexReader::Result> FileIndexReader::next(
     vector_size_t maxOutputRows) {
-  return indexReader_->next(maxOutputRows);
+  auto result = indexReader_->next(maxOutputRows);
+  if (result != nullptr) {
+    numIndexOutputRows_ += result->size();
+  }
+  return result;
 }
 
 std::unordered_map<std::string, RuntimeMetric> FileIndexReader::runtimeStats() {
-  // TODO: Populate with format-specific stats in a follow-up.
-  // File-based IO stats are tracked externally via IoStatistics.
-  return {};
+  std::unordered_map<std::string, RuntimeMetric> stats;
+  if (numIndexLookupRequests_ != 0) {
+    stats[std::string(kNumFileIndexLookupRequests)] = RuntimeMetric(
+        static_cast<int64_t>(numIndexLookupRequests_),
+        RuntimeCounter::Unit::kNone);
+  }
+  if (numIndexOutputRows_ != 0) {
+    stats[std::string(kNumFileIndexOutputRows)] = RuntimeMetric(
+        static_cast<int64_t>(numIndexOutputRows_), RuntimeCounter::Unit::kNone);
+  }
+  return stats;
 }
 
 std::string FileIndexReader::toString() const {

--- a/velox/connectors/hive/FileIndexReader.h
+++ b/velox/connectors/hive/FileIndexReader.h
@@ -92,6 +92,13 @@ class FileIndexReader : public SplitIndexReader {
 
   std::string toString() const;
 
+  /// The number of startLookup() calls made to the format-specific IndexReader.
+  static constexpr std::string_view kNumFileIndexLookupRequests{
+      "numFileIndexLookupRequests"};
+  /// The total number of output rows returned across all next() calls.
+  static constexpr std::string_view kNumFileIndexOutputRows{
+      "numFileIndexOutputRows"};
+
  private:
   // Creates the file reader for reading file metadata and schema.
   std::unique_ptr<dwio::common::Reader> createFileReader();
@@ -148,6 +155,10 @@ class FileIndexReader : public SplitIndexReader {
   // Reusable column vectors for building index bounds.
   std::vector<VectorPtr> lowerBoundColumns_;
   std::vector<VectorPtr> upperBoundColumns_;
+
+  // Performance counters for runtime stats.
+  uint64_t numIndexLookupRequests_{0};
+  uint64_t numIndexOutputRows_{0};
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveIndexSource.cpp
+++ b/velox/connectors/hive/HiveIndexSource.cpp
@@ -17,6 +17,7 @@
 
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/time/Timer.h"
+#include "velox/connectors/hive/FileDataSource.h"
 #include "velox/connectors/hive/FileIndexReader.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorUtil.h"
@@ -456,17 +457,29 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
       return nullptr;
     }
 
+    IterationStats iterationStats;
+    std::optional<std::unique_ptr<IndexSource::Result>> result;
+
     // Initialize lookup on first call.
     if (state_ == State::kInit) {
-      indexReader_->startLookup(request_, options_);
+      {
+        NanosecondTimer timer(&iterationStats.lookupTimeNs);
+        indexReader_->startLookup(request_, options_);
+      }
       setState(State::kRead);
     }
 
     if (!indexReader_->hasNext()) {
       setState(State::kEnd);
+    } else {
+      result = getOutput(size, iterationStats);
+    }
+
+    indexSource_->recordIterationStats(iterationStats);
+    if (state_ == State::kEnd && !result.has_value()) {
       return nullptr;
     }
-    return getOutput(size);
+    return result;
   }
 
  private:
@@ -523,25 +536,37 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
     }
   }
 
-  std::unique_ptr<IndexSource::Result> getOutput(vector_size_t size) {
-    auto result = indexReader_->next(size);
+  std::unique_ptr<IndexSource::Result> getOutput(
+      vector_size_t size,
+      IterationStats& iterationStats) {
+    std::unique_ptr<IndexSource::Result> result;
+    {
+      NanosecondTimer timer(&iterationStats.nextTimeNs);
+      result = indexReader_->next(size);
+    }
     if (result == nullptr) {
       VELOX_CHECK(!indexReader_->hasNext());
       setState(State::kEnd);
       return nullptr;
     }
     if (indexSource_->remainingFilterExprSet_ == nullptr) {
+      CpuWallTimer timer(iterationStats.outputTiming);
       result->output = indexSource_->projectOutput(
           result->output->size(), nullptr, result->output);
       return result;
     }
-    return evaluateRemainingFilter(std::move(result));
+    return evaluateRemainingFilter(std::move(result), iterationStats);
   }
 
   std::unique_ptr<IndexSource::Result> evaluateRemainingFilter(
-      std::unique_ptr<IndexSource::Result> result) {
+      std::unique_ptr<IndexSource::Result> result,
+      IterationStats& iterationStats) {
     auto& output = result->output;
-    const auto numRemainingRows = indexSource_->evaluateRemainingFilter(output);
+    vector_size_t numRemainingRows;
+    {
+      NanosecondTimer timer(&iterationStats.postFilterTimeNs);
+      numRemainingRows = indexSource_->evaluateRemainingFilter(output);
+    }
 
     if (numRemainingRows == 0) {
       return getEmptyResult();
@@ -556,8 +581,11 @@ class HiveLookupIterator : public IndexSource::ResultIterator {
           result->inputHits,
           indexSource_->pool_);
     }
-    output =
-        indexSource_->projectOutput(numRemainingRows, remainingIndices, output);
+    {
+      CpuWallTimer timer(iterationStats.outputTiming);
+      output = indexSource_->projectOutput(
+          numRemainingRows, remainingIndices, output);
+    }
     return result;
   }
 
@@ -909,11 +937,14 @@ HiveIndexSource::createUnionLookupIterator(
 }
 
 std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
-  std::unordered_map<std::string, RuntimeMetric> stats;
+  // Start with accumulated per-call timing stats.
+  auto stats = runtimeStats_;
+
   if (remainingFilterTimeNs_ != 0) {
     stats[std::string(Connector::kTotalRemainingFilterTime)] =
         RuntimeMetric(remainingFilterTimeNs_, RuntimeCounter::Unit::kNanos);
   }
+
   // Merge stats from all readers.
   for (auto& reader : readers_) {
     for (auto& [key, metric] : reader->runtimeStats()) {
@@ -925,7 +956,85 @@ std::unordered_map<std::string, RuntimeMetric> HiveIndexSource::runtimeStats() {
       }
     }
   }
+  // Add I/O stats from ioStatistics_ (storage read, ram cache, ssd cache).
+  if (ioStatistics_) {
+    if (ioStatistics_->read().count() > 0) {
+      stats[std::string(FileDataSource::kStorageReadBytes)] = RuntimeMetric(
+          ioStatistics_->read().sum(),
+          ioStatistics_->read().count(),
+          ioStatistics_->read().min(),
+          ioStatistics_->read().max(),
+          RuntimeCounter::Unit::kBytes);
+    }
+    if (ioStatistics_->ramHit().count() > 0) {
+      stats[std::string(FileDataSource::kNumRamRead)] =
+          RuntimeMetric(ioStatistics_->ramHit().count());
+      stats[std::string(FileDataSource::kRamReadBytes)] = RuntimeMetric(
+          ioStatistics_->ramHit().sum(),
+          ioStatistics_->ramHit().count(),
+          ioStatistics_->ramHit().min(),
+          ioStatistics_->ramHit().max(),
+          RuntimeCounter::Unit::kBytes);
+    }
+    if (ioStatistics_->ssdRead().count() > 0) {
+      stats[std::string(FileDataSource::kNumLocalRead)] =
+          RuntimeMetric(ioStatistics_->ssdRead().count());
+      stats[std::string(FileDataSource::kLocalReadBytes)] = RuntimeMetric(
+          ioStatistics_->ssdRead().sum(),
+          ioStatistics_->ssdRead().count(),
+          ioStatistics_->ssdRead().min(),
+          ioStatistics_->ssdRead().max(),
+          RuntimeCounter::Unit::kBytes);
+    }
+  }
+
   return stats;
+}
+
+void HiveIndexSource::recordIterationStats(
+    const IterationStats& iterationStats) {
+  const auto totalTimeNs = iterationStats.lookupTimeNs +
+      iterationStats.nextTimeNs + iterationStats.outputTiming.wallNanos +
+      iterationStats.postFilterTimeNs;
+  if (totalTimeNs != 0) {
+    exec::addOperatorRuntimeStats(
+        std::string_view("connectorLookupWallNanos"),
+        RuntimeCounter(
+            static_cast<int64_t>(totalTimeNs), RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.lookupTimeNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kIndexSetupWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.lookupTimeNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.nextTimeNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kIndexReadWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.nextTimeNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.outputTiming.cpuNanos != 0) {
+    exec::addOperatorRuntimeStats(
+        std::string_view("connectorResultPrepareCpuNanos"),
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.outputTiming.cpuNanos),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
+  if (iterationStats.postFilterTimeNs != 0) {
+    exec::addOperatorRuntimeStats(
+        IterationStats::kPostFilterWallNanos,
+        RuntimeCounter(
+            static_cast<int64_t>(iterationStats.postFilterTimeNs),
+            RuntimeCounter::Unit::kNanos),
+        runtimeStats_);
+  }
 }
 
 vector_size_t HiveIndexSource::evaluateRemainingFilter(

--- a/velox/connectors/hive/HiveIndexSource.h
+++ b/velox/connectors/hive/HiveIndexSource.h
@@ -18,6 +18,7 @@
 #include <folly/Executor.h>
 #include <folly/container/F14Map.h>
 #include "velox/common/io/IoStatistics.h"
+#include "velox/common/time/CpuWallTimer.h"
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
@@ -32,6 +33,30 @@
 namespace facebook::velox::connector::hive {
 
 class HiveConfig;
+
+/// Captures per-iteration timing breakdown for index lookups. Each field is
+/// reported as a separate runtime stat in addition to the aggregate
+/// connectorLookupWallNanos.
+struct IterationStats {
+  /// Wall time spent in indexReader_->startLookup() for this iteration.
+  uint64_t lookupTimeNs{0};
+  /// Wall time spent in indexReader_->next() for this iteration.
+  uint64_t nextTimeNs{0};
+  /// Time spent projecting the output columns for this iteration. Uses
+  /// CpuWallTiming to capture both wall and CPU time, since the downstream stat
+  /// (kConnectorResultPrepareTime) reports CPU nanos.
+  CpuWallTiming outputTiming;
+  /// Wall time spent evaluating the remaining filter for this iteration.
+  uint64_t postFilterTimeNs{0};
+
+  /// Per-phase stat names reported by HiveIndexSource::recordIterationStats().
+  static constexpr std::string_view kIndexSetupWallNanos{
+      "connectorIndexSetupWallNanos"};
+  static constexpr std::string_view kIndexReadWallNanos{
+      "connectorIndexReadWallNanos"};
+  static constexpr std::string_view kPostFilterWallNanos{
+      "connectorPostFilterWallNanos"};
+};
 
 /// Provides index lookup for Hive-metastore-backed tables.
 ///
@@ -125,6 +150,10 @@ class HiveIndexSource : public IndexSource,
   // Creates a FileIndexReader for a single split.
   void createFileIndexReader(std::shared_ptr<const HiveConnectorSplit> split);
 
+  // Records per-iteration timing breakdown using addOperatorRuntimeStats to
+  // preserve per-call count/min/max granularity.
+  void recordIterationStats(const IterationStats& iterationStats);
+
   FileHandleFactory* const fileHandleFactory_;
   ConnectorQueryCtx* const connectorQueryCtx_;
   const std::shared_ptr<HiveConfig> hiveConfig_;
@@ -183,6 +212,9 @@ class HiveIndexSource : public IndexSource,
 
   std::shared_ptr<io::IoStatistics> ioStatistics_;
   std::shared_ptr<IoStats> ioStats_;
+
+  // Per-call timing stats accumulated via addOperatorRuntimeStats().
+  std::unordered_map<std::string, RuntimeMetric> runtimeStats_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/docs/monitoring/stats.rst
+++ b/velox/docs/monitoring/stats.rst
@@ -197,6 +197,9 @@ These stats are reported only by IndexLookupJoin operator
    * - clientNumLazyDecodedResultBatches
      -
      - The number of lazy decoded result batches returned from the storage client.
+   * - numIndexSplits
+     -
+     - The number of index splits provided for index lookup.
 
 Merge
 -----
@@ -408,6 +411,19 @@ These stats are reported only by connector data or index sources.
        read. When filters are present, overlapping request ranges are split at
        boundaries to enable per-request output tracking. Without filters,
        overlapping ranges are merged to minimize I/O.
+   * - numIndexStripeTotalRows
+     -
+     - The total number of rows in all loaded stripes during index lookup.
+       Measures the full stripe row count regardless of how many rows are
+       actually needed. Comparing with numIndexMatchedRows shows cluster
+       index selectivity within stripes.
+   * - numIndexMatchedRows
+     -
+     - The total number of rows matched by the cluster index across all
+       stripes during index lookup. These are the rows identified as matching
+       the lookup bounds within each stripe, before any ScanSpec filter
+       pushdown. Comparing with numFileIndexOutputRows shows filter
+       selectivity.
 
 FileBasedDataSource
 -------------------

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -227,6 +227,20 @@ class IndexReader {
   static constexpr std::string_view kNumIndexLookupReadSegments =
       "numIndexLookupReadSegments";
 
+  /// Tracks the total number of rows in all loaded stripes. Measures the full
+  /// stripe row count regardless of how many rows are actually needed by
+  /// index lookups. Comparing with kNumIndexMatchedRows shows cluster index
+  /// selectivity within stripes.
+  static constexpr std::string_view kNumIndexStripeTotalRows =
+      "numIndexStripeTotalRows";
+
+  /// Tracks the total number of rows matched by the cluster index across all
+  /// stripes. These are the rows identified as matching the lookup bounds
+  /// within each stripe, before any ScanSpec filter pushdown. Comparing with
+  /// actual output rows shows filter selectivity.
+  static constexpr std::string_view kNumIndexMatchedRows =
+      "numIndexMatchedRows";
+
   virtual ~IndexReader() = default;
 
   /// Options for controlling index reader behavior.

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -669,6 +669,14 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
     if (!split.hasConnectorSplit()) {
       noMoreIndexSplits_ = true;
       VELOX_CHECK(!indexSplits_.empty());
+      {
+        auto lockedStats = stats_.wlock();
+        lockedStats->addRuntimeStat(
+            kNumIndexSplits,
+            RuntimeCounter(
+                static_cast<int64_t>(indexSplits_.size()),
+                RuntimeCounter::Unit::kNone));
+      }
       indexSource_->addSplits(std::move(indexSplits_));
       return true;
     }

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -81,6 +81,8 @@ class IndexLookupJoin : public Operator {
   /// The number of lookup results received from remote storage with error.
   static constexpr std::string_view kClientNumErrorResults{
       "clientNumErrorResults"};
+  /// The number of index splits provided for index lookup.
+  static constexpr std::string_view kNumIndexSplits{"numIndexSplits"};
 
  private:
   using ResultIterator = connector::IndexSource::ResultIterator;


### PR DESCRIPTION
Summary:
Add performance metrics and I/O counters across the index lookup
pipeline to enable bottleneck analysis and selectivity monitoring.

IndexLookupJoin operator:
- numIndexSplits: split count

HiveIndexSource connector:
- connectorLookupWallTime: end-to-end iteration wall time
- connectorResultPrepareTime: output projection CPU time
- connectorIndexSetupWallNanos: startLookup() wall time
- connectorIndexReadWallNanos: next() data read wall time
- connectorPostFilterWallNanos: remaining filter wall time
- storageReadBytes/ramReadBytes/localReadBytes: cache stats

FileIndexReader:
- numFileIndexLookupRequests: startLookup() call count
- numFileIndexOutputRows: total output rows from next()

IndexReader (SelectiveNimbleIndexReader):
- numIndexStripeTotalRows: total rows in loaded stripes
- numIndexMatchedRows: rows matched by cluster index

Nimble-level timing (wall + CPU time for I/O-heavy phases):
- nimbleIndexStripeLoadWallNanos/CpuNanos: stripe loading
- nimbleIndexDataReadWallNanos/CpuNanos: data chunk reading
- nimbleIndexChunkLoadWallNanos/CpuNanos: index chunk I/O + decode
- nimbleIndexChunkCacheHits: index chunk cache hit count
- nimbleIndexNumSeeks: index seekAtOrAfter call count
- nimbleIndexDataChunkLoads: data chunk load count

Differential Revision: D99739876


