### PR TITLE
fix: Add `toIntermediate` and fix Spark approx_percentile signature

### DIFF
--- a/velox/functions/lib/aggregates/ApproxPercentileAggregateBase.h
+++ b/velox/functions/lib/aggregates/ApproxPercentileAggregateBase.h
@@ -232,6 +232,59 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
     return false;
   }
 
+  bool supportsToIntermediate() const override {
+    return true;
+  }
+
+  void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const override {
+    auto* self = const_cast<ApproxPercentileAggregateBase*>(this);
+    if (rows.hasSelections()) {
+      self->decodeArguments(rows, args);
+    }
+    const auto numRows = rows.size();
+
+    std::vector<detail::KllSketch<T, std::allocator<T>>> sketches;
+    sketches.reserve(numRows);
+    detail::KllSketchAccumulator<T> kProbe(allocator_, fixedRandomSeed_);
+    AccuracyPolicy::setOnAccumulator(&kProbe, self->accuracy_);
+    const auto sketchK = kProbe.getSketch().k();
+
+    for (vector_size_t row = 0; row < numRows; ++row) {
+      if (!rows.isValid(row) || self->decodedValue_.isNullAt(row)) {
+        sketches.emplace_back();
+        continue;
+      }
+
+      int64_t count = 1;
+
+      if constexpr (kHasWeight) {
+        if (self->hasWeight_) {
+          if (self->decodedWeight_.isNullAt(row)) {
+            sketches.emplace_back();
+            continue;
+          }
+          count = self->decodedWeight_.template valueAt<int64_t>(row);
+          self->checkWeight(count);
+        }
+      }
+
+      const auto value = self->decodedValue_.template valueAt<T>(row);
+      sketches.push_back(
+          detail::KllSketch<T, std::allocator<T>>::fromRepeatedValue(
+              value,
+              count,
+              sketchK,
+              std::allocator<T>(),
+              detail::getRandomSeed(fixedRandomSeed_)));
+    }
+
+    auto resultPtr = &result;
+    self->writeIntermediateFromSketches(sketches, numRows, resultPtr);
+  }
+
   void addRawInput(
       char** groups,
       const SelectivityVector& rows,
@@ -394,122 +447,7 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
               fixedRandomSeed_));
     }
 
