### PR TITLE
feat(ci): Add fuzzer failure analysis to CI failure comment workflow

### DIFF
--- a/.claude/skills/ci-failure-analysis/SKILL.md
+++ b/.claude/skills/ci-failure-analysis/SKILL.md
@@ -5,8 +5,10 @@ The workflow run ID is {{RUN_ID}}.
 Failure metadata (JSON array of failed jobs):
 {{FAILURE_METADATA}}
 
-Each entry has: "job" (job name), "type" ("build" or "test"), and
-optionally "failed_tests" (newline-separated test names).
+Each entry has: "job" (job name), "type" ("build", "test", or "unknown"), and
+optionally "failed_tests" (newline-separated test names). A type of "unknown"
+means no structured failure metadata was available (e.g., Fuzzer Jobs) — you
+must determine the failure type from the job logs.
 
 Your task:
 1. Use `gh api` to download the logs for the failed jobs in this workflow run.
@@ -33,18 +35,29 @@ Your task:
 
 3. For BUILD failures: Find compiler `error:` lines with file paths and error messages.
 
-4. Get the PR diff: `gh pr diff {{PR_NUMBER}} --repo {{REPOSITORY}}`
+4. For FUZZER failures (from the "Fuzzer Jobs" workflow): Fuzzers run via
+   `run-fuzzer-parallel.sh` which launches multiple instances in parallel.
+   Look for crash reports, assertion failures (VELOX_CHECK, VELOX_FAIL),
+   segfaults, or timeouts in the logs. Key information to extract:
+   - The fuzzer name (e.g., "Presto Fuzzer", "Join Fuzzer", "Spark Expression Fuzzer")
+   - The error message or assertion failure
+   - The seed value (from `--seed` flag or log output) for reproduction
+   - The file and line number from stack traces
+   - The reproduce command uses the fuzzer binary with `--seed <seed>` flag
+
+5. Get the PR diff: `gh pr diff {{PR_NUMBER}} --repo {{REPOSITORY}}`
    Determine if the failures are likely caused by the PR changes.
 
-5. Search open issues for known failures:
+6. Search open issues for known failures:
    `gh issue list --repo {{REPOSITORY}} --search "<test_name>" --state open --limit 5`
    Check if any failing test has a known open issue.
 
-6. Check if the same tests fail on the main branch (pre-existing flaky test):
-   `gh run list --repo {{REPOSITORY}} --branch main --workflow "Linux Build using GCC" --limit 3 --json conclusion,databaseId`
-   If recent main runs also failed, note this.
+7. Check if the same failures occur on the main branch (pre-existing/flaky):
+   `gh run list --repo {{REPOSITORY}} --branch main --workflow "<workflow_name>" --limit 3 --json conclusion,databaseId`
+   Use the appropriate workflow name: "Linux Build using GCC" for build/test
+   failures, "Fuzzer Jobs" for fuzzer failures.
 
-7. Post a SINGLE comment on the PR with your analysis using:
+8. Post a SINGLE comment on the PR with your analysis using:
    `gh pr comment {{PR_NUMBER}} --repo {{REPOSITORY}} --body "<comment>"`
 
 Format the comment as follows (use markdown):

--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -15,9 +15,10 @@
 name: CI Failure Comment
 
 # This workflow runs in the context of the base repo (not the fork) and has
-# write access to post PR comments. It is triggered when the Linux Build
-# workflow completes and uses Claude to analyze failure logs, correlate with
-# the PR diff and open issues, and post a rich diagnostic comment.
+# write access to post PR comments. It is triggered when the Linux Build or
+# Fuzzer Jobs workflow completes with a failure and uses Claude to analyze
+# failure logs, correlate with the PR diff and open issues, and post a rich
+# diagnostic comment.
 #
 # Security: This workflow never checks out or executes PR code. It reads
 # failure metadata from artifacts uploaded by our own status jobs, then uses
@@ -28,13 +29,13 @@ on:
   workflow_dispatch:
     inputs:
       run_id:
-        description: Workflow run ID to analyze (from a failed Linux Build run)
+        description: Workflow run ID to analyze (from a failed CI run)
         required: true
       pr_number:
         description: PR number to comment on
         required: true
   workflow_run:
