### PR TITLE
Add map_values_all_match UDF (#17143)

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -120,6 +120,13 @@ Map Functions
         SELECT map_values_in_range(MAP(ARRAY[1, 2], ARRAY[null, 50]), 0, 100); -- {1 -> null, 2 -> 50}
         SELECT map_values_in_range(MAP(ARRAY[1, 2, 3], ARRAY[5, 50, 500]), 10, 100); -- {2 -> 50}
 
+.. function:: map_values_all_match(x(K,V), function(V, boolean)) -> boolean
+
+    Returns true if all values in the given map match the predicate and false otherwise. NULL if the predicate function returns NULL for one or more values and true for all other values. Equivalent to ``all_match(map_values(x), predicate)`` but avoids materializing the intermediate array. ::
+
+        SELECT map_values_all_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x > 0); -- true
+        SELECT map_values_all_match(map(array['a', 'b', 'c'], array[1, 2, 3]), x -> x > 1); -- false
+
 .. function:: map_remove_null_values(map(K,V)) -> map(K,V)
 
     Returns a map by removing all the keys in input map with null values. If input

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -306,6 +306,7 @@ std::unordered_set<std::string> skipFunctionsSOT = {
                      // instances
     "array_subset", // Velox-only function, not available in Presto
     "map_values_in_range", // Velox-only function, not available in Presto
+    "map_values_all_match", // Velox-only function, not available in Presto
     "transform_with_index", // Velox-only function, not available in Presto
     "dot_product", // Velox-only function, not available in Presto
     "remap_keys", // Velox-only function, not available in Presto

--- a/velox/functions/prestosql/ArrayAndMapMatch.cpp
+++ b/velox/functions/prestosql/ArrayAndMapMatch.cpp
@@ -267,6 +267,7 @@ class MapValuesMatchFunction
   }
 };
 
+class AllValuesMatchFunction : public MapValuesMatchFunction<true, false> {};
 class AnyValuesMatchFunction : public MapValuesMatchFunction<false, true> {};
 class NoValuesMatchFunction : public MapValuesMatchFunction<true, true> {};
 
@@ -358,5 +359,11 @@ VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     valuesSignatures(),
     exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
     std::make_unique<NoValuesMatchFunction>());
+
+VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
+    udf_map_values_all_match,
+    valuesSignatures(),
+    exec::VectorFunctionMetadataBuilder().defaultNullBehavior(false).build(),
+    std::make_unique<AllValuesMatchFunction>());
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -274,6 +274,9 @@ void registerMapFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_no_values_match, prefix + "no_values_match");
 
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_map_values_all_match, prefix + "map_values_all_match");
+
   registerMapConcatFunction(prefix + "map_concat");
 
   registerFunction<


### PR DESCRIPTION
Summary:

Adds a new Velox-only function `map_values_all_match(map(K,V), function(V, boolean)) -> boolean` that returns true if all values of a map match the given predicate.

This fills a gap in the existing map match function family: `any_values_match` and `no_values_match` exist as Presto-standard functions, but the "all" variant for values was missing. This function is equivalent to `all_match(map_values(x), predicate)` but avoids materializing the intermediate array.

Behavior:
- Returns true if all values match the predicate (including empty maps)
- Returns false if one or more values don't match
- Returns NULL if the predicate returns NULL for some values and true for all others

The implementation adds `AllValuesMatchFunction` as a one-line class reusing the existing `MapValuesMatchFunction<true, false>` template.

Differential Revision: D99604194


