### PR TITLE
feat(function): Add Spark ANSI interval unary minus, add, and subtract

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -49,7 +49,9 @@ Mathematical Functions
 .. spark:function:: add(x, y) -> [same as x]
 
     Returns the result of adding x to y. The types of x and y must be the same.
-    Corresponds to sparks's operator ``+``.
+    For interval inputs (``interval day to second`` and
+    ``interval year to month``), overflow always throws an exception.
+    Corresponds to Spark's operator ``+``.
 
 .. spark:function:: add(x, y) -> decimal
 
@@ -81,7 +83,8 @@ Mathematical Functions
 .. function:: checked_add(x, y) -> [same as x]
 
     Returns the result of adding x to y. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to Spark's operator ``+`` with ``failOnError`` as true.
+    For integral and interval types, overflow results in an error. Corresponds
+    to Spark's operator ``+`` with ``failOnError`` as true.
 
 .. function:: checked_div(x, y) -> bigint
 
@@ -103,7 +106,8 @@ Mathematical Functions
 .. function:: checked_subtract(x, y) -> [same as x]
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to Spark's operator ``-`` with ``failOnError`` as true.
+    For integral and interval types, overflow results in an error. Corresponds
+    to Spark's operator ``-`` with ``failOnError`` as true.
 
 .. spark:function:: cos(x) -> double
 
@@ -426,6 +430,8 @@ Mathematical Functions
 .. spark:function:: subtract(x, y) -> [same as x]
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
+    For interval inputs (``interval day to second`` and
+    ``interval year to month``), overflow always throws an exception.
     Corresponds to Spark's operator ``-``.
 
 .. spark:function:: subtract(x, y) -> decimal
@@ -451,9 +457,10 @@ Mathematical Functions
 .. spark:function:: unaryminus(x) -> [same as x] (ANSI compliant)
 
     Returns the negative of ``x``. Corresponds to Spark's operator ``-``.
