### PR TITLE
feat(cudf): Add CudfExpand operator

### DIFF
--- a/velox/experimental/cudf/exec/CMakeLists.txt
+++ b/velox/experimental/cudf/exec/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   CudfBatchConcat.cpp
   CudfConversion.cpp
   CudfEnforceSingleRow.cpp
+  CudfExpand.cpp
   CudfFilterProject.cpp
   CudfHashAggregation.cpp
   CudfHashJoin.cpp

--- a/velox/experimental/cudf/exec/CudfExpand.cpp
+++ b/velox/experimental/cudf/exec/CudfExpand.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "velox/experimental/cudf/exec/CudfExpand.h"
+#include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/expression/AstUtils.h"
+#include "velox/experimental/cudf/vector/CudfVector.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+#include "velox/expression/Expr.h"
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/copying.hpp>
+#include <cudf/scalar/scalar.hpp>
+#include <cudf/table/table.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+CudfExpand::CudfExpand(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const core::ExpandNode>& expandNode)
+    : Operator(
+          driverCtx,
+          expandNode->outputType(),
+          operatorId,
+          expandNode->id(),
+          "CudfExpand"),
+      NvtxHelper(
+          nvtx3::rgb{255, 165, 0}, // Orange
+          operatorId,
+          fmt::format("[{}]", expandNode->id())) {
+  const auto& inputType = expandNode->inputType();
+  const auto numRows = expandNode->projections().size();
+  fieldProjections_.reserve(numRows);
+  constantProjections_.reserve(numRows);
+  constantOutputs_.reserve(numRows);
+  const auto numColumns = expandNode->names().size();
+  for (const auto& rowProjections : expandNode->projections()) {
+    std::vector<column_index_t> rowProjection;
+    rowProjection.reserve(numColumns);
+    std::vector<std::shared_ptr<const core::ConstantTypedExpr>>
+        constantProjection;
+    constantProjection.reserve(numColumns);
+    for (const auto& columnProjection : rowProjections) {
+      if (auto field = core::TypedExprs::asFieldAccess(columnProjection)) {
+        rowProjection.push_back(inputType->getChildIdx(field->name()));
+        constantProjection.push_back(nullptr);
+      } else if (
+          auto constant = core::TypedExprs::asConstant(columnProjection)) {
+        rowProjection.push_back(kConstantChannel);
+        constantProjection.push_back(constant);
+      } else {
+        VELOX_USER_FAIL(
+            "Expand operator doesn't support this expression. Only column references and constants are supported. {}",
+            columnProjection->toString());
+      }
+    }
+
+    fieldProjections_.emplace_back(std::move(rowProjection));
+    constantProjections_.emplace_back(std::move(constantProjection));
+  }
+}
+
+void CudfExpand::initialize() {
+  if (constantProjections_.empty()) {
+    return;
+  }
+  const auto numColumns = constantProjections_[0].size();
+  for (const auto& projections : constantProjections_) {
+    std::vector<std::unique_ptr<cudf::scalar>> constantOutput;
+    constantOutput.reserve(numColumns);
+    for (const auto& constant : projections) {
+      if (constant) {
+        VELOX_CHECK(!constant->hasValueVector());
+        constantOutput.push_back(makeScalarFromVariant(constant->type(), constant->value()));
+      } else {
+        constantOutput.push_back(nullptr);
+      }
+    }
+    constantOutputs_.emplace_back(std::move(constantOutput));
+  }
+}
+
+bool CudfExpand::needsInput() const {
+  return !noMoreInput_ && input_ == nullptr;
+}
+
+void CudfExpand::addInput(RowVectorPtr input) {
+  input_ = std::move(input);
+}
+
+RowVectorPtr CudfExpand::getOutput() {
+  VELOX_NVTX_OPERATOR_FUNC_RANGE();
+  if (!input_) {
+    return nullptr;
+  }
+
+  const auto numInput = input_->size();
+
+  auto cudfInput = std::dynamic_pointer_cast<cudf_velox::CudfVector>(input_);
+  VELOX_CHECK_NOT_NULL(
+      cudfInput, "CudfExpand expects CudfVector input, got regular RowVector");
+
+  const auto& rowProjection = fieldProjections_[rowIndex_];
+  const auto& constantProjection = constantOutputs_[rowIndex_];
+  const auto numColumns = rowProjection.size();
+
+  auto stream = cudfInput->stream();
+
+  // Check if this is the last projection
+  const bool isLastProjection = (rowIndex_ == fieldProjections_.size() - 1);
+
+  // Build output columns
+  std::vector<std::unique_ptr<cudf::column>> outputColumns;
+  outputColumns.reserve(numColumns);
+
+  if (isLastProjection) {
+    // Last projection: move columns from input table when possible
+    auto inputTable = cudfInput->release();
+    auto inputColumns = inputTable->release();
+    
+    // Count how many times each input column is used in this projection
+    std::vector<int> columnUseCount(inputColumns.size(), 0);
+    for (auto i = 0; i < numColumns; ++i) {
+      if (rowProjection[i] != kConstantChannel) {
+        columnUseCount[rowProjection[i]]++;
+      }
+    }
+    
+    // Track remaining uses for each column
+    std::vector<int> columnRemainingUses = columnUseCount;
+    
+    for (auto i = 0; i < numColumns; ++i) {
+      if (rowProjection[i] == kConstantChannel) {
+        const auto& scalar = constantProjection[i];
+        outputColumns.push_back(
+            cudf::make_column_from_scalar(*scalar, numInput, stream, get_output_mr()));
+      } else {
+        auto colIdx = rowProjection[i];
+        columnRemainingUses[colIdx]--;
+        
+        if (columnRemainingUses[colIdx] == 0) {
+          // Last use of this column, can move
+          outputColumns.push_back(std::move(inputColumns[colIdx]));
+        } else {
+          // Not the last use, must copy
+          outputColumns.push_back(
+              std::make_unique<cudf::column>(*inputColumns[colIdx], stream, get_output_mr()));
+        }
+      }
+    }
+  } else {
+    // Not last projection: copy columns from table view
+    auto inputTableView = cudfInput->getTableView();
+    
+    for (auto i = 0; i < numColumns; ++i) {
+      if (rowProjection[i] == kConstantChannel) {
+        const auto& scalar = constantProjection[i];
+        outputColumns.push_back(
+            cudf::make_column_from_scalar(*scalar, numInput, stream, get_output_mr()));
+      } else {
+        auto inputColumn = inputTableView.column(rowProjection[i]);
+        outputColumns.push_back(
+            std::make_unique<cudf::column>(inputColumn, stream, get_output_mr()));
+      }
+    }
+  }
+
+  ++rowIndex_;
+  if (rowIndex_ == fieldProjections_.size()) {
+    rowIndex_ = 0;
+    input_ = nullptr;
+  }
+
+  // Create output table and wrap in CudfVector
+  auto outputTable = std::make_unique<cudf::table>(std::move(outputColumns));
+  return std::make_shared<cudf_velox::CudfVector>(
+      pool(), outputType_, numInput, std::move(outputTable), stream);
+}
+
+} // namespace facebook::velox::cudf_velox
+

