### PR TITLE
refactor(ABFS): Allow registration of default providers

### DIFF
--- a/velox/connectors/hive/storage_adapters/abfs/AbfsPath.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsPath.h
@@ -54,6 +54,9 @@ static constexpr const char* kAzureOAuthAuthType = "OAuth";
 
 static constexpr const char* kAzureSASAuthType = "SAS";
 
+// The default suffix for Azure Data Lake Storage Gen2 account names.
+static constexpr const char* kAzureAccountNameSuffix = ".dfs.core.windows.net";
+
 // For performance, re - use SAS tokens until the expiry is within this number
 // of seconds.
 static constexpr const char* kAzureSasTokenRenewPeriod =

--- a/velox/connectors/hive/storage_adapters/abfs/AbfsPath.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AbfsPath.h
@@ -54,9 +54,6 @@ static constexpr const char* kAzureOAuthAuthType = "OAuth";
 
 static constexpr const char* kAzureSASAuthType = "SAS";
 
-// The default suffix for Azure Data Lake Storage Gen2 account names.
-static constexpr const char* kAzureAccountNameSuffix = ".dfs.core.windows.net";
-
 // For performance, re - use SAS tokens until the expiry is within this number
 // of seconds.
 static constexpr const char* kAzureSasTokenRenewPeriod =

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.cpp
@@ -15,9 +15,12 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h"
-#include "velox/connectors/hive/storage_adapters/abfs/AzureClientProviderImpl.h"
 
+#include <fmt/format.h>
 #include <folly/Synchronized.h>
+
+#include "velox/connectors/hive/storage_adapters/abfs/AbfsPath.h"
+#include "velox/connectors/hive/storage_adapters/abfs/AzureClientProviderImpl.h"
 
 namespace facebook::velox::filesystems {
 
@@ -32,6 +35,26 @@ azureClientFactoryRegistry() {
   return factories;
 }
 
+const std::unordered_map<std::string, AzureClientProviderFactory>&
+defaultProviderRegistry() {
+  static const std::unordered_map<std::string, AzureClientProviderFactory>
+      kRegistry = {
+          {kAzureSharedKeyAuthType,
+           [](const std::string& /*account*/) {
+             return std::make_unique<SharedKeyAzureClientProvider>();
+           }},
+          {kAzureOAuthAuthType,
+           [](const std::string& /*account*/) {
+             return std::make_unique<OAuthAzureClientProvider>();
+           }},
+          {kAzureSASAuthType,
+           [](const std::string& /*account*/) {
+             return std::make_unique<FixedSasAzureClientProvider>();
+           }},
+      };
+  return kRegistry;
+}
+
 } // namespace
 
 void AzureClientProviderFactories::registerFactory(
@@ -44,19 +67,56 @@ void AzureClientProviderFactories::registerFactory(
   });
 }
 
+AzureClientProviderFactory
+AzureClientProviderFactories::getDefaultProviderFactory(
+    const std::string& authType) {
+  const auto& registry = defaultProviderRegistry();
+  auto it = registry.find(authType);
+
+  if (it != registry.end()) {
+    return it->second;
+  }
+
+  return nullptr;
+}
+
 AzureClientProviderFactory AzureClientProviderFactories::getClientFactory(
-    const std::string& account) {
+    const std::string& account,
+    const config::ConfigBase& config) {
   return azureClientFactoryRegistry().withRLock(
       [&](const auto& factories) -> AzureClientProviderFactory {
         if (auto it = factories.find(account); it != factories.end()) {
           return it->second;
         }
-        VELOX_USER_FAIL(
-            "No AzureClientProviderFactory registered for account '{}'."
-            "Please use `registerAzureClientProvider` or "
-            "`registerAzureClientProviderFactory` to register a factory for "
-            "the account before using it.",
+        LOG(INFO) << "No AzureClientProviderFactory registered for account '"
+                  << account << "', creating default provider from config.";
+
+        // Extract auth type from config to avoid capturing non-copyable
+        // ConfigBase. This allows the returned factory to be safely stored and
+        // called later.
+        auto authTypeKey = fmt::format(
+            "{}.{}{}", kAzureAccountAuthType, account, kAzureAccountNameSuffix);
+        VELOX_USER_CHECK(
+            config.valueExists(authTypeKey),
+            "No AzureClientProviderFactory registered for account '{}' and no "
+            "auth type found in config key '{}'. "
+            "Please either register a factory using `registerAzureClientProvider` "
+            "or `registerAzureClientProviderFactory`, or provide auth type in config.",
+            account,
+            authTypeKey);
+
+        auto authType = config.get<std::string>(authTypeKey).value();
+
+        // Return a factory based on the auth type that doesn't depend on config
+        auto factory = getDefaultProviderFactory(authType);
+        VELOX_USER_CHECK(
+            factory != nullptr,
+            "Unsupported auth type '{}' for account '{}'. "
+            "Supported auth types are SharedKey, OAuth and SAS.",
+            authType,
             account);
+
+        return factory;
       });
 }
 
@@ -64,7 +124,7 @@ std::unique_ptr<AzureBlobClient>
 AzureClientProviderFactories::getReadFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
     const config::ConfigBase& config) {
-  auto factory = getClientFactory(abfsPath->accountName());
+  auto factory = getClientFactory(abfsPath->accountName(), config);
   return factory(abfsPath->accountName())->getReadFileClient(abfsPath, config);
 }
 