-    workflows: [Linux Build using GCC]
+    workflows: [Linux Build using GCC, Fuzzer Jobs]
     types:
       - completed
 
@@ -48,9 +49,10 @@ permissions:
 jobs:
   analyze-and-comment:
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.workflow_run.event == 'pull_request' &&
-       github.event.workflow_run.conclusion == 'failure')
+      github.repository == 'facebookincubator/velox' &&
+      (github.event_name == 'workflow_dispatch' ||
+       (github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'failure'))
     runs-on: ubuntu-latest
     steps:
       - name: Get PR number
@@ -91,28 +93,39 @@ jobs:
       - name: Collect failure metadata
         if: steps.pr.outputs.number
         id: metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ inputs.run_id || github.event.workflow_run.id }}
         run: |
           FAILURES_DIR="/tmp/ci-failures"
-          if [ ! -d "$FAILURES_DIR" ] || [ -z "$(ls -A "$FAILURES_DIR" 2>/dev/null)" ]; then
-            echo "No failure artifacts found."
-            echo "has_failures=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Collect all failure.json contents into a single JSON array.
-          METADATA="["
-          FIRST=true
-          for entry in "$FAILURES_DIR"/ci-failure-*/failure.json; do
-            if [ -f "$entry" ]; then
-              if [ "$FIRST" = true ]; then
-                FIRST=false
-              else
-                METADATA="$METADATA,"
+          if [ -d "$FAILURES_DIR" ] && [ -n "$(ls -A "$FAILURES_DIR" 2>/dev/null)" ]; then
+            # Collect all failure.json contents into a single JSON array.
+            METADATA="["
+            FIRST=true
+            for entry in "$FAILURES_DIR"/ci-failure-*/failure.json; do
+              if [ -f "$entry" ]; then
+                if [ "$FIRST" = true ]; then
+                  FIRST=false
+                else
+                  METADATA="$METADATA,"
+                fi
+                METADATA="$METADATA$(cat "$entry")"
               fi
-              METADATA="$METADATA$(cat "$entry")"
+            done
+            METADATA="$METADATA]"
+          else
+            # No failure artifacts — build metadata from failed jobs in the run.
+            # This handles workflows (e.g., Fuzzer Jobs) that don't upload
+            # ci-failure-* artifacts.
+            METADATA=$(gh api "repos/${REPO}/actions/runs/${RUN_ID}/jobs" \
+              --paginate --jq '[.jobs[] | select(.conclusion == "failure") | {job: .name, type: "unknown"}]')
+            if [ "$METADATA" = "[]" ] || [ -z "$METADATA" ]; then
+              echo "No failure artifacts or failed jobs found."
+              echo "has_failures=false" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
-          done
-          METADATA="$METADATA]"
+          fi
 
           echo "has_failures=true" >> "$GITHUB_OUTPUT"
           {


### PR DESCRIPTION
Follow-up to #17015 (CI failure reporting with Claude analysis).

## Summary

- Add `Fuzzer Jobs` to the `workflow_run` trigger in `ci-failure-comment.yml` so fuzzer failures on PRs are also analyzed by Claude and reported as PR comments
- When no `ci-failure-*` artifacts exist (fuzzers don't upload them), fall back to querying the run's failed jobs via `gh api` to build failure metadata for Claude
- Add fork guard (`github.repository == 'facebookincubator/velox'`) to prevent unnecessary runs on personal forks
- Each triggering workflow gets its own independent `ci-failure-comment` invocation scoped to its own run ID, so fuzzer and Linux Build analyses never mix

## Test plan

- [x] Verified `Fuzzer Jobs` workflow triggers on `pull_request` (paths: `velox/**`)
- [x] Verified `ci-failure-comment.yml` artifact download is scoped to `run-id` — fuzzer invocation won't see Linux Build artifacts
- [x] Verified fallback `gh api` query correctly builds metadata from failed jobs when no artifacts exist
- [x] Verified `RUN_ID` uses `inputs.run_id || github.event.workflow_run.id` for both `workflow_dispatch` and `workflow_run` paths
- [ ] Validate on a PR with a fuzzer failure that Claude posts correct analysis comment