### PR TITLE
fix: Fix processedStrides_ counting per stride instead of per stripe (#17123)

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -602,8 +602,10 @@ int64_t DwrfRowReader::nextRowNumber() {
         const auto skipRows = getReader().randomSkip()->nextSkip();
         if (skipRows >= numStripeRows) {
           getReader().randomSkip()->consume(numStripeRows);
-          const auto numStrides = bits::divRoundUp(numStripeRows, strideSize);
-          skippedStrides_ += numStrides;
+          if (strideSize > 0) {
+            skippedStrides_ += static_cast<int64_t>(
+                bits::divRoundUp(numStripeRows, strideSize));
+          }
           goto advanceToNextStripe;
         }
       }
@@ -613,6 +615,9 @@ int64_t DwrfRowReader::nextRowNumber() {
 
     checkSkipStrides(strideSize);
     if (currentRowInStripe_ < rowsInCurrentStripe_) {
+      if (strideSize > 0 && currentRowInStripe_ % strideSize == 0) {
+        ++processedStrides_;
+      }
       nextRowNumber_ = firstRowOfStripe_[currentStripe_] + currentRowInStripe_;
       return *nextRowNumber_;
     }
@@ -705,7 +710,6 @@ void DwrfRowReader::loadCurrentStripe() {
   const auto loadUnitIdx = currentStripe_ - firstStripe_;
   currentUnit_ = castDwrfUnit(&unitLoader_->getLoadedUnit(loadUnitIdx));
   rowsInCurrentStripe_ = currentUnit_->getNumRows();
-  ++processedStrides_;
 }
 
 size_t DwrfRowReader::estimatedReaderMemory() const {

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -503,6 +503,32 @@ TEST_F(E2EFilterTest, mutationCornerCases) {
   testMutationCornerCases();
 }
 
+// Verify processedStrides counts actual strides read, not stripes loaded.
+// With multi-stride data, processedStrides + skippedStrides must equal the
+// total number of strides across all stripes.
+TEST_F(E2EFilterTest, processedStridesCount) {
+  rowType_ = test::DataSetBuilder::makeRowType("long_val:bigint", false);
+  filterGenerator_ = std::make_unique<FilterGenerator>(rowType_, seed_);
+  auto customize = [&]() {};
+  auto batches = makeDataset(customize, true, false);
+  writeToMemory(rowType_, batches, true);
+  std::vector<std::string> filterable = {"long_val"};
+  testRowGroupSkip(batches, filterable);
+
+  const auto totalRows = kBatchCount * kBatchSize;
+  const auto totalStrides = (totalRows + kRowsInGroup - 1) / kRowsInGroup;
+  // With 4 batches x 25,000 rows in one stripe and kRowsInGroup=10,000,
+  // totalStrides is 10. The filter must skip some and process the rest.
+  // processedStrides > 1 proves we count per stride, not per stripe
+  // (the old bug gave processedStrides=1 for a single stripe).
+  EXPECT_EQ(10, totalStrides);
+  EXPECT_GT(runtimeStats_.skippedStrides, 0);
+  EXPECT_GT(runtimeStats_.processedStrides, 1);
+  EXPECT_EQ(
+      totalStrides,
+      runtimeStats_.skippedStrides + runtimeStats_.processedStrides);
+}
+
 // Define main so that gflags get processed.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Summary:

CONTEXT: D71324408 introduced processedStrides_ but incremented it once per stripe load in loadCurrentStripe(). This undercounts when a stripe has multiple strides, producing incorrect stride-level statistics.

WHAT: Move processedStrides_ increment from loadCurrentStripe() (once per stripe) to nextRowNumber() (once per stride read, guarded by strideSize > 0 and stride boundary alignment). This gives an accurate count of strides actually processed.

Differential Revision: D100236453


