### PR TITLE
feat(function): Add ip_version and ip_prefix_masklen Presto functions (#17157) (#17157)

### DIFF
--- a/velox/docs/functions/presto/ipaddress.rst
+++ b/velox/docs/functions/presto/ipaddress.rst
@@ -69,6 +69,35 @@ IP Functions
         SELECT IP_PREFIX_SUBNETS(IPPREFIX '192.168.1.0/24', 25); -- [{192.168.1.0/25}, {192.168.1.128/25}]
         SELECT IP_PREFIX_SUBNETS(IPPREFIX '2a03:2880:c000::/34', 36); -- [{2a03:2880:c000::/36}, {2a03:2880:d000::/36}, {2a03:2880:e000::/36}, {2a03:2880:f000::/36}]
 
+.. function:: ip_version(ip_address) -> bigint
+
+    Returns ``4`` if ``ip_address`` is an IPv4 address, ``6`` if it is an IPv6 address.
+    IPv4-mapped IPv6 addresses (e.g. ``::ffff:1.2.3.4``) are treated as IPv4.
+    ``ip_address`` is of type ``IPADDRESS``. ::
+
+        SELECT ip_version(IPADDRESS '1.2.3.4'); -- 4
+        SELECT ip_version(IPADDRESS '::ffff:1.2.3.4'); -- 4
+        SELECT ip_version(IPADDRESS '64:ff9b::17'); -- 6
+        SELECT ip_version(IPADDRESS '2001:db8::1'); -- 6
+
+.. function:: ip_version(ip_prefix) -> bigint
+
+    Returns ``4`` if ``ip_prefix`` contains an IPv4 address, ``6`` if it contains an IPv6 address.
+    IPv4-mapped IPv6 prefixes are treated as IPv4.
+    ``ip_prefix`` is of type ``IPPREFIX``. ::
+
+        SELECT ip_version(IPPREFIX '1.2.3.4/24'); -- 4
+        SELECT ip_version(IPPREFIX '64:ff9b::17/64'); -- 6
+
+.. function:: ip_prefix_masklen(ip_prefix) -> bigint
+
+    Returns the prefix length (mask length) of ``ip_prefix``.
+    The value is in the range [0, 32] for IPv4 and [0, 128] for IPv6. ::
+
+        SELECT ip_prefix_masklen(IPPREFIX '1.2.3.4/24'); -- 24
+        SELECT ip_prefix_masklen(IPPREFIX '64:ff9b::17/128'); -- 128
+        SELECT ip_prefix_masklen(IPPREFIX '::/0'); -- 0
+
 .. function:: is_private_ip(ip_address) -> boolean
 
     Returns whether ``ip_address`` of type ``IPADDRESS`` is a private or reserved IP address

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -503,6 +503,8 @@ std::unordered_set<std::string> skipFunctionsSOT = {
     "s2_cell_level",
     "s2_cell_parent",
     "s2_cell_to_token",
+    "ip_version", // New function, pending Presto Java implementation
+    "ip_prefix_masklen", // New function, pending Presto Java implementation
 };
 
 int main(int argc, char** argv) {

--- a/velox/functions/prestosql/IPAddressFunctions.h
+++ b/velox/functions/prestosql/IPAddressFunctions.h
@@ -602,6 +602,40 @@ struct IsPrivateIPFunction {
   }
 };
 
+template <typename T>
+struct IPVersionFromIPAddressFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<IPAddress>& ip) {
+    result = isIPv4(*ip) ? 4 : 6;
+  }
+};
+
+template <typename T>
+struct IPVersionFromIPPrefixFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<IPPrefix>& ipPrefix) {
+    result = isIPv4(*ipPrefix.template at<0>()) ? 4 : 6;
+  }
+};
+
+template <typename T>
+struct IPPrefixMaskLenFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<int64_t>& result,
+      const arg_type<IPPrefix>& ipPrefix) {
+    result =
+        static_cast<int64_t>(static_cast<uint8_t>(*ipPrefix.template at<1>()));
+  }
+};
+
 void registerIPAddressFunctions(const std::string& prefix) {
   registerIPAddressType();
   registerIPPrefixType();
@@ -625,6 +659,12 @@ void registerIPAddressFunctions(const std::string& prefix) {
       {prefix + "ip_prefix_subnets"});
   registerFunction<IsPrivateIPFunction, bool, IPAddress>(
       {prefix + "is_private_ip"});
+  registerFunction<IPVersionFromIPAddressFunction, int64_t, IPAddress>(
+      {prefix + "ip_version"});
+  registerFunction<IPVersionFromIPPrefixFunction, int64_t, IPPrefix>(
+      {prefix + "ip_version"});
+  registerFunction<IPPrefixMaskLenFunction, int64_t, IPPrefix>(
+      {prefix + "ip_prefix_masklen"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/IPAddressFunctionsTest.cpp
@@ -721,4 +721,48 @@ TEST_F(IPAddressFunctionsTest, IsPrivateIPTest) {
   EXPECT_EQ(std::nullopt, isPrivateIP(std::nullopt));
 }
 
+TEST_F(IPAddressFunctionsTest, ipVersionFromAddress) {
+  auto ipVersionFromAddress = [this](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("ip_version(cast(c0 as ipaddress))", input);
+  };
+
+  ASSERT_EQ(ipVersionFromAddress("1.2.3.4"), 4);
+  ASSERT_EQ(ipVersionFromAddress("255.255.255.255"), 4);
+  ASSERT_EQ(ipVersionFromAddress("::ffff:1.2.3.4"), 4);
+  ASSERT_EQ(ipVersionFromAddress("64:ff9b::17"), 6);
+  ASSERT_EQ(ipVersionFromAddress("2001:db8::1"), 6);
+  ASSERT_EQ(ipVersionFromAddress("::"), 6);
+  ASSERT_EQ(ipVersionFromAddress(std::nullopt), std::nullopt);
+}
+
+TEST_F(IPAddressFunctionsTest, ipVersionFromPrefix) {
+  auto ipVersionFromPrefix = [this](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>("ip_version(cast(c0 as ipprefix))", input);
+  };
+
+  ASSERT_EQ(ipVersionFromPrefix("1.2.3.4/24"), 4);
+  ASSERT_EQ(ipVersionFromPrefix("192.168.0.0/16"), 4);
+  ASSERT_EQ(ipVersionFromPrefix("::ffff:1.2.3.4/24"), 4);
+  ASSERT_EQ(ipVersionFromPrefix("64:ff9b::17/64"), 6);
+  ASSERT_EQ(ipVersionFromPrefix("2001:db8::/32"), 6);
+  ASSERT_EQ(ipVersionFromPrefix("::1/128"), 6);
+  ASSERT_EQ(ipVersionFromPrefix(std::nullopt), std::nullopt);
+}
+
+TEST_F(IPAddressFunctionsTest, ipPrefixMaskLen) {
+  auto ipPrefixMaskLen = [this](const std::optional<std::string>& input) {
+    return evaluateOnce<int64_t>(
+        "ip_prefix_masklen(cast(c0 as ipprefix))", input);
+  };
+
+  ASSERT_EQ(ipPrefixMaskLen("1.2.3.4/24"), 24);
+  ASSERT_EQ(ipPrefixMaskLen("1.2.3.4/32"), 32);
+  ASSERT_EQ(ipPrefixMaskLen("0.0.0.0/0"), 0);
+  ASSERT_EQ(ipPrefixMaskLen("64:ff9b::17/64"), 64);
+  ASSERT_EQ(ipPrefixMaskLen("64:ff9b::17/128"), 128);
+  ASSERT_EQ(ipPrefixMaskLen("::1/128"), 128);
+  ASSERT_EQ(ipPrefixMaskLen("::/0"), 0);
+  ASSERT_EQ(ipPrefixMaskLen(std::nullopt), std::nullopt);
+}
+
 } // namespace facebook::velox::functions::prestosql


### PR DESCRIPTION
Summary:
Add three new IP address utility functions:
- ip_version(IPADDRESS) -> BIGINT
- ip_version(IPPREFIX) -> BIGINT
- ip_prefix_masklen(IPPREFIX) -> BIGINT

Without these functions, users who need IP version or prefix length
must cast to VARCHAR and parse the string representation. This forces
them to either defer the conversion to typed IPADDRESS/IPPREFIX and
carry raw VARCHAR throughout their dataflow, or create redundant
columns for metadata that should be derivable from the type itself.

This has three costs:

Correctness — String-based workarounds are error-prone. IPv4-mapped
IPv6 addresses like ::ffff:1.2.3.4 contain ":" but are IPv4.
Different string representations of the same IP can cause silent
mismatches. Dedicated functions operate on the native binary
representation, eliminating these classes of bugs.

Performance — String interaction is significantly slower than
operating on the typed representation. ip_version is a single bit
check on the 128-bit address; ip_prefix_masklen reads the stored
prefix length byte directly — no VARCHAR cast, no allocation, no
parsing.

Completeness — Presto already has a rich set of IP functions
(ip_prefix, ip_subnet_min, ip_subnet_max, ip_prefix_collapse,
is_subnet_of, is_private_ip), but lacks these two basic introspection
primitives. Adding them promotes the use of typed IPADDRESS/IPPREFIX
at the entry point of data pipelines.

Existing art: BigQuery has NET.IP_VERSION(). PostgreSQL's inet type
supports family() and masklen().

Presto docs: https://prestodb.io/docs/current/functions/ip.html
Discussion: https://fb.workplace.com/groups/presto.dev/permalink/31395723200049562/

Pulled By:
tc25898


tc25898

Reviewed By: kaikalur

Differential Revision: D100568584


