### PR TITLE
feat(cudf): Add all the binary functions in AST

### DIFF
--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -58,6 +58,29 @@ cudf::ast::literal createLiteral(
       scalars);
 }
 
+// Cast the input var to type
+template <TypeKind kind>
+cudf::ast::literal makeScalarAndLiteral(
+    const TypePtr& type,
+    int64_t value,
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
+  using T = typename TypeTraits<kind>::NativeType;
+  if constexpr (cudf::is_fixed_width<T>()) {
+    auto scalar = makeScalarFromValue<T>(type, value, false);
+    scalars.emplace_back(std::move(scalar));
+    return makeLiteralFromScalar<T>(*(scalars.back()), type);
+  }
+  VELOX_NYI("Scalar creation not implemented for type " + type->toString());
+}
+
+cudf::ast::literal createLiteral(
+    const TypePtr& type,
+    int64_t value,
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
+  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      makeScalarAndLiteral, type->kind(), type, value, scalars);
+}
+
 // Helper function to extract literals from array elements based on type
 void extractArrayLiterals(
     const ArrayVector* arrayVector,
@@ -136,34 +159,56 @@ std::string stripPrefix(const std::string& input, const std::string& prefix) {
 
 using Op = cudf::ast::ast_operator;
 const std::unordered_map<std::string, Op> prestoBinaryOps = {
+    // Arithmetic operators
     {"plus", Op::ADD},
     {"minus", Op::SUB},
     {"multiply", Op::MUL},
     {"divide", Op::DIV},
+    // Only supports floating type
+    {"mod", Op::MOD},
+    {"power", Op::POW},
+
+    // Comparison operators
     {"eq", Op::EQUAL},
     {"neq", Op::NOT_EQUAL},
     {"lt", Op::LESS},
     {"gt", Op::GREATER},
     {"lte", Op::LESS_EQUAL},
     {"gte", Op::GREATER_EQUAL},
+
+    // Logical operators
     {"and", Op::NULL_LOGICAL_AND},
     {"or", Op::NULL_LOGICAL_OR},
-    {"mod", Op::MOD},
+
+    // Bitwise operators
+    {"bitwise_and", Op::BITWISE_AND},
+    {"bitwise_or", Op::BITWISE_OR},
+    {"bitwise_xor", Op::BITWISE_XOR},
 };
 
 const std::unordered_map<std::string, Op> sparkBinaryOps = {
+    // Arithmetic operators
     {"add", Op::ADD},
     {"subtract", Op::SUB},
     {"multiply", Op::MUL},
     {"divide", Op::DIV},
+    {"remainder", Op::MOD},
+
+    // Comparison operators
     {"equalto", Op::EQUAL},
     {"lessthan", Op::LESS},
     {"greaterthan", Op::GREATER},
     {"lessthanorequal", Op::LESS_EQUAL},
     {"greaterthanorequal", Op::GREATER_EQUAL},
+
+    // Logical operators
     {"and", Op::NULL_LOGICAL_AND},
     {"or", Op::NULL_LOGICAL_OR},
-    {"mod", Op::MOD},
+
+    // Bitwise operators
+    {"bitwise_and", Op::BITWISE_AND},
+    {"bitwise_or", Op::BITWISE_OR},
+    {"bitwise_xor", Op::BITWISE_XOR},
 };
 
 const std::unordered_map<std::string, Op> binaryOps = [] {
@@ -353,6 +398,19 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
       }
       return true;
     }
+    if (name == "bitwise_and" || name == "bitwise_or" || name == "bitwise_xor" || ) {
+      // Spark result type is same with the input type, Presto result type is
+      // int64_t
+      // Spark case and Presto int64_t case
+      if (expr->type() == expr->inputs()[0]->type()) {
+        // For tinyint, the result type is tinyint in Spark but is integer in cudf
+        return expr->type()->kind() == TypeKind::BIGINT || expr->type()->kind() == TypeKind::INTEGER;
+      }
+      return isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);
+    }
+    if (name == "mod" || name == "remainder") {
+      return true;
+    }
     return len == 2 &&
         isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);
   }
@@ -363,6 +421,11 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
   }
   if (name == "isnotnull" && len == 1) {
     return isOpAndInputsSupported(Op::IS_NULL, inputCudfDataTypes);
+  }
+  if (name == "pmod") {
+    // The data type is decided by a mixed operation, do we have the way to
+    // check it?
+    return true;
   }
 
   // Between: value >= lower AND value <= upper
@@ -616,7 +679,14 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     VELOX_CHECK_EQ(len, 2);
     auto const& op1 = pushExprToTree(expr->inputs()[0]);
     auto const& op2 = pushExprToTree(expr->inputs()[1]);
-    return tree.push(Operation{binaryOps.at(name), op1, op2});
+    auto const& op3 = tree.push(Operation{binaryOps.at(name), op1, op2});
+    if (name == "bitwise_and" || name == "bitwise_or" || name == "bitwise_xor" || name == "mod" || name == "remainder") {
+      if (expr->type()->kind() == TypeKind::BIGINT &&
+          expr->inputs()[0]->type()->kind() != TypeKind::BIGINT) {
+        return tree.push(Operation{Op::CAST_TO_INT64, op3});
+      }
+    }
+    return op3;
   } else if (unaryOps.find(name) != unaryOps.end()) {
     VELOX_CHECK_EQ(len, 1);
     auto const& op1 = pushExprToTree(expr->inputs()[0]);
@@ -693,6 +763,13 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     } else {
       VELOX_FAIL("Unsupported type for cast operation");
     }
