### PR TITLE
fix(build): Fix missing `glog` dependency for target `dbgen`

### DIFF
--- a/velox/tpch/gen/dbgen/CMakeLists.txt
+++ b/velox/tpch/gen/dbgen/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(
 
 target_compile_definitions(dbgen PRIVATE DBNAME=dss MAC ORACLE TPCH)
 target_include_directories(dbgen PRIVATE include)
-target_link_libraries(dbgen PRIVATE fmt::fmt Folly::folly glog::glog)
+target_link_libraries(dbgen PRIVATE fmt::fmt Folly::folly glog::glog gflags::gflags)
 
 # Suppress warnings when compiling dbgen.
 target_compile_options(dbgen PRIVATE -w)

--- a/velox/tpch/gen/dbgen/CMakeLists.txt
+++ b/velox/tpch/gen/dbgen/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(
 
 target_compile_definitions(dbgen PRIVATE DBNAME=dss MAC ORACLE TPCH)
 target_include_directories(dbgen PRIVATE include)
-target_link_libraries(dbgen PRIVATE fmt::fmt Folly::folly)
+target_link_libraries(dbgen PRIVATE fmt::fmt Folly::folly glog::glog)
 
 # Suppress warnings when compiling dbgen.
 target_compile_options(dbgen PRIVATE -w)


### PR DESCRIPTION
Target `dbgen` [needs](https://github.com/facebookincubator/velox/blob/fed3e61d86fcfc1998128a5b6257a601dccf8e85/velox/tpch/gen/dbgen/build.cpp#L39) `velox/common/base/Exceptions.h` but doesn't have the glog / glags dependencies declared in CMakeLists.txt. The patch fixes the issue.

Otherwise, there is a build error when using bundled `glog`:

```
cmake --build /root/Public/code/gluten/ep/build-velox/build/velox_ep/cmake-build-debug --target velox -j 30
[0/2] Re-checking globbed directories...
[2/806] Building CXX object velox/tpch/gen/dbgen/CMakeFiles/dbgen.dir/build.cpp.o
FAILED: [code=1] velox/tpch/gen/dbgen/CMakeFiles/dbgen.dir/build.cpp.o
/usr/bin/ccache /usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CONTEXT_DYN_LINK -DBOOST_CONTEXT_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_REGEX_DYN_LINK -DBOOST_REGEX_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DDBNAME=dss -DFOLLY_HAS_COROUTINES=1 -DGFLAGS_IS_A_DLL=0 -DMAC -DORACLE -DTPCH -DVELOX_ENABLE_PARQUET -I/root/Public/code/gluten/ep/build-velox/build/velox_ep/. -I/root/Public/code/gluten/ep/build-velox/build/velox_ep/velox/external/xxhash -I/root/Public/code/gluten/ep/build-velox/build/velox_ep/velox/tpch/gen/dbgen/include -isystem /root/Public/code/gluten/ep/build-velox/build/velox_ep/velox -isystem /root/Public/code/gluten/ep/build-velox/build/velox_ep/velox/external -isystem /usr/include/libdwarf -isystem /root/Public/code/gluten/ep/build-velox/build/velox_ep/cmake-build-debug/_deps/gflags-build/include -mavx2 -mfma -mavx -mf16c -mlzcnt -mbmi2 -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-implicit-fallthrough          -Wno-class-memaccess          -Wno-comment          -Wno-int-in-bool-context          -Wno-redundant-move          -Wno-array-bounds          -Wno-maybe-uninitialized          -Wno-unused-result          -Wno-format-overflow          -Wno-strict-aliasing -g -std=gnu++20 -fPIC -fdiagnostics-color=always -fcoroutines -w -MD -MT velox/tpch/gen/dbgen/CMakeFiles/dbgen.dir/build.cpp.o -MF velox/tpch/gen/dbgen/CMakeFiles/dbgen.dir/build.cpp.o.d -o velox/tpch/gen/dbgen/CMakeFiles/dbgen.dir/build.cpp.o -c /root/Public/code/gluten/ep/build-velox/build/velox_ep/velox/tpch/gen/dbgen/build.cpp
In file included from /root/Public/code/gluten/ep/build-velox/build/velox_ep/./velox/common/base/Exceptions.h:27,
                 from /root/Public/code/gluten/ep/build-velox/build/velox_ep/velox/tpch/gen/dbgen/build.cpp:39:
/root/Public/code/gluten/ep/build-velox/build/velox_ep/./velox/common/base/VeloxException.h:27:10: fatal error: glog/logging.h: No such file or directory
   27 | #include <glog/logging.h>
      |          ^~~~~~~~~~~~~~~~
```