--- a/velox/experimental/cudf/exec/CudfExpand.cpp
+++ b/velox/experimental/cudf/exec/CudfExpand.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-
 #include "velox/experimental/cudf/exec/CudfExpand.h"
 #include "velox/experimental/cudf/exec/GpuResources.h"
+#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
 #include "velox/experimental/cudf/expression/AstUtils.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
-#include "velox/experimental/cudf/exec/VeloxCudfInterop.h"
+
 #include "velox/expression/Expr.h"
 
 #include <cudf/column/column.hpp>
@@ -87,7 +87,8 @@ void CudfExpand::initialize() {
     for (const auto& constant : projections) {
       if (constant) {
         VELOX_CHECK(!constant->hasValueVector());
-        constantOutput.push_back(makeScalarFromVariant(constant->type(), constant->value()));
+        constantOutput.push_back(
+            makeScalarFromVariant(constant->type(), constant->value()));
       } else {
         constantOutput.push_back(nullptr);
       }
@@ -133,7 +134,7 @@ RowVectorPtr CudfExpand::getOutput() {
     // Last projection: move columns from input table when possible
     auto inputTable = cudfInput->release();
     auto inputColumns = inputTable->release();
-    
+
     // Count how many times each input column is used in this projection
     std::vector<int> columnUseCount(inputColumns.size(), 0);
     for (auto i = 0; i < numColumns; ++i) {
@@ -141,42 +142,46 @@ RowVectorPtr CudfExpand::getOutput() {
         columnUseCount[rowProjection[i]]++;
       }
     }
-    
+
     // Track remaining uses for each column
     std::vector<int> columnRemainingUses = columnUseCount;
-    
+
     for (auto i = 0; i < numColumns; ++i) {
       if (rowProjection[i] == kConstantChannel) {
         const auto& scalar = constantProjection[i];
         outputColumns.push_back(
-            cudf::make_column_from_scalar(*scalar, numInput, stream, get_output_mr()));
+            cudf::make_column_from_scalar(
+                *scalar, numInput, stream, get_output_mr()));
       } else {
         auto colIdx = rowProjection[i];
         columnRemainingUses[colIdx]--;
-        
+
         if (columnRemainingUses[colIdx] == 0) {
           // Last use of this column, can move
           outputColumns.push_back(std::move(inputColumns[colIdx]));
         } else {
           // Not the last use, must copy
           outputColumns.push_back(
-              std::make_unique<cudf::column>(*inputColumns[colIdx], stream, get_output_mr()));
+              std::make_unique<cudf::column>(
+                  *inputColumns[colIdx], stream, get_output_mr()));
         }
       }
     }
   } else {
     // Not last projection: copy columns from table view
     auto inputTableView = cudfInput->getTableView();
-    
+
     for (auto i = 0; i < numColumns; ++i) {
       if (rowProjection[i] == kConstantChannel) {
         const auto& scalar = constantProjection[i];
         outputColumns.push_back(
-            cudf::make_column_from_scalar(*scalar, numInput, stream, get_output_mr()));
+            cudf::make_column_from_scalar(
+                *scalar, numInput, stream, get_output_mr()));
       } else {
         auto inputColumn = inputTableView.column(rowProjection[i]);
         outputColumns.push_back(
-            std::make_unique<cudf::column>(inputColumn, stream, get_output_mr()));
+            std::make_unique<cudf::column>(
+                inputColumn, stream, get_output_mr()));
       }
     }
   }
