### PR TITLE
feat(iceberg): Add Iceberg V3 deletion vector writer

### DIFF
--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -14,6 +14,7 @@
 set(
   ICEBERG_SOURCES
   DeletionVectorReader.cpp
+  DeletionVectorWriter.cpp
   EqualityDeleteFileReader.cpp
   IcebergColumnHandle.cpp
   IcebergConfig.cpp
@@ -34,6 +35,7 @@ velox_add_library(
   ${ICEBERG_SOURCES}
   HEADERS
   DeletionVectorReader.h
+  DeletionVectorWriter.h
   EqualityDeleteFileReader.h
   IcebergColumnHandle.h
   IcebergConfig.h

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.cpp
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
+
+#include <algorithm>
+#include <fstream>
+
+#include <folly/json.h>
+#include <folly/lang/Bits.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+namespace {
+
+// Roaring Bitmap portable format constants.
+constexpr uint32_t kSerialCookieNoRun = 12'346;
+constexpr uint32_t kNoOffsetThreshold = 4;
+constexpr uint32_t kMaxArrayContainerCardinality = 4'096;
+// Full bitmap container: 2^16 bits = 1024 uint64 words = 8192 bytes.
+constexpr size_t kBitmapContainerBytes = 8'192;
+constexpr size_t kBitmapContainerWords = 1'024;
+
+// Puffin file format constants (per Iceberg spec).
+constexpr char kPuffinMagic[] = {'\x50', '\x55', '\x46', '\x31'};
+constexpr size_t kPuffinMagicSize = 4;
+constexpr uint32_t kPuffinFooterFlags = 0;
+
+// Puffin blob metadata constants (per Iceberg V3 deletion vector spec).
+constexpr char kDeletionVectorBlobType[] = "deletion-vector-v1";
+constexpr char kCompressionCodecNone[] = "none";
+// Iceberg spec: source-field-id for whole-row deletes is INT_MAX - 1.
+constexpr int32_t kWholeRowDeleteFieldId = 2'147'483'646;
+
+void writeLittleEndian(std::string& out, uint16_t val) {
+  val = folly::Endian::little(val);
+  out.append(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+void writeLittleEndian(std::string& out, uint32_t val) {
+  val = folly::Endian::little(val);
+  out.append(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+void writeLittleEndian(std::string& out, uint64_t val) {
+  val = folly::Endian::little(val);
+  out.append(reinterpret_cast<const char*>(&val), sizeof(val));
+}
+
+// Serializes the key-cardinality header for a 32-bit Roaring Bitmap.
+void serializeKeyCardinality(
+    std::string& data,
+    const std::vector<std::pair<uint16_t, std::vector<uint16_t>>>& containers) {
+  for (const auto& [key, values] : containers) {
+    writeLittleEndian(data, key);
+    auto cardMinus1 = static_cast<uint16_t>(values.size() - 1);
+    writeLittleEndian(data, cardMinus1);
+  }
+}
+
+// Serializes the offset section for a 32-bit Roaring Bitmap.
+// Offsets point to where each container's data begins, measured from the start
+// of the serialized bitmap. The header consists of: cookie (4) + count (4) +
+// key-cardinality pairs (numContainers * 4) + offset section (numContainers *
+// 4). Offsets are relative to byte 0 of the serialized output, so the first
+// container's data starts immediately after the full header including offsets.
+void serializeOffsets(
+    std::string& data,
+    const std::vector<std::pair<uint16_t, std::vector<uint16_t>>>& containers) {
+  auto numContainers = static_cast<uint32_t>(containers.size());
+  uint32_t headerSize = 4 + 4 + numContainers * 4 + numContainers * 4;
+  uint32_t runningOffset = headerSize;
+  for (const auto& [key, values] : containers) {
+    writeLittleEndian(data, runningOffset);
+    if (values.size() <= kMaxArrayContainerCardinality) {
+      runningOffset += static_cast<uint32_t>(values.size()) * 2;
+    } else {
+      runningOffset += kBitmapContainerBytes;
+    }
+  }
+}
+
+// Serializes container data (array or bitmap) for a 32-bit Roaring Bitmap.
+// Array containers store sorted uint16 values directly. Bitmap containers
+// store a 65536-bit bitset as 1024 little-endian uint64 words, covering the
+// full uint16 range [0, 65535].
+void serializeContainerData(
+    std::string& data,
+    const std::vector<std::pair<uint16_t, std::vector<uint16_t>>>& containers) {
+  for (const auto& [key, values] : containers) {
+    if (values.size() <= kMaxArrayContainerCardinality) {
+      for (auto value : values) {
+        writeLittleEndian(data, value);
+      }
+    } else {
+      std::vector<uint64_t> bitmap(kBitmapContainerWords, 0);
+      for (auto value : values) {
+        bitmap[value / 64] |= (1ULL << (value % 64));
+      }
+      for (auto word : bitmap) {
+        writeLittleEndian(data, word);
+      }
+    }
+  }
+}
+
+} // namespace
+
+void DeletionVectorWriter::addDeletedPosition(int64_t position) {
+  VELOX_CHECK_GE(position, 0, "Deleted position must be non-negative.");
+  positions_.push_back(position);
+}
+
+void DeletionVectorWriter::addDeletedPositions(
+    const std::vector<int64_t>& positions) {
+  for (auto pos : positions) {
+    addDeletedPosition(pos);
+  }
+}
+
+std::string DeletionVectorWriter::serialize32(
+    const std::vector<uint32_t>& sorted) const {
+  if (sorted.empty()) {
+    std::string data;
+    writeLittleEndian(data, kSerialCookieNoRun);
+    uint32_t zero = 0;
+    writeLittleEndian(data, zero);
+    return data;
+  }
+
+  // Group values by high 16 bits (container key).
+  std::map<uint16_t, std::vector<uint16_t>> containerMap;
+  for (auto val : sorted) {
+    auto key = static_cast<uint16_t>(val >> 16);
+    auto low = static_cast<uint16_t>(val & 0xFFFF);
+    containerMap[key].push_back(low);
+  }
+
+  std::vector<std::pair<uint16_t, std::vector<uint16_t>>> containers(
+      containerMap.begin(), containerMap.end());
+  auto numContainers = static_cast<uint32_t>(containers.size());
+
+  std::string data;
+  writeLittleEndian(data, kSerialCookieNoRun);
+  writeLittleEndian(data, numContainers);
+  serializeKeyCardinality(data, containers);
+  if (numContainers >= kNoOffsetThreshold) {
+    serializeOffsets(data, containers);
+  }
+  serializeContainerData(data, containers);
+  return data;
+}
+
+std::string DeletionVectorWriter::serialize() const {
+  if (positions_.empty()) {
+    std::string data;
+    writeLittleEndian(data, static_cast<uint64_t>(0));
+    return data;
+  }
+
+  // Sort and deduplicate positions.
+  std::vector<int64_t> sorted = positions_;
+  std::sort(sorted.begin(), sorted.end());
+  sorted.erase(std::unique(sorted.begin(), sorted.end()), sorted.end());
+
+  // Partition into 32-bit high groups.
+  // Roaring64Bitmap format: [numGroups: uint64] then for each group:
+  //   [highBits: uint32] [serialized 32-bit RoaringBitmap]
+  std::map<uint32_t, std::vector<uint32_t>> groups;
+  for (auto pos : sorted) {
+    // Safe cast: addDeletedPosition() rejects negative values.
+    auto upos = static_cast<uint64_t>(pos);
+    groups[static_cast<uint32_t>(upos >> 32)].push_back(
+        static_cast<uint32_t>(upos & 0xFFFFFFFF));
+  }
+
+  std::string data;
+  writeLittleEndian(data, static_cast<uint64_t>(groups.size()));
+
+  for (auto& [highBits, lowValues] : groups) {
+    writeLittleEndian(data, highBits);
+    data.append(serialize32(lowValues));
+  }
+
+  return data;
+}
+
+void DeletionVectorWriter::clear() {
+  positions_.clear();
+}
+
+std::pair<uint64_t, uint64_t> writePuffinFile(
+    const std::string& filePath,
+    const std::string& blobData,
+    const std::string& referencedDataFile) {
+  uint64_t blobOffset = kPuffinMagicSize;
+  uint64_t blobLength = blobData.size();
+
+  folly::dynamic blobMeta = folly::dynamic::object(
+      "type", kDeletionVectorBlobType)(
+      "fields",
+      folly::dynamic::array(
+          folly::dynamic::object("source-field-id", kWholeRowDeleteFieldId)));
+  blobMeta["offset"] = blobOffset;
+  blobMeta["length"] = blobLength;
+  blobMeta["compression-codec"] = kCompressionCodecNone;
+
+  folly::dynamic properties = folly::dynamic::object;
+  properties["referenced-data-file"] = referencedDataFile;
+  blobMeta["properties"] = properties;
+
+  folly::dynamic footer = folly::dynamic::object;
+  footer["blobs"] = folly::dynamic::array(blobMeta);
+  footer["properties"] = folly::dynamic::object;
+
+  std::string footerJson = folly::toJson(footer);
+  uint32_t footerPayloadSize = static_cast<uint32_t>(footerJson.size());
+
+  std::string fileContent;
+  fileContent.append(kPuffinMagic, kPuffinMagicSize);
+  fileContent.append(blobData);
+  fileContent.append(footerJson);
+  uint32_t littleEndianSize = folly::Endian::little(footerPayloadSize);
+  fileContent.append(
+      reinterpret_cast<const char*>(&littleEndianSize),
+      sizeof(littleEndianSize));
+  uint32_t littleEndianFlags = folly::Endian::little(kPuffinFooterFlags);
+  fileContent.append(
+      reinterpret_cast<const char*>(&littleEndianFlags),
+      sizeof(littleEndianFlags));
+  fileContent.append(kPuffinMagic, kPuffinMagicSize);
+
+  std::ofstream out(filePath, std::ios::binary | std::ios::trunc);
+  VELOX_CHECK(
+      out.good(), "Failed to open Puffin file for writing: {}", filePath);
+  out.write(
+      fileContent.data(), static_cast<std::streamsize>(fileContent.size()));
+  out.close();
+  VELOX_CHECK(!out.fail(), "Failed to write Puffin file: {}", filePath);
+
+  return {blobOffset, blobLength};
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/DeletionVectorWriter.h
+++ b/velox/connectors/hive/iceberg/DeletionVectorWriter.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+/// Writes Iceberg V3 deletion vectors as serialized 64-bit roaring bitmaps.
+///
+/// Deletion vectors are an Iceberg V3 feature (format version 3). The roaring
+/// bitmap encoding itself is version-independent, but the Puffin blob type
+/// "deletion-vector-v1" is defined by the Iceberg V3 spec.
+///
+/// DVs are compact roaring bitmaps stored as blobs inside Puffin files to mark
+/// deleted rows in data files. This writer collects deleted row positions and
+/// serializes them in the Roaring64Bitmap portable format, compatible with
+/// Java's Roaring64Bitmap used by the Presto coordinator.
+///
+/// The 64-bit format partitions positions by their upper 32 bits into groups,
+/// each group containing a standard 32-bit RoaringBitmap for the lower 32
+/// bits. This supports files with more than 4 billion rows.
+///
+/// Usage:
+///   DeletionVectorWriter writer;
+///   writer.addDeletedPosition(5);
+///   writer.addDeletedPosition(5'000'000'000LL);
+///   std::string blob = writer.serialize();
+class DeletionVectorWriter {
+ public:
+  DeletionVectorWriter() = default;
+
+  /// Adds a deleted row position (0-based file row offset).
+  void addDeletedPosition(int64_t position);
+
+  /// Adds multiple deleted row positions.
+  void addDeletedPositions(const std::vector<int64_t>& positions);
+
+  /// Returns the number of deleted positions collected so far.
+  size_t numPositions() const {
+    return positions_.size();
+  }
+
+  /// Serializes collected positions into a 64-bit roaring bitmap.
+  ///
+  /// Format: Roaring64Bitmap portable serialization —
+  ///   [numGroups: uint64]
+  ///   For each group (sorted by highBits):
+  ///     [highBits: uint32]
+  ///     [32-bit RoaringBitmap in portable format]
+  ///
+  /// Each 32-bit RoaringBitmap uses SERIAL_COOKIE_NO_RUNCONTAINER (12346)
+  /// with array containers (cardinality <= 4096) or bitmap containers.
+  ///
+  /// @return Binary string containing the serialized 64-bit roaring bitmap.
+  std::string serialize() const;
+
+  /// Clears all collected positions.
+  void clear();
+
+ private:
+  /// Serializes a single 32-bit roaring bitmap from sorted, deduplicated
+  /// values in the range [0, 2^32).
+  std::string serialize32(const std::vector<uint32_t>& sorted) const;
+
+  std::vector<int64_t> positions_;
+};
+
+/// Writes a Puffin file containing a single deletion vector blob.
+///
+/// The Puffin file format consists of:
+///   - 4-byte magic: "PUF1"
+///   - Blob data (the serialized roaring bitmap)
+///   - Footer: blob metadata + footer payload size + magic
+///
+/// @param filePath Path to write the Puffin file.
+/// @param blobData Serialized roaring bitmap bytes.
+/// @param referencedDataFile Path of the data file this DV applies to.
+/// @return Pair of (blobOffset, blobLength) within the written file.
+std::pair<uint64_t, uint64_t> writePuffinFile(
+    const std::string& filePath,
+    const std::string& blobData,
+    const std::string& referencedDataFile);
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -120,4 +120,20 @@ if(NOT VELOX_DISABLE_GOOGLETEST)
     velox_dwio_common_test_utils
     GTest::gtest
   )
+
+  add_executable(velox_hive_iceberg_deletion_vector_writer_test DeletionVectorWriterTest.cpp)
+  add_test(
+    velox_hive_iceberg_deletion_vector_writer_test
+    velox_hive_iceberg_deletion_vector_writer_test
+  )
+
+  target_link_libraries(
+    velox_hive_iceberg_deletion_vector_writer_test
+    velox_hive_connector
+    velox_hive_iceberg_splitreader
+    velox_exec_test_lib
+    velox_dwio_common_test_utils
+    GTest::gtest
+    GTest::gtest_main
+  )
 endif()

--- a/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
+++ b/velox/connectors/hive/iceberg/tests/DeletionVectorWriterTest.cpp
@@ -1,0 +1,319 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/DeletionVectorWriter.h"
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempFilePath.h"
+#include "velox/connectors/hive/iceberg/DeletionVectorReader.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive::iceberg;
+using namespace facebook::velox::common::testutil;
+
+namespace {
+
+/// Extracts which bits are set in a bitmap buffer.
+std::vector<uint64_t> getSetBits(const BufferPtr& bitmap, uint64_t size) {
+  auto* raw = bitmap->as<uint8_t>();
+  std::vector<uint64_t> result;
+  for (uint64_t i = 0; i < size; ++i) {
+    if (bits::isBitSet(raw, i)) {
+      result.push_back(i);
+    }
+  }
+  return result;
+}
+
+} // namespace
+
+class DeletionVectorWriterTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    memory::MemoryManager::initialize(memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    filesystems::registerLocalFileSystem();
+    pool_ = memory::memoryManager()->addLeafPool("DeletionVectorWriterTest");
+  }
+
+  BufferPtr allocateBitmap(uint64_t numBits) {
+    auto numBytes = bits::nbytes(numBits);
+    return AlignedBuffer::allocate<uint8_t>(numBytes, pool_.get(), 0);
+  }
+
+  /// Writes serialized bitmap to a temp file, reads it back with
+  /// DeletionVectorReader, and verifies the positions match.
+  void verifyRoundTrip(
+      const std::vector<int64_t>& positions,
+      uint64_t batchSize) {
+    DeletionVectorWriter writer;
+    writer.addDeletedPositions(positions);
+    EXPECT_EQ(writer.numPositions(), positions.size());
+
+    auto blobData = writer.serialize();
+
+    auto tempFile = TempFilePath::create();
+    {
+      std::ofstream out(
+          tempFile->getPath(), std::ios::binary | std::ios::trunc);
+      out.write(blobData.data(), static_cast<std::streamsize>(blobData.size()));
+    }
+
+    auto fileSize = static_cast<uint64_t>(blobData.size());
+
+    // Create IcebergDeleteFile with DV metadata.
+    std::unordered_map<int32_t, std::string> lowerBounds;
+    std::unordered_map<int32_t, std::string> upperBounds;
+    lowerBounds[DeletionVectorReader::kDvOffsetFieldId] = "0";
+    upperBounds[DeletionVectorReader::kDvLengthFieldId] =
+        std::to_string(fileSize);
+
+    IcebergDeleteFile dvFile(
+        FileContent::kDeletionVector,
+        tempFile->getPath(),
+        dwio::common::FileFormat::DWRF,
+        positions.size(),
+        fileSize,
+        {},
+        lowerBounds,
+        upperBounds);
+
+    DeletionVectorReader reader(dvFile, 0, pool_.get());
+
+    // Collect all set bits across batches.
+    std::vector<uint64_t> allSetBits;
+    int64_t maxPos = positions.empty()
+        ? 0
+        : *std::max_element(positions.begin(), positions.end());
+    uint64_t totalRows = static_cast<uint64_t>(maxPos) + batchSize;
+
+    for (uint64_t offset = 0; offset < totalRows; offset += batchSize) {
+      auto bitmap = allocateBitmap(batchSize);
+      reader.readDeletePositions(offset, batchSize, bitmap);
+      auto bits = getSetBits(bitmap, batchSize);
+      for (auto b : bits) {
+        allSetBits.push_back(offset + b);
+      }
+    }
+
+    // Sort and deduplicate the expected positions.
+    std::vector<int64_t> expected = positions;
+    std::sort(expected.begin(), expected.end());
+    expected.erase(
+        std::unique(expected.begin(), expected.end()), expected.end());
+
+    EXPECT_EQ(allSetBits.size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+      EXPECT_EQ(allSetBits[i], static_cast<uint64_t>(expected[i]));
+    }
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(DeletionVectorWriterTest, emptyBitmap) {
+  DeletionVectorWriter writer;
+  EXPECT_EQ(writer.numPositions(), 0);
+
+  auto data = writer.serialize();
+  // Empty 64-bit bitmap: numGroups=0 as uint64 (8 bytes).
+  EXPECT_EQ(data.size(), 8);
+}
+
+TEST_F(DeletionVectorWriterTest, singlePosition) {
+  verifyRoundTrip({42}, 100);
+}
+
+TEST_F(DeletionVectorWriterTest, multiplePositions) {
+  verifyRoundTrip({0, 5, 10, 99}, 100);
+}
+
+TEST_F(DeletionVectorWriterTest, consecutivePositions) {
+  std::vector<int64_t> positions;
+  positions.reserve(100);
+  for (int64_t i = 0; i < 100; ++i) {
+    positions.push_back(i);
+  }
+  verifyRoundTrip(positions, 200);
+}
+
+TEST_F(DeletionVectorWriterTest, multipleContainers) {
+  // Positions spanning two containers (key=0 and key=1).
+  verifyRoundTrip({5, 100, 65536, 65600}, 70000);
+}
+
+TEST_F(DeletionVectorWriterTest, largeCardinalityBitmapContainer) {
+  // More than 4096 positions in a single container triggers bitmap container.
+  std::vector<int64_t> positions;
+  positions.reserve(5000);
+  for (int64_t i = 0; i < 5000; ++i) {
+    positions.push_back(i * 2); // Even numbers 0..9998.
+  }
+  verifyRoundTrip(positions, 10100);
+}
+
+TEST_F(DeletionVectorWriterTest, duplicatePositions) {
+  // addDeletedPosition() does not deduplicate — numPositions() counts all
+  // insertions including duplicates. serialize() deduplicates via std::set.
+  DeletionVectorWriter writer;
+  writer.addDeletedPosition(5);
+  writer.addDeletedPosition(5);
+  writer.addDeletedPosition(10);
+  writer.addDeletedPosition(10);
+  writer.addDeletedPosition(10);
+  EXPECT_EQ(writer.numPositions(), 5);
+
+  auto data = writer.serialize();
+
+  auto tempFile = TempFilePath::create();
+  {
+    std::ofstream out(tempFile->getPath(), std::ios::binary | std::ios::trunc);
+    out.write(data.data(), static_cast<std::streamsize>(data.size()));
+  }
+
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  std::unordered_map<int32_t, std::string> upperBounds;
+  lowerBounds[DeletionVectorReader::kDvOffsetFieldId] = "0";
+  upperBounds[DeletionVectorReader::kDvLengthFieldId] =
+      std::to_string(data.size());
+
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      tempFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      2, // Only 2 unique positions.
+      data.size(),
+      {},
+      lowerBounds,
+      upperBounds);
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get());
+
+  auto bitmap = allocateBitmap(20);
+  reader.readDeletePositions(0, 20, bitmap);
+
+  auto setBits = getSetBits(bitmap, 20);
+  EXPECT_EQ(setBits, (std::vector<uint64_t>{5, 10}));
+}
+
+TEST_F(DeletionVectorWriterTest, clearPositions) {
+  DeletionVectorWriter writer;
+  writer.addDeletedPosition(1);
+  writer.addDeletedPosition(2);
+  EXPECT_EQ(writer.numPositions(), 2);
+
+  writer.clear();
+  EXPECT_EQ(writer.numPositions(), 0);
+
+  auto data = writer.serialize();
+  EXPECT_EQ(data.size(), 8); // Empty bitmap.
+}
+
+TEST_F(DeletionVectorWriterTest, negativePositionRejected) {
+  DeletionVectorWriter writer;
+  VELOX_ASSERT_THROW(
+      writer.addDeletedPosition(-1), "Deleted position must be non-negative");
+}
+
+TEST_F(DeletionVectorWriterTest, fourOrMoreContainersWithOffsets) {
+  // With >= 4 containers, the roaring format includes an offset section.
+  std::vector<int64_t> positions;
+  positions.reserve(5);
+  for (int i = 0; i < 5; ++i) {
+    positions.push_back(static_cast<int64_t>(i) * 65536 + 42);
+  }
+  verifyRoundTrip(positions, 5 * 65536 + 100);
+}
+
+TEST_F(DeletionVectorWriterTest, puffinFileRoundTrip) {
+  DeletionVectorWriter writer;
+  writer.addDeletedPositions({3, 7, 42, 100});
+  auto blobData = writer.serialize();
+
+  auto tempFile = TempFilePath::create();
+  auto [blobOffset, blobLength] = writePuffinFile(
+      tempFile->getPath(), blobData, "/data/test-data-file.parquet");
+
+  EXPECT_EQ(blobOffset, 4); // After "PUF1" magic.
+  EXPECT_EQ(blobLength, blobData.size());
+
+  // Read the blob back from the Puffin file using DeletionVectorReader.
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  std::unordered_map<int32_t, std::string> upperBounds;
+  lowerBounds[DeletionVectorReader::kDvOffsetFieldId] =
+      std::to_string(blobOffset);
+  upperBounds[DeletionVectorReader::kDvLengthFieldId] =
+      std::to_string(blobLength);
+
+  // Get full file size.
+  std::ifstream in(tempFile->getPath(), std::ios::binary | std::ios::ate);
+  auto fileSize = static_cast<uint64_t>(in.tellg());
+
+  IcebergDeleteFile dvFile(
+      FileContent::kDeletionVector,
+      tempFile->getPath(),
+      dwio::common::FileFormat::DWRF,
+      4,
+      fileSize,
+      {},
+      lowerBounds,
+      upperBounds);
+
+  DeletionVectorReader reader(dvFile, 0, pool_.get());
+
+  auto bitmap = allocateBitmap(200);
+  reader.readDeletePositions(0, 200, bitmap);
+
+  auto setBits = getSetBits(bitmap, 200);
+  EXPECT_EQ(setBits, (std::vector<uint64_t>{3, 7, 42, 100}));
+}
+
+/// Verifies 64-bit positions (>4 billion) serialize and deserialize correctly.
+/// This exercises the Roaring64Bitmap group partitioning for large data files.
+TEST_F(DeletionVectorWriterTest, largePositions64Bit) {
+  // Positions beyond the 32-bit range.
+  std::vector<int64_t> positions = {
+      100,
+      65'536,
+      5'000'000'000LL,
+      5'000'000'001LL,
+      10'000'000'000LL,
+  };
+  verifyRoundTrip(positions, 1'024);
+}
+
+/// Verifies mixed 32-bit and 64-bit positions in the same bitmap.
+TEST_F(DeletionVectorWriterTest, mixed32And64BitPositions) {
+  std::vector<int64_t> positions = {
+      0,
+      1,
+      65'535,
+      65'536,
+      4'294'967'295LL,
+      4'294'967'296LL,
+      8'589'934'592LL,
+  };
+  verifyRoundTrip(positions, 2'048);
+}


### PR DESCRIPTION
Summary:
Add DeletionVectorWriter for serializing deletion vectors to Puffin
format with Roaring Bitmap encoding. Supports both 32-bit and 64-bit
position ranges with bounds checking.

Part of https://github.com/prestodb/presto/issues/27198

Reviewed By: raymondlin1

Differential Revision: D100061161