-    VELOX_CHECK(result);
-    auto rowResult = (*result)->as<RowVector>();
-    VELOX_CHECK(rowResult);
-    auto pool = rowResult->pool();
-
-    // percentiles_ can be uninitialized during an intermediate aggregation step
-    // when all input intermediate states are nulls. Result should be nulls in
-    // this case.
-    using Idx = ApproxPercentileIntermediateTypeChildIndex;
-    if (!percentiles_) {
-      rowResult->ensureWritable(SelectivityVector{numGroups});
-      // rowResult->childAt(i) for i = kPercentiles, kPercentilesIsArray, and
-      // kAccuracy are expected to be constant in addIntermediateResults.
-      rowResult->childAt(static_cast<int>(Idx::kPercentiles)) =
-          BaseVector::createNullConstant(ARRAY(DOUBLE()), numGroups, pool);
-      rowResult->childAt(static_cast<int>(Idx::kPercentilesIsArray)) =
-          BaseVector::createNullConstant(BOOLEAN(), numGroups, pool);
-      rowResult->childAt(static_cast<int>(Idx::kAccuracy)) =
-          BaseVector::createNullConstant(
-              CppToType<AccuracyIntermediateType>::create(), numGroups, pool);
-
-      // Set nulls for all rows.
-      auto rawNulls = rowResult->mutableRawNulls();
-      bits::fillBits(rawNulls, 0, rowResult->size(), bits::kNull);
-      return;
-    }
-    auto& values = percentiles_->values;
-    auto size = values.size();
-    auto elements =
-        BaseVector::create<FlatVector<double>>(DOUBLE(), size, pool);
-    std::copy(values.begin(), values.end(), elements->mutableRawValues());
-    auto array = std::make_shared<ArrayVector>(
-        pool,
-        ARRAY(DOUBLE()),
-        nullptr,
-        1,
-        AlignedBuffer::allocate<vector_size_t>(1, pool, 0),
-        AlignedBuffer::allocate<vector_size_t>(1, pool, size),
-        std::move(elements));
-    rowResult->childAt(static_cast<int>(Idx::kPercentiles)) =
-        BaseVector::wrapInConstant(numGroups, 0, std::move(array));
-    rowResult->childAt(static_cast<int>(Idx::kPercentilesIsArray)) =
-        std::make_shared<ConstantVector<bool>>(
-            pool,
-            numGroups,
-            false,
-            BOOLEAN(),
-            static_cast<bool&&>(percentiles_->isArray));
-
-    bool isDefaultAccuracy = AccuracyPolicy::isDefaultAccuracy(accuracy_);
-    auto accuracyIntermediateValue = accuracy_;
-    rowResult->childAt(static_cast<int>(Idx::kAccuracy)) =
-        std::make_shared<ConstantVector<AccuracyIntermediateType>>(
-            pool,
-            numGroups,
-            isDefaultAccuracy,
-            CppToType<AccuracyIntermediateType>::create(),
-            std::move(accuracyIntermediateValue));
-    auto k =
-        rowResult->childAt(static_cast<int>(Idx::kK))->asFlatVector<int32_t>();
-    auto n =
-        rowResult->childAt(static_cast<int>(Idx::kN))->asFlatVector<int64_t>();
-    auto minValue =
-        rowResult->childAt(static_cast<int>(Idx::kMinValue))->asFlatVector<T>();
-    auto maxValue =
-        rowResult->childAt(static_cast<int>(Idx::kMaxValue))->asFlatVector<T>();
-    auto items =
-        rowResult->childAt(static_cast<int>(Idx::kItems))->as<ArrayVector>();
-    auto levels =
-        rowResult->childAt(static_cast<int>(Idx::kLevels))->as<ArrayVector>();
-
-    rowResult->resize(numGroups);
-    k->resize(numGroups);
-    n->resize(numGroups);
-    minValue->resize(numGroups);
-    maxValue->resize(numGroups);
-    items->resize(numGroups);
-    levels->resize(numGroups);
-
-    auto itemsElements = items->elements()->asFlatVector<T>();
-    auto levelsElements = levels->elements()->asFlatVector<int32_t>();
-    size_t itemsCount = 0;
-    vector_size_t levelsCount = 0;
-    for (auto& sketch : sketches) {
-      auto v = sketch.toView();
-      itemsCount += v.items.size();
-      levelsCount += v.levels.size();
-    }
-    VELOX_CHECK_LE(itemsCount, std::numeric_limits<vector_size_t>::max());
-    itemsElements->resetNulls();
-    itemsElements->resize(itemsCount);
-    levelsElements->resetNulls();
-    levelsElements->resize(levelsCount);
-
-    auto rawItems = itemsElements->mutableRawValues();
-    auto rawLevels = levelsElements->mutableRawValues();
-    itemsCount = 0;
-    levelsCount = 0;
-    for (int i = 0; i < sketches.size(); ++i) {
-      auto v = sketches[i].toView();
-      if (v.n == 0) {
-        rowResult->setNull(i, true);
-      } else {
-        rowResult->setNull(i, false);
-        k->set(i, v.k);
-        n->set(i, v.n);
-        minValue->set(i, v.minValue);
-        maxValue->set(i, v.maxValue);
-        std::copy(v.items.begin(), v.items.end(), rawItems + itemsCount);
-        items->setOffsetAndSize(i, itemsCount, v.items.size());
-        itemsCount += v.items.size();
-        std::copy(v.levels.begin(), v.levels.end(), rawLevels + levelsCount);
-        levels->setOffsetAndSize(i, levelsCount, v.levels.size());
-        levelsCount += v.levels.size();
-      }
-    }
+    writeIntermediateFromSketches(sketches, numGroups, result);
   }
 
  protected:
@@ -902,6 +840,128 @@ class ApproxPercentileAggregateBase : public exec::Aggregate {
       if (!views.empty()) {
         auto tracker = trackRowSize(group);
         accumulator->append(views);
+      }
+    }
+  }
+
+  void writeIntermediateFromSketches(
+      const std::vector<detail::KllSketch<T, std::allocator<T>>>& sketches,
+      int32_t numGroups,
+      VectorPtr* result) const {
+    VELOX_CHECK(result);
+    auto rowResult = (*result)->as<RowVector>();
+    VELOX_CHECK(rowResult);
+    auto pool = rowResult->pool();
+
+    // percentiles_ can be uninitialized during an intermediate aggregation step
+    // when all input intermediate states are nulls. Result should be nulls in
+    // this case.
+    using Idx = ApproxPercentileIntermediateTypeChildIndex;
+    if (!percentiles_) {
+      rowResult->ensureWritable(SelectivityVector{numGroups});
+      // rowResult->childAt(i) for i = kPercentiles, kPercentilesIsArray, and
+      // kAccuracy are expected to be constant in addIntermediateResults.
+      rowResult->childAt(static_cast<int>(Idx::kPercentiles)) =
+          BaseVector::createNullConstant(ARRAY(DOUBLE()), numGroups, pool);
+      rowResult->childAt(static_cast<int>(Idx::kPercentilesIsArray)) =
+          BaseVector::createNullConstant(BOOLEAN(), numGroups, pool);
+      rowResult->childAt(static_cast<int>(Idx::kAccuracy)) =
+          BaseVector::createNullConstant(
+              CppToType<AccuracyIntermediateType>::create(), numGroups, pool);
+
+      // Set nulls for all rows.
+      auto rawNulls = rowResult->mutableRawNulls();
+      bits::fillBits(rawNulls, 0, rowResult->size(), bits::kNull);
+      return;
+    }
+    auto& values = percentiles_->values;
+    auto size = values.size();
+    auto elements =
+        BaseVector::create<FlatVector<double>>(DOUBLE(), size, pool);
+    std::copy(values.begin(), values.end(), elements->mutableRawValues());
+    auto array = std::make_shared<ArrayVector>(
+        pool,
+        ARRAY(DOUBLE()),
+        nullptr,
+        1,
+        AlignedBuffer::allocate<vector_size_t>(1, pool, 0),
+        AlignedBuffer::allocate<vector_size_t>(1, pool, size),
+        std::move(elements));
+    rowResult->childAt(static_cast<int>(Idx::kPercentiles)) =
+        BaseVector::wrapInConstant(numGroups, 0, std::move(array));
+    rowResult->childAt(static_cast<int>(Idx::kPercentilesIsArray)) =
+        std::make_shared<ConstantVector<bool>>(
+            pool,
+            numGroups,
+            false,
+            BOOLEAN(),
+            static_cast<bool>(percentiles_->isArray));
+
+    bool isDefaultAccuracy = AccuracyPolicy::isDefaultAccuracy(accuracy_);
+    auto accuracyIntermediateValue = accuracy_;
+    rowResult->childAt(static_cast<int>(Idx::kAccuracy)) =
+        std::make_shared<ConstantVector<AccuracyIntermediateType>>(
+            pool,
+            numGroups,
+            isDefaultAccuracy,
+            CppToType<AccuracyIntermediateType>::create(),
+            std::move(accuracyIntermediateValue));
+    auto k =
+        rowResult->childAt(static_cast<int>(Idx::kK))->asFlatVector<int32_t>();
+    auto n =
+        rowResult->childAt(static_cast<int>(Idx::kN))->asFlatVector<int64_t>();
+    auto minValue =
+        rowResult->childAt(static_cast<int>(Idx::kMinValue))->asFlatVector<T>();
+    auto maxValue =
+        rowResult->childAt(static_cast<int>(Idx::kMaxValue))->asFlatVector<T>();
+    auto items =
+        rowResult->childAt(static_cast<int>(Idx::kItems))->as<ArrayVector>();
+    auto levels =
+        rowResult->childAt(static_cast<int>(Idx::kLevels))->as<ArrayVector>();
+
+    rowResult->resize(numGroups);
+    k->resize(numGroups);
+    n->resize(numGroups);
+    minValue->resize(numGroups);
+    maxValue->resize(numGroups);
+    items->resize(numGroups);
+    levels->resize(numGroups);
+
+    auto itemsElements = items->elements()->asFlatVector<T>();
+    auto levelsElements = levels->elements()->asFlatVector<int32_t>();
+    size_t itemsCount = 0;
+    vector_size_t levelsCount = 0;
+    for (auto& sketch : sketches) {
+      auto v = sketch.toView();
+      itemsCount += v.items.size();
+      levelsCount += v.levels.size();
+    }
+    VELOX_CHECK_LE(itemsCount, std::numeric_limits<vector_size_t>::max());
+    itemsElements->resetNulls();
+    itemsElements->resize(itemsCount);
+    levelsElements->resetNulls();
+    levelsElements->resize(levelsCount);
+
+    auto rawItems = itemsElements->mutableRawValues();
+    auto rawLevels = levelsElements->mutableRawValues();
+    itemsCount = 0;
+    levelsCount = 0;
+    for (int i = 0; i < sketches.size(); ++i) {
+      auto v = sketches[i].toView();
+      if (v.n == 0) {
+        rowResult->setNull(i, true);
+      } else {
+        rowResult->setNull(i, false);
+        k->set(i, v.k);
+        n->set(i, v.n);
+        minValue->set(i, v.minValue);
+        maxValue->set(i, v.maxValue);
+        std::copy(v.items.begin(), v.items.end(), rawItems + itemsCount);
+        items->setOffsetAndSize(i, itemsCount, v.items.size());
+        itemsCount += v.items.size();
+        std::copy(v.levels.begin(), v.levels.end(), rawLevels + levelsCount);
+        levels->setOffsetAndSize(i, levelsCount, v.levels.size());
+        levelsCount += v.levels.size();
       }
     }
   }

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -447,6 +447,37 @@ TEST_F(ApproxPercentileTest, partialFull) {
   waitForAllTasksToBeDeleted();
 }
 