+  } else if (name == "pmod") {
+    // pmod(a, b) = (a % b + b) % b
+    auto const& a = pushExprToTree(expr->inputs()[0]);
+    auto const& b = pushExprToTree(expr->inputs()[1]);
+    auto const& r1 = tree.push(Operation{Op::MOD, a, b});
+    auto const& r2 = tree.push(Operation{Op::ADD, r1, b});
+    return tree.push(Operation{Op::MOD, r2, b});
   } else if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr)) {
     // Refer to the appropriate side
     const auto fieldName =

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -58,29 +58,6 @@ cudf::ast::literal createLiteral(
       scalars);
 }
 
-// Cast the input var to type
-template <TypeKind kind>
-cudf::ast::literal makeScalarAndLiteral(
-    const TypePtr& type,
-    int64_t value,
-    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
-  using T = typename TypeTraits<kind>::NativeType;
-  if constexpr (cudf::is_fixed_width<T>()) {
-    auto scalar = makeScalarFromValue<T>(type, value, false);
-    scalars.emplace_back(std::move(scalar));
-    return makeLiteralFromScalar<T>(*(scalars.back()), type);
-  }
-  VELOX_NYI("Scalar creation not implemented for type " + type->toString());
-}
-
-cudf::ast::literal createLiteral(
-    const TypePtr& type,
-    int64_t value,
-    std::vector<std::unique_ptr<cudf::scalar>>& scalars) {
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
-      makeScalarAndLiteral, type->kind(), type, value, scalars);
-}
-
 // Helper function to extract literals from array elements based on type
 void extractArrayLiterals(
     const ArrayVector* arrayVector,

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -166,7 +166,6 @@ const std::unordered_map<std::string, Op> prestoBinaryOps = {
     {"divide", Op::DIV},
     // Only supports floating type
     {"mod", Op::MOD},
-    {"power", Op::POW},
 
     // Comparison operators
     {"eq", Op::EQUAL},
@@ -398,7 +397,7 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
       }
       return true;
     }
-    if (name == "bitwise_and" || name == "bitwise_or" || name == "bitwise_xor" || ) {
+    if (name == "bitwise_and" || name == "bitwise_or" || name == "bitwise_xor") {
       // Spark result type is same with the input type, Presto result type is
       // int64_t
       // Spark case and Presto int64_t case
@@ -409,13 +408,14 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
       return isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);
     }
     if (name == "mod" || name == "remainder") {
-// | Engine | SQL Function Name | Input Type Category  | Underlying Implementation |
-// | ------ | ----------------- | -------------------- | ------------------------- |
-// | Presto | `mod`             | Integral types       | `checked_mod`             |
-// | Presto | `mod`             | Floating-point types | `mod`                     |
-// | Spark  | `remainder`       | Integral types       | `mod`                     |
-// | Spark  | `remainder`       | Floating-point types | `mod`                     |
-      return expr->type()->kind() == TypeKind::FLOAT || expr->type()->kind() == TypeKind::DOUBLE;
+      // | Engine | SQL Function Name | Input Type Category  | Underlying Implementation |
+      // | ------ | ----------------- | -------------------- | ------------------------- |
+      // | Presto | `mod`             | Integral types       | `checked_mod`             |
+      // | Presto | `mod`             | Floating-point types | `mod`                     |
+      // | Spark  | `remainder`       | Integral types       | `mod`                     |
+      // | Spark  | `remainder`       | Floating-point types | `mod`                     |
+      // Float input returns double which Velox CPU requires float.
+      return expr->type()->kind() == TypeKind::DOUBLE;
     }
     return len == 2 &&
         isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);
@@ -427,11 +427,6 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
   }
   if (name == "isnotnull" && len == 1) {
     return isOpAndInputsSupported(Op::IS_NULL, inputCudfDataTypes);
-  }
-  if (name == "pmod") {
-    // The data type is decided by a mixed operation, do we have the way to
-    // check it?
-    return true;
   }
 
   // Between: value >= lower AND value <= upper

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -392,7 +392,9 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
       // | Spark  | `remainder`       | Integral types       | `mod`                     |
       // | Spark  | `remainder`       | Floating-point types | `mod`                     |
       // Float input returns double which Velox CPU requires float.
-      return expr->type()->kind() == TypeKind::DOUBLE;
+      return expr->type()->kind() == TypeKind::DOUBLE ||
+          expr->type()->kind() == TypeKind::BIGINT ||
+          expr->type()->kind() == TypeKind::INTEGER;
     }
     return len == 2 &&
         isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -402,14 +402,20 @@ bool isAstExprSupported(const std::shared_ptr<velox::exec::Expr>& expr) {
       // Spark result type is same with the input type, Presto result type is
       // int64_t
       // Spark case and Presto int64_t case
-      if (expr->type() == expr->inputs()[0]->type()) {
+      if (expr->type()->equivalent(*(expr->inputs()[0]->type()))) {
         // For tinyint, the result type is tinyint in Spark but is integer in cudf
         return expr->type()->kind() == TypeKind::BIGINT || expr->type()->kind() == TypeKind::INTEGER;
       }
       return isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);
     }
     if (name == "mod" || name == "remainder") {
-      return true;
+// | Engine | SQL Function Name | Input Type Category  | Underlying Implementation |
+// | ------ | ----------------- | -------------------- | ------------------------- |
+// | Presto | `mod`             | Integral types       | `checked_mod`             |
+// | Presto | `mod`             | Floating-point types | `mod`                     |
+// | Spark  | `remainder`       | Integral types       | `mod`                     |
+// | Spark  | `remainder`       | Floating-point types | `mod`                     |
+      return expr->type()->kind() == TypeKind::FLOAT || expr->type()->kind() == TypeKind::DOUBLE;
     }
     return len == 2 &&
         isOpAndInputsSupported(binaryOps.at(name), inputCudfDataTypes);
