### PR TITLE
fix: Integer overflow in range filter boundary conversion (#17216)

### DIFF
--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -122,6 +122,62 @@ std::unique_ptr<common::Filter> toInt64In(
 
 } // namespace
 
+namespace {
+std::unique_ptr<common::Filter> bigintOrImpl(
+    std::vector<std::unique_ptr<common::Filter>> inputs,
+    bool nullAllowed) {
+  std::vector<std::unique_ptr<common::BigintRange>> ranges;
+  for (auto& input : inputs) {
+    if (input->kind() == common::FilterKind::kIsNull) {
+      nullAllowed = true;
+    } else if (input->kind() != common::FilterKind::kAlwaysFalse) {
+      VELOX_CHECK(
+          isBigintRange(input),
+          "Expected BigintRange filter, got: {}",
+          input->toString());
+      ranges.emplace_back(asBigintRange(input));
+    }
+  }
+  if (ranges.empty()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
+  if (ranges.size() == 1) {
+    if (nullAllowed) {
+      return std::make_unique<common::BigintRange>(
+          ranges[0]->lower(), ranges[0]->upper(), true);
+    }
+    return std::move(ranges[0]);
+  }
+  return std::make_unique<common::BigintMultiRange>(
+      std::move(ranges), nullAllowed);
+}
+} // namespace
+
+std::unique_ptr<common::Filter> bigintOr(
+    std::unique_ptr<common::Filter> a,
+    std::unique_ptr<common::Filter> b,
+    bool nullAllowed) {
+  std::vector<std::unique_ptr<common::Filter>> inputs;
+  inputs.emplace_back(std::move(a));
+  inputs.emplace_back(std::move(b));
+  return bigintOrImpl(std::move(inputs), nullAllowed);
+}
+
+std::unique_ptr<common::Filter> bigintOr(
+    std::unique_ptr<common::Filter> a,
+    std::unique_ptr<common::Filter> b,
+    std::unique_ptr<common::Filter> c,
+    bool nullAllowed) {
+  std::vector<std::unique_ptr<common::Filter>> inputs;
+  inputs.emplace_back(std::move(a));
+  inputs.emplace_back(std::move(b));
+  inputs.emplace_back(std::move(c));
+  return bigintOrImpl(std::move(inputs), nullAllowed);
+}
+
 std::shared_ptr<ExprToSubfieldFilterParser>
     ExprToSubfieldFilterParser::parser_ =
         std::make_shared<PrestoExprToSubfieldFilterParser>();
@@ -194,6 +250,12 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
 
   if (typeKind == TypeKind::TINYINT || typeKind == TypeKind::SMALLINT ||
       typeKind == TypeKind::INTEGER || typeKind == TypeKind::BIGINT) {
+    if (lessThanFilter->kind() == common::FilterKind::kAlwaysFalse) {
+      return greaterThanFilter;
+    }
+    if (greaterThanFilter->kind() == common::FilterKind::kAlwaysFalse) {
+      return lessThanFilter;
+    }
     VELOX_CHECK(isBigintRange(lessThanFilter));
     VELOX_CHECK(isBigintRange(greaterThanFilter));
 
@@ -207,6 +269,14 @@ std::unique_ptr<common::Filter> ExprToSubfieldFilterParser::makeNotEqualFilter(
   if (typeKind == TypeKind::HUGEINT) {
     VELOX_NYI();
   } else {
+    if (lessThanFilter->kind() == common::FilterKind::kAlwaysFalse ||
+        lessThanFilter->kind() == common::FilterKind::kIsNull) {
+      return greaterThanFilter;
+    }
+    if (greaterThanFilter->kind() == common::FilterKind::kAlwaysFalse ||
+        greaterThanFilter->kind() == common::FilterKind::kIsNull) {
+      return lessThanFilter;
+    }
     std::vector<std::unique_ptr<common::Filter>> filters;
     filters.emplace_back(std::move(lessThanFilter));
     filters.emplace_back(std::move(greaterThanFilter));

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -23,9 +23,15 @@
 
 namespace facebook::velox::exec {
 
-inline std::unique_ptr<common::BigintRange> lessThan(
+inline std::unique_ptr<common::Filter> lessThan(
     int64_t max,
     bool nullAllowed = false) {
+  if (max == std::numeric_limits<int64_t>::min()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
   return std::make_unique<common::BigintRange>(
       std::numeric_limits<int64_t>::min(), max - 1, nullAllowed);
 }
@@ -37,9 +43,15 @@ inline std::unique_ptr<common::BigintRange> lessThanOrEqual(
       std::numeric_limits<int64_t>::min(), max, nullAllowed);
 }
 
-inline std::unique_ptr<common::BigintRange> greaterThan(
+inline std::unique_ptr<common::Filter> greaterThan(
     int64_t min,
     bool nullAllowed = false) {
+  if (min == std::numeric_limits<int64_t>::max()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
   return std::make_unique<common::BigintRange>(
       min + 1, std::numeric_limits<int64_t>::max(), nullAllowed);
 }
@@ -185,29 +197,16 @@ between(int64_t min, int64_t max, bool nullAllowed = false) {
   return std::make_unique<common::BigintRange>(min, max, nullAllowed);
 }
 
-inline std::unique_ptr<common::BigintMultiRange> bigintOr(
-    std::unique_ptr<common::BigintRange> a,
-    std::unique_ptr<common::BigintRange> b,
-    bool nullAllowed = false) {
-  std::vector<std::unique_ptr<common::BigintRange>> filters;
-  filters.emplace_back(std::move(a));
-  filters.emplace_back(std::move(b));
-  return std::make_unique<common::BigintMultiRange>(
-      std::move(filters), nullAllowed);
-}
+std::unique_ptr<common::Filter> bigintOr(
+    std::unique_ptr<common::Filter> a,
+    std::unique_ptr<common::Filter> b,
+    bool nullAllowed = false);
 
-inline std::unique_ptr<common::BigintMultiRange> bigintOr(
-    std::unique_ptr<common::BigintRange> a,
-    std::unique_ptr<common::BigintRange> b,
-    std::unique_ptr<common::BigintRange> c,
-    bool nullAllowed = false) {
-  std::vector<std::unique_ptr<common::BigintRange>> filters;
-  filters.emplace_back(std::move(a));
-  filters.emplace_back(std::move(b));
-  filters.emplace_back(std::move(c));
-  return std::make_unique<common::BigintMultiRange>(
-      std::move(filters), nullAllowed);
-}
+std::unique_ptr<common::Filter> bigintOr(
+    std::unique_ptr<common::Filter> a,
+    std::unique_ptr<common::Filter> b,
+    std::unique_ptr<common::Filter> c,
+    bool nullAllowed = false);
 
 inline std::unique_ptr<common::BytesValues> equal(
     const std::string& value,
@@ -351,9 +350,15 @@ orFilter(std::unique_ptr<T> a, std::unique_ptr<T> b, bool nullAllowed = false) {
   return std::make_unique<common::MultiRange>(std::move(filters), nullAllowed);
 }
 
-inline std::unique_ptr<common::HugeintRange> lessThanHugeint(
+inline std::unique_ptr<common::Filter> lessThanHugeint(
     int128_t max,
     bool nullAllowed = false) {
+  if (max == std::numeric_limits<int128_t>::min()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
   return std::make_unique<common::HugeintRange>(
       std::numeric_limits<int128_t>::min(), max - 1, nullAllowed);
 }
@@ -365,9 +370,15 @@ inline std::unique_ptr<common::HugeintRange> lessThanOrEqualHugeint(
       std::numeric_limits<int128_t>::min(), max, nullAllowed);
 }
 
-inline std::unique_ptr<common::HugeintRange> greaterThanHugeint(
+inline std::unique_ptr<common::Filter> greaterThanHugeint(
     int128_t min,
     bool nullAllowed = false) {
+  if (min == std::numeric_limits<int128_t>::max()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
   return std::make_unique<common::HugeintRange>(
       min + 1, std::numeric_limits<int128_t>::max(), nullAllowed);
 }
@@ -401,9 +412,15 @@ between(const Timestamp& min, const Timestamp& max, bool nullAllowed = false) {
   return std::make_unique<common::TimestampRange>(min, max, nullAllowed);
 }
 
-inline std::unique_ptr<common::TimestampRange> lessThan(
+inline std::unique_ptr<common::Filter> lessThan(
     Timestamp max,
     bool nullAllowed = false) {
+  if (max == std::numeric_limits<Timestamp>::min()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
   --max;
   return std::make_unique<common::TimestampRange>(
       std::numeric_limits<Timestamp>::min(), max, nullAllowed);
@@ -416,9 +433,15 @@ inline std::unique_ptr<common::TimestampRange> lessThanOrEqual(
       std::numeric_limits<Timestamp>::min(), max, nullAllowed);
 }
 
-inline std::unique_ptr<common::TimestampRange> greaterThan(
+inline std::unique_ptr<common::Filter> greaterThan(
     Timestamp min,
     bool nullAllowed = false) {
+  if (min == std::numeric_limits<Timestamp>::max()) {
+    if (nullAllowed) {
+      return std::make_unique<common::IsNull>();
+    }
+    return std::make_unique<common::AlwaysFalse>();
+  }
   ++min;
   return std::make_unique<common::TimestampRange>(
       min, std::numeric_limits<Timestamp>::max(), nullAllowed);

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -129,6 +129,30 @@ TEST_F(ExprToSubfieldFilterTest, neq) {
   VELOX_ASSERT_FILTER(bigintOr(lessThan(42), greaterThan(42)), filter);
 }
 
+TEST_F(ExprToSubfieldFilterTest, neqBoundary) {
+  {
+    auto call = parseCallExpr("a <> 9223372036854775807", ROW("a", BIGINT()));
+    auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+    ASSERT_TRUE(filter);
+    validateSubfield(subfield, {"a"});
+
+    VELOX_ASSERT_FILTER(lessThan(std::numeric_limits<int64_t>::max()), filter);
+  }
+
+  {
+    auto call =
+        parseCallExpr("a <> -9223372036854775807 - 1", ROW("a", BIGINT()));
+    auto [subfield, filter] = leafCallToSubfieldFilter(call);
+
+    ASSERT_TRUE(filter);
+    validateSubfield(subfield, {"a"});
+
+    VELOX_ASSERT_FILTER(
+        greaterThan(std::numeric_limits<int64_t>::min()), filter);
+  }
+}
+
 TEST_F(ExprToSubfieldFilterTest, lte) {
   auto call = parseCallExpr("a <= 42", ROW("a", BIGINT()));
   auto [subfield, filter] = leafCallToSubfieldFilter(call);

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -104,7 +104,7 @@ void checkSimd(const Filter* filter, const T* values, ScalarTest scalarTest) {
 
 TEST(FilterTest, bigIntRange) {
   // x = 1
-  auto filter = equal(1, false);
+  std::unique_ptr<common::Filter> filter = equal(1, false);
   auto testInt64 = [&](int64_t x) { return filter->testInt64(x); };
   EXPECT_TRUE(filter->testInt64(1));
 
@@ -210,6 +210,52 @@ TEST(FilterTest, bigIntRange) {
         1111};
     checkSimd(filter.get(), n16, testInt64);
   }
+}
+
+TEST(FilterTest, bigIntRangeBoundaryOverflow) {
+  auto filter = greaterThan(std::numeric_limits<int64_t>::max());
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+  EXPECT_FALSE(filter->testInt64(0));
+
+  filter = lessThan(std::numeric_limits<int64_t>::min());
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_FALSE(filter->testInt64(0));
+
+  filter = greaterThan(std::numeric_limits<int64_t>::max(), true);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = lessThan(std::numeric_limits<int64_t>::min(), true);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = greaterThan(std::numeric_limits<int64_t>::max() - 1);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max() - 1));
+
+  filter = lessThan(std::numeric_limits<int64_t>::min() + 1);
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::min() + 1));
+}
+
+TEST(FilterTest, hugeintRangeBoundaryOverflow) {
+  auto filter = greaterThanHugeint(std::numeric_limits<int128_t>::max());
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt128(std::numeric_limits<int128_t>::max()));
+  EXPECT_FALSE(filter->testInt128(0));
+
+  filter = lessThanHugeint(std::numeric_limits<int128_t>::min());
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt128(std::numeric_limits<int128_t>::min()));
+  EXPECT_FALSE(filter->testInt128(0));
 }
 
 TEST(FilterTest, negatedBigintRange) {
@@ -702,6 +748,71 @@ TEST(FilterTest, bigintMultiRange) {
   EXPECT_TRUE(filter->testInt64Range(105, 115, true));
   EXPECT_FALSE(filter->testInt64Range(15, 45, false));
   EXPECT_FALSE(filter->testInt64Range(15, 45, true));
+}
+
+TEST(FilterTest, bigintOrWithBoundaryOverflow) {
+  auto filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max()), between(1, 10));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(5));
+  EXPECT_FALSE(filter->testInt64(50));
+
+  filter =
+      bigintOr(between(1, 10), lessThan(std::numeric_limits<int64_t>::min()));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(5));
+  EXPECT_FALSE(filter->testInt64(50));
+
+  filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max()),
+      lessThan(std::numeric_limits<int64_t>::min()));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kAlwaysFalse);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::max()));
+  EXPECT_FALSE(filter->testInt64(std::numeric_limits<int64_t>::min()));
+
+  filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max(), true),
+      lessThan(std::numeric_limits<int64_t>::min(), true));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max()),
+      lessThan(std::numeric_limits<int64_t>::min(), true));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max(), true),
+      lessThan(std::numeric_limits<int64_t>::min()));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kIsNull);
+  EXPECT_FALSE(filter->testInt64(0));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max(), true), between(1, 10));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(5));
+  EXPECT_FALSE(filter->testInt64(50));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = bigintOr(
+      between(1, 10), lessThan(std::numeric_limits<int64_t>::min(), true));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(5));
+  EXPECT_FALSE(filter->testInt64(50));
+  EXPECT_TRUE(filter->testNull());
+
+  filter = bigintOr(
+      greaterThan(std::numeric_limits<int64_t>::max()),
+      lessThan(std::numeric_limits<int64_t>::min()),
+      between(100, 200));
+  EXPECT_EQ(filter->kind(), common::FilterKind::kBigintRange);
+  EXPECT_TRUE(filter->testInt64(150));
+  EXPECT_FALSE(filter->testInt64(50));
 }
 
 TEST(FilterTest, boolValue) {
@@ -1994,7 +2105,8 @@ TEST(FilterTest, mergeWithBytesMultiRange) {
 }
 
 TEST(FilterTest, hugeIntRange) {
-  auto filter = equalHugeint(HugeInt::build(1, 1), false);
+  std::unique_ptr<common::Filter> filter =
+      equalHugeint(HugeInt::build(1, 1), false);
   auto max = DecimalUtil::kLongDecimalMax;
   auto min = DecimalUtil::kLongDecimalMin;
 
@@ -2084,7 +2196,8 @@ TEST(FilterTest, dateRange) {
 
 TEST(FilterTest, timestampRange) {
   // x = timestamp '1970-01-01 00:00:10.123'
-  auto filter = equal(Timestamp(10, 123000000), false);
+  std::unique_ptr<common::Filter> filter =
+      equal(Timestamp(10, 123000000), false);
   EXPECT_FALSE(filter->testNull());
 
   EXPECT_TRUE(filter->testTimestamp(Timestamp(10, 123000000)));


### PR DESCRIPTION
Summary:

When converting exclusive bounds to inclusive bounds for BigintRange, HugeintRange, and TimestampRange filters, the code unconditionally increments/decrements the boundary value. This overflows when the value is at the type limit (e.g., greaterThan(INT64_MAX) computes INT64_MAX + 1, which wraps to INT64_MIN, creating a range that matches everything instead of nothing). Guard against overflow by returning AlwaysFalse (or IsNull when nulls are allowed) when the boundary is at the type limit. This fixes incorrect query results for filters like WHERE col > 9223372036854775807.

Reviewed By: Yuhta

Differential Revision: D101039167
