### PR TITLE
fix: Replace static inline registration with traits-based pattern in QueryConfig (#17195)

### DIFF
--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <fmt/format.h>
 #include <re2/re2.h>
 
 #include "velox/common/config/Config.h"
@@ -22,14 +23,301 @@
 
 namespace facebook::velox::core {
 
-namespace detail {
+namespace {
 
-std::vector<config::ConfigProperty>& queryConfigProperties() {
-  static std::vector<config::ConfigProperty> kProperties;
-  return kProperties;
+// Maps C++ types to ConfigPropertyType.
+template <typename T>
+constexpr config::ConfigPropertyType configPropertyTypeOf() {
+  if constexpr (std::is_same_v<T, bool>) {
+    return config::ConfigPropertyType::kBoolean;
+  } else if constexpr (std::is_integral_v<T>) {
+    return config::ConfigPropertyType::kInteger;
+  } else if constexpr (std::is_floating_point_v<T>) {
+    return config::ConfigPropertyType::kDouble;
+  } else {
+    return config::ConfigPropertyType::kString;
+  }
 }
 
-} // namespace detail
+// Converts a default value to its string representation.
+template <typename T>
+std::string configPropertyDefaultToString(const T& value) {
+  if constexpr (std::is_same_v<T, bool>) {
+    return value ? "true" : "false";
+  } else if constexpr (std::is_arithmetic_v<T>) {
+    return fmt::format("{}", value);
+  } else {
+    return std::string(value);
+  }
+}
+
+// Registers a property from its traits struct.
+template <typename PropertyTraits>
+void registerProperty(std::vector<config::ConfigProperty>& registry) {
+  registry.push_back({
+      PropertyTraits::key,
+      configPropertyTypeOf<typename PropertyTraits::type>(),
+      configPropertyDefaultToString<typename PropertyTraits::type>(
+          PropertyTraits::defaultValue),
+      PropertyTraits::description,
+  });
+}
+
+} // namespace
+
+const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
+  static const std::vector<config::ConfigProperty> kProperties = [] {
+    std::vector<config::ConfigProperty> properties;
+#define VELOX_REGISTER_QUERY_CONFIG(constName) \
+  registerProperty<QueryConfig::constName##Property>(properties)
+
+    // Memory.
+    VELOX_REGISTER_QUERY_CONFIG(kQueryMaxMemoryPerNode);
+
+    // Session.
+    VELOX_REGISTER_QUERY_CONFIG(kSessionTimezone);
+    VELOX_REGISTER_QUERY_CONFIG(kSessionStartTime);
+    VELOX_REGISTER_QUERY_CONFIG(kAdjustTimestampToTimezone);
+
+    // Expression evaluation.
+    VELOX_REGISTER_QUERY_CONFIG(kExprEvalSimplified);
+    VELOX_REGISTER_QUERY_CONFIG(kExprEvalFlatNoNulls);
+    VELOX_REGISTER_QUERY_CONFIG(kExprTrackCpuUsage);
+    VELOX_REGISTER_QUERY_CONFIG(kExprTrackCpuUsageForFunctions);
+    VELOX_REGISTER_QUERY_CONFIG(kExprAdaptiveCpuSampling);
+    VELOX_REGISTER_QUERY_CONFIG(kExprAdaptiveCpuSamplingMaxOverheadPct);
+    VELOX_REGISTER_QUERY_CONFIG(kExprDedupNonDeterministic);
+    VELOX_REGISTER_QUERY_CONFIG(kExprMaxArraySizeInReduce);
+    VELOX_REGISTER_QUERY_CONFIG(kExprMaxCompiledRegexes);
+
+    // Operator.
+    VELOX_REGISTER_QUERY_CONFIG(kOperatorTrackCpuUsage);
+
+    // Cast.
+    VELOX_REGISTER_QUERY_CONFIG(kLegacyCast);
+    VELOX_REGISTER_QUERY_CONFIG(kCastMatchStructByName);
+
+    // Local exchange.
+    VELOX_REGISTER_QUERY_CONFIG(kMaxLocalExchangeBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxLocalExchangePartitionCount);
+    VELOX_REGISTER_QUERY_CONFIG(
+        kMinLocalExchangePartitionCountToUsePartitionBuffer);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxLocalExchangePartitionBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kLocalExchangePartitionBufferPreserveEncoding);
+    VELOX_REGISTER_QUERY_CONFIG(kLocalMergeSourceQueueSize);
+
+    // Exchange.
+    VELOX_REGISTER_QUERY_CONFIG(kMaxExchangeBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxMergeExchangeBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kMinExchangeOutputBatchBytes);
+
+    // Aggregation.
+    VELOX_REGISTER_QUERY_CONFIG(kMaxPartialAggregationMemory);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxExtendedPartialAggregationMemory);
+    VELOX_REGISTER_QUERY_CONFIG(kAbandonPartialAggregationMinRows);
+    VELOX_REGISTER_QUERY_CONFIG(kAbandonPartialAggregationMinPct);
+    VELOX_REGISTER_QUERY_CONFIG(kAggregationCompactionBytesThreshold);
+    VELOX_REGISTER_QUERY_CONFIG(kAggregationCompactionUnusedMemoryRatio);
+    VELOX_REGISTER_QUERY_CONFIG(kAggregationMemoryCompactionReclaimEnabled);
+
+    // TopN row number.
+    VELOX_REGISTER_QUERY_CONFIG(kAbandonPartialTopNRowNumberMinRows);
+    VELOX_REGISTER_QUERY_CONFIG(kAbandonPartialTopNRowNumberMinPct);
+
+    // Hash build dedup.
+    VELOX_REGISTER_QUERY_CONFIG(kAbandonDedupHashMapMinRows);
+    VELOX_REGISTER_QUERY_CONFIG(kAbandonDedupHashMapMinPct);
+
+    // Miscellaneous.
+    VELOX_REGISTER_QUERY_CONFIG(kMaxElementsSizeInRepeatAndSequence);
+
+    // Partitioned output.
+    VELOX_REGISTER_QUERY_CONFIG(kPartitionedOutputEagerFlush);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxPartitionedOutputBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBufferSize);
+
+    // Output batch.
+    VELOX_REGISTER_QUERY_CONFIG(kPreferredOutputBatchBytes);
+    VELOX_REGISTER_QUERY_CONFIG(kPreferredOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kMergeJoinOutputBatchStartSize);
+
+    // Table scan.
+    VELOX_REGISTER_QUERY_CONFIG(kTableScanGetOutputTimeLimitMs);
+    VELOX_REGISTER_QUERY_CONFIG(kTableScanOutputBatchRowsOverride);
+
+    // Hash table.
+    VELOX_REGISTER_QUERY_CONFIG(kHashAdaptivityEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kAdaptiveFilterReorderingEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kParallelOutputJoinBuildRowsEnabled);
+
+    // Spill.
+    VELOX_REGISTER_QUERY_CONFIG(kSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kAggregationSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kJoinSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kMixedGroupedModeHashJoinSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kOrderBySpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kWindowSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kWindowSpillMinReadBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kWriterSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kRowNumberSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kMarkDistinctSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kTopNRowNumberSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kLocalMergeSpillEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxSpillRunRows);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxSpillBytes);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxSpillLevel);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxSpillFileSize);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillCompressionKind);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillNumMaxMergeFiles);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillPrefixSortEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillWriteBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillReadBufferSize);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillFileCreateConfig);
+    VELOX_REGISTER_QUERY_CONFIG(kAggregationSpillFileCreateConfig);
+    VELOX_REGISTER_QUERY_CONFIG(kHashJoinSpillFileCreateConfig);
+    VELOX_REGISTER_QUERY_CONFIG(kRowNumberSpillFileCreateConfig);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillStartPartitionBit);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillNumPartitionBits);
+    VELOX_REGISTER_QUERY_CONFIG(kMinSpillableReservationPct);
+    VELOX_REGISTER_QUERY_CONFIG(kSpillableReservationGrowthPct);
+
+    // Writer.
+    VELOX_REGISTER_QUERY_CONFIG(kWriterFlushThresholdBytes);
+
+    // Presto-specific.
+    VELOX_REGISTER_QUERY_CONFIG(kPrestoArrayAggIgnoreNulls);
+
+    // Spark-specific.
+    VELOX_REGISTER_QUERY_CONFIG(kSparkAnsiEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkBloomFilterExpectedNumItems);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkBloomFilterNumBits);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkBloomFilterMaxNumBits);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkBloomFilterMaxNumItems);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkLegacyDateFormatter);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkLegacyStatisticalAggregate);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkJsonIgnoreNullFields);
+    VELOX_REGISTER_QUERY_CONFIG(kSparkCollectListIgnoreNulls);
+
+    // Task writer.
+    VELOX_REGISTER_QUERY_CONFIG(kTaskWriterCount);
+
+    // Hash probe.
+    VELOX_REGISTER_QUERY_CONFIG(kHashProbeFinishEarlyOnEmptyBuild);
+    VELOX_REGISTER_QUERY_CONFIG(kHashProbeDynamicFilterPushdownEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kHashProbeStringDynamicFilterPushdownEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kHashProbeBloomFilterPushdownMaxSize);
+    VELOX_REGISTER_QUERY_CONFIG(kMinTableRowsForParallelJoinBuild);
+
+    // Debug and validation.
+    VELOX_REGISTER_QUERY_CONFIG(kValidateOutputFromOperators);
+    VELOX_REGISTER_QUERY_CONFIG(kEnableExpressionEvaluationCache);
+    VELOX_REGISTER_QUERY_CONFIG(kMaxSharedSubexprResultsCached);
+
+    // Split preload.
+    VELOX_REGISTER_QUERY_CONFIG(kMaxSplitPreloadPerDriver);
+
+    // Driver.
+    VELOX_REGISTER_QUERY_CONFIG(kDriverCpuTimeSliceLimitMs);
+
+    // Window.
+    VELOX_REGISTER_QUERY_CONFIG(kWindowNumSubPartitions);
+
+    // Prefix sort.
+    VELOX_REGISTER_QUERY_CONFIG(kPrefixSortNormalizedKeyMaxBytes);
+    VELOX_REGISTER_QUERY_CONFIG(kPrefixSortMinRows);
+    VELOX_REGISTER_QUERY_CONFIG(kPrefixSortMaxStringPrefixLength);
+
+    // Query trace.
+    VELOX_REGISTER_QUERY_CONFIG(kQueryTraceEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kQueryTraceDir);
+    VELOX_REGISTER_QUERY_CONFIG(kQueryTraceNodeId);
+    VELOX_REGISTER_QUERY_CONFIG(kQueryTraceMaxBytes);
+    VELOX_REGISTER_QUERY_CONFIG(kQueryTraceTaskRegExp);
+    VELOX_REGISTER_QUERY_CONFIG(kQueryTraceDryRun);
+    VELOX_REGISTER_QUERY_CONFIG(kOpTraceDirectoryCreateConfig);
+
+    // Debug expression.
+    VELOX_REGISTER_QUERY_CONFIG(kDebugDisableExpressionWithPeeling);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugDisableCommonSubExpressions);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugDisableExpressionWithMemoization);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugDisableExpressionWithLazyInputs);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugMemoryPoolNameRegex);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugMemoryPoolWarnThresholdBytes);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugLambdaFunctionEvaluationBatchSize);
+    VELOX_REGISTER_QUERY_CONFIG(kDebugBingTileChildrenMaxZoomShift);
+
+    // Nimble.
+    VELOX_REGISTER_QUERY_CONFIG(kSelectiveNimbleReaderEnabled);
+
+    // Scale writer.
+    VELOX_REGISTER_QUERY_CONFIG(kScaleWriterRebalanceMaxMemoryUsageRatio);
+    VELOX_REGISTER_QUERY_CONFIG(kScaleWriterMaxPartitionsPerWriter);
+    VELOX_REGISTER_QUERY_CONFIG(
+        kScaleWriterMinPartitionProcessedBytesRebalanceThreshold);
+    VELOX_REGISTER_QUERY_CONFIG(
+        kScaleWriterMinProcessedBytesRebalanceThreshold);
+
+    // Table scan scaling.
+    VELOX_REGISTER_QUERY_CONFIG(kTableScanScaledProcessingEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kTableScanScaleUpMemoryUsageRatio);
+
+    // Shuffle.
+    VELOX_REGISTER_QUERY_CONFIG(kShuffleCompressionKind);
+
+    // Map.
+    VELOX_REGISTER_QUERY_CONFIG(kThrowExceptionOnDuplicateMapKeys);
+
+    // Index lookup join.
+    VELOX_REGISTER_QUERY_CONFIG(kIndexLookupJoinMaxPrefetchBatches);
+    VELOX_REGISTER_QUERY_CONFIG(kIndexLookupJoinSplitOutput);
+
+    // Exchange request.
+    VELOX_REGISTER_QUERY_CONFIG(kRequestDataSizesMaxWaitSec);
+
+    // Streaming aggregation.
+    VELOX_REGISTER_QUERY_CONFIG(kStreamingAggregationMinOutputBatchRows);
+    VELOX_REGISTER_QUERY_CONFIG(kStreamingAggregationEagerFlush);
+
+    // Exchange optimization.
+    VELOX_REGISTER_QUERY_CONFIG(kSkipRequestDataSizeWithSingleSourceEnabled);
+    VELOX_REGISTER_QUERY_CONFIG(kExchangeLazyFetchingEnabled);
+
+    // JSON cast.
+    VELOX_REGISTER_QUERY_CONFIG(kFieldNamesInJsonCastEnabled);
+
+    // Operator stats.
+    VELOX_REGISTER_QUERY_CONFIG(kOperatorTrackExpressionStats);
+    VELOX_REGISTER_QUERY_CONFIG(kEnableOperatorBatchSizeStats);
+
+    // Unnest.
+    VELOX_REGISTER_QUERY_CONFIG(kUnnestSplitOutput);
+
+    // Memory reclaimer.
+    VELOX_REGISTER_QUERY_CONFIG(kQueryMemoryReclaimerPriority);
+
+    // Splits.
+    VELOX_REGISTER_QUERY_CONFIG(kMaxNumSplitsListenedTo);
+
+    // Source and tags.
+    VELOX_REGISTER_QUERY_CONFIG(kSource);
+    VELOX_REGISTER_QUERY_CONFIG(kClientTags);
+
+    // Row size tracking.
+    VELOX_REGISTER_QUERY_CONFIG(kRowSizeTrackingMode);
+
+    // Join build.
+    VELOX_REGISTER_QUERY_CONFIG(kJoinBuildVectorHasherMaxNumDistinct);
+
+    // Mark sorted.
+    VELOX_REGISTER_QUERY_CONFIG(kMarkSortedZeroCopyThreshold);
+
+#undef VELOX_REGISTER_QUERY_CONFIG
+
+    return properties;
+  }();
+  return kProperties;
+}
 
 QueryConfig::QueryConfig(std::unordered_map<std::string, std::string> values)
     : QueryConfig{

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -15,88 +15,58 @@
  */
 #pragma once
 
-#include <fmt/format.h>
 #include "velox/common/config/Config.h"
 #include "velox/common/config/ConfigProperty.h"
 #include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::core {
 
-namespace detail {
+/// Macros for defining query config properties.
+///
+/// To add a new property, add two lines (order doesn't matter, but
+/// grouping related properties together helps readability):
+///
+/// 1. In QueryConfig.h (inside the class body):
+///   VELOX_QUERY_CONFIG(kSpillEnabled, spillEnabled, "spill_enabled",
+///       bool, false, "Global enable spilling flag.");
+///
+/// 2. In QueryConfig.cpp (inside registeredProperties()):
+///   VELOX_REGISTER_QUERY_CONFIG(kSpillEnabled);
+///
+/// VELOX_QUERY_CONFIG generates:
+///   - struct kSpillEnabledProperty {
+///         using type = bool;
+///         static constexpr const char* key = "spill_enabled";
+///         static constexpr auto defaultValue = false;
+///         static constexpr const char* description = "Global enable...";
+///     };
+///   - static constexpr const char* kSpillEnabled = "spill_enabled"
+///   - bool spillEnabled() const {
+///         return get<bool>(kSpillEnabled, false);
+///     }
+///
+/// VELOX_QUERY_CONFIG_PROPERTY generates the same but without the accessor.
+/// Used for legacy properties with custom accessor logic (capacity parsing,
+/// validation, clamping). New properties should use VELOX_QUERY_CONFIG and
+/// put validation in QueryConfig::validateConfig() and
+/// QueryConfigProvider::normalize().
+/// TODO: Unify validateConfig() and normalize() into a single validation path.
+#define VELOX_QUERY_CONFIG_PROPERTY(                 \
+    constName, keyStr, CppType, defaultVal, desc)    \
+  struct constName##Property {                       \
+    using type = CppType;                            \
+    static constexpr const char* key = keyStr;       \
+    static constexpr auto defaultValue = defaultVal; \
+    static constexpr const char* description = desc; \
+  };                                                 \
+  static constexpr const char* constName = keyStr;
 
