### PR TITLE
refactor: Remove redundant hive. prefix from Hive connector config keys (#17192)

### DIFF
--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -21,20 +21,20 @@ namespace facebook::velox::connector::hive {
 
 bool FileConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
   return session->get<bool>(
-      kOrcUseColumnNamesSession, config_->get<bool>(kOrcUseColumnNames, false));
+      kOrcUseColumnNamesSession, configValue<bool>(kOrcUseColumnNames, false));
 }
 
 bool FileConfig::isParquetUseColumnNames(
     const config::ConfigBase* session) const {
   return session->get<bool>(
       kParquetUseColumnNamesSession,
-      config_->get<bool>(kParquetUseColumnNames, false));
+      configValue<bool>(kParquetUseColumnNames, false));
 }
 
 bool FileConfig::allowInt32Narrowing(const config::ConfigBase* session) const {
   return session->get<bool>(
       kAllowInt32NarrowingSession,
-      config_->get<bool>(kAllowInt32Narrowing, false));
+      configValue<bool>(kAllowInt32Narrowing, false));
 }
 
 bool FileConfig::isFileColumnNamesReadAsLowerCase(
@@ -93,9 +93,8 @@ uint64_t FileConfig::filePreloadThreshold() const {
 }
 
 uint8_t FileConfig::readTimestampUnit(const config::ConfigBase* session) const {
-  const auto unit = session->get<uint8_t>(
-      kReadTimestampUnitSession,
-      config_->get<uint8_t>(kReadTimestampUnit, 3 /*milli*/));
+  const auto unit = sessionValue<uint8_t>(
+      session, kReadTimestampUnitSession, kReadTimestampUnit, 3 /*milli*/);
   VELOX_CHECK(
       unit == 3 || unit == 6 /*micro*/ || unit == 9 /*nano*/,
       "Invalid timestamp unit.");
@@ -104,9 +103,11 @@ uint8_t FileConfig::readTimestampUnit(const config::ConfigBase* session) const {
 
 bool FileConfig::readTimestampPartitionValueAsLocalTime(
     const config::ConfigBase* session) const {
-  return session->get<bool>(
+  return sessionValue<bool>(
+      session,
       kReadTimestampPartitionValueAsLocalTimeSession,
-      config_->get<bool>(kReadTimestampPartitionValueAsLocalTime, true));
+      kReadTimestampPartitionValueAsLocalTime,
+      true);
 }
 
 bool FileConfig::readStatsBasedFilterReorderDisabled(
@@ -118,9 +119,11 @@ bool FileConfig::readStatsBasedFilterReorderDisabled(
 
 bool FileConfig::preserveFlatMapsInMemory(
     const config::ConfigBase* session) const {
-  return session->get<bool>(
+  return sessionValue<bool>(
+      session,
       kPreserveFlatMapsInMemorySession,
-      config_->get<bool>(kPreserveFlatMapsInMemory, false));
+      kPreserveFlatMapsInMemory,
+      false);
 }
 
 bool FileConfig::indexEnabled(const config::ConfigBase* session) const {
@@ -130,9 +133,11 @@ bool FileConfig::indexEnabled(const config::ConfigBase* session) const {
 
 bool FileConfig::readerCollectColumnCpuMetrics(
     const config::ConfigBase* session) const {
-  return session->get<bool>(
+  return sessionValue<bool>(
+      session,
       kReaderCollectColumnCpuMetricsSession,
-      config_->get<bool>(kReaderCollectColumnCpuMetrics, false));
+      kReaderCollectColumnCpuMetrics,
+      false);
 }
 
 bool FileConfig::fileMetadataCacheEnabled(
@@ -151,21 +156,21 @@ uint64_t FileConfig::orcFooterSpeculativeIoSize(
     const config::ConfigBase* session) const {
   return session->get<uint64_t>(
       kOrcFooterSpeculativeIoSizeSession,
-      config_->get<uint64_t>(kOrcFooterSpeculativeIoSize, 256UL << 10));
+      configValue<uint64_t>(kOrcFooterSpeculativeIoSize, 256UL << 10));
 }
 
 uint64_t FileConfig::parquetFooterSpeculativeIoSize(
     const config::ConfigBase* session) const {
   return session->get<uint64_t>(
       kParquetFooterSpeculativeIoSizeSession,
-      config_->get<uint64_t>(kParquetFooterSpeculativeIoSize, 256UL << 10));
+      configValue<uint64_t>(kParquetFooterSpeculativeIoSize, 256UL << 10));
 }
 
 uint64_t FileConfig::nimbleFooterSpeculativeIoSize(
     const config::ConfigBase* session) const {
   return session->get<uint64_t>(
       kNimbleFooterSpeculativeIoSizeSession,
-      config_->get<uint64_t>(kNimbleFooterSpeculativeIoSize, 8UL << 20));
+      configValue<uint64_t>(kNimbleFooterSpeculativeIoSize, 8UL << 20));
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -18,10 +18,7 @@
 #include <optional>
 #include <string>
 #include "velox/common/base/Exceptions.h"
-
-namespace facebook::velox::config {
-class ConfigBase;
-}
+#include "velox/common/config/Config.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -32,19 +29,19 @@ namespace facebook::velox::connector::hive {
 class FileConfig {
  public:
   /// Maps table field names to file field names using names, not indices.
-  static constexpr const char* kOrcUseColumnNames = "hive.orc.use-column-names";
+  static constexpr const char* kOrcUseColumnNames = "orc.use-column-names";
   static constexpr const char* kOrcUseColumnNamesSession =
       "orc_use_column_names";
 
   /// Maps table field names to file field names using names, not indices.
   static constexpr const char* kParquetUseColumnNames =
-      "hive.parquet.use-column-names";
+      "parquet.use-column-names";
   static constexpr const char* kParquetUseColumnNamesSession =
       "parquet_use_column_names";
 
   /// Allows reading INT32 physical type columns as a narrower integer type.
   static constexpr const char* kAllowInt32Narrowing =
-      "hive.parquet.allow-int32-narrowing";
+      "parquet.allow-int32-narrowing";
   static constexpr const char* kAllowInt32NarrowingSession =
       "allow_int32_narrowing";
 
@@ -91,15 +88,14 @@ class FileConfig {
       "parallel_unit_load_count";
 
   // The unit for reading timestamps from files.
-  static constexpr const char* kReadTimestampUnit =
-      "hive.reader.timestamp-unit";
+  static constexpr const char* kReadTimestampUnit = "reader.timestamp-unit";
   static constexpr const char* kReadTimestampUnitSession =
-      "hive.reader.timestamp_unit";
+      "reader.timestamp_unit";
 
   static constexpr const char* kReadTimestampPartitionValueAsLocalTime =
-      "hive.reader.timestamp-partition-value-as-local-time";
+      "reader.timestamp-partition-value-as-local-time";
   static constexpr const char* kReadTimestampPartitionValueAsLocalTimeSession =
-      "hive.reader.timestamp_partition_value_as_local_time";
+      "reader.timestamp_partition_value_as_local_time";
 
   static constexpr const char* kReadStatsBasedFilterReorderDisabled =
       "stats-based-filter-reorder-disabled";
@@ -109,9 +105,9 @@ class FileConfig {
   /// Whether to preserve flat maps in memory as FlatMapVectors instead of
   /// converting them to MapVectors.
   static constexpr const char* kPreserveFlatMapsInMemory =
-      "hive.preserve-flat-maps-in-memory";
+      "preserve-flat-maps-in-memory";
   static constexpr const char* kPreserveFlatMapsInMemorySession =
-      "hive.preserve_flat_maps_in_memory";
+      "preserve_flat_maps_in_memory";
 
   /// Whether to use the cluster index for filter-based row pruning.
   /// When enabled, filters from ScanSpec are converted to index bounds for
@@ -122,9 +118,9 @@ class FileConfig {
   /// Whether to collect per-column timing stats (decode/decompress CPU time).
   /// Disabled by default to avoid overhead (~100ns per operation).
   static constexpr const char* kReaderCollectColumnCpuMetrics =
-      "hive.reader.collect-column-cpu-metrics";
+      "reader.collect-column-cpu-metrics";
   static constexpr const char* kReaderCollectColumnCpuMetricsSession =
-      "hive.reader.collect_column_cpu_metrics";
+      "reader.collect_column_cpu_metrics";
 
   /// Whether to cache file metadata (footer, stripes, index) in the
   /// process-wide AsyncDataCache. When enabled, the first reader performs a
@@ -148,15 +144,15 @@ class FileConfig {
   /// metadata in a single IO operation. Format-specific configs with different
   /// defaults: ORC/Parquet default to 256KB, Nimble defaults to 8MB.
   static constexpr const char* kOrcFooterSpeculativeIoSize =
-      "hive.orc.footer-speculative-io-size";
+      "orc.footer-speculative-io-size";
   static constexpr const char* kOrcFooterSpeculativeIoSizeSession =
       "orc_footer_speculative_io_size";
   static constexpr const char* kParquetFooterSpeculativeIoSize =
-      "hive.parquet.footer-speculative-io-size";
+      "parquet.footer-speculative-io-size";
   static constexpr const char* kParquetFooterSpeculativeIoSizeSession =
       "parquet_footer_speculative_io_size";
   static constexpr const char* kNimbleFooterSpeculativeIoSize =
-      "hive.nimble.footer-speculative-io-size";
+      "nimble.footer-speculative-io-size";
   static constexpr const char* kNimbleFooterSpeculativeIoSizeSession =
       "nimble_footer_speculative_io_size";
 
@@ -233,6 +229,38 @@ class FileConfig {
   }
 
  protected:
+  static constexpr const char* kLegacyPrefix = "hive.";
+
+  // Looks up a config value by 'key', falling back to 'hive.' + key if not
+  // found. Used during migration away from redundant 'hive.' prefix in
+  // config keys.
+  template <typename T>
+  T configValue(const std::string& key, const T& defaultValue) const {
+    if (auto val = config_->get<T>(key)) {
+      return val.value();
+    }
+    return config_->get<T>(std::string(kLegacyPrefix) + key, defaultValue);
+  }
+
+  // Looks up a session property by 'sessionKey' (then 'hive.' + sessionKey),
+  // falling back to connector config by 'configKey' (then 'hive.' + configKey).
+  // Used during migration away from redundant 'hive.' prefix in property
+  // names.
+  template <typename T>
+  T sessionValue(
+      const config::ConfigBase* session,
+      const std::string& sessionKey,
+      const std::string& configKey,
+      const T& defaultValue) const {
+    if (auto val = session->get<T>(sessionKey)) {
+      return val.value();
+    }
+    if (auto val = session->get<T>(std::string(kLegacyPrefix) + sessionKey)) {
+      return val.value();
+    }
+    return configValue<T>(configKey, defaultValue);
+  }
+
   std::shared_ptr<const config::ConfigBase> config_;
 };
 

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -68,34 +68,43 @@ uint32_t HiveConfig::maxPartitionsPerWriters(
 }
 
 uint32_t HiveConfig::maxBucketCount(const config::ConfigBase* session) const {
-  return session->get<uint32_t>(
-      kMaxBucketCountSession, config_->get<uint32_t>(kMaxBucketCount, 100'000));
+  return sessionValue<uint32_t>(
+      session, kMaxBucketCountSession, kMaxBucketCount, 100'000);
 }
 
 bool HiveConfig::immutablePartitions() const {
-  return config_->get<bool>(kImmutablePartitions, false);
+  return configValue<bool>(kImmutablePartitions, false);
 }
 
 std::string HiveConfig::gcsEndpoint() const {
-  return config_->get<std::string>(kGcsEndpoint, std::string(""));
+  return configValue<std::string>(kGcsEndpoint, std::string(""));
 }
 
 std::string HiveConfig::gcsCredentialsPath() const {
-  return config_->get<std::string>(kGcsCredentialsPath, std::string(""));
+  return configValue<std::string>(kGcsCredentialsPath, std::string(""));
 }
 
 std::optional<int> HiveConfig::gcsMaxRetryCount() const {
-  return static_cast<std::optional<int>>(config_->get<int>(kGcsMaxRetryCount));
+  if (auto val = config_->get<int>(kGcsMaxRetryCount)) {
+    return val;
+  }
+  return config_->get<int>(std::string(kLegacyPrefix) + kGcsMaxRetryCount);
 }
 
 std::optional<std::string> HiveConfig::gcsMaxRetryTime() const {
-  return static_cast<std::optional<std::string>>(
-      config_->get<std::string>(kGcsMaxRetryTime));
+  if (auto val = config_->get<std::string>(kGcsMaxRetryTime)) {
+    return val;
+  }
+  return config_->get<std::string>(
+      std::string(kLegacyPrefix) + kGcsMaxRetryTime);
 }
 
 std::optional<std::string> HiveConfig::gcsAuthAccessTokenProvider() const {
-  return static_cast<std::optional<std::string>>(
-      config_->get<std::string>(kGcsAuthAccessTokenProvider));
+  if (auto val = config_->get<std::string>(kGcsAuthAccessTokenProvider)) {
+    return val;
+  }
+  return config_->get<std::string>(
+      std::string(kLegacyPrefix) + kGcsAuthAccessTokenProvider);
 }
 
 bool HiveConfig::isPartitionPathAsLowerCase(
@@ -123,7 +132,11 @@ bool HiveConfig::isFileHandleCacheEnabled() const {
 }
 
 std::string HiveConfig::writeFileCreateConfig() const {
-  return config_->get<std::string>(kWriteFileCreateConfig, "");
+  // Legacy key used snake_case: "hive.write_file_create_config".
+  if (auto val = config_->get<std::string>(kWriteFileCreateConfig)) {
+    return val.value();
+  }
+  return config_->get<std::string>("hive.write_file_create_config", "");
 }
 
 uint32_t HiveConfig::sortWriterMaxOutputRows(
@@ -159,9 +172,8 @@ uint64_t HiveConfig::maxTargetFileSizeBytes(
 
 uint32_t HiveConfig::maxRowsPerIndexRequest(
     const config::ConfigBase* session) const {
-  return session->get<uint32_t>(
-      kMaxRowsPerIndexRequestSession,
-      config_->get<uint32_t>(kMaxRowsPerIndexRequest, 0));
+  return sessionValue<uint32_t>(
+      session, kMaxRowsPerIndexRequestSession, kMaxRowsPerIndexRequest, 0);
 }
 
 std::string HiveConfig::user(const config::ConfigBase* session) const {

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -46,29 +46,27 @@ class HiveConfig : public FileConfig {
       "max_partitions_per_writers";
 
   /// Maximum number of buckets allowed to output by the table writers.
-  static constexpr const char* kMaxBucketCount = "hive.max-bucket-count";
-  static constexpr const char* kMaxBucketCountSession = "hive.max_bucket_count";
+  static constexpr const char* kMaxBucketCount = "max-bucket-count";
+  static constexpr const char* kMaxBucketCountSession = "max_bucket_count";
 
   /// Whether new data can be inserted into an unpartition table.
   /// Velox currently does not support appending data to existing partitions.
-  static constexpr const char* kImmutablePartitions =
-      "hive.immutable-partitions";
+  static constexpr const char* kImmutablePartitions = "immutable-partitions";
 
   /// The GCS storage endpoint server.
-  static constexpr const char* kGcsEndpoint = "hive.gcs.endpoint";
+  static constexpr const char* kGcsEndpoint = "gcs.endpoint";
 
   /// The GCS service account configuration JSON key file.
-  static constexpr const char* kGcsCredentialsPath =
-      "hive.gcs.json-key-file-path";
+  static constexpr const char* kGcsCredentialsPath = "gcs.json-key-file-path";
 
   /// The GCS maximum retry counter of transient errors.
-  static constexpr const char* kGcsMaxRetryCount = "hive.gcs.max-retry-count";
+  static constexpr const char* kGcsMaxRetryCount = "gcs.max-retry-count";
 
   /// The GCS maximum time allowed to retry transient errors.
-  static constexpr const char* kGcsMaxRetryTime = "hive.gcs.max-retry-time";
+  static constexpr const char* kGcsMaxRetryTime = "gcs.max-retry-time";
 
   static constexpr const char* kGcsAuthAccessTokenProvider =
-      "hive.gcs.auth.access-token-provider";
+      "gcs.auth.access-token-provider";
 
   static constexpr const char* kPartitionPathAsLowerCaseSession =
       "partition_path_as_lower_case";
@@ -95,7 +93,7 @@ class HiveConfig : public FileConfig {
   /// file system through hive connector and data sink. The config is free form.
   /// The form should be defined by the underlying file system.
   static constexpr const char* kWriteFileCreateConfig =
-      "hive.write_file_create_config";
+      "write-file-create-config";
 
   /// Maximum number of rows for sort writer in one batch of output.
   static constexpr const char* kSortWriterMaxOutputRows =
@@ -127,9 +125,9 @@ class HiveConfig : public FileConfig {
   /// The limit is applied to the actual output rows after filtering.
   /// 0 means no limit (default).
   static constexpr const char* kMaxRowsPerIndexRequest =
-      "hive.max-rows-per-index-request";
+      "max-rows-per-index-request";
   static constexpr const char* kMaxRowsPerIndexRequestSession =
-      "hive.max_rows_per_index_request";
+      "max_rows_per_index_request";
 
   static constexpr const char* kUser = "user";
   static constexpr const char* kSource = "source";

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -683,6 +683,11 @@ Each query can override the config by setting corresponding query session proper
    :widths: 20 20 10 10 70
    :header-rows: 1
 
+   * - Configuration Property Name
+     - Session Property Name
+     - Type
+     - Default Value
+     - Description
    * - user
      -
      - string
@@ -704,6 +709,15 @@ Hive Connector
 Hive Connector config is initialized on velox runtime startup and is shared among queries as the default config.
 Each query can override the config by setting corresponding query session properties such as in Prestissimo.
 
+Configuration property names use kebab-case (e.g., ``max-bucket-count``).
+Session property names use snake_case (e.g., ``max_bucket_count``).
+Properties without a session property name in the table below are fixed for the lifetime of the process
+and cannot be modified per query.
+
+Properties of type ``capacity`` accept human-readable size strings such as ``512kB``, ``128MB``, ``1GB``, etc.
+Properties of type ``integer`` with byte-valued defaults (shown as ``256KB``, ``8MB``, etc. for readability)
+must be specified as raw byte counts.
+
 .. list-table::
    :widths: 20 20 10 10 70
    :header-rows: 1
@@ -713,13 +727,13 @@ Each query can override the config by setting corresponding query session proper
      - Type
      - Default Value
      - Description
-   * - hive.max-partitions-per-writers
-     -
+   * - max-partitions-per-writers
+     - max_partitions_per_writers
      - integer
-     - 100
+     - 128
      - Maximum number of (bucketed) partitions per a single table writer instance.
-   * - hive.max-bucket-count
-     - hive.max_bucket_count
+   * - max-bucket-count
+     - max_bucket_count
      - integer
      - 100000
      - Maximum number of buckets that a table writer is allowed to write to.
@@ -731,7 +745,7 @@ Each query can override the config by setting corresponding query session proper
        the update mode field of the table writer operator output. ``OVERWRITE``
        sets the update mode to indicate overwriting a partition if exists. ``ERROR`` sets the update mode to indicate
        error throwing if writing to an existing partition.
-   * - hive.immutable-partitions
+   * - immutable-partitions
      -
      - bool
      - false
@@ -768,7 +782,7 @@ Each query can override the config by setting corresponding query session proper
      - Maximum size in bytes to coalesce requests to be fetched in a single request.
    * - max-coalesced-distance
      -
-     - integer
+     - capacity
      - 512KB
      - Maximum distance in capacity units between chunks to be fetched that may be coalesced into a single request.
    * - load-quantum
@@ -795,12 +809,12 @@ Each query can override the config by setting corresponding query session proper
      - Maximum number of rows for sort writer in one batch of output. This is to limit the memory usage of sort writer.
    * - sort-writer-max-output-bytes
      - sort_writer_max_output_bytes
-     - string
+     - capacity
      - 10MB
      - Maximum bytes for sort writer in one batch of output. This is to limit the memory usage of sort writer.
    * - max-target-file-size
      - max_target_file_size
-     - string
+     - capacity
      - 0B
      - Maximum target file size for writers. When a file exceeds this size during writing, the writer
        closes the current file and starts writing to a new file. Accepts human-readable values like
@@ -820,26 +834,26 @@ Each query can override the config by setting corresponding query session proper
        and also skip staging to the ssd cache. This helps to prevent the cache space pollution
        from the one-time table scan by large batch query when mixed running with interactive
        query which has high data locality.
-   * - hive.reader.stats_based_filter_reorder_disabaled
-     - hive.reader.stats_based_filter_reorder_disabaled
+   * - stats-based-filter-reorder-disabled
+     - stats_based_filter_reorder_disabled
      - bool
      - false
      - If true, disable the stats based filter reordering during the read processing, and the
        filter execution order is totally determined by the filter type. Otherwise, the file
        reader will dynamically adjust the filter execution order based on the past filter
        execution stats.
-   * - hive.reader.timestamp-partition-value-as-local-time
-     - hive.reader.timestamp_partition_value_as_local_time
+   * - reader.timestamp-partition-value-as-local-time
+     - reader.timestamp_partition_value_as_local_time
      - bool
      - true
      - Reads timestamp partition value as local time if true. Otherwise, reads as UTC.
-   * - hive.preserve-flat-maps-in-memory
-     - hive.preserve_flat_maps_in_memory
+   * - preserve-flat-maps-in-memory
+     - preserve_flat_maps_in_memory
      - bool
      - false
      - Whether to preserve flat maps in memory as FlatMapVectors instead of converting them to MapVectors. This is only applied during data reading inside the DWRF and Nimble readers, not during downstream processing like expression evaluation etc.
-   * - hive.max-rows-per-index-request
-     - hive.max_rows_per_index_request
+   * - max-rows-per-index-request
+     - max_rows_per_index_request
      - integer
      - 0
      - Maximum number of output rows to return per index lookup request. The limit is applied to the actual output rows
@@ -859,29 +873,29 @@ Each query can override the config by setting corresponding query session proper
        strong references so they are never evicted. This avoids re-reading and re-parsing metadata on every stripe
        access when weak-pointer cache entries would otherwise expire. Can be used independently of
        file-metadata-cache-enabled. Currently only supported by Nimble format.
-   * - hive.reader.collect-column-cpu-metrics
-     - hive.reader.collect_column_cpu_metrics
+   * - reader.collect-column-cpu-metrics
+     - reader.collect_column_cpu_metrics
      - bool
      - false
      - If true, enables collection of per-column timing statistics during file reading. This includes
        decompression and decode CPU time metrics for each column, reported as runtime metrics in the format
        ``column_<nodeId>.<type>.decompressCPUTimeNanos`` and ``column_<nodeId>.<type>.decodeCPUTimeNanos``.
        Useful for performance analysis and identifying slow columns.
-   * - hive.orc.footer-speculative-io-size
+   * - orc.footer-speculative-io-size
      - orc_footer_speculative_io_size
      - integer
      - 256KB
      - Speculative tail-read size in bytes when opening ORC files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
-   * - hive.parquet.footer-speculative-io-size
+   * - parquet.footer-speculative-io-size
      - parquet_footer_speculative_io_size
      - integer
      - 256KB
      - Speculative tail-read size in bytes when opening Parquet files. Controls how many bytes are read from the end
        of the file to load the footer and nearby metadata in a single IO operation.
        Set to 0 for adaptive mode.
-   * - hive.nimble.footer-speculative-io-size
+   * - nimble.footer-speculative-io-size
      - nimble_footer_speculative_io_size
      - integer
      - 8MB
@@ -1113,23 +1127,23 @@ These semantics are similar to the `Apache Hadoop-Aws module <https://hadoop.apa
      - Type
      - Default Value
      - Description
-   * - hive.gcs.endpoint
+   * - gcs.endpoint
      - string
      -
      - The GCS storage URI.
-   * - hive.gcs.json-key-file-path
+   * - gcs.json-key-file-path
      - string
      -
      - The GCS service account configuration JSON key file.
-   * - hive.gcs.max-retry-count
+   * - gcs.max-retry-count
      - integer
      -
      - The GCS maximum retry counter of transient errors.
-   * - hive.gcs.max-retry-time
+   * - gcs.max-retry-time
      - string
      -
      - The GCS maximum time allowed to retry transient errors.
-   * - hive.gcs.auth.access-token-provider
+   * - gcs.auth.access-token-provider
      - string
      -
      - A custom OAuth credential provider, if specified, will be used to create the client in favor of other


### PR DESCRIPTION
Summary:
Removes the redundant `hive.` prefix from Hive connector config and session property keys in `FileConfig.h` and `HiveConfig.h`. These properties are already scoped to the Hive connector, making the prefix unnecessary.

Adds fallback helpers (`configValue`, `sessionValue`) to `FileConfig` that check the new key first, then fall back to the legacy `hive.`-prefixed key for backward compatibility with existing config files. Legacy keys are constructed by prepending `"hive."` to the new key — no duplicate string constants.

Also updates documentation to use new key names and fixes `max-partitions-per-writers` default (was 100, should be 128).

Fixes https://github.com/facebookincubator/velox/issues/17188


Test Plan:
- Backward compatible — existing config files using `hive.`-prefixed keys continue to work via fallback.
- No behavioral change — only config key naming.

Reviewed By: xiaoxmeng

Differential Revision: D100909069

Pulled By: mbasmanova


