### PR TITLE
perf: Avoid flattening constant ARRAY/MAP in moveOrCopyResult (#17218)

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -474,4 +474,119 @@ VectorEncoding::Simple EvalCtx::wrapEncoding() const {
   return !peeledEncoding_ ? VectorEncoding::Simple::FLAT
                           : peeledEncoding_->wrapEncoding();
 }
+
+namespace {
+
+// Returns true if flattening 'v' would be expensive because it is a constant
+// encoding of a complex type (ARRAY, MAP, or wide ROW) and the constant
+// covers more rows than the non-constant side ('constantRows' >
+// 'totalRows' - 'constantRows').
+bool isExpensiveConstant(
+    const BaseVector& v,
+    vector_size_t constantRows,
+    vector_size_t totalRows) {
+  if (!v.isConstantEncoding() || constantRows <= totalRows - constantRows) {
+    return false;
+  }
+  const auto& type = *v.type();
+  if (type.isArray() || type.isMap()) {
+    // Only worth it when the constant array/map is non-empty.  An empty
+    // constant is cheap to flatten (just offsets/sizes, no element copies).
+    if (v.isNullAt(0)) {
+      return false;
+    }
+    auto* wrapped = v.wrappedVector();
+    auto idx = v.wrappedIndex(0);
+    return wrapped->asUnchecked<ArrayVectorBase>()->sizeAt(idx) > 0;
+  }
+  return type.isRow() && type.asRow().size() > 10;
+}
+
+// Build a dictionary result that combines data rows from 'dataSource' with a
+// single appended constant row from 'constant'.  'selectedRows' indicates
+// which rows come from dataSource; all other rows map to the constant.
+//
+// 'base' is the flat vector that will back the dictionary.  It must already
+// contain the data rows from dataSource (copied by the caller) and be sized
+// to dictSize + 1.  This function appends the constant at position dictSize
+// and builds the index mapping.
+VectorPtr buildDictWithConstant(
+    VectorPtr base,
+    const BaseVector& constant,
+    const SelectivityVector& selectedRows,
+    vector_size_t dictSize,
+    memory::MemoryPool* pool) {
+  auto appendIndex = dictSize;
+  auto constantIndex = static_cast<vector_size_t>(constant.wrappedIndex(0));
+  auto* constantBase = constant.wrappedVector();
+
+  VELOX_CHECK(
+      !constant.isNullAt(0),
+      "buildDictWithConstant should not be called with a null constant");
+  base->copy(constantBase, appendIndex, constantIndex, 1);
+
+  auto indices = allocateIndices(dictSize, pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  // Default: all rows map to the constant.
+  std::fill(rawIndices, rawIndices + dictSize, appendIndex);
+  // Selected rows use identity mapping (their own data).
+  selectedRows.applyToSelected(
+      [&](vector_size_t row) { rawIndices[row] = row; });
+
+  return BaseVector::wrapInDictionary(
+      nullptr, indices, dictSize, std::move(base));
+}
+
+} // namespace
+
+void EvalCtx::moveOrCopyResult(
+    const VectorPtr& localResult,
+    const SelectivityVector& rows,
+    VectorPtr& result) const {
+#ifndef NDEBUG
+  if (localResult != nullptr) {
+    localResult->validate();
+  }
+#endif
+  if (resultShouldBePreserved(result, rows)) {
+    auto totalRows = std::max<vector_size_t>(result->size(), rows.end());
+    auto selectedRows = rows.countSelected();
+    // When result is constant, the constant covers totalRows - selectedRows.
+    if (isExpensiveConstant(*result, totalRows - selectedRows, totalRows)) {
+      // Result is constant; localResult has data for selected rows.
+      auto dictSize = totalRows;
+      auto newResult =
+          BaseVector::create(result->type(), dictSize + 1, result->pool());
+      newResult->copy(localResult.get(), rows, nullptr);
+
+      result = buildDictWithConstant(
+          std::move(newResult), *result, rows, dictSize, result->pool());
+    } else if (
+        localResult &&
+        // When localResult is constant, the constant covers selectedRows.
+        isExpensiveConstant(*localResult, selectedRows, totalRows)) {
+      // localResult is constant; result has data for other rows.
+      BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
+      auto* pool = result->pool();
+      auto dictSize = result->size();
+      result->resize(dictSize + 1);
+
+      // Invert: selected rows should map to the constant, others keep
+      // identity.  Build a complement selectivity for the non-selected rows.
+      SelectivityVector nonSelectedRows(dictSize, true);
+      rows.applyToSelected(
+          [&](vector_size_t row) { nonSelectedRows.setValid(row, false); });
+      nonSelectedRows.updateBounds();
+
+      result = buildDictWithConstant(
+          std::move(result), *localResult, nonSelectedRows, dictSize, pool);
+    } else {
+      BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
+      result->copy(localResult.get(), rows, nullptr);
+    }
+  } else {
+    result = localResult;
+  }
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -468,24 +468,11 @@ class EvalCtx {
   }
 
   // Copy "rows" of localResult into results if "result" is partially populated
-  // and must be preserved. Copy localResult pointer into result otherwise.
+  // and must be preserved.  Copy localResult pointer into result otherwise.
   void moveOrCopyResult(
       const VectorPtr& localResult,
       const SelectivityVector& rows,
-      VectorPtr& result) const {
-#ifndef NDEBUG
-    if (localResult != nullptr) {
-      // Make sure local/temporary vectors have consistent state.
-      localResult->validate();
-    }
-#endif
-    if (resultShouldBePreserved(result, rows)) {
-      BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
-      result->copy(localResult.get(), rows, nullptr);
-    } else {
-      result = localResult;
-    }
-  }
+      VectorPtr& result) const;
 
   /// Adds nulls from 'rawNulls' to positions of 'result' given by
   /// 'rows'. Ensures that '*result' is writable, of sufficient size

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1776,6 +1776,133 @@ TEST_P(ParameterizedExprTest, switchExprWithNull) {
   assertEqualVectors(expected, result);
 }
 
+// Verify that IF with a constant ARRAY result (ELSE branch) works correctly.
+// Exercises the moveOrCopyResult fast path when result is a constant
+// complex-type.
+TEST_P(ParameterizedExprTest, switchConstantArrayResult) {
+  vector_size_t size = 100;
+  auto c0 = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto c1 = makeArrayVector<double>(
+      size,
+      [](auto /*row*/) { return 10; },
+      [](auto row, auto idx) { return row * 10.0 + idx; },
+      [](auto row) { return row % 10 != 0; });
+  auto input = makeRowVector({c0, c1});
+
+  // if(is_null(c1), constant_default, c1)
+  // The constant default is the ELSE, so result starts as constant.
+  // The fast path wraps the result in a dictionary.
+  auto result = evaluate(
+      "if(c1 is null, array_constructor(0.0e0, 0.0e0, 0.0e0, 0.0e0, 0.0e0, "
+      "0.0e0, 0.0e0, 0.0e0, 0.0e0, 0.0e0), c1)",
+      input);
+
+  // Verify the fast path produced a dictionary (not a flat copy).
+  ASSERT_EQ(result->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto expected = makeArrayVector<double>(
+      size,
+      [](auto) { return 10; },
+      [](auto row, auto idx) {
+        if (row % 10 == 0) {
+          return row * 10.0 + idx;
+        }
+        return 0.0;
+      });
+  assertEqualVectors(expected, result);
+}
+
+// Verify that IF with a constant ARRAY source (THEN branch) works correctly.
+// Exercises the moveOrCopyResult fast path when localResult is a constant
+// complex-type.
+TEST_P(ParameterizedExprTest, switchConstantArraySource) {
+  vector_size_t size = 100;
+  auto c0 = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto c1 = makeArrayVector<double>(
+      size,
+      [](auto /*row*/) { return 10; },
+      [](auto row, auto idx) { return row * 10.0 + idx; },
+      [](auto row) { return row % 10 != 0; });
+  auto input = makeRowVector({c0, c1});
+
+  // if(c1 is not null, c1, constant_default)
+  // The constant default is the THEN for null rows, so localResult is
+  // constant when overwriting selected rows of a non-constant result.
+  // The fast path wraps the result in a dictionary.
+  auto result = evaluate(
+      "if(c1 is not null, c1, array_constructor(0.0e0, 0.0e0, 0.0e0, 0.0e0, "
+      "0.0e0, 0.0e0, 0.0e0, 0.0e0, 0.0e0, 0.0e0))",
+      input);
+
+  // Verify the fast path produced a dictionary (not a flat copy).
+  ASSERT_EQ(result->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto expected = makeArrayVector<double>(
+      size,
+      [](auto) { return 10; },
+      [](auto row, auto idx) {
+        if (row % 10 == 0) {
+          return row * 10.0 + idx;
+        }
+        return 0.0;
+      });
+  assertEqualVectors(expected, result);
+}
+
+// Verify that an empty constant array produces a flat result (no dictionary),
+// since flattening an empty array is cheap.
+TEST_P(ParameterizedExprTest, switchEmptyConstantArrayIsFlat) {
+  vector_size_t size = 100;
+  auto c0 = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto c1 = makeArrayVector<double>(
+      size,
+      [](auto /*row*/) { return 10; },
+      [](auto row, auto idx) { return row * 10.0 + idx; },
+      [](auto row) { return row % 10 != 0; });
+  auto input = makeRowVector({c0, c1});
+
+  // if(is_null(c1), empty_array, c1)
+  auto result = evaluate(
+      "if(c1 is null, cast(array_constructor() as double[]), c1)", input);
+
+  // Empty constant array is cheap to flatten — result should be flat, not
+  // dictionary.
+  ASSERT_NE(result->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto expected = makeArrayVector<double>(
+      size,
+      [](auto row) { return row % 10 == 0 ? 10 : 0; },
+      [](auto row, auto idx) { return row * 10.0 + idx; });
+  assertEqualVectors(expected, result);
+}
+
+// Verify that a null constant array does not trigger the dictionary fast path.
+TEST_P(ParameterizedExprTest, switchNullConstantArrayIsFlat) {
+  vector_size_t size = 100;
+  // c0: 0..99 (all non-null), c1: array of 10 doubles (all non-null).
+  auto c0 = makeFlatVector<int32_t>(size, [](auto row) { return row; });
+  auto c1 = makeArrayVector<double>(
+      size,
+      [](auto /*row*/) { return 10; },
+      [](auto row, auto idx) { return row * 10.0 + idx; });
+  auto input = makeRowVector({c0, c1});
+
+  // if(c0 < 10, c1, cast(null as double[]))
+  // ~90% of rows get null, ~10% keep c1 data.
+  auto result = evaluate("if(c0 < 10, c1, cast(null as double[]))", input);
+
+  // Null constant is cheap to flatten — result should not be dictionary.
+  ASSERT_NE(result->encoding(), VectorEncoding::Simple::DICTIONARY);
+
+  auto expected = makeArrayVector<double>(
+      size,
+      [](auto /*row*/) { return 10; },
+      [](auto row, auto idx) { return row * 10.0 + idx; },
+      // Rows >= 10 are null.
+      [](auto row) { return row >= 10; });
+  assertEqualVectors(expected, result);
+}
+
 // Verify that computePropagatesNulls iterates over all then-clauses when
 // checking null propagation. Uses a 3-WHEN CASE where the 3rd then-clause
 // (coalesce) does not propagate nulls. Null rows matching that clause must
@@ -4044,7 +4171,7 @@ TEST_P(ParameterizedExprTest, cseUnderTryWithIf) {
   // errors when combined with TRY. In this case a VectorFunction sizes the
   // result based on rows.end(), can throw user exceptions, and doesn't resize
   // the result Vector to include rows that produced exceptions. If that
-  // funciton is evaluated as part of CSE, e.g. on both sides of an if
+  // function is evaluated as part of CSE, e.g. on both sides of an if
   // statement, and the last row produces an exception, the result Vector will
   // be smaller than rows.size(). This test validates that in CSE we can
   // tolerate this and does not rely on the fact the result Vector is at least


### PR DESCRIPTION
Summary:

When a SwitchExpr (IF expression) has a constant complex-type branch (e.g., a default 100-element zero array for null embeddings), the existing code in moveOrCopyResult flattens the constant into all N rows via ensureWritable before overwriting selected rows with actual data.  This causes N deep copies of the constant array elements.

This change adds a fast path in moveOrCopyResult that detects when either the existing result or the incoming localResult is a constant ARRAY, MAP, or wide ROW (>10 children).  Instead of flattening, it appends the constant's single row to a flat base vector and wraps in a dictionary that maps constant rows to that appended row.  The fast path is only taken when:
- The constant side covers more rows than the non-constant side.
- The constant array/map is non-empty (empty constants are cheap to flatten).

Differential Revision: D101228087