@@ -194,4 +199,3 @@ RowVectorPtr CudfExpand::getOutput() {
 }
 
 } // namespace facebook::velox::cudf_velox
-

--- a/velox/experimental/cudf/exec/CudfExpand.h
+++ b/velox/experimental/cudf/exec/CudfExpand.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/cudf/exec/NvtxHelper.h"
+
+#include "velox/core/Expressions.h"
+#include "velox/exec/Operator.h"
+
+#include <cudf/scalar/scalar.hpp>
+
+namespace facebook::velox::cudf_velox {
+
+class CudfExpand : public exec::Operator, public NvtxHelper {
+ public:
+  CudfExpand(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const core::ExpandNode>& expandNode);
+
+  bool needsInput() const override;
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr;
+  }
+
+ private:
+  void initialize() override;
+
+  std::vector<std::vector<column_index_t>> fieldProjections_;
+
+  std::vector<std::vector<std::shared_ptr<const core::ConstantTypedExpr>>>
+      constantProjections_;
+
+  // Store cuDF scalars for constant values
+  std::vector<std::vector<std::unique_ptr<cudf::scalar>>> constantOutputs_;
+
+  // Used to indicate the index of fieldProjections_.
+  int32_t rowIndex_{0};
+};
+
+} // namespace facebook::velox::cudf_velox
+

