### PR TITLE
feat(joins): Add nullAsValue flag for IS NOT DISTINCT FROM join key semantics (#17137)

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1674,11 +1674,15 @@ void HashJoinNode::addDetails(std::stringstream& stream) const {
   if (nullAware_) {
     stream << ", null aware";
   }
+  if (nullAsValue_) {
+    stream << ", null as value";
+  }
 }
 
 folly::dynamic HashJoinNode::serialize() const {
   auto obj = serializeBase();
   obj["nullAware"] = nullAware_;
+  obj["nullAsValue"] = nullAsValue_;
   obj["useHashTableCache"] = useHashTableCache_;
   return obj;
 }
@@ -1695,6 +1699,7 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
   VELOX_CHECK_EQ(2, sources.size());
 
   auto nullAware = obj["nullAware"].asBool();
+  auto nullAsValue = obj.getDefault("nullAsValue", false).asBool();
   auto useHashTableCache = obj.getDefault("useHashTableCache", false).asBool();
   auto leftKeys = deserializeFields(obj["leftKeys"], context);
   auto rightKeys = deserializeFields(obj["rightKeys"], context);
@@ -1716,7 +1721,8 @@ PlanNodePtr HashJoinNode::create(const folly::dynamic& obj, void* context) {
       sources[0],
       sources[1],
       outputType,
-      useHashTableCache);
+      useHashTableCache,
+      nullAsValue);
 }
 
 MergeJoinNode::MergeJoinNode(

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -3292,6 +3292,12 @@ class AbstractJoinNode : public PlanNode {
 /// EXISTS.
 class HashJoinNode : public AbstractJoinNode {
  public:
+  /// @param nullAware Applies to semi and anti joins only. When true, the
+  /// join semantic is IN / NOT IN (three-valued NULL logic). When false, the
+  /// join semantic is EXISTS / NOT EXISTS.
+  /// @param nullAsValue When true, join keys use IS NOT DISTINCT FROM
+  /// semantics where NULL equals NULL. Used to implement SQL set operations
+  /// (EXCEPT, INTERSECT). Mutually exclusive with nullAware.
   HashJoinNode(
       const PlanNodeId& id,
       JoinType joinType,
@@ -3302,7 +3308,8 @@ class HashJoinNode : public AbstractJoinNode {
       PlanNodePtr left,
       PlanNodePtr right,
       RowTypePtr outputType,
-      bool useHashTableCache = false)
+      bool useHashTableCache = false,
+      bool nullAsValue = false)
       : AbstractJoinNode(
             id,
             joinType,
@@ -3313,8 +3320,13 @@ class HashJoinNode : public AbstractJoinNode {
             std::move(right),
             std::move(outputType)),
         nullAware_{nullAware},
+        nullAsValue_{nullAsValue},
         useHashTableCache_{useHashTableCache} {
     validate();
+
+    VELOX_USER_CHECK(
+        !nullAware || !nullAsValue,
+        "nullAware and nullAsValue are mutually exclusive");
 
     if (isCountingJoin()) {
       VELOX_USER_CHECK(
@@ -3344,11 +3356,17 @@ class HashJoinNode : public AbstractJoinNode {
     explicit Builder(const HashJoinNode& other)
         : AbstractJoinNode::Builder<HashJoinNode, Builder>(other) {
       nullAware_ = other.isNullAware();
+      nullAsValue_ = other.isNullAsValue();
       useHashTableCache_ = other.useHashTableCache();
     }
 
     Builder& nullAware(bool value) {
       nullAware_ = value;
+      return *this;
+    }
+
+    Builder& nullAsValue(bool value) {
+      nullAsValue_ = value;
       return *this;
     }
 
@@ -3384,11 +3402,13 @@ class HashJoinNode : public AbstractJoinNode {
           left_.value(),
           right_.value(),
           outputType_.value(),
-          useHashTableCache_.value_or(false));
+          useHashTableCache_.value_or(false),
+          nullAsValue_.value_or(false));
     }
 
    private:
     std::optional<bool> nullAware_;
+    std::optional<bool> nullAsValue_;
     std::optional<bool> useHashTableCache_;
   };
 
@@ -3416,6 +3436,13 @@ class HashJoinNode : public AbstractJoinNode {
     return nullAware_;
   }
 
+  /// Returns true when join keys use IS NOT DISTINCT FROM semantics where
+  /// NULL equals NULL. Used to implement SQL set operations (EXCEPT,
+  /// INTERSECT).
+  bool isNullAsValue() const {
+    return nullAsValue_;
+  }
+
   /// Returns whether hash table caching is enabled for broadcast joins.
   /// Only used by Presto-on-Spark.
   bool useHashTableCache() const {
@@ -3430,6 +3457,7 @@ class HashJoinNode : public AbstractJoinNode {
   void addDetails(std::stringstream& stream) const override;
 
   const bool nullAware_;
+  const bool nullAsValue_;
   const bool useHashTableCache_;
 };
 

--- a/velox/core/tests/PlanNodeBuilderTest.cpp
+++ b/velox/core/tests/PlanNodeBuilderTest.cpp
@@ -671,6 +671,7 @@ TEST_F(PlanNodeBuilderTest, hashJoinNode) {
   const auto verify = [&](const std::shared_ptr<const HashJoinNode>& node) {
     EXPECT_EQ(node->id(), id);
     EXPECT_EQ(node->isNullAware(), nullAware);
+    EXPECT_FALSE(node->isNullAsValue());
     EXPECT_EQ(node->joinType(), joinType);
     EXPECT_EQ(node->leftKeys(), leftKeys);
     EXPECT_EQ(node->rightKeys(), rightKeys);

--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -6,8 +6,10 @@ Velox supports inner, left, right, full outer, left semi filter, left semi
 project, right semi filter, right semi project, anti, and counting hash joins
 using either partitioned or broadcast distribution strategies. Semi project and
 anti joins support additional null-aware flag to distinguish between IN
-(null aware) and EXISTS (regular) semantics. Counting joins implement EXCEPT ALL
-and INTERSECT ALL semantics. Velox also supports cross joins.
+(null aware) and EXISTS (regular) semantics. Anti, left semi filter, and
+counting joins support a null-as-value flag that enables IS NOT DISTINCT FROM
+semantics for join keys (NULL equals NULL), used to implement SQL set operations
+(EXCEPT, INTERSECT, EXCEPT ALL, INTERSECT ALL). Velox also supports cross joins.
 
 Velox also supports inner and left merge join for the case where join inputs are
 sorted on the join keys. Right, full, left semi, right semi, and anti merge joins
@@ -31,6 +33,12 @@ kAnti, or kCountingAnti.
 kLeftSemiProject, kRightSemiProject and kAnti joins support an additional
 nullAware flag to distinguish between IN (null aware) and EXISTS (regular)
 semantics. See :doc:`Anti joins <anti-join>` for detailed semantics.
+
+kAnti, kLeftSemiFilter, kCountingAnti, and kCountingLeftSemiFilter joins support
+an additional nullAsValue flag that makes join keys use IS NOT DISTINCT FROM
+semantics where NULL equals NULL. This is used to implement SQL set operations
+(EXCEPT, INTERSECT, EXCEPT ALL, INTERSECT ALL) which require NULLs to match.
+The nullAsValue and nullAware flags are mutually exclusive.
 
 Filter is optional. If specified it can be any expression over the results of
 the join. This expression will be evaluated using the same expression

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -549,6 +549,8 @@ and emitting results.
      - Join type: inner, left, right, full, left semi filter, left semi project, right semi filter, right semi project, anti. You can read about different join types in this `blog post <https://dataschool.com/how-to-teach-people-sql/sql-join-types-explained-visually/>`_.
    * - nullAware
      - Applies to anti and semi project joins only. Indicates whether the join semantic is IN (nullAware = true) or EXISTS (nullAware = false).
+   * - nullAsValue
+     - Optional. When true, join keys use IS NOT DISTINCT FROM semantics where NULL equals NULL. Used to implement SQL set operations (EXCEPT, INTERSECT, EXCEPT ALL, INTERSECT ALL). Mutually exclusive with nullAware.
    * - useHashTableCache
      - Optional. Used only by Presto-on-Spark. When true, enables caching of the hash table built for broadcast joins so that subsequent tasks can reuse it.
    * - leftKeys

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -64,6 +64,7 @@ HashBuild::HashBuild(
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
       nullAware_{joinNode_->isNullAware()},
+      nullAsValue_{joinNode_->isNullAsValue()},
       needProbedFlagSpill_{needRightSideJoin(joinType_)},
       dropDuplicates_(joinNode_->canDropDuplicates()),
       vectorHasherMaxNumDistinct_(
@@ -249,7 +250,7 @@ void HashBuild::setupTable() {
     // Right semi join needs to tag build rows that were probed.
     const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
     const bool hasCountFlag = joinNode_->isCountingJoin();
-    if (isLeftNullAwareJoinWithFilter(joinNode_)) {
+    if (nullAsValue_ || isLeftNullAwareJoinWithFilter(joinNode_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // or left semi project join with filter set.
       table_ = HashTable<false>::createForJoin(
@@ -452,7 +453,7 @@ void HashBuild::addInput(RowVectorPtr input) {
   }
 
   if (!isRightJoin(joinType_) && !isFullJoin(joinType_) &&
-      !isRightSemiProjectJoin(joinType_) &&
+      !isRightSemiProjectJoin(joinType_) && !nullAsValue_ &&
       !isLeftNullAwareJoinWithFilter(joinNode_)) {
     deselectRowsWithNulls(hashers, activeRows_);
     if (nullAware_ && !joinHasNullKeys_ &&

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -268,6 +268,8 @@ class HashBuild final : public Operator {
 
   const bool nullAware_;
 
+  const bool nullAsValue_;
+
   // Sets to true for join type which needs right side join processing. The hash
   // table spiller then needs to record the probed flag, and the spilled input
   // reader also needs to restore the recorded probed flag. This is used to

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -128,6 +128,7 @@ HashProbe::HashProbe(
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
       nullAware_{joinNode_->isNullAware()},
+      nullAsValue_{joinNode_->isNullAsValue()},
       probeType_(joinNode_->sources()[0]->outputType()),
       canOutputBuildRowsInParallel_(
           driverCtx->queryConfig().parallelOutputJoinBuildRowsEnabled() &&
@@ -690,7 +691,9 @@ void HashProbe::decodeAndDetectNonNullKeys() {
     hashers_[i]->decode(*key, nonNullInputRows_);
   }
 
-  deselectRowsWithNulls(hashers_, nonNullInputRows_);
+  if (!nullAsValue_) {
+    deselectRowsWithNulls(hashers_, nonNullInputRows_);
+  }
   if (isRightSemiProjectJoin(joinType_) &&
       nonNullInputRows_.countSelected() < input_->size()) {
     probeSideHasNullKeys_ = true;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -397,6 +397,8 @@ class HashProbe : public Operator {
 
   const bool nullAware_;
 
+  const bool nullAsValue_;
+
   const RowTypePtr probeType_;
 
   // Flag to indicate whether this hash probe operator can output build-side

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -429,7 +429,7 @@ void VectorHasher::lookupValueIdsTyped(
     return;
   }
 
-  if (decoded.isIdentityMapping()) {
+  if (decoded.isIdentityMapping() && !decoded.mayHaveNulls()) {
     if (Kind == TypeKind::BIGINT && isRange_) {
       lookupIdsRangeSimd<int64_t>(decoded, rows, result);
       rows.updateBounds();

--- a/velox/exec/tests/CountingJoinTest.cpp
+++ b/velox/exec/tests/CountingJoinTest.cpp
@@ -44,11 +44,12 @@ class CountingJoinTest : public OperatorTestBase {
                             .planNode(),
                         "",
                         {"c0"},
-                        joinType)
+                        joinType,
+                        /*nullAware=*/false,
+                        /*nullAsValue=*/true)
                     .planNode();
-    assertEqualResults(
-        {makeRowVector({makeFlatVector<int32_t>(expected)})},
-        {AssertQueryBuilder(plan).copyResults(pool())});
+    AssertQueryBuilder(plan).assertResults(
+        makeRowVector({makeFlatVector<int32_t>(expected)}));
   }
 };
 
@@ -128,11 +129,12 @@ TEST_F(CountingJoinTest, multipleProbeBatches) {
                 PlanBuilder(planNodeIdGenerator).values(buildVector).planNode(),
                 "",
                 {"c0"},
-                joinType)
+                joinType,
+                /*nullAware=*/false,
+                /*nullAsValue=*/true)
             .planNode();
-    assertEqualResults(
-        {makeRowVector({makeFlatVector<int32_t>(expected)})},
-        {AssertQueryBuilder(plan).copyResults(pool())});
+    AssertQueryBuilder(plan).assertResults(
+        makeRowVector({makeFlatVector<int32_t>(expected)}));
   };
 
   // Probe: {1:3, 2:3, 3:3}, Build: {1:1, 2:2, 3:1}
@@ -164,18 +166,20 @@ TEST_F(CountingJoinTest, multipleKeys) {
               PlanBuilder(planNodeIdGenerator).values(buildVector).planNode(),
               "",
               {"c0", "c1"},
-              core::JoinType::kCountingAnti)
+              core::JoinType::kCountingAnti,
+              /*nullAware=*/false,
+              /*nullAsValue=*/true)
           .planNode();
 
   auto expected = makeRowVector({
       makeFlatVector<int32_t>({1, 2}),
       makeFlatVector<int32_t>({20, 10}),
   });
-  assertEqualResults(
-      {expected}, {AssertQueryBuilder(plan).copyResults(pool())});
+  AssertQueryBuilder(plan).assertResults(expected);
 }
 
-// Null join keys never match anything (including other nulls).
+// Null join keys match each other with nullAsValue (IS NOT DISTINCT FROM
+// semantics), as required by SQL set operations (EXCEPT ALL, INTERSECT ALL).
 TEST_F(CountingJoinTest, nullKeys) {
   // Probe: {1, null, 1, null, 2}, Build: {1, null, 3}
   auto probeVector = makeRowVector(
@@ -185,31 +189,34 @@ TEST_F(CountingJoinTest, nullKeys) {
 
   auto test = [&](core::JoinType joinType,
                   const std::vector<std::optional<int32_t>>& expected) {
+    SCOPED_TRACE(core::JoinTypeName::toName(joinType));
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-    auto plan =
-        PlanBuilder(planNodeIdGenerator)
-            .values(probeVector)
-            .hashJoin(
-                {"c0"},
-                {"u0"},
-                PlanBuilder(planNodeIdGenerator).values(buildVector).planNode(),
-                "",
-                {"c0"},
-                joinType)
-            .planNode();
-    assertEqualResults(
-        {makeRowVector({makeNullableFlatVector<int32_t>(expected)})},
-        {AssertQueryBuilder(plan).copyResults(pool())});
+    auto plan = PlanBuilder(planNodeIdGenerator)
+                    .values({probeVector})
+                    .hashJoin(
+                        {"c0"},
+                        {"u0"},
+                        PlanBuilder(planNodeIdGenerator)
+                            .values({buildVector})
+                            .planNode(),
+                        "",
+                        {"c0"},
+                        joinType,
+                        /*nullAware=*/false,
+                        /*nullAsValue=*/true)
+                    .planNode();
+    AssertQueryBuilder(plan).assertResults(
+        makeRowVector({makeNullableFlatVector<int32_t>(expected)}));
   };
 
-  // EXCEPT ALL: non-null key 1 appears twice on probe and once on build, so one
-  // copy is removed. Key 2 has no build match. Null keys have no match and pass
-  // through.
-  test(core::JoinType::kCountingAnti, {1, std::nullopt, std::nullopt, 2});
+  // EXCEPT ALL: null keys match. Probe has 2 nulls, build has 1 null, so 1
+  // null passes through. Key 1 appears twice on probe, once on build, so 1
+  // copy passes through. Key 2 has no build match.
+  test(core::JoinType::kCountingAnti, {1, std::nullopt, 2});
 
-  // INTERSECT ALL: non-null key 1 appears twice on probe and once on build, so
-  // one copy is kept. Null keys have no match and are excluded.
-  test(core::JoinType::kCountingLeftSemiFilter, {1});
+  // INTERSECT ALL: null keys match. min(2, 1) = 1 null kept.
+  // Key 1: min(2, 1) = 1. Key 2: no match.
+  test(core::JoinType::kCountingLeftSemiFilter, {1, std::nullopt});
 }
 
 // Verifies that the build side deduplicates rows and stores only distinct keys.
@@ -233,7 +240,9 @@ TEST_F(CountingJoinTest, buildSideDedup) {
                           .planNode(),
                       "",
                       {"c0"},
-                      core::JoinType::kCountingAnti)
+                      core::JoinType::kCountingAnti,
+                      /*nullAware=*/false,
+                      /*nullAsValue=*/true)
                   .planNode();
 
   auto expected =
@@ -284,7 +293,9 @@ TEST_F(CountingJoinTest, multipleBuildDrivers) {
                             .planNode(),
                         "",
                         probeKeys,
-                        joinType)
+                        joinType,
+                        /*nullAware=*/false,
+                        /*nullAsValue=*/true)
                     .planNode();
     auto task = AssertQueryBuilder(plan)
                     .maxDrivers(kNumDrivers)

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -495,6 +495,75 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithNull) {
   }
 }
 
+// Verifies that nullAsValue flag makes NULL keys match each other in anti and
+// left semi filter joins, as required by SQL set operations (EXCEPT,
+// INTERSECT).
+TEST_P(MultiThreadedHashJoinTest, nullAsValueAntiJoin) {
+  // Probe: (1, null), (2, 3). Build: (1, null), (2, 4).
+  // With nullAsValue, (1, null) matches on both keys and is anti-joined away.
+  // (2, 3) does not match (2, 4) because 3 != 4, so it passes through.
+  auto probeVector = makeRowVector(
+      {"c0", "c1"},
+      {makeNullableFlatVector<int32_t>({1, 2}),
+       makeNullableFlatVector<int32_t>({std::nullopt, 3})});
+  auto buildVector = makeRowVector(
+      {"u0", "u1"},
+      {makeNullableFlatVector<int32_t>({1, 2}),
+       makeNullableFlatVector<int32_t>({std::nullopt, 4})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVector})
+          .hashJoin(
+              {"c0", "c1"},
+              {"u0", "u1"},
+              PlanBuilder(planNodeIdGenerator).values({buildVector}).planNode(),
+              "",
+              {"c0", "c1"},
+              core::JoinType::kAnti,
+              /*nullAware=*/false,
+              /*nullAsValue=*/true)
+          .planNode();
+  AssertQueryBuilder(plan).assertResults(makeRowVector(
+      {"c0", "c1"},
+      {makeNullableFlatVector<int32_t>({2}),
+       makeNullableFlatVector<int32_t>({3})}));
+}
+
+TEST_P(MultiThreadedHashJoinTest, nullAsValueSemiJoin) {
+  // Probe: (1, null), (2, 3). Build: (1, null), (2, 4).
+  // With nullAsValue, (1, null) matches and passes through semi join.
+  // (2, 3) does not match (2, 4), so it is filtered out.
+  auto probeVector = makeRowVector(
+      {"c0", "c1"},
+      {makeNullableFlatVector<int32_t>({1, 2}),
+       makeNullableFlatVector<int32_t>({std::nullopt, 3})});
+  auto buildVector = makeRowVector(
+      {"u0", "u1"},
+      {makeNullableFlatVector<int32_t>({1, 2}),
+       makeNullableFlatVector<int32_t>({std::nullopt, 4})});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probeVector})
+          .hashJoin(
+              {"c0", "c1"},
+              {"u0", "u1"},
+              PlanBuilder(planNodeIdGenerator).values({buildVector}).planNode(),
+              "",
+              {"c0", "c1"},
+              core::JoinType::kLeftSemiFilter,
+              /*nullAware=*/false,
+              /*nullAsValue=*/true)
+          .planNode();
+  AssertQueryBuilder(plan).assertResults(makeRowVector(
+      {"c0", "c1"},
+      {makeNullableFlatVector<int32_t>({1}),
+       makeNullableFlatVector<int32_t>({std::nullopt})}));
+}
+
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithLargeOutput) {
   // Build the identical left and right vectors to generate large join
   // outputs.

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -537,6 +537,22 @@ TEST_F(PlanNodeSerdeTest, hashJoin) {
              .planNode();
 
   testSerde(plan);
+
+  // nullAsValue join (used for EXCEPT/INTERSECT).
+  plan = PlanBuilder(planNodeIdGenerator)
+             .values({probe})
+             .hashJoin(
+                 {"t0"},
+                 {"u0"},
+                 PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+                 "",
+                 {"t0", "t1"},
+                 core::JoinType::kAnti,
+                 /*nullAware=*/false,
+                 /*nullAsValue=*/true)
+             .planNode();
+
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, topN) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -413,6 +413,28 @@ TEST_F(PlanNodeToStringTest, hashJoin) {
   ASSERT_EQ(
       "-- HashJoin[2][ANTI t_c0=u_c0] -> t_c0:SMALLINT, t_c1:INTEGER\n",
       plan->toString(true, false));
+
+  plan = PlanBuilder()
+             .values({data_})
+             .project({"c0 as t_c0", "c1 as t_c1"})
+             .hashJoin(
+                 {"t_c0"},
+                 {"u_c0"},
+                 PlanBuilder()
+                     .values({data_})
+                     .project({"c0 as u_c0", "c1 as u_c1"})
+                     .planNode(),
+                 "",
+                 {"t_c0", "t_c1"},
+                 core::JoinType::kAnti,
+                 false /*nullAware*/,
+                 true /*nullAsValue*/)
+             .planNode();
+
+  ASSERT_EQ("-- HashJoin[2]\n", plan->toString());
+  ASSERT_EQ(
+      "-- HashJoin[2][ANTI t_c0=u_c0, null as value] -> t_c0:SMALLINT, t_c1:INTEGER\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, mergeJoin) {

--- a/velox/exec/tests/utils/HashJoinTestBase.h
+++ b/velox/exec/tests/utils/HashJoinTestBase.h
@@ -400,6 +400,11 @@ class HashJoinBuilder {
     return *this;
   }
 
+  HashJoinBuilder& nullAsValue(bool nullAsValue) {
+    nullAsValue_ = nullAsValue;
+    return *this;
+  }
+
   HashJoinBuilder& joinFilter(const std::string& joinFilter) {
     joinFilter_ = joinFilter;
     return *this;
@@ -566,7 +571,8 @@ class HashJoinBuilder {
                   joinFilter_,
                   joinOutputLayout_,
                   joinType_,
-                  nullAware_)
+                  nullAware_,
+                  nullAsValue_)
               .capturePlanNode<core::HashJoinNode>(joinNode)
               .optionalProject(outputProjections_)
               .planNode();
@@ -804,6 +810,7 @@ class HashJoinBuilder {
   int32_t numDrivers_{1};
   core::JoinType joinType_{core::JoinType::kInner};
   bool nullAware_{false};
+  bool nullAsValue_{false};
   std::string referenceQuery_;
 
   RowTypePtr probeType_;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1729,7 +1729,8 @@ PlanBuilder& PlanBuilder::hashJoin(
     const std::string& filter,
     const std::vector<std::string>& outputLayout,
     core::JoinType joinType,
-    bool nullAware) {
+    bool nullAware,
+    bool nullAsValue) {
   VELOX_CHECK_NOT_NULL(planNode_, "HashJoin cannot be the source node");
   VELOX_CHECK_EQ(leftKeys.size(), rightKeys.size());
 
@@ -1770,7 +1771,9 @@ PlanBuilder& PlanBuilder::hashJoin(
       std::move(filterExpr),
       std::move(planNode_),
       build,
-      outputType);
+      outputType,
+      /*useHashTableCache=*/false,
+      nullAsValue);
   VELOX_CHECK(!planNode_->supportsBarrier());
   return *this;
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -1304,7 +1304,8 @@ class PlanBuilder {
       const std::string& filter,
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner,
-      bool nullAware = false);
+      bool nullAware = false,
+      bool nullAsValue = false);
 
   /// Add a MergeJoinNode to join two inputs using one or more join keys and an
   /// optional filter. The caller is responsible to ensure that inputs are


### PR DESCRIPTION
Summary:

Add a `nullAsValue` boolean flag to `HashJoinNode` that makes join keys use IS NOT DISTINCT FROM semantics where NULL equals NULL. This is different from the existing `nullAware` flag which implements IN/NOT IN three-valued logic. The two flags are mutually exclusive.

When `nullAsValue` is true:
- HashBuild stores rows with NULL keys in the hash table (uses `HashTable<false>`)
- HashBuild does not filter out NULL key rows during `addInput`
- HashProbe does not filter out NULL key rows during probe

The hash table comparison logic (`HashTable<false>::compareKeys`) already treats NULLs as equal values via `CompareFlags::NullHandlingMode::kNullAsValue`, so no changes are needed in the comparison path.

This flag is needed to correctly implement SQL set operations (EXCEPT, INTERSECT, EXCEPT ALL, INTERSECT ALL) which require NULL=NULL per the SQL standard.

Part of https://github.com/facebookincubator/axiom/issues/1235

Differential Revision: D100545193