-// Maps C++ types to ConfigPropertyType.
-template <typename T>
-constexpr config::ConfigPropertyType configPropertyTypeOf() {
-  if constexpr (std::is_same_v<T, bool>) {
-    return config::ConfigPropertyType::kBoolean;
-  } else if constexpr (std::is_integral_v<T>) {
-    return config::ConfigPropertyType::kInteger;
-  } else if constexpr (std::is_floating_point_v<T>) {
-    return config::ConfigPropertyType::kDouble;
-  } else {
-    return config::ConfigPropertyType::kString;
+#define VELOX_QUERY_CONFIG(                                                 \
+    constName, accessorName, keyStr, CppType, defaultVal, desc)             \
+  VELOX_QUERY_CONFIG_PROPERTY(constName, keyStr, CppType, defaultVal, desc) \
+  CppType accessorName() const {                                            \
+    return get<CppType>(constName, defaultVal);                             \
   }
-}
-
-// Converts a default value to its string representation.
-template <typename T>
-std::string configPropertyDefaultToString(const T& value) {
-  if constexpr (std::is_same_v<T, bool>) {
-    return value ? "true" : "false";
-  } else if constexpr (std::is_arithmetic_v<T>) {
-    return fmt::format("{}", value);
-  } else {
-    return std::string(value);
-  }
-}
-
-// Appends a ConfigProperty to a vector at static init time.
-struct ConfigPropertyRegistration {
-  ConfigPropertyRegistration(
-      const char* name,
-      config::ConfigPropertyType type,
-      std::optional<std::string> defaultValue,
-      std::string description,
-      std::vector<config::ConfigProperty>& registry) {
-    registry.push_back(
-        {name, type, std::move(defaultValue), std::move(description)});
-  }
-};
-
-// Returns the mutable registry for static-init registration.
-std::vector<config::ConfigProperty>& queryConfigProperties();
-
-} // namespace detail
-
-/// Defines a simple query config property: static constexpr key constant,
-/// typed accessor method, and registers a ConfigProperty entry.
-/// Use for properties whose accessor is a plain get<CppType>(key, default).
-// NOLINTBEGIN(bugprone-macro-parentheses)
-#define VELOX_QUERY_CONFIG(                                               \
-    constName, accessorName, key, CppType, defaultVal, desc)              \
-  static constexpr const char* constName = key;                           \
-  CppType accessorName() const {                                          \
-    return get<CppType>(constName, defaultVal);                           \
-  }                                                                       \
-  static inline detail::ConfigPropertyRegistration constName##_reg_ {     \
-    key, detail::configPropertyTypeOf<CppType>(),                         \
-        detail::configPropertyDefaultToString<CppType>(defaultVal), desc, \
-        detail::queryConfigProperties()                                   \
-  }
-// NOLINTEND(bugprone-macro-parentheses)
-
-/// Registers a config property without generating an accessor.
-/// Use for properties with custom accessor logic (validation, clamping,
-/// capacity parsing, etc.). The accessor must be written separately.
-// NOLINTBEGIN(bugprone-macro-parentheses)
-#define VELOX_QUERY_CONFIG_PROPERTY(constName, key, CppType, defaultVal, desc) \
-  static constexpr const char* constName = key;                                \
-  static inline detail::ConfigPropertyRegistration constName##_reg_ {          \
-    key, detail::configPropertyTypeOf<CppType>(),                              \
-        detail::configPropertyDefaultToString<CppType>(defaultVal), desc,      \
-        detail::queryConfigProperties()                                        \
-  }
-// NOLINTEND(bugprone-macro-parentheses)
 
 /// A simple wrapper around velox::IConfig. Defines constants for query
 /// config properties and accessor methods.