+TEST_F(ApproxPercentileTest, partialFinalAbandonWithWeight) {
+  std::vector<RowVectorPtr> data = {
+      makeRowVector({
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(150, [](auto /*row*/) { return 1; }),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+          makeFlatVector<int64_t>(150, [](auto /*row*/) { return 1; }),
+      }),
+  };
+
+  createDuckDbTable(data);
+
+  auto plan =
+      PlanBuilder()
+          .values(data)
+          .partialAggregation({"c0"}, {"approx_percentile(c1, c2, 0.5, 0.01)"})
+          .finalAggregation()
+          .planNode();
+
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "100")
+      .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "50")
+      .maxDrivers(1)
+      .plan(plan)
+      .assertResults("SELECT c0, c0 FROM tmp GROUP BY 1");
+}
+
 TEST_F(ApproxPercentileTest, finalAggregateAccuracy) {
   auto batch = makeRowVector(
       {makeFlatVector<int32_t>(1000, [](auto row) { return row; })});

--- a/velox/functions/sparksql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/ApproxPercentileAggregate.cpp
@@ -103,7 +103,7 @@ void addSignatures(
           .returnType(inputType)
           .intermediateType(intermediateType)
           .argumentType(inputType)
-          .argumentType("double")
+          .constantArgumentType("double")
           .build());
   // Signature 2: approx_percentile(T, double, integer) -> T (single percentile,
   // explicit accuracy).
@@ -112,16 +112,16 @@ void addSignatures(
           .returnType(inputType)
           .intermediateType(intermediateType)
           .argumentType(inputType)
-          .argumentType("double")
-          .argumentType("integer")
+          .constantArgumentType("double")
+          .constantArgumentType("integer")
           .build());
   signatures.push_back(
       exec::AggregateFunctionSignatureBuilder()
           .returnType(inputType)
           .intermediateType(intermediateType)
           .argumentType(inputType)
-          .argumentType("double")
-          .argumentType("bigint")
+          .constantArgumentType("double")
+          .constantArgumentType("bigint")
           .build());
   // Signature 3: approx_percentile(T, array(double)) -> array(T) (percentile
   // array, default accuracy).
@@ -131,7 +131,7 @@ void addSignatures(
           .returnType(arrayReturnType)
           .intermediateType(intermediateType)
           .argumentType(inputType)
-          .argumentType("array(double)")
+          .constantArgumentType("array(double)")
           .build());
   // Signature 4: approx_percentile(T, array(double), integer) -> array(T)
   // (percentile array, explicit accuracy).
@@ -140,16 +140,16 @@ void addSignatures(
           .returnType(arrayReturnType)
           .intermediateType(intermediateType)
           .argumentType(inputType)
-          .argumentType("array(double)")
-          .argumentType("integer")
+          .constantArgumentType("array(double)")
+          .constantArgumentType("integer")
           .build());
   signatures.push_back(
       exec::AggregateFunctionSignatureBuilder()
           .returnType(arrayReturnType)
           .intermediateType(intermediateType)
           .argumentType(inputType)
-          .argumentType("array(double)")
-          .argumentType("bigint")
+          .constantArgumentType("array(double)")
+          .constantArgumentType("bigint")
           .build());
 }
 