@@ -680,7 +686,7 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     auto const& op1 = pushExprToTree(expr->inputs()[0]);
     auto const& op2 = pushExprToTree(expr->inputs()[1]);
     auto const& op3 = tree.push(Operation{binaryOps.at(name), op1, op2});
-    if (name == "bitwise_and" || name == "bitwise_or" || name == "bitwise_xor" || name == "mod" || name == "remainder") {
+    if (name == "bitwise_and" || name == "bitwise_or" || name == "bitwise_xor") {
       if (expr->type()->kind() == TypeKind::BIGINT &&
           expr->inputs()[0]->type()->kind() != TypeKind::BIGINT) {
         return tree.push(Operation{Op::CAST_TO_INT64, op3});
@@ -763,13 +769,6 @@ cudf::ast::expression const& AstContext::pushExprToTree(
     } else {
       VELOX_FAIL("Unsupported type for cast operation");
     }
-  } else if (name == "pmod") {
-    // pmod(a, b) = (a % b + b) % b
-    auto const& a = pushExprToTree(expr->inputs()[0]);
-    auto const& b = pushExprToTree(expr->inputs()[1]);
-    auto const& r1 = tree.push(Operation{Op::MOD, a, b});
-    auto const& r2 = tree.push(Operation{Op::ADD, r1, b});
-    return tree.push(Operation{Op::MOD, r2, b});
   } else if (auto fieldExpr = std::dynamic_pointer_cast<FieldReference>(expr)) {
     // Refer to the appropriate side
     const auto fieldName =

--- a/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
+++ b/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/experimental/cudf/expression/AstExpression.h"
 #include "velox/experimental/cudf/expression/ExpressionEvaluator.h"
 
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
@@ -76,6 +77,13 @@ class CudfFunctionBaseTest : public velox::functions::test::FunctionBaseTest {
     VELOX_CHECK(result.has_value(), "Expression returned null: {}", expr);
 
     return result.value();
+  }
+
+  bool canEvaluateWithAst(
+      const std::string& expr,
+      const RowTypePtr& rowType) {
+    auto exprSet = compileExpression(expr, rowType);
+    return ASTExpression::canEvaluate(exprSet->expr(0));
   }
 };
 

--- a/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
+++ b/velox/experimental/cudf/tests/CudfFunctionBaseTest.h
@@ -54,6 +54,29 @@ class CudfFunctionBaseTest : public velox::functions::test::FunctionBaseTest {
         cudf::get_current_device_resource_ref());
     return result->childAt(0);
   }
+
+  template <typename TReturn, typename... TArgs>
+  TReturn evaluateOnceValue(
+      const std::string& expr,
+      std::optional<TArgs>... args) {
+    auto result = evaluateOnce<TReturn, TArgs...>(expr, args...);
+
+    VELOX_CHECK(result.has_value(), "Expression returned null: {}", expr);
+
+    return result.value();
+  }
+
+  template <typename TReturn, typename... TArgs>
+  TReturn evaluateOnceValue(
+      const std::string& expr,
+      const std::initializer_list<TypePtr>& types,
+      std::optional<TArgs>... args) {
+    auto result = evaluateOnce<TReturn, TArgs...>(expr, types, args...);
+
+    VELOX_CHECK(result.has_value(), "Expression returned null: {}", expr);
+
+    return result.value();
+  }
 };
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -640,7 +640,8 @@ TEST_F(CudfFilterProjectTest, divideScalarVariants) {
   testDivideScalarVariants(vectors);
 }
 
-TEST_F(CudfFilterProjectTest, moduloOperation) {
+// mod for integral is checkedModulus which is not supported in cudf.
+TEST_F(CudfFilterProjectTest, DISABLED_moduloOperation) {
   vector_size_t batchSize = 1000;
   auto vectors = makeVectors(rowType_, 2, batchSize);
   createDuckDbTable(vectors);
@@ -1728,11 +1729,10 @@ TEST_F(CudfSimpleFilterProjectTest, mod) {
       canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {SMALLINT(), SMALLINT()})));
   EXPECT_FALSE(canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {INTEGER(), INTEGER()})));
   EXPECT_FALSE(canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {BIGINT(), BIGINT()})));
+  EXPECT_FALSE(canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {REAL(), REAL()})));
 
   auto modResult = evaluateOnceValue<double, double>("c0 % 10.0", 47);
   EXPECT_EQ(modResult, 7);
-  auto modResult2 = evaluateOnceValue<float, float>("c0 % 10.0", 47);
-  EXPECT_EQ(modResult2, 7);
 
   std::vector<double> numerDouble = {0, 6, 0, -7, -1, -9, 9, 10.1};
   std::vector<double> denomDouble = {1, 2, -1, 3, -1, -3, -3, -99.9};
@@ -1747,148 +1747,47 @@ TEST_F(CudfSimpleFilterProjectTest, mod) {
       "mod(c0, c1)", specialInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
 }
 
