### PR TITLE
feat: Add configProvider() to Connector and HiveConfigProvider (#17197)

### DIFF
--- a/velox/common/config/ConfigProperty.h
+++ b/velox/common/config/ConfigProperty.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include <fmt/format.h>
 #include "velox/common/Enums.h"
 
 namespace facebook::velox::config {
@@ -46,5 +47,46 @@ struct ConfigProperty {
   /// Human-readable description of the property.
   std::string description;
 };
+
+namespace detail {
+
+template <typename T>
+constexpr ConfigPropertyType configPropertyTypeOf() {
+  if constexpr (std::is_same_v<T, bool>) {
+    return ConfigPropertyType::kBoolean;
+  } else if constexpr (std::is_integral_v<T>) {
+    return ConfigPropertyType::kInteger;
+  } else if constexpr (std::is_floating_point_v<T>) {
+    return ConfigPropertyType::kDouble;
+  } else {
+    return ConfigPropertyType::kString;
+  }
+}
+
+template <typename T>
+std::string configPropertyDefaultToString(const T& value) {
+  if constexpr (std::is_same_v<T, bool>) {
+    return value ? "true" : "false";
+  } else if constexpr (std::is_arithmetic_v<T>) {
+    return fmt::format("{}", value);
+  } else {
+    return std::string(value);
+  }
+}
+
+} // namespace detail
+
+/// Registers a property from a traits struct into a vector.
+/// The traits struct must have: key, type, defaultValue, description.
+template <typename PropertyTraits>
+void registerConfigProperty(std::vector<ConfigProperty>& registry) {
+  registry.push_back({
+      PropertyTraits::key,
+      detail::configPropertyTypeOf<typename PropertyTraits::type>(),
+      detail::configPropertyDefaultToString<typename PropertyTraits::type>(
+          PropertyTraits::defaultValue),
+      PropertyTraits::description,
+  });
+}
 
 } // namespace facebook::velox::config

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -23,6 +23,7 @@
 #include "velox/common/base/SpillConfig.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/caching/ScanTracker.h"
+#include "velox/common/config/ConfigProvider.h"
 #include "velox/common/file/TokenProvider.h"
 #include "velox/common/future/VeloxPromise.h"
 #include "velox/core/ExpressionEvaluator.h"
@@ -611,6 +612,12 @@ class Connector {
 
   const std::shared_ptr<const config::ConfigBase>& connectorConfig() const {
     return config_;
+  }
+
+  /// Returns the config provider for this connector's session properties,
+  /// or nullptr if the connector has no session-overridable properties.
+  virtual const config::ConfigProvider* configProvider() const {
+    return nullptr;
   }
 
   /// Returns true if this connector would accept a filter dynamically

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -32,6 +32,7 @@ velox_add_library(
   FileIndexReader.cpp
   FileSplitReader.cpp
   HiveConfig.cpp
+  HiveConfigProvider.cpp
   HiveConnector.cpp
   HiveConnectorSplit.cpp
   HiveConnectorUtil.cpp
@@ -55,6 +56,9 @@ velox_add_library(
   FileSplitReader.h
   FileTableHandle.h
   HiveConfig.h
+  HiveConfigMacrosDefine.h
+  HiveConfigMacrosUndef.h
+  HiveConfigProvider.h
   HiveConnector.h
   HiveConnectorSplit.h
   HiveConnectorUtil.h

--- a/velox/connectors/hive/FileConfig.cpp
+++ b/velox/connectors/hive/FileConfig.cpp
@@ -15,43 +15,43 @@
  */
 
 #include "velox/connectors/hive/FileConfig.h"
+
 #include "velox/common/config/Config.h"
 
 namespace facebook::velox::connector::hive {
 
-bool FileConfig::isOrcUseColumnNames(const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kOrcUseColumnNamesSession, configValue<bool>(kOrcUseColumnNames, false));
-}
+const std::vector<config::ConfigProperty>& FileConfig::registeredProperties() {
+  static const std::vector<config::ConfigProperty> kProperties = [] {
+    std::vector<config::ConfigProperty> properties;
+#define VELOX_HIVE_CONFIG_REGISTER(constName) \
+  config::registerConfigProperty<FileConfig::constName##Property>(properties)
 
-bool FileConfig::isParquetUseColumnNames(
-    const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kParquetUseColumnNamesSession,
-      configValue<bool>(kParquetUseColumnNames, false));
-}
+    VELOX_HIVE_CONFIG_REGISTER(kOrcUseColumnNamesSession);
+    VELOX_HIVE_CONFIG_REGISTER(kParquetUseColumnNamesSession);
+    VELOX_HIVE_CONFIG_REGISTER(kAllowInt32NarrowingSession);
+    VELOX_HIVE_CONFIG_REGISTER(kReadTimestampPartitionValueAsLocalTimeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kPreserveFlatMapsInMemorySession);
+    VELOX_HIVE_CONFIG_REGISTER(kReaderCollectColumnCpuMetricsSession);
+    VELOX_HIVE_CONFIG_REGISTER(kOrcFooterSpeculativeIoSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kParquetFooterSpeculativeIoSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kNimbleFooterSpeculativeIoSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kFileColumnNamesReadAsLowerCaseSession);
+    VELOX_HIVE_CONFIG_REGISTER(kIgnoreMissingFilesSession);
+    VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedBytesSession);
+    VELOX_HIVE_CONFIG_REGISTER(kLoadQuantumSession);
+    VELOX_HIVE_CONFIG_REGISTER(kReadStatsBasedFilterReorderDisabledSession);
+    VELOX_HIVE_CONFIG_REGISTER(kIndexEnabledSession);
+    VELOX_HIVE_CONFIG_REGISTER(kFileMetadataCacheEnabledSession);
+    VELOX_HIVE_CONFIG_REGISTER(kPinFileMetadataSession);
+    VELOX_HIVE_CONFIG_REGISTER(kMaxCoalescedDistanceSession);
+    VELOX_HIVE_CONFIG_REGISTER(kParallelUnitLoadCountSession);
+    VELOX_HIVE_CONFIG_REGISTER(kReadTimestampUnitSession);
 
-bool FileConfig::allowInt32Narrowing(const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kAllowInt32NarrowingSession,
-      configValue<bool>(kAllowInt32Narrowing, false));
-}
+#undef VELOX_HIVE_CONFIG_REGISTER
 
-bool FileConfig::isFileColumnNamesReadAsLowerCase(
-    const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kFileColumnNamesReadAsLowerCaseSession,
-      config_->get<bool>(kFileColumnNamesReadAsLowerCase, false));
-}
-
-bool FileConfig::ignoreMissingFiles(const config::ConfigBase* session) const {
-  return session->get<bool>(kIgnoreMissingFilesSession, false);
-}
-
-int64_t FileConfig::maxCoalescedBytes(const config::ConfigBase* session) const {
-  return session->get<int64_t>(
-      kMaxCoalescedBytesSession,
-      config_->get<int64_t>(kMaxCoalescedBytes, 128 << 20)); // 128MB
+    return properties;
+  }();
+  return kProperties;
 }
 
 int32_t FileConfig::maxCoalescedDistanceBytes(
@@ -83,11 +83,6 @@ size_t FileConfig::parallelUnitLoadCount(
   return count;
 }
 
-int32_t FileConfig::loadQuantum(const config::ConfigBase* session) const {
-  return session->get<int32_t>(
-      kLoadQuantumSession, config_->get<int32_t>(kLoadQuantum, 8 << 20));
-}
-
 uint64_t FileConfig::filePreloadThreshold() const {
   return config_->get<uint64_t>(kFilePreloadThreshold, 8UL << 20);
 }
@@ -99,78 +94,6 @@ uint8_t FileConfig::readTimestampUnit(const config::ConfigBase* session) const {
       unit == 3 || unit == 6 /*micro*/ || unit == 9 /*nano*/,
       "Invalid timestamp unit.");
   return unit;
-}
-
-bool FileConfig::readTimestampPartitionValueAsLocalTime(
-    const config::ConfigBase* session) const {
-  return sessionValue<bool>(
-      session,
-      kReadTimestampPartitionValueAsLocalTimeSession,
-      kReadTimestampPartitionValueAsLocalTime,
-      true);
-}
-
-bool FileConfig::readStatsBasedFilterReorderDisabled(
-    const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kReadStatsBasedFilterReorderDisabledSession,
-      config_->get<bool>(kReadStatsBasedFilterReorderDisabled, false));
-}
-
-bool FileConfig::preserveFlatMapsInMemory(
-    const config::ConfigBase* session) const {
-  return sessionValue<bool>(
-      session,
-      kPreserveFlatMapsInMemorySession,
-      kPreserveFlatMapsInMemory,
-      false);
-}
-
-bool FileConfig::indexEnabled(const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kIndexEnabledSession, config_->get<bool>(kIndexEnabled, false));
-}
-
-bool FileConfig::readerCollectColumnCpuMetrics(
-    const config::ConfigBase* session) const {
-  return sessionValue<bool>(
-      session,
-      kReaderCollectColumnCpuMetricsSession,
-      kReaderCollectColumnCpuMetrics,
-      false);
-}
-
-bool FileConfig::fileMetadataCacheEnabled(
-    const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kFileMetadataCacheEnabledSession,
-      config_->get<bool>(kFileMetadataCacheEnabled, false));
-}
-
-bool FileConfig::pinFileMetadata(const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kPinFileMetadataSession, config_->get<bool>(kPinFileMetadata, false));
-}
-
-uint64_t FileConfig::orcFooterSpeculativeIoSize(
-    const config::ConfigBase* session) const {
-  return session->get<uint64_t>(
-      kOrcFooterSpeculativeIoSizeSession,
-      configValue<uint64_t>(kOrcFooterSpeculativeIoSize, 256UL << 10));
-}
-
-uint64_t FileConfig::parquetFooterSpeculativeIoSize(
-    const config::ConfigBase* session) const {
-  return session->get<uint64_t>(
-      kParquetFooterSpeculativeIoSizeSession,
-      configValue<uint64_t>(kParquetFooterSpeculativeIoSize, 256UL << 10));
-}
-
-uint64_t FileConfig::nimbleFooterSpeculativeIoSize(
-    const config::ConfigBase* session) const {
-  return session->get<uint64_t>(
-      kNimbleFooterSpeculativeIoSizeSession,
-      configValue<uint64_t>(kNimbleFooterSpeculativeIoSize, 8UL << 20));
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/FileConfig.h
+++ b/velox/connectors/hive/FileConfig.h
@@ -15,10 +15,11 @@
  */
 #pragma once
 
-#include <optional>
 #include <string>
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/config/Config.h"
+#include "velox/common/config/ConfigProperty.h"
+#include "velox/connectors/hive/HiveConfigMacrosDefine.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -28,133 +29,215 @@ namespace facebook::velox::connector::hive {
 /// bucketing, and write-path options.
 class FileConfig {
  public:
-  /// Maps table field names to file field names using names, not indices.
-  static constexpr const char* kOrcUseColumnNames = "orc.use-column-names";
-  static constexpr const char* kOrcUseColumnNamesSession =
-      "orc_use_column_names";
+  static const std::vector<config::ConfigProperty>& registeredProperties();
 
-  /// Maps table field names to file field names using names, not indices.
-  static constexpr const char* kParquetUseColumnNames =
-      "parquet.use-column-names";
-  static constexpr const char* kParquetUseColumnNamesSession =
-      "parquet_use_column_names";
+  // --- VELOX_HIVE_CONFIG_LEGACY properties ---
 
-  /// Allows reading INT32 physical type columns as a narrower integer type.
-  static constexpr const char* kAllowInt32Narrowing =
-      "parquet.allow-int32-narrowing";
-  static constexpr const char* kAllowInt32NarrowingSession =
-      "allow_int32_narrowing";
+  VELOX_HIVE_CONFIG_LEGACY(
+      kOrcUseColumnNamesSession,
+      kOrcUseColumnNames,
+      isOrcUseColumnNames,
+      "orc_use_column_names",
+      "orc.use-column-names",
+      bool,
+      false,
+      "Map ORC table field names to file field names using names, not indices.")
 
-  /// Reads the source file column name as lower case.
+  VELOX_HIVE_CONFIG_LEGACY(
+      kParquetUseColumnNamesSession,
+      kParquetUseColumnNames,
+      isParquetUseColumnNames,
+      "parquet_use_column_names",
+      "parquet.use-column-names",
+      bool,
+      false,
+      "Map Parquet table field names to file field names using names, not indices.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kAllowInt32NarrowingSession,
+      kAllowInt32Narrowing,
+      allowInt32Narrowing,
+      "allow_int32_narrowing",
+      "parquet.allow-int32-narrowing",
+      bool,
+      false,
+      "Allow reading INT32 Parquet columns as a narrower integer type.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kReadTimestampPartitionValueAsLocalTimeSession,
+      kReadTimestampPartitionValueAsLocalTime,
+      readTimestampPartitionValueAsLocalTime,
+      "reader.timestamp_partition_value_as_local_time",
+      "reader.timestamp-partition-value-as-local-time",
+      bool,
+      true,
+      "Read timestamp partition values as local time.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kPreserveFlatMapsInMemorySession,
+      kPreserveFlatMapsInMemory,
+      preserveFlatMapsInMemory,
+      "preserve_flat_maps_in_memory",
+      "preserve-flat-maps-in-memory",
+      bool,
+      false,
+      "Preserve flat maps in memory as FlatMapVectors.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kReaderCollectColumnCpuMetricsSession,
+      kReaderCollectColumnCpuMetrics,
+      readerCollectColumnCpuMetrics,
+      "reader.collect_column_cpu_metrics",
+      "reader.collect-column-cpu-metrics",
+      bool,
+      false,
+      "Collect per-column CPU timing stats.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kOrcFooterSpeculativeIoSizeSession,
+      kOrcFooterSpeculativeIoSize,
+      orcFooterSpeculativeIoSize,
+      "orc_footer_speculative_io_size",
+      "orc.footer-speculative-io-size",
+      uint64_t,
+      256UL << 10,
+      "Speculative tail-read size in bytes for ORC files.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kParquetFooterSpeculativeIoSizeSession,
+      kParquetFooterSpeculativeIoSize,
+      parquetFooterSpeculativeIoSize,
+      "parquet_footer_speculative_io_size",
+      "parquet.footer-speculative-io-size",
+      uint64_t,
+      256UL << 10,
+      "Speculative tail-read size in bytes for Parquet files.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kNimbleFooterSpeculativeIoSizeSession,
+      kNimbleFooterSpeculativeIoSize,
+      nimbleFooterSpeculativeIoSize,
+      "nimble_footer_speculative_io_size",
+      "nimble.footer-speculative-io-size",
+      uint64_t,
+      8UL << 20,
+      "Speculative tail-read size in bytes for Nimble files.")
+
+  // --- VELOX_HIVE_CONFIG properties ---
+
+  VELOX_HIVE_CONFIG(
+      kFileColumnNamesReadAsLowerCaseSession,
+      isFileColumnNamesReadAsLowerCase,
+      "file_column_names_read_as_lower_case",
+      bool,
+      false,
+      "Read source file column names as lower case.")
   static constexpr const char* kFileColumnNamesReadAsLowerCase =
       "file-column-names-read-as-lower-case";
-  static constexpr const char* kFileColumnNamesReadAsLowerCaseSession =
-      "file_column_names_read_as_lower_case";
 
-  static constexpr const char* kIgnoreMissingFilesSession =
-      "ignore_missing_files";
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kIgnoreMissingFilesSession,
+      "ignore_missing_files",
+      bool,
+      false,
+      "Ignore missing files during table scan.")
+  bool ignoreMissingFiles(const config::ConfigBase* session) const {
+    return session->get<bool>(
+        kIgnoreMissingFilesSession,
+        kIgnoreMissingFilesSessionProperty::defaultValue);
+  }
 
-  /// The max coalesce bytes for a request.
+  VELOX_HIVE_CONFIG(
+      kMaxCoalescedBytesSession,
+      maxCoalescedBytes,
+      "max-coalesced-bytes",
+      int64_t,
+      128 << 20,
+      "Maximum coalesced bytes for a read request.")
   static constexpr const char* kMaxCoalescedBytes = "max-coalesced-bytes";
-  static constexpr const char* kMaxCoalescedBytesSession =
-      "max-coalesced-bytes";
 
-  /// The max merge distance to combine read requests.
-  /// Note: The session property name differs from the constant name for
-  /// backward compatibility with Presto.
+  VELOX_HIVE_CONFIG(
+      kLoadQuantumSession,
+      loadQuantum,
+      "load-quantum",
+      int32_t,
+      8 << 20,
+      "Total size in bytes for a direct coalesce request.")
+  static constexpr const char* kLoadQuantum = "load-quantum";
+
+  VELOX_HIVE_CONFIG(
+      kReadStatsBasedFilterReorderDisabledSession,
+      readStatsBasedFilterReorderDisabled,
+      "stats_based_filter_reorder_disabled",
+      bool,
+      false,
+      "Disable stats-based filter reordering.")
+  static constexpr const char* kReadStatsBasedFilterReorderDisabled =
+      "stats-based-filter-reorder-disabled";
+
+  VELOX_HIVE_CONFIG(
+      kIndexEnabledSession,
+      indexEnabled,
+      "index_enabled",
+      bool,
+      false,
+      "Use cluster index for filter-based row pruning.")
+  static constexpr const char* kIndexEnabled = "index-enabled";
+
+  VELOX_HIVE_CONFIG(
+      kFileMetadataCacheEnabledSession,
+      fileMetadataCacheEnabled,
+      "file_metadata_cache_enabled",
+      bool,
+      false,
+      "Cache file metadata in AsyncDataCache.")
+  static constexpr const char* kFileMetadataCacheEnabled =
+      "file-metadata-cache-enabled";
+
+  VELOX_HIVE_CONFIG(
+      kPinFileMetadataSession,
+      pinFileMetadata,
+      "pin_file_metadata",
+      bool,
+      false,
+      "Pin parsed metadata objects in reader cache.")
+  static constexpr const char* kPinFileMetadata = "pin-file-metadata";
+
+  // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kMaxCoalescedDistanceSession,
+      "orc_max_merge_distance",
+      std::string,
+      "512kB",
+      "Maximum merge distance to combine read requests.")
   static constexpr const char* kMaxCoalescedDistance = "max-coalesced-distance";
