### PR TITLE
fix: Generate majority positive frame offset values in Window Fuzzer (#17153)

### DIFF
--- a/velox/exec/fuzzer/WindowFuzzer.cpp
+++ b/velox/exec/fuzzer/WindowFuzzer.cpp
@@ -83,12 +83,20 @@ std::string WindowFuzzer::generateKRowsFrameBound(
 
   constexpr int64_t kMax = std::numeric_limits<int64_t>::max();
   constexpr int64_t kMin = std::numeric_limits<int64_t>::min();
-  // For frames with kPreceding, kFollowing bounds, pick a valid k, in the
-  // range of 1 to 10, 70% of times. Test for random k values remaining times.
-  int64_t minKValue, maxKValue;
+  // For frames with kPreceding, kFollowing bounds:
+  // - 70%: pick a valid k in the range [1, 10].
+  // - 20%: pick a valid k in the full positive range [1, INT64_MAX].
+  // - 10%: pick from the full range [INT64_MIN, INT64_MAX] to exercise
+  //   invalid (negative/zero) offsets and verify both Velox and the reference
+  //   DB reject them consistently.
+  int64_t minKValue;
+  int64_t maxKValue;
   if (vectorFuzzer_.coinToss(0.7)) {
     minKValue = 1;
     maxKValue = 10;
+  } else if (vectorFuzzer_.coinToss(2.0 / 3.0)) {
+    minKValue = 1;
+    maxKValue = kMax;
   } else {
     minKValue = kMin;
     maxKValue = kMax;


### PR DESCRIPTION
Summary:

The Window Fuzzer's `generateKRowsFrameBound()` function previously used `[INT64_MIN, INT64_MAX]` as the range for random k values 30% of the time. This produced negative frame offsets (e.g. `-5 PRECEDING`) which are semantically invalid — both Presto and Velox reject them. When the fuzzer verifies results against a Presto reference database, these invalid queries cause Presto errors, inflating the 'reference DB failed' count and pushing the verification ratio below the 50% threshold.

Analysis of 8 recent Window Fuzzer failures on GitHub CI showed that 75 out of 105 total Presto errors (71%) were caused by negative frame offsets. This was the dominant source of flakiness (8% failure rate on push-to-main).

Fix: Change the distribution of generated k values to:
- 70%: valid, small range [1, 10]
- 20%: valid, full positive range [1, INT64_MAX]
- 10%: invalid, full range [INT64_MIN, INT64_MAX] to exercise negative/zero offsets and verify both Velox and the reference DB reject them consistently.

This retains coverage of invalid inputs at a low enough rate to avoid pushing the verification ratio below threshold, while ensuring the fuzzer verifies error behavior against the reference DB (requires the error verification in the follow-up diff D100732002).

Differential Revision: D100657400
