### PR TITLE
docs(tdigest): Add documentation for winsorized_mean and approx_winsorized_mean (#17175)

### DIFF
--- a/velox/docs/functions/presto/tdigest.rst
+++ b/velox/docs/functions/presto/tdigest.rst
@@ -105,6 +105,55 @@ Functions
     Returns the mean of values between ``low_quantile`` and ``high_quantile`` (inclusive) from the T-digest ``digest``.
     Both quantile values must be between zero and one (inclusive), and ``low_quantile`` must be less than or equal to ``high_quantile``.
 
+.. function:: winsorized_mean(digest: tdigest<double>, low_quantile: double, high_quantile: double) -> double
+
+    Returns the Winsorized mean from the T-digest ``digest``. Values below
+    ``low_quantile`` are replaced with the boundary value at that quantile.
+    Values above ``high_quantile`` are replaced with the boundary value at
+    that quantile. The mean is then computed on all values including the
+    replaced tails. Both quantile values must be between zero and one
+    (inclusive), and ``low_quantile`` must be less than or equal to
+    ``high_quantile``.
+
+    Unlike :func:`trimmed_mean` which excludes tail values entirely,
+    ``winsorized_mean`` replaces them with the boundary values, keeping the
+    total count unchanged.
+
+.. function:: approx_winsorized_mean(x: double, low_quantile: double, high_quantile: double) -> double
+
+    Returns the approximate Winsorized mean of all input values of ``x``
+    using a T-digest sketch. This is a single-pass aggregate that replaces
+    values below ``low_quantile`` with the boundary value at that quantile,
+    and values above ``high_quantile`` with the boundary value at that
+    quantile, then computes the mean.
+
+    ``low_quantile`` and ``high_quantile`` must be constants between zero and
+    one (inclusive), and ``low_quantile`` must be less than or equal to
+    ``high_quantile``. The default compression factor is ``100``.
+
+    This function replaces the common two-pass pattern of computing percentile
+    thresholds with ``approx_percentile`` and then capping values with
+    ``LEAST``/``GREATEST`` before computing ``AVG``.
+
+    Example::
+
+        -- Old two-pass pattern:
+        WITH t AS (
+            SELECT APPROX_PERCENTILE(x, 0.99) AS thresh FROM data
+        )
+        SELECT AVG(LEAST(data.x, t.thresh)) FROM data, t;
+
+        -- New single-pass equivalent:
+        SELECT approx_winsorized_mean(x, 0.0, 0.99) FROM data;
+
+.. function:: approx_winsorized_mean(x: double, low_quantile: double, high_quantile: double, compression: double) -> double
+   :noindex:
+
+    Like the above, but with a specified compression factor. ``compression``
+    must be a positive constant. The default is ``100``, maximum is ``1000``,
+    and values lower than ``10`` are rounded to ``10``. Higher compression
+    means more accuracy at the cost of more memory.
+
 .. function:: value_at_quantile(digest: tdigest<double>, quantile: double) -> double
 
     Returns the approximate percentile value from the T-digest ``digest`` at the given ``quantile``.

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -128,6 +128,8 @@ std::unordered_map<std::string, std::shared_ptr<ArgValuesGenerator>>
          std::make_shared<TDigestArgValuesGenerator>("destructure_tdigest")},
         {"trimmed_mean",
          std::make_shared<TDigestArgValuesGenerator>("trimmed_mean")},
