### PR TITLE
feat(tdigest): Add winsorized_mean() scalar function on TDigest (#17173)

### DIFF
--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -128,6 +128,8 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
          std::make_shared<TDigestArgValuesGenerator>("destructure_tdigest")},
         {"trimmed_mean",
          std::make_shared<TDigestArgValuesGenerator>("trimmed_mean")},
+        {"winsorized_mean",
+         std::make_shared<TDigestArgValuesGenerator>("winsorized_mean")},
         {"hash_counts",
          std::make_shared<SetDigestArgValuesGenerator>("hash_counts")},
         {"cardinality",
@@ -165,6 +167,7 @@ std::unordered_set<std::string> skipFunctions = {
     "construct_tdigest",
     "destructure_tdigest",
     "trimmed_mean",
+    "winsorized_mean",
     // Fuzzer and the underlying engine are confused about SetDigest functions
     // (since KHLL is a user defined type), and tries to pass a
     // VARBINARY (since KHLL's implementation uses an

--- a/velox/functions/lib/TDigest.h
+++ b/velox/functions/lib/TDigest.h
@@ -127,6 +127,17 @@ class TDigest {
   double trimmedMean(double lowerQuantileBound, double upperQuantileBound)
       const;
 
+  /// Calculate the Winsorized mean of the digest.
+  /// Values below the lower quantile are replaced with the lower boundary
+  /// value. Values above the upper quantile are replaced with the upper
+  /// boundary value. The mean is then computed on all N values:
+  ///   winsorizedMean = (trimmedSum + countLow * qLow + countHigh * qHigh) / N
+  /// @param lowerQuantileBound Lower quantile bound in [0, 1].
+  /// @param upperQuantileBound Upper quantile bound in [0, 1].
+  /// @return The Winsorized mean of the digest.
+  double winsorizedMean(double lowerQuantileBound, double upperQuantileBound)
+      const;
+
   /// Returns the compression parameter.
   double compression() const {
     return compression_;
@@ -765,6 +776,66 @@ double TDigest<A>::trimmedMean(
   }
 
   return std::numeric_limits<double>::quiet_NaN();
+}
+
+template <typename A>
+double TDigest<A>::winsorizedMean(
+    double lowerQuantileBound,
+    double upperQuantileBound) const {
+  VELOX_CHECK_GE(lowerQuantileBound, 0.0, "Lower quantile bound must be >= 0");
+  VELOX_CHECK_LE(lowerQuantileBound, 1.0, "Lower quantile bound must be <= 1");
+  VELOX_CHECK_GE(upperQuantileBound, 0.0, "Upper quantile bound must be >= 0");
+  VELOX_CHECK_LE(upperQuantileBound, 1.0, "Upper quantile bound must be <= 1");
+  VELOX_CHECK_LE(
+      lowerQuantileBound,
+      upperQuantileBound,
+      "Lower quantile bound must be less than or equal to upper quantile bound");
+
+  if (weights_.size() == 0) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  if (lowerQuantileBound == 0 && upperQuantileBound == 1) {
+    return sum() / totalWeight();
+  }
+
+  double totalWeightVal{totalWeight()};
+  double lowerIndex{lowerQuantileBound * totalWeightVal};
+  double upperIndex{upperQuantileBound * totalWeightVal};
+
+  // Note: estimateQuantile() uses half-weight interpolation within each
+  // centroid, while the centroid walk below uses raw weight boundaries.
+  // This is a known approximation inherent to the TDigest sketch — the
+  // boundary values and weight partitioning operate under subtly different
+  // geometric assumptions, but the error is bounded by the centroid size
+  // at the tails, which is small by design.
+
+  // Walk centroids computing the sum of the middle region, using the same
+  // fractional-weight logic as trimmedMean.
+  double weightSoFar{0};
+  double sumInBounds{0};
+
+  for (size_t i = 0; i < weights_.size(); i++) {
+    double centroidStart{weightSoFar};
+    double centroidEnd{weightSoFar + weights_[i]};
+
+    double overlapStart{std::max(centroidStart, lowerIndex)};
+    double overlapEnd{std::min(centroidEnd, upperIndex)};
+
+    if (overlapStart < overlapEnd) {
+      sumInBounds += means_[i] * (overlapEnd - overlapStart);
+    }
+
+    weightSoFar = centroidEnd;
+  }
+
+  // Replace tails with boundary values instead of discarding them.
+  double lowerTailWeight{lowerIndex};
+  double upperTailWeight{totalWeightVal - upperIndex};
+
+  return (sumInBounds + lowerTailWeight * estimateQuantile(lowerQuantileBound) +
+          upperTailWeight * estimateQuantile(upperQuantileBound)) /
+      totalWeightVal;
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/TDigestTest.cpp
+++ b/velox/functions/lib/tests/TDigestTest.cpp
@@ -575,5 +575,143 @@ TEST_F(TDigestTest, largeWeightFloatingPointPrecision) {
   ASSERT_FALSE(std::isnan(digest.estimateQuantile(0.5)));
 }
 
+TEST_F(TDigestTest, winsorizedMeanFullRange) {
+  // winsorizedMean(0, 1) should equal sum() / totalWeight() (regular mean).
+  constexpr int N = 1e5;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  ASSERT_NEAR(
+      digest.winsorizedMean(0, 1),
+      digest.sum() / digest.totalWeight(),
+      kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanUniform) {
+  // Uniform distribution: winsorization has minimal effect on mean.
+  constexpr int N = 1e6;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  double exactMean = (N - 1) / 2.0;
+  ASSERT_NEAR(digest.winsorizedMean(0.01, 0.99), exactMean, exactMean * 0.01);
+}
+
+TEST_F(TDigestTest, winsorizedMeanVsTrimmedMean) {
+  // winsorizedMean(p, 1-p) should be between trimmedMean(p, 1-p) and mean().
+  constexpr int N = 1e5;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  std::default_random_engine gen(common::testutil::getRandomSeed(42));
+  std::exponential_distribution<> dist(1.0);
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, dist(gen));
+  }
+  digest.compress(positions);
+  double mean = digest.sum() / digest.totalWeight();
+  double trimmed = digest.trimmedMean(0.05, 0.95);
+  double winsorized = digest.winsorizedMean(0.05, 0.95);
+  ASSERT_GE(winsorized, std::min(trimmed, mean) - kSumError);
+  ASSERT_LE(winsorized, std::max(trimmed, mean) + kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanOneSided) {
+  // One-sided upper winsorization should reduce the mean.
+  constexpr int N = 1e5;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  double result = digest.winsorizedMean(0, 0.99);
+  double regularMean = digest.sum() / digest.totalWeight();
+  ASSERT_LE(result, regularMean + kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanEmpty) {
+  TDigest digest;
+  ASSERT_TRUE(std::isnan(digest.winsorizedMean(0.01, 0.99)));
+}
+
+TEST_F(TDigestTest, winsorizedMeanSingleElement) {
+  TDigest digest;
+  std::vector<int16_t> positions;
+  digest.add(positions, 42.0);
+  digest.compress(positions);
+  ASSERT_EQ(digest.winsorizedMean(0.01, 0.99), 42.0);
+}
+
+TEST_F(TDigestTest, winsorizedMeanAllSame) {
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < 1000; ++i) {
+    digest.add(positions, 7.0);
+  }
+  digest.compress(positions);
+  ASSERT_NEAR(digest.winsorizedMean(0.1, 0.9), 7.0, kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanEqualBounds) {
+  // winsorizedMean(0.5, 0.5) should equal estimateQuantile(0.5).
+  // Both tails cover the full weight and sumInBounds == 0.
+  constexpr int N{10'000};
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  ASSERT_NEAR(
+      digest.winsorizedMean(0.5, 0.5), digest.estimateQuantile(0.5), kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanInvalid) {
+  TDigest digest;
+  std::vector<int16_t> positions;
+  digest.add(positions, 1.0);
+  digest.compress(positions);
+  ASSERT_THROW(digest.winsorizedMean(-0.1, 0.5), VeloxRuntimeError);
+  ASSERT_THROW(digest.winsorizedMean(0.5, 1.1), VeloxRuntimeError);
+  ASSERT_THROW(digest.winsorizedMean(0.9, 0.1), VeloxRuntimeError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanAccuracy) {
+  // Compare against exact winsorized mean on raw data.
+  constexpr int N = 1e5;
+  std::vector<double> values(N);
+  TDigest digest;
+  std::vector<int16_t> positions;
+  std::default_random_engine gen(common::testutil::getRandomSeed(42));
+  std::lognormal_distribution<> dist(0, 1.0);
+  for (int i = 0; i < N; ++i) {
+    values[i] = dist(gen);
+    digest.add(positions, values[i]);
+  }
+  digest.compress(positions);
+  std::sort(values.begin(), values.end());
+
+  // Compute exact winsorized mean at (0.01, 0.99).
+  int lowerK = static_cast<int>(0.01 * N);
+  int upperK = static_cast<int>(0.99 * N);
+  double qLow = values[lowerK];
+  double qHigh = values[upperK];
+  double exactSum = 0;
+  for (int i = 0; i < N; ++i) {
+    exactSum += std::max(qLow, std::min(qHigh, values[i]));
+  }
+  double exactWinsorizedMean = exactSum / N;
+
+  double approx = digest.winsorizedMean(0.01, 0.99);
+  ASSERT_NEAR(
+      approx, exactWinsorizedMean, std::abs(exactWinsorizedMean) * 0.02);
+}
+
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TDigestFunctions.h
+++ b/velox/functions/prestosql/TDigestFunctions.h
@@ -234,8 +234,9 @@ struct TrimmedMeanFunction {
     VELOX_USER_CHECK(
         0 <= upperQuantileBound && upperQuantileBound <= 1,
         "Upper quantile bound must be between 0 and 1");
-    VELOX_USER_CHECK(
-        lowerQuantileBound <= upperQuantileBound,
+    VELOX_USER_CHECK_LE(
+        lowerQuantileBound,
+        upperQuantileBound,
         "Lower quantile bound must be less than or equal to upper quantile bound");
     // Deserialize the TDigest
     auto digest = TDigest<>::fromSerialized(input.data());
@@ -243,6 +244,40 @@ struct TrimmedMeanFunction {
       return false;
     }
     result = digest.trimmedMean(lowerQuantileBound, upperQuantileBound);
+    if (std::isnan(result)) {
+      return false;
+    }
+    return true;
+  }
+};
+/// Computes the Winsorized mean from a serialized TDigest. Values below the
+/// lower quantile are replaced with the boundary value at that quantile, and
+/// values above the upper quantile are replaced with the boundary value at
+/// that quantile. The mean is then computed on all values including the
+/// replaced tails.
+template <typename T>
+struct WinsorizedMeanFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<double>& result,
+      const arg_type<SimpleTDigest<double>>& input,
+      const arg_type<double>& lowerQuantileBound,
+      const arg_type<double>& upperQuantileBound) {
+    VELOX_USER_CHECK(
+        0 <= lowerQuantileBound && lowerQuantileBound <= 1,
+        "Lower quantile bound must be between 0 and 1");
+    VELOX_USER_CHECK(
+        0 <= upperQuantileBound && upperQuantileBound <= 1,
+        "Upper quantile bound must be between 0 and 1");
+    VELOX_USER_CHECK_LE(
+        lowerQuantileBound,
+        upperQuantileBound,
+        "Lower quantile bound must be less than or equal to upper quantile bound");
+    auto digest = TDigest<>::fromSerialized(input.data());
+    if (digest.size() == 0) {
+      return false;
+    }
+    result = digest.winsorizedMean(lowerQuantileBound, upperQuantileBound);
     if (std::isnan(result)) {
       return false;
     }

--- a/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
@@ -76,5 +76,11 @@ void registerTDigestFunctions(const std::string& prefix) {
       SimpleTDigest<double>,
       double,
       double>({prefix + "trimmed_mean"});
+  registerFunction<
+      WinsorizedMeanFunction,
+      double,
+      SimpleTDigest<double>,
+      double,
+      double>({prefix + "winsorized_mean"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/TDigestFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/TDigestFunctionsTest.cpp
@@ -746,3 +746,129 @@ TEST_F(TDigestFunctionsTest, testTrimmedMean) {
     ASSERT_TRUE(abs(result.value() - expectedMean) / standardDeviation <= 0.05);
   }
 }
+
+TEST_F(TDigestFunctionsTest, testWinsorizedMean) {
+  const auto winsorizedMean = [&](const std::optional<std::string>& input,
+                                  const std::optional<double>& lowQuantile,
+                                  const std::optional<double>& highQuantile) {
+    return evaluateOnce<double>(
+        "winsorized_mean(c0, c1, c2)",
+        TDIGEST_DOUBLE,
+        input,
+        lowQuantile,
+        highQuantile);
+  };
+
+  // Create TDigest with uniform distribution.
+  facebook::velox::functions::TDigest<> tDigest;
+  std::vector<int16_t> positions;
+  std::vector<double> values;
+
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<double> distribution(0.0, NUMBER_OF_ENTRIES);
+
+  for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
+    double value{distribution(gen)};
+    tDigest.add(positions, value);
+    values.push_back(value);
+  }
+  tDigest.compress(positions);
+  std::sort(values.begin(), values.end());
+
+  // Serialize TDigest.
+  auto serializedSize{tDigest.serializedByteSize()};
+  std::vector<char> buffer(serializedSize);
+  tDigest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  // Full range (0, 1) should equal regular mean.
+  auto fullRangeResult{winsorizedMean(serializedDigest, 0.0, 1.0)};
+  double expectedFullMean{tDigest.sum() / tDigest.totalWeight()};
+  ASSERT_NEAR(
+      fullRangeResult.value(), expectedFullMean, expectedFullMean * 0.01);
+
+  // Test quantile pairs with computed expected values.
+  std::vector<std::pair<double, double>> quantilePairs = {
+      {0.1, 0.9},
+      {0.25, 0.75},
+      {0.01, 0.99},
+  };
+
+  for (const auto& [lowQuantile, highQuantile] : quantilePairs) {
+    int lowIndex{static_cast<int>(NUMBER_OF_ENTRIES * lowQuantile)};
+    int highIndex{static_cast<int>(NUMBER_OF_ENTRIES * highQuantile)};
+    double lowBound{values[lowIndex]};
+    double highBound{values[highIndex]};
+    double exactSum{0};
+    for (const auto& value : values) {
+      exactSum += std::max(lowBound, std::min(highBound, value));
+    }
+    double expectedMean{exactSum / NUMBER_OF_ENTRIES};
+
+    auto result{winsorizedMean(serializedDigest, lowQuantile, highQuantile)};
+    double standardDeviation{
+        std::sqrt(distribution.max() * distribution.max() / 12)};
+    ASSERT_TRUE(abs(result.value() - expectedMean) / standardDeviation <= 0.05);
+  }
+}
+
+TEST_F(TDigestFunctionsTest, testWinsorizedMeanEmptyDigest) {
+  // Empty TDigest should return NULL.
+  facebook::velox::functions::TDigest<> tDigest;
+  std::vector<int16_t> positions;
+  tDigest.compress(positions);
+  auto serializedSize{tDigest.serializedByteSize()};
+  std::vector<char> buffer(serializedSize);
+  tDigest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  auto result = evaluateOnce<double>(
+      "winsorized_mean(c0, c1, c2)",
+      TDIGEST_DOUBLE,
+      std::optional<std::string>(serializedDigest),
+      std::optional<double>(0.1),
+      std::optional<double>(0.9));
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(TDigestFunctionsTest, testWinsorizedMeanInvalidBounds) {
+  // Create a simple TDigest.
+  facebook::velox::functions::TDigest<> tDigest;
+  std::vector<int16_t> positions;
+  tDigest.add(positions, 1.0);
+  tDigest.compress(positions);
+  auto serializedSize{tDigest.serializedByteSize()};
+  std::vector<char> buffer(serializedSize);
+  tDigest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  // Out-of-range lower bound.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<double>(
+          "winsorized_mean(c0, c1, c2)",
+          TDIGEST_DOUBLE,
+          std::optional<std::string>(serializedDigest),
+          std::optional<double>(-0.1),
+          std::optional<double>(0.5)),
+      "between 0 and 1");
+
+  // Out-of-range upper bound.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<double>(
+          "winsorized_mean(c0, c1, c2)",
+          TDIGEST_DOUBLE,
+          std::optional<std::string>(serializedDigest),
+          std::optional<double>(0.0),
+          std::optional<double>(1.1)),
+      "between 0 and 1");
+
+  // Lower > upper.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<double>(
+          "winsorized_mean(c0, c1, c2)",
+          TDIGEST_DOUBLE,
+          std::optional<std::string>(serializedDigest),
+          std::optional<double>(0.9),
+          std::optional<double>(0.1)),
+      "less than or equal");
+}


### PR DESCRIPTION
Summary:

Add a `winsorized_mean(tdigest, lower_quantile, upper_quantile) -> double` scalar function that operates on a serialized TDigest, mirroring the existing `trimmed_mean` function.

This enables the composition pattern `winsorized_mean(tdigest_agg(value), 0.01, 0.99)` which computes a Winsorized mean in a single logical expression, though as two function calls. The standalone `approx_winsorized_mean` aggregate (next diff in stack) provides the true single-pass version.

Implementation follows the exact same pattern as `TrimmedMeanFunction` (TDigestFunctions.h:224-251): deserialize TDigest from input, validate bounds, call `digest.winsorizedMean()`, return result or NULL for empty digests.

Reviewed By: natashasehgal

Differential Revision: D100455865


