### PR TITLE
feat: Make Spark CAST(string as timestamp) ANSI-compliant

### DIFF
--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -5,19 +5,16 @@ Conversion Functions
 .. spark:function:: cast(value AS type) -> type
 
     Explicitly cast a ``value`` to a specified ``type``.
-    For cast pairs with Velox Spark ANSI support, behavior follows Spark ANSI
-    mode. Currently, ANSI mode is supported for casting from string to boolean,
-    integral, and date types. Other cast pairs follow the behavior used when
-    Spark ANSI mode is disabled:
 
-    * If the ``value`` exceeds the range of the ``type``, no error is raised.
-      Instead, the ``value`` is "wrapped" around.
+    Behavior depends on the source and target types. Unless otherwise noted
+    below, examples reflect behavior when Spark ANSI mode is disabled.
+
+    * If the ``value`` exceeds the range of the ``type``, behavior is
+      type-dependent and documented in the corresponding section below.
 
     * If the ``value`` has an invalid format or contains characters incompatible
-      with the target ``type``, the cast function returns NULL. ::
-
-        SELECT cast(128 as tinyint); -- -128
-        SELECT cast('2012-Oct-23' as date); -- NULL
+      with the target ``type``, the result is type-dependent and documented in
+      the corresponding section below.
 
 .. spark:function:: try_cast(value AS type) -> type
 
@@ -410,6 +407,35 @@ Valid examples
   SELECT cast(cast(1.79769e+308 as double) as timestamp); -- 294247-01-10 04:00:54.775807
   SELECT cast(cast('inf' as double) as timestamp); -- NULL
   SELECT cast(cast('nan' as double) as timestamp); -- NULL