+        {"winsorized_mean",
+         std::make_shared<TDigestArgValuesGenerator>("winsorized_mean")},
         {"hash_counts",
          std::make_shared<SetDigestArgValuesGenerator>("hash_counts")},
         {"cardinality",
@@ -165,6 +167,7 @@ std::unordered_set<std::string> skipFunctions = {
     "construct_tdigest",
     "destructure_tdigest",
     "trimmed_mean",
+    "winsorized_mean",
     // Fuzzer and the underlying engine are confused about SetDigest functions
     // (since KHLL is a user defined type), and tries to pass a
     // VARBINARY (since KHLL's implementation uses an

--- a/velox/functions/lib/TDigest.h
+++ b/velox/functions/lib/TDigest.h
@@ -127,6 +127,17 @@ class TDigest {
   double trimmedMean(double lowerQuantileBound, double upperQuantileBound)
       const;
 
+  /// Calculate the Winsorized mean of the digest.
+  /// Values below the lower quantile are replaced with the lower boundary
+  /// value. Values above the upper quantile are replaced with the upper
+  /// boundary value. The mean is then computed on all N values:
+  ///   winsorizedMean = (trimmedSum + countLow * qLow + countHigh * qHigh) / N
+  /// @param lowerQuantileBound Lower quantile bound in [0, 1].
+  /// @param upperQuantileBound Upper quantile bound in [0, 1].
+  /// @return The Winsorized mean of the digest.
+  double winsorizedMean(double lowerQuantileBound, double upperQuantileBound)
+      const;
+
   /// Returns the compression parameter.
   double compression() const {
     return compression_;
@@ -765,6 +776,66 @@ double TDigest<A>::trimmedMean(
   }
 
   return std::numeric_limits<double>::quiet_NaN();
+}
+
+template <typename A>
+double TDigest<A>::winsorizedMean(
+    double lowerQuantileBound,
+    double upperQuantileBound) const {
+  VELOX_CHECK_GE(lowerQuantileBound, 0.0, "Lower quantile bound must be >= 0");
+  VELOX_CHECK_LE(lowerQuantileBound, 1.0, "Lower quantile bound must be <= 1");
+  VELOX_CHECK_GE(upperQuantileBound, 0.0, "Upper quantile bound must be >= 0");
+  VELOX_CHECK_LE(upperQuantileBound, 1.0, "Upper quantile bound must be <= 1");
+  VELOX_CHECK_LE(
+      lowerQuantileBound,
+      upperQuantileBound,
+      "Lower quantile bound must be less than or equal to upper quantile bound");
+
+  if (weights_.size() == 0) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+
+  if (lowerQuantileBound == 0 && upperQuantileBound == 1) {
+    return sum() / totalWeight();
+  }
+
+  double totalWeightVal{totalWeight()};
+  double lowerIndex{lowerQuantileBound * totalWeightVal};
+  double upperIndex{upperQuantileBound * totalWeightVal};
+
+  // Note: estimateQuantile() uses half-weight interpolation within each
+  // centroid, while the centroid walk below uses raw weight boundaries.
+  // This is a known approximation inherent to the TDigest sketch — the
+  // boundary values and weight partitioning operate under subtly different
+  // geometric assumptions, but the error is bounded by the centroid size
+  // at the tails, which is small by design.
+
+  // Walk centroids computing the sum of the middle region, using the same
+  // fractional-weight logic as trimmedMean.
+  double weightSoFar{0};
+  double sumInBounds{0};
+
+  for (size_t i = 0; i < weights_.size(); i++) {
+    double centroidStart{weightSoFar};
+    double centroidEnd{weightSoFar + weights_[i]};
+
+    double overlapStart{std::max(centroidStart, lowerIndex)};
+    double overlapEnd{std::min(centroidEnd, upperIndex)};
+
+    if (overlapStart < overlapEnd) {
+      sumInBounds += means_[i] * (overlapEnd - overlapStart);
+    }
+
+    weightSoFar = centroidEnd;
+  }
+
+  // Replace tails with boundary values instead of discarding them.
+  double lowerTailWeight{lowerIndex};
+  double upperTailWeight{totalWeightVal - upperIndex};
+
+  return (sumInBounds + lowerTailWeight * estimateQuantile(lowerQuantileBound) +
+          upperTailWeight * estimateQuantile(upperQuantileBound)) /
+      totalWeightVal;
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/lib/tests/TDigestTest.cpp
+++ b/velox/functions/lib/tests/TDigestTest.cpp
@@ -575,5 +575,143 @@ TEST_F(TDigestTest, largeWeightFloatingPointPrecision) {
   ASSERT_FALSE(std::isnan(digest.estimateQuantile(0.5)));
 }
 
+TEST_F(TDigestTest, winsorizedMeanFullRange) {
+  // winsorizedMean(0, 1) should equal sum() / totalWeight() (regular mean).
+  constexpr int N = 1e5;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  ASSERT_NEAR(
+      digest.winsorizedMean(0, 1),
+      digest.sum() / digest.totalWeight(),
+      kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanUniform) {
+  // Uniform distribution: winsorization has minimal effect on mean.
+  constexpr int N = 1e6;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  double exactMean = (N - 1) / 2.0;
+  ASSERT_NEAR(digest.winsorizedMean(0.01, 0.99), exactMean, exactMean * 0.01);
+}
+
+TEST_F(TDigestTest, winsorizedMeanVsTrimmedMean) {
+  // winsorizedMean(p, 1-p) should be between trimmedMean(p, 1-p) and mean().
+  constexpr int N = 1e5;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  std::default_random_engine gen(common::testutil::getRandomSeed(42));
+  std::exponential_distribution<> dist(1.0);
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, dist(gen));
+  }
+  digest.compress(positions);
+  double mean = digest.sum() / digest.totalWeight();
+  double trimmed = digest.trimmedMean(0.05, 0.95);
+  double winsorized = digest.winsorizedMean(0.05, 0.95);
+  ASSERT_GE(winsorized, std::min(trimmed, mean) - kSumError);
+  ASSERT_LE(winsorized, std::max(trimmed, mean) + kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanOneSided) {
+  // One-sided upper winsorization should reduce the mean.
+  constexpr int N = 1e5;
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  double result = digest.winsorizedMean(0, 0.99);
+  double regularMean = digest.sum() / digest.totalWeight();
+  ASSERT_LE(result, regularMean + kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanEmpty) {
+  TDigest digest;
+  ASSERT_TRUE(std::isnan(digest.winsorizedMean(0.01, 0.99)));
+}
+
+TEST_F(TDigestTest, winsorizedMeanSingleElement) {
+  TDigest digest;
+  std::vector<int16_t> positions;
+  digest.add(positions, 42.0);
+  digest.compress(positions);
+  ASSERT_EQ(digest.winsorizedMean(0.01, 0.99), 42.0);
+}
+
+TEST_F(TDigestTest, winsorizedMeanAllSame) {
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < 1000; ++i) {
+    digest.add(positions, 7.0);
+  }
+  digest.compress(positions);
+  ASSERT_NEAR(digest.winsorizedMean(0.1, 0.9), 7.0, kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanEqualBounds) {
+  // winsorizedMean(0.5, 0.5) should equal estimateQuantile(0.5).
+  // Both tails cover the full weight and sumInBounds == 0.
+  constexpr int N{10'000};
+  TDigest digest;
+  std::vector<int16_t> positions;
+  for (int i = 0; i < N; ++i) {
+    digest.add(positions, i);
+  }
+  digest.compress(positions);
+  ASSERT_NEAR(
+      digest.winsorizedMean(0.5, 0.5), digest.estimateQuantile(0.5), kSumError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanInvalid) {
+  TDigest digest;
+  std::vector<int16_t> positions;
+  digest.add(positions, 1.0);
+  digest.compress(positions);
+  ASSERT_THROW(digest.winsorizedMean(-0.1, 0.5), VeloxRuntimeError);
+  ASSERT_THROW(digest.winsorizedMean(0.5, 1.1), VeloxRuntimeError);
+  ASSERT_THROW(digest.winsorizedMean(0.9, 0.1), VeloxRuntimeError);
+}
+
+TEST_F(TDigestTest, winsorizedMeanAccuracy) {
+  // Compare against exact winsorized mean on raw data.
+  constexpr int N = 1e5;
+  std::vector<double> values(N);
+  TDigest digest;
+  std::vector<int16_t> positions;
+  std::default_random_engine gen(common::testutil::getRandomSeed(42));
+  std::lognormal_distribution<> dist(0, 1.0);
+  for (int i = 0; i < N; ++i) {
+    values[i] = dist(gen);
+    digest.add(positions, values[i]);
+  }
+  digest.compress(positions);
+  std::sort(values.begin(), values.end());
+
+  // Compute exact winsorized mean at (0.01, 0.99).
+  int lowerK = static_cast<int>(0.01 * N);
+  int upperK = static_cast<int>(0.99 * N);
+  double qLow = values[lowerK];
+  double qHigh = values[upperK];
+  double exactSum = 0;
+  for (int i = 0; i < N; ++i) {
+    exactSum += std::max(qLow, std::min(qHigh, values[i]));
+  }
+  double exactWinsorizedMean = exactSum / N;
+
+  double approx = digest.winsorizedMean(0.01, 0.99);
+  ASSERT_NEAR(
+      approx, exactWinsorizedMean, std::abs(exactWinsorizedMean) * 0.02);
+}
+
 } // namespace
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/TDigestFunctions.h
+++ b/velox/functions/prestosql/TDigestFunctions.h
@@ -234,8 +234,9 @@ struct TrimmedMeanFunction {
     VELOX_USER_CHECK(
         0 <= upperQuantileBound && upperQuantileBound <= 1,
         "Upper quantile bound must be between 0 and 1");
-    VELOX_USER_CHECK(
-        lowerQuantileBound <= upperQuantileBound,
+    VELOX_USER_CHECK_LE(
+        lowerQuantileBound,
+        upperQuantileBound,
         "Lower quantile bound must be less than or equal to upper quantile bound");
     // Deserialize the TDigest
     auto digest = TDigest<>::fromSerialized(input.data());
@@ -243,6 +244,40 @@ struct TrimmedMeanFunction {
       return false;
     }
     result = digest.trimmedMean(lowerQuantileBound, upperQuantileBound);
+    if (std::isnan(result)) {
+      return false;
+    }
+    return true;
+  }
+};
+/// Computes the Winsorized mean from a serialized TDigest. Values below the
+/// lower quantile are replaced with the boundary value at that quantile, and
+/// values above the upper quantile are replaced with the boundary value at
+/// that quantile. The mean is then computed on all values including the
+/// replaced tails.
+template <typename T>
+struct WinsorizedMeanFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<double>& result,
+      const arg_type<SimpleTDigest<double>>& input,
+      const arg_type<double>& lowerQuantileBound,
+      const arg_type<double>& upperQuantileBound) {
+    VELOX_USER_CHECK(
+        0 <= lowerQuantileBound && lowerQuantileBound <= 1,
+        "Lower quantile bound must be between 0 and 1");
+    VELOX_USER_CHECK(
+        0 <= upperQuantileBound && upperQuantileBound <= 1,
+        "Upper quantile bound must be between 0 and 1");
+    VELOX_USER_CHECK_LE(
+        lowerQuantileBound,
+        upperQuantileBound,
+        "Lower quantile bound must be less than or equal to upper quantile bound");
+    auto digest = TDigest<>::fromSerialized(input.data());
+    if (digest.size() == 0) {
+      return false;
+    }
+    result = digest.winsorizedMean(lowerQuantileBound, upperQuantileBound);
     if (std::isnan(result)) {
       return false;
     }

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -22,6 +22,7 @@ const char* const kApproxDistinct = "approx_distinct";
 const char* const kApproxMostFrequent = "approx_most_frequent";
 const char* const kApproxPercentile = "approx_percentile";
 const char* const kApproxSet = "approx_set";
+const char* const kApproxWinsorizedMean = "approx_winsorized_mean";
 const char* const kQDigestAgg = "qdigest_agg";
 const char* const kArbitrary = "arbitrary";
 const char* const kAnyValue = "any_value";

--- a/velox/functions/prestosql/aggregates/ApproxWinsorizedMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxWinsorizedMeanAggregate.cpp
@@ -1,0 +1,396 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstring>
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/functions/lib/TDigest.h"
+#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+
+constexpr double kMinCompression{10.0};
+constexpr double kMaxCompression{1'000.0};
+
+// The intermediate type is varbinary containing:
+//   [8 bytes: lowerQuantile double][8 bytes: upperQuantile double][TDigest
+//   bytes]
+// This ensures quantile bounds survive partial-to-final distributed
+// aggregation.
+constexpr size_t kQuantileBoundsHeaderSize{2 * sizeof(double)};
+
+// Accumulates a TDigest sketch for computing the winsorized mean of a set of
+// values. Stores the TDigest and the optional compression parameter.
+struct WinsorizedMeanAccumulator {
+  explicit WinsorizedMeanAccumulator(HashStringAllocator* allocator)
+      : digest(StlAllocator<double>(allocator)) {}
+
+  double compression{0.0};
+  facebook::velox::functions::TDigest<StlAllocator<double>> digest;
+};
+
+// Velox aggregate function implementing approx_winsorized_mean using
+// TDigest-based quantile estimation. Builds a TDigest in a single pass,
+// then computes the Winsorized mean at extractValues time.
+//
+// The intermediate type is varbinary with a 16-byte header containing
+// the lower and upper quantile bounds, followed by the serialized TDigest.
+// This ensures quantile bounds survive partial-to-final distributed
+// aggregation.
+class ApproxWinsorizedMeanAggregate : public exec::Aggregate {
+ private:
+  // Whether the optional compression parameter was provided.
+  bool hasCompression_{false};
+  // Validated compression factor, shared across all rows. Zero means unset.
+  double compression_{0.0};
+  // Lower quantile bound for winsorization [0.0, 1.0].
+  double lowerQuantile_{0.0};
+  // Upper quantile bound for winsorization [0.0, 1.0].
+  double upperQuantile_{1.0};
+  // True once quantile bounds have been set from the first non-null row.
+  bool quantileBoundsSet_{false};
+  // Decoded input columns for raw input processing.
+  DecodedVector decodedValue_;
+  DecodedVector decodedLower_;
+  DecodedVector decodedUpper_;
+  DecodedVector decodedCompression_;
+  // Decoded intermediate input for partial-to-final aggregation.
+  DecodedVector decodedIntermediate_;
+
+ public:
+  ApproxWinsorizedMeanAggregate(const TypePtr& resultType, bool hasCompression)
+      : exec::Aggregate(resultType), hasCompression_{hasCompression} {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(WinsorizedMeanAccumulator);
+  }
+
+  int32_t accumulatorAlignmentSize() const override {
+    return alignof(WinsorizedMeanAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  WinsorizedMeanAccumulator* getAccumulator(char* group) {
+    return value<WinsorizedMeanAccumulator>(group);
+  }
+
+  // Decodes raw input columns: args[0]=value, args[1]=lower, args[2]=upper,
+  // and optionally args[3]=compression.
+  void decodeArguments(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    decodedValue_.decode(*args[0], rows, true);
+    decodedLower_.decode(*args[1], rows, true);
+    decodedUpper_.decode(*args[2], rows, true);
+    if (hasCompression_) {
+      decodedCompression_.decode(*args[3], rows, true);
+    }
+  }
+
+  // Validates that quantile bounds are in [0,1] with lower <= upper, and
+  // ensures all rows use the same bounds. Throws on inconsistency.
+  void checkAndSetQuantileBounds(vector_size_t row) {
+    double lower = decodedLower_.valueAt<double>(row);
+    double upper = decodedUpper_.valueAt<double>(row);
+    VELOX_USER_CHECK(
+        !std::isnan(lower) && !std::isnan(upper),
+        "Quantile bounds must not be NaN.");
+    VELOX_USER_CHECK_GE(lower, 0.0, "Lower quantile bound must be >= 0");
+    VELOX_USER_CHECK_LE(lower, 1.0, "Lower quantile bound must be <= 1");
+    VELOX_USER_CHECK_GE(upper, 0.0, "Upper quantile bound must be >= 0");
+    VELOX_USER_CHECK_LE(upper, 1.0, "Upper quantile bound must be <= 1");
+    VELOX_USER_CHECK_LE(
+        lower,
+        upper,
+        "Lower quantile bound must be less than or equal to upper quantile bound");
+    if (!quantileBoundsSet_) {
+      lowerQuantile_ = lower;
+      upperQuantile_ = upper;
+      quantileBoundsSet_ = true;
+    } else if (lowerQuantile_ != lower || upperQuantile_ != upper) {
+      VELOX_USER_FAIL("Quantile bounds must be the same for all rows");
+    }
+  }
+
+  // Validates compression is positive, at most kMaxCompression, and consistent
+  // across rows. Clamps to kMinCompression and applies to the accumulator.
+  void checkAndSetCompression(
+      WinsorizedMeanAccumulator* accumulator,
+      vector_size_t row) {
+    double compressionValue = decodedCompression_.valueAt<double>(row);
+    VELOX_USER_CHECK(
+        !std::isnan(compressionValue), "Compression factor must not be NaN.");
+    VELOX_USER_CHECK_GT(
+        compressionValue, 0, "Compression factor must be positive.");
+    VELOX_USER_CHECK_LE(
+        compressionValue,
+        kMaxCompression,
+        "Compression must be at most {}",
+        kMaxCompression);
+    compressionValue = std::max(compressionValue, kMinCompression);
+    if (compression_ == 0.0) {
+      compression_ = compressionValue;
+    } else if (compression_ != compressionValue) {
+      VELOX_USER_FAIL("Compression factor must be the same for all rows");
+    }
+    if (accumulator->compression == 0.0) {
+      accumulator->compression = compression_;
+    }
+    if (accumulator->digest.compression() != compression_) {
+      accumulator->digest.setCompression(compression_);
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodeArguments(rows, args);
+    std::vector<int16_t> positions;
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedValue_.isNullAt(row)) {
+        return;
+      }
+      double inputValue = decodedValue_.valueAt<double>(row);
+      if (std::isnan(inputValue)) {
+        VELOX_USER_FAIL("Cannot add NaN to approx_winsorized_mean");
+      }
+      checkAndSetQuantileBounds(row);
+      auto* accumulator = getAccumulator(groups[row]);
+      if (hasCompression_) {
+        checkAndSetCompression(accumulator, row);
+      }
+      accumulator->digest.add(positions, inputValue);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodeArguments(rows, args);
+    auto* accumulator = getAccumulator(group);
+    std::vector<int16_t> positions;
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedValue_.isNullAt(row)) {
+        return;
+      }
+      double inputValue = decodedValue_.valueAt<double>(row);
+      if (std::isnan(inputValue)) {
+        VELOX_USER_FAIL("Cannot add NaN to approx_winsorized_mean");
+      }
+      checkAndSetQuantileBounds(row);
+      if (hasCompression_) {
+        checkAndSetCompression(accumulator, row);
+      }
+      accumulator->digest.add(positions, inputValue);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addIntermediate<false>(groups, rows, args);
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addIntermediate<true>(group, rows, args);
+  }
+
+  template <bool kSingleGroup>
+  void addIntermediate(
+      std::conditional_t<kSingleGroup, char*, char**> group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    decodedIntermediate_.decode(*args[0], rows);
+    std::vector<int16_t> positions;
+    rows.applyToSelected([&](vector_size_t row) {
+      if (decodedIntermediate_.isNullAt(row)) {
+        return;
+      }
+
+      WinsorizedMeanAccumulator* accumulator;
+      if constexpr (kSingleGroup) {
+        accumulator = getAccumulator(group);
+      } else {
+        accumulator = getAccumulator(group[row]);
+      }
+
+      auto serialized = decodedIntermediate_.valueAt<StringView>(row);
+      VELOX_CHECK_GE(
+          serialized.size(),
+          kQuantileBoundsHeaderSize,
+          "Intermediate data too small to contain quantile bounds header");
+      auto* data = serialized.data();
+
+      // Restore quantile bounds from the varbinary header.
+      if (!quantileBoundsSet_) {
+        memcpy(&lowerQuantile_, data, sizeof(double));
+        memcpy(&upperQuantile_, data + sizeof(double), sizeof(double));
+        quantileBoundsSet_ = true;
+      }
+
+      // Merge the TDigest bytes after the header.
+      accumulator->digest.mergeDeserialized(
+          positions, data + kQuantileBoundsHeaderSize);
+    });
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    if (numGroups == 0) {
+      (*result)->resize(0);
+      return;
+    }
+    auto flatResult = (*result)->asFlatVector<double>();
+    flatResult->resize(numGroups);
+    std::vector<int16_t> positions;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      auto group = groups[i];
+      if (!group) {
+        flatResult->setNull(i, true);
+        continue;
+      }
+      auto* accumulator = getAccumulator(group);
+      if (!isInitialized(group) || accumulator->digest.size() == 0) {
+        flatResult->setNull(i, true);
+        continue;
+      }
+      accumulator->digest.compress(positions);
+      double winsorizedMeanValue =
+          accumulator->digest.winsorizedMean(lowerQuantile_, upperQuantile_);
+      if (std::isnan(winsorizedMeanValue)) {
+        flatResult->setNull(i, true);
+      } else {
+        flatResult->set(i, winsorizedMeanValue);
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    // Serialize as varbinary: [lowerQuantile][upperQuantile][TDigest bytes]
+    if (numGroups == 0) {
+      (*result)->resize(0);
+      return;
+    }
+    auto flatResult = (*result)->asFlatVector<StringView>();
+    flatResult->resize(numGroups);
+    std::vector<int16_t> positions;
+    for (int32_t i = 0; i < numGroups; ++i) {
+      auto group = groups[i];
+      if (!group) {
+        flatResult->setNull(i, true);
+        continue;
+      }
+      auto* accumulator = getAccumulator(group);
+      if (!isInitialized(group) || accumulator->digest.size() == 0) {
+        flatResult->setNull(i, true);
+        continue;
+      }
+
+      accumulator->digest.compress(positions);
+      auto digestSize = accumulator->digest.serializedByteSize();
+      int32_t totalSize =
+          static_cast<int32_t>(kQuantileBoundsHeaderSize + digestSize);
+
+      char* rawBuffer = flatResult->getRawStringBufferWithSpace(totalSize);
+      // Write quantile bounds header.
+      memcpy(rawBuffer, &lowerQuantile_, sizeof(double));
+      memcpy(rawBuffer + sizeof(double), &upperQuantile_, sizeof(double));
+      // Write TDigest after header.
+      accumulator->digest.serialize(rawBuffer + kQuantileBoundsHeaderSize);
+
+      flatResult->setNoCopy(i, StringView(rawBuffer, totalSize));
+    }
+  }
+
+ protected:
+  void initializeNewGroupsInternal(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (auto i : indices) {
+      auto group = groups[i];
+      new (group + offset_) WinsorizedMeanAccumulator(allocator_);
+    }
+  }
+
+  void destroyInternal(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      if (isInitialized(group)) {
+        value<WinsorizedMeanAccumulator>(group)->~WinsorizedMeanAccumulator();
+      }
+    }
+  }
+};
+} // namespace
+
+void registerApproxWinsorizedMeanAggregate(
+    const std::vector<std::string>& names,
+    bool overwrite) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures;
+  // (value DOUBLE, lower DOUBLE, upper DOUBLE) -> DOUBLE
+  signatures.push_back(
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("varbinary")
+          .argumentType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .build());
+  // (value DOUBLE, lower DOUBLE, upper DOUBLE, compression DOUBLE) -> DOUBLE
+  signatures.push_back(
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("varbinary")
+          .argumentType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .argumentType("double")
+          .build());
+  exec::registerAggregateFunction(
+      names,
+      signatures,
+      [](core::AggregationNode::Step /*step*/,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        bool hasCompression = argTypes.size() == 4;
+        return std::make_unique<ApproxWinsorizedMeanAggregate>(
+            resultType, hasCompression);
+      },
+      {},
+      false /*registerCompanionFunctions*/,
+      overwrite);
+}
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -17,6 +17,7 @@ velox_add_library(
   ApproxDistinctAggregate.cpp
   ApproxMostFrequentAggregate.cpp
   ApproxPercentileAggregate.cpp
+  ApproxWinsorizedMeanAggregate.cpp
   ArbitraryAggregate.cpp
   ArrayAggAggregate.cpp
   AverageAggregate.cpp

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -306,6 +306,9 @@ extern void registerVarPopAggregate(
 extern void registerTDigestAggregate(
     const std::vector<std::string>& names,
     bool overwrite);
+extern void registerApproxWinsorizedMeanAggregate(
+    const std::vector<std::string>& names,
+    bool overwrite);
 extern void registerKHyperLogLogAggregates(
     const std::vector<std::string>& names,
     bool withCompanionFunctions,
@@ -463,6 +466,8 @@ void registerAllAggregateFunctions(
   registerVarPopAggregate(
       {prefix + kVarPop}, withCompanionFunctions, overwrite);
   registerTDigestAggregate({prefix + kTDigestAgg}, overwrite);
+  registerApproxWinsorizedMeanAggregate(
+      {prefix + kApproxWinsorizedMean}, overwrite);
   registerNoisyApproxSfmAggregate(
       {prefix + kNoisyApproxSetSfm},
       {prefix + kNoisyApproxDistinctSfm},

--- a/velox/functions/prestosql/aggregates/tests/ApproxWinsorizedMeanAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxWinsorizedMeanAggregateTest.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <random>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/utils/AggregationTestBase.h"
+
+using namespace facebook::velox::functions::aggregate::test;
+using facebook::velox::exec::test::AssertQueryBuilder;
+using facebook::velox::exec::test::PlanBuilder;
+
+namespace facebook::velox::aggregate::test {
+
+class ApproxWinsorizedMeanAggregateTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+  }
+};
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, globalFullRange) {
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>({1.0, 2.0, 3.0, 4.0, 5.0}),
+       makeConstant<double>(0.0, 5),
+       makeConstant<double>(1.0, 5)});
+  auto expected = makeRowVector({makeFlatVector<double>({3.0})});
+  testAggregations(
+      {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2)"}, {expected});
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, groupBy) {
+  auto vectors = makeRowVector(
+      {makeFlatVector<int32_t>({1, 1, 1, 1, 1, 2, 2, 2, 2, 2}),
+       makeFlatVector<double>(
+           {1.0, 2.0, 3.0, 4.0, 100.0, 10.0, 20.0, 30.0, 40.0, 50.0}),
+       makeConstant<double>(0.0, 10),
+       makeConstant<double>(1.0, 10)});
+
+  auto expected = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2}), makeFlatVector<double>({22.0, 30.0})});
+  testAggregations(
+      {vectors}, {"c0"}, {"approx_winsorized_mean(c1, c2, c3)"}, {expected});
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, nullHandling) {
+  auto vectors = makeRowVector(
+      {makeNullableFlatVector<double>(
+           {1.0, std::nullopt, 3.0, std::nullopt, 5.0}),
+       makeConstant<double>(0.0, 5),
+       makeConstant<double>(1.0, 5)});
+  auto expected = makeRowVector({makeFlatVector<double>({3.0})});
+  testAggregations(
+      {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2)"}, {expected});
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, allNulls) {
+  auto vectors = makeRowVector(
+      {makeNullableFlatVector<double>({std::nullopt, std::nullopt}),
+       makeConstant<double>(0.0, 2),
+       makeConstant<double>(1.0, 2)});
+  auto expected =
+      makeRowVector({makeNullableFlatVector<double>({std::nullopt})});
+  testAggregations(
+      {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2)"}, {expected});
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, invalidBounds) {
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>({1.0, 2.0, 3.0}),
+       makeConstant<double>(-0.1, 3),
+       makeConstant<double>(0.5, 3)});
+  VELOX_ASSERT_THROW(
+      testAggregations(
+          {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2)"}, {""}),
+      ">= 0");
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, boundsReversed) {
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>({1.0, 2.0, 3.0}),
+       makeConstant<double>(0.9, 3),
+       makeConstant<double>(0.1, 3)});
+  VELOX_ASSERT_THROW(
+      testAggregations(
+          {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2)"}, {""}),
+      "less than or equal");
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, nanInput) {
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>({1.0, std::numeric_limits<double>::quiet_NaN()}),
+       makeConstant<double>(0.0, 2),
+       makeConstant<double>(1.0, 2)});
+  VELOX_ASSERT_THROW(
+      testAggregations(
+          {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2)"}, {""}),
+      "Cannot add NaN");
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, withCompression) {
+  std::vector<double> values(1'000);
+  for (int i = 0; i < 1'000; ++i) {
+    values[i] = i;
+  }
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>(values),
+       makeConstant<double>(0.0, 1'000),
+       makeConstant<double>(1.0, 1'000),
+       makeConstant<double>(200.0, 1'000)});
+  auto expected = makeRowVector({makeFlatVector<double>({499.5})});
+  testAggregations(
+      {vectors}, {}, {"approx_winsorized_mean(c0, c1, c2, c3)"}, {expected});
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, nonDefaultBoundsDistributed) {
+  // Exercises non-default quantile bounds (0.01, 0.99) through an explicit
+  // partial→final plan to verify that quantile bounds survive the
+  // intermediate varbinary serialization.
+  constexpr int N{1'000};
+  std::vector<double> values(N);
+  for (int i = 0; i < N; ++i) {
+    values[i] = i;
+  }
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>(values),
+       makeConstant<double>(0.01, N),
+       makeConstant<double>(0.99, N)});
+
+  // Build partial→final plan to test distributed aggregation path.
+  auto plan =
+      PlanBuilder()
+          .values({vectors})
+          .partialAggregation({}, {"approx_winsorized_mean(c0, c1, c2)"})
+          .finalAggregation()
+          .planNode();
+  auto resultVector = AssertQueryBuilder(plan).copyResults(pool());
+  auto result = resultVector->childAt(0)->asFlatVector<double>()->valueAt(0);
+  // Uniform distribution winsorized at 1%/99% — mean should be close to
+  // regular mean (499.5) since uniform is symmetric.
+  ASSERT_NEAR(result, 499.5, 499.5 * 0.02);
+}
+
+TEST_F(ApproxWinsorizedMeanAggregateTest, accuracy) {
+  constexpr int N{100'000};
+  std::vector<double> values(N);
+  std::default_random_engine generator(42);
+  std::lognormal_distribution<> distribution(0, 1.0);
+  for (int i = 0; i < N; ++i) {
+    values[i] = distribution(generator);
+  }
+
+  auto vectors = makeRowVector(
+      {makeFlatVector<double>(values),
+       makeConstant<double>(0.01, N),
+       makeConstant<double>(0.99, N)});
+
+  std::sort(values.begin(), values.end());
+  int lowerIndex{static_cast<int>(N * 0.01)};
+  int upperIndex{static_cast<int>(N * 0.99)};
+  double lowBound{values[lowerIndex]};
+  double highBound{values[upperIndex]};
+  double exactSum{0};
+  for (auto value : values) {
+    exactSum += std::max(lowBound, std::min(highBound, value));
+  }
+  double exactMean{exactSum / N};
+
+  auto plan = PlanBuilder()
+                  .values({vectors})
+                  .singleAggregation({}, {"approx_winsorized_mean(c0, c1, c2)"})
+                  .planNode();
+  auto resultVector = AssertQueryBuilder(plan).copyResults(pool());
+  auto result = resultVector->childAt(0)->asFlatVector<double>()->valueAt(0);
+  ASSERT_NEAR(result, exactMean, std::abs(exactMean) * 0.05);
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(
   ApproxDistinctTest.cpp
   ApproxMostFrequentTest.cpp
   ApproxPercentileTest.cpp
+  ApproxWinsorizedMeanAggregateTest.cpp
   ArbitraryTest.cpp
   ArrayAggTest.cpp
   VectorSumTest.cpp

--- a/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/TDigestFunctionsRegistration.cpp
@@ -76,5 +76,11 @@ void registerTDigestFunctions(const std::string& prefix) {
       SimpleTDigest<double>,
       double,
       double>({prefix + "trimmed_mean"});
+  registerFunction<
+      WinsorizedMeanFunction,
+      double,
+      SimpleTDigest<double>,
+      double,
+      double>({prefix + "winsorized_mean"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/TDigestFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/TDigestFunctionsTest.cpp
@@ -746,3 +746,129 @@ TEST_F(TDigestFunctionsTest, testTrimmedMean) {
     ASSERT_TRUE(abs(result.value() - expectedMean) / standardDeviation <= 0.05);
   }
 }
+
+TEST_F(TDigestFunctionsTest, testWinsorizedMean) {
+  const auto winsorizedMean = [&](const std::optional<std::string>& input,
+                                  const std::optional<double>& lowQuantile,
+                                  const std::optional<double>& highQuantile) {
+    return evaluateOnce<double>(
+        "winsorized_mean(c0, c1, c2)",
+        TDIGEST_DOUBLE,
+        input,
+        lowQuantile,
+        highQuantile);
+  };
+
+  // Create TDigest with uniform distribution.
+  facebook::velox::functions::TDigest<> tDigest;
+  std::vector<int16_t> positions;
+  std::vector<double> values;
+
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<double> distribution(0.0, NUMBER_OF_ENTRIES);
+
+  for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
+    double value{distribution(gen)};
+    tDigest.add(positions, value);
+    values.push_back(value);
+  }
+  tDigest.compress(positions);
+  std::sort(values.begin(), values.end());
+
+  // Serialize TDigest.
+  auto serializedSize{tDigest.serializedByteSize()};
+  std::vector<char> buffer(serializedSize);
+  tDigest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  // Full range (0, 1) should equal regular mean.
+  auto fullRangeResult{winsorizedMean(serializedDigest, 0.0, 1.0)};
+  double expectedFullMean{tDigest.sum() / tDigest.totalWeight()};
+  ASSERT_NEAR(
+      fullRangeResult.value(), expectedFullMean, expectedFullMean * 0.01);
+
+  // Test quantile pairs with computed expected values.
+  std::vector<std::pair<double, double>> quantilePairs = {
+      {0.1, 0.9},
+      {0.25, 0.75},
+      {0.01, 0.99},
+  };
+
+  for (const auto& [lowQuantile, highQuantile] : quantilePairs) {
+    int lowIndex{static_cast<int>(NUMBER_OF_ENTRIES * lowQuantile)};
+    int highIndex{static_cast<int>(NUMBER_OF_ENTRIES * highQuantile)};
+    double lowBound{values[lowIndex]};
+    double highBound{values[highIndex]};
+    double exactSum{0};
+    for (const auto& value : values) {
+      exactSum += std::max(lowBound, std::min(highBound, value));
+    }
+    double expectedMean{exactSum / NUMBER_OF_ENTRIES};
+
+    auto result{winsorizedMean(serializedDigest, lowQuantile, highQuantile)};
+    double standardDeviation{
+        std::sqrt(distribution.max() * distribution.max() / 12)};
+    ASSERT_TRUE(abs(result.value() - expectedMean) / standardDeviation <= 0.05);
+  }
+}
+
+TEST_F(TDigestFunctionsTest, testWinsorizedMeanEmptyDigest) {
+  // Empty TDigest should return NULL.
+  facebook::velox::functions::TDigest<> tDigest;
+  std::vector<int16_t> positions;
+  tDigest.compress(positions);
+  auto serializedSize{tDigest.serializedByteSize()};
+  std::vector<char> buffer(serializedSize);
+  tDigest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  auto result = evaluateOnce<double>(
+      "winsorized_mean(c0, c1, c2)",
+      TDIGEST_DOUBLE,
+      std::optional<std::string>(serializedDigest),
+      std::optional<double>(0.1),
+      std::optional<double>(0.9));
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST_F(TDigestFunctionsTest, testWinsorizedMeanInvalidBounds) {
+  // Create a simple TDigest.
+  facebook::velox::functions::TDigest<> tDigest;
+  std::vector<int16_t> positions;
+  tDigest.add(positions, 1.0);
+  tDigest.compress(positions);
+  auto serializedSize{tDigest.serializedByteSize()};
+  std::vector<char> buffer(serializedSize);
+  tDigest.serialize(buffer.data());
+  std::string serializedDigest(buffer.begin(), buffer.end());
+
+  // Out-of-range lower bound.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<double>(
+          "winsorized_mean(c0, c1, c2)",
+          TDIGEST_DOUBLE,
+          std::optional<std::string>(serializedDigest),
+          std::optional<double>(-0.1),
+          std::optional<double>(0.5)),
+      "between 0 and 1");
+
+  // Out-of-range upper bound.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<double>(
+          "winsorized_mean(c0, c1, c2)",
+          TDIGEST_DOUBLE,
+          std::optional<std::string>(serializedDigest),
+          std::optional<double>(0.0),
+          std::optional<double>(1.1)),
+      "between 0 and 1");
+
+  // Lower > upper.
+  VELOX_ASSERT_THROW(
+      evaluateOnce<double>(
+          "winsorized_mean(c0, c1, c2)",
+          TDIGEST_DOUBLE,
+          std::optional<std::string>(serializedDigest),
+          std::optional<double>(0.9),
+          std::optional<double>(0.1)),
+      "less than or equal");
+}


### PR DESCRIPTION
Summary:

Add documentation for the two new Winsorized mean functions to the T-Digest functions RST page:
- `winsorized_mean(tdigest, lower, upper)` — scalar function operating on a pre-built TDigest
- `approx_winsorized_mean(value, lower, upper[, compression])` — single-pass aggregate function

Documentation includes parameter descriptions, the distinction from trimmed_mean (replaces vs excludes tail values), and an example showing how the single-pass aggregate replaces the common two-pass APPROX_PERCENTILE + LEAST + AVG pattern.

Reviewed By: natashasehgal

Differential Revision: D100455863
