### PR TITLE
feat(serializer): Add Arrow IPC VectorSerde and factory registry

### DIFF
--- a/velox/serializers/ArrowSerializer.cpp
+++ b/velox/serializers/ArrowSerializer.cpp
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/ArrowSerializer.h"
+
+#include <cstdint>
+#include <limits>
+
+#include <arrow/buffer.h>
+#include <arrow/c/bridge.h>
+#include <arrow/io/memory.h>
+#include <arrow/ipc/reader.h>
+#include <arrow/ipc/writer.h>
+#include <arrow/record_batch.h>
+#include <arrow/result.h>
+#include <folly/Range.h>
+#include <folly/ScopeGuard.h>
+
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/arrow/Bridge.h"
+
+namespace facebook::velox::serializer::arrow {
+namespace {
+
+// Adapts a Velox OutputStream to an arrow::io::OutputStream so that Arrow IPC
+// writes flow directly into the Velox output without an intermediate buffer.
+class VeloxArrowOutputStream : public ::arrow::io::OutputStream {
+ public:
+  explicit VeloxArrowOutputStream(velox::OutputStream* sink) : sink_(sink) {}
+
+  ::arrow::Status Write(const void* data, int64_t nbytes) override {
+    sink_->write(reinterpret_cast<const char*>(data), nbytes);
+    position_ += nbytes;
+    return ::arrow::Status::OK();
+  }
+
+  ::arrow::Result<int64_t> Tell() const override {
+    return position_;
+  }
+
+  ::arrow::Status Close() override {
+    closed_ = true;
+    return ::arrow::Status::OK();
+  }
+
+  bool closed() const override {
+    return closed_;
+  }
+
+ private:
+  velox::OutputStream* sink_;
+  int64_t position_{0};
+  bool closed_{false};
+};
+
+// Extracts the specified row ranges from a RowVector into a new contiguous
+// RowVector. Returns the input directly when ranges cover the full vector.
+RowVectorPtr extractRanges(
+    const RowVectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges,
+    memory::MemoryPool* pool) {
+  if (ranges.size() == 1 && ranges[0].begin == 0 &&
+      ranges[0].size == vector->size()) {
+    return vector;
+  }
+
+  vector_size_t totalRows = 0;
+  for (const auto& range : ranges) {
+    totalRows += range.size;
+  }
+
+  auto rowType = asRowType(vector->type());
+  const auto numChildren = vector->childrenSize();
+  std::vector<VectorPtr> children;
+  children.reserve(numChildren);
+  for (int32_t i = 0; i < numChildren; ++i) {
+    auto child = vector->childAt(i);
+    auto newChild = BaseVector::create(child->type(), totalRows, pool);
+    vector_size_t outIdx = 0;
+    for (const auto& range : ranges) {
+      newChild->copy(child.get(), outIdx, range.begin, range.size);
+      outIdx += range.size;
+    }
+    children.push_back(std::move(newChild));
+  }
+
+  BufferPtr nulls;
+  if (vector->mayHaveNulls()) {
+    nulls = AlignedBuffer::allocate<bool>(totalRows, pool);
+    auto rawNulls = nulls->asMutable<uint64_t>();
+    vector_size_t outIdx = 0;
+    for (const auto& range : ranges) {
+      for (vector_size_t j = 0; j < range.size; ++j) {
+        bits::setBit(rawNulls, outIdx++, !vector->isNullAt(range.begin + j));
+      }
+    }
+  }
+
+  return std::make_shared<RowVector>(
+      pool, rowType, nulls, totalRows, std::move(children));
+}
+
+void serializeToArrowIpc(
+    const RowVectorPtr& vector,
+    const folly::Range<const IndexRange*>& ranges,
+    memory::MemoryPool* pool,
+    OutputStream* stream) {
+  auto toSerialize = extractRanges(vector, ranges, pool);
+
+  // Export Velox vector to Arrow C Data Interface (zero-copy for fixed-width).
+  ArrowArray arrowArray{};
+  ArrowSchema arrowSchema{};
+  auto releaseArrowArray = folly::makeGuard([&]() {
+    if (arrowArray.release) {
+      arrowArray.release(&arrowArray);
+    }
+  });
+  auto releaseArrowSchema = folly::makeGuard([&]() {
+    if (arrowSchema.release) {
+      arrowSchema.release(&arrowSchema);
+    }
+  });
+  exportToArrow(toSerialize, arrowArray, pool);
+  exportToArrow(toSerialize, arrowSchema);
+
+  // Import into Arrow C++ RecordBatch (zero-copy wrapper).
+  // ImportRecordBatch takes ownership on success.
+  auto batch = ::arrow::ImportRecordBatch(&arrowArray, &arrowSchema);
+  if (!batch.ok()) {
+    VELOX_FAIL("Arrow ImportRecordBatch failed: {}", batch.status().ToString());
+  }
+  releaseArrowArray.dismiss();
+  releaseArrowSchema.dismiss();
+
+  // Write IPC stream directly to the Velox output stream.
+  auto sink = std::make_shared<VeloxArrowOutputStream>(stream);
+  auto writer = ::arrow::ipc::MakeStreamWriter(sink, (*batch)->schema());
+  VELOX_CHECK(
+      writer.ok(),
+      "Arrow MakeStreamWriter failed: {}",
+      writer.status().ToString());
+  auto writeStatus = (*writer)->WriteRecordBatch(**batch);
+  VELOX_CHECK(
+      writeStatus.ok(),
+      "Arrow WriteRecordBatch failed: {}",
+      writeStatus.ToString());
+  auto closeStatus = (*writer)->Close();
+  VELOX_CHECK(
+      closeStatus.ok(),
+      "Arrow writer Close failed: {}",
+      closeStatus.ToString());
+}
+
+// Batch serializer: single-shot serialize of a RowVector subset.
+class ArrowBatchVectorSerializer : public BatchVectorSerializer {
+ public:
+  explicit ArrowBatchVectorSerializer(memory::MemoryPool* pool) : pool_(pool) {}
+
+  void serialize(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      Scratch& /*scratch*/,
+      OutputStream* stream) override {
+    serializeToArrowIpc(vector, ranges, pool_, stream);
+  }
+
+  void estimateSerializedSize(
+      VectorPtr /*vector*/,
+      const folly::Range<const IndexRange*>& ranges,
+      vector_size_t** sizes,
+      Scratch& /*scratch*/) override {
+    for (int32_t i = 0; i < static_cast<int32_t>(ranges.size()); ++i) {
+      *sizes[i] += static_cast<vector_size_t>(ranges[i].size * sizeof(int64_t));
+    }
+  }
+
+ private:
+  memory::MemoryPool* pool_;
+};
+
+// Iterative serializer: accumulates rows across multiple append() calls,
+// materializes into a single RowVector on flush().
+class ArrowIterativeVectorSerializer : public IterativeVectorSerializer {
+ public:
+  ArrowIterativeVectorSerializer(
+      RowTypePtr type,
+      int32_t /*numRows*/,
+      StreamArena* streamArena)
+      : type_(std::move(type)), pool_(streamArena->pool()) {}
+
+  void append(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges,
+      Scratch& /*scratch*/) override {
+    for (const auto& range : ranges) {
+      accumulated_.emplace_back(vector, range);
+      numRows_ += range.size;
+    }
+  }
+
+  size_t maxSerializedSize() const override {
+    // Rough upper-bound estimate.
+    return numRows_ * type_->size() * sizeof(int64_t) + 1'024;
+  }
+
+  void flush(OutputStream* stream) override {
+    if (numRows_ == 0) {
+      return;
+    }
+
+    auto& sourceVector = accumulated_.at(0).first;
+    const auto numChildren = sourceVector->childrenSize();
+    std::vector<VectorPtr> children;
+    children.reserve(numChildren);
+    for (int32_t col = 0; col < numChildren; ++col) {
+      auto child = BaseVector::create(
+          sourceVector->childAt(col)->type(), numRows_, pool_);
+      vector_size_t outIdx = 0;
+      for (const auto& [accVector, range] : accumulated_) {
+        child->copy(
+            accVector->childAt(col).get(), outIdx, range.begin, range.size);
+        outIdx += range.size;
+      }
+      children.push_back(std::move(child));
+    }
+
+    // Arrow RecordBatch does not support top-level (struct-level) nulls.
+    // RowVector nulls are not propagated; this matches the remote function
+    // use case where the wrapping RowVector is never null at the row level.
+    auto merged = std::make_shared<RowVector>(
+        pool_, type_, BufferPtr{}, numRows_, std::move(children));
+
+    IndexRange fullRange{0, numRows_};
+    serializeToArrowIpc(merged, folly::Range(&fullRange, 1), pool_, stream);
+
+    accumulated_.clear();
+    numRows_ = 0;
+  }
+
+ private:
+  RowTypePtr type_;
+  memory::MemoryPool* pool_;
+  std::vector<std::pair<RowVectorPtr, IndexRange>> accumulated_;
+  vector_size_t numRows_{0};
+};
+
+} // namespace
+
+std::unique_ptr<IterativeVectorSerializer>
+ArrowVectorSerde::createIterativeSerializer(
+    RowTypePtr type,
+    int32_t numRows,
+    StreamArena* streamArena,
+    const Options* /*options*/) {
+  return std::make_unique<ArrowIterativeVectorSerializer>(
+      std::move(type), numRows, streamArena);
+}
+
+std::unique_ptr<BatchVectorSerializer> ArrowVectorSerde::createBatchSerializer(
+    memory::MemoryPool* pool,
+    const Options* /*options*/) {
+  return std::make_unique<ArrowBatchVectorSerializer>(pool);
+}
+
+namespace {
+
+// Parses an Arrow IPC stream from an arrow::Buffer and produces a Velox
+// RowVector. The buffer's data stays alive via the Arrow ownership chain:
+// arrow::Buffer → RecordBatch (SliceBuffer) → ArrowArray → BufferView.
+RowVectorPtr deserializeFromArrowBuffer(
+    const std::shared_ptr<::arrow::Buffer>& arrowBuffer,
+    velox::memory::MemoryPool* pool,
+    const RowTypePtr& type) {
+  auto bufferReader = std::make_shared<::arrow::io::BufferReader>(arrowBuffer);
+
+  auto reader = ::arrow::ipc::RecordBatchStreamReader::Open(bufferReader);
+  VELOX_CHECK(
+      reader.ok(),
+      "Arrow IPC reader open failed: {}",
+      reader.status().ToString());
+
+  std::shared_ptr<::arrow::RecordBatch> batch;
+  auto readStatus = (*reader)->ReadNext(&batch);
+  VELOX_CHECK(
+      readStatus.ok(), "Arrow IPC ReadNext failed: {}", readStatus.ToString());
+  VELOX_CHECK_NOT_NULL(batch, "Arrow IPC stream contained no record batches.");
+
+  ArrowArray arrowArray{};
+  ArrowSchema arrowSchema{};
+  auto exportStatus =
+      ::arrow::ExportRecordBatch(*batch, &arrowArray, &arrowSchema);
+  if (!exportStatus.ok()) {
+    if (arrowArray.release) {
+      arrowArray.release(&arrowArray);
+    }
+    if (arrowSchema.release) {
+      arrowSchema.release(&arrowSchema);
+    }
+    VELOX_FAIL("Arrow ExportRecordBatch failed: {}", exportStatus.ToString());
+  }
+
+  // importFromArrowAsOwner takes ownership of arrowArray and arrowSchema.
+  auto imported = importFromArrowAsOwner(arrowSchema, arrowArray, pool);
+  auto importedRow = std::dynamic_pointer_cast<RowVector>(imported);
+  VELOX_CHECK_NOT_NULL(
+      importedRow, "Arrow IPC deserialized data is not a RowVector.");
+
+  return std::make_shared<RowVector>(
+      pool,
+      type,
+      importedRow->nulls(),
+      importedRow->size(),
+      importedRow->children());
+}
+
+// Wraps a folly::IOBuf as an arrow::Buffer. Coalesces if fragmented (zero-copy
+// if already contiguous). Captures the IOBuf to keep the memory alive.
+// The exposed data_/size_ pointers are valid for the lifetime of this object.
+// Thread safety: not thread-safe; callers must not access the buffer
+// concurrently with destruction.
+class IOBufArrowBuffer : public ::arrow::Buffer {
+ public:
+  explicit IOBufArrowBuffer(const folly::IOBuf& iobuf)
+      : ::arrow::Buffer(nullptr, 0),
+        ownedBuf_(iobuf.cloneCoalescedAsValueWithHeadroomTailroom(0, 0)) {
+    data_ = ownedBuf_.data();
+    size_ = static_cast<int64_t>(ownedBuf_.length());
+    capacity_ = size_;
+  }
+
+ private:
+  folly::IOBuf ownedBuf_;
+};
+
+std::shared_ptr<::arrow::Buffer> wrapIOBufAsArrowBuffer(
+    const folly::IOBuf& iobuf) {
+  return std::make_shared<IOBufArrowBuffer>(iobuf);
+}
+
+} // namespace
+
+void ArrowVectorSerde::deserialize(
+    ByteInputStream* source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* /*options*/) {
+  const auto totalSize = source->remainingSize();
+  VELOX_CHECK_GT(totalSize, 0, "Empty input to Arrow IPC deserializer.");
+  // readBytes() takes int32_t, so cap at INT32_MAX (~2 GB).
+  constexpr size_t kMaxArrowIpcPayloadSize =
+      static_cast<size_t>(std::numeric_limits<int32_t>::max());
+  VELOX_CHECK_LE(
+      totalSize,
+      kMaxArrowIpcPayloadSize,
+      "Arrow IPC payload too large: {} bytes.",
+      totalSize);
+
+  std::string data;
+  data.resize(totalSize);
+  source->readBytes(
+      reinterpret_cast<uint8_t*>(data.data()), static_cast<int32_t>(totalSize));
+
+  auto arrowBuffer = ::arrow::Buffer::FromString(std::move(data));
+  *result = deserializeFromArrowBuffer(arrowBuffer, pool, type);
+}
+
+void ArrowVectorSerde::deserialize(
+    const folly::IOBuf& source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* /*options*/) {
+  VELOX_CHECK_GT(
+      source.computeChainDataLength(),
+      0,
+      "Empty input to Arrow IPC deserializer.");
+
+  // Wrap IOBuf as arrow::Buffer (zero-copy for contiguous IOBufs).
+  auto arrowBuffer = wrapIOBufAsArrowBuffer(source);
+  *result = deserializeFromArrowBuffer(arrowBuffer, pool, type);
+}
+
+void ArrowVectorSerde::registerVectorSerde() {
+  velox::registerVectorSerde(std::make_unique<ArrowVectorSerde>());
+}
+
+void ArrowVectorSerde::registerNamedVectorSerde() {
+  velox::registerNamedVectorSerde(
+      std::string(kSerdeName), std::make_unique<ArrowVectorSerde>());
+}
+
+void ArrowVectorSerde::tryRegisterNamedVectorSerde() {
+  if (!velox::isRegisteredNamedVectorSerde(std::string(kSerdeName))) {
+    registerNamedVectorSerde();
+  }
+}
+
+void ArrowVectorSerde::registerVectorSerdeFactory() {
+  velox::registerVectorSerdeFactory(std::string(kSerdeName), [] {
+    return std::make_unique<ArrowVectorSerde>();
+  });
+}
+
+} // namespace facebook::velox::serializer::arrow

