### PR TITLE
feat(cudf): Bypass cudf folder in clang-tidy check

### DIFF
--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -46,7 +46,7 @@ def git_changed_lines(commit):
         if match:
             matched_file = match.group(1)
             # Exclude all files in cudf directories
-            if 'cudf/' not in matched_file:
+            if "cudf/" not in matched_file:
                 file = matched_file
 
         match = re.match(r"^@@", line)
@@ -75,7 +75,7 @@ def tidy(args):
 
     # Exclude all files in cudf directories
     # as clang-tidy doesn't support CUDA compiler flags and CUDA headers
-    files = [file for file in files if 'cudf/' not in file ]
+    files = [file for file in files if "cudf/" not in file]
 
     in_gha = os.environ.get("GITHUB_ACTIONS") is not None
     changed_lines = git_changed_lines(args.commit)

--- a/scripts/checks/run-clang-tidy.py
+++ b/scripts/checks/run-clang-tidy.py
@@ -44,7 +44,10 @@ def git_changed_lines(commit):
 
         match = re.match(r"^\+\+\+ b/(.*(\.cpp|\.h|\.hpp))$", line)
         if match:
-            file = match.group(1)
+            matched_file = match.group(1)
+            # Exclude all files in cudf directories
+            if 'cudf/' not in matched_file:
+                file = matched_file
 
         match = re.match(r"^@@", line)
         if match and file != "" and len(fields) >= 3:
@@ -70,8 +73,11 @@ def tidy(args):
     files = util.input_files(args.files)
     files = [file for file in files if re.match(r".*(\.cpp|\.h|\.hpp)$", file)]
 
-    in_gha = os.environ.get("GITHUB_ACTIONS") is not None
+    # Exclude all files in cudf directories
+    # as clang-tidy doesn't support CUDA compiler flags and CUDA headers
+    files = [file for file in files if 'cudf/' not in file ]
 
+    in_gha = os.environ.get("GITHUB_ACTIONS") is not None
     changed_lines = git_changed_lines(args.commit)
 
     line_filter = json.dumps(


### PR DESCRIPTION
Extract from https://github.com/facebookincubator/velox/pull/16760 to solve
```
# Dependency .clang-tidy config errors:
_build/release/_deps/rmm-src/cpp/.clang-tidy:16:1: error: unknown key 'AnalyzeTemporaryDtors'
_build/release/_deps/cudf-src/cpp/.clang-tidy:53:1: error: unknown key 'ExcludeHeaderFilterRegex'

# CUDA compiler flag errors (clang-tidy doesn't understand nvcc flags):
error: GPU arch sm_35 is supported by CUDA versions between 7.0 and 11.8 (inclusive)
error: unknown argument: '--extended-lambda'
error: unknown argument: '--generate-code=arch=compute_70,code=[compute_70,sm_70]'
error: unknown argument: '-Xcompiler=-fPIC'
error: unknown argument: '-ccbin'
error: unknown argument: '-forward-unknown-to-host-compiler'

# Missing CUDA header:
__clang_cuda_runtime_wrapper.h:486:10: error: 'curand_mtgp32_kernel.h' file not found

# Files that failed clang-tidy processing:
[6/10]  velox/experimental/cudf/exec/util/InteropUtil.h
[7/10]  velox/experimental/cudf/tests/CudfFunctionBaseTest.h
[8/10]  velox/experimental/cudf/tests/InteropTest.cpp
[9/10]  velox/experimental/cudf/tests/SubfieldFilterAstTest.cpp
[10/10] velox/experimental/cudf/tests/utils/CudfHiveConnectorTestBase.cpp
```
Also resolve the issue in https://github.com/facebookincubator/velox/pull/16750