### PR TITLE
feat: Add extraction pushdown in common reader framework (#17198)

### DIFF
--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -116,6 +116,19 @@ void ColumnLoader::loadInternal(
   }
 }
 
+void TransformColumnLoader::loadInternal(
+    RowSet rows,
+    ValueHook* hook,
+    vector_size_t resultSize,
+    VectorPtr* result) {
+  process::TraceContext trace("TransformColumnLoader::loadInternal");
+  VectorPtr fileResult;
+  ColumnLoader::loadInternal(rows, hook, resultSize, &fileResult);
+  if (fileResult) {
+    *result = transform_(fileResult, fieldReader_->memoryPool());
+  }
+}
+
 void DeltaUpdateColumnLoader::loadInternal(
     RowSet rows,
     ValueHook* hook,

--- a/velox/dwio/common/ColumnLoader.h
+++ b/velox/dwio/common/ColumnLoader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/SelectiveStructColumnReader.h"
 #include "velox/vector/LazyVector.h"
 
@@ -50,6 +51,34 @@ class ColumnLoader : public VectorLoader {
   // these differ, 'structReader' has been advanced since the creation
   // of 'this' and 'this' is no longer loadable.
   const uint64_t version_;
+};
+
+/// Wraps a ColumnLoader and applies a post-read transform when the lazy
+/// vector is loaded.  Used for mixed extraction transforms where the reader
+/// produces the file type and the transform converts to the extraction
+/// output type (e.g., MAP → ROW<keys, sz> for MapKeys + Size extractions).
+class TransformColumnLoader : public ColumnLoader {
+ public:
+  TransformColumnLoader(
+      SelectiveStructColumnReaderBase* structReader,
+      SelectiveColumnReader* fieldReader,
+      uint64_t version,
+      common::ScanSpec::VectorTransform transform)
+      : ColumnLoader(structReader, fieldReader, version),
+        transform_(std::move(transform)) {}
+
+  bool supportsHook() const override {
+    return false;
+  }
+
+ private:
+  void loadInternal(
+      RowSet rows,
+      ValueHook* hook,
+      vector_size_t resultSize,
+      VectorPtr* result) override;
+
+  common::ScanSpec::VectorTransform transform_;
 };
 
 class DeltaUpdateColumnLoader : public VectorLoader {

--- a/velox/dwio/common/Reader.cpp
+++ b/velox/dwio/common/Reader.cpp
@@ -112,6 +112,40 @@ VectorPtr RowReader::projectColumns(
     }
   }
 
+  // Apply post-read transforms for column extraction pushdown.
+  // This runs after filtering/dictionary wrapping so the vectors have the
+  // correct row count.  If a child has more elements than the output size
+  // (e.g., text reader pre-allocates), slice it first.
+  bool hasTransforms = false;
+  for (auto& childSpec : spec.children()) {
+    if (!childSpec->projectOut() || !childSpec->hasTransform()) {
+      continue;
+    }
+    auto i = childSpec->channel();
+    if (children[i]) {
+      auto child = children[i];
+      if (child->size() > size) {
+        child = child->slice(0, size);
+      }
+      children[i] = childSpec->transform()(child, input->pool());
+      hasTransforms = true;
+    }
+  }
+
+  // Rebuild rowType if transforms changed any child types.
+  if (hasTransforms) {
+    auto rowNames = rowType->asRow().names();
+    std::vector<TypePtr> rowTypes;
+    rowTypes.reserve(numColumns);
+    for (column_index_t i = 0; i < numColumns; ++i) {
+      rowTypes.push_back(
+          children[i] ? children[i]->type() : rowType->childAt(i));
+    }
+    rowType =
+        ROW(std::vector<std::string>(rowNames.begin(), rowNames.end()),
+            std::move(rowTypes));
+  }
+
   return std::make_shared<RowVector>(
       input->pool(), rowType, outputNulls, size, std::move(children));
 }

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -209,34 +209,69 @@ RowSet SelectiveRepeatedColumnReader::applyFilter(const RowSet& rows) {
   return outputRows_;
 }
 