--- a/velox/experimental/cudf/exec/CudfExpand.h
+++ b/velox/experimental/cudf/exec/CudfExpand.h
@@ -62,4 +62,3 @@ class CudfExpand : public exec::Operator, public NvtxHelper {
 };
 
 } // namespace facebook::velox::cudf_velox
-

--- a/velox/experimental/cudf/exec/OperatorAdapters.cpp
+++ b/velox/experimental/cudf/exec/OperatorAdapters.cpp
@@ -19,6 +19,7 @@
 #include "velox/experimental/cudf/exec/CudfAssignUniqueId.h"
 #include "velox/experimental/cudf/exec/CudfBatchConcat.h"
 #include "velox/experimental/cudf/exec/CudfEnforceSingleRow.h"
+#include "velox/experimental/cudf/exec/CudfExpand.h"
 #include "velox/experimental/cudf/exec/CudfFilterProject.h"
 #include "velox/experimental/cudf/exec/CudfHashAggregation.h"
 #include "velox/experimental/cudf/exec/CudfHashJoin.h"
@@ -36,6 +37,7 @@
 #include "velox/exec/AssignUniqueId.h"
 #include "velox/exec/CallbackSink.h"
 #include "velox/exec/EnforceSingleRow.h"
+#include "velox/exec/Expand.h"
 #include "velox/exec/FilterProject.h"
 #include "velox/exec/HashAggregation.h"
 #include "velox/exec/HashBuild.h"
@@ -837,6 +839,46 @@ class CallbackSinkAdapter : public OperatorAdapter {
   }
 };
 
+/// ExpandAdapter - Replaces with CudfExpand
+class ExpandAdapter : public OperatorAdapter {
+ public:
+  ExpandAdapter() : OperatorAdapter("Expand") {}
+
+  bool canHandle(const exec::Operator* op) const override {
+    return dynamic_cast<const exec::Expand*>(op) != nullptr;
+  }
+
+  bool canRunOnGPU(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* /*ctx*/) const override {
+    return std::dynamic_pointer_cast<const core::ExpandNode>(planNode) !=
+        nullptr;
+  }
+
+  bool acceptsGpuInput() const override {
+    return true;
+  }
+
+  bool producesGpuOutput() const override {
+    return true;
+  }
+
+  std::vector<std::unique_ptr<exec::Operator>> createReplacements(
+      const exec::Operator* /*op*/,
+      const core::PlanNodePtr& planNode,
+      exec::DriverCtx* ctx,
+      int32_t operatorId) const override {
+    auto expandPlanNode =
+        std::dynamic_pointer_cast<const core::ExpandNode>(planNode);
+
+    std::vector<std::unique_ptr<exec::Operator>> result;
+    result.push_back(
+        std::make_unique<CudfExpand>(operatorId, ctx, expandPlanNode));
+    return result;
+  }
+};
+
 /// Registration Function
 void registerAllOperatorAdapters() {
   auto& registry = OperatorAdapterRegistry::getInstance();
@@ -858,6 +900,7 @@ void registerAllOperatorAdapters() {
   registry.registerAdapter(std::make_unique<AssignUniqueIdAdapter>());
   registry.registerAdapter(std::make_unique<MarkDistinctAdapter>());
   registry.registerAdapter(std::make_unique<EnforceSingleRowAdapter>());
+  registry.registerAdapter(std::make_unique<ExpandAdapter>());
   registry.registerAdapter(std::make_unique<ValuesAdapter>());
   registry.registerAdapter(std::make_unique<CallbackSinkAdapter>());
 }

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -165,7 +165,6 @@ inline std::unique_ptr<cudf::scalar> makeScalarFromConstantExpr(
       createCudfScalar, constValue->typeKind(), constValue, toType);
 }
 
