### PR TITLE
feat: Support row group skip for Parquet decimal

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -266,7 +266,8 @@ bool testFilters(
         partitionKeys,
     const std::unordered_map<std::string, FileColumnHandlePtr>&
         partitionKeysHandle,
-    bool asLocalTime) {
+    bool asLocalTime,
+    dwio::common::FileFormat fileFormat) {
   const auto totalRows = reader->numberOfRows();
   const auto& fileTypeWithId = reader->typeWithId();
   const auto& rowType = reader->rowType();
@@ -307,7 +308,8 @@ bool testFilters(
                 child->filter(),
                 columnStats.get(),
                 totalRows.value(),
-                typeWithId->type())) {
+                typeWithId->type(),
+                fileFormat)) {
           VLOG(1) << "Skipping " << filePath
                   << " based on stats and filter for column "
                   << child->fieldName();

--- a/velox/connectors/hive/FileConnectorUtil.h
+++ b/velox/connectors/hive/FileConnectorUtil.h
@@ -75,6 +75,7 @@ bool testFilters(
         partitionKey,
     const std::unordered_map<std::string, FileColumnHandlePtr>&
         partitionKeysHandle,
-    bool asLocalTime);
+    bool asLocalTime,
+    dwio::common::FileFormat fileFormat);
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -348,7 +348,8 @@ bool FileSplitReader::filterOnStats(
           fileSplit_->partitionKeys,
           *partitionKeys_,
           fileConfig_->readTimestampPartitionValueAsLocalTime(
-              connectorQueryCtx_->sessionProperties()))) {
+              connectorQueryCtx_->sessionProperties()),
+          fileSplit_->fileFormat)) {
     ++runtimeStats.processedSplits;
     return true;
   }

--- a/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/EqualityDeleteFileReader.cpp
@@ -217,7 +217,8 @@ EqualityDeleteFileReader::EqualityDeleteFileReader(
           deleteSplit->partitionKeys,
           {},
           fileConfig->readTimestampPartitionValueAsLocalTime(
-              connectorQueryCtx->sessionProperties()))) {
+              connectorQueryCtx->sessionProperties()),
+          deleteSplit->fileFormat)) {
     runtimeStats.skippedSplitBytes += static_cast<int64_t>(deleteSplit->length);
     return;
   }

--- a/velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDwrfStatsCollector.cpp
@@ -263,7 +263,7 @@ void setBounds(
     int32_t truncateLength,
     IcebergDataFileStatistics::ColumnStats& out) {
   if (const auto* intStats =
-          dynamic_cast<const dwio::common::IntegerColumnStatistics*>(
+          dynamic_cast<const dwio::common::IntegerColumnStatistics<int64_t>*>(
               &columnStatistics)) {
     const auto min = intStats->getMinimum();
     const auto max = intStats->getMaximum();

--- a/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
+++ b/velox/connectors/hive/iceberg/PositionalDeleteFileReader.cpp
@@ -120,7 +120,8 @@ PositionalDeleteFileReader::PositionalDeleteFileReader(
           deleteSplit_->partitionKeys,
           {},
           fileConfig_->readTimestampPartitionValueAsLocalTime(
-              connectorQueryCtx_->sessionProperties()))) {
+              connectorQueryCtx_->sessionProperties()),
+          deleteSplit_->fileFormat)) {
     // We only count the number of base splits skipped as skippedSplits runtime
     // statistics in Velox.  Skipped delta split is only counted as skipped
     // bytes.

--- a/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
+++ b/velox/connectors/hive/tests/FileConnectorUtilTest.cpp
@@ -389,7 +389,8 @@ TEST_F(FileConnectorUtilTest, testFiltersNoFilters) {
           filePath,
           /*partitionKey=*/{},
           /*partitionKeysHandle=*/{},
-          /*asLocalTime=*/false));
+          /*asLocalTime=*/false,
+          dwio::common::FileFormat::DWRF));
 }
 
 TEST_F(FileConnectorUtilTest, testFiltersPartitionKeyPasses) {
@@ -427,7 +428,8 @@ TEST_F(FileConnectorUtilTest, testFiltersPartitionKeyPasses) {
           filePath,
           partitionKeys,
           partitionKeysHandle,
-          /*asLocalTime=*/false));
+          /*asLocalTime=*/false,
+          dwio::common::FileFormat::DWRF));
 }
 
 TEST_F(FileConnectorUtilTest, testFiltersPartitionKeyFails) {
@@ -465,7 +467,8 @@ TEST_F(FileConnectorUtilTest, testFiltersPartitionKeyFails) {
           filePath,
           partitionKeys,
           partitionKeysHandle,
-          /*asLocalTime=*/false));
+          /*asLocalTime=*/false,
+          dwio::common::FileFormat::DWRF));
 }
 
 TEST_F(FileConnectorUtilTest, testFiltersNullPartitionKeyRejectsNotNull) {
@@ -503,7 +506,8 @@ TEST_F(FileConnectorUtilTest, testFiltersNullPartitionKeyRejectsNotNull) {
           filePath,
           partitionKeys,
           partitionKeysHandle,
-          /*asLocalTime=*/false));
+          /*asLocalTime=*/false,
+          dwio::common::FileFormat::DWRF));
 }
 
 TEST_F(FileConnectorUtilTest, testFiltersIntegerPartitionKey) {
@@ -537,7 +541,8 @@ TEST_F(FileConnectorUtilTest, testFiltersIntegerPartitionKey) {
             filePath,
             partitionKeys,
             partitionKeysHandle,
-            /*asLocalTime=*/false));
+            /*asLocalTime=*/false,
+            dwio::common::FileFormat::DWRF));
   }
 
   // Non-matching partition value.