-TEST_F(CudfSimpleFilterProjectTest, power) {
-  constexpr double kInf = std::numeric_limits<double>::infinity();
-  constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
-
-  auto powerResult = evaluateOnceValue<double, double>("power(c0, 2.0)", 3.0);
-  EXPECT_DOUBLE_EQ(powerResult, 9.0);
-  auto powerResult2 =
-      evaluateOnceValue<double, int64_t, int64_t>("power(c0, 2)", 3.0);
-  EXPECT_DOUBLE_EQ(powerResult2, 9.0);
-  auto powerResult3 =
-      evaluateOnceValue<double, int64_t, int64_t>("pow(c0, 2)", 3.0);
-  EXPECT_DOUBLE_EQ(powerResult3, 9.0);
-
-  auto powerInput = makeRowVector(
-      {makeFlatVector<double>(
-           {0, 0, 0, -1, -1, -1, -9, 9.1, 10.1, 11.1, -11.1}),
-       makeFlatVector<double>(
-           {0, 1, -1, 0, 1, -1, -3.3, 123456.432, -99.9, 0, 100000})});
-  assertExpressionMatchesCpu(
-      "power(c0, c1)", powerInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
-  assertExpressionMatchesCpu(
-      "pow(c0, c1)", powerInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
-
-  auto powerNanInput = makeRowVector(
-      {makeFlatVector<double>({1, kNan, kNan, kNan}),
-       makeFlatVector<double>({kNan, 1, kInf, 0})});
-  assertExpressionMatchesCpu(
-      "power(c0, c1)", powerNanInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
-  assertExpressionMatchesCpu(
-      "pow(c0, c1)", powerNanInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
-
-  auto powerInfInput = makeRowVector(
-      {makeFlatVector<double>({1, 1, 2, 2, kInf, kInf, kInf}),
-       makeFlatVector<double>({kInf, -kInf, kInf, -kInf, 1, 0, kNan})});
-  assertExpressionMatchesCpu(
-      "power(c0, c1)", powerInfInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
-  assertExpressionMatchesCpu(
-      "pow(c0, c1)", powerInfInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
-
-  auto powerIntInput = makeRowVector(
-      {makeFlatVector<int64_t>({9, 10, 11, -9, -10, -11, 0}),
-       makeFlatVector<int64_t>({3, -3, 0, -1, 199999, 77, 0})});
-  assertExpressionMatchesCpu(
-      "power(c0, c1)", powerIntInput, ROW({"c0", "c1"}, {BIGINT(), BIGINT()}));
-  assertExpressionMatchesCpu(
-      "pow(c0, c1)", powerIntInput, ROW({"c0", "c1"}, {BIGINT(), BIGINT()}));
-}
 
 TEST_F(CudfSimpleFilterProjectTest, bitwiseOperators) {
-  auto bitwiseAndResult =
-      evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 31, 15);
-  EXPECT_EQ(bitwiseAndResult, 15);
-  auto bitwiseAndResult16 = evaluateOnceValue<int64_t, int16_t, int16_t>(
-      "bitwise_and(c0, c1)", 31, 15);
-  EXPECT_EQ(bitwiseAndResult16, 15);
-  auto bitwiseAndResult8 = evaluateOnceValue<int64_t, int8_t, int8_t>(
-      "bitwise_and(c0, c1)", 31, 15);
-  EXPECT_EQ(bitwiseAndResult8, 15);
-  auto bitwiseAndResult64 = evaluateOnceValue<int64_t, int64_t, int64_t>(
-      "bitwise_and(c0, c1)", 31, 15);
-  EXPECT_EQ(bitwiseAndResult64, 15);
-
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 0, -1), 0);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 3, 8), 0);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", -4, 12), 12);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 60, 21), 20);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int16_t, int16_t>(
-          "bitwise_and(c0, c1)",
-          std::numeric_limits<int16_t>::min(),
-          std::numeric_limits<int16_t>::max()),
-      0);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int16_t, int16_t>(
-          "bitwise_and(c0, c1)",
-          std::numeric_limits<int16_t>::max(),
-          std::numeric_limits<int16_t>::max()),
-      std::numeric_limits<int16_t>::max());
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int32_t, int32_t>(
-          "bitwise_and(c0, c1)",
-          std::numeric_limits<int32_t>::min(),
-          std::numeric_limits<int32_t>::max()),
-      0);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int64_t, int64_t>(
-          "bitwise_and(c0, c1)",
-          std::numeric_limits<int64_t>::min(),
-          std::numeric_limits<int64_t>::max()),
-      0);
-
-  auto bitwiseOrResult =
-      evaluateOnceValue<int64_t, int32_t>("bitwise_or(c0, 15)", 16);
-  EXPECT_EQ(bitwiseOrResult, 31);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", 0, -1), -1);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", 3, 8), 11);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", -4, 12), -4);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", 60, 21), 61);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int16_t, int16_t>(
-          "bitwise_or(c0, c1)",
-          std::numeric_limits<int16_t>::min(),
-          std::numeric_limits<int16_t>::max()),
-      -1);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int32_t, int32_t>(
-          "bitwise_or(c0, c1)",
-          std::numeric_limits<int32_t>::min(),
-          std::numeric_limits<int32_t>::max()),
-      -1);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int64_t, int64_t>(
-          "bitwise_or(c0, c1)",
-          std::numeric_limits<int64_t>::min(),
-          std::numeric_limits<int64_t>::max()),
-      -1);
-
-  auto bitwiseXorResult =
-      evaluateOnceValue<int64_t, int32_t>("bitwise_xor(c0, 15)", 31);
-  EXPECT_EQ(bitwiseXorResult, 16);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", 0, -1), -1);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", 3, 8), 11);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", -4, 12), -16);
-  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", 60, 21), 41);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int16_t, int16_t>(
-          "bitwise_xor(c0, c1)",
-          std::numeric_limits<int16_t>::min(),
-          std::numeric_limits<int16_t>::max()),
-      -1);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int32_t, int32_t>(
-          "bitwise_xor(c0, c1)",
-          std::numeric_limits<int32_t>::min(),
-          std::numeric_limits<int32_t>::max()),
-      -1);
-  EXPECT_EQ(
-      evaluateOnceValue<int64_t, int64_t, int64_t>(
-          "bitwise_xor(c0, c1)",
-          std::numeric_limits<int64_t>::min(),
-          std::numeric_limits<int64_t>::max()),
-      -1);
+    // Test with int16_t
+    {
+      std::vector<int16_t> a = {31, std::numeric_limits<int16_t>::min(), std::numeric_limits<int16_t>::max()};
+      std::vector<int16_t> b = {15, std::numeric_limits<int16_t>::max(), std::numeric_limits<int16_t>::max()};
+      auto input = makeRowVector({makeFlatVector<int16_t>(a), makeFlatVector<int16_t>(b)});
+      assertExpressionMatchesCpu("bitwise_and(c0, c1)", input, ROW({{"c0", SMALLINT()}, {"c1", SMALLINT()}}));
+      assertExpressionMatchesCpu("bitwise_or(c0, c1)", input, ROW({{"c0", SMALLINT()}, {"c1", SMALLINT()}}));
+      assertExpressionMatchesCpu("bitwise_xor(c0, c1)", input, ROW({{"c0", SMALLINT()}, {"c1", SMALLINT()}}));
+    }
+    // Test with int64_t
+    {
+      std::vector<int64_t> a = {31, std::numeric_limits<int64_t>::min(), std::numeric_limits<int64_t>::max()};
+      std::vector<int64_t> b = {15, std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max()};
+      auto input = makeRowVector({makeFlatVector<int64_t>(a), makeFlatVector<int64_t>(b)});
+      assertExpressionMatchesCpu("bitwise_and(c0, c1)", input, ROW({{"c0", BIGINT()}, {"c1", BIGINT()}}));
+      assertExpressionMatchesCpu("bitwise_or(c0, c1)", input, ROW({{"c0", BIGINT()}, {"c1", BIGINT()}}));
+      assertExpressionMatchesCpu("bitwise_xor(c0, c1)", input, ROW({{"c0", BIGINT()}, {"c1", BIGINT()}}));
+    }
+  // Test bitwise_and
+  {
+    std::vector<int32_t> a = {31, 0, 3, -4, 60, std::numeric_limits<int32_t>::min()};
+    std::vector<int32_t> b = {15, -1, 8, 12, 21, std::numeric_limits<int32_t>::max()};
+    auto input = makeRowVector({makeFlatVector<int32_t>(a), makeFlatVector<int32_t>(b)});
+    assertExpressionMatchesCpu("bitwise_and(c0, c1)", input, ROW({{"c0", INTEGER()}, {"c1", INTEGER()}}));
+  }
+  // Test bitwise_or
+  {
+    std::vector<int32_t> a = {16, 0, 3, -4, 60, std::numeric_limits<int32_t>::min()};
+    std::vector<int32_t> b = {15, -1, 8, 12, 21, std::numeric_limits<int32_t>::max()};
+    auto input = makeRowVector({makeFlatVector<int32_t>(a), makeFlatVector<int32_t>(b)});
+    assertExpressionMatchesCpu("bitwise_or(c0, c1)", input, ROW({{"c0", INTEGER()}, {"c1", INTEGER()}}));
+  }
+  // Test bitwise_xor
+  {
+    std::vector<int32_t> a = {31, 0, 3, -4, 60, std::numeric_limits<int32_t>::min()};
+    std::vector<int32_t> b = {15, -1, 8, 12, 21, std::numeric_limits<int32_t>::max()};
+    auto input = makeRowVector({makeFlatVector<int32_t>(a), makeFlatVector<int32_t>(b)});
+    assertExpressionMatchesCpu("bitwise_xor(c0, c1)", input, ROW({{"c0", INTEGER()}, {"c1", INTEGER()}}));
+  }
 }
 
 } // namespace

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -1720,4 +1720,41 @@ TEST_F(CudfFilterProjectTest, andAndAndWithDecimalDivideBelowExpr) {
   facebook::velox::test::assertEqualVectors(expected, result);
 }
 
