### PR TITLE
feat: Add `TimestampUtcType` as built-in logical type

### DIFF
--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -117,6 +117,7 @@ INTERVAL DAY TO SECOND  BIGINT
 INTERVAL YEAR TO MONTH  INTEGER
 TIME                    BIGINT
 TIME_MICRO_UTC          BIGINT
+TIMESTAMP_UTC           TIMESTAMP
 ======================  ======================================================
 
 DECIMAL type carries additional `precision`,
@@ -132,9 +133,11 @@ upto 38 precision, with a range of :math:`[-10^{38} + 1, +10^{38} - 1]`.
 All the three values, precision, scale, unscaled value are required to represent a
 decimal value.
 
-TIME type represents time in milliseconds of local timezone from midnight. Thus min/max value can range from 0 to 23:59:59.999.
-TIME_MICRO_UTC type represents time in microseconds from midnight, timezone unaware. Thus min/max value can range from 00:00:00.000000 to 23:59:59.999999.
+TIME represents time in milliseconds since midnight, subject to session timezone interpretation. Thus min/max value can range from 0 to 23:59:59.999.
+TIME_MICRO_UTC represents time in microseconds since midnight in UTC, not subject to session timezone adjustment. Thus min/max value can range from 00:00:00.000000 to 23:59:59.999999.
 The TIME and TIME_MICRO_UTC types are backed by BIGINT physical type.
+
+TIMESTAMP represents a timestamp subject to session timezone interpretation. TIMESTAMP_UTC represents a timestamp in UTC, not subject to session timezone adjustment. Both types are backed by TIMESTAMP physical type.
 
 Custom Types
 ~~~~~~~~~~~~
@@ -314,6 +317,8 @@ key differences are listed below.
   Example::
 
       SELECT cast('12:30:45.123456' as time)  -- 12:30:45.123456
+
+* Spark uses TIMESTAMP_UTC to support TimestampNTZType. TIMESTAMP_UTC is not subject to session timezone adjustment.
 
 * In function comparisons, nested null values are handled as values.
   Example::

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -105,7 +105,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         .connectorSessionProperty(
             kHiveConnectorId,
             HiveConfig::kReadTimestampUnitSession,
-            std::to_string(static_cast<int>(timestampPrecision_)))
+            std::to_string(static_cast<int>(readTimestampPrecision_)))
         .splits(splits)
         .assertResults(sql);
   }
@@ -213,10 +213,6 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         rootPool_->addAggregateChild("ParquetTableScanTest.Writer");
     options.memoryPool = childPool.get();
 
-    if (options.parquetWriteTimestampUnit.has_value()) {
-      timestampPrecision_ = options.parquetWriteTimestampUnit.value();
-    }
-
     auto writer = std::make_unique<Writer>(
         std::move(sink), options, asRowType(data[0]->type()));
 
@@ -226,44 +222,30 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     writer->close();
   }
 
