### PR TITLE
misc: Prepare for TimestampUtcType full support

### DIFF
--- a/velox/connectors/hive/FileConnectorUtil.cpp
+++ b/velox/connectors/hive/FileConnectorUtil.cpp
@@ -205,6 +205,7 @@ bool applyPartitionFilter(
       return applyFilter(*filter, folly::to<bool>(partitionValue));
     }
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       auto result = util::fromTimestampString(
           StringView(partitionValue), util::TimestampParseMode::kPrestoCast);
       VELOX_CHECK(!result.hasError());

--- a/velox/connectors/hive/FileSplitReader.cpp
+++ b/velox/connectors/hive/FileSplitReader.cpp
@@ -74,6 +74,7 @@ VectorPtr newConstantFromStringImpl(
                       VELOX_USER_FAIL("{}", status.message());
                     });
     if constexpr (kind == TypeKind::TIMESTAMP) {
+      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       if (isLocalTimestamp) {
         copy.toGMT(Timestamp::defaultTimezone());
       }

--- a/velox/connectors/hive/iceberg/IcebergDataSink.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSink.cpp
@@ -76,6 +76,7 @@ template <>
 folly::dynamic extractPartitionValue<TypeKind::TIMESTAMP>(
     const VectorPtr& child,
     vector_size_t row) {
+  VELOX_DCHECK(child->type()->equivalent(*TIMESTAMP()));
   return child->asChecked<SimpleVector<Timestamp>>()->valueAt(row).toMicros();
 }
 

--- a/velox/connectors/hive/iceberg/PartitionSpec.cpp
+++ b/velox/connectors/hive/iceberg/PartitionSpec.cpp
@@ -49,6 +49,10 @@ bool isValidPartitionType(const TypePtr& type) {
 }
 
 bool canTransform(TransformType transformType, const TypePtr& type) {
+  if (type->isTimestamp()) {
+    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
+  }
+
   switch (transformType) {
     case TransformType::kIdentity:
       return type->isTinyint() || type->isSmallint() || type->isInteger() ||

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -293,10 +293,13 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     VELOX_CHECK(options.parquetWriteTimestampUnit.has_value());
     const auto [values, expectedValues] = timestampValues(
         options.parquetWriteTimestampUnit.value(), readTimestampPrecision);
+    // Parquet writer relies on Arrow bridge for schema conversion.
+    // TODO: Switch back to TIMESTAMP_UTC() once Arrow bridge supports
+    // TimestampUtcType.
     auto vector = makeRowVector(
         {"t"},
         {
-            makeFlatVector<Timestamp>(values, TIMESTAMP_UTC()),
+            makeFlatVector<Timestamp>(values, TIMESTAMP()),
         });
     auto file = TempFilePath::create();
     writeToParquetFile(file->getPath(), {vector}, options);

--- a/velox/dwio/text/reader/TextReader.cpp
+++ b/velox/dwio/text/reader/TextReader.cpp
@@ -1432,6 +1432,7 @@ void TextRowReader::readElement(
       break;
 
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(t->equivalent(*TIMESTAMP()));
       const std::string& s = getString(*this, isNull, delim);
 
       // Early return if no data vector or at EOF

--- a/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.cpp
+++ b/velox/exec/fuzzer/DuckQueryRunnerToSqlPlanNodeVisitor.cpp
@@ -36,6 +36,7 @@ bool containsMap(const TypePtr& type) {
 bool isSupportedType(const TypePtr& type) {
   // DuckDB doesn't support nanosecond precision for timestamps.
   if (type->kind() == TypeKind::TIMESTAMP) {
+    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return false;
   }
   for (auto i = 0; i < type->size(); ++i) {

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -712,6 +712,14 @@ void CastExpr::applyCastPrimitivesDispatch(
     VectorPtr& result) {
   context.ensureWritable(rows, toType, result);
 
+  if (fromType->kind() == TypeKind::TIMESTAMP) {
+    VELOX_DCHECK(fromType->equivalent(*TIMESTAMP()));
+  }
+
+  if constexpr (ToKind == TypeKind::TIMESTAMP) {
+    VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
+  }
+
   if (isSupportedFastUpcast(fromType, toType)) {
     VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
         applyNumericUpcast,

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -85,6 +85,7 @@ VectorPtr CastExpr::castFromDate(
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
       static const int64_t kMillisPerDay{86'400'000};
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
@@ -157,6 +158,7 @@ VectorPtr CastExpr::castToDate(
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(fromType->equivalent(*TIMESTAMP()));
       auto* inputVector = input.as<SimpleVector<Timestamp>>();
       const auto* timeZone =
           getTimeZoneFromConfig(context.execCtx()->queryCtx()->queryConfig());
@@ -306,6 +308,7 @@ VectorPtr CastExpr::castFromTime(
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(toType->equivalent(*TIMESTAMP()));
       // if input is constant, create a constant output vector
       if (input.isConstantEncoding()) {
         auto constantInput = input.as<ConstantVector<int64_t>>();
@@ -378,6 +381,7 @@ VectorPtr CastExpr::castToTime(
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(fromType->equivalent(*TIMESTAMP()));
       VectorPtr castResult;
       context.ensureWritable(rows, TIME(), castResult);
       (*castResult).clearNulls(rows);
@@ -878,6 +882,7 @@ void CastExpr::applyPeeled(
       fromType->kind() == TypeKind::TIMESTAMP &&
       (toType->kind() == TypeKind::VARCHAR ||
        toType->kind() == TypeKind::VARBINARY)) {
+    VELOX_DCHECK(fromType->equivalent(*TIMESTAMP()));
     result = applyTimestampToVarcharCast(toType, rows, context, input);
   } else if (toType->kind() == TypeKind::VARBINARY) {
     switch (fromType->kind()) {

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1889,6 +1889,7 @@ struct ToISO8601Function {
       const core::QueryConfig& config,
       const arg_type<Timestamp>* /*input*/) {
     if (inputTypes[0]->isTimestamp()) {
+      VELOX_DCHECK(inputTypes[0]->equivalent(*TIMESTAMP()));
       timeZone_ = getTimeZoneFromConfig(config);
     }
   }

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneRegistration.cpp
@@ -308,6 +308,7 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
     auto* rawResults = timestampWithTzResult->mutableRawValues();
 
     if (input.typeKind() == TypeKind::TIMESTAMP) {
+      VELOX_DCHECK(input.type()->equivalent(*TIMESTAMP()));
       const auto inputVector = input.as<SimpleVector<Timestamp>>();
       castFromTimestamp(*inputVector, context, rows, rawResults);
     } else if (input.typeKind() == TypeKind::VARCHAR) {
@@ -333,6 +334,7 @@ class TimestampWithTimeZoneCastOperator final : public exec::CastOperator {
     context.ensureWritable(rows, resultType, result);
 
     if (resultType->kind() == TypeKind::TIMESTAMP) {
+      VELOX_DCHECK(resultType->equivalent(*TIMESTAMP()));
       castToTimestamp(input, context, rows, *result);
     } else if (resultType->kind() == TypeKind::VARCHAR) {
       castToString(input, context, rows, *result);

--- a/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CollectSetAggregate.cpp
@@ -230,6 +230,7 @@ std::unique_ptr<exec::Aggregate> createSetAgg(
           velox::aggregate::prestosql::FloatSetAccumulatorNaNUnaware<double>>>(
           resultType);
     case TypeKind::TIMESTAMP:
+      VELOX_DCHECK(inputType->equivalent(*TIMESTAMP()));
       return std::make_unique<SparkCollectSetAggregate<Timestamp>>(resultType);
     case TypeKind::VARBINARY:
       [[fallthrough]];

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -141,6 +141,7 @@ void serializeTyped<TypeKind::TIMESTAMP>(
     const raw_vector<uint8_t*>& nulls,
     char* buffer,
     std::vector<size_t>& offsets) {
+  VELOX_DCHECK(decoded.base()->type()->equivalent(*TIMESTAMP()));
   const auto* rawData = decoded.data<Timestamp>();
   if (!decoded.mayHaveNulls()) {
     for (auto i = 0; i < rows.size(); ++i) {
@@ -259,6 +260,7 @@ void CompactRow::initialize(const TypePtr& type) {
       supportsBulkCopy_ = decoded_.isIdentityMapping();
       break;
     case TypeKind::TIMESTAMP:
+      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       valueBytes_ = sizeof(int64_t);
       fixedWidthTypeKind_ = true;
       break;
@@ -281,6 +283,7 @@ void CompactRow::initialize(const TypePtr& type) {
 namespace {
 std::optional<int32_t> fixedValueSize(const TypePtr& type) {
   if (type->isTimestamp()) {
+    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return sizeof(int64_t);
   }
   if (type->isFixedWidth()) {
@@ -671,6 +674,7 @@ void CompactRow::serializeFixedWidth(vector_size_t index, char* buffer) const {
       *reinterpret_cast<bool*>(buffer) = decoded_.valueAt<bool>(index);
       break;
     case TypeKind::TIMESTAMP: {
+      VELOX_DCHECK(decoded_.base()->type()->equivalent(*TIMESTAMP()));
       auto micros = decoded_.valueAt<Timestamp>(index).toMicros();
       ::memcpy(buffer, &micros, sizeof(int64_t));
       break;

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -108,6 +108,7 @@ void UnsafeRowFast::initialize(const TypePtr& type) {
       supportsBulkCopy_ = decoded_.isIdentityMapping();
       break;
     case TypeKind::TIMESTAMP:
+      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       valueBytes_ = sizeof(int64_t);
       fixedWidthTypeKind_ = true;
       break;
@@ -181,6 +182,7 @@ void UnsafeRowFast::serializeFixedWidth(vector_size_t index, char* buffer)
       *reinterpret_cast<bool*>(buffer) = decoded_.valueAt<bool>(index);
       break;
     case TypeKind::TIMESTAMP:
+      VELOX_DCHECK(decoded_.base()->type()->equivalent(*TIMESTAMP()));
       *reinterpret_cast<int64_t*>(buffer) =
           decoded_.valueAt<Timestamp>(index).toMicros();
       break;

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -327,6 +327,7 @@ const char* exportArrowFormatStr(
     case TypeKind::UNKNOWN:
       return "n"; // NullType
     case TypeKind::TIMESTAMP:
+      VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
       return exportArrowFormatTimestampStr(options, formatBuffer);
     // Complex/nested types.
     case TypeKind::ARRAY:
@@ -759,6 +760,7 @@ size_t getArrowElementSize(const TypePtr& type, const ArrowOptions& options) {
   if (type->isShortDecimal() && !options.useDecimalTypeWidth) {
     return sizeof(int128_t);
   } else if (type->isTimestamp()) {
+    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return sizeof(int64_t);
   } else if (type->isTime()) {
     if (type->equivalent(*TIME())) {
@@ -798,6 +800,7 @@ void exportValues(
       : AlignedBuffer::allocate<uint8_t>(
             checkedMultiply<size_t>(out.length, size), pool);
   if (type->kind() == TypeKind::TIMESTAMP) {
+    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     gatherFromTimestampBuffer(vec, rows, options.timestampUnit, *values);
   } else if (
       type->kind() == TypeKind::BIGINT && type->isTime() &&
@@ -2271,6 +2274,7 @@ VectorPtr importFromArrowImpl(
         arrowArray.null_count,
         wrapInBufferView);
   } else if (type->isTimestamp()) {
+    VELOX_DCHECK(type->equivalent(*TIMESTAMP()));
     return createTimestampVector(
         pool,
         type,


### PR DESCRIPTION
Preparation for fully supporting `TimestampUtcType` which shares the
Timestamp physical type but is timezone-agnostic. Add Timestamp type
checks to ensure existing functionality remains unaffected until it is
fully adapted to support the new type.

Parquet scanning has already been enabled for `TimestampUtcType`, so no
additional checks are needed for it.

Related issue: https://github.com/facebookincubator/velox/issues/17087.