### PR TITLE
fix: Skip approx_percentile in Spark Aggregation Fuzzer

### DIFF
--- a/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
+++ b/velox/functions/sparksql/fuzzer/SparkAggregationFuzzerTest.cpp
@@ -90,6 +90,9 @@ int main(int argc, char** argv) {
       "first_ignore_null",
       "last_ignore_null",
       "regr_replacement",
+      // https://github.com/facebookincubator/velox/issues/17124
+      // Correctness mismatches and OOM during KLL sketch operations.
+      "approx_percentile",
   };
 
   using facebook::velox::exec::test::TransformResultVerifier;


### PR DESCRIPTION
Summary:
`approx_percentile` is a major contributing source of Spark Aggregation Fuzzer flakiness — 7 failures out of 98 push-to-main runs (7.1% failure rate) over the last 3 weeks. Two independent bugs:

1. Correctness mismatch: Velox and Spark produce different results across various input types (TINYINT, INTEGER, BIGINT) and both single and array percentile variants.

2. Excessive memory / OOM: The aggregation operator attempts to allocate ~28GB during KLL sketch operations, triggering SIGABRT or SIGKILL on CI runners.

Skip `approx_percentile` until both issues are resolved.

Tracking issue: https://github.com/facebookincubator/velox/issues/17124

Differential Revision: D100395771


