### PR TITLE
Use varint encoding for row count in encoding prefix

### DIFF
--- a/velox/experimental/wave/dwio/nimble/Encoding.h
+++ b/velox/experimental/wave/dwio/nimble/Encoding.h
@@ -22,10 +22,9 @@ class Encoding {
   // The binary layout for each Encoding begins with the same prefix:
   // 1 byte: EncodingType
   // 1 byte: DataType
-  // 4 bytes: uint32_t num rows
+  // 1-5 bytes: varint num rows
   static constexpr int kEncodingTypeOffset = 0;
   static constexpr int kDataTypeOffset = 1;
   static constexpr int kRowCountOffset = 2;
-  static constexpr int kPrefixSize = 6;
 };
 } // namespace facebook::wave::nimble

--- a/velox/experimental/wave/dwio/nimble/EncodingPrimitives.h
+++ b/velox/experimental/wave/dwio/nimble/EncodingPrimitives.h
@@ -132,4 +132,26 @@ inline TReturn peek(const char* pos) {
   return static_cast<TReturn>(*reinterpret_cast<const T*>(pos));
 }
 
+// Read a varint-encoded uint32 from pos, advancing pos past the varint.
+inline uint32_t readVarint32(const char*& pos) {
+  uint32_t value = (*pos) & 127;
+  if (!(*(pos++) & 128)) {
+    return value;
+  }
+  value |= (*pos & 127) << 7;
+  if (!(*(pos++) & 128)) {
+    return value;
+  }
+  value |= (*pos & 127) << 14;
+  if (!(*(pos++) & 128)) {
+    return value;
+  }
+  value |= (*pos & 127) << 21;
+  if (!(*(pos++) & 128)) {
+    return value;
+  }
+  value |= (*(pos++) & 127) << 28;
+  return value;
+}
+
 } // namespace facebook::wave::nimble::encoding

--- a/velox/experimental/wave/dwio/nimble/NimbleFileFormat.cpp
+++ b/velox/experimental/wave/dwio/nimble/NimbleFileFormat.cpp
@@ -33,8 +33,9 @@ NimbleEncoding::NimbleEncoding(std::string_view encodingData, bool encodeNulls)
   encodingType_ = encoding::peek<uint8_t, EncodingType>(encodingData_.data());
   dataType_ = encoding::peek<uint8_t, DataType>(
       encodingData_.data() + Encoding::kDataTypeOffset);
-  numValues_ = encoding::peek<uint32_t>(
-      encodingData_.data() + Encoding::kRowCountOffset);
+  const char* pos = encodingData_.data() + Encoding::kRowCountOffset;
+  numValues_ = encoding::readVarint32(pos);
+  prefixSize_ = pos - encodingData_.data();
 }
 
 NimbleEncoding::NimbleEncoding(
@@ -45,6 +46,7 @@ NimbleEncoding::NimbleEncoding(
       encodingType_(encodingType),
       dataType_(dataType),
       numValues_(numValues),
+      prefixSize_(0),
       encodeNulls_(false) {}
 
 uint8_t NimbleEncoding::childrenCount() const {

--- a/velox/experimental/wave/dwio/nimble/NimbleFileFormat.h
+++ b/velox/experimental/wave/dwio/nimble/NimbleFileFormat.h
@@ -48,10 +48,10 @@ class NimbleEncoding {
 
   // Get a string_view of just the encoded data region (excluding prefix)
   std::string_view encodedData() const {
-    return encodingData_.substr(facebook::wave::nimble::Encoding::kPrefixSize);
+    return encodingData_.substr(prefixSize_);
   }
 
-  // Get pointer to the encoded data region (after the 6-byte prefix)
+  // Get pointer to the encoded data region (after the variable-size prefix)
   const char* encodedDataPtr() const {
     return encodedData().data();
   }
@@ -182,6 +182,7 @@ class NimbleEncoding {
   facebook::wave::nimble::EncodingType encodingType_;
   facebook::wave::nimble::DataType dataType_;
   uint32_t numValues_;
+  uint32_t prefixSize_;
   std::vector<std::unique_ptr<NimbleEncoding>> children_;
   void* deviceEncodedData_{nullptr};
   facebook::velox::wave::WaveBufferPtr decodedResultBuffer_;


### PR DESCRIPTION
Summary:
Change the Nimble encoding prefix row count field from a fixed 4-byte uint32_t to varint encoding. For typical small row counts (< 128 rows), this saves 3 bytes per encoding prefix.

The change is gated by a minor version bump (1 → 2) for backward compatibility:
- Write path: All encodings now use `Encoding::Options{.useVarintRowCount = true}`
- Read path: Files with `minorVersion() >= 2` decode with varint row counts; older files use the fixed 4-byte format

Key changes:
- Bump `kVersionMinor` from 1 to 2 in Constants.h
- Thread `useVarintRowCount=true` through VeloxWriter, IndexWriter, and VectorizedStatistics encode paths
- Version-gate decode in VeloxReader, SelectiveNimbleReader, SelectiveNimbleIndexReader, ChunkedDecoder, and IndexReader
- Update test utilities (TestUtils, VeloxWriterTest) to handle varint prefix parsing
- Update ~80 hardcoded physicalSize values in FieldWriterStatsTest to account for smaller prefixes

Differential Revision: D97174231


