### PR TITLE
feat: Add IndexLookupJoinBridge for multi-threaded index split sharing (#17109)

### DIFF
--- a/velox/exec/BlockingReason.cpp
+++ b/velox/exec/BlockingReason.cpp
@@ -35,6 +35,7 @@ const auto& blockingReasonNames() {
       {BlockingReason::kWaitForArbitration, "kWaitForArbitration"},
       {BlockingReason::kWaitForScanScaleUp, "kWaitForScanScaleUp"},
       {BlockingReason::kWaitForIndexLookup, "kWaitForIndexLookup"},
+      {BlockingReason::kWaitForIndexSplits, "kWaitForIndexSplits"},
       {BlockingReason::kWaitForRPC, "kWaitForRPC"},
   };
   return kNames;

--- a/velox/exec/BlockingReason.h
+++ b/velox/exec/BlockingReason.h
@@ -55,6 +55,9 @@ enum class BlockingReason {
   /// Used by IndexLookupJoin operator, indicating that it was blocked by the
   /// async index lookup.
   kWaitForIndexLookup,
+  /// Used by IndexLookupJoin follower operators waiting for the leader to
+  /// finish collecting index splits via the IndexLookupJoinBridge.
+  kWaitForIndexSplits,
   /// Used by RPC operators, indicating that the operator is blocked waiting
   /// for an async RPC response (e.g., LLM inference, embedding lookups).
   kWaitForRPC,

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -47,6 +47,7 @@ velox_add_library(
   HashTable.cpp
   HashTableCache.cpp
   IndexLookupJoin.cpp
+  IndexLookupJoinBridge.cpp
   JoinBridge.cpp
   Limit.cpp
   LocalPartition.cpp
@@ -153,6 +154,7 @@ velox_add_library(
   HashTableCache.h
   HilbertIndex.h
   IndexLookupJoin.h
+  IndexLookupJoinBridge.h
   JoinBridge.h
   Limit.h
   LocalPartition.h

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -879,6 +879,10 @@ struct DriverFactory {
   /// based on this pipeline.
   std::vector<core::PlanNodeId> needsSpatialJoinBridges() const;
 
+  /// Returns plan node IDs for which IndexLookupJoin Bridges must be created
+  /// based on this pipeline.
+  std::vector<core::PlanNodeId> needsIndexLookupJoinBridges() const;
+
   static std::vector<DriverAdapter> adapters;
 };
 

--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -384,6 +384,7 @@ IndexLookupJoin::IndexLookupJoin(
               lookupTableHandle_->connectorId())),
       maxNumInputBatches_(
           1 + driverCtx->queryConfig().indexLookupJoinMaxPrefetchBatches()),
+      isIndexSplitCollector_{driverCtx->partitionId == 0},
       joinNode_{joinNode},
       indexStatWriter_(std::make_shared<IndexLazyStatWriter>(this)) {
   duplicateJoinKeyCheck(joinNode_->leftKeys());
@@ -424,6 +425,13 @@ void IndexLookupJoin::initialize() {
       lookupTableHandle_,
       lookupColumnHandles_,
       connectorQueryCtx_.get());
+
+  if (lookupTableHandle_->needsIndexSplit()) {
+    auto* driverCtx = operatorCtx_->driverCtx();
+    joinBridge_ = driverCtx->task->getIndexLookupJoinBridge(
+        driverCtx->splitGroupId, planNodeId());
+    VELOX_CHECK_NOT_NULL(joinBridge_);
+  }
 
   createIndexSplitTracer();
 }
@@ -711,6 +719,9 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
     if (!split.hasConnectorSplit()) {
       noMoreIndexSplits_ = true;
       VELOX_CHECK(!indexSplits_.empty());
+      // Publish splits to the bridge for followers before consuming locally.
+      VELOX_CHECK_NOT_NULL(joinBridge_);
+      joinBridge_->setIndexSplits(indexSplits_);
       indexSource_->addSplits(std::move(indexSplits_));
       return true;
     }
@@ -718,6 +729,20 @@ bool IndexLookupJoin::collectIndexSplits(ContinueFuture* future) {
     traceIndexSplit(split);
     indexSplits_.push_back(std::move(split.connectorSplit));
   }
+}
+
+bool IndexLookupJoin::waitForIndexSplits(ContinueFuture* future) {
+  VELOX_CHECK(needsIndexSplits());
+  VELOX_CHECK(!isIndexSplitCollector_);
+  VELOX_CHECK(indexSplits_.empty());
+
+  auto splits = joinBridge_->splitsOrFuture(future);
+  if (splits.empty()) {
+    return false;
+  }
+  noMoreIndexSplits_ = true;
+  indexSource_->addSplits(std::move(splits));
+  return true;
 }
 
 bool IndexLookupJoin::startDrain() {
@@ -748,9 +773,16 @@ bool IndexLookupJoin::needsInput() const {
 BlockingReason IndexLookupJoin::isBlocked(ContinueFuture* future) {
   // Handle split collection for index sources that require splits.
   if (needsIndexSplits()) {
-    if (!collectIndexSplits(future)) {
-      VELOX_CHECK(future->valid());
-      return BlockingReason::kWaitForSplit;
+    if (isIndexSplitCollector_) {
+      if (!collectIndexSplits(future)) {
+        VELOX_CHECK(future->valid());
+        return BlockingReason::kWaitForSplit;
+      }
+    } else {
+      if (!waitForIndexSplits(future)) {
+        VELOX_CHECK(future->valid());
+        return BlockingReason::kWaitForIndexSplits;
+      }
     }
   }
 

--- a/velox/exec/IndexLookupJoin.h
+++ b/velox/exec/IndexLookupJoin.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 #pragma once
+
+#include "velox/exec/IndexLookupJoinBridge.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/VectorHasher.h"
 
@@ -185,7 +187,13 @@ class IndexLookupJoin : public Operator {
   // Collects splits for the index source until no more splits signal is
   // received. Returns true if all splits have been collected and the index
   // source is ready. Returns false if we are still waiting for splits.
+  // Only called by the split collector operator (partitionId == 0).
   bool collectIndexSplits(ContinueFuture* future);
+
+  // Waits for the split collector to share index splits via the bridge.
+  // Returns true if splits are available and have been added to the index
+  // source. Returns false if we are still waiting for splits.
+  bool waitForIndexSplits(ContinueFuture* future);
 
   // Applies the join filter directly on the lookup result, updating the
   // lookup result to only include rows that pass the filter. Returns true if
@@ -326,6 +334,10 @@ class IndexLookupJoin : public Operator {
   const std::shared_ptr<connector::Connector> connector_;
   const size_t maxNumInputBatches_;
 
+  // True if this operator (partitionId == 0) is responsible for collecting
+  // index splits from the task and sharing them via the bridge.
+  const bool isIndexSplitCollector_;
+
   // The lookup join plan node used to initialize this operator and reset after
   // that.
   std::shared_ptr<const core::IndexLookupJoinNode> joinNode_;
@@ -407,6 +419,10 @@ class IndexLookupJoin : public Operator {
   // The start time of the current lookup driver block wait, and reset after the
   // driver wait completes.
   std::optional<size_t> blockWaitStartNs_;
+
+  // The bridge for sharing index splits across operators in the same pipeline.
+  // Null if the index source does not need splits.
+  std::shared_ptr<IndexLookupJoinBridge> joinBridge_;
 
   // Split collection state for index sources that require splits.
   // True if we have received the no-more-splits signal for the index source.

--- a/velox/exec/IndexLookupJoinBridge.cpp
+++ b/velox/exec/IndexLookupJoinBridge.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/IndexLookupJoinBridge.h"
+
+namespace facebook::velox::exec {
+
+void IndexLookupJoinBridge::setIndexSplits(
+    std::vector<std::shared_ptr<connector::ConnectorSplit>> splits) {
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_CHECK(started_, "Bridge must be started before setting index splits");
+    VELOX_CHECK(
+        !cancelled_, "Setting index splits after the bridge is cancelled");
+    VELOX_CHECK(
+        indexSplits_.empty(), "setIndexSplits must be called only once");
+    VELOX_CHECK(!splits.empty(), "Index splits must not be empty");
+    indexSplits_ = std::move(splits);
+    promises = std::move(promises_);
+  }
+  notify(std::move(promises));
+}
+
+std::vector<std::shared_ptr<connector::ConnectorSplit>>
+IndexLookupJoinBridge::splitsOrFuture(ContinueFuture* future) {
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(
+      !cancelled_, "Getting index splits after the bridge is cancelled");
+  if (!indexSplits_.empty()) {
+    return indexSplits_;
+  }
+  promises_.emplace_back("IndexLookupJoinBridge::splitsOrFuture");
+  *future = promises_.back().getSemiFuture();
+  return {};
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/IndexLookupJoinBridge.h
+++ b/velox/exec/IndexLookupJoinBridge.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/exec/JoinBridge.h"
+
+namespace facebook::velox::exec {
+
+/// Coordinates sharing of index splits among multiple IndexLookupJoin operators
+/// in the same pipeline. The leader operator (driverId 0) collects all splits
+/// from the task and publishes them via setIndexSplits(). Follower operators
+/// wait for splits via splitsOrFuture().
+class IndexLookupJoinBridge : public JoinBridge {
+ public:
+  /// Called by the leader operator after collecting all index splits. Stores
+  /// the splits and notifies all waiting followers. Must be called only once.
+  void setIndexSplits(
+      std::vector<std::shared_ptr<connector::ConnectorSplit>> splits);
+
+  /// Returns splits if already available, otherwise sets 'future' and returns
+  /// an empty vector. The caller should block on the future and retry.
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> splitsOrFuture(
+      ContinueFuture* future);
+
+ private:
+  // Empty until the leader calls setIndexSplits() with a non-empty vector.
+  std::vector<std::shared_ptr<connector::ConnectorSplit>> indexSplits_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -478,7 +478,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
   std::vector<std::unique_ptr<Operator>> operators;
   operators.reserve(planNodes.size());
 
-  for (int32_t i = 0; i < planNodes.size(); i++) {
+  for (int32_t i = 0; i < planNodes.size(); ++i) {
     // Id of the Operator being made. This is not the same as 'i'
     // because some PlanNodes may get fused.
     auto id = operators.size();
@@ -829,6 +829,21 @@ std::vector<core::PlanNodeId> DriverFactory::needsSpatialJoinBridges() const {
     }
   }
 
+  return planNodeIds;
+}
+
+std::vector<core::PlanNodeId> DriverFactory::needsIndexLookupJoinBridges()
+    const {
+  std::vector<core::PlanNodeId> planNodeIds;
+  for (const auto& planNode : planNodes) {
+    if (auto joinNode =
+            std::dynamic_pointer_cast<const core::IndexLookupJoinNode>(
+                planNode)) {
+      if (joinNode->needsIndexSplit()) {
+        planNodeIds.emplace_back(joinNode->id());
+      }
+    }
+  }
   return planNodeIds;
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -27,6 +27,7 @@
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/HashJoinBridge.h"
+#include "velox/exec/IndexLookupJoinBridge.h"
 #include "velox/exec/LocalPlanner.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
@@ -1313,6 +1314,8 @@ void Task::createSplitGroupStateLocked(uint32_t splitGroupId) {
         splitGroupId, factory->needsNestedLoopJoinBridges());
     addSpatialJoinBridgesLocked(
         splitGroupId, factory->needsSpatialJoinBridges());
+    addIndexLookupJoinBridgesLocked(
+        splitGroupId, factory->needsIndexLookupJoinBridges());
     addCustomJoinBridgesLocked(splitGroupId, factory->planNodes);
 
     core::PlanNodeId tableScanNodeId;
@@ -2352,6 +2355,26 @@ void Task::addSpatialJoinBridgesLocked(
     VELOX_CHECK(
         inserted, "Join bridge for node {} is already present", planNodeId);
   }
+}
+
+void Task::addIndexLookupJoinBridgesLocked(
+    uint32_t splitGroupId,
+    const std::vector<core::PlanNodeId>& planNodeIds) {
+  auto& splitGroupState = splitGroupStates_[splitGroupId];
+  for (const auto& planNodeId : planNodeIds) {
+    auto const inserted =
+        splitGroupState.bridges
+            .emplace(planNodeId, std::make_shared<IndexLookupJoinBridge>())
+            .second;
+    VELOX_CHECK(
+        inserted, "Join bridge for node {} is already present", planNodeId);
+  }
+}
+
+std::shared_ptr<IndexLookupJoinBridge> Task::getIndexLookupJoinBridge(
+    uint32_t splitGroupId,
+    const core::PlanNodeId& planNodeId) {
+  return getJoinBridgeInternal<IndexLookupJoinBridge>(splitGroupId, planNodeId);
 }
 
 std::shared_ptr<HashJoinBridge> Task::getHashJoinBridge(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -35,6 +35,7 @@ namespace facebook::velox::exec {
 class OutputBufferManager;
 
 class HashJoinBridge;
+class IndexLookupJoinBridge;
 class NestedLoopJoinBridge;
 class SpatialJoinBridge;
 class SplitListener;
@@ -560,6 +561,11 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const std::vector<core::PlanNodeId>& planNodeIds);
 
+  /// Adds IndexLookupJoinBridge's for all the specified plan node IDs.
+  void addIndexLookupJoinBridgesLocked(
+      uint32_t splitGroupId,
+      const std::vector<core::PlanNodeId>& planNodeIds);
+
   /// Adds custom join bridges for all the specified plan nodes.
   void addCustomJoinBridgesLocked(
       uint32_t splitGroupId,
@@ -584,6 +590,11 @@ class Task : public std::enable_shared_from_this<Task> {
 
   /// Returns a SpatialJoinBridge for 'planNodeId'.
   std::shared_ptr<SpatialJoinBridge> getSpatialJoinBridge(
+      uint32_t splitGroupId,
+      const core::PlanNodeId& planNodeId);
+
+  /// Returns an IndexLookupJoinBridge for 'planNodeId'.
+  std::shared_ptr<IndexLookupJoinBridge> getIndexLookupJoinBridge(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/tests/IndexLookupJoinBridgeTest.cpp
+++ b/velox/exec/tests/IndexLookupJoinBridgeTest.cpp
@@ -1,0 +1,241 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/IndexLookupJoinBridge.h"
+
+#include <folly/executors/InlineExecutor.h>
+#include <gtest/gtest.h>
+#include <thread>
+
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::connector;
+
+namespace {
+
+std::shared_ptr<ConnectorSplit> makeFakeSplit(const std::string& id) {
+  return std::make_shared<ConnectorSplit>(id);
+}
+
+std::vector<std::shared_ptr<ConnectorSplit>> makeFakeSplits(int count) {
+  std::vector<std::shared_ptr<ConnectorSplit>> splits;
+  splits.reserve(count);
+  for (int i = 0; i < count; ++i) {
+    splits.push_back(makeFakeSplit("connector_" + std::to_string(i)));
+  }
+  return splits;
+}
+
+class IndexLookupJoinBridgeTest : public testing::Test {
+ protected:
+  std::shared_ptr<IndexLookupJoinBridge> createBridge() {
+    auto bridge = std::make_shared<IndexLookupJoinBridge>();
+    bridge->start();
+    return bridge;
+  }
+};
+
+TEST_F(IndexLookupJoinBridgeTest, setAndGetSplits) {
+  auto bridge = createBridge();
+  auto splits = makeFakeSplits(3);
+  const auto expectedSize = splits.size();
+
+  bridge->setIndexSplits(std::move(splits));
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto result = bridge->splitsOrFuture(&future);
+  ASSERT_FALSE(result.empty());
+  ASSERT_EQ(result.size(), expectedSize);
+  ASSERT_FALSE(future.valid());
+}
+
+TEST_F(IndexLookupJoinBridgeTest, splitsOrFutureBlocks) {
+  auto bridge = createBridge();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto result = bridge->splitsOrFuture(&future);
+  ASSERT_TRUE(result.empty());
+  ASSERT_TRUE(future.valid());
+
+  // Set splits and verify the future is fulfilled.
+  auto splits = makeFakeSplits(2);
+  bridge->setIndexSplits(std::move(splits));
+
+  std::move(future).via(&folly::InlineExecutor::instance()).get();
+
+  // Now splitsOrFuture should return immediately on repeated calls.
+  for (int i = 0; i < 3; ++i) {
+    ContinueFuture future2 = ContinueFuture::makeEmpty();
+    auto result2 = bridge->splitsOrFuture(&future2);
+    ASSERT_FALSE(result2.empty());
+    ASSERT_EQ(result2.size(), 2);
+    ASSERT_FALSE(future2.valid());
+  }
+}
+
+TEST_F(IndexLookupJoinBridgeTest, multipleFollowers) {
+  auto bridge = createBridge();
+
+  // Multiple followers wait for splits.
+  const int numFollowers = 4;
+  std::vector<ContinueFuture> futures;
+  for (int i = 0; i < numFollowers; ++i) {
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    auto result = bridge->splitsOrFuture(&future);
+    ASSERT_TRUE(result.empty());
+    ASSERT_TRUE(future.valid());
+    futures.push_back(std::move(future));
+  }
+
+  // Leader sets splits.
+  bridge->setIndexSplits(makeFakeSplits(5));
+
+  // All futures should be fulfilled.
+  for (auto& future : futures) {
+    std::move(future).via(&folly::InlineExecutor::instance()).get();
+  }
+
+  // All followers can now get splits.
+  for (int i = 0; i < numFollowers; ++i) {
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    auto result = bridge->splitsOrFuture(&future);
+    ASSERT_FALSE(result.empty());
+    ASSERT_EQ(result.size(), 5);
+    ASSERT_FALSE(future.valid());
+  }
+}
+
+TEST_F(IndexLookupJoinBridgeTest, setBeforeGet) {
+  auto bridge = createBridge();
+
+  // Leader sets splits before any follower calls splitsOrFuture.
+  bridge->setIndexSplits(makeFakeSplits(3));
+
+  // Followers get splits immediately without blocking.
+  for (int i = 0; i < 3; ++i) {
+    ContinueFuture future = ContinueFuture::makeEmpty();
+    auto result = bridge->splitsOrFuture(&future);
+    ASSERT_FALSE(result.empty());
+    ASSERT_EQ(result.size(), 3);
+    ASSERT_FALSE(future.valid());
+  }
+}
+
+TEST_F(IndexLookupJoinBridgeTest, setTwiceThrows) {
+  auto bridge = createBridge();
+  bridge->setIndexSplits(makeFakeSplits(1));
+
+  VELOX_ASSERT_THROW(
+      bridge->setIndexSplits(makeFakeSplits(1)),
+      "setIndexSplits must be called only once");
+}
+
+TEST_F(IndexLookupJoinBridgeTest, setEmptySplitsThrows) {
+  auto bridge = createBridge();
+
+  VELOX_ASSERT_THROW(
+      bridge->setIndexSplits({}), "Index splits must not be empty");
+}
+
+TEST_F(IndexLookupJoinBridgeTest, setBeforeStartThrows) {
+  auto bridge = std::make_shared<IndexLookupJoinBridge>();
+  // Do not call start().
+
+  VELOX_ASSERT_THROW(
+      bridge->setIndexSplits(makeFakeSplits(1)),
+      "Bridge must be started before setting index splits");
+}
+
+TEST_F(IndexLookupJoinBridgeTest, cancelUnblocksFollowers) {
+  auto bridge = createBridge();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  auto result = bridge->splitsOrFuture(&future);
+  ASSERT_TRUE(result.empty());
+  ASSERT_TRUE(future.valid());
+
+  bridge->cancel();
+
+  // Future should be fulfilled by cancel.
+  std::move(future).via(&folly::InlineExecutor::instance()).get();
+}
+
+TEST_F(IndexLookupJoinBridgeTest, getAfterCancelThrows) {
+  auto bridge = createBridge();
+  bridge->cancel();
+
+  ContinueFuture future = ContinueFuture::makeEmpty();
+  VELOX_ASSERT_THROW(
+      bridge->splitsOrFuture(&future),
+      "Getting index splits after the bridge is cancelled");
+}
+
+TEST_F(IndexLookupJoinBridgeTest, setAfterCancelThrows) {
+  auto bridge = createBridge();
+  bridge->cancel();
+
+  VELOX_ASSERT_THROW(
+      bridge->setIndexSplits(makeFakeSplits(1)),
+      "Setting index splits after the bridge is cancelled");
+}
+
+TEST_F(IndexLookupJoinBridgeTest, concurrentSetAndGet) {
+  auto bridge = createBridge();
+  const int numFollowers = 8;
+  const int numSplits = 5;
+
+  std::vector<std::thread> threads;
+  std::atomic_int successCount{0};
+  std::atomic_bool stop{false};
+
+  // Start followers that keep getting splits until stopped.
+  threads.reserve(numFollowers);
+  for (int i = 0; i < numFollowers; ++i) {
+    threads.emplace_back([&bridge, &successCount, &stop, numSplits]() {
+      ContinueFuture future = ContinueFuture::makeEmpty();
+      auto result = bridge->splitsOrFuture(&future);
+      if (result.empty()) {
+        std::move(future).via(&folly::InlineExecutor::instance()).get();
+      }
+      while (!stop.load()) {
+        ContinueFuture f = ContinueFuture::makeEmpty();
+        auto r = bridge->splitsOrFuture(&f);
+        ASSERT_FALSE(r.empty());
+        ASSERT_EQ(r.size(), numSplits);
+        ASSERT_FALSE(f.valid());
+        ++successCount;
+      }
+    });
+  }
+
+  // Give followers time to register.
+  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+  // Leader sets splits.
+  bridge->setIndexSplits(makeFakeSplits(numSplits));
+
+  // Let followers run for a while.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  stop.store(true);
+
+  for (auto& t : threads) {
+    t.join();
+  }
+  ASSERT_GE(successCount.load(), numFollowers);
+}
+
+} // namespace

--- a/velox/exec/tests/IndexLookupJoinTestExtra.cpp
+++ b/velox/exec/tests/IndexLookupJoinTestExtra.cpp
@@ -24,6 +24,7 @@
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/IndexLookupJoin.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -1664,6 +1665,323 @@ DEBUG_ONLY_TEST_P(IndexLookupJoinTest, noNeedsIndexSplitSplitOperationFails) {
     queryThread.join();
   }
 }
+// Verifies that when multiple drivers are waiting for index splits (the
+// collector waiting for splits from the task, followers waiting on the bridge),
+// aborting the task unblocks all drivers and the task terminates cleanly.
+DEBUG_ONLY_TEST_P(IndexLookupJoinTest, abortDuringIndexSplitWait) {
+  if (GetParam().serialExecution || !GetParam().needsIndexSplit) {
+    return;
+  }
+
+  keyType_ = ROW({"u0"}, {BIGINT()});
+  valueType_ = ROW({"u1", "u2"}, {BIGINT(), VARCHAR()});
+  tableType_ = concat(keyType_, valueType_);
+  probeType_ = ROW({"t0", "t1", "t2"}, {BIGINT(), BIGINT(), VARCHAR()});
+
+  IndexTableData tableData;
+  generateIndexTableData({100}, tableData, pool_);
+  const auto probeVectors =
+      generateProbeInput(3, 100, 1, tableData, pool_, {"t0"});
+  const auto probeFiles = createProbeFiles(probeVectors);
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/1,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, /*needsIndexSplit=*/true);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2"}),
+      makeIndexColumnHandles({"u0", "u1", "u2"}));
+  auto plan = makeLookupPlan(
+      planNodeIdGenerator,
+      indexScanNode,
+      {"t0"},
+      {"u0"},
+      {},
+      /*filter=*/"",
+      /*hasMarker=*/false,
+      core::JoinType::kLeft,
+      {"t0", "t1", "u1", "u2"});
+
+  const int numDrivers = 4;
+
+  // Use TestValue to capture the task when the collector enters
+  // collectIndexSplits, and hold it there until the test signals.
+  folly::EventCount collectSplitWait;
+  std::atomic_bool collectSplitReached{false};
+  folly::EventCount collectUnblockWait;
+  std::atomic_bool collectUnblockFlag{false};
+  std::mutex mutex;
+  std::shared_ptr<Task> task;
+
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::IndexLookupJoin::collectIndexSplits",
+      std::function<void(const IndexLookupJoin*)>(
+          [&](const IndexLookupJoin* op) {
+            {
+              std::lock_guard<std::mutex> lock(mutex);
+              if (task == nullptr) {
+                task = op->operatorCtx()->task();
+                collectSplitReached = true;
+                collectSplitWait.notifyAll();
+              }
+            }
+            // Hold the collector here until the test signals.
+            collectUnblockWait.await([&] { return collectUnblockFlag.load(); });
+          }));
+
+  // Run the query in a separate thread. Don't provide index splits so the
+  // collector blocks.
+  std::thread queryThread([&] {
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .plan(plan)
+            .splits(probeScanNodeId_, makeHiveConnectorSplits(probeFiles))
+            .maxDrivers(numDrivers)
+            .copyResults(pool()),
+        "Aborted");
+  });
+
+  // Wait for the collector to enter collectIndexSplits.
+  collectSplitWait.await([&] { return collectSplitReached.load(); });
+
+  // Wait until all non-collector drivers are off-thread (blocked on the
+  // bridge). The collector is held by the TestValue callback above.
+  while (true) {
+    int offThreadCount = 0;
+    task->testingVisitDrivers([&](Driver* driver) {
+      if (!driver->isOnThread()) {
+        ++offThreadCount;
+      }
+    });
+    // All followers (numDrivers - 1) should be off-thread.
+    if (offThreadCount >= numDrivers - 1) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
+  }
+
+  // Abort the task while all drivers are blocked.
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    ASSERT_NE(task, nullptr);
+    ASSERT_EQ(task->state(), TaskState::kRunning);
+    task->requestAbort();
+  }
+
+  // Wait for all follower drivers to finish. The collector is still held by
+  // the TestValue callback, so only 1 driver (the collector) should remain.
+  while (true) {
+    int aliveCount = 0;
+    task->testingVisitDrivers([&](Driver*) { ++aliveCount; });
+    if (aliveCount == 1) {
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10)); // NOLINT
+  }
+
+  // Release the collector from the TestValue callback.
+  collectUnblockFlag = true;
+  collectUnblockWait.notifyAll();
+
+  queryThread.join();
+
+  // Verify the task terminated properly.
+  ASSERT_TRUE(waitForTaskAborted(task.get()));
+}
+
+TEST_P(IndexLookupJoinTest, multiDriverWithIndexSplits) {
+  if (GetParam().serialExecution || !GetParam().needsIndexSplit) {
+    return;
+  }
+  IndexTableData tableData;
+  generateIndexTableData({100, 1, 1}, tableData, pool_);
+  const int numProbeSplits{5};
+  const auto probeVectors = generateProbeInput(
+      numProbeSplits,
+      256,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      GetParam().hasNullKeys,
+      {},
+      {},
+      100);
+  const auto probeFiles = createProbeFiles(probeVectors);
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", {tableData.tableVectors});
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, GetParam().needsIndexSplit);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+      makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+  for (const auto joinType : {core::JoinType::kInner, core::JoinType::kLeft}) {
+    SCOPED_TRACE(
+        fmt::format("joinType: {}", core::JoinTypeName::toName(joinType)));
+    const auto duckDbSql = joinType == core::JoinType::kInner
+        ? "SELECT u.c3, t.c5 FROM t, u WHERE t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2"
+        : "SELECT u.c3, t.c5 FROM t LEFT JOIN u ON t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2";
+    auto plan = makeLookupPlan(
+        planNodeIdGenerator,
+        indexScanNode,
+        {"t0", "t1", "t2"},
+        {"u0", "u1", "u2"},
+        {},
+        /*filter=*/"",
+        /*hasMarker=*/false,
+        joinType,
+        {"u3", "t5"});
+
+    for (int numDrivers : {2, 4}) {
+      SCOPED_TRACE(fmt::format("numDrivers: {}", numDrivers));
+      auto task = runLookupQuery(
+          plan,
+          probeFiles,
+          /*serialExecution=*/false,
+          /*barrierExecution=*/false,
+          100,
+          GetParam().numPrefetches,
+          GetParam().needsIndexSplit,
+          duckDbSql,
+          numDrivers);
+      auto taskStats = toPlanStats(task->taskStats());
+      ASSERT_EQ(taskStats.at(joinNodeId_).numDrivers, numDrivers);
+    }
+  }
+}
+
+// Verifies IndexLookupJoin works correctly with grouped execution where the
+// probe side is grouped. Each split group creates its own set of drivers with
+// partitionId 0..numDrivers-1, and the partitionId==0 driver in each group
+// acts as the split collector for that group's index splits.
+TEST_P(IndexLookupJoinTest, groupedExecution) {
+  if (GetParam().serialExecution || !GetParam().needsIndexSplit) {
+    return;
+  }
+  IndexTableData tableData;
+  generateIndexTableData({100, 1, 1}, tableData, pool_);
+  const int numProbeSplitsPerGroup{2};
+  const int numSplitGroups{3};
+  const int numDrivers{2};
+  const auto probeVectors = generateProbeInput(
+      numProbeSplitsPerGroup * numSplitGroups,
+      256,
+      1,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      GetParam().hasNullKeys,
+      {},
+      {},
+      100);
+  const auto probeFiles = createProbeFiles(probeVectors);
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", {tableData.tableVectors});
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, GetParam().needsIndexSplit);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+      makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+  for (const auto joinType : {core::JoinType::kInner, core::JoinType::kLeft}) {
+    SCOPED_TRACE(
+        fmt::format("joinType: {}", core::JoinTypeName::toName(joinType)));
+    auto outputLayout = std::vector<std::string>{"u3", "t5"};
+    auto plan = PlanBuilder(planNodeIdGenerator, pool())
+                    .tableScan(probeType_)
+                    .capturePlanNodeId(probeScanNodeId_)
+                    .startIndexLookupJoin()
+                    .leftKeys({"t0", "t1", "t2"})
+                    .rightKeys({"u0", "u1", "u2"})
+                    .indexSource(indexScanNode)
+                    .outputLayout(outputLayout)
+                    .joinType(joinType)
+                    .endIndexLookupJoin()
+                    .capturePlanNodeId(joinNodeId_)
+                    .partitionedOutput({}, 1, outputLayout)
+                    .planFragment();
+
+    plan.executionStrategy = core::ExecutionStrategy::kGrouped;
+    plan.groupedExecutionLeafNodeIds.emplace(probeScanNodeId_);
+    plan.numSplitGroups = numSplitGroups;
+
+    auto queryCtx = core::QueryCtx::create(executor_.get());
+    std::unordered_map<std::string, std::string> configs;
+    configs[QueryConfig::kIndexLookupJoinMaxPrefetchBatches] =
+        std::to_string(GetParam().numPrefetches);
+    queryCtx->testingOverrideConfigUnsafe(std::move(configs));
+
+    auto task = exec::Task::create(
+        "grouped-index-lookup-join",
+        std::move(plan),
+        0,
+        std::move(queryCtx),
+        Task::ExecutionMode::kParallel);
+    task->start(numDrivers, /*concurrentSplitGroups=*/2);
+
+    // Add probe splits with group IDs.
+    int fileIdx = 0;
+    for (int group = 0; group < numSplitGroups; ++group) {
+      for (int j = 0; j < numProbeSplitsPerGroup; ++j) {
+        task->addSplit(
+            probeScanNodeId_,
+            Split(
+                makeHiveConnectorSplit(probeFiles[fileIdx++]->getPath()),
+                group));
+      }
+      task->noMoreSplitsForGroup(probeScanNodeId_, group);
+    }
+    task->noMoreSplits(probeScanNodeId_);
+
+    // Add one index split per group so each group's collector finds its split.
+    for (int group = 0; group < numSplitGroups; ++group) {
+      task->addSplit(
+          indexScanNodeId_,
+          Split(
+              std::make_shared<TestIndexConnectorSplit>(
+                  kTestIndexConnectorName),
+              group));
+      task->noMoreSplitsForGroup(indexScanNodeId_, group);
+    }
+
+    // Consume output via OutputBufferManager.
+    auto outputBufferManager = exec::OutputBufferManager::getInstanceRef();
+    outputBufferManager->deleteResults(task->taskId(), 0);
+
+    waitForTaskCompletion(task.get());
+    ASSERT_EQ(task->state(), TaskState::kFinished);
+
+    auto taskStats = toPlanStats(task->taskStats());
+    ASSERT_EQ(
+        taskStats.at(joinNodeId_).numDrivers, numDrivers * numSplitGroups);
+  }
+}
+
 } // namespace
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.cpp
@@ -438,12 +438,14 @@ std::shared_ptr<Task> IndexLookupJoinTestBase::runLookupQuery(
     int maxOutputRows,
     int numPrefetchBatches,
     bool needsIndexSplit,
-    const std::string& duckDbVerifySql) {
+    const std::string& duckDbVerifySql,
+    int maxDrivers) {
   AssertQueryBuilder queryBuilder(duckDbQueryRunner_);
   queryBuilder.plan(plan)
       .splits(probeScanNodeId_, makeHiveConnectorSplits(probeFiles))
       .serialExecution(serialExecution)
       .barrierExecution(barrierExecution)
+      .maxDrivers(maxDrivers)
       .config(QueryConfig::kMaxOutputBatchRows, std::to_string(maxOutputRows))
       .config(
           QueryConfig::kIndexLookupJoinMaxPrefetchBatches,

--- a/velox/exec/tests/utils/IndexLookupJoinTestBase.h
+++ b/velox/exec/tests/utils/IndexLookupJoinTestBase.h
@@ -175,7 +175,8 @@ class IndexLookupJoinTestBase : public HiveConnectorTestBase {
       int maxBatchRows,
       int numPrefetchBatches,
       bool needsIndexSplit,
-      const std::string& duckDbVerifySql);
+      const std::string& duckDbVerifySql,
+      int maxDrivers = 1);
 
   /// Verifies the results of the index lookup join query with and without match
   /// column.

--- a/velox/exec/tests/utils/TestIndexStorageConnector.cpp
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.cpp
@@ -271,7 +271,11 @@ std::shared_ptr<connector::IndexSource::ResultIterator> TestIndexSource::lookup(
   checkNotFailed();
   VELOX_CHECK(!tableHandle_->needsIndexSplit() || !splits_.empty());
   const auto numInputRows = request.input->size();
-  auto& hashTable = tableHandle_->indexTable()->table;
+  auto* indexTable = tableHandle_->indexTable().get();
+  auto& hashTable = indexTable->table;
+  // Serialize access to the shared hash table. The hashers contain stateful
+  // DecodedVectors that are not thread-safe for concurrent access.
+  std::lock_guard<std::mutex> l(indexTable->mutex);
   auto lookup = std::make_unique<HashLookup>(hashTable->hashers(), pool_.get());
   SelectivityVector activeRows(numInputRows);
   VELOX_CHECK(activeRows.isAllSelected());

--- a/velox/exec/tests/utils/TestIndexStorageConnector.h
+++ b/velox/exec/tests/utils/TestIndexStorageConnector.h
@@ -31,6 +31,11 @@ struct TestIndexTable {
   RowTypePtr dataType;
   std::shared_ptr<BaseHashTable> table;
 
+  // Mutex to serialize concurrent access to the hash table. The hash table's
+  // hashers contain stateful DecodedVectors that are not thread-safe for
+  // concurrent joinProbe calls from multiple index sources.
+  mutable std::mutex mutex;
+
   TestIndexTable(
       RowTypePtr _keyType,
       RowTypePtr _dataType,


### PR DESCRIPTION
Summary:

CONTEXT: IndexLookupJoin operators are currently limited to single-thread
execution because each operator independently collects index splits from the
task. When multiple operators are instantiated from the same plan node, only
one can collect splits.

WHAT: Introduce a leader/follower pattern where driver 0 (leader) collects
all index splits and shares them with other operators via an
IndexLookupJoinBridge. Followers wait on the bridge (kWaitForIndexSplits)
until the leader publishes splits, then each creates its own IndexSource
with the shared splits. This removes the single-thread execution limitation.

Also rewrote the index benchmark to use actual Velox join operators
(IndexLookupJoin / HashJoin) with TableScan-based probe side and
configurable parallelism via --num_drivers, --num_splits, and --join_mode.

Benchmark (index_large.nimble + probe_large.nimble, index=raw_url, warm):

| Drivers | Splits | Join Mode | Wall Time | Speedup | Output Rows | Peak Memory | Mem Reduction |
|---------|--------|-----------|-----------|---------|-------------|-------------|---------------|
| 1       | 1      | Hash      | 22.12s    | —       | 15,431      | ~9.8GB      | —             |
| 1       | 1      | Index     | 11.70s    | **1.89x** | 15,431    | 4.39GB      | **2.23x**     |
| 2       | 2      | Hash      | 20.96s    | —       | 30,862      | ~9.8GB      | —             |
| 2       | 2      | Index     | 10.85s    | **1.93x** | 30,862    | 4.39GB      | **2.23x**     |
| 4       | 4      | Hash      | 22.24s    | —       | 61,724      | ~9.8GB      | —             |
| 4       | 4      | Index     | 12.45s    | **1.79x** | 61,724    | 4.39GB      | **2.23x**     |

Index lookup join delivers 1.8-1.9x wall time speedup and 2.2x memory
reduction vs hash join, consistent across 1-4 drivers. Both modes scale
linearly in throughput — wall time stays constant as drivers/splits increase.

Reviewed By: zacw7

Differential Revision: D100127392