--- a/velox/serializers/ArrowSerializer.h
+++ b/velox/serializers/ArrowSerializer.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string_view>
+
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::serializer::arrow {
+
+/// Serializes Velox vectors using Arrow IPC stream format. Uses the Arrow C
+/// Data Interface bridge for zero-copy conversion where possible, then the
+/// Arrow C++ IPC writer/reader for wire format serialization.
+class ArrowVectorSerde : public VectorSerde {
+ public:
+  ArrowVectorSerde() : VectorSerde(std::string(kSerdeName)) {}
+
+  std::unique_ptr<IterativeVectorSerializer> createIterativeSerializer(
+      RowTypePtr type,
+      int32_t numRows,
+      StreamArena* streamArena,
+      const Options* options) override;
+
+  std::unique_ptr<BatchVectorSerializer> createBatchSerializer(
+      memory::MemoryPool* pool,
+      const Options* options) override;
+
+  void deserialize(
+      ByteInputStream* source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options) override;
+
+  /// Deserializes from an IOBuf directly with zero-copy semantics. Wraps the
+  /// IOBuf memory as an Arrow buffer, avoiding the coalesce copy in the
+  /// ByteInputStream path.
+  void deserialize(
+      const folly::IOBuf& source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options) override;
+
+  /// Registers as the global default vector serde.
+  static void registerVectorSerde();
+
+  /// Registers in the named serde registry under kSerdeName.
+  static void registerNamedVectorSerde();
+
+  /// Registers in the named serde registry only if not already registered.
+  static void tryRegisterNamedVectorSerde();
+
+  /// Registers a factory in the serde factory registry under kSerdeName.
+  static void registerVectorSerdeFactory();
+
+  static std::string_view name() {
+    return kSerdeName;
+  }
+
+ private:
+  // Identifier used for registry lookup.
+  static constexpr std::string_view kSerdeName{"ArrowIpc"};
+};
+
+} // namespace facebook::velox::serializer::arrow

