### PR TITLE
fix: SwitchExpr::computePropagatesNulls skips then-clauses due to wrong loop stride (#17155)

### DIFF
--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -192,8 +192,8 @@ void SwitchExpr::computePropagatesNulls() {
   // - All "then" clauses and optional "else" clause use the same inputs.
   // - All "condition" clauses use a subset of "then"/"else" inputs.
 
-  for (auto i = 0; i < numCases_; i += 2) {
-    if (!inputs_[i + 1]->propagatesNulls()) {
+  for (auto i = 0; i < numCases_; ++i) {
+    if (!inputs_[i * 2 + 1]->propagatesNulls()) {
       propagatesNulls_ = false;
       return;
     }

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1776,6 +1776,36 @@ TEST_P(ParameterizedExprTest, switchExprWithNull) {
   assertEqualVectors(expected, result);
 }
 
+// Verify that computePropagatesNulls iterates over all then-clauses when
+// checking null propagation. Uses a 3-WHEN CASE where the 3rd then-clause
+// (coalesce) does not propagate nulls. Null rows matching that clause must
+// return the coalesce result (0), not NULL.
+TEST_P(ParameterizedExprTest, switchPropagatesNullsAllThenClauses) {
+  auto c0 = makeNullableFlatVector<int64_t>({1, 2, std::nullopt, std::nullopt});
+  auto input = makeRowVector({c0});
+
+  // The 3rd then-clause uses coalesce, which does not propagate nulls. When
+  // c0 is null, cond1 and cond2 are false, cond3 (IS NULL) is true, and the
+  // result should be coalesce(null, 0) = 0.
+  auto result = evaluate(
+      "case when c0 = 1 then c0 + 10 "
+      "when c0 = 2 then c0 + 20 "
+      "when c0 is null then coalesce(c0, cast(0 as bigint)) end",
+      input);
+
+  auto expected = makeNullableFlatVector<int64_t>({11, 22, 0, 0});
+  assertEqualVectors(expected, result);
+
+  // Verify propagatesNulls is false since the 3rd then-clause (coalesce) does
+  // not propagate nulls.
+  auto typedExpr = parseExpression(
+      "case when c0 = 1 then c0 + 10 "
+      "when c0 = 2 then c0 + 20 "
+      "when c0 is null then coalesce(c0, cast(0 as bigint)) end",
+      ROW({"c0"}, {BIGINT()}));
+  EXPECT_FALSE(propagatesNulls(typedExpr));
+}
+
 TEST_P(ParameterizedExprTest, ifWithConstant) {
   vector_size_t size = 4;
 


### PR DESCRIPTION
Summary:

The first loop in `computePropagatesNulls()` uses `i += 2` as the loop increment, but `numCases_` counts WHEN clauses (not `inputs_` indices). This causes the loop to skip every other then-clause when checking null propagation.

`inputs_` is laid out as `{cond0, then0, cond1, then1, ..., optionalElse}` with `numCases_ = inputs_.size() / 2`. The loop should iterate `i = 0..numCases_-1` accessing `inputs_[i * 2 + 1]`, but instead iterates `i = 0, 2, 4, ...` accessing `inputs_[i + 1]`. For 3+ WHEN clauses, the 3rd (and later) then-clauses are never checked.

The second loop in the **same function** already uses the correct pattern: `for (auto i = 0; i < numCases_; ++i)` with `inputs_[i * 2 + 1]`.

**Impact:** When a skipped then-clause doesn't propagate nulls (e.g., `coalesce`), `propagatesNulls_` is incorrectly left `true`. This causes `evalSpecialForm` to deselect null rows and write NULLs instead of evaluating them through the CASE logic.

```sql
-- Returns NULL instead of 0 when x is null:
CASE WHEN x = 1 THEN x + 10
     WHEN x = 2 THEN x + 20
     WHEN x IS NULL THEN coalesce(x, 0)
     ELSE x + 100
END
```

Differential Revision: D100698733


