### PR TITLE
misc: Make the `DirectBufferedInput` ctor used for clone protected

### DIFF
--- a/velox/dwio/common/DirectBufferedInput.h
+++ b/velox/dwio/common/DirectBufferedInput.h
@@ -237,22 +237,8 @@ class DirectBufferedInput : public BufferedInput {
   void reset() override;
 
  protected:
-  // Some members are protected to allow custom extended buffered inputs.
-  // Regions that are candidates for loading.
-  const StringIdLease fileNum_;
-  const std::shared_ptr<cache::ScanTracker> tracker_;
-  const StringIdLease groupId_;
-  const std::shared_ptr<IoStatistics> ioStatistics_;
-  const std::shared_ptr<velox::IoStats> ioStats_;
-  folly::Executor* const executor_;
-  const uint64_t fileSize_;
-  const io::ReaderOptions options_;
-  std::vector<LoadRequest> requests_;
-
-  // Distinct coalesced loads in 'coalescedLoads_'.
-  std::vector<std::shared_ptr<cache::CoalescedLoad>> coalescedLoads_;
-
- private:
+  // The constructor and some member variables are protected to allow custom
+  // extended buffered inputs.
   // Constructor used by clone().
   DirectBufferedInput(
       std::shared_ptr<ReadFileInputStream> input,
@@ -273,6 +259,21 @@ class DirectBufferedInput : public BufferedInput {
         fileSize_(input_->getLength()),
         options_(readerOptions) {}
 
+  // Regions that are candidates for loading.
+  const StringIdLease fileNum_;
+  const std::shared_ptr<cache::ScanTracker> tracker_;
+  const StringIdLease groupId_;
+  const std::shared_ptr<IoStatistics> ioStatistics_;
+  const std::shared_ptr<velox::IoStats> ioStats_;
+  folly::Executor* const executor_;
+  const uint64_t fileSize_;
+  const io::ReaderOptions options_;
+  std::vector<LoadRequest> requests_;
+
+  // Distinct coalesced loads in 'coalescedLoads_'.
+  std::vector<std::shared_ptr<cache::CoalescedLoad>> coalescedLoads_;
+
+ private:
   std::vector<int32_t> groupRequests(
       const std::vector<LoadRequest*>& requests,
       bool prefetch) const;

--- a/velox/dwio/common/tests/BufferedInputTest.cpp
+++ b/velox/dwio/common/tests/BufferedInputTest.cpp
@@ -695,18 +695,44 @@ class CustomDirectBufferedInput
     VELOX_NYI("Not implemented in CustomBufferedInputBuilder");
   }
 
+  std::unique_ptr<facebook::velox::dwio::common::BufferedInput> clone()
+      const override {
+    return std::unique_ptr<facebook::velox::dwio::common::BufferedInput>(
+        new CustomDirectBufferedInput(
+            input_,
+            fileNum_,
+            tracker_,
+            groupId_,
+            ioStatistics_,
+            ioStats_,
+            executor_,
+            options_));
+  }
+
  protected:
   // Expose protected members to verify their accessibility.
   using facebook::velox::dwio::common::DirectBufferedInput::coalescedLoads_;
-  using facebook::velox::dwio::common::DirectBufferedInput::executor_;
-  using facebook::velox::dwio::common::DirectBufferedInput::fileNum_;
-  using facebook::velox::dwio::common::DirectBufferedInput::fileSize_;
-  using facebook::velox::dwio::common::DirectBufferedInput::groupId_;
-  using facebook::velox::dwio::common::DirectBufferedInput::ioStatistics_;
-  using facebook::velox::dwio::common::DirectBufferedInput::ioStats_;
-  using facebook::velox::dwio::common::DirectBufferedInput::options_;
   using facebook::velox::dwio::common::DirectBufferedInput::requests_;
-  using facebook::velox::dwio::common::DirectBufferedInput::tracker_;
+
+ private:
+  CustomDirectBufferedInput(
+      std::shared_ptr<facebook::velox::dwio::common::ReadFileInputStream> input,
+      facebook::velox::StringIdLease fileNum,
+      std::shared_ptr<facebook::velox::cache::ScanTracker> tracker,
+      facebook::velox::StringIdLease groupId,
+      std::shared_ptr<facebook::velox::io::IoStatistics> ioStatistics,
+      std::shared_ptr<facebook::velox::IoStats> ioStats,
+      folly::Executor* executor,
+      const facebook::velox::io::ReaderOptions& readerOptions)
+      : DirectBufferedInput(
+            std::move(input),
+            std::move(fileNum),
+            std::move(tracker),
+            std::move(groupId),
+            std::move(ioStatistics),
+            std::move(ioStats),
+            executor,
+            readerOptions) {}
 };
 
 class CustomBufferedInputBuilder


### PR DESCRIPTION
The clone currently only carries the existing `ReadFileInputStream` and not all 
original constructor inputs, so rebuilding from ReadFile would not be behavior-
equivalent. This PR makes it protected to allow reuse of `input_`
(ReadFileInputStream), which retains the internal `fileIoContext_`.

Follow-up for: https://github.com/facebookincubator/velox/commit/084f2221a6a640cb7aa35a4fd067024166eb2d68.