--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -29,6 +29,12 @@ velox_link_libraries(
   velox_vector
 )
 
+set(ARROW_SERDE velox_arrow_serializer)
+velox_add_library(${ARROW_SERDE} ArrowSerializer.cpp HEADERS ArrowSerializer.h)
+
+velox_link_libraries(${ARROW_SERDE} velox_vector velox_arrow_bridge arrow)
+unset(ARROW_SERDE)
+
 velox_add_library(
   velox_presto_serializer
   CompactRowSerializer.cpp

--- a/velox/serializers/tests/ArrowSerializerTest.cpp
+++ b/velox/serializers/tests/ArrowSerializerTest.cpp
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/ArrowSerializer.h"
+
+#include <gtest/gtest.h>
+#include <atomic>
+#include <numeric>
+#include <string>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/ByteStream.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::serializer::arrow {
+namespace {
+
+std::string makeTestFactoryName() {
+  static std::atomic<uint64_t> nextFactoryId{0};
+  return "ArrowIpcTest" +
+      std::to_string(nextFactoryId.fetch_add(1, std::memory_order_relaxed));
+}
+
+class ArrowSerializerTest : public testing::Test,
+                            public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    ArrowVectorSerde::registerNamedVectorSerde();
+    serde_ = std::make_unique<ArrowVectorSerde>();
+  }
+
+  void TearDown() override {
+    deregisterNamedVectorSerde("ArrowIpc");
+    deregisterVectorSerde();
+  }
+
+  // Serialize and deserialize a RowVector via the batch path.
+  RowVectorPtr roundTrip(const RowVectorPtr& input) {
+    auto iobuf = rowVectorToIOBufBatch(input, *pool_, serde_.get());
+    return IOBufToRowVector(
+        iobuf, asRowType(input->type()), *pool_, serde_.get());
+  }
+
+  std::unique_ptr<ArrowVectorSerde> serde_;
+};
+
+TEST_F(ArrowSerializerTest, factoryRegistryCreatesSerdeByName) {
+  const auto name = makeTestFactoryName();
+  EXPECT_FALSE(isRegisteredVectorSerdeFactory(name));
+
+  registerVectorSerdeFactory(
+      name, [] { return std::make_unique<ArrowVectorSerde>(); });
+
+  EXPECT_TRUE(isRegisteredVectorSerdeFactory(name));
+  auto serde = createVectorSerde(name);
+  ASSERT_NE(serde, nullptr);
+  EXPECT_EQ(serde->kind(), ArrowVectorSerde::name());
+}
+
+TEST_F(ArrowSerializerTest, factoryRegistryRejectsDuplicateName) {
+  const auto name = makeTestFactoryName();
+  registerVectorSerdeFactory(
+      name, [] { return std::make_unique<ArrowVectorSerde>(); });
+
+  VELOX_ASSERT_THROW(
+      registerVectorSerdeFactory(
+          name, [] { return std::make_unique<ArrowVectorSerde>(); }),
+      "already registered");
+}
+
+TEST_F(ArrowSerializerTest, factoryRegistryRejectsUnknownName) {
+  const auto name = makeTestFactoryName();
+  EXPECT_FALSE(isRegisteredVectorSerdeFactory(name));
+  VELOX_ASSERT_THROW(createVectorSerde(name), "is not registered");
+}
+
+TEST_F(ArrowSerializerTest, integers) {
+  auto input = makeRowVector({
+      makeFlatVector<int8_t>({1, -2, 3}),
+      makeFlatVector<int16_t>({100, -200, 300}),
+      makeFlatVector<int32_t>({1'000, -2'000, 3'000}),
+      makeFlatVector<int64_t>({10'000, -20'000, 30'000}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, floats) {
+  auto input = makeRowVector({
+      makeFlatVector<float>({1.5f, -2.5f, 3.5f}),
+      makeFlatVector<double>({1.1, -2.2, 3.3}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, booleans) {
+  auto input = makeRowVector({
+      makeFlatVector<bool>({true, false, true, false, true}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, strings) {
+  auto input = makeRowVector({
+      makeFlatVector<StringView>({"short", "", "a longer string value here"}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, longStrings) {
+  // Non-inline StringViews (>12 bytes) and very long strings.
+  const std::string str128(128, 'a');
+  const std::string str4k(4'096, 'b');
+  const std::string str64k(65'536, 'c');
+  auto input = makeRowVector({
+      makeFlatVector<StringView>({
+          StringView(str128),
+          StringView(str4k),
+          StringView(str64k),
+          ""_sv,
+          "inline"_sv,
+      }),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, emptyStrings) {
+  auto input = makeRowVector({
+      makeFlatVector<StringView>({""_sv, ""_sv, ""_sv}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, nulls) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+      makeNullableFlatVector<StringView>(
+          {std::nullopt, "hello"_sv, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, nullsInEveryScalarType) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<bool>({true, std::nullopt, false}),
+      makeNullableFlatVector<int8_t>({1, std::nullopt, 3}),
+      makeNullableFlatVector<int16_t>({100, std::nullopt, 300}),
+      makeNullableFlatVector<int32_t>({1'000, std::nullopt, 3'000}),
+      makeNullableFlatVector<int64_t>({10'000, std::nullopt, 30'000}),
+      makeNullableFlatVector<float>({1.5f, std::nullopt, 3.5f}),
+      makeNullableFlatVector<double>({1.1, std::nullopt, 3.3}),
+      makeNullableFlatVector<StringView>(
+          {"hello"_sv, std::nullopt, "world"_sv}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, allNullsInt) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, allNullsString) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<StringView>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, allNullsBool) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<bool>({std::nullopt, std::nullopt, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, allNullsDouble) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<double>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, emptyBatch) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({}),
+  });
+  auto result = roundTrip(input);
+  ASSERT_EQ(result->size(), 0);
+}
+
+TEST_F(ArrowSerializerTest, arrayType) {
+  auto input = makeRowVector({
+      makeArrayVector<int32_t>({{1, 2, 3}, {4, 5}, {}}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, mapType) {
+  auto input = makeRowVector({
+      makeMapVector<int32_t, StringView>(
+          {{{1, "a"_sv}, {2, "b"_sv}}, {{3, "c"_sv}}}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, rowType) {
+  auto input = makeRowVector({
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 2}),
+          makeFlatVector<StringView>({"x"_sv, "y"_sv}),
+      }),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, singleRow) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({42}),
+      makeFlatVector<StringView>({"only-one"_sv}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, largeBatch) {
+  constexpr int kSize{10'000};
+  std::vector<int64_t> values(kSize);
+  std::iota(values.begin(), values.end(), 0);
+  auto input = makeRowVector({makeFlatVector<int64_t>(values)});
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, mixedTypeColumns) {
+  auto input = makeRowVector({
+      makeFlatVector<bool>({true, false, true}),
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<double>({1.1, 2.2, 3.3}),
+      makeFlatVector<StringView>({"a"_sv, "bb"_sv, "ccc"_sv}),
+      makeFlatVector<int64_t>({100, 200, 300}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, nullableArrayElements) {
+  auto input = makeRowVector({
+      makeNullableArrayVector<int32_t>(
+          {{{1, std::nullopt, 3}}, {{std::nullopt}}, std::nullopt}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, nullableMapEntries) {
+  auto input = makeRowVector({
+      makeMapVector<int32_t, StringView>(
+          {{{1, "a"_sv}, {2, std::nullopt}}, {{3, "c"_sv}}}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, nestedArrayOfRows) {
+  auto innerRow = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4}),
+      makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv, "d"_sv}),
+  });
+  auto offsets = AlignedBuffer::allocate<vector_size_t>(2, pool());
+  auto rawOffsets = offsets->asMutable<vector_size_t>();
+  rawOffsets[0] = 0;
+  rawOffsets[1] = 2;
+  auto sizes = AlignedBuffer::allocate<vector_size_t>(2, pool());
+  auto rawSizes = sizes->asMutable<vector_size_t>();
+  rawSizes[0] = 2;
+  rawSizes[1] = 2;
+  auto arrayOfRows = std::make_shared<ArrayVector>(
+      pool(),
+      ARRAY(ROW({INTEGER(), VARCHAR()})),
+      nullptr,
+      2,
+      offsets,
+      sizes,
+      innerRow);
+  auto input = makeRowVector({arrayOfRows});
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, multipleColumnsOfSameType) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeFlatVector<int64_t>({10, 20, 30}),
+      makeFlatVector<int64_t>({100, 200, 300}),
+  });
+  auto result = roundTrip(input);
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, iterativeSerializer) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({10, 20, 30, 40, 50}),
+  });
+
+  auto iobuf = rowVectorToIOBuf(input, *pool_, serde_.get());
+  auto result =
+      IOBufToRowVector(iobuf, asRowType(input->type()), *pool_, serde_.get());
+  test::assertEqualVectors(input, result);
+}
+
+TEST_F(ArrowSerializerTest, iterativeSerializerAppendsMultipleVectors) {
+  // Use the iterative serializer to accumulate multiple input vectors into a
+  // single serialized payload, then deserialize and verify the result is the
+  // row-wise concatenation of the inputs.
+  auto rowType = ROW({"a", "b"}, {BIGINT(), VARCHAR()});
+
+  auto vec1 = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}),
+      makeFlatVector<StringView>({"x"_sv, "y"_sv}),
+  });
+  auto vec2 = makeRowVector({
+      makeFlatVector<int64_t>({3, 4, 5}),
+      makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv}),
+  });
+  auto vec3 = makeRowVector({
+      makeFlatVector<int64_t>({6}),
+      makeFlatVector<StringView>({"z"_sv}),
+  });
+
+  StreamArena arena(pool_.get());
+  auto serializer = serde_->createIterativeSerializer(
+      rowType, vec1->size() + vec2->size() + vec3->size(), &arena, nullptr);
+  serializer->append(vec1);
+  serializer->append(vec2);
+  serializer->append(vec3);
+
+  IOBufOutputStream stream(*pool_);
+  serializer->flush(&stream);
+
+  auto result =
+      IOBufToRowVector(*stream.getIOBuf(), rowType, *pool_, serde_.get());
+
+  auto expected = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6}),
+      makeFlatVector<StringView>(
+          {"x"_sv, "y"_sv, "a"_sv, "b"_sv, "c"_sv, "z"_sv}),
+  });
+  test::assertEqualVectors(expected, result);
+}
+
+TEST_F(ArrowSerializerTest, deserializeFromByteInputStream) {
+  // Exercises the deserialize(ByteInputStream*, ...) overload directly,
+  // which reads all bytes into a std::string before wrapping in an
+  // arrow::Buffer. The IOBuf overload takes a separate zero-copy path.
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<StringView>({"a"_sv, "b"_sv, "c"_sv, "d"_sv, "e"_sv}),
+  });
+  auto iobuf = rowVectorToIOBufBatch(input, *pool_, serde_.get());
+
+  std::vector<ByteRange> ranges;
+  for (const auto& range : iobuf) {
+    ranges.push_back(
+        ByteRange{
+            const_cast<uint8_t*>(range.data()),
+            static_cast<int32_t>(range.size()),
+            0});
+  }
+  auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
+
+  RowVectorPtr result;
+  serde_->deserialize(
+      byteStream.get(),
+      pool_.get(),
+      asRowType(input->type()),
+      &result,
+      nullptr);
+  test::assertEqualVectors(input, result);
+}
+
+// Note: Arrow RecordBatch does not support top-level (struct-level) nulls.
+// RowVector-level nulls are not preserved through Arrow IPC serialization.
+// This matches the remote function use case where the wrapping RowVector
+// is never null at the row level. Column-level nulls are fully supported.
+
+TEST_F(ArrowSerializerTest, namedSerdeRegistration) {
+  ASSERT_TRUE(isRegisteredNamedVectorSerde("ArrowIpc"));
+  auto* serde = getNamedVectorSerde("ArrowIpc");
+  ASSERT_NE(serde, nullptr);
+  ASSERT_EQ(serde->kind(), "ArrowIpc");
+}
+
+} // namespace
+} // namespace facebook::velox::serializer::arrow

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -32,6 +32,23 @@ target_link_libraries(
   GTest::gmock
 )
 
+add_executable(velox_arrow_serializer_test ArrowSerializerTest.cpp)
+
+add_test(
+  NAME velox_arrow_serializer_test
+  COMMAND velox_arrow_serializer_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+  velox_arrow_serializer_test
+  velox_arrow_serializer
+  velox_gtest_utils
+  velox_vector_test_lib
+  GTest::gtest
+  GTest::gtest_main
+)
+
 # Split velox_serializer_test into individual test binaries for parallel
 # execution.
 set(

--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -73,6 +73,12 @@ getNamedVectorSerdeImpl() {
   return namedSerdes;
 }
 
+std::unordered_map<std::string, VectorSerdeFactory>&
+getVectorSerdeFactoryImpl() {
+  static std::unordered_map<std::string, VectorSerdeFactory> factories;
+  return factories;
+}
+
 } // namespace
 
 void IterativeVectorSerializer::append(const RowVectorPtr& vector) {
@@ -102,6 +108,8 @@ std::string VectorSerde::kindName(Kind kind) {
       return "CompactRow";
     case Kind::kUnsafeRow:
       return "UnsafeRow";
+    case Kind::kArrowIpc:
+      return "ArrowIpc";
   }
   VELOX_UNREACHABLE(
       fmt::format("Unknown vector serde kind: {}", static_cast<int32_t>(kind)));
@@ -111,7 +119,9 @@ VectorSerde::Kind VectorSerde::kindByName(const std::string& kindName) {
   static const std::unordered_map<std::string, Kind> kNameToKind = {
       {"Presto", Kind::kPresto},
       {"CompactRow", Kind::kCompactRow},
-      {"UnsafeRow", Kind::kUnsafeRow}};
+      {"UnsafeRow", Kind::kUnsafeRow},
+      {"ArrowIpc", Kind::kArrowIpc},
+  };
   const auto it = kNameToKind.find(kindName);
   VELOX_CHECK(
       it != kNameToKind.end(), "Unknown vector serde kind: {}", kindName);
@@ -147,34 +157,79 @@ bool isRegisteredVectorSerde() {
 
 /// Named serde helper functions.
 void registerNamedVectorSerde(
-    const std::string& kind,
+    const std::string& serdeName,
     std::unique_ptr<VectorSerde> serdeToRegister) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
   VELOX_CHECK(
-      namedSerdeMap.find(kind) == namedSerdeMap.end(),
+      namedSerdeMap.find(serdeName) == namedSerdeMap.end(),
       "Vector serde '{}' is already registered.",
-      kind);
-  namedSerdeMap[kind] = std::move(serdeToRegister);
+      serdeName);
+  namedSerdeMap[serdeName] = std::move(serdeToRegister);
 }
 
-void deregisterNamedVectorSerde(const std::string& kind) {
+void deregisterNamedVectorSerde(const std::string& serdeName) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
-  namedSerdeMap.erase(kind);
+  namedSerdeMap.erase(serdeName);
 }
 
-bool isRegisteredNamedVectorSerde(const std::string& kind) {
+bool isRegisteredNamedVectorSerde(const std::string& serdeName) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
-  return namedSerdeMap.find(kind) != namedSerdeMap.end();
+  return namedSerdeMap.find(serdeName) != namedSerdeMap.end();
 }
 
-VectorSerde* getNamedVectorSerde(const std::string& kind) {
+VectorSerde* getNamedVectorSerde(const std::string& serdeName) {
   auto& namedSerdeMap = getNamedVectorSerdeImpl();
-  auto it = namedSerdeMap.find(kind);
+  auto it = namedSerdeMap.find(serdeName);
   VELOX_CHECK(
       it != namedSerdeMap.end(),
       "Named vector serde '{}' is not registered.",
-      kind);
+      serdeName);
   return it->second.get();
+}
+
+void registerVectorSerdeFactory(
+    const std::string& name,
+    VectorSerdeFactory factory) {
+  auto& factories = getVectorSerdeFactoryImpl();
+  VELOX_CHECK(
+      factories.find(name) == factories.end(),
+      "Vector serde factory is already registered: {}",
+      name);
+  factories[name] = std::move(factory);
+}
+
+bool isRegisteredVectorSerdeFactory(const std::string& name) {
+  auto& factories = getVectorSerdeFactoryImpl();
+  return factories.find(name) != factories.end();
+}
+
+std::unique_ptr<VectorSerde> createVectorSerde(const std::string& name) {
+  auto& factories = getVectorSerdeFactoryImpl();
+  auto it = factories.find(name);
+  VELOX_CHECK(
+      it != factories.end(),
+      "Vector serde factory is not registered: {}",
+      name);
+  return it->second();
+}
+
+void VectorSerde::deserialize(
+    const folly::IOBuf& source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* options) {
+  std::vector<ByteRange> ranges;
+  ranges.reserve(4);
+  for (const auto& range : source) {
+    ranges.emplace_back(
+        ByteRange{
+            const_cast<uint8_t*>(range.data()),
+            static_cast<int32_t>(range.size()),
+            0});
+  }
+  auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
+  deserialize(byteStream.get(), pool, type, result, options);
 }
 
 void VectorStreamGroup::createStreamTree(
@@ -318,26 +373,12 @@ RowVectorPtr IOBufToRowVector(
     const RowTypePtr& outputType,
     memory::MemoryPool& pool,
     VectorSerde* serde) {
-  std::vector<ByteRange> ranges;
-  ranges.reserve(4);
-
-  for (const auto& range : ioBuf) {
-    ranges.emplace_back(
-        ByteRange{
-            const_cast<uint8_t*>(range.data()),
-            static_cast<int32_t>(range.size()),
-            0});
-  }
-
-  auto byteStream = std::make_unique<BufferInputStream>(std::move(ranges));
-  RowVectorPtr outputVector;
-
-  // If not supplied, use the default one.
   if (serde == nullptr) {
     serde = getVectorSerde();
   }
-  serde->deserialize(
-      byteStream.get(), &pool, outputType, &outputVector, nullptr);
+
+  RowVectorPtr outputVector;
+  serde->deserialize(ioBuf, &pool, outputType, &outputVector, nullptr);
   return outputVector;
 }
 
@@ -365,7 +406,7 @@ folly::IOBuf rowVectorToIOBufBatch(
   IndexRange range{0, rangeEnd};
   Scratch scratch;
   serializer->serialize(rowVector, folly::Range(&range, 1), scratch, &stream);
-  return std::move(*stream.getIOBuf());
+  return *stream.getIOBuf();
 }
 
 } // namespace facebook::velox

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <functional>
+
 #include <folly/Range.h>
 
 #include "velox/common/base/RuntimeMetrics.h"
@@ -210,6 +212,7 @@ class VectorSerde {
     kPresto,
     kCompactRow,
     kUnsafeRow,
+    kArrowIpc,
   };
 
   static std::string kindName(Kind type);
@@ -354,6 +357,17 @@ class VectorSerde {
     VELOX_NYI();
   }
 
+  /// Deserializes data directly from an IOBuf, enabling zero-copy paths for
+  /// formats like Arrow IPC that can wrap IOBuf memory without copying. The
+  /// default implementation converts to a ByteInputStream and calls the
+  /// regular deserialize().
+  virtual void deserialize(
+      const folly::IOBuf& source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options = nullptr);
+
  protected:
   explicit VectorSerde(std::string kind) : kind_(std::move(kind)) {}
 
@@ -375,16 +389,33 @@ VectorSerde* getVectorSerde();
 /// Register/deregister a named vector serde. `serdeName` is a handle that
 /// allows users to register multiple serde formats.
 void registerNamedVectorSerde(
-    const std::string& kind,
+    const std::string& serdeName,
     std::unique_ptr<VectorSerde> serdeToRegister);
-void deregisterNamedVectorSerde(const std::string& kind);
+void deregisterNamedVectorSerde(const std::string& serdeName);
 
 /// Check if a named vector serde has been registered with `serdeName` as a
 /// handle.
-bool isRegisteredNamedVectorSerde(const std::string& kind);
+bool isRegisteredNamedVectorSerde(const std::string& serdeName);
 
 /// Get the vector serde identified by `serdeName`. Throws if not found.
-VectorSerde* getNamedVectorSerde(const std::string& kind);
+VectorSerde* getNamedVectorSerde(const std::string& serdeName);
+
+/// Factory function type for creating new VectorSerde instances by name.
+using VectorSerdeFactory = std::function<std::unique_ptr<VectorSerde>()>;
+
+/// Registers a factory that creates new VectorSerde instances under 'name'.
+/// 'name' is an arbitrary identifier chosen by the caller (e.g. "ArrowIpc",
+/// "Presto") and does not need to correspond to a VectorSerde::Kind.
+void registerVectorSerdeFactory(
+    const std::string& name,
+    VectorSerdeFactory factory);
+
+/// Returns true if a factory has been registered under 'name'.
+bool isRegisteredVectorSerdeFactory(const std::string& name);
+
+/// Creates a new VectorSerde instance using the factory registered under
+/// 'name'. Throws if no factory is registered for 'name'.
+std::unique_ptr<VectorSerde> createVectorSerde(const std::string& name);
 
 class VectorStreamGroup : public StreamArena {
  public:


### PR DESCRIPTION
Summary: Adds an Arrow IPC VectorSerde implementation, a named factory registry for creating VectorSerde instances by kind, and direct IOBuf deserialization so Arrow IPC payloads can avoid the ByteInputStream copy path. The serializer uses the Arrow C Data Interface and Arrow IPC streams, with tests for scalar and nested types, null handling, large strings, and registry error paths.

Differential Revision: D100358119


