### PR TITLE
fix: Change default TpchConnectorSplit weight

### DIFF
--- a/velox/connectors/tpch/TpchConnectorSplit.h
+++ b/velox/connectors/tpch/TpchConnectorSplit.h
@@ -32,7 +32,7 @@ struct TpchConnectorSplit : public connector::ConnectorSplit {
       bool cacheable,
       size_t totalParts,
       size_t partNumber)
-      : ConnectorSplit(connectorId, /*_splitWeight=*/0, cacheable),
+      : ConnectorSplit(connectorId, /*_splitWeight=*/1, cacheable),
         totalParts(totalParts),
         partNumber(partNumber) {
     VELOX_CHECK_GE(totalParts, 1, "totalParts must be >= 1");


### PR DESCRIPTION
Summary:
Avoid setting weight to 0, as it effectively gives a signal to the scheduler
that split has 0 data to process

Differential Revision: D100745378