+TEST_F(CudfSimpleFilterProjectTest, binaryOperators) {
+  // Test modulo operation
+  auto modResult = evaluateOnceValue<double, double>("c0 % 10.0", 47);
+  EXPECT_EQ(modResult, 7);
+  auto modResult2 = evaluateOnceValue<float, float>("c0 % 10.0", 47);
+  EXPECT_EQ(modResult2, 7);
+
+  // Test power operation
+  auto powerResult = evaluateOnceValue<double, double>("power(c0, 2.0)", 3.0);
+  EXPECT_DOUBLE_EQ(powerResult, 9.0);
+
+  // Test bitwise AND operation
+  auto bitwiseAndResult =
+      evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 31, 15);
+  EXPECT_EQ(bitwiseAndResult, 15);
+  auto bitwiseAndResult16 = evaluateOnceValue<int64_t, int16_t, int16_t>(
+      "bitwise_and(c0, c1)", 31, 15);
+  EXPECT_EQ(bitwiseAndResult16, 15);
+  auto bitwiseAndResult8 = evaluateOnceValue<int64_t, int8_t, int8_t>(
+      "bitwise_and(c0, c1)", 31, 15);
+  EXPECT_EQ(bitwiseAndResult8, 15);
+  auto bitwiseAndResult64 = evaluateOnceValue<int64_t, int64_t, int64_t>(
+      "bitwise_and(c0, c1)", 31, 15);
+  EXPECT_EQ(bitwiseAndResult64, 15);
+
+  // Test bitwise OR operation
+  auto bitwiseOrResult =
+      evaluateOnceValue<int64_t, int32_t>("bitwise_or(c0, 15)", 16);
+  EXPECT_EQ(bitwiseOrResult, 31);
+
+  // Test bitwise XOR operation
+  auto bitwiseXorResult =
+      evaluateOnceValue<int64_t, int32_t>("bitwise_xor(c0, 15)", 31);
+  EXPECT_EQ(bitwiseXorResult, 16);
+
+}
+
 } // namespace