-  void testTimestampRead(const WriterOptions& options) {
-    auto stringToTimestamp = [](std::string_view view) {
-      return util::fromTimestampString(
-                 view.data(),
-                 view.size(),
-                 util::TimestampParseMode::kPrestoCast)
-          .thenOrThrow(folly::identity, [&](const Status& status) {
-            VELOX_USER_FAIL("{}", status.message());
-          });
-    };
-    std::vector<std::string_view> views = {
-        "2015-06-01 19:34:56.007",
-        "2015-06-02 19:34:56.12306",
-        "2001-02-03 03:34:06.056",
-        "1998-03-01 08:01:06.996669",
-        "2022-12-23 03:56:01",
-        "1980-01-24 00:23:07",
-        "1999-12-08 13:39:26.123456",
-        "2023-04-21 09:09:34.5",
-        "2000-09-12 22:36:29",
-        "2007-12-12 04:27:56.999",
-    };
-    std::vector<Timestamp> values;
-    values.reserve(views.size());
-    for (auto view : views) {
-      values.emplace_back(stringToTimestamp(view));
-    }
-
+  void testTimestampRead(
+      const WriterOptions& options,
+      TimestampPrecision readTimestampPrecision) {
+    VELOX_CHECK(options.parquetWriteTimestampUnit.has_value());
+    const auto [values, expectedValues] = timestampValues(
+        options.parquetWriteTimestampUnit.value(), readTimestampPrecision);
     auto vector = makeRowVector(
         {"t"},
         {
             makeFlatVector<Timestamp>(values),
         });
-    auto schema = asRowType(vector->type());
     auto file = TempFilePath::create();
     writeToParquetFile(file->getPath(), {vector}, options);
-    loadData(schema, vector);
+    loadData(
+        asRowType(vector->type()),
+        makeRowVector(
+            {"t"},
+            {
+                makeFlatVector<Timestamp>(expectedValues),
+            }));
 
+    readTimestampPrecision_ = readTimestampPrecision;
+    auto guard = folly::makeGuard(
+        [&] { readTimestampPrecision_ = kDefaultReadTimestampPrecision; });
     assertSelectWithFilter(
         {makeSplit(file->getPath())}, {"t"}, {}, "", "SELECT t from tmp");
     assertSelectWithFilter(
@@ -304,6 +286,38 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         "SELECT t from tmp where t != TIMESTAMP '2000-09-12 22:36:29'");
   }
 
+  void testTimestampUtcRead(
+      const WriterOptions& options,
+      TimestampPrecision readTimestampPrecision) {
+    VELOX_CHECK(options.parquetWriteTimestampUnit.has_value());
+    const auto [values, expectedValues] = timestampValues(
+        options.parquetWriteTimestampUnit.value(), readTimestampPrecision);
+    auto vector = makeRowVector(
+        {"t"},
+        {
+            makeFlatVector<Timestamp>(values, TIMESTAMP_UTC()),
+        });
+    auto file = TempFilePath::create();
+    writeToParquetFile(file->getPath(), {vector}, options);
+
+    loadData(
+        ROW({"t"}, {TIMESTAMP_UTC()}),
+        makeRowVector(
+            {"t"},
+            {
+                // Expect values are used for creating duckdb table, so keep
+                // using TIMESTAMP here.
+                makeFlatVector<Timestamp>(expectedValues),
+            }));
+
+    readTimestampPrecision_ = readTimestampPrecision;
+    auto guard = folly::makeGuard(
+        [&] { readTimestampPrecision_ = kDefaultReadTimestampPrecision; });
+
+    assertSelectWithFilter(
+        {makeSplit(file->getPath())}, {"t"}, {}, "", "SELECT t from tmp");
+  }
+
  private:
   RowTypePtr getRowType(std::vector<std::string>&& outputColumnNames) const {
     std::vector<TypePtr> types;
@@ -314,8 +328,62 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     return ROW(std::move(outputColumnNames), std::move(types));
   }
 
+  std::pair<std::vector<Timestamp>, std::vector<Timestamp>> timestampValues(
+      TimestampPrecision writeTimestampPrecision,
+      TimestampPrecision readTimestampPrecision) {
+    auto stringToTimestamp = [](std::string_view view) {
+      return util::fromTimestampString(
+                 view.data(),
+                 view.size(),
+                 util::TimestampParseMode::kPrestoCast)
+          .value();
+    };
+    std::vector<std::string_view> views = {
+        "2015-06-01 19:34:56.007",
+        "2015-06-02 19:34:56.12306",
+        "2001-02-03 03:34:06.056",
+        "1998-03-01 08:01:06.996669",
+        "2022-12-23 03:56:01",
+        "1980-01-24 00:23:07",
+        "1999-12-08 13:39:26.123456",
+        "2023-04-21 09:09:34.5",
+        "2000-09-12 22:36:29",
+        "2007-12-12 04:27:56.999",
+    };
+
+    std::vector<Timestamp> values;
+    std::vector<Timestamp> expectedValues;
+    values.reserve(views.size());
+    for (auto view : views) {
+      auto ts = stringToTimestamp(view);
+      values.emplace_back(ts);
+      if (readTimestampPrecision == TimestampPrecision::kMilliseconds) {
+        expectedValues.emplace_back(Timestamp::fromMillis(ts.toMillis()));
+        continue;
+      }
+      if (readTimestampPrecision == TimestampPrecision::kMicroseconds) {
+        if (writeTimestampPrecision == TimestampPrecision::kMilliseconds) {
+          expectedValues.emplace_back(
+              Timestamp::fromMicros(ts.toMillis() * 1'000));
+          continue;
+        }
+        if (writeTimestampPrecision == TimestampPrecision::kMicroseconds) {
+          expectedValues.emplace_back(Timestamp::fromMicros(ts.toMicros()));
+          continue;
+        }
+      }
+      VELOX_NYI(
+          "Not implemented, read precision: {}, write precision: {}",
+          static_cast<int>(readTimestampPrecision),
+          static_cast<int>(writeTimestampPrecision));
+    }
+    return {values, expectedValues};
+  }
+
   RowTypePtr rowType_;
-  TimestampPrecision timestampPrecision_ = TimestampPrecision::kMicroseconds;
+  const TimestampPrecision kDefaultReadTimestampPrecision =
+      TimestampPrecision::kMicroseconds;
+  TimestampPrecision readTimestampPrecision_ = kDefaultReadTimestampPrecision;
   std::shared_ptr<io::IoStatistics> dataIoStats_ =
       std::make_shared<io::IoStatistics>();
   std::shared_ptr<io::IoStatistics> metadataIoStats_ =
@@ -1093,45 +1161,83 @@ TEST_F(ParquetTableScanTest, sessionTimezone) {
       "Asia/Shanghai");
 }
 
-TEST_F(ParquetTableScanTest, timestampInt64Dictionary) {
+TEST_F(ParquetTableScanTest, timestampInt64DictionaryMicro) {
   WriterOptions options;
   options.writeInt96AsTimestamp = false;
   options.enableDictionary = true;
   options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
-  testTimestampRead(options);
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
 }
 
-TEST_F(ParquetTableScanTest, timestampInt64Plain) {
+TEST_F(ParquetTableScanTest, timestampInt64DictionaryMilli) {
+  WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = true;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampInt64PlainMicro) {
   WriterOptions options;
   options.writeInt96AsTimestamp = false;
   options.enableDictionary = false;
   options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
-  testTimestampRead(options);
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
 }
 
-TEST_F(ParquetTableScanTest, timestampInt96Dictionary) {
+TEST_F(ParquetTableScanTest, timestampInt64PlainMilli) {
+  WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = false;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampInt96DictionaryMicro) {
   WriterOptions options;
   options.writeInt96AsTimestamp = true;
   options.enableDictionary = true;
   options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
-  testTimestampRead(options);
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
 }
 
-TEST_F(ParquetTableScanTest, timestampInt96Plain) {
+TEST_F(ParquetTableScanTest, timestampInt96DictionaryMilli) {
+  WriterOptions options;
+  options.writeInt96AsTimestamp = true;
+  options.enableDictionary = true;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampInt96PlainMicro) {
   WriterOptions options;
   options.writeInt96AsTimestamp = true;
   options.enableDictionary = false;
   options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
-  testTimestampRead(options);
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampInt96PlainMilli) {
+  WriterOptions options;
+  options.writeInt96AsTimestamp = true;
+  options.enableDictionary = false;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampRead(options, TimestampPrecision::kMilliseconds);
 }
 
 TEST_F(ParquetTableScanTest, timestampConvertedType) {
   auto stringToTimestamp = [](std::string_view view) {
     return util::fromTimestampString(
                view.data(), view.size(), util::TimestampParseMode::kPrestoCast)
-        .thenOrThrow(folly::identity, [&](const Status& status) {
-          VELOX_USER_FAIL("{}", status.message());
-        });
+        .value();
   };
   std::vector<std::string_view> expected = {
       "1970-01-01 00:00:00.010",
@@ -1189,6 +1295,42 @@ TEST_F(ParquetTableScanTest, timestampPrecisionMicrosecond) {
     });
     assertEqualResults({expected}, {result});
   }
+}
+
+TEST_F(ParquetTableScanTest, timestampUtcPlainMicro) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = false;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
+  testTimestampUtcRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampUtcRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampUtcDictionaryMicro) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = true;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMicroseconds;
+  testTimestampUtcRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampUtcRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampUtcPlainMilli) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = false;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampUtcRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampUtcRead(options, TimestampPrecision::kMilliseconds);
+}
+
+TEST_F(ParquetTableScanTest, timestampUtcDictionaryMilli) {
+  parquet::WriterOptions options;
+  options.writeInt96AsTimestamp = false;
+  options.enableDictionary = true;
+  options.parquetWriteTimestampUnit = TimestampPrecision::kMilliseconds;
+  testTimestampUtcRead(options, TimestampPrecision::kMicroseconds);
+  testTimestampUtcRead(options, TimestampPrecision::kMilliseconds);
 }
 
 TEST_F(ParquetTableScanTest, testColumnNotExists) {

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -98,6 +98,19 @@ class SimpleFunctionTest : public functions::test::FunctionBaseTest {
               .supportsFlatNoNullsFastPath());
     }
   }
+
+  std::vector<Timestamp> stringToTimestamp(
+      std::vector<std::string_view> views) {
+    std::vector<Timestamp> values;
+    values.reserve(views.size());
+    for (auto view : views) {
+      values.emplace_back(
+          util::fromTimestampString(
+              view.data(), view.size(), util::TimestampParseMode::kPrestoCast)
+              .value());
+    }
+    return values;
+  }
 };
 
 template <typename T>
