### PR TITLE
build(cudf): Migrate RMM usage to CCCL MR design

### DIFF
--- a/CMake/resolve_dependency_modules/cudf.cmake
+++ b/CMake/resolve_dependency_modules/cudf.cmake
@@ -17,12 +17,12 @@ include_guard(GLOBAL)
 # 3.30.4 is the minimum version required by cudf
 cmake_minimum_required(VERSION 3.30.4)
 
-# rapids_cmake commit cac9e0e from 2026-04-10
+# rapids_cmake commit d79e071 from 2026-05-01
 set(VELOX_rapids_cmake_VERSION 26.06)
-set(VELOX_rapids_cmake_COMMIT cac9e0ee144fdab03e8bd19f2124ec0239c36924)
+set(VELOX_rapids_cmake_COMMIT d79e071f805e709771b80008d50a8b3a5bed93ca)
 set(
   VELOX_rapids_cmake_BUILD_SHA256_CHECKSUM
-  a43b508ac36a1154a656b2996180ec1e73b08feaa344888856b67661f70ebac5
+  d0f9eea4feaef1cc325e86eac787052ec951659fdcf21abdfb06efc337a63179
 )
 set(
   VELOX_rapids_cmake_SOURCE_URL
@@ -30,22 +30,22 @@ set(
 )
 velox_resolve_dependency_url(rapids_cmake)
 
-# rmm commit b899854 from 2026-04-10
+# rmm commit 2357ddd from 2026-05-04
 set(VELOX_rmm_VERSION 26.06)
-set(VELOX_rmm_COMMIT b89985443b4e68edfd44d5b4fc91813d7e3d5b52)
+set(VELOX_rmm_COMMIT 2357ddddcff042ba378e8de6f89e4a995a23b2db)
 set(
   VELOX_rmm_BUILD_SHA256_CHECKSUM
-  f010961681329599d22a0b09f8cef7f68c4d9ce70a6dc5be9ff258e40fae0168
+  61492c2da88e7f6a6a4edc7101cce4698c156704d135db0b80119f4b9a2c575c
 )
 set(VELOX_rmm_SOURCE_URL "https://github.com/rapidsai/rmm/archive/${VELOX_rmm_COMMIT}.tar.gz")
 velox_resolve_dependency_url(rmm)
 
-# kvikio commit 974cb68 from 2026-04-10
+# kvikio commit 247b64e from 2026-05-02
 set(VELOX_kvikio_VERSION 26.06)
-set(VELOX_kvikio_COMMIT 974cb68f00d00c1ba237bb7e2fe5d892d028d057)
+set(VELOX_kvikio_COMMIT 247b64e97ecb7cb9ccb06ab123aea87ac571c5b4)
 set(
   VELOX_kvikio_BUILD_SHA256_CHECKSUM
-  9c3869ca8b701be045c11c5c094ac6ef35f0dd67b1babafbe17db73202472dd5
+  6419490de95e412cefdbafffc73fac6b2162bc2200076611883fe41637028198
 )
 set(
   VELOX_kvikio_SOURCE_URL
@@ -53,12 +53,12 @@ set(
 )
 velox_resolve_dependency_url(kvikio)
 
-# cudf commit 431604c from 2026-04-13
+# cudf commit d09d10d from 2026-05-04
 set(VELOX_cudf_VERSION 26.06 CACHE STRING "cudf version")
-set(VELOX_cudf_COMMIT 431604c73f18de37baaefcabe4f0e9a3d56627b2)
+set(VELOX_cudf_COMMIT d09d10d14d3ed932b8de93638809101af5c7fec3)
 set(
   VELOX_cudf_BUILD_SHA256_CHECKSUM
-  c11f7f501abdbe73bd38ba3e8704219ced6dfb3cd867278f3c1330e6b5b494d6
+  5042ec46beb8260eb60d13b9cd44f26357b9756628f7d58659c77e88c67e15d5
 )
 set(VELOX_cudf_SOURCE_URL "https://github.com/rapidsai/cudf/archive/${VELOX_cudf_COMMIT}.tar.gz")
 velox_resolve_dependency_url(cudf)

--- a/velox/experimental/cudf/CudfNoDefaults.h
+++ b/velox/experimental/cudf/CudfNoDefaults.h
@@ -64,7 +64,7 @@ namespace facebook::velox::cudf_velox {
 /// function directly. Use this at call sites where you intentionally want
 /// the current default device memory resource.
 inline rmm::device_async_resource_ref get_temp_mr() {
-  return rmm::mr::get_current_device_resource();
+  return rmm::mr::get_current_device_resource_ref();
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.cpp
+++ b/velox/experimental/cudf/exec/GpuResources.cpp
@@ -26,112 +26,54 @@
 #include <rmm/mr/cuda_async_managed_memory_resource.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/mr/managed_memory_resource.hpp>
-#include <rmm/mr/owning_wrapper.hpp>
 #include <rmm/mr/pool_memory_resource.hpp>
 #include <rmm/mr/prefetch_resource_adaptor.hpp>
 
 #include <common/base/Exceptions.h>
 
 #include <cstdlib>
-#include <memory>
 #include <string_view>
 
 namespace facebook::velox::cudf_velox {
 
-namespace {
-/// \brief Makes a cuda resource
-[[nodiscard]] auto makeCudaMr() {
-  return std::make_shared<rmm::mr::cuda_memory_resource>();
-}
-
-/// \brief Makes a pool<cuda> resource
-[[nodiscard]] auto makePoolMr(int percent) {
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      makeCudaMr(), rmm::percent_of_free_device_memory(percent));
-}
-
-/// \brief Makes an async resource
-[[nodiscard]] auto makeAsyncMr() {
-  return std::make_shared<rmm::mr::cuda_async_memory_resource>();
-}
-
-/// \brief Makes a managed resource
-[[nodiscard]] auto makeManagedMr() {
-  return std::make_shared<rmm::mr::managed_memory_resource>();
-}
-
-/// \brief Makes a prefetch<managed> resource
-[[nodiscard]] auto makePrefetchManagedMr() {
-  return rmm::mr::make_owning_wrapper<rmm::mr::prefetch_resource_adaptor>(
-      makeManagedMr());
-}
-
-/// \brief Makes an arena<cuda> resource
-[[nodiscard]] auto makeArenaMr(int percent) {
-  return rmm::mr::make_owning_wrapper<rmm::mr::arena_memory_resource>(
-      makeCudaMr(), rmm::percent_of_free_device_memory(percent));
-}
-
-/// \brief Makes a pool<managed> resource
-[[nodiscard]] auto makeManagedPoolMr(int percent) {
-  return rmm::mr::make_owning_wrapper<rmm::mr::pool_memory_resource>(
-      makeManagedMr(), rmm::percent_of_free_device_memory(percent));
-}
-
-/// \brief Makes a prefetch<pool<managed>> resource
-[[nodiscard]] auto makePrefetchManagedPoolMr(int percent) {
-  return rmm::mr::make_owning_wrapper<rmm::mr::prefetch_resource_adaptor>(
-      makeManagedPoolMr(percent));
-}
-
-/// \brief Makes a managed_async resource (experimental, requires CUDA 13+)
-[[nodiscard]] auto makeManagedAsyncMr() {
-  return std::make_shared<rmm::mr::cuda_async_managed_memory_resource>();
-}
-
-/// \brief Makes a prefetch<managed_async> resource (experimental, requires CUDA
-/// 13+)
-[[nodiscard]] auto makePrefetchManagedAsyncMr() {
-  return rmm::mr::make_owning_wrapper<rmm::mr::prefetch_resource_adaptor>(
-      makeManagedAsyncMr());
-}
-
-void enablePrefetching() {
-  cudf::prefetch::enable();
-}
-
-} // namespace
-
-std::shared_ptr<rmm::mr::device_memory_resource> createMemoryResource(
+cuda::mr::any_resource<cuda::mr::device_accessible> createMemoryResource(
     std::string_view mode,
     int percent) {
-  if (mode == "cuda")
-    return makeCudaMr();
-  if (mode == "pool")
-    return makePoolMr(percent);
-  if (mode == "async")
-    return makeAsyncMr();
-  if (mode == "arena")
-    return makeArenaMr(percent);
-  if (mode == "managed")
-    return makeManagedMr();
-  if (mode == "managed_pool")
-    return makeManagedPoolMr(percent);
-  if (mode == "managed_async")
-    return makeManagedAsyncMr();
-  if (mode == "prefetch_managed") {
-    enablePrefetching();
-    return makePrefetchManagedMr();
-  }
-  if (mode == "prefetch_managed_pool") {
-    enablePrefetching();
-    return makePrefetchManagedPoolMr(percent);
-  }
-  if (mode == "prefetch_managed_async") {
-    enablePrefetching();
-    return makePrefetchManagedAsyncMr();
+  if (mode == "cuda") {
+    return rmm::mr::cuda_memory_resource{};
+  } else if (mode == "pool") {
+    return rmm::mr::pool_memory_resource(
+        rmm::mr::cuda_memory_resource{},
+        rmm::percent_of_free_device_memory(percent));
+  } else if (mode == "async") {
+    return rmm::mr::cuda_async_memory_resource{};
+  } else if (mode == "arena") {
+    return rmm::mr::arena_memory_resource(
+        rmm::mr::cuda_memory_resource{},
+        rmm::percent_of_free_device_memory(percent));
+  } else if (mode == "managed") {
+    return rmm::mr::managed_memory_resource{};
+  } else if (mode == "managed_pool") {
+    return rmm::mr::pool_memory_resource(
+        rmm::mr::managed_memory_resource{},
+        rmm::percent_of_free_device_memory(percent));
+  } else if (mode == "managed_async") {
+    return rmm::mr::cuda_async_managed_memory_resource{};
+  } else if (mode == "prefetch_managed") {
+    cudf::prefetch::enable();
+    return rmm::mr::prefetch_resource_adaptor(
+        rmm::mr::managed_memory_resource{});
+  } else if (mode == "prefetch_managed_pool") {
+    cudf::prefetch::enable();
+    return rmm::mr::prefetch_resource_adaptor(
+        rmm::mr::pool_memory_resource(
+            rmm::mr::managed_memory_resource{},
+            rmm::percent_of_free_device_memory(percent)));
+  } else if (mode == "prefetch_managed_async") {
+    cudf::prefetch::enable();
+    return rmm::mr::prefetch_resource_adaptor(
+        rmm::mr::cuda_async_managed_memory_resource{});
   }
   VELOX_FAIL(
       "Unknown memory resource mode: " + std::string(mode) +
@@ -143,11 +85,11 @@ cudf::detail::cuda_stream_pool& cudfGlobalStreamPool() {
   return cudf::detail::global_cuda_stream_pool();
 };
 
-std::shared_ptr<rmm::mr::device_memory_resource> mr_;
-std::shared_ptr<rmm::mr::device_memory_resource> output_mr_;
+std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
+std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> output_mr_;
 
 rmm::device_async_resource_ref get_output_mr() {
-  return output_mr_.get();
+  return output_mr_.value();
 }
 
 } // namespace facebook::velox::cudf_velox

--- a/velox/experimental/cudf/exec/GpuResources.h
+++ b/velox/experimental/cudf/exec/GpuResources.h
@@ -18,16 +18,18 @@
 
 #include <cudf/detail/utilities/stream_pool.hpp>
 
-#include <rmm/mr/device_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <memory>
+#include <cuda/memory_resource>
+
+#include <optional>
 #include <string_view>
 
 namespace facebook::velox::cudf_velox {
 
-extern std::shared_ptr<rmm::mr::device_memory_resource> mr_;
-extern std::shared_ptr<rmm::mr::device_memory_resource> output_mr_;
+extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> mr_;
+extern std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
+    output_mr_;
 
 /// Returns the memory resource designated for output vector allocations.
 rmm::device_async_resource_ref get_output_mr();
@@ -39,7 +41,7 @@ rmm::device_async_resource_ref get_output_mr();
  * @param percent The initial percent of GPU memory to allocate for memory
  * resource.
  */
-[[nodiscard]] std::shared_ptr<rmm::mr::device_memory_resource>
+[[nodiscard]] cuda::mr::any_resource<cuda::mr::device_accessible>
 createMemoryResource(std::string_view mode, int percent);
 
 /**

--- a/velox/experimental/cudf/exec/ToCudf.cpp
+++ b/velox/experimental/cudf/exec/ToCudf.cpp
@@ -36,6 +36,7 @@
 #include "velox/exec/Values.h"
 
 #include <cudf/detail/nvtx/ranges.hpp>
+#include <cudf/utilities/memory_resource.hpp>
 
 #include <cuda.h>
 
@@ -316,8 +317,8 @@ void registerCudf() {
   const std::string mrMode = CudfConfig::getInstance().memoryResource;
   auto mr = cudf_velox::createMemoryResource(
       mrMode, CudfConfig::getInstance().memoryPercent);
-  cudf::set_current_device_resource(mr.get());
-  mr_ = mr;
+  cudf::set_current_device_resource(mr);
+  mr_ = std::move(mr);
 
   const auto& outputMrMode = CudfConfig::getInstance().outputMemoryResource;
   if (!outputMrMode.empty() && outputMrMode != mrMode) {
@@ -345,8 +346,8 @@ void registerCudf() {
 }
 
 void unregisterCudf() {
-  output_mr_ = nullptr;
-  mr_ = nullptr;
+  output_mr_.reset();
+  mr_.reset();
   exec::DriverFactory::adapters.erase(
       std::remove_if(
           exec::DriverFactory::adapters.begin(),


### PR DESCRIPTION
## Summary

This PR migrates Velox's usage of RMM memory resources to align with the new design from CCCL.

Part of https://github.com/rapidsai/rmm/issues/2011.
Depends on https://github.com/rapidsai/cudf/pull/22008.