--- a/velox/experimental/cudf/tests/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/FilterProjectTest.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <limits>
+
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/exec/ToCudf.h"
 #include "velox/experimental/cudf/tests/CudfFunctionBaseTest.h"
@@ -1720,18 +1722,80 @@ TEST_F(CudfFilterProjectTest, andAndAndWithDecimalDivideBelowExpr) {
   facebook::velox::test::assertEqualVectors(expected, result);
 }
 
-TEST_F(CudfSimpleFilterProjectTest, binaryOperators) {
-  // Test modulo operation
+TEST_F(CudfSimpleFilterProjectTest, mod) {
+  EXPECT_FALSE(canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {TINYINT(), TINYINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {SMALLINT(), SMALLINT()})));
+  EXPECT_FALSE(canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {INTEGER(), INTEGER()})));
+  EXPECT_FALSE(canEvaluateWithAst("mod(c0, c1)", ROW({"c0", "c1"}, {BIGINT(), BIGINT()})));
+
   auto modResult = evaluateOnceValue<double, double>("c0 % 10.0", 47);
   EXPECT_EQ(modResult, 7);
   auto modResult2 = evaluateOnceValue<float, float>("c0 % 10.0", 47);
   EXPECT_EQ(modResult2, 7);
 
-  // Test power operation
+  std::vector<double> numerDouble = {0, 6, 0, -7, -1, -9, 9, 10.1};
+  std::vector<double> denomDouble = {1, 2, -1, 3, -1, -3, -3, -99.9};
+  auto input = makeRowVector(
+      {makeFlatVector<double>(numerDouble), makeFlatVector<double>(denomDouble)});
+  assertExpressionMatchesCpu("mod(c0, c1)", input, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+
+  auto specialInput = makeRowVector(
+      {makeFlatVector<double>({5.1, std::numeric_limits<double>::quiet_NaN(), 5.1, std::numeric_limits<double>::infinity(), 5.1}),
+       makeFlatVector<double>({0.0, 5.1, std::numeric_limits<double>::quiet_NaN(), 5.1, std::numeric_limits<double>::infinity()})});
+  assertExpressionMatchesCpu(
+      "mod(c0, c1)", specialInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+}
+
+TEST_F(CudfSimpleFilterProjectTest, power) {
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+  constexpr double kNan = std::numeric_limits<double>::quiet_NaN();
+
   auto powerResult = evaluateOnceValue<double, double>("power(c0, 2.0)", 3.0);
   EXPECT_DOUBLE_EQ(powerResult, 9.0);
+  auto powerResult2 =
+      evaluateOnceValue<double, int64_t, int64_t>("power(c0, 2)", 3.0);
+  EXPECT_DOUBLE_EQ(powerResult2, 9.0);
+  auto powerResult3 =
+      evaluateOnceValue<double, int64_t, int64_t>("pow(c0, 2)", 3.0);
+  EXPECT_DOUBLE_EQ(powerResult3, 9.0);
 
-  // Test bitwise AND operation
+  auto powerInput = makeRowVector(
+      {makeFlatVector<double>(
+           {0, 0, 0, -1, -1, -1, -9, 9.1, 10.1, 11.1, -11.1}),
+       makeFlatVector<double>(
+           {0, 1, -1, 0, 1, -1, -3.3, 123456.432, -99.9, 0, 100000})});
+  assertExpressionMatchesCpu(
+      "power(c0, c1)", powerInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+  assertExpressionMatchesCpu(
+      "pow(c0, c1)", powerInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+
+  auto powerNanInput = makeRowVector(
+      {makeFlatVector<double>({1, kNan, kNan, kNan}),
+       makeFlatVector<double>({kNan, 1, kInf, 0})});
+  assertExpressionMatchesCpu(
+      "power(c0, c1)", powerNanInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+  assertExpressionMatchesCpu(
+      "pow(c0, c1)", powerNanInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+
+  auto powerInfInput = makeRowVector(
+      {makeFlatVector<double>({1, 1, 2, 2, kInf, kInf, kInf}),
+       makeFlatVector<double>({kInf, -kInf, kInf, -kInf, 1, 0, kNan})});
+  assertExpressionMatchesCpu(
+      "power(c0, c1)", powerInfInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+  assertExpressionMatchesCpu(
+      "pow(c0, c1)", powerInfInput, ROW({"c0", "c1"}, {DOUBLE(), DOUBLE()}));
+
+  auto powerIntInput = makeRowVector(
+      {makeFlatVector<int64_t>({9, 10, 11, -9, -10, -11, 0}),
+       makeFlatVector<int64_t>({3, -3, 0, -1, 199999, 77, 0})});
+  assertExpressionMatchesCpu(
+      "power(c0, c1)", powerIntInput, ROW({"c0", "c1"}, {BIGINT(), BIGINT()}));
+  assertExpressionMatchesCpu(
+      "pow(c0, c1)", powerIntInput, ROW({"c0", "c1"}, {BIGINT(), BIGINT()}));
+}
+
+TEST_F(CudfSimpleFilterProjectTest, bitwiseOperators) {
   auto bitwiseAndResult =
       evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 31, 15);
   EXPECT_EQ(bitwiseAndResult, 15);
@@ -1745,16 +1809,86 @@ TEST_F(CudfSimpleFilterProjectTest, binaryOperators) {
       "bitwise_and(c0, c1)", 31, 15);
   EXPECT_EQ(bitwiseAndResult64, 15);
 
-  // Test bitwise OR operation
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 0, -1), 0);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 3, 8), 0);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", -4, 12), 12);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_and(c0, c1)", 60, 21), 20);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int16_t, int16_t>(
+          "bitwise_and(c0, c1)",
+          std::numeric_limits<int16_t>::min(),
+          std::numeric_limits<int16_t>::max()),
+      0);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int16_t, int16_t>(
+          "bitwise_and(c0, c1)",
+          std::numeric_limits<int16_t>::max(),
+          std::numeric_limits<int16_t>::max()),
+      std::numeric_limits<int16_t>::max());
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int32_t, int32_t>(
+          "bitwise_and(c0, c1)",
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max()),
+      0);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int64_t, int64_t>(
+          "bitwise_and(c0, c1)",
+          std::numeric_limits<int64_t>::min(),
+          std::numeric_limits<int64_t>::max()),
+      0);
+
   auto bitwiseOrResult =
       evaluateOnceValue<int64_t, int32_t>("bitwise_or(c0, 15)", 16);
   EXPECT_EQ(bitwiseOrResult, 31);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", 0, -1), -1);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", 3, 8), 11);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", -4, 12), -4);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_or(c0, c1)", 60, 21), 61);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int16_t, int16_t>(
+          "bitwise_or(c0, c1)",
+          std::numeric_limits<int16_t>::min(),
+          std::numeric_limits<int16_t>::max()),
+      -1);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int32_t, int32_t>(
+          "bitwise_or(c0, c1)",
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max()),
+      -1);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int64_t, int64_t>(
+          "bitwise_or(c0, c1)",
+          std::numeric_limits<int64_t>::min(),
+          std::numeric_limits<int64_t>::max()),
+      -1);
 
