### PR TITLE
feat: support paimon append & primary with rawConvertible=true read

### DIFF
--- a/velox/connectors/hive/paimon/CMakeLists.txt
+++ b/velox/connectors/hive/paimon/CMakeLists.txt
@@ -31,10 +31,12 @@ velox_add_library(
   velox_hive_paimon_connector
   PaimonConnector.cpp
   PaimonDataSource.cpp
+  PaimonSplitReader.cpp
   HEADERS
   PaimonConfig.h
   PaimonConnector.h
   PaimonDataSource.h
+  PaimonSplitReader.h
 )
 
 velox_link_libraries(velox_hive_paimon_connector velox_hive_paimon_split velox_hive_connector)

--- a/velox/connectors/hive/paimon/PaimonDataSource.cpp
+++ b/velox/connectors/hive/paimon/PaimonDataSource.cpp
@@ -15,6 +15,10 @@
  */
 #include "velox/connectors/hive/paimon/PaimonDataSource.h"
 
+#include "velox/common/Casts.h"
+#include "velox/connectors/hive/paimon/PaimonConnectorSplit.h"
+#include "velox/connectors/hive/paimon/PaimonSplitReader.h"
+
 namespace facebook::velox::connector::hive::paimon {
 
 PaimonDataSource::PaimonDataSource(
@@ -35,13 +39,47 @@ PaimonDataSource::PaimonDataSource(
           paimonConfig) {}
 
 void PaimonDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
-  VELOX_NYI("PaimonDataSource::addSplit");
+  paimonSplit_ = checkedPointerCast<PaimonConnectorSplit>(split);
+
+  if (!paimonSplit_->rawConvertible()) {
+    VELOX_NYI(
+        "Paimon merge-on-read is not yet implemented. "
+        "Primary-key tables with rawConvertible=false require merge-on-read "
+        "to deduplicate records across LSM levels.");
+  }
+
+  // Create a FileConnectorSplit for the first data file and delegate to
+  // FileDataSource::addSplit(), which calls createSplitReader() to create
+  // a PaimonSplitReader that handles all files internally.
+  const auto& firstFile = paimonSplit_->dataFiles().front();
+  auto firstFileSplit = std::make_shared<FileConnectorSplit>(
+      paimonSplit_->connectorId,
+      firstFile.path,
+      paimonSplit_->fileFormat(),
+      /*_start=*/0,
+      /*_length=*/std::numeric_limits<uint64_t>::max(),
+      /*splitWeight=*/0,
+      /*cacheable=*/true,
+      /*_properties=*/std::nullopt,
+      paimonSplit_->partitionKeys());
+
+  FileDataSource::addSplit(std::move(firstFileSplit));
 }
 
-std::optional<RowVectorPtr> PaimonDataSource::next(
-    uint64_t size,
-    velox::ContinueFuture& future) {
-  VELOX_NYI("PaimonDataSource::next");
+std::unique_ptr<FileSplitReader> PaimonDataSource::createSplitReader() {
+  return std::make_unique<PaimonSplitReader>(
+      split_,
+      paimonSplit_,
+      tableHandle_,
+      &partitionKeys_,
+      connectorQueryCtx_,
+      fileConfig_,
+      readerOutputType_,
+      ioStatistics_,
+      ioStats_,
+      fileHandleFactory_,
+      ioExecutor_,
+      scanSpec_);
 }
 
 } // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonDataSource.h
+++ b/velox/connectors/hive/paimon/PaimonDataSource.h
@@ -20,11 +20,22 @@
 
 namespace facebook::velox::connector::hive::paimon {
 
+class PaimonConnectorSplit;
+
 /// Paimon-specific data source that extends FileDataSource.
 ///
-/// Handles PaimonConnectorSplit which may contain multiple data files
-/// in a single logical split (one per LSM-tree level in a bucket).
-/// Currently only supports append-only tables with rawConvertible=true.
+/// Acts as an orchestrator that selects the right reading strategy based on
+/// split properties:
+///
+///   rawConvertible=true (append-only or fully-compacted primary-key):
+///     Creates a PaimonSplitReader that handles multi-file iteration,
+///     deletion vectors, and _rowkind internally. FileDataSource::next()
+///     drives the read loop — no override needed.
+///
+///   rawConvertible=false (primary-key with overlapping keys):
+///     Merge path. A PaimonMergeReader opens all files simultaneously and
+///     performs a sorted merge by primary key, deduplicating by sequence
+///     number. Not yet implemented.
 class PaimonDataSource : public FileDataSource {
  public:
   PaimonDataSource(
@@ -38,8 +49,15 @@ class PaimonDataSource : public FileDataSource {
 
   void addSplit(std::shared_ptr<ConnectorSplit> split) override;
 
-  std::optional<RowVectorPtr> next(uint64_t size, velox::ContinueFuture& future)
-      override;
+ protected:
+  /// Creates a PaimonSplitReader with all data files from the Paimon split.
+  /// Called by FileDataSource::addSplit() during split initialization.
+  std::unique_ptr<FileSplitReader> createSplitReader() override;
+
+ private:
+  // The original Paimon split. Stored so createSplitReader() can access
+  // the full list of data files.
+  std::shared_ptr<PaimonConnectorSplit> paimonSplit_;
 };
 
 } // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonSplitReader.cpp
+++ b/velox/connectors/hive/paimon/PaimonSplitReader.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/paimon/PaimonSplitReader.h"
+
+#include <limits>
+
+namespace facebook::velox::connector::hive::paimon {
+
+PaimonSplitReader::PaimonSplitReader(
+    const std::shared_ptr<const FileConnectorSplit>& fileSplit,
+    std::shared_ptr<const PaimonConnectorSplit> paimonSplit,
+    const FileTableHandlePtr& tableHandle,
+    const std::unordered_map<std::string, FileColumnHandlePtr>* partitionKeys,
+    const ConnectorQueryCtx* connectorQueryCtx,
+    const std::shared_ptr<const FileConfig>& fileConfig,
+    const RowTypePtr& readerOutputType,
+    const std::shared_ptr<io::IoStatistics>& ioStatistics,
+    const std::shared_ptr<IoStats>& ioStats,
+    FileHandleFactory* fileHandleFactory,
+    folly::Executor* executor,
+    const std::shared_ptr<common::ScanSpec>& scanSpec)
+    : FileSplitReader(
+          fileSplit,
+          tableHandle,
+          partitionKeys,
+          connectorQueryCtx,
+          fileConfig,
+          readerOutputType,
+          ioStatistics,
+          ioStats,
+          fileHandleFactory,
+          executor,
+          scanSpec),
+      paimonSplit_(std::move(paimonSplit)) {
+  // Validate all data files upfront.
+  for (const auto& dataFile : paimonSplit_->dataFiles()) {
+    VELOX_CHECK(
+        !dataFile.deletionFile.has_value(),
+        "Paimon deletion vector reading is not yet implemented. "
+        "File '{}' has a deletion vector with {} deleted rows.",
+        dataFile.path,
+        dataFile.deletionFile.has_value() ? dataFile.deletionFile->cardinality
+                                          : 0);
+    VELOX_CHECK_EQ(
+        dataFile.type,
+        PaimonDataFile::Type::kData,
+        "Paimon changelog file reading is not yet supported. "
+        "File '{}' has type {}.",
+        dataFile.path,
+        dataFile.type);
+  }
+
+  // Build FileConnectorSplits for all data files so we can switch between
+  // them during multi-file iteration.
+  const auto& dataFiles = paimonSplit_->dataFiles();
+  fileSplits_.reserve(dataFiles.size());
+  for (const auto& dataFile : dataFiles) {
+    fileSplits_.emplace_back(makeFileConnectorSplit(dataFile));
+  }
+}
+
+void PaimonSplitReader::prepareSplit(
+    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    dwio::common::RuntimeStatistics& runtimeStats,
+    const folly::F14FastMap<std::string, std::string>& /*fileReadOps*/) {
+  // Save for re-use when advancing to subsequent files.
+  metadataFilter_ = std::move(metadataFilter);
+  runtimeStats_ = &runtimeStats;
+}
+
+uint64_t PaimonSplitReader::next(uint64_t size, VectorPtr& output) {
+  while (ensureFileSplitReader()) {
+    // When deletion vectors are implemented, apply the deletion bitmap
+    // here via Mutation.deletedRows, following the same pattern as
+    // IcebergSplitReader::next().
+    const auto rowsRead = FileSplitReader::next(size, output);
+    if (rowsRead > 0) {
+      return rowsRead;
+    }
+    // Current file exhausted, try the next one.
+    finishFileSplitReader();
+  }
+  return 0;
+}
+
+bool PaimonSplitReader::ensureFileSplitReader() {
+  if (baseReader_ != nullptr) {
+    VELOX_CHECK_NOT_NULL(baseRowReader_);
+    return true;
+  }
+  VELOX_CHECK_NULL(baseRowReader_);
+
+  while (currentFileIndex_ < fileSplits_.size()) {
+    // Point to the current file.
+    fileSplit_ = fileSplits_[currentFileIndex_];
+
+    // Initialize the base reader for this file.
+    FileSplitReader::prepareSplit(metadataFilter_, *runtimeStats_);
+    if (!emptySplit_) {
+      return true;
+    }
+    ++currentFileIndex_;
+  }
+  return false; // All files exhausted.
+}
+
+void PaimonSplitReader::finishFileSplitReader() {
+  VELOX_CHECK_LT(currentFileIndex_, fileSplits_.size());
+  VELOX_CHECK_NOT_NULL(baseReader_);
+  VELOX_CHECK_NOT_NULL(baseRowReader_);
+  ++currentFileIndex_;
+  baseReader_ = nullptr;
+  baseRowReader_ = nullptr;
+  emptySplit_ = false;
+}
+
+std::shared_ptr<FileConnectorSplit> PaimonSplitReader::makeFileConnectorSplit(
+    const PaimonDataFile& dataFile) const {
+  return std::make_shared<FileConnectorSplit>(
+      paimonSplit_->connectorId,
+      dataFile.path,
+      paimonSplit_->fileFormat(),
+      /*_start=*/0,
+      /*_length=*/std::numeric_limits<uint64_t>::max(),
+      /*splitWeight=*/0,
+      /*cacheable=*/true,
+      /*_properties=*/std::nullopt,
+      paimonSplit_->partitionKeys());
+}
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/PaimonSplitReader.h
+++ b/velox/connectors/hive/paimon/PaimonSplitReader.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/FileSplitReader.h"
+#include "velox/connectors/hive/paimon/PaimonConnectorSplit.h"
+
+namespace facebook::velox::connector::hive::paimon {
+
+/// Reader for rawConvertible Paimon splits. Extends FileSplitReader to handle
+/// Paimon-specific concerns:
+///
+///   - Multi-file iteration: A single Paimon split may contain multiple data
+///     files (one per LSM level in a bucket). This reader iterates through
+///     all files sequentially, transparently advancing to the next file when
+///     the current one is exhausted.
+///
+///   - Deletion vectors: Roaring bitmaps marking deleted row positions within
+///     a data file. Loaded in prepareSplit(), applied in next() via
+///     Mutation.deletedRows (same pattern as IcebergSplitReader). (NYI)
+///
+///   - _rowkind system column: Change type (+I/-U/+U/-D) for changelog files
+///     and input changelog mode. Handled in adaptColumns(). (NYI)
+///
+/// Also serves as the building block for PaimonMergeReader, which composes
+/// multiple PaimonSplitReaders to perform merge-on-read for primary-key
+/// tables with rawConvertible=false.
+class PaimonSplitReader : public FileSplitReader {
+ public:
+  /// @param fileSplit FileConnectorSplit for the first data file (set by
+  ///        FileDataSource::addSplit before calling createSplitReader).
+  /// @param paimonSplit The full Paimon split. PaimonSplitReader builds
+  ///        FileConnectorSplits for all data files internally.
+  PaimonSplitReader(
+      const std::shared_ptr<const FileConnectorSplit>& fileSplit,
+      std::shared_ptr<const PaimonConnectorSplit> paimonSplit,
+      const FileTableHandlePtr& tableHandle,
+      const std::unordered_map<std::string, FileColumnHandlePtr>* partitionKeys,
+      const ConnectorQueryCtx* connectorQueryCtx,
+      const std::shared_ptr<const FileConfig>& fileConfig,
+      const RowTypePtr& readerOutputType,
+      const std::shared_ptr<io::IoStatistics>& ioStatistics,
+      const std::shared_ptr<IoStats>& ioStats,
+      FileHandleFactory* fileHandleFactory,
+      folly::Executor* executor,
+      const std::shared_ptr<common::ScanSpec>& scanSpec);
+
+  ~PaimonSplitReader() override = default;
+
+  /// Saves metadata filter and runtime stats for use by
+  /// ensureFileSplitReader(). File validation is done in the constructor.
+  void prepareSplit(
+      std::shared_ptr<common::MetadataFilter> metadataFilter,
+      dwio::common::RuntimeStatistics& runtimeStats,
+      const folly::F14FastMap<std::string, std::string>& fileReadOps = {})
+      override;
+
+  /// Reads from the current file. When a file is exhausted, transparently
+  /// advances to the next file in the split. Returns 0 only when all files
+  /// are exhausted.
+  uint64_t next(uint64_t size, VectorPtr& output) override;
+
+ private:
+  // Builds a FileConnectorSplit from a PaimonDataFile.
+  std::shared_ptr<FileConnectorSplit> makeFileConnectorSplit(
+      const PaimonDataFile& dataFile) const;
+
+  // Ensures a file split reader is ready to produce rows. If the current
+  // reader is exhausted, advances to the next non-empty file. Returns true
+  // if a reader is ready, false when all files are exhausted.
+  bool ensureFileSplitReader();
+
+  // Cleans up the current file reader after it is exhausted and advances
+  // currentFileIndex_ so ensureFileSplitReader() opens the next file.
+  void finishFileSplitReader();
+
+  const std::shared_ptr<const PaimonConnectorSplit> paimonSplit_;
+
+  // FileConnectorSplits built from paimonSplit_->dataFiles(), one per file.
+  // Used to switch the base reader between files during iteration.
+  std::vector<std::shared_ptr<FileConnectorSplit>> fileSplits_;
+
+  // Index of the next data file to open.
+  size_t currentFileIndex_{0};
+
+  // Saved from prepareSplit() for re-use when advancing to subsequent files.
+  std::shared_ptr<common::MetadataFilter> metadataFilter_;
+  dwio::common::RuntimeStatistics* runtimeStats_{nullptr};
+};
+
+} // namespace facebook::velox::connector::hive::paimon

--- a/velox/connectors/hive/paimon/tests/PaimonConnectorTest.cpp
+++ b/velox/connectors/hive/paimon/tests/PaimonConnectorTest.cpp
@@ -17,9 +17,13 @@
 
 #include <gtest/gtest.h>
 
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/ConnectorRegistry.h"
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/paimon/PaimonConnectorSplit.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
 
 namespace facebook::velox::connector::hive::paimon {
 namespace {
@@ -40,6 +44,77 @@ class PaimonConnectorTest : public exec::test::HiveConnectorTestBase {
   void TearDown() override {
     ConnectorRegistry::global().erase(kPaimonConnectorId);
     HiveConnectorTestBase::TearDown();
+  }
+
+  /// Creates a table handle for the Paimon connector.
+  static std::shared_ptr<HiveTableHandle> makePaimonTableHandle(
+      const RowTypePtr& dataColumns = nullptr,
+      common::SubfieldFilters subfieldFilters = {},
+      const core::TypedExprPtr& remainingFilter = nullptr) {
+    return std::make_shared<HiveTableHandle>(
+        kPaimonConnectorId,
+        "paimon_table",
+        std::move(subfieldFilters),
+        remainingFilter,
+        dataColumns);
+  }
+
+  /// Creates column assignments for all columns as regular columns.
+  static connector::ColumnHandleMap makePaimonColumnHandles(
+      const RowTypePtr& rowType) {
+    connector::ColumnHandleMap assignments;
+    assignments.reserve(rowType->size());
+    for (uint32_t i = 0; i < rowType->size(); ++i) {
+      const auto& name = rowType->nameOf(i);
+      assignments[name] = std::make_shared<HiveColumnHandle>(
+          name,
+          HiveColumnHandle::ColumnType::kRegular,
+          rowType->childAt(i),
+          rowType->childAt(i));
+    }
+    return assignments;
+  }
+
+  /// Builds a table scan plan using the Paimon connector.
+  core::PlanNodePtr makePaimonScanPlan(
+      const RowTypePtr& outputType,
+      const RowTypePtr& dataColumns = nullptr,
+      common::SubfieldFilters subfieldFilters = {},
+      const core::TypedExprPtr& remainingFilter = nullptr) {
+    auto tableHandle = makePaimonTableHandle(
+        dataColumns ? dataColumns : outputType,
+        std::move(subfieldFilters),
+        remainingFilter);
+    auto assignments =
+        makePaimonColumnHandles(dataColumns ? dataColumns : outputType);
+    return exec::test::PlanBuilder()
+        .startTableScan()
+        .connectorId(kPaimonConnectorId)
+        .outputType(outputType)
+        .tableHandle(tableHandle)
+        .assignments(assignments)
+        .endTableScan()
+        .planNode();
+  }
+
+  /// Creates a PaimonConnectorSplit from file paths.
+  std::shared_ptr<PaimonConnectorSplit> makePaimonSplit(
+      const std::vector<std::string>& filePaths,
+      PaimonTableType tableType = PaimonTableType::kAppendOnly,
+      dwio::common::FileFormat format = dwio::common::FileFormat::DWRF,
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          partitionKeys = {},
+      bool rawConvertible = true) {
+    PaimonConnectorSplitBuilder builder(
+        kPaimonConnectorId, /*snapshotId=*/1, tableType, format);
+    for (const auto& filePath : filePaths) {
+      builder.addFile(filePath, /*fileSize=*/0);
+    }
+    for (const auto& [key, value] : partitionKeys) {
+      builder.partitionKey(key, value);
+    }
+    builder.rawConvertible(rawConvertible);
+    return builder.build();
   }
 };
 
@@ -65,6 +140,189 @@ TEST_F(PaimonConnectorTest, connectorFactory) {
   HiveConfig hiveConfig(connector->connectorConfig());
   EXPECT_TRUE(hiveConfig.isFileHandleCacheEnabled());
   EXPECT_EQ(hiveConfig.numCacheFileHandles(), 500);
+}
+
+// E2E test: read a single file from an append-only Paimon split.
+TEST_F(PaimonConnectorTest, appendOnlySingleFile) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto vectors = makeVectors(rowType, 1, 100);
+
+  auto filePaths = makeFilePaths(1);
+  writeToFile(filePaths[0]->getPath(), vectors);
+
+  auto split = makePaimonSplit({filePaths[0]->getPath()});
+  auto plan = makePaimonScanPlan(rowType);
+
+  exec::test::AssertQueryBuilder(plan).split(split).assertResults(vectors);
+}
+
+// E2E test: read multiple files from a single append-only Paimon split.
+TEST_F(PaimonConnectorTest, appendOnlyMultipleFiles) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+  auto vectors1 = makeVectors(rowType, 1, 100);
+  auto vectors2 = makeVectors(rowType, 1, 50);
+
+  auto filePaths = makeFilePaths(2);
+  writeToFile(filePaths[0]->getPath(), vectors1);
+  writeToFile(filePaths[1]->getPath(), vectors2);
+
+  auto split =
+      makePaimonSplit({filePaths[0]->getPath(), filePaths[1]->getPath()});
+  auto plan = makePaimonScanPlan(rowType);
+
+  // Expected result is all rows from both files.
+  std::vector<RowVectorPtr> expected;
+  expected.insert(expected.end(), vectors1.begin(), vectors1.end());
+  expected.insert(expected.end(), vectors2.begin(), vectors2.end());
+
+  exec::test::AssertQueryBuilder(plan).split(split).assertResults(expected);
+}
+
+// Verify that empty splits (no data files) are rejected by
+// PaimonConnectorSplit.
+TEST_F(PaimonConnectorTest, rejectsEmptySplit) {
+  VELOX_ASSERT_THROW(
+      makePaimonSplit({}), "PaimonConnectorSplit requires non-empty dataFiles");
+}
+
+// E2E test: read with partition keys from an append-only Paimon split.
+TEST_F(PaimonConnectorTest, appendOnlyWithPartitionKeys) {
+  // Data file columns (not including partition column).
+  auto dataRowType = ROW({"c0"}, {BIGINT()});
+  auto vectors = makeVectors(dataRowType, 1, 100);
+
+  auto filePaths = makeFilePaths(1);
+  writeToFile(filePaths[0]->getPath(), vectors);
+
+  // The output includes both the data column and the partition column.
+  auto outputType = ROW({"c0", "p0"}, {BIGINT(), VARCHAR()});
+  auto tableHandle = makePaimonTableHandle(outputType);
+
+  connector::ColumnHandleMap assignments;
+  assignments["c0"] = std::make_shared<HiveColumnHandle>(
+      "c0", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
+  assignments["p0"] = std::make_shared<HiveColumnHandle>(
+      "p0", HiveColumnHandle::ColumnType::kPartitionKey, VARCHAR(), VARCHAR());
+
+  auto plan = exec::test::PlanBuilder()
+                  .startTableScan()
+                  .connectorId(kPaimonConnectorId)
+                  .outputType(outputType)
+                  .tableHandle(tableHandle)
+                  .assignments(assignments)
+                  .endTableScan()
+                  .planNode();
+
+  auto split = makePaimonSplit(
+      {filePaths[0]->getPath()},
+      PaimonTableType::kAppendOnly,
+      dwio::common::FileFormat::DWRF,
+      {{"p0", std::optional<std::string>("2024-01-01")}});
+
+  // Build expected output with the partition value filled in.
+  auto expectedC0 = vectors[0]->childAt(0);
+  auto numRows = vectors[0]->size();
+  auto expectedP0 =
+      BaseVector::createConstant(VARCHAR(), "2024-01-01", numRows, pool());
+
+  auto expected = makeRowVector({"c0", "p0"}, {expectedC0, expectedP0});
+
+  exec::test::AssertQueryBuilder(plan).split(split).assertResults({expected});
+}
+
+// Verify that non-rawConvertible splits trigger NYI (merge-on-read).
+TEST_F(PaimonConnectorTest, rejectsNonRawConvertible) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto vectors = makeVectors(rowType, 1, 10);
+
+  auto filePaths = makeFilePaths(1);
+  writeToFile(filePaths[0]->getPath(), vectors);
+
+  auto split = makePaimonSplit(
+      {filePaths[0]->getPath()},
+      PaimonTableType::kAppendOnly,
+      dwio::common::FileFormat::DWRF,
+      /*partitionKeys=*/{},
+      /*rawConvertible=*/false);
+
+  auto plan = makePaimonScanPlan(rowType);
+
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(plan).split(split).copyResults(pool()),
+      "Paimon merge-on-read is not yet implemented");
+}
+
+// E2E test: primary-key table with rawConvertible=true reads successfully.
+// When fully compacted (rawConvertible), primary-key tables can be read
+// the same way as append-only — each file is independent, no merge needed.
+TEST_F(PaimonConnectorTest, primaryKeyRawConvertible) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto vectors = makeVectors(rowType, 1, 10);
+
+  auto filePaths = makeFilePaths(1);
+  writeToFile(filePaths[0]->getPath(), vectors);
+
+  auto split = makePaimonSplit(
+      {filePaths[0]->getPath()},
+      PaimonTableType::kPrimaryKey,
+      dwio::common::FileFormat::DWRF);
+
+  auto plan = makePaimonScanPlan(rowType);
+
+  exec::test::AssertQueryBuilder(plan).split(split).assertResults(vectors);
+}
+
+// Verify that primary-key table with rawConvertible=false triggers NYI.
+TEST_F(PaimonConnectorTest, rejectsPrimaryKeyNonRawConvertible) {
+  auto rowType = ROW({"c0"}, {BIGINT()});
+  auto vectors = makeVectors(rowType, 1, 10);
+
+  auto filePaths = makeFilePaths(1);
+  writeToFile(filePaths[0]->getPath(), vectors);
+
+  auto split = makePaimonSplit(
+      {filePaths[0]->getPath()},
+      PaimonTableType::kPrimaryKey,
+      dwio::common::FileFormat::DWRF,
+      /*partitionKeys=*/{},
+      /*rawConvertible=*/false);
+
+  auto plan = makePaimonScanPlan(rowType);
+
+  VELOX_ASSERT_THROW(
+      exec::test::AssertQueryBuilder(plan).split(split).copyResults(pool()),
+      "Paimon merge-on-read is not yet implemented");
+}
+
+// E2E test: multiple splits each with multiple files.
+TEST_F(PaimonConnectorTest, appendOnlyMultipleSplits) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), VARCHAR()});
+
+  // Split 1 with 2 files.
+  auto vectors1a = makeVectors(rowType, 1, 50);
+  auto vectors1b = makeVectors(rowType, 1, 30);
+  // Split 2 with 1 file.
+  auto vectors2a = makeVectors(rowType, 1, 40);
+
+  auto filePaths = makeFilePaths(3);
+  writeToFile(filePaths[0]->getPath(), vectors1a);
+  writeToFile(filePaths[1]->getPath(), vectors1b);
+  writeToFile(filePaths[2]->getPath(), vectors2a);
+
+  auto split1 =
+      makePaimonSplit({filePaths[0]->getPath(), filePaths[1]->getPath()});
+  auto split2 = makePaimonSplit({filePaths[2]->getPath()});
+
+  auto plan = makePaimonScanPlan(rowType);
+
+  std::vector<RowVectorPtr> expected;
+  expected.insert(expected.end(), vectors1a.begin(), vectors1a.end());
+  expected.insert(expected.end(), vectors1b.begin(), vectors1b.end());
+  expected.insert(expected.end(), vectors2a.begin(), vectors2a.end());
+
+  exec::test::AssertQueryBuilder(plan)
+      .splits({split1, split2})
+      .assertResults(expected);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Introduces the PaimonSplitReader framework for reading Paimon tables in Velox/Presto.

**PaimonSplitReader** (extends FileSplitReader): Multi-file reader for rawConvertible Paimon splits. A single Paimon split (one partition × bucket) can contain multiple data files across LSM levels. PaimonSplitReader receives the full PaimonConnectorSplit, builds FileConnectorSplits internally, and handles sequential file iteration transparently — when a file is exhausted, it resets the base reader and advances to the next non-empty file. Deletion vectors and changelog files are validated upfront and throw VELOX_NYI.

**PaimonDataSource** (extends FileDataSource): Refactored to be a pure orchestrator. addSplit() validates the split and selects the read path (rawConvertible vs merge-on-read NYI). createSplitReader() simply passes the PaimonConnectorSplit to PaimonSplitReader. Does not override next() — FileDataSource::next() drives the read loop, getting filter eval, column projection, and stats tracking for free.

**PaimonMergeReader**: NYI placeholder for merge-on-read (primary-key tables with rawConvertible=false). Includes MergeEngine interface stub for future deduplicate/partial-update strategies.

Currently working: append-only and primary-key tables with rawConvertible=true, single and multi-file splits, partition keys.
NYI: deletion vectors, changelog files, merge-on-read, _rowkind column, streaming reads.

Reviewed By: xiaoxmeng

Differential Revision: D99660568