@@ -115,9 +85,7 @@ class QueryConfig {
       std::shared_ptr<const config::IConfig> config);
 
   /// Returns all registered query config properties.
-  static const std::vector<config::ConfigProperty>& registeredProperties() {
-    return detail::queryConfigProperties();
-  }
+  static const std::vector<config::ConfigProperty>& registeredProperties();
 
   /// Maximum memory that a query can use on a single host.
   VELOX_QUERY_CONFIG_PROPERTY(
@@ -125,7 +93,7 @@ class QueryConfig {
       "query_max_memory_per_node",
       std::string,
       "0B",
-      "Maximum memory that a query can use on a single host.");
+      "Maximum memory that a query can use on a single host.")
 
   /// User provided session timezone. Stores a string with the actual timezone
   /// name, e.g: "America/Los_Angeles".
@@ -135,7 +103,7 @@ class QueryConfig {
       "session_timezone",
       std::string,
       "",
-      "Session timezone name, e.g. 'America/Los_Angeles'.");
+      "Session timezone name, e.g. 'America/Los_Angeles'.")
 
   /// Session start time in milliseconds since Unix epoch. This represents when
   /// the query session began execution. Used for functions that need to know
@@ -146,7 +114,7 @@ class QueryConfig {
       "start_time",
       int64_t,
       0,
-      "Session start time in milliseconds since Unix epoch.");
+      "Session start time in milliseconds since Unix epoch.")
 
   /// If true, timezone-less timestamp conversions (e.g. string to timestamp,
   /// when the string does not specify a timezone) will be adjusted to the user
@@ -157,7 +125,7 @@ class QueryConfig {
       "adjust_timestamp_to_session_timezone",
       bool,
       false,
-      "Adjust timezone-less timestamp conversions to session timezone.");
+      "Adjust timezone-less timestamp conversions to session timezone.")
 
   /// Whether to use the simplified expression evaluation path. False by
   /// default.
@@ -167,7 +135,7 @@ class QueryConfig {
       "expression.eval_simplified",
       bool,
       false,
-      "Use simplified expression evaluation path.");
+      "Use simplified expression evaluation path.")
 
   /// Whether to enable the FlatNoNulls fast path for expression evaluation.
   /// When enabled, expressions skip null checking and vector decoding when all
@@ -178,7 +146,7 @@ class QueryConfig {
       "expression.eval_flat_no_nulls",
       bool,
       true,
-      "Enable FlatNoNulls fast path for expression evaluation.");
+      "Enable FlatNoNulls fast path for expression evaluation.")
 
   /// Whether to track CPU usage for individual expressions (supported by call
   /// and cast expressions). False by default. Can be expensive when processing
@@ -189,7 +157,7 @@ class QueryConfig {
       "expression.track_cpu_usage",
       bool,
       false,
-      "Track CPU usage for individual expressions.");
+      "Track CPU usage for individual expressions.")
 
   /// Takes a comma separated list of function names to track CPU usage for.
   /// Only applicable when kExprTrackCpuUsage is set to false. Is empty by
@@ -200,7 +168,7 @@ class QueryConfig {
       "expression.track_cpu_usage_for_functions",
       std::string,
       "",
-      "Comma-separated function names to track CPU usage for.");
+      "Comma-separated function names to track CPU usage for.")
 
   /// Enables adaptive per-function CPU usage sampling. When enabled, each
   /// function is calibrated over the first 6 batches (1 warmup + 5
@@ -211,7 +179,7 @@ class QueryConfig {
       "expression.adaptive_cpu_sampling",
       bool,
       false,
-      "Enable adaptive per-function CPU usage sampling.");
+      "Enable adaptive per-function CPU usage sampling.")
 
   /// Maximum acceptable overhead percentage for CPU tracking per function.
   /// Used with kExprAdaptiveCpuSampling.
@@ -221,7 +189,7 @@ class QueryConfig {
       "expression.adaptive_cpu_sampling_max_overhead_pct",
       double,
       1.0,
-      "Maximum acceptable overhead percentage for CPU tracking per function.");
+      "Maximum acceptable overhead percentage for CPU tracking per function.")
 
   /// Controls whether non-deterministic expressions are deduplicated during
   /// compilation. If set to false, non-deterministic functions (such as
@@ -232,7 +200,7 @@ class QueryConfig {
       "expression.dedup_non_deterministic",
       bool,
       true,
-      "Deduplicate non-deterministic expressions during compilation.");
+      "Deduplicate non-deterministic expressions during compilation.")
 
   /// Whether to track CPU usage for stages of individual operators. True by
   /// default. Can be expensive when processing small batches, e.g. < 10K rows.
@@ -242,7 +210,7 @@ class QueryConfig {
       "track_operator_cpu_usage",
       bool,
       true,
-      "Track CPU usage for stages of individual operators.");
+      "Track CPU usage for stages of individual operators.")
 
   /// Flags used to configure the CAST operator:
   VELOX_QUERY_CONFIG(
@@ -251,7 +219,7 @@ class QueryConfig {
       "legacy_cast",
       bool,
       false,
-      "Use legacy CAST behavior.");
+      "Use legacy CAST behavior.")
 
   /// This flag makes the Row conversion to by applied in a way that the casting
   /// row field are matched by name instead of position.
@@ -261,7 +229,7 @@ class QueryConfig {
       "cast_match_struct_by_name",
       bool,
       false,
-      "Match Row fields by name instead of position in CAST.");
+      "Match Row fields by name instead of position in CAST.")
 
   /// Reduce() function will throw an error if encountered an array of size
   /// greater than this.
@@ -271,7 +239,7 @@ class QueryConfig {
       "expression.max_array_size_in_reduce",
       uint64_t,
       100'000,
-      "Maximum array size allowed in reduce() function.");
+      "Maximum array size allowed in reduce() function.")
 
   /// Controls maximum number of compiled regular expression patterns per
   /// function instance per thread of execution.
@@ -281,7 +249,7 @@ class QueryConfig {
       "expression.max_compiled_regexes",
       uint64_t,
       100,
-      "Maximum compiled regex patterns per function instance per thread.");
+      "Maximum compiled regex patterns per function instance per thread.")
 
   /// Used for backpressure to block local exchange producers when the local
   /// exchange buffer reaches or exceeds this size.
@@ -291,7 +259,7 @@ class QueryConfig {
       "max_local_exchange_buffer_size",
       uint64_t,
       32UL << 20,
-      "Max local exchange buffer size in bytes for backpressure.");
+      "Max local exchange buffer size in bytes for backpressure.")
 
   /// Limits the number of partitions created by a local exchange.
   VELOX_QUERY_CONFIG(
@@ -300,7 +268,7 @@ class QueryConfig {
       "max_local_exchange_partition_count",
       uint32_t,
       std::numeric_limits<uint32_t>::max(),
-      "Maximum number of partitions in local exchange.");
+      "Maximum number of partitions in local exchange.")
 
   /// Minimum number of local exchange output partitions to use buffered
   /// partitioning.