-  // Test bitwise XOR operation
   auto bitwiseXorResult =
       evaluateOnceValue<int64_t, int32_t>("bitwise_xor(c0, 15)", 31);
   EXPECT_EQ(bitwiseXorResult, 16);
-
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", 0, -1), -1);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", 3, 8), 11);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", -4, 12), -16);
+  EXPECT_EQ(evaluateOnceValue<int64_t, int32_t, int32_t>("bitwise_xor(c0, c1)", 60, 21), 41);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int16_t, int16_t>(
+          "bitwise_xor(c0, c1)",
+          std::numeric_limits<int16_t>::min(),
+          std::numeric_limits<int16_t>::max()),
+      -1);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int32_t, int32_t>(
+          "bitwise_xor(c0, c1)",
+          std::numeric_limits<int32_t>::min(),
+          std::numeric_limits<int32_t>::max()),
+      -1);
+  EXPECT_EQ(
+      evaluateOnceValue<int64_t, int64_t, int64_t>(
+          "bitwise_xor(c0, c1)",
+          std::numeric_limits<int64_t>::min(),
+          std::numeric_limits<int64_t>::max()),
+      -1);
 }
 
 } // namespace

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -886,5 +886,35 @@ TEST_F(CudfFilterProjectTest, unaryMathFunctions) {
   testUnaryFunction("abs(c0)", -5.5, 5.5);
 }
 