-
 template <TypeKind kind>
 std::unique_ptr<cudf::scalar> makeScalarFromVariant(
     const TypePtr& type,
@@ -185,7 +184,7 @@ inline std::unique_ptr<cudf::scalar> makeScalarFromVariant(
     const TypePtr& type,
     const variant& var) {
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-    makeScalarFromVariant, type->kind(), type, var);
+      makeScalarFromVariant, type->kind(), type, var);
 }
 
 template <TypeKind kind>

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -165,6 +165,29 @@ inline std::unique_ptr<cudf::scalar> makeScalarFromConstantExpr(
       createCudfScalar, constValue->typeKind(), constValue, toType);
 }
 
+
+template <TypeKind kind>
+std::unique_ptr<cudf::scalar> makeScalarFromVariant(
+    const TypePtr& type,
+    const variant& var) {
+  using T = typename TypeTraits<kind>::NativeType;
+  if constexpr (cudf::is_fixed_width<T>() || kind == TypeKind::VARCHAR) {
+    if (var.isNull()) {
+      return makeScalarFromValue<T>(type, T(), true);
+    }
+    auto value = var.value<T>();
+    return makeScalarFromValue(type, value, false);
+  }
+  VELOX_NYI("Scalar creation not implemented for type " + type->toString());
+}
+
+inline std::unique_ptr<cudf::scalar> makeScalarFromVariant(
+    const TypePtr& type,
+    const variant& var) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+    makeScalarFromVariant, type->kind(), type, var);
+}
+
 template <TypeKind kind>
 cudf::ast::literal makeScalarAndLiteral(
     const TypePtr& type,

--- a/velox/experimental/cudf/tests/CMakeLists.txt
+++ b/velox/experimental/cudf/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(velox_cudf_aggregation_test Main.cpp AggregationTest.cpp)
 add_executable(velox_cudf_assign_unique_id_test Main.cpp AssignUniqueIdTest.cpp)
 add_executable(velox_cudf_config_test Main.cpp ConfigTest.cpp)
 add_executable(velox_cudf_enforce_single_row_test Main.cpp EnforceSingleRowTest.cpp)
+add_executable(velox_cudf_expand_test Main.cpp ExpandTest.cpp)
 add_executable(velox_cudf_expression_selection_test Main.cpp ExpressionEvaluatorSelectionTest.cpp)
 add_executable(velox_cudf_filter_project_test Main.cpp FilterProjectTest.cpp)
 add_executable(velox_cudf_hash_join_test HashJoinTest.cpp Main.cpp)
@@ -62,6 +63,12 @@ add_test(
 add_test(
   NAME velox_cudf_enforce_single_row_test
   COMMAND velox_cudf_enforce_single_row_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_test(
+  NAME velox_cudf_expand_test
+  COMMAND velox_cudf_expand_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -168,6 +175,7 @@ set_tests_properties(velox_cudf_aggregation_test PROPERTIES LABELS cuda_driver T
 set_tests_properties(velox_cudf_assign_unique_id_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(velox_cudf_config_test PROPERTIES LABELS cuda_driver TIMEOUT 300)
 set_tests_properties(velox_cudf_enforce_single_row_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
+set_tests_properties(velox_cudf_expand_test PROPERTIES LABELS cuda_driver TIMEOUT 3000)
 set_tests_properties(
   velox_cudf_expression_selection_test
   PROPERTIES LABELS cuda_driver TIMEOUT 3000
@@ -222,6 +230,16 @@ target_link_libraries(velox_cudf_config_test velox_cudf_exec Folly::folly gtest 
 
 target_link_libraries(
   velox_cudf_enforce_single_row_test
+  velox_cudf_exec
+  velox_exec
+  velox_exec_test_lib
+  velox_test_util
+  gtest
+  gtest_main
+)
+
+target_link_libraries(
+  velox_cudf_expand_test
   velox_cudf_exec
   velox_exec
   velox_exec_test_lib

--- a/velox/experimental/cudf/tests/ExpandTest.cpp
+++ b/velox/experimental/cudf/tests/ExpandTest.cpp
@@ -57,16 +57,11 @@ TEST_F(CudfExpandTest, simpleConstant) {
   children.push_back(makeNullConstant(TypeKind::INTEGER, 3));
   auto expected = makeRowVector(children);
 
-  auto plan = PlanBuilder(pool())
-                  .values({data})
-                  .expand(
-                      {{"k1",
-                        "k2",
-                        "a",
-                        "b",
-                        "100 as c",
-                        "null::integer as d"}})
-                  .planNode();
+  auto plan =
+      PlanBuilder(pool())
+          .values({data})
+          .expand({{"k1", "k2", "a", "b", "100 as c", "null::integer as d"}})
+          .planNode();
 
   assertQuery(plan, expected);
 }
@@ -167,21 +162,19 @@ TEST_F(CudfExpandTest, countDistinct) {
 }
 
 TEST_F(CudfExpandTest, duplicateColumnProjection) {
-  // Test case where the same input column is projected to multiple output columns
+  // Test case where the same input column is projected to multiple output
+  // columns
   auto data = makeRowVectorData(100);
 
   createDuckDbTable({data});
 
   // Project k1 to both output columns c1 and c2
-  auto plan =
-      PlanBuilder()
-          .values({data})
-          .expand({{"k1 as c1", "k1 as c2", "a", "b", "0 as gid"}})
-          .planNode();
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .expand({{"k1 as c1", "k1 as c2", "a", "b", "0 as gid"}})
+                  .planNode();
 
-  assertQuery(
-      plan,
-      "SELECT k1 as c1, k1 as c2, a, b, 0 as gid FROM tmp");
+  assertQuery(plan, "SELECT k1 as c1, k1 as c2, a, b, 0 as gid FROM tmp");
 }
 
 TEST_F(CudfExpandTest, invalidUseCases) {
@@ -200,4 +193,3 @@ TEST_F(CudfExpandTest, invalidUseCases) {
       PlanBuilder().values({data}).expand({}),
       "projections must not be empty.");
 }
-

--- a/velox/experimental/cudf/tests/ExpandTest.cpp
+++ b/velox/experimental/cudf/tests/ExpandTest.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/cudf/exec/ToCudf.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class CudfExpandTest : public HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    cudf_velox::registerCudf();
+  }
+
+  void TearDown() override {
+    cudf_velox::unregisterCudf();
+    HiveConnectorTestBase::TearDown();
+  }
+
+  RowVectorPtr makeRowVectorData(vector_size_t size) {
+    return makeRowVector(
+        {"k1", "k2", "a", "b"},
+        {
+            makeFlatVector<int64_t>(size, [](auto row) { return row % 11; }),
+            makeFlatVector<int64_t>(size, [](auto row) { return row % 17; }),
+            makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+            makeFlatVector<std::string>(
+                size, [](auto row) { return std::string(row % 15, 'x'); }),
+        });
+  }
+};
+
+TEST_F(CudfExpandTest, simpleConstant) {
+  auto data = makeRowVectorData(3);
+  auto children = data->children();
+  // Add simple constant columns (no complex types like arrays)
+  children.push_back(makeFlatVector<int64_t>({100, 100, 100}));
+  children.push_back(makeNullConstant(TypeKind::INTEGER, 3));
+  auto expected = makeRowVector(children);
+
+  auto plan = PlanBuilder(pool())
+                  .values({data})
+                  .expand(
+                      {{"k1",
+                        "k2",
+                        "a",
+                        "b",
+                        "100 as c",
+                        "null::integer as d"}})
+                  .planNode();
+
+  assertQuery(plan, expected);
+}
+
+TEST_F(CudfExpandTest, groupingSets) {
+  auto data = makeRowVectorData(1'000);
+
+  createDuckDbTable({data});
+
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .expand(
+              {{"k1",
+                "null::bigint as k2",
+                "a",
+                "b",
+                "0 as group_id_0",
+                "0 as group_id_1"},
+               {"k1", "null", "a", "b", "0", "1"},
+               {"null", "k2", "a", "b", "1", "2"}})
+          .singleAggregation(
+              {"k1", "k2", "group_id_0", "group_id_1"},
+              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+          .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY GROUPING SETS ((k1), (k1), (k2))");
+}
+
+TEST_F(CudfExpandTest, cube) {
+  auto data = makeRowVectorData(1'000);
+
+  createDuckDbTable({data});
+
+  // Cube.
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .expand({
+              {"k1", "k2", "a", "b", "0 as gid"},
+              {"k1", "null", "a", "b", "1"},
+              {"null", "k2", "a", "b", "2"},
+              {"null", "null", "a", "b", "3"},
+          })
+          .singleAggregation(
+              {"k1", "k2", "gid"},
+              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+          .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY CUBE (k1, k2)");
+}
+
+TEST_F(CudfExpandTest, rollup) {
+  auto data = makeRowVectorData(1'000);
+
+  createDuckDbTable({data});
+
+  // Rollup.
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .expand(
+              {{"k1 as foo", "k2", "a", "b", "0 as gid"},
+               {"k1", "null", "a", "b", "1"},
+               {"null", "null", "a", "b", "2"}})
+          .singleAggregation(
+              {"foo", "k2", "gid"},
+              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+          .project({"foo", "k2", "count_1", "sum_a", "max_b"})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY ROLLUP (k1, k2)");
+}
+
+TEST_F(CudfExpandTest, countDistinct) {
+  auto data = makeRowVectorData(1'000);
+
+  createDuckDbTable({data});
+
+  // count distinct.
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .expand({{"a", "null::varchar as b", "1 as gid"}, {"null", "b", "2"}})
+          .singleAggregation({"a", "b", "gid"}, {})
+          .singleAggregation({}, {"count(a) as count_a", "count(b) as count_b"})
+          .planNode();
+
+  assertQuery(plan, "SELECT count(distinct a), count(distinct b) FROM tmp");
+}
+
+TEST_F(CudfExpandTest, duplicateColumnProjection) {
+  // Test case where the same input column is projected to multiple output columns
+  auto data = makeRowVectorData(100);
+
+  createDuckDbTable({data});
+
+  // Project k1 to both output columns c1 and c2
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .expand({{"k1 as c1", "k1 as c2", "a", "b", "0 as gid"}})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1 as c1, k1 as c2, a, b, 0 as gid FROM tmp");
+}
+
+TEST_F(CudfExpandTest, invalidUseCases) {
+  auto data = makeRowVector(
+      ROW({"k1", "k2", "a", "b"}, {BIGINT(), BIGINT(), BIGINT(), VARCHAR()}),
+      10);
+
+  VELOX_ASSERT_USER_THROW(
+      PlanBuilder().values({data}).expand(
+          {{"k1", "k1", "a", "b", "0 as gid"},
+           {"k1", "null", "a", "b", "1"},
+           {"null", "null", "a", "b", "2"}}),
+      "Found duplicate column name in Expand plan node: k1.");
+
+  VELOX_ASSERT_RUNTIME_THROW(
+      PlanBuilder().values({data}).expand({}),
+      "projections must not be empty.");
+}
+


### PR DESCRIPTION
Add CudfExpand operator replaces CPU Expand operator, the operator copies the columns except the last group because the cudf::table columns is std::unique_ptr while CPU RowVector columns is std::shared_ptr<FlatVector>, so here will be a performance issue.
Future optimization, add CudfVectorView inherits from CudfVector, contains std::vector<column_view> and may hold the source table, copy to get cudf::table if the downstream operator requires the table instead of table_view