--- a/velox/functions/sparksql/aggregates/tests/ApproxPercentileAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/ApproxPercentileAggregateTest.cpp
@@ -382,6 +382,37 @@ TEST_F(ApproxPercentileAggregateTest, partialFinalGroupBy) {
   AssertQueryBuilder(plan).assertResults(expectedResult);
 }
 
+TEST_F(ApproxPercentileAggregateTest, partialFinalAbandon) {
+  std::vector<RowVectorPtr> data = {
+      makeRowVector({
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+      }),
+      makeRowVector({
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+          makeFlatVector<int32_t>(150, [](auto row) { return row; }),
+      }),
+  };
+
+  createDuckDbTable(data);
+
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .partialAggregation(
+                      {"c0"},
+                      {"spark_approx_percentile(c1, 0.5)",
+                       "spark_approx_percentile(c1, 0.5, 10000)"})
+                  .finalAggregation()
+                  .planNode();
+
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "100")
+      .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "50")
+      .maxDrivers(1)
+      .plan(plan)
+      .assertResults("SELECT c0, c0, c0 FROM tmp GROUP BY 1");
+}
+
 // Test final aggregation accuracy by merging multiple partial results.
 TEST_F(ApproxPercentileAggregateTest, finalAggregateAccuracy) {
   auto batch = makeRowVector(


### PR DESCRIPTION
This PR adds a `toIntermediate()` fast path in `ApproxPercentileAggregateBase`, 
so when partial aggregation is abandoned, `GroupingSet::toIntermediate()` no 
longer falls back to per-row KLL accumulator allocation, but instead builds the 
intermediate results directly from raw input.

This PR also fixes the Spark `approx_percentile` signature by making `percentile`
and `accuracy` to be constants. This aligns with Spark’s requirement:
[ApproximatePercentile.scala](https://github.com/apache/spark/blob/v4.0.0/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/ApproximatePercentile.scala#L125-L141).

Related issue: https://github.com/facebookincubator/velox/issues/17124.