### PR TITLE
refactor: Rename hive.reader.collect-column-stats to collect-column-cpu-metrics (#17070)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -128,11 +128,11 @@ bool FileConfig::indexEnabled(const config::ConfigBase* session) const {
       kIndexEnabledSession, config_->get<bool>(kIndexEnabled, false));
 }
 
-bool FileConfig::readerCollectColumnStats(
+bool FileConfig::readerCollectColumnCpuMetrics(
     const config::ConfigBase* session) const {
   return session->get<bool>(
-      kReaderCollectColumnStatsSession,
-      config_->get<bool>(kReaderCollectColumnStats, false));
+      kReaderCollectColumnCpuMetricsSession,
+      config_->get<bool>(kReaderCollectColumnCpuMetrics, false));
 }
 
 bool FileConfig::fileMetadataCacheEnabled(

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -121,10 +121,10 @@ class FileConfig {
 
   /// Whether to collect per-column timing stats (decode/decompress CPU time).
   /// Disabled by default to avoid overhead (~100ns per operation).
-  static constexpr const char* kReaderCollectColumnStats =
-      "hive.reader.collect-column-stats";
-  static constexpr const char* kReaderCollectColumnStatsSession =
-      "hive.reader.collect_column_stats";
+  static constexpr const char* kReaderCollectColumnCpuMetrics =
+      "hive.reader.collect-column-cpu-metrics";
+  static constexpr const char* kReaderCollectColumnCpuMetricsSession =
+      "hive.reader.collect_column_cpu_metrics";
 
   /// Whether to cache file metadata (footer, stripes, index) in the
   /// process-wide AsyncDataCache. When enabled, the first reader performs a
@@ -212,7 +212,7 @@ class FileConfig {
 
   /// Whether to collect per-column timing stats (decode/decompress CPU time).
   /// Disabled by default to avoid overhead (~100ns per operation).
-  bool readerCollectColumnStats(const config::ConfigBase* session) const;
+  bool readerCollectColumnCpuMetrics(const config::ConfigBase* session) const;
 
   /// Whether to cache file metadata in the process-wide AsyncDataCache.
   bool fileMetadataCacheEnabled(const config::ConfigBase* session) const;

--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -156,8 +156,8 @@ void configureRowReaderOptions(
         fileConfig->parallelUnitLoadCount(sessionProperties));
     rowReaderOptions.setIndexEnabled(
         fileConfig->indexEnabled(sessionProperties));
-    rowReaderOptions.setCollectColumnStats(
-        fileConfig->readerCollectColumnStats(sessionProperties));
+    rowReaderOptions.setCollectColumnCpuMetrics(
+        fileConfig->readerCollectColumnCpuMetrics(sessionProperties));
   }
 }
 

--- a/velox/connectors/hive/tests/FileConfigTest.cpp
+++ b/velox/connectors/hive/tests/FileConfigTest.cpp
@@ -45,7 +45,7 @@ TEST(FileConfigTest, defaultConfig) {
   EXPECT_FALSE(config.readStatsBasedFilterReorderDisabled(emptySession.get()));
   EXPECT_FALSE(config.preserveFlatMapsInMemory(emptySession.get()));
   EXPECT_FALSE(config.indexEnabled(emptySession.get()));
-  EXPECT_FALSE(config.readerCollectColumnStats(emptySession.get()));
+  EXPECT_FALSE(config.readerCollectColumnCpuMetrics(emptySession.get()));
   EXPECT_FALSE(config.fileMetadataCacheEnabled(emptySession.get()));
   EXPECT_FALSE(config.pinFileMetadata(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 256UL << 10);
@@ -68,7 +68,7 @@ TEST(FileConfigTest, overrideConfig) {
       {FileConfig::kReadStatsBasedFilterReorderDisabled, "true"},
       {FileConfig::kPreserveFlatMapsInMemory, "true"},
       {FileConfig::kIndexEnabled, "true"},
-      {FileConfig::kReaderCollectColumnStats, "true"},
+      {FileConfig::kReaderCollectColumnCpuMetrics, "true"},
       {FileConfig::kFileMetadataCacheEnabled, "true"},
       {FileConfig::kPinFileMetadata, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSize, std::to_string(512UL << 10)},
@@ -91,7 +91,7 @@ TEST(FileConfigTest, overrideConfig) {
   EXPECT_TRUE(config.readStatsBasedFilterReorderDisabled(emptySession.get()));
   EXPECT_TRUE(config.preserveFlatMapsInMemory(emptySession.get()));
   EXPECT_TRUE(config.indexEnabled(emptySession.get()));
-  EXPECT_TRUE(config.readerCollectColumnStats(emptySession.get()));
+  EXPECT_TRUE(config.readerCollectColumnCpuMetrics(emptySession.get()));
   EXPECT_TRUE(config.fileMetadataCacheEnabled(emptySession.get()));
   EXPECT_TRUE(config.pinFileMetadata(emptySession.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(emptySession.get()), 512UL << 10);
@@ -115,7 +115,7 @@ TEST(FileConfigTest, overrideSession) {
       {FileConfig::kReadStatsBasedFilterReorderDisabledSession, "true"},
       {FileConfig::kPreserveFlatMapsInMemorySession, "true"},
       {FileConfig::kIndexEnabledSession, "true"},
-      {FileConfig::kReaderCollectColumnStatsSession, "true"},
+      {FileConfig::kReaderCollectColumnCpuMetricsSession, "true"},
       {FileConfig::kFileMetadataCacheEnabledSession, "true"},
       {FileConfig::kPinFileMetadataSession, "true"},
       {FileConfig::kOrcFooterSpeculativeIoSizeSession,
@@ -137,7 +137,7 @@ TEST(FileConfigTest, overrideSession) {
   EXPECT_TRUE(config.readStatsBasedFilterReorderDisabled(session.get()));
   EXPECT_TRUE(config.preserveFlatMapsInMemory(session.get()));
   EXPECT_TRUE(config.indexEnabled(session.get()));
-  EXPECT_TRUE(config.readerCollectColumnStats(session.get()));
+  EXPECT_TRUE(config.readerCollectColumnCpuMetrics(session.get()));
   EXPECT_TRUE(config.fileMetadataCacheEnabled(session.get()));
   EXPECT_TRUE(config.pinFileMetadata(session.get()));
   EXPECT_EQ(config.orcFooterSpeculativeIoSize(session.get()), 128UL << 10);

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -859,8 +859,8 @@ Each query can override the config by setting corresponding query session proper
        strong references so they are never evicted. This avoids re-reading and re-parsing metadata on every stripe
        access when weak-pointer cache entries would otherwise expire. Can be used independently of
        file-metadata-cache-enabled. Currently only supported by Nimble format.
-   * - hive.reader.collect-column-stats
-     - hive.reader.collect_column_stats
+   * - hive.reader.collect-column-cpu-metrics
+     - hive.reader.collect_column_cpu_metrics
      - bool
      - false
      - If true, enables collection of per-column timing statistics during file reading. This includes

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -475,13 +475,18 @@ class RowReaderOptions {
     passStringBuffersFromDecoder_ = passStringBuffersFromDecoder;
   }
 
-  bool collectColumnStats() const {
-    return collectColumnStats_;
+  bool collectColumnCpuMetrics() const {
+    return collectColumnCpuMetrics_;
   }
 
-  RowReaderOptions& setCollectColumnStats(bool collect) {
-    collectColumnStats_ = collect;
+  RowReaderOptions& setCollectColumnCpuMetrics(bool collect) {
+    collectColumnCpuMetrics_ = collect;
     return *this;
+  }
+
+  // Legacy alias — remove after Nimble OSS bumps Velox.
+  RowReaderOptions& setCollectColumnStats(bool collect) {
+    return setCollectColumnCpuMetrics(collect);
   }
 
  private:
@@ -548,7 +553,7 @@ class RowReaderOptions {
   // NOTE: we will control this option with a session property
   // for prod. Tests are parameterized on both branches.
   bool passStringBuffersFromDecoder_{false};
-  bool collectColumnStats_{false};
+  bool collectColumnCpuMetrics_{false};
 };
 
 /// Options for creating a Reader.

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -683,7 +683,7 @@ struct ColumnReaderStatistics {
   void initColumnStatsCollection(
       const TypeWithId& schema,
       const RowReaderOptions& options) {
-    if (!options.collectColumnStats()) {
+    if (!options.collectColumnCpuMetrics()) {
       return;
     }
     columnMetricsSet.emplace();


### PR DESCRIPTION
Summary:

CONTEXT: The config name "collect-column-stats" is misleading — it sounds
like it collects data statistics (min/max/count), but it actually collects
per-column CPU timing metrics (decode and decompress time).

WHAT: Rename the config key and all related symbols:
- Config: collect-column-stats -> collect-column-cpu-metrics
- Session: collect_column_stats -> collect_column_cpu_metrics
- C++ API: collectColumnStats -> collectColumnCpuMetrics

Differential Revision: D100038180
