### PR TITLE
feat(cudf): Remove getVariant path from createLiteral

### DIFF
--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -46,7 +46,7 @@ cudf::ast::literal createLiteral(
     size_t atIndex = 0) {
   const auto kind = vector->typeKind();
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      makeLiteralFromVector, kind, vector, scalars, atIndex);
+      makeScalarAndLiteralFromVector, kind, vector, scalars, atIndex);
 }
 
 // Helper function to extract literals from array elements based on type

--- a/velox/experimental/cudf/expression/AstExpressionUtils.h
+++ b/velox/experimental/cudf/expression/AstExpressionUtils.h
@@ -45,11 +45,8 @@ cudf::ast::literal createLiteral(
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     size_t atIndex = 0) {
   const auto kind = vector->typeKind();
-  const auto& type = vector->type();
-  variant value =
-      VELOX_DYNAMIC_TYPE_DISPATCH(getVariant, kind, vector, atIndex);
-  return VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
-      makeScalarAndLiteral, kind, type, value, scalars);
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      makeLiteralFromVector, kind, vector, scalars, atIndex);
 }
 
 // Helper function to extract literals from array elements based on type

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -62,16 +62,6 @@ cudf::ast::literal makeLiteralFromScalar(
   }
 }
 
-template <TypeKind kind>
-variant getVariant(const VectorPtr& vector, size_t atIndex = 0) {
-  using T = typename facebook::velox::KindToFlatVector<kind>::WrapperType;
-  if constexpr (!std::is_same_v<T, ComplexType>) {
-    return vector->as<SimpleVector<T>>()->valueAt(atIndex);
-  } else {
-    return Variant();
-  }
-}
-
 template <typename T>
 std::unique_ptr<cudf::scalar> makeScalarFromValue(
     const TypePtr& type,

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -183,7 +183,7 @@ cudf::ast::literal makeScalarAndLiteral(
 }
 
 template <TypeKind kind>
-cudf::ast::literal makeLiteralFromVector(
+cudf::ast::literal makeScalarAndLiteralFromVector(
     const VectorPtr& vector,
     std::vector<std::unique_ptr<cudf::scalar>>& scalars,
     size_t atIndex = 0) {

--- a/velox/experimental/cudf/expression/AstUtils.h
+++ b/velox/experimental/cudf/expression/AstUtils.h
@@ -155,6 +155,18 @@ static std::unique_ptr<cudf::scalar> createCudfScalar(
       vector->type(), vector->value(), vector->isNullAt(0), toType);
 }
 
+template <TypeKind Kind>
+static std::unique_ptr<cudf::scalar> createCudfScalarFromVector(
+    const velox::VectorPtr& vector,
+    size_t atIndex = 0) {
+  using T = typename TypeTraits<Kind>::NativeType;
+  auto simpleVector = vector->as<SimpleVector<T>>();
+  return makeScalarFromValue<T>(
+      vector->type(),
+      simpleVector->valueAt(atIndex),
+      simpleVector->isNullAt(atIndex));
+}
+
 inline std::unique_ptr<cudf::scalar> makeScalarFromConstantExpr(
     const std::shared_ptr<velox::exec::Expr>& expr,
     std::optional<cudf::type_id> toType = std::nullopt) {
@@ -178,6 +190,17 @@ cudf::ast::literal makeScalarAndLiteral(
     return makeLiteralFromScalar<T>(*(scalars.back()), type);
   }
   VELOX_NYI("Scalar creation not implemented for type {}", type->toString());
+}
+
+template <TypeKind kind>
+cudf::ast::literal makeLiteralFromVector(
+    const VectorPtr& vector,
+    std::vector<std::unique_ptr<cudf::scalar>>& scalars,
+    size_t atIndex = 0) {
+  using T = typename TypeTraits<kind>::NativeType;
+  auto scalar = createCudfScalarFromVector<kind>(vector, atIndex);
+  scalars.emplace_back(std::move(scalar));
+  return makeLiteralFromScalar<T>(*(scalars.back()), vector->type());
 }
 
 } // namespace facebook::velox::cudf_velox


### PR DESCRIPTION
Before that, the vector data -> Variant -> scalar, the intermediate struct is not essential, make the conversion complex, even more, if the data type is not supported in Variant, we must process it different path, this add complexity and fault occurance.