### PR TITLE
feat: Add expression.min_rows_for_peeling config to skip peeling for small batches (#17203)

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -1151,6 +1151,17 @@ class QueryConfig {
       false,
       "Disable dictionary peeling optimization in expression evaluation.")
 
+  /// Minimum number of rows in the selectivity vector for peeling to be
+  /// applied during expression evaluation. For small batches, the overhead of
+  /// peeling can outweigh the benefits.
+  VELOX_QUERY_CONFIG(
+      kMinRowsForPeeling,
+      minRowsForPeeling,
+      "expression.min_rows_for_peeling",
+      int32_t,
+      0,
+      "Minimum number of rows to process for peeling optimization in expression evaluation to be active.");
+
   /// Disable optimization in expression evaluation to re-use cached results for
   /// common sub-expressions.
   VELOX_QUERY_CONFIG(

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -512,6 +512,7 @@ class ExecCtx {
           !queryConfig.debugDisableExpressionsWithMemoization() &&
           exprEvalCacheEnabled;
       peelingEnabled = !queryConfig.debugDisableExpressionsWithPeeling();
+      minRowsForPeeling = queryConfig.minRowsForPeeling();
       sharedSubExpressionReuseEnabled =
           !queryConfig.debugDisableCommonSubExpressions();
       deferredLazyLoadingEnabled =
@@ -531,6 +532,9 @@ class ExecCtx {
     bool dictionaryMemoizationEnabled;
     /// True if peeling is enabled during experssion evaluation.
     bool peelingEnabled;
+    /// Minimum number of rows required for peeling to be applied during
+    /// expression evaluation.
+    int32_t minRowsForPeeling;
     /// True if shared subexpression reuse is enabled during experssion
     /// evaluation.
     bool sharedSubExpressionReuseEnabled;

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -168,8 +168,9 @@ TEST_F(QueryConfigTest, expressionEvaluationRelatedConfigs) {
             std::make_shared<core::ExecCtx>(pool.get(), queryCtx.get());
         auto evalCtx = std::make_shared<exec::EvalCtx>(execCtx.get());
 
+        SelectivityVector rows(100, true);
         ASSERT_EQ(
-            evalCtx->peelingEnabled(),
+            evalCtx->peelingEnabled(rows),
             !queryConfig.debugDisableExpressionsWithPeeling());
         ASSERT_EQ(
             evalCtx->sharedSubExpressionReuseEnabled(),
@@ -203,6 +204,24 @@ TEST_F(QueryConfigTest, expressionEvaluationRelatedConfigs) {
   testConfig(createConfig(false, true, false, false));
   testConfig(createConfig(false, false, true, false));
   testConfig(createConfig(false, false, false, true));
+
+  // Verify minRowsForPeeling: peeling is suppressed when the number of
+  // selected rows is below the threshold.
+  {
+    auto queryCtx = core::QueryCtx::create(
+        nullptr, QueryConfig({{core::QueryConfig::kMinRowsForPeeling, "50"}}));
+    auto execCtx = std::make_shared<core::ExecCtx>(pool.get(), queryCtx.get());
+    auto evalCtx = std::make_shared<exec::EvalCtx>(execCtx.get());
+
+    SelectivityVector belowThreshold(30, true);
+    ASSERT_FALSE(evalCtx->peelingEnabled(belowThreshold));
+
+    SelectivityVector atThreshold(50, true);
+    ASSERT_TRUE(evalCtx->peelingEnabled(atThreshold));
+
+    SelectivityVector aboveThreshold(100, true);
+    ASSERT_TRUE(evalCtx->peelingEnabled(aboveThreshold));
+  }
 }
 
 TEST_F(QueryConfigTest, sessionStartTime) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -589,9 +589,16 @@ class EvalCtx {
     return execCtx_->optimizationParams().maxSharedSubexprResultsCached;
   }
 
-  /// Returns true if peeling is enabled.
-  bool peelingEnabled() const {
-    return execCtx_->optimizationParams().peelingEnabled;
+  /// Returns true if peeling is enabled for the given rows. Peeling is
+  /// disabled globally via OptimizationParams::peelingEnabled, or suppressed
+  /// for small batches when the number of selected rows is below
+  /// OptimizationParams::minRowsForPeeling, since for small batches the cost
+  /// of wrapping inputs in dictionary vectors and materializing them outweighs
+  /// the benefit of peeling.
+  bool peelingEnabled(const SelectivityVector& rows) const {
+    const auto& params = execCtx_->optimizationParams();
+    return params.peelingEnabled &&
+        rows.countSelected() >= params.minRowsForPeeling;
   }
 
   /// Returns true if shared subexpression reuse is enabled.

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1101,7 +1101,7 @@ void Expr::evalEncodings(
     EvalCtx& context,
     VectorPtr& result) {
   if (deterministic_ && !skipFieldDependentOptimizations() &&
-      context.peelingEnabled()) {
+      context.peelingEnabled(rows)) {
     bool hasFlat = false;
     for (auto* field : distinctFields_) {
       if (isFlat(*context.getField(field->index(context)))) {
@@ -1535,15 +1535,39 @@ bool Expr::applyFunctionWithPeeling(
     VectorPtr& result) {
   LocalDecodedVector localDecoded(context);
   LocalSelectivityVector newRowsHolder(context);
-  if (!context.peelingEnabled()) {
-    if (distinctFields_.size() < 2) {
-      // If we have a single input, velox needs to ensure that the
-      // vectorFunction would receive a flat or constant input.
-      for (int i = 0; i < inputValues_.size(); ++i) {
-        if (inputValues_[i]->encoding() == VectorEncoding::Simple::DICTIONARY) {
-          BaseVector::flattenVector(inputValues_[i]);
+  // When peeling was always enabled, VectorFunctions would implicitly always
+  // receive flat or constant inputs. Now that peeling can be suppressed for
+  // small batches, we must preserve that guarantee for three cases:
+  //
+  // 1. Single constant input (e.g. map_from_entries({null, ...}),
+  //    array_sort(constant_array)): fall through to the peeling path since
+  //    constant peeling is cheap.
+  //
+  // 2. Single dictionary-encoded argument: flatten the dictionary before
+  //    calling applyFunction.
+  //
+  // 3. Single dictionary-encoded argument with all other arguments being
+  //    constants (e.g. in-predicate: dict_wrap(c0) in (40, 42)): flatten the
+  //    dictionary — the constants pass through unchanged.
+  if (!context.peelingEnabled(applyRows) &&
+      !(inputValues_.size() == 1 &&
+        inputValues_[0]->encoding() == VectorEncoding::Simple::CONSTANT)) {
+    int dictIndex = -1;
+    bool canFlatten = true;
+
+    for (int i = 0; i < inputValues_.size(); ++i) {
+      auto encoding = inputValues_[i]->encoding();
+      if (encoding == VectorEncoding::Simple::DICTIONARY) {
+        if (dictIndex != -1) {
+          // More than one dictionary-encoded input.
+          canFlatten = false;
+          break;
         }
+        dictIndex = i;
       }
+    }
+    if (canFlatten && dictIndex != -1) {
+      BaseVector::flattenVector(inputValues_[dictIndex]);
       applyFunction(applyRows, context, result);
       return true;
     }

--- a/velox/expression/fuzzer/CMakeLists.txt
+++ b/velox/expression/fuzzer/CMakeLists.txt
@@ -69,6 +69,7 @@ add_executable(velox_expression_fuzzer_test ExpressionFuzzerTest.cpp)
 target_link_libraries(
   velox_expression_fuzzer_test
   velox_expression_fuzzer
+  velox_core
   velox_functions_prestosql
   velox_fuzzer_util
   velox_hive_connector

--- a/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerTest.cpp
@@ -17,6 +17,7 @@
 #include <folly/init/Init.h>
 #include <unordered_set>
 
+#include "velox/core/QueryConfig.h"
 #include "velox/exec/fuzzer/PrestoQueryRunner.h"
 #include "velox/expression/fuzzer/ArgTypesGenerator.h"
 #include "velox/expression/fuzzer/ArgValuesGenerators.h"
@@ -543,8 +544,10 @@ int main(int argc, char** argv) {
       initialSeed,
       skipFunctions,
       exprTransformers,
-      {{"session_timezone", "America/Los_Angeles"},
-       {"adjust_timestamp_to_session_timezone", "true"}},
+      {{facebook::velox::core::QueryConfig::kSessionTimezone,
+        "America/Los_Angeles"},
+       {facebook::velox::core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+       {facebook::velox::core::QueryConfig::kMinRowsForPeeling, "50"}},
       argTypesGenerators,
       argValuesGenerators,
       referenceQueryRunner,

--- a/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
+++ b/velox/expression/fuzzer/ExpressionFuzzerVerifier.cpp
@@ -177,7 +177,19 @@ ExpressionFuzzerVerifier::generateInput(
 
     // Finally create the input row.
     RowVectorPtr rowVector = vectorMaker.rowVector(names, children);
-    inputs.push_back({rowVector, SelectivityVector(vecSize)});
+    // Randomly deselect rows to exercise code paths that depend on the
+    // number of selected rows, such as the minRowsForPeeling threshold
+    // that suppresses expression peeling for small batches.
+    SelectivityVector activeRows(vecSize);
+    if (vectorFuzzer.coinToss(0.3)) {
+      for (vector_size_t i = 0; i < vecSize; ++i) {
+        if (vectorFuzzer.coinToss(0.5)) {
+          activeRows.setValid(i, false);
+        }
+      }
+      activeRows.updateBounds();
+    }
+    inputs.push_back({rowVector, activeRows});
   }
   // Return the input rows and the metadata.
   return {inputs, metadata};
@@ -329,7 +341,11 @@ void ExpressionFuzzerVerifier::retryWithTry(
     }
     // Re-evaluate the original expression on rows that didn't produce an
     // error (i.e. returned non-NULL results when evaluated with TRY).
-    inputsToRetry[i].activeRows = extractNonNullRows(tryResult.result);
+    // Intersect with the original activeRows to avoid including rows that
+    // were never evaluated (whose result values are uninitialized).
+    auto nonNullRows = extractNonNullRows(tryResult.result);
+    nonNullRows.intersect(inputsToRetry[i].activeRows);
+    inputsToRetry[i].activeRows = nonNullRows;
     if (inputsToRetry[i].activeRows.hasSelections()) {
       inputsToRetryWithoutErrors.push_back(std::move(inputsToRetry[i]));
     }

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -426,13 +426,27 @@ class ExprTest : public testing::Test, public VectorTestBase {
   parse::ParseOptions options_;
 };
 
-class ParameterizedExprTest : public ExprTest,
-                              public testing::WithParamInterface<bool> {
+struct ExprTestParams {
+  bool cacheEnabled;
+  int32_t minRowsForPeeling;
+
+  friend std::ostream& operator<<(std::ostream& os, const ExprTestParams& p) {
+    return os << "cacheEnabled=" << p.cacheEnabled
+              << ", minRowsForPeeling=" << p.minRowsForPeeling;
+  }
+};
+
+class ParameterizedExprTest
+    : public ExprTest,
+      public testing::WithParamInterface<ExprTestParams> {
  public:
   ParameterizedExprTest() {
+    const auto& params = GetParam();
     std::unordered_map<std::string, std::string> configData(
         {{core::QueryConfig::kEnableExpressionEvaluationCache,
-          GetParam() ? "true" : "false"}});
+          params.cacheEnabled ? "true" : "false"},
+         {core::QueryConfig::kMinRowsForPeeling,
+          std::to_string(params.minRowsForPeeling)}});
     queryCtx_ = velox::core::QueryCtx::create(
         nullptr, core::QueryConfig(std::move(configData)));
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
@@ -458,7 +472,13 @@ TEST_P(ParameterizedExprTest, moreEncodings) {
 
   auto result =
       evaluate("if(c1 = 'grapes', c0 + 10, c0)", makeRowVector({a, b}));
-  ASSERT_EQ(VectorEncoding::Simple::DICTIONARY, result->encoding());
+  // When peeling is active, the result is wrapped back in the original
+  // dictionary encoding. When peeling is suppressed (minRowsForPeeling >
+  // number of rows), the result is flat.
+  auto expectedOutputEncoding = GetParam().minRowsForPeeling <= size / 2
+      ? VectorEncoding::Simple::DICTIONARY
+      : VectorEncoding::Simple::FLAT;
+  ASSERT_EQ(expectedOutputEncoding, result->encoding());
   ASSERT_EQ(size / 2, result->size());
 
   auto expected = makeFlatVector<int64_t>(size / 2, [&fruits](auto row) {
@@ -1962,7 +1982,42 @@ class TestingSingleArgDeterministicFunction : public exec::VectorFunction {
   }
 };
 
+// Single-argument deterministic function that takes an array and asserts it
+// receives a flat-encoded (ARRAY) or constant-encoded input. Used to verify
+// that constant peeling continues to work when peeling is disabled.
+class TestingSingleArgArrayFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    auto& arg = args[0];
+    VELOX_CHECK(
+        arg->encoding() == VectorEncoding::Simple::ARRAY ||
+            arg->encoding() == VectorEncoding::Simple::CONSTANT,
+        "Expected ARRAY or CONSTANT encoding, got {}",
+        arg->encoding());
+    BaseVector::ensureWritable(rows, outputType, context.pool(), result);
+    result->copy(arg.get(), rows, nullptr);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .typeVariable("T")
+                .returnType("array(T)")
+                .argumentType("array(T)")
+                .build()};
+  }
+};
+
 } // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_testing_single_arg_array,
+    TestingSingleArgArrayFunction::signatures(),
+    std::make_unique<TestingSingleArgArrayFunction>());
 
 VELOX_DECLARE_VECTOR_FUNCTION_WITH_METADATA(
     udf_testing_constant,
@@ -5050,7 +5105,12 @@ TEST_P(ParameterizedExprTest, evaluatesArgumentsOnNonIncreasingSelection) {
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ExprTest,
     ParameterizedExprTest,
-    testing::ValuesIn({false, true}));
+    testing::ValuesIn(
+        std::vector<ExprTestParams>{
+            {false, 0},
+            {false, 2000},
+            {true, 0},
+            {true, 2000}}));
 
 TEST_F(ExprTest, disablePeeling) {
   // Verify that peeling is disabled when the config is set by checking whether
@@ -5119,6 +5179,18 @@ TEST_F(ExprTest, disablePeeling) {
   ASSERT_NO_THROW(evaluateMultiple(
       {"dict_wrap(c0) in (40, 42)"},
       makeRowVector({flatInput}),
+      {},
+      execCtx.get()));
+
+  // Ensure functions that receive a single constant-encoded complex input
+  // continue to peel even when peeling is disabled.
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_testing_single_arg_array, "testing_single_arg_array");
+  auto constantArray = BaseVector::wrapInConstant(
+      dictSize, 0, makeArrayVector<int64_t>({{1, 2, 3}}));
+  ASSERT_NO_THROW(evaluateMultiple(
+      {"testing_single_arg_array(c0)"},
+      makeRowVector({constantArray}),
       {},
       execCtx.get()));
 }

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -169,21 +169,6 @@ RowVectorPtr replicateCommonDictionaryLayer(
       children);
 }
 
-// Applies modifications to the input test cases based on the input row
-// metadata, which includes making sure specific columns are wrapped in common
-// dictionary and/or wrapped in a lazy shim layer.
-void applyModificationsToInput(
-    std::vector<fuzzer::InputTestCase>& inputTestCases,
-    const InputRowMetadata& inputRowMetadata) {
-  for (auto& testCase : inputTestCases) {
-    auto& inputVector = testCase.inputVector;
-    inputVector = replicateCommonDictionaryLayer(
-        inputVector, inputRowMetadata.columnsToWrapInCommonDictionary);
-    inputVector = VectorFuzzer::fuzzRowChildrenToLazy(
-        inputVector, inputRowMetadata.columnsToWrapInLazy);
-  }
-}
-
 void ExpressionRunner::run(
     const std::string& inputPaths,
     const std::string& inputSelectivityVectorPaths,
@@ -199,7 +184,14 @@ void ExpressionRunner::run(
     bool useSeperatePoolForInput) {
   VELOX_CHECK(!sql.empty());
   auto memoryManager = memory::memoryManager();
-  auto queryCtx = core::QueryCtx::create();
+  auto queryCtx = core::QueryCtx::create(
+      nullptr,
+      core::QueryConfig(
+          {{facebook::velox::core::QueryConfig::kSessionTimezone,
+            "America/Los_Angeles"},
+           {facebook::velox::core::QueryConfig::kAdjustTimestampToTimezone,
+            "true"},
+           {facebook::velox::core::QueryConfig::kMinRowsForPeeling, "50"}}));
   std::shared_ptr<memory::MemoryPool> deserializerPool{
       memoryManager->addLeafPool()};
   std::shared_ptr<memory::MemoryPool> pool = useSeperatePoolForInput
@@ -236,7 +228,10 @@ void ExpressionRunner::run(
           "Input vector is not a RowVector: {}",
           vector->toString());
       VELOX_CHECK_GT(inputVector->size(), 0, "Input vector must not be empty.");
-      if (inputSelectivityPaths.size() > i) {
+      inputVector = replicateCommonDictionaryLayer(
+          inputVector, inputRowMetadata.columnsToWrapInCommonDictionary);
+      if (inputSelectivityPaths.size() > i &&
+          !inputSelectivityPaths[i].empty()) {
         inputTestCases.push_back(
             {inputVector,
              restoreSelectivityVectorFromFile(
@@ -246,7 +241,6 @@ void ExpressionRunner::run(
             {inputVector, SelectivityVector(inputVector->size(), true)});
       }
     }
-    applyModificationsToInput(inputTestCases, inputRowMetadata);
   }
 
   VELOX_CHECK(inputTestCases.size() > 0);
@@ -318,6 +312,11 @@ void ExpressionRunner::run(
     }
 
   } else if (mode == "common" || mode == "simplified") {
+    for (auto& testCase : inputTestCases) {
+      auto& inputVector = testCase.inputVector;
+      inputVector = VectorFuzzer::fuzzRowChildrenToLazy(
+          inputVector, inputRowMetadata.columnsToWrapInLazy);
+    }
     std::shared_ptr<exec::ExprSet> exprSet = mode == "common"
         ? std::make_shared<exec::ExprSet>(typedExprs, &execCtx)
         : std::make_shared<exec::ExprSetSimplified>(typedExprs, &execCtx);


### PR DESCRIPTION
Summary:

For small batches, peeling dictionary encoding from inputs before calling vector functions can create more overhead than it saves. This diff adds a configurable `expression.min_rows_for_peeling` threshold (default: 0) that suppresses peeling when the number of selected rows (to process) falls below it.

When peeling is suppressed, some VectorFunctions still expect flat or constant inputs. To preserve this guarantee:
- A single constant-encoded input continues to be peeled (cheap and required since some UDFs have started to rely on this expectation. Running the fuzzer exposed this gap)
- A single dictionary-encoded input (possibly alongside constant inputs, e.g. in-predicate) is flattened before evaluation.

Added fuzzer coverage:
Extended the expression fuzzer to exercise partial selectivity by randomly deselecting rows. Set the peeling threshold to 25 (1/4 of the default batch size). Both these now allow us to exercise the functionality exposed via the new expression.min_rows_for_peeling config.

Additional fixes to fuzzer:
- Fixed retryWithTry to avoid evaluating uninitialized rows.
- Fixed a bug in ExpressionRunner where the query config diverged from the one used in fuzzer tests.
- Fixed inputs being double-wrapped in lazy vectors when using verify mode in ExpressionRunner.
- Fixed ExpressionRunner failing to load a repro when no selectivity vector files were provided.

Unit tests
Extended existing tests in ExprTest to exercise with peeling enabled and disabled.

Additional Context:
Single-arg VectorFunctions are expected to receive only flat or constant inputs. Fuzz testing revealed latent bugs in several UDFs: some had constant-input optimizations that mishandled errors under TRY (e.g. reporting the error only for the representative row instead of all selected rows), and others assumed constant-encoded complex types would always be peeled, so they asserted flat encoding unconditionally. These bugs were masked because peeling always ran for constant-encoded inputs. To keep this change low risk, the constant-peeling guarantee is preserved explicitly in the disabled-peeling path for single-arg functions.

Reviewed By: Yuhta

Differential Revision: D101074993