@@ -310,7 +278,7 @@ class QueryConfig {
       "min_local_exchange_partition_count_to_use_partition_buffer",
       uint32_t,
       33,
-      "Min local exchange partition count to use buffered partitioning.");
+      "Minimum output partitions to use buffered partitioning.")
 
   /// Maximum size in bytes to accumulate for a single partition of a local
   /// exchange before flushing.
@@ -320,7 +288,7 @@ class QueryConfig {
       "max_local_exchange_partition_buffer_size",
       uint64_t,
       64UL * 1024,
-      "Max bytes per local exchange partition buffer before flushing.");
+      "Max bytes to accumulate per local exchange partition.")
 
   /// Try to preserve the encoding of the input vector when copying it to the
   /// buffer.
@@ -330,7 +298,7 @@ class QueryConfig {
       "local_exchange_partition_buffer_preserve_encoding",
       bool,
       false,
-      "Preserve encoding of input vectors in local exchange partition buffer.");
+      "Preserve encoding of input vector in partition buffer.")
 
   /// Maximum number of vectors buffered in each local merge source before
   /// blocking to wait for consumers.
@@ -340,7 +308,7 @@ class QueryConfig {
       "local_merge_source_queue_size",
       uint32_t,
       2,
-      "Max vectors buffered per local merge source before blocking.");
+      "Maximum vectors buffered in each local merge source.")
 
   /// Maximum size in bytes to accumulate in ExchangeQueue. Enforced
   /// approximately, not strictly.
@@ -350,7 +318,7 @@ class QueryConfig {
       "exchange.max_buffer_size",
       uint64_t,
       32UL << 20,
-      "Max bytes to accumulate in ExchangeQueue.");
+      "Maximum bytes to accumulate in ExchangeQueue.")
 
   /// Maximum size in bytes to accumulate among all sources of the merge
   /// exchange. Enforced approximately, not strictly.
@@ -360,7 +328,7 @@ class QueryConfig {
       "merge_exchange.max_buffer_size",
       uint64_t,
       128UL << 20,
-      "Max bytes to accumulate among all merge exchange sources.");
+      "Maximum bytes to accumulate among all merge exchange sources.")
 
   /// The minimum number of bytes to accumulate in the ExchangeQueue
   /// before unblocking a consumer.
@@ -370,7 +338,7 @@ class QueryConfig {
       "min_exchange_output_batch_bytes",
       uint64_t,
       2UL << 20,
-      "Min bytes to accumulate in ExchangeQueue before unblocking consumer.");
+      "Minimum bytes to accumulate before unblocking an exchange consumer.")
 
   VELOX_QUERY_CONFIG(
       kMaxPartialAggregationMemory,
@@ -378,7 +346,7 @@ class QueryConfig {
       "max_partial_aggregation_memory",
       uint64_t,
       1L << 24,
-      "Max memory for partial aggregation.");
+      "Maximum memory for partial aggregation.")
 
   VELOX_QUERY_CONFIG(
       kMaxExtendedPartialAggregationMemory,
@@ -386,7 +354,7 @@ class QueryConfig {
       "max_extended_partial_aggregation_memory",
       uint64_t,
       1L << 26,
-      "Max memory for extended partial aggregation.");
+      "Maximum memory for extended partial aggregation.")
 
   VELOX_QUERY_CONFIG(
       kAbandonPartialAggregationMinRows,
@@ -394,7 +362,7 @@ class QueryConfig {
       "abandon_partial_aggregation_min_rows",
       int32_t,
       100'000,
-      "Min rows before considering abandoning partial aggregation.");
+      "Minimum input rows before checking whether to abandon partial aggregation.")
 
   VELOX_QUERY_CONFIG(
       kAbandonPartialAggregationMinPct,
@@ -402,7 +370,7 @@ class QueryConfig {
       "abandon_partial_aggregation_min_pct",
       int32_t,
       80,
-      "Min percentage threshold for abandoning partial aggregation.");
+      "Abandon partial aggregation if reduction percentage exceeds this.")
 
   /// Memory threshold in bytes for triggering string compaction during
   /// global aggregation. Disabled by default (0).
@@ -412,7 +380,7 @@ class QueryConfig {
       "aggregation_compaction_bytes_threshold",
       uint64_t,
       0,
-      "Byte threshold for triggering string compaction in aggregation.");
+      "Memory threshold in bytes for triggering string compaction during aggregation.")
 
   /// Ratio of unused (evicted) bytes to total bytes that triggers compaction.
   VELOX_QUERY_CONFIG(
@@ -421,7 +389,7 @@ class QueryConfig {
       "aggregation_compaction_unused_memory_ratio",
       double,
       0.25,
-      "Unused-to-total byte ratio that triggers aggregation compaction.");
+      "Ratio of unused bytes to total bytes that triggers compaction.")
 
   /// If true, enables lightweight memory compaction before spilling during
   /// memory reclaim in aggregation.
@@ -431,7 +399,7 @@ class QueryConfig {
       "aggregation_memory_compaction_reclaim_enabled",
       bool,
       false,
-      "Enable memory compaction before spilling in aggregation reclaim.");
+      "Enable memory compaction before spilling during aggregation reclaim.")
 
   VELOX_QUERY_CONFIG(
       kAbandonPartialTopNRowNumberMinRows,
@@ -439,7 +407,7 @@ class QueryConfig {
       "abandon_partial_topn_row_number_min_rows",
       int32_t,
       100'000,
-      "Min rows before considering abandoning partial TopN row number.");
+      "Minimum rows before checking whether to abandon partial TopN row number.")
 
   VELOX_QUERY_CONFIG(
       kAbandonPartialTopNRowNumberMinPct,
@@ -447,7 +415,7 @@ class QueryConfig {
       "abandon_partial_topn_row_number_min_pct",
       int32_t,
       80,
-      "Min percentage threshold for abandoning partial TopN row number.");
+      "Abandon partial TopN row number if reduction percentage exceeds this.")
 
   /// Number of input rows to receive before starting to check whether to
   /// abandon building a HashTable without duplicates in HashBuild.
@@ -457,7 +425,7 @@ class QueryConfig {
       "abandon_dedup_hashmap_min_rows",
       int32_t,
       100'000,
-      "Min rows before checking whether to abandon dedup hash map.");
+      "Minimum rows before checking whether to abandon dedup hash map.")
 
   /// Abandons building a HashTable without duplicates in HashBuild for left
   /// semi/anti join if the percentage of distinct keys exceeds this threshold.
@@ -467,7 +435,7 @@ class QueryConfig {
       "abandon_dedup_hashmap_min_pct",
       int32_t,
       0,
-      "Min distinct key percentage to abandon dedup hash map. 0 = disabled.");
+      "Abandon dedup hash map if distinct key percentage exceeds this. 0 disables.")
 
   VELOX_QUERY_CONFIG(
       kMaxElementsSizeInRepeatAndSequence,
@@ -475,7 +443,7 @@ class QueryConfig {
       "max_elements_size_in_repeat_and_sequence",
       int32_t,
       10'000,
-      "Max elements size in repeat and sequence functions.");
+      "Maximum elements size in repeat and sequence functions.")
 
   /// If true, the PartitionedOutput operator will flush rows eagerly.
   VELOX_QUERY_CONFIG(
@@ -484,7 +452,7 @@ class QueryConfig {
       "partitioned_output_eager_flush",
       bool,
       false,
-      "Flush PartitionedOutput rows eagerly without waiting for buffer size.");
+      "Flush PartitionedOutput rows eagerly without buffering.")
 
   /// The maximum number of bytes to buffer in PartitionedOutput operator to
   /// avoid creating tiny SerializedPages.
@@ -494,7 +462,7 @@ class QueryConfig {
       "max_page_partitioning_buffer_size",
       uint64_t,
       32UL << 20,
-      "Max bytes to buffer in PartitionedOutput operator.");
+      "Maximum bytes to buffer in PartitionedOutput operator.")
 
   /// The maximum size in bytes for the task's buffered output.
   VELOX_QUERY_CONFIG(
@@ -503,7 +471,7 @@ class QueryConfig {
       "max_output_buffer_size",
       uint64_t,
       32UL << 20,
-      "Max size in bytes for the task's buffered output.");
+      "Maximum size in bytes for the task's buffered output.")
 
   /// Preferred size of batches in bytes to be returned by operators from
   /// Operator::getOutput.
@@ -513,7 +481,7 @@ class QueryConfig {
       "preferred_output_batch_bytes",
       uint64_t,
       10UL << 20,
-      "Preferred batch size in bytes from Operator::getOutput.");
+      "Preferred size of output batches in bytes.")
 
   /// Preferred number of rows to be returned by operators from
   /// Operator::getOutput. Used when average row size is not known.
@@ -522,7 +490,7 @@ class QueryConfig {
       "preferred_output_batch_rows",
       uint32_t,
       1024,
-      "Preferred number of output batch rows.");
+      "Preferred number of rows in output batches.")
 
   /// Max number of rows that could be return by operators from
   /// Operator::getOutput.