@@ -1749,6 +1762,156 @@ TEST_F(SimpleFunctionTest, timeMicroUtcTypeTest) {
     auto expected =
         makeArrayVector<int64_t>({{2, 3, 4}, {5, 6, 7}}, TIME_MICRO_UTC());
     assertEqualVectors(expected, result);
+  }
+}
+
+template <typename T, typename TTimestamp>
+struct TimestampPlusOneFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void call(out_type<Timestamp>& out, const arg_type<Timestamp>& input) {
+    if constexpr (std::is_same_v<TTimestamp, Timestamp>) {
+      out = Timestamp::fromMillis(input.toMillis() + 1);
+    } else if constexpr (std::is_same_v<TTimestamp, TimestampUtc>) {
+      out = Timestamp::fromMicros(input.toMicros() + 1);
+    }
+  }
+};
+
+template <typename T>
+struct ArrayTimestampFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  void call(
+      out_type<Array<Timestamp>>& out,
+      const arg_type<Array<Timestamp>>& input) {
+    for (int i = 0; i < input.size(); i++) {
+      if (input[i].has_value()) {
+        out.push_back(Timestamp::fromMillis(input[i].value().toMillis() + 1));
+      }
+    }
+  }
+
+  void call(
+      out_type<Array<TimestampUtc>>& out,
+      const arg_type<Array<TimestampUtc>>& input) {
+    for (int i = 0; i < input.size(); i++) {
+      if (input[i].has_value()) {
+        out.push_back(Timestamp::fromMicros(input[i].value().toMicros() + 1));
+      }
+    }
+  }
+};
+
+TEST_F(SimpleFunctionTest, timestampTypeTest) {
+  std::vector<Timestamp> input = stringToTimestamp({
+      "2015-06-01 19:34:56.007",
+      "2015-06-02 19:34:56.12306",
+      "2001-02-03 03:34:06.056",
+      "1998-03-01 08:01:06.996669",
+      "2022-12-23 03:56:01",
+      "1980-01-24 00:23:07",
+      "1999-12-08 13:39:26.123456",
+      "2023-04-21 09:09:34.5",
+      "2000-09-12 22:36:29",
+      "2007-12-12 04:27:56.999",
+  });
+  std::vector<Timestamp> expected = stringToTimestamp({
+      "2015-06-01 19:34:56.008",
+      "2015-06-02 19:34:56.124",
+      "2001-02-03 03:34:06.057",
+      "1998-03-01 08:01:06.997",
+      "2022-12-23 03:56:01.001",
+      "1980-01-24 00:23:07.001",
+      "1999-12-08 13:39:26.124",
+      "2023-04-21 09:09:34.501",
+      "2000-09-12 22:36:29.001",
+      "2007-12-12 04:27:57.000",
+  });
+
+  {
+    registerFunction<
+        ParameterBinder<TimestampPlusOneFunction, Timestamp>,
+        Timestamp,
+        Timestamp>({"timestamp_plus_one"});
+    auto result = evaluate(
+        "timestamp_plus_one(c0)",
+        makeRowVector({
+            makeFlatVector<Timestamp>(input),
+        }));
+    assertEqualVectors(makeFlatVector<Timestamp>(expected), result);
+  }
+
+  // Test out Timestamp in complex type.
+  {
+    registerFunction<
+        ArrayTimestampFunction,
+        Array<Timestamp>,
+        Array<Timestamp>>({"array_timestamp"});
+
+    auto data = makeRowVector({
+        makeArrayVector<Timestamp>({{input}}),
+    });
+
+    auto result = evaluate("array_timestamp(c0)", data);
+    assertEqualVectors(makeArrayVector<Timestamp>({{expected}}), result);
+  }
+}
+
+TEST_F(SimpleFunctionTest, timestampUtcTypeTest) {
+  std::vector<Timestamp> input = stringToTimestamp({
+      "2015-06-01 19:34:56.007",
+      "2015-06-02 19:34:56.12306",
+      "2001-02-03 03:34:06.056",
+      "1998-03-01 08:01:06.996669",
+      "2022-12-23 03:56:01",
+      "1980-01-24 00:23:07",
+      "1999-12-08 13:39:26.123456",
+      "2023-04-21 09:09:34.5",
+      "2000-09-12 22:36:29",
+      "2007-12-12 04:27:56.999",
+  });
+  std::vector<Timestamp> expected = stringToTimestamp({
+      "2015-06-01 19:34:56.007001",
+      "2015-06-02 19:34:56.123061",
+      "2001-02-03 03:34:06.056001",
+      "1998-03-01 08:01:06.996670",
+      "2022-12-23 03:56:01.000001",
+      "1980-01-24 00:23:07.000001",
+      "1999-12-08 13:39:26.123457",
+      "2023-04-21 09:09:34.500001",
+      "2000-09-12 22:36:29.000001",
+      "2007-12-12 04:27:56.999001",
+  });
+
+  {
+    registerFunction<
+        ParameterBinder<TimestampPlusOneFunction, TimestampUtc>,
+        TimestampUtc,
+        TimestampUtc>({"timestamp_utc_plus_one"});
+    auto result = evaluate(
+        "timestamp_utc_plus_one(c0)",
+        makeRowVector({
+            makeFlatVector<Timestamp>(input, TIMESTAMP_UTC()),
+        }));
+    assertEqualVectors(
+        makeFlatVector<Timestamp>(expected, TIMESTAMP_UTC()), result);
+  }
+
+  // Test out TimestampUtc in complex type.
+  {
+    registerFunction<
+        ArrayTimestampFunction,
+        Array<TimestampUtc>,
+        Array<TimestampUtc>>({"array_timestamp_utc"});
+
+    auto data = makeRowVector({
+        makeArrayVector<Timestamp>({{input}}, TIMESTAMP_UTC()),
+    });
+
+    auto result = evaluate("array_timestamp_utc(c0)", data);
+    assertEqualVectors(
+        makeArrayVector<Timestamp>({{expected}}, TIMESTAMP_UTC()), result);
   }
 }
 

