### PR TITLE
test(exec): Guard operator blocking stats collection with TSAN atomic

### DIFF
--- a/velox/common/base/Portability.h
+++ b/velox/common/base/Portability.h
@@ -20,7 +20,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <mutex>
-#include <vector>
 
 inline size_t count_trailing_zeros(uint64_t x) {
   return x == 0 ? 64 : __builtin_ctzll(x);
@@ -89,15 +88,4 @@ using tsan_lock_guard = TsanEmptyLockGuard<T>;
 
 #endif
 
-template <typename T>
-inline void resizeTsanAtomic(
-    std::vector<tsan_atomic<T>>& vector,
-    int32_t newSize) {
-  std::vector<tsan_atomic<T>> newVector(newSize);
-  auto numCopy = std::min<int32_t>(newSize, vector.size());
-  for (auto i = 0; i < numCopy; ++i) {
-    newVector[i] = tsanAtomicValue(vector[i]);
-  }
-  vector = std::move(newVector);
-}
 } // namespace facebook::velox

--- a/velox/common/caching/SsdFileTracker.h
+++ b/velox/common/caching/SsdFileTracker.h
@@ -30,7 +30,12 @@ namespace facebook::velox::cache {
 class SsdFileTracker {
  public:
   void resize(int32_t numRegions) {
-    resizeTsanAtomic(regionScores_, numRegions);
+    std::vector<tsan_atomic<double>> newScores(numRegions);
+    auto numCopy = std::min<int32_t>(numRegions, regionScores_.size());
+    for (auto i = 0; i < numCopy; ++i) {
+      newScores[i] = tsanAtomicValue(regionScores_[i]);
+    }
+    regionScores_ = std::move(newScores);
   }
 
   void regionRead(int32_t region, int32_t bytes) {

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -25,6 +25,7 @@
 #include <folly/portability/SysSyscall.h>
 
 #include "velox/common/base/Counters.h"
+#include "velox/common/base/Portability.h"
 #include "velox/common/base/StatsReporter.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/core/PlanFragment.h"
@@ -104,10 +105,10 @@ struct ThreadState {
   std::atomic<bool> isTerminated{false};
   /// True if there is a future outstanding that will schedule this on an
   /// executor thread when some promise is realized.
-  bool hasBlockingFuture{false};
+  tsan_atomic<bool> hasBlockingFuture{false};
   /// Timestamp in microseconds when the driver became blocked. Used to record
   /// blocked time when the driver is terminated while still blocked.
-  uint64_t blockingStartUs{0};
+  tsan_atomic<uint64_t> blockingStartUs{0};
   /// The number of suspension requests on a on-thread driver. If > 0, this
   /// driver thread is in a (recursive) section waiting for RPC or memory
   /// strategy decision. The thread is not supposed to access its memory, which
@@ -172,8 +173,8 @@ struct ThreadState {
     obj["tid"] = tid.load();
     obj["isTerminated"] = isTerminated.load();
     obj["isEnqueued"] = isEnqueued.load();
-    obj["hasBlockingFuture"] = hasBlockingFuture;
-    obj["blockingStartUs"] = blockingStartUs;
+    obj["hasBlockingFuture"] = tsanAtomicValue(hasBlockingFuture);
+    obj["blockingStartUs"] = tsanAtomicValue(blockingStartUs);
     obj["isSuspended"] = suspended();
     obj["startExecTime"] = startExecTimeMs;
     return obj;
@@ -706,7 +707,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
 
   std::vector<std::unique_ptr<Operator>> operators_; // NOLINT
 
-  BlockingReason blockingReason_{BlockingReason::kNotBlocked};
+  tsan_atomic<BlockingReason> blockingReason_{BlockingReason::kNotBlocked};
 
   // Stores the operator where the driver was last blocked. Note that the driver
   // always resumes at the leaf (consumer) to prioritize getting data out of the


### PR DESCRIPTION
Summary:
Three fields in Driver/ThreadState are accessed from the Task termination thread (via closeByTask → updateOperatorBlockingStats) while written by the driver's execution thread or BlockingState::setResume callback, creating data races when queries are cancelled:

- blockingReason_ (BlockingReason enum): written by runInternal(), read by updateOperatorBlockingStats()
- hasBlockingFuture (bool): written by BlockingState::setResume() callback, read by updateOperatorBlockingStats()
- blockingStartUs (uint64_t): same pattern as hasBlockingFuture

Other ThreadState fields (isEnqueued, isTerminated, thread, tid, numSuspensions) are already std::atomic — these three were missed.

Wrap all three fields in tsan_atomic<T>, which is std::atomic<T> under sanitizer builds and plain T in production — zero runtime cost. Use tsanAtomicValue() in toJson() where folly::dynamic doesn't accept std::atomic<T> directly.

The change to Portability.h and SsdFileTracker.h was due to clang-tidy issues on GCC: see https://github.com/facebookincubator/velox/pull/17201#issuecomment-4256386907 Triggers a clang-tidy error on GCC 14: the C++20 constexpr std::vector destructor eagerly instantiates unique_ptr<Operator>::~unique_ptr() while Operator is still incomplete. Just moved resizeTsanAtomic inline

Suggested review order:
1. Driver.h — ThreadState field types + toJson(), then blockingReason_ type
2. Portability.h — removed <vector> and resizeTsanAtomic()
3. SsdFileTracker.h — inlined resize logic

Differential Revision: D100904528


