### PR TITLE
fix(ci): Pass github_token to claude-code-action for fork PR support

### DIFF
--- a/.github/workflows/ci-failure-comment.yml
+++ b/.github/workflows/ci-failure-comment.yml
@@ -175,6 +175,7 @@ jobs:
         uses: izaitsevfb/claude-code-action@ececd56fb999d06b4dd2477437bc408938295d76 # forked-pr-fix
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ github.token }}
           claude_args: --model claude-opus-4-6 --allowedTools Bash Read Grep Glob
           prompt: ${{ steps.prompt.outputs.value }}
         env:


### PR DESCRIPTION
## Summary

The CI Failure Comment workflow (`ci-failure-comment.yml`) fails on fork PRs because the `claude-code-action` OIDC token exchange checks that the triggering actor has write access to the repository. Fork PR authors don't have write access, causing a `401 Unauthorized` error.

Fix: pass `github_token: ${{ github.token }}` explicitly so the action uses the workflow's own GITHUB_TOKEN (with the declared permissions) instead of the OIDC flow.

**Security:** No change in exposure — the same token is already available to Claude via the `GH_TOKEN` env var. The workflow's token is scoped to exactly the permissions declared in the file (`contents: read`, `pull-requests: write`, `issues: write`, `actions: read`) and is automatically revoked after the job completes.

Example failure: https://github.com/facebookincubator/velox/actions/runs/24424455191/job/71354986089

## Test plan

- Verified fix by pushing branch to upstream and dispatching `workflow_dispatch` against a failed fork PR run (run ID `24422420081`, PR #16048)
- Run succeeded: https://github.com/facebookincubator/velox/actions/runs/24426241515