+TEST_F(CudfFilterProjectTest, binaryOperators) {
+  // Test remainder (Spark's modulo)
+  auto remainderResult =
+      evaluateOnceValue<int32_t, int32_t>("remainder(c0, 10)", 47);
+  EXPECT_EQ(remainderResult, 7);
+
+  // Test pmod (positive modulo)
+  auto pmodResult = evaluateOnceValue<int32_t, int32_t>("pmod(c0, 10)", -13);
+  EXPECT_EQ(pmodResult, 7);
+
+  // Test bitwiseand (Spark's bitwise AND)
+  auto bitwiseAndResult =
+      evaluateOnceValue<int32_t, int32_t>("bitwise_and(c0, 15)", 31);
+  EXPECT_EQ(bitwiseAndResult, 15);
+
+  auto bitwiseAndResult64 =
+      evaluateOnceValue<int64_t, int64_t>("bitwise_and(c0, 15)", 31);
+  EXPECT_EQ(bitwiseAndResult64, 15);
+
+  // Test bitwiseor (Spark's bitwise OR)
+  auto bitwiseOrResult =
+      evaluateOnceValue<int64_t, int64_t>("bitwise_or(c0, 15)", 16);
+  EXPECT_EQ(bitwiseOrResult, 31);
+
+  // Test bitwisexor (Spark's bitwise XOR)
+  auto bitwiseXorResult =
+      evaluateOnceValue<int64_t, int64_t>("bitwise_xor(c0, 15)", 31);
+  EXPECT_EQ(bitwiseXorResult, 16);
+}
+
 } // namespace
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -899,10 +899,7 @@ TEST_F(CudfFilterProjectTest, remainder) {
   EXPECT_FALSE(
       canEvaluateWithAst(
           "remainder(c0, c1)", ROW({"c0", "c1"}, {BIGINT(), BIGINT()})));
-
-  auto remainderFloatResult =
-      evaluateOnceValue<float, float, float>("remainder(c0, c1)", 47.0, 10.0);
-  EXPECT_FLOAT_EQ(remainderFloatResult, 7.0);
+  EXPECT_FALSE(canEvaluateWithAst("remainder(c0, c1)", ROW({"c0", "c1"}, {REAL(), REAL()})));
 
   auto remainderDoubleResult = evaluateOnceValue<double, double, double>(
       "remainder(c0, c1)", 47.0, 10.0);

--- a/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
+++ b/velox/experimental/cudf/tests/sparksql/FilterProjectTest.cpp
@@ -886,17 +886,48 @@ TEST_F(CudfFilterProjectTest, unaryMathFunctions) {
   testUnaryFunction("abs(c0)", -5.5, 5.5);
 }
 
-TEST_F(CudfFilterProjectTest, binaryOperators) {
-  // Test remainder (Spark's modulo)
-  auto remainderResult =
-      evaluateOnceValue<int32_t, int32_t>("remainder(c0, 10)", 47);
-  EXPECT_EQ(remainderResult, 7);
+TEST_F(CudfFilterProjectTest, remainder) {
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "remainder(c0, c1)", ROW({"c0", "c1"}, {TINYINT(), TINYINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "remainder(c0, c1)", ROW({"c0", "c1"}, {SMALLINT(), SMALLINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "remainder(c0, c1)", ROW({"c0", "c1"}, {INTEGER(), INTEGER()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "remainder(c0, c1)", ROW({"c0", "c1"}, {BIGINT(), BIGINT()})));
 
-  // Test pmod (positive modulo)
-  auto pmodResult = evaluateOnceValue<int32_t, int32_t>("pmod(c0, 10)", -13);
-  EXPECT_EQ(pmodResult, 7);
+  auto remainderFloatResult =
+      evaluateOnceValue<float, float, float>("remainder(c0, c1)", 47.0, 10.0);
+  EXPECT_FLOAT_EQ(remainderFloatResult, 7.0);
 
-  // Test bitwiseand (Spark's bitwise AND)
+  auto remainderDoubleResult = evaluateOnceValue<double, double, double>(
+      "remainder(c0, c1)", 47.0, 10.0);
+  EXPECT_DOUBLE_EQ(remainderDoubleResult, 7.0);
+}
+
+TEST_F(CudfFilterProjectTest, bitwiseOperators) {
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "bitwise_and(c0, c1)", ROW({"c0", "c1"}, {TINYINT(), TINYINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "bitwise_and(c0, c1)", ROW({"c0", "c1"}, {SMALLINT(), SMALLINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "bitwise_or(c0, c1)", ROW({"c0", "c1"}, {TINYINT(), TINYINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "bitwise_or(c0, c1)", ROW({"c0", "c1"}, {SMALLINT(), SMALLINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "bitwise_xor(c0, c1)", ROW({"c0", "c1"}, {TINYINT(), TINYINT()})));
+  EXPECT_FALSE(
+      canEvaluateWithAst(
+          "bitwise_xor(c0, c1)", ROW({"c0", "c1"}, {SMALLINT(), SMALLINT()})));
   auto bitwiseAndResult =
       evaluateOnceValue<int32_t, int32_t>("bitwise_and(c0, 15)", 31);
   EXPECT_EQ(bitwiseAndResult, 15);
@@ -905,15 +936,19 @@ TEST_F(CudfFilterProjectTest, binaryOperators) {
       evaluateOnceValue<int64_t, int64_t>("bitwise_and(c0, 15)", 31);
   EXPECT_EQ(bitwiseAndResult64, 15);
 
-  // Test bitwiseor (Spark's bitwise OR)
   auto bitwiseOrResult =
       evaluateOnceValue<int64_t, int64_t>("bitwise_or(c0, 15)", 16);
   EXPECT_EQ(bitwiseOrResult, 31);
+  auto bitwiseOrResult32 =
+      evaluateOnceValue<int32_t, int32_t>("bitwise_or(c0, 15)", 31);
+  EXPECT_EQ(bitwiseOrResult32, 31);
 
-  // Test bitwisexor (Spark's bitwise XOR)
   auto bitwiseXorResult =
       evaluateOnceValue<int64_t, int64_t>("bitwise_xor(c0, 15)", 31);
   EXPECT_EQ(bitwiseXorResult, 16);
+  auto bitwiseXorResult32 =
+      evaluateOnceValue<int32_t, int32_t>("bitwise_xor(c0, 15)", 31);
+  EXPECT_EQ(bitwiseXorResult32, 16);
 }
 
 } // namespace


### PR DESCRIPTION
Support the other binary operators including pmod, bitwise_and, bitwise_left_shift can also be represented by existing ast operator, but it introduces extra complexity, I assume it does not perform better than registering function in ExpressionEvaluator, so not support them in AST.
Remove mod int test from it should be checkedModulus.
As this issue https://github.com/rapidsai/cudf/issues/22096 replies, adding more ast operator will affect performance, so we will not support these operators in cudf AST tree.