-  static constexpr const char* kMaxCoalescedDistanceSession =
-      "orc_max_merge_distance";
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kParallelUnitLoadCountSession,
+      "parallel_unit_load_count",
+      size_t,
+      0,
+      "Number of units to load in parallel. 0 disables.")
+  static constexpr const char* kParallelUnitLoadCount =
+      "parallel-unit-load-count";
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kReadTimestampUnitSession,
+      "reader.timestamp_unit",
+      uint8_t,
+      3,
+      "Unit for reading timestamps (0=second, 3=millisecond, 6=microsecond, 9=nanosecond).")
+  static constexpr const char* kReadTimestampUnit = "reader.timestamp-unit";
+
+  // --- Server-only properties (no macro) ---
 
   /// The number of prefetch rowgroups.
   static constexpr const char* kPrefetchRowGroups = "prefetch-rowgroups";
 
-  /// The total size in bytes for a direct coalesce request. Up to 8MB load
-  /// quantum size is supported when SSD cache is enabled.
-  static constexpr const char* kLoadQuantum = "load-quantum";
-  static constexpr const char* kLoadQuantumSession = "load-quantum";
-
   /// The threshold of file size in bytes when the whole file is fetched with
   /// meta data together. Optimization to decrease the small IO requests.
   static constexpr const char* kFilePreloadThreshold = "file-preload-threshold";
