### PR TITLE
fix: Populate null placeholders in VariantToVector<ROW> children (#17193)

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -1054,6 +1054,9 @@ struct VariantToVector<TypeKind::ROW> {
     for (size_t i = 0; i < data.size(); ++i) {
       if (data[i].isNull()) {
         bits::setNull(rawNulls, i, true);
+        for (auto j{0u}; j < childCount; ++j) {
+          children[j].push_back(Variant::null(type->childAt(j)->kind()));
+        }
         continue;
       }
       const auto& row = data[i].row();

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -71,6 +71,8 @@ class VariantToVectorTest : public testing::Test, public test::VectorTestBase {
     VELOX_EXPECT_EQ_TYPES(vector->type(), type);
     EXPECT_EQ(vector->size(), values.size());
 
+    vector->validate();
+
     for (auto i = 0; i < values.size(); ++i) {
       EXPECT_EQ(values[i], vector->variantAt(i));
       EXPECT_TRUE(vector->variantAt(i).isTypeCompatible(type));
@@ -273,6 +275,19 @@ TEST_F(VariantToVectorTest, createFromVariantsRow) {
   testFromVariants(
       ROW({"a", "b"}, {INTEGER(), DOUBLE()}),
       {Variant::row({1, 1.0}), Variant::row({2, 2.0})});
+
+  // All nulls.
+  testFromVariants(
+      ROW({"a", "b"}, {INTEGER(), DOUBLE()}),
+      {Variant::null(TypeKind::ROW), Variant::null(TypeKind::ROW)});
+
+  // Mixed nulls and values.
+  testFromVariants(
+      ROW({"a", "b"}, {INTEGER(), DOUBLE()}),
+      {Variant::row({1, 1.0}),
+       Variant::null(TypeKind::ROW),
+       Variant::row({2, 2.0}),
+       Variant::null(TypeKind::ROW)});
 }
 
 TEST_F(VariantToVectorTest, createFromVariantsEmpty) {


### PR DESCRIPTION
Summary:

When creating a RowVector from Variants where some rows are null, `VariantToVector<ROW>::makeVector` skips adding entries to child vectors for null rows (`continue` at line 1057). This creates a size mismatch: the parent RowVector has size N but children have size < N. Any downstream `slice()` on this vector fails in `Buffer::sliceBufferZeroCopy` because the children's nulls buffers are too small.

For example, `SELECT * FROM (VALUES (CAST(null AS row(a bigint, b varchar))), (CAST(null AS row(a bigint, b varchar)))) t(r)` produces a RowVector with size 2 but children with size 0, which fails on slice.

Fix: when a ROW variant is null, push null Variants into each child vector so child sizes match the parent. This is structurally different from ARRAY/MAP which use offset/size encoding and don't need padding for null entries.

Differential Revision: D100905054