@@ -531,7 +499,7 @@ class QueryConfig {
       "max_output_batch_rows",
       uint32_t,
       10000,
-      "Max number of output batch rows.");
+      "Maximum number of rows in output batches.")
 
   /// Initial output batch size in rows for MergeJoin operator.
   VELOX_QUERY_CONFIG_PROPERTY(
@@ -539,7 +507,7 @@ class QueryConfig {
       "merge_join_output_batch_start_size",
       uint32_t,
       0,
-      "Initial output batch size in rows for MergeJoin operator.");
+      "Initial output batch size in rows for MergeJoin. 0 disables dynamic adjustment.")
 
   /// TableScan operator will exit getOutput() method after this many
   /// milliseconds even if it has no data to return yet. Zero means 'no time
@@ -550,7 +518,7 @@ class QueryConfig {
       "table_scan_getoutput_time_limit_ms",
       uint32_t,
       5'000,
-      "TableScan getOutput time limit in milliseconds. 0 = no limit.");
+      "Time limit in ms for TableScan getOutput(). 0 means no limit.")
 
   /// If non-zero, overrides the number of rows in each output batch produced
   /// by the TableScan operator. Zero means 'no override'.
@@ -560,7 +528,7 @@ class QueryConfig {
       "table_scan_output_batch_rows_override",
       uint32_t,
       0,
-      "Override for TableScan output batch rows. 0 = no override.");
+      "Override number of rows in TableScan output batches. 0 means no override.")
 
   /// If false, the 'group by' code is forced to use generic hash mode
   /// hashtable.
@@ -570,7 +538,7 @@ class QueryConfig {
       "hash_adaptivity_enabled",
       bool,
       true,
-      "Enable hash adaptivity in group-by.");
+      "Enable hash adaptivity for group-by hash mode selection.")
 
   /// If true, the conjunction expression can reorder inputs based on the time
   /// taken to calculate them.
@@ -580,7 +548,7 @@ class QueryConfig {
       "adaptive_filter_reordering_enabled",
       bool,
       true,
-      "Reorder conjunction inputs based on evaluation time.");
+      "Allow conjunction to reorder inputs based on evaluation time.")
 
   /// If true, allow hash probe drivers to generate build-side rows in parallel.
   VELOX_QUERY_CONFIG(
@@ -589,7 +557,7 @@ class QueryConfig {
       "parallel_output_join_build_rows_enabled",
       bool,
       false,
-      "Allow hash probe drivers to generate build-side rows in parallel.");
+      "Allow hash probe drivers to generate build-side rows in parallel.")
 
   /// Global enable spilling flag.
   VELOX_QUERY_CONFIG(
@@ -598,7 +566,7 @@ class QueryConfig {
       "spill_enabled",
       bool,
       false,
-      "Global enable spilling flag.");
+      "Global enable spilling flag.")
 
   /// Aggregation spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -607,7 +575,7 @@ class QueryConfig {
       "aggregation_spill_enabled",
       bool,
       true,
-      "Enable aggregation spilling. Requires spill_enabled.");
+      "Enable aggregation spilling. Requires spill_enabled.")
 
   /// Join spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -616,7 +584,7 @@ class QueryConfig {
       "join_spill_enabled",
       bool,
       true,
-      "Enable join spilling. Requires spill_enabled.");
+      "Enable join spilling. Requires spill_enabled.")
 
   /// Config to enable hash join spill for mixed grouped execution mode.
   VELOX_QUERY_CONFIG(
@@ -625,7 +593,7 @@ class QueryConfig {
       "mixed_grouped_mode_hash_join_spill_enabled",
       bool,
       false,
-      "Enable hash join spill for mixed grouped execution mode.");
+      "Enable hash join spill for mixed grouped execution mode.")
 
   /// OrderBy spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -634,7 +602,7 @@ class QueryConfig {
       "order_by_spill_enabled",
       bool,
       true,
-      "Enable order-by spilling. Requires spill_enabled.");
+      "Enable order-by spilling. Requires spill_enabled.")
 
   /// Window spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -643,7 +611,7 @@ class QueryConfig {
       "window_spill_enabled",
       bool,
       true,
-      "Enable window spilling. Requires spill_enabled.");
+      "Enable window spilling. Requires spill_enabled.")
 
   /// When processing spilled window data, read batches of whole partitions
   /// having at least that many rows.
@@ -653,7 +621,7 @@ class QueryConfig {
       "window_spill_min_read_batch_rows",
       uint32_t,
       1'000,
-      "Min rows per batch when reading spilled window data.");
+      "Minimum rows to read per batch when processing spilled window data.")
 
   /// If true, the memory arbitrator will reclaim memory from table writer by
   /// flushing its buffered data to disk. Requires spill_enabled.
@@ -663,7 +631,7 @@ class QueryConfig {
       "writer_spill_enabled",
       bool,
       true,
-      "Enable writer spilling. Requires spill_enabled.");
+      "Enable writer spilling by flushing buffered data to disk.")
 
   /// RowNumber spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -672,7 +640,7 @@ class QueryConfig {
       "row_number_spill_enabled",
       bool,
       true,
-      "Enable row number spilling. Requires spill_enabled.");
+      "Enable RowNumber spilling. Requires spill_enabled.")
 
   /// MarkDistinct spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -681,7 +649,7 @@ class QueryConfig {
       "mark_distinct_spill_enabled",
       bool,
       false,
-      "Enable mark distinct spilling. Requires spill_enabled.");
+      "Enable MarkDistinct spilling. Requires spill_enabled.")
 
   /// TopNRowNumber spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -690,7 +658,7 @@ class QueryConfig {
       "topn_row_number_spill_enabled",
       bool,
       true,
-      "Enable TopN row number spilling. Requires spill_enabled.");
+      "Enable TopNRowNumber spilling. Requires spill_enabled.")
 
   /// LocalMerge spilling flag, only applies if "spill_enabled" flag is set.
   VELOX_QUERY_CONFIG(
@@ -699,7 +667,7 @@ class QueryConfig {
       "local_merge_spill_enabled",
       bool,
       false,
-      "Enable local merge spilling. Requires spill_enabled.");
+      "Enable LocalMerge spilling. Requires spill_enabled.")
 
   /// Specify the max number of local sources to merge at a time.
   /// Uses std::numeric_limits<uint32_t>::max() as default.
@@ -714,7 +682,7 @@ class QueryConfig {
       "max_spill_run_rows",
       uint64_t,
       12UL << 20,
-      "Max rows to fill and spill per spill run. 0 = no limit.");
+      "Maximum rows to fill and spill per spill run. 0 means no limit.")
 
   /// The max spill bytes limit set for each query. Default is 100 GB.
   VELOX_QUERY_CONFIG(
@@ -723,7 +691,7 @@ class QueryConfig {
       "max_spill_bytes",
       uint64_t,
       100UL << 30,
-      "Max spill bytes per query. 0 = no limit.");
+      "Maximum total spill bytes per query. 0 means no limit.")
 
   /// The max allowed spilling level with zero being the initial spilling level.
   VELOX_QUERY_CONFIG(
@@ -732,7 +700,7 @@ class QueryConfig {
       "max_spill_level",
       int32_t,
       1,
-      "Max allowed spilling level. -1 = no limit.");
+      "Maximum allowed spilling level. -1 means no limit.")
 
   /// The max allowed spill file size. If it is zero, then there is no limit.
   VELOX_QUERY_CONFIG(
@@ -741,7 +709,7 @@ class QueryConfig {
       "max_spill_file_size",
       uint64_t,
       0,
-      "Max spill file size in bytes. 0 = no limit.");
+      "Maximum spill file size. 0 means no limit.")
 
   VELOX_QUERY_CONFIG(
       kSpillCompressionKind,
@@ -749,7 +717,7 @@ class QueryConfig {
       "spill_compression_codec",
       std::string,
       "none",
-      "Spill compression codec.");
+      "Compression codec for spill data.")
 
   /// The max number of files to merge at a time when merging sorted spilled
   /// files. 0 means unlimited.