--- a/velox/functions/prestosql/tests/TypeOfTest.cpp
+++ b/velox/functions/prestosql/tests/TypeOfTest.cpp
@@ -61,6 +61,7 @@ TEST_F(TypeOfTest, basic) {
   EXPECT_EQ("varbinary", typeOf(VARBINARY()));
 
   EXPECT_EQ("timestamp", typeOf(TIMESTAMP()));
+  EXPECT_EQ("timestamp utc", typeOf(TIMESTAMP_UTC()));
   EXPECT_EQ("date", typeOf(DATE()));
   EXPECT_EQ("time", typeOf(TIME()));
   EXPECT_EQ("time micro utc", typeOf(TIME_MICRO_UTC()));

--- a/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
+++ b/velox/functions/prestosql/types/parser/tests/TypeParserTest.cpp
@@ -110,6 +110,11 @@ TEST_F(TypeParserTest, varbinary) {
   ASSERT_EQ(*parseType("varbinary"), *VARBINARY());
 }
 
+TEST_F(TypeParserTest, timestamp) {
+  ASSERT_EQ(*parseType("timestamp"), *TIMESTAMP());
+  ASSERT_EQ(*parseType("timestamp utc"), *TIMESTAMP_UTC());
+}
+
 TEST_F(TypeParserTest, time) {
   ASSERT_EQ(*parseType("time"), *TIME());
   ASSERT_EQ(*parseType("time micro utc"), *TIME_MICRO_UTC());

--- a/velox/type/SimpleFunctionApi.h
+++ b/velox/type/SimpleFunctionApi.h
@@ -234,6 +234,14 @@ struct Varchar {
   Varchar() {}
 };
 
+struct TimestampUtcT {
+  using type = Timestamp;
+
+  static constexpr const char* typeName = "timestamp utc";
+};
+
+using TimestampUtc = CustomType<TimestampUtcT>;
+
 // Type to use for inputs and outputs of simple functions with BigintEnum types.
 // E.g. arg_type<BigintEnum<E1>> and out_type<BigintEnum<E1>>.
 template <typename E>
@@ -297,6 +305,13 @@ struct CppToType<Varbinary> : public CppToTypeBase<TypeKind::VARBINARY> {};
 
 template <>
 struct CppToType<Date> : public CppToTypeBase<TypeKind::INTEGER> {};
+
+template <>
+struct CppToType<TimestampUtc> : public CppToTypeBase<TypeKind::TIMESTAMP> {
+  static auto create() {
+    return TimestampUtcType::get();
+  }
+};
 
 template <typename T>
 struct CppToType<Generic<T>> : public CppToTypeBase<TypeKind::UNKNOWN> {};
@@ -412,7 +427,7 @@ struct SimpleTypeTrait<CustomType<T, providesCustomComparison>>
   static constexpr bool isFixedWidth = physical_t::isFixedWidth;
 
   // This is different than the physical type name.
-  static constexpr char* name = T::typeName;
+  static constexpr const char* name = T::typeName;
 };
 
 /// MaterializeType template.

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -269,6 +269,7 @@ void Type::registerSerDe() {
   registry.Register(
       "IntervalYearMonthType", IntervalYearMonthType::deserialize);
   registry.Register("DateType", DateType::deserialize);
+  registry.Register("TimestampUtcType", TimestampUtcType::deserialize);
   registry.Register("TimeType", TimeTypeFactory::deserialize);
 }
 
@@ -1027,6 +1028,10 @@ VELOX_DEFINE_SCALAR_ACCESSOR(VARBINARY);
 
 #undef VELOX_DEFINE_SCALAR_ACCESSOR
 
+TypePtr TIMESTAMP_UTC() {
+  return TimestampUtcType::get();
+}
+
 TypePtr UNKNOWN() {
   return TypeFactory<TypeKind::UNKNOWN>::create();
 }
@@ -1364,6 +1369,7 @@ const SingletonTypeMap& singletonBuiltInTypes() {
       {"VARCHAR", VARCHAR()},
       {"VARBINARY", VARBINARY()},
       {"TIMESTAMP", TIMESTAMP()},
+      {"TIMESTAMP UTC", TIMESTAMP_UTC()},
       {"INTERVAL DAY TO SECOND", INTERVAL_DAY_TIME()},
       {"INTERVAL YEAR TO MONTH", INTERVAL_YEAR_MONTH()},
       {"DATE", DATE()},
@@ -1547,6 +1553,13 @@ const auto& typeParameterKindNames() {
 } // namespace
 
 VELOX_DEFINE_ENUM_NAME(TypeParameterKind, typeParameterKindNames);
+
+folly::dynamic TimestampUtcType::serialize() const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = "TimestampUtcType";
+  obj["type"] = name();
+  return obj;
+}
 
 template <TimePrecision kPrecision, bool kLocalTime>
 folly::dynamic TimeType<kPrecision, kLocalTime>::serialize() const {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1493,6 +1493,37 @@ using TimestampType = ScalarType<TypeKind::TIMESTAMP>;
 using VarcharType = ScalarType<TypeKind::VARCHAR>;
 using VarbinaryType = ScalarType<TypeKind::VARBINARY>;
 
+// Timestamp type in UTC that is not subject to session timezone adjustment.
+class TimestampUtcType final : public TimestampType {
+ public:
+  static std::shared_ptr<const TimestampUtcType> get() {
+    VELOX_CONSTEXPR_SINGLETON TimestampUtcType kInstance;
+    return {std::shared_ptr<const TimestampUtcType>{}, &kInstance};
+  }
+
+  const char* name() const override {
+    return "TIMESTAMP UTC";
+  }
+
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+
+  folly::dynamic serialize() const override;
+
+  static TypePtr deserialize(const folly::dynamic& /*obj*/) {
+    return TimestampUtcType::get();
+  }
+
+ protected:
+  constexpr TimestampUtcType() = default;
+};
+
 constexpr long kMillisInSecond = 1000;
 constexpr long kMillisInMinute = 60 * kMillisInSecond;
 constexpr long kMillisInHour = 60 * kMillisInMinute;
@@ -2311,6 +2342,8 @@ VELOX_SCALAR_ACCESSOR(DOUBLE);
 VELOX_SCALAR_ACCESSOR(TIMESTAMP);
 VELOX_SCALAR_ACCESSOR(VARCHAR);
 VELOX_SCALAR_ACCESSOR(VARBINARY);
+
+TypePtr TIMESTAMP_UTC();
 
 TypePtr UNKNOWN();
 

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -108,6 +108,7 @@ TEST(TypeTest, timestamp) {
   EXPECT_STREQ(t0->kindName(), "TIMESTAMP");
   ASSERT_EQ(t0->begin(), t0->end());
   ASSERT_EQ(approximateTypeEncodingwidth(t0), 1);
+  EXPECT_TRUE(t0->equivalent(*createType(TypeKind::TIMESTAMP, {})));
 
   testTypeSerde(t0);
 }
@@ -155,6 +156,25 @@ TEST(TypeTest, timestampComparison) {
   EXPECT_GE(t1, t1Copy);
   EXPECT_GE(t1, t1lessNanos);
   EXPECT_GE(t1, t1lessSeconds);
+}
+
+TEST(TypeTest, timestampUtc) {
+  const auto t = TIMESTAMP_UTC();
+  ASSERT_EQ(t->toString(), "TIMESTAMP UTC");
+  ASSERT_EQ(t->size(), 0);
+  VELOX_ASSERT_THROW(t->childAt(0), "scalar type has no children");
+  ASSERT_EQ(t->kind(), TypeKind::TIMESTAMP);
+  EXPECT_STREQ(t->kindName(), "TIMESTAMP");
+  ASSERT_EQ(t->begin(), t->end());
+  ASSERT_EQ(approximateTypeEncodingwidth(t), 1);
+
+  testTypeSerde(t);
+
+  EXPECT_TRUE(t->isTimestamp());
+  EXPECT_TRUE(t->equivalent(*TIMESTAMP_UTC()));
+  EXPECT_TRUE(TIMESTAMP_UTC()->equivalent(*TimestampUtcType::get()));
+  EXPECT_FALSE(t->equivalent(*TIMESTAMP()));
+  EXPECT_FALSE(TIMESTAMP()->equivalent(*t));
 }
 
 TEST(TypeTest, date) {


### PR DESCRIPTION
This PR introduces a new built-in logical type `TimestampUtcType` to represent 
Spark’s `TimestampNTZType`. It is backed by the `Timestamp` physical type while 
remaining timezone-agnostic.
In Spark, values stored as `Timestamp(isAdjustedToUTC = false)` are read as
`TimestampNTZType`, and this PR confirms that the existing Parquet reader works
as-is for `TimestampUtcType`. The custom [TimestampNTZType](https://github.com/facebookincubator/velox/blob/main/velox/functions/sparksql/types/TimestampNTZType.h) for Spark will be
removed and replaced with this new type.

More context: https://github.com/facebookincubator/velox/discussions/16886.
Related issue: https://github.com/facebookincubator/velox/issues/17087.
Spark's implementation: [TimestampNTZType.scala](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/TimestampNTZType.scala).