@@ -72,7 +132,7 @@ std::unique_ptr<AzureDataLakeFileClient>
 AzureClientProviderFactories::getWriteFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
     const config::ConfigBase& config) {
-  auto factory = getClientFactory(abfsPath->accountName());
+  auto factory = getClientFactory(abfsPath->accountName(), config);
   return factory(abfsPath->accountName())->getWriteFileClient(abfsPath, config);
 }
 

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.cpp
@@ -81,8 +81,9 @@ AzureClientProviderFactories::getDefaultProviderFactory(
 }
 
 AzureClientProviderFactory AzureClientProviderFactories::getClientFactory(
-    const std::string& account,
+    const std::shared_ptr<AbfsPath>& abfsPath,
     const config::ConfigBase& config) {
+  const auto& account = abfsPath->accountName();
   return azureClientFactoryRegistry().withRLock(
       [&](const auto& factories) -> AzureClientProviderFactory {
         if (auto it = factories.find(account); it != factories.end()) {
@@ -91,11 +92,11 @@ AzureClientProviderFactory AzureClientProviderFactories::getClientFactory(
         LOG(INFO) << "No AzureClientProviderFactory registered for account '"
                   << account << "', creating default provider from config.";
 
-        // Extract auth type from config to avoid capturing non-copyable
-        // ConfigBase. This allows the returned factory to be safely stored and
-        // called later.
+        // Build the auth-type key using the full account-name-with-suffix so
+        // ABFS URLs targeting non-public clouds or custom endpoints resolve
+        // the same key that the provider implementations already use.
         auto authTypeKey = fmt::format(
-            "{}.{}{}", kAzureAccountAuthType, account, kAzureAccountNameSuffix);
+            "{}.{}", kAzureAccountAuthType, abfsPath->accountNameWithSuffix());
         VELOX_USER_CHECK(
             config.valueExists(authTypeKey),
             "No AzureClientProviderFactory registered for account '{}' and no "
@@ -124,7 +125,7 @@ std::unique_ptr<AzureBlobClient>
 AzureClientProviderFactories::getReadFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
     const config::ConfigBase& config) {
-  auto factory = getClientFactory(abfsPath->accountName(), config);
+  auto factory = getClientFactory(abfsPath, config);
   return factory(abfsPath->accountName())->getReadFileClient(abfsPath, config);
 }
 
@@ -132,7 +133,7 @@ std::unique_ptr<AzureDataLakeFileClient>
 AzureClientProviderFactories::getWriteFileClient(
     const std::shared_ptr<AbfsPath>& abfsPath,
     const config::ConfigBase& config) {
-  auto factory = getClientFactory(abfsPath->accountName(), config);
+  auto factory = getClientFactory(abfsPath, config);
   return factory(abfsPath->accountName())->getWriteFileClient(abfsPath, config);
 }
 

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h
@@ -40,20 +40,27 @@ class AzureClientProviderFactories {
       const AzureClientProviderFactory& factory);
 
   /// Get the registered AzureClientProviderFactory for the specified
-  /// account. Throws exception if no factory is registered for the account.
+  /// account. If no factory is registered, creates a default provider
+  /// based on the auth type specified in the config.
   static AzureClientProviderFactory getClientFactory(
-      const std::string& account);
+      const std::string& account,
+      const config::ConfigBase& config);
+
+  /// Returns a factory for the specified auth type from the default
+  /// provider registry. Returns nullptr if the auth type is not supported.
+  static AzureClientProviderFactory getDefaultProviderFactory(
+      const std::string& authType);
 
   /// Uses the registered AzureClientProviderFactory to create an
-  /// AzureBlobClient for file read operations. Throws exception if no factory
-  /// is registered for the account specified in `abfsPath`.
+  /// AzureBlobClient for file read operations. If no factory is registered
+  /// for the account, creates a default provider based on config.
   static std::unique_ptr<AzureBlobClient> getReadFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
       const config::ConfigBase& config);
 
   /// Uses the registered AzureClientProviderFactory to create an
-  /// AzureDataLakeFileClient for file write operations. Throws exception if no
-  /// factory is registered for the account specified in `abfsPath`.
+  /// AzureDataLakeFileClient for file write operations. If no factory is
+  /// registered for the account, creates a default provider based on config.
   static std::unique_ptr<AzureDataLakeFileClient> getWriteFileClient(
       const std::shared_ptr<AbfsPath>& abfsPath,
       const config::ConfigBase& config);

--- a/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h
+++ b/velox/connectors/hive/storage_adapters/abfs/AzureClientProviderFactories.h
@@ -39,11 +39,14 @@ class AzureClientProviderFactories {
       const std::string& account,
       const AzureClientProviderFactory& factory);
 
-  /// Get the registered AzureClientProviderFactory for the specified
-  /// account. If no factory is registered, creates a default provider
-  /// based on the auth type specified in the config.
+  /// Get the registered AzureClientProviderFactory for the account in
+  /// abfsPath. If no factory is registered, creates a default provider based
+  /// on the auth type specified in the config. The registry is keyed by the
+  /// short account name; the config fallback uses the full
+  /// account-name-with-suffix so non-public Azure clouds and custom endpoints
+  /// resolve the correct auth-type key.
   static AzureClientProviderFactory getClientFactory(
-      const std::string& account,
+      const std::shared_ptr<AbfsPath>& abfsPath,
       const config::ConfigBase& config);
 
   /// Returns a factory for the specified auth type from the default

--- a/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/RegisterAbfsFileSystem.cpp
@@ -72,21 +72,11 @@ void registerAzureClientProvider(const config::ConfigBase& config) {
 
   for (const auto& [accountName, authType] :
        extractCacheKeyFromConfig(config)) {
-    if (authType == kAzureSharedKeyAuthType) {
-      AzureClientProviderFactories::registerFactory(
-          accountName, [](const std::string&) {
-            return std::make_unique<SharedKeyAzureClientProvider>();
-          });
-    } else if (authType == kAzureOAuthAuthType) {
-      AzureClientProviderFactories::registerFactory(
-          accountName, [](const std::string&) {
-            return std::make_unique<OAuthAzureClientProvider>();
-          });
-    } else if (authType == kAzureSASAuthType) {
-      AzureClientProviderFactories::registerFactory(
-          accountName, [](const std::string&) {
-            return std::make_unique<FixedSasAzureClientProvider>();
-          });
+    auto factory =
+        AzureClientProviderFactories::getDefaultProviderFactory(authType);
+
+    if (factory) {
+      AzureClientProviderFactories::registerFactory(accountName, factory);
     } else {
       VELOX_USER_FAIL(
           "Unsupported auth type {}, supported auth types are SharedKey, OAuth and SAS.",

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -298,7 +298,7 @@ TEST_F(AbfsFileSystemTest, clientProviderFactoryNotRegistered) {
       std::string("abfs://test@test1.dfs.core.windows.net/test");
   VELOX_ASSERT_THROW(
       abfs_->openFileForRead(abfsFile),
-      "No AzureClientProviderFactory registered for account 'test1'.");
+      "No AzureClientProviderFactory registered for account 'test1'");
 }
 
 TEST_F(AbfsFileSystemTest, registerAbfsFileSink) {

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AbfsFileSystemTest.cpp
@@ -444,7 +444,7 @@ TEST_F(AbfsFileSystemTest, clientProviderFactoryNotRegistered) {
       std::string("abfs://test@test1.dfs.core.windows.net/test");
   VELOX_ASSERT_THROW(
       abfs_->openFileForRead(abfsFile),
-      "No AzureClientProviderFactory registered for account 'test1'.");
+      "No AzureClientProviderFactory registered for account 'test1'");
 }
 
 TEST_F(AbfsFileSystemTest, registerAbfsFileSink) {

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
@@ -111,7 +111,7 @@ TEST(AzureClientProviderFactoriesTest, registerFromConfig) {
   }
 
   {
-    // Invalid config key.
+    // Invalid config key - missing suffix.
     const config::ConfigBase config(
         {{"fs.azure.account.auth.type.efg", "SharedKey"},
          {"fs.azure.account.key.efg.dfs.core.windows.net", "456"}},
@@ -132,7 +132,9 @@ TEST(AzureClientProviderFactoriesTest, registerCustomFactory) {
         return std::make_unique<DummyAzureClientProvider>();
       });
 
-  ASSERT_NO_THROW(AzureClientProviderFactories::getClientFactory("efg"));
+  ASSERT_NO_THROW(
+      AzureClientProviderFactories::getClientFactory(
+          "efg", config::ConfigBase({})));
   VELOX_ASSERT_THROW(
       AzureClientProviderFactories::getReadFileClient(
           abfsPath, config::ConfigBase({})),
@@ -141,8 +143,143 @@ TEST(AzureClientProviderFactoriesTest, registerCustomFactory) {
       AzureClientProviderFactories::getWriteFileClient(
           abfsPath, config::ConfigBase({})),
       "DummyAzureClientProvider: Not implemented.");
-
   VELOX_ASSERT_THROW(
-      AzureClientProviderFactories::getClientFactory("efg2"),
-      "No AzureClientProviderFactory registered for account 'efg2'.");
+      AzureClientProviderFactories::getClientFactory(
+          "efg2", config::ConfigBase({})),
+      "No AzureClientProviderFactory registered for account 'efg2' and no "
+      "auth type found in config key 'fs.azure.account.auth.type.efg2.dfs.core.windows.net'");
+}
+
+TEST(
+    AzureClientProviderFactoriesTest,
+    defaultProviderFromConfigWithoutRegistration) {
+  const auto abfsPath = std::make_shared<AbfsPath>(
+      "abfss://abc@testaccount.dfs.core.windows.net/file/test.txt");
+
+  {
+    // OAuth auth type - should work without explicit registration
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net", "OAuth"},
+         {"fs.azure.account.oauth2.client.id.testaccount.dfs.core.windows.net",
+          "123"},
+         {"fs.azure.account.oauth2.client.secret.testaccount.dfs.core.windows.net",
+          "456"},
+         {"fs.azure.account.oauth2.client.endpoint.testaccount.dfs.core.windows.net",
+          "https://login.microsoftonline.com/{TENANTID}/oauth2/token"}},
+        false);
+
+    // Should create client without prior registration
+    ASSERT_NE(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        nullptr);
+    ASSERT_NE(
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config),
+        nullptr);
+  }
+
+  {
+    // SharedKey auth type - should work without explicit registration
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net", "SharedKey"},
+         {"fs.azure.account.key.testaccount.dfs.core.windows.net",
+          "dGVzdGtleQ=="}},
+        false);
+
+    ASSERT_NE(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        nullptr);
+    ASSERT_NE(
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config),
+        nullptr);
+  }
+
+  {
+    // SAS auth type - should work without explicit registration
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net", "SAS"},
+         {"fs.azure.sas.fixed.token.testaccount.dfs.core.windows.net",
+          "sv=2021-06-08&ss=b&srt=sco&sp=rwdlac"}},
+        false);
+
+    ASSERT_NE(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        nullptr);
+    ASSERT_NE(
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config),
+        nullptr);
+  }
+
+  {
+    // Invalid auth type - should fail with clear error
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net", "InvalidAuth"},
+         {"fs.azure.account.key.testaccount.dfs.core.windows.net", "456"}},
+        false);
+
+    VELOX_ASSERT_THROW(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        "Unsupported auth type 'InvalidAuth' for account 'testaccount'");
+  }
+
+  {
+    // Missing auth type config - should fail with clear error
+    const config::ConfigBase config(
+        {{"fs.azure.account.key.testaccount.dfs.core.windows.net", "456"}},
+        false);
+
+    VELOX_ASSERT_THROW(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        "No AzureClientProviderFactory registered for account 'testaccount' and no auth type found in config key 'fs.azure.account.auth.type.testaccount.dfs.core.windows.net'");
+  }
+}
+
+TEST(AzureClientProviderFactoriesTest, registeredFactoryTakesPrecedence) {
+  const auto abfsPath = std::make_shared<AbfsPath>(
+      "abfss://abc@precedencetest.dfs.core.windows.net/file/test.txt");
+
+  // Register a custom factory
+  registerAzureClientProviderFactory(
+      "precedencetest",
+      [](const std::string& account) -> std::unique_ptr<AzureClientProvider> {
+        return std::make_unique<DummyAzureClientProvider>();
+      });
+
+  // Even with valid config, registered factory should take precedence
+  const config::ConfigBase config(
+      {{"fs.azure.account.auth.type.precedencetest.dfs.core.windows.net", "SharedKey"},
+       {"fs.azure.account.key.precedencetest.dfs.core.windows.net", "456"}},
+      false);
+
+  // Should use the registered DummyAzureClientProvider, not create from config
+  VELOX_ASSERT_THROW(
+      AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+      "DummyAzureClientProvider: Not implemented.");
+}
+
+TEST(AzureClientProviderFactoriesTest, multipleAccountsSingleConfig) {
+  const auto abfsPath1 = std::make_shared<AbfsPath>(
+      "abfss://abc@account1.dfs.core.windows.net/file/test.txt");
+  const auto abfsPath2 = std::make_shared<AbfsPath>(
+      "abfss://abc@account2.dfs.core.windows.net/file/test.txt");
+
+  // Even with valid config, registered factory should take precedence.
+  const config::ConfigBase config(
+      {{"fs.azure.account.auth.type.account1.dfs.core.windows.net", "SharedKey"},
+       {"fs.azure.account.key.account1.dfs.core.windows.net", "123"},
+       {"fs.azure.account.auth.type.account2.dfs.core.windows.net", "SharedKey"},
+       {"fs.azure.account.key.account2.dfs.core.windows.net", "456"}},
+      false);
+
+  ASSERT_NE(
+      AzureClientProviderFactories::getReadFileClient(abfsPath1, config),
+      nullptr);
+  ASSERT_NE(
+      AzureClientProviderFactories::getWriteFileClient(abfsPath1, config),
+      nullptr);
+  ASSERT_NE(
+      AzureClientProviderFactories::getReadFileClient(abfsPath2, config),
+      nullptr);
+  ASSERT_NE(
+      AzureClientProviderFactories::getWriteFileClient(abfsPath2, config),
+      nullptr);
 }

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
@@ -111,7 +111,7 @@ TEST(AzureClientProviderFactoriesTest, registerFromConfig) {
   }
 
   {
-    // Invalid config key.
+    // Invalid config key - missing suffix.
     const config::ConfigBase config(
         {{"fs.azure.account.auth.type.efg", "SharedKey"},
          {"fs.azure.account.key.efg.dfs.core.windows.net", "456"}},
@@ -132,7 +132,9 @@ TEST(AzureClientProviderFactoriesTest, registerCustomFactory) {
         return std::make_unique<DummyAzureClientProvider>();
       });
 
-  ASSERT_NO_THROW(AzureClientProviderFactories::getClientFactory("efg"));
+  ASSERT_NO_THROW(
+      AzureClientProviderFactories::getClientFactory(
+          "efg", config::ConfigBase({})));
   VELOX_ASSERT_THROW(
       AzureClientProviderFactories::getReadFileClient(
           abfsPath, config::ConfigBase({})),
@@ -141,8 +143,149 @@ TEST(AzureClientProviderFactoriesTest, registerCustomFactory) {
       AzureClientProviderFactories::getWriteFileClient(
           abfsPath, config::ConfigBase({})),
       "DummyAzureClientProvider: Not implemented.");
-
   VELOX_ASSERT_THROW(
-      AzureClientProviderFactories::getClientFactory("efg2"),
-      "No AzureClientProviderFactory registered for account 'efg2'.");
+      AzureClientProviderFactories::getClientFactory(
+          "efg2", config::ConfigBase({})),
+      "No AzureClientProviderFactory registered for account 'efg2' and no "
+      "auth type found in config key 'fs.azure.account.auth.type.efg2.dfs.core.windows.net'");
+}
+
+TEST(
+    AzureClientProviderFactoriesTest,
+    defaultProviderFromConfigWithoutRegistration) {
+  const auto abfsPath = std::make_shared<AbfsPath>(
+      "abfss://abc@testaccount.dfs.core.windows.net/file/test.txt");
+
+  {
+    // OAuth auth type - should work without explicit registration
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net",
+          "OAuth"},
+         {"fs.azure.account.oauth2.client.id.testaccount.dfs.core.windows.net",
+          "123"},
+         {"fs.azure.account.oauth2.client.secret.testaccount.dfs.core.windows.net",
+          "456"},
+         {"fs.azure.account.oauth2.client.endpoint.testaccount.dfs.core.windows.net",
+          "https://login.microsoftonline.com/{TENANTID}/oauth2/token"}},
+        false);
+
+    // Should create client without prior registration
+    ASSERT_NE(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        nullptr);
+    ASSERT_NE(
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config),
+        nullptr);
+  }
+
+  {
+    // SharedKey auth type - should work without explicit registration
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net",
+          "SharedKey"},
+         {"fs.azure.account.key.testaccount.dfs.core.windows.net",
+          "dGVzdGtleQ=="}},
+        false);
+
+    ASSERT_NE(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        nullptr);
+    ASSERT_NE(
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config),
+        nullptr);
+  }
+
+  {
+    // SAS auth type - should work without explicit registration
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net", "SAS"},
+         {"fs.azure.sas.fixed.token.testaccount.dfs.core.windows.net",
+          "sv=2021-06-08&ss=b&srt=sco&sp=rwdlac"}},
+        false);
+
+    ASSERT_NE(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        nullptr);
+    ASSERT_NE(
+        AzureClientProviderFactories::getWriteFileClient(abfsPath, config),
+        nullptr);
+  }
+
+  {
+    // Invalid auth type - should fail with clear error
+    const config::ConfigBase config(
+        {{"fs.azure.account.auth.type.testaccount.dfs.core.windows.net",
+          "InvalidAuth"},
+         {"fs.azure.account.key.testaccount.dfs.core.windows.net", "456"}},
+        false);
+
+    VELOX_ASSERT_THROW(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        "Unsupported auth type 'InvalidAuth' for account 'testaccount'");
+  }
+
+  {
+    // Missing auth type config - should fail with clear error
+    const config::ConfigBase config(
+        {{"fs.azure.account.key.testaccount.dfs.core.windows.net", "456"}},
+        false);
+
+    VELOX_ASSERT_THROW(
+        AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+        "No AzureClientProviderFactory registered for account 'testaccount' and no auth type found in config key 'fs.azure.account.auth.type.testaccount.dfs.core.windows.net'");
+  }
+}
+
+TEST(AzureClientProviderFactoriesTest, registeredFactoryTakesPrecedence) {
+  const auto abfsPath = std::make_shared<AbfsPath>(
+      "abfss://abc@precedencetest.dfs.core.windows.net/file/test.txt");
+
+  // Register a custom factory
+  registerAzureClientProviderFactory(
+      "precedencetest",
+      [](const std::string& account) -> std::unique_ptr<AzureClientProvider> {
+        return std::make_unique<DummyAzureClientProvider>();
+      });
+
+  // Even with valid config, registered factory should take precedence
+  const config::ConfigBase config(
+      {{"fs.azure.account.auth.type.precedencetest.dfs.core.windows.net",
+        "SharedKey"},
+       {"fs.azure.account.key.precedencetest.dfs.core.windows.net", "456"}},
+      false);
+
+  // Should use the registered DummyAzureClientProvider, not create from config
+  VELOX_ASSERT_THROW(
+      AzureClientProviderFactories::getReadFileClient(abfsPath, config),
+      "DummyAzureClientProvider: Not implemented.");
+}
+
+TEST(AzureClientProviderFactoriesTest, multipleAccountsSingleConfig) {
+  const auto abfsPath1 = std::make_shared<AbfsPath>(
+      "abfss://abc@account1.dfs.core.windows.net/file/test.txt");
+  const auto abfsPath2 = std::make_shared<AbfsPath>(
+      "abfss://abc@account2.dfs.core.windows.net/file/test.txt");
+
+  // Even with valid config, registered factory should take precedence.
+  const config::ConfigBase config(
+      {{"fs.azure.account.auth.type.account1.dfs.core.windows.net",
+        "SharedKey"},
+       {"fs.azure.account.key.account1.dfs.core.windows.net", "123"},
+       {"fs.azure.account.auth.type.account2.dfs.core.windows.net",
+        "SharedKey"},
+       {"fs.azure.account.key.account2.dfs.core.windows.net", "456"}},
+      false);
+
+  ASSERT_NE(
+      AzureClientProviderFactories::getReadFileClient(abfsPath1, config),
+      nullptr);
+  ASSERT_NE(
+      AzureClientProviderFactories::getWriteFileClient(abfsPath1, config),
+      nullptr);
+  ASSERT_NE(
+      AzureClientProviderFactories::getReadFileClient(abfsPath2, config),
+      nullptr);
+  ASSERT_NE(
+      AzureClientProviderFactories::getWriteFileClient(abfsPath2, config),
+      nullptr);
 }

