### PR TITLE
fix(cudf): Synchronize stream before freeing Arrow host buffers in toCudfTable

### DIFF
--- a/velox/experimental/cudf/exec/CudfConversion.cpp
+++ b/velox/experimental/cudf/exec/CudfConversion.cpp
@@ -145,13 +145,11 @@ RowVectorPtr CudfFromVelox::getOutput() {
   // Get a stream from the global stream pool
   auto stream = cudfGlobalStreamPool().get_stream();
 
-  // Convert RowVector to cudf table
+  // Convert RowVector to cudf table.  toCudfTable synchronizes the stream
+  // internally before releasing Arrow host buffers, so no additional sync
+  // is needed here.
   auto tbl = with_arrow::toCudfTable(
       input, input->pool(), stream, get_output_mr(), timestampTimeZone_);
-
-  // Synchronize to ensure toCudfTable finishes reading from input's CPU buffers
-  // before input goes out of scope
-  stream.synchronize();
 
   VELOX_CHECK_NOT_NULL(tbl);
 

--- a/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
+++ b/velox/experimental/cudf/exec/VeloxCudfInterop.cpp
@@ -166,6 +166,13 @@ std::unique_ptr<cudf::table> toCudfTable(
       arrowOptions);
   auto tbl = cudf::from_arrow(&arrowSchema, &arrowArray, stream, mr);
 
+  // Synchronize before releasing Arrow resources.  cudf::from_arrow uses
+  // cudaMemcpyBatchAsync (CUDA 13.0+) with cudaMemcpySrcAccessOrderStream,
+  // which defers reading the host source buffers until the stream reaches
+  // each copy.  The Arrow arrays must therefore stay alive until the stream
+  // has executed those copies.
+  stream.synchronize();
+
   // Release Arrow resources
   if (arrowArray.release) {
     arrowArray.release(&arrowArray);


### PR DESCRIPTION
## Summary

Fixes #17163.

`toCudfTable()` frees Arrow host buffers immediately after `cudf::from_arrow()` returns, but `from_arrow()` uses `cudaMemcpyBatchAsync` (CUDA 13.0+) with `cudaMemcpySrcAccessOrderStream` which defers reading source buffers until the stream reaches each copy. The freed host memory is then read by the CUDA driver's event handler thread, causing a SIGSEGV.

Move `stream.synchronize()` into `toCudfTable()` before the Arrow resource release so that all async H2D copies complete while source buffers are still valid. Remove the now-redundant synchronize from `CudfFromVelox::getOutput()`.

## Testing

Ran `velox_cudf_tpch_benchmark` Q11 SF100 with `--num_repeats=100 --num_drivers=4` — crashes immediately without the fix, completes all iterations with the fix (verified across multiple runs). All existing Velox-cuDF tests are passing.