@@ -759,7 +727,7 @@ class QueryConfig {
       "spill_num_max_merge_files",
       uint32_t,
       0,
-      "Max number of spill files to merge at a time. 0 = unlimited.");
+      "Maximum files to merge at a time when merging sorted spill files. 0 means unlimited.")
 
   /// Enable the prefix sort or fallback to timsort in spill.
   VELOX_QUERY_CONFIG(
@@ -768,7 +736,7 @@ class QueryConfig {
       "spill_prefixsort_enabled",
       bool,
       false,
-      "Enable prefix sort in spill instead of timsort.");
+      "Enable prefix sort in spill instead of timsort.")
 
   /// Specifies spill write buffer size in bytes. 0 disables buffering.
   VELOX_QUERY_CONFIG(
@@ -777,7 +745,7 @@ class QueryConfig {
       "spill_write_buffer_size",
       uint64_t,
       1L << 20,
-      "Spill write buffer size in bytes. 0 = no buffering.");
+      "Spill write buffer size in bytes. 0 disables buffering.")
 
   /// Specifies the buffer size in bytes to read from one spilled file.
   VELOX_QUERY_CONFIG(
@@ -786,7 +754,7 @@ class QueryConfig {
       "spill_read_buffer_size",
       uint64_t,
       1L << 20,
-      "Spill read buffer size in bytes.");
+      "Buffer size in bytes to read from one spilled file.")
 
   /// Config used to create spill files.
   VELOX_QUERY_CONFIG(
@@ -795,7 +763,7 @@ class QueryConfig {
       "spill_file_create_config",
       std::string,
       "",
-      "Free-form config for creating spill files.");
+      "Config for creating spill files, passed to underlying file system.")
 
   /// Config used to create aggregation spill files.
   VELOX_QUERY_CONFIG(
@@ -804,7 +772,7 @@ class QueryConfig {
       "aggregation_spill_file_create_config",
       std::string,
       "",
-      "Free-form config for creating aggregation spill files.");
+      "Config for creating aggregation spill files.")
 
   /// Config used to create hash join spill files.
   VELOX_QUERY_CONFIG(
@@ -813,7 +781,7 @@ class QueryConfig {
       "hash_join_spill_file_create_config",
       std::string,
       "",
-      "Free-form config for creating hash join spill files.");
+      "Config for creating hash join spill files.")
 
   /// Config used to create row number spill files.
   VELOX_QUERY_CONFIG(
@@ -822,7 +790,7 @@ class QueryConfig {
       "row_number_spill_file_create_config",
       std::string,
       "",
-      "Free-form config for creating row number spill files.");
+      "Config for creating row number spill files.")
 
   /// Default offset spill start partition bit.
   VELOX_QUERY_CONFIG(
@@ -831,7 +799,7 @@ class QueryConfig {
       "spiller_start_partition_bit",
       uint8_t,
       48,
-      "Offset spill start partition bit.");
+      "Start partition bit offset for spilling.")
 
   /// Default number of spill partition bits. Max 3 (8-way partitioning).
   VELOX_QUERY_CONFIG_PROPERTY(
@@ -839,7 +807,7 @@ class QueryConfig {
       "spiller_num_partition_bits",
       uint8_t,
       3,
-      "Number of spill partition bits. Max 3 for 8-way partitioning.");
+      "Number of bits for spill partition calculation.")
 
   /// The minimal available spillable memory reservation in percentage of the
   /// current memory usage.
@@ -849,7 +817,7 @@ class QueryConfig {
       "min_spillable_reservation_pct",
       int32_t,
       5,
-      "Min spillable memory reservation as percentage of current usage.");
+      "Minimum available spillable memory reservation as percentage of usage.")
 
   /// The spillable memory reservation growth percentage.
   VELOX_QUERY_CONFIG(
@@ -858,7 +826,7 @@ class QueryConfig {
       "spillable_reservation_growth_pct",
       int32_t,
       10,
-      "Spillable memory reservation growth percentage.");
+      "Spillable memory reservation growth percentage.")
 
   /// Minimum memory footprint size required to reclaim memory from a file
   /// writer by flushing its buffered data to disk.
@@ -868,7 +836,7 @@ class QueryConfig {
       "writer_flush_threshold_bytes",
       uint64_t,
       96L << 20,
-      "Min memory footprint to reclaim from writer by flushing.");
+      "Minimum memory footprint to reclaim from a file writer by flushing.")
 
   /// If true, array_agg() aggregation function will ignore nulls in the input.
   VELOX_QUERY_CONFIG(
@@ -877,7 +845,7 @@ class QueryConfig {
       "presto.array_agg.ignore_nulls",
       bool,
       false,
-      "Ignore nulls in array_agg() aggregation.");
+      "If true, array_agg() ignores nulls in the input.")
 
   /// If true, Spark function's behavior is ANSI-compliant.
   VELOX_QUERY_CONFIG(
@@ -886,7 +854,7 @@ class QueryConfig {
       "spark.ansi_enabled",
       bool,
       false,
-      "Enable ANSI-compliant behavior for Spark functions.");
+      "Enable ANSI-compliant behavior for Spark functions.")
 
   /// The default number of expected items for the bloomfilter.
   VELOX_QUERY_CONFIG(
@@ -895,7 +863,7 @@ class QueryConfig {
       "spark.bloom_filter.expected_num_items",
       int64_t,
       1'000'000L,
-      "Default expected number of items for Spark bloom filter.");
+      "Default number of expected items for the Spark bloom filter.")
 
   /// The default number of bits to use for the bloom filter.
   VELOX_QUERY_CONFIG(
@@ -904,7 +872,7 @@ class QueryConfig {
       "spark.bloom_filter.num_bits",
       int64_t,
       8'388'608L,
-      "Default number of bits for Spark bloom filter.");
+      "Default number of bits for the Spark bloom filter.")
 
   /// The max number of bits to use for the bloom filter.
   VELOX_QUERY_CONFIG(
@@ -913,7 +881,7 @@ class QueryConfig {
       "spark.bloom_filter.max_num_bits",
       int64_t,
       67'108'864,
-      "Max number of bits for Spark bloom filter.");
+      "Maximum number of bits for the Spark bloom filter.")
 
   /// The max number of items to use for the bloom filter.
   VELOX_QUERY_CONFIG(
@@ -922,7 +890,7 @@ class QueryConfig {
       "spark.bloom_filter.max_num_items",
       int64_t,
       4'000'000L,
-      "Max number of items for Spark bloom filter.");
+      "Maximum number of items for the Spark bloom filter.")
 
   /// The current spark partition id. No default (throws if not set).
   static constexpr const char* kSparkPartitionId = "spark.partition_id";
@@ -934,7 +902,7 @@ class QueryConfig {
       "spark.legacy_date_formatter",
       bool,
       false,
-      "Use simple date formatter instead of Joda.");
+      "Use simple date formatter instead of Joda for Spark.")
 
   /// If true, Spark statistical aggregation functions return NaN instead of
   /// NULL when dividing by zero.
@@ -944,7 +912,7 @@ class QueryConfig {
       "spark.legacy_statistical_aggregate",
       bool,
       false,
-      "Return NaN instead of NULL for division by zero in Spark stats.");
+      "Return NaN instead of NULL for Spark statistical aggregation on divide-by-zero.")
 
   /// If true, ignore null fields when generating JSON string.
   VELOX_QUERY_CONFIG(
@@ -953,7 +921,7 @@ class QueryConfig {
       "spark.json_ignore_null_fields",
       bool,
       true,
-      "Ignore null fields when generating JSON string.");
+      "Ignore null fields when generating JSON string in Spark.")
 
   /// If true, collect_list aggregate function will ignore nulls in the input.
   VELOX_QUERY_CONFIG(
@@ -962,7 +930,7 @@ class QueryConfig {
       "spark.collect_list.ignore_nulls",
       bool,
       true,
-      "Ignore nulls in collect_list aggregate function.");
+      "If true, Spark collect_list() ignores nulls in the input.")
 
   /// The number of local parallel table writer operators per task.
   VELOX_QUERY_CONFIG(
@@ -971,7 +939,7 @@ class QueryConfig {
       "task_writer_count",
       uint32_t,
       4,
-      "Number of local parallel table writer operators per task.");
+      "Number of local parallel table writer operators per task.")
 
   /// The number of local parallel table writer operators per task for
   /// partitioned writes. If not set, use "task_writer_count". No default.
@@ -986,7 +954,7 @@ class QueryConfig {
       "hash_probe_finish_early_on_empty_build",
       bool,
       false,
-      "Finish hash probe early on empty build table.");
+      "Finish hash probe early on empty build table.")
 
   /// Whether hash probe can generate any dynamic filter and push down to
   /// upstream operators.
@@ -996,7 +964,7 @@ class QueryConfig {
       "hash_probe_dynamic_filter_pushdown_enabled",
       bool,
       true,
-      "Enable dynamic filter pushdown from hash probe.");
+      "Enable dynamic filter generation and pushdown from hash probe.")
 
   /// Whether hash probe can generate dynamic filter for string types.
   VELOX_QUERY_CONFIG(
@@ -1005,7 +973,7 @@ class QueryConfig {
       "hash_probe_string_dynamic_filter_pushdown_enabled",
       bool,
       false,
-      "Enable dynamic filter pushdown for string types from hash probe.");
+      "Enable dynamic filter pushdown for string types from hash probe.")
 
   /// The maximum byte size of Bloom filter from hash probe. 0 = disabled.
   VELOX_QUERY_CONFIG(
@@ -1014,7 +982,7 @@ class QueryConfig {
       "hash_probe_bloom_filter_pushdown_max_size",
       uint64_t,
       0,
-      "Max byte size of Bloom filter from hash probe. 0 = disabled.");
+      "Maximum byte size of Bloom filter from hash probe. 0 disables.")
 
   /// The minimum number of table rows that can trigger the parallel hash join
   /// table build.
@@ -1024,7 +992,7 @@ class QueryConfig {
       "min_table_rows_for_parallel_join_build",
       uint32_t,
       1'000,
-      "Min table rows to trigger parallel hash join build.");
+      "Minimum table rows to trigger parallel hash join table build.")
 
   /// If set to true, validate output vectors of every operator for consistency.
   VELOX_QUERY_CONFIG(
@@ -1033,7 +1001,7 @@ class QueryConfig {
       "debug.validate_output_from_operators",
       bool,
       false,
-      "Validate output vectors from operators for consistency.");
+      "Validate output vectors from every operator for consistency.")
 
   /// If true, enable caches in expression evaluation for performance.
   VELOX_QUERY_CONFIG(
@@ -1042,7 +1010,7 @@ class QueryConfig {
       "enable_expression_evaluation_cache",
       bool,
       true,
-      "Enable caches in expression evaluation for performance.");
+      "Enable caches in expression evaluation for performance.")
 
   /// For a given shared subexpression, the maximum distinct sets of inputs we
   /// cache results for.