+
+From strings
+^^^^^^^^^^^^
+
+*(ANSI compliant)*
+
+Casting from strings to timestamp uses Spark-compatible timestamp parsing.
+The parser accepts date-only values, both ``' '`` and ``'T'`` as date-time
+separators, fractional seconds, and leading or trailing spaces.
+
+Casting from invalid strings returns NULL when ANSI mode is disabled and throws
+an error when ANSI mode is enabled.
+
+Valid examples
+
+::
+
+  SELECT cast('1970-01-01' as timestamp); -- 1970-01-01 00:00:00
+  SELECT cast('2000-01-01 12:21:56' as timestamp); -- 2000-01-01 12:21:56
+  SELECT cast('2000-01-01T12:21:56' as timestamp); -- 2000-01-01 12:21:56
+  SELECT cast(' 2000-01-01 12:21:56 ' as timestamp); -- 2000-01-01 12:21:56
+  SELECT cast('2015-03-18 12:03:17.123' as timestamp); -- 2015-03-18 12:03:17.123
+
+Invalid examples
+
+::
+
+  SELECT cast('INVALID' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
+  SELECT cast('2012-Oct-01' as timestamp); -- NULL (ANSI OFF) / ERROR (ANSI ON)
 
 From boolean
 ^^^^^^^^^^^^

--- a/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
+++ b/velox/functions/sparksql/specialforms/SparkCastExpr.cpp
@@ -108,7 +108,8 @@ bool SparkCastCallToSpecialForm::isAnsiSupported(
     const TypePtr& fromType,
     const TypePtr& toType) {
   if (fromType->isVarchar()) {
-    if (toType->isBoolean() || toType->isDate() || toType->isDecimal()) {
+    if (toType->isBoolean() || toType->isTimestamp() || toType->isDate() ||
+        toType->isDecimal()) {
       return true;
     }
     if (isIntegralType(toType)) {
@@ -143,9 +144,6 @@ exec::ExprPtr SparkCastCallToSpecialForm::constructSpecialForm(
   const bool isTryCast = !SparkQueryConfig{config}.ansiEnabled() ||
       !isAnsiSupported(fromType, type);
 
-  // For ANSI-supported casts, CAST mirrors TRY_CAST when ANSI is disabled.
-  // The distinction is controlled by the 'allowOverflow' flag in
-  // SparkCastHooks.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),
@@ -165,7 +163,6 @@ exec::ExprPtr SparkTryCastCallToSpecialForm::constructSpecialForm(
       "TRY_CAST statements expect exactly 1 argument, received {}.",
       compiledChildren.size());
 
-  // TRY_CAST always uses allowOverflow=false to return NULL on cast failures.
   return std::make_shared<SparkCastExpr>(
       type,
       std::move(compiledChildren[0]),

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -1383,8 +1383,56 @@ TEST_F(SparkCastExprTestAnsiOn, stringToBoolean) {
   testInvalidString("nan");
 }
 
-TEST_F(SparkCastExprTestAnsiOn, stringToTimestamp) {
+TEST_F(SparkCastExprTest, stringToTimestampAdditionalValidForms) {
+  for (auto ansiEnabled : {false, true}) {
+    setAnsiSupport(ansiEnabled);
+
+    auto input = makeRowVector({makeFlatVector<std::string>({
+        "2000-01-01 12:21:56",
+        "2000-01-01T12:21:56",
+        " 2000-01-01 12:21:56 ",
+    })});
+
+    auto result =
+        evaluate<SimpleVector<Timestamp>>("cast(c0 as timestamp)", input);
+
+    ASSERT_FALSE(result->isNullAt(0));
+    ASSERT_FALSE(result->isNullAt(1));
+    ASSERT_FALSE(result->isNullAt(2));
+    EXPECT_EQ(result->valueAt(0), result->valueAt(1));
+    EXPECT_EQ(result->valueAt(0), result->valueAt(2));
+  }
+}
+
+TEST_F(SparkCastExprTest, tryCastStringToTimestampInvalid) {
+  for (auto ansiEnabled : {false, true}) {
+    setAnsiSupport(ansiEnabled);
+
+    auto input = makeRowVector(
+        {makeFlatVector<std::string>({"INVALID", "2012-Oct-01"})});
+
+    auto result =
+        evaluate<SimpleVector<Timestamp>>("try_cast(c0 as timestamp)", input);
+
+    ASSERT_TRUE(result->isNullAt(0));
+    ASSERT_TRUE(result->isNullAt(1));
+  }
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToTimestampValid) {
   testStringToTimestamp();
+}
+
+TEST_F(SparkCastExprTestAnsiOn, stringToTimestampInvalidThrows) {
+  auto testInvalidTimestamp = [this](const std::string& value) {
+    auto input = makeRowVector({makeFlatVector<std::string>({value})});
+    VELOX_ASSERT_THROW(
+        (evaluate<SimpleVector<Timestamp>>("cast(c0 as timestamp)", input)),
+        "Unable to parse timestamp value");
+  };
+
+  testInvalidTimestamp("INVALID");
+  testInvalidTimestamp("2012-Oct-01");
 }
 
 TEST_F(SparkCastExprTestAnsiOn, stringToDate) {
@@ -1667,7 +1715,8 @@ TEST_F(SparkCastExprTestAnsiOff, stringToBoolean) {
 
 TEST_F(SparkCastExprTestAnsiOff, stringToTimestamp) {
   testStringToTimestamp();
-  testCast<std::string, Timestamp>("timestamp", {"INVALID"}, {std::nullopt});
+  testCast<std::string, Timestamp>(
+      "timestamp", {"INVALID", "2012-Oct-01"}, {std::nullopt, std::nullopt});
 }
 
 TEST_F(SparkCastExprTestAnsiOff, stringToDate) {


### PR DESCRIPTION
## Summary

This PR makes Spark CAST(string as timestamp) ANSI-compliant.
Before this change, invalid string-to-timestamp casts in ANSI mode did not raise an exception in the Spark cast path. Instead, they followed null like behavior. This change makes invalid string-to-timestamp casts raise a cast error under ANSI `CAST`, while preserving null on error behavior for non ANSI / try cast behavior.

## Changes

- mark `string -> timestamp` as ANSI-supported in `SparkCastExpr`
- handle string-to-timestamp cast hook failures in `CastExpr-inl.h` by:
  - setting null for try-cast / null-on-error paths
  - raising a bad cast exception for ANSI cast paths

