### PR TITLE
perf(decimal): Add helper for extracting decimal components efficiently

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -463,15 +463,17 @@ VectorPtr CastExpr::applyDecimalToIntegralCast(
   const auto scaleFactor = DecimalUtil::kPowersOfTen[precisionScale.second];
   if (hooks_->truncate()) {
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-      resultBuffer[row] =
-          static_cast<To>(simpleInput->valueAt(row) / scaleFactor);
+      auto value = simpleInput->valueAt(row);
+      auto integralPart =
+          DecimalUtil::getDecimalParts(value, precisionScale.second).first;
+      resultBuffer[row] = static_cast<To>(integralPart);
     });
   } else {
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
       auto value = simpleInput->valueAt(row);
-      auto integralPart = value / scaleFactor;
+      auto [integralPart, fractionPart] =
+          DecimalUtil::getDecimalParts(value, precisionScale.second);
       if (hooks_->getPolicy() != SparkTryCastPolicy) {
-        auto fractionPart = value % scaleFactor;
         auto sign = value >= 0 ? 1 : -1;
         bool needsRoundUp =
             (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -469,15 +469,17 @@ VectorPtr CastExpr::applyDecimalToIntegralCast(
   const auto scaleFactor = DecimalUtil::kPowersOfTen[precisionScale.second];
   if (hooks_->truncate()) {
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
-      resultBuffer[row] =
-          static_cast<To>(simpleInput->valueAt(row) / scaleFactor);
+      auto value = simpleInput->valueAt(row);
+      auto integralPart =
+          DecimalUtil::getDecimalParts(value, precisionScale.second).first;
+      resultBuffer[row] = static_cast<To>(integralPart);
     });
   } else {
     applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
       auto value = simpleInput->valueAt(row);
-      auto integralPart = value / scaleFactor;
+      auto [integralPart, fractionPart] =
+          DecimalUtil::getDecimalParts(value, precisionScale.second);
       if (hooks_->getPolicy() != SparkTryCastPolicy) {
-        auto fractionPart = value % scaleFactor;
         auto sign = value >= 0 ? 1 : -1;
         bool needsRoundUp =
             (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -89,6 +89,21 @@ class DecimalUtil {
   static constexpr uint64_t kInt64Mask = ~(static_cast<uint64_t>(1) << 63);
   static constexpr uint128_t kInt128Mask = (static_cast<uint128_t>(1) << 127);
 
+  /// @brief Return the integral and decimal parts of an unscaled decimal.
+  /// @tparam T The type of input value.
+  /// @param value The input unscaled value.
+  /// @param scale The scale of the decimal.
+  /// @return A std::pair<T,T> with the integral and decimal components.
+  template <typename T>
+  inline static std::pair<T, T> getDecimalParts(T value, uint8_t scale) {
+    if (scale < std::size(kPowersOfTen)) {
+      constexpr auto lookup = getDivisorTable<T>(
+          std::make_index_sequence<std::size(kPowersOfTen)>());
+      return lookup[scale](value);
+    }
+    VELOX_UNREACHABLE("Attempted to get decimal parts using invalid scale");
+  }
+
   FOLLY_ALWAYS_INLINE static void valueInRange(int128_t value) {
     VELOX_USER_CHECK(
         (value >= kLongDecimalMin && value <= kLongDecimalMax),
@@ -413,10 +428,10 @@ class DecimalUtil {
           return writePosition - startPosition;
         }
       }
-      auto [position, errorCode] = std::to_chars(
-          writePosition,
-          writePosition + maxSize,
-          unscaledValue / DecimalUtil::kPowersOfTen[scale]);
+      auto [integral, fraction] = getDecimalParts(unscaledValue, scale);
+      auto [position, errorCode] =
+          std::to_chars(writePosition, writePosition + maxSize, integral);
+
       VELOX_DCHECK_EQ(
           errorCode,
           std::errc(),
@@ -426,7 +441,6 @@ class DecimalUtil {
 
       if (scale > 0) {
         *writePosition++ = '.';
-        uint128_t fraction = unscaledValue % DecimalUtil::kPowersOfTen[scale];
         // Append leading zeros.
         int numLeadingZeros = std::max(scale - countDigits(fraction), 0);
         std::memset(writePosition, '0', numLeadingZeros);
@@ -612,5 +626,23 @@ class DecimalUtil {
       int32_t& parsedPrecision,
       int32_t& parsedScale,
       int128_t& out);
+
+  // Divide value by 10^Scale, returning the quotient and remainder.
+  // Scale is kept as a template parameter here because it makes the divisor
+  // constant, which lets the compiler apply strength reduction.
+  template <uint8_t Scale, typename T>
+  inline static std::pair<T, T> getDecimalParts(T value) {
+    static_assert(
+        Scale >= 0 && Scale <= std::size(kPowersOfTen),
+        "Decimal scale out of range.");
+    auto integralPart = value / kPowersOfTen[Scale];
+    auto fractionalPart = value % kPowersOfTen[Scale];
+    return {integralPart, fractionalPart};
+  }
+
+  template <typename T, std::size_t... Is>
+  inline constexpr static auto getDivisorTable(std::index_sequence<Is...>) {
+    return std::array{&getDecimalParts<Is, T>...};
+  }
 }; // DecimalUtil
 } // namespace facebook::velox

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -89,6 +89,21 @@ class DecimalUtil {
   static constexpr uint64_t kInt64Mask = ~(static_cast<uint64_t>(1) << 63);
   static constexpr uint128_t kInt128Mask = (static_cast<uint128_t>(1) << 127);
 
+  /// @brief Return the integral and decimal parts of an unscaled decimal.
+  /// @tparam T The type of input value.
+  /// @param value The input unscaled value.
+  /// @param scale The scale of the decimal.
+  /// @return A std::pair<T,T> with the integral and decimal components.
+  template <typename T>
+  inline static std::pair<T, T> getDecimalParts(T value, uint8_t scale) {
+    if (scale < std::size(kPowersOfTen)) {
+      constexpr auto lookup = getDivisorTable<T>(
+          std::make_index_sequence<std::size(kPowersOfTen)>());
+      return lookup[scale](value);
+    }
+    VELOX_UNREACHABLE("Attempted to get decimal parts using invalid scale");
+  }
+
   FOLLY_ALWAYS_INLINE static void valueInRange(int128_t value) {
     VELOX_USER_CHECK(
         (value >= kLongDecimalMin && value <= kLongDecimalMax),
@@ -424,10 +439,10 @@ class DecimalUtil {
           return writePosition - startPosition;
         }
       }
-      auto [position, errorCode] = std::to_chars(
-          writePosition,
-          writePosition + maxSize,
-          unscaledValue / DecimalUtil::kPowersOfTen[scale]);
+      auto [integral, fraction] = getDecimalParts(unscaledValue, scale);
+      auto [position, errorCode] =
+          std::to_chars(writePosition, writePosition + maxSize, integral);
+
       VELOX_DCHECK_EQ(
           errorCode,
           std::errc(),
@@ -437,7 +452,6 @@ class DecimalUtil {
 
       if (scale > 0) {
         *writePosition++ = '.';
-        uint128_t fraction = unscaledValue % DecimalUtil::kPowersOfTen[scale];
         // Append leading zeros.
         int numLeadingZeros = std::max(scale - countDigits(fraction), 0);
         std::memset(writePosition, '0', numLeadingZeros);
@@ -623,5 +637,23 @@ class DecimalUtil {
       int32_t& parsedPrecision,
       int32_t& parsedScale,
       int128_t& out);
+
+  // Divide value by 10^Scale, returning the quotient and remainder.
+  // Scale is kept as a template parameter here because it makes the divisor
+  // constant, which lets the compiler apply strength reduction.
+  template <uint8_t Scale, typename T>
+  inline static std::pair<T, T> getDecimalParts(T value) {
+    static_assert(
+        Scale >= 0 && Scale <= std::size(kPowersOfTen),
+        "Decimal scale out of range.");
+    auto integralPart = value / kPowersOfTen[Scale];
+    auto fractionalPart = value % kPowersOfTen[Scale];
+    return {integralPart, fractionalPart};
+  }
+
+  template <typename T, std::size_t... Is>
+  inline constexpr static auto getDivisorTable(std::index_sequence<Is...>) {
+    return std::array{&getDecimalParts<Is, T>...};
+  }
 }; // DecimalUtil
 } // namespace facebook::velox


### PR DESCRIPTION
Move the logic for extracting integral and fractional parts from decimals to its own function where the scale divisors are constants.
This lets the compiler reduce the division to a more efficient multiplication plus a shift. libstdc++ does this for `std::to_chars` with base 10, and the same can be done here since the decimal scales are known in advance.

This improves the performance of the decimal cast benchmarks like cast_decimal_as_bigint and cast_decimal_to_inline_string.

Copy of #15519 which went stale.