### PR TITLE
perf: Eagerly finishInput in IndexLookupJoin::getOutput (#17130)

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -803,8 +803,9 @@ RowVectorPtr IndexLookupJoin::getOutput() {
   // the scan operator.
   RuntimeStatWriterScopeGuard guard(indexStatWriter_.get());
 
+  bool earlyFinishInput = false;
   SCOPE_EXIT {
-    if (numInputBatches() == 0 && isDraining()) {
+    if (!earlyFinishInput && numInputBatches() == 0 && isDraining()) {
       finishDrain();
     }
   };
@@ -818,6 +819,22 @@ RowVectorPtr IndexLookupJoin::getOutput() {
     return nullptr;
   }
   auto output = getOutputFromLookupResult(batch);
+
+  // Finish the input batch eagerly once the lookup is fully exhausted.
+  // This releases the ResultIterator and probe input, reducing steady-state
+  // pool usage. We skip finishDrain in the SCOPE_EXIT above since the driver
+  // hasn't consumed our output yet — finishDrain will be triggered on the
+  // next getOutput() call when batch.empty() returns nullptr.
+  if (output != nullptr && !batch.empty() && batch.lookupResult == nullptr &&
+      !batch.lookupFuture.valid() && batch.lookupResultIter != nullptr &&
+      !batch.lookupResultIter->hasNext() &&
+      !hasRemainingOutputForLeftJoin(batch)) {
+    finishInput(batch);
+    earlyFinishInput = true;
+    TestValue::adjust(
+        "facebook::velox::exec::IndexLookupJoin::earlyFinishInput", this);
+  }
+
   if (output == nullptr) {
     return nullptr;
   }

--- a/velox/exec/tests/IndexLookupJoinTestExtra.cpp
+++ b/velox/exec/tests/IndexLookupJoinTestExtra.cpp
@@ -2139,6 +2139,89 @@ TEST_P(IndexLookupJoinTest, groupedExecutionLeafValidation) {
 
 } // namespace
 
+// Verifies that IndexLookupJoin eagerly releases lookup result memory at
+// finishInput time (not just at task end). Uses a TestValue injection point
+// to observe that the operator's pool is empty immediately after
+// earlyFinishInput runs, proving the ResultIterator and probe input were
+// released while the last output batch is still in flight.
+DEBUG_ONLY_TEST_P(IndexLookupJoinTest, earlyFinishInput) {
+  IndexTableData tableData;
+  generateIndexTableData({100, 1, 1}, tableData, pool_);
+
+  const auto probeVectors = generateProbeInput(
+      /*numBatches=*/3,
+      /*batchSize=*/100,
+      /*numDuplicateProbeRows=*/50,
+      tableData,
+      pool_,
+      {"t0", "t1", "t2"},
+      GetParam().hasNullKeys,
+      {},
+      {},
+      100);
+  const auto probeFiles = createProbeFiles(probeVectors);
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", {tableData.tableVectors});
+
+  const auto indexTable = TestIndexTable::create(
+      /*numEqualJoinKeys=*/3,
+      tableData.keyVectors,
+      tableData.valueVectors,
+      *pool());
+  const auto indexTableHandle = makeIndexTableHandle(
+      indexTable, GetParam().asyncLookup, GetParam().needsIndexSplit);
+
+  for (auto joinType : {core::JoinType::kInner, core::JoinType::kLeft}) {
+    SCOPED_TRACE(fmt::format("joinType={}", static_cast<int>(joinType)));
+
+    std::atomic<int> earlyFinishCount{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::IndexLookupJoin::earlyFinishInput",
+        std::function<void(exec::Operator*)>(
+            [&](exec::Operator* /*op*/) { ++earlyFinishCount; }));
+
+    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+    const auto indexScanNode = makeIndexScanNode(
+        planNodeIdGenerator,
+        indexTableHandle,
+        makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+        makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+    auto plan = makeLookupPlan(
+        planNodeIdGenerator,
+        indexScanNode,
+        {"t0", "t1", "t2"},
+        {"u0", "u1", "u2"},
+        {},
+        /*filter=*/"",
+        /*hasMarker=*/false,
+        joinType,
+        {"u3", "t5"});
+
+    const auto duckDbSql = joinType == core::JoinType::kInner
+        ? "SELECT u.c3, t.c5 FROM t, u WHERE t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2"
+        : "SELECT u.c3, t.c5 FROM t LEFT JOIN u ON t.c0 = u.c0 AND t.c1 = u.c1 AND t.c2 = u.c2";
+
+    auto task = runLookupQuery(
+        plan,
+        probeFiles,
+        GetParam().serialExecution,
+        GetParam().serialExecution,
+        100,
+        GetParam().numPrefetches,
+        GetParam().needsIndexSplit,
+        duckDbSql);
+
+    ASSERT_EQ(task->pool()->usedBytes(), 0)
+        << "Task pool should be fully released after completion";
+
+    if (!GetParam().hasNullKeys) {
+      ASSERT_GT(earlyFinishCount.load(), 0)
+          << "Expected early finishInput to be called at least once";
+    }
+  }
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     IndexLookupJoinTest,
     IndexLookupJoinTest,


### PR DESCRIPTION
Summary:

Currently we call finishInput in IndexLookupJoin in 2 cases:
1) If the input was empty, we call it in getOutput right away for inner joins, or after we've already sent all the 
rows from the left side for a left outer join.
2) If we've finished processing all the join results, and (if it's a left outer join) after processing any remaining 
hits.

In both cases we only detect this once getOutput is called and we have no more output to return.

One of the roles of finishInput is to release the memory the IndexLookupJoin is holding for the current input
batch, notably the ResultIterator which holds onto a pointer to the results RowVector and a pointer to the input RowVector in the Batch. This means we can't free any of this memory until the Driver finishes processing the current batch, and attempts to process the next batch from IndexLookupJoin.

If we instead eagerly detect in getOutput that we have finished the batch we can call finishInput early, so that as soon as the downstream Operators are done with the results/input we can free the memory. This doesn't reduce peak memory, but reduces the length of the peak.

We only do this in the case when prefetch is disabled because otherwise the logic to determine whether or not we are finished is more complicated.

Differential Revision: D100033500