-
-  /// When set to be larger than 0, parallel unit loader feature is enabled and
-  /// it configures how many units (e.g., stripes) we load in parallel.
-  /// When set to 0, parallel unit loader feature is disabled and on demand unit
-  /// loader would be used.
-  static constexpr const char* kParallelUnitLoadCount =
-      "parallel-unit-load-count";
-  static constexpr const char* kParallelUnitLoadCountSession =
-      "parallel_unit_load_count";
-
-  // The unit for reading timestamps from files.
-  static constexpr const char* kReadTimestampUnit = "reader.timestamp-unit";
-  static constexpr const char* kReadTimestampUnitSession =
-      "reader.timestamp_unit";
-
-  static constexpr const char* kReadTimestampPartitionValueAsLocalTime =
-      "reader.timestamp-partition-value-as-local-time";
-  static constexpr const char* kReadTimestampPartitionValueAsLocalTimeSession =
-      "reader.timestamp_partition_value_as_local_time";
-
-  static constexpr const char* kReadStatsBasedFilterReorderDisabled =
-      "stats-based-filter-reorder-disabled";
-  static constexpr const char* kReadStatsBasedFilterReorderDisabledSession =
-      "stats_based_filter_reorder_disabled";
-
-  /// Whether to preserve flat maps in memory as FlatMapVectors instead of
-  /// converting them to MapVectors.
-  static constexpr const char* kPreserveFlatMapsInMemory =
-      "preserve-flat-maps-in-memory";
-  static constexpr const char* kPreserveFlatMapsInMemorySession =
-      "preserve_flat_maps_in_memory";
-
-  /// Whether to use the cluster index for filter-based row pruning.
-  /// When enabled, filters from ScanSpec are converted to index bounds for
-  /// efficient row skipping based on the file's cluster index.
-  static constexpr const char* kIndexEnabled = "index-enabled";
-  static constexpr const char* kIndexEnabledSession = "index_enabled";
-
-  /// Whether to collect per-column timing stats (decode/decompress CPU time).
-  /// Disabled by default to avoid overhead (~100ns per operation).
-  static constexpr const char* kReaderCollectColumnCpuMetrics =
-      "reader.collect-column-cpu-metrics";
-  static constexpr const char* kReaderCollectColumnCpuMetricsSession =
-      "reader.collect_column_cpu_metrics";
-
-  /// Whether to cache file metadata (footer, stripes, index) in the
-  /// process-wide AsyncDataCache. When enabled, the first reader performs a
-  /// speculative tail read and populates the cache; subsequent readers on the
-  /// same file hit the cache for zero-IO metadata init.
-  static constexpr const char* kFileMetadataCacheEnabled =
-      "file-metadata-cache-enabled";
-  static constexpr const char* kFileMetadataCacheEnabledSession =
-      "file_metadata_cache_enabled";
-
-  /// Whether to pin parsed metadata objects (e.g., StripeGroup, IndexGroup)
-  /// in the reader's metadata cache with strong references so they are never
-  /// evicted. This avoids re-reading and re-parsing metadata on every stripe
-  /// access when weak-pointer cache entries would otherwise expire.
-  /// Currently only supported by Nimble format.
-  static constexpr const char* kPinFileMetadata = "pin-file-metadata";
-  static constexpr const char* kPinFileMetadataSession = "pin_file_metadata";
-
-  /// Speculative tail-read size in bytes when opening files. Controls how many
-  /// bytes are read from the end of the file to load the footer and nearby
-  /// metadata in a single IO operation. Format-specific configs with different
-  /// defaults: ORC/Parquet default to 256KB, Nimble defaults to 8MB.
-  static constexpr const char* kOrcFooterSpeculativeIoSize =
-      "orc.footer-speculative-io-size";
-  static constexpr const char* kOrcFooterSpeculativeIoSizeSession =
-      "orc_footer_speculative_io_size";
-  static constexpr const char* kParquetFooterSpeculativeIoSize =
-      "parquet.footer-speculative-io-size";
-  static constexpr const char* kParquetFooterSpeculativeIoSizeSession =
-      "parquet_footer_speculative_io_size";
-  static constexpr const char* kNimbleFooterSpeculativeIoSize =
-      "nimble.footer-speculative-io-size";
-  static constexpr const char* kNimbleFooterSpeculativeIoSizeSession =
-      "nimble_footer_speculative_io_size";
 
   explicit FileConfig(std::shared_ptr<const config::ConfigBase> config) {
     VELOX_CHECK_NOT_NULL(
@@ -164,65 +247,16 @@ class FileConfig {
 
   virtual ~FileConfig() = default;
 
-  bool isOrcUseColumnNames(const config::ConfigBase* session) const;
-
-  bool isParquetUseColumnNames(const config::ConfigBase* session) const;
-
-  bool allowInt32Narrowing(const config::ConfigBase* session) const;
-
-  bool isFileColumnNamesReadAsLowerCase(
-      const config::ConfigBase* session) const;
-
-  bool ignoreMissingFiles(const config::ConfigBase* session) const;
-
-  int64_t maxCoalescedBytes(const config::ConfigBase* session) const;
-
   int32_t maxCoalescedDistanceBytes(const config::ConfigBase* session) const;
 
   int32_t prefetchRowGroups() const;
 
   size_t parallelUnitLoadCount(const config::ConfigBase* session) const;
 
-  int32_t loadQuantum(const config::ConfigBase* session) const;
-
   uint64_t filePreloadThreshold() const;
 
   // Returns the timestamp unit used when reading timestamps from files.
   uint8_t readTimestampUnit(const config::ConfigBase* session) const;
-
-  // Whether to read timestamp partition value as local time. If false, read as
-  // UTC.
-  bool readTimestampPartitionValueAsLocalTime(
-      const config::ConfigBase* session) const;
-
-  /// Returns true if the stats based filter reorder for read is disabled.
-  bool readStatsBasedFilterReorderDisabled(
-      const config::ConfigBase* session) const;
-
-  /// Whether to preserve flat maps in memory as FlatMapVectors instead of
-  /// converting them to MapVectors.
-  bool preserveFlatMapsInMemory(const config::ConfigBase* session) const;
-
-  /// Whether to use the cluster index for filter-based row pruning.
-  bool indexEnabled(const config::ConfigBase* session) const;
-
-  /// Whether to collect per-column timing stats (decode/decompress CPU time).
-  /// Disabled by default to avoid overhead (~100ns per operation).
-  bool readerCollectColumnCpuMetrics(const config::ConfigBase* session) const;
-
-  /// Whether to cache file metadata in the process-wide AsyncDataCache.
-  bool fileMetadataCacheEnabled(const config::ConfigBase* session) const;
-
-  /// Whether to pin parsed metadata objects in the reader's metadata cache.
-  bool pinFileMetadata(const config::ConfigBase* session) const;
-
-  /// Returns the speculative tail read size in bytes for footer.
-  /// ORC/Parquet default to 256KB, Nimble defaults to 8MB. 0 means adaptive.
-  uint64_t orcFooterSpeculativeIoSize(const config::ConfigBase* session) const;
-  uint64_t parquetFooterSpeculativeIoSize(
-      const config::ConfigBase* session) const;
-  uint64_t nimbleFooterSpeculativeIoSize(
-      const config::ConfigBase* session) const;
 
   const std::shared_ptr<const config::ConfigBase>& config() const {
     return config_;
@@ -265,3 +299,5 @@ class FileConfig {
 };
 
 } // namespace facebook::velox::connector::hive
+
+#include "velox/connectors/hive/HiveConfigMacrosUndef.h"

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -15,10 +15,9 @@
  */
 
 #include "velox/connectors/hive/HiveConfig.h"
-#include "velox/common/config/Config.h"
-#include "velox/core/QueryConfig.h"
 
 #include <boost/algorithm/string.hpp>
+#include "velox/common/config/Config.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -39,6 +38,34 @@ stringToInsertExistingPartitionsBehavior(const std::string& strValue) {
 
 } // namespace
 
+const std::vector<config::ConfigProperty>& HiveConfig::registeredProperties() {
+  static const std::vector<config::ConfigProperty> kProperties = [] {
+    // Start with FileConfig properties.
+    auto properties = FileConfig::registeredProperties();
+#define VELOX_HIVE_CONFIG_REGISTER(constName) \
+  config::registerConfigProperty<HiveConfig::constName##Property>(properties)
+
+    VELOX_HIVE_CONFIG_REGISTER(kInsertExistingPartitionsBehaviorSession);
+    VELOX_HIVE_CONFIG_REGISTER(kSortWriterMaxOutputBytesSession);
+    VELOX_HIVE_CONFIG_REGISTER(kMaxTargetFileSizeSession);
+    VELOX_HIVE_CONFIG_REGISTER(kMaxPartitionsPerWritersSession);
+    VELOX_HIVE_CONFIG_REGISTER(kAllowNullPartitionKeysSession);
+    VELOX_HIVE_CONFIG_REGISTER(kPartitionPathAsLowerCaseSession);
+    VELOX_HIVE_CONFIG_REGISTER(kSortWriterMaxOutputRowsSession);
+    VELOX_HIVE_CONFIG_REGISTER(kSortWriterFinishTimeSliceLimitMsSession);
+    VELOX_HIVE_CONFIG_REGISTER(kUser);
+    VELOX_HIVE_CONFIG_REGISTER(kSource);
+    VELOX_HIVE_CONFIG_REGISTER(kSchema);
+    VELOX_HIVE_CONFIG_REGISTER(kMaxBucketCountSession);
+    VELOX_HIVE_CONFIG_REGISTER(kMaxRowsPerIndexRequestSession);
+
+#undef VELOX_HIVE_CONFIG_REGISTER
+
+    return properties;
+  }();
+  return kProperties;
+}
+
 // static
 std::string HiveConfig::insertExistingPartitionsBehaviorString(
     InsertExistingPartitionsBehavior behavior) {
@@ -58,18 +85,6 @@ HiveConfig::insertExistingPartitionsBehavior(
   return stringToInsertExistingPartitionsBehavior(session->get<std::string>(
       kInsertExistingPartitionsBehaviorSession,
       config_->get<std::string>(kInsertExistingPartitionsBehavior, "ERROR")));
-}
-
-uint32_t HiveConfig::maxPartitionsPerWriters(
-    const config::ConfigBase* session) const {
-  return session->get<uint32_t>(
-      kMaxPartitionsPerWritersSession,
-      config_->get<uint32_t>(kMaxPartitionsPerWriters, 128));
-}
-
-uint32_t HiveConfig::maxBucketCount(const config::ConfigBase* session) const {
-  return sessionValue<uint32_t>(
-      session, kMaxBucketCountSession, kMaxBucketCount, 100'000);
 }
 
 bool HiveConfig::immutablePartitions() const {
@@ -107,18 +122,6 @@ std::optional<std::string> HiveConfig::gcsAuthAccessTokenProvider() const {
       std::string(kLegacyPrefix) + kGcsAuthAccessTokenProvider);
 }
 
-bool HiveConfig::isPartitionPathAsLowerCase(
-    const config::ConfigBase* session) const {
-  return session->get<bool>(kPartitionPathAsLowerCaseSession, true);
-}
-
-bool HiveConfig::allowNullPartitionKeys(
-    const config::ConfigBase* session) const {
-  return session->get<bool>(
-      kAllowNullPartitionKeysSession,
-      config_->get<bool>(kAllowNullPartitionKeys, true));
-}
-
 int32_t HiveConfig::numCacheFileHandles() const {
   return config_->get<int32_t>(kNumCacheFileHandles, 20'000);
 }
@@ -139,13 +142,6 @@ std::string HiveConfig::writeFileCreateConfig() const {
   return config_->get<std::string>("hive.write_file_create_config", "");
 }
 
-uint32_t HiveConfig::sortWriterMaxOutputRows(
-    const config::ConfigBase* session) const {
-  return session->get<uint32_t>(
-      kSortWriterMaxOutputRowsSession,
-      config_->get<uint32_t>(kSortWriterMaxOutputRows, 1024));
-}
-
 uint64_t HiveConfig::sortWriterMaxOutputBytes(
     const config::ConfigBase* session) const {
   return config::toCapacity(
@@ -155,12 +151,6 @@ uint64_t HiveConfig::sortWriterMaxOutputBytes(
       config::CapacityUnit::BYTE);
 }
 
-uint64_t HiveConfig::sortWriterFinishTimeSliceLimitMs(
-    const config::ConfigBase* session) const {
-  return session->get<uint64_t>(
-      kSortWriterFinishTimeSliceLimitMsSession,
-      config_->get<uint64_t>(kSortWriterFinishTimeSliceLimitMs, 5'000));
-}
 uint64_t HiveConfig::maxTargetFileSizeBytes(
     const config::ConfigBase* session) const {
   return config::toCapacity(
@@ -168,26 +158,6 @@ uint64_t HiveConfig::maxTargetFileSizeBytes(
           kMaxTargetFileSizeSession,
           config_->get<std::string>(kMaxTargetFileSize, "0B")),
       config::CapacityUnit::BYTE);
-}
-
-uint32_t HiveConfig::maxRowsPerIndexRequest(
-    const config::ConfigBase* session) const {
-  return sessionValue<uint32_t>(
-      session, kMaxRowsPerIndexRequestSession, kMaxRowsPerIndexRequest, 0);
-}
-
-std::string HiveConfig::user(const config::ConfigBase* session) const {
-  return session->get<std::string>(kUser, config_->get<std::string>(kUser, ""));
-}
-
-std::string HiveConfig::source(const config::ConfigBase* session) const {
-  return session->get<std::string>(
-      kSource, config_->get<std::string>(kSource, ""));
-}
-
-std::string HiveConfig::schema(const config::ConfigBase* session) const {
-  return session->get<std::string>(
-      kSchema, config_->get<std::string>(kSchema, ""));
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/connectors/hive/FileConfig.h"
+#include "velox/connectors/hive/HiveConfigMacrosDefine.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -24,6 +25,10 @@ namespace facebook::velox::connector::hive {
 /// Hive table format concerns.
 class HiveConfig : public FileConfig {
  public:
+  /// Returns all registered session-overridable properties from both
+  /// FileConfig and HiveConfig.
+  static const std::vector<config::ConfigProperty>& registeredProperties();
+
   enum class InsertExistingPartitionsBehavior {
     kError,
     kOverwrite,
@@ -32,22 +37,128 @@ class HiveConfig : public FileConfig {
   static std::string insertExistingPartitionsBehaviorString(
       InsertExistingPartitionsBehavior behavior);
 
-  /// Behavior on insert into existing partitions.
-  static constexpr const char* kInsertExistingPartitionsBehaviorSession =
-      "insert_existing_partitions_behavior";
+  // --- VELOX_HIVE_CONFIG_PROPERTY properties ---
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kInsertExistingPartitionsBehaviorSession,
+      "insert_existing_partitions_behavior",
+      std::string,
+      "ERROR",
+      "Behavior when inserting into existing partitions: ERROR, OVERWRITE.")
   static constexpr const char* kInsertExistingPartitionsBehavior =
       "insert-existing-partitions-behavior";
 
-  /// Maximum number of (bucketed) partitions per a single table writer
-  /// instance.
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kSortWriterMaxOutputBytesSession,
+      "sort_writer_max_output_bytes",
+      std::string,
+      "10MB",
+      "Maximum output bytes for sort writer.")
+  static constexpr const char* kSortWriterMaxOutputBytes =
+      "sort-writer-max-output-bytes";
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kMaxTargetFileSizeSession,
+      "max_target_file_size",
+      std::string,
+      "0B",
+      "Maximum target file size. 0 means no limit.")
+  static constexpr const char* kMaxTargetFileSize = "max-target-file-size";
+
+  // --- VELOX_HIVE_CONFIG properties ---
+
+  VELOX_HIVE_CONFIG(
+      kMaxPartitionsPerWritersSession,
+      maxPartitionsPerWriters,
+      "max_partitions_per_writers",
+      uint32_t,
+      128,
+      "Maximum partitions per writer.")
   static constexpr const char* kMaxPartitionsPerWriters =
       "max-partitions-per-writers";
-  static constexpr const char* kMaxPartitionsPerWritersSession =
-      "max_partitions_per_writers";
 
-  /// Maximum number of buckets allowed to output by the table writers.
-  static constexpr const char* kMaxBucketCount = "max-bucket-count";
-  static constexpr const char* kMaxBucketCountSession = "max_bucket_count";
+  VELOX_HIVE_CONFIG(
+      kAllowNullPartitionKeysSession,
+      allowNullPartitionKeys,
+      "allow_null_partition_keys",
+      bool,
+      true,
+      "Allow null partition keys.")
+  static constexpr const char* kAllowNullPartitionKeys =
+      "allow-null-partition-keys";
+
+  VELOX_HIVE_CONFIG_PROPERTY(
+      kPartitionPathAsLowerCaseSession,
+      "partition_path_as_lower_case",
+      bool,
+      true,
+      "Write partition path segments as lower case.")
+  bool isPartitionPathAsLowerCase(const config::ConfigBase* session) const {
+    return session->get<bool>(
+        kPartitionPathAsLowerCaseSession,
+        kPartitionPathAsLowerCaseSessionProperty::defaultValue);
+  }
+
+  VELOX_HIVE_CONFIG(
+      kSortWriterMaxOutputRowsSession,
+      sortWriterMaxOutputRows,
+      "sort_writer_max_output_rows",
+      uint32_t,
+      1024,
+      "Maximum output rows for sort writer.")
+  static constexpr const char* kSortWriterMaxOutputRows =
+      "sort-writer-max-output-rows";
+
+  VELOX_HIVE_CONFIG(
+      kSortWriterFinishTimeSliceLimitMsSession,
+      sortWriterFinishTimeSliceLimitMs,
+      "sort_writer_finish_time_slice_limit_ms",
+      uint64_t,
+      5000,
+      "Time slice limit in ms for sort writer finish. 0 means no limit.")
+  static constexpr const char* kSortWriterFinishTimeSliceLimitMs =
+      "sort-writer-finish-time-slice-limit-ms";
+
+  VELOX_HIVE_CONFIG(kUser, user, "user", std::string, "", "User of the query.")
+
+  VELOX_HIVE_CONFIG(
+      kSource,
+      source,
+      "source",
+      std::string,
+      "",
+      "Source of the query.")
+
+  VELOX_HIVE_CONFIG(
+      kSchema,
+      schema,
+      "schema",
+      std::string,
+      "",
+      "Schema of the query.")
+
+  // --- VELOX_HIVE_CONFIG_LEGACY properties ---
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kMaxBucketCountSession,
+      kMaxBucketCount,
+      maxBucketCount,
+      "max_bucket_count",
+      "max-bucket-count",
+      uint32_t,
+      100'000,
+      "Maximum bucket count.")
+
+  VELOX_HIVE_CONFIG_LEGACY(
+      kMaxRowsPerIndexRequestSession,
+      kMaxRowsPerIndexRequest,
+      maxRowsPerIndexRequest,
+      "max_rows_per_index_request",
+      "max-rows-per-index-request",
+      uint32_t,
+      0,
+      "Maximum rows per index lookup request. 0 means no limit.")
+  // --- Server-only properties (no macro) ---
 
   /// Whether new data can be inserted into an unpartition table.
   /// Velox currently does not support appending data to existing partitions.
@@ -68,14 +179,6 @@ class HiveConfig : public FileConfig {
   static constexpr const char* kGcsAuthAccessTokenProvider =
       "gcs.auth.access-token-provider";
 
-  static constexpr const char* kPartitionPathAsLowerCaseSession =
-      "partition_path_as_lower_case";
-
-  static constexpr const char* kAllowNullPartitionKeys =
-      "allow-null-partition-keys";
-  static constexpr const char* kAllowNullPartitionKeysSession =
-      "allow_null_partition_keys";
-
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
 
@@ -95,50 +198,8 @@ class HiveConfig : public FileConfig {
   static constexpr const char* kWriteFileCreateConfig =
       "write-file-create-config";
 
-  /// Maximum number of rows for sort writer in one batch of output.
-  static constexpr const char* kSortWriterMaxOutputRows =
-      "sort-writer-max-output-rows";
-  static constexpr const char* kSortWriterMaxOutputRowsSession =
-      "sort_writer_max_output_rows";
-
-  /// Maximum bytes for sort writer in one batch of output.
-  static constexpr const char* kSortWriterMaxOutputBytes =
-      "sort-writer-max-output-bytes";
-  static constexpr const char* kSortWriterMaxOutputBytesSession =
-      "sort_writer_max_output_bytes";
-
-  /// Sort Writer will exit finish() method after this many milliseconds even if
-  /// it has not completed its work yet. Zero means no time limit.
-  static constexpr const char* kSortWriterFinishTimeSliceLimitMs =
-      "sort-writer-finish-time-slice-limit-ms";
-  static constexpr const char* kSortWriterFinishTimeSliceLimitMsSession =
-      "sort_writer_finish_time_slice_limit_ms";
-
-  /// Maximum target file size. When a file exceeds this size during writing,
-  /// the writer will close the current file and start writing to a new file.
-  /// Accepts human-readable values like "1GB". Zero means no limit (default).
-  static constexpr const char* kMaxTargetFileSize = "max-target-file-size";
-  static constexpr const char* kMaxTargetFileSizeSession =
-      "max_target_file_size";
-
-  /// Maximum number of output rows to return per index lookup request.
-  /// The limit is applied to the actual output rows after filtering.
-  /// 0 means no limit (default).
-  static constexpr const char* kMaxRowsPerIndexRequest =
-      "max-rows-per-index-request";
-  static constexpr const char* kMaxRowsPerIndexRequestSession =
-      "max_rows_per_index_request";
-
-  static constexpr const char* kUser = "user";
-  static constexpr const char* kSource = "source";
-  static constexpr const char* kSchema = "schema";
-
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const config::ConfigBase* session) const;
-
-  uint32_t maxPartitionsPerWriters(const config::ConfigBase* session) const;
-
-  uint32_t maxBucketCount(const config::ConfigBase* session) const;
 
   bool immutablePartitions() const;
 
@@ -152,10 +213,6 @@ class HiveConfig : public FileConfig {
 
   std::optional<std::string> gcsAuthAccessTokenProvider() const;
 
-  bool isPartitionPathAsLowerCase(const config::ConfigBase* session) const;
-
-  bool allowNullPartitionKeys(const config::ConfigBase* session) const;
-
   int32_t numCacheFileHandles() const;
 
   uint64_t fileHandleExpirationDurationMs() const;
@@ -166,30 +223,14 @@ class HiveConfig : public FileConfig {
 
   std::string writeFileCreateConfig() const;
 
-  uint32_t sortWriterMaxOutputRows(const config::ConfigBase* session) const;
-
   uint64_t sortWriterMaxOutputBytes(const config::ConfigBase* session) const;
-
-  uint64_t sortWriterFinishTimeSliceLimitMs(
-      const config::ConfigBase* session) const;
 
   uint64_t maxTargetFileSizeBytes(const config::ConfigBase* session) const;
 
-  /// Returns the maximum number of rows to read per index lookup request.
-  /// 0 means no limit (default).
-  uint32_t maxRowsPerIndexRequest(const config::ConfigBase* session) const;
-
-  /// User of the query. Used for storage logging.
-  std::string user(const config::ConfigBase* session) const;
-
-  /// Source of the query. Used for storage access and logging.
-  std::string source(const config::ConfigBase* session) const;
-
-  /// Schema of the query. Used for storage logging.
-  std::string schema(const config::ConfigBase* session) const;
-
-  HiveConfig(std::shared_ptr<const config::ConfigBase> config)
+  explicit HiveConfig(std::shared_ptr<const config::ConfigBase> config)
       : FileConfig(std::move(config)) {}
 };
 
 } // namespace facebook::velox::connector::hive
+
+#include "velox/connectors/hive/HiveConfigMacrosUndef.h"

--- a/velox/connectors/hive/HiveConfigMacrosDefine.h
+++ b/velox/connectors/hive/HiveConfigMacrosDefine.h
@@ -1,0 +1,102 @@
+// NOLINT(facebook-hte-MultipleIncludeGuardMissing)
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Macros for defining Hive connector config properties. Same traits-based
+// pattern as VELOX_QUERY_CONFIG in QueryConfig.h.
+//
+// No #pragma once — this file is intentionally included multiple times
+// (once per header that defines config properties). Each inclusion must
+// be paired with HiveConfigMacrosUndef.h to scope the macros.
+//
+// To add a new property, add two lines (order doesn't matter, but
+// grouping related properties together helps readability):
+//
+// 1. In FileConfig.h or HiveConfig.h (inside the class body):
+//   VELOX_HIVE_CONFIG(kMaxPartitionsPerWritersSession,
+//       maxPartitionsPerWriters, "max_partitions_per_writers",
+//       uint32_t, 128, "Maximum partitions per writer.")
+//
+// 2. In the matching .cpp file (inside registeredProperties()):
+//   VELOX_HIVE_CONFIG_REGISTER(kMaxPartitionsPerWritersSession);
+//
+// VELOX_HIVE_CONFIG generates:
+//   - struct kMaxPartitionsPerWritersSessionProperty {
+//         using type = uint32_t;
+//         static constexpr const char* key = "max_partitions_per_writers";
+//         static constexpr auto defaultValue = 128;
+//         static constexpr const char* description = "Maximum partitions...";
+//     };
+//   - static constexpr const char* kMaxPartitionsPerWritersSession =
+//         "max_partitions_per_writers"
+//   - uint32_t maxPartitionsPerWriters(const ConfigBase* session) const {
+//         return session->get<uint32_t>(kMaxPartitionsPerWritersSession,
+//             config_->get<uint32_t>(toConfigKey(...), 128));
+//     }
+//
+// VELOX_HIVE_CONFIG_PROPERTY generates the same but without the accessor.
+// Used for properties with custom accessor logic: capacity parsing,
+// validation, or session-only properties that should not fall back to
+// connector config (e.g., ignoreMissingFiles, isPartitionPathAsLowerCase).
+// New properties should use VELOX_HIVE_CONFIG and put validation in
+// HiveConfigProvider::normalize() and HiveConnector constructor.
+// TODO: Unify validation into a single path.
+//
+// VELOX_HIVE_CONFIG_LEGACY is the same as VELOX_HIVE_CONFIG but takes an
+// explicit config key and uses sessionValue() for legacy 'hive.' prefix
+// fallback.
+
+#ifdef VELOX_HIVE_CONFIG_MACROS_DEFINED
+#error "HiveConfigMacrosDefine.h included twice without HiveConfigMacrosUndef.h"
+#endif
+// NOLINTBEGIN(facebook-modularize-issue-check)
+#define VELOX_HIVE_CONFIG_MACROS_DEFINED
+
+#define VELOX_HIVE_CONFIG_PROPERTY(                  \
+    constName, keyStr, CppType, defaultVal, desc)    \
+  struct constName##Property {                       \
+    using type = CppType;                            \
+    static constexpr const char* key = keyStr;       \
+    static constexpr auto defaultValue = defaultVal; \
+    static constexpr const char* description = desc; \
+  };                                                 \
+  static constexpr const char* constName = keyStr;
+
+#define VELOX_HIVE_CONFIG(                                              \
+    constName, accessorName, key, CppType, defaultVal, desc)            \
+  VELOX_HIVE_CONFIG_PROPERTY(constName, key, CppType, defaultVal, desc) \
+  CppType accessorName(const config::ConfigBase* session) const {       \
+    return session->get<CppType>(                                       \
+        constName,                                                      \
+        config_->get<CppType>(                                          \
+            config::ConfigBase::toConfigKey(constName), defaultVal));   \
+  }
+
+#define VELOX_HIVE_CONFIG_LEGACY(                                       \
+    constName,                                                          \
+    configConstName,                                                    \
+    accessorName,                                                       \
+    key,                                                                \
+    configKey,                                                          \
+    CppType,                                                            \
+    defaultVal,                                                         \
+    desc)                                                               \
+  VELOX_HIVE_CONFIG_PROPERTY(constName, key, CppType, defaultVal, desc) \
+  static constexpr const char* configConstName = configKey;             \
+  CppType accessorName(const config::ConfigBase* session) const {       \
+    return sessionValue<CppType>(                                       \
+        session, constName, configConstName, defaultVal);               \
+  }
+// NOLINTEND(facebook-modularize-issue-check)

--- a/velox/connectors/hive/HiveConfigMacrosUndef.h
+++ b/velox/connectors/hive/HiveConfigMacrosUndef.h
@@ -1,0 +1,29 @@
+// NOLINT(facebook-hte-MultipleIncludeGuardMissing)
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Undefines macros from HiveConfigMacrosDefine.h.
+// Must be included after all macro usage.
+// No #pragma once — see HiveConfigMacrosDefine.h for explanation.
+
+#ifndef VELOX_HIVE_CONFIG_MACROS_DEFINED
+#error "HiveConfigMacrosUndef.h included without HiveConfigMacrosDefine.h"
+#endif
+#undef VELOX_HIVE_CONFIG_MACROS_DEFINED
+
+#undef VELOX_HIVE_CONFIG
+#undef VELOX_HIVE_CONFIG_LEGACY
+#undef VELOX_HIVE_CONFIG_PROPERTY

--- a/velox/connectors/hive/HiveConfigProvider.cpp
+++ b/velox/connectors/hive/HiveConfigProvider.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/connectors/hive/HiveConfigProvider.h"
+
+#include "velox/connectors/hive/HiveConfig.h"
+
+namespace facebook::velox::connector::hive {
+
+std::vector<config::ConfigProperty> HiveConfigProvider::properties() const {
+  return HiveConfig::registeredProperties();
+}
+
+std::string HiveConfigProvider::normalize(
+    std::string_view /*name*/,
+    std::string_view value) const {
+  return std::string(value);
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfigProvider.h
+++ b/velox/connectors/hive/HiveConfigProvider.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/config/ConfigProvider.h"
+
+namespace facebook::velox::connector::hive {
+
+/// Exposes Hive connector session-overridable properties.
+class HiveConfigProvider : public config::ConfigProvider {
+ public:
+  /// Returns all session-overridable Hive connector properties.
+  std::vector<config::ConfigProperty> properties() const override;
+
+  /// Validates and normalizes a property value.
+  std::string normalize(std::string_view name, std::string_view value)
+      const override;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -17,6 +17,7 @@
 #include "velox/connectors/hive/HiveConnector.h"
 
 #include "velox/connectors/hive/HiveConfig.h"
+#include "velox/connectors/hive/HiveConfigProvider.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/connectors/hive/HiveDataSource.h"
 #include "velox/connectors/hive/HiveIndexSource.h"
@@ -52,6 +53,11 @@ HiveConnector::HiveConnector(
     LOG(INFO) << "Hive connector " << connectorId()
               << " created with file handle cache disabled";
   }
+}
+
+const config::ConfigProvider* HiveConnector::configProvider() const {
+  static const HiveConfigProvider kProvider;
+  return &kProvider;
 }
 
 std::unique_ptr<DataSource> HiveConnector::createDataSource(

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -34,6 +34,8 @@ class HiveConnector : public Connector {
       std::shared_ptr<const config::ConfigBase> config,
       folly::Executor* executor);
 
+  const config::ConfigProvider* configProvider() const override;
+
   bool canAddDynamicFilter() const override {
     return true;
   }

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <fmt/format.h>
 #include <re2/re2.h>
 
 #include "velox/common/config/Config.h"
@@ -23,53 +22,11 @@
 
 namespace facebook::velox::core {
 
-namespace {
-
-// Maps C++ types to ConfigPropertyType.
-template <typename T>
-constexpr config::ConfigPropertyType configPropertyTypeOf() {
-  if constexpr (std::is_same_v<T, bool>) {
-    return config::ConfigPropertyType::kBoolean;
-  } else if constexpr (std::is_integral_v<T>) {
-    return config::ConfigPropertyType::kInteger;
-  } else if constexpr (std::is_floating_point_v<T>) {
-    return config::ConfigPropertyType::kDouble;
-  } else {
-    return config::ConfigPropertyType::kString;
-  }
-}
-
-// Converts a default value to its string representation.
-template <typename T>
-std::string configPropertyDefaultToString(const T& value) {
-  if constexpr (std::is_same_v<T, bool>) {
-    return value ? "true" : "false";
-  } else if constexpr (std::is_arithmetic_v<T>) {
-    return fmt::format("{}", value);
-  } else {
-    return std::string(value);
-  }
-}
-
-// Registers a property from its traits struct.
-template <typename PropertyTraits>
-void registerProperty(std::vector<config::ConfigProperty>& registry) {
-  registry.push_back({
-      PropertyTraits::key,
-      configPropertyTypeOf<typename PropertyTraits::type>(),
-      configPropertyDefaultToString<typename PropertyTraits::type>(
-          PropertyTraits::defaultValue),
-      PropertyTraits::description,
-  });
-}
-
-} // namespace
-
 const std::vector<config::ConfigProperty>& QueryConfig::registeredProperties() {
   static const std::vector<config::ConfigProperty> kProperties = [] {
     std::vector<config::ConfigProperty> properties;
 #define VELOX_REGISTER_QUERY_CONFIG(constName) \
-  registerProperty<QueryConfig::constName##Property>(properties)
+  config::registerConfigProperty<QueryConfig::constName##Property>(properties)
 
     // Memory.
     VELOX_REGISTER_QUERY_CONFIG(kQueryMaxMemoryPerNode);


### PR DESCRIPTION
Summary:

Add a virtual configProvider() method to the Connector base class that returns the connector's session-overridable properties. Returns nullptr by default.

Add HiveConfigProvider that exposes ~30 session-overridable properties from HiveConfig and FileConfig (e.g., max_partitions_per_writers, orc_use_column_names, file_column_names_read_as_lower_case). Server-only properties (GCS credentials, cache sizes, immutable partitions) are excluded.

Override configProvider() in HiveConnector to return a HiveConfigProvider instance. This enables external systems to discover and validate Hive connector session properties via the ConfigProvider interface.

Differential Revision: D100910941