--- a/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
+++ b/velox/connectors/hive/storage_adapters/abfs/tests/AzureClientProviderFactoriesTest.cpp
@@ -134,7 +134,7 @@ TEST(AzureClientProviderFactoriesTest, registerCustomFactory) {
 
   ASSERT_NO_THROW(
       AzureClientProviderFactories::getClientFactory(
-          "efg", config::ConfigBase({})));
+          abfsPath, config::ConfigBase({})));
   VELOX_ASSERT_THROW(
       AzureClientProviderFactories::getReadFileClient(
           abfsPath, config::ConfigBase({})),
@@ -143,11 +143,16 @@ TEST(AzureClientProviderFactoriesTest, registerCustomFactory) {
       AzureClientProviderFactories::getWriteFileClient(
           abfsPath, config::ConfigBase({})),
       "DummyAzureClientProvider: Not implemented.");
+
+  // Unregistered account on a non-public Azure cloud — the fallback auth-type
+  // key must use the real suffix from the URL, not .dfs.core.windows.net.
+  const auto unregisteredPath =
+      std::make_shared<AbfsPath>("abfs://test@efg2.dfs.core.foobar.net/test");
   VELOX_ASSERT_THROW(
       AzureClientProviderFactories::getClientFactory(
-          "efg2", config::ConfigBase({})),
+          unregisteredPath, config::ConfigBase({})),
       "No AzureClientProviderFactory registered for account 'efg2' and no "
-      "auth type found in config key 'fs.azure.account.auth.type.efg2.dfs.core.windows.net'");
+      "auth type found in config key 'fs.azure.account.auth.type.efg2.dfs.core.foobar.net'");
 }
 
 TEST(


### PR DESCRIPTION
ABFS connector that allows creating Azure clients directly from the configuration without requiring explicit factory registration.

Previously, an explicit registration was necessary but the connector already provided default clients for the supported auth types that only needed to be registered for an account prior to its use.

This change allows the registration to occur on first use without explicit prior registration.