### PR TITLE
fix(cudf): Fix CudfEnforceSingleRow hang by moving input_ in getOutput

### DIFF
--- a/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
+++ b/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
@@ -95,7 +95,7 @@ RowVectorPtr CudfEnforceSingleRow::getOutput() {
     return nullptr;
   }
 
-  return std::move(input_);
+  return std::exchange(input_, nullptr);
 }
 
 bool CudfEnforceSingleRow::isFinished() {

--- a/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
+++ b/velox/experimental/cudf/exec/CudfEnforceSingleRow.cpp
@@ -95,7 +95,7 @@ RowVectorPtr CudfEnforceSingleRow::getOutput() {
     return nullptr;
   }
 
-  return input_;
+  return std::move(input_);
 }
 
 bool CudfEnforceSingleRow::isFinished() {


### PR DESCRIPTION
Fix operator hang caused by missing `std::move()` in `getOutput()`.

`CudfEnforceSingleRow::getOutput()` returned `input_` without `std::move()`, leaving `input_` non-null after returning. Since `isFinished()` checks `noMoreInput_ && input_ == nullptr`, it never returned true, causing the driver to poll the operator indefinitely.