### PR TITLE
feat: Add NULLIF special form

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -72,6 +72,7 @@ void ITypedExpr::registerSerDe() {
   registry.Register("FieldAccessTypedExpr", core::FieldAccessTypedExpr::create);
   registry.Register("InputTypedExpr", core::InputTypedExpr::create);
   registry.Register("LambdaTypedExpr", core::LambdaTypedExpr::create);
+  registry.Register("NullIfTypedExpr", core::NullIfTypedExpr::create);
 }
 
 void InputTypedExpr::accept(
@@ -685,6 +686,65 @@ TypedExprPtr CastTypedExpr::create(const folly::dynamic& obj, void* context) {
 
   return std::make_shared<CastTypedExpr>(
       std::move(type), std::move(inputs), obj["isTryCast"].asBool());
+}
+
+NullIfTypedExpr::NullIfTypedExpr(
+    TypedExprPtr value,
+    TypedExprPtr comparand,
+    TypePtr commonType)
+    : ITypedExpr{ExprKind::kNullIf, value->type(), {std::move(value), std::move(comparand)}},
+      commonType_(std::move(commonType)) {}
+
+TypedExprPtr NullIfTypedExpr::rewriteInputNames(
+    const std::unordered_map<std::string, TypedExprPtr>& mapping) const {
+  auto newInputs = rewriteInputsRecursive(mapping);
+  return std::make_shared<NullIfTypedExpr>(
+      std::move(newInputs[0]), std::move(newInputs[1]), commonType_);
+}
+
+size_t NullIfTypedExpr::localHash() const {
+  static const size_t kBaseHash =
+      folly::hasher<std::string_view>()("NullIfTypedExpr");
+  return bits::hashMix(kBaseHash, commonType_->hashKind());
+}
+
+bool NullIfTypedExpr::operator==(const ITypedExpr& other) const {
+  const auto* otherNullIf = dynamic_cast<const NullIfTypedExpr*>(&other);
+  if (!otherNullIf) {
+    return false;
+  }
+  return *type() == *otherNullIf->type() &&
+      *commonType_ == *otherNullIf->commonType_ &&
+      *inputs()[0] == *otherNullIf->inputs()[0] &&
+      *inputs()[1] == *otherNullIf->inputs()[1];
+}
+
+std::string NullIfTypedExpr::toString() const {
+  return fmt::format(
+      "nullif({}, {})", inputs()[0]->toString(), inputs()[1]->toString());
+}
+
+void NullIfTypedExpr::accept(
+    const ITypedExprVisitor& visitor,
+    ITypedExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+folly::dynamic NullIfTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("NullIfTypedExpr");
+  obj["commonType"] = commonType_->serialize();
+  return obj;
+}
+
+// static
+TypedExprPtr NullIfTypedExpr::create(const folly::dynamic& obj, void* context) {
+  auto type = core::deserializeType(obj, context);
+  auto inputs = deserializeInputs(obj, context);
+  auto commonType = Type::create(obj["commonType"]);
+
+  VELOX_CHECK_EQ(inputs.size(), 2);
+  return std::make_shared<NullIfTypedExpr>(
+      std::move(inputs[0]), std::move(inputs[1]), std::move(commonType));
 }
 
 } // namespace facebook::velox::core

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -610,6 +610,52 @@ class CastTypedExpr : public ITypedExpr {
 
 using CastTypedExprPtr = std::shared_ptr<const CastTypedExpr>;
 
+/// NULLIF(a, b) expression. Returns NULL if a equals b, otherwise returns a.
+///
+/// The comparison uses the common supertype of a and b, but the return type is
+/// a's original type. The common type is stored as metadata and used internally
+/// to cast both inputs for comparison only.
+class NullIfTypedExpr : public ITypedExpr {
+ public:
+  /// @param value The first argument. Its type determines the return type.
+  /// @param comparand The second argument to compare against.
+  /// @param commonType The common supertype used to cast both inputs for
+  /// comparison.
+  NullIfTypedExpr(
+      TypedExprPtr value,
+      TypedExprPtr comparand,
+      TypePtr commonType);
+
+  /// Returns the common supertype used for comparison.
+  const TypePtr& commonType() const {
+    return commonType_;
+  }
+
+  TypedExprPtr rewriteInputNames(
+      const std::unordered_map<std::string, TypedExprPtr>& mapping)
+      const override;
+
+  std::string toString() const override;
+
+  size_t localHash() const override;
+
+  void accept(
+      const ITypedExprVisitor& visitor,
+      ITypedExprVisitorContext& context) const override;
+
+  bool operator==(const ITypedExpr& other) const override;
+
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  // The common supertype used to cast both inputs for comparison.
+  const TypePtr commonType_;
+};
+
+using NullIfTypedExprPtr = std::shared_ptr<const NullIfTypedExpr>;
+
 /// A collection of convenience methods for working with expressions.
 class TypedExprs {
  public:
@@ -682,6 +728,9 @@ class ITypedExprVisitor {
   virtual void visit(const LambdaTypedExpr& expr, ITypedExprVisitorContext& ctx)
       const = 0;
 
+  virtual void visit(const NullIfTypedExpr& expr, ITypedExprVisitorContext& ctx)
+      const = 0;
+
  protected:
   void visitInputs(const ITypedExpr& expr, ITypedExprVisitorContext& ctx)
       const {
@@ -731,6 +780,11 @@ class DefaultTypedExprVisitor : public ITypedExprVisitor {
   }
 
   void visit(const LambdaTypedExpr& expr, ITypedExprVisitorContext& ctx)
+      const override {
+    visitInputs(expr, ctx);
+  }
+
+  void visit(const NullIfTypedExpr& expr, ITypedExprVisitorContext& ctx)
       const override {
     visitInputs(expr, ctx);
   }

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -28,6 +28,7 @@ enum class ExprKind : int32_t {
   kConstant = 6,
   kConcat = 7,
   kLambda = 8,
+  kNullIf = 9,
 };
 
 VELOX_DECLARE_ENUM_NAME(ExprKind);
@@ -99,6 +100,10 @@ class ITypedExpr : public ISerializable {
 
   bool isLambdaKind() const {
     return kind_ == ExprKind::kLambda;
+  }
+
+  bool isNullIfKind() const {
+    return kind_ == ExprKind::kNullIf;
   }
 
   template <typename T>

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -909,6 +909,13 @@ class SummarizeExprVisitor : public ITypedExprVisitor {
     myCtx.expressionCounts()["lambda"]++;
     expr.body()->accept(*this, ctx);
   }
+
+  void visit(const NullIfTypedExpr& expr, ITypedExprVisitorContext& ctx)
+      const override {
+    auto& myCtx = static_cast<Context&>(ctx);
+    myCtx.expressionCounts()["nullif"]++;
+    visitInputs(expr, ctx);
+  }
 };
 
 void appendCounts(

--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -55,6 +55,7 @@ velox_add_library(
   FunctionCallToSpecialForm.cpp
   GenericWriter.cpp
   LambdaExpr.cpp
+  NullIfExpr.cpp
   PeeledEncoding.cpp
   PrestoCastHooks.cpp
   RegisterSpecialForm.cpp
@@ -94,6 +95,7 @@ velox_add_library(
   FunctionCallToSpecialForm.h
   KindToSimpleType.h
   LambdaExpr.h
+  NullIfExpr.h
   PeeledEncoding.h
   PrestoCastHooks.h
   RegisterSpecialForm.h

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -98,14 +98,7 @@ class CastExpr : public SpecialForm {
 
   std::string toSql(std::vector<VectorPtr>*) const override;
 
- private:
-  /// Apply the cast after generating the input vectors
-  /// @param rows The list of rows being processed
-  /// @param input The input vector to be casted
-  /// @param context The context
-  /// @param fromType the input type
-  /// @param toType the target type
-  /// @param result The result vector
+  /// Casts 'input' from 'fromType' to 'toType' for selected 'rows'.
   void apply(
       const SelectivityVector& rows,
       const VectorPtr& input,
@@ -114,6 +107,7 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& result);
 
+ private:
   VectorPtr applyMap(
       const SelectivityVector& rows,
       const MapVector* input,

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -115,6 +115,7 @@ enum class SpecialFormKind : int32_t {
   kTry = 6,
   kAnd = 7,
   kOr = 8,
+  kNullIf = 9,
   kCustom = 999,
 };
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -22,6 +22,7 @@
 #include "velox/expression/ExprUtils.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/LambdaExpr.h"
+#include "velox/expression/NullIfExpr.h"
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
 #include "velox/expression/SpecialFormRegistry.h"
@@ -421,6 +422,15 @@ ExprPtr compileRewrittenExpression(
     case core::ExprKind::kCast: {
       result = compileCast(
           expr, compiledInputs, trackCpuUsage, ctx.queryCtx->queryConfig());
+      break;
+    }
+    case core::ExprKind::kNullIf: {
+      const auto* nullIf = expr->asUnchecked<core::NullIfTypedExpr>();
+      result = NullIfExpr::create(
+          std::move(compiledInputs),
+          nullIf->commonType(),
+          trackCpuUsage,
+          ctx.queryCtx->queryConfig());
       break;
     }
     case core::ExprKind::kCall: {

--- a/velox/expression/ExprConstants.h
+++ b/velox/expression/ExprConstants.h
@@ -26,5 +26,6 @@ inline constexpr const char* kCast = "cast";
 inline constexpr const char* kTryCast = "try_cast";
 inline constexpr const char* kTry = "try";
 inline constexpr const char* kRowConstructor = "row_constructor";
+inline constexpr const char* kNullIf = "nullif";
 
 } // namespace facebook::velox::expression

--- a/velox/expression/NullIfExpr.cpp
+++ b/velox/expression/NullIfExpr.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/NullIfExpr.h"
+#include "velox/expression/ExprConstants.h"
+
+namespace facebook::velox::exec {
+
+NullIfExpr::NullIfExpr(
+    std::vector<ExprPtr>&& inputs,
+    std::shared_ptr<CastExpr> castExpr,
+    bool trackCpuUsage)
+    : SpecialForm(
+          SpecialFormKind::kNullIf,
+          inputs[0]->type(),
+          inputs,
+          expression::kNullIf,
+          /*supportsFlatNoNullsFastPath=*/false,
+          trackCpuUsage),
+      castExpr_(std::move(castExpr)),
+      needsCastA_(
+          castExpr_ && !inputs_[0]->type()->equivalent(*castExpr_->type())),
+      needsCastB_(
+          castExpr_ && !inputs_[1]->type()->equivalent(*castExpr_->type())) {
+  VELOX_CHECK_EQ(inputs_.size(), 2, "NULLIF requires exactly 2 inputs");
+  if (castExpr_ == nullptr) {
+    const auto& a = inputs_[0]->type();
+    const auto& b = inputs_[1]->type();
+    VELOX_CHECK(
+        a->equivalent(*b),
+        "NULLIF inputs must have the same type when castExpr is not provided: {} vs {}",
+        a->toString(),
+        b->toString());
+  }
+}
+
+void NullIfExpr::evalSpecialForm(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  // Evaluate both inputs.
+  VectorPtr aResult;
+  inputs_[0]->eval(rows, context, aResult);
+
+  VectorPtr bResult;
+  inputs_[1]->eval(rows, context, bResult);
+
+  // Cast to common type for comparison if needed.
+  VectorPtr castA;
+  VectorPtr castB;
+  if (needsCastA_) {
+    castExpr_->apply(
+        rows, aResult, context, inputs_[0]->type(), castExpr_->type(), castA);
+  }
+  if (needsCastB_) {
+    castExpr_->apply(
+        rows, bResult, context, inputs_[1]->type(), castExpr_->type(), castB);
+  }
+
+  const auto& compareA = castA ? castA : aResult;
+  const auto& compareB = castB ? castB : bResult;
+
+  // Find rows where a does not equal b. These rows return a's value.
+  // Rows where a equals b return NULL. Rows where either is null are
+  // indeterminate and return a's value (which may itself be null).
+  LocalSelectivityVector nonNullRows(context, rows);
+
+  // TODO: Spark uses kNullAsValue which produces different results for complex
+  // types with nested nulls, e.g. NULLIF(ARRAY[1, NULL], ARRAY[1, NULL]).
+  rows.applyToSelected([&](auto row) {
+    auto equal = compareA->equalValueAt(
+        compareB.get(),
+        row,
+        row,
+        CompareFlags::NullHandlingMode::kNullAsIndeterminate);
+    if (equal.has_value() && equal.value()) {
+      nonNullRows->setValid(row, false);
+    }
+  });
+  nonNullRows->updateBounds();
+
+  if (nonNullRows->isSubset(rows) && rows.isSubset(*nonNullRows)) {
+    // No matches — return a as is.
+    context.moveOrCopyResult(aResult, rows, result);
+    return;
+  }
+
+  if (!nonNullRows->hasSelections()) {
+    // All rows match — return constant null.
+    result = BaseVector::createNullConstant(type(), rows.end(), context.pool());
+    return;
+  }
+
+  // Some rows match — copy only non-null rows from a, set remaining to null.
+  BaseVector::ensureWritable(rows, type(), context.pool(), result);
+  result->copy(aResult.get(), *nonNullRows, /*toSourceRow=*/nullptr);
+
+  LocalSelectivityVector nullRows(context, rows);
+  nullRows->deselect(*nonNullRows);
+  result->addNulls(*nullRows);
+}
+
+// static
+ExprPtr NullIfExpr::create(
+    std::vector<ExprPtr>&& inputs,
+    const TypePtr& commonType,
+    bool trackCpuUsage,
+    const core::QueryConfig& config) {
+  VELOX_USER_CHECK_EQ(
+      inputs.size(),
+      2,
+      "NULLIF requires exactly 2 arguments, received {}.",
+      inputs.size());
+
+  // Create a CastExpr for casting evaluated vectors to commonType. The child
+  // expression passed here is not used — we call apply() directly with
+  // pre-evaluated vectors. We use CastCallToSpecialForm to get proper hooks.
+  std::shared_ptr<CastExpr> castExpr;
+  if (*inputs[0]->type() != *commonType || *inputs[1]->type() != *commonType) {
+    CastCallToSpecialForm castFactory;
+    std::vector<ExprPtr> castInputs = {inputs[0]};
+    castExpr =
+        std::dynamic_pointer_cast<CastExpr>(castFactory.constructSpecialForm(
+            commonType,
+            std::move(castInputs),
+            /*trackCpuUsage=*/false,
+            config));
+  }
+
+  return std::make_shared<NullIfExpr>(
+      std::move(inputs), std::move(castExpr), trackCpuUsage);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/NullIfExpr.h
+++ b/velox/expression/NullIfExpr.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/CastExpr.h"
+#include "velox/expression/SpecialForm.h"
+
+namespace facebook::velox::exec {
+
+/// NULLIF(a, b): returns NULL if a equals b, otherwise returns a.
+///
+/// The comparison casts both inputs to 'commonType' internally. The return type
+/// is a's original type. Evaluates each input exactly once.
+class NullIfExpr : public SpecialForm {
+ public:
+  /// @param inputs Exactly two inputs: the value and the comparand.
+  /// @param castExpr Optional. Used to cast inputs to a common type for
+  /// comparison. Must be provided when input types differ. When null, inputs
+  /// must have the same type and are compared directly.
+  NullIfExpr(
+      std::vector<ExprPtr>&& inputs,
+      std::shared_ptr<CastExpr> castExpr,
+      bool trackCpuUsage);
+
+  /// Creates a NullIfExpr, building a CastExpr with proper hooks when input
+  /// types differ from commonType.
+  static ExprPtr create(
+      std::vector<ExprPtr>&& inputs,
+      const TypePtr& commonType,
+      bool trackCpuUsage,
+      const core::QueryConfig& config);
+
+  void evalSpecialForm(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result) override;
+
+ private:
+  // NULLIF does not propagate nulls: NULLIF(NULL, x) returns NULL (from the
+  // first argument), but NULLIF(x, NULL) returns x, not NULL.
+  void computePropagatesNulls() override {
+    propagatesNulls_ = false;
+  }
+
+  // Casts evaluated vectors to the common type for comparison. Null when both
+  // input types already match (no casting needed).
+  std::shared_ptr<CastExpr> castExpr_;
+
+  // Whether each input needs to be cast to the common type for comparison.
+  const bool needsCastA_;
+  const bool needsCastB_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
  *

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   Main.cpp
   MapViewTest.cpp
   MapWriterTest.cpp
+  NullIfExprTest.cpp
   PeeledEncodingTest.cpp
   ReverseSignatureBinderTest.cpp
   RowViewTest.cpp

--- a/velox/expression/tests/NullIfExprTest.cpp
+++ b/velox/expression/tests/NullIfExprTest.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class NullIfExprTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  // Parses a SQL expression string into a TypedExprPtr.
+  core::TypedExprPtr parseExpr(
+      const std::string& sql,
+      const RowTypePtr& rowType) {
+    parse::ParseOptions options;
+    auto iExpr = parse::DuckSqlExpressionsParser(options).parseExpr(sql);
+    return core::Expressions::inferTypes(iExpr, rowType, pool());
+  }
+
+  // Evaluates NULLIF(a, b). Common type defaults to a's type.
+  VectorPtr evaluateNullIf(
+      const core::TypedExprPtr& aExpr,
+      const core::TypedExprPtr& bExpr,
+      const RowVectorPtr& input,
+      const TypePtr& commonType = nullptr) {
+    auto nullIfExpr = std::make_shared<core::NullIfTypedExpr>(
+        aExpr, bExpr, commonType ? commonType : aExpr->type());
+
+    ExprSet exprSet({nullIfExpr}, execCtx_.get());
+    EvalCtx context(execCtx_.get(), &exprSet, input.get());
+
+    std::vector<VectorPtr> result(1);
+    SelectivityVector rows(input->size());
+    exprSet.eval(rows, context, result);
+    return result[0];
+  }
+
+  // Evaluates NULLIF(a, b) using column references.
+  VectorPtr evaluateNullIf(
+      const VectorPtr& a,
+      const VectorPtr& b,
+      const TypePtr& commonType = nullptr) {
+    auto aField = std::make_shared<core::FieldAccessTypedExpr>(a->type(), "a");
+    auto bField = std::make_shared<core::FieldAccessTypedExpr>(b->type(), "b");
+    return evaluateNullIf(
+        aField, bField, makeRowVector({"a", "b"}, {a, b}), commonType);
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{core::QueryCtx::create()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+};
+
+// Same-type inputs, some equal, some not.
+TEST_F(NullIfExprTest, sameType) {
+  auto a = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
+  auto b = makeFlatVector<int32_t>({1, 0, 3, 0, 5});
+
+  auto result = evaluateNullIf(a, b);
+
+  auto expected = makeNullableFlatVector<int32_t>(
+      {std::nullopt, 2, std::nullopt, 4, std::nullopt});
+  assertEqualVectors(expected, result);
+}
+
+// All rows equal — should return constant null.
+TEST_F(NullIfExprTest, allEqual) {
+  auto a = makeFlatVector<int32_t>({1, 2, 3});
+  auto b = makeFlatVector<int32_t>({1, 2, 3});
+
+  auto result = evaluateNullIf(a, b);
+
+  auto expected = makeNullableFlatVector<int32_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  assertEqualVectors(expected, result);
+}
+
+// No rows equal — should return a as is.
+TEST_F(NullIfExprTest, noneEqual) {
+  auto a = makeFlatVector<int32_t>({1, 2, 3});
+  auto b = makeFlatVector<int32_t>({4, 5, 6});
+
+  auto result = evaluateNullIf(a, b);
+  assertEqualVectors(a, result);
+}
+
+// Null in first argument.
+TEST_F(NullIfExprTest, nullInFirst) {
+  auto a = makeNullableFlatVector<int32_t>({std::nullopt, 2, std::nullopt});
+  auto b = makeFlatVector<int32_t>({1, 2, 3});
+
+  auto result = evaluateNullIf(a, b);
+
+  // NULLIF(NULL, x) returns NULL (the first argument).
+  auto expected = makeNullableFlatVector<int32_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+  assertEqualVectors(expected, result);
+}
+
+// Null in second argument.
+TEST_F(NullIfExprTest, nullInSecond) {
+  auto a = makeFlatVector<int32_t>({1, 2, 3});
+  auto b = makeNullableFlatVector<int32_t>(
+      {std::nullopt, std::nullopt, std::nullopt});
+
+  auto result = evaluateNullIf(a, b);
+
+  // NULLIF(x, NULL) returns x (comparison is indeterminate).
+  assertEqualVectors(a, result);
+}
+
+// Both arguments null.
+TEST_F(NullIfExprTest, bothNull) {
+  auto a = makeNullableFlatVector<int32_t>({std::nullopt, std::nullopt});
+  auto b = makeNullableFlatVector<int32_t>({std::nullopt, std::nullopt});
+
+  auto result = evaluateNullIf(a, b);
+
+  // NULLIF(NULL, NULL) returns NULL (first argument).
+  auto expected = makeNullableFlatVector<int32_t>({std::nullopt, std::nullopt});
+  assertEqualVectors(expected, result);
+}
+
+// Different types with common supertype.
+TEST_F(NullIfExprTest, differentTypes) {
+  auto a = makeFlatVector<int16_t>({1, 2, 3, 4});
+  auto b = makeFlatVector<int64_t>({1, 0, 3, 0});
+
+  auto result = evaluateNullIf(a, b, BIGINT());
+
+  // Return type is SMALLINT (first argument's type).
+  EXPECT_EQ(result->type()->kind(), TypeKind::SMALLINT);
+  auto expected =
+      makeNullableFlatVector<int16_t>({std::nullopt, 2, std::nullopt, 4});
+  assertEqualVectors(expected, result);
+}
+
+// Arrays with nested nulls. With kNullAsIndeterminate, ARRAY[1, NULL] is not
+// equal to ARRAY[1, NULL] (comparison is indeterminate), so NULLIF returns the
+// first array unchanged.
+TEST_F(NullIfExprTest, arrayWithNestedNulls) {
+  auto a = makeArrayVectorFromJson<int32_t>({
+      "[1, null, 3]",
+      "[4, 5]",
+      "[null]",
+      "[1, 2, null]",
+  });
+  auto b = makeArrayVectorFromJson<int32_t>({
+      "[1, null, 3]",
+      "[4, 5]",
+      "[null]",
+      "[1, 1, null]",
+  });
+
+  auto result = evaluateNullIf(a, b);
+
+  // Row 0: [1, null, 3] vs [1, null, 3] — indeterminate, returns a.
+  // Row 1: [4, 5] vs [4, 5] — equal, returns NULL.
+  // Row 2: [null] vs [null] — indeterminate, returns a ([null]).
+  // Row 3: [1, 2, null] vs [1, 1, null] — not equal, returns a.
+  auto expected = makeArrayVectorFromJson<int32_t>({
+      "[1, null, 3]",
+      "null",
+      "[null]",
+      "[1, 2, null]",
+  });
+  assertEqualVectors(expected, result);
+}
+
+// Asserts the result has at least one null and returns the set of unique
+// non-null values.
+template <typename T>
+std::unordered_set<T> uniqueNonNullValues(const VectorPtr& result) {
+  auto* values = result->as<SimpleVector<T>>();
+  VELOX_CHECK_NOT_NULL(values);
+
+  std::unordered_set<T> unique;
+  bool hasNull = false;
+  for (vector_size_t row = 0; row < result->size(); ++row) {
+    if (result->isNullAt(row)) {
+      hasNull = true;
+    } else {
+      unique.insert(values->valueAt(row));
+    }
+  }
+
+  EXPECT_TRUE(hasNull) << "Expected some null rows";
+  EXPECT_FALSE(unique.empty()) << "Expected some non-null rows";
+  return unique;
+}
+
+// Non-deterministic expression evaluated once. NULLIF(rand() < 0.5, true)
+// should produce only NULL and false, never true. If the expression is
+// evaluated twice, the condition and return value can diverge, producing true.
+TEST_F(NullIfExprTest, nonDeterministic) {
+  auto input = makeRowVector(ROW({}), 1'000);
+
+  auto aExpr = parseExpr("rand() < 0.5", input->rowType());
+  auto bExpr = parseExpr("true", input->rowType());
+
+  auto result = evaluateNullIf(aExpr, bExpr, input);
+
+  // Only 'false' should appear as a non-null value.
+  EXPECT_THAT(uniqueNonNullValues<bool>(result), testing::ElementsAre(false));
+}
+
+// Same as nonDeterministic but with different input types to exercise the cast
+// path. NULLIF(cast(rand() * 10 as smallint), 5::bigint) returns NULL when the
+// cast result is 5, else returns the smallint value. Value 5 should never
+// appear in the output. The return type must be SMALLINT.
+TEST_F(NullIfExprTest, nonDeterministicWithCast) {
+  auto input = makeRowVector(ROW({}), 1'000);
+
+  auto aExpr = parseExpr("cast(rand() * 5.0 as smallint)", input->rowType());
+  auto bExpr = parseExpr("3::bigint", input->rowType());
+
+  auto result = evaluateNullIf(aExpr, bExpr, input, BIGINT());
+
+  EXPECT_EQ(result->type()->kind(), TypeKind::SMALLINT);
+
+  // All values 0-5 except 3 (which is nulled out).
+  EXPECT_THAT(
+      uniqueNonNullValues<int16_t>(result),
+      testing::UnorderedElementsAre(0, 1, 2, 4, 5));
+}
+
+} // namespace
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Summary:
Add NULLIF as a native Velox special form that evaluates each input
exactly once. This fixes incorrect results when NULLIF is used with
non-deterministic expressions like rand().

Previously, NULLIF(a, b) was rewritten to IF(eq(a, b), NULL, a) by
the planner, duplicating expression 'a' in the tree. Velox evaluates
each occurrence independently, so non-deterministic expressions
produce different values in the condition and the else branch.

For example, NULLIF(rand() < 0.5, true) could return TRUE, which
should be impossible — nullif(x, true) can only return NULL or FALSE.

The new implementation:
- NullIfTypedExpr carries two inputs and a commonType for comparison.
- NullIfExpr evaluates each input once, casts to commonType using
  CastExpr::apply (now public), compares, and returns the first
  input's value with NULLs where equal.
- Comparison uses kNullAsIndeterminate (Presto semantics). A TODO
  notes that Spark uses kNullAsValue, which differs for complex
  types with nested nulls.

https://velox-lib.io/blog/nullif-special-form

Fixes: https://github.com/facebookincubator/velox/issues/17110

Differential Revision: D101170683


