### PR TITLE
fix: Minify get_json_object object|array result align with spark

### DIFF
--- a/velox/functions/sparksql/GetJsonObject.h
+++ b/velox/functions/sparksql/GetJsonObject.h
@@ -18,6 +18,8 @@
 
 #include <folly/Likely.h>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #include "velox/core/QueryConfig.h"
 #include "velox/functions/Macros.h"
@@ -247,7 +249,6 @@ struct GetJsonObjectFunction {
   bool extractStringResult(
       simdjson::simdjson_result<simdjson::ondemand::value> rawResult,
       out_type<Varchar>& result) {
-    std::stringstream ss;
     switch (rawResult.type()) {
       // For number and bool types, we need to explicitly get the value
       // for specific types instead of using `ss << rawResult`. Thus, we
@@ -296,11 +297,26 @@ struct GetJsonObjectFunction {
         return false;
       }
       // For nested case, e.g., for "{"my": {"hello": 10}}",
-      // "$.my" will return an object type.
+      // "$.my" will return an object type. Use simdjson::minify on a padded
+      // copy of the raw sub-JSON so output matches Spark-style compact text
+      // (no insignificant whitespace), without a full DOM parse.
       case simdjson::ondemand::json_type::object:
       case simdjson::ondemand::json_type::array: {
-        ss << rawResult;
-        result.append(ss.str());
+        std::string_view slice;
+        if (simdjson::to_json_string(rawResult).get(slice)) {
+          return false;
+        }
+        simdjson::padded_string padded(slice.data(), slice.size());
+        std::string minified;
+        minified.resize(padded.size());
+        size_t dstLen = 0;
+        if (simdjson::minify(
+                padded.data(), padded.size(), minified.data(), dstLen) !=
+            simdjson::SUCCESS) {
+          return false;
+        }
+        minified.resize(dstLen);
+        result.append(minified);
         return true;
       }
       default:

--- a/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
+++ b/velox/functions/sparksql/tests/GetJsonObjectTest.cpp
@@ -91,24 +91,24 @@ TEST_F(GetJsonObjectTest, basic) {
       getJsonObject(R"({"my": {"hello": true}})", "$.my.  hello"), "true");
   EXPECT_EQ(getJsonObject(R"({"a$ ": {"b": 10}})", "$.a$ .b"), "10");
   EXPECT_EQ(getJsonObject(R"({"a$. b": {"c": 10}})", "$.a$. b"), std::nullopt);
-  // Json object as result.
+  // Json object as result (minified to match Spark-style compact JSON).
   EXPECT_EQ(
       getJsonObject(
           R"({"my": {"info": {"name": "Alice", "age": "5", "id": "001"}}})",
           "$.my.info"),
-      R"({"name": "Alice", "age": "5", "id": "001"})");
+      R"({"name":"Alice","age":"5","id":"001"})");
   EXPECT_EQ(
       getJsonObject(
           R"({"my": {"info": {"name": "Alice", "age": "5", "id": "001"}}})",
           "$['my']['info']"),
-      R"({"name": "Alice", "age": "5", "id": "001"})");
+      R"({"name":"Alice","age":"5","id":"001"})");
 
   // Array as result.
   EXPECT_EQ(
       getJsonObject(
           R"([{"my": {"info": {"name": "Alice"}}}, {"other": ["v1", "v2"]}])",
           "$[1].other"),
-      R"(["v1", "v2"])");
+      R"(["v1","v2"])");
   // Array element as result.
   EXPECT_EQ(
       getJsonObject(
@@ -198,7 +198,7 @@ TEST_F(GetJsonObjectTest, incompleteJson) {
       getJsonObject(
           R"({"my": {"info": {"name": "Alice", "age": "5", "id": "001"}}},)",
           "$['my']['info']"),
-      R"({"name": "Alice", "age": "5", "id": "001"})");
+      R"({"name":"Alice","age":"5","id":"001"})");
 }
 
 TEST_F(GetJsonObjectTest, number) {


### PR DESCRIPTION
For json string
{"aaaaaa":{"bbbbbb":[{"key1": "kkk1","value1": "vvv1"},{"key2": "kkk2","value2": "vvv2"}]}
call get_json_object with json path '$.aaaaaa.bbbbbb'
velox result is:[{"key1": "kkk1","value1": "vvv1"},{"key2": "kkk2","value2": "vvv2"}]
spark result is: [{"key1":"kkk1","value1":"vvv1"},{"key2":"kkk2","value2":"vvv2"}]
In Spark's output, there is no space after the colon,
but in Velox's output, there is a space after the colon.
When subsequent processing of the result from get_json_object is space-sensitive, it will yield different results — for example, when further calculations using regexp_extract are performed.