### PR TITLE
fix(connector): Fix execution operators to use query-scoped ConnectorRegistry lookup

### DIFF
--- a/velox/exec/IndexLookupJoin.cpp
+++ b/velox/exec/IndexLookupJoin.cpp
@@ -324,6 +324,7 @@ IndexLookupJoin::IndexLookupJoin(
           spillConfig_.has_value() ? &(spillConfig_.value()) : nullptr)},
       connector_(
           connector::ConnectorRegistry::tryGet(
+              *driverCtx->task->queryCtx(),
               lookupTableHandle_->connectorId())),
       maxNumInputBatches_(
           1 + driverCtx->queryConfig().indexLookupJoinMaxPrefetchBatches()),

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -92,7 +92,9 @@ TableScan::TableScan(
           operatorType(),
           tableHandle_->connectorId())),
       connector_(
-          connector::ConnectorRegistry::tryGet(tableHandle_->connectorId())),
+          connector::ConnectorRegistry::tryGet(
+              *driverCtx->task->queryCtx(),
+              tableHandle_->connectorId())),
       getOutputTimeLimitMs_(
           driverCtx_->queryConfig().tableScanGetOutputTimeLimitMs()),
       outputBatchRowsOverride_(

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -64,7 +64,8 @@ TableWriter::TableWriter(
         &nonReclaimableSection_);
   }
   const auto& connectorId = tableWriteNode->insertTableHandle()->connectorId();
-  connector_ = connector::ConnectorRegistry::tryGet(connectorId);
+  connector_ = connector::ConnectorRegistry::tryGet(
+      *driverCtx->task->queryCtx(), connectorId);
   connectorQueryCtx_ = operatorCtx_->createConnectorQueryCtx(
       connectorId,
       planNodeId(),


### PR DESCRIPTION
Summary:
TableScan, TableWriter, and IndexLookupJoin all called ConnectorRegistry::tryGet(connectorId) (global-only) in their constructors, ignoring the query-scoped API that was already implemented and tested. This meant per-query connector registry overrides attached to QueryCtx were silently bypassed during execution.

Change each operator to use ConnectorRegistry::tryGet(queryCtx, connectorId), which checks for a per-query registry override first, then falls back to the global registry. The QueryCtx is available via driverCtx->task->queryCtx() in all three constructors. When no override is set (the default), behavior is identical to the old global-only call.

Differential Revision: D100662333