-    When ``x`` is the minimum value of an integral type, returns the same value
-    as ``x`` following the behavior when Spark ANSI mode is disabled, and throws
-    an exception when Spark ANSI mode is enabled.
+    For integral inputs, negating the minimum value returns the same value when
+    Spark ANSI mode is disabled and throws an overflow exception when Spark
+    ANSI mode is enabled. For interval inputs (``interval day to second`` and
+    ``interval year to month``), overflow always throws an exception.
 
 .. spark:function:: unhex(x) -> varbinary
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -166,17 +166,23 @@ template <typename T>
 struct UnaryMinusFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void initialize(
-      const std::vector<TypePtr>& /*inputTypes*/,
+      const std::vector<TypePtr>& inputTypes,
       const core::QueryConfig& config,
       const TInput* /*a*/) {
-    ansiEnabled_ = SparkQueryConfig{config}.ansiEnabled();
+    VELOX_DCHECK(!inputTypes.empty());
+    const auto& inputType = inputTypes.front();
+    // Spark's ANSI interval types always use exact arithmetic, independent of
+    // spark.sql.ansi.enabled.
+    failOnError_ = inputType->isIntervalDayTime() ||
+        inputType->isIntervalYearMonth() ||
+        SparkQueryConfig{config}.ansiEnabled();
   }
 
   template <typename TInput>
   FOLLY_ALWAYS_INLINE Status call(TInput& result, const TInput a) {
     if constexpr (std::is_integral_v<TInput>) {
       if (FOLLY_UNLIKELY(a == std::numeric_limits<TInput>::min())) {
-        if (ansiEnabled_) {
+        if (failOnError_) {
           if (threadSkipErrorDetails()) {
             return Status::UserError();
           }
@@ -192,7 +198,7 @@ struct UnaryMinusFunction {
   }
 
  private:
-  bool ansiEnabled_ = false;
+  bool failOnError_ = false;
 };
 
 template <typename T>

--- a/velox/functions/sparksql/registration/RegisterMath.cpp
+++ b/velox/functions/sparksql/registration/RegisterMath.cpp
@@ -123,6 +123,32 @@ void registerMathFunctions(const std::string& prefix) {
       UnaryMinusFunction,
       ShortDecimal<P1, S1>,
       ShortDecimal<P1, S1>>({prefix + "unaryminus"});
+  registerFunction<UnaryMinusFunction, IntervalDayTime, IntervalDayTime>(
+      {prefix + "unaryminus"});
+  registerFunction<UnaryMinusFunction, IntervalYearMonth, IntervalYearMonth>(
+      {prefix + "unaryminus"});
+  // Spark ANSI intervals always use exact arithmetic. Register both names to
+  // support legacy plans and plans that route failOnError through checked_*.
+  registerFunction<
+      CheckedAddFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "add", prefix + "checked_add"});
+  registerFunction<
+      CheckedAddFunction,
+      IntervalYearMonth,
+      IntervalYearMonth,
+      IntervalYearMonth>({prefix + "add", prefix + "checked_add"});
+  registerFunction<
+      CheckedSubtractFunction,
+      IntervalDayTime,
+      IntervalDayTime,
+      IntervalDayTime>({prefix + "subtract", prefix + "checked_subtract"});
+  registerFunction<
+      CheckedSubtractFunction,
+      IntervalYearMonth,
+      IntervalYearMonth,
+      IntervalYearMonth>({prefix + "subtract", prefix + "checked_subtract"});
 
   registerDecimalAdd(prefix);
   registerDecimalSubtract(prefix);

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(
   HashTest.cpp
   InitcapTest.cpp
   InTest.cpp
+  IntervalArithmeticTest.cpp
   JsonArrayLengthTest.cpp
   JsonObjectKeysTest.cpp
   LeastGreatestTest.cpp

--- a/velox/functions/sparksql/tests/IntervalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/IntervalArithmeticTest.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+
+#include <fmt/format.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class IntervalArithmeticTest : public SparkFunctionBaseTest {
+ protected:
+  void setAnsiEnabled(bool enabled) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{SparkQueryConfig::qualify(SparkQueryConfig::kAnsiEnabled),
+          enabled ? "true" : "false"}});
+  }
+
+  template <typename T>
+  std::optional<T> unaryminus(const TypePtr& type, std::optional<T> value) {
+    return evaluateOnce<T>("unaryminus(c0)", type, value);
+  }
+
+  template <typename T>
+  std::optional<T>
+  add(const TypePtr& type, std::optional<T> left, std::optional<T> right) {
+    return evaluateOnce<T>("add(c0, c1)", {type, type}, left, right);
+  }
+
+  template <typename T>
+  std::optional<T>
+  subtract(const TypePtr& type, std::optional<T> left, std::optional<T> right) {
+    return evaluateOnce<T>("subtract(c0, c1)", {type, type}, left, right);
+  }
+
+  template <typename T>
+  std::optional<T> checkedAdd(
+      const TypePtr& type,
+      std::optional<T> left,
+      std::optional<T> right) {
+    return evaluateOnce<T>("checked_add(c0, c1)", {type, type}, left, right);
+  }
+
+  template <typename T>
+  std::optional<T> checkedSubtract(
+      const TypePtr& type,
+      std::optional<T> left,
+      std::optional<T> right) {
+    return evaluateOnce<T>(
+        "checked_subtract(c0, c1)", {type, type}, left, right);
+  }
+
+  template <typename T>
+  std::optional<T> tryCheckedAdd(
+      const TypePtr& type,
+      std::optional<T> left,
+      std::optional<T> right) {
+    return evaluateOnce<T>(
+        "try(checked_add(c0, c1))", {type, type}, left, right);
+  }
+
+  template <typename T>
+  std::optional<T> tryCheckedSubtract(
+      const TypePtr& type,
+      std::optional<T> left,
+      std::optional<T> right) {
+    return evaluateOnce<T>(
+        "try(checked_subtract(c0, c1))", {type, type}, left, right);
+  }
+
+  template <typename T>
+  void testUnaryMinus(const TypePtr& type, T value) {
+    for (const bool ansiEnabled : {false, true}) {
+      SCOPED_TRACE(fmt::format("ANSI enabled: {}", ansiEnabled));
+      setAnsiEnabled(ansiEnabled);
+
+      EXPECT_EQ(unaryminus<T>(type, value), -value);
+      EXPECT_EQ(unaryminus<T>(type, -value), value);
+      EXPECT_EQ(unaryminus<T>(type, 0), 0);
+      VELOX_ASSERT_THROW(
+          unaryminus<T>(type, std::numeric_limits<T>::min()),
+          "Arithmetic overflow");
+    }
+  }
+
+  template <typename T>
+  void testAdd(const TypePtr& type) {
+    for (const bool ansiEnabled : {false, true}) {
+      SCOPED_TRACE(fmt::format("ANSI enabled: {}", ansiEnabled));
+      setAnsiEnabled(ansiEnabled);
+
+      EXPECT_EQ(add<T>(type, 1, 2), 3);
+      EXPECT_EQ(add<T>(type, -2, 1), -1);
+      EXPECT_EQ(checkedAdd<T>(type, 1, 2), 3);
+      VELOX_ASSERT_THROW(
+          add<T>(type, std::numeric_limits<T>::max(), 1),
+          "Arithmetic overflow");
+      VELOX_ASSERT_THROW(
+          add<T>(type, std::numeric_limits<T>::min(), -1),
+          "Arithmetic overflow");
+      VELOX_ASSERT_THROW(
+          checkedAdd<T>(type, std::numeric_limits<T>::max(), 1),
+          "Arithmetic overflow");
+      VELOX_ASSERT_THROW(
+          checkedAdd<T>(type, std::numeric_limits<T>::min(), -1),
+          "Arithmetic overflow");
+      EXPECT_EQ(
+          tryCheckedAdd<T>(type, std::numeric_limits<T>::max(), 1),
+          std::nullopt);
+    }
+  }
+
+  template <typename T>
+  void testSubtract(const TypePtr& type) {
+    for (const bool ansiEnabled : {false, true}) {
+      SCOPED_TRACE(fmt::format("ANSI enabled: {}", ansiEnabled));
+      setAnsiEnabled(ansiEnabled);
+
+      EXPECT_EQ(subtract<T>(type, 3, 1), 2);
+      EXPECT_EQ(subtract<T>(type, 1, 2), -1);
+      EXPECT_EQ(checkedSubtract<T>(type, 3, 1), 2);
+      VELOX_ASSERT_THROW(
+          subtract<T>(type, std::numeric_limits<T>::min(), 1),
+          "Arithmetic overflow");
+      VELOX_ASSERT_THROW(
+          subtract<T>(type, std::numeric_limits<T>::max(), -1),
+          "Arithmetic overflow");
+      VELOX_ASSERT_THROW(
+          checkedSubtract<T>(type, std::numeric_limits<T>::min(), 1),
+          "Arithmetic overflow");
+      VELOX_ASSERT_THROW(
+          checkedSubtract<T>(type, std::numeric_limits<T>::max(), -1),
+          "Arithmetic overflow");
+      EXPECT_EQ(
+          tryCheckedSubtract<T>(type, std::numeric_limits<T>::min(), 1),
+          std::nullopt);
+    }
+  }
+};
+
+TEST_F(IntervalArithmeticTest, unaryMinus) {
+  testUnaryMinus<int64_t>(INTERVAL_DAY_TIME(), 1'000);
+  testUnaryMinus<int32_t>(INTERVAL_YEAR_MONTH(), 12);
+}
+
+TEST_F(IntervalArithmeticTest, add) {
+  testAdd<int64_t>(INTERVAL_DAY_TIME());
+  testAdd<int32_t>(INTERVAL_YEAR_MONTH());
+}
+
+TEST_F(IntervalArithmeticTest, subtract) {
+  testSubtract<int64_t>(INTERVAL_DAY_TIME());
+  testSubtract<int32_t>(INTERVAL_YEAR_MONTH());
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
### Summary

Add `unaryminus`, `add`, and `subtract` support for Spark's `INTERVAL DAY TO SECOND` and `INTERVAL YEAR TO MONTH` types.

Interval overflow always raises an error, matching Spark in both ANSI modes. `add` and `subtract` are registered under both their plain and `checked_*` names because Gluten emits the checked names for ANSI evaluation. Existing numeric and decimal behavior is unchanged.

Related: [apache/incubator-gluten#10134](https://github.com/apache/incubator-gluten/issues/10134)