@@ -1052,7 +1020,7 @@ class QueryConfig {
       "max_shared_subexpr_results_cached",
       uint32_t,
       10,
-      "Max distinct input sets cached per shared subexpression.");
+      "Maximum distinct input sets to cache for shared subexpressions.")
 
   /// Maximum number of splits to preload. Set to 0 to disable preloading.
   VELOX_QUERY_CONFIG(
@@ -1061,7 +1029,7 @@ class QueryConfig {
       "max_split_preload_per_driver",
       int32_t,
       2,
-      "Max splits to preload per driver. 0 = disabled.");
+      "Maximum number of splits to preload. 0 disables preloading.")
 
   /// If not zero, specifies the cpu time slice limit in ms that a driver thread
   /// can continuously run without yielding.
@@ -1071,7 +1039,7 @@ class QueryConfig {
       "driver_cpu_time_slice_limit_ms",
       uint32_t,
       0,
-      "CPU time slice limit in ms for driver thread. 0 = no limit.");
+      "CPU time slice limit in ms before yielding. 0 means no limit.")
 
   /// Window operator sub-partition count per thread.
   VELOX_QUERY_CONFIG(
@@ -1080,7 +1048,7 @@ class QueryConfig {
       "window_num_sub_partitions",
       uint32_t,
       1,
-      "Number of sub-partitions per thread in window operator.");
+      "Number of sub-partitions per thread in Window operator.")
 
   /// Maximum number of bytes to use for the normalized key in prefix-sort.
   VELOX_QUERY_CONFIG(
@@ -1089,7 +1057,7 @@ class QueryConfig {
       "prefixsort_normalized_key_max_bytes",
       uint32_t,
       128,
-      "Max bytes for normalized key in prefix-sort. 0 = disabled.");
+      "Maximum bytes for normalized key in prefix-sort. 0 disables.")
 
   /// Minimum number of rows to use prefix-sort.
   VELOX_QUERY_CONFIG(
@@ -1098,7 +1066,7 @@ class QueryConfig {
       "prefixsort_min_rows",
       uint32_t,
       128,
-      "Min rows to use prefix-sort.");
+      "Minimum rows to use prefix-sort.")
 
   /// Maximum number of bytes to be stored in prefix-sort buffer for a string
   /// key.
@@ -1108,7 +1076,7 @@ class QueryConfig {
       "prefixsort_max_string_prefix_length",
       uint32_t,
       16,
-      "Max string prefix length stored in prefix-sort buffer.");
+      "Maximum bytes stored in prefix-sort buffer for a string key.")
 
   /// Enable query tracing flag.
   VELOX_QUERY_CONFIG(
@@ -1117,7 +1085,7 @@ class QueryConfig {
       "query_trace_enabled",
       bool,
       false,
-      "Enable query tracing.");
+      "Enable query tracing.")
 
   /// Base dir of a query to store tracing data.
   VELOX_QUERY_CONFIG(
@@ -1126,7 +1094,7 @@ class QueryConfig {
       "query_trace_dir",
       std::string,
       "",
-      "Base directory for query trace data.");
+      "Base directory for storing query trace data.")
 
   /// The plan node id whose input data will be traced.
   VELOX_QUERY_CONFIG(
@@ -1135,7 +1103,7 @@ class QueryConfig {
       "query_trace_node_id",
       std::string,
       "",
-      "Plan node id to trace input data for.");
+      "Plan node id whose input data will be traced.")
 
   /// The max trace bytes limit. Tracing is disabled if zero.
   VELOX_QUERY_CONFIG(
@@ -1144,7 +1112,7 @@ class QueryConfig {
       "query_trace_max_bytes",
       uint64_t,
       0,
-      "Max trace bytes. 0 = disabled.");
+      "Maximum trace bytes. Tracing disabled if zero.")
 
   /// The regexp of traced task id.
   VELOX_QUERY_CONFIG(
@@ -1153,7 +1121,7 @@ class QueryConfig {
       "query_trace_task_reg_exp",
       std::string,
       "",
-      "Regexp to match task ids for tracing.");
+      "Regexp for task ids to enable tracing on.")
 
   /// If true, only collect input trace without actual execution.
   VELOX_QUERY_CONFIG(
@@ -1162,7 +1130,7 @@ class QueryConfig {
       "query_trace_dry_run",
       bool,
       false,
-      "Collect input trace only without execution.");
+      "Collect input trace without actual execution.")
 
   /// Config used to create operator trace directory.
   VELOX_QUERY_CONFIG(
@@ -1171,7 +1139,7 @@ class QueryConfig {
       "op_trace_directory_create_config",
       std::string,
       "",
-      "Free-form config for creating operator trace directory.");
+      "Config for creating operator trace directory.")
 
   /// Disable optimization in expression evaluation to peel common dictionary
   /// layer from inputs.
@@ -1181,7 +1149,7 @@ class QueryConfig {
       "debug_disable_expression_with_peeling",
       bool,
       false,
-      "Disable dictionary peeling optimization in expression evaluation.");
+      "Disable dictionary peeling optimization in expression evaluation.")
 
   /// Disable optimization in expression evaluation to re-use cached results for
   /// common sub-expressions.
@@ -1191,7 +1159,7 @@ class QueryConfig {
       "debug_disable_common_sub_expressions",
       bool,
       false,
-      "Disable common sub-expression caching in expression evaluation.");
+      "Disable common sub-expression caching in expression evaluation.")
 
   /// Disable optimization in expression evaluation to re-use cached results
   /// between subsequent dictionary-encoded input batches.
@@ -1201,7 +1169,7 @@ class QueryConfig {
       "debug_disable_expression_with_memoization",
       bool,
       false,
-      "Disable memoization optimization in expression evaluation.");
+      "Disable dictionary memoization in expression evaluation.")
 
   /// Disable optimization in expression evaluation to delay loading of lazy
   /// inputs unless required.
@@ -1211,7 +1179,7 @@ class QueryConfig {
       "debug_disable_expression_with_lazy_inputs",
       bool,
       false,
-      "Disable lazy input loading optimization in expression evaluation.");
+      "Disable lazy input loading optimization in expression evaluation.")
 
   /// Fix the random seed used in approx_percentile. No default (optional).
   static constexpr const char*
@@ -1225,7 +1193,7 @@ class QueryConfig {
       "debug_memory_pool_name_regex",
       std::string,
       "",
-      "Regex to match memory pools for allocation callsite tracking.");
+      "Regex to match memory pools for allocation callsite tracking.")
 
   /// Warning threshold in bytes for debug memory pools. Uses toCapacity
   /// for parsing.
@@ -1234,7 +1202,7 @@ class QueryConfig {
       "debug_memory_pool_warn_threshold_bytes",
       std::string,
       "0B",
-      "Warning threshold in bytes for debug memory pools.");
+      "Warning threshold in bytes for debug memory pools.")
 
   /// Batch size for lambda function evaluation over arrays and maps.
   VELOX_QUERY_CONFIG(
@@ -1243,7 +1211,7 @@ class QueryConfig {
       "debug_lambda_function_evaluation_batch_size",
       int32_t,
       10'000,
-      "Batch size for lambda function evaluation over arrays and maps.");
+      "Batch size for lambda function evaluation over arrays and maps.")
 
   /// Max zoom level difference for bing_tile_children UDF.
   VELOX_QUERY_CONFIG(
@@ -1252,7 +1220,7 @@ class QueryConfig {
       "debug_bing_tile_children_max_zoom_shift",
       uint8_t,
       7,
-      "Max zoom level difference for bing_tile_children UDF.");
+      "Maximum zoom level difference for bing_tile_children.")
 
   /// Temporary flag to control whether selective Nimble reader should be used.
   VELOX_QUERY_CONFIG(
@@ -1261,7 +1229,7 @@ class QueryConfig {
       "selective_nimble_reader_enabled",
       bool,
       true,
-      "Use selective Nimble reader.");
+      "Enable selective Nimble reader.")
 
   /// The max ratio of query memory usage to max capacity for scale writer
   /// exchange to stop scaling.
@@ -1271,7 +1239,7 @@ class QueryConfig {
       "scaled_writer_rebalance_max_memory_usage_ratio",
       double,
       0.7,
-      "Max memory usage ratio for scale writer exchange to stop scaling.");
+      "Max memory usage ratio before scale writer exchange stops scaling.")
 
   /// The max number of logical table partitions per writer thread.
   VELOX_QUERY_CONFIG(
@@ -1280,7 +1248,7 @@ class QueryConfig {
       "scaled_writer_max_partitions_per_writer",
       uint32_t,
       128,
-      "Max logical table partitions per writer thread.");
+      "Max logical table partitions per table writer thread.")
 
   /// Minimum data processed per partition to trigger writer scaling.
   VELOX_QUERY_CONFIG(
@@ -1289,7 +1257,7 @@ class QueryConfig {
       "scaled_writer_min_partition_processed_bytes_rebalance_threshold",
       uint64_t,
       128 << 20,
-      "Min bytes processed per partition to trigger writer scaling.");
+      "Minimum bytes processed per partition to trigger writer scaling.")
 
   /// Minimum total data processed to trigger skewed partition rebalancing.
   VELOX_QUERY_CONFIG(
@@ -1298,7 +1266,7 @@ class QueryConfig {
       "scaled_writer_min_processed_bytes_rebalance_threshold",
       uint64_t,
       256 << 20,
-      "Min total bytes processed to trigger partition rebalancing.");
+      "Minimum total bytes processed to trigger skewed partition rebalancing.")
 
   /// If true, enables the scaled table scan processing.
   VELOX_QUERY_CONFIG(
@@ -1307,7 +1275,7 @@ class QueryConfig {
       "table_scan_scaled_processing_enabled",
       bool,
       false,
-      "Enable scaled table scan processing.");
+      "Enable scaled table scan processing based on memory usage.")
 
   /// The query memory usage ratio for scan controller to decide if it can
   /// increase running scan threads.
