### PR TITLE
fix: SsdFile::disableFileCow to not throw on unsupported filesystems (#17074)

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -986,13 +986,20 @@ void SsdFile::disableFileCow() {
 #ifdef linux
   const std::unordered_map<std::string, std::string> attributes = {
       {std::string(LocalWriteFile::Attributes::kNoCow), "true"}};
-  writeFile_->setAttributes(attributes);
-  if (evictLogWriteFile_ != nullptr) {
-    evictLogWriteFile_->setAttributes(attributes);
-  }
-  if (checkpointWriteFile_ != nullptr) {
-    checkpointWriteFile_->setAttributes(attributes);
-  }
+  auto trySetNoCow = [&](WriteFile* file, std::string_view filePath) {
+    if (file == nullptr) {
+      return;
+    }
+    try {
+      file->setAttributes(attributes);
+    } catch (const std::exception& e) {
+      VELOX_SSD_CACHE_LOG(WARNING) << "Failed to disable copy-on-write for "
+                                   << filePath << ": " << e.what();
+    }
+  };
+  trySetNoCow(writeFile_.get(), fileName_);
+  trySetNoCow(evictLogWriteFile_.get(), evictLogFilePath());
+  trySetNoCow(checkpointWriteFile_.get(), checkpointFilePath());
 #endif // linux
 }
 


### PR DESCRIPTION
Summary:

`SsdFile::disableFileCow()` calls `WriteFile::setAttributes()` to set
the `FS_NOCOW_FL` inode flag, which prevents btrfs copy-on-write
amplification on SSD cache files. Under the hood this issues
`ioctl(FS_IOC_GETFLAGS / FS_IOC_SETFLAGS)`, which throws via
`VELOX_CHECK` when the underlying filesystem does not support the flag
(e.g. tmpfs, ext4 on older kernels). This exception propagated through
the `SsdFile` constructor, causing `SsdFileTest.disabledCow` to be
flaky across CI configurations that use different filesystem types.

COW disabling is a performance optimization (not a correctness
requirement), so failures should be tolerated. The fix wraps each
`setAttributes` call in a try/catch that logs a WARNING and continues
rather than crashing.

Reviewed By: zacw7

Differential Revision: D99516031
