### PR TITLE
feat: Add Arrow bridge support for `TimestampUtcType`

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -293,13 +293,10 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     VELOX_CHECK(options.parquetWriteTimestampUnit.has_value());
     const auto [values, expectedValues] = timestampValues(
         options.parquetWriteTimestampUnit.value(), readTimestampPrecision);
-    // Parquet writer relies on Arrow bridge for schema conversion.
-    // TODO: Switch back to TIMESTAMP_UTC() once Arrow bridge supports
-    // TimestampUtcType.
     auto vector = makeRowVector(
         {"t"},
         {
-            makeFlatVector<Timestamp>(values, TIMESTAMP()),
+            makeFlatVector<Timestamp>(values, TIMESTAMP_UTC()),
         });
     auto file = TempFilePath::create();
     writeToParquetFile(file->getPath(), {vector}, options);

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -16,6 +16,8 @@
 
 #include "velox/vector/arrow/Bridge.h"
 
+#include <cstring>
+
 #include "velox/buffer/Buffer.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CheckedArithmetic.h"
@@ -145,6 +147,9 @@ struct VeloxToArrowSchemaBridgeHolder {
   // format.
   std::string formatBuffer;
 
+  // Buffer required to keep ArrowSchema.metadata alive.
+  std::string metadataBuffer;
+
   void setChildAtIndex(
       size_t index,
       std::unique_ptr<ArrowSchema>&& child,
@@ -161,6 +166,88 @@ struct VeloxToArrowSchemaBridgeHolder {
     schema.children[index] = childrenOwned[index].get();
   }
 };
+
+constexpr std::string_view kVeloxTimestampTypeMetadataKey{
+    "velox.logical_timestamp"};
+constexpr std::string_view kVeloxTimestampUtcMetadataValue{"utc"};
+
+void appendInt32(std::string& metadata, int32_t value) {
+  constexpr auto kInt32Size = sizeof(int32_t);
+  const auto start = metadata.size();
+  metadata.resize(start + kInt32Size);
+  std::memcpy(metadata.data() + start, &value, kInt32Size);
+}
+
+const std::string& timestampUtcMetadataBlob() {
+  static const std::string metadata = [] {
+    std::string encoded;
+    appendInt32(encoded, 1);
+    appendInt32(
+        encoded, static_cast<int32_t>(kVeloxTimestampTypeMetadataKey.size()));
+    encoded.append(kVeloxTimestampTypeMetadataKey);
+    appendInt32(
+        encoded, static_cast<int32_t>(kVeloxTimestampUtcMetadataValue.size()));
+    encoded.append(kVeloxTimestampUtcMetadataValue);
+    return encoded;
+  }();
+  return metadata;
+}
+
+bool hasTimestampUtcMetadata(const char* metadata) {
+  if (metadata == nullptr) {
+    return false;
+  }
+
+  // Keep this decoding behavior in sync with arrow/c/bridge.cc::DecodeMetadata.
+  auto readInt32 = [&](int32_t* out) -> bool {
+    int32_t value;
+    std::memcpy(&value, metadata, sizeof(int32_t));
+    metadata += sizeof(int32_t);
+    *out = value;
+    return *out >= 0;
+  };
+
+  auto readStringView = [&](std::string_view* out) -> bool {
+    int32_t length;
+    if (!readInt32(&length)) {
+      return false;
+    }
+    *out = std::string_view{metadata, static_cast<size_t>(length)};
+    metadata += length;
+    return true;
+  };
+
+  int32_t numPairs;
+  if (!readInt32(&numPairs) || numPairs == 0) {
+    return false;
+  }
+
+  for (int32_t i = 0; i < numPairs; ++i) {
+    std::string_view key;
+    if (!readStringView(&key)) {
+      return false;
+    }
+
+    std::string_view value;
+    if (!readStringView(&value)) {
+      return false;
+    }
+
+    if (key == kVeloxTimestampTypeMetadataKey &&
+        value == kVeloxTimestampUtcMetadataValue) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+TypePtr importTimestampTypeFromArrow(const ArrowSchema& arrowSchema) {
+  if (hasTimestampUtcMetadata(arrowSchema.metadata)) {
+    return TIMESTAMP_UTC();
+  }
+  return TIMESTAMP();
+}
 
 // Release function for ArrowArray. Arrow standard requires it to recurse down
 // to children and dictionary arrays, and set release and private_data to null
@@ -231,6 +318,7 @@ static void releaseArrowSchema(ArrowSchema* arrowSchema) {
 }
 
 const char* exportArrowFormatTimestampStr(
+    const TypePtr& type,
     const ArrowOptions& options,
     std::string& formatBuffer) {
   switch (options.timestampUnit) {
@@ -250,7 +338,10 @@ const char* exportArrowFormatTimestampStr(
       VELOX_UNREACHABLE();
   }
 
-  if (options.timestampTimeZone.has_value()) {
+  // TimestampUtcType is timezone-agnostic, which never carries timezone
+  // information. The TimestampType represents local time, so we include the
+  // timezone information if it's provided in options.
+  if (type->equivalent(*TIMESTAMP()) && options.timestampTimeZone.has_value()) {
     formatBuffer += options.timestampTimeZone.value();
   }
 
@@ -327,8 +418,7 @@ const char* exportArrowFormatStr(
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
-      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
-      return exportArrowFormatTimestampStr(options, formatBuffer);
+      return exportArrowFormatTimestampStr(type, options, formatBuffer);
     // Complex/nested types.
     case TypeKind::ARRAY:
       static_assert(sizeof(vector_size_t) == 4);
@@ -760,7 +850,6 @@ size_t getArrowElementSize(const TypePtr& type, const ArrowOptions& options) {
   if (type->isShortDecimal() && !options.useDecimalTypeWidth) {
     return sizeof(int128_t);
   } else if (type->isTimestamp()) {
-    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return sizeof(int64_t);
   } else if (type->isTime()) {
     if (type->equivalent(*TIME())) {
@@ -800,7 +889,6 @@ void exportValues(
       : AlignedBuffer::allocate<uint8_t>(
             checkedMultiply<size_t>(out.length, size), pool);
   if (type->kind() == TypeKind::TIMESTAMP) {
-    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     gatherFromTimestampBuffer(vec, rows, options.timestampUnit, *values);
   } else if (
       type->kind() == TypeKind::BIGINT && type->isTime() &&
@@ -1408,7 +1496,7 @@ TypePtr importFromArrowImpl(
 
     case 't': // temporal types.
       if (format[1] == 's') {
-        return TIMESTAMP();
+        return importTimestampTypeFromArrow(arrowSchema);
       }
       if (format[1] == 'd' && format[2] == 'D') {
         return DATE();
@@ -1505,7 +1593,8 @@ void exportToArrow(
 
   arrowSchema.name = nullptr;
 
-  // No additional metadata for now.
+  // No additional metadata by default. Some types may set this later if needed
+  // (e.g. TIMESTAMP_UTC).
   arrowSchema.metadata = nullptr;
 
   // All supported types are semantically nullable.
@@ -1513,6 +1602,12 @@ void exportToArrow(
 
   // Allocate private data buffer holder and recurse down to children types.
   auto bridgeHolder = std::make_unique<VeloxToArrowSchemaBridgeHolder>();
+  auto setTimestampUtcMetadata = [&]() {
+    // Velox's TIMESTAMP_UTC type does not have a direct equivalent in Arrow,
+    // so we encode the timezone-agnostic information in schema metadata.
+    bridgeHolder->metadataBuffer = timestampUtcMetadataBlob();
+    arrowSchema.metadata = bridgeHolder->metadataBuffer.data();
+  };
 
   if (vec->encoding() == VectorEncoding::Simple::DICTIONARY) {
     arrowSchema.n_children = 0;
@@ -1522,7 +1617,12 @@ void exportToArrow(
       arrowSchema.dictionary = nullptr;
       arrowSchema.format =
           exportArrowFormatStr(type, options, bridgeHolder->formatBuffer);
+      if (type->equivalent(*TIMESTAMP_UTC())) {
+        setTimestampUtcMetadata();
+      }
     } else {
+      // The top-level dictionary schema represents index type only.
+      arrowSchema.metadata = nullptr;
       arrowSchema.format = "i";
       bridgeHolder->dictionary = std::make_unique<ArrowSchema>();
       arrowSchema.dictionary = bridgeHolder->dictionary.get();
@@ -1561,6 +1661,9 @@ void exportToArrow(
     arrowSchema.format =
         exportArrowFormatStr(type, options, bridgeHolder->formatBuffer);
     arrowSchema.dictionary = nullptr;
+    if (type->equivalent(*TIMESTAMP_UTC())) {
+      setTimestampUtcMetadata();
+    }
 
     if (type->kind() == TypeKind::MAP) {
       // Need to wrap the key and value types in a struct type.
@@ -2274,7 +2377,6 @@ VectorPtr importFromArrowImpl(
         arrowArray.null_count,
         wrapInBufferView);
   } else if (type->isTimestamp()) {
-    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return createTimestampVector(
         pool,
         type,

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -77,6 +77,33 @@ class ArrowBridgeArrayExportTest : public testing::Test {
     EXPECT_EQ(nullptr, arrowArray.private_data);
   }
 
+  void testFlatTimestampType(const TypePtr& type) {
+    for (TimestampUnit unit :
+         {TimestampUnit::kSecond,
+          TimestampUnit::kMilli,
+          TimestampUnit::kMicro,
+          TimestampUnit::kNano}) {
+      options_.timestampUnit = unit;
+      testFlatVector<Timestamp>(
+          {
+              Timestamp(0, 0),
+              std::nullopt,
+              Timestamp(1699300965, 12'349),
+              Timestamp(-2208960000, 0), // 1900-01-01
+              Timestamp(3155788800, 999'999'999),
+              std::nullopt,
+          },
+          type);
+    }
+
+    // Out of range. If nanosecond precision is represented in Arrow,
+    // timestamps starting around 2263-01-01 should overflow and throw a user
+    // exception.
+    EXPECT_THROW(
+        testFlatVector<Timestamp>({Timestamp(9246211200, 0)}, type),
+        VeloxUserError);
+  }
+
   // Construct and test a constant vector based on a scalar value.
   template <typename T>
   void testConstant(
@@ -533,29 +560,11 @@ TEST_F(ArrowBridgeArrayExportTest, flatDate) {
 }
 
 TEST_F(ArrowBridgeArrayExportTest, flatTimestamp) {
-  for (TimestampUnit unit :
-       {TimestampUnit::kSecond,
-        TimestampUnit::kMilli,
-        TimestampUnit::kMicro,
-        TimestampUnit::kNano}) {
-    options_.timestampUnit = unit;
-    testFlatVector<Timestamp>(
-        {
-            Timestamp(0, 0),
-            std::nullopt,
-            Timestamp(1699300965, 12'349),
-            Timestamp(-2208960000, 0), // 1900-01-01
-            Timestamp(3155788800, 999'999'999),
-            std::nullopt,
-        },
-        TIMESTAMP());
-  }
+  testFlatTimestampType(TIMESTAMP());
+}
 
-  // Out of range. If nanosecond precision is represented in Arrow, timestamps
-  // starting around 2263-01-01 should overflow and throw a user exception.
-  EXPECT_THROW(
-      testFlatVector<Timestamp>({Timestamp(9246211200, 0)}, TIMESTAMP()),
-      VeloxUserError);
+TEST_F(ArrowBridgeArrayExportTest, flatTimestampUtc) {
+  testFlatTimestampType(TIMESTAMP_UTC());
 }
 
 TEST_F(ArrowBridgeArrayExportTest, flatTime) {
@@ -1394,6 +1403,64 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
          std::nullopt});
   }
 
+  void testTimestampUtcRoundtrip() {
+    auto roundtripVector = [&](const VectorPtr& input) {
+      ArrowSchema schema;
+      ArrowArray data;
+      velox::exportToArrow(input, schema, options_);
+      velox::exportToArrow(input, data, pool_.get(), options_);
+
+      auto output = importFromArrow(schema, data, pool_.get());
+      facebook::velox::test::assertEqualVectors(input, output);
+
+      if (isViewer()) {
+        schema.release(&schema);
+        data.release(&data);
+      } else {
+        EXPECT_EQ(nullptr, schema.release);
+        EXPECT_EQ(nullptr, data.release);
+      }
+    };
+
+    auto flatVector = vectorMaker_.flatVectorNullable<Timestamp>(
+        {
+            Timestamp(0, 0),
+            std::nullopt,
+            Timestamp(1699300965, 12'349),
+            Timestamp(-2208960000, 0),
+            Timestamp(3155788800, 999'999'999),
+        },
+        TIMESTAMP_UTC());
+    roundtripVector(flatVector);
+
+    auto dictionaryValues = vectorMaker_.flatVector<Timestamp>(
+        {
+            Timestamp(0, 0),
+            Timestamp(1699300965, 12'349),
+            Timestamp(3155788800, 999'999'999),
+        },
+        TIMESTAMP_UTC());
+    auto dictionaryVector = BaseVector::wrapInDictionary(
+        nullptr, makeIndicesInReverse(3, pool_.get()), 3, dictionaryValues);
+    roundtripVector(dictionaryVector);
+
+    using NullableTimestampArray =
+        std::optional<std::vector<std::optional<Timestamp>>>;
+    std::vector<NullableTimestampArray> nestedValues = {
+        std::vector<std::optional<Timestamp>>{
+            Timestamp(0, 0),
+            std::nullopt,
+            Timestamp(2, 200),
+        },
+        std::nullopt,
+        std::vector<std::optional<Timestamp>>{Timestamp(-2208960000, 0)},
+        std::vector<std::optional<Timestamp>>{},
+    };
+    auto nestedVector = vectorMaker_.arrayVectorNullable<Timestamp>(
+        nestedValues, ARRAY(TIMESTAMP_UTC()));
+    roundtripVector(nestedVector);
+  }
+
   template <typename TOutput, typename TInput>
   void testImportWithoutNullsBuffer(
       std::vector<std::optional<TInput>> inputValues,
@@ -2024,6 +2091,10 @@ TEST_F(ArrowBridgeArrayImportAsViewerTest, scalar) {
   testImportScalar();
 }
 
+TEST_F(ArrowBridgeArrayImportAsViewerTest, timestampUtc) {
+  testTimestampUtcRoundtrip();
+}
+
 TEST_F(ArrowBridgeArrayImportAsViewerTest, without_nulls_buffer) {
   std::vector<std::optional<int64_t>> inputValues = {1, 2, 3, 4, 5};
   testImportWithoutNullsBuffer<int64_t>(inputValues, "l");
@@ -2128,6 +2199,10 @@ class ArrowBridgeArrayImportAsOwnerTest
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, scalar) {
   testImportScalar();
+}
+
+TEST_F(ArrowBridgeArrayImportAsOwnerTest, timestampUtc) {
+  testTimestampUtcRoundtrip();
 }
 
 TEST_F(ArrowBridgeArrayImportAsOwnerTest, without_nulls_buffer) {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -22,13 +22,15 @@
 
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/vector/arrow/Bridge.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::test {
 namespace {
 
 static void mockRelease(ArrowSchema*) {}
 
-class ArrowBridgeSchemaExportTest : public testing::Test {
+class ArrowBridgeSchemaExportTest : public testing::Test,
+                                    public VectorTestBase {
  protected:
   static void SetUpTestCase() {
     memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
@@ -37,11 +39,12 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
   void testScalarType(
       const TypePtr& type,
       const char* arrowFormat,
-      const ArrowOptions& options = ArrowOptions{}) {
+      const ArrowOptions& options = ArrowOptions{},
+      bool expectMetadata = false) {
     ArrowSchema arrowSchema;
     exportToArrow(type, arrowSchema, options);
 
-    verifyScalarType(arrowSchema, arrowFormat);
+    verifyScalarType(arrowSchema, arrowFormat, nullptr, expectMetadata);
 
     arrowSchema.release(&arrowSchema);
     EXPECT_EQ(nullptr, arrowSchema.release);
@@ -51,14 +54,19 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
   void verifyScalarType(
       const ArrowSchema& arrowSchema,
       const char* arrowFormat,
-      const char* name = nullptr) {
+      const char* name = nullptr,
+      bool expectMetadata = false) {
     EXPECT_STREQ(arrowFormat, arrowSchema.format);
     if (name == nullptr) {
       EXPECT_EQ(nullptr, arrowSchema.name);
     } else {
       EXPECT_STREQ(name, arrowSchema.name);
     }
-    EXPECT_EQ(nullptr, arrowSchema.metadata);
+    if (expectMetadata) {
+      EXPECT_NE(nullptr, arrowSchema.metadata);
+    } else {
+      EXPECT_EQ(nullptr, arrowSchema.metadata);
+    }
     EXPECT_EQ(arrowSchema.flags | ARROW_FLAG_NULLABLE, ARROW_FLAG_NULLABLE);
 
     EXPECT_EQ(0, arrowSchema.n_children);
@@ -126,11 +134,11 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     // complex vector first, then wrap it in a dictionary.
     auto constantVector = isScalar
         ? BaseVector::createConstant(
-              type, variant(type->kind()), constantSize, pool_.get())
+              type, variant(type->kind()), constantSize, pool())
         : BaseVector::wrapInConstant(
               constantSize,
               3, // index to use for the constant
-              BaseVector::create(type, 100, pool_.get()));
+              BaseVector::create(type, 100, pool()));
 
     velox::exportToArrow(constantVector, arrowSchema, options);
 
@@ -170,8 +178,7 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
       const TypePtr& type,
       ArrowSchema& out,
       const ArrowOptions& options = ArrowOptions{}) {
-    velox::exportToArrow(
-        BaseVector::create(type, 0, pool_.get()), out, options);
+    velox::exportToArrow(BaseVector::create(type, 0, pool()), out, options);
   }
 
   ArrowSchema makeArrowSchema(const char* format) {
@@ -187,9 +194,6 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
         .private_data = nullptr,
     };
   }
-
-  std::shared_ptr<memory::MemoryPool> pool_{
-      memory::memoryManager()->addLeafPool()};
 };
 
 TEST_F(ArrowBridgeSchemaExportTest, scalar) {
@@ -206,33 +210,60 @@ TEST_F(ArrowBridgeSchemaExportTest, scalar) {
   testScalarType(VARCHAR(), "u");
   testScalarType(VARBINARY(), "z");
 
-  // Test default timezone
-  testScalarType(
-      TIMESTAMP(), "tss:", {.timestampUnit = TimestampUnit::kSecond});
-  testScalarType(TIMESTAMP(), "tsm:", {.timestampUnit = TimestampUnit::kMilli});
-  testScalarType(TIMESTAMP(), "tsu:", {.timestampUnit = TimestampUnit::kMicro});
-  testScalarType(TIMESTAMP(), "tsn:", {.timestampUnit = TimestampUnit::kNano});
-
   testScalarType(VARCHAR(), "vu", {.exportToStringView = true});
   testScalarType(VARBINARY(), "vz", {.exportToStringView = true});
 
-  // Test specific timezone
-  testScalarType(
-      TIMESTAMP(),
-      "tss:+01:0",
-      {.timestampUnit = TimestampUnit::kSecond, .timestampTimeZone = "+01:0"});
-  testScalarType(
-      TIMESTAMP(),
-      "tsm:+01:0",
-      {.timestampUnit = TimestampUnit::kMilli, .timestampTimeZone = "+01:0"});
-  testScalarType(
-      TIMESTAMP(),
-      "tsu:+01:0",
-      {.timestampUnit = TimestampUnit::kMicro, .timestampTimeZone = "+01:0"});
-  testScalarType(
-      TIMESTAMP(),
-      "tsn:+01:0",
-      {.timestampUnit = TimestampUnit::kNano, .timestampTimeZone = "+01:0"});
+  {
+    struct TimestampCase {
+      TimestampUnit unit;
+      const char* format;
+    };
+
+    const TimestampCase kDefaultTimestampCases[] = {
+        {TimestampUnit::kSecond, "tss:"},
+        {TimestampUnit::kMilli, "tsm:"},
+        {TimestampUnit::kMicro, "tsu:"},
+        {TimestampUnit::kNano, "tsn:"},
+    };
+
+    const TimestampCase kTimezoneTimestampCases[] = {
+        {TimestampUnit::kSecond, "tss:+01:0"},
+        {TimestampUnit::kMilli, "tsm:+01:0"},
+        {TimestampUnit::kMicro, "tsu:+01:0"},
+        {TimestampUnit::kNano, "tsn:+01:0"},
+    };
+
+    for (const auto& timestampCase : kDefaultTimestampCases) {
+      testScalarType(
+          TIMESTAMP(),
+          timestampCase.format,
+          {.timestampUnit = timestampCase.unit});
+    }
+
+    for (const auto& timestampCase : kDefaultTimestampCases) {
+      testScalarType(
+          TIMESTAMP_UTC(),
+          timestampCase.format,
+          {.timestampUnit = timestampCase.unit},
+          true);
+    }
+
+    for (const auto& timestampCase : kTimezoneTimestampCases) {
+      testScalarType(
+          TIMESTAMP(),
+          timestampCase.format,
+          {.timestampUnit = timestampCase.unit, .timestampTimeZone = "+01:0"});
+    }
+
+    // TIMESTAMP_UTC is timezone-agnostic and ignores timestampTimeZone option.
+    for (const auto& timestampCase : kDefaultTimestampCases) {
+      testScalarType(
+          TIMESTAMP_UTC(),
+          timestampCase.format,
+          {.timestampUnit = timestampCase.unit, .timestampTimeZone = "+01:0"},
+          true);
+    }
+  }
 
   testScalarType(DATE(), "tdD");
   testScalarType(INTERVAL_YEAR_MONTH(), "tiM");
@@ -312,11 +343,53 @@ TEST_F(ArrowBridgeSchemaExportTest, constant) {
       "Flattening is only supported for scalar types.");
 }
 
+TEST_F(ArrowBridgeSchemaExportTest, dictionaryTimestampUtc) {
+  auto dictionaryValues = makeFlatVector<Timestamp>(
+      {
+          Timestamp(0, 0),
+          Timestamp(1, 12'349),
+          Timestamp(2, 999'999'999),
+      },
+      TIMESTAMP_UTC());
+  auto dictionaryVector =
+      wrapInDictionary(makeIndicesInReverse(3), dictionaryValues);
+
+  ArrowSchema arrowSchema;
+  velox::exportToArrow(dictionaryVector, arrowSchema);
+
+  auto importedType = importFromArrow(arrowSchema);
+  EXPECT_EQ(*TIMESTAMP_UTC(), *importedType);
+
+  arrowSchema.release(&arrowSchema);
+
+  velox::exportToArrow(
+      dictionaryVector, arrowSchema, ArrowOptions{.flattenDictionary = true});
+
+  importedType = importFromArrow(arrowSchema);
+  EXPECT_EQ(*TIMESTAMP_UTC(), *importedType);
+
+  arrowSchema.release(&arrowSchema);
+}
+
 class ArrowBridgeSchemaImportTest : public ArrowBridgeSchemaExportTest {
  protected:
-  TypePtr testSchemaImport(const char* format) {
+  TypePtr testSchemaImport(
+      const char* format,
+      bool withTimestampUtcMetadata = false) {
     auto arrowSchema = makeArrowSchema(format);
+
+    ArrowSchema timestampUtcSchema;
+    if (withTimestampUtcMetadata) {
+      exportToArrow(TIMESTAMP_UTC(), timestampUtcSchema);
+      arrowSchema.metadata = timestampUtcSchema.metadata;
+    }
+
     auto type = importFromArrow(arrowSchema);
+
+    if (withTimestampUtcMetadata) {
+      timestampUtcSchema.release(&timestampUtcSchema);
+    }
+
     arrowSchema.release(&arrowSchema);
     return type;
   }
@@ -426,6 +499,7 @@ TEST_F(ArrowBridgeSchemaImportTest, scalar) {
 
   // Temporal.
   EXPECT_EQ(*TIMESTAMP(), *testSchemaImport("tsn:"));
+  EXPECT_EQ(*TIMESTAMP_UTC(), *testSchemaImport("tsn:", true));
   EXPECT_EQ(*DATE(), *testSchemaImport("tdD"));
   EXPECT_EQ(*INTERVAL_YEAR_MONTH(), *testSchemaImport("tiM"));
 
@@ -538,6 +612,8 @@ TEST_F(ArrowBridgeSchemaTest, roundtrip) {
   roundtripTest(VARCHAR());
   roundtripTest(VARCHAR(), {.exportToStringView = true});
   roundtripTest(REAL());
+  roundtripTest(TIMESTAMP());
+  roundtripTest(TIMESTAMP_UTC());
   roundtripTest(ARRAY(DOUBLE()));
   roundtripTest(ARRAY(ARRAY(ARRAY(ARRAY(VARBINARY())))));
   roundtripTest(MAP(VARCHAR(), REAL()));


### PR DESCRIPTION
**Problem:** Both Velox `TIMESTAMP` (local time) and `TIMESTAMP_UTC` (timezone-
agnostic) map to the same Arrow format string `ts`. Arrow cannot distinguish 
them from the format alone.
 
**Solution:** Tag `TIMESTAMP_UTC` with Arrow schema metadata during export and
detect it during import.
   
**Export (Velox → Arrow):**
- `TIMESTAMP` → `ts` (with optional timezone from options, e.g. `tsn:+01:0`)
- `TIMESTAMP_UTC` → `ts` + metadata `velox.logical_timestamp=utc` (never
includes timezone)

**Import (Arrow → Velox):**
- `ts` without metadata → `TIMESTAMP`
- `ts` with `velox.logical_timestamp=utc` → `TIMESTAMP_UTC`

The metadata is Velox-specific. Other Arrow consumers will ignore it and treat both as
regular timestamps.

Related issue: https://github.com/facebookincubator/velox/issues/17087.