### PR TITLE
feat: Add isPointLookup() to EncodedKeyBounds (#17138)

### DIFF
--- a/velox/serializers/KeyEncoder.h
+++ b/velox/serializers/KeyEncoder.h
@@ -92,6 +92,13 @@ struct EncodedKeyBounds {
   /// (inclusive or exclusive based on IndexBound.inclusive).
   std::optional<std::string> upperKey;
 
+  /// Returns true if this represents a point lookup (both bounds present and
+  /// equal).
+  bool isPointLookup() const {
+    return lowerKey.has_value() && upperKey.has_value() &&
+        lowerKey.value() == upperKey.value();
+  }
+
   /// Returns a human-readable string representation with hex-encoded keys.
   std::string toString() const;
 };

--- a/velox/serializers/tests/KeyEncoderTest.cpp
+++ b/velox/serializers/tests/KeyEncoderTest.cpp
@@ -10894,6 +10894,44 @@ TEST_F(KeyEncoderTest, encodedKeyBoundsToString) {
     EXPECT_EQ(str, "EncodedKeyBounds{lowerKey=, upperKey=}");
   }
 }
+TEST(EncodedKeyBoundsTest, isPointLookup) {
+  struct TestCase {
+    std::optional<std::string> lowerKey;
+    std::optional<std::string> upperKey;
+    bool expected;
+
+    std::string debugString() const {
+      auto keyStr = [](const std::optional<std::string>& key) -> std::string {
+        return key.has_value() ? fmt::format("\"{}\"", key.value()) : "nullopt";
+      };
+      return fmt::format(
+          "lowerKey={}, upperKey={}, expected={}",
+          keyStr(lowerKey),
+          keyStr(upperKey),
+          expected);
+    }
+  };
+
+  const std::vector<TestCase> testCases = {
+      {"abc", "abc", true},
+      {"abc", "def", false},
+      {"abc", std::nullopt, false},
+      {std::nullopt, "abc", false},
+      {std::nullopt, std::nullopt, false},
+      {"", "", true},
+      {std::string("\x00\xFF", 2), std::string("\x00\xFF", 2), true},
+      {std::string("\x00\xFF", 2), std::string("\x00\xFE", 2), false},
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.debugString());
+    EncodedKeyBounds bounds;
+    bounds.lowerKey = testCase.lowerKey;
+    bounds.upperKey = testCase.upperKey;
+    EXPECT_EQ(bounds.isPointLookup(), testCase.expected);
+  }
+}
+
 } // namespace facebook::velox::serializer::test
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:

CONTEXT: Index lookup needs to distinguish between point lookups
(exact key match) and range lookups (lower/upper bounds). Dense index
only supports point lookups while cluster index supports both.

WHAT: Add isPointLookup() method to EncodedKeyBounds that returns
true when both bounds are present and equal. Add unit test coverage.

Reviewed By: tanjialiang, han-yan01

Differential Revision: D100556652


