### PR TITLE
fix(build): Build spark-server stage in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
       args:
         - SPARK_VERSION=3.5.1
       dockerfile: scripts/docker/java.dockerfile
+      target: spark-server
 
   fedora:
     extends: base-block


### PR DESCRIPTION
The docker compose yml for spark-server was missing the target stage and unless explicitly specified via docker/podman build it would only build the last target presto-java.