+void SelectiveRepeatedColumnReader::getExtractionSizeValues(
+    const RowSet& rows,
+    VectorPtr* result) {
+  VELOX_DCHECK_NOT_NULL(result);
+  FlatVector<int64_t>* flatResult = nullptr;
+  if (*result && result->get()->type()->isBigint()) {
+    flatResult = result->get()->asFlatVector<int64_t>();
+  }
+  if (!flatResult || !flatResult->values()) {
+    *result = std::make_shared<FlatVector<int64_t>>(
+        pool_,
+        BIGINT(),
+        nullptr,
+        rows.size(),
+        AlignedBuffer::allocate<int64_t>(rows.size(), pool_),
+        std::vector<BufferPtr>{});
+    flatResult = result->get()->asFlatVector<int64_t>();
+  } else {
+    flatResult->resize(static_cast<vector_size_t>(rows.size()));
+  }
+  auto* sizesData = flatResult->mutableRawValues();
+  auto* nulls = nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  for (vector_size_t i = 0; i < static_cast<vector_size_t>(rows.size()); ++i) {
+    sizesData[i] =
+        (nulls && bits::isBitNull(nulls, rows[i])) ? 0 : allLengths_[rows[i]];
+  }
+  setComplexNulls(rows, *result);
+}
+
 SelectiveListColumnReader::SelectiveListColumnReader(
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     FormatParams& params,
     velox::common::ScanSpec& scanSpec)
     : SelectiveRepeatedColumnReader(requestedType, params, scanSpec, fileType) {
+  VELOX_CHECK(
+      scanSpec.extractionType() ==
+              velox::common::ScanSpec::ExtractionType::kNone ||
+          scanSpec.extractionType() ==
+              velox::common::ScanSpec::ExtractionType::kSize,
+      "Array column reader only supports kNone and kSize extraction, got: {}",
+      static_cast<int>(scanSpec.extractionType()));
 }
 
 uint64_t SelectiveListColumnReader::skip(uint64_t numValues) {
   numValues = formatData_->skipNulls(numValues);
-  if (child_) {
-    std::array<int32_t, kBufferSize> buffer;
-    uint64_t childElements = 0;
-    uint64_t lengthsRead = 0;
-    while (lengthsRead < numValues) {
-      uint64_t chunk =
-          std::min(numValues - lengthsRead, static_cast<uint64_t>(kBufferSize));
-      readLengths(buffer.data(), chunk, nullptr);
-      for (size_t i = 0; i < chunk; ++i) {
-        childElements += static_cast<size_t>(buffer[i]);
-      }
-      lengthsRead += chunk;
+  std::array<int32_t, kBufferSize> buffer{};
+  uint64_t childElements = 0;
+  uint64_t lengthsRead = 0;
+  while (lengthsRead < numValues) {
+    uint64_t chunk =
+        std::min(numValues - lengthsRead, static_cast<uint64_t>(kBufferSize));
+    readLengths(buffer.data(), static_cast<int32_t>(chunk), nullptr);
+    for (size_t i = 0; i < chunk; ++i) {
+      childElements += static_cast<size_t>(buffer[i]);
     }
-    child_->seekTo(child_->readOffset() + childElements, false);
-    childTargetReadOffset_ += childElements;
-  } else {
-    VELOX_FAIL("Repeated reader with no children");
+    lengthsRead += chunk;
   }
+  if (child_) {
+    child_->seekTo(
+        child_->readOffset() + static_cast<int64_t>(childElements), false);
+  }
+  childTargetReadOffset_ += static_cast<int64_t>(childElements);
   return numValues;
 }
 
@@ -245,14 +280,26 @@ void SelectiveListColumnReader::read(
     const RowSet& rows,
     const uint64_t* incomingNulls) {
   // Catch up if the child is behind the length stream.
-  child_->seekTo(childTargetReadOffset_, false);
+  if (child_) {
+    child_->seekTo(childTargetReadOffset_, false);
+  }
   prepareRead<char>(offset, rows, incomingNulls);
   auto activeRows = applyFilter(rows);
   nestedRowsAllSelected_ = activeRows.size() == rows.back() + 1 &&
       scanSpec_->maxArrayElementsCount() ==
           std::numeric_limits<vector_size_t>::max();
   makeNestedRowSet(activeRows, rows.back());
-  if (child_ && !nestedRows_.empty()) {
+  // When deltaUpdate is set, treat extractionType as kNone so all child
+  // streams are read.  The extraction transform is applied after the
+  // delta update.
+  if (scanSpec_->extractionType() ==
+          velox::common::ScanSpec::ExtractionType::kSize &&
+      !scanSpec_->deltaUpdate()) {
+    // Size extraction: only need offsets/sizes, skip child stream.
+    if (child_ && !nestedRows_.empty()) {
+      child_->seekTo(child_->readOffset() + nestedRows_.back() + 1, false);
+    }
+  } else if (child_ && !nestedRows_.empty()) {
     child_->readWithTiming(child_->readOffset(), nestedRows_, nullptr);
     nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
         nestedRows_.size() == child_->outputRows().size();
@@ -266,6 +313,17 @@ void SelectiveListColumnReader::getValues(
     const RowSet& rows,
     VectorPtr* result) {
   VELOX_DCHECK_NOT_NULL(result);
+
+  // When deltaUpdate is set, treat extractionType as kNone so the reader
+  // produces the full array.  The extraction transform is applied after
+  // the delta update.
+  if (scanSpec_->extractionType() ==
+          velox::common::ScanSpec::ExtractionType::kSize &&
+      !scanSpec_->deltaUpdate()) {
+    getExtractionSizeValues(rows, result);
+    return;
+  }
+
   prepareResult(*result, requestedType_, rows.size(), pool_);
   auto* resultArray = result->get()->asUnchecked<ArrayVector>();
   makeOffsetsAndSizes(rows, *resultArray);
@@ -311,6 +369,12 @@ void SelectiveMapColumnReaderBase::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
+  // When deltaUpdate is set, treat extractionType as kNone so all streams
+  // are read.  The extraction transform is applied after the delta update.
+  const auto extractionType = scanSpec_->deltaUpdate()
+      ? velox::common::ScanSpec::ExtractionType::kNone
+      : scanSpec_->extractionType();
+
   // Catch up if child readers are behind the length stream.
   if (keyReader_) {
     keyReader_->seekTo(childTargetReadOffset_, false);
@@ -326,17 +390,63 @@ void SelectiveMapColumnReaderBase::read(
       scanSpec_->maxArrayElementsCount(),
       std::numeric_limits<vector_size_t>::max());
   makeNestedRowSet(activeRows, rows.back());
-  if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
-    keyReader_->readWithTiming(keyReader_->readOffset(), nestedRows_, nullptr);
-    nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
-        nestedRows_.size() == keyReader_->outputRows().size();
-    nestedRows_ = keyReader_->outputRows();
-    if (!nestedRows_.empty()) {
+
+  if (extractionType == velox::common::ScanSpec::ExtractionType::kSize) {
+    // Size extraction: only need offsets/sizes, skip both key and value
+    // streams.  Advance children past the nested rows without reading.
+    if (keyReader_ && !nestedRows_.empty()) {
+      keyReader_->seekTo(
+          keyReader_->readOffset() + nestedRows_.back() + 1, false);
+    }
+    if (elementReader_ && !nestedRows_.empty()) {
+      elementReader_->seekTo(
+          elementReader_->readOffset() + nestedRows_.back() + 1, false);
+    }
+  } else if (extractionType == velox::common::ScanSpec::ExtractionType::kKeys) {
+    // Keys extraction: read only keys, skip values.
+    if (keyReader_ && !nestedRows_.empty()) {
+      keyReader_->readWithTiming(
+          keyReader_->readOffset(), nestedRows_, nullptr);
+      nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
+          nestedRows_.size() == keyReader_->outputRows().size();
+      nestedRows_ = keyReader_->outputRows();
+    }
+    if (elementReader_ && !nestedRows_.empty()) {
+      elementReader_->seekTo(
+          elementReader_->readOffset() + nestedRows_.back() + 1, false);
+    }
+  } else if (
+      extractionType == velox::common::ScanSpec::ExtractionType::kValues) {
+    // Values extraction: read only values, skip keys.
+    if (keyReader_ && !nestedRows_.empty()) {
+      keyReader_->seekTo(
+          keyReader_->readOffset() + nestedRows_.back() + 1, false);
+    }
+    if (elementReader_ && !nestedRows_.empty()) {
       elementReader_->readWithTiming(
           elementReader_->readOffset(), nestedRows_, nullptr);
       nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
           nestedRows_.size() == elementReader_->outputRows().size();
       nestedRows_ = elementReader_->outputRows();
+    }
+  } else {
+    // Normal read: read both keys and values.
+    VELOX_CHECK_EQ(
+        static_cast<int>(extractionType),
+        static_cast<int>(velox::common::ScanSpec::ExtractionType::kNone));
+    if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
+      keyReader_->readWithTiming(
+          keyReader_->readOffset(), nestedRows_, nullptr);
+      nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
+          nestedRows_.size() == keyReader_->outputRows().size();
+      nestedRows_ = keyReader_->outputRows();
+      if (!nestedRows_.empty()) {
+        elementReader_->readWithTiming(
+            elementReader_->readOffset(), nestedRows_, nullptr);
+        nestedRowsAllSelected_ = nestedRowsAllSelected_ &&
+            nestedRows_.size() == elementReader_->outputRows().size();
+        nestedRows_ = elementReader_->outputRows();
+      }
     }
   }
   numValues_ = activeRows.size();
@@ -362,14 +472,84 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
   scanSpec_->children()[1]->setProjectOut(true);
 }
 
+void SelectiveMapColumnReaderBase::getExtractionValues(
+    const RowSet& rows,
+    VectorPtr* result) {
+  VELOX_DCHECK_NOT_NULL(result);
+  const auto extractionType = scanSpec_->extractionType();
+  VELOX_DCHECK_NE(
+      static_cast<int>(extractionType),
+      static_cast<int>(velox::common::ScanSpec::ExtractionType::kNone));
+
+  // When deltaUpdate is set, treat extractionType as kNone so the reader
+  // produces the full map.  The extraction transform is applied after
+  // the delta update.
+  if (extractionType == velox::common::ScanSpec::ExtractionType::kSize &&
+      !scanSpec_->deltaUpdate()) {
+    getExtractionSizeValues(rows, result);
+    return;
+  }
+
+  // kKeys or kValues: compute offsets/sizes via a reusable MapVector,
+  // then read elements and construct the output ArrayVector.
+  prepareResult(
+      extractionOffsetsTemp_,
+      requestedType_,
+      static_cast<vector_size_t>(rows.size()),
+      pool_);
+  auto* tempMap = extractionOffsetsTemp_->asUnchecked<MapVector>();
+  makeOffsetsAndSizes(rows, *tempMap);
+  setComplexNulls(rows, extractionOffsetsTemp_);
+
+  // Extract elements from the existing result to reuse across batches.
+  VectorPtr elements;
+  if (*result && result->get()->encoding() == VectorEncoding::Simple::ARRAY) {
+    elements = result->get()->asUnchecked<ArrayVector>()->elements();
+  }
+  if (extractionType == velox::common::ScanSpec::ExtractionType::kKeys) {
+    if (!nestedRows_.empty()) {
+      keyReader_->getValues(nestedRows_, &elements);
+    }
+  } else {
+    if (!nestedRows_.empty()) {
+      prepareStructResult(requestedType_->childAt(1), &elements);
+      elementReader_->getValues(nestedRows_, &elements);
+    }
+  }
+  auto elemType = elements
+      ? elements->type()
+      : requestedType_->childAt(
+            extractionType == velox::common::ScanSpec::ExtractionType::kKeys
+                ? 0
+                : 1);
+  *result = std::make_shared<ArrayVector>(
+      pool_,
+      ARRAY(elemType),
+      tempMap->nulls(),
+      rows.size(),
+      tempMap->offsets(),
+      tempMap->sizes(),
+      elements);
+}
+
 void SelectiveMapColumnReader::getValues(
     const RowSet& rows,
     VectorPtr* result) {
   VELOX_DCHECK_NOT_NULL(result);
-  VELOX_CHECK(
-      !result->get() || result->get()->type()->isMap(),
-      "Expect MAP result vector, got {}",
-      result->get()->type()->toString());
+  const auto extractionType = scanSpec_->extractionType();
+
+  // When deltaUpdate is set, treat extractionType as kNone so the reader
+  // produces the full map.  The extraction transform is applied after
+  // the delta update.
+  if (extractionType != velox::common::ScanSpec::ExtractionType::kNone &&
+      !scanSpec_->deltaUpdate()) {
+    getExtractionValues(rows, result);
+    return;
+  }
+
+  // Normal path: produce MapVector.  If the result has a non-MAP type
+  // (e.g., from a previous extraction transform), prepareResult will
+  // replace it with a fresh MapVector.
   prepareResult(*result, requestedType_, rows.size(), pool_);
   auto* resultMap = result->get()->asUnchecked<MapVector>();
   makeOffsetsAndSizes(rows, *resultMap);
@@ -393,6 +573,10 @@ SelectiveMapAsStructColumnReader::SelectiveMapAsStructColumnReader(
     ScanSpec& scanSpec)
     : SelectiveMapColumnReaderBase(requestedType, params, scanSpec, fileType) {
   VELOX_CHECK(scanSpec_->isFlatMapAsStruct() && requestedType_->isMap());
+  VELOX_CHECK_EQ(
+      static_cast<int>(scanSpec.extractionType()),
+      static_cast<int>(velox::common::ScanSpec::ExtractionType::kNone),
+      "Flat map as struct reader does not support extraction pushdown");
   mapScanSpec_.addMapKeyFieldRecursively(*requestedType_->childAt(0));
   mapScanSpec_.addMapValueFieldRecursively(*requestedType_->childAt(1));
   column_index_t maxChannel = 0;

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -85,6 +85,10 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
     return i;
   }
 
+  /// Produce a FlatVector<int64_t> of sizes directly from allLengths_ for
+  /// kSize extraction.  Reuses the result vector across batches.
+  void getExtractionSizeValues(const RowSet& rows, VectorPtr* result);
+
   void ensureAllLengthsBuffer(vector_size_t size);
 
   BufferPtr allLengthsHolder_;
@@ -112,7 +116,9 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
       velox::common::ScanSpec& scanSpec);
 
   void resetFilterCaches() override {
-    child_->resetFilterCaches();
+    if (child_) {
+      child_->resetFilterCaches();
+    }
   }
 
   uint64_t skip(uint64_t numValues) override;
@@ -133,8 +139,12 @@ class SelectiveMapColumnReaderBase : public SelectiveRepeatedColumnReader {
   using SelectiveRepeatedColumnReader::SelectiveRepeatedColumnReader;
 
   void resetFilterCaches() override {
-    keyReader_->resetFilterCaches();
-    elementReader_->resetFilterCaches();
+    if (keyReader_) {
+      keyReader_->resetFilterCaches();
+    }
+    if (elementReader_) {
+      elementReader_->resetFilterCaches();
+    }
   }
 
   uint64_t skip(uint64_t numValues) override;
@@ -144,16 +154,27 @@ class SelectiveMapColumnReaderBase : public SelectiveRepeatedColumnReader {
 
   void seekToRowGroup(int64_t index) override {
     SelectiveRepeatedColumnReader::seekToRowGroup(index);
-    keyReader_->seekToRowGroup(index);
-    keyReader_->setReadOffsetRecursive(0);
-    elementReader_->seekToRowGroup(index);
-    elementReader_->setReadOffsetRecursive(0);
+    if (keyReader_) {
+      keyReader_->seekToRowGroup(index);
+      keyReader_->setReadOffsetRecursive(0);
+    }
+    if (elementReader_) {
+      elementReader_->seekToRowGroup(index);
+      elementReader_->setReadOffsetRecursive(0);
+    }
     childTargetReadOffset_ = 0;
   }
 
  protected:
+  /// Handle extraction types (kSize, kKeys, kValues) in getValues.
+  void getExtractionValues(const RowSet& rows, VectorPtr* result);
+
   std::unique_ptr<SelectiveColumnReader> keyReader_;
   std::unique_ptr<SelectiveColumnReader> elementReader_;
+
+  // Reusable MapVector for computing offsets/sizes in kKeys/kValues extraction.
+  // Not needed for kSize (sizes computed directly from allLengths_).
+  VectorPtr extractionOffsetsTemp_;
 };
 
 class SelectiveMapColumnReader : public SelectiveMapColumnReaderBase {

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -451,7 +451,7 @@ void SelectiveStructColumnReaderBase::read(
     auto* reader = children_.at(fieldIndex);
     if (reader->isTopLevel() && childSpec->projectOut() &&
         !childSpec->hasFilter() && generateLazyChildren_) {
-      // Will make a LazyVector.
+      // Will make a LazyVector (with or without transform).
       continue;
     }
 
@@ -531,6 +531,16 @@ bool SelectiveStructColumnReaderBase::isChildMissing(
 
 std::unique_ptr<velox::dwio::common::ColumnLoader>
 SelectiveStructColumnReaderBase::makeColumnLoader(vector_size_t index) {
+  // Check if the child at this index has a transform with kNone extraction.
+  // If so, return a TransformColumnLoader to apply the transform lazily.
+  for (const auto& childSpec : scanSpec_->children()) {
+    if (childSpec->subscript() == index && childSpec->hasTransform() &&
+        childSpec->extractionType() ==
+            velox::common::ScanSpec::ExtractionType::kNone) {
+      return std::make_unique<velox::dwio::common::TransformColumnLoader>(
+          this, children_[index], numReads_, childSpec->transform());
+    }
+  }
   return std::make_unique<velox::dwio::common::ColumnLoader>(
       this, children_[index], numReads_);
 }
@@ -541,6 +551,37 @@ void SelectiveStructColumnReaderBase::getValues(
   VELOX_CHECK(!scanSpec_->children().empty());
   VELOX_CHECK_NOT_NULL(
       *result, "SelectiveStructColumnReaderBase expects a non-null result");
+
+  // When deltaUpdate is set, skip kField extraction so the reader produces
+  // the full struct.  The extraction transform is applied after the delta
+  // update.
+  if (!isRoot_ &&
+      scanSpec_->extractionType() ==
+          velox::common::ScanSpec::ExtractionType::kField &&
+      !scanSpec_->deltaUpdate()) {
+    auto fieldIdx = scanSpec_->extractionFieldIndex();
+    for (const auto& childSpec : scanSpec_->children()) {
+      if (childSpec->channel() == fieldIdx && !childSpec->isConstant()) {
+        auto index = static_cast<vector_size_t>(childSpec->subscript());
+        if (childSpec->hasFilter() || !children_[index]->isTopLevel() ||
+            !generateLazyChildren_) {
+          children_[index]->getValues(rows, result);
+        } else {
+          // Lazy loading: create a LazyVector for the extracted field.
+          setOutputRowsForLazy(rows);
+          setLazyField(
+              makeColumnLoader(index),
+              children_[index]->requestedType(),
+              static_cast<vector_size_t>(rows.size()),
+              pool_,
+              *result);
+        }
+        return;
+      }
+    }
+    VELOX_UNREACHABLE();
+  }
+
   VELOX_CHECK(
       result->get()->type()->isRow(),
       "Struct reader expects a result of type ROW.");
@@ -580,6 +621,15 @@ void SelectiveStructColumnReaderBase::getValues(
             pool_,
             childResult);
       }
+      // If the column also has an extraction transform (e.g., MapKeys on a
+      // MAP_CONCAT delta-updated column), apply it after the delta update.
+      // The delta update modifies the column (e.g., MAP_CONCAT adds entries),
+      // and extraction should see the updated data.
+      if (childSpec->hasTransform() && childResult) {
+        // Force-load lazy vectors so the transform can process them.
+        childResult = BaseVector::loadedVectorShared(childResult);
+        childResult = childSpec->transform()(childResult, pool_);
+      }
       continue;
     }
 
@@ -618,13 +668,16 @@ void SelectiveStructColumnReaderBase::getValues(
 
     // LazyVector result.
     setOutputRowsForLazy(rows);
+    // When the child has a transform (e.g., extraction pushdown), the lazy
+    // vector type is the transform's output type, not the file column type.
+    auto lazyType =
+        (childSpec->hasTransform() && childSpec->transformOutputType())
+        ? childSpec->transformOutputType()
+        : resultRow->type()->childAt(channel);
     setLazyField(
-        makeColumnLoader(index),
-        resultRow->type()->childAt(channel),
-        rows.size(),
-        pool_,
-        childResult);
+        makeColumnLoader(index), lazyType, rows.size(), pool_, childResult);
   }
+
   resultRow->updateContainsLazyNotLoaded();
 }
 


### PR DESCRIPTION
Summary:

Add getExtractionSizeValues() and getExtractionValues() to map/list
readers.  Add kField handling in struct reader (direct child getValues
with lazy loading support).  Add TransformColumnLoader for mixed
multi-extraction lazy path.  Add text reader transform support in
RowReader::projectColumns().  Reader checks deltaUpdate() to bypass
extraction when delta updates are active.

Reviewed By: maniloya

Differential Revision: D97671736


