### PR TITLE
fix(build): Fix `-Werror=type-limits` warnings in `DecimalUtil.cpp`

### DIFF
--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -20,9 +20,7 @@
 namespace facebook::velox {
 namespace {
 std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
-  VELOX_DCHECK_GE(scale, 0);
-  VELOX_DCHECK_LT(
-      static_cast<size_t>(scale), sizeof(DecimalUtil::kPowersOfTen));
+  VELOX_DCHECK_LT(scale, std::size(DecimalUtil::kPowersOfTen));
   const bool isFraction = (scale > 0);
   if (unscaledValue == 0) {
     if (isFraction) {


### PR DESCRIPTION
## Summary
- Remove redundant `VELOX_DCHECK_GE(scale, 0)` where `scale` is `uint8_t` (always >= 0).
- Replace `sizeof(DecimalUtil::kPowersOfTen)` with `std::size(DecimalUtil::kPowersOfTen)` to compare against the array element count (39) instead of its byte size (624). This now correctly validates `scale < 39` (array element count) instead of `scale < 624` (byte size).

These warnings are only observed in debug builds (GCC 14.2.0) because `VELOX_DCHECK_*` macros expand to no-ops in release builds.

Fixes #17161

With these changes, the build passes in debug mode with `-Werror=type-limits` enabled.