@@ -559,7 +564,8 @@ TEST_F(FileConnectorUtilTest, testFiltersIntegerPartitionKey) {
             filePath,
             partitionKeys,
             partitionKeysHandle,
-            /*asLocalTime=*/false));
+            /*asLocalTime=*/false,
+            dwio::common::FileFormat::DWRF));
   }
 }
 
@@ -588,7 +594,8 @@ TEST_F(FileConnectorUtilTest, testFiltersMissingColumn) {
           filePath,
           /*partitionKey=*/{},
           /*partitionKeysHandle=*/{},
-          /*asLocalTime=*/false));
+          /*asLocalTime=*/false,
+          dwio::common::FileFormat::DWRF));
 }
 
 } // namespace facebook::velox::connector

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/common/ScanSpec.h"
 
 #include "velox/core/Expressions.h"
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Statistics.h"
 
 namespace facebook::velox::common {
@@ -218,9 +219,13 @@ void ScanSpec::moveAdaptationFrom(ScanSpec& other) {
 }
 
 namespace {
+
+// Test the filter against integer column statistics. T could be int64_t or
+// int128_t.
+template <typename T>
 bool testIntFilter(
     const common::Filter* filter,
-    dwio::common::IntegerColumnStatistics* intStats,
+    dwio::common::IntegerColumnStatistics<T>* intStats,
     bool mayHaveNull) {
   if (!intStats) {
     return true;
@@ -228,26 +233,32 @@ bool testIntFilter(
 
   if (intStats->getMinimum().has_value() &&
       intStats->getMaximum().has_value()) {
-    return filter->testInt64Range(
-        intStats->getMinimum().value(),
-        intStats->getMaximum().value(),
-        mayHaveNull);
+    const auto minValue = intStats->getMinimum().value();
+    const auto maxValue = intStats->getMaximum().value();
+    if constexpr (std::is_same_v<T, int64_t>) {
+      return filter->testInt64Range(minValue, maxValue, mayHaveNull);
+    }
+    return filter->testInt128Range(minValue, maxValue, mayHaveNull);
   }
 
   // only min value
   if (intStats->getMinimum().has_value()) {
-    return filter->testInt64Range(
-        intStats->getMinimum().value(),
-        std::numeric_limits<int64_t>::max(),
-        mayHaveNull);
+    const auto minValue = intStats->getMinimum().value();
+    const auto maxValue = std::numeric_limits<int64_t>::max();
+    if constexpr (std::is_same_v<T, int64_t>) {
+      return filter->testInt64Range(minValue, maxValue, mayHaveNull);
+    }
+    return filter->testInt128Range(minValue, maxValue, mayHaveNull);
   }
 
   // only max value
   if (intStats->getMaximum().has_value()) {
-    return filter->testInt64Range(
-        std::numeric_limits<int64_t>::min(),
-        intStats->getMaximum().value(),
-        mayHaveNull);
+    const auto minValue = std::numeric_limits<int64_t>::min();
+    const auto maxValue = intStats->getMaximum().value();
+    if constexpr (std::is_same_v<T, int64_t>) {
+      return filter->testInt64Range(minValue, maxValue, mayHaveNull);
+    }
+    return filter->testInt128Range(minValue, maxValue, mayHaveNull);
   }
 
   return true;
@@ -346,7 +357,8 @@ bool testFilter(
     const common::Filter* filter,
     dwio::common::ColumnStatistics* stats,
     uint64_t totalRows,
-    const TypePtr& type) {
+    const TypePtr& type,
+    dwio::common::FileFormat fileFormat) {
   bool mayHaveNull{true};
 
   // Has-null statistics is often not set. Hence, we supplement it with
@@ -369,20 +381,27 @@ bool testFilter(
   if (mayHaveNull && filter->testNull()) {
     return true;
   }
-  if (type->isDecimal()) {
-    // The min and max value in the metadata for decimal type in Parquet can be
-    // stored in different physical types, including int32, int64 and
-    // fixed_len_byte_array. The loading of them is not supported in Metadata.
+
+  if (fileFormat != dwio::common::FileFormat::PARQUET && type->isDecimal()) {
+    // For non-Parquet files, row group skip based on stats for decimal column
+    // is not supported.
     return true;
   }
+
   switch (type->kind()) {
-    case TypeKind::BIGINT:
-    case TypeKind::INTEGER:
+    case TypeKind::TINYINT:
     case TypeKind::SMALLINT:
-    case TypeKind::TINYINT: {
+    case TypeKind::INTEGER:
+    case TypeKind::BIGINT: {
       auto* intStats =
-          dynamic_cast<dwio::common::IntegerColumnStatistics*>(stats);
-      return testIntFilter(filter, intStats, mayHaveNull);
+          dynamic_cast<dwio::common::IntegerColumnStatistics<int64_t>*>(stats);
+      return testIntFilter<int64_t>(filter, intStats, mayHaveNull);
+    }
+    case TypeKind::HUGEINT: {
+      VELOX_CHECK(type->isLongDecimal());
+      auto* intStats =
+          dynamic_cast<dwio::common::IntegerColumnStatistics<int128_t>*>(stats);
+      return testIntFilter<int128_t>(filter, intStats, mayHaveNull);
     }
     case TypeKind::REAL:
     case TypeKind::DOUBLE: {

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -31,7 +31,8 @@
 namespace facebook::velox {
 namespace dwio::common {
 class ColumnStatistics;
-}
+enum class FileFormat;
+} // namespace dwio::common
 namespace common {
 
 /// Describes the filtering and value extraction for a
@@ -601,7 +602,8 @@ bool testFilter(
     const common::Filter* filter,
     dwio::common::ColumnStatistics* stats,
     uint64_t totalRows,
-    const TypePtr& type);
+    const TypePtr& type,
+    dwio::common::FileFormat fileFormat);
 
 } // namespace common
 } // namespace facebook::velox

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -337,10 +337,10 @@ class DoubleColumnStatistics : public virtual ColumnStatistics {
   std::optional<double> sum_;
 };
 
-/**
- * Statistics for all of the integer columns, such as byte, short, int, and
- * long.
- */
+/// Statistics for all of the integer columns, such as byte, short, int, long,
+/// and int128_t. T is the type of statistics value. By default, it is int64_t
+/// and can be changed to int128_t for huge int statistics.
+template <typename T = int64_t>
 class IntegerColumnStatistics : public virtual ColumnStatistics {
  public:
   IntegerColumnStatistics(
@@ -348,9 +348,9 @@ class IntegerColumnStatistics : public virtual ColumnStatistics {
       std::optional<bool> hasNull,
       std::optional<uint64_t> rawSize,
       std::optional<uint64_t> size,
-      std::optional<int64_t> min,
-      std::optional<int64_t> max,
-      std::optional<int64_t> sum)
+      std::optional<T> min,
+      std::optional<T> max,
+      std::optional<T> sum)
       : ColumnStatistics(valueCount, hasNull, rawSize, size),
         min_(min),
         max_(max),
@@ -358,9 +358,9 @@ class IntegerColumnStatistics : public virtual ColumnStatistics {
 
   IntegerColumnStatistics(
       const ColumnStatistics& colStats,
-      std::optional<int64_t> min,
-      std::optional<int64_t> max,
-      std::optional<int64_t> sum)
+      std::optional<T> min,
+      std::optional<T> max,
+      std::optional<T> sum)
       : ColumnStatistics(colStats), min_(min), max_(max), sum_(sum) {}
 
   ~IntegerColumnStatistics() override = default;
@@ -369,7 +369,7 @@ class IntegerColumnStatistics : public virtual ColumnStatistics {
    * Get optional smallest value in the column. Only defined if
    * getNumberOfValues is non-zero.
    */
-  std::optional<int64_t> getMinimum() const {
+  std::optional<T> getMinimum() const {
     return min_;
   }
 
@@ -377,7 +377,7 @@ class IntegerColumnStatistics : public virtual ColumnStatistics {
    * Get optional largest value in the column. Only defined if getNumberOfValues
    * is non-zero.
    */
-  std::optional<int64_t> getMaximum() const {
+  std::optional<T> getMaximum() const {
     return max_;
   }
 
@@ -385,7 +385,7 @@ class IntegerColumnStatistics : public virtual ColumnStatistics {
    * Get optional sum of the column. Only valid if getNumberOfValues is non-zero
    * and sum doesn't overflow
    */
-  std::optional<int64_t> getSum() const {
+  std::optional<T> getSum() const {
     return sum_;
   }
 
@@ -403,9 +403,9 @@ class IntegerColumnStatistics : public virtual ColumnStatistics {
  protected:
   IntegerColumnStatistics() {}
 
-  std::optional<int64_t> min_;
-  std::optional<int64_t> max_;
-  std::optional<int64_t> sum_;
+  std::optional<T> min_;
+  std::optional<T> max_;
+  std::optional<T> sum_;
 };
 
 /**

--- a/velox/dwio/common/StatisticsBuilder.h
+++ b/velox/dwio/common/StatisticsBuilder.h
@@ -201,7 +201,7 @@ class BooleanStatisticsBuilder : public virtual StatisticsBuilder,
 };
 
 class IntegerStatisticsBuilder : public virtual StatisticsBuilder,
-                                 public IntegerColumnStatistics {
+                                 public IntegerColumnStatistics<> {
  public:
   explicit IntegerStatisticsBuilder(const StatisticsBuilderOptions& options)
       : StatisticsBuilder{options} {

--- a/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/utils/E2EFilterTestBase.cpp
@@ -687,7 +687,9 @@ void E2EFilterTestBase::testRowGroupSkip(
   // Makes a row group skipping filter for the first bigint column.
   for (auto& field : filterable) {
     VectorPtr child = getChildBySubfield(batches[0].get(), Subfield(field));
-    if (child->type() == BIGINT() || child->typeKind() == TypeKind::VARCHAR) {
+    if (child->typeKind() == TypeKind::BIGINT ||
+        child->typeKind() == TypeKind::HUGEINT ||
+        child->typeKind() == TypeKind::VARCHAR) {
       specs.emplace_back();
       specs.back().field = field;
       specs.back().isForRowGroupSkip = true;

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -347,6 +347,15 @@ class ColumnStats : public AbstractColumnStats {
         }
       }
     }
+    if (max == std::numeric_limits<T>::max()) {
+      return std::make_unique<velox::common::AlwaysFalse>();
+    }
+    // Add 1 to max to make sure the filter has no overlap with the data ranging
+    // from min to max.
+    max += 1;
+    if constexpr (std::is_same_v<T, int128_t>) {
+      return std::make_unique<velox::common::HugeintRange>(max, max, false);
+    }
     return std::make_unique<velox::common::BigintRange>(
         getIntegerValue(max), getIntegerValue(max), false);
   }

--- a/velox/dwio/dwrf/common/Statistics.cpp
+++ b/velox/dwio/dwrf/common/Statistics.cpp
@@ -34,7 +34,7 @@ std::unique_ptr<ColumnStatistics> buildColumnStatisticsFromProto(
   if (!stats.hasNumberOfValues() || stats.numberOfValues() > 0) {
     if (stats.hasIntStatistics()) {
       const auto& intStats = stats.intStatistics();
-      return std::make_unique<IntegerColumnStatistics>(
+      return std::make_unique<IntegerColumnStatistics<>>(
           colStats,
           intStats.hasMinimum() ? std::optional(intStats.minimum())
                                 : std::nullopt,

--- a/velox/dwio/dwrf/reader/DwrfData.cpp
+++ b/velox/dwio/dwrf/reader/DwrfData.cpp
@@ -180,7 +180,11 @@ void DwrfData::filterRowGroups(
         ColumnStatisticsWrapper(&entry.statistics()), *dwrfContext);
     if (filter &&
         !testFilter(
-            filter, columnStats.get(), rowGroupSize, fileType_->type())) {
+            filter,
+            columnStats.get(),
+            rowGroupSize,
+            fileType_->type(),
+            dwio::common::FileFormat::DWRF)) {
       VLOG(1) << "Drop stride " << i << " on " << scanSpec.toString();
       bits::setBit(result.filterResult.data(), i);
       continue;
@@ -192,7 +196,8 @@ void DwrfData::filterRowGroups(
               metadataFilter,
               columnStats.get(),
               rowGroupSize,
-              fileType_->type())) {
+              fileType_->type(),
+              dwio::common::FileFormat::DWRF)) {
         bits::setBit(
             result.metadataFilterResults[metadataFiltersStartIndex + j]
                 .second.data(),

--- a/velox/dwio/dwrf/test/ColumnStatisticsBase.h
+++ b/velox/dwio/dwrf/test/ColumnStatisticsBase.h
@@ -89,7 +89,7 @@ class ColumnStatisticsBase {
     // stats should be merged
     IntegerStatisticsBuilder target{options()};
     target.merge(*builder.build());
-    auto stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    auto stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(3, stats->getNumberOfValues());
     EXPECT_EQ(1, stats->getMinimum());
     EXPECT_EQ(5, stats->getMaximum());
@@ -99,14 +99,14 @@ class ColumnStatisticsBase {
     builder.addValues(0);
     builder.addValues(6);
     target.merge(*builder.build());
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(8, stats->getNumberOfValues());
     EXPECT_EQ(0, stats->getMinimum());
     EXPECT_EQ(6, stats->getMaximum());
     EXPECT_EQ(24, stats->getSum());
 
     target.merge(*builder.build());
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(13, stats->getNumberOfValues());
     EXPECT_EQ(0, stats->getMinimum());
     EXPECT_EQ(6, stats->getMaximum());
@@ -114,7 +114,7 @@ class ColumnStatisticsBase {
 
     // add value
     target.addValues(100, 2);
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(15, stats->getNumberOfValues());
     EXPECT_EQ(0, stats->getMinimum());
     EXPECT_EQ(100, stats->getMaximum());
@@ -134,13 +134,13 @@ class ColumnStatisticsBase {
       DwrfFormat format) {
     IntegerStatisticsBuilder target{options()};
     target.addValues(1, 5);
-    auto stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    auto stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(5, stats->getSum());
 
     // merge missing stats
     target.merge(
         *buildColumnStatisticsFromProto(columnStatisticsWrapper, context()));
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(stats, nullptr);
 
     // merge again
@@ -158,12 +158,12 @@ class ColumnStatisticsBase {
 
     target.merge(
         *buildColumnStatisticsFromProto(columnStatisticsWrapper, context()));
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(stats, nullptr);
 
     // add again
     target.addValues(2);
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(stats, nullptr);
   }
 
@@ -173,13 +173,13 @@ class ColumnStatisticsBase {
       DwrfFormat format) {
     IntegerStatisticsBuilder target{options()};
     target.addValues(1, 5);
-    auto stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    auto stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(5, stats->getSum());
 
     // merge empty stats
     target.merge(
         *buildColumnStatisticsFromProto(columnStatisticsWrapper, context()));
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(5, stats->getSum());
 
     // merge again
@@ -193,7 +193,7 @@ class ColumnStatisticsBase {
     }
     target.merge(
         *buildColumnStatisticsFromProto(columnStatisticsWrapper, context()));
-    stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(stats, nullptr);
   }
 
@@ -204,13 +204,13 @@ class ColumnStatisticsBase {
           target.reset();
           target.addValues(val1);
           auto stats =
-              as<dwio::common::IntegerColumnStatistics>(target.build());
+              as<dwio::common::IntegerColumnStatistics<>>(target.build());
           EXPECT_EQ(val1, stats->getMaximum());
           EXPECT_EQ(val1, stats->getMinimum());
           EXPECT_EQ(val1, stats->getSum());
 
           target.addValues(val2);
-          stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+          stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
           EXPECT_EQ(max, stats->getMaximum());
           EXPECT_EQ(min, stats->getMinimum());
           EXPECT_FALSE(stats->getSum().has_value());
@@ -231,7 +231,7 @@ class ColumnStatisticsBase {
     // items
     target.reset();
     target.addValues(std::numeric_limits<int64_t>::max() / 10, 11);
-    auto stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+    auto stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
     EXPECT_EQ(11, stats->getNumberOfValues());
     EXPECT_EQ(stats->getMaximum().value(), stats->getMinimum().value());
     EXPECT_FALSE(stats->getSum().has_value());
@@ -243,7 +243,7 @@ class ColumnStatisticsBase {
       IntegerStatisticsBuilder builder{options()};
       builder.addValues(val2);
       target.merge(builder);
-      stats = as<dwio::common::IntegerColumnStatistics>(target.build());
+      stats = as<dwio::common::IntegerColumnStatistics<>>(target.build());
       EXPECT_FALSE(stats->getSum().has_value());
     };
     testMergeOverflow(std::numeric_limits<int64_t>::min(), -1);

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
@@ -172,7 +172,7 @@ void validateIntStats(const VectorPtr& batch, const ColumnStatistics& stats) {
       sum += val;
     }
   }
-  auto& intStats = dynamic_cast<const IntegerColumnStatistics&>(stats);
+  auto& intStats = dynamic_cast<const IntegerColumnStatistics<>&>(stats);
   ASSERT_EQ(min, intStats.getMinimum());
   ASSERT_EQ(max, intStats.getMaximum());
   ASSERT_EQ(sum, intStats.getSum());

--- a/velox/dwio/dwrf/test/TestDwrfColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestDwrfColumnStatistics.cpp
@@ -393,7 +393,7 @@ TEST(MapStatisticsBuilderTest, innerStatsType) {
     statsBuilder.addValues(2);
     mapStatsBuilder.addValues(createKeyInfo(1), statsBuilder);
 
-    auto& intStats = dynamic_cast<IntegerColumnStatistics&>(
+    auto& intStats = dynamic_cast<IntegerColumnStatistics<>&>(
         *mapStatsBuilder.getEntryStatistics().at(KeyInfo{1}));
 
     EXPECT_EQ(1, intStats.getMinimum());

--- a/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
@@ -85,7 +85,7 @@ TEST_F(TestStatisticsBuilderUtils, addIntegerValues) {
     StatisticsBuilderUtils::addValues<int32_t>(
         builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
-    auto intStats = dynamic_cast<IntegerColumnStatistics*>(stats.get());
+    auto intStats = dynamic_cast<IntegerColumnStatistics<>*>(stats.get());
     EXPECT_EQ(10, intStats->getNumberOfValues());
     EXPECT_FALSE(intStats->hasNull().value());
     EXPECT_EQ(10, intStats->getMaximum().value());
@@ -104,7 +104,7 @@ TEST_F(TestStatisticsBuilderUtils, addIntegerValues) {
     StatisticsBuilderUtils::addValues<int32_t>(
         builder, vec, common::Ranges::of(0, size));
     auto stats = builder.build();
-    auto intStats = dynamic_cast<IntegerColumnStatistics*>(stats.get());
+    auto intStats = dynamic_cast<IntegerColumnStatistics<>*>(stats.get());
     EXPECT_EQ(19, intStats->getNumberOfValues());
     EXPECT_TRUE(intStats->hasNull().value());
     EXPECT_EQ(10, intStats->getMaximum().value());

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -83,6 +83,13 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
         offset,
         rows,
         nullptr);
+    if (scanSpec_->filter()) {
+      VELOX_USER_CHECK(
+          canPushdownFilterOn(),
+          "Filter pushdown is not accepted. Requested type: {}, file type: {}.",
+          requestedType_->toString(),
+          fileType_->type()->toString());
+    }
     readCommon<IntegerColumnReader, true>(rows);
     readOffset_ += rows.back() + 1;
   }
@@ -99,11 +106,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
   void rescaleDecimalValues(
       const ParquetTypeWithId& fileType,
       VectorPtr& result) {
-    int32_t requestedScale = getDecimalPrecisionScale(*requestedType_).second;
-    int32_t fileScale = fileType.type()->isDecimal()
-        ? getDecimalPrecisionScale(*fileType.type()).second
-        : 0;
-    int32_t scaleAdjust = requestedScale - fileScale;
+    int32_t scaleAdjust = scaleToAdjust(fileType.type(), requestedType_);
     VELOX_USER_CHECK_GE(
         scaleAdjust,
         0,
@@ -129,10 +132,10 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
     }
   }
 
-  /// Multiplies all non-null values in result by multiplier.
-  /// Overflow is impossible because convertType validates precInc >= scaleInc,
-  /// guaranteeing that originalValue * 10^scaleAdjust fits within the target
-  /// precision.
+  // Multiplies all non-null values in result by multiplier.
+  // Overflow is impossible because convertType validates precInc >= scaleInc,
+  // guaranteeing that originalValue * 10^scaleAdjust fits within the target
+  // precision.
   template <typename T>
   void applyDecimalScaleMultiplier(const VectorPtr& result, T multiplier)
       const {
@@ -151,6 +154,34 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
         }
       }
     }
+  }
+
+  int32_t scaleToAdjust(const TypePtr& fileType, const TypePtr& requestedType)
+      const {
+    int32_t requestedScale = getDecimalPrecisionScale(*requestedType).second;
+    int32_t fileScale =
+        fileType->isDecimal() ? getDecimalPrecisionScale(*fileType).second : 0;
+    return requestedScale - fileScale;
+  }
+
+  bool canPushdownFilterOn() {
+    VELOX_CHECK(scanSpec_->filter());
+    if (requestedType_->isDecimal() &&
+        scaleToAdjust(fileType_->type(), requestedType_) != 0) {
+      // Cannot push down filters if rescaling is needed, because the filter
+      // values are not rescaled and thus cannot be correctly compared to the
+      // file values.
+      switch (scanSpec_->filter()->kind()) {
+        case common::FilterKind::kAlwaysFalse:
+        case common::FilterKind::kAlwaysTrue:
+        case common::FilterKind::kIsNull:
+        case common::FilterKind::kIsNotNull:
+          break;
+        default:
+          return false;
+      }
+    }
+    return true;
   }
 };
 

--- a/velox/dwio/parquet/reader/Metadata.cpp
+++ b/velox/dwio/parquet/reader/Metadata.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/parquet/reader/Metadata.h"
+#include "arrow/type.h"
 #include "velox/dwio/parquet/thrift/ParquetThrift.h"
 
 #include <thrift/lib/cpp2/FieldRef.h>
@@ -232,10 +233,62 @@ inline std::optional<std::string> getMax(
       : columnChunkStats.max().to_optional();
 }
 
+// Retrieves the minimum or maximum decimal value from column chunk statistics
+// based on the specified physical type and precision. Supports three physical
+// types to meet the requirements of Arrow: INT32, INT64, and
+// FIXED_LEN_BYTE_ARRAY.
+// https://github.com/apache/arrow/blob/apache-arrow-18.0.0/cpp/src/parquet/arrow/schema.cc#L363-L368
+// When min is true, it retrieves the minimum value; otherwise, it retrieves the
+// maximum value.
+template <typename T, bool min>
+inline std::optional<T> getDecimalMinMax(
+    const thrift::Statistics& columnChunkStats,
+    thrift::Type physicalType,
+    uint8_t precision) {
+  const char* data;
+  if constexpr (min) {
+    data = columnChunkStats.min_value()
+        ? columnChunkStats.min_value()->data()
+        : (columnChunkStats.min() ? columnChunkStats.min()->data() : nullptr);
+  } else {
+    data = columnChunkStats.max_value()
+        ? columnChunkStats.max_value()->data()
+        : (columnChunkStats.max() ? columnChunkStats.max()->data() : nullptr);
+  }
+
+  switch (physicalType) {
+    case thrift::Type::INT32:
+      return data ? std::optional<T>(load<int32_t>(data)) : std::nullopt;
+    case thrift::Type::INT64:
+      return data ? std::optional<T>(load<int64_t>(data)) : std::nullopt;
+    case thrift::Type::FIXED_LEN_BYTE_ARRAY: {
+      if (data == nullptr) {
+        return std::nullopt;
+      }
+      const auto size = arrow::DecimalType::DecimalSize(precision);
+      // Extracts min or max from big-endian string.
+      T value = 0;
+      for (auto i = 0; i < size; ++i) {
+        value = (value << 8) | (data[i] & 0xFF);
+      }
+
+      // If the value is negative, extend the sign bit.
+      const bool isNegative = (data[0] & 0x80) != 0;
+      if (isNegative) {
+        value -= (static_cast<T>(1) << (size * 8));
+      }
+      return std::optional<T>(value);
+    }
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+
 std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
     const thrift::Statistics& columnChunkStats,
     const velox::Type& type,
-    uint64_t numRowsInRowGroup) {
+    uint64_t numRowsInRowGroup,
+    thrift::Type physicalType) {
   std::optional<uint64_t> nullCount =
       columnChunkStats.null_count().to_optional();
   std::optional<uint64_t> valueCount = nullCount
@@ -250,7 +303,7 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
       return std::make_unique<dwio::common::BooleanColumnStatistics>(
           valueCount, hasNull, std::nullopt, std::nullopt, std::nullopt);
     case TypeKind::TINYINT:
-      return std::make_unique<dwio::common::IntegerColumnStatistics>(
+      return std::make_unique<dwio::common::IntegerColumnStatistics<>>(
           valueCount,
           hasNull,
           std::nullopt,
@@ -259,7 +312,7 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
           getMax<int8_t>(columnChunkStats),
           std::nullopt);
     case TypeKind::SMALLINT:
-      return std::make_unique<dwio::common::IntegerColumnStatistics>(
+      return std::make_unique<dwio::common::IntegerColumnStatistics<>>(
           valueCount,
           hasNull,
           std::nullopt,
@@ -268,7 +321,7 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
           getMax<int16_t>(columnChunkStats),
           std::nullopt);
     case TypeKind::INTEGER:
-      return std::make_unique<dwio::common::IntegerColumnStatistics>(
+      return std::make_unique<dwio::common::IntegerColumnStatistics<>>(
           valueCount,
           hasNull,
           std::nullopt,
@@ -276,15 +329,41 @@ std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromThrift(
           getMin<int32_t>(columnChunkStats),
           getMax<int32_t>(columnChunkStats),
           std::nullopt);
-    case TypeKind::BIGINT:
-      return std::make_unique<dwio::common::IntegerColumnStatistics>(
+    case TypeKind::BIGINT: {
+      std::optional<int64_t> min = type.isDecimal()
+          ? getDecimalMinMax<int64_t, true>(
+                columnChunkStats,
+                physicalType,
+                getDecimalPrecisionScale(type).first)
+          : getMin<int64_t>(columnChunkStats);
+      std::optional<int64_t> max = type.isDecimal()
+          ? getDecimalMinMax<int64_t, false>(
+                columnChunkStats,
+                physicalType,
+                getDecimalPrecisionScale(type).first)
+          : getMax<int64_t>(columnChunkStats);
+      return std::make_unique<dwio::common::IntegerColumnStatistics<>>(
           valueCount,
           hasNull,
           std::nullopt,
           std::nullopt,
-          getMin<int64_t>(columnChunkStats),
-          getMax<int64_t>(columnChunkStats),
+          min,
+          max,
           std::nullopt);
+    }
+    case TypeKind::HUGEINT: {
+      const auto precision = getDecimalPrecisionScale(type).first;
+      return std::make_unique<dwio::common::IntegerColumnStatistics<int128_t>>(
+          valueCount,
+          hasNull,
+          std::nullopt,
+          std::nullopt,
+          getDecimalMinMax<int128_t, true>(
+              columnChunkStats, physicalType, precision),
+          getDecimalMinMax<int128_t, false>(
+              columnChunkStats, physicalType, precision),
+          std::nullopt);
+    }
     case TypeKind::REAL:
       return std::make_unique<dwio::common::DoubleColumnStatistics>(
           valueCount,
@@ -384,12 +463,16 @@ ColumnChunkMetaDataPtr::getColumnStatistics(
     const TypePtr type,
     int64_t numRows) {
   VELOX_CHECK(hasStatistics());
+  const auto physicalType = apache::thrift::can_throw(
+      *apache::thrift::can_throw(thriftColumnChunkPtr(ptr_)->meta_data())
+           ->type());
   return buildColumnStatisticsFromThrift(
       apache::thrift::can_throw(
           *apache::thrift::can_throw(thriftColumnChunkPtr(ptr_)->meta_data())
                ->statistics()),
       *type,
-      numRows);
+      numRows,
+      physicalType);
 };
 
 std::string ColumnChunkMetaDataPtr::getColumnMetadataStatsMinValue() {

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/parquet/reader/ParquetData.h"
 
 #include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/parquet/reader/ParquetStatsContext.h"
 
 namespace facebook::velox::parquet {
@@ -94,7 +95,12 @@ bool ParquetData::rowGroupMatches(
   if (columnChunk.hasStatistics()) {
     auto columnStats =
         columnChunk.getColumnStatistics(type, rowGroup.numRows());
-    return testFilter(filter, columnStats.get(), rowGroup.numRows(), type);
+    return testFilter(
+        filter,
+        columnStats.get(),
+        rowGroup.numRows(),
+        type,
+        dwio::common::FileFormat::PARQUET);
   }
   return true;
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -1681,7 +1681,7 @@ TEST_F(ParquetReaderTest, columnStatistics) {
     EXPECT_EQ(stats->getNumberOfValues(), 5);
     EXPECT_FALSE(stats->hasNull().value());
     auto* intStats =
-        dynamic_cast<dwio::common::IntegerColumnStatistics*>(stats.get());
+        dynamic_cast<dwio::common::IntegerColumnStatistics<>*>(stats.get());
     ASSERT_NE(intStats, nullptr);
     EXPECT_EQ(intStats->getMinimum(), 1);
     EXPECT_EQ(intStats->getMaximum(), 5);
@@ -1731,7 +1731,7 @@ TEST_F(ParquetReaderTest, columnStatisticsWithNulls) {
   EXPECT_EQ(stats->getNumberOfValues(), 3);
   EXPECT_TRUE(stats->hasNull().value());
   auto* intStats =
-      dynamic_cast<dwio::common::IntegerColumnStatistics*>(stats.get());
+      dynamic_cast<dwio::common::IntegerColumnStatistics<>*>(stats.get());
   ASSERT_NE(intStats, nullptr);
   EXPECT_EQ(intStats->getMinimum(), 1);
   EXPECT_EQ(intStats->getMaximum(), 5);
@@ -1766,7 +1766,7 @@ TEST_F(ParquetReaderTest, columnStatisticsMultipleRowGroups) {
   EXPECT_EQ(stats->getNumberOfValues(), 10);
   EXPECT_FALSE(stats->hasNull().value());
   auto* intStats =
-      dynamic_cast<dwio::common::IntegerColumnStatistics*>(stats.get());
+      dynamic_cast<dwio::common::IntegerColumnStatistics<>*>(stats.get());
   ASSERT_NE(intStats, nullptr);
   // Global min/max across all row groups.
   EXPECT_EQ(intStats->getMinimum(), 1);

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -2000,7 +2000,7 @@ TEST_F(ParquetTableScanTest, shortAndLongDecimalReadWithLargerPrecision) {
   // 20 rows (10 rows per group). Data is in plain uncompressed format:
   //   a: [100.01 .. 100.20]
   //   b: [100000000000000.00001 .. 100000000000000.00020]
-  // This test reads the DECIMAL(5, 2)a and DECIMAL(20, 5) file columns
+  // This test reads the DECIMAL(5, 2) and DECIMAL(20, 5) file columns
   // with DECIMAL(8, 2) and DECIMAL(22, 5) row types.
   vector_size_t kSize = 20;
   std::vector<int64_t> unscaledShortValues(kSize);
@@ -2039,6 +2039,75 @@ TEST_F(ParquetTableScanTest, shortAndLongDecimalReadWithLargerPrecision) {
 
   assertEqualVectors(expectedDecimalVectors->childAt(0), rows->childAt(0));
   assertEqualVectors(expectedDecimalVectors->childAt(1), rows->childAt(1));
+}
+
+TEST_F(ParquetTableScanTest, decimalRescale) {
+  // decimal.parquet holds two columns (a: DECIMAL(5, 2), b: DECIMAL(20, 5)) and
+  // 20 rows (10 rows per group). Data is in plain uncompressed format:
+  //   a: [100.01 .. 100.20]
+  //   b: [100000000000000.00001 .. 100000000000000.00020]
+  std::vector<int64_t> unscaledShortValues(20);
+  std::iota(unscaledShortValues.begin(), unscaledShortValues.end(), 10001);
+  for (auto i = 0; i < unscaledShortValues.size(); ++i) {
+    unscaledShortValues[i] *= 1000;
+  }
+
+  // Read the DECIMAL(5, 2) file column with DECIMAL(16, 5) row type, which
+  // requires rescaling the unscaled value.
+  loadData(
+      ROW({"a"}, {DECIMAL(16, 5)}),
+      makeRowVector(
+          {"a"},
+          {
+              makeFlatVector(unscaledShortValues, DECIMAL(16, 5)),
+          }));
+
+  assertSelectWithFilter(
+      {makeSplit(getExampleFilePath("decimal.parquet"))},
+      {"a"},
+      {},
+      "",
+      "SELECT a FROM tmp");
+  VELOX_ASSERT_USER_THROW(
+      assertSelectWithFilter(
+          {makeSplit(getExampleFilePath("decimal.parquet"))},
+          {"a"},
+          {"a < 100.07000::DECIMAL(16, 5)"},
+          "",
+          "SELECT a FROM tmp WHERE a < 100.07000"),
+      "Filter pushdown is not accepted. Requested type: DECIMAL(16, 5), file type: DECIMAL(5, 2).");
+}
+
+TEST_F(ParquetTableScanTest, decimalRowGroupSkip) {
+  std::vector<int128_t> longDecimalValues;
+  loadData(
+      ROW({"b"}, {DECIMAL(20, 5)}),
+      makeRowVector(
+          {"b"},
+          {
+              makeFlatVector(longDecimalValues, DECIMAL(20, 5)),
+          }));
+
+  parse::ParseOptions options;
+  options.parseDecimalAsDouble = false;
+  auto plan = PlanBuilder(pool_.get())
+                  .setParseOptions(options)
+                  .tableScan(
+                      ROW({"b"}, {DECIMAL(20, 5)}),
+                      {},
+                      "b < 100000000000000.00001",
+                      nullptr)
+                  .planNode();
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .splits({makeSplit(getExampleFilePath("decimal.parquet"))})
+                  .assertResults("SELECT b FROM tmp");
+  ASSERT_EQ(
+      task->taskStats()
+          .pipelineStats[0]
+          .operatorStats[0]
+          .runtimeStats["skippedStrides"]
+          .sum,
+      2);
 }
 
 TEST_F(ParquetTableScanTest, inFilter) {


### PR DESCRIPTION
Retrieves the minimum and maximum decimal value from Parquet column chunk 
statistics based on the specified physical type and precision. Supports three 
physical types to meet the requirements of Arrow: `INT32`, `INT64`, and 
`FIXED_LEN_BYTE_ARRAY`.
Supports row group skip based on the decimal statistics. When rescaling is
required, the range filters' pushdown are rejected because the scale in Filter
objects are from the requested type, not the same as file type.
Verified with E2EFilterTest and new tests in ParquetTableScanTest.

Replace https://github.com/facebookincubator/velox/pull/11646.