### PR TITLE
feat: Exclude index source from grouped execution leaf validation (#17139)

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -130,6 +130,25 @@ inline size_t numSourceNodes(const core::PlanNode* planNode) {
   return !indexNode->needsIndexSplit() ? 1 : indexNode->sources().size();
 }
 
+// Collects IDs of IndexLookupJoinNode's lookup source (index) TableScanNodes.
+// These nodes are NOT separate pipeline leaves in Velox's LocalPlanner
+// (it only plans the probe source) and must be excluded from
+// groupedExecutionLeafNodeIds validation.
+void collectIndexSourceIds(
+    const core::PlanNodePtr& node,
+    std::unordered_set<core::PlanNodeId>& indexSourceIds) {
+  if (auto indexJoin =
+          std::dynamic_pointer_cast<const core::IndexLookupJoinNode>(node)) {
+    indexSourceIds.insert(indexJoin->lookupSource()->id());
+    // Only recurse into the probe side (sources()[0]), not the lookup source.
+    collectIndexSourceIds(indexJoin->sources()[0], indexSourceIds);
+    return;
+  }
+  for (const auto& source : node->sources()) {
+    collectIndexSourceIds(source, indexSourceIds);
+  }
+}
+
 // Add 'running time' metrics from CpuWallTiming structures to have them
 // available aggregated per thread.
 void addRunningTimeOperatorMetrics(exec::OperatorStats& op) {
@@ -1262,9 +1281,20 @@ void Task::validateGroupedExecutionLeafNodes() {
         !planFragment_.groupedExecutionLeafNodeIds.empty(),
         "groupedExecutionLeafNodeIds must not be empty in "
         "grouped execution mode");
+
+    // Collect IndexLookupJoin lookup source node IDs. These are in
+    // groupedExecutionLeafNodeIds (for coordinator-side grouped split
+    // scheduling) but are NOT separate pipeline leaves in Velox —
+    // IndexLookupJoin manages the index source internally.
+    std::unordered_set<core::PlanNodeId> indexSourceIds;
+    collectIndexSourceIds(planFragment_.planNode, indexSourceIds);
+
     // Check that each node designated as the grouped execution leaf node
     // existing in a pipeline that will run grouped execution.
     for (const auto& leafNodeId : planFragment_.groupedExecutionLeafNodeIds) {
+      if (indexSourceIds.count(leafNodeId)) {
+        continue;
+      }
       bool found{false};
       for (auto& factory : driverFactories_) {
         if (leafNodeId == factory->leafNodeId()) {

--- a/velox/exec/tests/IndexLookupJoinTestExtra.cpp
+++ b/velox/exec/tests/IndexLookupJoinTestExtra.cpp
@@ -1928,6 +1928,7 @@ TEST_P(IndexLookupJoinTest, groupedExecution) {
 
     plan.executionStrategy = core::ExecutionStrategy::kGrouped;
     plan.groupedExecutionLeafNodeIds.emplace(probeScanNodeId_);
+    plan.groupedExecutionLeafNodeIds.emplace(indexScanNodeId_);
     plan.numSplitGroups = numSplitGroups;
 
     auto queryCtx = core::QueryCtx::create(executor_.get());
@@ -1937,7 +1938,7 @@ TEST_P(IndexLookupJoinTest, groupedExecution) {
     queryCtx->testingOverrideConfigUnsafe(std::move(configs));
 
     auto task = exec::Task::create(
-        "grouped-index-lookup-join",
+        fmt::format("grouped-index-lookup-join-{}", joinType),
         std::move(plan),
         0,
         std::move(queryCtx),
@@ -1980,6 +1981,60 @@ TEST_P(IndexLookupJoinTest, groupedExecution) {
     ASSERT_EQ(
         taskStats.at(joinNodeId_).numDrivers, numDrivers * numSplitGroups);
   }
+}
+
+// Verifies that grouped execution leaf validation passes when the index
+// source node ID is in groupedExecutionLeafNodeIds. Without the validation
+// exclusion in collectIndexLookupSourceIds, Task::start() would reject the
+// plan because it cannot find the index source node in any driver factory.
+TEST_P(IndexLookupJoinTest, groupedExecutionLeafValidation) {
+  if (GetParam().serialExecution) {
+    return;
+  }
+
+  const auto indexTableHandle = makeIndexTableHandle(
+      nullptr, GetParam().asyncLookup, GetParam().needsIndexSplit);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  const auto indexScanNode = makeIndexScanNode(
+      planNodeIdGenerator,
+      indexTableHandle,
+      makeScanOutputType({"u0", "u1", "u2", "u3", "u5"}),
+      makeIndexColumnHandles({"u0", "u1", "u2", "u3", "u5"}));
+
+  auto outputLayout = std::vector<std::string>{"u3", "t5"};
+  auto plan = PlanBuilder(planNodeIdGenerator, pool())
+                  .tableScan(probeType_)
+                  .capturePlanNodeId(probeScanNodeId_)
+                  .startIndexLookupJoin()
+                  .leftKeys({"t0", "t1", "t2"})
+                  .rightKeys({"u0", "u1", "u2"})
+                  .indexSource(indexScanNode)
+                  .outputLayout(outputLayout)
+                  .joinType(core::JoinType::kInner)
+                  .endIndexLookupJoin()
+                  .capturePlanNodeId(joinNodeId_)
+                  .partitionedOutput({}, 1, outputLayout)
+                  .planFragment();
+
+  plan.executionStrategy = core::ExecutionStrategy::kGrouped;
+  plan.groupedExecutionLeafNodeIds.emplace(probeScanNodeId_);
+  plan.groupedExecutionLeafNodeIds.emplace(indexScanNodeId_);
+  plan.numSplitGroups = 1;
+
+  auto queryCtx = core::QueryCtx::create(executor_.get());
+  auto task = exec::Task::create(
+      "grouped-execution-leaf-validation",
+      std::move(plan),
+      0,
+      std::move(queryCtx),
+      Task::ExecutionMode::kParallel);
+
+  // Task::start() runs validateGroupedExecutionLeafNodes which would throw
+  // if the index source node ID is not excluded from validation.
+  ASSERT_NO_THROW(task->start(1));
+
+  task->requestAbort().wait();
+  ASSERT_TRUE(waitForTaskAborted(task.get()));
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

When IndexLookupJoin has `needsIndexSplit=true`, its index TableScan node ID is included in `groupedExecutionLeafNodeIds` for coordinator-side split scheduling. However, this node is NOT a separate pipeline leaf in Velox — IndexLookupJoin manages the index source internally. Without this change, `validateGroupedExecutionLeafNodes` rejects the plan because it cannot find the index source node ID in any driver factory.

Add `collectIndexLookupSourceIds` to collect index lookup source node IDs and skip them during leaf validation. Fix `noMoreSplitsForGroup` to handle missing split stores (creates a store with noMoreSplits already set). Fix `getSplitOrFuture` to propagate global `noMoreSplits` to newly created per-group stores.

Reviewed By: xiaoxmeng

Differential Revision: D100372349
