### PR TITLE
fix(parquet): Null pointer dereference in TimestampColumnReader (#17191)

### DIFF
--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -17,6 +17,9 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveIntegerColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetColumnReader.h"
+#include "velox/dwio/parquet/reader/ParquetData.h"
+#include "velox/dwio/parquet/reader/ParquetTypeWithId.h"
 #include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::parquet {

--- a/velox/dwio/parquet/reader/TimestampColumnReader.h
+++ b/velox/dwio/parquet/reader/TimestampColumnReader.h
@@ -189,7 +189,7 @@ class TimestampColumnReader : public IntegerColumnReader {
                   range->nullAllowed(),
                   filePrecision_));
         } else {
-          filters.emplace_back(filter->clone(range->nullAllowed()));
+          filters.emplace_back(filter->clone(filter->nullAllowed()));
         }
       }
       auto newMultiRange =


### PR DESCRIPTION
Summary:

In TimestampColumnReader::readHelper(), when processing a MultiRange filter
containing a non-TimestampRange sub-filter, the code dereferences a null
pointer. The range variable from a failed dynamic_cast is nullptr in the else
branch, but range->nullAllowed() is called, causing a guaranteed crash.

Fix: Use filter->nullAllowed() instead of range->nullAllowed().

Differential Revision: D100899436


