### PR TITLE
fix(cudf): Remove deprecated call to filtered_join

### DIFF
--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -17,12 +17,12 @@ include_guard(GLOBAL)
 # 3.30.4 is the minimum version required by cudf
 cmake_minimum_required(VERSION 3.30.4)
 
-# rapids_cmake commit fa303cb from 2026-03-24
+# rapids_cmake commit cac9e0e from 2026-04-10
 set(VELOX_rapids_cmake_VERSION 26.06)
-set(VELOX_rapids_cmake_COMMIT fa303cb883f0e127fb2bb950d303626239050964)
+set(VELOX_rapids_cmake_COMMIT cac9e0ee144fdab03e8bd19f2124ec0239c36924)
 set(
   VELOX_rapids_cmake_BUILD_SHA256_CHECKSUM
-  633616ce36fa21097483e793caa0dd94b355ea3735b6cb2a83e6f0fc10866bbd
+  a43b508ac36a1154a656b2996180ec1e73b08feaa344888856b67661f70ebac5
 )
 set(
   VELOX_rapids_cmake_SOURCE_URL
@@ -30,22 +30,22 @@ set(
 )
 velox_resolve_dependency_url(rapids_cmake)
 
-# rmm commit ad99c11 from 2026-03-23
+# rmm commit b899854 from 2026-04-10
 set(VELOX_rmm_VERSION 26.06)
-set(VELOX_rmm_COMMIT ad99c114b62b9e1c8277563fe353ffb80589c84b)
+set(VELOX_rmm_COMMIT b89985443b4e68edfd44d5b4fc91813d7e3d5b52)
 set(
   VELOX_rmm_BUILD_SHA256_CHECKSUM
-  baf203f4579bd778118360839bad57836aae4b07e482bec486ce5a850d92199d
+  f010961681329599d22a0b09f8cef7f68c4d9ce70a6dc5be9ff258e40fae0168
 )
 set(VELOX_rmm_SOURCE_URL "https://github.com/rapidsai/rmm/archive/${VELOX_rmm_COMMIT}.tar.gz")
 velox_resolve_dependency_url(rmm)
 
-# kvikio commit b2bbfcc from 2026-03-24
+# kvikio commit 974cb68 from 2026-04-10
 set(VELOX_kvikio_VERSION 26.06)
-set(VELOX_kvikio_COMMIT b2bbfcc3147fbadcdaf0e3f4b9737d9dd4bf76a0)
+set(VELOX_kvikio_COMMIT 974cb68f00d00c1ba237bb7e2fe5d892d028d057)
 set(
   VELOX_kvikio_BUILD_SHA256_CHECKSUM
-  d805843c9534a29815a66a1f047d4cac17cc6654da324a1f2a615330a8106ca1
+  9c3869ca8b701be045c11c5c094ac6ef35f0dd67b1babafbe17db73202472dd5
 )
 set(
   VELOX_kvikio_SOURCE_URL
@@ -53,12 +53,12 @@ set(
 )
 velox_resolve_dependency_url(kvikio)
 
-# cudf commit b593be9 from 2026-03-24
+# cudf commit 431604c from 2026-04-13
 set(VELOX_cudf_VERSION 26.06 CACHE STRING "cudf version")
-set(VELOX_cudf_COMMIT b593be9ab0bf144997efce09aaf9946f05113a39)
+set(VELOX_cudf_COMMIT 431604c73f18de37baaefcabe4f0e9a3d56627b2)
 set(
   VELOX_cudf_BUILD_SHA256_CHECKSUM
-  8f42f98a160388f45384f4ffa5f7c565c0532e6294dea1491b875cdfd28a70ec
+  c11f7f501abdbe73bd38ba3e8704219ced6dfb3cd867278f3c1330e6b5b494d6
 )
 set(VELOX_cudf_SOURCE_URL "https://github.com/rapidsai/cudf/archive/${VELOX_cudf_COMMIT}.tar.gz")
 velox_resolve_dependency_url(cudf)

--- a/velox/experimental/cudf/exec/CudfHashJoin.cpp
+++ b/velox/experimental/cudf/exec/CudfHashJoin.cpp
@@ -1213,7 +1213,6 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::leftSemiFilterJoin(
       cudf::filtered_join filter_join(
           rightTableView.select(rightKeyIndices_),
           cudf::null_equality::UNEQUAL,
-          cudf::set_as_build_table::RIGHT,
           stream);
       leftJoinIndices = filter_join.semi_join(
           leftTableView.select(leftKeyIndices_), stream, get_temp_mr());
@@ -1527,7 +1526,6 @@ CudfHashJoinProbe::rightSemiFilterJoin(
     cudf::filtered_join filter_join(
         leftTableView.select(leftKeyIndices_),
         cudf::null_equality::UNEQUAL,
-        cudf::set_as_build_table::RIGHT,
         stream);
     rightJoinIndices = filter_join.semi_join(
         rightTableView.select(rightKeyIndices_), stream, get_temp_mr());
@@ -1603,7 +1601,6 @@ std::vector<std::unique_ptr<cudf::table>> CudfHashJoinProbe::antiJoin(
       cudf::filtered_join filter_join(
           rightTableView.select(rightKeyIndices_),
           cudf::null_equality::UNEQUAL,
-          cudf::set_as_build_table::RIGHT,
           stream);
       leftJoinIndices = filter_join.anti_join(
           leftTableView.select(leftKeyIndices_), stream, get_temp_mr());

--- a/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
+++ b/velox/experimental/cudf/exec/CudfMarkDistinct.cpp
@@ -110,10 +110,7 @@ RowVectorPtr CudfMarkDistinct::getOutput() {
         stream,
         tempMr);
     seenFilter_ = std::make_unique<cudf::filtered_join>(
-        seenKeys_->view(),
-        cudf::null_equality::EQUAL,
-        cudf::set_as_build_table::RIGHT,
-        stream);
+        seenKeys_->view(), cudf::null_equality::EQUAL, stream);
 
   } else {
     // Subsequent batch: probe the persistent filter — no hash table rebuild.
@@ -164,10 +161,7 @@ RowVectorPtr CudfMarkDistinct::getOutput() {
           seenKeys_->view(), newKeys->view()};
       seenKeys_ = cudf::concatenate(seenPlusNew, stream, tempMr);
       seenFilter_ = std::make_unique<cudf::filtered_join>(
-          seenKeys_->view(),
-          cudf::null_equality::EQUAL,
-          cudf::set_as_build_table::RIGHT,
-          stream);
+          seenKeys_->view(), cudf::null_equality::EQUAL, stream);
     }
   }
 


### PR DESCRIPTION
This PR updates cudf and dependencies to avoid the `filtered_join` constructor that was deprecated in https://github.com/rapidsai/cudf/pull/21982.