@@ -1317,7 +1285,7 @@ class QueryConfig {
       "table_scan_scale_up_memory_usage_ratio",
       double,
       0.7,
-      "Memory usage ratio threshold for scan scale-up.");
+      "Memory usage ratio threshold for scaling up scan threads.")
 
   /// Specifies the shuffle compression kind.
   VELOX_QUERY_CONFIG(
@@ -1326,7 +1294,7 @@ class QueryConfig {
       "shuffle_compression_codec",
       std::string,
       "none",
-      "Shuffle compression codec.");
+      "Compression codec for shuffle data.")
 
   /// When true, throw exception on duplicate map key.
   VELOX_QUERY_CONFIG(
@@ -1335,7 +1303,7 @@ class QueryConfig {
       "throw_exception_on_duplicate_map_keys",
       bool,
       false,
-      "Throw exception on duplicate map keys.");
+      "Throw exception on duplicate map keys.")
 
   /// Max number of input batches to prefetch for index lookup. 0 = disabled.
   VELOX_QUERY_CONFIG(
@@ -1344,7 +1312,7 @@ class QueryConfig {
       "index_lookup_join_max_prefetch_batches",
       uint32_t,
       0,
-      "Max input batches to prefetch for index lookup. 0 = disabled.");
+      "Maximum input batches to prefetch for index lookup. 0 disables.")
 
   /// If true, index join operator may split output per input batch.
   VELOX_QUERY_CONFIG(
@@ -1353,7 +1321,7 @@ class QueryConfig {
       "index_lookup_join_split_output",
       bool,
       true,
-      "Allow index join operator to split output per input batch.");
+      "Allow index join operator to split output based on batch size.")
 
   // Max wait time for exchange request in seconds.
   VELOX_QUERY_CONFIG(
@@ -1362,7 +1330,7 @@ class QueryConfig {
       "request_data_sizes_max_wait_sec",
       int32_t,
       10,
-      "Max wait time for exchange data size request in seconds.");
+      "Maximum wait time for exchange request in seconds.")
 
   /// In streaming aggregation, min output rows before producing a batch.
   VELOX_QUERY_CONFIG(
@@ -1371,7 +1339,7 @@ class QueryConfig {
       "streaming_aggregation_min_output_batch_rows",
       int32_t,
       0,
-      "Min output batch rows in streaming aggregation. 0 = use default.");
+      "Minimum rows to accumulate before producing streaming aggregation output. 0 uses default.")
 
   /// TODO: Remove after dependencies are cleaned up.
   VELOX_QUERY_CONFIG(
@@ -1380,7 +1348,7 @@ class QueryConfig {
       "streaming_aggregation_eager_flush",
       bool,
       false,
-      "Enable eager flush in streaming aggregation.");
+      "Enable eager flush for streaming aggregation.")
 
   // If true, skip request data size if there is only single source.
   VELOX_QUERY_CONFIG(
@@ -1389,7 +1357,7 @@ class QueryConfig {
       "skip_request_data_size_with_single_source_enabled",
       bool,
       false,
-      "Skip request data size with single source exchange.");
+      "Skip request data size check with single exchange source.")
 
   /// If true, exchange clients defer data fetching until next() is called.
   VELOX_QUERY_CONFIG(
@@ -1398,7 +1366,7 @@ class QueryConfig {
       "exchange_lazy_fetching_enabled",
       bool,
       false,
-      "Defer exchange data fetching until next() is called.");
+      "Defer exchange data fetching until next() is called.")
 
   /// If true, use struct field names as JSON element names when casting row to
   /// json.
@@ -1408,7 +1376,7 @@ class QueryConfig {
       "field_names_in_json_cast_enabled",
       bool,
       false,
-      "Use struct field names as JSON element names in CAST to JSON.");
+      "Use struct field names as JSON element names in CAST to JSON.")
 
   /// If true, operators track stats for non-special-form expressions.
   VELOX_QUERY_CONFIG(
@@ -1417,7 +1385,7 @@ class QueryConfig {
       "operator_track_expression_stats",
       bool,
       false,
-      "Track expression stats in operators.");
+      "Track expression stats in operators that evaluate expressions.")
 
   /// If true, enable operator input/output batch size stats collection.
   VELOX_QUERY_CONFIG(
@@ -1426,7 +1394,7 @@ class QueryConfig {
       "enable_operator_batch_size_stats",
       bool,
       true,
-      "Enable operator input/output batch size stats collection.");
+      "Enable input/output batch size stats collection in driver execution.")
 
   /// If true, the unnest operator may split output per input batch.
   VELOX_QUERY_CONFIG(
@@ -1435,7 +1403,7 @@ class QueryConfig {
       "unnest_split_output",
       bool,
       true,
-      "Allow unnest operator to split output per input batch.");
+      "Allow unnest operator to split output based on batch size.")
 
   /// Priority of the query in the memory pool reclaimer. Lower means higher
   /// priority.
@@ -1445,7 +1413,7 @@ class QueryConfig {
       "query_memory_reclaimer_priority",
       int32_t,
       std::numeric_limits<int32_t>::max(),
-      "Query priority in memory pool reclaimer. Lower means higher priority.");
+      "Query priority in memory pool reclaimer. Lower means higher priority.")
 
   /// The max number of input splits to listen to by SplitListener.
   VELOX_QUERY_CONFIG(
@@ -1454,7 +1422,7 @@ class QueryConfig {
       "max_num_splits_listened_to",
       int32_t,
       0,
-      "Max input splits to listen to per table scan node per worker.");
+      "Max input splits to listen to by SplitListener per scan node per worker.")
 
   /// Source of the query.
   VELOX_QUERY_CONFIG(
@@ -1463,7 +1431,7 @@ class QueryConfig {
       "source",
       std::string,
       "",
-      "Source of the query.");
+      "Source of the query.")
 
   /// Client tags of the query.
   VELOX_QUERY_CONFIG(
@@ -1472,7 +1440,7 @@ class QueryConfig {
       "client_tags",
       std::string,
       "",
-      "Client tags of the query.");
+      "Client tags of the query.")
 
   /// Enable (reader) row size tracker. Uses enum stored as int32_t.
   VELOX_QUERY_CONFIG_PROPERTY(
@@ -1480,7 +1448,7 @@ class QueryConfig {
       "row_size_tracking_mode",
       int32_t,
       2,
-      "Row size tracking mode (0=disabled, 1=exclude delta, 2=enabled).");
+      "Row size tracking mode: 0=disabled, 1=exclude delta splits, 2=enabled for all.")
 
   /// Maximum number of distinct values to keep when merging vector hashers in
   /// join HashBuild.
@@ -1490,7 +1458,7 @@ class QueryConfig {
       "join_build_vector_hasher_max_num_distinct",
       uint32_t,
       1'000'000,
-      "Max distinct values to keep when merging vector hashers in join.");
+      "Max distinct values to keep when merging vector hashers in join HashBuild.")
 
   /// Batch size threshold for zero-copy optimization in MarkSorted operator.
   VELOX_QUERY_CONFIG(
@@ -1499,7 +1467,7 @@ class QueryConfig {
       "mark_sorted_zero_copy_threshold",
       int32_t,
       1000,
-      "Batch size threshold for zero-copy in MarkSorted operator.");
+      "Batch size threshold for zero-copy in MarkSorted operator.")
 
   // --- Hand-written accessors for properties that need custom logic ---
 
@@ -1605,7 +1573,8 @@ class QueryConfig {
 
   std::shared_ptr<const config::IConfig> config_;
 };
-} // namespace facebook::velox::core
 
 #undef VELOX_QUERY_CONFIG
 #undef VELOX_QUERY_CONFIG_PROPERTY
+
+} // namespace facebook::velox::core


### PR DESCRIPTION
Summary:

The VELOX_QUERY_CONFIG macro previously used static inline member variables to register properties at static init time. This caused duplicate registrations when multiple shared libraries included QueryConfig.h, because each .so initialized its own copy of the static inline variable, all pushing to the same vector.

Replace with a traits-based pattern: the macro generates a constexpr traits struct (key, type, default, description) and the accessor method. Property registration happens in QueryConfig.cpp via VELOX_REGISTER_QUERY_CONFIG, which reads from the traits struct. No static inline variables, no cross-.so initialization issues.

Also move helper functions (configPropertyTypeOf, configPropertyDefaultToString, registerProperty) from the header to QueryConfig.cpp since they are only used for registration.

Reviewed By: jagill

Differential Revision: D100977425


