### PR TITLE
perf: Avoid double lookup when inserting not-preset-yet element into set

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -2040,13 +2040,10 @@ void addStats(
     std::unordered_map<std::string, exec::ExprStats>& stats,
     std::unordered_set<const exec::Expr*>& uniqueExprs,
     bool excludeSpecialForm) {
-  auto it = uniqueExprs.find(&expr);
-  if (it != uniqueExprs.end()) {
+  if (!uniqueExprs.insert(&expr).second) {
     // Common sub-expression. Skip to avoid double counting.
     return;
   }
-
-  uniqueExprs.insert(&expr);
 
   bool excludeSplFormExpr = excludeSpecialForm && expr.isSpecialForm();
   // Do not aggregate empty stats.


### PR DESCRIPTION
Summary: 
This change was generated by pointing an AI agent at hot functions showing up in our internal profiles. It was reviewed by a human (outside the velox team):
Optimized facebook::velox::exec::addStats in fbcode/velox/expression/Expr.cpp by combining the redundant find() + insert() pattern into a single insert() call on the uniqueExprs unordered_set. The original code performed two hash lookups per call — one for find(&expr) and another for insert(&expr). The optimized code uses insert(&expr).second to both check membership and insert in a single hash lookup, eliminating redundant hash computation. Functionality is preserved: the function still skips already-seen expressions to avoid double counting.

Pull Request resolved: https://github.com/facebookincubator/velox/pull/17063

Reviewed By: yuxuanchen1997

Differential Revision: D99849133


