### PR TITLE
refactor(udf): Accept std::string_view in vector function registration APIs (#17119)

### DIFF
--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -22,7 +22,7 @@
 
 namespace facebook::velox::exec {
 
-std::string sanitizeName(const std::string& name) {
+std::string sanitizeName(std::string_view name) {
   std::string sanitizedName;
   sanitizedName.resize(name.size());
   std::transform(

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
@@ -29,7 +30,7 @@
 
 namespace facebook::velox::exec {
 
-std::string sanitizeName(const std::string& name);
+std::string sanitizeName(std::string_view name);
 
 /// Return a list of primitive type names.
 const std::vector<std::string> primitiveTypeNames();

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -217,7 +217,7 @@ getVectorFunctionWithMetadata(
 /// with the given name will be replaced.
 /// Returns true iff an insertion actually happened
 bool registerStatefulVectorFunction(
-    const std::string& name,
+    std::string_view name,
     std::vector<FunctionSignaturePtr> signatures,
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata,
@@ -243,7 +243,7 @@ bool registerStatefulVectorFunction(
 
 // Returns true iff an insertion actually happened
 bool registerVectorFunction(
-    const std::string& name,
+    std::string_view name,
     std::vector<FunctionSignaturePtr> signatures,
     std::unique_ptr<VectorFunction> func,
     VectorFunctionMetadata metadata,

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <string_view>
 #include <vector>
 #include "velox/core/ITypedExpr.h"
 #include "velox/expression/EvalCtx.h"
@@ -235,7 +236,7 @@ getVectorFunctionWithMetadata(
 /// expressions.
 /// Returns true iff an new function is inserted
 bool registerVectorFunction(
-    const std::string& name,
+    std::string_view name,
     std::vector<FunctionSignaturePtr> signatures,
     std::unique_ptr<VectorFunction> func,
     VectorFunctionMetadata metadata = {},
@@ -287,7 +288,7 @@ VectorFunctionFactory makeVectorFunctionFactory() {
 // name is replaced.
 // Returns true iff the function was inserted
 bool registerStatefulVectorFunction(
-    const std::string& name,
+    std::string_view name,
     std::vector<FunctionSignaturePtr> signatures,
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata = {},
@@ -300,36 +301,36 @@ bool registerStatefulVectorFunction(
 
 // Declares a vectorized UDF function given a tag. Goes into the UDF .cpp file.
 #define VELOX_DECLARE_VECTOR_FUNCTION(tag, signatures, function) \
-  void _VELOX_REGISTER_FUNC_NAME(tag)(const std::string& name) { \
+  void _VELOX_REGISTER_FUNC_NAME(tag)(std::string_view name) {   \
     facebook::velox::exec::registerVectorFunction(               \
         (name), (signatures), (function));                       \
   }
 
-#define VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(             \
-    tag, signatures, metadata, function)                         \
-  void _VELOX_REGISTER_FUNC_NAME(tag)(const std::string& name) { \
-    facebook::velox::exec::registerVectorFunction(               \
-        (name), (signatures), (function), (metadata));           \
+#define VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(           \
+    tag, signatures, metadata, function)                       \
+  void _VELOX_REGISTER_FUNC_NAME(tag)(std::string_view name) { \
+    facebook::velox::exec::registerVectorFunction(             \
+        (name), (signatures), (function), (metadata));         \
   }
 
 // Declares a stateful vectorized UDF.
 #define VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(tag, signatures, function) \
-  void _VELOX_REGISTER_FUNC_NAME(tag)(const std::string& name) {          \
+  void _VELOX_REGISTER_FUNC_NAME(tag)(std::string_view name) {            \
     facebook::velox::exec::registerStatefulVectorFunction(                \
         (name), (signatures), (function));                                \
   }
 
-#define VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(    \
-    tag, signatures, metadata, function)                         \
-  void _VELOX_REGISTER_FUNC_NAME(tag)(const std::string& name) { \
-    facebook::velox::exec::registerStatefulVectorFunction(       \
-        (name), (signatures), (function), (metadata));           \
+#define VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION_WITH_METADATA(  \
+    tag, signatures, metadata, function)                       \
+  void _VELOX_REGISTER_FUNC_NAME(tag)(std::string_view name) { \
+    facebook::velox::exec::registerStatefulVectorFunction(     \
+        (name), (signatures), (function), (metadata));         \
   }
 
 // Registers a vectorized UDF associated with a given tag.
 // This should be used in the same namespace the declare macro is used in.
-#define VELOX_REGISTER_VECTOR_FUNCTION(tag, name)                   \
-  {                                                                 \
-    extern void _VELOX_REGISTER_FUNC_NAME(tag)(const std::string&); \
-    _VELOX_REGISTER_FUNC_NAME(tag)(name);                           \
+#define VELOX_REGISTER_VECTOR_FUNCTION(tag, name)                 \
+  {                                                               \
+    extern void _VELOX_REGISTER_FUNC_NAME(tag)(std::string_view); \
+    _VELOX_REGISTER_FUNC_NAME(tag)(name);                         \
   }

--- a/velox/functions/prestosql/ArraySum.cpp
+++ b/velox/functions/prestosql/ArraySum.cpp
@@ -296,11 +296,13 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
 } // namespace
 
 // Register function.
-void registerVectorFunction_udf_array_sum(const std::string& name) {
+void registerVectorFunction_udf_array_sum(std::string_view name) {
   facebook::velox::exec::registerStatefulVectorFunction(
       name, signatures(), create<false>);
   facebook::velox::exec::registerStatefulVectorFunction(
-      name + "_propagate_element_null", signatures(), create<true>);
+      std::string(name) + "_propagate_element_null",
+      signatures(),
+      create<true>);
 }
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:

Update registerVectorFunction, registerStatefulVectorFunction, and
sanitizeName to accept std::string_view instead of const std::string&.
This allows callers to pass constexpr string_view constants without
heap-allocating a std::string.

Also update the VELOX_DECLARE_*_VECTOR_FUNCTION and
VELOX_REGISTER_VECTOR_FUNCTION macros to use std::string_view, and fix
the one manual registerVectorFunction_ definition in ArraySum.cpp.

Reviewed By: pedroerp

Differential Revision: D100333695


