### PR TITLE
fix(fuzzer): Handle task completion timeout in MemoryArbitrationFuzzer

### DIFF
--- a/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
+++ b/velox/exec/fuzzer/MemoryArbitrationFuzzer.cpp
@@ -957,7 +957,10 @@ void MemoryArbitrationFuzzer::verify() {
 
           const auto plan = plans.at(getRandomIndex(rng, plans.size() - 1));
           test::AssertQueryBuilder builder(plan.plan);
-          builder.queryCtx(queryCtx);
+          // Use a long timeout (1 hour) to avoid false failures from CI thread
+          // starvation while still catching real deadlocks.
+          static constexpr uint64_t kOneHourUs{3'600'000'000ULL};
+          builder.queryCtx(queryCtx).maxWaitMicros(kOneHourUs);
           for (const auto& [planNodeId, nodeSplits] : plan.splits) {
             builder.splits(planNodeId, nodeSplits);
           }

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -331,51 +331,55 @@ AssertQueryBuilder::readCursor() {
     }
   }
 
-  return test::readCursorAsync(params_, [&](exec::TaskCursor* taskCursor) {
-    if (taskCursor->noMoreSplits()) {
-      return ContinueFuture::makeEmpty();
-    }
-    auto& task = taskCursor->task();
-    if (params_.barrierExecution) {
-      int numSplits{0};
-      for (auto& [nodeId, nodeSplits] : splits_) {
-        if (nodeSplits.empty()) {
-          task->noMoreSplits(nodeId);
-          continue;
+  return test::readCursorAsync(
+      params_,
+      [&](exec::TaskCursor* taskCursor) {
+        if (taskCursor->noMoreSplits()) {
+          return ContinueFuture::makeEmpty();
         }
-        ++numSplits;
-        if (addSplitWithSequence_) {
-          task->addSplitWithSequence(
-              nodeId, std::move(nodeSplits[0]), ++sequenceId_);
-          task->setMaxSplitSequenceId(nodeId, sequenceId_);
-        } else {
-          task->addSplit(nodeId, std::move(nodeSplits[0]));
-        }
-        nodeSplits.erase(nodeSplits.cbegin());
-      }
-      if (numSplits > 0) {
-        VELOX_CHECK_EQ(
-            numSplits,
-            splits_.size(),
-            "Barrier task execution mode requires all the sources have the same number of splits");
-        return task->requestBarrier();
-      }
-      taskCursor->setNoMoreSplits();
-    } else {
-      for (auto& [nodeId, nodeSplits] : splits_) {
-        for (auto& split : nodeSplits) {
-          if (addSplitWithSequence_) {
-            task->addSplitWithSequence(nodeId, std::move(split), ++sequenceId_);
-            task->setMaxSplitSequenceId(nodeId, sequenceId_);
-          } else {
-            task->addSplit(nodeId, std::move(split));
+        auto& task = taskCursor->task();
+        if (params_.barrierExecution) {
+          int numSplits{0};
+          for (auto& [nodeId, nodeSplits] : splits_) {
+            if (nodeSplits.empty()) {
+              task->noMoreSplits(nodeId);
+              continue;
+            }
+            ++numSplits;
+            if (addSplitWithSequence_) {
+              task->addSplitWithSequence(
+                  nodeId, std::move(nodeSplits[0]), ++sequenceId_);
+              task->setMaxSplitSequenceId(nodeId, sequenceId_);
+            } else {
+              task->addSplit(nodeId, std::move(nodeSplits[0]));
+            }
+            nodeSplits.erase(nodeSplits.cbegin());
           }
+          if (numSplits > 0) {
+            VELOX_CHECK_EQ(
+                numSplits,
+                splits_.size(),
+                "Barrier task execution mode requires all the sources have the same number of splits");
+            return task->requestBarrier();
+          }
+          taskCursor->setNoMoreSplits();
+        } else {
+          for (auto& [nodeId, nodeSplits] : splits_) {
+            for (auto& split : nodeSplits) {
+              if (addSplitWithSequence_) {
+                task->addSplitWithSequence(
+                    nodeId, std::move(split), ++sequenceId_);
+                task->setMaxSplitSequenceId(nodeId, sequenceId_);
+              } else {
+                task->addSplit(nodeId, std::move(split));
+              }
+            }
+            task->noMoreSplits(nodeId);
+          }
+          taskCursor->setNoMoreSplits();
         }
-        task->noMoreSplits(nodeId);
-      }
-      taskCursor->setNoMoreSplits();
-    }
-    return ContinueFuture::makeEmpty();
-  });
+        return ContinueFuture::makeEmpty();
+      },
+      maxWaitMicros_);
 }
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -128,6 +128,13 @@ class AssertQueryBuilder {
     return *this;
   }
 
+  /// Set the maximum time to wait for task completion after all results have
+  /// been consumed. Default is 5 seconds.
+  AssertQueryBuilder& maxWaitMicros(uint64_t maxWaitMicros) {
+    maxWaitMicros_ = maxWaitMicros;
+    return *this;
+  }
+
   /// Spilling directory, if not empty, then the task's spilling directory would
   /// be built from it.
   AssertQueryBuilder& spillDirectory(const std::string& dir) {
@@ -221,6 +228,9 @@ class AssertQueryBuilder {
   bool addSplitWithSequence_{false};
   // The sequence Id to be used when addSplitWithSequence_ is true.
   int32_t sequenceId_{0};
+  // Maximum time in microseconds to wait for task completion after all results
+  // have been consumed.
+  uint64_t maxWaitMicros_{5'000'000};
 };
 
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
## Summary

The Memory Arbitration Fuzzer intermittently crashes in CI with `SIGABRT` when a task fails to complete within the 5-second default timeout under heavy concurrent load. `readCursorAsync()` throws `VELOX_FAIL("Failed to wait for task to complete after 5.00s, ...")` with error code `kInvalidState` when a task remains in `Running` state past the timeout.

Under heavy contention (4 fuzzer instances × 72 threads on a 4-core CI runner), threads get starved and tasks legitimately cannot complete within 5 seconds — but this crashes the fuzzer because its error handler assumes any `kInvalidState` must be from an injected fault (spill FS fault or task abort request).

## Fix

Extend the task-completion timeout in the fuzzer to **1 hour** instead of trying to recognize and recover from the 5s default. This avoids false `SIGABRT` crashes from CI thread starvation while still catching real deadlocks.

To make this configurable, add a `maxWaitMicros(uint64_t)` setter and a private `maxWaitMicros_{5'000'000}` member to `AssertQueryBuilder`. Default behavior is unchanged for all existing callers. The fuzzer calls `builder.maxWaitMicros(kOneHourUs)` once per query before reading the cursor.

`CursorParameters` (in the public `velox/exec/Cursor.h`) is left untouched — `TaskCursor::create` never reads this field, so it belongs in the test-only builder, not the public struct.

## Root cause analysis

Examined 3 CI failures over 2 weeks (Apr 7, 9, 11) — all had the identical signature:
- `Expression: injectedSpillFsFault || injectedTaskAbortRequest`
- `injectedSpillFsFault: false, injectedTaskAbortRequest: false`
- `Failed to wait for task to complete after 5.00s`
- Different plan types (HashJoin, OrderBy, TopNRowNumber) — not operator-specific
- All drivers were stuck in `enqueued` state, waiting for CPU or memory arbitration

## Test plan

- [x] Reproduced the original crash with 4 parallel fuzzer instances under elevated memory pressure (`--arbitrator_capacity 128MB --allocator_capacity 512MB --num_batches 64 --global_arbitration_pct 20 --task_abort_interval_ms 500`). Instance 3 crashed with `exit 134 (SIGABRT)` and the exact same error as CI.
- [x] Applied fix, rebuilt, re-ran the same 4-instance stress test — all 4 instances passed.
- [x] **Latest validation (2026-04-17, gpu1, 8 CPU/30GB RAM):** built incrementally with `ninja -j 4`, ran **4 concurrent instances × 15 min** (seeds 101–104). All 4 exited cleanly. **0 FATAL crashes, 0 "Failed to wait" errors** across all logs; 408 expected `MEM_ABORTED` events confirm the arbitrator was actively exercised. Memory peaked at ~5GB / 30GB.
