### PR TITLE
fix: Use consistent kebab-case for sort-writer finish time slice config key

### DIFF
--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -112,7 +112,7 @@ class HiveConfig : public FileConfig {
   /// Sort Writer will exit finish() method after this many milliseconds even if
   /// it has not completed its work yet. Zero means no time limit.
   static constexpr const char* kSortWriterFinishTimeSliceLimitMs =
-      "sort-writer_finish_time_slice_limit_ms";
+      "sort-writer-finish-time-slice-limit-ms";
   static constexpr const char* kSortWriterFinishTimeSliceLimitMsSession =
       "sort_writer_finish_time_slice_limit_ms";
 

--- a/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
+++ b/velox/experimental/cudf/connectors/hive/CudfHiveConfig.h
@@ -97,7 +97,7 @@ class CudfHiveConfig {
   /// Sort Writer will exit finish() method after this many milliseconds even if
   /// it has not completed its work yet. Zero means no time limit.
   static constexpr const char* kSortWriterFinishTimeSliceLimitMs =
-      "sort-writer_finish_time_slice_limit_ms";
+      "sort-writer-finish-time-slice-limit-ms";
   static constexpr const char* kSortWriterFinishTimeSliceLimitMsSession =
       "sort_writer_finish_time_slice_limit_ms";
 


### PR DESCRIPTION
The connector config key `kSortWriterFinishTimeSliceLimitMs` used mixed kebab/snake case (`sort-writer_finish_time_slice_limit_ms`). All other sort-writer connector keys use kebab-case consistently (`sort-writer-max-output-rows`, `sort-writer-max-output-bytes`). Fixed to `sort-writer-finish-time-slice-limit-ms`.

Applied to both `HiveConfig.h` and `CudfHiveConfig.h`.

Fixes #17187