### PR TITLE
fix(ci): Strip ANSI color codes before extracting build errors

### DIFF
--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -187,7 +187,10 @@ jobs:
         id: build-errors
         if: failure() && steps.build.outcome == 'failure'
         run: |
-          BUILD_ERRORS=$(grep -E '^.*:(error|fatal error):' /tmp/build-output.log | head -50 || true)
+          # Strip ANSI color codes before grepping — the build uses
+          # -fdiagnostics-color=always which embeds escape sequences that
+          # prevent matching literal ': error:'.
+          BUILD_ERRORS=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/build-output.log | grep -E ' (error|fatal error):' | head -50 || true)
           if [[ -n $BUILD_ERRORS ]]; then
             {
               echo 'build-failure-details<<EOF'
@@ -541,7 +544,10 @@ jobs:
         id: build-errors
         if: failure() && steps.build.outcome == 'failure'
         run: |
-          BUILD_ERRORS=$(grep -E '^.*:(error|fatal error):' /tmp/build-output.log | head -50 || true)
+          # Strip ANSI color codes before grepping — the build uses
+          # -fdiagnostics-color=always which embeds escape sequences that
+          # prevent matching literal ': error:'.
+          BUILD_ERRORS=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/build-output.log | grep -E ' (error|fatal error):' | head -50 || true)
           if [[ -n $BUILD_ERRORS ]]; then
             {
               echo 'build-failure-details<<EOF'

--- a/.github/workflows/linux-build-base.yml
+++ b/.github/workflows/linux-build-base.yml
@@ -187,10 +187,10 @@ jobs:
         id: build-errors
         if: failure() && steps.build.outcome == 'failure'
         run: |
-          # Strip ANSI color codes before grepping — the build uses
-          # -fdiagnostics-color=always which embeds escape sequences that
-          # prevent matching literal ': error:'.
-          BUILD_ERRORS=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/build-output.log | grep -E ' (error|fatal error):' | head -50 || true)
+          # Strip ANSI escape sequences before grepping — the build uses
+          # -fdiagnostics-color=always which embeds SGR and erase (ESC[K)
+          # codes that prevent matching literal ': error:'.
+          BUILD_ERRORS=$(sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' /tmp/build-output.log | grep -E ' (error|fatal error):' | head -50 || true)
           if [[ -n $BUILD_ERRORS ]]; then
             {
               echo 'build-failure-details<<EOF'
@@ -544,10 +544,10 @@ jobs:
         id: build-errors
         if: failure() && steps.build.outcome == 'failure'
         run: |
-          # Strip ANSI color codes before grepping — the build uses
-          # -fdiagnostics-color=always which embeds escape sequences that
-          # prevent matching literal ': error:'.
-          BUILD_ERRORS=$(sed 's/\x1b\[[0-9;]*m//g' /tmp/build-output.log | grep -E ' (error|fatal error):' | head -50 || true)
+          # Strip ANSI escape sequences before grepping — the build uses
+          # -fdiagnostics-color=always which embeds SGR and erase (ESC[K)
+          # codes that prevent matching literal ': error:'.
+          BUILD_ERRORS=$(sed 's/\x1b\[[0-9;]*[a-zA-Z]//g' /tmp/build-output.log | grep -E ' (error|fatal error):' | head -50 || true)
           if [[ -n $BUILD_ERRORS ]]; then
             {
               echo 'build-failure-details<<EOF'


### PR DESCRIPTION
Fixes #17141

## Summary

Two bugs prevented build error extraction from working:

1. **ANSI escape codes**: The build uses `-fdiagnostics-color=always` which embeds ANSI escape sequences in the log. The grep for `: error:` fails because invisible codes sit between `:` and `error`. Fix: strip codes with `sed` before grepping.

2. **Wrong grep pattern**: The pattern `'^.*:(error|fatal error):'` expected `:error:` with no space, but GCC format is `file:line:col: error: msg` (space before `error`). This means the grep never matched even without ANSI codes. Fix: use `' (error|fatal error):'` instead.

Applied to both the adapters and ubuntu-debug extract steps.

## Test plan

- [x] Verified sed strips ANSI codes correctly
- [x] Verified grep pattern matches `error:` and `fatal error:` in GCC format
- [x] Verified normal build lines don't match
- [ ] Validate on next PR with a build failure that BUILD_FAILURE_DETAILS is populated