### PR TITLE
perf: Replace sort-based map_concat dedup with hash-based mapConcat (#17142)

### DIFF
--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -16,15 +16,17 @@
 #include "velox/functions/lib/MapConcat.h"
 #include "velox/expression/DecodedArgs.h"
 #include "velox/expression/VectorFunction.h"
-#include "velox/vector/TypeAliases.h"
+#include "velox/vector/MapConcat.h"
 
 namespace facebook::velox::functions {
 namespace {
 
 // See documentation at https://prestodb.io/docs/current/functions/map.html
-template <bool EmptyForNull, bool AllowSingleArg>
 class MapConcatFunction : public exec::VectorFunction {
  public:
+  MapConcatFunction(bool emptyForNull, bool allowSingleArg)
+      : emptyForNull_(emptyForNull), allowSingleArg_(allowSingleArg) {}
+
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -39,135 +41,55 @@ class MapConcatFunction : public exec::VectorFunction {
     }
     VELOX_CHECK(mapType->kindEquals(outputType));
 
-    const size_t numArgs = args.size();
-    if constexpr (!AllowSingleArg) {
+    const auto numArgs = static_cast<int>(args.size());
+    if (!allowSingleArg_) {
       VELOX_CHECK_GE(numArgs, 2);
     }
 
     exec::DecodedArgs decodedArgs(rows, args, context);
-    vector_size_t maxSize = 0;
-    for (int i = 0; i < numArgs; i++) {
-      const DecodedVector* decodedArg = decodedArgs.at(i);
-      const MapVector* inputMap = decodedArg->base()->as<MapVector>();
-      const vector_size_t* rawSizes = inputMap->rawSizes();
-      rows.applyToSelected([&](vector_size_t row) {
-        if (EmptyForNull && decodedArg->isNullAt(row)) {
-          return;
-        }
-        maxSize += rawSizes[decodedArg->index(row)];
-      });
-    }
 
-    const TypePtr& keyType = outputType->asMap().keyType();
-    const TypePtr& valueType = outputType->asMap().valueType();
-
-    memory::MemoryPool* pool = context.pool();
-    auto combinedKeys = BaseVector::create(keyType, maxSize, pool);
-    auto combinedValues = BaseVector::create(valueType, maxSize, pool);
-
-    // Initialize offsets and sizes to 0 so that canonicalize() will
-    // work also for sparse 'rows'.
-    BufferPtr offsets = allocateOffsets(rows.end(), pool);
-    int* rawOffsets = offsets->asMutable<vector_size_t>();
-
-    BufferPtr sizes = allocateSizes(rows.end(), pool);
-    int* rawSizes = sizes->asMutable<vector_size_t>();
-
-    vector_size_t offset = 0;
-    rows.applyToSelected([&](vector_size_t row) {
-      rawOffsets[row] = offset;
-      // Reuse the last offset and size if null key must create empty map
-      for (int i = 0; i < numArgs; i++) {
-        const DecodedVector* decodedArg = decodedArgs.at(i);
-        if (EmptyForNull && decodedArg->isNullAt(row)) {
-          continue; // Treat NULL maps as empty.
-        }
-        const MapVector* inputMap = decodedArg->base()->as<MapVector>();
-        const vector_size_t index = decodedArg->index(row);
-        const vector_size_t inputOffset = inputMap->offsetAt(index);
-        const vector_size_t inputSize = inputMap->sizeAt(index);
-        combinedKeys->copy(
-            inputMap->mapKeys().get(), offset, inputOffset, inputSize);
-        combinedValues->copy(
-            inputMap->mapValues().get(), offset, inputOffset, inputSize);
-        offset += inputSize;
+    // UNKNOWN key type means all maps must be empty.
+    if (outputType->asMap().keyType()->kind() == TypeKind::UNKNOWN) {
+      for (auto i = 0; i < numArgs; ++i) {
+        auto* decoded = decodedArgs.at(i);
+        auto* map = decoded->base()->as<MapVector>();
+        rows.applyToSelected([&](vector_size_t row) {
+          VELOX_CHECK_EQ(
+              map->sizeAt(decoded->index(row)),
+              0,
+              "Map with UNKNOWN key type must be empty");
+        });
       }
-      rawSizes[row] = offset - rawOffsets[row];
-    });
-
-    auto combinedMap = std::make_shared<MapVector>(
-        pool,
-        outputType,
-        BufferPtr(nullptr),
-        rows.end(),
-        offsets,
-        sizes,
-        combinedKeys,
-        combinedValues);
-
-    MapVector::canonicalize(combinedMap, true);
-
-    combinedKeys = combinedMap->mapKeys();
-    combinedValues = combinedMap->mapValues();
-
-    // Check for duplicate keys
-    SelectivityVector uniqueKeys(offset);
-    vector_size_t duplicateCnt = 0;
-    bool throwExceptionOnDuplicateMapKeys = false;
-    if (auto* ctx = context.execCtx()->queryCtx()) {
-      throwExceptionOnDuplicateMapKeys =
-          ctx->queryConfig().throwExceptionOnDuplicateMapKeys();
-    }
-    rows.applyToSelected([&](vector_size_t row) {
-      const int mapOffset = rawOffsets[row];
-      const int mapSize = rawSizes[row];
-      if (duplicateCnt) {
-        rawOffsets[row] -= duplicateCnt;
-      }
-      for (vector_size_t i = 1; i < mapSize; i++) {
-        if (combinedKeys->equalValueAt(
-                combinedKeys.get(), mapOffset + i, mapOffset + i - 1)) {
-          if (throwExceptionOnDuplicateMapKeys) {
-            const auto duplicateKey = combinedKeys->wrappedVector()->toString(
-                combinedKeys->wrappedIndex(mapOffset + i));
-            VELOX_USER_FAIL("Duplicate map key {} was found.", duplicateKey);
-          }
-          duplicateCnt++;
-          // "remove" duplicate entry
-          uniqueKeys.setValid(mapOffset + i - 1, false);
-          rawSizes[row]--;
-        }
-      }
-    });
-
-    if (duplicateCnt) {
-      uniqueKeys.updateBounds();
-      const vector_size_t uniqueCount = uniqueKeys.countSelected();
-
-      BufferPtr uniqueIndices = allocateIndices(uniqueCount, pool);
-      vector_size_t* rawUniqueIndices =
-          uniqueIndices->asMutable<vector_size_t>();
-      vector_size_t index = 0;
-      uniqueKeys.applyToSelected(
-          [&](vector_size_t row) { rawUniqueIndices[index++] = row; });
-
-      VectorPtr keys =
-          BaseVector::transpose(uniqueIndices, std::move(combinedKeys));
-      VectorPtr values =
-          BaseVector::transpose(uniqueIndices, std::move(combinedValues));
-
-      combinedMap = std::make_shared<MapVector>(
-          pool,
+      auto emptyMap = std::make_shared<MapVector>(
+          context.pool(),
           outputType,
           BufferPtr(nullptr),
-          rows.end(),
-          offsets,
-          sizes,
-          std::move(keys),
-          std::move(values));
+          1,
+          allocateOffsets(1, context.pool()),
+          allocateSizes(1, context.pool()),
+          BaseVector::create(outputType->asMap().keyType(), 0, context.pool()),
+          BaseVector::create(
+              outputType->asMap().valueType(), 0, context.pool()));
+      auto constant = BaseVector::wrapInConstant(rows.end(), 0, emptyMap);
+      context.moveOrCopyResult(constant, rows, result);
+      return;
     }
 
-    context.moveOrCopyResult(combinedMap, rows, result);
+    std::vector<DecodedVector*> inputs;
+    inputs.reserve(numArgs);
+    for (auto i = 0; i < numArgs; ++i) {
+      inputs.push_back(decodedArgs.at(i));
+    }
+
+    MapConcatConfig config;
+    config.emptyForNull = emptyForNull_;
+    if (auto* ctx = context.execCtx()->queryCtx()) {
+      config.throwOnDuplicateKeys =
+          ctx->queryConfig().throwExceptionOnDuplicateMapKeys();
+    }
+
+    auto merged = mapConcat(context.pool(), outputType, inputs, rows, config);
+    context.moveOrCopyResult(merged, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -180,37 +102,39 @@ class MapConcatFunction : public exec::VectorFunction {
                 .variableArity("map(K,V)")
                 .build()};
   }
+
+ private:
+  // When true, treat null map inputs as empty maps rather than propagating
+  // null.
+  const bool emptyForNull_;
+
+  // When true, allow a single map argument (Spark semantics).
+  const bool allowSingleArg_;
 };
 } // namespace
 
 void registerMapConcatFunction(const std::string& name) {
   exec::registerVectorFunction(
       name,
-      MapConcatFunction</*EmptyForNull=*/false,
-                        /*AllowSingleArg=*/false>::signatures(),
-      std::make_unique<MapConcatFunction<
-          /*EmptyForNull=*/false,
-          /*AllowSingleArg=*/false>>());
+      MapConcatFunction::signatures(),
+      std::make_unique<MapConcatFunction>(
+          /*emptyForNull=*/false, /*allowSingleArg=*/false));
 }
 
 void registerMapConcatAllowSingleArg(const std::string& name) {
   exec::registerVectorFunction(
       name,
-      MapConcatFunction</*EmptyForNull=*/false,
-                        /*AllowSingleArg=*/true>::signatures(),
-      std::make_unique<MapConcatFunction<
-          /*EmptyForNull=*/false,
-          /*AllowSingleArg=*/true>>());
+      MapConcatFunction::signatures(),
+      std::make_unique<MapConcatFunction>(
+          /*emptyForNull=*/false, /*allowSingleArg=*/true));
 }
 
 void registerMapConcatEmptyNullsFunction(const std::string& name) {
   exec::registerVectorFunction(
       name,
-      MapConcatFunction</*EmptyForNull=*/true,
-                        /*AllowSingleArg=*/false>::signatures(),
-      std::make_unique<MapConcatFunction<
-          /*EmptyForNull=*/true,
-          /*AllowSingleArg=*/false>>(),
+      MapConcatFunction::signatures(),
+      std::make_unique<MapConcatFunction>(
+          /*emptyForNull=*/true, /*allowSingleArg=*/false),
       exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build());
 }
 } // namespace facebook::velox::functions

--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -21,6 +21,7 @@ velox_add_library(
   FlatMapVector.cpp
   FlatVector.cpp
   LazyVector.cpp
+  MapConcat.cpp
   SelectivityVector.cpp
   SequenceVector.cpp
   SimpleVector.cpp
@@ -50,6 +51,7 @@ velox_add_library(
   FlatVector.h
   FunctionVector.h
   LazyVector.h
+  MapConcat.h
   NullsBuilder.h
   SelectivityVector.h
   SequenceVector-inl.h

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -24,6 +24,7 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatMapVector.h"
 #include "velox/vector/LazyVector.h"
+#include "velox/vector/MapConcat.h"
 #include "velox/vector/SimpleVector.h"
 
 namespace facebook::velox {
@@ -1600,203 +1601,20 @@ void MapVector::copyRanges(
   copyRangesImpl(source, ranges, &values_, &keys_);
 }
 
-namespace {
-
-struct UpdateSource {
-  vector_size_t entryIndex;
-  int8_t sourceIndex;
-};
-
-template <typename T>
-class UpdateMapRow {
- public:
-  void insert(
-      const DecodedVector* decoded,
-      vector_size_t entryIndex,
-      int8_t sourceIndex) {
-    values_[decoded->valueAt<T>(entryIndex)] = {entryIndex, sourceIndex};
-  }
-
-  template <typename F>
-  void forEachEntry(F&& func) {
-    for (auto& [_, source] : values_) {
-      func(source);
-    }
-  }
-
-  void clear() {
-    values_.clear();
-  }
-
- private:
-  folly::F14FastMap<T, UpdateSource> values_;
-};
-
-template <>
-class UpdateMapRow<void> {
- public:
-  void insert(
-      const DecodedVector* decoded,
-      vector_size_t entryIndex,
-      int8_t sourceIndex) {
-    references_[{decoded->base(), decoded->index(entryIndex)}] = {
-        entryIndex, sourceIndex};
-  }
-
-  template <typename F>
-  void forEachEntry(F&& func) {
-    for (auto& [_, source] : references_) {
-      func(source);
-    }
-  }
-
-  void clear() {
-    references_.clear();
-  }
-
- private:
-  struct Reference {
-    const BaseVector* base;
-    vector_size_t index;
-
-    bool operator==(const Reference& other) const {
-      return base->equalValueAt(other.base, index, other.index);
-    }
-  };
-
-  struct ReferenceHasher {
-    uint64_t operator()(const Reference& key) const {
-      return key.base->hashValueAt(key.index);
-    }
-  };
-
-  folly::F14FastMap<Reference, UpdateSource, ReferenceHasher> references_;
-};
-
-} // namespace
-
-template <TypeKind kKeyTypeKind>
-MapVectorPtr MapVector::updateImpl(
-    const folly::Range<DecodedVector*>& others) const {
-  auto newNulls = nulls();
-  for (auto& other : others) {
-    if (!other.nulls()) {
-      continue;
-    }
-    if (newNulls.get() == nulls().get()) {
-      newNulls = allocateNulls(size(), pool());
-      if (!rawNulls()) {
-        bits::copyBits(
-            other.nulls(), 0, newNulls->asMutable<uint64_t>(), 0, size());
-      } else {
-        bits::andBits(
-            newNulls->asMutable<uint64_t>(),
-            rawNulls(),
-            other.nulls(),
-            0,
-            size());
-      }
-    } else {
-      bits::andBits(newNulls->asMutable<uint64_t>(), other.nulls(), 0, size());
-    }
-  }
-
-  auto newOffsets = allocateIndices(size(), pool());
-  auto* rawNewOffsets = newOffsets->asMutable<vector_size_t>();
-  auto newSizes = allocateIndices(size(), pool());
-  auto* rawNewSizes = newSizes->asMutable<vector_size_t>();
-
-  std::vector<DecodedVector> keys;
-  keys.reserve(1 + others.size());
-  keys.emplace_back(*keys_);
-  for (auto& other : others) {
-    auto& otherKeys = other.base()->asChecked<MapVector>()->keys_;
-    VELOX_CHECK(*keys_->type() == *otherKeys->type());
-    keys.emplace_back(*otherKeys);
-  }
-  std::vector<std::vector<BaseVector::CopyRange>> ranges(1 + others.size());
-
-  // Subscript symbols in this function:
-  //
-  // i, ii : Top level row index.  `ii' is the index into other base at i.
-  // j, jj : Key/value vector index.  `jj' is the offset version of `j'.
-  // k : Index into `others' and `ranges' for choosing a map vector.
-  UpdateMapRow<typename TypeTraits<kKeyTypeKind>::NativeType> mapRow;
-  vector_size_t numEntries = 0;
-  for (vector_size_t i = 0; i < size(); ++i) {
-    rawNewOffsets[i] = numEntries;
-    if (newNulls && bits::isBitNull(newNulls->as<uint64_t>(), i)) {
-      rawNewSizes[i] = 0;
-      continue;
-    }
-    bool needUpdate = false;
-    for (auto& other : others) {
-      auto ii = other.index(i);
-      if (other.base()->asUnchecked<MapVector>()->sizeAt(ii) > 0) {
-        needUpdate = true;
-        break;
-      }
-    }
-    if (!needUpdate) {
-      // Fast path for no update on current row.
-      rawNewSizes[i] = sizeAt(i);
-      if (sizeAt(i) > 0) {
-        ranges[0].push_back({offsetAt(i), numEntries, sizeAt(i)});
-        numEntries += sizeAt(i);
-      }
-      continue;
-    }
-    for (int k = 0; k < keys.size(); ++k) {
-      auto* vector =
-          k == 0 ? this : others[k - 1].base()->asUnchecked<MapVector>();
-      auto ii = k == 0 ? i : others[k - 1].index(i);
-      auto offset = vector->offsetAt(ii);
-      auto size = vector->sizeAt(ii);
-      for (vector_size_t j = 0; j < size; ++j) {
-        auto jj = offset + j;
-        VELOX_CHECK(!keys[k].isNullAt(jj), "Map key cannot be null");
-        mapRow.insert(&keys[k], jj, k);
-      }
-    }
-    vector_size_t newSize = 0;
-    mapRow.forEachEntry([&](UpdateSource source) {
-      ranges[source.sourceIndex].push_back(
-          {source.entryIndex, numEntries + newSize, 1});
-      ++newSize;
-    });
-    mapRow.clear();
-    rawNewSizes[i] = newSize;
-    numEntries += newSize;
-  }
-
-  auto newKeys = BaseVector::create(mapKeys()->type(), numEntries, pool());
-  auto newValues = BaseVector::create(mapValues()->type(), numEntries, pool());
-  for (int k = 0; k < ranges.size(); ++k) {
-    auto* vector =
-        k == 0 ? this : others[k - 1].base()->asUnchecked<MapVector>();
-    newKeys->copyRanges(vector->mapKeys().get(), ranges[k]);
-    newValues->copyRanges(vector->mapValues().get(), ranges[k]);
-  }
-
-  return std::make_shared<MapVector>(
-      pool(),
-      type(),
-      std::move(newNulls),
-      size(),
-      std::move(newOffsets),
-      std::move(newSizes),
-      std::move(newKeys),
-      std::move(newValues));
-}
-
 MapVectorPtr MapVector::update(
     const folly::Range<DecodedVector*>& others) const {
-  VELOX_CHECK(!others.empty());
-  VELOX_CHECK_LT(others.size(), std::numeric_limits<int8_t>::max());
   for (auto& other : others) {
     VELOX_CHECK_EQ(size(), other.size());
   }
-  return VELOX_DYNAMIC_TYPE_DISPATCH(updateImpl, keys_->typeKind(), others);
+  DecodedVector decodedSelf(static_cast<const BaseVector&>(*this));
+  std::vector<DecodedVector*> inputs;
+  inputs.reserve(1 + others.size());
+  inputs.push_back(&decodedSelf);
+  for (auto& other : others) {
+    inputs.push_back(&other);
+  }
+  SelectivityVector allRows(size(), true);
+  return mapConcat(pool(), type(), inputs, allRows, {});
 }
 
 MapVectorPtr MapVector::update(const std::vector<MapVectorPtr>& others) const {

--- a/velox/vector/MapConcat.cpp
+++ b/velox/vector/MapConcat.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/MapConcat.h"
+
+#include <folly/container/F14Map.h>
+
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox {
+namespace {
+
+struct UpdateSource {
+  vector_size_t entryIndex;
+  int8_t sourceIndex;
+};
+
+template <typename T>
+class UpdateMapRow {
+ public:
+  // Returns true if the key was newly inserted, false if it overwrote an
+  // existing entry.
+  bool insert(
+      const DecodedVector* decoded,
+      vector_size_t entryIndex,
+      int8_t sourceIndex) {
+    auto [iter, inserted] = values_.insert_or_assign(
+        decoded->valueAt<T>(entryIndex), UpdateSource{entryIndex, sourceIndex});
+    return inserted;
+  }
+
+  template <typename F>
+  void forEachEntry(F&& func) {
+    for (auto& [_, source] : values_) {
+      func(source);
+    }
+  }
+
+  size_t size() const {
+    return values_.size();
+  }
+
+  void reserve(size_t capacity) {
+    values_.reserve(capacity);
+  }
+
+  void clear() {
+    values_.clear();
+  }
+
+ private:
+  folly::F14FastMap<T, UpdateSource> values_;
+};
+
+template <>
+class UpdateMapRow<void> {
+ public:
+  bool insert(
+      const DecodedVector* decoded,
+      vector_size_t entryIndex,
+      int8_t sourceIndex) {
+    auto [iter, inserted] = references_.insert_or_assign(
+        Reference{decoded->base(), decoded->index(entryIndex)},
+        UpdateSource{entryIndex, sourceIndex});
+    return inserted;
+  }
+
+  template <typename F>
+  void forEachEntry(F&& func) {
+    for (auto& [_, source] : references_) {
+      func(source);
+    }
+  }
+
+  size_t size() const {
+    return references_.size();
+  }
+
+  void reserve(size_t capacity) {
+    references_.reserve(capacity);
+  }
+
+  void clear() {
+    references_.clear();
+  }
+
+ private:
+  struct Reference {
+    const BaseVector* base;
+    vector_size_t index;
+
+    bool operator==(const Reference& other) const {
+      return base->equalValueAt(other.base, index, other.index);
+    }
+  };
+
+  struct ReferenceHasher {
+    uint64_t operator()(const Reference& key) const {
+      return key.base->hashValueAt(key.index);
+    }
+  };
+
+  folly::F14FastMap<Reference, UpdateSource, ReferenceHasher> references_;
+};
+
+// Returns the error message string for a duplicate key.
+std::string duplicateKeyMessage(
+    const DecodedVector& keys,
+    vector_size_t entryIndex) {
+  return keys.base()->toString(keys.index(entryIndex));
+}
+
+template <TypeKind kKeyTypeKind>
+MapVectorPtr mapConcatImpl(
+    memory::MemoryPool* pool,
+    const TypePtr& outputType,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const MapConcatConfig& config) {
+  const auto numInputs = inputs.size();
+  const auto numRows = rows.end();
+
+  // Step 1: Compute output nulls.
+  BufferPtr newNulls;
+  if (!config.emptyForNull) {
+    for (size_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+      auto* nulls = inputs[inputIdx]->nulls(&rows);
+      if (!nulls) {
+        continue;
+      }
+      if (!newNulls) {
+        newNulls = allocateNulls(numRows, pool);
+        auto* raw = newNulls->asMutable<uint64_t>();
+        bits::copyBits(nulls, 0, raw, 0, numRows);
+      } else {
+        bits::andBits(newNulls->asMutable<uint64_t>(), nulls, 0, numRows);
+      }
+    }
+  }
+
+  // Step 2: Decode keys for all inputs.
+  const auto& expectedKeyType = outputType->asMap().keyType();
+  std::vector<DecodedVector> keys;
+  keys.reserve(numInputs);
+  for (size_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+    auto* mapVector = inputs[inputIdx]->base()->asChecked<MapVector>();
+    auto& mapKeys = mapVector->mapKeys();
+    VELOX_CHECK(
+        *expectedKeyType == *mapKeys->type(),
+        "Map key type mismatch: {} vs {}",
+        expectedKeyType->toString(),
+        mapKeys->type()->toString());
+    keys.emplace_back(*mapKeys);
+  }
+
+  // Step 3: Allocate output metadata.
+  auto newOffsets = allocateOffsets(numRows, pool);
+  auto* rawNewOffsets = newOffsets->asMutable<vector_size_t>();
+  auto newSizes = allocateSizes(numRows, pool);
+  auto* rawNewSizes = newSizes->asMutable<vector_size_t>();
+
+  // Step 4: Per-row merge.
+  std::vector<std::vector<BaseVector::CopyRange>> ranges(numInputs);
+  UpdateMapRow<typename TypeTraits<kKeyTypeKind>::NativeType> mapRow;
+  vector_size_t numEntries = 0;
+
+  rows.applyToSelected([&](vector_size_t row) {
+    rawNewOffsets[row] = numEntries;
+
+    // Check null propagation.
+    if (newNulls && bits::isBitNull(newNulls->as<uint64_t>(), row)) {
+      rawNewSizes[row] = 0;
+      return;
+    }
+
+    // Count total entries and non-empty inputs for this row.
+    vector_size_t totalEntries{0};
+    int nonEmptyCount{0};
+    int nonEmptyIdx{-1};
+    for (size_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+      if (config.emptyForNull && inputs[inputIdx]->isNullAt(row)) {
+        continue;
+      }
+      auto decodedIndex = inputs[inputIdx]->index(row);
+      auto* mapVector = inputs[inputIdx]->base()->asUnchecked<MapVector>();
+      auto size = mapVector->sizeAt(decodedIndex);
+      if (size > 0) {
+        ++nonEmptyCount;
+        nonEmptyIdx = inputIdx;
+      }
+      totalEntries += size;
+    }
+
+    if (totalEntries == 0) {
+      rawNewSizes[row] = 0;
+      return;
+    }
+
+    // Fast path: only one input has entries for this row.  No dedup possible.
+    if (nonEmptyCount == 1) {
+      auto decodedIndex = inputs[nonEmptyIdx]->index(row);
+      auto* mapVector = inputs[nonEmptyIdx]->base()->asUnchecked<MapVector>();
+      auto offset = mapVector->offsetAt(decodedIndex);
+      ranges[nonEmptyIdx].push_back({offset, numEntries, totalEntries});
+      rawNewSizes[row] = totalEntries;
+      numEntries += totalEntries;
+      return;
+    }
+
+    // Build hash map for this row.
+    mapRow.reserve(totalEntries);
+    for (size_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+      if (config.emptyForNull && inputs[inputIdx]->isNullAt(row)) {
+        continue;
+      }
+      auto decodedIndex = inputs[inputIdx]->index(row);
+      auto* mapVector = inputs[inputIdx]->base()->asUnchecked<MapVector>();
+      auto offset = mapVector->offsetAt(decodedIndex);
+      auto size = mapVector->sizeAt(decodedIndex);
+      for (vector_size_t entryIdx = 0; entryIdx < size; ++entryIdx) {
+        auto entryOffset = offset + entryIdx;
+        VELOX_CHECK(
+            !keys[inputIdx].isNullAt(entryOffset), "Map key cannot be null");
+        bool inserted = mapRow.insert(&keys[inputIdx], entryOffset, inputIdx);
+        if (config.throwOnDuplicateKeys && !inserted) {
+          VELOX_USER_FAIL(
+              "Duplicate map key {} was found.",
+              duplicateKeyMessage(keys[inputIdx], entryOffset));
+        }
+      }
+    }
+
+    // If no dedup happened, use bulk copy ranges (much faster than
+    // per-entry ranges).
+    if (mapRow.size() == totalEntries) {
+      mapRow.clear();
+      for (size_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+        if (config.emptyForNull && inputs[inputIdx]->isNullAt(row)) {
+          continue;
+        }
+        auto decodedIndex = inputs[inputIdx]->index(row);
+        auto* mapVector = inputs[inputIdx]->base()->asUnchecked<MapVector>();
+        auto offset = mapVector->offsetAt(decodedIndex);
+        auto size = mapVector->sizeAt(decodedIndex);
+        if (size > 0) {
+          ranges[inputIdx].push_back({offset, numEntries, size});
+          numEntries += size;
+        }
+      }
+      rawNewSizes[row] = totalEntries;
+      return;
+    }
+
+    // Dedup happened — collect deduplicated entries into per-entry copy
+    // ranges.
+    vector_size_t newSize{0};
+    mapRow.forEachEntry([&](UpdateSource source) {
+      ranges[source.sourceIndex].push_back(
+          {source.entryIndex, numEntries + newSize, 1});
+      ++newSize;
+    });
+    mapRow.clear();
+    rawNewSizes[row] = newSize;
+    numEntries += newSize;
+  });
+
+  // Step 5: Build result vectors.
+  auto newKeys =
+      BaseVector::create(outputType->asMap().keyType(), numEntries, pool);
+  auto newValues =
+      BaseVector::create(outputType->asMap().valueType(), numEntries, pool);
+  for (size_t inputIdx = 0; inputIdx < numInputs; ++inputIdx) {
+    auto* mapVector = inputs[inputIdx]->base()->asUnchecked<MapVector>();
+    newKeys->copyRanges(mapVector->mapKeys().get(), ranges[inputIdx]);
+    newValues->copyRanges(mapVector->mapValues().get(), ranges[inputIdx]);
+  }
+
+  return std::make_shared<MapVector>(
+      pool,
+      outputType,
+      std::move(newNulls),
+      numRows,
+      std::move(newOffsets),
+      std::move(newSizes),
+      std::move(newKeys),
+      std::move(newValues));
+}
+
+} // namespace
+
+MapVectorPtr mapConcat(
+    memory::MemoryPool* pool,
+    const TypePtr& outputType,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const MapConcatConfig& config) {
+  VELOX_CHECK_GT(inputs.size(), 0);
+  VELOX_CHECK_LT(inputs.size(), std::numeric_limits<int8_t>::max());
+  const auto& keyType = outputType->asMap().keyType();
+  // Route to UpdateMapRow<void> (BaseVector::equalValueAt/hashValueAt) when the
+  // key type provides custom comparison, so that custom hash and equality are
+  // respected for dedup.
+  if (keyType->providesCustomComparison()) {
+    return mapConcatImpl<TypeKind::ROW>(pool, outputType, inputs, rows, config);
+  }
+  return VELOX_DYNAMIC_TYPE_DISPATCH(
+      mapConcatImpl, keyType->kind(), pool, outputType, inputs, rows, config);
+}
+
+} // namespace facebook::velox

--- a/velox/vector/MapConcat.h
+++ b/velox/vector/MapConcat.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <span>
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox {
+
+/// Configuration for mapConcat().
+struct MapConcatConfig {
+  /// Treat null map inputs as empty maps instead of propagating null to the
+  /// output row.
+  bool emptyForNull{false};
+
+  /// Throw an exception when duplicate keys are found across inputs.
+  bool throwOnDuplicateKeys{false};
+};
+
+/// Merge multiple map vectors into a single MapVector.  All inputs are provided
+/// as DecodedVectors.  For each selected row, entries from all inputs are
+/// merged.  When duplicate keys exist across inputs, the entry from the last
+/// input wins.  Only rows selected in 'rows' are processed; unselected rows
+/// get size 0 in the output.
+MapVectorPtr mapConcat(
+    memory::MemoryPool* pool,
+    const TypePtr& outputType,
+    std::span<DecodedVector* const> inputs,
+    const SelectivityVector& rows,
+    const MapConcatConfig& config);
+
+} // namespace facebook::velox

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(
   FlatMapVectorTest.cpp
   IsWritableVectorTest.cpp
   LazyVectorTest.cpp
+  MapConcatTest.cpp
   MayHaveNullsRecursiveTest.cpp
   SelectivityVectorTest.cpp
   StringVectorBufferTest.cpp

--- a/velox/vector/tests/MapConcatTest.cpp
+++ b/velox/vector/tests/MapConcatTest.cpp
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/vector/MapConcat.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox {
+namespace {
+
+class MapConcatTest : public testing::Test, public velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+  }
+
+  // Decode a vector and return the DecodedVector.  Caller must keep the
+  // returned object alive while using the pointer.
+  std::unique_ptr<DecodedVector> decode(const VectorPtr& vector) {
+    auto decoded = std::make_unique<DecodedVector>(*vector);
+    return decoded;
+  }
+
+  // Helper to call mapConcat with VectorPtrs (decodes internally).
+  MapVectorPtr concat(
+      const std::vector<VectorPtr>& inputs,
+      const SelectivityVector& rows,
+      const MapConcatConfig& config = {}) {
+    std::vector<std::unique_ptr<DecodedVector>> decodedOwners;
+    std::vector<DecodedVector*> decodedPtrs;
+    decodedOwners.reserve(inputs.size());
+    decodedPtrs.reserve(inputs.size());
+    for (const auto& input : inputs) {
+      decodedOwners.push_back(decode(input));
+      decodedPtrs.push_back(decodedOwners.back().get());
+    }
+    return mapConcat(pool(), inputs[0]->type(), decodedPtrs, rows, config);
+  }
+};
+
+TEST_F(MapConcatTest, basic) {
+  // Two maps with no overlapping keys.
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}},
+      {{4, 40}, {5, 50}, {6, 60}},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{7, 70}},
+      {{8, 80}, {9, 90}},
+      {{10, 100}},
+  });
+
+  SelectivityVector rows(3);
+  auto result = concat({map1, map2}, rows);
+
+  // Row 0: {1->10, 2->20, 7->70}
+  ASSERT_EQ(result->sizeAt(0), 3);
+  // Row 1: {3->30, 8->80, 9->90}
+  ASSERT_EQ(result->sizeAt(1), 3);
+  // Row 2: {4->40, 5->50, 6->60, 10->100}
+  ASSERT_EQ(result->sizeAt(2), 4);
+
+  // Verify by comparing with expected.
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}, {7, 70}},
+      {{3, 30}, {8, 80}, {9, 90}},
+      {{4, 40}, {5, 50}, {6, 60}, {10, 100}},
+  });
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_TRUE(expected->equalValueAt(result.get(), i, i))
+        << "at " << i << ": expected " << expected->toString(i) << ", got "
+        << result->toString(i);
+  }
+}
+
+TEST_F(MapConcatTest, duplicateKeys) {
+  // Keys 2 and 3 overlap.  Last input wins.
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{2, 200}, {3, 300}, {4, 400}},
+  });
+
+  SelectivityVector rows(1);
+  auto result = concat({map1, map2}, rows);
+
+  // Key 2 -> 200 (from map2), key 3 -> 300 (from map2).
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 200}, {3, 300}, {4, 400}},
+  });
+  ASSERT_TRUE(expected->equalValueAt(result.get(), 0, 0))
+      << "expected " << expected->toString(0) << ", got "
+      << result->toString(0);
+}
+
+TEST_F(MapConcatTest, throwOnDuplicateKeys) {
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{2, 200}, {3, 300}},
+  });
+
+  SelectivityVector rows(1);
+  MapConcatConfig config;
+  config.throwOnDuplicateKeys = true;
+  VELOX_ASSERT_USER_THROW(
+      concat({map1, map2}, rows, config), "Duplicate map key");
+}
+
+TEST_F(MapConcatTest, emptyForNull) {
+  // When emptyForNull is true, null inputs are treated as empty maps.
+  auto map1 = makeNullableMapVector<int64_t, int64_t>({
+      {{{1, 10}, {2, 20}}},
+      std::nullopt,
+      {{{3, 30}}},
+  });
+  auto map2 = makeNullableMapVector<int64_t, int64_t>({
+      std::nullopt,
+      {{{4, 40}}},
+      {{{5, 50}}},
+  });
+
+  SelectivityVector rows(3);
+  MapConcatConfig config;
+  config.emptyForNull = true;
+  auto result = concat({map1, map2}, rows, config);
+
+  // Row 0: map1 has {1->10, 2->20}, map2 is null (empty).  Result: {1->10,
+  // 2->20}.
+  ASSERT_FALSE(result->isNullAt(0));
+  ASSERT_EQ(result->sizeAt(0), 2);
+  // Row 1: map1 is null (empty), map2 has {4->40}.  Result: {4->40}.
+  ASSERT_FALSE(result->isNullAt(1));
+  ASSERT_EQ(result->sizeAt(1), 1);
+  // Row 2: both non-null.  Result: {3->30, 5->50}.
+  ASSERT_FALSE(result->isNullAt(2));
+  ASSERT_EQ(result->sizeAt(2), 2);
+}
+
+TEST_F(MapConcatTest, nullPropagation) {
+  // Default behavior: null in any input => null row.
+  auto map1 = makeNullableMapVector<int64_t, int64_t>({
+      {{{1, 10}}},
+      std::nullopt,
+      {{{3, 30}}},
+  });
+  auto map2 = makeNullableMapVector<int64_t, int64_t>({
+      std::nullopt,
+      {{{4, 40}}},
+      {{{5, 50}}},
+  });
+
+  SelectivityVector rows(3);
+  auto result = concat({map1, map2}, rows);
+
+  // Row 0: map2 is null -> null.
+  ASSERT_TRUE(result->isNullAt(0));
+  // Row 1: map1 is null -> null.
+  ASSERT_TRUE(result->isNullAt(1));
+  // Row 2: both non-null.
+  ASSERT_FALSE(result->isNullAt(2));
+  ASSERT_EQ(result->sizeAt(2), 2);
+}
+
+TEST_F(MapConcatTest, partialRows) {
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {{1, 10}},
+      {{2, 20}},
+      {{3, 30}},
+      {{4, 40}},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{5, 50}},
+      {{6, 60}},
+      {{7, 70}},
+      {{8, 80}},
+  });
+
+  // Only process rows 1 and 3.
+  SelectivityVector rows(4, false);
+  rows.setValid(1, true);
+  rows.setValid(3, true);
+  rows.updateBounds();
+
+  auto result = concat({map1, map2}, rows);
+
+  // Unselected rows get size 0.
+  ASSERT_EQ(result->sizeAt(0), 0);
+  ASSERT_EQ(result->sizeAt(2), 0);
+  // Selected rows are merged.
+  ASSERT_EQ(result->sizeAt(1), 2);
+  ASSERT_EQ(result->sizeAt(3), 2);
+}
+
+TEST_F(MapConcatTest, multipleInputs) {
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {{1, 10}},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{2, 20}},
+  });
+  auto map3 = makeMapVector<int64_t, int64_t>({
+      {{3, 30}},
+  });
+
+  SelectivityVector rows(1);
+  auto result = concat({map1, map2, map3}, rows);
+
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}, {3, 30}},
+  });
+  ASSERT_TRUE(expected->equalValueAt(result.get(), 0, 0))
+      << "expected " << expected->toString(0) << ", got "
+      << result->toString(0);
+}
+
+TEST_F(MapConcatTest, multipleInputsDuplicateKeys) {
+  // Key 1 appears in all three.  Last input wins.
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{1, 100}, {3, 30}},
+  });
+  auto map3 = makeMapVector<int64_t, int64_t>({
+      {{1, 1000}, {4, 40}},
+  });
+
+  SelectivityVector rows(1);
+  auto result = concat({map1, map2, map3}, rows);
+
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{1, 1000}, {2, 20}, {3, 30}, {4, 40}},
+  });
+  ASSERT_TRUE(expected->equalValueAt(result.get(), 0, 0))
+      << "expected " << expected->toString(0) << ", got "
+      << result->toString(0);
+}
+
+TEST_F(MapConcatTest, varcharKeys) {
+  auto map1 = makeMapVector<StringView, int64_t>({
+      {{StringView("a"), 1}, {StringView("b"), 2}},
+  });
+  auto map2 = makeMapVector<StringView, int64_t>({
+      {{StringView("b"), 20}, {StringView("c"), 3}},
+  });
+
+  SelectivityVector rows(1);
+  auto result = concat({map1, map2}, rows);
+
+  auto expected = makeMapVector<StringView, int64_t>({
+      {{StringView("a"), 1}, {StringView("b"), 20}, {StringView("c"), 3}},
+  });
+  ASSERT_TRUE(expected->equalValueAt(result.get(), 0, 0))
+      << "expected " << expected->toString(0) << ", got "
+      << result->toString(0);
+}
+
+TEST_F(MapConcatTest, emptyMaps) {
+  auto map1 = makeMapVector<int64_t, int64_t>({
+      {},
+      {{1, 10}},
+      {},
+  });
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{2, 20}},
+      {},
+      {},
+  });
+
+  SelectivityVector rows(3);
+  auto result = concat({map1, map2}, rows);
+
+  auto expected = makeMapVector<int64_t, int64_t>({
+      {{2, 20}},
+      {{1, 10}},
+      {},
+  });
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_TRUE(expected->equalValueAt(result.get(), i, i))
+        << "at " << i << ": expected " << expected->toString(i) << ", got "
+        << result->toString(i);
+  }
+}
+
+TEST_F(MapConcatTest, dictionaryEncoded) {
+  auto base = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}},
+      {{4, 40}, {5, 50}},
+  });
+
+  // Dictionary that reverses the order: [2, 1, 0].
+  auto indices = makeIndices({2, 1, 0});
+  auto dict = wrapInDictionary(indices, 3, base);
+
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{6, 60}},
+      {{7, 70}},
+      {{8, 80}},
+  });
+
+  SelectivityVector rows(3);
+  auto result = concat({dict, map2}, rows);
+
+  // Row 0: dict[0] = base[2] = {4->40, 5->50} + {6->60}.
+  ASSERT_EQ(result->sizeAt(0), 3);
+  // Row 1: dict[1] = base[1] = {3->30} + {7->70}.
+  ASSERT_EQ(result->sizeAt(1), 2);
+  // Row 2: dict[2] = base[0] = {1->10, 2->20} + {8->80}.
+  ASSERT_EQ(result->sizeAt(2), 3);
+}
+
+TEST_F(MapConcatTest, constantEncoded) {
+  auto base = makeMapVector<int64_t, int64_t>({
+      {{1, 10}, {2, 20}},
+  });
+
+  // Constant vector repeating base[0] for 3 rows.
+  auto constant = BaseVector::wrapInConstant(3, 0, base);
+
+  auto map2 = makeMapVector<int64_t, int64_t>({
+      {{3, 30}},
+      {{4, 40}},
+      {{5, 50}},
+  });
+
+  SelectivityVector rows(3);
+  auto result = concat({constant, map2}, rows);
+
+  // Each row: {1->10, 2->20} + one new entry.
+  ASSERT_EQ(result->sizeAt(0), 3);
+  ASSERT_EQ(result->sizeAt(1), 3);
+  ASSERT_EQ(result->sizeAt(2), 3);
+}
+
+TEST_F(MapConcatTest, emptyForNullAllNull) {
+  // When all inputs are null for a row and emptyForNull is true, result is
+  // an empty map (not null).
+  auto map1 = makeNullableMapVector<int64_t, int64_t>({
+      std::nullopt,
+  });
+  auto map2 = makeNullableMapVector<int64_t, int64_t>({
+      std::nullopt,
+  });
+
+  SelectivityVector rows(1);
+  MapConcatConfig config;
+  config.emptyForNull = true;
+  auto result = concat({map1, map2}, rows, config);
+
+  ASSERT_FALSE(result->isNullAt(0));
+  ASSERT_EQ(result->sizeAt(0), 0);
+}
+
+// Custom type where keys are compared modulo 100.  So 1 and 101 are considered
+// equal, but native int64_t == treats them as different.
+class Mod100Type : public BigintType {
+ public:
+  constexpr Mod100Type() : BigintType{ProvideCustomComparison{}} {}
+
+  int32_t compare(const int64_t& left, const int64_t& right) const override {
+    return static_cast<int32_t>((left % 100) - (right % 100));
+  }
+
+  uint64_t hash(const int64_t& value) const override {
+    return folly::hasher<int64_t>()(value % 100);
+  }
+
+  bool equivalent(const Type& other) const override {
+    return this == &other;
+  }
+
+  const char* name() const override {
+    return "MOD100";
+  }
+
+  std::string toString() const override {
+    return name();
+  }
+};
+
+TEST_F(MapConcatTest, customComparisonType) {
+  // Keys 1 and 101 are different by native ==, but equal by Mod100Type
+  // comparison (both are 1 mod 100).  Dedup should treat them as the same key.
+  static const Mod100Type kMod100Type;
+  auto mod100TypePtr =
+      std::shared_ptr<const Type>(std::shared_ptr<const Type>{}, &kMod100Type);
+  auto mapType = MAP(mod100TypePtr, BIGINT());
+
+  // Build map1 with key 1, map2 with key 101.
+  auto map1Keys = makeFlatVector<int64_t>({1}, mod100TypePtr);
+  auto map1Values = makeFlatVector<int64_t>({10});
+  auto map1 = std::make_shared<MapVector>(
+      pool(),
+      mapType,
+      BufferPtr(nullptr),
+      1,
+      allocateOffsets(1, pool()),
+      allocateSizes(1, pool()),
+      map1Keys,
+      map1Values);
+  // Set offset=0, size=1 for row 0.
+  map1->setOffsetAndSize(0, 0, 1);
+
+  auto map2Keys = makeFlatVector<int64_t>({101}, mod100TypePtr);
+  auto map2Values = makeFlatVector<int64_t>({20});
+  auto map2 = std::make_shared<MapVector>(
+      pool(),
+      mapType,
+      BufferPtr(nullptr),
+      1,
+      allocateOffsets(1, pool()),
+      allocateSizes(1, pool()),
+      map2Keys,
+      map2Values);
+  map2->setOffsetAndSize(0, 0, 1);
+
+  SelectivityVector rows(1);
+  auto result = concat({map1, map2}, rows);
+
+  // With custom comparison, 1 and 101 are the same key.  Last input wins,
+  // so the result should have 1 entry with value 20 (from map2).
+  ASSERT_EQ(result->sizeAt(0), 1);
+}
+
+} // namespace
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:

Extract the hash-based map merge logic from MapVector::update() into a shared mapConcat() utility in velox/vector/MapConcat.h.  Both MapVector::update() and the MapConcatFunction (Presto/Spark map_concat UDF) now delegate to this shared implementation.

This replaces the O(N log N) sort-based dedup in MapConcatFunction (canonicalize + adjacent-compare + compact) with O(N) hash-based dedup (F14FastMap per row).  Two fast paths avoid unnecessary overhead:

1. When no duplicate keys are detected (hash map size == total entries), bulk CopyRanges are used instead of per-entry ranges.
2. Pre-reserving the hash map to totalEntries eliminates rehashing during insertion.

Also moves EmptyForNull and AllowSingleArg from template parameters to constructor fields in MapConcatFunction.

MapConcatConfig knobs:
- emptyForNull: treat null map inputs as empty (for the EmptyForNull variant).
- throwOnDuplicateKeys: throw on duplicate keys across inputs.

Reviewed By: bikramSingh91

Differential Revision: D100235866
