### PR TITLE
feat(cudf): Add cudaGetLastError on debug mode in CudfOperator.h

### DIFF
--- a/velox/experimental/cudf/exec/CudfOperator.h
+++ b/velox/experimental/cudf/exec/CudfOperator.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/experimental/cudf/CudfConfig.h"
+#include "velox/experimental/cudf/exec/DebugUtil.h"
 #include "velox/experimental/cudf/exec/NvtxHelper.h"
 
 #include "velox/common/base/SpillConfig.h"
@@ -128,24 +129,29 @@ class CudfOperatorBase : public exec::Operator, public NvtxHelper {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kAddInput, className_);
     doAddInput(std::move(input));
+    checkCudaErrorInDebug();
   }
 
   RowVectorPtr getOutput() final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kGetOutput, className_);
-    return doGetOutput();
+    auto result = doGetOutput();
+    checkCudaErrorInDebug();
+    return result;
   }
 
   void noMoreInput() final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kNoMoreInput, className_);
     doNoMoreInput();
+    checkCudaErrorInDebug();
   }
 
   void close() final {
     VELOX_NVTX_OPERATOR_FUNC_RANGE_IF(
         nvtxMethods_ & NvtxMethodFlag::kClose, className_);
     doClose();
+    checkCudaErrorInDebug();
   }
 
  protected:

--- a/velox/experimental/cudf/exec/DebugUtil.h
+++ b/velox/experimental/cudf/exec/DebugUtil.h
@@ -16,11 +16,12 @@
 
 #pragma once
 
-#include <cuda_runtime.h>
-
-#include "velox/common/base/Exceptions.h"
 #include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
+
+#include "velox/common/base/Exceptions.h"
+
+#include <cuda_runtime.h>
 
 namespace facebook::velox::cudf_velox {
 
@@ -29,9 +30,7 @@ inline void checkCudaErrorInDebug() {
   if (CudfConfig::getInstance().debugEnabled) {
     cudaError_t err = cudaGetLastError();
     VELOX_CHECK(
-        err == cudaSuccess,
-        "CUDA error detected: {}",
-        cudaGetErrorString(err));
+        err == cudaSuccess, "CUDA error detected: {}", cudaGetErrorString(err));
   }
 }
 

--- a/velox/experimental/cudf/exec/DebugUtil.h
+++ b/velox/experimental/cudf/exec/DebugUtil.h
@@ -16,9 +16,25 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/experimental/cudf/CudfConfig.h"
 #include "velox/experimental/cudf/vector/CudfVector.h"
 
 namespace facebook::velox::cudf_velox {
+
+/// Helper function to check for CUDA errors in debug mode.
+inline void checkCudaErrorInDebug() {
+  if (CudfConfig::getInstance().debugEnabled) {
+    cudaError_t err = cudaGetLastError();
+    VELOX_CHECK(
+        err == cudaSuccess,
+        "CUDA error detected: {}",
+        cudaGetErrorString(err));
+  }
+}
+
 class DebugUtil {
  public:
   std::string toString(


### PR DESCRIPTION
In debug mode, CUDA errors from GPU operations may go undetected until much later, making them hard to attribute. This adds cudaGetLastError checks at the boundary of each operator method to surface errors as early as possible.