### PR TITLE
fix: Disable FileHandleCache in TableEvolutionFuzzer to prevent fd exhaustion

### DIFF
--- a/velox/exec/tests/TableEvolutionFuzzerTest.cpp
+++ b/velox/exec/tests/TableEvolutionFuzzerTest.cpp
@@ -43,7 +43,8 @@ void registerFactories(folly::Executor* ioExecutor) {
   auto hiveConnector = factory.newConnector(
       TableEvolutionFuzzer::connectorId(),
       std::make_shared<config::ConfigBase>(
-          std::unordered_map<std::string, std::string>()),
+          std::unordered_map<std::string, std::string>{
+              {connector::hive::HiveConfig::kEnableFileHandleCache, "false"}}),
       ioExecutor);
   connector::ConnectorRegistry::global().insert(
       hiveConnector->connectorId(), hiveConnector);


### PR DESCRIPTION
## Summary

Fixes #17105.

The `TableEvolutionFuzzerTest` creates a `HiveConnector` with default config, which enables a `FileHandleCache` with 20,000 capacity and no expiration. Each fuzzer iteration writes parquet files to a fresh temp directory, scans them (caching the read handles), then deletes the directory. The cache retains open fds to the deleted inodes, and after 60-115 iterations the process hits `ulimit -n` and crashes with EMFILE.

This disables the file handle cache for this test. The fuzzer uses unique temp paths each iteration, so the cache provides zero hit rate — it only accumulates stale fds.

It is possible to work around this issue by setting a higher `ulimit` but it doesn't really make sense to keep the file handle cache enabled if it's not providing value for this test.

I verified that `TableEvolutionFuzzerTest.run` no longer fails with "Too many open files" in our test environment here: https://github.com/rapidsai/velox-testing/actions/runs/24226417564